### PR TITLE
feat(cloud): add --subnet to pin cloud launch to an explicit subnet

### DIFF
--- a/docs/system-specs/modules/cloud.md
+++ b/docs/system-specs/modules/cloud.md
@@ -67,7 +67,7 @@ claim that a hostile in-process agent is fully contained.
 | Module | Role |
 |--------|------|
 | `aws.py` | The single `run_aws` chokepoint — fixed argv, no shell, sandbox-wrapped, `--profile` only (never boto3, never a raw key). `checked`/`checked_json`; `AccessDenied → exact IAM action` mapping; `env_credentials_hint()`. |
-| `ec2.py` | `deploy`/`status`/`stop`/`start`/`destroy` via `aws cloudformation` + `ec2`; AZ- **and egress-**aware `discover_network`; tag-based stateless discovery; `_validate_cidr`. `find_stack` verifies BOTH `kirocrew:managed=true` AND `kirocrew:instance==<tag>` before status/stop/start/destroy touch a stack — so a same-prefix managed stack with a different instance tag can't be acted on by the wrong `--tag`. |
+| `ec2.py` | `deploy`/`status`/`stop`/`start`/`destroy` via `aws cloudformation` + `ec2`; AZ- **and egress-**aware `discover_network` + `resolve_explicit_subnet` (`--subnet` pin, same guarantees); tag-based stateless discovery; `_validate_cidr`. `find_stack` verifies BOTH `kirocrew:managed=true` AND `kirocrew:instance==<tag>` before status/stop/start/destroy touch a stack — so a same-prefix managed stack with a different instance tag can't be acted on by the wrong `--tag`. |
 | `iam.py` | Least-privilege launcher policy generator (applied by the user, never by KiroCrew) + read-only reachability check + the **content-fixed instance permissions-boundary document** (`boundary_policy_document`/`boundary_arn`) and its constants (`BOUNDARY_NAME`). |
 | `ssm.py` | SSM `send-command` run-and-poll (base64-wrapped remote scripts) + `start-session` port-forward; `port_is_free` / `wait_for_local_port`. |
 | `login.py` | `kiro-cli` device-code / social sign-in on the box over SSM. |
@@ -97,15 +97,32 @@ a fallback when no `SourceBucket` is passed.
 `_subnet_egress_kinds` classifies each subnet's effective route table (explicit
 association, else the VPC main table) as NAT (`NatGatewayId`/`NetworkInterfaceId`
 default route) or IGW (`igw-` default route). It prefers a **NAT** subnet (works
-regardless of a public IP), then an **IGW** subnet — and the template's Instance
-`NetworkInterfaces` block forces `AssociatePublicIpAddress: true`, so an
-IGW-routed subnet works even when its `MapPublicIpOnLaunch` is false. A subnet
+regardless of a public IP), then an **IGW** subnet — and the launcher threads the
+resolved egress kind into the template's `AssociatePublicIp` parameter: **IGW →
+`true`** (the Instance `NetworkInterfaces` block attaches a public IP, so an
+IGW-routed subnet works even when its `MapPublicIpOnLaunch` is false), **NAT →
+`false`** (a private-subnet instance gets NO public IP — it would be unused
+surface and can violate SCPs that deny RunInstances-with-public-IP). A subnet
 with only a local route (no 0.0.0.0/0 egress) is never chosen — the deploy would
 otherwise hang to the `WaitCondition` timeout. An **explicit** route-table
 association overrides the main table even when it has no egress: a subnet bound
 to a local-only table is treated as no-egress (excluded from the main-table
-fallback), so it can't be mistaken for having the main table's egress. The
-optional SSH CIDR is also **normalized** (host bits cleared, `1.2.3.4/24` →
+fallback), so it can't be mistaken for having the main table's egress.
+
+`launch --subnet <subnet-id>` bypasses discovery entirely —
+`resolve_explicit_subnet` pins the launch to the given subnet (the only way to
+target a dedicated/private-subnet VPC while a default VPC exists, since
+discovery always prefers the default VPC). The explicit path keeps discovery's
+launch-time guarantees: the subnet must exist in the region, its AZ must offer
+the chosen instance type, and it must pass the same `_subnet_egress_kinds`
+egress check (NAT or IGW) — each failing fast with actionable text instead of
+hanging to the `WaitCondition` timeout, and the same NAT→no-public-IP /
+IGW→public-IP parameter wiring applies. `--subnet` applies only to a **new**
+stack; reusing an existing stack warns interactively that its network is fixed,
+and **hard-fails under `--yes`** — a script's explicitly requested pin must not
+be silently ignored.
+
+The optional SSH CIDR is also **normalized** (host bits cleared, `1.2.3.4/24` →
 `1.2.3.0/24`) so the SG ingress rule is canonical. `get_stack_failures` sorts the
 specific bootstrap reason ahead of CloudFormation's generic `[WaitCondition]`
 cascade lines (events are newest-first, so the generic line would otherwise bury

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1574,6 +1574,7 @@ Examples:
   kirocrew cloud launch                  # interactive: provision + configure + open dashboard
   kirocrew cloud launch --size power     # non-interactive size
   kirocrew cloud launch --new            # create a separate new instance
+  kirocrew cloud launch --subnet subnet-0abc…  # pin the launch to an exact subnet
   kirocrew cloud list                    # list your cloud instances
   kirocrew cloud connect                 # reopen the dashboard over SSM
   kirocrew cloud stop | start            # pause / resume (save cost)
@@ -1605,6 +1606,15 @@ Examples:
         default="",
         choices=_cloud_size_choices(),
         help="Instance size tier (default: balanced / interactive picker)",
+    )
+    _c_launch.add_argument(
+        "--subnet",
+        default="",
+        metavar="SUBNET_ID",
+        help="Launch into this exact subnet (subnet-xxxx) instead of network "
+        "auto-discovery — required to target a dedicated/private-subnet VPC "
+        "when a default VPC exists. The subnet must have internet egress "
+        "(NAT or IGW route).",
     )
     _c_launch.add_argument("-y", "--yes", action="store_true", help="Accept defaults, no prompts")
     _c_launch.add_argument(

--- a/src/kiro_crew/cli_cloud.py
+++ b/src/kiro_crew/cli_cloud.py
@@ -51,6 +51,7 @@ def _cloud_launch(args: argparse.Namespace) -> int:
         profile=profile,
         region=region,
         size_key=getattr(args, "size", "") or "",
+        subnet_id=getattr(args, "subnet", "") or "",
         assume_yes=getattr(args, "yes", False),
         force_new=getattr(args, "new", False),
         keep_on_failure=getattr(args, "keep_on_failure", False),

--- a/src/kiro_crew/cloud/ec2.py
+++ b/src/kiro_crew/cloud/ec2.py
@@ -87,6 +87,9 @@ _REPO_RE = re.compile(r"^[A-Za-z0-9_.:/@+-]{1,255}$")
 _REPO_SPEC = FieldSpec(name="repo", type=str, max_len=255, pattern=_REPO_RE)
 _REF_RE = re.compile(r"^[A-Za-z0-9_./-]{1,128}$")
 _REF_SPEC = FieldSpec(name="ref", type=str, max_len=128, pattern=_REF_RE)
+# EC2 subnet ids are `subnet-` + 8 (EC2-Classic era) or 17 hex chars.
+_SUBNET_ID_RE = re.compile(r"^subnet-[0-9a-f]{8,17}$")
+_SUBNET_ID_SPEC = FieldSpec(name="subnet_id", type=str, max_len=24, pattern=_SUBNET_ID_RE)
 
 
 def _validate_cidr(cidr: str) -> str:
@@ -158,6 +161,10 @@ def validate_tag(tag: str) -> str:
     return val
 
 
+def validate_subnet_id(subnet_id: str) -> str:
+    return validate_field(subnet_id, _SUBNET_ID_SPEC) or ""
+
+
 @dataclass
 class DeployResult:
     """Outcome of a launch."""
@@ -199,8 +206,14 @@ def azs_offering_instance_type(instance_type: str, profile: str, region: str) ->
     return {o.get("Location", "") for o in offerings if o.get("Location")}
 
 
-def discover_network(profile: str, region: str, instance_type: str = "") -> tuple[str, str]:
-    """Resolve a (vpc_id, subnet_id) to launch into.
+def discover_network(
+    profile: str, region: str, instance_type: str = ""
+) -> tuple[str, str, str]:
+    """Resolve a (vpc_id, subnet_id, egress_kind) to launch into.
+
+    ``egress_kind`` is ``"nat"`` or ``"igw"`` — the caller uses it to decide
+    whether the instance needs a public IP (IGW egress requires one; a NAT
+    subnet must NOT get one).
 
     Prefers the account's **default VPC** and a public subnet within it. When an
     ``instance_type`` is given, the subnet is chosen in an AZ that actually
@@ -228,7 +241,7 @@ def discover_network(profile: str, region: str, instance_type: str = "") -> tupl
         if len(vpc_list) != 1:
             raise aws.AWSError(
                 "no default VPC found — create one (`aws ec2 create-default-vpc`) "
-                "or specify a VPC/subnet, then retry.",
+                "or pass `--subnet <subnet-id>`, then retry.",
                 action="ec2:DescribeVpcs",
             )
     vpc_id = vpc_list[0]["VpcId"]
@@ -271,20 +284,72 @@ def discover_network(profile: str, region: str, instance_type: str = "") -> tupl
     egress = _subnet_egress_kinds(vpc_id, profile, region)  # {subnet_id: "igw"|"nat"}
     nat = [s for s in candidates if egress.get(s["SubnetId"]) == "nat"]
     if nat:
-        return vpc_id, nat[0]["SubnetId"]
+        return vpc_id, nat[0]["SubnetId"], "nat"
     igw = [s for s in candidates if egress.get(s["SubnetId"]) == "igw"]
     if igw:
         # Prefer one that also auto-assigns a public IP, but the template's
-        # AssociatePublicIpAddress makes any IGW subnet workable.
+        # conditional AssociatePublicIpAddress makes any IGW subnet workable.
         igw.sort(key=lambda s: not s.get("MapPublicIpOnLaunch"))
-        return vpc_id, igw[0]["SubnetId"]
+        return vpc_id, igw[0]["SubnetId"], "igw"
     raise aws.AWSError(
         f"no subnet in VPC {vpc_id} has a verified internet egress route (internet "
         "gateway or NAT). KiroCrew needs outbound access to install packages and "
         "reach SSM. Add an internet gateway + public route (or a NAT), or pass a "
-        "subnet that has one, then retry.",
+        "subnet that has one via `--subnet`, then retry.",
         action="ec2:DescribeRouteTables",
     )
+
+
+def resolve_explicit_subnet(
+    subnet_id: str, profile: str, region: str, instance_type: str = ""
+) -> tuple[str, str, str]:
+    """Resolve a user-chosen ``--subnet`` to ``(vpc_id, subnet_id, egress_kind)``.
+
+    The explicit path skips VPC discovery entirely (the point of the flag:
+    launching into a dedicated VPC that auto-discovery would never pick while a
+    default VPC exists) but keeps the launch-time guarantees discover_network
+    provides: the subnet must exist, its AZ must offer ``instance_type``, and it
+    must have a verified internet-egress route (NAT or IGW) — a subnet without
+    egress would hang the launch until the WaitCondition timeout, so fail fast
+    with actionable text instead.
+    """
+    data = aws.checked_json(
+        ["ec2", "describe-subnets", "--subnet-ids", subnet_id],
+        profile,
+        region,
+        action="ec2:DescribeSubnets",
+    )
+    subnet_list = data.get("Subnets", []) if isinstance(data, dict) else []
+    if not subnet_list:
+        raise aws.AWSError(
+            f"subnet {subnet_id} not found in {region} — check the id and --region.",
+            action="ec2:DescribeSubnets",
+        )
+    subnet = subnet_list[0]
+    vpc_id = subnet.get("VpcId", "")
+    az = subnet.get("AvailabilityZone", "")
+    if instance_type:
+        try:
+            ok_azs = azs_offering_instance_type(instance_type, profile, region)
+        except aws.AWSError:
+            ok_azs = set()  # non-fatal — same fallback as discover_network
+        if ok_azs and az not in ok_azs:
+            raise aws.AWSError(
+                f"subnet {subnet_id} is in {az}, which does not offer "
+                f"{instance_type} — pick a subnet in one of "
+                f"{', '.join(sorted(ok_azs))}, or a different size.",
+                action="ec2:DescribeInstanceTypeOfferings",
+            )
+    egress = _subnet_egress_kinds(vpc_id, profile, region)
+    if subnet_id not in egress:
+        raise aws.AWSError(
+            f"subnet {subnet_id} has no verified internet egress route (NAT or "
+            "internet gateway). Kiro Crew needs outbound access to install "
+            "packages and reach SSM — add a NAT (or IGW) default route to the "
+            "subnet's route table, then retry.",
+            action="ec2:DescribeRouteTables",
+        )
+    return vpc_id, subnet_id, egress[subnet_id]
 
 
 def _subnet_egress_kinds(vpc_id: str, profile: str, region: str) -> dict:
@@ -360,6 +425,7 @@ def build_deploy_argv(
     tier: sizes.SizeTier,
     vpc_id: str,
     subnet_id: str,
+    associate_public_ip: str = "true",
     permissions_boundary_arn: str,
     repo: str = "",
     ref: str = "",
@@ -381,6 +447,7 @@ def build_deploy_argv(
         f"VolumeSizeGb={tier.disk_gb}",
         f"VpcId={vpc_id}",
         f"SubnetId={subnet_id}",
+        f"AssociatePublicIp={associate_public_ip}",
         f"StackTag={tag}",
         f"PermissionsBoundaryArn={permissions_boundary_arn}",
     ]
@@ -421,6 +488,7 @@ def deploy(
     tier: sizes.SizeTier,
     profile: str = "",
     region: str = "",
+    subnet_id: str = "",
     repo: str = "",
     ref: str = "",
     allow_ssh_cidr: str = "",
@@ -434,15 +502,19 @@ def deploy(
 
     When ``ship_source`` (default) the local source is packaged and uploaded to
     S3 so the instance installs from it (private-repo safe) instead of cloning
-    GitHub. ``dry_run`` returns the exact argv without calling AWS. ``proc_sink``
-    is forwarded to :func:`aws.run_aws` for the (long) deploy call so a caller
-    running deploy on a background thread can terminate the child on Ctrl+C.
+    GitHub. ``subnet_id`` pins the launch to an explicit subnet (validated by
+    :func:`resolve_explicit_subnet`) instead of auto-discovery. ``dry_run``
+    returns the exact argv without calling AWS. ``proc_sink`` is forwarded to
+    :func:`aws.run_aws` for the (long) deploy call so a caller running deploy on
+    a background thread can terminate the child on Ctrl+C.
     """
     if not dry_run:
         aws.assert_human_action("cloudformation:CreateStack")
     tag = validate_tag(tag)
     profile = validate_profile(profile)
     region = validate_region(region)
+    if subnet_id:
+        subnet_id = validate_subnet_id(subnet_id)
     if allow_ssh_cidr:
         allow_ssh_cidr = _validate_cidr(allow_ssh_cidr)
     if repo:
@@ -458,7 +530,8 @@ def deploy(
             tag=tag,
             tier=tier,
             vpc_id="<auto>",
-            subnet_id="<auto>",
+            subnet_id=subnet_id or "<auto>",
+            associate_public_ip="<auto>",
             permissions_boundary_arn="<auto>",
             repo=repo,
             ref=ref,
@@ -507,9 +580,16 @@ def deploy(
                 logger.info("could not remove uploaded source after failed launch")
 
     # Any failure from here to a successful deploy orphans the uploaded source —
-    # network discovery included — so clean it up on the way out.
+    # network discovery/validation included — so clean it up on the way out.
     try:
-        vpc_id, subnet_id = discover_network(profile, region, tier.instance_type)
+        if subnet_id:
+            vpc_id, subnet_id, egress_kind = resolve_explicit_subnet(
+                subnet_id, profile, region, tier.instance_type
+            )
+        else:
+            vpc_id, subnet_id, egress_kind = discover_network(
+                profile, region, tier.instance_type
+            )
     except Exception:
         _cleanup_uploaded_source()
         raise
@@ -518,6 +598,10 @@ def deploy(
         tier=tier,
         vpc_id=vpc_id,
         subnet_id=subnet_id,
+        # A NAT-routed (private) subnet must NOT get a public IP — it is unused
+        # surface and can violate SCPs that deny RunInstances-with-public-IP.
+        # An IGW subnet REQUIRES one for egress.
+        associate_public_ip="false" if egress_kind == "nat" else "true",
         permissions_boundary_arn=boundary_arn,
         repo="" if ship_source else repo,
         ref="" if ship_source else ref,

--- a/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
+++ b/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
@@ -31,6 +31,16 @@ Parameters:
   SubnetId:
     Type: AWS::EC2::Subnet::Id
     Description: Subnet to launch into (a public subnet in the chosen VPC).
+  AssociatePublicIp:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: >-
+      Attach a public IP to the instance ENI. The launcher passes "false" for
+      NAT-routed (private) subnets, where a public IP is unused surface and can
+      trip SCPs that deny RunInstances-with-public-IP, and "true" for
+      IGW-routed subnets, where it is REQUIRED for egress. Default "true"
+      preserves the historical behavior for direct template deploys.
   StackTag:
     Type: String
     Default: kirocrew
@@ -123,6 +133,7 @@ Conditions:
   HasSshCidr: !Not [!Equals [!Ref AllowSshCidr, ""]]
   IsArm: !Equals [!Ref Architecture, arm64]
   HasS3Source: !Not [!Equals [!Ref SourceBucket, ""]]
+  WantPublicIp: !Equals [!Ref AssociatePublicIp, "true"]
 
 Resources:
   # --- IAM: instance role trusts EC2 and gets SSM core (enables Session Manager
@@ -218,28 +229,29 @@ Resources:
             - !FindInMap [ArchToAmiParam, arm64, Param]
             - !FindInMap [ArchToAmiParam, x8664, Param]
       IamInstanceProfile: !Ref InstanceProfile
-      # Attach the ENI explicitly so we can force a public IP. discover_network
-      # prefers a NAT subnet, but when only an internet-gateway subnet is
-      # available a public IP is REQUIRED for egress — and the subnet's
-      # MapPublicIpOnLaunch may be false. AssociatePublicIpAddress overrides that
-      # at the instance level so bootstrap (dnf/npm/pip + SSM) can't silently hang
-      # to the WaitCondition timeout. Harmless in a NAT/private subnet (the extra
-      # public IP is simply unused). SubnetId/SecurityGroupIds move here because
-      # they're mutually exclusive with the top-level forms.
+      # Attach the ENI explicitly so the public-IP decision is instance-level
+      # (the subnet's MapPublicIpOnLaunch may disagree either way). The launcher
+      # computes the subnet's egress kind and passes AssociatePublicIp
+      # accordingly: "true" for IGW-routed subnets — where a public IP is
+      # REQUIRED for egress or bootstrap (dnf/npm/pip + SSM) silently hangs to
+      # the WaitCondition timeout — and "false" for NAT-routed (private)
+      # subnets, where a public IP is unused attack surface and can violate
+      # SCPs that deny RunInstances-with-public-IP. SubnetId/SecurityGroupIds
+      # move here because they're mutually exclusive with the top-level forms.
       NetworkInterfaces:
         - DeviceIndex: 0
           # ── Documented accepted tradeoff (CWE-1188) ──
-          # A public IP widens attack surface, but is REQUIRED for egress when
-          # only an IGW subnet is available (bootstrap would otherwise hang). It
-          # is accepted, not an oversight, because it is defense-in-depth capped:
+          # On IGW-only subnets a public IP widens attack surface but is
+          # REQUIRED for egress (bootstrap would otherwise hang). It is
+          # accepted, not an oversight, because it is defense-in-depth capped:
           #   * InstanceSecurityGroup has NO default inbound ingress (SSM-only,
           #     egress-only); optional SSH is gated behind HasSshCidr with a
           #     validated CIDR (rejects ranges wider than /16).
           #   * IMDSv2 enforced (HttpTokens: required, HopLimit: 1) below.
           #   * EBS root encrypted.
-          # Preferred posture is still a private subnet + NAT (discover_network
-          # picks that first); this only forces the public IP on IGW-only subnets.
-          AssociatePublicIpAddress: true
+          # NAT-routed (private) subnets — discovery's first preference and the
+          # --subnet flag's advertised posture — launch with NO public IP.
+          AssociatePublicIpAddress: !If [WantPublicIp, true, false]
           SubnetId: !Ref SubnetId
           GroupSet: [!Ref InstanceSecurityGroup]
       # Enforce IMDSv2 (token-required) and a hop limit of 1. KiroCrew runs a

--- a/src/kiro_crew/cloud/wizard.py
+++ b/src/kiro_crew/cloud/wizard.py
@@ -21,6 +21,7 @@ from kiro_crew.cloud import connect as connect_mod
 from kiro_crew.cloud import ec2, iam, login, sizes, ssm, ui
 from kiro_crew.cloud.aws import AWSError
 from kiro_crew.cloud.config import DEFAULT_REGION, CloudConfig
+from kiro_crew.validation import ValidationError
 
 _TOTAL_STEPS = 6
 
@@ -36,6 +37,7 @@ def _deploy_with_progress(
     tier: sizes.SizeTier,
     profile: str,
     region: str,
+    subnet_id: str = "",
     disable_rollback: bool = False,
 ) -> ec2.DeployResult:
     """Run ``ec2.deploy`` while streaming live CloudFormation + bootstrap logs.
@@ -60,6 +62,7 @@ def _deploy_with_progress(
                 tier=tier,
                 profile=profile,
                 region=region,
+                subnet_id=subnet_id,
                 disable_rollback=disable_rollback,
                 proc_sink=lambda p: deploy_proc.__setitem__("proc", p),
             )
@@ -304,6 +307,7 @@ def launch(
     region: str = "",
     *,
     size_key: str = "",
+    subnet_id: str = "",
     assume_yes: bool = False,
     force_new: bool = False,
     keep_on_failure: bool = False,
@@ -311,13 +315,24 @@ def launch(
 ) -> int:
     """Run the full interactive launch flow. Returns a process exit code.
 
-    ``hold_tunnel=False`` closes the SSM tunnel and returns instead of blocking
-    on it — used when the wizard is embedded in a larger flow (``kirocrew
-    setup``) that still has steps to print after this one.
+    ``subnet_id`` (``--subnet``) pins the launch to an explicit subnet instead
+    of network auto-discovery — for dedicated-VPC / private-subnet setups the
+    default-VPC preference would otherwise never pick. ``hold_tunnel=False``
+    closes the SSM tunnel and returns instead of blocking on it — used when the
+    wizard is embedded in a larger flow (``kirocrew setup``) that still has
+    steps to print after this one.
     """
     cfg = CloudConfig.load()
     profile = profile or cfg.profile
     region = region or cfg.region or DEFAULT_REGION
+    if subnet_id:
+        try:
+            subnet_id = ec2.validate_subnet_id(subnet_id)
+        except ValidationError as exc:
+            # argparse can't charset-check the id; surface a clean one-liner
+            # instead of a traceback (launch() is also a public entrypoint).
+            ui.fail(str(exc))
+            return 1
 
     print(ui.BANNER)
     steps = ui.Steps(_TOTAL_STEPS)
@@ -402,6 +417,16 @@ def launch(
                 return 0
     else:
         ui.detail("Keeping the existing stack; instance size is unchanged.")
+        if subnet_id:
+            if assume_yes:
+                # Non-interactive: an explicitly requested pin that would be
+                # silently ignored is worse than an early exit — a script that
+                # passed --subnet expects the instance IN that subnet.
+                ui.fail("--subnet cannot apply to the existing stack (its network is fixed).")
+                ui.detail("Use `kirocrew cloud launch --new --subnet …` for a fresh instance.")
+                return 1
+            ui.warn("--subnet is ignored for an existing stack (its network is fixed).")
+            ui.detail("Use `kirocrew cloud launch --new --subnet …` for a fresh instance.")
 
     # ── 4. Launch ─────────────────────────────────────────────────────────
     steps.step("Launching")
@@ -409,6 +434,8 @@ def launch(
         assert tier is not None
         tag = _new_tag()
         ui.info(f"CloudFormation stack: {ec2.stack_name(tag)}")
+        if subnet_id:
+            ui.info(f"Subnet: {subnet_id} (explicit --subnet; auto-discovery skipped)")
         # NB: do NOT persist last_tag yet. Saving it BEFORE the deploy succeeds
         # would leave cloud.json pointing at a ROLLBACK_COMPLETE / no-instance
         # stack on a failed first launch, and the NEXT `launch` would then treat
@@ -424,6 +451,7 @@ def launch(
                 tier=tier,
                 profile=profile,
                 region=region,
+                subnet_id=subnet_id,
                 disable_rollback=keep_on_failure,
             )
         except AWSError as exc:

--- a/test/test_cloud_cli.py
+++ b/test/test_cloud_cli.py
@@ -46,6 +46,20 @@ class TestDispatch:
         assert rc == 0
         assert captured["force_new"] is True
 
+    def test_launch_passes_subnet_flag(self, monkeypatch):
+        captured = {}
+
+        monkeypatch.setattr(cli_cloud, "_resolve", lambda _args: ("dev", "ap-southeast-1"))
+        monkeypatch.setattr(
+            cli_cloud.wizard, "launch", lambda **kwargs: captured.update(kwargs) or 0
+        )
+
+        rc = cli_cloud._cloud_launch(
+            _args(profile="", region="", subnet="subnet-0123456789abcdef0", yes=True)
+        )
+        assert rc == 0
+        assert captured["subnet_id"] == "subnet-0123456789abcdef0"
+
     def test_dispatch_keyboard_interrupt_returns_130(self, monkeypatch, capsys):
         def raise_interrupt(_args):
             raise KeyboardInterrupt

--- a/test/test_cloud_ec2.py
+++ b/test/test_cloud_ec2.py
@@ -70,6 +70,16 @@ class TestValidation:
         with pytest.raises(ValidationError):
             ec2.validate_tag("a" * 52)
 
+    def test_subnet_id_valid(self):
+        assert ec2.validate_subnet_id("subnet-0123456789abcdef0") == "subnet-0123456789abcdef0"
+        assert ec2.validate_subnet_id("subnet-12345678") == "subnet-12345678"  # classic 8-hex
+
+    def test_subnet_id_bad_charset_rejected(self):
+        # flows into subprocess argv — charset-validate like the other fields
+        for bad in ("subnet-XYZ", "subnet-123", "vpc-0123456789abcdef0", "subnet-1; rm -rf"):
+            with pytest.raises(ValidationError):
+                ec2.validate_subnet_id(bad)
+
     def test_region_pattern(self):
         assert ec2.validate_region("us-east-1") == "us-east-1"
         with pytest.raises(ValidationError):
@@ -254,6 +264,16 @@ class TestTemplate:
         text = ec2.load_template()
         assert "MetadataOptions" in text
         assert "HttpTokens: required" in text
+
+    def test_public_ip_is_conditional_on_egress_kind(self):
+        # A NAT-routed (private) subnet must not get a public IP; only IGW
+        # subnets (where it is required for egress) do. The launcher passes the
+        # AssociatePublicIp parameter from the computed egress kind.
+        text = ec2.load_template()
+        assert "AssociatePublicIp:" in text  # the parameter exists
+        assert 'WantPublicIp: !Equals [!Ref AssociatePublicIp, "true"]' in text
+        assert "AssociatePublicIpAddress: !If [WantPublicIp, true, false]" in text
+        assert "AssociatePublicIpAddress: true" not in text  # never hardcoded
 
     def test_sub_escape_for_shell_vars(self):
         # ${!tail_ctx} is CFN !Sub's escape syntax: it renders the literal
@@ -452,6 +472,20 @@ class TestDeployDryRun:
         # source-shipping placeholders present by default
         assert "SourceBucket=<auto>" in r.argv
 
+    def test_dry_run_shows_explicit_subnet(self, monkeypatch):
+        monkeypatch.setattr(aws, "run_aws", lambda *a, **k: pytest.fail("dry run must not hit AWS"))
+        r = ec2.deploy(
+            tag="t1",
+            tier=sizes.default_tier(),
+            profile="dev",
+            region="us-east-1",
+            subnet_id="subnet-0123456789abcdef0",
+            dry_run=True,
+        )
+        assert "SubnetId=subnet-0123456789abcdef0" in r.argv
+        assert "VpcId=<auto>" in r.argv  # resolved from the subnet at real-run time
+        assert "AssociatePublicIp=<auto>" in r.argv  # egress kind known only at real run
+
     def test_dry_run_no_source_when_disabled(self, monkeypatch):
         monkeypatch.setattr(aws, "run_aws", lambda *a, **k: pytest.fail("dry run must not hit AWS"))
         r = ec2.deploy(
@@ -478,7 +512,7 @@ class TestDeployShipsSource:
                 f"{tag}/kirocrew-src.tar.gz",
             ),
         )
-        monkeypatch.setattr(ec2, "discover_network", lambda *a, **k: ("vpc-1", "subnet-1"))
+        monkeypatch.setattr(ec2, "discover_network", lambda *a, **k: ("vpc-1", "subnet-1", "igw"))
         captured = {}
 
         def fake_run(argv, profile="", region="", *, timeout=ec2._DEPLOY_TIMEOUT, proc_sink=None):
@@ -493,6 +527,8 @@ class TestDeployShipsSource:
         )
         r = ec2.deploy(tag="t1", tier=sizes.default_tier(), profile="dev", region="us-east-1")
         assert "SourceBucket=kirocrew-src-1-us-east-1" in captured["argv"]
+        # IGW-routed subnet -> the public IP is required for egress
+        assert "AssociatePublicIp=true" in captured["argv"]
         assert "SourceKey=t1/kirocrew-src.tar.gz" in captured["argv"]
         # the pre-created shared boundary ARN flows into the deploy params
         assert f"PermissionsBoundaryArn={_BOUNDARY_ARN}" in captured["argv"]
@@ -550,6 +586,105 @@ class TestDeployCleansSourceOnEarlyFailure:
         assert deleted == ["t1"]
 
 
+class TestDeployExplicitSubnet:
+    def _stub_deploy_deps(self, monkeypatch):
+        import kiro_crew.cloud.source as source_mod
+
+        monkeypatch.setattr(ec2, "find_stack", lambda *a, **k: None)
+        monkeypatch.setattr(source_mod, "ensure_instance_boundary", lambda *a, **k: _BOUNDARY_ARN)
+        monkeypatch.setattr(source_mod, "upload_source", lambda *a, **k: ("b", "t1/k.tar.gz"))
+        monkeypatch.setattr(
+            ec2,
+            "describe",
+            lambda *a, **k: {"instance_id": "i-1", "stack_status": "CREATE_COMPLETE"},
+        )
+
+    def test_explicit_subnet_skips_discovery(self, monkeypatch):
+        self._stub_deploy_deps(monkeypatch)
+        monkeypatch.setattr(
+            ec2,
+            "discover_network",
+            lambda *a, **k: pytest.fail("--subnet must bypass discover_network"),
+        )
+        monkeypatch.setattr(
+            ec2,
+            "resolve_explicit_subnet",
+            lambda subnet_id, *a, **k: ("vpc-dedicated", subnet_id, "nat"),
+        )
+        captured = {}
+
+        def fake_run(argv, profile="", region="", *, timeout=ec2._DEPLOY_TIMEOUT, proc_sink=None):
+            captured["argv"] = argv
+            return (0, "ok", "")
+
+        monkeypatch.setattr(aws, "run_aws", fake_run)
+        ec2.deploy(
+            tag="t1",
+            tier=sizes.default_tier(),
+            profile="dev",
+            region="ap-southeast-1",
+            subnet_id="subnet-0123456789abcdef0",
+        )
+        assert "VpcId=vpc-dedicated" in captured["argv"]
+        assert "SubnetId=subnet-0123456789abcdef0" in captured["argv"]
+        # NAT-routed pin -> no public IP on the instance
+        assert "AssociatePublicIp=false" in captured["argv"]
+
+    def test_discovered_nat_subnet_suppresses_public_ip(self, monkeypatch):
+        # The egress-kind wiring must also cover the auto-discovery path.
+        self._stub_deploy_deps(monkeypatch)
+        monkeypatch.setattr(
+            ec2, "discover_network", lambda *a, **k: ("vpc-1", "subnet-priv", "nat")
+        )
+        captured = {}
+
+        def fake_run(argv, profile="", region="", *, timeout=ec2._DEPLOY_TIMEOUT, proc_sink=None):
+            captured["argv"] = argv
+            return (0, "ok", "")
+
+        monkeypatch.setattr(aws, "run_aws", fake_run)
+        ec2.deploy(tag="t1", tier=sizes.default_tier(), profile="dev", region="us-east-1")
+        assert "AssociatePublicIp=false" in captured["argv"]
+
+    def test_bad_subnet_id_rejected_before_any_aws_call(self, monkeypatch):
+        monkeypatch.setattr(
+            aws, "run_aws", lambda *a, **k: pytest.fail("must not reach AWS on a bad subnet id")
+        )
+        with pytest.raises(ValidationError):
+            ec2.deploy(
+                tag="t1",
+                tier=sizes.default_tier(),
+                profile="dev",
+                region="us-east-1",
+                subnet_id="subnet-nope!",
+            )
+
+    def test_explicit_subnet_failure_deletes_uploaded_source(self, monkeypatch):
+        # Same cleanup contract as discovery: a validation failure after the
+        # source upload must not orphan the tarball in S3.
+        import kiro_crew.cloud.source as source_mod
+
+        deleted: list[str] = []
+        self._stub_deploy_deps(monkeypatch)
+        monkeypatch.setattr(source_mod, "delete_source", lambda tag, *a, **k: deleted.append(tag))
+        monkeypatch.setattr(
+            ec2,
+            "resolve_explicit_subnet",
+            lambda *a, **k: (_ for _ in ()).throw(
+                aws.AWSError("no verified internet egress", action="ec2:DescribeRouteTables")
+            ),
+        )
+        with pytest.raises(aws.AWSError):
+            ec2.deploy(
+                tag="t1",
+                tier=sizes.default_tier(),
+                profile="dev",
+                region="us-east-1",
+                subnet_id="subnet-0123456789abcdef0",
+            )
+        assert deleted == ["t1"]
+
+
 def _igw_route_table(subnet_ids):
     """A route table with an internet-gateway default route, associated to
     ``subnet_ids`` (explicit associations)."""
@@ -597,9 +732,10 @@ class TestDiscoverNetwork:
             return {}
 
         monkeypatch.setattr(aws, "checked_json", fake_json)
-        vpc, subnet = ec2.discover_network("dev", "us-east-1")
+        vpc, subnet, kind = ec2.discover_network("dev", "us-east-1")
         assert vpc == "vpc-default"
         assert subnet == "subnet-public"
+        assert kind == "igw"
 
     def test_skips_az_that_does_not_offer_type(self, monkeypatch):
         def fake_json(args, profile="", region="", *, action, timeout=aws.DEFAULT_TIMEOUT):
@@ -628,8 +764,9 @@ class TestDiscoverNetwork:
             return {}
 
         monkeypatch.setattr(aws, "checked_json", fake_json)
-        vpc, subnet = ec2.discover_network("dev", "us-east-1", "t4g.xlarge")
+        vpc, subnet, kind = ec2.discover_network("dev", "us-east-1", "t4g.xlarge")
         assert subnet == "subnet-1b"
+        assert kind == "igw"
 
     def test_raises_when_no_subnet_has_internet_egress(self, monkeypatch):
         # Public-IP flag set, but no route table has a 0.0.0.0/0 route -> the
@@ -698,7 +835,7 @@ class TestDiscoverNetwork:
             return {}
 
         monkeypatch.setattr(aws, "checked_json", fake_json)
-        _vpc, subnet = ec2.discover_network("dev", "us-east-1")
+        _vpc, subnet, _kind = ec2.discover_network("dev", "us-east-1")
         assert subnet == "subnet-main"
 
     def test_explicit_no_egress_subnet_not_covered_by_main_table(self, monkeypatch):
@@ -782,7 +919,7 @@ class TestDiscoverNetwork:
             return {}
 
         monkeypatch.setattr(aws, "checked_json", fake_json)
-        _vpc, subnet = ec2.discover_network("dev", "us-east-1")
+        _vpc, subnet, _kind = ec2.discover_network("dev", "us-east-1")
         assert subnet == "subnet-nat"
 
     def test_igw_subnet_without_public_ip_is_usable(self, monkeypatch):
@@ -808,7 +945,7 @@ class TestDiscoverNetwork:
             return {}
 
         monkeypatch.setattr(aws, "checked_json", fake_json)
-        _vpc, subnet = ec2.discover_network("dev", "us-east-1")
+        _vpc, subnet, _kind = ec2.discover_network("dev", "us-east-1")
         assert subnet == "subnet-igw-nopub"
 
     def test_raises_when_no_az_offers_type(self, monkeypatch):
@@ -843,6 +980,84 @@ class TestDiscoverNetwork:
         with pytest.raises(aws.AWSError) as ei:
             ec2.discover_network("dev", "us-east-1")
         assert "no default VPC" in str(ei.value)
+
+
+class TestResolveExplicitSubnet:
+    def test_resolves_vpc_and_keeps_private_nat_subnet(self, monkeypatch):
+        def fake_json(args, profile="", region="", *, action, timeout=aws.DEFAULT_TIMEOUT):
+            if "describe-subnets" in args and "--subnet-ids" in args:
+                return {
+                    "Subnets": [
+                        {
+                            "SubnetId": "subnet-priv",
+                            "VpcId": "vpc-dedicated",
+                            "AvailabilityZone": "ap-southeast-1a",
+                        }
+                    ]
+                }
+            if "describe-route-tables" in args:
+                return {"RouteTables": [_nat_route_table(["subnet-priv"])]}
+            return {}
+
+        monkeypatch.setattr(aws, "checked_json", fake_json)
+        vpc, subnet, kind = ec2.resolve_explicit_subnet("subnet-priv", "dev", "ap-southeast-1")
+        assert (vpc, subnet, kind) == ("vpc-dedicated", "subnet-priv", "nat")
+
+    def test_missing_subnet_raises(self, monkeypatch):
+        monkeypatch.setattr(aws, "checked_json", lambda *a, **k: {"Subnets": []})
+        with pytest.raises(aws.AWSError, match="not found"):
+            ec2.resolve_explicit_subnet("subnet-gone", "dev", "us-east-1")
+
+    def test_no_egress_subnet_raises(self, monkeypatch):
+        # An isolated subnet (local route only) would hang the launch to the
+        # WaitCondition timeout — the explicit path must fail fast like discovery.
+        def fake_json(args, profile="", region="", *, action, timeout=aws.DEFAULT_TIMEOUT):
+            if "describe-subnets" in args and "--subnet-ids" in args:
+                return {
+                    "Subnets": [
+                        {
+                            "SubnetId": "subnet-iso",
+                            "VpcId": "vpc-1",
+                            "AvailabilityZone": "us-east-1a",
+                        }
+                    ]
+                }
+            if "describe-route-tables" in args:
+                return {
+                    "RouteTables": [
+                        {
+                            "Routes": [
+                                {"DestinationCidrBlock": "10.0.0.0/16", "GatewayId": "local"}
+                            ],
+                            "Associations": [{"SubnetId": "subnet-iso"}],
+                        }
+                    ]
+                }
+            return {}
+
+        monkeypatch.setattr(aws, "checked_json", fake_json)
+        with pytest.raises(aws.AWSError, match="egress"):
+            ec2.resolve_explicit_subnet("subnet-iso", "dev", "us-east-1")
+
+    def test_az_not_offering_type_raises(self, monkeypatch):
+        def fake_json(args, profile="", region="", *, action, timeout=aws.DEFAULT_TIMEOUT):
+            if "describe-subnets" in args and "--subnet-ids" in args:
+                return {
+                    "Subnets": [
+                        {
+                            "SubnetId": "subnet-1e",
+                            "VpcId": "vpc-1",
+                            "AvailabilityZone": "us-east-1e",
+                        }
+                    ]
+                }
+            if "describe-instance-type-offerings" in args:
+                return {"InstanceTypeOfferings": [{"Location": "us-east-1b"}]}
+            return {}
+
+        monkeypatch.setattr(aws, "checked_json", fake_json)
+        with pytest.raises(aws.AWSError, match="does not offer"):
+            ec2.resolve_explicit_subnet("subnet-1e", "dev", "us-east-1", "t4g.xlarge")
 
 
 class TestStatusAndList:
@@ -1187,7 +1402,7 @@ class TestStackEventsAndFailures:
         monkeypatch.setattr(ec2, "find_stack", lambda *a, **k: None)
         monkeypatch.setattr(source_mod, "ensure_instance_boundary", lambda *a, **k: _BOUNDARY_ARN)
         monkeypatch.setattr(source_mod, "upload_source", lambda *a, **k: ("b", "k"))
-        monkeypatch.setattr(ec2, "discover_network", lambda *a, **k: ("vpc-1", "subnet-1"))
+        monkeypatch.setattr(ec2, "discover_network", lambda *a, **k: ("vpc-1", "subnet-1", "igw"))
         captured = {}
 
         def fake_run(argv, profile="", region="", *, timeout=ec2._DEPLOY_TIMEOUT, proc_sink=None):
@@ -1214,7 +1429,7 @@ class TestStackEventsAndFailures:
         monkeypatch.setattr(ec2, "find_stack", lambda *a, **k: None)
         monkeypatch.setattr(source_mod, "ensure_instance_boundary", lambda *a, **k: _BOUNDARY_ARN)
         monkeypatch.setattr(source_mod, "upload_source", lambda *a, **k: ("b", "k"))
-        monkeypatch.setattr(ec2, "discover_network", lambda *a, **k: ("vpc-1", "subnet-1"))
+        monkeypatch.setattr(ec2, "discover_network", lambda *a, **k: ("vpc-1", "subnet-1", "igw"))
         monkeypatch.setattr(
             aws, "run_aws", lambda *a, **k: (1, "", "Failed to create/update the stack")
         )

--- a/test/test_cloud_wizard.py
+++ b/test/test_cloud_wizard.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from kiro_crew.cloud import aws
 from kiro_crew.cloud import connect as connect_mod
 from kiro_crew.cloud import ec2, iam, login, ssm, wizard
@@ -56,6 +58,92 @@ def _patch_post_launch(monkeypatch, *, logged_in: bool = True) -> dict[str, list
     monkeypatch.setattr(ec2, "_instance_state", lambda *_a, **_k: "running")
     monkeypatch.setattr(ssm, "instance_is_managed", lambda *_a, **_k: True)
     return calls
+
+
+class TestLaunchSubnetFlag:
+    def test_malformed_subnet_fails_before_any_aws_call(self, monkeypatch, capsys):
+        # Validation runs before the wizard's first AWS reachability check, so a
+        # typo'd --subnet renders one clean line instead of a traceback later.
+        cfg = CloudConfig(profile="dev", region="us-west-2", last_tag="")
+        monkeypatch.setattr(wizard.CloudConfig, "load", classmethod(lambda cls, *a: cfg))
+        monkeypatch.setattr(
+            wizard.iam,
+            "reachability_check",
+            lambda *a, **k: pytest.fail("must not reach AWS on a malformed subnet id"),
+        )
+
+        assert wizard.launch(profile="dev", region="us-west-2", subnet_id="subnet-XYZ") == 1
+        assert "subnet_id" in capsys.readouterr().out
+
+    def test_subnet_with_existing_stack_fails_under_yes(self, monkeypatch, capsys):
+        # Non-interactive: an explicitly requested pin that would be silently
+        # ignored must exit early, not warn-and-proceed into the wrong network.
+        cfg = CloudConfig(profile="dev", region="us-west-2", last_tag="kc-old")
+        monkeypatch.setattr(wizard.CloudConfig, "load", classmethod(lambda cls, *a: cfg))
+        monkeypatch.setattr(
+            wizard.iam,
+            "reachability_check",
+            lambda *a, **k: {
+                "reachable": True,
+                "account": "1",
+                "ec2_reachable": True,
+                "cloudformation_reachable": True,
+                "ssm_reachable": True,
+            },
+        )
+        monkeypatch.setattr(wizard, "_ensure_session_manager_plugin", lambda **k: True)
+        monkeypatch.setattr(wizard, "_select_existing_launch", lambda *a, **k: object())
+
+        rc = wizard.launch(
+            profile="dev",
+            region="us-west-2",
+            subnet_id="subnet-0123456789abcdef0",
+            assume_yes=True,
+        )
+        assert rc == 1
+        assert "--subnet cannot apply" in capsys.readouterr().out
+
+    def test_subnet_threads_through_to_deploy(self, monkeypatch):
+        cfg = CloudConfig(profile="dev", region="us-west-2", last_tag="")
+        _patch_post_launch(monkeypatch)
+        captured = {}
+
+        monkeypatch.setattr(wizard.CloudConfig, "load", classmethod(lambda cls, *a: cfg))
+        monkeypatch.setattr(wizard.CloudConfig, "save", lambda self, *a: None)
+        monkeypatch.setattr(
+            wizard.iam,
+            "reachability_check",
+            lambda *a, **k: {
+                "reachable": True,
+                "account": "1",
+                "ec2_reachable": True,
+                "cloudformation_reachable": True,
+                "ssm_reachable": True,
+            },
+        )
+        monkeypatch.setattr(wizard, "_ensure_session_manager_plugin", lambda **k: True)
+        monkeypatch.setattr(wizard, "_select_existing_launch", lambda *a, **k: None)
+
+        def fake_deploy_with_progress(**kwargs):
+            captured.update(kwargs)
+            return ec2.DeployResult(
+                tag=kwargs["tag"],
+                stack_name=ec2.stack_name(kwargs["tag"]),
+                region="us-west-2",
+                instance_id="i-new",
+                status="CREATE_COMPLETE",
+            )
+
+        monkeypatch.setattr(wizard, "_deploy_with_progress", fake_deploy_with_progress)
+
+        rc = wizard.launch(
+            profile="dev",
+            region="us-west-2",
+            subnet_id="subnet-0123456789abcdef0",
+            assume_yes=True,
+        )
+        assert rc == 0
+        assert captured["subnet_id"] == "subnet-0123456789abcdef0"
 
 
 class TestLaunchResume:


### PR DESCRIPTION
Closes #1801.

## What

`cloud launch` gains `--subnet <subnet-id>`, pinning the launch to an explicit subnet instead of network auto-discovery.

```
kirocrew cloud launch --subnet subnet-0123456789abcdef0
```

## Why

Network selection was hardwired in `discover_network()`: the **default VPC** when one exists, else the account's only VPC. A dedicated/private-subnet VPC could therefore never be targeted while a default VPC existed — even though the SSM transport (#1500, #1606) and the template's own comments make private-subnet + NAT the flagship posture, and even though the no-default-VPC error already told users to *"specify a VPC/subnet"* (an option that didn't exist). The only workaround was deleting the region's default VPC so the exactly-one-VPC fallback fired.

## How

- `resolve_explicit_subnet()` (ec2.py) resolves the subnet to its `(vpc_id, subnet_id)` and keeps every launch-time guarantee discovery provides:
  - subnet must exist in the region (clear error, not a raw CLI failure);
  - its AZ must offer the chosen instance type (same non-fatal fallback as discovery when offerings can't be determined);
  - it must pass the identical `_subnet_egress_kinds` NAT/IGW egress check — a no-egress subnet fails fast with actionable text instead of hanging to the WaitCondition timeout.
- The id is charset-validated (`validate_subnet_id`, `subnet-` + 8/17 hex) at the wizard and deploy entrypoints, since it flows into subprocess argv — same pattern as tag/region/profile/CIDR.
- `--subnet` applies only to a **new** stack; reusing an existing stack warns that its network is fixed and points at `--new --subnet …`.
- Dry runs echo the explicit subnet (`SubnetId=…`, `VpcId=<auto>`); a validation failure after the source upload cleans up the S3 tarball exactly like discovery failures do.
- The launcher UI prints the pinned subnet at step 4 so the choice is visible in the transcript.
- Docs: `docs/system-specs/modules/cloud.md` updated; discovery error texts now reference `--subnet` for real.

No IAM policy change — the explicit path uses only describe calls the least-privilege policy already grants (`DescribeSubnets`, `DescribeRouteTables`, `DescribeInstanceTypeOfferings`).

## Tests

- `resolve_explicit_subnet`: happy path (private NAT subnet in a dedicated VPC), missing subnet, no-egress subnet, AZ-doesn't-offer-type — all raise `AWSError` with actionable text.
- `deploy`: `--subnet` bypasses `discover_network` (fails the test if called), malformed id rejected before any AWS call, S3 source cleanup on explicit-path failure, dry-run argv.
- Wizard: malformed `--subnet` fails with one clean line before the first AWS call; the id threads through to `_deploy_with_progress`.
- CLI: `--subnet` threads from argparse to `wizard.launch`.
- `flake8` / `isort` / `mypy` clean; full suite green (4 unrelated `test_mcp_discovery` probe-timeout flakes under xdist pass serially).
