### PR TITLE
fix(cli): shut down chat cleanly on ctrl-c

### DIFF
--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -2174,7 +2174,7 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
         _jail_reexec_gate(args.command, getattr(args, "no_jail", False))
 
     if args.command == "chat":
-        asyncio.run(_chat(args.message, args.model, agent=getattr(args, "agent", None)))
+        _run_chat(args.message, args.model, agent=getattr(args, "agent", None))
     elif args.command == "gateway":
         # Seam-supplied pre-launch checks (CPP IdentityProvider seam). Runs
         # HERE in the gateway dispatch — not in boot_platform (which runs for
@@ -2347,7 +2347,7 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
 
 
 from kiro_crew.cli_bench import bench_cmd, register_bench_parser  # noqa: E402
-from kiro_crew.cli_chat import _chat  # noqa: E402
+from kiro_crew.cli_chat import _run_chat  # noqa: E402
 from kiro_crew.cli_cloud import add_size_choices as _cloud_size_choices  # noqa: E402
 from kiro_crew.cli_cloud import handle_cloud  # noqa: E402
 from kiro_crew.cli_commands import (  # noqa: E402

--- a/src/kiro_crew/cli_chat.py
+++ b/src/kiro_crew/cli_chat.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import gc
 import logging
 import os
@@ -110,17 +111,28 @@ async def _chat(message: str | None, model: str | None, agent: str | None = None
     provider: LLMProvider = build_provider_factory(cfg)(
         "cli_chat", agent=agent_name, channel_id=channel_id
     )
-    await provider.start()
+    try:
+        await provider.start()
 
-    if message:
-        await _send_and_print(provider, message)
-    else:
-        await _interactive(provider, cfg)
+        if message:
+            await _send_and_print(provider, message)
+        else:
+            await _interactive(provider, cfg)
+    finally:
+        try:
+            await provider.shutdown()
+        finally:
+            # Force GC so subprocess transports are collected while the loop is
+            # still open, avoiding "Event loop is closed" noise on exit.
+            gc.collect()
 
-    await provider.shutdown()
-    # Force GC so subprocess transports are collected while the loop is
-    # still open, avoiding "Event loop is closed" noise on exit.
-    gc.collect()
+
+def _run_chat(message: str | None, model: str | None, agent: str | None = None) -> None:
+    """Run chat at the sync CLI boundary and render SIGINT as a clean exit."""
+    try:
+        asyncio.run(_chat(message, model, agent=agent))
+    except KeyboardInterrupt:
+        print("\nBye! 👻")
 
 
 async def _send_and_print(provider: LLMProvider, message: str) -> None:

--- a/test/test_cli_chat.py
+++ b/test/test_cli_chat.py
@@ -1,0 +1,50 @@
+"""Regression tests for interrupting CLI chat."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew import cli_chat
+from kiro_crew.config import KiroCrewConfig
+
+
+def _patch_provider(monkeypatch) -> MagicMock:
+    provider = MagicMock()
+    provider.start = AsyncMock()
+    provider.shutdown = AsyncMock()
+    cfg = KiroCrewConfig()
+    monkeypatch.setattr(cli_chat.KiroCrewConfig, "load", classmethod(lambda cls: cfg))
+    monkeypatch.setattr(
+        cli_chat,
+        "build_provider_factory",
+        lambda config: lambda *args, **kwargs: provider,
+    )
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_cancelled_turn_shuts_down_provider(monkeypatch) -> None:
+    provider = _patch_provider(monkeypatch)
+    monkeypatch.setattr(
+        cli_chat,
+        "_send_and_print",
+        AsyncMock(side_effect=asyncio.CancelledError()),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await cli_chat._chat("hello", None)
+
+    provider.shutdown.assert_awaited_once()
+
+
+def test_run_chat_renders_keyboard_interrupt_as_clean_exit(monkeypatch, capsys) -> None:
+    def interrupt(coro) -> None:
+        coro.close()
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli_chat.asyncio, "run", interrupt)
+
+    cli_chat._run_chat(None, None)
+
+    assert capsys.readouterr().out == "\nBye! 👻\n"

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -557,6 +557,7 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "cli.py::_ensure_node",
         "cli.py::_node_ok",
         "cli.py::main",
+        "cli_chat.py::_run_chat",
         "cli_chat.py::_tui",
         # NOT a subprocess spawn: the AST heuristic matches ``asyncio.run`` (attr
         # ``run`` on base ``asyncio``), here used only to drive the now-async


### PR DESCRIPTION
## Problem / Motivation

Pressing Ctrl+C while `kirocrew chat` has a turn in flight exits with a raw double traceback. Because provider shutdown only ran after a normal return, the backend child could also be left for the orphan sweep.

## Why it matters

Interrupting a long or stalled CLI turn should not look like a crash or leave a child process running.

## What changed (motivation → approach → change)

`asyncio.Runner` cancels its main task before re-raising `KeyboardInterrupt` at the synchronous boundary. `_chat` now owns the provider lifecycle in a `try/finally`, ensuring shutdown and transport collection run during cancellation. A small synchronous wrapper catches the final `KeyboardInterrupt` and prints the existing clean exit message.

## Tests

- Added regression coverage that cancellation propagates only after provider shutdown.
- Added coverage that the synchronous boundary converts `KeyboardInterrupt` to `Bye! 👻` without a traceback.
- `pytest test/test_cli_chat.py -n0 -q`
- `pytest test/test_cli.py -n0 -q`

## Manual verification

Sent a real SIGINT during a fake in-flight provider stream. The stream unwound, provider shutdown completed, `Bye! 👻` printed, and the process exited 0 with no stderr traceback.

## Related Issues

Fixes #1665

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff