### PR TITLE
fix(telemetry): name a closed conversation from its persisted title

### DIFF
--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -522,6 +522,20 @@ Telegram turn is booked as dashboard spend (observable in the row store as a
 the transport that created the session and is therefore the only field that
 distinguishes them.
 
+**A conversation's `title` is attached by the endpoint, from two sources in
+order.** `cost_breakdown` names nothing — slot keys are all the row store holds.
+`handlers/telemetry._with_conversation_titles` resolves the live slot's
+`display_title` first, so a rename shows before it has been flushed; a session
+with no live slot falls back to the `title` on its transcript's metadata line,
+read through `ConversationLog.get_metadata` off the event loop and keyed by
+`slot_transcript_key(slot)`, which is what folds a channel-born slot onto the
+channel's own transcript. Only an explicit metadata title counts: `list_sessions`
+would answer with the first user message and then with the session key, which
+turns a ranking label into prompt text and leaves no way to tell a named
+conversation from an unnamed one. A row with neither source reports an absent
+title rather than its key. Both sources pass the same two scanners on the way
+out, so where a title came from cannot change what leaves the endpoint.
+
 **The growth slope is fitted per segment, never across the window.** Occupancy
 is a sawtooth: a compaction drops it back toward empty, and 7 of the 8
 top-spending conversations measured carry one to four such drops. A secant from
@@ -545,7 +559,10 @@ Tests: `test/test_usage.py` (`TestReadContextTokens`,
 (channel attribution incl. the bare dashboard slot form, no-truncation,
 prior-window deltas, band bucketing, post-compaction slope, growth
 withholding, non-finite rejection) and `test/metrics/test_telemetry_titles.py`
-(title redaction + cache purity), plus the `context-trace` endpoint.
+(title redaction + cache purity, and the closed-conversation fallback: the
+canonical transcript key, live-wins-over-persisted, one read per shared
+transcript, and no title where the metadata line names none), plus the
+`context-trace` endpoint.
 
 ## Circular-import rule
 

--- a/src/kiro_crew/dashboard/handlers/telemetry.py
+++ b/src/kiro_crew/dashboard/handlers/telemetry.py
@@ -38,6 +38,7 @@ from aiohttp import web
 from kiro_crew import __version__, beacon
 from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.config.paths import config_dir
+from kiro_crew.dashboard.chat_utils import slot_transcript_key
 from kiro_crew.dashboard.handlers.usage import context_occupancy, context_trace, cost_breakdown
 from kiro_crew.dashboard.state import NEW_SESSION_TITLE
 from kiro_crew.hooks import validate_file_path
@@ -595,7 +596,7 @@ async def api_telemetry_startup(request: web.Request) -> web.Response:
     context = await asyncio.to_thread(_context_block)
     cost = await asyncio.to_thread(_cost_block)
     if cost:
-        cost = _with_conversation_titles(request, cost)
+        cost = await _with_conversation_titles(request, cost)
     return web.json_response(
         {
             "enabled": enabled,
@@ -632,20 +633,65 @@ async def api_context_trace(request: web.Request) -> web.Response:
     return web.json_response(trace)
 
 
-def _with_conversation_titles(request: web.Request, cost: dict[str, Any]) -> dict[str, Any]:
+def _persisted_titles(conversation_log: Any, slot_keys: list[str]) -> dict[str, str]:
+    """Read the persisted title for each of *slot_keys*. Blocking; call off-loop.
+
+    ``get_metadata`` rather than ``list_sessions``: the latter falls back to the
+    first user message and then to the session key when the metadata line names
+    no title, which would turn a ranking label into prompt text and leave no way
+    to tell a named conversation from an unnamed one. Only an explicit
+    ``metadata["title"]`` counts here, which is the same thing the live slot
+    carries.
+
+    Keyed by SLOT key on the way out, so the caller never has to know how a slot
+    maps onto a transcript. Distinct slots can share one transcript (a
+    channel-born slot's conversation IS the channel's), so the read is
+    deduplicated by transcript key rather than by slot.
+    """
+    by_transcript: dict[str, str] = {}
+    out: dict[str, str] = {}
+    for slot_key in slot_keys:
+        try:
+            transcript_key = slot_transcript_key(slot_key)
+        except Exception:  # pragma: no cover — a key shape no rule recognises
+            continue
+        if transcript_key not in by_transcript:
+            try:
+                meta = conversation_log.get_metadata(transcript_key) or {}
+            except Exception:
+                logger.debug("no persisted title for %s", transcript_key, exc_info=True)
+                meta = {}
+            by_transcript[transcript_key] = str(meta.get("title") or "")
+        title = by_transcript[transcript_key]
+        if title and title != NEW_SESSION_TITLE:
+            out[slot_key] = title
+    return out
+
+
+async def _with_conversation_titles(request: web.Request, cost: dict[str, Any]) -> dict[str, Any]:
     """Attach a redacted human title to each ranked conversation, where known.
 
-    Titles live only on the in-memory slot, so a conversation the user has since
-    closed has none to attach. That is reported as an absent title rather than
-    filled with the raw key, leaving the frontend to decide how to render an
-    unnamed row — a ranking of opaque keys is not a ranking anyone can act on.
+    A title is resolved from the live slot first, so a rename is reflected before
+    it has been persisted. A conversation the user has since closed has no slot,
+    and its title is read back from the transcript's metadata line instead —
+    without that fallback the longer the window, the more of the ranking renders
+    unnamed, which is backwards for the question the window exists to answer.
+
+    A row with neither still reports an absent title rather than the raw key,
+    leaving the frontend to decide how to render an unnamed row.
 
     ``display_title`` is LLM-authored (``chat_title._generate_title_via_kiro``),
     so it carries the same two scanners the slot's own serialization applies at
     ``_ChatSlot.to_dict``. This endpoint is a SECOND serialization boundary for
     that field, and the scan is load-bearing rather than duplicated: a title set
     through ``api_chat_slot_resume`` is written to the slot unredacted, so
-    nothing upstream of here has sanitised it.
+    nothing upstream of here has sanitised it. A persisted title takes the same
+    path, so where it came from cannot change what leaves here.
+
+    The metadata reads are the only blocking work, and they run in a thread: the
+    surrounding handler already offloads its three other blocks, and this one is
+    bounded by the ranked rows (``_COST_TOP_CONVOS``) rather than by the number
+    of sessions on disk.
 
     Rows are copied before the title is attached. ``cost_breakdown`` hands back
     its memoised object by reference, so writing into the row would store the
@@ -662,12 +708,32 @@ def _with_conversation_titles(request: web.Request, cost: dict[str, Any]) -> dic
     get_slot = getattr(state, "get_slot", None)
     if not callable(get_slot):
         return cost
-    rows = []
-    for row in cost.get("conversations") or []:
-        slot = get_slot(str(row.get("slot") or ""))
+
+    conversations = cost.get("conversations") or []
+    titles: dict[str, str] = {}
+    unresolved: list[str] = []
+    for row in conversations:
+        slot_key = str(row.get("slot") or "")
+        if not slot_key:
+            continue
+        slot = get_slot(slot_key)
         title = getattr(slot, "display_title", "") if slot is not None else ""
         if title and title != NEW_SESSION_TITLE:
-            safe, _ = redact_exfiltration_urls(str(title))
+            titles[slot_key] = str(title)
+        elif slot_key not in titles:
+            unresolved.append(slot_key)
+
+    conversation_log = getattr(state, "conversation_log", None)
+    if unresolved and conversation_log is not None:
+        titles.update(
+            await asyncio.to_thread(_persisted_titles, conversation_log, unresolved)
+        )
+
+    rows = []
+    for row in conversations:
+        title = titles.get(str(row.get("slot") or ""))
+        if title:
+            safe, _ = redact_exfiltration_urls(title)
             safe, _ = redact_credentials(safe)
             row = {**row, "title": safe}
         rows.append(row)

--- a/test/metrics/test_telemetry_titles.py
+++ b/test/metrics/test_telemetry_titles.py
@@ -6,7 +6,8 @@ two scanners over it before the dashboard sees it. ``/api/telemetry/startup`` is
 a SECOND boundary for the same field, so it must run them too — the scan is
 load-bearing rather than duplicated, because a title set through
 ``api_chat_slot_resume`` is written to the slot unredacted and nothing upstream
-of this handler has sanitised it.
+of this handler has sanitised it. A title read back from a transcript takes the
+same path, so where a title came from cannot change what leaves here.
 
 The second invariant here is cache purity: ``cost_breakdown`` returns its
 memoised object by reference, so attaching a title in place would write into
@@ -17,21 +18,35 @@ map is private (``DashboardState._slots``); ``get_slot()`` is the only public wa
 in. A double that instead exposes a ``slots`` attribute passes while production
 resolves nothing and every row renders unnamed, so one test here asserts the
 production class actually carries the accessor this handler calls.
+
+The fourth is what counts as a title on the persisted path. ``get_metadata``
+reports only an explicit ``metadata["title"]``; ``list_sessions`` would fall back
+to the first user message and then to the session key, which turns a ranking
+label into prompt text and removes any way to tell a named conversation from an
+unnamed one. The tests below pin that only an explicit title is read.
 """
+import json
 from types import SimpleNamespace
 
+import pytest
+
+from kiro_crew.dashboard.chat_utils import slot_transcript_key
 from kiro_crew.dashboard.handlers.telemetry import _with_conversation_titles
 from kiro_crew.dashboard.state import NEW_SESSION_TITLE, DashboardState
+from kiro_crew.history import ConversationLog
 
 
-def _request(slots: dict) -> SimpleNamespace:
+def _request(slots: dict, conversation_log=None) -> SimpleNamespace:
     """Minimal stand-in for the aiohttp request the handler reads.
 
-    Exposes ``get_slot`` and nothing else, matching ``DashboardState``'s public
-    surface -- a double with a richer interface than production can hide exactly
-    the defect this file exists to catch.
+    Exposes ``get_slot`` and ``conversation_log`` and nothing else, matching
+    ``DashboardState``'s public surface -- a double with a richer interface than
+    production can hide exactly the defect this file exists to catch.
     """
-    state = SimpleNamespace(get_slot=lambda key: slots.get(key))
+    state = SimpleNamespace(
+        get_slot=lambda key: slots.get(key),
+        conversation_log=conversation_log,
+    )
     return SimpleNamespace(app={"state": state})
 
 
@@ -40,56 +55,164 @@ def test_the_handler_calls_an_accessor_the_real_state_actually_has():
     # rather than silently degrade every row to "Untitled" at runtime.
     assert callable(getattr(DashboardState, "get_slot", None))
     assert not hasattr(DashboardState, "slots")
+    # Same for the transcript store the closed-conversation fallback reads.
+    assert "conversation_log" in DashboardState.__init__.__code__.co_names or hasattr(
+        DashboardState, "conversation_log"
+    )
 
 
 def _cost(*slot_keys: str) -> dict:
     return {"conversations": [{"slot": k, "credits": 1.0} for k in slot_keys]}
 
 
-def test_a_credential_shaped_title_is_redacted():
+@pytest.mark.asyncio
+async def test_a_credential_shaped_title_is_redacted():
     # A real AWS-key shape. The scanner recognises it; the point is that this
     # endpoint runs the scanner at all.
     leaked = "notes for AKIA" + "IOSFODNN7EXAMPLE"
     slots = {"chat-1-1": SimpleNamespace(display_title=leaked)}
-    out = _with_conversation_titles(_request(slots), _cost("chat-1-1"))
+    out = await _with_conversation_titles(_request(slots), _cost("chat-1-1"))
     title = out["conversations"][0]["title"]
     assert "AKIA" + "IOSFODNN7EXAMPLE" not in title
     assert "REDACTED" in title
 
 
-def test_an_ordinary_title_survives_unchanged():
+@pytest.mark.asyncio
+async def test_an_ordinary_title_survives_unchanged():
     slots = {"chat-1-1": SimpleNamespace(display_title="Telemetry cost page")}
-    out = _with_conversation_titles(_request(slots), _cost("chat-1-1"))
+    out = await _with_conversation_titles(_request(slots), _cost("chat-1-1"))
     assert out["conversations"][0]["title"] == "Telemetry cost page"
 
 
-def test_the_input_payload_is_not_mutated():
+@pytest.mark.asyncio
+async def test_the_input_payload_is_not_mutated():
     # cost_breakdown hands back its cache by reference; writing through it would
     # pin this title into module-global state for the rest of the TTL.
     payload = _cost("chat-1-1")
     slots = {"chat-1-1": SimpleNamespace(display_title="Telemetry cost page")}
-    out = _with_conversation_titles(_request(slots), payload)
+    out = await _with_conversation_titles(_request(slots), payload)
     assert "title" not in payload["conversations"][0]
     assert out["conversations"][0]["title"] == "Telemetry cost page"
     assert out["conversations"][0] is not payload["conversations"][0]
 
 
-def test_a_closed_conversation_gets_no_title_rather_than_its_key():
-    out = _with_conversation_titles(_request({}), _cost("chat-9-9"))
+@pytest.mark.asyncio
+async def test_a_conversation_with_no_slot_and_no_transcript_gets_no_title():
+    out = await _with_conversation_titles(_request({}), _cost("chat-9-9"))
     assert "title" not in out["conversations"][0]
 
 
-def test_the_placeholder_title_is_treated_as_absent():
+@pytest.mark.asyncio
+async def test_the_placeholder_title_is_treated_as_absent():
     slots = {"chat-1-1": SimpleNamespace(display_title=NEW_SESSION_TITLE)}
-    out = _with_conversation_titles(_request(slots), _cost("chat-1-1"))
+    out = await _with_conversation_titles(_request(slots), _cost("chat-1-1"))
     assert "title" not in out["conversations"][0]
 
 
-def test_a_state_without_the_accessor_returns_the_payload_unchanged():
+@pytest.mark.asyncio
+async def test_a_state_without_the_accessor_returns_the_payload_unchanged():
     req = SimpleNamespace(app={"state": SimpleNamespace()})
     payload = _cost("chat-1-1")
-    out = _with_conversation_titles(req, payload)
+    out = await _with_conversation_titles(req, payload)
     # Content, not identity: the handler always rebuilds the rows so it can
     # never write into the caller's (cached) object.
     assert out == payload
     assert "title" not in out["conversations"][0]
+
+
+class TestClosedConversations:
+    """A conversation with no live slot is named from its transcript metadata.
+
+    The write side already persists it (``chat_title._persist_title`` ->
+    ``ConversationLog.set_title``). These drive the REAL ``ConversationLog`` so
+    the slot-key-to-transcript-key mapping is production's, not a restatement of
+    it -- that mapping is where a naive ``dashboard_`` + slot goes wrong for every
+    channel-born conversation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_persisted_title_names_a_closed_conversation(self, tmp_path):
+        log = ConversationLog(tmp_path)
+        log.set_title(slot_transcript_key("chat-1-1"), "Telemetry cost page")
+
+        out = await _with_conversation_titles(
+            _request({}, conversation_log=log), _cost("chat-1-1")
+        )
+        assert out["conversations"][0]["title"] == "Telemetry cost page"
+
+    @pytest.mark.asyncio
+    async def test_a_channel_conversation_resolves_through_the_real_mapping(self, tmp_path):
+        # The shape a naive f"dashboard_{slot}" join silently misses.
+        slot_key = "slack_1785370133.085469"
+        log = ConversationLog(tmp_path)
+        log.set_title(slot_transcript_key(slot_key), "Support thread")
+
+        out = await _with_conversation_titles(
+            _request({}, conversation_log=log), _cost(slot_key)
+        )
+        assert out["conversations"][0]["title"] == "Support thread"
+
+    @pytest.mark.asyncio
+    async def test_the_live_title_wins_over_the_persisted_one(self, tmp_path):
+        # A rename lands on the slot first and is flushed to the transcript on a
+        # worker thread, so the live value is the fresher of the two.
+        log = ConversationLog(tmp_path)
+        log.set_title(slot_transcript_key("chat-1-1"), "Old name")
+        slots = {"chat-1-1": SimpleNamespace(display_title="New name")}
+
+        out = await _with_conversation_titles(
+            _request(slots, conversation_log=log), _cost("chat-1-1")
+        )
+        assert out["conversations"][0]["title"] == "New name"
+
+    @pytest.mark.asyncio
+    async def test_a_transcript_without_an_explicit_title_yields_none(self, tmp_path):
+        # The `list_sessions` contract would answer with the first user message
+        # and then with the session key, so this row would render as prompt text
+        # or as `dashboard_chat-1-1`. Only an explicit metadata title counts.
+        path = tmp_path / "dashboard_chat-1-1.jsonl"
+        path.write_text(
+            json.dumps({"_type": "metadata", "created_at": "2026-08-01T00:00:00+00:00"})
+            + "\n"
+            + json.dumps({"role": "user", "content": "please audit the billing export"})
+            + "\n",
+            encoding="utf-8",
+        )
+        log = ConversationLog(tmp_path)
+
+        out = await _with_conversation_titles(
+            _request({}, conversation_log=log), _cost("chat-1-1")
+        )
+        row = out["conversations"][0]
+        assert "title" not in row, f"unnamed row acquired a title: {row.get('title')!r}"
+
+    @pytest.mark.asyncio
+    async def test_a_persisted_title_is_redacted_like_a_live_one(self, tmp_path):
+        leaked = "notes for AKIA" + "IOSFODNN7EXAMPLE"
+        log = ConversationLog(tmp_path)
+        log.set_title(slot_transcript_key("chat-1-1"), leaked)
+
+        out = await _with_conversation_titles(
+            _request({}, conversation_log=log), _cost("chat-1-1")
+        )
+        title = out["conversations"][0]["title"]
+        assert "AKIA" + "IOSFODNN7EXAMPLE" not in title
+        assert "REDACTED" in title
+
+    @pytest.mark.asyncio
+    async def test_rows_sharing_one_transcript_are_read_once(self, tmp_path):
+        log = ConversationLog(tmp_path)
+        log.set_title(slot_transcript_key("chat-1-1"), "Telemetry cost page")
+        reads: list[str] = []
+        real = log.get_metadata
+
+        def counting(key: str):
+            reads.append(key)
+            return real(key)
+
+        log.get_metadata = counting  # type: ignore[method-assign]
+        payload = _cost("chat-1-1", "chat-1-1", "chat-1-1")
+
+        out = await _with_conversation_titles(_request({}, conversation_log=log), payload)
+        assert [r["title"] for r in out["conversations"]] == ["Telemetry cost page"] * 3
+        assert len(reads) == 1, f"one transcript read {len(reads)} times: {reads}"


### PR DESCRIPTION
Fixes #1753.

## Problem

The spend ranking resolves a conversation's title only from the live slot
(`_with_conversation_titles` → `state.get_slot`), so a session the user has since
closed renders unnamed. The issue measured 18 of 36 sessions in a 7-day window —
3,317 credits that cannot be attributed to anything a person recognises. The
longer the window, the worse the ratio, which is backwards for a figure whose job
is answering "what did I spend this on".

## The title is already persisted

The issue reads this as a missing write path. It is not:
`chat_title.py:675 _persist_title` calls
`conversation_log.set_title(effective_session_key(slot), slot.title)`, which
lands on the transcript's metadata line via `update_metadata` under the
cross-process lock. Only the read side was missing.

So this attaches the persisted title when no live slot can name the row, and
changes nothing about how titles are written. Details of the investigation are
in the issue thread.

## Three decisions worth stating

**Resolve through `slot_transcript_key(slot)`.** That is what folds a
channel-born slot onto the channel's own transcript. A plain `dashboard_` + slot
join matches only the bare dashboard shape — I probed ten slot shapes and it got
three of them — so every Slack and Telegram conversation would join to a key no
file carries and stay silently untitled. The caller passes the canonical key and
lets the history layer own filename normalisation.

**Read via `get_metadata`, not `list_sessions`.** When the metadata line names no
title, `list_sessions` scans up to 21 lines for the first user message and uses
`content[:80]`, then falls back to the session key. Wiring that in would render
prompt text as a ranking label and remove the absence signal — it never returns a
row without a title. Swapping the resolver for that behaviour in a probe turned
an unnamed row's title into `'please audit the billing export'`, which is the
outcome `test_a_transcript_without_an_explicit_title_yields_none` exists to
prevent. `get_metadata` reports only an explicit `metadata["title"]`, which is
the same thing the live slot carries.

**The reads run in a thread.** `api_telemetry_startup` already offloads its three
other blocks; `_with_conversation_titles` could be synchronous only while it read
memory. The work is bounded by the ranked rows rather than by the sessions on
disk, and deduplicated by transcript key so slots sharing one conversation read
it once.

A live title still wins over the persisted one, so a rename shows before it has
been flushed. Both sources pass the same two scanners, so where a title came from
cannot change what leaves the endpoint.

## Tests

Six cases added to `test/metrics/test_telemetry_titles.py`, driving the real
`ConversationLog` so the key mapping is production's rather than a restatement:

- a persisted title names a closed conversation;
- a channel-born conversation resolves through the real mapping (the case a naive
  join misses);
- the live title wins over the persisted one;
- a transcript with no explicit metadata title yields no title;
- a persisted title is redacted like a live one;
- rows sharing one transcript read it once.

The existing six become `async`; their assertions are unchanged.

**Fail-before / pass-after:** with the fallback disabled and everything else
intact, 4 of the 6 fail. The other two pass either way by design — the
live-wins case exercises a path this does not touch, and the no-explicit-title
case is a guard on the `list_sessions` semantics rather than evidence of the fix
(the probe above is what demonstrates it bites).

`test/metrics/` + `test/test_usage.py`: 413 passed, 1 skipped. `isort`, `flake8`,
`mypy`, `git diff --check` clean; docs-lint and the diff-scoped brand gate pass.

`docs/system-specs/modules/metrics.md` documents the two-source resolution and
the reason for the narrow API, in the same commit.
