### PR TITLE
fix(skills): persist the skill-usage ledger on Windows

### DIFF
--- a/src/kiro_crew/skill_usage.py
+++ b/src/kiro_crew/skill_usage.py
@@ -26,11 +26,11 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import tempfile
 import threading
 import time
 from pathlib import Path
+
+from kiro_crew.atomic_write import atomic_write
 
 logger = logging.getLogger(__name__)
 
@@ -185,24 +185,15 @@ class SkillUsageLedger:
             }
             self._dirty = False
         try:
-            self._path.parent.mkdir(parents=True, exist_ok=True)
-            fd, tmp = tempfile.mkstemp(
-                prefix=".skill-usage-", suffix=".tmp", dir=str(self._path.parent)
-            )
-            try:
-                # os.fdopen takes ownership of fd immediately, so fd is always
-                # closed on context exit even if fchmod/dump raises. Doing
-                # os.fchmod(fd, ...) BEFORE fdopen would leak fd if it raised
-                # (the finally only unlinks tmp, it does not close fd).
-                with os.fdopen(fd, "w") as fh:
-                    os.fchmod(fh.fileno(), 0o600)
-                    json.dump(payload, fh)
-                os.replace(tmp, self._path)
-            finally:
-                try:
-                    os.unlink(tmp)
-                except OSError:
-                    pass
+            # The shared helper, not a hand-rolled temp-file dance: it applies
+            # the mode through ``platform_compat.fchmod_safe`` (a no-op where
+            # ``os.fchmod`` does not exist) and retries the rename against the
+            # Windows window in which an indexer or AV scanner holds a transient
+            # handle on either path. Naming ``os.fchmod`` directly would raise
+            # AttributeError there, which the handler below does NOT catch: it
+            # would escape the method with ``_dirty`` already cleared, so this
+            # snapshot is dropped instead of being retried by that handler.
+            atomic_write(self._path, json.dumps(payload), mode=0o600)
         except OSError as exc:
             logger.warning("skill-usage: could not write %s: %s", self._path, exc)
             with self._lock:

--- a/test/test_skill_usage.py
+++ b/test/test_skill_usage.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 
+from kiro_crew import platform_compat, skill_usage
 from kiro_crew.skill_usage import (
     _MAX_AGE_SECS,
     SkillUsageLedger,
@@ -83,3 +85,69 @@ class TestSkillUsageLedger:
     def test_flush_noop_when_clean(self, tmp_path):
         led = _ledger(tmp_path)
         assert led.flush() is False  # nothing recorded → nothing to write
+
+
+def _quiet(tmp_path) -> SkillUsageLedger:
+    """A ledger whose debounce is armed, so the explicit flush is the only writer.
+
+    ``_last_flush`` starts at 0.0, so the first ``record`` would spawn the
+    background flush thread and race the assertions below — it snapshots under
+    the lock, so it can win the rename carrying a different tally.
+    """
+    led = _ledger(tmp_path)
+    led._last_flush = time.time()
+    return led
+
+
+class TestPersistenceWithoutPosixFchmod:
+    """The ledger has to persist where ``os.fchmod`` does not exist.
+
+    The attribute is hidden rather than these tests being confined to Windows, so
+    the guard runs on the POSIX matrix that carries most of CI. ``IS_POSIX`` is
+    flipped with it because ``fchmod_safe`` only reaches ``os.fchmod`` on POSIX:
+    deleting the name alone would exercise a combination no platform is ever in.
+    """
+
+    @staticmethod
+    def _as_windows(monkeypatch) -> None:
+        monkeypatch.delattr(os, "fchmod", raising=False)
+        assert not hasattr(os, "fchmod"), "precondition: os.fchmod must be hidden"
+        monkeypatch.setattr(platform_compat, "IS_POSIX", False)
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+
+    def test_flush_persists_when_os_fchmod_is_absent(self, tmp_path, monkeypatch):
+        self._as_windows(monkeypatch)
+        led = _quiet(tmp_path)
+        led.record("x")
+        led.record("x")
+
+        assert led.flush() is True, "the tally must reach disk, not be dropped"
+        # Assert the RELOAD, not the in-memory tally: a fresh ledger is what the
+        # ranking consults on the next run, and only that proves persistence.
+        assert _ledger(tmp_path).score("x")[0] == 2.0
+        # Cleared before the write and left cleared on success — a re-armed flag
+        # here would mean a successful write was recorded as failed.
+        assert led._dirty is False
+
+    def test_failed_write_rearms_dirty_so_the_next_flush_retries(self, tmp_path, monkeypatch):
+        self._as_windows(monkeypatch)
+        real = skill_usage.atomic_write
+        attempts: list[object] = []
+
+        def flaky(path, content, **kwargs):
+            attempts.append(path)
+            if len(attempts) == 1:
+                raise OSError("transient write failure")
+            return real(path, content, **kwargs)
+
+        monkeypatch.setattr(skill_usage, "atomic_write", flaky)
+        led = _quiet(tmp_path)
+        led.record("x")
+
+        assert led.flush() is False
+        assert led._dirty is True, "a failed write must re-arm, or the tally is lost"
+        assert not (tmp_path / "skill-usage.json").exists()
+
+        assert led.flush() is True
+        assert len(attempts) == 2
+        assert _ledger(tmp_path).score("x")[0] == 1.0

--- a/test/windows-expected-failures.txt
+++ b/test/windows-expected-failures.txt
@@ -219,7 +219,6 @@ test/test_session.py::TestResetWithPid::test_reset_with_pid_survives_shutdown_fo
 test/test_session_pid_sig.py::TestNoNofollowPlatform::test_lstat_open_swap_refused
 test/test_session_pid_sig.py::TestNoNofollowPlatform::test_regular_file_still_reads
 test/test_session_pid_sig.py::TestNoNofollowPlatform::test_symlink_present_at_lstat_refused
-test/test_skill_usage.py::TestSkillUsageLedger::test_persist_roundtrip
 test/test_slack_config_handlers.py::test_write_env_updates_adds_and_preserves
 test/test_slack_config_handlers.py::test_write_env_updates_is_atomic_and_owner_only
 test/test_slack_gateway.py::TestBgSessionDashboardBranch::test_bg_session_prints_dashboard_url


### PR DESCRIPTION
## Problem

On Windows, skill-usage snapshots fail to persist, so hotness history is absent
or stale after a restart. In-memory ranking still works for the lifetime of the
process: `record()` keeps updating `_hits` / `_last_seen`, and `score()` reads
them normally. What is lost is the snapshot, and with it everything the ledger
knows across restarts.

## Root cause

`SkillUsageLedger.flush()` calls `os.fchmod`, which does not exist on Windows.
`flush()`'s only handler catches `OSError`, so the `AttributeError` escapes the
method — and it escapes after `_dirty` was already cleared inside the lock.
`os.replace` is never reached, so nothing is written, and the `except` branch
that re-arms `_dirty` never runs, so that failure is not rescheduled by the
failure path. A later `record()` can still set `_dirty` again, but every flush
takes the same route and fails the same way.

## Fix

Route the write through the shared `atomic_write` helper:

```python
atomic_write(self._path, json.dumps(payload), mode=0o600)
```

replacing the hand-rolled `mkdir` / `mkstemp` / `fdopen` / `fchmod` / `replace` /
`unlink` sequence. The helper gives:

- portable mode handling via `platform_compat.fchmod_safe`, which is the shim
  `AGENTS.md`'s cross-platform table names for this call;
- a unique temp file and its cleanup;
- a bounded retry for the Windows rename, where an indexer or AV scanner holding
  a transient handle on either path fails `os.replace`;
- the requested `0o600` on POSIX, unchanged from what ships today.

Swapping only the `os.fchmod` call would leave the next line a bare `os.replace`,
which is the second Windows-hostile call in the same sequence.

`flush()`'s contract is unchanged: `True` on write, `False` with `_dirty`
re-armed on a failed write, `False` when clean.

## Tests

The failing Windows round-trip was already tracked in
`test/windows-expected-failures.txt`. This PR burns down that existing entry by
fixing the product path and enabling the test on Windows.

- `TestSkillUsageLedger::test_persist_roundtrip` — removed from the
  expected-failures list, so it now runs on the Windows matrix. This is the
  end-to-end regression.
- `test_flush_persists_when_os_fchmod_is_absent` — the tally reaches disk where
  `os.fchmod` is absent, and a **fresh ledger over the same path reloads it**.
  The reload is the assertion; an in-memory check would pass on process state
  alone.
- `test_failed_write_rearms_dirty_so_the_next_flush_retries` — a failed write
  returns `False` and re-arms `_dirty`; the next flush succeeds and the data is
  readable from a fresh ledger.

The attribute is hidden with `monkeypatch.delattr` rather than the tests being
confined to Windows, so they guard the Windows path from the POSIX matrix that
carries most of CI. `platform_compat.IS_POSIX` is flipped with it, because
`fchmod_safe` only reaches `os.fchmod` on POSIX — deleting the name alone would
exercise a combination no platform is ever in. This mirrors
`test_mcp_gateway_prewarm.py::test_flush_persists_when_os_fchmod_is_absent`,
which guards the same shape in `HotKeyStore`.

Temp-file cleanup is deliberately not re-tested here: it is `atomic_write`'s own
contract and `test_atomic_write_retry.py` already covers it, including after a
permanent rename failure. Asserting it from the ledger's tests would bind them to
the helper's internals.

## Validation

Run on native Windows 11, Python 3.10.

```
before:  3 failed, 7 passed
after:  10 passed, 0 skipped
```

Two of the three fail with `AttributeError: module 'os' has no attribute
'fchmod'` — the defect itself. The third (`test_failed_write_rearms_dirty...`)
fails structurally, because it patches `skill_usage.atomic_write`, which does not
exist before the fix; it is a contract guard on the retry path rather than
evidence of the bug.

`test/test_atomic_write_retry.py`: 7 passed — the helper's own contract is
unaffected.

`isort`, `flake8`, `mypy` and `git diff --check` clean on the changed files;
docs-lint and the diff-scoped brand gate pass.
