### PR TITLE
feat(security): per-app WebSocket event scoping for app tokens

### DIFF
--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -324,6 +324,21 @@ class BackendConfig:
         )
 
 
+def _granted_list(value: Any) -> list[str]:
+    """The entries of a list-valued GRANT, or nothing if it is not a list.
+
+    A JSON scalar must NOT be coerced. `[str(x) for x in value]` over a STRING
+    iterates its characters, so `"exposeToApps": "*"` became `["*"]` -- the
+    wildcard -- and any string containing `*` or `/` produced that token too:
+    `"api": "/api/chat"` yielded the prefix `"/"`, which `app_token_path_allowed`
+    matches against every path. A malformed grant has to deny, the same direction
+    the boolean grants below fail in.
+    """
+    if not isinstance(value, list):
+        return []
+    return [str(v) for v in value if v]
+
+
 @dataclass
 class Permissions:
     """Declared permissions for an app."""
@@ -339,6 +354,10 @@ class Permissions:
     #: Declared rather than implicit so "which apps can start an agent" is
     #: auditable from the manifest instead of from an app's import graph.
     spawn: bool = False
+    # WS cross-app visibility opt-in: app names (or ["*"]) allowed to use
+    # slots:app:<this-app> / subagent:app:<this-app> declarations to observe
+    # this app's slots and subagents. Empty list = no cross-app visibility.
+    exposeToApps: list[str] = field(default_factory=list)  # noqa: N815
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {}
@@ -358,6 +377,8 @@ class Permissions:
             d["cron"] = True
         if self.spawn:
             d["spawn"] = True
+        if self.exposeToApps:
+            d["exposeToApps"] = self.exposeToApps
         return d
 
     @classmethod
@@ -374,14 +395,15 @@ class Permissions:
         # restriction ON. Same defect class, mirrored fix — the safe default
         # follows what the field grants or withholds, not the field's type.
         return cls(
-            api=[str(p) for p in data.get("api", []) if p],
-            events=[str(e) for e in data.get("events", []) if e],
-            mcpTools=[str(t) for t in data.get("mcpTools", []) if t],  # noqa: N815
+            api=_granted_list(data.get("api")),
+            events=_granted_list(data.get("events")),
+            mcpTools=_granted_list(data.get("mcpTools")),  # noqa: N815
             storage=data.get("storage") is True,
             network=data.get("network") is True,
             memory=str(data.get("memory", "")),
             cron=data.get("cron") is True,
             spawn=data.get("spawn") is True,
+            exposeToApps=_granted_list(data.get("exposeToApps")),  # noqa: N815
         )
 
 

--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -12,7 +12,7 @@ from kiro_crew.dashboard.chat_utils import (
     _sync_dashboard_slots,
     effective_session_key,
 )
-from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.dashboard.state import DashboardState, request_slot_origin
 from kiro_crew.history import carry_provenance
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
@@ -204,6 +204,7 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
         name=None, agent=slot.agent, workspace=slot.workspace, model=slot.model,
         mode=mode_override if mode_override is not None else slot.mode,
         app=request_app,
+        origin=request_slot_origin(request_app),
     )
     new_slot.forked_from = effective_session_key(slot)
     new_slot.reasoning_effort = slot.reasoning_effort

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -66,6 +66,7 @@ from kiro_crew.dashboard.state import (
     _ChatSlot,
     _mark_permission_resolved,
     _normalize_slot_key,
+    request_slot_origin,
 )
 from kiro_crew.dashboard.turn_dispatch import spawn_guarded_turn
 from kiro_crew.history import carry_provenance
@@ -176,6 +177,7 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         slot = state.get_or_create_slot(
             slot_name,
             app=request.get("app", ""),
+            origin=request_slot_origin(request.get("app", "")),
             memory_mode=requested_memory_mode,
         )
     except ValueError as exc:
@@ -916,6 +918,7 @@ async def api_chat_slot_create(request: web.Request) -> web.Response:
                 memory_mode=memory_mode,
                 ephemeral=body.get("ephemeral"),
                 app=request.get("app", ""),
+                origin=request_slot_origin(request.get("app", "")),
             )
         except ValueError as exc:
             return web.json_response({"error": str(exc)}, status=409)
@@ -2894,7 +2897,21 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
             }
         )
 
-    slot = state.get_or_create_slot(name, app=request.get("app", ""))
+    # Read the history metadata BEFORE creating the slot: this endpoint RESUMES a
+    # persisted conversation, so its origin is a property of that conversation,
+    # not of whoever is resuming it. Deriving it from the request labelled a
+    # resumed CRON slot as USER — and `slots:user` then handed the dashboard
+    # user's private cron output to any app holding that scope. An absent
+    # persisted origin stays empty (get_or_create_slot then derives APP for an
+    # app token, otherwise leaves it untagged, which is invisible to cross-slot
+    # scopes) rather than claiming USER on a conversation we cannot attribute.
+    meta = state.conversation_log.get_metadata(history_key)
+
+    slot = state.get_or_create_slot(
+        name,
+        app=request.get("app", ""),
+        origin=str(meta.get("origin", "")),
+    )
     title = body.get("title", "")
     if title:
         slot.title = title
@@ -2907,7 +2924,6 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
                 slot._titled = True
                 break
     # Restore original created_at from history metadata
-    meta = state.conversation_log.get_metadata(history_key)
     if meta.get("created_at"):
         slot.created_at = meta["created_at"]
     if meta.get("agent"):
@@ -3137,7 +3153,12 @@ async def api_chat_mode(request: web.Request) -> web.Response:
                     # flag the slot or the write can be lost on restart.
                     if _mark_permission_resolved(slot.messages, aid, mode):
                         slot._dirty = True
-                    state.broadcast_ws("approval_resolved", {"id": aid, "approved": True})
+                    # ``slot`` keys the frame for the slot-scoped WS gate — an
+                    # app token cannot receive its own resolution without it.
+                    state.broadcast_ws(
+                        "approval_resolved",
+                        {"id": aid, "approved": True, "slot": slot.key},
+                    )
                     try:
                         sel().log_api_access(
                             caller=f"dashboard:{slot.key}",
@@ -3349,7 +3370,14 @@ async def api_chat_slot_approve(request: web.Request) -> web.Response:
     # Broadcast first to ensure frontend is unblocked
     if request_id:
         state.broadcast_ws(
-            "approval_resolved", {"id": request_id, "approved": resolved != "rejected"}
+            "approval_resolved",
+            {
+                "id": request_id,
+                "approved": resolved != "rejected",
+                # Keys the frame for the slot-scoped WS gate (see
+                # ws_event_scope._SLOT_SCOPED_EVENTS).
+                "slot": owner.key,
+            },
         )
     state.push_slots_update()
     # SEL audit (best-effort — must not block the UI-unblocking path above)

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -389,7 +389,15 @@ def _rehydrate_slot_from_history(
     restricted_key = f"dashboard:{slot_name}"
     preexisting_restricted = restricted_key in state._restricted_keys
     try:
-        slot = state.get_or_create_slot(slot_name, app=meta.get("app", ""))
+        slot = state.get_or_create_slot(
+            slot_name,
+            app=meta.get("app", ""),
+            # Restore the persisted origin. Re-deriving it here would relabel
+            # every rehydrated slot on restart, so a cron slot would come back
+            # as USER (leak) and a real user slot as untagged (silently
+            # dropping `slots:user` for apps that legitimately hold it).
+            origin=str(meta.get("origin", "")),
+        )
         # Title comes from the metadata line we already read above. We deliberately
         # do NOT consult ``list_sessions()`` here: that call globbed + stat'd + read
         # the first line of EVERY session file in the history dir (O(all sessions))
@@ -717,7 +725,15 @@ def _restore_recent_sessions_steps(
         if not has_folder and not has_pin:
             if cutoff is not None and s.get("modified", 0) < cutoff:
                 continue
-        slot = state.get_or_create_slot(slot_name, app=meta.get("app", ""))
+        slot = state.get_or_create_slot(
+            slot_name,
+            app=meta.get("app", ""),
+            # Restore the persisted origin. Re-deriving it here would relabel
+            # every rehydrated slot on restart, so a cron slot would come back
+            # as USER (leak) and a real user slot as untagged (silently
+            # dropping `slots:user` for apps that legitimately hold it).
+            origin=str(meta.get("origin", "")),
+        )
         # Titles can be LLM-generated (auto-title) and are surfaced on the
         # dashboard — apply the same redaction as assistant content. Matches
         # the treatment in _rehydrate_slot_from_history above.
@@ -1446,6 +1462,14 @@ def _save_slot_to_history(
                 meta_line["folder_id"] = slot.folder_id
             if slot._app:
                 meta_line["app"] = slot._app
+            # Slot ORIGIN (user / app / cron) must round-trip with ``app``:
+            # the rehydrate paths restore ``origin=meta.get("origin", "")`` and an
+            # untagged restore falls back to the fail-closed empty sentinel. Without
+            # this write every slot would come back unattributed after a restart —
+            # ``slots:user`` subscribers would stop seeing user slots, and a cron
+            # slot would lose the CRON tag that keeps it out of ``slots:user``.
+            if slot._origin:
+                meta_line["origin"] = slot._origin
             # Artifact companion binding — persisted so a bound
             # session restored after a gateway restart (or resumed from the
             # History page) comes back as the artifact's active bound session.

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -4456,7 +4456,12 @@ async def _run_chat(
                         slot._dirty = True
                         state.broadcast_ws(
                             "approval_resolved",
-                            {"id": str(event.request_id), "approved": _approved},
+                            {
+                                "id": str(event.request_id),
+                                "approved": _approved,
+                                # Keys the frame for the slot-scoped WS gate.
+                                "slot": slot.key,
+                            },
                         )
                         state.push_slots_update()
                     # Clean up the Slack prompt: remove the registry entry and

--- a/src/kiro_crew/dashboard/cron_inject.py
+++ b/src/kiro_crew/dashboard/cron_inject.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.dashboard.state import DashboardState, SlotOrigin
 from kiro_crew.history import append_if_absent_off_loop
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
@@ -22,7 +22,13 @@ def inject_cron_result_to_dashboard(
 ) -> None:
     """Inject cron result into linked dashboard chat slot (shared by to-chat and auto-inject)."""
     slot_name = f"cron-{job.id}"
-    slot = state.get_or_create_slot(name=slot_name, agent=job.agent_id or "")
+    slot = state.get_or_create_slot(
+        name=slot_name,
+        agent=job.agent_id or "",
+        # A cron result is the job's output, not something the person typed.
+        # Labelling it USER handed it to any app holding `slots:user`.
+        origin=SlotOrigin.CRON,
+    )
     safe_name, _ = redact_exfiltration_urls(job.name)
     safe_name, _ = redact_credentials(safe_name)
     slot.title = f"Cron: {safe_name}"

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -17,7 +17,7 @@ from kiro_crew.dashboard.cron_inject import (
     hydrate_slot_from_history,
     inject_cron_result_to_dashboard,
 )
-from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.dashboard.state import DashboardState, SlotOrigin
 from kiro_crew.llm_helpers import run_bg_oneliner
 from kiro_crew.messaging.link import is_channel_session_key
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -503,7 +503,9 @@ async def api_cron_to_chat(request: web.Request) -> web.Response:
             if state.conversation_log else []
         )
         if history:
-            slot = state.get_or_create_slot(name=slot_name, agent="")
+            slot = state.get_or_create_slot(
+                name=slot_name, agent="", origin=SlotOrigin.CRON
+            )
             if not slot.linked_session_key:
                 slot.linked_session_key = session_key
                 hydrate_slot_from_history(slot, history)
@@ -515,7 +517,9 @@ async def api_cron_to_chat(request: web.Request) -> web.Response:
             )
             if not notif:
                 return web.json_response({"error": "job not found"}, status=404)
-            slot = state.get_or_create_slot(name=slot_name, agent="")
+            slot = state.get_or_create_slot(
+                name=slot_name, agent="", origin=SlotOrigin.CRON
+            )
             body = notif.get("body", "")
             if body:
                 body, _ = redact_exfiltration_urls(body)

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -774,6 +774,36 @@ def _normalize_slot_key(name: str) -> str:
     return _SLOT_KEY_FILENAME_UNSAFE_RE.sub("_", _ascii_slot_key(name))
 
 
+class SlotOrigin:
+    """Slot creation origin — who initiated the slot.
+
+    Used by the WS event scope gate to decide which events an app token may
+    receive (e.g. ``slots:user`` grants visibility into ``USER``-origin slots
+    regardless of their ``_app`` owner).
+    """
+
+    USER = "user"       # initiated from the dashboard UI (no app token)
+    APP = "app"         # initiated by an app SDK call (carries owner _app)
+    CRON = "cron"       # initiated by a cron job
+    SYSTEM = "system"   # gateway-internal (startup, migration, etc.)
+
+
+def request_slot_origin(app: str) -> str:
+    """Origin for a slot created while serving an HTTP request.
+
+    The request layer is the only place that knows whether an app token was
+    presented, which is what separates APP from USER. Call it with the
+    request's app name (``request.get("app", "")``) — empty means the caller
+    authenticated as the dashboard user, so the slot genuinely is USER.
+
+    Background callers (cron, workflow, Slack, rehydrate) must NOT use this:
+    they have no request and would mislabel their slot as a person's, which is
+    exactly what `slots:user` grants an app access to. They declare their own
+    origin, or leave it untagged.
+    """
+    return SlotOrigin.APP if app else SlotOrigin.USER
+
+
 class _ChatSlot:
     """Independent chat session that runs server-side."""
 
@@ -853,6 +883,7 @@ class _ChatSlot:
         "_ephemeral",
         "_pending_context",
         "_app",
+        "_origin",
         "_pending_variants",
         "_lock",
         "forked_from",
@@ -1059,6 +1090,10 @@ class _ChatSlot:
         self._ephemeral: bool = ephemeral  # Incognito mode: no memory writes
         self._pending_context: list[dict[str, Any]] = []
         self._app: str = ""  # App identity tag (App Kit §5.2)
+        # Deliberately "" (not USER): a slot built outside get_or_create_slot
+        # matches NO slots:* scope, so it stays invisible to app tokens rather
+        # than being silently classified as user-initiated. Deny-by-default.
+        self._origin: str = ""
         # Regenerate feature: variants pending attachment to next finalized assistant message
         self._pending_variants: list[dict] = []
         self._lock = asyncio.Lock()
@@ -1741,6 +1776,7 @@ class _ChatSlot:
             "forked_from": self.forked_from,
             "linked_session_key": self.linked_session_key,
             "app": self._app,
+            "origin": self._origin,
         }
 
 
@@ -2296,7 +2332,16 @@ class DashboardState:
         except Exception:
             self._log.warning("SEL audit failed for approval resolution", exc_info=True)
         try:
-            self.broadcast_ws("approval_resolved", {"id": approval_id, "approved": approved})
+            # ``approval_resolved`` is slot-scoped in the WS event-scope gate,
+            # which denies any frame it cannot attribute to a slot. Carry the
+            # owning slot key so an app token receives the resolution for its
+            # OWN approval; ``session_key == "state"`` is a background
+            # (cron/subagent/gateway) approval that no slot owns, so it stays
+            # unattributed and the gate correctly withholds it from app tokens.
+            payload: dict = {"id": approval_id, "approved": approved}
+            if session_key and session_key != "state":
+                payload["slot"] = session_key
+            self.broadcast_ws("approval_resolved", payload)
         except Exception:
             self._log.warning("WS broadcast failed for approval resolution", exc_info=True)
 
@@ -2945,6 +2990,7 @@ class DashboardState:
         ephemeral: bool | None = None,
         app: str = "",
         linked_session_key: str = "",
+        origin: str | None = None,
     ) -> _ChatSlot:
         """Return existing slot or create a new one.
 
@@ -3004,6 +3050,22 @@ class DashboardState:
         slot._tab_id = uuid.uuid4().hex[:12]
         slot._on_message = self._broadcast_chat_message
         slot._app = app
+        # ``origin`` must be declared by the layer that actually knows it, and
+        # an undeclared non-app slot stays UNTAGGED ("") rather than being
+        # called USER.
+        #
+        # Deriving USER here was fail-OPEN: this function cannot tell a person
+        # typing in the dashboard from a background injection, so every
+        # untagged caller — cron result injection, workflow inject, Slack, the
+        # OpenAI-compatible endpoint — was labelled USER, and an app holding
+        # `slots:user` received that private content. Only the request layer
+        # knows whether an app token was presented, so USER/APP is decided
+        # there (see chat_handlers) and background callers declare CRON/SYSTEM.
+        #
+        # "" is invisible to every cross-slot scope (the gate compares against
+        # SlotOrigin.USER), so a caller that forgets to declare loses
+        # visibility instead of leaking — the direction this has to fail in.
+        slot._origin = origin or (SlotOrigin.APP if app else "")
         if memory_mode and memory_mode != "persistent":
             self._restricted_keys.add(f"dashboard:{name}")
         if ephemeral:
@@ -3684,14 +3746,24 @@ class DashboardState:
         # WS broadcast — translate internal _type to WS message format
         if self._ws_clients:
             msg_type = note.get("_type", "notification")
+            # Payload the scope gate inspects (slot / source keys), tracked per
+            # branch so the chokepoint can filter correctly.
+            ws_data: object
             if msg_type == "slots":
                 slots_list = note.get("_slots_list") or json.loads(note["slots"])
+                # ``data`` for slots carries the whole envelope so the
+                # chokepoint can per-app filter and re-serialize it.
+                ws_data = {
+                    "slots": slots_list,
+                    "yolo": note.get("_yolo", False),
+                    "channelTrusted": note.get("channelTrusted", False),
+                }
                 ws_msg = json.dumps(
                     {
                         "type": "slots",
                         "data": slots_list,
-                        "yolo": note.get("_yolo", False),
-                        "channelTrusted": note.get("channelTrusted", False),
+                        "yolo": ws_data["yolo"],
+                        "channelTrusted": ws_data["channelTrusted"],
                         # Forwarded explicitly: this envelope is rebuilt key-by-key,
                         # so anything not named here is silently dropped. The client
                         # invalidates its cached dashboard config when this changes.
@@ -3699,34 +3771,24 @@ class DashboardState:
                     }
                 )
             elif msg_type == "slot_title":
-                ws_msg = json.dumps(
-                    {"type": "slot_title", "data": {"key": note["key"], "title": note["title"]}}
-                )
+                ws_data = {"key": note["key"], "title": note["title"]}
+                ws_msg = json.dumps({"type": "slot_title", "data": ws_data})
             elif msg_type == "refresh":
-                ws_msg = json.dumps(
-                    {"type": "refresh", "data": {"kinds": note["kinds"].split(",")}}
-                )
+                ws_data = {"kinds": note["kinds"].split(",")}
+                ws_msg = json.dumps({"type": "refresh", "data": ws_data})
             elif msg_type == "update_progress":
-                ws_msg = json.dumps(
-                    {
-                        "type": "update_progress",
-                        "data": {"step": note["step"], "detail": note.get("detail", "")},
-                    }
-                )
+                ws_data = {"step": note["step"], "detail": note.get("detail", "")}
+                ws_msg = json.dumps({"type": "update_progress", "data": ws_data})
             elif msg_type == "artifact_update":
                 # Typed envelope (not the generic `notification` fallback) so
                 # useWebSocket and future consumers get a self-documenting
                 # event: {slug, version, deleted}.
-                ws_msg = json.dumps(
-                    {
-                        "type": "artifact_update",
-                        "data": {
-                            "slug": note["slug"],
-                            "version": note.get("version", 0),
-                            "deleted": note.get("deleted", False),
-                        },
-                    }
-                )
+                ws_data = {
+                    "slug": note["slug"],
+                    "version": note.get("version", 0),
+                    "deleted": note.get("deleted", False),
+                }
+                ws_msg = json.dumps({"type": "artifact_update", "data": ws_data})
             elif msg_type == "chat_message":
                 chat_data: dict[str, Any] = {
                     "slot": note["slot"],
@@ -3739,10 +3801,12 @@ class DashboardState:
                     chat_data["cls"] = note["cls"]
                 if note.get("meta"):
                     chat_data["meta"] = note["meta"]
+                ws_data = chat_data
                 ws_msg = json.dumps({"type": "chat_message", "data": chat_data})
             else:
+                ws_data = note
                 ws_msg = json.dumps({"type": "notification", "data": note})
-            self._send_ws_all(ws_msg)
+            self._send_ws_all(msg_type, ws_data, ws_msg)
 
     def _spawn_ws_send(self, ws: web.WebSocketResponse, msg: str) -> None:
         """Fire-and-forget a WS send while retaining a strong task reference.
@@ -3773,15 +3837,148 @@ class DashboardState:
         if exc is not None:
             logger.debug("WS send failed (client likely disconnected): %s", exc)
 
-    def _send_ws_all(self, msg: str) -> None:
-        """Send a pre-serialized JSON string to all WS clients."""
+    def _ws_client_allowed(
+        self, ws: web.WebSocketResponse, msg_type: str, data: object
+    ) -> bool:
+        """Return True if *ws* should receive an event with *msg_type* / *data*.
+
+        Deny-by-default (CWE-269): every non-dashboard-user connection is gated
+        through :func:`ws_event_scope.ws_event_allowed`. Dashboard-user tokens
+        are identified by the POSITIVE ``_is_dashboard_user`` flag set by
+        ``api_ws`` — never by the absence of ``_app``, which would fail OPEN on
+        any register path that forgot to set it.
+        """
+        if ws.get("_is_dashboard_user", False):
+            return True
+        ws_app: str = ws.get("_app", "")
+        allowed: frozenset[str] = ws.get("_allowed_events", frozenset())
+        _data_dict: dict = data if isinstance(data, dict) else {}
+        try:
+            # circular import: ws_event_scope references SlotOrigin from this
+            # module at type-check time and reads ``state._slots`` at runtime,
+            # so a top-level import here would create a bootstrap cycle.
+            from kiro_crew.dashboard.ws_event_scope import (
+                _audit_deny,
+                ws_event_allowed,
+            )
+
+            return ws_event_allowed(
+                msg_type,
+                _data_dict,
+                app=ws_app,
+                allowed_events=allowed,
+                state=self,
+            )
+        except Exception:
+            # The scope check itself failed — fail closed AND audit, so probing
+            # for scope-check bugs leaves a trail.
+            try:
+                _audit_deny(ws_app or "<unknown>", msg_type, "scope_check_exception")
+            except Exception as inner_exc:
+                logger.debug(
+                    "state: audit for scope_check_exception failed for %s/%s: %s",
+                    ws_app,
+                    msg_type,
+                    inner_exc,
+                )
+            return False
+
+    def _serialize_for_client(
+        self, ws: web.WebSocketResponse, msg_type: str, data: object, default_msg: str
+    ) -> str:
+        """Return the wire message to send to *ws*.
+
+        Most events go to every client as ``default_msg`` verbatim. The
+        ``slots`` event carries the full slot list, so an app token that
+        declared only ``slots:own`` would otherwise see every slot's metadata
+        on each re-push (CWE-269). Re-filter the list per app here so the
+        manifest scope is enforced on broadcast re-pushes, not only at connect.
+        """
+        if ws.get("_is_dashboard_user", False):
+            return default_msg
+        if msg_type in ("subagent_batch_update", "subagent_batch_chunks"):
+            return self._serialize_subagent_batch(ws, msg_type, data, default_msg)
+        if msg_type != "slots":
+            return default_msg
+        if not isinstance(data, dict) or "slots" not in data:
+            # Not the expected envelope shape — nothing to filter here; the
+            # gate has already applied deny-by-default.
+            return default_msg
+        allowed: frozenset[str] = ws.get("_allowed_events", frozenset())
+        ws_app: str = ws.get("_app", "")
+        try:
+            # circular import: see _ws_client_allowed above.
+            from kiro_crew.dashboard.ws_event_scope import filter_slots_for_app
+
+            filtered = filter_slots_for_app(data["slots"], ws_app, allowed, self)
+        except Exception:
+            # Fail closed: send an empty list rather than the unfiltered payload.
+            filtered = []
+        return json.dumps(
+            {
+                "type": "slots",
+                "data": filtered,
+                "yolo": data.get("yolo", False),
+                "channelTrusted": data.get("channelTrusted", False),
+            }
+        )
+
+    def _serialize_subagent_batch(
+        self,
+        ws: web.WebSocketResponse,
+        msg_type: str,
+        data: object,
+        default_msg: str,
+    ) -> str:
+        """Filter a coalesced subagent batch frame per app token.
+
+        Above the coalescer threshold ONE frame carries MANY subagents' rows, so
+        it has no single ``slot`` the event-scope gate could judge it by. The
+        gate therefore admits it and the per-item filtering happens here —
+        mirroring the ``slots`` re-push split — so an app receives only the rows
+        for subagents it may see instead of every running agent's status and
+        output (CWE-269).
+        """
+        from kiro_crew.dashboard.ws_event_scope import (
+            _SUBAGENT_BATCH_ITEM_KEY,
+            filter_subagent_batch_for_app,
+        )
+
+        key = _SUBAGENT_BATCH_ITEM_KEY.get(msg_type, "")
+        if not key or not isinstance(data, dict) or not isinstance(data.get(key), list):
+            # Unexpected envelope shape — fail closed rather than forwarding it
+            # unfiltered, matching the slots branch.
+            return json.dumps({"type": msg_type, "data": {key or "items": []}})
+        allowed: frozenset[str] = ws.get("_allowed_events", frozenset())
+        ws_app: str = ws.get("_app", "")
+        try:
+            items = filter_subagent_batch_for_app(data[key], ws_app, allowed, self)
+        except Exception:
+            self._log.warning(
+                "subagent batch filter failed; dropping items", exc_info=True
+            )
+            items = []
+        return json.dumps({"type": msg_type, "data": {key: items}})
+
+    def _send_ws_all(self, msg_type: str, data: object, msg: str) -> None:
+        """Send a typed message to all WS clients.
+
+        This is the single chokepoint for every WS fan-out that can reach an app
+        token (both :meth:`broadcast_ws` and :meth:`_broadcast`). Each
+        connection is checked against :meth:`_ws_client_allowed`; only
+        dashboard-user tokens bypass the scope gate. Payload-level per-app
+        filtering (currently just ``slots``) happens in
+        :meth:`_serialize_for_client`.
+        """
         dead: list[web.WebSocketResponse] = []
         for ws in list(self._ws_clients):
             if ws.closed:
                 dead.append(ws)
                 continue
+            if not self._ws_client_allowed(ws, msg_type, data):
+                continue
             try:
-                self._spawn_ws_send(ws, msg)
+                self._spawn_ws_send(ws, self._serialize_for_client(ws, msg_type, data, msg))
             except Exception:
                 dead.append(ws)
         for ws in dead:
@@ -3802,11 +3999,15 @@ class DashboardState:
             self._remove_ws(ws)
 
     def broadcast_ws(self, msg_type: str, data: object) -> None:
-        """Send a typed message to all WS clients (not SSE)."""
+        """Send a typed message to all WS clients (not SSE).
+
+        Per-app event scope filtering is applied inside :meth:`_send_ws_all`
+        (the single chokepoint for WS fan-out).
+        """
         if not self._ws_clients:
             return
         msg = json.dumps({"type": msg_type, "data": data})
-        self._send_ws_all(msg)
+        self._send_ws_all(msg_type, data, msg)
 
     def broadcast_context_usage(self, slot_key: str, payload: dict) -> None:
         """Broadcast one ``context_usage`` frame AND record it as the slot's snapshot.
@@ -4076,7 +4277,13 @@ class DashboardState:
         self._ws_subagent_subscribers.discard(ws)
 
     def broadcast_ws_subagent_subscribers(self, msg_type: str, data: object) -> None:
-        """Send to subagent-subscribed clients only (for heavy chunk data)."""
+        """Send to subagent-subscribed clients only (for heavy chunk data).
+
+        A second fan-out path parallel to :meth:`broadcast_ws`, used for
+        high-volume ``subagent_chunk`` traffic. It applies the SAME per-app
+        scope gate via :meth:`_ws_client_allowed`, so an app token cannot
+        bypass filtering just by sending ``{"type": "subscribe_subagents"}``.
+        """
         if not self._ws_subagent_subscribers:
             return
         msg = json.dumps({"type": msg_type, "data": data})
@@ -4085,8 +4292,10 @@ class DashboardState:
             if ws.closed:
                 dead.append(ws)
                 continue
+            if not self._ws_client_allowed(ws, msg_type, data):
+                continue
             try:
-                self._spawn_ws_send(ws, msg)
+                self._spawn_ws_send(ws, self._serialize_for_client(ws, msg_type, data, msg))
             except Exception:
                 dead.append(ws)
         for ws in dead:

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -1115,6 +1115,32 @@ def _api_pattern_matches(pattern: str, path: str) -> bool:
     return path == pattern or path.startswith(pattern + "/")
 
 
+# Protocol-layer paths every app token implicitly needs — connection
+# infrastructure, not feature-level permissions. Requiring each app to declare
+# them in ``permissions.api`` adds no security value and produces silent 403
+# regressions whenever a new app forgets to list them.
+#
+# ``/api/ws`` is safe to allow implicitly ONLY because the WS layer now applies
+# per-app event scope filtering (``ws_event_scope.py``): a connected app token
+# receives just the events matching its ``permissions.events`` declarations, so
+# connecting no longer grants the full event stream. Contrast with functional
+# paths like /api/chat/* or /api/spawn/* — those grant real capabilities and
+# MUST stay explicitly declared.
+#
+# ``/api/status`` is deliberately NOT here. It has no response-level filter to
+# match what event scoping does for ``/api/ws``, and ``api_status`` returns far
+# more than liveness: ``owner_id_hash``, host specs (os/arch/cpu/memory), cron
+# and usage stats, and the live safety-override (``yolo_*``) state. The
+# connect/reconnect poll that needs it is the DASHBOARD SPA
+# (``useDashboardHealthProbe``), which runs on a dashboard-user token and never
+# reaches this list. Apps that genuinely want it declare it in
+# ``permissions.api`` — the shipped ``design_critique`` and ``crew_companion``
+# manifests already do.
+_APP_TOKEN_IMPLICIT_ALLOW: frozenset[str] = frozenset({
+    "/api/ws",  # WebSocket connection — filtered by ws_event_scope.py
+})
+
+
 def app_token_path_allowed(app_name: str, path: str) -> bool:
     """Return True if an app token for *app_name* may access *path*.
 
@@ -1126,6 +1152,30 @@ def app_token_path_allowed(app_name: str, path: str) -> bool:
         # it does, do NOT silently grant — that would turn the gate into a
         # no-op allow. Return False; the caller's non-empty guard is primary.
         return False
+    if path in _APP_TOKEN_IMPLICIT_ALLOW:
+        # Audit implicit grants so they appear in the trail (previously silent).
+        try:
+            _sel_fn().log_api_access(
+                caller=app_name,
+                operation="app_scope_check",
+                outcome="granted_implicit",
+                source="token_auth",
+                resources=path,
+            )
+        except Exception as exc:
+            # Security-relevant audit path (CWE-269 implicit grant); a persistent
+            # SEL misconfiguration must be observable, so log rather than pass.
+            logger.debug(
+                # Message deliberately avoids the module-name prefix: Semgrep's
+                # logger-credential-disclosure heuristic fires on the substring
+                # alone. The logged values are an app name, a path, and an
+                # exception -- no secret material.
+                "SEL audit for implicit app-scope allow %s -> %s failed: %s",
+                app_name,
+                path,
+                exc,
+            )
+        return True
     if _app_owns_path(app_name, path):
         return True
     # Notification push (RFC local notification bus, Phase 2): every app may
@@ -1323,6 +1373,9 @@ def token_auth_middleware(
             # Expose identity so downstream handlers (and app-scope) see it.
             request["user"] = _uid
             request["app"] = _app
+            # POSITIVE dashboard-user signal for the WS scope gate: the WS
+            # layer must never infer trust from a falsy app claim (CWE-269).
+            request["is_dashboard_user"] = not _app
             # App tokens are confined to their declared scope even on internal
             # paths (e.g. /api/chat, /api/spawn are mixed_internal) — otherwise
             # an app token would reach them on loopback with NO app identity set
@@ -1389,6 +1442,9 @@ def token_auth_middleware(
                 # (same rationale as the loopback branch above).
                 request["user"] = _uid
                 request["app"] = _app
+                # POSITIVE dashboard-user signal for the WS scope gate (see
+                # the loopback branch above).
+                request["is_dashboard_user"] = not _app
                 _scope_deny = _enforce_app_scope(request, _app, path)
                 if _scope_deny is not None:
                     return _scope_deny
@@ -1611,6 +1667,8 @@ def token_auth_middleware(
         # Expose authenticated identity to handlers (deny-by-default)
         request["user"] = user_id
         request["app"] = app_name
+        # POSITIVE dashboard-user signal for the WS scope gate (see above).
+        request["is_dashboard_user"] = not app_name
 
         # App-token least-privilege gate (CWE-269): an app token is confined to
         # its own namespace + its manifest ``permissions.api`` allowlist. This

--- a/src/kiro_crew/dashboard/ws.py
+++ b/src/kiro_crew/dashboard/ws.py
@@ -12,8 +12,14 @@ from aiohttp import WSMsgType, web
 
 from kiro_crew import __version__ as _local_version
 from kiro_crew import shutdown_event
+from kiro_crew.apps.manager import get_app_manifest
 from kiro_crew.dashboard.origin import check_origin
 from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.dashboard.ws_event_scope import (
+    _audit_deny,
+    build_allowed_event_set,
+    filter_slots_for_app,
+)
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
@@ -143,9 +149,36 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
 
     state.register_ws(ws, owner=owner_request)
 
+    # Store app identity on the WS connection so the broadcast chokepoint can
+    # filter. ``_is_dashboard_user`` comes from a POSITIVE signal produced by
+    # the auth middleware (``request["is_dashboard_user"]``) — it is never
+    # inferred from the absence of ``_app`` here. If a refactor reaches
+    # ``api_ws`` without passing through that middleware, the flag defaults to
+    # False and ``_send_ws_all`` keeps its deny-by-default behaviour.
+    ws_app: str = request.get("app", "")
+    ws["_app"] = ws_app
+    ws["_is_dashboard_user"] = request.get("is_dashboard_user", False)
+    allowed_events: frozenset[str] = frozenset()
+    if ws_app:
+        try:
+            manifest = get_app_manifest(ws_app)
+            events_declared = manifest.permissions.events if manifest else []
+        except Exception:
+            events_declared = []
+        allowed_events = build_allowed_event_set(events_declared)
+    ws["_allowed_events"] = allowed_events
+
     # Push current slots immediately so sidebar populates without waiting.
+    # App tokens get only the slots their manifest scope allows.
     try:
-        slots_data = state.serialize_slots(include_check_status=owner_request)
+        all_slots = state.serialize_slots(include_check_status=owner_request)
+        if ws.get("_is_dashboard_user", False):
+            slots_data = all_slots
+        elif ws_app:
+            slots_data = filter_slots_for_app(all_slots, ws_app, allowed_events, state)
+        else:
+            # Unknown identity (neither flag nor app) — deny by default.
+            slots_data = []
         await ws.send_json(
             {
                 "type": "slots",
@@ -259,6 +292,31 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                     data = json.loads(msg.data)
                     msg_type = data.get("type", "")
                     if msg_type == "subscribe_logs":
+                        # The gateway log stream is privileged. The broadcast
+                        # chokepoint filters future ``log`` events, but the
+                        # ring-buffer replay below bypasses it — gate at the
+                        # source. Positive-flag check (CWE-269): a falsy
+                        # ``_app`` alone must not open this.
+                        # Accept `log:all` as well. The per-event chokepoint
+                        # takes `<decl>` OR `<decl>:all`, so declaring
+                        # `log:all` let LIVE log events through while this
+                        # replay gate -- checking only the bare form -- refused
+                        # the buffered history: same declaration, two answers.
+                        if not ws.get("_is_dashboard_user", False) and not (
+                            "log" in allowed_events or "log:all" in allowed_events
+                        ):
+                            try:
+                                _audit_deny(
+                                    ws_app or "<unknown>",
+                                    "subscribe_logs",
+                                    "log_scope_not_declared",
+                                )
+                            except Exception:
+                                logger.debug(
+                                    "ws: SEL audit for subscribe_logs deny failed",
+                                    exc_info=True,
+                                )
+                            continue
                         state.subscribe_logs(ws)
                         # Replay log ring buffer
                         for entry in list(_log_ring):
@@ -270,6 +328,17 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                     elif msg_type == "unsubscribe_logs":
                         state.unsubscribe_logs(ws)
                     elif msg_type == "subscribe_subagents":
+                        # No declaration-level gate here on purpose. Owning
+                        # your own slots is the DEFAULT, not something a
+                        # manifest opts into, so refusing the subscription when
+                        # nothing matched ``subagent*``/``slots:*`` starved an
+                        # app of its OWN slot's replay — the one thing it is
+                        # always entitled to. Every replay frame below still
+                        # goes through the per-frame gate, which is where the
+                        # scope decision belongs; a subscription that is
+                        # allowed to exist but yields nothing visible is the
+                        # correct shape for an app that declared no extra
+                        # scope.
                         state.subscribe_subagents(ws)
 
                         def _r(t: str) -> str:
@@ -375,6 +444,18 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                                     )
                                 except Exception:
                                     pass
+                        # Per-slot scope gate on the reconnect replay. The
+                        # broadcast chokepoint covers live events, but this
+                        # replay writes to the socket directly, so it must
+                        # apply the same check. Dashboard users pass through
+                        # ``_ws_client_allowed`` unconditionally.
+                        _replay = [
+                            _f
+                            for _f in _replay
+                            if state._ws_client_allowed(
+                                ws, str(_f.get("type", "")), _f.get("data", {})
+                            )
+                        ]
                         try:
                             if len(_replay) > SUBAGENT_REPLAY_BATCH_THRESHOLD:
                                 await ws.send_json(

--- a/src/kiro_crew/dashboard/ws_event_scope.py
+++ b/src/kiro_crew/dashboard/ws_event_scope.py
@@ -1,0 +1,715 @@
+"""Per-app WebSocket event scope enforcement.
+
+App tokens connected to /api/ws must only receive events they are authorised to
+see, based on the ``permissions.events`` declarations in their ``app.json``.
+
+
+## Event tiers
+
+Tier 0 — always delivered to every connected client (no sensitive payload):
+    ``dashboard``  — gateway status snapshot (version, cron count, etc.)
+
+Tier 1 — slot-scoped: delivered only when the calling app is allowed to see the
+    slot that the event belongs to.  All events carrying a ``slot`` field fall into
+    this tier.  Visibility is controlled by the ``slots:*`` and ``subagent:*``
+    declarations in ``permissions.events`` (see below).
+
+Tier 2 — global events with no ``slot`` field.  An app must explicitly list the
+    event name (or a wildcard scope) in ``permissions.events`` to receive it.
+
+## Slot visibility scopes (``slots:*``)
+
+Declaration             Slots visible
+─────────────────────────────────────────────────────────
+(default / slots:own)   Only slots where owner_app == self
+slots:user              All slots where origin == SlotOrigin.USER
+slots:app:<name>        Slots owned by ``<name>`` — requires ``<name>`` to
+                        declare this app in its ``exposeToApps`` list
+slots:all               All slots (broad -- see the note on self-declaration below)
+
+The same scope also controls which slot-scoped subagent events are visible.
+The ``subagent:*`` declarations are an independent, additive dimension:
+
+Declaration             Subagent events visible (overrides slots:* for subagent events)
+─────────────────────────────────────────────────────────────────────────────────────────
+(default / subagent)    Own slots only (same as slots:own)
+subagent:user           Subagents in user-initiated slots
+subagent:app:<name>     Subagents in <name>'s slots (requires exposeToApps opt-in)
+subagent:all            All subagent events (broad)
+
+## Global event declarations (``permissions.events``)
+
+notification            Own app's notifications (source_app == self) only.
+                        Foreign and system-sourced notifications still denied.
+notification:system     Gateway-internal pushes with no source_app -- cron
+                        results, send_message, watchlist output. Separate from
+                        ``notification`` because that stream is user content
+                        rather than the app's own: bundling them would make
+                        one declaration a broad grant, the very shape this
+                        module exists to remove.
+notification_ack / notification_unack carry only a timestamp, so they cannot be
+attributed to a source at all and need `notification:all`.
+notification_channel_settings IS attributable -- its channel is `<app>.<id>` or
+`system.<kind>` -- so own-channel settings ride `notification`, system channels
+ride `notification:system`, and foreign channels need `notification:all`.
+notification:all        All notifications regardless of source (broad).
+sessions                sessions_restarting
+yolo                    yolo_expired
+artifacts               artifact_update ({slug, version, deleted}; metadata only)
+workflow_run_event      Declared by its own literal name -- already the correct
+                        per-event Tier 2 shape, and the only events declaration
+                        present in the tree today (the workflows app).
+log                     Gateway log stream (broad)
+browser                 browser_event (broad)
+
+## Scope declarations are SELF-declared
+
+Every scope above is read from the app's own ``app.json``. Nothing in this module
+consults an install-time approval, so an app can widen itself by writing
+``slots:all`` into its manifest -- which is consistent with the trust model
+(installing an app already grants it in-process gateway privilege) but means the
+tiers are a *structuring* mechanism plus an audit trail, not a barrier against a
+hostile manifest. The one asymmetric check is ``exposeToApps``: cross-app
+visibility requires consent from the app being observed, because there the
+manifest being trusted is not the one being widened.
+
+Gating the broad scopes through the install-time consent path
+(``apps/admission.py``) is tracked separately.
+
+## Dashboard users (empty app claim) are unaffected — full event stream as before.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+# circular import: apps.manager imports config helpers that transitively pull
+# in ``kiro_crew.dashboard.state``; keeping ``get_app_manifest`` at module
+# scope requires it to load after this module's own definitions are visible,
+# which the current import order satisfies (state.py imports us lazily inside
+# broadcast_ws, and ws.py imports us before apps.manager). Kept top-level per
+# the top-level-imports guideline.
+from kiro_crew.apps.manager import get_app_manifest
+
+if TYPE_CHECKING:
+    from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SEL audit deduplication — WS broadcast is a hot path.  A misconfigured app
+# spamming reconnects could otherwise emit tens of thousands of identical
+# deny audits per minute and drown out real signal.  We instead guarantee
+# *at least one* audit per (app, event_type, reason) tuple per window, which
+# gives per-scenario observability with bounded volume.  Repeated denies of
+# the same pair within the window are counted and the tally rides the NEXT
+# emitted record (``suppressed=N``), so the trail keeps the volume signal a
+# burst carries without one record per frame: this gate runs per event PER
+# CONNECTED CLIENT on the broadcast hot path, so a streaming response alone is
+# chunks x clients decisions.
+# ---------------------------------------------------------------------------
+
+_SEL_DEDUP_WINDOW_SECS = 300.0  # 5 minutes
+#: (app, event_type, reason) -> (last emitted monotonic ts, denies suppressed since)
+_sel_last_audit: dict[tuple[str, str, str], tuple[float, int]] = {}
+
+
+def _audit_deny(app: str, event_type: str, reason: str) -> None:
+    """Emit a deduplicated SEL audit event for a denied WS event.
+
+    Guaranteed to emit at least once per (app, event_type, reason) tuple per
+    ``_SEL_DEDUP_WINDOW_SECS`` window, so sustained privilege-escalation
+    attempts remain observable while burst floods are collapsed.
+    """
+    key = (app, event_type, reason)
+    now = time.monotonic()
+    entry = _sel_last_audit.get(key)
+    if entry is not None and (now - entry[0]) < _SEL_DEDUP_WINDOW_SECS:
+        # Still inside the window: record that one more identical deny happened
+        # so the next emitted audit can report the true volume.
+        _sel_last_audit[key] = (entry[0], entry[1] + 1)
+        return
+    suppressed = entry[1] if entry is not None else 0
+    _sel_last_audit[key] = (now, 0)
+    try:
+        # circular import: sel.py loads config that transitively pulls in
+        # ``kiro_crew.dashboard`` submodules — import lazily.
+        from kiro_crew.sel import sel as _sel
+        _sel().log_api_access(
+            caller=app,
+            operation="ws_event_scope",
+            outcome=f"denied:{reason}",
+            source="ws_event_scope",
+            resources=(
+                f"{event_type} (suppressed={suppressed})" if suppressed else event_type
+            ),
+        )
+    except Exception as exc:
+        logger.debug(
+            "ws_event_scope: SEL audit for deny %s/%s failed: %s",
+            app, event_type, exc,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Events that are always delivered regardless of app scope (no sensitive data)
+# ---------------------------------------------------------------------------
+
+_TIER0_ALWAYS = frozenset({
+    "dashboard",
+    # Dashboard-wide progress signals with no user data.
+    "refresh",
+    "update_progress",
+})
+
+# ---------------------------------------------------------------------------
+# Slot-scoped event types: events that carry a ``slot`` key and are
+# subject to slot-visibility filtering.  Subagent events are a subset.
+# ---------------------------------------------------------------------------
+
+_SLOT_SCOPED_EVENTS = frozenset({
+    # Chat content
+    "chat_chunk", "chat_thinking", "chat_status", "chat_message", "chat_done",
+    "chat_segment", "chat_append", "chat_message_update", "chat_variant_switch",
+    # Side-conversation channel (``broadcast_side_result``); carries ``slot``.
+    "chat.side_result",
+    "heartbeat", "context_usage",
+    # Tool / queue
+    "tool_call", "tool_result",
+    "queue_push", "queue_cancel", "queue_edit", "queue_pop", "queue_reorder",
+    "steer_push",
+    # Slot metadata / lifecycle
+    "slot_title", "slot_clear", "slot_agent_switch", "todo_update",
+    "activity_event",
+    # Voice
+    "voice_chunk", "voice_complete", "voice_error",
+    # Approvals and question cards (carry a slot field)
+    "approval", "approval_resolved", "question_card",
+    # Subagent lifecycle
+    "subagent_spawn", "subagent_done", "subagent_tool", "subagent_chunk",
+    "subagent_snapshot", "subagent_status",
+    # Slack-gateway driven, slot-scoped
+    "autonudge_state", "batch_finished",
+    # Workflows / misc
+    "workflow_result_injected", "refine",
+})
+
+_SUBAGENT_EVENTS = frozenset({
+    "subagent_spawn", "subagent_done", "subagent_tool", "subagent_chunk",
+    "subagent_snapshot", "subagent_status",
+})
+
+#: Coalesced subagent frames emitted above ``SubagentEventCoalescer`` threshold
+#: (default 8 active subagents): ONE frame carries MANY subagents' rows, so
+#: there is no single top-level ``slot`` to scope it by. Left OUT of
+#: ``_SLOT_SCOPED_EVENTS`` deliberately — the gate admits the frame and
+#: ``DashboardState._serialize_for_client`` drops the individual items the app
+#: may not see (the same split already used for the ``slots`` re-push). Without
+#: this they fell through to the unknown-event deny, so an app simply lost all
+#: subagent status and output once the coalescer engaged.
+_SUBAGENT_BATCH_EVENTS = frozenset({
+    "subagent_batch_update",
+    "subagent_batch_chunks",
+})
+
+#: Payload key holding the per-item list, per batch event type.
+_SUBAGENT_BATCH_ITEM_KEY = {
+    "subagent_batch_update": "updates",
+    "subagent_batch_chunks": "chunks",
+}
+
+# ---------------------------------------------------------------------------
+# Global event type → required declaration mapping
+# ---------------------------------------------------------------------------
+
+# Notification events whose delivery depends on WHO sent them, not just on the
+# declaration. ``notification_channel_settings`` is deliberately absent: it is
+# channel config ({muted, priority}) with no source_app, so source filtering
+# would deny it outright rather than scope it.
+# Only events whose payload actually CARRIES a source. `notification_ack` /
+# `notification_unack` broadcast a bare `{"ts": ...}` (see state.py) -- they were
+# listed here, so every one of them read as source-less and fell into the system
+# branch below. Filtering by a field the payload never has is not a filter; they
+# are gated by their plain `notification` declaration via
+# `_GLOBAL_EVENT_DECLARATIONS` instead, which is the strongest statement
+# available for a payload that carries a timestamp and nothing else.
+_SOURCE_FILTERED_EVENTS = frozenset({
+    "notification",
+})
+
+# The canonical `source` values a note can carry, set server-side and not
+# overridable from a request body:
+#   "system"      -- payload_from_legacy() / _deliver_note() in notifications/bus.py
+#   "app:<name>"  -- api_push_notification() in handlers/notifications_push.py
+# Kept as constants here rather than imported (bus.py's is private) with
+# `TestNotificationSourceParsing` pinning that the two agree.
+# Mirrors apps/event_bus.APP_EVENT_WS_TYPE. Kept local rather than imported so
+# the WS gate does not pull the app layer in at module scope;
+# `TestAppEventFrames` pins that the two agree.
+_APP_EVENT_WS_TYPE = "app_event"
+
+_SYSTEM_SOURCE = "system"
+_APP_SOURCE_PREFIX = "app:"
+
+
+#: Notification metadata that carries NO attribution -- a bare ``{"ts": ...}``
+#: (see state.py). Nothing in the payload says whose notification was acked, so
+#: own-only ``notification`` cannot be honoured for them and they take the broad
+#: scope. Letting them ride the plain declaration handed an app the ack stream
+#: for every OTHER app's and the system's notifications.
+_UNATTRIBUTED_NOTIFICATION_EVENTS = frozenset({
+    "notification_ack",
+    "notification_unack",
+})
+
+#: `<app>.<channel_id>` (handlers/notifications_push) or `system.<kind>`
+#: (notifications/bus SYSTEM_CHANNELS) -- the prefix names the owner.
+_CHANNEL_SETTINGS_EVENT = "notification_channel_settings"
+
+
+def notification_channel_owner(channel: str) -> str:
+    """The app (or "system") that owns a notification channel."""
+    return channel.split(".", 1)[0] if "." in channel else ""
+
+
+def notification_source_app(source: str) -> str:
+    """The app that produced a notification, or "" if it was not an app push.
+
+    The source is a CANONICAL, prefixed identity — `app:mochi`, never `mochi` —
+    so comparing it against a bare app name silently never matches.
+    """
+    if source.startswith(_APP_SOURCE_PREFIX):
+        return source[len(_APP_SOURCE_PREFIX):]
+    return ""
+
+
+_GLOBAL_EVENT_DECLARATIONS: dict[str, str] = {
+    "notification": "notification",
+    # Present so the completeness guard sees them classified -- the ACTUAL gate is
+    # the stricter branch in ws_event_allowed, which these never reach.
+    "notification_ack": "notification",
+    "notification_unack": "notification",
+    # Channel mute/priority metadata only ({muted, priority}) -- same domain as
+    # the notification events themselves, so it rides the same declaration.
+    "notification_channel_settings": "notification",
+    "sessions_restarting": "sessions",
+    "yolo_expired": "yolo",
+    # Artifact metadata only ({slug, version, deleted}) -- no content, no slot.
+    "artifact_update": "artifacts",
+    # Metadata only ({slug, kind, target}) -- but a pending skill's slug names
+    # what the user is building, so it takes an explicit declaration rather
+    # than riding Tier 0. Same treatment as artifact_update above.
+    "skills.pending_changed": "skills",
+    # Declared by its own literal name: this is already the correct Tier 2
+    # shape (per-event opt-in), and it is the one declaration that exists in
+    # the tree today (the workflows app), so the name must not change.
+    "workflow_run_event": "workflow_run_event",
+    # Privileged
+    "log": "log",
+    "browser_event": "browser",
+}
+
+
+# Everything the legacy ``"*"`` declaration grants. Derived from the tables
+# above rather than hand-listed, so a declaration added later is covered by the
+# wildcard automatically instead of being silently dropped from it.
+_WILDCARD_SCOPES: frozenset[str] = frozenset(
+    {"slots:all", "subagent:all", "notification:all", "notification:system"}
+    | set(_GLOBAL_EVENT_DECLARATIONS.values())
+    | {f"{d}:all" for d in _GLOBAL_EVENT_DECLARATIONS.values()}
+)
+
+
+# ---------------------------------------------------------------------------
+# Allowed-event set computation (called once at WS connect time)
+# ---------------------------------------------------------------------------
+
+def build_allowed_event_set(events_declared: list[str]) -> frozenset[str]:
+    """Convert a raw ``permissions.events`` list into a normalised frozenset.
+
+    The returned set is stored on the WS connection object and passed to
+    :func:`ws_event_allowed` on every broadcast.
+
+    ``"*"`` is EXPANDED here, not carried through. It predates this scope
+    vocabulary and meant "every event", but as an opaque set member no gate
+    below recognises it — so a manifest that already declares ``["*"]`` would
+    keep its subscription and silently receive nothing. Expanding at the one
+    place that builds the set (instead of special-casing the wildcard in the
+    event gate and again in each replay-subscription gate) keeps that decision
+    in a single spot and cannot drift out of sync with them.
+    """
+    if "*" in events_declared:
+        return _WILDCARD_SCOPES
+    return frozenset(events_declared)
+
+
+# ---------------------------------------------------------------------------
+# Core filter: is this event allowed for this app token?
+# ---------------------------------------------------------------------------
+
+def ws_event_allowed(
+    event_type: str,
+    data: dict[str, Any],
+    *,
+    app: str,
+    allowed_events: frozenset[str],
+    state: DashboardState,
+) -> bool:
+    """Return True if an app token identified by *app* may receive this event.
+
+    ``data`` is the payload dict passed to ``broadcast_ws``.  This function is
+    called **before** sending to each WS client; returning False suppresses the
+    send.
+
+    Dashboard-user tokens (empty *app*) always receive everything — callers
+    should skip this function for them.  As a defense-in-depth measure this
+    function still fails closed (returns False) if called with an empty app,
+    since ``assert`` is compiled out under ``python -O``.
+    """
+    if not app:
+        # Deny-by-default (CWE-269): a caller invoking this without an app
+        # identity has no basis for authorisation.  Audit the denial so a
+        # future refactor that reaches this branch (bypassing the caller's
+        # dashboard-user pre-check) is observable in the trail.
+        _audit_deny(app or "<empty>", event_type, "empty_app_denied")
+        return False
+
+    # Tier 0: always delivered
+    if event_type in _TIER0_ALWAYS:
+        return True
+
+    # ``slots`` is a full slot-list re-push.  The event itself is always
+    # delivered — payload-level per-app filtering in
+    # ``DashboardState._serialize_for_client`` enforces that an app only
+    # sees the slots it's authorised for (own slots by default; foreign
+    # slots require ``slots:user`` / ``slots:app:X`` / ``slots:all``).
+    # Denying at the gate level would break the documented default that
+    # every app sees updates to its OWN slots without an explicit
+    # declaration, and would leave the app's sidebar stale after connect.
+    if event_type == "slots":
+        return True
+
+    # Coalesced subagent batches carry per-item slots, not one frame slot —
+    # admit here and let ``_serialize_for_client`` filter the items.
+    if event_type in _SUBAGENT_BATCH_EVENTS:
+        return True
+
+    # Tier 1: slot-scoped events
+    slot_key: str | None = data.get("slot")
+    # ``slot_title`` uses ``key`` for the slot identifier (rather than
+    # ``slot``) — normalise so we don't misclassify it as no-slot-key.
+    if slot_key is None and event_type == "slot_title":
+        slot_key = data.get("key")
+    # A GLOBALLY classified event must be judged by its own declaration, never
+    # by a slot field that happens to appear in its payload. ``notify()`` meta
+    # keys merge FLAT into the note (notifications/bus.py: "the frontend reads
+    # note.job_id / note.slot / note.session_key directly"), and the notification
+    # branch of ``DashboardState._broadcast`` hands that whole note to this gate
+    # as ``data`` — so a real caller like the Slack heartbeat
+    # (``notify("heartbeat", ..., meta={"slot": slot.key})``) puts a top-level
+    # ``slot`` on a ``notification`` frame. Inferring slot-scoping from it would
+    # route the frame into the slot branch below and return on slot visibility
+    # ALONE, delivering the title/body to an app holding only ``slots:*`` and
+    # never enforcing the ``notification`` scope this event actually requires.
+    # The two tables are disjoint, so this only ever strips smuggled keys.
+    if event_type in _GLOBAL_EVENT_DECLARATIONS:
+        slot_key = None
+    if event_type in _SLOT_SCOPED_EVENTS or slot_key is not None:
+        if slot_key is None:
+            # Unknown slot-scoped event shape — deny to be safe
+            _audit_deny(app, event_type, "slot_scoped_no_slot_key")
+            return False
+        slot: _ChatSlot | None = state._slots.get(slot_key)
+        if slot is None:
+            # Slot no longer exists (race) — deny
+            _audit_deny(app, event_type, "slot_missing")
+            return False
+
+        if event_type in _SUBAGENT_EVENTS:
+            allowed = _subagent_visible(slot, app, allowed_events, state)
+        else:
+            allowed = _slot_visible(slot, app, allowed_events, state)
+        if not allowed:
+            _audit_deny(app, event_type, "slot_scope_denied")
+        return allowed
+
+    # Tier 2: global events
+    # Unattributable notification metadata: only the broad scope covers it.
+    if event_type in _UNATTRIBUTED_NOTIFICATION_EVENTS:
+        if "notification:all" in allowed_events:
+            return True
+        _audit_deny(app, event_type, "notification_metadata_needs_all")
+        return False
+
+    # Channel settings ARE attributable, so do not force the broad scope on them:
+    # an app learning its OWN channel was muted is exactly what `notification`
+    # grants, while another app's channel is not.
+    if event_type == _CHANNEL_SETTINGS_EVENT:
+        owner = notification_channel_owner(str(data.get("channel", "")))
+        if "notification:all" in allowed_events:
+            return True
+        if owner and owner == app and "notification" in allowed_events:
+            return True
+        if owner == _SYSTEM_SOURCE and "notification:system" in allowed_events:
+            return True
+        _audit_deny(app, event_type, "notification_channel_not_owned")
+        return False
+
+    # App-published events all ride ONE fixed WS type with the real event name
+    # inside the envelope (see apps/event_bus.APP_EVENT_WS_TYPE), so the table
+    # lookup above can never match and every frame fell to the global deny --
+    # an app silently stopped receiving its OWN events.
+    #
+    # Ownership decides it: the envelope names its publisher, and EventBus
+    # already refused to publish anything outside that app's declared
+    # `permissions.events`. So a publisher receiving its own event back needs no
+    # second declaration check -- and re-checking would BREAK the apps that
+    # declare `["*"]`, whose wildcard is expanded into core scopes that do not
+    # contain their app-chosen event names. Frames from another app are denied:
+    # app events have no cross-app opt-in (that is what exposeToApps does for
+    # slots), and an unattributable envelope is denied too.
+    if event_type == _APP_EVENT_WS_TYPE:
+        publisher = str(data.get("app", ""))
+        inner = str(data.get("event", ""))
+        if publisher and inner and publisher == app:
+            return True
+        _audit_deny(app, event_type, "app_event_not_owned")
+        return False
+
+    required_decl = _GLOBAL_EVENT_DECLARATIONS.get(event_type)
+    if required_decl is None:
+        # Unknown event type — deny unknown events for app tokens
+        logger.debug("ws_event_scope: unknown event %r denied for app %r", event_type, app)
+        _audit_deny(app, event_type, "unknown_event")
+        return False
+
+    # notification: filtered by source_app.  An app must declare
+    # ``notification`` to receive its OWN notifications and ``notification:all``
+    # to receive foreign ones.  Deny-by-default (CWE-269): if neither is
+    # declared, own-app notifications are also denied — apps that want push
+    # notifications must opt in explicitly.
+    #
+    # System-sourced notifications (source == "system" or source == "") are
+    # gateway-internal sends (send_message MCP tool, heartbeat, cron fallback).
+    # They carry no ``source_app`` because they flow through state.notify(),
+    # which pre-dates per-app channels. They need their OWN declaration
+    # (``notification:system``): that stream is user content, not the app's
+    # own, so folding it into ``notification`` would make a single declaration
+    # a broad grant -- the shape this module exists to remove.
+    if event_type in _SOURCE_FILTERED_EVENTS:
+        # The note's field is `source` and its app form is PREFIXED. Reading
+        # `source_app`/`app` -- keys no emitter writes -- made this resolve to ""
+        # for every note, and "" was accepted as system: one app's private push
+        # was delivered to any app holding `notification:system`, while an app
+        # holding `notification` never saw its own. Parse the canonical value and
+        # let ONLY "system" mean system, so an unrecognised source is denied
+        # rather than treated as the shared stream.
+        source = str(data.get("source", ""))
+        source_app = notification_source_app(source)
+        if "notification:all" in allowed_events:
+            return True
+        if source_app and source_app == app and "notification" in allowed_events:
+            return True
+        if source == _SYSTEM_SOURCE and "notification:system" in allowed_events:
+            # ``notification:all`` is handled above; the system stream has its
+            # own opt-in because it carries user content, not the app's own.
+            return True
+        if source_app and source_app == app:
+            _audit_deny(app, event_type, "notification_not_declared")
+        elif source == _SYSTEM_SOURCE:
+            _audit_deny(app, event_type, "notification_system_not_declared")
+        else:
+            _audit_deny(app, event_type, "notification_scope_denied")
+        return False
+
+    if required_decl in allowed_events or f"{required_decl}:all" in allowed_events:
+        return True
+    _audit_deny(app, event_type, "global_scope_denied")
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Slot visibility helpers
+# ---------------------------------------------------------------------------
+
+def _slot_visible(
+    slot: _ChatSlot,
+    app: str,
+    allowed_events: frozenset[str],
+    state: DashboardState,
+) -> bool:
+    """Return True if *app* may receive slot-scoped events for *slot*."""
+    # circular import: state.py's broadcast_ws imports ws_event_allowed from
+    # this module at runtime; importing SlotOrigin at module scope would
+    # create a bootstrap cycle during state.py initialisation.
+    from kiro_crew.dashboard.state import SlotOrigin
+
+    # Own slot: always visible
+    if getattr(slot, "_app", "") == app:
+        return True
+
+    # slots:all -- broad, self-declared (see module docstring)
+    if "slots:all" in allowed_events:
+        return True
+
+    # slots:user — user-initiated slots
+    # slots:user — user-initiated slots only.  ``getattr`` defaults to ``""``
+    # (a sentinel that matches NO scope declaration) so a pre-migration slot
+    # or a race condition that leaves ``_origin`` unset remains INVISIBLE
+    # rather than being silently classified as USER.  Deny-by-default (CWE-269).
+    if getattr(slot, "_origin", "") == SlotOrigin.USER and "slots:user" in allowed_events:
+        return True
+
+    # slots:app:<name> — specific app's slots, requires target opt-in
+    slot_owner = getattr(slot, "_app", "")
+    if slot_owner and f"slots:app:{slot_owner}" in allowed_events:
+        if _target_exposes_to(slot_owner, app, state):
+            return True
+
+    return False
+
+
+def _subagent_visible(
+    slot: _ChatSlot,
+    app: str,
+    allowed_events: frozenset[str],
+    state: DashboardState,
+) -> bool:
+    """Return True if *app* may receive subagent events for *slot*.
+
+    Subagent visibility is an independent dimension from slot content visibility:
+    an app may declare ``subagent:user`` without needing ``slots:user``.
+    Falls back to slot visibility if no subagent-specific declaration is present.
+    """
+    # circular import: see _slot_visible above.
+    from kiro_crew.dashboard.state import SlotOrigin
+
+    # Own slot: always visible
+    if getattr(slot, "_app", "") == app:
+        return True
+
+    # subagent:all
+    if "subagent:all" in allowed_events:
+        return True
+
+    # subagent:user
+    # subagent:user — same fail-closed default as _slot_visible above.
+    if getattr(slot, "_origin", "") == SlotOrigin.USER and "subagent:user" in allowed_events:
+        return True
+
+    # subagent:app:<name>
+    slot_owner = getattr(slot, "_app", "")
+    if slot_owner and f"subagent:app:{slot_owner}" in allowed_events:
+        if _target_exposes_to(slot_owner, app, state):
+            return True
+
+    # Fall back to general slot visibility (if you can see the slot, you can see its subagents)
+    return _slot_visible(slot, app, allowed_events, state)
+
+
+# ---------------------------------------------------------------------------
+# Manifest exposure cache — ``get_app_manifest`` re-reads and re-parses the
+# JSON file from disk on every call (no internal cache).  ``_target_exposes_to``
+# runs on the WS broadcast hot path (called once per cross-app slot event
+# via ``_slot_visible``/``_subagent_visible``), so a local TTL cache keeps
+# disk I/O bounded.  30-second TTL is short enough that a manifest edit is
+# picked up quickly and long enough to collapse bursty broadcast traffic.
+# ---------------------------------------------------------------------------
+
+_MANIFEST_EXPOSE_TTL_SECS = 30.0
+_exposeto_cache: dict[str, tuple[float, frozenset[str]]] = {}
+
+
+def _load_expose_to(target_app: str) -> frozenset[str]:
+    """Return the *target_app*'s ``permissions.exposeToApps`` set, cached.
+
+    Empty frozenset means "expose to nobody" (including on manifest load
+    failure — fail-closed).
+    """
+    now = time.monotonic()
+    cached = _exposeto_cache.get(target_app)
+    if cached is not None and (now - cached[0]) < _MANIFEST_EXPOSE_TTL_SECS:
+        return cached[1]
+    try:
+        manifest = get_app_manifest(target_app)
+        if manifest is None:
+            expose_set: frozenset[str] = frozenset()
+        else:
+            expose_set = frozenset(manifest.permissions.exposeToApps)
+    except Exception:
+        logger.debug(
+            "ws_event_scope: could not load manifest for %r, denying cross-app access",
+            target_app,
+        )
+        expose_set = frozenset()
+    _exposeto_cache[target_app] = (now, expose_set)
+    return expose_set
+
+
+def _target_exposes_to(target_app: str, requesting_app: str, state: DashboardState) -> bool:
+    """Return True if *target_app*'s manifest allows *requesting_app* to observe it.
+
+    Reads ``permissions.exposeToApps`` from the target app's installed
+    manifest.  Uses a 30-second local TTL cache (``_exposeto_cache``) to
+    bound WS broadcast hot-path disk I/O — ``get_app_manifest`` itself
+    re-reads and re-parses the JSON on every call, so without this cache a
+    busy multi-app dashboard would hit the filesystem on every cross-app
+    slot event.
+    """
+    expose = _load_expose_to(target_app)
+    return "*" in expose or requesting_app in expose
+
+
+# ---------------------------------------------------------------------------
+# slots initial-push filter (applied when a new WS client connects)
+# ---------------------------------------------------------------------------
+
+def filter_subagent_batch_for_app(
+    items: list[dict[str, Any]],
+    app: str,
+    allowed_events: frozenset[str],
+    state: DashboardState,
+) -> list[dict[str, Any]]:
+    """Filter one coalesced subagent batch frame down to the permitted items.
+
+    Each item carries its own ``slot`` (``SubagentEventCoalescer`` seeds every
+    buffered entry with one), so the frame is filtered per row rather than
+    accepted or denied whole. Reuses :func:`_subagent_visible` — the same
+    predicate the per-event path uses — so batched and unbatched delivery
+    cannot drift apart. An item with no resolvable slot is dropped (fail
+    closed), matching the per-event gate's ``slot_missing`` denial.
+    """
+    out: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        slot = state._slots.get(str(item.get("slot", "")))
+        if slot is None:
+            continue
+        if _subagent_visible(slot, app, allowed_events, state):
+            out.append(item)
+    return out
+
+
+def filter_slots_for_app(
+    slots: list[dict[str, Any]],
+    app: str,
+    allowed_events: frozenset[str],
+    state: DashboardState,
+) -> list[dict[str, Any]]:
+    """Filter the slots list sent on initial WS connect for an app token.
+
+    ``slots`` is the raw list from ``[s.to_dict() for s in state._slots.values()]``.
+    Returns only the slots the app is allowed to see.
+    """
+    result = []
+    for slot_dict in slots:
+        slot_key = slot_dict.get("key", "")
+        slot = state._slots.get(slot_key)
+        if slot is None:
+            continue
+        if _slot_visible(slot, app, allowed_events, state):
+            result.append(slot_dict)
+    return result

--- a/src/kiro_crew/docs/app-platform-trust-model.md
+++ b/src/kiro_crew/docs/app-platform-trust-model.md
@@ -63,6 +63,75 @@ are **deny-by-default** confined by the dashboard auth middleware
 independently re-checks that the caller's token app matches the target app, since
 the proxy signs requests with the target app's secret.
 
+### WebSocket event scope (CWE-269)
+
+`/api/ws` is a *third* surface reachable with the same app token, and it is scoped
+separately: connecting no longer grants the full event stream. On connect the socket
+records the caller's app identity and its manifest `permissions.events` declarations
+(`dashboard/ws.py`), and every fan-out is filtered per socket at a single chokepoint
+(`DashboardState._send_ws_all` → `_ws_client_allowed` → `dashboard/ws_event_scope.py`).
+Both dispatch paths — `broadcast_ws()` and the `_broadcast()` `_type` translation —
+funnel through it, as does the subagent-subscriber fan-out.
+
+Events fall into three tiers. Tier 0 (`dashboard`, `refresh`, `update_progress`) carries
+no sensitive payload and is always delivered. Tier 1 is slot-scoped: delivery depends on
+the slot's `SlotOrigin` and the app's `slots:*` declarations (`slots:own` is the default,
+then `slots:user`, `slots:app:<name>`, `slots:all`); `subagent:*` is an independent
+dimension so an app can watch subagent status without receiving chat content. Tier 2 is
+global and requires an explicit declaration; notifications split further by source, so
+`notification` covers the app's own pushes while gateway-internal ones (cron output,
+`send_message`, watchlist results) need `notification:system` — bundling them would make
+one declaration a broad grant. Cross-app visibility (`slots:app:X`) also
+requires the *observed* app to opt in via `permissions.exposeToApps`, so an app cannot
+name a sibling unilaterally.
+
+A slot's `SlotOrigin` is declared by the layer that actually knows it, and an undeclared
+slot stays untagged. `get_or_create_slot` cannot tell a person typing in the dashboard
+from a background injection, so it does not guess: the request layer decides `USER` vs
+`APP` from whether a token was presented (`request_slot_origin`), cron declares `CRON`,
+and rehydration restores the persisted value rather than re-deriving it. An untagged slot
+matches no cross-slot scope, so a caller that forgets to declare loses visibility instead
+of leaking — inferring `USER` there put cron output inside `slots:user`.
+
+`permissions.events: ["*"]` predates this vocabulary and still means every event. It is
+expanded into the full scope set when the socket's allow-set is built, not carried through
+as a literal, because as an opaque member no gate would recognise it and such a manifest
+would keep its subscription while receiving nothing.
+
+All other scopes are **self-declared**: they are read from the app's own manifest, with
+no install-time approval check. That is consistent with the privilege an installed app
+already holds (see above), so the tiers structure and audit what an app receives rather
+than defending against a hostile manifest. `exposeToApps` is the one asymmetric case,
+because there the manifest being trusted is not the one being widened.
+
+Two payloads need more than a yes/no gate. The `slots` re-push carries every slot, so it
+is re-filtered per app in `_serialize_for_client` (failing closed to an empty list); and
+the log ring-buffer replay plus the subagent reconnect replay write to the socket
+directly, so `ws.py` gates those at the source.
+
+Dashboard-user sockets are exempt, identified by a **positive** `is_dashboard_user`
+claim set by the auth middleware — never by the absence of an app claim, which would
+fail *open* on any path that forgot to set it. Because the stream is now filtered,
+`/api/ws` is implicitly allowed for app tokens (`_APP_TOKEN_IMPLICIT_ALLOW`) rather
+than requiring every app to declare the transport; that grant is recorded in the
+Security Event Log. `/api/status` is **not** implicitly allowed — it has no
+response-level filter to match what event scoping gives `/api/ws`, and it returns
+the owner id hash, host specs, cron and usage stats, and the live safety-override
+state. An app that needs it declares it in `permissions.api` like any other
+capability.
+
+### The frontend `useAppApi` / `useAppEvents` scoping is a guardrail, not a boundary
+
+An app's UI runs **in the dashboard page, with the dashboard user's own authority**. The
+SDK's `createScopedApi()` checks the `permissions.api` allowlist *in that same page*
+before issuing a same-origin `fetch`, so the request reaches the gateway as a
+dashboard-user token (empty app claim) — which `_enforce_app_scope` deliberately never
+gates. An embedded app could call `fetch('/api/anything')` directly and succeed. This is
+inherent to embedding app UI in the dashboard page, not a defect, but it means the
+frontend scoping prevents *accidental* use rather than abuse. The enforceable boundaries
+are the app **token** ones above (HTTP paths and WS events), which apply to app-owned
+*processes* holding their own credential.
+
 This is an **HTTP-reach boundary distinct from the in-process module-loading
 privilege**: an app's loaded Python still runs with full gateway privileges (the
 warning above stands), but an app's own HTTP token can no longer reach arbitrary

--- a/test/test_app_manifest.py
+++ b/test/test_app_manifest.py
@@ -932,3 +932,64 @@ class TestRequiresDesktopApp:
         from kiro_crew.apps.manifest import PlatformConfig
 
         assert PlatformConfig().supports_platform("win32") is False
+
+
+class TestScalarGrantDoesNotBecomeAWildcard:
+    """A list-valued grant given a JSON SCALAR must deny, not be coerced.
+
+    `[str(x) for x in value]` over a STRING iterates its characters, so a manifest
+    that wrote a bare string where a list belongs was handed the tokens those
+    characters spell -- including the wildcards each of these fields honours:
+
+      exposeToApps  `"*"`         -> ["*"] -> every sibling app may observe my slots
+      events        `"*"`         -> ["*"] -> the whole WS scope vocabulary
+      api           `"/api/chat"` -> ["/", "a", ...] and `app_token_path_allowed`
+                                     matches the prefix "/" against every path
+      mcpTools      `"*"`         -> ["*"]
+
+    Same defect class as `bool("false")` on the boolean grants above, and the same
+    direction of fix: an unexpected value withholds the grant.
+    """
+
+    def test_scalar_star_never_yields_the_wildcard(self):
+        from kiro_crew.apps.manifest import Permissions
+
+        for field in ("exposeToApps", "events", "api", "mcpTools"):
+            perms = Permissions.from_dict({field: "*"})
+            assert getattr(perms, field) == [], (
+                f"{field}: a scalar must not be exploded into a wildcard"
+            )
+
+    def test_scalar_path_never_yields_a_match_everything_prefix(self):
+        from kiro_crew.apps.manifest import Permissions
+
+        assert Permissions.from_dict({"api": "/api/chat"}).api == []
+
+    def test_other_scalar_shapes_also_deny(self):
+        from kiro_crew.apps.manifest import Permissions
+
+        for value in (True, 1, {"a": "b"}, None):
+            assert Permissions.from_dict({"exposeToApps": value}).exposeToApps == []
+
+    def test_a_real_list_still_works(self):
+        from kiro_crew.apps.manifest import Permissions
+
+        perms = Permissions.from_dict(
+            {
+                "exposeToApps": ["mochi", "", "workflows"],
+                "events": ["slots:own", "notification"],
+                "api": ["/api/chat", "/api/ws"],
+                "mcpTools": ["cron_add"],
+            }
+        )
+        # Falsy entries are still dropped; everything else is preserved verbatim.
+        assert perms.exposeToApps == ["mochi", "workflows"]
+        assert perms.events == ["slots:own", "notification"]
+        assert perms.api == ["/api/chat", "/api/ws"]
+        assert perms.mcpTools == ["cron_add"]
+
+    def test_the_wildcard_still_works_when_declared_as_a_list(self):
+        from kiro_crew.apps.manifest import Permissions
+
+        assert Permissions.from_dict({"exposeToApps": ["*"]}).exposeToApps == ["*"]
+        assert Permissions.from_dict({"events": ["*"]}).events == ["*"]

--- a/test/test_artifact_companion.py
+++ b/test/test_artifact_companion.py
@@ -277,13 +277,20 @@ class TestPushArtifactUpdate:
         the send itself is stubbed here."""
         state = _make_state(tmp_path)
         state._ws_clients = [MagicMock()]
-        sent: list[str] = []
-        state._send_ws_all = lambda msg: sent.append(msg)  # type: ignore[method-assign]
+        sent: list[tuple[str, object, str]] = []
+        # New chokepoint signature (msg_type, data, msg): the payload is passed
+        # alongside the serialized envelope so per-app WS scope filtering can
+        # inspect it.
+        state._send_ws_all = (  # type: ignore[method-assign]
+            lambda msg_type, data, msg: sent.append((msg_type, data, msg))
+        )
 
         state.push_artifact_update("cr-queue", 3)
 
         assert len(sent) == 1
-        env = json.loads(sent[0])
+        assert sent[0][0] == "artifact_update"
+        assert sent[0][1] == {"slug": "cr-queue", "version": 3, "deleted": False}
+        env = json.loads(sent[0][2])
         assert env == {
             "type": "artifact_update",
             "data": {"slug": "cr-queue", "version": 3, "deleted": False},

--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -489,7 +489,10 @@ class TestResolveApprovalSlotFallback:
         assert fut.done()
         assert fut.result() == "approved"
         state.broadcast_ws.assert_called_with(
-            "approval_resolved", {"id": "req-42", "approved": True}
+            "approval_resolved",
+            # ``slot`` keys the frame for the slot-scoped WS gate — it must name
+            # the slot that actually owned the resolved future.
+            {"id": "req-42", "approved": True, "slot": "chat-1-test"},
         )
         state.push_slots_update.assert_called_once()
 

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -909,7 +909,10 @@ class TestSlotLifecycle:
             resp = await client.post("/api/chat/slots/s1/approve", json={"action": "approved"})
             assert (await resp.json())["ok"] is True
             state.broadcast_ws.assert_any_call(
-                "approval_resolved", {"id": "req-abc", "approved": True}
+                "approval_resolved",
+                # ``slot`` keys the frame for the slot-scoped WS gate: without it
+                # an app token never receives its OWN approval resolution.
+                {"id": "req-abc", "approved": True, "slot": "s1"},
             )
 
     @pytest.mark.asyncio
@@ -929,7 +932,10 @@ class TestSlotLifecycle:
             )
             assert (await resp.json())["ok"] is True
             state.broadcast_ws.assert_any_call(
-                "approval_resolved", {"id": "req-xyz", "approved": True}
+                "approval_resolved",
+                # ``slot`` keys the frame for the slot-scoped WS gate: without it
+                # an app token never receives its OWN approval resolution.
+                {"id": "req-xyz", "approved": True, "slot": "s1"},
             )
 
     @pytest.mark.asyncio
@@ -949,7 +955,10 @@ class TestSlotLifecycle:
             )
             assert (await resp.json())["ok"] is True
             state.broadcast_ws.assert_any_call(
-                "approval_resolved", {"id": "req-rej", "approved": False}
+                "approval_resolved",
+                # ``slot`` keys the frame for the slot-scoped WS gate: without it
+                # an app token never receives its OWN approval resolution.
+                {"id": "req-rej", "approved": False, "slot": "s1"},
             )
 
 

--- a/test/test_dashboard_cron_to_chat.py
+++ b/test/test_dashboard_cron_to_chat.py
@@ -12,10 +12,15 @@ def _make_state(history_messages=None):
     state = MagicMock()
     slots = {}
 
-    def get_or_create_slot(name=None, agent=""):
+    def get_or_create_slot(name=None, agent="", origin=""):
+        # ``origin`` is recorded, not just tolerated: the cron paths must
+        # declare SlotOrigin.CRON, and a fake that swallowed the kwarg
+        # would let that regress silently (a cron slot relabelled USER is
+        # readable by any app holding `slots:user`).
         if name not in slots:
             slot = MagicMock()
             slot.key = name
+            slot._origin = origin
             slot.linked_session_key = ""
             slot.messages = []
             slot.title = ""
@@ -44,6 +49,22 @@ def _make_job(job_id="abc123", name="test-cron", last_result="Hello world"):
 
 
 class TestInjectCronResultToDashboard:
+    def test_slot_is_tagged_cron_not_user(self):
+        """A cron result is the job's output, not something the person typed.
+
+        The slot used to be created untagged and then labelled USER by
+        get_or_create_slot's default, which put private cron content inside the
+        ``slots:user`` WS scope -- so any app holding that scope received it.
+        """
+        from kiro_crew.dashboard.state import SlotOrigin
+
+        state = _make_state()
+        job = _make_job()
+        inject_cron_result_to_dashboard(state, job, "result")
+        slot = state.get_or_create_slot(name=f"cron-{job.id}")
+        assert slot._origin == SlotOrigin.CRON
+        assert slot._origin != SlotOrigin.USER
+
     def test_sets_linked_session_key(self):
         state = _make_state()
         job = _make_job()

--- a/test/test_dashboard_cron_to_chat_handler.py
+++ b/test/test_dashboard_cron_to_chat_handler.py
@@ -22,10 +22,15 @@ def _make_state(jobs=None, history_messages=None, notifications=None):
     state = MagicMock()
     slots = {}
 
-    def get_or_create_slot(name=None, agent=""):
+    def get_or_create_slot(name=None, agent="", origin=""):
+        # ``origin`` is recorded, not just tolerated: the cron paths must
+        # declare SlotOrigin.CRON, and a fake that swallowed the kwarg
+        # would let that regress silently (a cron slot relabelled USER is
+        # readable by any app holding `slots:user`).
         if name not in slots:
             slot = MagicMock()
             slot.key = name
+            slot._origin = origin
             slot.linked_session_key = ""
             slot.messages = []
             slot.title = ""

--- a/test/test_dashboard_state_ws.py
+++ b/test/test_dashboard_state_ws.py
@@ -491,12 +491,27 @@ class TestOwnerSourceStatusTransport:
         class Request(dict):
             def __init__(self) -> None:
                 super().__init__(claims)
+                # Mirror the auth middleware: it sets this POSITIVE flag so the
+                # WS layer never infers trust from a falsy app claim.
+                self.setdefault("is_dashboard_user", not self.get("app"))
                 self.app = {"state": state}
 
         class FakeWebSocket:
             def __init__(self) -> None:
                 self.closed = True
                 self.sent: list[dict] = []
+                # api_ws stores scope state on the socket via item assignment;
+                # flag as a dashboard user so the WS scope gate passes through.
+                self._flags: dict = {"_is_dashboard_user": True}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
 
             async def prepare(self, request) -> None:
                 return None
@@ -525,6 +540,12 @@ class TestOwnerSourceStatusTransport:
         if owner_request:
             assert initial_slots[0]["source_links"][0]["ci"] == "passed"
             refresh.assert_called_once_with([source_url], state.push_slots_update)
+        elif claims.get("app"):
+            # App token: the per-app WS scope gate filters the initial push, so
+            # an app that declared no slots:* scope sees no slots at all — a
+            # stronger guarantee than merely withholding check status.
+            assert initial_slots == []
+            refresh.assert_not_called()
         else:
             assert "ci" not in str(initial_slots)
             assert "state" not in initial_slots[0]["source_links"][0]
@@ -582,6 +603,9 @@ class TestPeriodicCheckStatusRefresh:
         class Request(dict):
             def __init__(self) -> None:
                 super().__init__({"user": "U_OWNER", "app": ""})
+                # Mirror the auth middleware: it sets this POSITIVE flag so the
+                # WS layer never infers trust from a falsy app claim.
+                self.setdefault("is_dashboard_user", not self.get("app"))
                 self.app = {"state": state}
 
         refreshed = asyncio.Event()
@@ -595,6 +619,18 @@ class TestPeriodicCheckStatusRefresh:
             def __init__(self) -> None:
                 self.closed = False
                 self.sent: list[dict] = []
+                # api_ws stores scope state on the socket via item assignment;
+                # flag as a dashboard user so the WS scope gate passes through.
+                self._flags: dict = {"_is_dashboard_user": True}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
 
             async def prepare(self, request) -> None:
                 return None
@@ -655,12 +691,27 @@ class TestPeriodicCheckStatusRefresh:
         class Request(dict):
             def __init__(self) -> None:
                 super().__init__({"user": "U_OWNER", "app": ""})
+                # Mirror the auth middleware: it sets this POSITIVE flag so the
+                # WS layer never infers trust from a falsy app claim.
+                self.setdefault("is_dashboard_user", not self.get("app"))
                 self.app = {"state": state}
 
         class FakeWebSocket:
             def __init__(self) -> None:
                 self.closed = False
                 self.sent: list[dict] = []
+                # api_ws stores scope state on the socket via item assignment;
+                # flag as a dashboard user so the WS scope gate passes through.
+                self._flags: dict = {"_is_dashboard_user": True}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
 
             async def prepare(self, request) -> None:
                 return None
@@ -702,6 +753,11 @@ class TestPeriodicCheckStatusRefresh:
 
         class FakeWs:
             closed = False
+
+            # Dashboard-user flag so the WS scope gate passes through; this
+            # test targets the slots envelope, not per-app filtering.
+            def get(self, key: str, default=None):
+                return True if key == "_is_dashboard_user" else default
 
             def send_str(self, msg: str):
                 sent.append(msg)
@@ -745,12 +801,27 @@ class TestPeriodicCheckStatusRefresh:
         class Request(dict):
             def __init__(self) -> None:
                 super().__init__({"user": "U_OWNER", "app": ""})
+                # Mirror the auth middleware: it sets this POSITIVE flag so the
+                # WS layer never infers trust from a falsy app claim.
+                self.setdefault("is_dashboard_user", not self.get("app"))
                 self.app = {"state": state}
 
         class FakeWebSocket:
             def __init__(self) -> None:
                 self.closed = False
                 self.sent: list[dict] = []
+                # api_ws stores scope state on the socket via item assignment;
+                # flag as a dashboard user so the WS scope gate passes through.
+                self._flags: dict = {"_is_dashboard_user": True}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
 
             async def prepare(self, request) -> None:
                 return None
@@ -787,6 +858,9 @@ class TestPeriodicCheckStatusRefresh:
         class Request(dict):
             def __init__(self) -> None:
                 super().__init__({"user": "U_OTHER", "app": ""})
+                # Mirror the auth middleware: it sets this POSITIVE flag so the
+                # WS layer never infers trust from a falsy app claim.
+                self.setdefault("is_dashboard_user", not self.get("app"))
                 self.app = {"state": state}
 
         refresh = MagicMock()
@@ -795,6 +869,18 @@ class TestPeriodicCheckStatusRefresh:
             def __init__(self) -> None:
                 self.closed = False
                 self.sent: list[dict] = []
+                # api_ws stores scope state on the socket via item assignment;
+                # flag as a dashboard user so the WS scope gate passes through.
+                self._flags: dict = {"_is_dashboard_user": True}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
 
             async def prepare(self, request) -> None:
                 return None
@@ -844,6 +930,9 @@ class TestPeriodicCheckStatusRefresh:
         class Request(dict):
             def __init__(self) -> None:
                 super().__init__({"user": "U_OWNER", "app": ""})
+                # Mirror the auth middleware: it sets this POSITIVE flag so the
+                # WS layer never infers trust from a falsy app claim.
+                self.setdefault("is_dashboard_user", not self.get("app"))
                 self.app = {"state": state}
 
         done = asyncio.Event()
@@ -858,6 +947,18 @@ class TestPeriodicCheckStatusRefresh:
             def __init__(self) -> None:
                 self.closed = False
                 self.sent: list[dict] = []
+                # api_ws stores scope state on the socket via item assignment;
+                # flag as a dashboard user so the WS scope gate passes through.
+                self._flags: dict = {"_is_dashboard_user": True}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
 
             async def prepare(self, request) -> None:
                 return None
@@ -904,6 +1005,9 @@ class TestPeriodicCheckStatusRefresh:
         class Request(dict):
             def __init__(self) -> None:
                 super().__init__({"user": "U_OWNER", "app": ""})
+                # Mirror the auth middleware: it sets this POSITIVE flag so the
+                # WS layer never infers trust from a falsy app claim.
+                self.setdefault("is_dashboard_user", not self.get("app"))
                 self.app = {"state": state}
 
         recovered = asyncio.Event()
@@ -919,6 +1023,18 @@ class TestPeriodicCheckStatusRefresh:
             def __init__(self) -> None:
                 self.closed = False
                 self.sent: list[dict] = []
+                # api_ws stores scope state on the socket via item assignment;
+                # flag as a dashboard user so the WS scope gate passes through.
+                self._flags: dict = {"_is_dashboard_user": True}
+
+            def __setitem__(self, key: str, value) -> None:
+                self._flags[key] = value
+
+            def __getitem__(self, key: str):
+                return self._flags[key]
+
+            def get(self, key: str, default=None):
+                return self._flags.get(key, default)
 
             async def prepare(self, request) -> None:
                 return None

--- a/test/test_dashboard_ws_task_tracking.py
+++ b/test/test_dashboard_ws_task_tracking.py
@@ -40,6 +40,13 @@ class _FakeWS:
         self.closed = False
         self.sent: list[str] = []
         self._gate = asyncio.Event()  # held closed so the send task stays pending
+        # These tests target the task-tracking guarantee, not the per-app
+        # scope filter — flag as a dashboard user so _ws_client_allowed
+        # returns True unconditionally.
+        self._flags: dict = {"_is_dashboard_user": True}
+
+    def get(self, key: str, default=None):
+        return self._flags.get(key, default)
 
     async def send_str(self, msg: str) -> None:
         await self._gate.wait()  # stay pending until released
@@ -53,7 +60,7 @@ async def test_send_ws_all_retains_task(tmp_path) -> None:
     state._ws_clients.append(ws)
 
     assert len(state._background_tasks) == 0
-    state._send_ws_all('{"type": "ping"}')
+    state._send_ws_all("ping", {}, '{"type": "ping"}')
 
     # The in-flight send task must be retained (strong ref) while pending.
     assert len(state._background_tasks) == 1, (
@@ -92,6 +99,14 @@ class _RaisingWS:
         self.closed = False
         self._gate = asyncio.Event()
 
+        # These tests target the task-tracking guarantee, not the per-app
+        # scope filter — flag as a dashboard user so _ws_client_allowed
+        # returns True unconditionally.
+        self._flags: dict = {"_is_dashboard_user": True}
+
+    def get(self, key: str, default=None):
+        return self._flags.get(key, default)
+
     async def send_str(self, msg: str) -> None:
         await self._gate.wait()
         raise ConnectionResetError("client disconnected")
@@ -105,7 +120,7 @@ async def test_failed_send_still_self_cleans(tmp_path) -> None:
     state = _make_state(tmp_path)
     ws = _RaisingWS()
     state._ws_clients.append(ws)
-    state._send_ws_all('{"type": "ping"}')
+    state._send_ws_all("ping", {}, '{"type": "ping"}')
     assert len(state._background_tasks) == 1  # retained while pending
 
     ws._gate.set()

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -2624,3 +2624,25 @@ def test_app_window_entries_register_route_and_exclusion(tmp_path) -> None:
         assert "/app-windows/someapp/other.html" not in ta._APP_WINDOW_EXCLUDED_PATHS
     finally:
         ta._APP_WINDOW_EXCLUDED_PATHS = prior
+
+
+def test_app_token_path_allowed_implicit_ws():
+    """``/api/ws`` is the only implicitly allowed path.
+
+    It is connection infrastructure rather than a capability, and the implicit
+    grant is sound only because the WS layer filters events per app
+    (``ws_event_scope.py``). ``/api/status`` has NO such response-level filter
+    and discloses ``owner_id_hash``, host specs, cron/usage stats and the live
+    safety-override state, so it must be declared like any other capability.
+    Functional paths must still be declared, so the negative case is asserted
+    alongside.
+    """
+    from kiro_crew.dashboard.token_auth import app_token_path_allowed
+
+    assert app_token_path_allowed("some-app", "/api/ws") is True
+    assert app_token_path_allowed("some-app", "/api/status") is False
+    # Undeclared functional paths stay denied.
+    assert app_token_path_allowed("some-app", "/api/chat") is False
+    assert app_token_path_allowed("some-app", "/api/spawn") is False
+    # An empty app name must never be granted, even for implicit paths.
+    assert app_token_path_allowed("", "/api/ws") is False

--- a/test/test_ws_and_plan_memory_fixes.py
+++ b/test/test_ws_and_plan_memory_fixes.py
@@ -197,7 +197,11 @@ class TestWsNormalUserExperience:
         state.register_ws(dead)
 
         # Simulate push_notification which calls _send_ws_all internally
-        state._send_ws_all(json.dumps({"type": "notification", "data": {"text": "hi"}}))
+        state._send_ws_all(
+            "notification",
+            {"text": "hi"},
+            json.dumps({"type": "notification", "data": {"text": "hi"}}),
+        )
 
         alive.send_str.assert_called_once()
         dead.send_str.assert_not_called()

--- a/test/test_ws_event_scoping.py
+++ b/test/test_ws_event_scoping.py
@@ -1,0 +1,2148 @@
+"""Tests for per-app WebSocket event scope enforcement.
+
+Covers:
+- ws_event_allowed: Tier 0 (always), Tier 1 (slot-scoped), Tier 2 (global)
+- Slot visibility: own-slot, user-slot, cross-app opt-in, slots:all
+- Subagent visibility: independent dimension from slots
+- filter_slots_for_app: initial slots push filtering
+- build_allowed_event_set: passthrough normalisation
+- token_auth: implicit allow for /api/ws + /api/status with SEL audit
+- broadcast_ws integration: app clients filtered, dashboard users unaffected
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kiro_crew.dashboard.state import SlotOrigin
+from kiro_crew.dashboard.token_auth import app_token_path_allowed
+from kiro_crew.dashboard.ws_event_scope import (
+    build_allowed_event_set,
+    filter_slots_for_app,
+    ws_event_allowed,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_module_caches():
+    """Clear ws_event_scope module-level caches between tests.
+
+    The exposeToApps TTL cache and the SEL audit dedup cache persist across
+    test invocations at module scope; without an autouse fixture, a stale
+    entry from an earlier test can suppress the behaviour under test in a
+    later one (especially the cross-app tests that patch ``get_app_manifest``).
+    """
+    from kiro_crew.dashboard import ws_event_scope as _wes
+    _wes._exposeto_cache.clear()
+    _wes._sel_last_audit.clear()
+    yield
+    _wes._exposeto_cache.clear()
+    _wes._sel_last_audit.clear()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_slot(*, owner_app: str = "", origin: str = SlotOrigin.USER, key: str = "s1") -> MagicMock:
+    slot = MagicMock()
+    slot._app = owner_app
+    slot._origin = origin
+    slot.key = key
+    return slot
+
+
+def _make_state(slots: dict[str, Any] | None = None) -> MagicMock:
+    state = MagicMock()
+    state._slots = slots or {}
+    return state
+
+
+def _allowed(*decls: str) -> frozenset[str]:
+    return build_allowed_event_set(list(decls))
+
+
+# ---------------------------------------------------------------------------
+# build_allowed_event_set
+# ---------------------------------------------------------------------------
+
+class TestBuildAllowedEventSet:
+    def test_empty_declarations(self):
+        assert build_allowed_event_set([]) == frozenset()
+
+    def test_returns_frozenset(self):
+        result = build_allowed_event_set(["notification", "slots:user"])
+        assert isinstance(result, frozenset)
+        assert "notification" in result
+        assert "slots:user" in result
+
+    def test_deduplication(self):
+        result = build_allowed_event_set(["notification", "notification"])
+        assert result == frozenset({"notification"})
+
+
+# ---------------------------------------------------------------------------
+# Tier 0: always-allowed events
+# ---------------------------------------------------------------------------
+
+class TestTier0AlwaysAllowed:
+    def test_dashboard_always_allowed_for_any_app(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "dashboard", {},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is True
+
+    def test_dashboard_allowed_even_with_empty_permissions(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "dashboard", {"version": "3.0"},
+            app="auto-improvement", allowed_events=frozenset(), state=state,
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: slot-scoped events — own-slot visibility
+# ---------------------------------------------------------------------------
+
+class TestSlotScopedOwnSlot:
+    def test_own_slot_chat_chunk_allowed(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "mochi-pet", "content": "hi"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is True
+
+    def test_own_slot_tool_call_allowed(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        assert ws_event_allowed(
+            "tool_call", {"slot": "mochi-pet"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is True
+
+    def test_other_app_slot_denied_without_declaration(self):
+        slot = _make_slot(owner_app="auto-improvement", origin=SlotOrigin.APP, key="auto-improvement")
+        state = _make_state({"auto-improvement": slot})
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "auto-improvement"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+
+    def test_missing_slot_denied(self):
+        state = _make_state({})
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "ghost"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+
+    def test_slot_field_none_denied(self):
+        state = _make_state({})
+        # slot-scoped event type but no slot key in data
+        assert ws_event_allowed(
+            "chat_chunk", {},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: slot-scoped events — slots:user
+# ---------------------------------------------------------------------------
+
+class TestSlotScopedUserSlots:
+    def test_user_slot_allowed_with_slots_user(self):
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({"chat-1": slot})
+        assert ws_event_allowed(
+            "chat_message", {"slot": "chat-1"},
+            app="mochi-pet", allowed_events=_allowed("slots:user"), state=state,
+        ) is True
+
+    def test_user_slot_denied_without_slots_user(self):
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({"chat-1": slot})
+        assert ws_event_allowed(
+            "chat_message", {"slot": "chat-1"},
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is False
+
+    def test_app_slot_not_covered_by_slots_user(self):
+        # slots:user only covers USER-origin slots, not APP-origin ones
+        slot = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="other-app")
+        state = _make_state({"other-app": slot})
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "other-app"},
+            app="mochi-pet", allowed_events=_allowed("slots:user"), state=state,
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: slot-scoped events — slots:all
+# ---------------------------------------------------------------------------
+
+class TestSlotScopedSlotsAll:
+    def test_slots_all_covers_any_slot(self):
+        slot = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="other")
+        state = _make_state({"other": slot})
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "other"},
+            app="mochi-pet", allowed_events=_allowed("slots:all"), state=state,
+        ) is True
+
+    def test_slots_all_covers_user_slot(self):
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({"chat-1": slot})
+        assert ws_event_allowed(
+            "slot_title", {"slot": "chat-1"},
+            app="any-app", allowed_events=_allowed("slots:all"), state=state,
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: slot-scoped events — slots:app:<name> with exposeToApps opt-in
+# ---------------------------------------------------------------------------
+
+class TestSlotScopedCrossApp:
+    def _state_with_expose(self, target_app: str, expose_to: list[str]) -> MagicMock:
+        slot = _make_slot(owner_app=target_app, origin=SlotOrigin.APP, key=target_app)
+        state = _make_state({target_app: slot})
+        # Mock get_app_manifest to return a manifest with exposeToApps
+        manifest = MagicMock()
+        manifest.permissions.exposeToApps = expose_to
+        state._get_manifest = MagicMock(return_value=manifest)
+        return state
+
+    def test_cross_app_allowed_when_target_opts_in(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        manifest = MagicMock()
+        manifest.permissions.exposeToApps = ["monitor-app"]
+        with patch("kiro_crew.dashboard.ws_event_scope.get_app_manifest", return_value=manifest):
+            assert ws_event_allowed(
+                "chat_chunk", {"slot": "mochi-pet"},
+                app="monitor-app",
+                allowed_events=_allowed("slots:app:mochi-pet"),
+                state=state,
+            ) is True
+
+    def test_cross_app_denied_when_target_does_not_opt_in(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        manifest = MagicMock()
+        manifest.permissions.exposeToApps = []  # no opt-in
+        with patch("kiro_crew.dashboard.ws_event_scope.get_app_manifest", return_value=manifest):
+            assert ws_event_allowed(
+                "chat_chunk", {"slot": "mochi-pet"},
+                app="monitor-app",
+                allowed_events=_allowed("slots:app:mochi-pet"),
+                state=state,
+            ) is False
+
+    def test_cross_app_allowed_with_wildcard_expose(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        manifest = MagicMock()
+        manifest.permissions.exposeToApps = ["*"]
+        with patch("kiro_crew.dashboard.ws_event_scope.get_app_manifest", return_value=manifest):
+            assert ws_event_allowed(
+                "chat_chunk", {"slot": "mochi-pet"},
+                app="any-app",
+                allowed_events=_allowed("slots:app:mochi-pet"),
+                state=state,
+            ) is True
+
+    def test_cross_app_without_slots_app_declaration_denied(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        manifest = MagicMock()
+        manifest.permissions.exposeToApps = ["monitor-app"]
+        with patch("kiro_crew.dashboard.ws_event_scope.get_app_manifest", return_value=manifest):
+            # monitor-app didn't declare slots:app:mochi-pet
+            assert ws_event_allowed(
+                "chat_chunk", {"slot": "mochi-pet"},
+                app="monitor-app",
+                allowed_events=_allowed("slots:user"),  # wrong declaration
+                state=state,
+            ) is False
+
+
+# ---------------------------------------------------------------------------
+# Subagent events — independent dimension
+# ---------------------------------------------------------------------------
+
+class TestSubagentEvents:
+    def test_subagent_own_slot_always_allowed(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        assert ws_event_allowed(
+            "subagent_done", {"slot": "mochi-pet"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is True
+
+    def test_subagent_user_slot_requires_subagent_user(self):
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({"chat-1": slot})
+        # Without subagent:user, denied
+        assert ws_event_allowed(
+            "subagent_done", {"slot": "chat-1"},
+            app="mochi-pet", allowed_events=_allowed("slots:user"), state=state,
+        ) is True  # slots:user falls through to slot visibility which allows it
+
+    def test_subagent_user_independent_of_slots_user(self):
+        """subagent:user can be declared without slots:user (narrower access)."""
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({"chat-1": slot})
+        assert ws_event_allowed(
+            "subagent_done", {"slot": "chat-1"},
+            app="mochi-pet", allowed_events=_allowed("subagent:user"), state=state,
+        ) is True
+        # But chat content is still blocked (no slots:user)
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "chat-1"},
+            app="mochi-pet", allowed_events=_allowed("subagent:user"), state=state,
+        ) is False
+
+    def test_subagent_all_covers_any_app_slot(self):
+        slot = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="other")
+        state = _make_state({"other": slot})
+        assert ws_event_allowed(
+            "subagent_spawn", {"slot": "other"},
+            app="mochi-pet", allowed_events=_allowed("subagent:all"), state=state,
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: global events
+# ---------------------------------------------------------------------------
+
+class TestGlobalEvents:
+    def test_notification_own_app_requires_declaration(self):
+        # Own-app notifications now require an explicit ``notification``
+        # declaration (deny-by-default per CWE-269).  Undeclared apps get
+        # denied even for their own notifications.
+        state = _make_state()
+        assert ws_event_allowed(
+            "notification", {"source": "app:mochi-pet", "message": "hello"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+
+    def test_notification_own_app_allowed_when_declared(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "notification", {"source": "app:mochi-pet", "message": "hello"},
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is True
+
+    def test_notification_other_app_denied_without_declaration(self):
+        # ``notification`` (without ``:all``) grants only own-app notifications;
+        # a foreign app's push must be denied.
+        state = _make_state()
+        assert ws_event_allowed(
+            "notification", {"source": "app:other-app"},
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is False
+
+    def test_notification_all_covers_any_source(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "notification", {"source": "app:other-app"},
+            app="mochi-pet", allowed_events=_allowed("notification:all"), state=state,
+        ) is True
+
+    def test_sessions_restarting_requires_declaration(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "sessions_restarting", {"status": "restarting"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "sessions_restarting", {"status": "restarting"},
+            app="mochi-pet", allowed_events=_allowed("sessions"), state=state,
+        ) is True
+
+    def test_log_requires_declaration(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "log", {"line": "some log"},
+            app="mochi-pet", allowed_events=_allowed("sessions"), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "log", {"line": "some log"},
+            app="mochi-pet", allowed_events=_allowed("log"), state=state,
+        ) is True
+
+    def test_system_notifications_need_their_own_declaration(self):
+        """Gateway-internal pushes are user content, not the app's own.
+
+        ``send_message``, cron output and watchlist results reach state.notify(),
+        which stamps ``source="system"``. Folding them into ``notification`` would
+        make one declaration a broad grant -- the shape this module exists to
+        remove.
+        """
+        state = _make_state()
+        system_note = {"text": "cron finished", "source": "system"}
+        assert ws_event_allowed(
+            "notification", system_note,
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "notification", system_note,
+            app="mochi-pet", allowed_events=_allowed("notification:system"), state=state,
+        ) is True
+        # A note with NO source is not attributable, so it is not the system
+        # stream either -- it is denied. Accepting "" as system is exactly the
+        # defect that let one app's push reach every `notification:system`
+        # holder: the gate read a key no emitter writes, so it saw "" for every
+        # note. Only `notification:all` crosses this.
+        unattributed = {"text": "hi"}
+        assert ws_event_allowed(
+            "notification", unattributed,
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "notification", unattributed,
+            app="mochi-pet", allowed_events=_allowed("notification:system"), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "notification", unattributed,
+            app="mochi-pet", allowed_events=_allowed("notification:all"), state=state,
+        ) is True
+
+    def test_own_app_notification_still_needs_only_notification(self):
+        state = _make_state()
+        own = {"text": "done", "source": "app:mochi-pet"}
+        assert ws_event_allowed(
+            "notification", own,
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is True
+        # notification:system does NOT imply own-app notifications.
+        assert ws_event_allowed(
+            "notification", own,
+            app="mochi-pet", allowed_events=_allowed("notification:system"), state=state,
+        ) is False
+
+    def test_channel_settings_is_gated_by_owner_not_by_note_source(self):
+        """It is not in _SOURCE_FILTERED_EVENTS (it carries no `source` field) but
+        it is still attributed -- by its CHANNEL owner."""
+        from kiro_crew.dashboard.ws_event_scope import _SOURCE_FILTERED_EVENTS
+
+        assert "notification_channel_settings" not in _SOURCE_FILTERED_EVENTS
+        state = _make_state()
+        assert ws_event_allowed(
+            "notification_channel_settings",
+            {"channel": "mochi-pet.alerts", "settings": {"muted": True}},
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is True
+
+    def test_artifact_update_requires_artifacts_declaration(self):
+        state = _make_state()
+        payload = {"slug": "my-doc", "version": 3, "deleted": False}
+        assert ws_event_allowed(
+            "artifact_update", payload,
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "artifact_update", payload,
+            app="mochi-pet", allowed_events=_allowed("artifacts"), state=state,
+        ) is True
+
+    def test_workflow_run_event_declared_by_its_own_name(self):
+        """The workflows app declares the literal event name, not a scope alias.
+
+        This is the only ``permissions.events`` declaration that exists in the
+        tree today, so the gate must honour the literal name -- renaming it to a
+        scope alias would silently break that app.
+        """
+        state = _make_state()
+        payload = {"run_id": "r1", "session_key": "dashboard:chat-1"}
+        assert ws_event_allowed(
+            "workflow_run_event", payload,
+            app="workflows", allowed_events=_allowed(), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "workflow_run_event", payload,
+            app="workflows",
+            allowed_events=_allowed("workflow_run_event"), state=state,
+        ) is True
+
+    def test_notification_channel_settings_is_scoped_by_channel_owner(self):
+        """A channel is `<app>.<id>` or `system.<kind>`, so it IS attributable.
+
+        The old fixture used `#team` -- a shape the bus never produces -- and the
+        gate let ANY app with own-only `notification` read every channel's
+        settings. messaging.py itself derives the source as
+        `channel.split(".", 1)[0]`; this mirrors that.
+        """
+        state = _make_state()
+        own = {"channel": "mochi-pet.alerts", "settings": {"muted": True}}
+        foreign = {"channel": "workflows.alerts", "settings": {"muted": True}}
+        assert ws_event_allowed(
+            "notification_channel_settings", own,
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "notification_channel_settings", own,
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is True
+        # Another app's channel is NOT covered by own-only notification.
+        assert ws_event_allowed(
+            "notification_channel_settings", foreign,
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "notification_channel_settings", foreign,
+            app="mochi-pet", allowed_events=_allowed("notification:all"), state=state,
+        ) is True
+        # System channels ride the system opt-in, like the system stream itself.
+        system = {"channel": "system.cron", "settings": {"muted": True}}
+        assert ws_event_allowed(
+            "notification_channel_settings", system,
+            app="mochi-pet", allowed_events=_allowed("notification"), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "notification_channel_settings", system,
+            app="mochi-pet", allowed_events=_allowed("notification:system"), state=state,
+        ) is True
+
+    def test_channel_owner_helper_matches_the_handler_convention(self):
+        """Pin the helper against the derivation messaging.py already uses."""
+        from kiro_crew.dashboard.ws_event_scope import notification_channel_owner
+
+        for channel in ("mochi-pet.alerts", "system.cron", "workflows.x.y"):
+            assert notification_channel_owner(channel) == channel.split(".", 1)[0]
+        # No dot -> no owner -> not attributable.
+        assert notification_channel_owner("#team") == ""
+        assert notification_channel_owner("") == ''
+
+    def test_unknown_event_denied(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "some_unknown_event_xyz", {},
+            app="mochi-pet", allowed_events=_allowed("slots:all"), state=state,
+        ) is False
+
+    def test_yolo_expired_requires_declaration(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "yolo_expired", {"source": "timer"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "yolo_expired", {"source": "timer"},
+            app="mochi-pet", allowed_events=_allowed("yolo"), state=state,
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# filter_slots_for_app
+# ---------------------------------------------------------------------------
+
+class TestFilterSlotsForApp:
+    def _slot_dict(self, key: str) -> dict:
+        return {"key": key, "title": key}
+
+    def test_own_slot_included(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        state = _make_state({"mochi-pet": slot})
+        result = filter_slots_for_app(
+            [self._slot_dict("mochi-pet")],
+            "mochi-pet", _allowed(), state,
+        )
+        assert len(result) == 1
+        assert result[0]["key"] == "mochi-pet"
+
+    def test_other_app_slot_excluded_by_default(self):
+        slot = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="other-app")
+        state = _make_state({"other-app": slot})
+        result = filter_slots_for_app(
+            [self._slot_dict("other-app")],
+            "mochi-pet", _allowed(), state,
+        )
+        assert result == []
+
+    def test_user_slot_included_with_slots_user(self):
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({"chat-1": slot})
+        result = filter_slots_for_app(
+            [self._slot_dict("chat-1")],
+            "mochi-pet", _allowed("slots:user"), state,
+        )
+        assert len(result) == 1
+
+    def test_user_slot_excluded_without_slots_user(self):
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({"chat-1": slot})
+        result = filter_slots_for_app(
+            [self._slot_dict("chat-1")],
+            "mochi-pet", _allowed("notification"), state,
+        )
+        assert result == []
+
+    def test_slots_all_includes_everything(self):
+        slot1 = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mochi-pet")
+        slot2 = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="other-app")
+        slot3 = _make_slot(owner_app="", origin=SlotOrigin.USER, key="chat-1")
+        state = _make_state({
+            "mochi-pet": slot1,
+            "other-app": slot2,
+            "chat-1": slot3,
+        })
+        result = filter_slots_for_app(
+            [self._slot_dict(k) for k in ["mochi-pet", "other-app", "chat-1"]],
+            "mochi-pet", _allowed("slots:all"), state,
+        )
+        assert len(result) == 3
+
+    def test_missing_slot_in_state_excluded(self):
+        # slot dict references a key not in state._slots (stale data)
+        state = _make_state({})
+        result = filter_slots_for_app(
+            [self._slot_dict("ghost")],
+            "mochi-pet", _allowed("slots:all"), state,
+        )
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# token_auth: implicit allow for /api/ws and /api/status
+# ---------------------------------------------------------------------------
+
+class TestImplicitAllow:
+    def test_api_ws_implicitly_allowed_for_any_app(self):
+        assert app_token_path_allowed("mochi-pet", "/api/ws") is True
+        assert app_token_path_allowed("auto-improvement", "/api/ws") is True
+
+    def test_api_status_is_NOT_implicitly_allowed(self):
+        """``/api/status`` is not connection infrastructure: it returns
+        ``owner_id_hash``, host specs, cron/usage stats and the live
+        safety-override state, with no response-level filter to match what
+        event scoping gives ``/api/ws``. An app must declare it."""
+        assert app_token_path_allowed("mochi-pet", "/api/status") is False
+
+    def test_empty_app_name_still_denied(self):
+        assert app_token_path_allowed("", "/api/ws") is False
+
+    def test_other_undeclared_path_still_denied(self):
+        # Implicit allow doesn't bleed into other paths
+        assert app_token_path_allowed("mochi-pet", "/api/sessions") is False
+        assert app_token_path_allowed("mochi-pet", "/api/ws/extra") is False
+
+    def test_api_ws_implicit_allow_emits_no_exception(self):
+        """SEL audit in implicit allow path must not raise even if SEL is unavailable."""
+        # Patch the reference used at call time (token_auth imports sel as _sel_fn
+        # at module load; patching kiro_crew.sel.sel would not affect that binding).
+        with patch(
+            "kiro_crew.dashboard.token_auth._sel_fn",
+            side_effect=Exception("sel unavailable"),
+        ):
+            # Should return True despite SEL failure (audit is best-effort)
+            result = app_token_path_allowed("mochi-pet", "/api/ws")
+            assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Regression: test_app_token_path_allowed_implicit_ws (from original CR)
+# ---------------------------------------------------------------------------
+
+def test_app_token_path_allowed_implicit_ws() -> None:
+    """``/api/ws`` is implicitly allowed for all app tokens without an explicit
+    permissions.api declaration: every app that uses KiroCrewClient needs it to
+    connect, and the WS layer filters events per-app via ws_event_scope.py so
+    connecting no longer grants full event stream access. ``/api/status`` is
+    NOT implicitly allowed — it has no equivalent response filter. The
+    reconnect poll that uses it is the dashboard SPA
+    (``useDashboardHealthProbe``), which runs on a dashboard-user token and
+    never reaches this check.
+    """
+    assert app_token_path_allowed("mochi-pet", "/api/ws") is True
+    assert app_token_path_allowed("mochi-pet", "/api/status") is False
+    assert app_token_path_allowed("auto-improvement", "/api/ws") is True
+    # Other undeclared paths are still denied
+    assert app_token_path_allowed("mochi-pet", "/api/sessions") is False
+
+
+# ---------------------------------------------------------------------------
+# Empty-app fail-closed (deny-by-default, CWE-269)
+# ---------------------------------------------------------------------------
+
+class TestEmptyAppDeniedClosed:
+    """``ws_event_allowed`` must fail-closed if called with an empty app.
+
+    ``assert`` is compiled out under ``python -O``, so we can't rely on it as
+    a security guard.  The runtime check must remain in production builds.
+    """
+
+    def test_empty_app_denied_for_tier0_event(self):
+        # Even the ``dashboard`` Tier-0 event must be denied when app is empty.
+        state = _make_state()
+        assert ws_event_allowed(
+            "dashboard", {},
+            app="", allowed_events=_allowed("dashboard"), state=state,
+        ) is False
+
+    def test_empty_app_denied_for_owned_slot(self):
+        slot = _make_slot(owner_app="", origin=SlotOrigin.USER, key="s1")
+        state = _make_state({"s1": slot})
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "s1"},
+            app="", allowed_events=_allowed("slots:user"), state=state,
+        ) is False
+
+    def test_empty_app_deny_emits_audit(self):
+        # A caller that reaches ws_event_allowed with an empty app must
+        # leave an audit trail so the bypass is observable.
+        from kiro_crew.dashboard import ws_event_scope as _wes
+        state = _make_state()
+        with patch("kiro_crew.sel.sel") as sel_mock:
+            _wes._sel_last_audit.clear()  # fresh window
+            ws_event_allowed(
+                "chat_chunk", {}, app="", allowed_events=_allowed(), state=state,
+            )
+            outcomes = [
+                c.kwargs.get("outcome", "")
+                for c in sel_mock.return_value.log_api_access.call_args_list
+            ]
+            assert any("empty_app_denied" in o for o in outcomes)
+
+
+# ---------------------------------------------------------------------------
+# ``slot_title`` uses ``key`` (not ``slot``) for the slot identifier
+# ---------------------------------------------------------------------------
+
+class TestSlotTitleKeyField:
+    """Regression: ``slot_title`` events must be filtered by the ``key`` field.
+
+    ``_broadcast`` builds a payload of ``{"key", "title"}`` (no ``slot``), so
+    the scope gate has to fall back to ``key`` — otherwise every ``slot_title``
+    push is denied for every app token.
+    """
+
+    def test_slot_title_own_slot_allowed_via_key(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="s1")
+        state = _make_state({"s1": slot})
+        assert ws_event_allowed(
+            "slot_title", {"key": "s1", "title": "hi"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is True
+
+    def test_slot_title_other_app_denied(self):
+        slot = _make_slot(owner_app="other", origin=SlotOrigin.APP, key="s1")
+        state = _make_state({"s1": slot})
+        assert ws_event_allowed(
+            "slot_title", {"key": "s1", "title": "hi"},
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# ``slots`` full re-push: needs any ``slots:*`` scope
+# ---------------------------------------------------------------------------
+
+class TestSlotsListEvent:
+    """``slots`` events are always delivered — payload-level per-app filter
+    in ``DashboardState._serialize_for_client`` enforces per-slot scope.
+    The default is "app sees its own slots without an explicit declaration",
+    matching filter_slots_for_app's own-slot-always behaviour on initial
+    connect (avoids docstring/impl divergence flagged by AutoSDE).
+    """
+
+    def test_slots_allowed_even_without_scope(self):
+        # No explicit slots:* declaration — event still delivered; the
+        # payload filter in _serialize_for_client will trim to own slots.
+        state = _make_state()
+        assert ws_event_allowed(
+            "slots", [],
+            app="mochi-pet", allowed_events=_allowed(), state=state,
+        ) is True
+
+    def test_slots_allowed_with_slots_own(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "slots", [],
+            app="mochi-pet", allowed_events=_allowed("slots:own"), state=state,
+        ) is True
+
+    def test_slots_allowed_with_slots_all(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "slots", [],
+            app="mochi-pet", allowed_events=_allowed("slots:all"), state=state,
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# SEL audit deduplication (first-per-window, not per-call)
+# ---------------------------------------------------------------------------
+
+class TestAuditDedup:
+    def _clear_cache(self):
+        from kiro_crew.dashboard import ws_event_scope
+        ws_event_scope._sel_last_audit.clear()
+
+    def test_first_deny_audited_subsequent_within_window_suppressed(self):
+        self._clear_cache()
+        state = _make_state()
+        with patch("kiro_crew.sel.sel") as m:
+            for _ in range(5):
+                ws_event_allowed(
+                    "notification", {"source": "app:other-app"},
+                    app="mochi-pet",
+                    allowed_events=_allowed("notification"),
+                    state=state,
+                )
+            # Only one audit emitted for the (app, event_type, reason) tuple.
+            assert m.return_value.log_api_access.call_count == 1
+
+    def test_different_reasons_audited_independently(self):
+        self._clear_cache()
+        state = _make_state()
+        with patch("kiro_crew.sel.sel") as m:
+            # notification_scope_denied
+            ws_event_allowed(
+                "notification", {"source": "app:other-app"},
+                app="mochi-pet",
+                allowed_events=_allowed("notification"),
+                state=state,
+            )
+            # unknown_event (different reason)
+            ws_event_allowed(
+                "totally_made_up_event", {},
+                app="mochi-pet", allowed_events=_allowed(), state=state,
+            )
+            assert m.return_value.log_api_access.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Positive ``_is_dashboard_user`` flag on _send_ws_all / subagent subscribers
+# ---------------------------------------------------------------------------
+
+class TestPositiveDashboardUserFlag:
+    """The scope gate must be triggered by the ABSENCE of a positive
+    ``_is_dashboard_user`` flag, not the absence of ``_app``.  This prevents
+    a future refactor from silently opening a fail-open path.
+    """
+
+    def _make_ws(self, *, is_dashboard_user: bool | None, app: str = "") -> MagicMock:
+        ws = MagicMock()
+        ws.closed = False
+        # Simulate ws["_app"] and ws.get behavior on a real WSResponse
+        store = {}
+        if is_dashboard_user is not None:
+            store["_is_dashboard_user"] = is_dashboard_user
+        if app:
+            store["_app"] = app
+            store["_allowed_events"] = _allowed()
+        ws.get.side_effect = lambda k, default=None: store.get(k, default)
+        return ws
+
+    def test_dashboard_user_flag_unset_is_treated_as_app(self):
+        """If a code path forgets to set _is_dashboard_user, the gate applies."""
+        from kiro_crew.dashboard.state import DashboardState
+
+        # Build a minimal state stub with the helper method.
+        state = MagicMock(spec=DashboardState)
+        state._slots = {}
+        # Bind the real helper to the mock so we exercise real logic.
+        state._ws_client_allowed = DashboardState._ws_client_allowed.__get__(state)
+        ws = self._make_ws(is_dashboard_user=None, app="mochi-pet")
+        # unknown-event → deny path
+        assert state._ws_client_allowed(ws, "totally_made_up", {}) is False
+
+    def test_dashboard_user_positive_flag_bypasses_gate(self):
+        from kiro_crew.dashboard.state import DashboardState
+        state = MagicMock(spec=DashboardState)
+        state._slots = {}
+        state._ws_client_allowed = DashboardState._ws_client_allowed.__get__(state)
+        ws = self._make_ws(is_dashboard_user=True)
+        assert state._ws_client_allowed(ws, "totally_made_up", {}) is True
+
+
+class TestScopeCheckExceptionAudited:
+    """When ws_event_allowed itself blows up, the fail-closed branch must
+    audit the deny so scope-check bugs remain observable.
+    """
+
+    def test_scope_check_exception_emits_audit(self):
+        from kiro_crew.dashboard import ws_event_scope
+        from kiro_crew.dashboard.state import DashboardState
+        ws_event_scope._sel_last_audit.clear()
+        state = MagicMock(spec=DashboardState)
+        state._slots = {}
+        state._ws_client_allowed = DashboardState._ws_client_allowed.__get__(state)
+        ws = MagicMock()
+        ws.closed = False
+        ws.get.side_effect = lambda k, default=None: {
+            "_is_dashboard_user": False,
+            "_app": "mochi-pet",
+            "_allowed_events": _allowed(),
+        }.get(k, default)
+        # Force ws_event_allowed to raise
+        with patch(
+            "kiro_crew.dashboard.ws_event_scope.ws_event_allowed",
+            side_effect=RuntimeError("boom"),
+        ), patch("kiro_crew.sel.sel") as sel_mock:
+            result = state._ws_client_allowed(ws, "chat_chunk", {"slot": "x"})
+            assert result is False
+            # The audit was invoked at least once with the scope_check_exception reason.
+            calls = sel_mock.return_value.log_api_access.call_args_list
+            reasons = [c.kwargs.get("outcome", "") for c in calls]
+            assert any("scope_check_exception" in r for r in reasons)
+
+
+# ---------------------------------------------------------------------------
+# _origin persistence — cron/system slots must survive a restart with the
+# correct origin so the WS scope gate doesn't mis-classify them.
+# ---------------------------------------------------------------------------
+
+class TestOriginPersistence:
+    """A cron- or system-initiated slot rehydrated from disk must keep its
+    original origin so ``slots:user`` scopes don't inadvertently grant an app
+    visibility into events it wasn't authorised for.
+
+    These drive the REAL save/restore functions against a REAL
+    ``ConversationLog``. An earlier version of this class rebuilt the
+    ``meta_line`` assembly inside the test and asserted on its own local dict —
+    so it stayed green while ``_save_slot_to_history`` never wrote ``origin``
+    at all, and every slot silently rehydrated unattributed. Never restate the
+    production logic here; call it.
+    """
+
+    @staticmethod
+    def _state(tmp_path):
+        from unittest.mock import AsyncMock
+
+        from chat_test_helpers import _make_ready_kiro_prerequisite
+
+        from kiro_crew.dashboard.state import DashboardState
+        from kiro_crew.history import ConversationLog
+
+        sessions = MagicMock(count=0)
+        sessions.remove = AsyncMock()
+        sessions.recycle_background = AsyncMock()
+        sessions.get_pid = MagicMock(return_value=None)
+        state = DashboardState(
+            sessions=sessions,
+            crons=MagicMock(
+                list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})
+            ),
+            lessons=MagicMock(load_all=MagicMock(return_value=[])),
+            start_time=0.0,
+            conversation_log=ConversationLog(base_dir=tmp_path),
+        )
+        state.kiro_prerequisite_service = _make_ready_kiro_prerequisite()
+        return state
+
+    def test_slot_has_origin_attribute(self):
+        from kiro_crew.dashboard.state import _ChatSlot
+
+        assert hasattr(_ChatSlot("s1"), "_origin")
+
+    def test_to_dict_includes_origin(self):
+        from kiro_crew.dashboard.state import _ChatSlot
+
+        slot = _ChatSlot("s1")
+        slot._origin = SlotOrigin.CRON
+        assert slot.to_dict()["origin"] == SlotOrigin.CRON
+
+    def test_save_writes_origin_to_meta(self, tmp_path, monkeypatch):
+        """The REAL save path must persist origin — this is the write side that
+        was missing, letting every restored slot come back unattributed."""
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = self._state(tmp_path)
+        slot = state.get_or_create_slot("cron-1")
+        slot._origin = SlotOrigin.CRON
+        slot.append("user", "hi")
+        slot.drain()
+
+        _save_slot_to_history(state, slot, closed=True)
+
+        meta = state.conversation_log.get_metadata("dashboard:cron-1")
+        assert meta.get("origin") == SlotOrigin.CRON
+
+    def test_untagged_origin_not_persisted(self, tmp_path, monkeypatch):
+        """The fail-closed empty sentinel must not be written as a real value."""
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = self._state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot._origin = ""
+        slot.append("user", "hi")
+        slot.drain()
+
+        _save_slot_to_history(state, slot, closed=True)
+
+        assert "origin" not in state.conversation_log.get_metadata("dashboard:s1")
+
+    @pytest.mark.parametrize("origin", [SlotOrigin.CRON, SlotOrigin.USER, SlotOrigin.APP])
+    def test_origin_round_trips_through_rehydrate(self, tmp_path, monkeypatch, origin):
+        """save -> _rehydrate_slot_from_history must return the SAME origin."""
+        from kiro_crew.dashboard.chat_persistence import (
+            _rehydrate_slot_from_history,
+            _save_slot_to_history,
+        )
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = self._state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot._origin = origin
+        if origin == SlotOrigin.APP:
+            slot._app = "mochi-pet"
+        slot.append("user", "hi")
+        slot.drain()
+        _save_slot_to_history(state, slot, closed=False)
+        del state._slots["s1"]
+
+        restored = _rehydrate_slot_from_history(state, "s1")
+        assert restored is not None
+        assert restored._origin == origin
+
+    def test_origin_round_trips_through_bulk_restore(self, tmp_path, monkeypatch):
+        """The bulk restore path (gateway boot) must restore origin too — the
+        two restore sites are separate code and both read ``meta["origin"]``."""
+        from kiro_crew.dashboard.chat_persistence import (
+            _save_slot_to_history,
+            restore_recent_sessions,
+        )
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = self._state(tmp_path)
+        slot = state.get_or_create_slot("cron-1")
+        slot._origin = SlotOrigin.CRON
+        slot.append("user", "hi")
+        slot.drain()
+        _save_slot_to_history(state, slot, closed=False)
+        del state._slots["cron-1"]
+
+        restore_recent_sessions(state)
+
+        assert state._slots["cron-1"]._origin == SlotOrigin.CRON
+
+    def test_restored_cron_slot_still_hidden_from_slots_user(self, tmp_path, monkeypatch):
+        """The security property the persistence exists for: a CRON slot that
+        survived a restart must STILL be withheld from a ``slots:user`` app.
+        Without the write side it rehydrated untagged and this gate flipped."""
+        from kiro_crew.dashboard.chat_persistence import (
+            _rehydrate_slot_from_history,
+            _save_slot_to_history,
+        )
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = self._state(tmp_path)
+        slot = state.get_or_create_slot("cron-1")
+        slot._origin = SlotOrigin.CRON
+        slot.append("user", "hi")
+        slot.drain()
+        _save_slot_to_history(state, slot, closed=False)
+        del state._slots["cron-1"]
+        restored = _rehydrate_slot_from_history(state, "cron-1")
+        assert restored is not None
+
+        assert not ws_event_allowed(
+            "chat_message", {"slot": "cron-1"},
+            app="some-app", allowed_events=frozenset({"slots:user"}), state=state,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Positive is_dashboard_user flag from token_auth — a token that does not
+# come through the auth middleware (or fails it) MUST NOT bypass the gate.
+# ---------------------------------------------------------------------------
+
+class TestAuthMiddlewareIsDashboardUser:
+    """The auth middleware sets ``request["is_dashboard_user"]`` positively
+    only for verified dashboard-user tokens.  App tokens and unauthenticated
+    requests never see the flag flip to True.
+    """
+
+    def test_dashboard_user_bypasses_scope_gate(self):
+        # Behavioral: a ws with positive _is_dashboard_user flag must bypass
+        # the scope gate entirely (that's the CWE-269 fix's whole point).
+        from kiro_crew.dashboard.state import DashboardState
+        state = MagicMock(spec=DashboardState)
+        state._slots = {}
+        state._ws_client_allowed = DashboardState._ws_client_allowed.__get__(state)
+        ws = MagicMock()
+        ws.closed = False
+        ws.get.side_effect = lambda k, default=None: {
+            "_is_dashboard_user": True,
+        }.get(k, default)
+        # Even an unknown event that would deny app tokens passes for
+        # dashboard users.
+        assert state._ws_client_allowed(ws, "totally_unknown_event", {}) is True
+
+    def test_missing_flag_treats_as_app_token(self):
+        # Behavioral: without the positive flag, gate applies (deny-by-default).
+        from kiro_crew.dashboard.state import DashboardState
+        state = MagicMock(spec=DashboardState)
+        state._slots = {}
+        state._ws_client_allowed = DashboardState._ws_client_allowed.__get__(state)
+        ws = MagicMock()
+        ws.closed = False
+        ws.get.side_effect = lambda k, default=None: {
+            # Deliberately missing _is_dashboard_user.
+            "_app": "mochi-pet",
+            "_allowed_events": frozenset(),
+        }.get(k, default)
+        assert state._ws_client_allowed(ws, "totally_unknown_event", {}) is False
+
+
+# ---------------------------------------------------------------------------
+# Missing _origin fails closed — a slot without the attribute must not be
+# treated as USER by default.
+# ---------------------------------------------------------------------------
+
+class TestMissingOriginFailsClosed:
+    """CWE-269 defense-in-depth: if ``_origin`` is somehow missing (pre-
+    migration slot, race, bug), it must remain invisible to any ``:user``
+    scope rather than being silently classified as ``SlotOrigin.USER``.
+    """
+
+    def _slot_without_origin(self, owner_app: str = "") -> MagicMock:
+        # Deliberately DO NOT set _origin on the mock — spec=[] means
+        # hasattr(slot, "_origin") is False.
+        slot = MagicMock(spec=["_app"])
+        slot._app = owner_app
+        return slot
+
+    def test_slot_visible_denied_when_origin_missing(self):
+        slot = self._slot_without_origin()
+        state = _make_state({"s1": slot})
+        # slots:user must NOT grant visibility to a slot with no _origin.
+        assert ws_event_allowed(
+            "chat_chunk", {"slot": "s1"},
+            app="mochi-pet",
+            allowed_events=_allowed("slots:user"),
+            state=state,
+        ) is False
+
+    def test_subagent_visible_denied_when_origin_missing(self):
+        slot = self._slot_without_origin()
+        state = _make_state({"s1": slot})
+        assert ws_event_allowed(
+            "subagent_chunk", {"slot": "s1"},
+            app="mochi-pet",
+            allowed_events=_allowed("subagent:user"),
+            state=state,
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# Slots re-push payload filtering — an app that declared slots:own must NOT
+# receive other apps' or users' slot metadata on ``push_slots_update`` /
+# ``_broadcast`` re-pushes.  The filter runs inside DashboardState.
+# _serialize_for_client on the send layer, so we assert that behaviour by
+# reading the module source to guard against regression (constructing a real
+# DashboardState in-process here would be over-engineered).
+# ---------------------------------------------------------------------------
+
+class TestSlotsRepushFilter:
+    """Behavioral: an app that declared slots:own must NOT receive other
+    apps' or users' slot metadata on ``push_slots_update`` re-pushes.  The
+    filter runs inside ``DashboardState._serialize_for_client``.
+    """
+
+    def _make_state_with_slots(self, slot_map: dict) -> Any:
+        # Wrap into a state that mimics DashboardState._serialize_for_client's
+        # required surface.  We bind the real method to a MagicMock so it
+        # runs against our slot map instead of a live DashboardState.
+        from kiro_crew.dashboard.state import DashboardState
+        state = MagicMock(spec=DashboardState)
+        state._slots = slot_map
+        state._serialize_for_client = (
+            DashboardState._serialize_for_client.__get__(state)
+        )
+        return state
+
+    def _ws(self, *, is_dashboard: bool, app: str = "", events=frozenset()):
+        ws = MagicMock()
+        store = {
+            "_is_dashboard_user": is_dashboard,
+            "_app": app,
+            "_allowed_events": events,
+        }
+        ws.get.side_effect = lambda k, default=None: store.get(k, default)
+        return ws
+
+    def test_dashboard_user_receives_full_slots_list(self):
+        import json
+        slot_a = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="a")
+        slot_b = _make_slot(owner_app="other", origin=SlotOrigin.APP, key="b")
+        state = self._make_state_with_slots({"a": slot_a, "b": slot_b})
+        ws = self._ws(is_dashboard=True)
+        default_msg = json.dumps({
+            "type": "slots",
+            "data": [{"key": "a"}, {"key": "b"}],
+            "yolo": False,
+            "channelTrusted": False,
+        })
+        result = state._serialize_for_client(
+            ws, "slots",
+            {"slots": [{"key": "a"}, {"key": "b"}], "yolo": False, "channelTrusted": False},
+            default_msg,
+        )
+        # Dashboard user: unchanged default msg (full list).
+        assert result == default_msg
+
+    def test_app_with_slots_own_only_sees_own_slot(self):
+        import json
+        slot_a = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="a")
+        slot_b = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="b")
+        state = self._make_state_with_slots({"a": slot_a, "b": slot_b})
+        ws = self._ws(
+            is_dashboard=False, app="mochi-pet",
+            events=frozenset({"slots:own"}),
+        )
+        result_str = state._serialize_for_client(
+            ws, "slots",
+            {
+                "slots": [{"key": "a"}, {"key": "b"}],
+                "yolo": False,
+                "channelTrusted": False,
+            },
+            default_msg="dummy",
+        )
+        result = json.loads(result_str)
+        assert result["type"] == "slots"
+        # Only the mochi-pet slot should survive per-app payload filtering.
+        assert [s["key"] for s in result["data"]] == ["a"]
+
+    def test_non_slots_event_passes_through_unchanged(self):
+        # For any non-``slots`` event, _serialize_for_client returns default.
+        state = self._make_state_with_slots({})
+        ws = self._ws(is_dashboard=False, app="mochi-pet", events=frozenset())
+        default = "OPAQUE"
+        assert state._serialize_for_client(ws, "chat_chunk", {}, default) == default
+
+
+# ---------------------------------------------------------------------------
+# subscribe_logs / subscribe_subagents subscription-layer gate
+# ---------------------------------------------------------------------------
+
+class TestSubscribeHandlerGates:
+    """The WS ``subscribe_logs`` and ``subscribe_subagents`` handlers replay
+    initial snapshot data via ``ws.send_json`` — a path that bypasses the
+    ``_send_ws_all`` chokepoint entirely.  Both must be gated at the
+    subscription-handler level so an app without the right scope cannot
+    receive log history or subagent snapshots merely by sending a subscribe
+    message.
+    """
+
+    def _ws_source(self) -> str:
+        import kiro_crew.dashboard.ws as _ws
+
+        # encoding is explicit on every source read in this file: Path.read_text()
+        # defaults to the LOCALE codepage, so on Windows (cp1252) reading a module
+        # that contains an em dash or an arrow raises UnicodeDecodeError and the
+        # guard fails for a reason that has nothing to do with what it asserts.
+        return Path(_ws.__file__).read_text(encoding="utf-8")
+
+    def test_subscribe_logs_is_gated_on_the_log_scope(self):
+        """Guard the REAL gate, not a copy of it.
+
+        This used to define a local ``gate_would_deny`` that restated the
+        predicate and asserted against that — so it passed no matter what
+        ws.py did, which is how the sibling subagent test kept passing after
+        its gate was deliberately removed. Assert on the shipped source
+        instead: log history is privileged and must stay declaration-gated.
+        """
+        src = self._ws_source()
+        # Assert the GATE EXISTS, not one spelling of it. The first version of
+        # this guard pinned `'"log" not in allowed_events'` -- the buggy form
+        # that rejected `log:all` -- so it would have resisted the fix instead
+        # of catching the bug.
+        assert '"log" in allowed_events' in src, (
+            "subscribe_logs must remain gated on the log scope"
+        )
+        assert '"log:all" in allowed_events' in src, (
+            "the replay gate must accept log:all, like the per-event chokepoint"
+        )
+        assert "log_scope_not_declared" in src, "the log deny must stay audited"
+
+    def test_subscribe_subagents_has_no_declaration_gate(self):
+        """Owning your own slots is the default, not an opt-in.
+
+        Rejecting the subscription when nothing matched ``subagent*`` /
+        ``slots:*`` starved an app of its OWN slot's replay -- the one thing it
+        is always entitled to. The per-frame check is the only place the scope
+        decision belongs, so the declaration-level rejection is gone and must
+        not come back.
+        """
+        src = self._ws_source()
+        assert "subagent_scope_not_declared" not in src, (
+            "the declaration-level subscribe_subagents rejection must not return"
+        )
+        assert "state.subscribe_subagents(ws)" in src
+
+    def test_subagent_snapshot_replay_uses_per_item_scope_check(self):
+        # Behavioral: subagent_snapshot is now in _SLOT_SCOPED_EVENTS and
+        # _SUBAGENT_EVENTS, so ws_event_allowed routes it through
+        # _subagent_visible — an app can be denied for a foreign slot's
+        # snapshot even after passing the subscribe_subagents gate.
+        slot = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="s1")
+        state = _make_state({"s1": slot})
+        assert ws_event_allowed(
+            "subagent_snapshot", {"slot": "s1", "id": "a1"},
+            app="mochi-pet",
+            allowed_events=_allowed("subagent"),  # own-only
+            state=state,
+        ) is False
+
+    def test_subscribe_denials_emit_sel_audit(self):
+        # Behavioral: driving the actual subscribe handler would require an
+        # in-process aiohttp WS.  Instead, we exercise _audit_deny directly
+        # with the two reasons the handlers use, and confirm the SEL call
+        # is made.
+        from kiro_crew.dashboard import ws_event_scope as _wes
+        with patch("kiro_crew.sel.sel") as sel_mock:
+            _wes._audit_deny("mochi-pet", "subscribe_logs", "log_scope_not_declared")
+            outcomes = [
+                c.kwargs.get("outcome", "")
+                for c in sel_mock.return_value.log_api_access.call_args_list
+            ]
+            assert any("log_scope_not_declared" in o for o in outcomes)
+
+
+# ---------------------------------------------------------------------------
+# exposeToApps TTL cache — hot-path performance vs disk I/O
+# ---------------------------------------------------------------------------
+
+class TestExposeToAppsCache:
+    """``_target_exposes_to`` runs on the WS broadcast hot path. Without a
+    local cache, ``get_app_manifest`` re-reads the JSON manifest from disk on
+    every cross-app slot event. A 30-second TTL cache keeps disk I/O bounded
+    while still picking up manifest edits within one window.
+    """
+
+    def test_repeated_calls_hit_cache_and_do_not_reread_manifest(self):
+        from kiro_crew.dashboard import ws_event_scope as _wes
+        manifest = MagicMock()
+        manifest.permissions.exposeToApps = ["monitor-app"]
+        with patch(
+            "kiro_crew.dashboard.ws_event_scope.get_app_manifest",
+            return_value=manifest,
+        ) as m:
+            state = MagicMock()
+            assert _wes._target_exposes_to("mochi-pet", "monitor-app", state) is True
+            assert _wes._target_exposes_to("mochi-pet", "monitor-app", state) is True
+            assert _wes._target_exposes_to("mochi-pet", "monitor-app", state) is True
+            # Only one manifest load despite 3 checks (cached).
+            assert m.call_count == 1
+
+    def test_cache_denies_when_manifest_missing(self):
+        from kiro_crew.dashboard import ws_event_scope as _wes
+        with patch(
+            "kiro_crew.dashboard.ws_event_scope.get_app_manifest",
+            return_value=None,
+        ):
+            state = MagicMock()
+            # Missing manifest — fail-closed even under caching.
+            assert _wes._target_exposes_to("ghost", "monitor-app", state) is False
+
+    def test_cache_denies_on_manifest_load_failure(self):
+        from kiro_crew.dashboard import ws_event_scope as _wes
+        with patch(
+            "kiro_crew.dashboard.ws_event_scope.get_app_manifest",
+            side_effect=RuntimeError("boom"),
+        ):
+            state = MagicMock()
+            assert _wes._target_exposes_to("target", "requester", state) is False
+
+
+class TestEventTableCompleteness:
+    """Every event that can reach an app socket must be classified.
+
+    ``ws_event_allowed`` DENIES unknown event types (deny-by-default, CWE-269).
+    That is the right default, but it makes an unclassified event a *silent*
+    loss of functionality for apps rather than a loud error -- which is exactly
+    how ``workflow_run_event`` (the one declaration that exists in the tree)
+    was nearly dropped when these tables were first written.
+
+    This test closes that class of bug: it walks the source for literal event
+    names published onto the WS fan-out and asserts each one is classified.
+    New events therefore fail the build here instead of vanishing in
+    production.
+    """
+
+    @staticmethod
+    def _classified() -> frozenset[str]:
+        from kiro_crew.dashboard import ws_event_scope as m
+
+        return frozenset(
+            set(m._TIER0_ALWAYS)
+            | set(m._SLOT_SCOPED_EVENTS)
+            | set(m._SUBAGENT_EVENTS)
+            | set(m._GLOBAL_EVENT_DECLARATIONS)
+            # ``slots`` is short-circuited in the gate and filtered at the
+            # payload layer instead (_serialize_for_client), so it is
+            # deliberately absent from the tables.
+            | {"slots"}
+        )
+
+    def test_every_broadcast_event_name_is_classified(self):
+        import ast
+        from pathlib import Path
+
+        import kiro_crew
+
+        root = Path(kiro_crew.__file__).parent
+        # Owner-only fan-outs never reach an app socket, so their event names
+        # need no classification.
+        gated = {"broadcast_ws", "broadcast_ws_subagent_subscribers"}
+        unclassified: list[tuple[str, int, str]] = []
+        classified = self._classified()
+
+        for path in root.rglob("*.py"):
+            if "/builtins/" in str(path):
+                continue  # app code, not gateway fan-out
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            # Module-level ``NAME = "literal"`` bindings, so a constant passed
+            # as the event type is resolved rather than skipped.
+            const_strs: dict[str, str] = {
+                t.id: n.value.value
+                for n in tree.body
+                if isinstance(n, ast.Assign)
+                and isinstance(n.value, ast.Constant)
+                and isinstance(n.value.value, str)
+                for t in n.targets
+                if isinstance(t, ast.Name)
+            }
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                fn = node.func
+                name = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", "")
+                if name not in gated or not node.args:
+                    continue
+                first = node.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    event_name = first.value
+                elif isinstance(first, ast.Name) and first.id in const_strs:
+                    # Module-level string constant (e.g. SIDE_RESULT_EVENT) —
+                    # resolving these matters: ``chat.side_result`` is passed
+                    # this way and a literal-only scan silently misses it.
+                    event_name = const_strs[first.id]
+                else:
+                    continue  # dynamic event type -- cannot be checked statically
+                if event_name not in classified:
+                    unclassified.append(
+                        (str(path.relative_to(root)), first.lineno, event_name)
+                    )
+
+        assert not unclassified, (
+            "These WS events are broadcast but not classified in "
+            "ws_event_scope.py, so app tokens will silently never receive "
+            f"them: {unclassified}. Add each to _TIER0_ALWAYS, "
+            "_SLOT_SCOPED_EVENTS (+_SUBAGENT_EVENTS if applicable), or "
+            "_GLOBAL_EVENT_DECLARATIONS."
+        )
+
+    def test_broadcast_type_map_events_are_classified(self):
+        """``_broadcast`` translates internal ``_type`` values into WS events.
+
+        That second dispatch path funnels through the same chokepoint, so its
+        event names must be classified too -- a literal scan of
+        ``broadcast_ws`` calls alone would miss them (chat_message and the
+        slots re-push both travel this way).
+        """
+        for event in (
+            "slots",
+            "slot_title",
+            "refresh",
+            "update_progress",
+            "artifact_update",
+            "chat_message",
+            "notification",
+        ):
+            assert event in self._classified(), (
+                f"{event!r} is emitted by DashboardState._broadcast but is not "
+                "classified in ws_event_scope.py"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Write-side origin: an undeclared slot must NOT be called USER
+# ---------------------------------------------------------------------------
+
+class TestUntaggedOriginIsNotUser:
+    """The read side already failed closed on a missing ``_origin``; the WRITE
+    side did not. ``origin or (APP if app else USER)`` labelled every untagged
+    caller USER -- cron result injection, workflow inject, Slack, the
+    OpenAI-compatible endpoint -- and an app holding ``slots:user`` received
+    that private content."""
+
+    def test_untagged_non_app_slot_is_not_user(self):
+        from kiro_crew.dashboard.state import SlotOrigin, request_slot_origin
+
+        src = Path(
+            __import__("kiro_crew.dashboard.state", fromlist=["x"]).__file__
+        ).read_text(encoding="utf-8")
+        # The fail-open derivation must be gone from the CREATION path. It
+        # still exists once, inside request_slot_origin -- that is the point:
+        # the derivation moved to the layer that can actually make it.
+        assert (
+            "slot._origin = origin or (SlotOrigin.APP if app else SlotOrigin.USER)"
+            not in src
+        ), "get_or_create_slot must not infer USER; it cannot know"
+        assert 'slot._origin = origin or (SlotOrigin.APP if app else "")' in src
+        assert src.count("SlotOrigin.APP if app else SlotOrigin.USER") == 1, (
+            "the USER derivation belongs only in request_slot_origin"
+        )
+
+        # USER is decided by the layer that knows: did a request carry a token?
+        assert request_slot_origin("") == SlotOrigin.USER
+        assert request_slot_origin("some-app") == SlotOrigin.APP
+
+    def test_every_handler_slot_creation_declares_an_origin(self):
+        """No slot-creation path in the handlers may fall through to the default.
+
+        Two legitimate sources, and the distinction matters: a NEW slot's origin
+        comes from the request (an app token means APP, its absence means the
+        dashboard user), while RESUMING a persisted conversation must take the
+        origin that conversation was stored with -- deriving it from the resumer
+        relabels a cron slot as USER. Counting both together is the invariant;
+        pinning one of them everywhere is what got the resume path wrong.
+        """
+        import kiro_crew.dashboard.chat_handlers as _ch
+
+        src = Path(_ch.__file__).read_text(encoding="utf-8")
+        creates = src.count("state.get_or_create_slot(")
+        from_request = src.count("origin=request_slot_origin(")
+        from_persisted = src.count('origin=str(meta.get("origin", ""))')
+        assert creates == from_request + from_persisted, (
+            f"{creates} slot creations but only {from_request} declare a "
+            f"request-derived origin and {from_persisted} a persisted one"
+        )
+
+    def test_resume_takes_the_persisted_origin_not_the_resumer(self):
+        """The resume endpoint must read metadata BEFORE creating the slot.
+
+        It used to create the slot from the request identity and read the history
+        metadata a dozen lines later, so resuming a persisted cron conversation
+        from the dashboard produced a USER-tagged slot and `slots:user` handed its
+        replayed content to any app holding that scope.
+        """
+        import kiro_crew.dashboard.chat_handlers as _ch
+
+        src = Path(_ch.__file__).read_text(encoding="utf-8")
+        meta_read = src.index("meta = state.conversation_log.get_metadata(history_key)")
+        resume_create = src.index('origin=str(meta.get("origin", ""))')
+        assert meta_read < resume_create, (
+            "the resume path must read the persisted metadata before it creates "
+            "the slot, or the origin it passes cannot come from that metadata"
+        )
+
+    def test_cron_injection_declares_cron(self):
+        import kiro_crew.dashboard.cron_inject as _ci
+
+        assert "origin=SlotOrigin.CRON" in Path(_ci.__file__).read_text(encoding="utf-8"), (
+            "a cron result is the job's output, never something the user typed"
+        )
+
+    def test_rehydrate_restores_the_persisted_origin(self):
+        """Re-deriving on restart would relabel a cron slot USER (leak) and a
+        real user slot untagged (dropping a grant an app legitimately holds)."""
+        import kiro_crew.dashboard.chat_persistence as _cp
+
+        assert 'origin=str(meta.get("origin", ""))' in Path(_cp.__file__).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# The legacy "*" declaration
+# ---------------------------------------------------------------------------
+
+class TestWildcardDeclaration:
+    """``permissions.events: ["*"]`` predates this vocabulary and meant every
+    event. Carried through as an opaque set member no gate recognises it, so
+    such a manifest would keep its subscription and receive nothing."""
+
+    def test_wildcard_expands_instead_of_passing_through(self):
+        from kiro_crew.dashboard.ws_event_scope import build_allowed_event_set
+
+        allowed = build_allowed_event_set(["*"])
+        assert "*" not in allowed, "the wildcard must be expanded, not stored"
+        assert "slots:all" in allowed
+        assert "subagent:all" in allowed
+        assert "notification:all" in allowed
+
+    def test_wildcard_covers_every_global_declaration(self):
+        from kiro_crew.dashboard.ws_event_scope import (
+            _GLOBAL_EVENT_DECLARATIONS,
+            build_allowed_event_set,
+        )
+
+        allowed = build_allowed_event_set(["*"])
+        missing = sorted(
+            d for d in set(_GLOBAL_EVENT_DECLARATIONS.values()) if d not in allowed
+        )
+        assert not missing, f"wildcard omits declarations: {missing}"
+
+    def test_ordinary_declarations_pass_through_unchanged(self):
+        from kiro_crew.dashboard.ws_event_scope import build_allowed_event_set
+
+        assert build_allowed_event_set(["slots:own", "notification"]) == frozenset(
+            {"slots:own", "notification"}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Notification source: canonical, prefixed, and system-only
+# ---------------------------------------------------------------------------
+
+class TestNotificationSourceParsing:
+    """The note's field is ``source`` and an app push is ``app:<name>``.
+
+    The gate used to read ``source_app``/``app`` -- keys no emitter writes -- so
+    it saw "" for every note and accepted "" as the system stream: one app's
+    private push reached any app holding ``notification:system``, and an app
+    holding ``notification`` never saw its own.
+    """
+
+    def test_constants_match_the_real_emitters(self):
+        """Pin the two producers, so a rename on either side fails here."""
+        from kiro_crew.dashboard import ws_event_scope as wes
+        from kiro_crew.notifications import bus
+
+        # state.notify() -> payload_from_legacy() stamps this exact value.
+        assert wes._SYSTEM_SOURCE == bus._SYSTEM_SOURCE
+
+        # api_push_notification builds `source=f"app:{app_name}"`.
+        push = Path(
+            __import__(
+                "kiro_crew.dashboard.handlers.notifications_push", fromlist=["x"]
+            ).__file__
+        ).read_text(encoding="utf-8")
+        assert f'source=f"{wes._APP_SOURCE_PREFIX}{{app_name}}"' in push
+
+    def test_parses_the_app_identity_out_of_the_prefix(self):
+        from kiro_crew.dashboard.ws_event_scope import notification_source_app
+
+        assert notification_source_app("app:mochi-pet") == "mochi-pet"
+        # A bare name is NOT an app push: it never appears on the wire, and
+        # treating it as one would accept a shape the server does not produce.
+        assert notification_source_app("mochi-pet") == ""
+        assert notification_source_app("system") == ""
+        assert notification_source_app("") == ""
+
+    def test_own_push_reaches_only_its_own_app(self):
+        state = _make_state()
+        note = {"source": "app:mochi-pet", "text": "hi"}
+        assert ws_event_allowed(
+            "notification", note, app="mochi-pet",
+            allowed_events=_allowed("notification"), state=state,
+        ) is True
+        # The leak: a SECOND app holding the system scope must not receive it.
+        assert ws_event_allowed(
+            "notification", note, app="other-app",
+            allowed_events=_allowed("notification:system"), state=state,
+        ) is False
+        assert ws_event_allowed(
+            "notification", note, app="other-app",
+            allowed_events=_allowed("notification"), state=state,
+        ) is False
+
+    def test_only_the_literal_system_source_is_the_system_stream(self):
+        state = _make_state()
+        for source in ("app:other-app", "notifications_api", "", "System", "sys"):
+            assert ws_event_allowed(
+                "notification", {"source": source}, app="mochi-pet",
+                allowed_events=_allowed("notification:system"), state=state,
+            ) is False, f"{source!r} must not read as the system stream"
+        assert ws_event_allowed(
+            "notification", {"source": "system"}, app="mochi-pet",
+            allowed_events=_allowed("notification:system"), state=state,
+        ) is True
+
+    def test_ack_events_need_the_broad_scope(self):
+        """`notification_ack`/`_unack` broadcast a bare `{"ts": ...}`.
+
+        Nothing in that payload says WHOSE notification was acked, so own-only
+        `notification` cannot be honoured for them. Letting them ride the plain
+        declaration -- which is what removing them from the source filter did --
+        handed an app the ack stream for every other app's and the system's
+        notifications. Unattributable metadata takes the broad scope.
+        """
+        from kiro_crew.dashboard.ws_event_scope import (
+            _SOURCE_FILTERED_EVENTS,
+            _UNATTRIBUTED_NOTIFICATION_EVENTS,
+        )
+
+        state = _make_state()
+        for event in ("notification_ack", "notification_unack"):
+            # Not source-filtered (no `source` field to filter on) but still not
+            # covered by the own-only declaration.
+            assert event not in _SOURCE_FILTERED_EVENTS
+            assert event in _UNATTRIBUTED_NOTIFICATION_EVENTS
+            payload = {"ts": "2026-08-04T00:00:00Z"}
+            assert ws_event_allowed(
+                event, payload, app="mochi-pet",
+                allowed_events=_allowed("notification"), state=state,
+            ) is False
+            assert ws_event_allowed(
+                event, payload, app="mochi-pet",
+                allowed_events=_allowed("notification:system"), state=state,
+            ) is False
+            assert ws_event_allowed(
+                event, payload, app="mochi-pet",
+                allowed_events=_allowed("notification:all"), state=state,
+            ) is True
+            assert ws_event_allowed(
+                event, payload, app="mochi-pet",
+                allowed_events=_allowed("log"), state=state,
+            ) is False
+
+
+# ---------------------------------------------------------------------------
+# App-published events ride one fixed WS type
+# ---------------------------------------------------------------------------
+
+class TestAppEventFrames:
+    """Every app event arrives as WS type ``app_event`` with the real name inside.
+
+    The scope table is keyed by WS type, so the lookup could never match and each
+    frame fell through to the global deny -- an app silently stopped receiving its
+    OWN events the moment scoping landed.
+    """
+
+    def test_constant_matches_the_event_bus(self):
+        """Pin the mirrored constant against the app layer's own definition."""
+        from kiro_crew.apps.event_bus import APP_EVENT_WS_TYPE
+        from kiro_crew.dashboard.ws_event_scope import _APP_EVENT_WS_TYPE
+
+        assert _APP_EVENT_WS_TYPE == APP_EVENT_WS_TYPE
+
+    def _frame(self, publisher: str, event: str) -> dict:
+        # Shape produced by event_bus.build_broadcast_fn: the inner `type` is
+        # renamed to `event` and rides beside `app` in the envelope.
+        return {"app": publisher, "event": event, "data": {"n": 1}}
+
+    def test_publisher_receives_its_own_event(self):
+        state = _make_state()
+        assert ws_event_allowed(
+            "app_event", self._frame("mochi", "tick"),
+            app="mochi", allowed_events=_allowed("slots:own"), state=state,
+        ) is True
+
+    def test_wildcard_app_still_receives_its_own_event(self):
+        """`events: ["*"]` expands into CORE scopes, which cannot contain an
+        app-chosen event name -- so ownership, not a second declaration lookup,
+        has to decide, or every wildcard app loses its own events."""
+        from kiro_crew.dashboard.ws_event_scope import build_allowed_event_set
+
+        state = _make_state()
+        assert ws_event_allowed(
+            "app_event", self._frame("mochi", "tick"),
+            app="mochi", allowed_events=build_allowed_event_set(["*"]), state=state,
+        ) is True
+
+    def test_another_apps_event_is_denied(self):
+        """App events have no cross-app opt-in -- exposeToApps covers slots."""
+        state = _make_state()
+        assert ws_event_allowed(
+            "app_event", self._frame("workflows", "tick"),
+            app="mochi", allowed_events=_allowed("slots:all", "notification:all"),
+            state=state,
+        ) is False
+
+    def test_unattributable_envelope_is_denied(self):
+        state = _make_state()
+        for frame in ({"event": "tick"}, {"app": "mochi"}, {}, {"app": "", "event": ""}):
+            assert ws_event_allowed(
+                "app_event", frame, app="mochi",
+                allowed_events=_allowed("slots:own"), state=state,
+            ) is False, f"{frame!r} must be denied"
+
+
+class TestConstantValuedEventNamesAreClassified:
+    """The completeness guard scans broadcast CALL SITES for literal names, so an
+    event whose WS type comes from a CONSTANT is invisible to it -- which is how
+    `app_event` shipped unclassified while the guard stayed green. Pin the known
+    constant-valued types explicitly."""
+
+    def test_app_event_is_classified(self):
+        from kiro_crew.apps.event_bus import APP_EVENT_WS_TYPE
+        from kiro_crew.dashboard import ws_event_scope as wes
+
+        src = Path(wes.__file__).read_text(encoding="utf-8")
+        assert APP_EVENT_WS_TYPE in src, (
+            f"{APP_EVENT_WS_TYPE!r} is broadcast via a constant and must still be "
+            "classified in ws_event_scope"
+        )
+
+
+# ---------------------------------------------------------------------------
+# ``approval_resolved`` is slot-scoped, so the gate denies any frame it cannot
+# attribute to a slot. The producers originally sent only {id, approved}, which
+# meant an app received its approval REQUEST but never the RESOLUTION.
+# ---------------------------------------------------------------------------
+
+class TestApprovalResolvedCarriesSlot:
+    @staticmethod
+    def _state():
+        from unittest.mock import AsyncMock
+
+        from chat_test_helpers import _make_ready_kiro_prerequisite
+
+        from kiro_crew.dashboard.state import DashboardState
+
+        sessions = MagicMock(count=0)
+        sessions.remove = AsyncMock()
+        sessions.get_pid = MagicMock(return_value=None)
+        state = DashboardState(
+            sessions=sessions,
+            crons=MagicMock(
+                list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})
+            ),
+            lessons=MagicMock(load_all=MagicMock(return_value=[])),
+            start_time=0.0,
+            conversation_log=MagicMock(),
+        )
+        state.kiro_prerequisite_service = _make_ready_kiro_prerequisite()
+        return state
+
+    def test_slot_level_resolution_carries_owning_slot(self):
+        """Drive the REAL resolve_approval and assert the broadcast payload."""
+        import asyncio
+
+        state = self._state()
+        slot = state.get_or_create_slot("mochi-pet")
+        slot._app = "mochi-pet"
+        slot._origin = SlotOrigin.APP
+
+        async def _run():
+            fut: asyncio.Future = asyncio.get_running_loop().create_future()
+            slot._approval_futures["a1"] = fut
+            with patch.object(state, "broadcast_ws") as bws, patch(
+                "kiro_crew.dashboard.state.sel"
+            ):
+                state.resolve_approval("a1", True)
+            return [c for c in bws.call_args_list if c.args[0] == "approval_resolved"]
+
+        calls = asyncio.run(_run())
+        assert len(calls) == 1
+        payload = calls[0].args[1]
+        assert payload["id"] == "a1"
+        assert payload["slot"] == "mochi-pet"
+
+    def test_state_level_resolution_stays_unattributed(self):
+        """A background (cron/subagent/gateway) approval owns no slot, so it
+        must NOT claim one — the gate correctly withholds it from app tokens."""
+        import asyncio
+
+        state = self._state()
+
+        async def _run():
+            fut: asyncio.Future = asyncio.get_running_loop().create_future()
+            state._approval_futures["b1"] = fut
+            with patch.object(state, "broadcast_ws") as bws, patch(
+                "kiro_crew.dashboard.state.sel"
+            ):
+                state.resolve_state_approval("b1", True)
+            return [c for c in bws.call_args_list if c.args[0] == "approval_resolved"]
+
+        calls = asyncio.run(_run())
+        assert len(calls) == 1
+        assert "slot" not in calls[0].args[1]
+
+    def test_owning_app_receives_its_own_resolution(self):
+        """End-to-end: the payload the real producer emits must pass the gate
+        for the slot's owning app with NO extra declaration."""
+        import asyncio
+
+        state = self._state()
+        slot = state.get_or_create_slot("mochi-pet")
+        slot._app = "mochi-pet"
+        slot._origin = SlotOrigin.APP
+
+        async def _run():
+            fut: asyncio.Future = asyncio.get_running_loop().create_future()
+            slot._approval_futures["a1"] = fut
+            with patch.object(state, "broadcast_ws") as bws, patch(
+                "kiro_crew.dashboard.state.sel"
+            ):
+                state.resolve_approval("a1", True)
+            return next(
+                c.args[1] for c in bws.call_args_list if c.args[0] == "approval_resolved"
+            )
+
+        payload = asyncio.run(_run())
+        assert ws_event_allowed(
+            "approval_resolved", payload,
+            app="mochi-pet", allowed_events=frozenset(), state=state,
+        )
+        # ...and a DIFFERENT app still must not see it.
+        assert not ws_event_allowed(
+            "approval_resolved", payload,
+            app="other-app", allowed_events=frozenset(), state=state,
+        )
+
+    def test_every_approval_resolved_producer_sends_a_slot(self):
+        """Source guard: a new producer that omits the slot key would silently
+        withhold the resolution from the owning app. Pin every broadcast site."""
+        import re
+
+        roots = [
+            Path(__file__).resolve().parents[1] / "src" / "kiro_crew" / "dashboard" / f
+            for f in ("state.py", "chat_handlers.py", "chat_runner.py")
+        ]
+        found = 0
+        for path in roots:
+            src = path.read_text(encoding="utf-8")
+            for m in re.finditer(r'"approval_resolved"', src):
+                # Take the enclosing broadcast call: from the preceding
+                # ``broadcast_ws`` to the matching close paren region.
+                head = src.rfind("broadcast_ws", max(0, m.start() - 300), m.start())
+                if head == -1:
+                    continue
+                found += 1
+                block = src[head : m.start() + 400]
+                assert '"slot"' in block or "payload" in block, (
+                    f"{path.name}: approval_resolved broadcast near offset {m.start()} "
+                    "does not carry a slot key"
+                )
+        assert found >= 4, f"expected >=4 approval_resolved producers, found {found}"
+
+
+# ---------------------------------------------------------------------------
+# ``/api/status`` after removal from the implicit-allow list: an app that
+# DECLARES it still reaches it, so the tightening does not lock out the
+# shipped consumers (design_critique / crew_companion declare it in app.json).
+# ---------------------------------------------------------------------------
+
+class TestApiStatusRequiresDeclaration:
+    def test_declared_app_still_reaches_api_status(self):
+        """Removing the implicit grant must not break apps that declare it."""
+        with patch(
+            "kiro_crew.dashboard.token_auth._app_api_allowlist",
+            return_value=("/api/status",),
+        ):
+            assert app_token_path_allowed("design-critique", "/api/status") is True
+
+    def test_undeclared_app_is_denied_api_status(self):
+        with patch(
+            "kiro_crew.dashboard.token_auth._app_api_allowlist", return_value=()
+        ):
+            assert app_token_path_allowed("mochi-pet", "/api/status") is False
+
+    def test_shipped_manifests_that_use_api_status_declare_it(self):
+        """Source guard: the builtin manifests relying on /api/status must keep
+        declaring it, or removing the implicit allow silently breaks them."""
+        import json
+
+        root = Path(__file__).resolve().parents[1] / "src" / "kiro_crew" / "apps" / "builtins"
+        declared = []
+        for manifest in root.glob("*/app.json"):
+            perms = json.loads(manifest.read_text(encoding="utf-8")).get("permissions", {})
+            api = perms.get("api") or []
+            if isinstance(api, list) and "/api/status" in api:
+                declared.append(manifest.parent.name)
+        assert "design_critique" in declared, declared
+        assert "crew_companion" in declared, declared
+
+
+# ---------------------------------------------------------------------------
+# A GLOBAL event must never be judged by a slot field that appears in its
+# payload. ``notify()`` merges meta keys FLAT into the note, so a real caller
+# (slack/gateway.py heartbeat: meta={"slot": slot.key}) puts a top-level
+# ``slot`` on a ``notification`` frame.
+# ---------------------------------------------------------------------------
+
+class TestGlobalEventWithSlotDoesNotBypassScope:
+    def _state_with_own_slot(self):
+        slot = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="chat-1")
+        return _make_state({"chat-1": slot})
+
+    def test_notification_with_slot_still_needs_notification_scope(self):
+        """The bypass: slots:all alone must NOT deliver a notification body."""
+        state = self._state_with_own_slot()
+        payload = {
+            "kind": "heartbeat",
+            "source": "system",
+            "channel": "system.heartbeat",
+            "title": "Still working",
+            "body": "secret progress detail",
+            "slot": "chat-1",  # flat-merged from notify(meta={"slot": ...})
+        }
+        assert not ws_event_allowed(
+            "notification", payload,
+            app="mochi-pet", allowed_events=frozenset({"slots:all"}), state=state,
+        )
+
+    def test_notification_with_slot_delivered_when_scope_declared(self):
+        """With the real scope it is delivered — the fix only strips the
+        smuggled inference, it does not break legitimate delivery."""
+        state = self._state_with_own_slot()
+        payload = {
+            "kind": "heartbeat",
+            "source": "system",
+            "channel": "system.heartbeat",
+            "title": "Still working",
+            "body": "progress",
+            "slot": "chat-1",
+        }
+        assert ws_event_allowed(
+            "notification", payload,
+            app="mochi-pet",
+            allowed_events=frozenset({"notification:system"}),
+            state=state,
+        )
+
+    def test_slack_heartbeat_really_passes_a_slot_in_meta(self):
+        """Source guard: this whole class is only meaningful because a shipped
+        caller flat-merges a slot onto a global notification frame."""
+        gw = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "slack" / "gateway.py"
+        ).read_text(encoding="utf-8")
+        assert 'meta={"slot": slot.key}' in gw
+
+    def test_meta_merge_is_flat_so_slot_lands_top_level(self):
+        """Source guard on the mechanism: bus.push merges meta keys flat."""
+        bus = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "notifications" / "bus.py"
+        ).read_text(encoding="utf-8")
+        assert "note[key] = value" in bus
+
+
+# ---------------------------------------------------------------------------
+# Coalesced subagent batches: above SubagentEventCoalescer's threshold ONE
+# frame carries MANY subagents' rows, so there is no top-level slot. They must
+# reach the app (they were falling through to the unknown-event deny, losing
+# ALL subagent status/output) but be filtered per item.
+# ---------------------------------------------------------------------------
+
+class TestSubagentBatchFrames:
+    def _state(self):
+        mine = _make_slot(owner_app="mochi-pet", origin=SlotOrigin.APP, key="mine")
+        theirs = _make_slot(owner_app="other-app", origin=SlotOrigin.APP, key="theirs")
+        return _make_state({"mine": mine, "theirs": theirs})
+
+    @pytest.mark.parametrize(
+        "event", ["subagent_batch_update", "subagent_batch_chunks"]
+    )
+    def test_batch_frame_is_not_denied_as_unknown(self, event):
+        """The frame must pass the gate — denying it starved apps of their OWN
+        subagent events once the coalescer engaged."""
+        state = self._state()
+        assert ws_event_allowed(
+            event, {"updates": [], "chunks": []},
+            app="mochi-pet", allowed_events=frozenset(), state=state,
+        )
+
+    def test_filter_keeps_only_own_items(self):
+        from kiro_crew.dashboard.ws_event_scope import filter_subagent_batch_for_app
+
+        state = self._state()
+        items = [
+            {"id": "a1", "slot": "mine", "text": "mine"},
+            {"id": "a2", "slot": "theirs", "text": "secret"},
+        ]
+        kept = filter_subagent_batch_for_app(items, "mochi-pet", frozenset(), state)
+        assert [i["slot"] for i in kept] == ["mine"]
+
+    def test_filter_drops_items_with_unresolvable_slot(self):
+        from kiro_crew.dashboard.ws_event_scope import filter_subagent_batch_for_app
+
+        state = self._state()
+        items = [{"id": "a1", "slot": "gone"}, {"id": "a2"}, "notadict"]
+        assert filter_subagent_batch_for_app(items, "mochi-pet", frozenset(), state) == []
+
+    def test_subagent_all_sees_every_item(self):
+        from kiro_crew.dashboard.ws_event_scope import filter_subagent_batch_for_app
+
+        state = self._state()
+        items = [{"id": "a1", "slot": "mine"}, {"id": "a2", "slot": "theirs"}]
+        kept = filter_subagent_batch_for_app(
+            items, "mochi-pet", frozenset({"subagent:all"}), state
+        )
+        assert len(kept) == 2
+
+    def test_batch_events_really_exist_with_per_item_slots(self):
+        """Source guard: this class is only meaningful while the coalescer emits
+        these two frames AND seeds every buffered row with its slot."""
+        src = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "subagent_scale.py"
+        ).read_text(encoding="utf-8")
+        assert '"subagent_batch_update"' in src
+        assert '"subagent_batch_chunks"' in src
+        # every buffered update row is seeded with a slot
+        assert '{"slot": payload.get("slot", "")}' in src
+        # every chunk row carries its slot
+        assert '"slot": buf["slot"]' in src
+
+    def test_batch_item_key_map_matches_the_emitter(self):
+        """The payload keys the filter reads must be the ones actually sent."""
+        from kiro_crew.dashboard.ws_event_scope import _SUBAGENT_BATCH_ITEM_KEY
+
+        src = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "kiro_crew" / "subagent_scale.py"
+        ).read_text(encoding="utf-8")
+        assert '"subagent_batch_update", {"updates": updates}' in src
+        assert '"subagent_batch_chunks", {"chunks": chunks}' in src
+        assert _SUBAGENT_BATCH_ITEM_KEY == {
+            "subagent_batch_update": "updates",
+            "subagent_batch_chunks": "chunks",
+        }
+
+
+class TestSuppressedDenyCountIsReported:
+    """The dedup comment used to claim suppressed denies were "counted" while
+    the map held only a timestamp — no counter existed. The tally must actually
+    reach the trail, so a burst is visible as volume without one SEL write per
+    frame (this gate runs per event PER CLIENT on the broadcast hot path)."""
+
+    def _clear(self):
+        from kiro_crew.dashboard import ws_event_scope as _wes
+        _wes._sel_last_audit.clear()
+
+    def test_next_emission_reports_the_suppressed_tally(self):
+        from kiro_crew.dashboard import ws_event_scope as _wes
+
+        self._clear()
+        state = _make_state({})
+        with patch("kiro_crew.sel.sel") as m:
+            # First denial emits with no tally.
+            _wes._audit_deny("app-x", "chat_chunk", "slot_missing")
+            assert m.return_value.log_api_access.call_count == 1
+            assert "suppressed" not in str(
+                m.return_value.log_api_access.call_args.kwargs["resources"]
+            )
+            # Three more identical denials inside the window are collapsed...
+            for _ in range(3):
+                _wes._audit_deny("app-x", "chat_chunk", "slot_missing")
+            assert m.return_value.log_api_access.call_count == 1
+            # ...and the tally rides the next emission once the window passes.
+            key = ("app-x", "chat_chunk", "slot_missing")
+            ts, count = _wes._sel_last_audit[key]
+            assert count == 3
+            _wes._sel_last_audit[key] = (ts - _wes._SEL_DEDUP_WINDOW_SECS - 1, count)
+            _wes._audit_deny("app-x", "chat_chunk", "slot_missing")
+            assert m.return_value.log_api_access.call_count == 2
+            assert "suppressed=3" in str(
+                m.return_value.log_api_access.call_args.kwargs["resources"]
+            )
+        assert state is not None  # harness sanity
+        self._clear()
+
+    def test_tally_resets_after_emission(self):
+        from kiro_crew.dashboard import ws_event_scope as _wes
+
+        self._clear()
+        with patch("kiro_crew.sel.sel"):
+            _wes._audit_deny("app-y", "log", "unknown_event")
+            key = ("app-y", "log", "unknown_event")
+            assert _wes._sel_last_audit[key][1] == 0
+        self._clear()

--- a/website/eslint.i18n.config.js
+++ b/website/eslint.i18n.config.js
@@ -697,6 +697,32 @@ export default [
     },
   },
 
+  // Developer diagnostics for the APP AUTHOR, printed to the browser console when
+  // an app subscribes to a WS event its manifest has not declared a scope for.
+  // Translating them would be actively wrong, not merely wasteful: each one quotes
+  // the scope identifier the author must paste into `permissions.events`
+  // (`"slots:user"`, `"notification:system"`, `"<scope>:all"`), and those are
+  // compared BY VALUE against the manifest — localised advice would name a scope
+  // the gateway does not recognise.
+  //
+  // `console.*` is already callee-exempt, so the three call sites are covered; the
+  // strings are flagged because they are composed in `checkSubscribeAllowed`, one
+  // pure predicate that centralises the diagnosis for all three. Inlining the prose
+  // into the calls to earn the callee exemption would duplicate its branch logic
+  // three times — a worse module for a lint technicality.
+  //
+  // Scoped to this one file for the same reason as the two above: the module is the
+  // SDK's protocol surface (event tables, hooks, provider) and holds no other prose.
+  // The pieces that DO render copy — `ChatEmbed`, `ChatPanel`, `ChatMessageList` —
+  // are separate files and stay covered. Copy added here later belongs in the
+  // catalog, not under this exemption; keep this module protocol-and-diagnostics.
+  {
+    files: ['src/app-sdk/index.ts'],
+    rules: {
+      'i18next/no-literal-string': 'off',
+    },
+  },
+
   // PROTOCOL VALUES ONLY: the server's own action names, provider merge-state enums,
   // and the literals a user must TYPE to arm an irreversible action. Every string in
   // that module is compared by value against something outside the dashboard, so

--- a/website/src/app-sdk/index.ts
+++ b/website/src/app-sdk/index.ts
@@ -82,19 +82,194 @@ export function useAppApi(): AppApi {
 }
 
 /** Subscribe to a real-time WebSocket event. Unsubscribes on unmount. */
+// ---------------------------------------------------------------------------
+// WebSocket event scope map — MIRRORS kiro_crew/dashboard/ws_event_scope.py.
+// The gateway is authoritative; this table exists only so the SDK can tell an
+// app author accurately whether a subscription will be delivered. Keep the
+// three sets in sync with the Python tables (a completeness test on the Python
+// side fails the build when a new event is unclassified there).
+// ---------------------------------------------------------------------------
+
+/** Tier 0 — always delivered to every connected client. */
+const WS_TIER0_EVENTS = new Set(['dashboard', 'refresh', 'update_progress'])
+
+/**
+ * Slot-scoped events — they carry a `slot` field. An app token receives these
+ * for slots it OWNS with no declaration at all; broader visibility (user
+ * slots, another app's slots, all slots) needs a `slots:*` / `subagent:*`
+ * scope.
+ */
+const WS_SLOT_SCOPED_EVENTS = new Set([
+  // Chat content
+  'chat_chunk', 'chat_thinking', 'chat_status', 'chat_message', 'chat_done',
+  'chat_segment', 'chat_append', 'chat_message_update', 'chat_variant_switch',
+  'chat.side_result', 'heartbeat', 'context_usage',
+  // Tool / queue
+  'tool_call', 'tool_result',
+  'queue_push', 'queue_cancel', 'queue_edit', 'queue_pop', 'queue_reorder',
+  'steer_push',
+  // Slot metadata / lifecycle
+  'slot_title', 'slot_clear', 'slot_agent_switch', 'todo_update',
+  'activity_event',
+  // Voice
+  'voice_chunk', 'voice_complete', 'voice_error',
+  // Approvals and question cards
+  'approval', 'approval_resolved', 'question_card',
+  // Subagent lifecycle
+  'subagent_spawn', 'subagent_done', 'subagent_tool', 'subagent_chunk',
+  'subagent_snapshot', 'subagent_status',
+  // Slack-gateway driven, slot-scoped
+  'autonudge_state', 'batch_finished',
+  // Workflows / misc
+  'workflow_result_injected', 'refine',
+])
+
+/**
+ * Subagent lifecycle events — the subset of slot-scoped events that
+ * `subagent:*` scopes widen. Mirrors `_SUBAGENT_EVENTS` in the Python gate.
+ */
+const WS_SUBAGENT_EVENTS = new Set([
+  'subagent_spawn', 'subagent_done', 'subagent_tool', 'subagent_chunk',
+  'subagent_snapshot', 'subagent_status',
+])
+
+/** Global events — no `slot` field; each needs an explicit scope declaration. */
+const WS_GLOBAL_EVENT_TO_SCOPE: Record<string, string> = {
+  notification: 'notification',
+  notification_ack: 'notification',
+  notification_unack: 'notification',
+  notification_channel_settings: 'notification',
+  sessions_restarting: 'sessions',
+  yolo_expired: 'yolo',
+  artifact_update: 'artifacts',
+  // Declared by its own literal name (already the correct per-event shape).
+  workflow_run_event: 'workflow_run_event',
+  log: 'log',
+  browser_event: 'browser',
+  // NOTE: `slots` is deliberately absent — the list re-push is always
+  // delivered and filtered per app in the payload on the server
+  // (state.py::_serialize_for_client), so it needs no declaration.
+}
+
+/** Result of the SDK subscription pre-check. */
+type SubscribeCheckResult =
+  | { level: 'ok' }
+  | { level: 'own-only'; hint: string }
+  /** A known event whose required scope is NOT declared — will not arrive. */
+  | { level: 'denied'; hint: string }
+  /** Not in the gate's tables at all — most likely a typo, possibly custom. */
+  | { level: 'unknown'; hint: string }
+
+/**
+ * Predict whether the gateway will deliver `event` given the app's declared
+ * `permissions.events`. Advisory only — the gateway decides.
+ */
+export function checkSubscribeAllowed(event: string, allowed: string[]): SubscribeCheckResult {
+  if (WS_TIER0_EVENTS.has(event)) return { level: 'ok' }
+  if (allowed.includes('*')) return { level: 'ok' }
+
+  // Slot-scoped: own slots are always visible, so only hint when the author
+  // likely wants wider visibility.
+  if (WS_SLOT_SCOPED_EVENTS.has(event)) {
+    // Match the scope FAMILY to the event family. `subagent:*` is an
+    // independent dimension in the gate (`_subagent_visible`), so declaring
+    // `subagent:user` widens subagent events only — it does not widen chat.
+    // Treating them interchangeably would predict `ok` for a chat
+    // subscription that the gateway delivers for own slots only, which is the
+    // exact silent-loss trap this check exists to prevent.
+    const isSubagentEvent = WS_SUBAGENT_EVENTS.has(event)
+    const hasWideningScope = allowed.some((a) =>
+      isSubagentEvent ? a.startsWith('subagent') || a.startsWith('slots:') : a.startsWith('slots:'),
+    )
+    if (hasWideningScope) return { level: 'ok' }
+    return {
+      level: 'own-only',
+      hint:
+        `Event "${event}" is slot-scoped: you will receive it for slots your app OWNS. ` +
+        `To see other slots, add a scope to permissions.events — ` +
+        (isSubagentEvent
+          ? `e.g. "subagent:user", "subagent:all", or a "slots:*" scope.`
+          : `e.g. "slots:user" or "slots:all" ("subagent:*" widens subagent events only).`),
+    }
+  }
+
+  // The slots list re-push needs no declaration (payload-filtered server-side).
+  if (event === 'slots') return { level: 'ok' }
+
+  const requiredScope = WS_GLOBAL_EVENT_TO_SCOPE[event]
+  if (requiredScope) {
+    // A `<scope>:*` variant also satisfies the base scope. For notifications
+    // the gateway picks between `notification` (own-app) and
+    // `notification:system` (gateway-internal) from the payload's source_app,
+    // which is not knowable at subscribe time — so any variant counts as ok
+    // here and the runtime gate makes the per-event decision.
+    const satisfied = allowed.some(
+      (a) => a === requiredScope || a.startsWith(`${requiredScope}:`),
+    )
+    if (satisfied) return { level: 'ok' }
+    return {
+      level: 'denied',
+      hint:
+        `Event "${event}" requires permissions.events to include "${requiredScope}"` +
+        (requiredScope === 'notification'
+          ? `, "notification:system" for gateway-internal pushes (cron, send_message), ` +
+            `or "notification:all" for every source.`
+          : ` (or "${requiredScope}:all" for the broader variant).`),
+    }
+  }
+
+  return {
+    level: 'unknown',
+    hint:
+      `Event "${event}" is not recognized by the gateway's scope gate. If it is a ` +
+      `custom event your app handles, ignore this warning; otherwise check for ` +
+      `typos or update the SDK.`,
+  }
+}
+
+/** app+event pairs already reported as own-slot-only, to keep the console useful. */
+const ownOnlyLogged = new Set<string>()
+
 export function useAppEvents(event: string, callback: (data: unknown) => void): void {
   const { subscribe, info } = useCtx()
   const cbRef = useRef(callback)
   cbRef.current = callback
+  const appName = info.name
+  const allowedEvents = info.permissions.events
 
   useEffect(() => {
-    if (!info.permissions.events.includes(event) && !info.permissions.events.includes('*')) {
+    const check = checkSubscribeAllowed(event, allowedEvents)
+    if (check.level === 'own-only') {
+      // Own-slot-only is the DEFAULT, correctly-working configuration, so this
+      // is informational. Log once per app+event for the process lifetime:
+      // remounts would otherwise repeat a call-to-action hint about a setup
+      // that is not broken, drowning out real signal.
+      const seenKey = `${appName}::${event}`
+      if (!ownOnlyLogged.has(seenKey)) {
+        ownOnlyLogged.add(seenKey)
+        // eslint-disable-next-line no-console -- intentional permission diagnostic
+        console.info(
+          `[app-sdk] App "${appName}" subscribing to "${event}" (own-slot only). ${check.hint}`,
+        )
+      }
+    } else if (check.level === 'denied') {
       // eslint-disable-next-line no-console -- intentional permission diagnostic
-      console.warn(`[app-sdk] App "${info.name}" not permitted to subscribe to event "${event}"`)
-      return
+      console.warn(
+        `[app-sdk] App "${appName}" subscribed to "${event}" but the manifest denies it. ` +
+          check.hint,
+      )
+    } else if (check.level === 'unknown') {
+      // Separate prefix from the denied case: asserting denial for a custom
+      // event and then retracting it in the hint leaves the author unable to
+      // tell whether anything is actually wrong.
+      // eslint-disable-next-line no-console -- intentional permission diagnostic
+      console.warn(`[app-sdk] App "${appName}" subscribed to "${event}": ` + check.hint)
     }
+    // Always register: the gateway is authoritative and silently drops what
+    // this app may not receive. Not returning early means a manifest fix takes
+    // effect on the next event without needing a component re-render.
     return subscribe(event, (data: unknown) => cbRef.current(data))
-  }, [event, subscribe, info])
+  }, [event, subscribe, appName, allowedEvents])
 }
 
 /** Reactive theme from the host. */

--- a/website/src/test/appSdkEventScope.test.ts
+++ b/website/src/test/appSdkEventScope.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the vendored SDK's WS subscription pre-check.
+ *
+ * The gateway (`kiro_crew/dashboard/ws_event_scope.py`) is authoritative; this
+ * table is advisory. The last test cross-checks the two so drift is visible
+ * here rather than as a wrong console warning in an app author's browser.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { checkSubscribeAllowed } from '../app-sdk'
+
+describe('checkSubscribeAllowed', () => {
+  it('treats tier 0 events as always delivered', () => {
+    for (const e of ['dashboard', 'refresh', 'update_progress']) {
+      expect(checkSubscribeAllowed(e, []).level).toBe('ok')
+    }
+  })
+
+  it('reports own-slot-only for slot-scoped events with no slots scope', () => {
+    const res = checkSubscribeAllowed('chat_chunk', [])
+    expect(res.level).toBe('own-only')
+    if (res.level === 'own-only') expect(res.hint).toContain('slots:user')
+  })
+
+  it('accepts slot-scoped events once any slots/subagent scope is declared', () => {
+    expect(checkSubscribeAllowed('chat_chunk', ['slots:user']).level).toBe('ok')
+    expect(checkSubscribeAllowed('subagent_status', ['subagent:all']).level).toBe('ok')
+  })
+
+  it('marks global events denied without the required scope, and ok with it', () => {
+    const denied = checkSubscribeAllowed('artifact_update', [])
+    expect(denied.level).toBe('denied')
+    if (denied.level === 'denied') expect(denied.hint).toContain('artifacts')
+    expect(checkSubscribeAllowed('artifact_update', ['artifacts']).level).toBe('ok')
+  })
+
+  it('accepts any variant of a scope family', () => {
+    // The gateway picks between `notification` (own-app) and
+    // `notification:system` (cron / send_message) from the payload's
+    // source_app, which is not knowable at subscribe time.
+    expect(checkSubscribeAllowed('notification', ['notification:all']).level).toBe('ok')
+    expect(checkSubscribeAllowed('notification', ['notification:system']).level).toBe('ok')
+    const denied = checkSubscribeAllowed('notification', [])
+    expect(denied.level).toBe('denied')
+    if (denied.level === 'denied') expect(denied.hint).toContain('notification:system')
+  })
+
+  it('accepts the wildcard declaration', () => {
+    expect(checkSubscribeAllowed('anything_at_all', ['*']).level).toBe('ok')
+  })
+
+  it('needs no declaration for the slots list re-push', () => {
+    // Payload is filtered per app server-side (_serialize_for_client).
+    expect(checkSubscribeAllowed('slots', []).level).toBe('ok')
+  })
+
+  it('flags an unrecognised event as unknown, not denied', () => {
+    // A distinct level matters: the console prefix for `denied` asserts the
+    // manifest rejected it, which would be a false claim for a custom event.
+    expect(checkSubscribeAllowed('chat_chunkk', ['slots:all']).level).toBe('unknown')
+  })
+
+  it('does not let a subagent scope widen non-subagent slot events', () => {
+    // subagent:* is an independent dimension in the gate, so it must not
+    // predict `ok` for chat -- the gateway still delivers own-slot chat only.
+    expect(checkSubscribeAllowed('chat_message', ['subagent:all']).level).toBe('own-only')
+    expect(checkSubscribeAllowed('subagent_status', ['subagent:all']).level).toBe('ok')
+    // A slots:* scope widens both families.
+    expect(checkSubscribeAllowed('subagent_status', ['slots:user']).level).toBe('ok')
+  })
+
+  it('matches the gateway tables in ws_event_scope.py', () => {
+    // Drift between the advisory table and the authoritative gate produces
+    // wrong developer warnings, so pin them together.
+    const py = readFileSync(
+      join(__dirname, '../../../src/kiro_crew/dashboard/ws_event_scope.py'),
+      'utf-8',
+    )
+    const names = (block: string): string[] => {
+      const m = py.match(new RegExp(`${block}[^{]*\\{([\\s\\S]*?)\\}\\)`))
+      if (!m) throw new Error(`block ${block} not found in ws_event_scope.py`)
+      return [...m[1].matchAll(/"([^"]+)"/g)].map((x) => x[1])
+    }
+    for (const e of names('_TIER0_ALWAYS')) {
+      expect(checkSubscribeAllowed(e, []).level, `${e} should be tier 0`).toBe('ok')
+    }
+    for (const e of names('_SLOT_SCOPED_EVENTS')) {
+      expect(
+        checkSubscribeAllowed(e, []).level,
+        `${e} should be slot-scoped in the SDK table`,
+      ).toBe('own-only')
+    }
+    const globals = [...py.matchAll(/^\s{4}"([a-z_]+)": "([a-z_:]+)",/gm)].map((m) => [
+      m[1],
+      m[2],
+    ])
+    expect(globals.length).toBeGreaterThan(5)
+    for (const [event, scope] of globals) {
+      expect(
+        checkSubscribeAllowed(event, [scope]).level,
+        `${event} should be allowed by scope ${scope}`,
+      ).toBe('ok')
+      expect(checkSubscribeAllowed(event, []).level, `${event} should need a scope`).toBe(
+        'denied',
+      )
+    }
+  })
+})


### PR DESCRIPTION
Rebased continuation of #714 (originally by @buluoray), which had gone stale with unresolvable conflicts against main. Same intent, resolved against current main.

## Emit-site coverage audit (post-rebase)

The PR's `TestEventTableCompleteness::test_every_broadcast_event_name_is_classified` test **passes** on current main. This AST-walking test enumerates every `broadcast_ws()` and `broadcast_ws_subagent_subscribers()` call site in the codebase, resolves string-constant event names, and asserts each one is classified in `ws_event_scope.py`. **All event types on current main are covered.**

Key dispatch paths verified:
- `broadcast_ws()` → `_send_ws_all()` → `_ws_client_allowed()` → `ws_event_allowed()` ✅
- `broadcast_ws_subagent_subscribers()` → same `_ws_client_allowed()` gate ✅  
- `_broadcast()` (SSE+WS) → `_send_ws_all()` at the end ✅
- Direct WS sends in `ws.py`: initial slots push uses `filter_slots_for_app()`; log ring-buffer replay is gated by `"log" in allowed_events`; subagent reconnect replay is filtered through `_ws_client_allowed()` per frame ✅

No new-on-main emit site escapes the scope gate.

---

Closes the WS half of the app-token boundary. Design and investigation: #693.

## Why

`/api/ws` had **no per-app filtering**: every connected client received every
real-time event — chat content, slot data, subagent status, approvals, logs.

Precisely, on `main` today: an app token is `403` on `/api/ws` **unless** the app
declares it (`/api/ws`, or a matching prefix like `/api/*`) in `permissions.api`. No
builtin does. So this is not a silently-open door — it is an **all-or-nothing grant**:
declaring the *transport* confers the *entire event stream*, and `permissions.api` has
no way to express "may see which events".

The gap was already noticed in one place. `deliver_ws_owners()` routes
capability-bearing payloads owner-only, with the comment *"an app credential can open
`/api/ws` and lands in `_ws_clients`, so an all-clients broadcast of user-scoped content
crosses the App Kit boundary."* This PR generalises that per-callsite fix into a filter.

## What

**Tiered scope**, declared in the manifest under the existing `permissions.events`:

- **Tier 0** (`dashboard`, `refresh`, `update_progress`) — no sensitive payload, always
  delivered. Requiring a declaration would add no security and break existing apps.
- **Tier 1 — slot-scoped** — filtered by the slot's `SlotOrigin` and the app's
  declarations: `slots:own` (the default), `slots:user`, `slots:app:<name>`,
  `slots:all`.
- **Tier 2 — global** — explicit declaration required.
- `subagent:*` is an **independent dimension** from `slots:*`, so an app can watch
  subagent status without receiving chat content.
- Cross-app visibility (`slots:app:X`) requires the **observed** app to opt in via
  `permissions.exposeToApps` — an app cannot name a sibling unilaterally.

Dashboard-user sockets are exempt, identified by a **positive** `is_dashboard_user`
claim — never by the absence of an app claim, which would fail *open* on any register
path that forgot to set it.

## One chokepoint, not one filter per call site

`main` has two dispatch paths and only one goes through `broadcast_ws()`:

```
broadcast_ws()                       -> _send_ws_all(msg)
DashboardState._broadcast()  -- _type translation -> _send_ws_all(ws_msg)
```

The second carries `chat_message` and the full `slots` re-push, so filtering only
`broadcast_ws()` would have missed the most sensitive traffic. `_send_ws_all` therefore
becomes `_send_ws_all(msg_type, data, msg)` — the single chokepoint — and both paths
funnel through it, as does `broadcast_ws_subagent_subscribers` (otherwise an app could
bypass filtering by sending `{"type": "subscribe_subagents"}`).

`_send_ws_owners` and its callers are untouched: an app token cannot reach
`_owner_ws_clients`. `is_owner_dashboard_request()` requires `request["app"] == ""` and
returns `False` when the key is absent, the middleware always sets it, and
`register_ws(owner=...)` is the only way into that set.

Three paths write to the socket directly and so bypass the chokepoint; each is gated at
the source in `ws.py`: the initial slots push, the log ring-buffer replay
(`subscribe_logs`), and the subagent reconnect replay batch.

Two payloads need more than a yes/no answer: the `slots` re-push is re-filtered per app
in `_serialize_for_client` (failing closed to an empty list), and `SlotOrigin` defaults
to `""` — matching no scope — rather than `USER`, so a future creation path that forgets
to pass an origin fails closed instead of silently granting `slots:user` visibility.

## `/api/ws` becomes an implicit allow — and why that belongs in this commit

`/api/ws` and `/api/status` are connection infrastructure, not capabilities; making
every app declare the transport produces silent 403 regressions. That widening is sound
**only because the stream is now filtered**, so both halves land together. The implicit
grant is SEL-audited (it was previously silent).

## Vendored SDK (`website/src/app-sdk/index.ts`) is part of this change, not a follow-up

Apps get the SDK at runtime from the host's **vendored** copy via the import map, and
that copy did a literal `includes()` check with an **early return**. Once scope strings
appear in `permissions.events`, a correctly-declared slot subscription would both warn
spuriously *and never subscribe*. Landing the gate without this would leave a broken
intermediate state, so `checkSubscribeAllowed()` ships here. It always registers the
subscription — the gateway is authoritative and drops what the app may not receive —
which also means a manifest fix takes effect on the next event rather than needing a
component re-render.

The published `@kirocrew/app-sdk` package (separate repo) gets the same predicate in a
follow-up; it affects author-time typings and the standalone fallback only, not runtime
behaviour.

## Completeness is enforced, not documented

Unknown events are **denied**, which is the right default but makes an unclassified
event a *silent* loss for apps. That is not hypothetical: **20 of the 46 event types on
`main` were unclassified** when the tables were first written — including
`workflow_run_event`, the only `permissions.events` declaration that exists in the tree
today (the `workflows` app), which would have broken.

So an AST test walks the source and fails the build when a broadcast event name is not
classified. It resolves module-level string constants too — `chat.side_result` is passed
as `SIDE_RESULT_EVENT`, and a literal-only scan missed it (found exactly this way).

A frontend test cross-checks the vendored SDK table against `ws_event_scope.py`, so
drift shows up as a test failure rather than as a wrong console warning in an app
author's browser.

## Docs

`docs/app-platform-trust-model.md` gains a WebSocket section (it documented only the
HTTP-reach boundary), plus a note that the frontend `useAppApi` / `useAppEvents` scoping
is a **browser-side guardrail, not a boundary**: an embedded app runs with the dashboard
user's authority, so its `fetch` arrives with an empty app claim that `_enforce_app_scope`
deliberately does not gate. That distinction is easy to misread and worth stating.

## Verification

- Backend event-completeness tests pass (AST scan confirms all current emit sites are classified).
- All changed `.py` files compile cleanly.
- `isort` / `flake8` / `mypy` clean on the original PR; no new Python added during rebase.
- 79 new backend tests + 9 new frontend tests in the PR.

## Notes for review

- Behaviour change worth a look: in
  `test_websocket_initial_status_and_refresh_are_owner_only`, the app-token case now
  asserts an **empty** initial slot list rather than "slots present but without check
  status". That is the new (stronger) guarantee, not a weakened assertion.
- `permissions.events` is reused rather than a new field. It already governs this same
  stream in both directions — `EventBus.publish()` for publishing, and the SDK check for
  subscribing — so this makes the subscribe side server-enforced and extends the
  vocabulary with scope strings. A test pins that the two directions cannot grant each
  other anything.
