### PR TITLE
fix(test): pin AppArmor predicate so no-backend guidance test is host-independent

### DIFF
--- a/test/test_sandbox_docker_detection.py
+++ b/test/test_sandbox_docker_detection.py
@@ -235,6 +235,13 @@ class TestWrapArgvDockerGuidance:
         monkeypatch.setattr(sandbox, "_inside_kirocrew_sandbox", lambda: False)
         monkeypatch.setattr(sandbox, "_inside_macos_sandbox", lambda: False)
         monkeypatch.setattr(sandbox, "is_docker_container", lambda: False)
+        # Pin the AppArmor predicate: without this the test asserts the GENERIC
+        # guidance but any host with kernel.apparmor_restrict_unprivileged_userns=1
+        # (the default on Ubuntu 23.10+, including GitHub's ubuntu-latest runners)
+        # takes the AppArmor branch instead, whose text deliberately omits the
+        # "install a supported sandbox backend" advice. Same convention as
+        # test_sandbox_backend_cache.py.
+        monkeypatch.setattr(sandbox, "_apparmor_userns_restricted", lambda: False)
         monkeypatch.setattr(
             sandbox,
             "_last_unshare_failure",


### PR DESCRIPTION
## Problem

`test/test_sandbox_docker_detection.py::TestWrapArgvDockerGuidance::test_bare_metal_no_backend_gets_generic_guidance`
**fails deterministically on `main`** — `Backend Tests (3.10, 3)` and
`Backend Tests (3.12, 3)`, with `Coverage Gate` failing downstream. Because PR CI
tests the merge with `main`, every open PR inherits the failure and cannot reach a
green rollup.

Observed on main's own CI: run
[31080059074](https://github.com/kirodotdev/KiroCrew/actions/runs/31080059074).

## Root cause

The test asserts the guidance contains `"install a supported sandbox backend"`, and
monkeypatches `detect_backend`, `_allow_unsandboxed_exec`, `_inside_kirocrew_sandbox`,
`_inside_macos_sandbox`, `is_docker_container` and `_last_unshare_failure` — but **not**
`_apparmor_userns_restricted`.

`_no_backend_guidance()` branches on exactly that predicate:

- **predicate false** → generic remedy text, which contains the asserted phrase;
- **predicate true** → AppArmor-specific remedy text, which *deliberately omits* that
  phrase. That omission is intentional and documented in the function's own docstring:
  on such a host a backend **does** exist and is one AppArmor profile away from working,
  so "install a backend" is actively misleading, and the only concrete thing the generic
  text offers is the opt-out that turns off the isolation the message exists to protect.

`kernel.apparmor_restrict_unprivileged_userns=1` is the **default on Ubuntu 23.10+**,
which includes GitHub's `ubuntu-latest` runners. So in CI the predicate is always true,
the AppArmor branch is always taken, and the assertion can never hold.

This is why it was not caught before merging: on a host without the restriction the
generic branch is taken and the test passes.

Verified directly against this source — with the predicate forced true the guidance ends:

```
...llows unsandboxed execution, but that removes the isolation this check exists to protect.
```

character-for-character what CI reported, and the asserted phrase is absent. With it
false, the phrase is present.

## Fix

Pin `_apparmor_userns_restricted` to `False` in that test, so it exercises the generic
branch its own docstring names ("On bare-metal Linux without user namespaces the generic
message is used") regardless of host.

This is the convention the suite already uses for this predicate — `test_sandbox_backend_cache.py`
pins it in **both** directions (`lambda: True` and `lambda: False`) precisely because
leaving it unpinned makes a test host-dependent. The new test simply omitted it.

## Scope

Deliberately a **one-line test-only change**, kept separate from any feature PR:

- it is unrelated to any in-flight feature work, so it does not belong in one of those diffs;
- it blocks *every* open PR, so it should land on its own rather than ride along behind
  one PR's review cycle.

No production behaviour changes. The AppArmor branch itself is untouched and still
covered by `test_sandbox_backend_cache.py`.

## Testing

- `test/test_sandbox_docker_detection.py` — 15 passed.
- Both branch directions of `_no_backend_guidance()` verified empirically (phrase present
  when the predicate is false, absent when true), which is what establishes the fix is
  non-vacuous rather than merely making a red test green.
