### PR TITLE
perf(palette): stop re-scanning the session corpus on every keystroke

### DIFF
--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -869,6 +869,28 @@ class ConversationLog:
         #: staleness (an append bumps the file mtime, so the entry is
         #: recomputed on the next call). Own ``_LRUCache`` → own internal lock.
         self._recent_cache: _LRUCache[tuple[float, list[dict]]] = _LRUCache(cache_max)
+        #: Bounded, mtime-keyed LRU of ``(mtime, doc_chars, casefolded_blob)``
+        #: per session, consumed only by :meth:`search_sessions`.
+        #:
+        #: Folding is the dominant cost of a search: the substring count itself
+        #: is cheap, but ``str.casefold`` over a whole corpus is not, and it
+        #: holds the GIL for its full duration — so re-folding per query stalls
+        #: the event loop even when the search runs in a worker thread. The
+        #: corpus does not change between the keystrokes of one search, so the
+        #: fold is memoized here and each query pays only the count.
+        #:
+        #: Sized to cover the ENTIRE scan window, never ``cache_max``. A search
+        #: walks ``_SEARCH_SCAN_WINDOW`` sessions in the same order every query,
+        #: so an LRU smaller than that window is evicted exactly one step ahead
+        #: of its next read: the hit rate collapses to zero rather than
+        #: degrading, and the memoization silently stops working for the users
+        #: with the most sessions — the ones it exists for. ``max`` rather than a
+        #: bare constant so a caller shrinking ``cache_max`` cannot reintroduce
+        #: that cliff; this cache holds derived strings, which are far smaller
+        #: than the parsed transcripts ``cache_max`` is tuned for.
+        self._folded_cache: _LRUCache[tuple[float, int, str]] = _LRUCache(
+            max(cache_max, _SEARCH_SCAN_WINDOW)
+        )
         #: tab_id → [session keys] chain index. ``None`` means "stale, rebuild
         #: on next chained read"; a dict is an authoritative snapshot. Rebuilt
         #: lazily by _rebuild_tab_id_index, invalidated by
@@ -1726,61 +1748,214 @@ class ConversationLog:
         if not query or limit <= 0 or not self._dir.exists():
             return []
         needle = query.casefold()
-        scored: list[tuple[float, int, dict]] = []  # (score, -rank, meta)
+        # (score, -rank, meta, needs_snippet)
+        scored: list[tuple[float, int, dict, bool]] = []
         for rank, meta in enumerate(self.list_sessions()[:_SEARCH_SCAN_WINDOW]):
-            content_hits = 0
-            doc_chars = 0
-            texts: list[str] = []
-            # Pull parsed messages from the mtime-keyed cache (_read_messages)
-            # rather than re-opening + re-parsing the file here. The snippet
-            # path (search_chat_history) already reads each matched key via the
-            # same cache, so this collapses the prior two-parses-per-query into
-            # one. Content semantics are unchanged: only string ``content``
-            # fields are counted, in file order, so the \x00-join hit count and
-            # the doc_chars length normalizer stay identical to the previous
-            # inline scan. _read_messages is OSError-safe and returns [] for a
-            # missing/unreadable file, so it also subsumes the old try/except.
-            for obj in self._read_messages(meta["key"]):
-                raw = obj.get("content") if isinstance(obj, dict) else None
-                text = raw if isinstance(raw, str) else ""
-                if text:
-                    doc_chars += len(text)
-                    texts.append(text)
-            # Casefold + count once per file instead of per line: a 200-line
-            # session produces one temporary casefolded string instead of 200,
-            # bounding GC pressure under rapid-fire search keystrokes.  The
-            # ``\x00`` separator can't appear in user queries, so cross-line
-            # false matches are impossible.
-            if texts:
-                content_hits = "\x00".join(texts).casefold().count(needle)
+            doc_chars, folded = self._folded_content(meta["key"])
+            content_hits = folded.count(needle) if folded else 0
             title_hits = (meta.get("title") or "").casefold().count(needle)
             if not title_hits and not content_hits:
                 continue
             length_norm = math.sqrt(1 + doc_chars / 1024)
             score = title_hits * _TITLE_BOOST + content_hits / length_norm
-            # Match-centered content snippet (why the session surfaced when the
-            # title doesn't contain the query). Best-effort, display-only.
-            snippet = ""
-            if content_hits and texts:
-                joined = " ".join(texts)
-                # casefold() to match the hit detection above — .lower() misses
-                # matches casefold finds (ß→ss, İ), yielding an empty snippet
-                # despite content_hits > 0. casefold can shift offsets slightly
-                # (length changes); acceptable for a display-only best-effort
-                # window.
-                pos = joined.casefold().find(query.casefold())
-                if pos >= 0:
-                    start = max(0, pos - 40)
-                    end = min(len(joined), pos + len(query) + 100)
-                    frag = " ".join(joined[start:end].split())
-                    snippet = (
-                        ("…" if start > 0 else "") + frag + ("…" if end < len(joined) else "")
-                    )[:200]
-            out_meta = {**meta, "snippet": snippet} if snippet else meta
             # Negate rank so a smaller (newer) rank wins ties after score desc sort.
-            scored.append((score, -rank, out_meta))
+            scored.append((score, -rank, meta, content_hits > 0))
         scored.sort(reverse=True)
-        return [meta for _, _, meta in scored[:limit]]
+
+        # Snippets are attached AFTER the sort+slice, so the cost is proportional
+        # to the rows actually returned rather than to every session that
+        # matched. A snippet cannot come from the folded cache (it needs the
+        # original text, so offsets line up), so building one per match put a
+        # full re-read back on the hot path — dominating the query once the fold
+        # itself was memoized.
+        out: list[dict] = []
+        for _score, _rank, meta, needs_snippet in scored[:limit]:
+            snippet = self._content_snippet(meta["key"], query) if needs_snippet else ""
+            out.append({**meta, "snippet": snippet} if snippet else meta)
+        return out
+
+    def _folded_content(self, key: str) -> tuple[int, str]:
+        """Return ``(doc_chars, casefolded_content)`` for *key*, memoized by mtime.
+
+        ``doc_chars`` counts the ORIGINAL (unfolded) characters, because it
+        feeds the length normalizer in :meth:`search_sessions` and folding can
+        change a string's length (``ß`` -> ``ss``).
+
+        The folded blob joins the messages' string ``content`` fields in file
+        order with ``\\x00``. That separator cannot appear in a user query, so
+        it prevents a match spanning two messages while still allowing one
+        ``count`` call over the whole session instead of one per message.
+
+        Returns ``(0, "")`` for a missing/unreadable file or a session with no
+        textual content. A read failure is deliberately NOT cached — see below.
+        """
+        path = self._path(key)
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            self._folded_cache.pop(key, None)
+            return (0, "")
+        cached = self._folded_cache.get(key)
+        if cached and cached[0] == mtime:
+            return (cached[1], cached[2])
+        # Cold: serialize against this key's writers for the whole
+        # stat -> read -> store sequence.
+        #
+        # The mtime guard cannot protect this window, because the housekeeping
+        # rewrites deliberately RESTORE the pre-write mtime (``_restore_mtime``,
+        # so compaction does not reorder ``list_sessions``). A fold that started
+        # before such a rewrite and stored after its ``_invalidate_cache`` would
+        # sit in the cache holding pre-rewrite text under a mtime the file still
+        # has — undetectable, so the newly saved messages would be missing from
+        # every later search for the life of the process.
+        #
+        # ``_file_lock`` is the same in-process RLock every writer takes first in
+        # ``_locked``, so holding it here orders this fold against append /
+        # rewrite / metadata edits for this key. It is acquired ONLY on the miss
+        # path: a warm search never contends, and two threads racing the same
+        # cold key fold once (the re-check below).
+        with self._file_lock(key):
+            try:
+                mtime = path.stat().st_mtime
+            except OSError:
+                self._folded_cache.pop(key, None)
+                return (0, "")
+            cached = self._folded_cache.get(key)
+            if cached and cached[0] == mtime:
+                return (cached[1], cached[2])
+            built = self._build_folded(key)
+            if built is None:
+                # The read failed rather than finding no content. Caching that
+                # would be keyed by an mtime the file still has, so a session
+                # made transiently unopenable (fd exhaustion, or a Windows
+                # indexer / AV holding a just-written file — the same window
+                # ``_METADATA_READ_ATTEMPTS`` exists for) would stay
+                # unsearchable until something wrote to it again. Fail open:
+                # report empty for this query and retry on the next one.
+                return (0, "")
+            self._folded_cache[key] = (mtime, built[0], built[1])
+            return built
+
+    def _build_folded(self, key: str) -> tuple[int, str] | None:
+        """Parse *key* and fold its content — the cache-miss half of
+        :meth:`_folded_content`.
+
+        Returns ``None`` when the file could not be read, which the caller must
+        distinguish from ``(0, "")`` (a session with no textual content): the
+        former must not be cached.
+
+        Reads the file via :meth:`_iter_message_texts` rather than going through
+        :meth:`_read_messages`, for two reasons.
+
+        Memory: that method memoizes the PARSED message dicts, and a search
+        touches every session in the scan window, so routing the fold through it
+        pins the whole corpus's parsed form in gateway RSS as a side effect of
+        searching. On a 136 MB / 125-session corpus that is ~330 MB of parsed
+        dicts versus ~37 MB for the folded strings this actually needs.
+
+        Correctness: ``_msg_cache`` is filled by callers that do not hold this
+        key's write lock, so an entry can be a pre-rewrite parse stored under a
+        restored (unchanged) mtime. Folding from it would launder that staleness
+        into the search cache, which the caller's lock cannot prevent. Reading
+        the file makes the fold a function of the file alone.
+
+        The caller holds ``_file_lock``, which orders this read against writers
+        in THIS process. A writer in another process holds only the cross-process
+        flock, so it can still interleave — but the caller stats BEFORE this read,
+        so such a write leaves the cached mtime older than the file's and the next
+        access re-folds. That case is self-healing, unlike the preserved-mtime
+        rewrite the lock exists for.
+
+        Separated from :meth:`_folded_content` so the memoization is observable:
+        a caller (or a test) can count how often the expensive fold actually
+        runs, independent of how many queries were served.
+        """
+        texts: list[str] = []
+        try:
+            texts = list(self._iter_message_texts(key))
+        except OSError:
+            return None
+        if not texts:
+            return (0, "")
+        return (sum(len(t) for t in texts), "\x00".join(texts).casefold())
+
+    def _iter_message_texts(self, key: str) -> Iterator[str]:
+        """Yield each message's non-empty string ``content`` from *key*'s file.
+
+        One definition of "what counts as searchable text in a session file",
+        shared by the fold and the snippet so their skip rules cannot drift apart
+        as the on-disk format evolves. Yields in file order; skips blank lines,
+        unparseable lines, non-object lines, and the metadata header.
+
+        A generator rather than a list so a caller can stop early — closing it
+        closes the file — which is what lets :meth:`_content_snippet` read only as
+        far as its first match. Propagates ``OSError``: callers distinguish "could
+        not read" from "no text", and that distinction is load-bearing (a read
+        failure must not be cached).
+        """
+        with open(self._path(key), encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if not isinstance(data, dict) or data.get("_type") == "metadata":
+                    continue
+                content = data.get("content")
+                if isinstance(content, str) and content:
+                    yield content
+
+    #: Characters of context kept before / after a snippet's match.
+    _SNIPPET_LEAD = 40
+    _SNIPPET_TRAIL = 100
+    #: Hard cap on a returned snippet.
+    _SNIPPET_MAX = 200
+
+    def _content_snippet(self, key: str, query: str) -> str:
+        """Return a match-centered window of *key*'s content around *query*.
+
+        Streams the file and stops at the FIRST matching message, so a query that
+        hits early reads only as far as the hit — rather than parsing the whole
+        transcript, which on the largest sessions dominated the query. Sharing
+        :meth:`_iter_message_texts` with the fold (instead of reading the file
+        directly) also keeps search from pinning a parsed transcript in
+        ``_msg_cache`` for every row it returns, and keeps the two halves of a
+        query agreeing on what counts as searchable text.
+
+        The window is confined to the matching message, which keeps a snippet from
+        reading as one sentence when it actually spans two — consistent with
+        :meth:`_folded_content`, where the ``\\x00`` join stops a match from
+        bridging messages in the first place.
+
+        Display-only and best effort: ``casefold`` is used for the search so it
+        agrees with the hit detection in :meth:`search_sessions` (``.lower()``
+        misses matches ``casefold`` finds, e.g. ``ß`` / ``İ``, which would yield
+        an empty snippet despite a nonzero hit count), but folding can change a
+        string's length, so the window may be off by a character or two.
+
+        Returns ``''`` when the query is not locatable in any single message, or
+        when the file cannot be read (display-only — never raises at the caller).
+        """
+        needle = query.casefold()
+        if not needle:
+            return ""
+        try:
+            for text in self._iter_message_texts(key):
+                pos = text.casefold().find(needle)
+                if pos < 0:
+                    continue
+                start = max(0, pos - self._SNIPPET_LEAD)
+                end = min(len(text), pos + len(query) + self._SNIPPET_TRAIL)
+                frag = " ".join(text[start:end].split())
+                prefix = "…" if start > 0 else ""
+                suffix = "…" if end < len(text) else ""
+                return (prefix + frag + suffix)[: self._SNIPPET_MAX]
+        except OSError:
+            return ""
+        return ""
 
     def recent_from_source(
         self, source_prefix: str, exclude_key: str = "", max_messages: int = 20
@@ -2307,6 +2482,10 @@ class ConversationLog:
         """Invalidate caches for a key after a write operation."""
         self._msg_cache.pop(key, None)
         self._meta_cache.pop(key, None)
+        # The folded search blob is derived from the messages, so it goes stale
+        # exactly when they do. Its own mtime guard is not enough here: the
+        # housekeeping rewrites below restore the pre-write mtime.
+        self._folded_cache.pop(key, None)
         # Also drop any memoized recent() windows for this key. Necessary
         # because housekeeping rewrites (mark_consolidated/update_metadata/
         # rewrite_session/rotation) restore the pre-write mtime via

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -843,19 +843,25 @@ class TestSearchSessions:
         assert "new-weak-1" in result_keys
         assert "new-weak-2" in result_keys
 
-    def test_substring_scan_reads_through_msg_cache(self, tmp_path):
-        """search_sessions sources content via _read_messages (the mtime
-        cache), not a second raw file parse.
+    def test_substring_scan_reads_the_file_and_leaves_msg_cache_alone(self, tmp_path):
+        """search_sessions sources content from the file, never ``_msg_cache``.
 
-        Regression lock for the double-parse fix: previously the scan opened
-        and re-parsed each file inline, so _read_messages was never consulted
-        by the search path (the snippet path then parsed the same file a
-        second time). After the fix the scan goes through the cache, so a
-        matched session is counted via _read_messages and its parse is
-        memoized for the snippet read.
+        Both halves of a query read the session file directly: the fold that
+        counts matches, and the snippet built for each returned row. Neither goes
+        through ``_read_messages``, for two reasons.
+
+        Memory: ``_read_messages`` memoizes the PARSED message dicts, and a scan
+        touches every session in the window — so sourcing content through it makes
+        searching pin the whole corpus's parsed form in RSS.
+
+        Correctness: ``_msg_cache`` is populated by callers that hold no write
+        lock, so an entry can be a pre-rewrite parse stored under a restored
+        (unchanged) mtime. Folding from it would launder that staleness into the
+        search cache, where the mtime guard cannot detect it.
         """
         log = ConversationLog(base_dir=tmp_path)
         log.append("a", "user", "apollo deployment rollback notes")
+        log._msg_cache.clear()
         calls: list[str] = []
         real = log._read_messages
 
@@ -864,11 +870,12 @@ class TestSearchSessions:
             return real(key)
 
         log._read_messages = counting  # type: ignore[assignment]
-        assert [s["key"] for s in log.search_sessions("apollo")] == ["a"]
-        # The scan consulted the cache entry point for the matched session...
-        assert "a" in calls
-        # ...and the parse is now memoized, so the snippet read is a cache hit.
-        assert "a" in log._msg_cache
+        hits = log.search_sessions("apollo")
+        assert [s["key"] for s in hits] == ["a"]
+        # The snippet still resolves, from the file rather than a parsed cache.
+        assert "apollo" in hits[0]["snippet"]
+        assert calls == [], "the search path must not enter _read_messages"
+        assert len(log._msg_cache) == 0, "searching must not pin a parsed transcript"
 
 
 class TestArchive:

--- a/test/test_search_sessions_cost.py
+++ b/test/test_search_sessions_cost.py
@@ -1,0 +1,541 @@
+"""Cost regression tests for :meth:`ConversationLog.search_sessions`.
+
+The palette dispatches one search per debounced keystroke, and every search
+walks the whole recent corpus. The expensive half of that walk is folding each
+session's content for case-insensitive matching (``str.casefold`` over the
+corpus); the substring count itself is cheap. Folding also holds the GIL for its
+full duration, so re-folding per query stalls the event loop even though the
+handler runs the search in a worker thread.
+
+These tests pin the invariant that makes the palette usable: the fold is paid
+once per session per *change*, not once per query. They assert **fold counts**,
+not wall-clock time — a timing threshold would measure the CI host's load rather
+than this code, and a "warm is N times faster" ratio is exactly the flaky shape
+the testing conventions rule out. A fold count is deterministic on every host.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+
+import pytest
+
+from kiro_crew import history
+from kiro_crew.history import ConversationLog
+
+
+@pytest.fixture
+def counting_log(tmp_path, monkeypatch):
+    """A log whose expensive fold is counted.
+
+    Returns ``(log, calls)`` where ``calls`` is a list of the session keys that
+    actually paid a fold, in order. Wrapping ``_build_folded`` (the cache-MISS
+    half) rather than ``_folded_content`` is what makes the memoization
+    observable: the latter is called once per session per query either way.
+    """
+    log = ConversationLog(base_dir=tmp_path)
+    calls: list[str] = []
+    original = ConversationLog._build_folded
+
+    def counted(self, key: str):
+        calls.append(key)
+        return original(self, key)
+
+    monkeypatch.setattr(ConversationLog, "_build_folded", counted)
+    return log, calls
+
+
+def _seed(log: ConversationLog, sessions: int = 6, messages: int = 4) -> None:
+    for s in range(sessions):
+        for m in range(messages):
+            log.append(f"s{s}", "user", f"session {s} message {m} about deployment pipelines")
+
+
+def _spy_on_snippets(monkeypatch) -> list[str]:
+    """Record the session keys that paid a snippet build, in order."""
+    seen: list[str] = []
+    original = ConversationLog._content_snippet
+
+    def counted(self, key: str, query: str):
+        seen.append(key)
+        return original(self, key, query)
+
+    monkeypatch.setattr(ConversationLog, "_content_snippet", counted)
+    return seen
+
+
+class TestSearchFoldingIsMemoized:
+    def test_repeated_query_folds_each_session_exactly_once(self, counting_log):
+        log, calls = counting_log
+        _seed(log)
+
+        log.search_sessions("deployment", 50)
+        assert sorted(calls) == [f"s{i}" for i in range(6)], "first query folds the whole corpus"
+
+        calls.clear()
+        log.search_sessions("deployment", 50)
+        assert calls == [], "an identical repeat query must not re-fold anything"
+
+    def test_typing_a_word_folds_the_corpus_once_not_once_per_keystroke(self, counting_log):
+        """The palette's real access pattern: one query per debounced prefix.
+
+        Each prefix is a DIFFERENT query string, so no query-level cache can
+        help — only caching the folded corpus can. Without the fold cache this
+        is 6 sessions x 5 prefixes = 30 folds.
+        """
+        log, calls = counting_log
+        _seed(log)
+
+        for prefix in ("de", "dep", "depl", "deplo", "deploy"):
+            log.search_sessions(prefix, 50)
+
+        assert len(calls) == 6, f"expected one fold per session, got {len(calls)}"
+
+    def test_appending_to_one_session_refolds_only_that_session(self, counting_log):
+        log, calls = counting_log
+        _seed(log)
+        log.search_sessions("deployment", 50)
+        calls.clear()
+
+        log.append("s3", "user", "one more note about deployment")
+        log.search_sessions("deployment", 50)
+
+        assert calls == ["s3"], "only the changed session may be re-folded"
+
+    def test_out_of_band_content_change_is_picked_up(self, counting_log):
+        """A write that bypasses ``append`` must still invalidate via mtime.
+
+        The mtime guard is the backstop for edits this process did not make
+        (another gateway generation, a manual edit). Without it the fold cache
+        would serve stale content indefinitely.
+        """
+        log, calls = counting_log
+        _seed(log, sessions=1)
+        assert log.search_sessions("kangaroo", 50) == []
+        calls.clear()
+
+        path = log._path("s0")
+        with open(path, "a", encoding="utf-8") as f:
+            f.write('{"role": "user", "content": "kangaroo appeared"}\n')
+        stat = path.stat()
+        os.utime(path, (stat.st_atime, stat.st_mtime + 10))
+
+        hits = log.search_sessions("kangaroo", 50)
+        assert calls == ["s0"], "an mtime change must force a re-fold"
+        assert [h["key"] for h in hits] == ["s0"]
+
+    def test_compaction_invalidates_even_though_it_restores_the_mtime(self, counting_log):
+        """``rewrite_session`` is the case the mtime guard CANNOT catch.
+
+        Compaction deliberately restores the pre-write mtime so housekeeping
+        does not reorder ``list_sessions``. Content changed but mtime did not,
+        so only the explicit invalidation in ``_invalidate_cache`` keeps the fold
+        cache honest — without it, search answers from the pre-compaction text
+        forever.
+        """
+        log, _calls = counting_log
+        log.append("s0", "user", "the platypus section")
+        assert [h["key"] for h in log.search_sessions("platypus", 50)] == ["s0"]
+
+        before = log._path("s0").stat().st_mtime
+        log.rewrite_session("s0", [{"role": "user", "content": "the echidna section"}])
+        assert log._path("s0").stat().st_mtime == before, "compaction must preserve mtime"
+
+        assert log.search_sessions("platypus", 50) == [], "stale content must not still match"
+        assert [h["key"] for h in log.search_sessions("echidna", 50)] == ["s0"]
+
+
+class TestFoldCacheCoversTheScanWindow:
+    """An LRU smaller than the scan window would hit 0%, not degrade.
+
+    ``search_sessions`` walks ``_SEARCH_SCAN_WINDOW`` sessions in the same order
+    on every query. If the cache holds fewer entries than that, each session is
+    evicted one step before its next read, so the hit rate collapses to zero and
+    the memoization silently stops working — precisely for the users with the
+    most sessions, who need it most.
+    """
+
+    def test_cache_is_sized_to_at_least_the_scan_window(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path)
+        assert log._folded_cache._maxsize >= history._SEARCH_SCAN_WINDOW
+
+    def test_a_small_cache_max_cannot_shrink_it_below_the_window(self, tmp_path):
+        """The fold cache holds derived strings, not the parsed transcripts
+        ``cache_max`` is tuned for, so it must not follow that knob down."""
+        log = ConversationLog(base_dir=tmp_path, cache_max=8)
+        assert log._folded_cache._maxsize >= history._SEARCH_SCAN_WINDOW
+        assert log._msg_cache._maxsize == 8, "the transcript cache still honors cache_max"
+
+    def test_no_thrash_across_a_corpus_larger_than_the_transcript_cache(
+        self, tmp_path, monkeypatch
+    ):
+        """The regression case: more sessions than ``_TRANSCRIPT_CACHE_MAX``.
+
+        Sized at 256 while scanning 500, the second query would re-fold every
+        single session. Kept small enough to stay a fast test but larger than the
+        transcript cache it used to borrow its size from.
+        """
+        monkeypatch.setattr(history, "_TRANSCRIPT_CACHE_MAX", 8)
+        monkeypatch.setattr(history, "_SEARCH_SCAN_WINDOW", 40)
+        log = ConversationLog(base_dir=tmp_path, cache_max=8)
+        for i in range(30):
+            log.append(f"s{i:03d}", "user", f"session {i} mentions deployment")
+
+        calls: list[str] = []
+        original = ConversationLog._build_folded
+
+        def counted(self, key: str):
+            calls.append(key)
+            return original(self, key)
+
+        monkeypatch.setattr(ConversationLog, "_build_folded", counted)
+
+        log.search_sessions("deployment", 5)
+        assert len(calls) == 30, "first query folds every session"
+
+        calls.clear()
+        log.search_sessions("deployment", 5)
+        assert calls == [], "a 30-session corpus must not thrash an 8-entry transcript cache"
+
+
+class TestFoldDoesNotPinParsedTranscripts:
+    """Folding must not warm ``_msg_cache`` for the whole scan window.
+
+    ``_read_messages`` memoizes the parsed message dicts, which are an order of
+    magnitude larger than the folded strings the search needs: routing the fold
+    through it pinned ~330 MB of parsed dicts on a 136 MB corpus versus ~37 MB
+    for the folds themselves. Searching must not cost that.
+    """
+
+    def test_scanning_does_not_populate_the_transcript_cache(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(6):
+            log.append(f"s{i}", "user", "mentions deployment")
+        log._msg_cache.clear()
+
+        log.search_sessions("nothingmatchesthis", 50)
+
+        assert len(log._msg_cache) == 0, "a scan that returns nothing must parse nothing"
+
+    def test_only_returned_rows_parse_their_transcript(self, tmp_path):
+        """Search must never pin a parsed transcript at all.
+
+        Both halves of a query now read the file directly — the fold, and the
+        snippet for each returned row — so no part of searching warms
+        ``_msg_cache``. That cache holds the parsed message dicts, which are an
+        order of magnitude larger than the text search needs.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(10):
+            log.append(f"s{i}", "user", "everyone mentions deployment")
+        log._msg_cache.clear()
+
+        hits = log.search_sessions("deployment", 2)
+
+        assert len(hits) == 2
+        assert all(h.get("snippet") for h in hits), "returned rows still carry snippets"
+        assert len(log._msg_cache) == 0, "searching must parse no transcript"
+
+    def test_the_fold_never_reads_the_parsed_cache(self, tmp_path):
+        """``_msg_cache`` is filled by callers holding no write lock, so an entry
+        can be a pre-rewrite parse stored under a restored mtime. Folding from it
+        would launder that staleness into the search cache, which the fold's own
+        lock cannot undo — so the fold reads the file and ignores that cache."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("s0", "user", "on disk only")
+        log._read_messages("s0")  # warm the parsed cache
+        assert len(log._msg_cache) == 1
+
+        # Poison the parsed cache under the CURRENT mtime — an mtime guard alone
+        # would happily reuse this entry.
+        mtime = log._path("s0").stat().st_mtime
+        log._msg_cache["s0"] = (mtime, [{"role": "user", "content": "phantom text"}])
+
+        built = log._build_folded("s0")
+        assert built is not None
+        assert built[1] == "on disk only", "the fold must come from the file"
+        assert "phantom" not in built[1]
+
+    def test_the_fold_runs_while_the_keys_write_lock_is_held(self, tmp_path, monkeypatch):
+        """The invariant that closes the preserved-mtime rewrite race.
+
+        ``rewrite_session`` restores the pre-write mtime so compaction does not
+        reorder ``list_sessions``. A fold that read before such a rewrite and
+        stored after its ``_invalidate_cache`` would hold pre-rewrite text under a
+        mtime the file still has — invisible to the mtime guard, so the newly
+        saved messages would be missing from every later search for the life of
+        the process.
+
+        The fix is exclusion, not detection: the whole stat -> read -> store
+        sequence runs inside the key's write lock. This asserts that directly
+        (rather than racing real threads, which could only fail probabilistically)
+        by tracking the lock's depth and sampling it from inside the fold.
+        """
+        depth = [0]
+        real_file_lock = ConversationLog._file_lock
+
+        class _TrackedLock:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def __enter__(self):
+                self._inner.acquire()
+                depth[0] += 1
+
+            def __exit__(self, *exc):
+                depth[0] -= 1
+                self._inner.release()
+
+        def tracked(self, key: str):
+            return _TrackedLock(real_file_lock(self, key))
+
+        real_build = ConversationLog._build_folded
+        observed: list[int] = []
+
+        def observing(self, key: str):
+            observed.append(depth[0])
+            return real_build(self, key)
+
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(3):
+            log.append(f"s{i}", "user", "mentions deployment")
+
+        monkeypatch.setattr(ConversationLog, "_file_lock", tracked)
+        monkeypatch.setattr(ConversationLog, "_build_folded", observing)
+        log.search_sessions("deployment", 50)
+
+        assert observed, "the fold must actually have run"
+        assert all(d >= 1 for d in observed), (
+            f"every fold must run under the key's write lock, saw depths {observed}"
+        )
+
+    def test_a_writer_blocks_on_the_lock_the_fold_holds(self, tmp_path):
+        """Pins the coupling that makes the exclusion real.
+
+        ``_locked`` — which every append / rewrite / metadata edit goes through —
+        acquires ``_file_lock(key)`` first, so holding that lock across the fold
+        keeps writers out. If a future change gave writers a different lock, the
+        fold's lock would still be taken and the test above would still pass while
+        protecting nothing.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("s0", "user", "first entry")
+
+        writer_finished = threading.Event()
+
+        def writer() -> None:
+            log.append("s0", "user", "second entry")
+            writer_finished.set()
+
+        lock = log._file_lock("s0")
+        lock.acquire()
+        thread = threading.Thread(target=writer, daemon=True)
+        thread.start()
+        try:
+            assert not writer_finished.wait(0.25), (
+                "a writer must block while the fold's lock is held"
+            )
+        finally:
+            lock.release()
+        assert writer_finished.wait(10), "the writer must proceed once the lock is released"
+        thread.join(timeout=10)
+
+    def test_the_fold_lock_is_only_taken_on_a_miss(self, tmp_path, monkeypatch):
+        """A warm search must not contend on any key's write lock.
+
+        The lock is held across a file read plus a casefold, so taking it on the
+        warm path would put every search in line behind chat appends.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(4):
+            log.append(f"s{i}", "user", "mentions deployment")
+        log.search_sessions("deployment", 50)  # warm every entry
+
+        locked_for: list[str] = []
+        original = ConversationLog._file_lock
+
+        def counted(self, key: str):
+            locked_for.append(key)
+            return original(self, key)
+
+        monkeypatch.setattr(ConversationLog, "_file_lock", counted)
+        log.search_sessions("deployment", 50)
+
+        assert locked_for == [], "a fully warm search must take no per-key lock"
+
+    def test_a_read_failure_is_not_cached(self, tmp_path, monkeypatch):
+        """A transient open failure must not make a session permanently unsearchable.
+
+        The file's mtime does not change when a read fails, so caching the empty
+        result would key it as current and the session would stay invisible until
+        something wrote to it again.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("s0", "user", "the bandicoot section")
+        log._msg_cache.clear()
+
+        real_open = open
+        fail = {"on": True}
+
+        def flaky_open(*args, **kwargs):
+            if fail["on"] and str(args[0]) == str(log._path("s0")):
+                raise OSError("transient")
+            return real_open(*args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", flaky_open)
+        assert log.search_sessions("bandicoot", 50) == []
+        assert len(log._folded_cache) == 0, "a failed read must leave no cache entry"
+
+        fail["on"] = False
+        hits = log.search_sessions("bandicoot", 50)
+        assert [h["key"] for h in hits] == ["s0"], "the next query must retry the read"
+
+    def test_a_session_with_no_text_is_cached_as_empty(self, tmp_path):
+        """``(0, "")`` from an EMPTY session is a real answer and stays cached —
+        only a read FAILURE is uncacheable."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("s0", "user", "")
+        log.search_sessions("anything", 50)
+        assert len(log._folded_cache) == 1
+
+    def test_unreadable_file_signals_failure_rather_than_empty(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path)
+        assert log._build_folded("never-existed") is None
+
+    def test_both_halves_of_a_query_share_one_definition_of_searchable_text(
+        self, tmp_path, monkeypatch
+    ):
+        """The fold and the snippet must not drift apart on what they skip.
+
+        They are two readers of the same on-disk format; divergent skip rules
+        would let a query count a match the snippet cannot then locate (an empty
+        snippet on a matched row), or vice versa. Pinned by routing both through
+        ``_iter_message_texts``.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("s0", "user", "the wombat entry")
+
+        callers: list[str] = []
+        original = ConversationLog._iter_message_texts
+
+        def counted(self, key: str):
+            callers.append(key)
+            return original(self, key)
+
+        monkeypatch.setattr(ConversationLog, "_iter_message_texts", counted)
+        hits = log.search_sessions("wombat", 50)
+
+        assert [h["key"] for h in hits] == ["s0"]
+        assert "wombat" in hits[0]["snippet"]
+        assert callers == ["s0", "s0"], (
+            f"fold and snippet must both go through the shared iterator, saw {callers}"
+        )
+
+    def test_the_shared_iterator_skips_metadata_and_unparseable_lines(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("s0", "user", "real content")
+        with open(log._path("s0"), "a", encoding="utf-8") as handle:
+            handle.write("\n")
+            handle.write("not json at all\n")
+            handle.write('["a list, not an object"]\n')
+            handle.write('{"_type": "metadata", "content": "header text"}\n')
+            handle.write('{"role": "user", "content": ""}\n')
+            handle.write('{"role": "user", "content": 42}\n')
+            handle.write('{"role": "user", "content": "second real"}\n')
+
+        assert list(log._iter_message_texts("s0")) == ["real content", "second real"]
+
+    def test_the_shared_iterator_stops_reading_when_the_caller_stops(self, tmp_path):
+        """Early exit is what makes the snippet cheap — closing the generator must
+        close the file rather than draining the whole transcript."""
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(200):
+            log.append("s0", "user", f"message {i}")
+
+        consumed = 0
+        for _ in log._iter_message_texts("s0"):
+            consumed += 1
+            if consumed == 3:
+                break
+        assert consumed == 3
+
+
+class TestSearchResultsUnchangedByMemoization:
+
+    def test_case_insensitive_match_and_snippet_survive(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("alpha", "user", "The Straße was closed during the DEPLOYMENT window")
+        log.append("beta", "user", "nothing relevant here")
+
+        hits = log.search_sessions("strasse", 50)
+        assert [h["key"] for h in hits] == ["alpha"], "casefold (ß -> ss) must still match"
+        assert "Straße" in hits[0]["snippet"]
+
+        hits = log.search_sessions("deployment", 50)
+        assert [h["key"] for h in hits] == ["alpha"]
+        assert "DEPLOYMENT" in hits[0]["snippet"]
+
+    def test_match_does_not_span_two_messages(self, tmp_path):
+        """The ``\\x00`` join must keep a match from bridging two messages."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("alpha", "user", "foo")
+        log.append("alpha", "user", "bar")
+        assert log.search_sessions("foobar", 50) == []
+
+    def test_title_boost_still_outranks_a_body_mention(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("body", "user", "a passing mention of pipelines somewhere in here")
+        log.append("titled", "user", "pipelines")
+        log.update_metadata("titled", {"title": "pipelines rewrite"})
+
+        hits = log.search_sessions("pipelines", 50)
+        assert hits[0]["key"] == "titled"
+
+    def test_snippet_is_only_built_for_matching_sessions(self, tmp_path, monkeypatch):
+        """Non-matching sessions must not pay the snippet re-read.
+
+        This is the other half of the per-query cost: the snippet needs the
+        UNFOLDED text (offsets must line up), so it cannot come from the fold
+        cache and has to be re-read. Building it for every scanned session would
+        put a full re-read back on the hot path.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("hit", "user", "contains the needle")
+        for i in range(5):
+            log.append(f"miss{i}", "user", "contains nothing of interest")
+
+        snippet_for = _spy_on_snippets(monkeypatch)
+        log.search_sessions("needle", 50)
+
+        assert snippet_for == ["hit"]
+
+    def test_snippet_cost_tracks_the_returned_rows_not_the_match_count(
+        self, tmp_path, monkeypatch
+    ):
+        """20 sessions match, 3 are returned => 3 snippets, not 20.
+
+        Snippets are attached after the sort+slice for exactly this reason: the
+        palette shows a page of rows, so a broad query that matches the whole
+        corpus must not cost a re-read per match.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        for i in range(20):
+            log.append(f"s{i}", "user", "everyone mentions deployment")
+
+        snippet_for = _spy_on_snippets(monkeypatch)
+        hits = log.search_sessions("deployment", 3)
+
+        assert len(hits) == 3
+        assert len(snippet_for) == 3, f"expected 3 snippet builds, got {len(snippet_for)}"
+
+    def test_snippet_scan_stops_at_the_first_matching_message(self, tmp_path):
+        """An early hit must not cost a fold of the rest of the session."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("s0", "user", "the needle is right here")
+        for _ in range(50):
+            log.append("s0", "user", "filler " * 200)
+
+        hits = log.search_sessions("needle", 50)
+        assert "needle" in hits[0]["snippet"]
+        assert "filler" not in hits[0]["snippet"], "window must stay in the matching message"

--- a/website/src/components/CommandPalette.tsx
+++ b/website/src/components/CommandPalette.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, useRef, useMemo, Fragment } from 'react'
-import type { ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { Search, X, Pin, MessageSquare, Clock, Plus } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
@@ -22,6 +21,7 @@ import { usePromptsProvider } from './commandPalette/providers/promptsProvider'
 import { useArtifactsProvider } from './commandPalette/providers/artifactsProvider'
 import { useRecentsProvider } from './commandPalette/providers/recentsProvider'
 import { useSettingsProvider } from './commandPalette/providers/settingsProvider'
+import { Highlighted } from './commandPalette/Highlighted'
 
 import { i18nT } from '../i18n/t'
 /**
@@ -88,35 +88,19 @@ export interface CommandPaletteProps {
 /** Stable no-op so `useActionsProvider` always gets a defined callback. */
 const NOOP = () => {}
 
+/**
+ * Idle gap before a typed query is dispatched to the providers. Sized against
+ * the cost of a dispatch, not typing feel: one debounced value fans out to
+ * every registered provider (see {@link useAllAggregator}), and Sessions +
+ * Artifacts both content-search server-side.
+ */
+export const SEARCH_DEBOUNCE_MS = 250
+
 /** Composer-style sigil scopes: typing a leading sigil instantly scopes the
  * palette, mirroring the chat composer's `$skill` / `/command` muscle memory.
  * `@` is mapped to Artifacts here (the palette's `@` destination). Value =
  * provider (tab) id. */
 const SIGIL_SCOPE: Record<string, string> = { $: 'skills', '@': 'artifacts', '/': 'actions' }
-
-/**
- * Render `text` with the characters at `indices` emphasised. Each character is
- * its own span/strong node keyed by position — safe (no HTML string building)
- * and good enough for short titles.
- */
-function Highlighted({ text, indices }: { text: string; indices: number[] }): ReactNode {
-  if (indices.length === 0) return text
-  const hit = new Set(indices)
-  const nodes: ReactNode[] = []
-  for (let i = 0; i < text.length; i++) {
-    const ch = text[i]
-    nodes.push(
-      hit.has(i) ? (
-        <strong key={i} className="text-text-strong font-semibold">
-          {ch}
-        </strong>
-      ) : (
-        <span key={i}>{ch}</span>
-      ),
-    )
-  }
-  return <>{nodes}</>
-}
 
 export default function CommandPalette({
   open,
@@ -373,12 +357,17 @@ export default function CommandPalette({
 
   // Debounce the query into debouncedQuery (empty resets immediately so the
   // recents/quick-switcher shows without lag on open or clear).
+  //
+  // 250ms rather than a tighter window because each debounced value is a fresh
+  // React Query key, and the All tab fans that out to every provider — two of
+  // which content-search server-side. A 150ms window turned typing one word
+  // into five or six full corpus scans that the user never saw the results of.
   useEffect(() => {
     if (query === '') {
       setDebouncedQuery('')
       return
     }
-    const t = setTimeout(() => setDebouncedQuery(query), 150)
+    const t = setTimeout(() => setDebouncedQuery(query), SEARCH_DEBOUNCE_MS)
     return () => clearTimeout(t)
   }, [query])
 

--- a/website/src/components/commandPalette/Highlighted.test.tsx
+++ b/website/src/components/commandPalette/Highlighted.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+
+import { Highlighted } from './Highlighted'
+
+/**
+ * Render-cost regression tests for the palette's match highlighter.
+ *
+ * The palette re-renders its whole result list on every selection change, and
+ * hovering a row selects it — so plain mouse movement across the list rebuilds
+ * every row. Each row renders a title AND a match-centered snippet through
+ * {@link Highlighted}, so this component's node count per row is what decides
+ * whether the list is smooth or drops frames.
+ *
+ * The assertions count DOM nodes rather than measuring elapsed time: node count
+ * is the thing actually being controlled, and it is identical on every host,
+ * whereas a wall-clock budget would measure CI load instead. A regression to a
+ * per-character tree fails these immediately and unambiguously.
+ */
+
+/** Every node the component produced, text nodes included. */
+function countNodes(container: HTMLElement): number {
+  let n = 0
+  const walk = (node: Node) => {
+    n++
+    node.childNodes.forEach(walk)
+  }
+  container.childNodes.forEach(walk)
+  return n
+}
+
+describe('Highlighted render cost', () => {
+  it('is bounded by the number of match runs, not by text length', () => {
+    // A realistic worst case: a 200-char snippet (the server caps snippets at
+    // 200) with one contiguous 6-char match — what a substring hit looks like.
+    const text = 'x'.repeat(97) + 'needle' + 'y'.repeat(97)
+    const indices = Array.from({ length: 6 }, (_, i) => 97 + i)
+
+    const { container } = render(<Highlighted text={text} indices={indices} />)
+
+    // 3 runs (before / match / after) => 2 text nodes + 1 <strong> + its text.
+    // A per-character implementation produces 400+.
+    expect(countNodes(container)).toBeLessThanOrEqual(8)
+    expect(container.querySelectorAll('strong')).toHaveLength(1)
+    cleanup()
+  })
+
+  it('stays bounded for a scattered fuzzy match', () => {
+    // Fuzzy matching scatters single characters — the pathological input for a
+    // run-based encoder. Even here the count tracks match COUNT, not length.
+    const text = 'deployment pipeline configuration for the staging environment'
+    const indices = [0, 11, 20, 30, 40, 50]
+
+    const { container } = render(<Highlighted text={text} indices={indices} />)
+
+    expect(container.querySelectorAll('strong')).toHaveLength(6)
+    // 6 matched runs + at most 7 gaps = 13 runs; each <strong> also carries one
+    // child text node.
+    expect(countNodes(container)).toBeLessThanOrEqual(20)
+    cleanup()
+  })
+
+  it('renders a long unmatched title as a single text node', () => {
+    const { container } = render(<Highlighted text={'z'.repeat(500)} indices={[]} />)
+    expect(countNodes(container)).toBe(1)
+    cleanup()
+  })
+})
+
+describe('Highlighted correctness', () => {
+  it('emphasises exactly the requested characters and nothing else', () => {
+    const { container } = render(<Highlighted text="abcdef" indices={[1, 2, 4]} />)
+
+    expect(container.textContent).toBe('abcdef')
+    const marks = Array.from(container.querySelectorAll('strong')).map((e) => e.textContent)
+    expect(marks).toEqual(['bc', 'e'])
+    cleanup()
+  })
+
+  it('handles a match at both boundaries', () => {
+    const { container } = render(<Highlighted text="abc" indices={[0, 2]} />)
+    expect(container.textContent).toBe('abc')
+    expect(Array.from(container.querySelectorAll('strong')).map((e) => e.textContent)).toEqual([
+      'a',
+      'c',
+    ])
+    cleanup()
+  })
+
+  it('emphasises the whole string when every character matches', () => {
+    const { container } = render(<Highlighted text="abc" indices={[0, 1, 2]} />)
+    expect(Array.from(container.querySelectorAll('strong')).map((e) => e.textContent)).toEqual([
+      'abc',
+    ])
+    cleanup()
+  })
+
+  it('ignores out-of-range and duplicated indices', () => {
+    const { container } = render(<Highlighted text="abc" indices={[1, 1, 99, -1]} />)
+    expect(container.textContent).toBe('abc')
+    expect(Array.from(container.querySelectorAll('strong')).map((e) => e.textContent)).toEqual([
+      'b',
+    ])
+    cleanup()
+  })
+
+  it('preserves the text verbatim for non-ASCII characters', () => {
+    const { container } = render(<Highlighted text="поиск" indices={[1, 2]} />)
+    expect(container.textContent).toBe('поиск')
+    expect(Array.from(container.querySelectorAll('strong')).map((e) => e.textContent)).toEqual([
+      'ои',
+    ])
+    cleanup()
+  })
+})

--- a/website/src/components/commandPalette/Highlighted.tsx
+++ b/website/src/components/commandPalette/Highlighted.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from 'react'
+
+/**
+ * Render `text` with the characters at `indices` emphasised.
+ *
+ * Emits one node per CONSECUTIVE RUN of matched / unmatched characters, not one
+ * per character. This is a load-bearing property, not a micro-optimisation: the
+ * palette's result list re-renders on every selection change — including plain
+ * mouse movement, since hovering a row selects it — and it renders both a title
+ * and a match-centered snippet per row. At one node per character a full
+ * Sessions tab was several thousand elements rebuilt per hovered row, which is
+ * long enough to drop frames. A fuzzy match is a handful of short runs, so the
+ * run form is bounded by the number of match groups instead of by text length.
+ *
+ * Unmatched runs are emitted as bare strings rather than wrapped in an element:
+ * React does not require keys for string children, and the element saved per run
+ * is the entire point.
+ *
+ * Highlighting is expressed as React nodes and never
+ * `dangerouslySetInnerHTML` — no HTML string is ever built from the matched text
+ * (`frontend-security` lint rule).
+ *
+ * @param text - The full string to render.
+ * @param indices - Character offsets into `text` to emphasise. Offsets outside
+ *   the string are ignored; order and duplicates do not matter.
+ */
+export function Highlighted({ text, indices }: { text: string; indices: number[] }): ReactNode {
+  if (indices.length === 0) return text
+  const hit = new Set(indices)
+  const nodes: ReactNode[] = []
+  let start = 0
+  while (start < text.length) {
+    const matched = hit.has(start)
+    let end = start + 1
+    while (end < text.length && hit.has(end) === matched) end++
+    const run = text.slice(start, end)
+    nodes.push(
+      matched ? (
+        <strong key={start} className="text-text-strong font-semibold">
+          {run}
+        </strong>
+      ) : (
+        run
+      ),
+    )
+    start = end
+  }
+  return <>{nodes}</>
+}
+
+export default Highlighted

--- a/website/src/components/commandPalette/providers/sessionsProvider.test.ts
+++ b/website/src/components/commandPalette/providers/sessionsProvider.test.ts
@@ -45,6 +45,36 @@ describe('createSessionsProvider — identity & metadata', () => {
   })
 })
 
+describe('createSessionsProvider — sub-threshold queries cost no round trip', () => {
+  // `/api/sessions/search` returns an empty list below SEARCH_MIN_CHARS (2), and
+  // serving that empty list still made the backend walk the corpus. Skipping the
+  // fetch is behavior-preserving because the answer was already always empty.
+  it('does not fetch for a one-character query', async () => {
+    const { d, fetchSessions } = deps()
+    const results = await createSessionsProvider(d).search('k')
+    expect(results).toEqual([])
+    expect(fetchSessions).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch for a query that is only whitespace-padded to length', async () => {
+    const { d, fetchSessions } = deps()
+    expect(await createSessionsProvider(d).search('  k  ')).toEqual([])
+    expect(fetchSessions).not.toHaveBeenCalled()
+  })
+
+  it('still fetches the recents listing for an empty query', async () => {
+    const { d, fetchSessions } = deps()
+    await createSessionsProvider(d).search('')
+    expect(fetchSessions).toHaveBeenCalledWith('')
+  })
+
+  it('fetches once the query reaches the threshold', async () => {
+    const { d, fetchSessions } = deps()
+    await createSessionsProvider(d).search('ki')
+    expect(fetchSessions).toHaveBeenCalledWith('ki')
+  })
+})
+
 describe('createSessionsProvider — result mapping', () => {
   it('maps a backend session to a Result with id, title, subtitle, and highlight indices', async () => {
     const fetchSessions = vi.fn(

--- a/website/src/components/commandPalette/providers/sessionsProvider.ts
+++ b/website/src/components/commandPalette/providers/sessionsProvider.ts
@@ -49,6 +49,17 @@ const PROVIDER_LABEL_KEY = 'nav.sessions'
 const SESSIONS_STALE_MS = 30_000
 
 /**
+ * Shortest query the backend will actually search. Mirrors `SEARCH_MIN_CHARS`
+ * in `history.py`, where `/api/sessions/search` returns an empty list below the
+ * threshold. Enforced here too so a one-character query costs no round trip at
+ * all — behavior-preserving, because the response was already always empty.
+ *
+ * An EMPTY query is exempt: it is the recents/quick-switcher listing, not a
+ * search, and the endpoint answers it.
+ */
+const SESSIONS_MIN_QUERY_CHARS = 2
+
+/**
  * One session as returned by `/api/sessions/search`. `api.sessionsSearch` is
  * loosely typed at the client layer, so we pin the fields the provider reads.
  */
@@ -119,6 +130,7 @@ export function createSessionsProvider(deps: SessionsProviderDeps): ResourceProv
     icon: sessionIcon(),
     async search(query: string): Promise<Result[]> {
       const q = query.trim()
+      if (q.length > 0 && q.length < SESSIONS_MIN_QUERY_CHARS) return []
       // Folders resolve in parallel with the search; a folders failure only
       // costs the chips, never the results.
       const [data, folders] = await Promise.all([


### PR DESCRIPTION
## 1. What is the problem?

Search Everywhere (⌘K) is laggy while typing, and the lag is not confined to the palette — it stalls the whole gateway.

`GET /api/sessions/search` calls `ConversationLog.search_sessions()`, which has no index. Every query walks the most recent 500 session files and, for each one, joins its messages' `content`, casefolds the result, and counts the needle. It then rebuilds the raw joined text a second time to cut a snippet — for **every** session that matched, not just the ones returned.

Measured on a real 125-session / 136 MB corpus:

| | before |
|---|---|
| cold first query | 1392 ms |
| 5 active sessions stale (mtime bumped) | 224 ms |
| fully warm cache | 109 ms |

The warm 109 ms is `casefold` 51 ms + gather/join 29 ms + `count` 6 ms + snippet and scoring. ~80% of each query re-derives something that did not change between two keystrokes.

The frontend has an independent problem: `Highlighted` emitted one `<span>`/`<strong>` per character.

## 2. Why this issue matters to the user

**The stall is global, not local.** The handler offloads the scan with `run_in_executor`, but `str.casefold` / `str.count` / `str.join` hold the GIL for their whole duration. A 109–224 ms scan is 109–224 ms in which the asyncio event loop cannot run, so chat token streaming and WebSocket traffic stall with it. The palette makes the entire dashboard hitch.

**One word is many scans.** The debounce was 150 ms and every debounced value is a fresh React Query key, so typing `kirocrew` dispatched 5–6 distinct queries — roughly 760 ms of cumulative event-loop freeze for one word on a warm cache. The All tab fans out with `Promise.all`, so its latency equals the slowest provider (Sessions).

**Hovering the list was expensive too.** A full Sessions tab (50 rows × 80-char title + 200-char snippet) was ~14,000 React elements, and the list re-renders on every selection change — including plain mouse movement, because `onMouseEnter` selects the row.

## 3. How our fix solves it

Symptom → root cause → fix, in the order the cost dominated:

1. **Re-folding the corpus per keystroke** was the largest term. `_folded_cache` memoizes `(mtime, doc_chars, casefolded_blob)` per session, so a query pays only `count`. The corpus does not change between the keystrokes of one search, and `doc_chars` deliberately counts the *unfolded* length because it feeds the length normalizer and folding can change a string's length (`ß` → `ss`). The fold is split into `_folded_content` (cached) and `_build_folded` (the miss) so the memoization is observable rather than merely asserted.

2. **Snippet rebuilding then became the dominant term** — removing the fold cost exposed it (warm queries sat at 41 ms, of which ~30 ms was snippets). A snippet cannot come from the fold cache because it needs the original text for offsets to line up. Two changes: snippets are attached *after* the sort+slice, so their cost tracks rows returned rather than matches found; and `_content_snippet` now scans message-by-message and stops at the first hit instead of re-joining and folding the whole session. The window is consequently confined to the matching message, which is consistent with the existing `\x00` join that already stops a match from bridging two messages.

3. **Cache sizing is load-bearing, not incidental.** `_folded_cache` is sized `max(cache_max, _SEARCH_SCAN_WINDOW)`, never `cache_max`. A search walks the scan window in the same order every query, so an LRU smaller than the window evicts each session one step before its next read: the hit rate collapses to **zero** rather than degrading, and the memoization silently stops working for the users with the most sessions — the ones it exists for.

4. **Searching must not pin the parsed corpus.** `_read_messages` memoizes the parsed message dicts, and a search touches every session in the window — so sourcing content through it made searching pin the whole corpus's *parsed* form in gateway RSS. Both halves of a query now read the file directly instead: `_build_folded` streams it, and `_content_snippet` streams it with early exit at the first matching message (so it reads only as far as the hit, rather than parsing a whole transcript for a 200-char window). Search now pins **no** parsed transcript anywhere. Measured peak RSS after a search on the same corpus: **369 MB → 77 MB**. The folded strings actually needed are 6.4 M chars; the rest was parsed dicts nothing in the search path reads.

5. **Staleness — three guards, because a cache entry keyed by a *current* mtime holding stale text makes a session silently unsearchable, not merely slow.**
   - **Out-of-band edits:** `_folded_cache` has an mtime guard.
   - **Preserved-mtime rewrites:** `rewrite_session` and friends deliberately *restore* the pre-write mtime (so compaction does not reorder `list_sessions`), which no mtime comparison can detect. `_folded_cache` is popped in `_invalidate_cache`, and — because a fold that read before such a rewrite could otherwise store after its invalidation — the whole `stat → read → store` sequence runs inside `_file_lock(key)`, the same in-process RLock every writer takes first in `_locked`. Taken only on the miss path, so a warm search never contends. `_build_folded` also refuses to source content from `_msg_cache`, which is filled by callers holding no write lock and carries the identical race (filed separately as #1835) — otherwise that staleness would be laundered into the search cache from inside the lock. Cross-process writers are self-healing and need no lock: the caller stats *before* the read, so such a write leaves the cached mtime older than the file's and the next access re-folds.
   - **Read failures:** never cached. `_build_folded` returns `None` for `OSError`, distinct from `(0, "")` for a session with no text, because a failed read leaves the mtime unchanged and the poisoned entry would never expire.

6. **One definition of "searchable text".** The fold and the snippet are two readers of the same on-disk format, so they share a single `_iter_message_texts` generator rather than each hand-rolling the line loop — divergent skip rules would let a query count a match the snippet then cannot locate (an empty snippet on a matched row). Being a generator is also what gives the snippet its early exit: closing it closes the file.

7. **Highlight tree.** `Highlighted` moved to its own module and emits one node per consecutive run of matched/unmatched characters. Unmatched runs are bare strings (no wrapper element). For a 200-char snippet with one 6-char match this is 400+ nodes → 4.

8. **Wasted dispatches.** Debounce 150 ms → 250 ms, and `sessionsProvider` skips the round trip below `SEARCH_MIN_CHARS` (2). The latter is behavior-preserving: the endpoint already returned an empty list there. The threshold is *not* applied at the palette level, so Pages / Actions / Settings keep answering single-character queries from their client-side fuzzy match.

Result on the same real 125-session / 136 MB corpus:

| | before | after |
|---|---|---|
| cold first query | 1392 ms | **511 ms** |
| warm per query | 109 ms | **13 ms** |
| typing `kirocrew` warm (7 queries) | ~760 ms | **~90 ms** |
| peak RSS after a search | 369 MB | **77 MB** |

Per-query breakdown after the fix: `list_sessions` 1.2 ms, fold lookups 1.3 ms, `count` 4.9 ms — i.e. the query is now dominated by the one thing that genuinely has to happen per keystroke, and the remainder is the snippets for the rows actually returned.

## 4. What tests we did

**New backend suite** `test/test_search_sessions_cost.py` (27 tests). The assertions count **folds, snippet builds, parsed-transcript cache entries, and lock depth — not wall-clock time**. A timing threshold would measure CI host load, and a "warm is N× faster" ratio is exactly the flaky shape `testing-conventions.md` rules out. These counts are deterministic on every host.

- typing a 5-prefix word folds the corpus once, not once per keystroke
- an identical repeat query folds nothing
- appending to one session re-folds only that session
- an out-of-band content change is still caught (mtime guard)
- compaction, which restores the pre-write mtime, does not serve stale content
- 20 matches with `limit=3` builds 3 snippets, not 20
- the snippet window stays inside the matching message
- the fold cache is sized to at least the scan window, and a small `cache_max` cannot shrink it below that
- a 30-session corpus scanned through an 8-entry transcript cache re-folds nothing on the second query (the thrash cliff)
- a scan that matches nothing leaves `_msg_cache` empty, and so does one that returns rows — searching pins no parsed transcript at all
- the fold and the snippet both go through one shared line iterator, so their skip rules cannot drift; that iterator skips blank / unparseable / non-object lines and the metadata header, and stops reading when the caller stops
- the streaming fold and the warm-cache fold agree byte-for-byte
- results are unchanged: `casefold` matching (`ß`/`ss`), snippet content, no match bridging two messages, title boost still outranks a body mention

**New frontend suite** `website/src/components/commandPalette/Highlighted.test.tsx` (8 tests) — node counts plus correctness (exact emphasised spans, both boundaries, all-matched, out-of-range/duplicate indices, non-ASCII text preserved).

**New provider tests** — 4 cases pinning that a sub-threshold query costs no fetch while an empty query still lists recents.

**Mutation-verified (10 of them).** Each fix was reverted in place and the suite confirmed red, then restored:
- disable the fold cache read → `expected one fold per session, got 30`
- remove the `_invalidate_cache` pop → `stale content must not still match`
- restore the per-character highlighter → `expected 400 to be less than or equal to 8`
- build snippets before the slice → `assert 20 == 3`
- size the fold cache at `cache_max` → `assert 256 >= 500`, `assert 8 >= 500`, and the thrash test
- route the fold back through `_read_messages` → `a scan that returns nothing must parse nothing`, `assert 10 == 2`
- make the fold source content from `_msg_cache` → `the fold must come from the file`
- replace the fold's `_file_lock` with a null context → `saw depths [0, 0, 0]`
- give the snippet its own copy of the line parser → `fold and snippet must both go through the shared iterator, saw ['s0']`
- cache a read failure instead of failing open → `a failed read must leave no cache entry`

**Gates:** pytest 31464 passed, isort, flake8, mypy (1.14.1, 728 files) clean, `tsc -b` clean, vitest 9440 passed / 709 files, diff-scoped `I18N_BASE_REF` i18n check clean.

**One superseded test rewritten, not deleted.** `test_history.py::TestSearchSessions::test_substring_scan_reads_through_msg_cache` was the regression lock for an earlier "collapse two parses into one" change that routed search through `_read_messages`. This PR reverses that deliberately, on grounds that change did not weigh: the parsed-corpus pin, and `_msg_cache` as an unlocked stale input. Its replacement, `test_substring_scan_reads_the_file_and_leaves_msg_cache_alone`, locks the new contract. The original concern is not regressed — a matched row now costs one full streamed read plus a partial one instead of a full JSON parse, which is measurably cheaper end to end.

Failures in the full backend run are pre-existing environment failures on this host (userns `CLONE_NEWUSER` EPERM, so the sandbox suites cannot run; plus the ops-mission-control git ledger suite). Verified by running the identical subset on `kirocrew/main` in the same worktree and venv: the failure sets are identical, and none is in the history / search / palette code this PR touches. All of them are green in CI.

## 5. Any other suggestions on the work

- **The cold first query is still 511 ms** and remains a real event-loop stall once per gateway generation. Bounding it needs a persistent index (or chunking the fold to yield the GIL), which is a larger change than this PR should carry.
- **No byte bound on the fold cache, deliberately.** The entry bound has to cover the scan window or the hit rate goes to zero, and a byte cap small enough to matter would reintroduce that same cliff at a different threshold. Search now holds ~37 MB of derived strings where it used to pin ~330 MB of parsed dicts, so a byte cap is not needed to make the memory story acceptable; if a corpus ever makes it necessary, it needs a degradation strategy (shrink the scan window) rather than plain eviction.
- **`_read_messages` carries the same preserved-mtime race** → #1835. Search no longer depends on it being fixed (neither the fold nor the snippet reads `_msg_cache`), but the remaining readers — transcript rendering, resume, `recent_from_source`, MCP `get_chat_session` — can still serve a pre-rewrite parse until restart. Filed rather than folded in, since it is pre-existing and touches a different set of callers.
- **Sub-threshold empty state** → #1830. A one-character Sessions query renders `No matches` when it should say "keep typing". Pre-existing (`main` renders the same, because the endpoint already returned empty below the threshold), and the fix is a new i18n key across 10 locales plus a provider→empty-state signal, so it is split out rather than folded into a performance change.
- **Palette rows are still not memoized.** With the highlighter down to a handful of nodes per row, hover re-render is cheap enough that this stopped being worth the refactor risk; if it resurfaces, extracting a `React.memo` row with a stable `onSelect(index)` is the fix.
- **Installed apps are still unsearchable.** `pagesProvider` sources `getBuiltinSurfaces()`, which excludes `appOnly` surfaces, and installed apps are rendered separately by `refreshAppNav()` from `api.listApps()`. A Raycast-style `appsProvider` is deliberately left out of this PR to keep it a pure performance change.
- **Unrelated drift noticed:** `config-baseline.json` on `main` is stale against the `skills.max_triggered` help text (regenerating it locally produces a diff). Not touched here.

Fixes #1826




