### PR TITLE
fix(stt): Build the Apple streaming helper against the shipping SDK

### DIFF
--- a/src/kiro_crew/apple_speech/StreamTranscribe.swift
+++ b/src/kiro_crew/apple_speech/StreamTranscribe.swift
@@ -72,6 +72,70 @@ func makeBuffer(_ bytes: [UInt8], format: AVAudioFormat) -> AVAudioPCMBuffer? {
     return buffer
 }
 
+// MARK: - Format conversion
+
+/// Renders the Int16 PCM the client streams into the format `SpeechAnalyzer` asked for.
+///
+/// `SpeechAnalyzer` accepts audio only in the format reported by
+/// `bestAvailableAudioFormat(compatibleWith:)` — a Float32 layout at whatever rate the
+/// on-device model wants, never the 16 kHz interleaved Int16 the browser sends. The
+/// framework ships no converter of its own for this, so `AVAudioConverter` does the
+/// work and each result is wrapped in `AnalyzerInput(buffer:)`.
+///
+/// `primeMethod = .none` trades a little resampling quality for latency: with priming
+/// on, the converter withholds the leading frames of the stream to fill its filter
+/// history, which delays the first partial against a ~100 ms chunk cadence.
+final class AnalyzerFormatConverter {
+    enum Failure: Error {
+        case unsupported(from: AVAudioFormat, to: AVAudioFormat)
+        case noOutputBuffer
+        case failed(NSError?)
+    }
+
+    private let target: AVAudioFormat
+    private var converter: AVAudioConverter?
+
+    init(target: AVAudioFormat) {
+        self.target = target
+    }
+
+    /// *buffer* in the analyzer's format — or *buffer* itself when the formats already
+    /// match, since the copy would be pure overhead.
+    func convert(_ buffer: AVAudioPCMBuffer) throws -> AVAudioPCMBuffer {
+        let source = buffer.format
+        guard source != target else { return buffer }
+        if converter == nil || converter?.inputFormat != source {
+            guard let made = AVAudioConverter(from: source, to: target) else {
+                throw Failure.unsupported(from: source, to: target)
+            }
+            made.primeMethod = .none
+            converter = made
+        }
+        guard let converter else { throw Failure.unsupported(from: source, to: target) }
+
+        // Output frames scale with the sample-rate ratio. Round UP: truncating the
+        // fractional frame would silently drop audio on every single chunk.
+        let ratio = target.sampleRate / source.sampleRate
+        let capacity = AVAudioFrameCount((Double(buffer.frameLength) * ratio).rounded(.up))
+        guard capacity > 0,
+            let out = AVAudioPCMBuffer(pcmFormat: target, frameCapacity: capacity)
+        else { throw Failure.noOutputBuffer }
+
+        var error: NSError?
+        var consumed = false
+        let status = converter.convert(to: out, error: &error) { _, inputStatus in
+            // Exactly one input buffer per call: `.haveData` once, then `.noDataNow` so
+            // the converter emits what it holds instead of waiting for more input that
+            // this call will never supply.
+            defer { consumed = true }
+            inputStatus.pointee = consumed ? .noDataNow : .haveData
+            return consumed ? nil : buffer
+        }
+        guard status != .error else { throw Failure.failed(error) }
+        return out
+    }
+}
+
 // MARK: - Main
 
 @main
@@ -225,7 +289,6 @@ struct StreamTranscribe {
                 interleaved: true)
         else { die("could not build a \(Int(sampleRate)) Hz mono Int16 input format") }
 
-        let converter = AnalyzerInputConverter(analyzerFormat: analyzerFormat)
         let (inputStream, inputContinuation) = AsyncStream<AnalyzerInput>.makeStream()
         let analyzer = SpeechAnalyzer(modules: [module])
 
@@ -257,6 +320,10 @@ struct StreamTranscribe {
         // them on the cooperative pool would starve the analyzer's own tasks.
         let readerDone = DispatchSemaphore(value: 0)
         Thread.detachNewThread {
+            // Built HERE, not in the enclosing scope: this thread is the converter's
+            // only user, so owning it locally keeps it off a cross-thread capture and
+            // out of the way of Swift's Sendable checking.
+            let converter = AnalyzerFormatConverter(target: analyzerFormat)
             let input = FileHandle.standardInput
             var carry: [UInt8] = []  // odd trailing byte from a torn Int16
             while true {
@@ -277,18 +344,17 @@ struct StreamTranscribe {
                     offset = end
                     guard let buffer = makeBuffer(slice, format: inputFormat) else { continue }
                     do {
-                        let converted = try converter.convert(buffer, at: nil)
-                        trace("fed \(slice.count)B -> \(converted.count) analyzerInput(s)")
-                        for c in converted {
-                            inputContinuation.yield(c)
-                        }
+                        let converted = try converter.convert(buffer)
+                        // A converter that produced no frames (short chunk swallowed by
+                        // resampling) has nothing to analyze; yielding it would only cost
+                        // a needless trip through the analyzer.
+                        guard converted.frameLength > 0 else { continue }
+                        trace("fed \(slice.count)B -> \(converted.frameLength) frame(s)")
+                        inputContinuation.yield(AnalyzerInput(buffer: converted))
                     } catch {
                         note("convert failed: \(error)")
                     }
                 }
-            }
-            if let flushed = try? converter.flush() {
-                for converted in flushed { inputContinuation.yield(converted) }
             }
             inputContinuation.finish()
             readerDone.signal()


### PR DESCRIPTION
## Problem

Selecting the **Apple** on-device STT provider gave you a mic button that did nothing: no dictation, no text, no transcript.

`StreamTranscribe.swift` referenced `AnalyzerInputConverter`, a type that **does not exist** in the Speech framework shipping in the macOS 26 SDK. The streaming helper therefore failed to compile on every host:

```
StreamTranscribe.swift:228:25: error: cannot find 'AnalyzerInputConverter' in scope
StreamTranscribe.swift:280:75: error: 'nil' requires a contextual type
```

Confirmed against the shipping interface — `Speech.swiftmodule/arm64e-apple-macos.swiftinterface` declares no converter type at all, and the real entry point is:

```swift
public struct AnalyzerInput : @unchecked Swift.Sendable {
  public init(buffer: AVFAudio.AVAudioPCMBuffer)
  public init(buffer: AVFAudio.AVAudioPCMBuffer, bufferStartTime: CoreMedia.CMTime?)
}
```

The chain that produces the dead button:

1. `apple` is advertised in `stt_stream._STREAMING_PROVIDERS`, so `SttSettings.handleProvider` turns **streaming on by default** the moment the provider is selected. The default configuration for this provider is therefore the streaming path.
2. Mic click opens the streaming WebSocket, `_run_apple_session` calls `StreamingSession.start()`, which calls `stream_helper_path()` -> `_build_helper()` -> `swiftc`.
3. The build fails, `_build_helper` returns `None`, `start()` returns `"streaming speech helper could not be built"`, and the socket closes.

`availability()` is loop-safe by contract and deliberately does **not** compile to find out (a 180s `swiftc` on the event loop would freeze chat turns), so it only stats for a Swift toolchain. The provider consequently kept advertising itself as available via `core._stt_providers()`, and the failure surfaced only at mic-click time.

Only the **streaming** helper was affected. `AppleTranscribe.swift` (batch) compiles and runs fine, so `apple` with streaming **off** already worked.

## Fix

Replace the missing type with an `AVAudioConverter`-backed `AnalyzerFormatConverter` that renders the client's 16 kHz interleaved Int16 into the format `SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith:)` asks for, and wrap each result in `AnalyzerInput(buffer:)`.

- `primeMethod = .none` so the converter does not withhold leading frames to fill its resampling filter history, which would delay the first partial against a ~100 ms chunk cadence.
- Output capacity scales by the sample-rate ratio, rounded **up** — truncating the fractional frame would drop audio on every chunk.
- Zero-frame conversions are skipped rather than yielded.
- The converter is constructed **inside** the stdin reader thread, its only user, so it is not captured across threads (this also keeps the new type out of Swift's `Sendable` diagnostics).
- The `converter.flush()` call is dropped: the analyzer's own `finalizeAndFinishThroughEndOfInput()` already drains, and `.none` priming leaves no meaningful tail.

## Verification

macOS 26.5.2, Xcode 26.6, Command Line Tools toolchain, arm64.

Compile, using the exact invocation `_build_helper` issues:

```
swiftc -O -parse-as-library -sdk <sdk> StreamTranscribe.swift -o <out>
```

**0 errors** (was 2). One pre-existing `ActorIsolatedCall` warning on the `trace` helper remains and is untouched by this diff.

Real run — `say`-synthesized speech transcoded to raw 16 kHz mono Int16 PCM and piped to the helper on stdin:

```
{"type":"ready"}
{"type":"partial","text":"Hello"}
{"type":"partial","text":"Hello this"}
{"type":"partial","text":"Hello, this is a"}
...
{"type":"partial","text":"Hello, this is a test of our device dictation and Ciro"}
{"type":"final","text":"Hello, this is a test of on device dictation and Kero crew"}
{"type":"done","text":"Hello, this is a test of on device dictation and Kero crew"}
```

Partials stream **while** audio is still being fed and then a final stabilizes — which is exactly the property `test_apple_speech.py::TestEndToEndMacOS::test_streaming_emits_partials_before_the_audio_ends` asserts.

## Why CI did not catch this

That test is the correct ratchet and it already exists — it simply never runs anywhere. `TestEndToEndMacOS` is `skipif`-gated on macOS, and each test then skips again when `_macos_major() < MIN_MACOS_MAJOR` (26) or when `_swiftc()` finds no toolchain. No lane in the pipeline satisfies all three conditions, so **nothing in CI ever compiles either Swift helper**, in this PR or on `main`.

Worth a follow-up issue: either a macOS 26 lane for `test/test_apple_speech.py`, or a compile-only gate cheap enough to run wherever a Swift toolchain happens to exist. Left out of this PR to keep the fix reviewable.

## Scope

Swift-only, one file. No Python, TypeScript, or i18n surface is touched, so no locale catalogs, error-code baseline, or generated settings are affected.
