### PR TITLE
test(sandbox): pin the guidance branch instead of reading the host's AppArmor sysctl

### DIFF
--- a/test/test_sandbox_docker_detection.py
+++ b/test/test_sandbox_docker_detection.py
@@ -235,6 +235,14 @@ class TestWrapArgvDockerGuidance:
         monkeypatch.setattr(sandbox, "_inside_kirocrew_sandbox", lambda: False)
         monkeypatch.setattr(sandbox, "_inside_macos_sandbox", lambda: False)
         monkeypatch.setattr(sandbox, "is_docker_container", lambda: False)
+        # The guidance branch is chosen by reading the REAL
+        # /proc/sys/kernel/apparmor_restrict_unprivileged_userns. Ubuntu 23.10+
+        # ships that as 1 — including the GitHub-hosted runners — so without this
+        # stub the AppArmor branch answers instead of the generic one and the
+        # assertion below fails on CI while passing on any host that lacks the
+        # restriction. "Bare metal, no backend" is a claim about the scenario, not
+        # about the machine running the test.
+        monkeypatch.setattr(sandbox, "_apparmor_userns_restricted", lambda: False)
         monkeypatch.setattr(
             sandbox,
             "_last_unshare_failure",
@@ -248,3 +256,43 @@ class TestWrapArgvDockerGuidance:
             wrap_argv(["kiro-cli", "chat"], mode="auto")
         assert "install a supported sandbox backend" in str(exc_info.value)
         assert "KIROCREW_ALLOW_UNSANDBOXED" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_apparmor_restricted_host_gets_profile_guidance(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On an AppArmor-restricted host the remedy is the profile, not the opt-out.
+
+        The counterpart of the generic case above. Both branches are now asserted
+        against an EXPLICIT host state, so neither is decided by whatever kernel
+        happens to run the suite — which is how the generic case came to fail on
+        Ubuntu runners while passing locally.
+        """
+        from kiro_crew import sandbox
+        from kiro_crew.sandbox import SandboxUnavailableError, wrap_argv
+
+        monkeypatch.setattr(sandbox, "detect_backend", lambda **_kw: "none")
+        monkeypatch.setattr(sandbox, "_allow_unsandboxed_exec", lambda: False)
+        monkeypatch.setattr(sandbox, "_inside_kirocrew_sandbox", lambda: False)
+        monkeypatch.setattr(sandbox, "_inside_macos_sandbox", lambda: False)
+        monkeypatch.setattr(sandbox, "is_docker_container", lambda: False)
+        monkeypatch.setattr(sandbox, "_apparmor_userns_restricted", lambda: True)
+        monkeypatch.delenv("APPIMAGE", raising=False)
+        monkeypatch.setattr(
+            sandbox,
+            "_last_unshare_failure",
+            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)"),
+        )
+        fake_sel = MagicMock()
+        fake_sel.return_value = fake_sel
+        monkeypatch.setattr(sandbox, "sel", fake_sel, raising=False)
+
+        if not sys.platform.startswith("linux"):
+            pytest.skip("AppArmor userns restriction is a Linux-only branch")
+
+        with pytest.raises(SandboxUnavailableError) as exc_info:
+            wrap_argv(["kiro-cli", "chat"], mode="auto")
+        message = str(exc_info.value)
+        assert "apparmor_restrict_unprivileged_userns" in message
+        # The profile is offered before the opt-out, and the opt-out is still named.
+        assert message.index("kirocrew service install") < message.index("last resort")


### PR DESCRIPTION
## What is the problem?

`Backend Tests` shard 3 is red on Python 3.10 and 3.12 for **every** PR opened against current `main` (confirmed on #1791 and #1798, which share nothing else):

```
FAILED test/test_sandbox_docker_detection.py::TestWrapArgvDockerGuidance::test_bare_metal_no_backend_gets_generic_guidance
assert 'install a supported sandbox backend' in 'Sandbox backend unavailable and allow_unsandboxed_exec is not set. ...'
```

The test looks green to whoever wrote it and to anyone running it on a non-Ubuntu box, so the red arrives only in CI and belongs to nobody's diff.

## Why this issue matters to the user

Not user-facing, but corrosive: an inherited red shard on every PR is exactly the condition under which people stop reading CI. It also masks real shard-3 failures behind a known-red, and it defeats the readiness aggregator that other automation depends on.

## How our fix solves it

The test stubs `detect_backend`, `is_docker_container`, `_inside_macos_sandbox` and `_last_unshare_failure` — but the branch it asserts on is chosen by a *fifth* input it left alone. `_apparmor_userns_restricted()` reads the real `/proc/sys/kernel/apparmor_restrict_unprivileged_userns`; Ubuntu 23.10+ ships it as `1`, GitHub-hosted runners included. So CI takes the AppArmor branch — whose remedy is the per-application profile — while the assertion demands the generic branch's "install a supported sandbox backend". A host without the restriction takes the generic branch and passes. "Bare metal, no backend" was a claim about the machine running the suite, not about the scenario under test.

Stubbing that probe to `False` makes the intended host state explicit. And because the other branch was previously reached only by accident of the runner, it now gets its own test: on an AppArmor-restricted host the message must name `apparmor_restrict_unprivileged_userns` and offer `kirocrew service install` *before* the last-resort opt-out — the ordering #1527 deliberately introduced, which nothing was pinning.

No production code changes; this is a test-isolation fix.

## What tests we did

- `pytest test/test_sandbox_docker_detection.py` — 16 passed (15 before, plus the new AppArmor-branch test).
- **Mutation-verified the diagnosis, not just the fix:** forcing the probe to `True` on a host that lacks the restriction reproduces CI's failure with byte-identical assertion text, and flipping it back turns the shard green. That is what identifies the sysctl as the cause rather than the Python version or the shard split.
- `isort --check-only` and `flake8` clean on the changed file.

## Any other suggestions on the work

- The same shape almost certainly exists elsewhere: any test asserting on `wrap_argv` guidance text is one unstubbed `/proc` read away from being host-dependent. A fixture that pins all five sandbox probes at once would make that class impossible rather than fixed one test at a time.
- Separately red on the same PRs and **not** addressed here: `test/test_open_slots_persistence.py::test_restore_open_slots_async_yields_between_tabs` fails the Windows shard with `assert 5 == 6`. Left alone deliberately — a yield-count assertion is a different failure mode and folding it in would make this diff two unrelated fixes.

Fixes #1803
