### PR TITLE
fix(chat): read the tool-purpose argument by shape, not by key allowlist

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -864,12 +864,22 @@ has nothing to go on and mirrors the language the user typed in — an inferred
 signal that flips mid-session the moment the user pastes an English stack trace,
 and one that persists, since purposes are stored in session history.
 
-Reading it back off the wire accepts **both** spellings — kiro-cli echoes the
-reserved arg in `rawInput` as either `__tool_use_purpose` or `__toolUsePurpose`
-depending on the call. `acp/_dispatch.py::extract_tool_purpose` (keys in
-`acp/types.py::TOOL_PURPOSE_KEYS`) is the single reader for both transports;
-matching one literal drops the purpose for the other half of the calls, and the
-concise pill silently falls back to the raw command line.
+Reading it back off the wire matches by **shape**, not by a list of literals.
+kiro-cli injects the `__tool_use_purpose` property into every tool schema it
+exposes, and echoes it back in `rawInput` as either that name or a camelCased
+`__toolUsePurpose` — but nothing validates the key, and the model paraphrases
+it: `__purpose`, `__thinking_purpose` and `__woohoo_purpose` all appear in real
+transcripts. `acp/_dispatch.py::extract_tool_purpose` prefers the canonical
+spellings in `acp/types.py::TOOL_PURPOSE_KEYS`, then accepts any *reserved*
+(dunder-prefixed) key whose name ends in `purpose`
+(`_dispatch.py::is_tool_purpose_key`), scanned in sorted order so the reading is
+deterministic. It is the single reader for both transports; matching literals
+drops the purpose for every paraphrased spelling, and the concise pill silently
+falls back to the raw command line while the unrecognized key leaks into the
+arguments view as if it were a real parameter. The dunder prefix is what keeps a
+tool's own functional `purpose` argument out of the match.
+`website/src/utils/toolPurpose.ts` is the frontend mirror, used by the
+pending-approval preview and the Mochi approval bubble.
 
 Three properties are load-bearing:
 

--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -17,6 +17,7 @@ import difflib
 import json
 import logging
 import math
+import re
 from pathlib import Path
 from typing import Any
 
@@ -254,19 +255,50 @@ def select_tool_title(title: object, raw_input: object) -> str | None:
     return None
 
 
+def is_tool_purpose_key(key: object) -> bool:
+    """True when ``key`` names the reserved tool-purpose argument.
+
+    Matched by SHAPE rather than by an allowlist of literals: any *reserved*
+    (dunder-prefixed) argument whose name ends in ``purpose`` once separators
+    and case are normalized away. The declared spelling is
+    ``__tool_use_purpose``, but the argument reaches us as whatever the model
+    actually emitted, and models paraphrase the name — ``__purpose``,
+    ``__thinking_purpose`` and ``__woohoo_purpose`` all occur in real
+    transcripts. An exact allowlist silently drops every one of them.
+
+    The ``__`` prefix is load-bearing: it keeps a *functional* argument that
+    happens to be called ``purpose`` (a tool legitimately taking a purpose
+    string) out of the match, because only dunder names are reserved. A tool
+    declaring its own dunder ``…purpose`` argument would be read as the purpose
+    line, which is the desired reading anyway — and harmless either way, since
+    this only picks the label and never rewrites the arguments sent to the tool.
+    """
+    if not isinstance(key, str) or not key.startswith("__"):
+        return False
+    return re.sub(r"[^a-z0-9]", "", key.lower()).endswith("purpose")
+
+
 def extract_tool_purpose(raw_input: object) -> str:
     """Pull the agent-authored purpose line out of a tool call's raw params.
 
-    Accepts every spelling in ``TOOL_PURPOSE_KEYS`` because kiro-cli echoes the
-    reserved argument back inconsistently (snake_case as declared in the tool
-    schema, camelCase on some calls). Reading only one literal drops the purpose
-    for the other half of the calls, which shows up as the dashboard's concise
+    The canonical spellings in ``TOOL_PURPOSE_KEYS`` are preferred (kiro-cli
+    echoes the reserved argument back as either the declared snake_case name or
+    a camelCased variant), then any other key matching
+    ``is_tool_purpose_key()``. Reading a fixed set of literals drops the purpose
+    for every paraphrased spelling, which shows up as the dashboard's concise
     tool pill falling back to the literal command line.
+
+    Off-canonical keys are scanned in sorted order so the choice is
+    deterministic when a call somehow carries more than one.
     """
     if not isinstance(raw_input, dict):
         return ""
     for key in TOOL_PURPOSE_KEYS:
         value = raw_input.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    for key in sorted(k for k in raw_input if is_tool_purpose_key(k)):
+        value = raw_input[key]
         if isinstance(value, str) and value.strip():
             return value
     return ""

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -141,10 +141,13 @@ KNOWN_SESSION_UPDATES = frozenset(
 # Reserved tool argument carrying the agent's own one-line reason for a call.
 # It is what the dashboard's concise tool label ("simplified tool names") shows
 # instead of the literal invocation, so a missed key silently degrades every
-# pill back to raw command text. BOTH spellings occur on the wire: our tool
-# schemas declare the snake_case key, but kiro-cli echoes some tool calls back
-# in ``rawInput`` with it camelCased — read via
-# ``_dispatch.extract_tool_purpose()``, never by indexing one literal.
+# pill back to raw command text. These are the CANONICAL spellings — our tool
+# schemas declare the snake_case name and kiro-cli echoes some calls back in
+# ``rawInput`` with it camelCased — but they are not the only ones on the wire:
+# models paraphrase the name (``__purpose``, ``__thinking_purpose``, …). Read
+# via ``_dispatch.extract_tool_purpose()``, which prefers these two and then
+# falls back to ``_dispatch.is_tool_purpose_key()`` shape matching; never index
+# one literal.
 TOOL_PURPOSE_KEYS: tuple[str, ...] = ("__tool_use_purpose", "__toolUsePurpose")
 
 # ── ACP Permission Outcomes ──

--- a/test/test_tool_purpose_key.py
+++ b/test/test_tool_purpose_key.py
@@ -1,0 +1,110 @@
+"""The reserved tool-purpose argument is read by SHAPE, not by an allowlist.
+
+kiro-cli injects a ``__tool_use_purpose`` property into every tool schema it
+exposes, so each tool call carries the agent's own one-line reason for the call
+— which the dashboard paints as the concise tool pill label. Nothing validates
+that key, though: it is a synthetic parameter the model fills in from prose, and
+models paraphrase the name. Real transcripts carry ``__purpose``,
+``__thinking_purpose`` and ``__woohoo_purpose``.
+
+Matching a fixed pair of literals dropped every paraphrase, which showed up as
+the pill silently falling back to the raw command line (and the stray key
+leaking into the arguments view as if it were a real parameter). These tests
+lock the shape match in, and lock OUT the two ways it could over-reach: a
+tool's own non-reserved ``purpose`` argument, and a name that merely contains
+the word.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew.acp._dispatch import extract_tool_purpose, is_tool_purpose_key
+from kiro_crew.acp.types import TOOL_PURPOSE_KEYS
+
+
+@pytest.mark.parametrize("key", list(TOOL_PURPOSE_KEYS))
+def test_canonical_spellings_match(key: str) -> None:
+    """The declared property and its camelCased echo both read."""
+    assert is_tool_purpose_key(key)
+    assert extract_tool_purpose({key: "Read the failing job log"}) == "Read the failing job log"
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "__purpose",  # observed in real transcripts (190+ calls in one session)
+        "__thinking_purpose",
+        "__woohoo_purpose",
+        "__toolPurpose",
+        "__tool-use-purpose",
+    ],
+)
+def test_paraphrased_spellings_match(key: str) -> None:
+    """A model-paraphrased name still yields the purpose line."""
+    assert is_tool_purpose_key(key)
+    assert extract_tool_purpose({key: "Read the failing job log", "command": "gh run view"}) == (
+        "Read the failing job log"
+    )
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "purpose",  # not reserved: could be a tool's own functional argument
+        "tool_use_purpose",
+        "_purpose",  # single underscore is not the reserved dunder prefix
+        "__purpose_of_the_call",  # does not END in "purpose"
+        "__purposefully",
+        "__command",
+    ],
+)
+def test_non_purpose_keys_do_not_match(key: str) -> None:
+    """Only reserved dunder names ending in "purpose" are claimed."""
+    assert not is_tool_purpose_key(key)
+    assert extract_tool_purpose({key: "not a purpose line"}) == ""
+
+
+def test_a_tools_own_purpose_argument_is_left_alone() -> None:
+    """A tool legitimately taking a ``purpose`` string is not misread as the
+    reserved argument — the pill would otherwise show a functional parameter."""
+    assert extract_tool_purpose({"purpose": "billing", "amount": 12}) == ""
+
+
+def test_canonical_spelling_wins_over_a_paraphrase() -> None:
+    """When both are present the declared property is authoritative."""
+    args = {"__purpose": "paraphrased", "__tool_use_purpose": "canonical"}
+    assert extract_tool_purpose(args) == "canonical"
+
+
+def test_multiple_paraphrases_resolve_deterministically() -> None:
+    """Sorted-key order, so the reading does not depend on wire order."""
+    forward = {"__woohoo_purpose": "second", "__alpha_purpose": "first"}
+    reverse = {"__alpha_purpose": "first", "__woohoo_purpose": "second"}
+    assert extract_tool_purpose(forward) == "first"
+    assert extract_tool_purpose(reverse) == "first"
+
+
+@pytest.mark.parametrize("value", ["", "   ", None, 42, ["a"], {"a": 1}])
+def test_blank_and_non_string_values_yield_nothing(value: object) -> None:
+    """A blank or non-string value is no purpose at all — the pill must fall
+    back to the raw label rather than render an empty prose label."""
+    assert extract_tool_purpose({"__purpose": value}) == ""
+
+
+def test_blank_canonical_falls_through_to_a_populated_paraphrase() -> None:
+    """A present-but-blank canonical key must not shadow a real purpose."""
+    args = {"__tool_use_purpose": "   ", "__purpose": "the real reason"}
+    assert extract_tool_purpose(args) == "the real reason"
+
+
+@pytest.mark.parametrize("raw", [None, "a string", 42, ["__purpose"], object()])
+def test_non_dict_params_yield_nothing(raw: object) -> None:
+    """Tool params arrive from the wire — a non-object payload is not a crash."""
+    assert extract_tool_purpose(raw) == ""
+
+
+def test_non_string_keys_are_tolerated() -> None:
+    """A JSON payload cannot produce them, but an internal caller could."""
+    assert not is_tool_purpose_key(42)
+    assert extract_tool_purpose({42: "nope", "__purpose": "yes"}) == "yes"

--- a/website/eslint.i18n.config.js
+++ b/website/eslint.i18n.config.js
@@ -717,6 +717,31 @@ export default [
     },
   },
 
+  // PROTOCOL KEY NAMES ONLY, same category as `wireValues.ts` above: this module's
+  // entire contents are the two spellings of kiro-cli's reserved tool-purpose
+  // ARGUMENT NAME (`__tool_use_purpose` and the camelCased echo) plus the regex that
+  // recognizes paraphrases of it. Each is compared by value against a key that
+  // arrives on the wire, so translating one silently stops matching and the tool
+  // pill falls back to raw command text in that locale — the exact defect the module
+  // exists to fix.
+  //
+  // The module has no path to user-visible copy of its own: it reads a string OUT of
+  // a payload and returns it verbatim. That returned string is model-authored prose,
+  // not interface copy, and is guarded at RENDER time against the active UI language
+  // by `utils/toolLabel.ts` instead.
+  //
+  // Scoped to this one file for the reason the three exemptions above are: a shape
+  // rule cannot express "reserved argument names, but only in this module". The
+  // dunder prefix looks like a self-anchoring shape, but admitting literals by it
+  // would also release every `__proto__` / `__dirname` guard string elsewhere in the
+  // tree from the gate.
+  {
+    files: ['src/utils/toolPurpose.ts'],
+    rules: {
+      'i18next/no-literal-string': 'off',
+    },
+  },
+
   // A GLSL-ONLY module: two shader programs (`VERT`, `FRAG`) as template literals,
   // plus CSS custom-property token names and Tailwind classes. The component
   // renders exactly one `<canvas aria-hidden="true">` and no text node, so it has

--- a/website/src/apps/mochi/panel/panelBridge.ts
+++ b/website/src/apps/mochi/panel/panelBridge.ts
@@ -22,6 +22,7 @@ import {
   type WatchStatus,
 } from '../api'
 import { approvalRoute } from './approvalActions'
+import { purposeFromToolArgs } from '../../../utils/toolPurpose'
 import type { NotificationPayload, PetMood, PetState } from '../src/shared/types'
 import type { PackManifest, PackMeta } from '../src/shared/appearanceTypes'
 
@@ -365,22 +366,19 @@ export function isRenderableChatRole(role: unknown): boolean {
 /**
  * The agent's own one-line statement of WHY it is calling the tool.
  *
- * Every tool call carries `__tool_use_purpose` in its arguments, so this is the
- * one field that describes the intent WITHOUT echoing the command — which is
- * what the pet's bubble wants: "needs your approval for <purpose>" stays
- * readable at bubble size and leaks no argument values onto the desktop.
+ * Every tool call carries a reserved purpose argument (see
+ * `utils/toolPurpose`), so this is the one field that describes the intent
+ * WITHOUT echoing the command — which is what the pet's bubble wants: "needs
+ * your approval for <purpose>" stays readable at bubble size and leaks no
+ * argument values onto the desktop.
  */
 function purposeFromToolInput(toolInput: string): string | undefined {
   try {
-    const parsed = JSON.parse(toolInput)
-    if (parsed !== null && typeof parsed === 'object') {
-      const p = (parsed as Record<string, unknown>).__tool_use_purpose
-      if (typeof p === 'string' && p.trim() !== '') return p.trim()
-    }
+    return purposeFromToolArgs(JSON.parse(toolInput)) || undefined
   } catch {
     // Not JSON (a bare shell string) — there is no declared purpose to read.
+    return undefined
   }
-  return undefined
 }
 
 export function permissionApprovalFromFrame(

--- a/website/src/apps/mochi/test/mochiTrustScopes.test.ts
+++ b/website/src/apps/mochi/test/mochiTrustScopes.test.ts
@@ -93,6 +93,17 @@ describe('permissionApprovalFromFrame carries the scope fields', () => {
     expect(req?.purpose).toBe('Walk around the screen')
   })
 
+  it('extracts the purpose under a model-paraphrased key spelling', () => {
+    const req = permissionApprovalFromFrame(
+      frame({
+        request_id: 'r1',
+        tool_title: 'T',
+        tool_input: JSON.stringify({ __purpose: 'Walk around the screen', action: 'move' }),
+      }),
+    )
+    expect(req?.purpose).toBe('Walk around the screen')
+  })
+
   it('has no purpose when the arguments are not JSON', () => {
     const req = permissionApprovalFromFrame(
       frame({ request_id: 'r1', tool_title: 'T', tool_input: 'rm -rf build' }),

--- a/website/src/pages/chat/CollapsibleToolGroup.tsx
+++ b/website/src/pages/chat/CollapsibleToolGroup.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, memo, type ReactNode } from 'react'
 import { CheckCircle, Handshake, Ban, Wrench, AlertTriangle } from 'lucide-react'
 import { sanitizeLlmOutput } from '../../utils/sanitize'
+import { purposeFromToolArgs } from '../../utils/toolPurpose'
 import { ToolInputText } from '../../components/ToolInputText'
 import { useRowDisclosure } from './rowDisclosure'
 
@@ -24,12 +25,6 @@ interface CollapsibleToolGroupProps {
   activityOpen?: boolean
 }
 
-/** Reserved tool argument holding the agent-authored purpose line. kiro-cli
- *  echoes it back under EITHER spelling, so both are read — matching only the
- *  snake_case one leaves the preview blank for the camelCase half of calls.
- *  Mirrors `TOOL_PURPOSE_KEYS` in `acp/types.py`. Protocol keys, not UI copy. */
-const PURPOSE_META_KEYS = ['__tool_use_purpose', '__toolUsePurpose'] as const
-
 /** Extract a human-readable command preview from permission meta. */
 function extractPreview(meta?: Record<string, unknown>): string {
   if (!meta) return ''
@@ -43,11 +38,9 @@ function extractPreview(meta?: Record<string, unknown>): string {
     // unreadable line with escaped \n / \t sequences.
     return JSON.stringify(ti, null, 2)
   }
-  for (const key of PURPOSE_META_KEYS) {
-    const purpose = meta[key]
-    if (typeof purpose === 'string' && purpose.trim()) return purpose
-  }
-  return ''
+  // Last resort: the agent-authored purpose line, read by shape so a
+  // paraphrased key spelling still previews (see utils/toolPurpose).
+  return purposeFromToolArgs(meta)
 }
 
 /** Collapsible row that wraps tool/thinking/permission messages — always collapsed unless autoExpand. */

--- a/website/src/test/CollapsibleToolGroup.purposePreview.test.tsx
+++ b/website/src/test/CollapsibleToolGroup.purposePreview.test.tsx
@@ -1,9 +1,11 @@
 /**
  * The pending-approval row previews what the tool is about to do. When the
  * permission meta carries no `tool_input`, the last resort is the
- * agent-authored purpose line — and kiro-cli echoes that reserved argument
- * under EITHER spelling (`__tool_use_purpose` / `__toolUsePurpose`), so
- * matching one literal left the preview blank for half the calls.
+ * agent-authored purpose line — and that reserved argument reaches us under
+ * whatever name the model emitted (the declared `__tool_use_purpose`, its
+ * camelCased echo, or a paraphrase like `__purpose`), so matching literals left
+ * the preview blank for whole sessions at a time. Read by shape instead; see
+ * `utils/toolPurpose`.
  */
 import { describe, it, expect } from 'vitest'
 import { renderWithProviders } from './helpers'
@@ -28,6 +30,11 @@ describe('CollapsibleToolGroup purpose preview', () => {
 
   it('previews the purpose under the camelCase spelling', () => {
     expect(preview({ __toolUsePurpose: 'Check the harness render errors' }))
+      .toContain('Check the harness render errors')
+  })
+
+  it('previews the purpose under a model-paraphrased spelling', () => {
+    expect(preview({ __purpose: 'Check the harness render errors' }))
       .toContain('Check the harness render errors')
   })
 

--- a/website/src/utils/toolPurpose.test.ts
+++ b/website/src/utils/toolPurpose.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Mirror of `test/test_tool_purpose_key.py` — the reserved tool-purpose
+ * argument is read by SHAPE, not by an allowlist of literals, because the key
+ * is a synthetic parameter the model fills in and models paraphrase its name
+ * (`__purpose`, `__thinking_purpose`, `__woohoo_purpose` all occur in real
+ * transcripts). Matching two literals left the purpose unread for whole
+ * sessions at a time.
+ */
+import { describe, it, expect } from 'vitest'
+import { isToolPurposeKey, purposeFromToolArgs, TOOL_PURPOSE_KEYS } from './toolPurpose'
+
+describe('isToolPurposeKey', () => {
+  it.each([...TOOL_PURPOSE_KEYS, '__purpose', '__thinking_purpose', '__woohoo_purpose', '__toolPurpose', '__tool-use-purpose'])(
+    'claims the reserved spelling %s',
+    key => { expect(isToolPurposeKey(key)).toBe(true) },
+  )
+
+  it.each(['purpose', 'tool_use_purpose', '_purpose', '__purpose_of_the_call', '__purposefully', '__command', ''])(
+    'leaves %s alone',
+    key => { expect(isToolPurposeKey(key)).toBe(false) },
+  )
+})
+
+describe('purposeFromToolArgs', () => {
+  it('reads the declared spelling', () => {
+    expect(purposeFromToolArgs({ __tool_use_purpose: 'Read the failing job log' }))
+      .toBe('Read the failing job log')
+  })
+
+  it('reads a paraphrased spelling alongside real arguments', () => {
+    expect(purposeFromToolArgs({ __purpose: 'Read the failing job log', command: 'gh run view' }))
+      .toBe('Read the failing job log')
+  })
+
+  it('prefers the declared spelling over a paraphrase', () => {
+    expect(purposeFromToolArgs({ __purpose: 'paraphrased', __tool_use_purpose: 'canonical' }))
+      .toBe('canonical')
+  })
+
+  it('resolves multiple paraphrases deterministically regardless of key order', () => {
+    expect(purposeFromToolArgs({ __woohoo_purpose: 'second', __alpha_purpose: 'first' })).toBe('first')
+    expect(purposeFromToolArgs({ __alpha_purpose: 'first', __woohoo_purpose: 'second' })).toBe('first')
+  })
+
+  it('does not misread a tool\u2019s own functional purpose argument', () => {
+    expect(purposeFromToolArgs({ purpose: 'billing', amount: 12 })).toBe('')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(purposeFromToolArgs({ __purpose: '  Read the log  ' })).toBe('Read the log')
+  })
+
+  it.each([[''], ['   '], [null], [42], [['a']], [{ a: 1 }]])(
+    'treats a blank or non-string value (%s) as no purpose',
+    value => { expect(purposeFromToolArgs({ __purpose: value })).toBe('') },
+  )
+
+  it('falls through a blank declared key to a populated paraphrase', () => {
+    expect(purposeFromToolArgs({ __tool_use_purpose: '   ', __purpose: 'the real reason' }))
+      .toBe('the real reason')
+  })
+
+  it.each([[null], [undefined], ['a string'], [42], [['__purpose']]])(
+    'returns nothing for a non-object payload (%s)',
+    args => { expect(purposeFromToolArgs(args)).toBe('') },
+  )
+})

--- a/website/src/utils/toolPurpose.ts
+++ b/website/src/utils/toolPurpose.ts
@@ -1,0 +1,57 @@
+/**
+ * Reader for the reserved tool-purpose argument.
+ *
+ * kiro-cli injects a `__tool_use_purpose` property ("A brief explanation why
+ * you are making this tool use") into EVERY tool schema it exposes — built-ins
+ * and MCP tools alike — so a tool call's arguments carry the agent's own
+ * one-line reason for the call. The dashboard surfaces that line as the tool
+ * pill label, the pending-approval preview, and the pet's approval bubble.
+ *
+ * Nothing validates the key, though: it is a synthetic parameter the model
+ * fills in from prose, and models paraphrase its name. Real transcripts carry
+ * `__purpose`, `__thinking_purpose` and `__woohoo_purpose` alongside the
+ * declared `__tool_use_purpose` and its camelCased echo. Matching a fixed list
+ * of literals therefore drops the purpose for whole sessions at a time, and the
+ * unrecognized key instead leaks into the arguments view as if it were a real
+ * parameter.
+ *
+ * So the match is by SHAPE, mirroring `_dispatch.is_tool_purpose_key()` /
+ * `extract_tool_purpose()` on the backend.
+ */
+
+/** The spellings kiro-cli itself emits: the declared snake_case property and
+ *  the camelCased echo some calls come back with. Preferred over a shape match
+ *  so the reading is stable when a call carries more than one candidate. */
+export const TOOL_PURPOSE_KEYS = ['__tool_use_purpose', '__toolUsePurpose'] as const
+
+/**
+ * True when `key` names the reserved tool-purpose argument.
+ *
+ * The `__` prefix is load-bearing: only dunder names are reserved, so a tool's
+ * own functional argument that happens to be called `purpose` stays out of the
+ * match.
+ */
+export function isToolPurposeKey(key: string): boolean {
+  if (!key.startsWith('__')) return false
+  return key.toLowerCase().replace(/[^a-z0-9]/g, '').endsWith('purpose')
+}
+
+/**
+ * The purpose line carried by a tool call's parsed arguments, or `''`.
+ *
+ * Canonical spellings win; other shape-matching keys are then scanned in sorted
+ * order so the choice is deterministic regardless of key order on the wire.
+ */
+export function purposeFromToolArgs(args: unknown): string {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return ''
+  const obj = args as Record<string, unknown>
+  for (const key of TOOL_PURPOSE_KEYS) {
+    const value = obj[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  for (const key of Object.keys(obj).filter(isToolPurposeKey).sort()) {
+    const value = obj[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return ''
+}


### PR DESCRIPTION
## Problem

Tool-call pills in the dashboard show the raw command line instead of the agent's
purpose, and the reserved purpose argument shows up in the expanded **Input**
table as if it were a real tool parameter:

```
Running: gh run view --repo kirodotdev/KiroCrew --job 92509928697 --log-failed 2>&1 | tail -40
  __purpose   读取 PR Hygiene 失败日志
  command     gh run view --repo kirodotdev/KiroCrew --job 92509928697 --log-failed 2>&1 | tail -40
```

The purpose is right there on the wire, and the dashboard renders neither of the
two things it should: it does not use it as the pill label, and it does not
recognize it as the reserved argument.

## Why it matters

The concise tool pill is the primary way a user reads what the agent is doing —
one prose line per call instead of a wall of shell. When it silently degrades to
raw commands, the chat becomes unreadable for the whole session, and the purpose
is *also* frozen empty into session history (`meta.purpose` is computed at
ingest), so the damage is permanent for those rows.

Measured on one dev desk, scanning the 25 most recent sessions:

| key on the wire | sessions | tool calls |
|---|---|---|
| `__tool_use_purpose` (declared) | most | thousands |
| `__purpose` | 3 | 260 |
| `__thinking_purpose` | 3 | 276 |
| `__woohoo_purpose` | 1 | 6 |

~540 tool calls across 6 sessions rendered with no purpose.

## Fix (symptom → root cause → change)

**Symptom:** the pill falls back to the raw command, and `__purpose` renders as a
tool argument.

**Root cause:** kiro-cli injects a `__tool_use_purpose` property ("A brief
explanation why you are making this tool use") into every tool schema it exposes
— built-ins and MCP tools alike — so every tool call carries the agent's own
reason for the call. But **nothing validates that key**: it is a synthetic
parameter the model fills in from prose, and models paraphrase its name. The
reader matched a two-literal allowlist:

```python
TOOL_PURPOSE_KEYS = ("__tool_use_purpose", "__toolUsePurpose")
```

so every paraphrase read as `""`. Two consequences follow mechanically: the pill
label falls back to the raw tool label, and the key — unrecognized — is rendered
by the arguments table like any other parameter.

**Change:** match by **shape** instead of by a list of literals. Any *reserved*
(dunder-prefixed) key whose name ends in `purpose` once separators and case are
normalized away is the purpose argument. Canonical spellings are still preferred;
other matches are scanned in sorted order so the reading is deterministic
regardless of key order on the wire.

The `__` prefix is load-bearing: it keeps a tool's own *functional* `purpose`
argument out of the match, so a tool that legitimately takes `purpose` is
unaffected. This only ever picks a display label — it never rewrites the
arguments sent to the tool, and it is upstream of every existing redaction sink,
so LLM-authored text is still scrubbed on every path.

- Backend: `src/kiro_crew/acp/_dispatch.py::is_tool_purpose_key` /
  `extract_tool_purpose` (the single reader for both ACP transports).
- Frontend: new `website/src/utils/toolPurpose.ts` mirror, replacing the same
  hardcoded pair in two places that read the key directly off a *permission
  request* frame — `pages/chat/CollapsibleToolGroup.tsx` (approval preview) and
  `apps/mochi/panel/panelBridge.ts` (pet approval bubble). Those frames carry
  `tool_input` as a JSON string with no normalized `purpose` field, so the
  frontend needs its own reader; the two implementations are kept honest by
  mirrored test files.
- Spec: `docs/system-specs/modules/config.md` updated — it previously documented
  the two-spelling contract as exhaustive.
- i18n: `website/eslint.i18n.config.js` gains a per-file exemption for the new
  module, in the same category as the existing `wireValues.ts` one. Its entire
  contents are protocol key names compared **by value** against a key that arrives
  on the wire, so translating one silently stops matching — the exact defect this
  PR fixes, reintroduced per locale. The module has no user-visible copy of its
  own: it reads a string out of a payload and returns it verbatim, and that string
  is guarded against the active UI language at render time by `utils/toolLabel.ts`.
  Inline `eslint-disable` is not an option — the diff-scoped gate runs with
  `allowInlineConfig: false` by design.

### Deliberately out of scope

- **Existing history rows stay blank.** `meta.purpose` is persisted at ingest, so
  this fixes new calls only. A render-time fallback that re-reads the key out of
  the stored `input` would recover the ~540 affected rows; it is a separate
  change and deliberately not bundled here.
- **The purpose key still appears in the Formatted Input table.** True before
  this change too (for the canonical spelling), so filtering it out is not a
  regression fix; and doing it *without* the render-time fallback above would
  make the purpose vanish entirely from historical rows.

Both are noted so the next reader does not mistake them for oversights.

## Tests

- `test/test_tool_purpose_key.py` (new, 29 cases) — canonical spellings; each
  paraphrase observed in real transcripts (`__purpose`, `__thinking_purpose`,
  `__woohoo_purpose`) plus `__toolPurpose` / `__tool-use-purpose`; and the
  over-reach cases that must NOT match: bare `purpose` (a tool's own functional
  argument), `_purpose`, `__purpose_of_the_call`, `__purposefully`. Also locks
  canonical-wins precedence, sorted-order determinism, blank/non-string values,
  blank-canonical fall-through, non-dict params, and non-string keys.
- `website/src/utils/toolPurpose.test.ts` (new, 32 cases) — the same matrix
  against the frontend mirror, so the two cannot drift silently.
- `website/src/test/CollapsibleToolGroup.purposePreview.test.tsx` — added a
  paraphrased-spelling case to the approval preview.
- `website/src/apps/mochi/test/mochiTrustScopes.test.ts` — added a paraphrased
  -spelling case to the pet approval bubble.

## Manual verification

N/A — unit coverage is sufficient. The defect is a pure key-matching decision on
a parsed payload, and the failing inputs were taken verbatim from real session
transcripts (`dashboard_chat-120`, `-113`, `-96`), so the tests exercise the exact
wire data that reproduced the bug.

Verified against a real transcript before and after: session
`dashboard_chat-120` has 51 tool calls whose args carry `__purpose`, every one of
them persisted with `meta.purpose == ""`; `extract_tool_purpose` now returns the
purpose for all 51.

## Screenshots

N/A — no layout, component, or styling change. The visible difference is which
string the existing pill renders, which is what the added unit tests assert.

## Gates

`pytest` (full suite), `isort`, `flake8`, `mypy` 1.14.1, `tsc -b`, `vitest`
(full, 9393 tests) all run locally in a CI-parity venv. Two pre-existing,
environment-only failures were confirmed to reproduce identically on a clean
`origin/main` checkout and are unrelated to this diff: the sandbox/ledger family
(this host cannot `unshare(CLONE_NEWUSER)` — EPERM) and
`src/i18n/format.test.ts` (asserts `Intl.DurationFormat` is undefined, true on
CI's Node 20, false on this host's Node 24).
