### PR TITLE
test(metrics): pin the unattributed-subagent exclusion on the context path

### DIFF
--- a/test/metrics/test_context_occupancy.py
+++ b/test/metrics/test_context_occupancy.py
@@ -116,6 +116,42 @@ class TestContextOccupancySkips:
         assert out["turns"] == 1
         assert [s["slot"] for s in out["sessions"]] == ["recent"]
 
+    def test_an_unattributed_subagent_reaches_neither_the_list_nor_the_spread(
+        self, _isolated_shards
+    ):
+        """A subagent row carrying no parent identity leaves before the sample.
+
+        ``is_session_slot`` is applied ahead of the percentile sample rather than
+        at the grouping step, so the spread and the session list describe one
+        population. Asserting only the session list would pass on a filter moved
+        after the sample, which is exactly the arrangement that lets ``p90``
+        disagree with every row beneath it.
+
+        Scoped to rows with no parent field, which is every row written so far.
+        This fixes the treatment of THOSE rows, not the rule for a row that can
+        name the session it belongs to.
+
+        The cost path pins the same rule for the same row shape in
+        ``test_cost_breakdown.py::test_a_subagent_is_not_a_session_and_reaches_no_figure``;
+        this is the context half, so a change has to face both.
+        """
+        _write(_isolated_shards, [
+            _row("chat-1-1", 100_000),
+            # No parent field: the shape every subagent row on disk has today.
+            _row("subagent:0000000a", 900_000),
+            _row("subagent:0000000b", 950_000),
+        ])
+        out = usage_mod.context_occupancy(14)
+
+        assert [s["slot"] for s in out["sessions"]] == ["chat-1-1"]
+        assert out["turns"] == 1, "a subagent turn reached the turn count"
+        # 10.0 is chat-1-1 alone. Were the subagents in the sample, every
+        # percentile would sit up near their 90-95%.
+        assert out["p50_pct"] == 10.0
+        assert out["p90_pct"] == 10.0
+        assert out["max_pct"] == 10.0
+        assert json.dumps(out).count("subagent") == 0
+
 
 class TestContextOccupancyLatestWins:
     """Identity and absolute numbers describe the session's LATEST turn."""


### PR DESCRIPTION
## Problem

`is_session_slot` gates two aggregates. Only one of them is pinned.

`cost_breakdown()` has `test_a_subagent_is_not_a_session_and_reaches_no_figure`.
`context_occupancy()` applies the same rule at `usage.py:300` and has nothing.

The placement there is deliberate, and the comment says why:

> Before the percentile sample, not after: the spread and the session list have
> to describe the same population, or the p90 on the card disagrees with every
> row beneath it.

Nothing holds that placement.

## What the gap allows

Moving the filter to just after `pcts.append(p)` — three lines, no test failure
in `test/metrics` today. On three synthetic rows (one session at 10%, two
subagents at 90% and 95%):

| | correct | filter moved after the sample |
|---|---|---|
| `sessions` | `['chat-1-1']` | `['chat-1-1']` — still correct |
| `turns` | 1 | 3 |
| `p50_pct` | 10.0 | 90.0 |
| `p90_pct` | 10.0 | 95.0 |
| `max_pct` | 10.0 | 95.0 |

The card reports a p90 of 95% while the only row beneath it reads 10%. The
session list is right the whole time, so a test asserting just the list — the
obvious thing to assert — never sees it.

## Change

One case in `TestContextOccupancySkips` asserting the turn count and all three
percentiles alongside the session list, so the rule has to hold on both halves.

I ran the mutation above across `test/metrics`: 327 passed, and this new case is
the only one that fails. That is the whole claim being made for it.

## Scope

The fixture rows carry no parent field, which is the shape of every subagent row
written so far. This pins the treatment of **those** rows and prescribes nothing
for a row that can name the session it belongs to — I am working on #1752, which
asks exactly that question, and the answer there is the maintainers' to make.

## Validation

`test/metrics`: 328 passed, 1 skipped. `flake8`, `isort`, `git diff --check`
clean; the diff-scoped brand gate passes.

Test-only; no production behaviour changes.
