### PR TITLE
feat(config-baseline): sync stale config-baseline.json with loader.py help text (stops worktree pollution)

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -1621,7 +1621,7 @@
       "sensitive": false,
       "tags": [],
       "label": "Max Triggered",
-      "help": "Maximum number of skills to load per message (≥1).",
+      "help": "Maximum number of skills a single message may flag as relevant (≥0). Each match injects that skill's full content, unless the skill sets inject_on_trigger: false in its frontmatter, in which case it contributes a one-line pointer naming it and its path and the agent reads the file if the skill applies. Set to 0 to stop flagging entirely and rely only on the Available Skills index, $skillname, and skill_search.",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 3

--- a/test/test_config_baseline.py
+++ b/test/test_config_baseline.py
@@ -100,27 +100,28 @@ class TestBaselineGenerator:
         for entry_dict in data["entries"]:
             keys = set(entry_dict.keys())
             assert required_keys <= keys, (
-                f"Entry {entry_dict.get('path', '?')!r} missing keys: "
-                f"{required_keys - keys}"
+                f"Entry {entry_dict.get('path', '?')!r} missing keys: " f"{required_keys - keys}"
             )
             unexpected = keys - required_keys - optional_keys
             assert not unexpected, (
-                f"Entry {entry_dict.get('path', '?')!r} has unexpected keys: "
-                f"{unexpected}"
+                f"Entry {entry_dict.get('path', '?')!r} has unexpected keys: " f"{unexpected}"
             )
 
-    def test_script_is_runnable_and_produces_valid_json(self) -> None:
+    def test_script_is_runnable_and_produces_valid_json(self, tmp_path: str) -> None:
         """Script is executable via python and produces valid JSON."""
+        out_path = os.path.join(str(tmp_path), "config-baseline.json")
+        env = os.environ.copy()
+        env["KIROCREW_BASELINE_OUTPUT"] = out_path
         result = subprocess.run(
             [sys.executable, _SCRIPT_PATH],
             capture_output=True,
             text=True,
             cwd=_REPO_ROOT,
+            env=env,
             timeout=30,
         )
         assert result.returncode == 0, f"Script failed:\n{result.stderr}"
 
-        out_path = os.path.join(_REPO_ROOT, "config-baseline.json")
         with open(out_path, encoding="utf-8") as f:
             data = json.load(f)  # Validates it's valid JSON
 
@@ -141,8 +142,7 @@ class TestBaselineGenerator:
         entry = entries_by_path.get("slack.reactions.*")
         assert entry is not None, "slack.reactions.* entry missing from baseline"
         assert entry.get("nullable") is True, (
-            "slack.reactions.* must be marked nullable (Optional[str] values); "
-            f"got {entry!r}"
+            "slack.reactions.* must be marked nullable (Optional[str] values); " f"got {entry!r}"
         )
         # And the base type is still 'string' — we didn't break the scalar type contract.
         assert entry["type"] == "string"


### PR DESCRIPTION
<!-- pr-context:start -->
## Summary
This PR combines 1 related change:
- **Sync stale config-baseline.json with loader.py help text (stops worktree pollution)**

## Changes and rationale

### Sync stale config-baseline.json with loader.py help text (stops worktree pollution)
**Review focus:** backend

## Review map

| Change | Primary files |
|---|---|
| Sync stale config-baseline.json with loader.py help text (stops worktree pollution) | `config-baseline.json` |

## Commits
- [`3bebd30`](https://github.com/kirodotdev/KiroCrew/pull/1833/commits/3bebd30213f152c092315df65777d12bc042cfed) feat(config-baseline): sync stale config-baseline.json with loader.py…

## Validation

Local build, static-analysis, and test gates completed before publication. Upstream CI and review checks on the current PR revision remain the authoritative merge signal.

<details><summary><strong>Changed files</strong> (6 files, +25/-13)</summary>

- `config-baseline.json` (+1/-1)
- `test/test_config_baseline.py` (+5/-2)
- `test/test_handlers_system_macos_paths.py` (+4/-0)
- `website/src/i18n/format.test.ts` (+9/-8)
- `website/src/i18n/unitLiterals.test.ts` (+2/-1)
- `website/src/test/fileExplorer.test.tsx` (+4/-1)

</details>

> This description updates automatically as related changes land; manually written text outside this block is preserved.
<!-- pr-context:end -->