### PR TITLE
fix: guard /api/voice/voices when aws CLI is absent

### DIFF
--- a/docs/system-specs/features/voice-streaming.md
+++ b/docs/system-specs/features/voice-streaming.md
@@ -119,7 +119,11 @@ instruction for two of the three kinds.
 - `GET /api/voice/voices` — list available Polly voices via `aws polly
   describe-voices` (respects `aws_profile`/`region`), cached in-process for 1
   hour. Each entry: `{ id, name, language, languageCode, gender, engines }`,
-  sorted by `languageCode` then `name`
+  sorted by `languageCode` then `name`. If the `aws` CLI is not resolvable on
+  the gateway's PATH (it is optional — the default Piper provider doesn't
+  need it), the endpoint returns `{ "voices": [] }` with a 200 instead of
+  erroring; the empty result is not cached, so the list recovers once `aws`
+  becomes available
 
 ## Content Filtering for Speech
 

--- a/src/kiro_crew/dashboard/chat_voice.py
+++ b/src/kiro_crew/dashboard/chat_voice.py
@@ -14,6 +14,7 @@ import contextlib
 import json
 import logging
 import os
+import shutil
 import tempfile
 import time
 
@@ -298,6 +299,17 @@ async def api_voice_voices(request: web.Request) -> web.Response:
     if _voices_cache is not None and (now - _voices_cache_ts) < _VOICES_CACHE_TTL:
         return web.json_response({"voices": _voices_cache})
 
+    if await asyncio.to_thread(shutil.which, "aws") is None:
+        # Polly voice listing needs the AWS CLI, which is optional (the
+        # default Piper provider works without it). When the gateway runs
+        # under launchd, its PATH may also lack the dirs where `aws` is
+        # installed (e.g. /usr/local/bin). Degrade to an empty list instead
+        # of a 500 + traceback. Not cached, so the list recovers as soon as
+        # `aws` becomes resolvable. The probe runs in a thread so a wedged
+        # network mount on PATH cannot stall the event loop.
+        logger.info("aws CLI not found on PATH — returning empty voices list")
+        return web.json_response({"voices": []})
+
     cmd = ["aws", "polly", "describe-voices", "--output", "json"]
     if _vc.aws_profile:
         cmd += ["--profile", _vc.aws_profile]
@@ -335,6 +347,17 @@ async def api_voice_voices(request: web.Request) -> web.Response:
             proc.kill()
         await proc.wait()
         return web.json_response({"error": "timeout"}, status=504)
+    except FileNotFoundError:
+        # Defense-in-depth behind the which() guard above: exec can still
+        # fail with ENOENT — the binary was removed between the check and
+        # the spawn, or `aws` is a script whose interpreter is missing.
+        # Same graceful degrade as the guard, with the exception logged so
+        # the non-PATH causes stay diagnosable.
+        logger.info(
+            "aws CLI could not be executed — returning empty voices list",
+            exc_info=True,
+        )
+        return web.json_response({"voices": []})
     except Exception:
         logger.exception("describe-voices error")
         return web.json_response({"error": "Failed to retrieve voices"}, status=500)

--- a/test/test_chat_voice.py
+++ b/test/test_chat_voice.py
@@ -372,6 +372,7 @@ class TestVoiceVoices:
             return proc
 
         monkeypatch.setattr("asyncio.create_subprocess_exec", mock_exec)
+        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/local/bin/aws")
 
         from kiro_crew.dashboard.chat_voice import api_voice_voices
         app = web.Application()
@@ -430,6 +431,7 @@ class TestVoiceVoices:
             return proc
 
         monkeypatch.setattr("asyncio.create_subprocess_exec", mock_exec)
+        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/local/bin/aws")
 
         from kiro_crew.dashboard.chat_voice import api_voice_voices
         app = web.Application()
@@ -464,6 +466,7 @@ class TestVoiceVoices:
             return proc
 
         monkeypatch.setattr("asyncio.create_subprocess_exec", mock_exec)
+        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/local/bin/aws")
 
         from kiro_crew.dashboard.chat_voice import api_voice_voices
         app = web.Application()
@@ -473,3 +476,61 @@ class TestVoiceVoices:
         async with TestClient(TestServer(app)) as client:
             resp = await client.get("/api/voice/voices")
             assert resp.status == 504
+
+    @pytest.mark.asyncio
+    async def test_voices_aws_not_found(self, tmp_path, monkeypatch):
+        """aws CLI absent from PATH → 200 with empty list, no subprocess spawn."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        mock_vc = MagicMock(aws_profile="", region="")
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._voices_cache", None)
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._voices_cache_ts", 0)
+
+        monkeypatch.setattr("shutil.which", lambda cmd: None)
+        spawn = AsyncMock()
+        monkeypatch.setattr("asyncio.create_subprocess_exec", spawn)
+
+        from kiro_crew.dashboard.chat_voice import api_voice_voices
+        app = web.Application()
+        app["state"] = _make_state(tmp_path)
+        app.router.add_get("/api/voice/voices", api_voice_voices)
+
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/api/voice/voices")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data == {"voices": []}
+        spawn.assert_not_called()
+        # The empty result must NOT be cached — the list should recover
+        # as soon as `aws` becomes resolvable.
+        from kiro_crew.dashboard import chat_voice
+        assert chat_voice._voices_cache is None
+
+    @pytest.mark.asyncio
+    async def test_voices_exec_file_not_found(self, tmp_path, monkeypatch):
+        """which() succeeds but the exec itself raises FileNotFoundError
+        (binary removed in between, or a script with a missing interpreter)
+        → same graceful empty-list degrade, no 500."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        mock_vc = MagicMock(aws_profile="", region="")
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._vc", mock_vc)
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._voices_cache", None)
+        monkeypatch.setattr("kiro_crew.dashboard.chat_voice._voices_cache_ts", 0)
+
+        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/local/bin/aws")
+
+        async def mock_exec(*args, **kwargs):
+            raise FileNotFoundError(2, "No such file or directory", "aws")
+
+        monkeypatch.setattr("asyncio.create_subprocess_exec", mock_exec)
+
+        from kiro_crew.dashboard.chat_voice import api_voice_voices
+        app = web.Application()
+        app["state"] = _make_state(tmp_path)
+        app.router.add_get("/api/voice/voices", api_voice_voices)
+
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/api/voice/voices")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data == {"voices": []}


### PR DESCRIPTION
## Problem / Motivation

`GET /api/voice/voices` shells out to `aws polly describe-voices` via
`create_subprocess_exec` unconditionally. On a host without the `aws` CLI on
`PATH` — common for a Dock-launched macOS app, whose launchd `PATH` omits
`/usr/local/bin` — the spawn raises `FileNotFoundError`, which the handler's
generic `except Exception` turns into an HTTP 500 plus a full ERROR traceback:

```
ERROR kiro_crew.dashboard.chat_voice: describe-voices error
Traceback (most recent call last):
  ...
FileNotFoundError: [Errno 2] No such file or directory: 'aws'
```

Voice is optional and defaults to local Piper (no AWS needed), so this fires
for users who never enabled Polly.

## Why it matters

Every load of the voice picker on such a host logs a full traceback and returns
a 500, making a benign "cloud voices unavailable" state look like a server
fault and cluttering the very logs I reach for when debugging. I ran into this
on my own machine — my `gateway.log` was filling with these `describe-voices`
tracebacks even though I've never turned voice on — which is what led me to
track it down.

## What changed (symptom → root cause → change)

- **Symptom:** 500 + ERROR traceback whenever `aws` is not on `PATH`.
- **Root cause:** `api_voice_voices` had no availability guard before spawning
  `aws`, unlike the sibling `synthesize_speech()` in `voice_reply.py`, which
  already guards with `shutil.which("aws")` and degrades quietly.
- **Change:** return `{"voices": []}` (200) with a one-line `logger.info` when
  `shutil.which("aws")` resolves nothing (the probe runs via `await asyncio.to_thread(...)` so a wedged network mount on `PATH` cannot stall the event loop), and add an `except FileNotFoundError` (ordered
  before the generic `except Exception`) for the case where `aws` resolves at `which()`-time but still cannot be exec'd (a TOCTOU removal after the check, or an `aws` that is not runnable — e.g. a script whose shebang interpreter is missing), degrading the same way.

Resolution deliberately stays on `shutil.which`/`PATH`:

- **Not** `platform_compat.trusted_system_bin()` — its trusted dirs are
  `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin` only; `aws` installs to
  `/usr/local/bin` (or a venv/`~/.local/bin`), so pinning would break Polly
  discovery on every machine. That primitive is for authz-backing OS
  introspection spawns; `describe-voices` backs no security decision.
- **Not** `env.augmented_path()` — that prepends same-uid-writable dirs, the
  resolution pattern #1621 is actively removing.

`shutil.which` resolves against the same `PATH` `create_subprocess_exec` uses,
so the guard adds no new resolution surface — it picks the exact binary exec
would, and the residual planted-binary risk is identical to the pre-existing
sibling spawn.

## Tests

`test/test_chat_voice.py`:

- **`test_voices_aws_not_found`** — `shutil.which` → `None`;
  asserts 200 + `{"voices": []}` and that `create_subprocess_exec` is
  **never called** (mutation-sensitive: removing the guard falls through to the
  spawn and fails).
- **`test_voices_exec_file_not_found`** — `which()` truthy but
  `exec` raises `FileNotFoundError`; asserts 200 + empty list (locks in the
  removed-between-check-and-spawn / missing-interpreter branch); the guard test also asserts the empty result is not cached, so the list recovers once `aws` appears.
- The three existing tests (`returns_list`, `cli_failure`, `timeout`) now pin
  `shutil.which` to a real path so they keep exercising the subprocess
  success/502/504 paths regardless of the CI host's `PATH`. `uses_cache` is
  untouched — the cache check runs before the new guard.

`test/test_spawn_audit.py` still passes: the spawn argv is unchanged, so the
`api_voice_voices` allowlist entry stays valid.

## Manual verification

- **Confirmed against the real logs:** 6 occurrences of this exact traceback in
  `~/.kiro/crew/gateway.log` on the running gateway (PID 81426), spanning
  ~3.5h, each `FileNotFoundError: [Errno 2] No such file or directory: 'aws'`
  at `chat_voice.py` → `create_subprocess_exec`.
- **Reproduced the fix in-process:** with `aws` stripped from `PATH`, the
  patched `api_voice_voices` returns `200 {"voices": []}` with a single INFO
  log and no ERROR/traceback (previously a 500 + traceback).
- **Local gate:** `pytest test/test_chat_voice.py` (20 passed) and
  `test/test_spawn_audit.py` (7 passed); `flake8`, `isort`, `mypy` clean on the
  changed files; `scripts/docs-lint.sh` passes.

## Screenshots / video

N/A — no user-visible UI change.

## Related Issues

None found — searched open issues for aws / PATH / voice and describe-voices;
no existing report.

## Adjacent, deliberately not in this PR

One behavior nuance for reviewers: previously the 500 made the frontend voice
picker fall back to its hardcoded `VOICE_OPTIONS_FALLBACK` list
(`website/src/pages/settings/VoicePanel.tsx`), because its guard is
`voicesQ.data?.voices ? … : FALLBACK` and an errored query leaves `data`
`undefined`. A clean empty `200` is truthy, so the picker now renders empty
instead. This is arguably more honest (with `aws` absent, Polly can't
synthesize, so those fallback voices were non-functional anyway), and the
frontend is outside this backend fix's scope. A one-line follow-up
(`voicesQ.data?.voices?.length ? …`) would restore the fallback for the empty
case; happy to fold it in or file it separately if you'd prefer.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated — `docs/system-specs/features/voice-streaming.md`
      notes the empty-list-when-aws-absent behavior
- [x] No secrets, credentials, or internal references in the diff



