### PR TITLE
fix(cli): self-heal stale editable installs instead of dying on missing deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dynamic = ["dependencies", "optional-dependencies"]
 Homepage = "https://github.com/kirodotdev/KiroCrew"
 
 [project.scripts]
-kirocrew = "kiro_crew.cli:main"
+kirocrew = "kiro_crew._bootstrap:main"
 
 [dependency-groups]
 # Pinned dev tool versions for reproducible CI. Bump as needed.

--- a/setup.cfg
+++ b/setup.cfg
@@ -189,10 +189,11 @@ kiro_crew =
 
 [options.entry_points]
 # Console scripts installed onto PATH by pip:
-#   kirocrew        -> kiro_crew.cli:main
+#   kirocrew        -> kiro_crew._bootstrap:main (self-heals stale editable
+#                      installs, then dispatches to kiro_crew.cli:main)
 #   kirocrew-browse -> kiro_crew.browser.cli:main
 console_scripts =
-    kirocrew = kiro_crew.cli:main
+    kirocrew = kiro_crew._bootstrap:main
     kirocrew-browse = kiro_crew.browser.cli:main
 
 # Configuration for pytest; enable coverage for KiroCrew, emit

--- a/src/kiro_crew/_bootstrap.py
+++ b/src/kiro_crew/_bootstrap.py
@@ -1,0 +1,117 @@
+"""Console-script entry that self-heals a stale editable install.
+
+``kirocrew`` is often run from a git checkout (``pip install -e .``). A plain
+``git pull`` never re-runs dependency resolution, so a commit that adds a
+runtime dependency leaves every subsequent CLI invocation dying at import
+time with a raw ``ModuleNotFoundError`` traceback — for a state the tool can
+repair itself. Release installs are unaffected (pip resolves
+``install_requires`` at install time) and ``kirocrew update`` already re-runs
+``pip install -e .``; this closes the git-pull gap.
+
+This module is the console-script entry point
+(``kirocrew = kiro_crew._bootstrap:main``). It imports the real CLI and, on
+``ModuleNotFoundError`` from a source checkout, runs ONE
+``pip install -e <repo>`` and retries the import in-process. A failed import
+is side-effect-free (Python evicts the failing module from ``sys.modules``),
+so the retry needs no re-exec — which also sidesteps the POSIX/Windows
+``execv`` divergence. On Windows the heal itself is skipped — a running
+console launcher cannot be replaced — and the one-line manual fix is printed
+instead, as it is outside a source checkout.
+
+Everything imported here MUST be stdlib: this module runs BEFORE the
+package's dependencies are known to exist. Output MUST stay ASCII-only —
+it prints before ``platform_compat.ensure_utf8_console()`` has run, so
+non-ASCII would UnicodeEncodeError on Windows cp1252 pipes.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+_PIP_TIMEOUT_SECS = 300
+
+
+def _import_cli() -> Callable[[], None]:
+    """Import the real CLI entry (separated so tests can stub the failure)."""
+    from kiro_crew.cli import main as cli_main
+
+    return cli_main
+
+
+def _source_checkout_root() -> Path | None:
+    """Repo root when running from an editable/source install, else ``None``.
+
+    An editable install resolves ``kiro_crew`` inside ``<repo>/src/``; a wheel
+    install resolves it inside ``site-packages``. Only the former has our
+    ``setup.cfg`` two levels up.
+    """
+    root = Path(__file__).resolve().parents[2]
+    if (root / "setup.cfg").is_file() and (root / "src" / "kiro_crew").is_dir():
+        return root
+    return None
+
+
+def _self_heal(missing: str) -> bool:
+    """Run ONE ``pip install -e <repo>``; ``True`` when it succeeded.
+
+    The argv is fixed and the repo path is derived from this module's own
+    ``__file__`` — never user or agent input. pip's own stderr flows to the
+    console so failures stay diagnosable.
+    """
+    if sys.platform == "win32":
+        # Windows locks a running console launcher, so pip cannot replace
+        # kirocrew.exe from inside a process started by it and the reinstall
+        # fails partway. The manual one-liner works there: the user runs it
+        # from a shell where kirocrew is not running.
+        return False
+    root = _source_checkout_root()
+    if root is None:
+        return False
+    print(
+        f"kirocrew: missing dependency {missing!r} - your checkout added "
+        "dependencies since the last install. Running one-time "
+        "`pip install -e .` to catch up...",
+        file=sys.stderr,
+    )
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "-e", str(root), "--quiet"],
+            timeout=_PIP_TIMEOUT_SECS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
+
+
+def main() -> None:
+    """Import the real CLI, self-healing a stale editable install once."""
+    try:
+        cli_main = _import_cli()
+    except ModuleNotFoundError as exc:
+        if not _self_heal(exc.name or str(exc)):
+            print(
+                f"kirocrew: cannot start - {exc}.\n"
+                "Your installed dependencies are older than your checkout. "
+                "Fix with: pip install -e <path to your Kiro Crew checkout>",
+                file=sys.stderr,
+            )
+            raise SystemExit(1) from exc
+        # Import-system finder caches are per-directory-mtime; a package
+        # installed after interpreter start can stay invisible on
+        # coarse-mtime filesystems without an explicit invalidation.
+        importlib.invalidate_caches()
+        try:
+            cli_main = _import_cli()
+        except ModuleNotFoundError as exc2:  # heal ran but did not cover it
+            print(
+                f"kirocrew: still failing after reinstall - {exc2}. "
+                "Check `pip install -e .` output for errors.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1) from exc2
+        print("kirocrew: dependencies restored.", file=sys.stderr)
+    cli_main()

--- a/src/kiro_crew/doc_parser.py
+++ b/src/kiro_crew/doc_parser.py
@@ -22,7 +22,14 @@ import zipfile
 import zlib
 from pathlib import Path
 
-from defusedxml.ElementTree import fromstring as _xml_fromstring
+# Optional so a stale install (git pull without `pip install -e .`) degrades
+# to "docx/pptx parsing unavailable" instead of killing every CLI entry at
+# import time — this module sits on the gateway's import path. NEVER fall
+# back to stdlib xml.etree: it resolves external entities (XXE).
+try:
+    from defusedxml.ElementTree import fromstring as _xml_fromstring
+except ModuleNotFoundError:  # pragma: no cover — exercised via monkeypatch
+    _xml_fromstring = None  # type: ignore[assignment]
 
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.sel import sel
@@ -80,6 +87,13 @@ def extract_text(path: str, mimetype: str = "", filename: str = "") -> str:
         fmt = {".docx": "docx", ".pptx": "pptx", ".pdf": "pdf"}.get(ext, "")
     if not fmt:
         return ""
+    if fmt in ("docx", "pptx") and _xml_fromstring is None:
+        logger.warning(
+            "Cannot parse %s: defusedxml is not installed (checkout newer "
+            "than installed deps?). Fix: pip install -e .",
+            filename or path,
+        )
+        return ""
     try:
         if fmt == "docx":
             return _extract_docx(path)
@@ -134,6 +148,7 @@ def _extract_docx(path: str) -> str:
 
     Must only be called from extract_text() which enforces is_sensitive_path().
     """
+    assert _xml_fromstring is not None  # extract_text() gates the None case
     if is_sensitive_path(path):
         return ""
     paragraphs: list[str] = []
@@ -165,6 +180,7 @@ def _extract_pptx(path: str) -> str:
 
     Must only be called from extract_text() which enforces is_sensitive_path().
     """
+    assert _xml_fromstring is not None  # extract_text() gates the None case
     if is_sensitive_path(path):
         return ""
     slides: list[tuple[int, str]] = []

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -1,0 +1,173 @@
+"""Tests for the ``kiro_crew._bootstrap`` console-entry self-heal.
+
+The bootstrap closes the git-pull gap for editable installs: a commit that
+adds a runtime dependency must not leave ``kirocrew`` dying on a raw
+``ModuleNotFoundError`` when one ``pip install -e .`` fixes it. These tests
+stub the import and the pip spawn — no real installs, no network.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import _bootstrap
+
+# ── Helpers ──
+
+
+def _fail_then_succeed(calls: list[str], sentinel):
+    """Import stub failing with ModuleNotFoundError once, then succeeding."""
+
+    def _import():
+        calls.append("import")
+        if len([c for c in calls if c == "import"]) == 1:
+            raise ModuleNotFoundError("No module named 'defusedxml'", name="defusedxml")
+        return sentinel
+
+    return _import
+
+
+# ── main() flow ──
+
+
+def test_happy_path_never_spawns_pip(monkeypatch):
+    ran: list[str] = []
+    monkeypatch.setattr(_bootstrap, "_import_cli", lambda: lambda: ran.append("cli"))
+    monkeypatch.setattr(
+        _bootstrap, "_self_heal", lambda missing: pytest.fail("heal must not run")
+    )
+    _bootstrap.main()
+    assert ran == ["cli"]
+
+
+def test_missing_dep_heals_once_and_retries(monkeypatch):
+    calls: list[str] = []
+    ran: list[str] = []
+    monkeypatch.setattr(
+        _bootstrap, "_import_cli", _fail_then_succeed(calls, lambda: ran.append("cli"))
+    )
+    monkeypatch.setattr(
+        _bootstrap, "_self_heal", lambda missing: calls.append(f"heal:{missing}") or True
+    )
+    _bootstrap.main()
+    assert calls == ["import", "heal:defusedxml", "import"]
+    assert ran == ["cli"]
+
+
+def test_heal_failure_exits_with_guidance(monkeypatch, capsys):
+    def _always_fail():
+        raise ModuleNotFoundError("No module named 'defusedxml'", name="defusedxml")
+
+    monkeypatch.setattr(_bootstrap, "_import_cli", _always_fail)
+    monkeypatch.setattr(_bootstrap, "_self_heal", lambda missing: False)
+    with pytest.raises(SystemExit) as exc_info:
+        _bootstrap.main()
+    assert exc_info.value.code == 1
+    assert "pip install -e" in capsys.readouterr().err
+
+
+def test_still_missing_after_heal_exits_without_looping(monkeypatch, capsys):
+    """The heal is attempted exactly once — no retry loop."""
+    imports: list[str] = []
+    heals: list[str] = []
+
+    def _always_fail():
+        imports.append("import")
+        raise ModuleNotFoundError("No module named 'defusedxml'", name="defusedxml")
+
+    monkeypatch.setattr(_bootstrap, "_import_cli", _always_fail)
+    monkeypatch.setattr(_bootstrap, "_self_heal", lambda missing: heals.append("heal") or True)
+    with pytest.raises(SystemExit) as exc_info:
+        _bootstrap.main()
+    assert exc_info.value.code == 1
+    assert imports == ["import", "import"]
+    assert heals == ["heal"]
+    assert "still failing" in capsys.readouterr().err
+
+
+# ── _self_heal ──
+
+
+def test_self_heal_refuses_outside_source_checkout(monkeypatch):
+    monkeypatch.setattr(_bootstrap, "_source_checkout_root", lambda: None)
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: pytest.fail("pip must not run")
+    )
+    assert _bootstrap._self_heal("defusedxml") is False
+
+
+def test_self_heal_skips_windows(monkeypatch, tmp_path):
+    """A running console launcher cannot be replaced on Windows -> no heal."""
+    monkeypatch.setattr(_bootstrap.sys, "platform", "win32")
+    monkeypatch.setattr(_bootstrap, "_source_checkout_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: pytest.fail("pip must not run")
+    )
+    assert _bootstrap._self_heal("defusedxml") is False
+
+
+def test_retry_invalidates_import_caches(monkeypatch):
+    """The just-installed package must be visible to the retry import."""
+    calls: list[str] = []
+
+    def _sentinel_cli() -> None:
+        return None
+
+    def _import():
+        calls.append("import")
+        if calls.count("import") == 1:
+            raise ModuleNotFoundError("No module named 'defusedxml'", name="defusedxml")
+        return _sentinel_cli
+
+    monkeypatch.setattr(_bootstrap, "_import_cli", _import)
+    monkeypatch.setattr(_bootstrap, "_self_heal", lambda missing: True)
+    monkeypatch.setattr(
+        _bootstrap.importlib, "invalidate_caches", lambda: calls.append("invalidate")
+    )
+    _bootstrap.main()
+    assert calls == ["import", "invalidate", "import"]
+
+
+def test_self_heal_runs_fixed_pip_argv(monkeypatch, tmp_path):
+    monkeypatch.setattr(_bootstrap.sys, "platform", "linux")  # POSIX heal path
+    monkeypatch.setattr(_bootstrap, "_source_checkout_root", lambda: tmp_path)
+    seen: dict = {}
+
+    def _fake_run(argv, timeout):
+        seen["argv"] = argv
+        seen["timeout"] = timeout
+
+        class _P:
+            returncode = 0
+
+        return _P()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    assert _bootstrap._self_heal("defusedxml") is True
+    assert seen["argv"][1:] == ["-m", "pip", "install", "-e", str(tmp_path), "--quiet"]
+    assert seen["timeout"] == _bootstrap._PIP_TIMEOUT_SECS
+
+
+def test_self_heal_reports_pip_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(_bootstrap.sys, "platform", "linux")  # POSIX heal path
+    monkeypatch.setattr(_bootstrap, "_source_checkout_root", lambda: tmp_path)
+
+    def _fake_run(argv, timeout):
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=timeout)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    assert _bootstrap._self_heal("defusedxml") is False
+
+
+# ── _source_checkout_root ──
+
+
+def test_source_checkout_root_detects_this_repo():
+    """Running from the repo's own tree, the root must resolve here."""
+    root = _bootstrap._source_checkout_root()
+    assert root is not None
+    assert (root / "setup.cfg").is_file()
+    assert Path(_bootstrap.__file__).is_relative_to(root)

--- a/test/test_doc_parser.py
+++ b/test/test_doc_parser.py
@@ -341,3 +341,37 @@ class TestXxeGuards:
         finally:
             if os.path.exists(secret_path):
                 os.unlink(secret_path)
+
+
+# ── Missing-parser degradation (stale editable install) ──
+
+
+def test_missing_defusedxml_degrades_without_stdlib_fallback(monkeypatch, caplog):
+    """No hardened parser -> empty string + warning; NEVER stdlib xml (XXE)."""
+    import kiro_crew.doc_parser as doc_parser
+
+    monkeypatch.setattr(doc_parser, "_xml_fromstring", None)
+    path = _make_docx(["hello"])
+    try:
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.doc_parser"):
+            assert extract_text(path, filename="a.docx") == ""
+    finally:
+        os.unlink(path)
+    assert any("defusedxml" in r.message for r in caplog.records)
+
+
+def test_missing_defusedxml_leaves_pdf_parsing_alone(monkeypatch, caplog):
+    """PDF extraction has no XML dependency and must keep working."""
+    import kiro_crew.doc_parser as doc_parser
+
+    monkeypatch.setattr(doc_parser, "_xml_fromstring", None)
+    fd, path = tempfile.mkstemp(suffix=".pdf")
+    os.close(fd)
+    try:
+        # The point is the dispatch path: a .pdf must reach the PDF parser,
+        # not be short-circuited by the missing-XML-parser gate.
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.doc_parser"):
+            extract_text(path, filename="a.pdf")
+    finally:
+        os.unlink(path)
+    assert not any("defusedxml" in r.message for r in caplog.records)

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -138,6 +138,13 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
     {
         "acp/runtime.py::_get_rss_mb",
         "acp/runtime.py::_get_rss_tree_mb",
+        # Console-entry self-heal for stale editable installs: ONE fixed
+        # `python -m pip install -e <repo>` argv, no shell. The repo path is
+        # derived from the module's own __file__ (never user/agent input) and
+        # only when setup.cfg + src/kiro_crew exist there. Runs before the
+        # package imports, so it cannot route through sandboxed_spawn_argv —
+        # mirrors dashboard/handlers/updates.py::_venv_pip_install below.
+        "_bootstrap.py::_self_heal",
         # Ops Mission Control ledger-sync tests: fixed `git` argv (init --bare / ls-files)
         # against a per-test tempdir. Nothing here is agent-influenced — the repo path is
         # `tempfile.mkdtemp()` and every argument is a literal in the test file. These are


### PR DESCRIPTION
## Problem

After `git pull` on an editable install, `kirocrew gateway` (and every other CLI command) dies at import time with a raw traceback:

```
  File ".../src/kiro_crew/doc_parser.py", line 25, in <module>
    from defusedxml.ElementTree import fromstring as _xml_fromstring
ModuleNotFoundError: No module named 'defusedxml'
```

Any commit that adds a runtime dependency (latest: defusedxml in b625b87a9) breaks every git-pull user until they manually run `pip install -e .`.

## Why it matters

`git pull` never re-runs dependency resolution, so this recurs on every dependency addition, forever, for every contributor and every from-source user. Release installs are unaffected (pip resolves `install_requires` at install time) and `kirocrew update` already reinstalls — only the git-pull path is exposed, and it fails with a traceback that doesn't name the fix.

## Fix (symptom → root cause → change)

Symptom: a raw `ModuleNotFoundError` from deep inside the import chain. Root cause: (1) the console entry imports the entire gateway tree eagerly, so any missing dep anywhere kills every command with no recovery path; (2) `doc_parser` — a leaf attachment-parsing feature — sits on that boot path with a hard import.

Two independent layers:

1. **Self-heal at the console entry.** New stdlib-only `kiro_crew._bootstrap:main` (entry points in `setup.cfg` + `pyproject.toml` repointed): imports the real CLI and, on `ModuleNotFoundError` from a source checkout (`setup.cfg` + `src/kiro_crew` two levels above `__file__`), runs ONE fixed-argv `pip install -e <repo>`, calls `importlib.invalidate_caches()`, and retries the import in-process — a failed import is side-effect-free, so no re-exec is needed. On Windows the heal is skipped (pip cannot replace the running `kirocrew.exe` launcher); there, as outside any source checkout, it prints the one-line manual fix instead of a traceback. Output is ASCII-only because it prints before `ensure_utf8_console()` runs. The pip spawn is registered in `BENIGN_SPAWNS` (fixed argv, path derived from our own `__file__`, runs before the package imports so it cannot route through `sandboxed_spawn_argv`).

2. **`doc_parser` degrades instead of killing boot.** The defusedxml import becomes optional; when absent, docx/pptx extraction returns `""` with an actionable warning (matching the module's documented never-raise contract). It NEVER falls back to stdlib `xml.etree` — that would reopen the XXE the dependency exists to close. PDF extraction is unaffected.

## Tests

- `test/test_bootstrap.py` (new): happy path never spawns pip; missing dep heals exactly once then retries; heal failure exits 1 with guidance; still-missing-after-heal exits without looping; pip refused outside a source checkout; Windows skip pinned; fixed pip argv + timeout pinned; retry ordering `import → invalidate_caches → import` pinned; checkout-root detection against the real repo tree.
- `test/test_doc_parser.py` (+2): missing defusedxml → `""` + warning with **no stdlib fallback**; PDF dispatch bypasses the XML gate.
- `test/test_spawn_audit.py`: `_bootstrap.py::_self_heal` allowlisted with justification (both repo-wide drift guards run green).

## Manual verification

In the worktree venv: `pip uninstall -y croniter && kirocrew --version` → prints the one-time heal notice, reinstalls, exits 0, dep restored. `pip uninstall -y defusedxml && kirocrew --version` → CLI boots normally (docx/pptx parsing disabled with warning). Full backend suite: 29,582 passed; the 20 failures are the known host-env sandbox/root-binary families, reproduced identically on pristine `origin/main`.

## Screenshots

N/A — CLI-only change, no UI surface.
