### PR TITLE
chore(deps-dev): bump pytest to 9.0.3 and pytest-split to 0.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ kirocrew = "kiro_crew.cli:main"
 [dependency-groups]
 # Pinned dev tool versions for reproducible CI. Bump as needed.
 dev = [
-    "pytest==8.4.1",
+    "pytest==9.0.3",
     "pytest-xdist==3.5.0",
     "pytest-timeout==2.2.0",
     "pytest-asyncio==0.20.3",
@@ -36,7 +36,7 @@ dev = [
     "coverage==7.10.6",
     "pytest-cov>=5",
     # Duration-balanced test sharding across parallel CI jobs (--splits/--group).
-    "pytest-split==0.9.0",
+    "pytest-split==0.11.0",
     "flake8==7.1.0",
     "mypy==1.14.1",
     "black==26.3.1",


### PR DESCRIPTION
## Summary

Bumps pytest from 8.4.1 to 9.0.3 (security fix: CVE-2025-71176) and bumps pytest-split from 0.9.0 to 0.11.0 to resolve the dependency conflict.

### Problem

Dependabot PR #1785 bumped pytest to 9.0.3 but left `pytest-split==0.9.0` pinned. pytest-split 0.9.0 requires `pytest>=5,<9`, making the dep group unresolvable — all backend CI jobs fail at the `Install dependencies` step with:

```
× No solution found when resolving dependencies:
╰─▶ Because pytest-split==0.9.0 depends on pytest>=5,<9 and you
    require pytest==9.0.3, we can conclude that your requirements are unsatisfiable.
```

### Fix

- `pytest`: 8.4.1 → 9.0.3
- `pytest-split`: 0.9.0 → 0.11.0 (adds pytest 9.x support, drops EOL Python 3.8/3.9)

All other pytest plugins (`pytest-xdist==3.5.0`, `pytest-timeout==2.2.0`, `pytest-asyncio==0.20.3`) are compatible with pytest 9 — verified via dry-run resolution.

No test code changes needed: no deprecated `py.path`, `pytest.yield_fixture`, or `pytest.warns(None)` usage found.

Closes #1785 (supersedes — that PR only bumped pytest without addressing the cascade).