### PR TITLE
test(sandbox): pin the AppArmor probe in the bare-metal guidance test

### DIFF
--- a/test/test_sandbox_docker_detection.py
+++ b/test/test_sandbox_docker_detection.py
@@ -235,6 +235,14 @@ class TestWrapArgvDockerGuidance:
         monkeypatch.setattr(sandbox, "_inside_kirocrew_sandbox", lambda: False)
         monkeypatch.setattr(sandbox, "_inside_macos_sandbox", lambda: False)
         monkeypatch.setattr(sandbox, "is_docker_container", lambda: False)
+        # "Bare metal" means the sysctl is RELAXED. Without pinning this the
+        # probe reads the real host, and on any Ubuntu 23.10+ kernel — which is
+        # every GitHub Linux runner — it returns True, so _no_backend_guidance()
+        # returns the AppArmor remedy instead of the generic one and the assert
+        # below cannot pass. The other tests in this class set
+        # is_docker_container=True and short-circuit before that branch, which is
+        # why this is the only one that was host-dependent.
+        monkeypatch.setattr(sandbox, "_apparmor_userns_restricted", lambda: False)
         monkeypatch.setattr(
             sandbox,
             "_last_unshare_failure",


### PR DESCRIPTION
## Problem

`Backend Tests (3.10, 3)` and `Backend Tests (3.12, 3)` fail on `main` and on every PR based on it:

```
FAILED test/test_sandbox_docker_detection.py::TestWrapArgvDockerGuidance::test_bare_metal_no_backend_gets_generic_guidance
  assert 'install a supported sandbox backend' in 'Sandbox backend unavailable and allow_unsandboxed_exec is not
  set. No OS-level sandbox backend is available on this h...n ~/.kiro/crew/config.json allows unsandboxed
  execution, but that removes the isolation this check exists to protect. '
```

`Coverage Gate` and `PR Readiness` go red downstream of those two shards. The test arrived with d443428a (*fix: detect Docker container context in sandbox for actionable error*, #1617 / #1630).

## Why it matters

This is not a flake — it fails **100% of the time on every GitHub Linux runner**, so it is not something a rerun clears. It blocks the readiness signal for every open PR that rebases onto `main`, which makes `PR Readiness` useless as a merge gate exactly when it is being relied on: a maintainer either learns to ignore two red shards (and stops noticing a real backend regression there), or merges past the gate. #1675 was merged with an admin bypass for this reason, and #1744 shows the identical two failures.

## Fix (symptom → root cause → change)

**Symptom.** The message the test receives is not the generic guidance it asserts on — it is the AppArmor guidance, which names a per-application profile as the remedy and deliberately never says "install a supported sandbox backend".

**Root cause.** `_no_backend_guidance()` (`src/kiro_crew/sandbox.py:2015`) branches on:

```python
if sys.platform.startswith("linux") and _apparmor_userns_restricted():
```

`_apparmor_userns_restricted()` reads `/proc/sys/kernel/apparmor_restrict_unprivileged_userns` **from the real host**. That knob is `1` on every Ubuntu 23.10+ kernel, which is every `ubuntu-24.04` GitHub runner. The test patches `detect_backend`, `_allow_unsandboxed_exec`, `_inside_kirocrew_sandbox`, `_inside_macos_sandbox`, `is_docker_container` and `_last_unshare_failure` — but not `_apparmor_userns_restricted`, the one input that selects the branch it is asserting on. So CI always took the AppArmor branch.

This is why it passes for anyone developing on a host without that sysctl (Amazon Linux, Debian 13, older kernels, macOS) and fails unconditionally in CI. The other four tests in the class set `is_docker_container=True` and return before that branch is reached, which is why this was the only host-dependent one.

**Change.** Pin the probe to `False` — which is what "bare metal" in the test's own name and docstring already meant — so the test states the host shape it intends instead of inheriting it:

```python
monkeypatch.setattr(sandbox, "_apparmor_userns_restricted", lambda: False)
```

Production code is untouched. This patches the **defining** module, per `docs/system-specs/common/testing-conventions.md` §"Patch the defining module, not a re-export".

### Why not add a test, and why no coverage is lost

The AppArmor branch is already covered, and the sibling suite already follows exactly this convention: `test/test_sandbox_backend_cache.py::TestNoBackendGuidanceNamesTheRightRemedy` drives `_no_backend_guidance()` directly and always pins `_apparmor_userns_restricted` — `True` for the AppArmor/AppImage/systemd remedies, and `False` in `test_a_relaxed_sysctl_is_not_treated_as_the_apparmor_case`. Both branches keep their assertions. This PR makes the `wrap_argv`-level test agree with that convention rather than duplicating coverage.

The test also still verifies the fail-closed invariant it was written for: `SandboxUnavailableError` is raised, and `KIROCREW_ALLOW_UNSANDBOXED` is not offered as a remedy.

## Tests

No new tests. The change makes an existing test deterministic; adding a test for a one-line test fix would duplicate coverage that `test_sandbox_backend_cache.py` already has for both branches.

The defect and the fix were both verified by simulating the CI host, since this host cannot reproduce it natively:

| run | host shape | before | after |
|---|---|---|---|
| `test_sandbox_docker_detection.py` | forced `apparmor_restrict_unprivileged_userns=1` (mirrors `ubuntu-24.04`) | **1 failed**, 14 passed | **15 passed** |
| `test_sandbox_docker_detection.py` | real host, Amazon Linux 2023 (no such sysctl) | 15 passed | **15 passed** |

The "before" failure reproduces the CI assertion and message text exactly. The point of the second row is that the test is now green on **both** host shapes — it no longer depends on the machine it runs on.

## Manual verification

N/A — the change is test-only and the behaviour under test is asserted mechanically. Gates run locally: `isort --check-only` clean, `flake8 -j 1 src/kiro_crew test` clean, `mypy src/kiro_crew/` clean (728 files).

I did not run the full 30k-test suite locally; the change's blast radius is one test function and CI covers the rest. Two unrelated pre-existing failures showed up in my local runs and are **not** from this diff — `test_sandbox_backend_cache.py::test_fail_closed_transient_message_advises_retry_not_optout` fails standalone on a clean `main` checkout on this host, and seven `test_service.py` takeover-refusal tests fail because my shell runs inside a userns sandbox where `/usr/bin/env` reports `uid 65534`. Both are green on CI.

## Screenshots

N/A — no user-visible UI change.

## Related

Unblocks the two red backend shards on `main`; #1744 is currently blocked by the same failure.
