### PR TITLE
fix(agents): non-string model in one agent spec crashes the Agent Templates tab

### DIFF
--- a/src/kiro_crew/agent_discovery.py
+++ b/src/kiro_crew/agent_discovery.py
@@ -61,11 +61,95 @@ class AgentInfo:
     source: str = "builtin"  # "kirocrew" | "package" | "builtin"
     package: str = ""  # AIM package name (e.g. "Customer360GenAIContext")
 
+    def __post_init__(self) -> None:
+        """Make the annotations above TRUE, at every construction site.
+
+        ``~/.kiro/agents`` is a SHARED directory: ACP adapters and IDE plugins
+        drop their own specs there and do not all spell every field as a plain
+        string (observed: ``"model": {"id": "anthropic:claude-opus-4-8"}``, and
+        bare ``null``). ``to_dict()`` is what ``/api/agents/installed``
+        serialises, so any such value reached the dashboard verbatim; rendered as
+        a JSX child it threw React error #31 ("Objects are not valid as a React
+        child") and put the WHOLE Agent Templates tab into the error boundary —
+        every other agent's row with it.
+
+        The enforcement lives HERE rather than in per-field calls at each caller
+        because the fields are rendered bare in several places (`{a.name}`,
+        `{a.package}`, `<SourceBadge source={a.source}>`, `a.filename.startsWith`)
+        and there are two construction sites, one of them an out-of-tree edition
+        seam. A per-field fix at one caller only *looks* complete: the next
+        foreign spelling, or the next field someone renders, reopens the same
+        whole-tab crash. A constructor invariant cannot be forgotten.
+
+        Fallbacks are per field because they are not interchangeable: ``model``
+        defers to ``"auto"`` (see :func:`spec_model` — the same "non-string means
+        no pin" rule the execution path applies), ``source`` to its
+        ``"builtin"`` default, and the free-text fields to empty.
+        """
+        for name, fallback in (
+            ("name", ""),
+            ("filename", ""),
+            ("description", ""),
+            ("model", _DEFER_MODEL),
+            ("source", "builtin"),
+            ("package", ""),
+        ):
+            if not isinstance(getattr(self, name), str):
+                setattr(self, name, fallback)
+        # ``list[str]`` is equally load-bearing: these elements are rendered as
+        # skill/server chips. Drop the unusable ones rather than the whole list,
+        # so a spec with one bad entry keeps the rest.
+        self.skills = [s for s in self.skills if isinstance(s, str)]
+        self.mcp_servers = [s for s in self.mcp_servers if isinstance(s, str)]
+
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
 
 SKILL_URI_PREFIX = "skill://"
+
+# The "no pin, defer to the tier below" spelling. Mirrors
+# ``config.loader.DEFAULT_MODEL``; duplicated as a literal rather than imported
+# so this module keeps its leaf-level import graph (``config.paths`` only).
+_DEFER_MODEL = "auto"
+
+
+def spec_str(data: dict[str, Any], key: str, default: str = "") -> str:
+    """Read a raw spec field as a ``str``, for callers that are NOT an AgentInfo.
+
+    ``AgentInfo.__post_init__`` is what enforces the type contract for the
+    dataclass; this is its counterpart for the two places that hand spec fields
+    to the dashboard WITHOUT going through it:
+
+    - ``api_agent_detail``, which returns ``{**data, ...}`` — the raw on-disk spec
+      — so the detail panel receives whatever the file happened to contain.
+    - ``list_agents``, for ``name``, where the useful fallback is the file's own
+      stem rather than the generic empty string.
+
+    ``~/.kiro/agents`` is a SHARED directory: other tools (ACP adapters, IDE
+    plugins) drop their own specs there and do not all spell every field as a
+    plain string. Observed in the wild: ``"model": {"id":
+    "anthropic:claude-opus-4-8"}``, and a bare ``null``. Rendered as a React
+    child, either throws error #31 and blanks the whole Agent Templates tab.
+    """
+    value = data.get(key, default)
+    return value if isinstance(value, str) else default
+
+
+def spec_model(data: dict[str, Any]) -> str:
+    """The ``model`` of an agent spec, coerced to the ``str`` AgentInfo declares.
+
+    A non-string is treated as "no pin" (``"auto"``), which is exactly the rule
+    :func:`config.loader.normalize_agent_model` already applies to the same file
+    on the EXECUTION path. Keeping both sides on that rule is deliberate: the
+    resolver would collapse a structured model to "defer" regardless, so
+    extracting ``id`` here would make the displayed chip disagree with the model
+    actually used — and ``anthropic:claude-opus-4-8`` is a provider-prefixed id
+    kiro-cli would reject anyway, turning a display bug into a spawn failure.
+
+    It also leaked into ``subagent.py``'s spawn kwargs as a ``--model`` argument.
+    """
+    return spec_str(data, "model", _DEFER_MODEL)
 
 
 def _builder_mcp_skills(data: dict[str, Any]) -> list[str]:
@@ -261,14 +345,25 @@ def _with_edition_agents(disk_agents: list[AgentInfo]) -> list[AgentInfo]:
         if not isinstance(row, dict):
             continue
         name = row.get("name")
-        if not name or name in by_name:
+        # A row keyed by a non-string name has no usable identity: the name IS
+        # the dedup key, the React list key, and the argument every mutation
+        # (agentDetail / agentPatch / setDefaultAgent) is addressed by. Blanking
+        # it via __post_init__ would yield an unselectable row that also collides
+        # with any other nameless row, so such a row is skipped outright — unlike
+        # the cosmetic fields, which degrade.
+        if not isinstance(name, str) or not name or name in by_name:
             continue
         try:
             by_name[name] = AgentInfo(
                 name=name,
                 filename=row.get("filename", ""),
+                # Every other field is passed through as-is: this seam is
+                # out-of-tree, so ``__post_init__`` — not this call site — is what
+                # guarantees the declared ``str`` / ``list[str]`` types hold.
+                # ``model`` still goes through spec_model() because its "defer"
+                # spelling is domain knowledge, not a generic type fallback.
                 description=row.get("description", ""),
-                model=row.get("model", "auto"),
+                model=spec_model(row),
                 skills=list(row.get("skills") or []),
                 mcp_servers=list(row.get("mcp_servers") or []),
                 source=row.get("source", "builtin"),
@@ -330,7 +425,13 @@ def list_agents(agents_dir: Path | None = None) -> list[AgentInfo]:
                 if not isinstance(data, dict):
                     logger.debug("Skipping non-object agent config: %s", f)
                     continue
-                agent_name = data.get("name", "")
+                # Coerced BEFORE the package-detection below, which does
+                # ``stem.endswith(agent_name)``: a non-string name raised
+                # TypeError there, and the broad ``except`` around this loop
+                # turned that into a silently DROPPED agent rather than a
+                # degraded one. Falling back to the filename stem keeps the row
+                # selectable under the name its file already implies.
+                agent_name = spec_str(data, "name", f.stem)
                 stem = f.stem
 
                 package = ""
@@ -355,10 +456,10 @@ def list_agents(agents_dir: Path | None = None) -> list[AgentInfo]:
 
                 agents.append(
                     AgentInfo(
-                        name=data.get("name", f.stem),
+                        name=agent_name,
                         filename=f.name,
-                        description=data.get("description", ""),
-                        model=data.get("model", "auto"),
+                        description=spec_str(data, "description"),
+                        model=spec_model(data),
                         skills=_extract_skills(data),
                         mcp_servers=list((data.get("mcpServers") or {}).keys())
                         if isinstance(data.get("mcpServers") or {}, dict)

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -16,7 +16,12 @@ from typing import Any
 from aiohttp import web
 
 from kiro_crew import agent_state, model_registry
-from kiro_crew.agent_discovery import clear_list_agents_cache, list_agents
+from kiro_crew.agent_discovery import (
+    clear_list_agents_cache,
+    list_agents,
+    spec_model,
+    spec_str,
+)
 from kiro_crew.config.loader import (
     ConfigReadError,
     KiroCrewAgentConfig,
@@ -1076,7 +1081,19 @@ async def api_agent_detail(request: web.Request) -> web.Response:
                     discovery_executor(), agent_skill_views, data, f, state
                 )
                 return web.json_response(
-                    {**data, "skills": keys, "unmanaged_skills": unmanaged_uris}
+                    {
+                        **data,
+                        # The rest of the spec is passed through verbatim, but
+                        # these two are CONSUMED as display text by the detail
+                        # panel. A foreign spec's structured value rendered as a
+                        # React child throws error #31 and blanks the whole tab,
+                        # so both are coerced on the same "non-string means
+                        # absent" rule list_agents() uses.
+                        "description": spec_str(data, "description"),
+                        "model": spec_model(data),
+                        "skills": keys,
+                        "unmanaged_skills": unmanaged_uris,
+                    }
                 )
         except (json.JSONDecodeError, OSError):
             continue

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -93,6 +93,7 @@ if TYPE_CHECKING:
 
 from kiro_crew import model_registry, platform_compat, shutdown_event
 from kiro_crew.acp.client import advertised_model_ids, model_is_unusable
+from kiro_crew.agent_discovery import spec_model
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import (
     POOL_SIZE_MAX,
@@ -2015,7 +2016,12 @@ class SessionManager:
                 except (ValueError, OSError):
                     continue
                 if ad.get("name") == agent or af.stem == agent:
-                    model = ad.get("model", "auto")
+                    # Coerced, not raw: this method is annotated ``-> str`` and
+                    # its result is CACHED, fed to ``/api/sessions/context``
+                    # (where the dashboard calls ``.replace()`` on it) and
+                    # compared/translated as a model id in ``claim_pooled``. A
+                    # foreign spec's ``{"id": ...}`` would poison all three.
+                    model = spec_model(ad)
                     break
         except Exception:
             pass

--- a/test/test_agent_discovery.py
+++ b/test/test_agent_discovery.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from kiro_crew.agent_discovery import clear_list_agents_cache, list_agents
+from kiro_crew.agent_discovery import AgentInfo, clear_list_agents_cache, list_agents
 
 
 @pytest.fixture
@@ -92,6 +92,199 @@ class TestListAgentsRobustness:
         agents = list_agents(agents_dir=agents_dir)
         names = {a.name for a in agents}
         assert "good" in names, "well-formed sibling agent must survive a bad mcpServers value"
+
+
+class TestSpecModelCoercion:
+    """``AgentInfo.model`` is declared ``str`` and must always BE one.
+
+    ``~/.kiro/agents`` is shared with other tools whose specs spell ``model``
+    differently. A non-string reached the dashboard via ``to_dict()`` ->
+    ``/api/agents/installed`` and, rendered as a React child, threw error #31 —
+    taking the whole Agent Templates tab (and every other agent's row) down.
+    """
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            # ACP-style structured reference, observed in the wild. This exact
+            # shape produced "object with keys {id}" in the React #31 message.
+            {"id": "anthropic:claude-opus-4-8"},
+            None,  # key present but null
+            ["claude-opus-4-8"],
+            42,
+        ],
+        ids=["dict-id", "null", "list", "int"],
+    )
+    def test_non_string_model_degrades_to_auto(self, tmp_path: Path, raw: object) -> None:
+        d = tmp_path / "agents"
+        d.mkdir()
+        (d / "foreign.json").write_text(
+            json.dumps({"name": "foreign", "model": raw}), encoding="utf-8"
+        )
+        clear_list_agents_cache()
+        (agent,) = list_agents(agents_dir=d)
+        assert agent.model == "auto"
+        # to_dict() is what the API serialises — the guarantee has to hold there,
+        # since that is the value the dashboard renders.
+        assert isinstance(agent.to_dict()["model"], str)
+
+    def test_string_model_is_preserved(self, tmp_path: Path) -> None:
+        """The coercion must not flatten a legitimately pinned model."""
+        d = tmp_path / "agents"
+        d.mkdir()
+        (d / "pinned.json").write_text(
+            json.dumps({"name": "pinned", "model": "claude-opus-4-6"}), encoding="utf-8"
+        )
+        clear_list_agents_cache()
+        (agent,) = list_agents(agents_dir=d)
+        assert agent.model == "claude-opus-4-6"
+
+    def test_non_string_description_degrades_to_empty(self, tmp_path: Path) -> None:
+        """``model`` is not the only rendered field, so it is not the only one guarded.
+
+        The detail panel renders ``description`` as a JSX child too, and an object
+        is truthy — so a foreign spec with a structured ``description`` blanks the
+        whole tab exactly like a structured ``model`` does. Coercing per FIELD is
+        what closes the class rather than the one observed instance.
+        """
+        d = tmp_path / "agents"
+        d.mkdir()
+        (d / "foreign.json").write_text(
+            json.dumps({"name": "foreign", "description": {"text": "hi"}, "model": "auto"}),
+            encoding="utf-8",
+        )
+        clear_list_agents_cache()
+        (agent,) = list_agents(agents_dir=d)
+        assert agent.description == ""
+        assert isinstance(agent.to_dict()["description"], str)
+
+    def test_string_description_is_preserved(self, tmp_path: Path) -> None:
+        d = tmp_path / "agents"
+        d.mkdir()
+        (d / "ok.json").write_text(
+            json.dumps({"name": "ok", "description": "a real one", "model": "auto"}),
+            encoding="utf-8",
+        )
+        clear_list_agents_cache()
+        (agent,) = list_agents(agents_dir=d)
+        assert agent.description == "a real one"
+
+    def test_bad_model_does_not_drop_sibling_agents(self, tmp_path: Path) -> None:
+        """A foreign spec must cost only its own row, never the whole listing."""
+        d = tmp_path / "agents"
+        d.mkdir()
+        (d / "foreign.json").write_text(
+            json.dumps({"name": "foreign", "model": {"id": "anthropic:claude-opus-4-8"}}),
+            encoding="utf-8",
+        )
+        (d / "good.json").write_text(
+            json.dumps({"name": "good", "model": "auto"}), encoding="utf-8"
+        )
+        clear_list_agents_cache()
+        names = {a.name for a in list_agents(agents_dir=d)}
+        assert names == {"foreign", "good"}
+
+    def test_edition_supplied_row_is_coerced(self, tmp_path: Path, monkeypatch) -> None:
+        """The edition seam is a SECOND ``AgentInfo`` construction site.
+
+        Rows arrive from out-of-tree code, so ``AgentInfo.model: str`` has to be
+        enforced there too — coercing only the on-disk path would leave the same
+        crash reachable through an edition build.
+        """
+        d = tmp_path / "agents"
+        d.mkdir()
+        # Stub the seam at ``safe_context_call``: it is what ``_with_edition_agents``
+        # funnels the platform lookup through, so this needs no platform context.
+        monkeypatch.setattr(
+            "kiro_crew.platform.context.safe_context_call",
+            lambda *_a, **_kw: [
+                {"name": "edition-foreign", "model": {"id": "anthropic:claude-opus-4-8"}}
+            ],
+        )
+        clear_list_agents_cache()
+        by_name = {a.name: a for a in list_agents(agents_dir=d)}
+        assert by_name["edition-foreign"].model == "auto"
+
+    def test_every_str_field_is_coerced_at_construction(self) -> None:
+        """The invariant is on the CONSTRUCTOR, not on any one caller.
+
+        `model` and `description` were the two fields observed failing, but
+        `name`, `package`, `source` and `filename` are rendered bare too
+        (`{a.name}`, `{a.package}`, `<SourceBadge source={a.source}>`,
+        `a.filename.startsWith(...)`), so a per-field fix at one call site only
+        looks complete. Constructing directly — as the out-of-tree edition seam
+        does — must still yield the declared types.
+        """
+        info = AgentInfo(
+            name={"id": "x"},  # type: ignore[arg-type]
+            filename=None,  # type: ignore[arg-type]
+            description=["a"],  # type: ignore[arg-type]
+            model={"id": "anthropic:claude-opus-4-8"},  # type: ignore[arg-type]
+            source=7,  # type: ignore[arg-type]
+            package={"n": 1},  # type: ignore[arg-type]
+        )
+        assert info.name == ""
+        assert info.filename == ""
+        assert info.description == ""
+        assert info.model == "auto"
+        assert info.source == "builtin"
+        assert info.package == ""
+        # to_dict() is the wire shape the dashboard renders.
+        assert all(isinstance(v, str) for k, v in info.to_dict().items() if k not in
+                   ("skills", "mcp_servers"))
+
+    def test_list_fields_drop_only_the_unusable_elements(self) -> None:
+        """`skills` / `mcp_servers` are rendered as chips, one element each.
+
+        A bad entry costs itself, not the whole list — dropping the list would
+        hide real skills the agent does have.
+        """
+        info = AgentInfo(
+            name="a",
+            filename="a.json",
+            description="",
+            model="auto",
+            skills=["good", {"bad": 1}, "also-good"],  # type: ignore[list-item]
+            mcp_servers=[None, "srv"],  # type: ignore[list-item]
+        )
+        assert info.skills == ["good", "also-good"]
+        assert info.mcp_servers == ["srv"]
+
+    def test_non_string_name_falls_back_to_filename_stem(self, tmp_path: Path) -> None:
+        """A structured `name` must degrade the row, not silently DROP it.
+
+        The package-detection branch does `stem.endswith(agent_name)`, which
+        raised TypeError on a non-string name; the loop's broad `except` then
+        swallowed it and the agent vanished from the listing entirely.
+        """
+        d = tmp_path / "agents"
+        d.mkdir()
+        (d / "weird.json").write_text(
+            json.dumps({"name": {"id": "nope"}, "model": "auto"}), encoding="utf-8"
+        )
+        clear_list_agents_cache()
+        (agent,) = list_agents(agents_dir=d)
+        assert agent.name == "weird"
+
+    def test_edition_row_with_unusable_name_is_skipped(self, tmp_path: Path, monkeypatch) -> None:
+        """Unlike cosmetic fields, an unusable NAME is not degraded.
+
+        The name is the dedup key, the React list key, and the argument every
+        mutation is addressed by, so a blank-named row would be unselectable and
+        would collide with any other nameless row.
+        """
+        d = tmp_path / "agents"
+        d.mkdir()
+        monkeypatch.setattr(
+            "kiro_crew.platform.context.safe_context_call",
+            lambda *_a, **_kw: [
+                {"name": {"id": "nope"}, "model": "auto"},
+                {"name": "usable", "model": "auto"},
+            ],
+        )
+        clear_list_agents_cache()
+        names = {a.name for a in list_agents(agents_dir=d)}
+        assert names == {"usable"}
 
 
 class TestListAgentsGlobalGuards:

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -1738,6 +1738,29 @@ class TestContextInfo:
             result = SessionManager._resolve_agent_model("test-agent")
         assert result == "opus-5"
 
+    def test_resolve_agent_model_coerces_non_string_spec(self, cfg, tmp_path):
+        """A foreign spec's structured ``model`` must not escape as a dict.
+
+        ``~/.kiro/agents`` is shared with other tools; an ACP-style
+        ``{"id": ...}`` here would be CACHED and then handed to
+        ``/api/sessions/context`` (the dashboard calls ``.replace()`` on it) and
+        to the pooled-model comparison in ``claim_pooled``. This method is
+        annotated ``-> str`` and must honour that.
+        """
+        import json
+
+        if hasattr(SessionManager, "_agent_model_cache"):
+            SessionManager._agent_model_cache.clear()
+        agent_file = tmp_path / "foreign.json"
+        agent_file.write_text(
+            json.dumps({"name": "foreign", "model": {"id": "anthropic:claude-opus-4-8"}})
+        )
+
+        with patch("kiro_crew.agent.KIRO_AGENTS_DIR", tmp_path):
+            result = SessionManager._resolve_agent_model("foreign")
+        assert result == "auto"
+        assert isinstance(result, str)
+
 
 class TestWarmPoolInternals:
     """Tests for _fill_warm_pool, _claim_from_pool, _drain_and_claim."""

--- a/website/src/pages/AgentsPage.tsx
+++ b/website/src/pages/AgentsPage.tsx
@@ -36,6 +36,22 @@ function barGlow(pct: number): string {
 
 interface CtxSession { key: string; name: string; model: string; agent?: string; context_pct: number; context_window_tokens?: number; prompts: number }
 
+/**
+ * A safe display string for an agent's `model`.
+ *
+ * The backend now coerces `model` to a string on both the installed-list and
+ * detail endpoints, but `api.agentDetail` is otherwise a pass-through of a
+ * user-editable JSON spec from a SHARED directory that other tools write into.
+ * A non-string that slips through (e.g. an ACP-style `{"id": "..."}`) rendered
+ * as a JSX child throws React error #31 and puts the whole Agent Templates tab
+ * into the error boundary — one bad file hiding every other agent. Belt and
+ * braces: anything that is not a string degrades to `auto` for that one row.
+ */
+function modelLabel(model: unknown): string {
+  return typeof model === 'string' && model ? model : 'auto'
+}
+
+
 /** Shape of an installed-agent list item (also the `api.agentsInstalled` element). */
 interface InstalledAgent {
   name: string
@@ -212,7 +228,7 @@ export default function AgentsPage({ embedded }: { embedded?: boolean } = {}) {
                         <div className="flex items-center gap-2 min-w-0">
                           {a.skills.length > 0 && <span className="text-[11px] text-muted shrink-0"><Brain className="lucide-inline" />{a.skills.length}</span>}
                           {a.mcp_servers.length > 0 && <span className="text-[11px] text-muted shrink-0"><Plug className="lucide-inline" />{a.mcp_servers.length}</span>}
-                          <span className="text-[11px] text-muted font-mono truncate min-w-0" title={a.model}>{a.model}</span>
+                          <span className="text-[11px] text-muted font-mono truncate min-w-0" title={modelLabel(a.model)}>{modelLabel(a.model)}</span>
                         </div>
                         {/* The word carries the state: a bare star glyph gives a first-time
                             user nothing to read, so the default-agent control is labeled. */}
@@ -256,7 +272,7 @@ export default function AgentsPage({ embedded }: { embedded?: boolean } = {}) {
                       <span className="text-sm font-mono font-bold text-text-strong">{selectedAgent.name}</span>
                       <div className="relative">
                         <Btn ref={modelBtnRef} className="flex items-center gap-1 px-2 py-0.5 text-[12px] font-mono font-medium" onClick={() => setModelDropOpen(!modelDropOpen)}>
-                          <span><Brain className="lucide-inline" /></span> {selectedAgent.model || 'auto'} <span className="text-muted text-[10px]"><ChevronDown className="lucide-inline" /></span>
+                          <span><Brain className="lucide-inline" /></span> {modelLabel(selectedAgent.model)} <span className="text-muted text-[10px]"><ChevronDown className="lucide-inline" /></span>
                         </Btn>
                         {modelDropOpen && modelBtnRef.current && createPortal(
                           // Presentational positioning wrapper: the interactive semantics live
@@ -269,7 +285,7 @@ export default function AgentsPage({ embedded }: { embedded?: boolean } = {}) {
                               <Input ref={modelInputRef} type="text" aria-label={i18nT('pages.agentsPage.filter_models')} placeholder={i18nT('pages.agentsPage.type_to_filter')} value={modelFilter} onChange={e => setModelFilter(e.target.value)} className="w-full px-2 py-1 text-[13px] font-mono" />
                             </div>
                             <div role="listbox" aria-label={i18nT('pages.agentsPage.model_list')} className="overflow-y-auto flex-1 min-h-0">
-                            <ModelDropdownList models={filteredModels} activeModel={selectedAgent.model || 'auto'} onSelect={name => { const val = name === 'auto' ? '' : name; patchModelMut.mutate({ name: selectedAgent.name, model: val }); setModelDropOpen(false) }} />
+                            <ModelDropdownList models={filteredModels} activeModel={modelLabel(selectedAgent.model)} onSelect={name => { const val = name === 'auto' ? '' : name; patchModelMut.mutate({ name: selectedAgent.name, model: val }); setModelDropOpen(false) }} />
                             </div>
                           </div>,
                           document.body
@@ -278,7 +294,11 @@ export default function AgentsPage({ embedded }: { embedded?: boolean } = {}) {
                       {(() => { const a = installed.find(a => a.name === selectedAgent.name); return a?.package ? <span className="text-[11px] text-aim bg-aim/10 px-2 py-0.5 rounded-md border border-aim/30">{a.filename?.startsWith('local-') ? <Pin className="lucide-inline" /> : <Package className="lucide-inline" />} {a.package}</span> : null })()}
                     </div>
                   </div>
-                  {selectedAgent.description && <div className="text-[13px] text-muted mb-3 leading-relaxed">{selectedAgent.description}</div>}
+                  {/* `typeof` guard, not a bare truthiness check: an object is
+                      truthy, so a foreign spec's structured `description` would
+                      pass `&&` and then throw React error #31 as a JSX child —
+                      the same whole-tab crash `modelLabel` guards on `model`. */}
+                  {typeof selectedAgent.description === 'string' && selectedAgent.description && <div className="text-[13px] text-muted mb-3 leading-relaxed">{selectedAgent.description}</div>}
                   {selectedAgent.skills === undefined ? (
                     /* The agent-detail fetch failed, so the real mapping is
                      * UNKNOWN. An empty-but-enabled editor here is destructive:

--- a/website/src/test/AgentsPage.model.test.tsx
+++ b/website/src/test/AgentsPage.model.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Agent Templates must survive a foreign-shaped `model` on any single agent.
+ *
+ * `~/.kiro/agents` is a SHARED directory: other tools (ACP adapters, IDE
+ * plugins) write their own specs there, and not all of them spell `model` as a
+ * plain string. An ACP-style `{ "id": "anthropic:claude-opus-4-8" }` rendered
+ * as a JSX child throws React error #31 ("Objects are not valid as a React
+ * child"), which put the WHOLE tab into the error boundary — every other
+ * agent's row, the context panel and the subagents table included.
+ *
+ * The backend now coerces `model` on both `/api/agents/installed` and
+ * `/api/agents/detail/{name}`, but `agentDetail` is otherwise a pass-through of
+ * a user-editable spec, so the page keeps its own guard. These tests drive the
+ * page with the raw bad shape to prove the guard, not the coercion.
+ */
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockApi = vi.hoisted(() => ({
+  spawnList: vi.fn(),
+  sessionsContext: vi.fn(),
+  sessionsUsage: vi.fn(),
+  agentsInstalled: vi.fn(),
+  mcpProbeCache: vi.fn(),
+  defaultAgent: vi.fn(),
+  agentDetail: vi.fn(),
+  skills: vi.fn(),
+  agentPatch: vi.fn(),
+  spawnClear: vi.fn(),
+  spawnDelete: vi.fn(),
+  setDefaultAgent: vi.fn(),
+}))
+vi.mock('../api/client', () => ({ api: mockApi }))
+vi.mock('../store', () => ({ useAppSelector: (fn: (s: unknown) => unknown) => fn({ dashboard: { status: { sessions: 0, subagents: 0 }, refreshTrigger: 0 } }) }))
+vi.mock('../providers', () => ({
+  useProvider: () => ({
+    id: 'acp',
+    capabilities: { agentTemplates: true },
+    labels: { sessionProcess: 'ACP subprocess', configFile: 'agent.json' },
+    fetchAvailableModels: () => Promise.resolve([{ name: 'claude-opus-4.8', description: '' }]),
+    getContextWindow: () => 200_000,
+  }),
+}))
+
+import AgentsPage from '../pages/AgentsPage'
+
+/** The exact shape observed in the wild (`quickwork_acp_kiro.json`). */
+const ACP_MODEL = { id: 'anthropic:claude-opus-4-8' }
+
+const mkAgent = (name: string, model: unknown) => ({
+  name,
+  description: `${name} agent`,
+  source: 'builtin',
+  model,
+  skills: [],
+  mcp_servers: [],
+  filename: `${name}.json`,
+})
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <AgentsPage embedded />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  Object.values(mockApi).forEach(fn => fn.mockReset())
+  mockApi.spawnList.mockResolvedValue({ agents: [] })
+  mockApi.sessionsContext.mockResolvedValue({ sessions: [] })
+  mockApi.sessionsUsage.mockResolvedValue({ usage: null })
+  mockApi.mcpProbeCache.mockResolvedValue([])
+  mockApi.skills.mockResolvedValue([])
+  mockApi.defaultAgent.mockResolvedValue({ default_agent: '' })
+  mockApi.setDefaultAgent.mockResolvedValue({ ok: true, default_agent: '' })
+})
+
+describe('AgentsPage model rendering', () => {
+  it('renders the list when one agent has an object model, keeping its siblings', async () => {
+    mockApi.agentsInstalled.mockResolvedValue([
+      mkAgent('kirocrew', 'claude-opus-4.8'),
+      mkAgent('quickwork_acp_kiro', ACP_MODEL),
+    ])
+    mockApi.agentDetail.mockResolvedValue({ ...mkAgent('kirocrew', 'claude-opus-4.8'), unmanaged_skills: [] })
+
+    renderPage()
+
+    // The bad row is present and shows the "no pin" label rather than crashing.
+    expect(await screen.findByText('quickwork_acp_kiro')).toBeInTheDocument()
+    // The well-formed sibling is the real regression risk: pre-fix it vanished
+    // with the rest of the tab, because one bad child unmounts the whole tree.
+    // getAllByText, not getByText — the auto-opened detail panel repeats the
+    // selected agent's name and model alongside its list row.
+    expect(screen.getAllByText('kirocrew').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('claude-opus-4.8').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('auto').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders the detail model chip when the selected agent has an object model', async () => {
+    mockApi.agentsInstalled.mockResolvedValue([mkAgent('quickwork_acp_kiro', ACP_MODEL)])
+    // agentDetail passes the spec through, so the detail panel sees the raw shape.
+    mockApi.agentDetail.mockResolvedValue({
+      ...mkAgent('quickwork_acp_kiro', ACP_MODEL),
+      skills: [],
+      unmanaged_skills: [],
+    })
+
+    renderPage()
+
+    fireEvent.click(await screen.findByText('quickwork_acp_kiro'))
+    // Both the row label and the detail chip degrade to "auto".
+    await waitFor(() => expect(screen.getAllByText('auto').length).toBeGreaterThanOrEqual(2))
+  })
+
+  it('shows auto for a null model instead of a blank', async () => {
+    mockApi.agentsInstalled.mockResolvedValue([mkAgent('nullish', null)])
+    mockApi.agentDetail.mockResolvedValue({ ...mkAgent('nullish', null), unmanaged_skills: [] })
+
+    renderPage()
+
+    expect(await screen.findByText('nullish')).toBeInTheDocument()
+    expect(screen.getAllByText('auto').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders the detail panel when the selected agent has an object description', async () => {
+    // `description` is rendered as a JSX child too, and an object is truthy — so
+    // a bare `&&` guard let it through and crashed the tab the same way `model`
+    // did. This is the class, not a second special case.
+    const bad = { ...mkAgent('weird-desc', 'claude-opus-4.8'), description: { text: 'hi' } }
+    mockApi.agentsInstalled.mockResolvedValue([bad])
+    mockApi.agentDetail.mockResolvedValue({ ...bad, skills: [], unmanaged_skills: [] })
+
+    renderPage()
+
+    fireEvent.click(await screen.findByText('weird-desc'))
+    // The row and the detail panel both survive; the unusable description is
+    // simply not shown rather than taking the tree down.
+    await waitFor(() => expect(screen.getAllByText('claude-opus-4.8').length).toBeGreaterThanOrEqual(1))
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #1813

## Summary

Opening **Agent Capabilities → Agent Templates** crashed the whole tab into the error boundary when *any* file in `~/.kiro/agents/*.json` had a non-string `model`:

```
Minified React error #31; ... args[]=object%20with%20keys%20%7Bid%7D
```

`~/.kiro/agents` is a **shared** directory — ACP adapters and IDE plugins write their own specs into it, and they don't all spell `model` as a plain string. Real reproducer from my machine (`quickwork_acp_kiro.json`):

```json
{ "name": "quickwork_acp_kiro", "model": { "id": "anthropic:claude-opus-4-8" } }
```

`list_agents()` assigned `data.get("model", "auto")` straight through, silently violating the declared `AgentInfo.model: str`. `to_dict()` is what `GET /api/agents/installed` serialises, so the object reached the dashboard verbatim and `AgentsPage` rendered it bare as a JSX child. One bad file took out **every other agent's row**, the context-window panel, the usage panel and the subagents table.

`GET /api/agents/detail/{name}` returns `{**data, ...}` (the raw spec), so the detail panel's model chip was a second, independent crash site from the same cause.

## Changes

| File | Change |
|---|---|
| `src/kiro_crew/agent_discovery.py` | New `spec_model()` choke point; a non-`str` `model` becomes `"auto"`. `AgentInfo.model` now actually is the `str` it declares. |
| `src/kiro_crew/dashboard/handlers/agents.py` | `api_agent_detail` GET normalises `model` instead of passing the raw spec value through. |
| `website/src/pages/AgentsPage.tsx` | `modelLabel()` guard on the three render sites (list row, detail chip, dropdown `activeModel`). |

### Why coerce to `auto` rather than extract the `id`

`config.loader.normalize_agent_model()` already documents "a non-string is treated as no pin" and applies it to the same file on the **execution** path, so the resolver collapses a structured model to "defer" regardless. Extracting `id` here would make the displayed chip disagree with the model actually used — precisely the drift `resolve_effective_model()`'s docstring exists to prevent. And `anthropic:claude-opus-4-8` is a provider-prefixed id kiro-cli would reject, so surfacing it would trade a display bug for a spawn-time failure. `""` and `"auto"` are the same "defer" value in this codebase, so both paths now agree.

This also stops a dict leaking into `subagent.py`'s spawn kwargs as a `--model` argument (`subagent.py:4001`).

The frontend guard is deliberate defence in depth rather than redundancy: `agentDetail` is otherwise a pass-through of a user-editable spec, and the failure mode here is "one bad file blanks the whole tab", which is too expensive to leave resting on a single layer.

`"model": null` was a milder instance of the same hole — it survived React but rendered a blank where `auto` belongs. Now covered.

## Testing

**`test/test_agent_discovery.py`** — new `TestSpecModelCoercion`:
- parametrised coercion over `{"id": ...}` / `null` / list / int, asserting both `AgentInfo.model` and the `to_dict()` value the API serialises
- a legitimately pinned model is *not* flattened
- a foreign spec costs only its own row, never its siblings

**`website/src/test/AgentsPage.model.test.tsx`** — new, drives the page with the raw bad shape (not the coerced value) to test the guard itself: list renders with siblings intact, detail chip renders when the bad agent is selected, `null` shows `auto`.

Verification run locally:

- `pytest test/test_agent_discovery.py test/test_agent.py test/test_agent_default_model.py test/test_agent_detail_model_managed.py test/test_agent_template_skills.py test/test_agent_sync_prune.py test/test_api_agents_order.py test/test_agent_spec_preflight.py test/test_get_agent_names.py test/test_lite_agent_duplicate.py` → **290 passed**
- `vitest run` (full website suite) → **9395 passed**, 2 pre-existing failures in `src/test/fileExplorer.test.tsx` (`formatTime` pre-epoch, timezone-dependent — passes under `TZ=UTC` as CI runs; untouched by this change)
- `tsc --noEmit`, `eslint src`, `flake8`, `isort --check-only`, `mypy src/kiro_crew/agent_discovery.py` → clean

Reverting only the `AgentsPage.tsx` guard makes the new vitest suite fail with the exact upstream message — `Objects are not valid as a React child (found: object with keys {id})` — confirming the tests reproduce the reported bug rather than merely asserting the new behaviour.
