### PR TITLE
feat(server): dev fleet worktree removal: refuse force on dirty+unmerged, ancestry-gate ref deletion, log verdicts

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -712,3 +712,37 @@ the request is refused with a descriptive error — regardless of the `force` fl
 
 The check uses `_live_worktree_path()` which performs a fresh filesystem resolution
 (no caching) to avoid TOCTOU issues where a previously-cached path is stale.
+
+## Forced Removal Refusal Matrix
+
+The `_worktree_remove` decision surface evaluates `force × PR-merged × dirty`
+and emits one audit action per outcome. `--force` is NEVER passed to
+`git worktree remove`; every path either refuses or removes without `--force`
+so that git's own dirty check is the atomic last line of defence.
+
+| force | PR merged | dirty | Outcome | Audit action |
+|-------|-----------|-------|---------|--------------|
+| True | No | True | **Refuse** — uncommitted changes on unmerged branch | `refused_dirty_unmerged` |
+| True | No | None | **Refuse** — cannot verify cleanliness | `refused_unverifiable` |
+| True | No | False | **Remove** (no `--force`); git's own check guards the TOCTOU window | `unmerged_clean_no_git_force` |
+| True | Yes | True | **Refuse** — fresh-MERGED confirms merge but tree is dirty | `refused_dirty_merged` |
+| True | Yes | None | **Refuse** — fresh-MERGED confirms merge but tree is unverifiable | `refused_unverifiable_merged` |
+| True | Yes | False | **Remove** (no `--force`); mirrors unmerged-clean TOCTOU pattern | `merged_clean_no_git_force` |
+| False | Yes | * | Non-forced path (squash-safe OID race guard) | n/a (no force audit) |
+| False | No | * | Non-forced path | n/a (no force audit) |
+
+Additional pre-gates (evaluated before the matrix above):
+
+| Condition | Outcome | Audit action |
+|-----------|---------|--------------|
+| Branch OID unpinnable | **Refuse** | `refused_unpinnable` |
+| Cached MERGED but fresh verification fails | **Refuse** | `refused_stale_merged` |
+| Fresh-MERGED but branch OID not contained in PR head | **Refuse** | `refused_uncontained_fresh_head` |
+| Target is the live gateway worktree | **Refuse** | (live-worktree guard) |
+| Worktree inside another worktree (containment) | **Refuse** | `refused_containment` |
+
+**Invariant:** `git worktree remove --force` is unreachable from any code path.
+Both clean-removal branches (unmerged and merged) set `force_use_git_force = False`
+explicitly, and every non-clean state is a hard refusal. A late dirty edit in the
+check-to-removal window is caught by git's own atomic dirty check (exit code != 0),
+surfaced as `refused_dirty_at_removal`.

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -2457,6 +2457,7 @@ async def _worktree_remove(
     name: str,
     force: bool = False,
     progress: Callable[[str], None] | None = None,
+    _caller: str = "handler",
 ) -> dict:
     """Remove a feature worktree. All safety gates preserved.
 
@@ -2495,7 +2496,8 @@ async def _worktree_remove(
         dirty = await _real_dirty(path)
         if dirty is not False:
             return {"ok": False, "error": (
-                "worktree has uncommitted changes (use force to override)"
+                "worktree has uncommitted changes"
+                " (force is allowed only when the PR is merged)"
                 if dirty else "cannot verify worktree state (git status failed)"
             )}
 
@@ -2509,17 +2511,200 @@ async def _worktree_remove(
                 "pr": _redact_pr(pr),
             }
 
+    # Teardown guard: even with force=True, refuse to destroy a dirty worktree
+    # whose PR is not merged — that combination means unrecoverable data loss
+    # (uncommitted edits on an unmerged branch). Force retains its meaning for
+    # merged-dirty and diverged-OID overrides where the work IS already shipped.
+    #
+    # force_use_git_force tracks whether the removal command should use --force.
+    # When the unmerged tree verified CLEAN here, we intentionally omit --force
+    # at removal time so git's own dirty check acts as the atomic last-line
+    # guard against edits made in the window between this check and the actual
+    # removal (TOCTOU mitigation).
+    force_use_git_force = force  # default: honour caller's force flag
+    if force and not _is_pr_merged(pr):
+        dirty = await _real_dirty(path)
+        if dirty is True:
+            logger.info(
+                "worktree_removal_audit: worktree=%s branch=%s caller=%s force=%s "
+                "dirty=True own=%s pr_state=%s verdict_oid=n/a "
+                "action=refused_dirty_unmerged",
+                name, branch, _caller, force, own,
+                (pr or {}).get("state", "none"),
+            )
+            return {
+                "ok": False,
+                "error": (
+                    "refusing forced removal: worktree has uncommitted changes "
+                    "and PR is not merged — this would cause unrecoverable data "
+                    f"loss (PR state: {(pr or {}).get('state', 'no PR')})"
+                ),
+                "pr": _redact_pr(pr),
+            }
+        elif dirty is None:
+            logger.info(
+                "worktree_removal_audit: worktree=%s branch=%s caller=%s force=%s "
+                "dirty=unknown own=%s pr_state=%s verdict_oid=n/a "
+                "action=refused_unverifiable",
+                name, branch, _caller, force, own,
+                (pr or {}).get("state", "none"),
+            )
+            return {
+                "ok": False,
+                "error": (
+                    "cannot verify worktree cleanliness (git status failed) — "
+                    "refusing forced removal"
+                ),
+                "pr": _redact_pr(pr),
+            }
+        # Tree verified clean + unmerged: force override allowed, but do NOT
+        # pass --force to git so a late dirty edit is caught at removal time.
+        force_use_git_force = False
+        logger.info(
+            "worktree_removal_audit: worktree=%s branch=%s caller=%s "
+            "force=%s dirty=False own=%s pr_state=%s "
+            "action=unmerged_clean_no_git_force",
+            name, branch, _caller, force, own,
+            (pr or {}).get("state", "none"),
+        )
+
     # Pin the branch ref NOW — the same OID the safety verdict below evaluates
     # is the expected-old-OID for the atomic delete. A commit landing at any
     # point after this pin moves the ref, update-ref -d fails, branch retained.
+    # Hoisted before the fresh-MERGED gate so containment uses the SAME pinned
+    # OID (closing a two-reads inconsistency where the first could fail while
+    # the second succeeds on retry).
     verdict_oid = (await _git(MAIN_REPO, "rev-parse", f"refs/heads/{branch}")) if branch else None
-    if branch and branch != BASE_BRANCH and verdict_oid is None:
+    if branch and branch != BASE_BRANCH and not verdict_oid:
+        logger.info(
+            "worktree_removal_audit: worktree=%s branch=%s caller=%s force=%s "
+            "dirty=n/a own=%s pr_state=%s verdict_oid=None "
+            "action=refused_unpinnable",
+            name, branch, _caller, force, own,
+            (pr or {}).get("state", "none"),
+        )
         return {"ok": False, "error": (
             "cannot pin branch OID (git rev-parse failed) — refusing removal"
         )}
 
+    # Fresh-MERGED gate: when force=True and the CACHED verdict says MERGED,
+    # confirm with a live gh query before allowing destruction of a dirty or
+    # unverifiable worktree. A permanently cached MERGED verdict (reused branch
+    # name whose old PR merged) would otherwise skip the unmerged guard above.
+    #
+    # CRITICAL: even when fresh verification CONFIRMS the PR is merged,
+    # a dirty or unverifiable worktree must NOT be removed with --force.
+    # Containment proves the branch's COMMITS are shipped; it says nothing
+    # about working-tree edits. `git worktree remove --force` bypasses git's
+    # own dirty check and would irrecoverably destroy uncommitted edits.
+    # Contract: NO path from this gate ever passes --force to git:
+    #   - dirty is not False → refuse outright (round 5)
+    #   - dirty is False → drop --force so git's own dirty check is the
+    #     atomic last line against edits arriving in the check-to-removal
+    #     window (round 6, mirrors the unmerged-clean TOCTOU pattern)
+    if force and _is_pr_merged(pr) and branch:
+        dirty = await _real_dirty(path)
+        if dirty is not False:
+            fresh_head = await _fetch_pr_head_oid(
+                branch, repo=(pr or {}).get("_repo")
+            )
+            if fresh_head is None:
+                logger.info(
+                    "worktree_removal_audit: worktree=%s branch=%s caller=%s "
+                    "force=%s dirty=%s own=%s pr_state=MERGED(cached) "
+                    "fresh_merged=False verdict_oid=%s "
+                    "action=refused_stale_merged",
+                    name, branch, _caller, force,
+                    "unknown" if dirty is None else "True", own,
+                    (verdict_oid or "").strip()[:12] if verdict_oid else "none",
+                )
+                return {
+                    "ok": False,
+                    "error": (
+                        "refusing forced removal: cached PR state is MERGED but "
+                        "fresh verification failed (stale cache or reused branch "
+                        "name) — cannot confirm work is shipped"
+                    ),
+                    "pr": _redact_pr(pr),
+                }
+            # Containment check: the branch's pinned OID must be contained in
+            # the freshly verified PR head. A reused branch name whose OLD PR
+            # merged returns a valid fresh_head, but the current branch OID
+            # (carrying new unmerged commits) won't be contained in it.
+            # Uses the single verdict_oid pin (hoisted above) — no second
+            # rev-parse that could diverge from the first.
+            assert verdict_oid  # guaranteed by the refused_unpinnable guard above
+            if not await _head_contained_in_pr(
+                MAIN_REPO, verdict_oid.strip(), fresh_head.strip()
+            ):
+                logger.info(
+                    "worktree_removal_audit: worktree=%s branch=%s caller=%s "
+                    "force=%s dirty=%s own=%s pr_state=MERGED(cached) "
+                    "fresh_head=%s verdict_oid=%s "
+                    "action=refused_uncontained_fresh_head",
+                    name, branch, _caller, force,
+                    "unknown" if dirty is None else "True", own,
+                    fresh_head.strip()[:12], verdict_oid.strip()[:12],
+                )
+                return {
+                    "ok": False,
+                    "error": (
+                        "refusing forced removal: branch has commits not "
+                        "contained in the verified PR head (possible reused "
+                        "branch name with new unmerged work)"
+                    ),
+                    "pr": _redact_pr(pr),
+                }
+            # Fresh verification confirms the PR is merged, but the worktree
+            # has uncommitted edits (dirty=True) or unverifiable state
+            # (dirty=None). Refuse: --force would bypass git's dirty check
+            # and destroy working-tree edits that containment cannot vouch for.
+            action = (
+                "refused_dirty_merged" if dirty is True
+                else "refused_unverifiable_merged"
+            )
+            logger.info(
+                "worktree_removal_audit: worktree=%s branch=%s caller=%s "
+                "force=%s dirty=%s own=%s pr_state=MERGED(fresh) "
+                "fresh_merged=True verdict_oid=%s "
+                "action=%s",
+                name, branch, _caller, force,
+                "unknown" if dirty is None else "True", own,
+                (verdict_oid or "").strip()[:12] if verdict_oid else "none",
+                action,
+            )
+            return {
+                "ok": False,
+                "error": (
+                    "refusing forced removal: PR is merged but worktree has "
+                    + (
+                        "uncommitted changes"
+                        if dirty is True
+                        else "unverifiable state (git status failed)"
+                    )
+                    + " — commit, stash, or clean the working tree first"
+                ),
+                "pr": _redact_pr(pr),
+            }
+        else:
+            # dirty is False: tree is clean NOW, but an editor save during the
+            # check-to-removal window could dirty it. Drop --force so git's own
+            # dirty check is the atomic last line of defence (mirrors the
+            # unmerged-clean TOCTOU pattern). No path from the fresh-MERGED gate
+            # ever passes --force to git.
+            force_use_git_force = False
+            logger.info(
+                "worktree_removal_audit: worktree=%s branch=%s caller=%s "
+                "force=%s dirty=False own=%s pr_state=MERGED(cached) "
+                "action=merged_clean_no_git_force",
+                name, branch, _caller, force, own,
+            )
+
     # Squash-safe race guard: for merged PRs, verify the branch tip matches
     # the PR's merged headRefOid. A commit pushed after merge moves the OID.
+    # The pr_head_oid is reused later in the ref-delete gate for squash-safe
+    # containment — hoist to this scope so both code paths see it.
+    pr_head_oid: str | None = None
     if not force and _is_pr_merged(pr) and branch:
         branch_oid = verdict_oid
         if branch_oid is None:
@@ -2608,15 +2793,55 @@ async def _worktree_remove(
                     "error": f"cannot re-verify pod state before removal: {_redact(str(exc))}",
                 }
         cmd = ["git", "-C", MAIN_REPO, "worktree", "remove", path]
-        if force:
+        if force_use_git_force:
             cmd.append("--force")
         rc, stdout, stderr = await _run_cmd(cmd, timeout=60)
         if rc != 0:
+            # When the removal runs without --force (TOCTOU guard for
+            # clean-unmerged override), a git refusal means the tree became
+            # dirty in the window — surface it as a specific audit event.
+            if force and not force_use_git_force:
+                logger.info(
+                    "worktree_removal_audit: worktree=%s branch=%s caller=%s "
+                    "force=%s dirty_at_removal=True verdict_oid=%s "
+                    "action=refused_dirty_at_removal",
+                    name, branch, _caller, force,
+                    (verdict_oid or "").strip()[:12] if verdict_oid else "none",
+                )
             return {"ok": False, "error": _redact((stderr or stdout).strip()[:300])}
 
-        # delete branch if shipped/empty — atomically against the pinned OID
+        # Delete branch if shipped/empty — atomically against the pinned OID.
+        # Fail-closed ancestry gate: even when the cached PR status says MERGED,
+        # verify the branch OID is actually contained in the base branch. A stale
+        # or wrong merged verdict cannot delete the only local pointer to unmerged
+        # commits — leaving a dangling ref is recoverable; deleting one is not.
+        # OR: squash-safe containment — a squash-merged branch head is never an
+        # ancestor of the base, but IS contained in the PR head (the squash
+        # commit). When ancestry fails, verify containment via _head_contained_in_pr
+        # using the pr_head_oid already fetched above (or fresh if needed).
         if branch and branch != BASE_BRANCH and verdict_oid:
+            should_delete = False
             if _is_pr_merged(pr) or own == 0:
+                remote = await _upstream_remote()
+                rc_anc, _, _ = await _run_cmd(
+                    [
+                        "git", "-C", MAIN_REPO, "merge-base", "--is-ancestor",
+                        verdict_oid.strip(), f"{remote}/{BASE_BRANCH}",
+                    ],
+                    timeout=10,
+                )
+                should_delete = rc_anc == 0
+                # Squash-safe fallback: ancestry fails for squash/rebase merges.
+                # Use the containment check (branch OID is ancestor of PR head).
+                if not should_delete and _is_pr_merged(pr):
+                    head_oid = pr_head_oid or await _fetch_pr_head_oid(
+                        branch, repo=(pr or {}).get("_repo")
+                    )
+                    if head_oid:
+                        should_delete = await _head_contained_in_pr(
+                            MAIN_REPO, verdict_oid.strip(), head_oid.strip()
+                        )
+            if should_delete:
                 await _git(
                     MAIN_REPO, "update-ref", "-d",
                     f"refs/heads/{branch}", verdict_oid.strip(), timeout=10,
@@ -2625,6 +2850,13 @@ async def _worktree_remove(
     # Every removal path lands here — the single-worktree handler, each parallel
     # prune worker, and the auto-prune reaper — so this is the one place the
     # cached snapshot has to be told the row is gone.
+    logger.info(
+        "worktree_removal_audit: worktree=%s branch=%s caller=%s force=%s "
+        "dirty=%s own=%s pr_state=%s verdict_oid=%s action=removed",
+        name, branch, _caller, force, "unknown", own,
+        (pr or {}).get("state", "none"),
+        (verdict_oid or "").strip()[:12] if verdict_oid else "none",
+    )
     _fleet_forget(name)
     return {"ok": True, "removed": True, "stopped_pod": stopped_pod, "pr": _redact_pr(pr)}
 
@@ -2984,7 +3216,9 @@ async def _prune_run(names: list[str]) -> dict:
                             # phase in {"stopping_pod", "removing"}
                             items[_nm]["status"] = phase
 
-                        res = await _worktree_remove(nm, force=False, progress=_progress)
+                        res = await _worktree_remove(
+                            nm, force=False, progress=_progress, _caller="prune"
+                        )
                         result = {"name": nm, **res}
                         if res.get("ok"):
                             status, error = "done", None
@@ -3115,7 +3349,7 @@ async def _auto_prune_once() -> dict:
         if not name or row.get("code") != "merged":
             continue
         try:
-            res = await _worktree_remove(name, force=False)
+            res = await _worktree_remove(name, force=False, _caller="reaper")
         except Exception as exc:  # noqa: BLE001
             res = {"ok": False, "error": _redact(str(exc))}
         if res.get("ok"):

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -4779,8 +4779,9 @@ async def test_auto_prune_once_removes_merged_only_and_records_failures():
     ]}
     seen = []
 
-    async def _fake_remove(name, force=False):
+    async def _fake_remove(name, force=False, _caller="handler"):
         assert force is False  # reaper never force-removes
+        assert _caller == "reaper"
         seen.append(name)
         return {"ok": True} if name == "wt-merged" else {"ok": False, "error": "nope"}
 
@@ -4911,7 +4912,7 @@ async def test_prune_run_per_item_states_and_failure_isolation(reset_prune_state
             return {"ok": False, "code": "active"}
         return {"ok": True, "code": "merged"}
 
-    async def fake_remove(nm, force=False, progress=None):
+    async def fake_remove(nm, force=False, progress=None, _caller="handler"):
         # exercise the phase callback the parallel driver passes in
         if progress is not None:
             progress("stopping_pod")
@@ -4960,7 +4961,7 @@ async def test_prune_run_exception_in_item_is_isolated(reset_prune_state):
     async def fake_prunable(path, branch):
         return {"ok": True, "code": "merged"}
 
-    async def fake_remove(nm, force=False, progress=None):
+    async def fake_remove(nm, force=False, progress=None, _caller="handler"):
         if nm == "wt-boom":
             raise RuntimeError("kaboom")
         return {"ok": True, "removed": True}
@@ -4999,7 +5000,7 @@ async def test_prune_run_caps_concurrency_at_semaphore_limit(reset_prune_state, 
         inflight -= 1
         return {"ok": True, "code": "merged"}
 
-    async def fake_remove(nm, force=False, progress=None):
+    async def fake_remove(nm, force=False, progress=None, _caller="handler"):
         return {"ok": True, "removed": True}
 
     with patch.object(mod, "_find_worktree", side_effect=fake_find), \
@@ -5069,7 +5070,7 @@ async def test_prune_run_deduplicates_names(reset_prune_state):
     async def fake_prunable(path, branch):
         return {"ok": True, "code": "merged"}
 
-    async def fake_remove(nm, force=False, progress=None):
+    async def fake_remove(nm, force=False, progress=None, _caller="handler"):
         removed.append(nm)
         return {"ok": True, "removed": True}
 
@@ -6045,3 +6046,1045 @@ async def test_serving_install_reason_recomputes_when_the_checkout_set_changes(
     await mod._serving_install_reason([{"path": "/wt/a"}, {"path": "/wt/b"}])
 
     assert seen == [("/wt/a",), ("/wt/a", "/wt/b")]
+
+
+# --- Worktree teardown guard tests (issue #1554) ---
+
+
+@pytest.mark.asyncio
+async def test_force_remove_refuses_dirty_unmerged_worktree():
+    """Regression for #1554: force=True must NOT destroy a dirty tree whose PR
+    is unmerged — that combination is unrecoverable data loss."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=True),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "OPEN"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=3),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=True)
+
+    assert result["ok"] is False
+    assert "uncommitted changes" in result["error"]
+    assert "not merged" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_force_remove_refuses_dirty_merged_worktree():
+    """Regression for #1554 round-5: force=True must NOT destroy a dirty tree
+    even when the PR IS merged — containment proves commits are shipped but
+    says nothing about working-tree edits. --force bypasses git's dirty check
+    and would irrecoverably destroy uncommitted edits."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=True),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "MERGED"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=3),
+        patch.object(mod, "_git", new_callable=AsyncMock, return_value="aaa1111"),
+        patch.object(
+            mod,
+            "_fetch_pr_head_oid",
+            new_callable=AsyncMock,
+            return_value="aaa1111",
+        ),
+        patch.object(mod, "_head_contained_in_pr", new_callable=AsyncMock, return_value=True),
+        patch.object(mod, "_load_cfg", return_value=None),
+        patch.object(mod, "_POD_AVAILABLE", False),
+        patch.object(mod, "_run_cmd", new_callable=AsyncMock, return_value=(0, "", "")),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=True)
+
+    assert result["ok"] is False
+    assert "uncommitted changes" in result["error"]
+    assert "commit, stash, or clean" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_ancestry_gate_skips_ref_delete_when_not_ancestor():
+    """When cached PR status wrongly says MERGED but the branch OID is NOT an
+    ancestor of the base branch AND containment also fails at the ref-delete
+    gate, the ref must survive (fail-closed gate)."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    git_calls: list[tuple] = []
+
+    async def _fake_run_cmd(cmd, **kwargs):
+        git_calls.append(tuple(cmd))
+        if "worktree" in cmd and "remove" in cmd:
+            return (0, "", "")
+        if "merge-base" in cmd and "--is-ancestor" in cmd:
+            return (1, "", "")
+        return (0, "", "")
+
+    async def _fake_contained(path, branch_oid, pr_head_oid):
+        # The squash-safe race guard passes (worktree path), but the
+        # ref-delete gate fails (MAIN_REPO path).
+        if path == "/fake/wt":
+            return True
+        return False
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=False),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "MERGED"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=0),
+        patch.object(mod, "_git", new_callable=AsyncMock, return_value="aaa1111"),
+        patch.object(mod, "_fetch_pr_head_oid", new_callable=AsyncMock, return_value="aaa1111"),
+        patch.object(
+            mod,
+            "_head_contained_in_pr",
+            new_callable=AsyncMock,
+            side_effect=_fake_contained,
+        ),
+        patch.object(mod, "_load_cfg", return_value=None),
+        patch.object(mod, "_POD_AVAILABLE", False),
+        patch.object(mod, "_run_cmd", new_callable=AsyncMock, side_effect=_fake_run_cmd),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is True
+    update_ref_calls = [c for c in git_calls if "update-ref" in c]
+    assert update_ref_calls == [], f"ref should NOT be deleted: {update_ref_calls}"
+
+
+@pytest.mark.asyncio
+async def test_ancestry_gate_allows_ref_delete_when_ancestor():
+    """When PR is merged and branch OID IS an ancestor of base, ref IS deleted."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    git_calls: list[tuple] = []
+    deleted_refs: list[str] = []
+
+    async def _fake_run_cmd(cmd, **kwargs):
+        git_calls.append(tuple(cmd))
+        if "worktree" in cmd and "remove" in cmd:
+            return (0, "", "")
+        if "merge-base" in cmd and "--is-ancestor" in cmd:
+            return (0, "", "")
+        return (0, "", "")
+
+    async def _fake_git(repo, *args, **kwargs):
+        if args and args[0] == "update-ref" and "-d" in args:
+            deleted_refs.append(args[2])
+            return ""
+        if args and args[0] == "rev-parse":
+            return "aaa1111"
+        return ""
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=False),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "MERGED"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=0),
+        patch.object(mod, "_git", new_callable=AsyncMock, side_effect=_fake_git),
+        patch.object(mod, "_fetch_pr_head_oid", new_callable=AsyncMock, return_value="aaa1111"),
+        patch.object(mod, "_head_contained_in_pr", new_callable=AsyncMock, return_value=True),
+        patch.object(mod, "_load_cfg", return_value=None),
+        patch.object(mod, "_POD_AVAILABLE", False),
+        patch.object(mod, "_run_cmd", new_callable=AsyncMock, side_effect=_fake_run_cmd),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is True
+    assert "refs/heads/feat-x" in deleted_refs
+
+
+@pytest.mark.asyncio
+async def test_empty_branch_still_deletes_ref():
+    """own==0 (empty branch) still results in ref deletion because an empty
+    branch is trivially an ancestor of the base (merge-base succeeds)."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    deleted_refs: list[str] = []
+
+    async def _fake_run_cmd(cmd, **kwargs):
+        if "worktree" in cmd and "remove" in cmd:
+            return (0, "", "")
+        if "merge-base" in cmd and "--is-ancestor" in cmd:
+            return (0, "", "")
+        return (0, "", "")
+
+    async def _fake_git(repo, *args, **kwargs):
+        if args and args[0] == "update-ref" and "-d" in args:
+            deleted_refs.append(args[2])
+            return ""
+        if args and args[0] == "rev-parse":
+            return "bbb2222"
+        return ""
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "empty-br", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=False),
+        patch.object(mod, "_pr_status_cached", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=0),
+        patch.object(mod, "_git", new_callable=AsyncMock, side_effect=_fake_git),
+        patch.object(mod, "_load_cfg", return_value=None),
+        patch.object(mod, "_POD_AVAILABLE", False),
+        patch.object(mod, "_run_cmd", new_callable=AsyncMock, side_effect=_fake_run_cmd),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+    ):
+        result = await mod._worktree_remove("empty-br", force=False)
+
+    assert result["ok"] is True
+    assert "refs/heads/empty-br" in deleted_refs
+
+
+@pytest.mark.asyncio
+async def test_removal_audit_log_emitted(caplog):
+    """Successful removal emits a structured audit line with verdict fields."""
+    import logging
+
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=False),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "MERGED"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=0),
+        patch.object(mod, "_git", new_callable=AsyncMock, return_value="aaa1111"),
+        patch.object(mod, "_fetch_pr_head_oid", new_callable=AsyncMock, return_value="aaa1111"),
+        patch.object(mod, "_head_contained_in_pr", new_callable=AsyncMock, return_value=True),
+        patch.object(mod, "_load_cfg", return_value=None),
+        patch.object(mod, "_POD_AVAILABLE", False),
+        patch.object(mod, "_run_cmd", new_callable=AsyncMock, return_value=(0, "", "")),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+        caplog.at_level(logging.INFO, logger="kiro_crew.apps.builtins.dev_fleet.server"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is True
+    audit_lines = [r for r in caplog.records if "worktree_removal_audit" in r.message]
+    assert len(audit_lines) == 1
+    msg = audit_lines[0].message
+    assert "worktree=feat-x" in msg
+    assert "branch=feat-x" in msg
+    assert "caller=handler" in msg
+    assert "action=removed" in msg
+    assert "pr_state=MERGED" in msg
+
+
+@pytest.mark.asyncio
+async def test_force_refuse_audit_log_emitted(caplog):
+    """The dirty+unmerged force refusal also emits an audit line."""
+    import logging
+
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=True),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "OPEN"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=3),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+        caplog.at_level(logging.INFO, logger="kiro_crew.apps.builtins.dev_fleet.server"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=True)
+
+    assert result["ok"] is False
+    audit_lines = [r for r in caplog.records if "worktree_removal_audit" in r.message]
+    assert len(audit_lines) == 1
+    msg = audit_lines[0].message
+    assert "action=refused_dirty_unmerged" in msg
+    assert "dirty=True" in msg
+
+
+# --- Regression tests for PR 1840: force guard fail-closed fixes ---
+
+
+@pytest.mark.asyncio
+async def test_force_remove_refuses_unknown_dirty_state(caplog):
+    """Regression (a): _real_dirty returns None (git status failed), force=True,
+    PR OPEN — removal must be refused, error names the unverifiable state.
+    Previously fell through (fail-open)."""
+    import logging
+
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=None),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "OPEN"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=3),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+        caplog.at_level(logging.INFO, logger="kiro_crew.apps.builtins.dev_fleet.server"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=True)
+
+    assert result["ok"] is False
+    assert "cannot verify worktree cleanliness" in result["error"]
+    assert "git status failed" in result["error"]
+    # Audit line with dirty=unknown and action=refused_unverifiable
+    audit_lines = [r for r in caplog.records if "worktree_removal_audit" in r.message]
+    assert len(audit_lines) == 1
+    msg = audit_lines[0].message
+    assert "action=refused_unverifiable" in msg
+    assert "dirty=unknown" in msg
+
+
+@pytest.mark.asyncio
+async def test_force_remove_refuses_stale_merged_cache(caplog):
+    """Regression (b): cached PR status MERGED but fresh _fetch_pr_head_oid
+    returns None (stale cache / reused branch name), force=True, dirty=True
+    — must refuse. Previously the guard was bypassed entirely."""
+    import logging
+
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=True),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "MERGED"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=3),
+        patch.object(
+            mod,
+            "_fetch_pr_head_oid",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        # verdict_oid pin succeeds so we reach the fresh-MERGED gate
+        patch.object(mod, "_git", new_callable=AsyncMock, return_value="abc123def456"),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+        caplog.at_level(logging.INFO, logger="kiro_crew.apps.builtins.dev_fleet.server"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=True)
+
+    assert result["ok"] is False
+    assert "stale cache" in result["error"] or "fresh verification failed" in result["error"]
+    audit_lines = [r for r in caplog.records if "worktree_removal_audit" in r.message]
+    assert len(audit_lines) == 1
+    msg = audit_lines[0].message
+    assert "action=refused_stale_merged" in msg
+
+
+@pytest.mark.asyncio
+async def test_force_remove_fresh_merged_refuses_dirty(caplog):
+    """Regression for #1554 round-5: cached MERGED + fresh verdict confirms
+    MERGED + dirty=True + force=True → removal REFUSED with audit line
+    action=refused_dirty_merged. Containment proves commits are shipped but
+    says nothing about working-tree edits."""
+    import logging
+
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=True),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "MERGED"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=3),
+        patch.object(mod, "_git", new_callable=AsyncMock, return_value="aaa1111"),
+        patch.object(
+            mod,
+            "_fetch_pr_head_oid",
+            new_callable=AsyncMock,
+            return_value="aaa1111",
+        ),
+        patch.object(mod, "_head_contained_in_pr", new_callable=AsyncMock, return_value=True),
+        patch.object(mod, "_load_cfg", return_value=None),
+        patch.object(mod, "_POD_AVAILABLE", False),
+        patch.object(mod, "_run_cmd", new_callable=AsyncMock, return_value=(0, "", "")),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+        caplog.at_level(logging.INFO, logger="kiro_crew.apps.builtins.dev_fleet.server"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=True)
+
+    assert result["ok"] is False
+    assert "uncommitted changes" in result["error"]
+    assert "commit, stash, or clean" in result["error"]
+    # Audit line with action=refused_dirty_merged
+    audit_lines = [r for r in caplog.records if "worktree_removal_audit" in r.message]
+    assert len(audit_lines) == 1
+    msg = audit_lines[0].message
+    assert "action=refused_dirty_merged" in msg
+    assert "pr_state=MERGED(fresh)" in msg
+
+
+@pytest.mark.asyncio
+async def test_force_remove_fresh_merged_refuses_unknown_dirty(caplog):
+    """Regression for #1554 round-5: cached MERGED + fresh verdict confirms
+    MERGED + dirty=None + force=True → removal REFUSED with audit line
+    action=refused_unverifiable_merged."""
+    import logging
+
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=None),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "MERGED"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=3),
+        patch.object(mod, "_git", new_callable=AsyncMock, return_value="aaa1111"),
+        patch.object(
+            mod,
+            "_fetch_pr_head_oid",
+            new_callable=AsyncMock,
+            return_value="aaa1111",
+        ),
+        patch.object(mod, "_head_contained_in_pr", new_callable=AsyncMock, return_value=True),
+        patch.object(mod, "_load_cfg", return_value=None),
+        patch.object(mod, "_POD_AVAILABLE", False),
+        patch.object(mod, "_run_cmd", new_callable=AsyncMock, return_value=(0, "", "")),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+        caplog.at_level(logging.INFO, logger="kiro_crew.apps.builtins.dev_fleet.server"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=True)
+
+    assert result["ok"] is False
+    assert "unverifiable state" in result["error"]
+    assert "commit, stash, or clean" in result["error"]
+    # Audit line with action=refused_unverifiable_merged
+    audit_lines = [r for r in caplog.records if "worktree_removal_audit" in r.message]
+    assert len(audit_lines) == 1
+    msg = audit_lines[0].message
+    assert "action=refused_unverifiable_merged" in msg
+    assert "pr_state=MERGED(fresh)" in msg
+
+
+@pytest.mark.asyncio
+async def test_force_remove_clean_merged_proceeds():
+    """Control: force=True + dirty=False + MERGED → removal proceeds WITHOUT --force.
+    Clean-tree force removals on merged branches proceed but drop --force so git's
+    own dirty check guards the TOCTOU window (round-6 fix)."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    run_cmd_calls: list[list[str]] = []
+
+    async def _fake_run_cmd(cmd, **kwargs):
+        run_cmd_calls.append(list(cmd))
+        return (0, "", "")
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=False),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "MERGED"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=3),
+        patch.object(mod, "_git", new_callable=AsyncMock, return_value="aaa1111"),
+        patch.object(
+            mod,
+            "_fetch_pr_head_oid",
+            new_callable=AsyncMock,
+            return_value="aaa1111",
+        ),
+        patch.object(mod, "_head_contained_in_pr", new_callable=AsyncMock, return_value=True),
+        patch.object(mod, "_load_cfg", return_value=None),
+        patch.object(mod, "_POD_AVAILABLE", False),
+        patch.object(mod, "_run_cmd", side_effect=_fake_run_cmd),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=True)
+
+    assert result["ok"] is True
+    # Round-6 assertion: the removal command must NOT contain --force —
+    # git's own dirty check is the atomic TOCTOU guard for merged-clean removals.
+    removal_cmds = [c for c in run_cmd_calls if "worktree" in c and "remove" in c]
+    assert len(removal_cmds) == 1, f"Expected exactly one removal cmd, got {removal_cmds}"
+    assert "--force" not in removal_cmds[0], (
+        f"Round-6 regression: merged+clean removal must not pass --force to git; "
+        f"got: {removal_cmds[0]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_squash_merge_ref_deletion():
+    """Squash-merge regression: PR merged, ancestry check fails (squash merge),
+    containment check passes → ref IS deleted. Previously squash-merged refs
+    accumulated forever because ancestry is the only gate that passed."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    deleted_refs: list[str] = []
+
+    async def _fake_run_cmd(cmd, **kwargs):
+        if "worktree" in cmd and "remove" in cmd:
+            return (0, "", "")
+        if "merge-base" in cmd and "--is-ancestor" in cmd:
+            # Ancestry fails — simulates squash merge
+            return (1, "", "")
+        return (0, "", "")
+
+    async def _fake_git(repo, *args, **kwargs):
+        if args and args[0] == "update-ref" and "-d" in args:
+            deleted_refs.append(args[2])
+            return ""
+        if args and args[0] == "rev-parse":
+            return "aaa1111"
+        return ""
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=False),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "MERGED"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=3),
+        patch.object(mod, "_git", new_callable=AsyncMock, side_effect=_fake_git),
+        patch.object(
+            mod,
+            "_fetch_pr_head_oid",
+            new_callable=AsyncMock,
+            return_value="aaa1111",
+        ),
+        # Containment passes — branch OID is ancestor of PR head (squash-safe)
+        patch.object(mod, "_head_contained_in_pr", new_callable=AsyncMock, return_value=True),
+        patch.object(mod, "_load_cfg", return_value=None),
+        patch.object(mod, "_POD_AVAILABLE", False),
+        patch.object(mod, "_run_cmd", new_callable=AsyncMock, side_effect=_fake_run_cmd),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is True
+    assert (
+        "refs/heads/feat-x" in deleted_refs
+    ), "ref should be deleted via squash-safe containment fallback"
+
+
+@pytest.mark.asyncio
+async def test_ref_delete_fails_closed_both_ancestry_and_containment_fail():
+    """Fail-closed control: ancestry fails AND containment fails → ref
+    survives (no deletion). Uses own==0 (empty branch) with an OPEN PR so
+    that ref deletion is attempted via the own==0 path without triggering
+    the non-forced squash-safe race guard (which only fires for merged PRs)."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    git_calls: list[tuple] = []
+
+    async def _fake_run_cmd(cmd, **kwargs):
+        git_calls.append(tuple(cmd))
+        if "worktree" in cmd and "remove" in cmd:
+            return (0, "", "")
+        if "merge-base" in cmd and "--is-ancestor" in cmd:
+            return (1, "", "")
+        return (0, "", "")
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=False),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "OPEN"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=0),
+        patch.object(mod, "_git", new_callable=AsyncMock, return_value="aaa1111"),
+        patch.object(
+            mod,
+            "_fetch_pr_head_oid",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch.object(mod, "_head_contained_in_pr", new_callable=AsyncMock, return_value=False),
+        patch.object(mod, "_load_cfg", return_value=None),
+        patch.object(mod, "_POD_AVAILABLE", False),
+        patch.object(mod, "_run_cmd", new_callable=AsyncMock, side_effect=_fake_run_cmd),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is True
+    update_ref_calls = [c for c in git_calls if "update-ref" in c]
+    assert update_ref_calls == [], f"ref should NOT be deleted: {update_ref_calls}"
+
+
+# --- Regression tests for PR 1840 round-3: TOCTOU + containment fixes ---
+
+
+@pytest.mark.asyncio
+async def test_toctou_clean_unmerged_force_omits_git_force(caplog):
+    """TOCTOU regression: when force=True overrides ONLY because the unmerged
+    tree verified clean, the removal command must NOT contain --force. This way
+    git's own dirty check acts as the atomic last-line guard — if the tree
+    became dirty in the window between the guard and the actual removal, git
+    itself refuses.
+
+    Regression for round-3 fix (b448aa32): at head 3543d9bc the --force flag
+    leaked through on this path; this test pinpoints the contract that
+    force_use_git_force is set to False and the audit action
+    'unmerged_clean_no_git_force' is emitted."""
+    import logging
+
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    captured_cmds: list[list[str]] = []
+
+    async def _capture_run_cmd(cmd, **kwargs):
+        captured_cmds.append(list(cmd))
+        if "worktree" in cmd and "remove" in cmd:
+            return (0, "", "")
+        if "merge-base" in cmd and "--is-ancestor" in cmd:
+            return (1, "", "")  # ancestry fails (irrelevant here)
+        return (0, "", "")
+
+    with (
+        caplog.at_level(logging.INFO),
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=False),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "OPEN"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=0),
+        patch.object(mod, "_git", new_callable=AsyncMock, return_value="aaa1111"),
+        patch.object(mod, "_load_cfg", return_value=None),
+        patch.object(mod, "_POD_AVAILABLE", False),
+        patch.object(mod, "_run_cmd", new_callable=AsyncMock, side_effect=_capture_run_cmd),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=True)
+
+    assert result["ok"] is True
+    removal_cmds = [c for c in captured_cmds if "worktree" in c and "remove" in c]
+    assert len(removal_cmds) == 1
+    assert "--force" not in removal_cmds[0], (
+        "clean-unmerged force path must NOT include --force in the git command"
+    )
+    # Verify the audit action was logged (regression: the action proves
+    # the code explicitly set force_use_git_force = False on this path)
+    audit_msgs = [
+        r.message for r in caplog.records
+        if "unmerged_clean_no_git_force" in r.message
+    ]
+    assert len(audit_msgs) == 1, (
+        "expected exactly one 'unmerged_clean_no_git_force' audit line"
+    )
+
+
+@pytest.mark.asyncio
+async def test_toctou_git_refusal_returns_error_with_audit(caplog):
+    """TOCTOU regression: when git worktree remove (without --force) fails
+    because the tree became dirty in the window, the function returns ok:False
+    and emits the refused_dirty_at_removal audit line."""
+    import logging
+
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    async def _failing_run_cmd(cmd, **kwargs):
+        if "worktree" in cmd and "remove" in cmd:
+            # Simulate git refusing because tree became dirty
+            return (1, "", "fatal: '/fake/wt' contains modified tracked files")
+        return (0, "", "")
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=False),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "OPEN"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=0),
+        patch.object(mod, "_git", new_callable=AsyncMock, return_value="aaa1111"),
+        patch.object(mod, "_load_cfg", return_value=None),
+        patch.object(mod, "_POD_AVAILABLE", False),
+        patch.object(mod, "_run_cmd", new_callable=AsyncMock, side_effect=_failing_run_cmd),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+        caplog.at_level(logging.INFO, logger="kiro_crew.apps.builtins.dev_fleet.server"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=True)
+
+    assert result["ok"] is False
+    assert "modified tracked files" in result["error"]
+    # Audit line must record the TOCTOU event
+    audit_lines = [r for r in caplog.records if "refused_dirty_at_removal" in r.message]
+    assert len(audit_lines) == 1
+    msg = audit_lines[0].message
+    assert "action=refused_dirty_at_removal" in msg
+    assert "dirty_at_removal=True" in msg
+
+
+@pytest.mark.asyncio
+async def test_containment_refuses_uncontained_fresh_head(caplog):
+    """Containment regression: cached PR=MERGED, fresh query returns a valid
+    head OID (old PR merged genuinely), but the branch's current OID is NOT
+    contained in that head (new unmerged commits on a reused branch name) →
+    force removal must be refused with refused_uncontained_fresh_head audit."""
+    import logging
+
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        # Dirty — so the fresh-MERGED gate fires (only fires for dirty/unknown)
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=True),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "MERGED"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=5),
+        # Fresh head returns the OLD PR's head (valid, non-None)
+        patch.object(
+            mod,
+            "_fetch_pr_head_oid",
+            new_callable=AsyncMock,
+            return_value="old_merged_pr_head_abc123",
+        ),
+        # rev-parse returns the branch's CURRENT OID (new commits)
+        patch.object(
+            mod, "_git", new_callable=AsyncMock, return_value="new_unmerged_oid_def456"
+        ),
+        # Containment fails — new commits not in old PR head
+        patch.object(mod, "_head_contained_in_pr", new_callable=AsyncMock, return_value=False),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+        caplog.at_level(logging.INFO, logger="kiro_crew.apps.builtins.dev_fleet.server"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=True)
+
+    assert result["ok"] is False
+    assert "not contained" in result["error"]
+    assert "reused branch" in result["error"]
+    # Audit
+    audit_lines = [r for r in caplog.records if "worktree_removal_audit" in r.message]
+    assert len(audit_lines) == 1
+    msg = audit_lines[0].message
+    assert "action=refused_uncontained_fresh_head" in msg
+
+
+@pytest.mark.asyncio
+async def test_containment_allows_when_contained():
+    """Round 5 regression: cached MERGED + fresh head + branch OID IS contained
+    in fresh head BUT worktree is dirty → refused_dirty_merged. Containment
+    proves commits are shipped; it cannot vouch for uncommitted working-tree
+    edits.
+
+    Pre-round-5 behavior was to allow this removal — the current contract
+    refuses it to prevent irrecoverable loss of uncommitted edits."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=True),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "MERGED"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=3),
+        patch.object(mod, "_git", new_callable=AsyncMock, return_value="aaa1111"),
+        patch.object(
+            mod,
+            "_fetch_pr_head_oid",
+            new_callable=AsyncMock,
+            return_value="aaa1111",
+        ),
+        # Containment passes — branch OID is contained in fresh head
+        patch.object(mod, "_head_contained_in_pr", new_callable=AsyncMock, return_value=True),
+        patch.object(mod, "_load_cfg", return_value=None),
+        patch.object(mod, "_POD_AVAILABLE", False),
+        patch.object(mod, "_run_cmd", new_callable=AsyncMock, return_value=(0, "", "")),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=True)
+
+    # Rounds 5-6: dirty tree is refused even when PR is verified-merged+contained
+    assert result["ok"] is False
+    assert "uncommitted changes" in result["error"]
+
+
+# --- Round 4 regressions: containment pin fail-closed ---
+
+
+@pytest.mark.asyncio
+async def test_containment_pin_falsy_refuses_unpinnable(caplog):
+    """Regression (round 4): cached MERGED + dirty + force=True, the
+    verdict_oid rev-parse returns falsy (None/empty) — a transient git
+    failure — must REFUSE the forced removal with refused_unpinnable audit
+    rather than silently skip containment and let the later removal proceed.
+
+    At 3ca2ac3a this failed open: `if pinned_oid and not _head_contained()`
+    skipped containment when pinned_oid was falsy."""
+    import logging
+
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=True),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "MERGED"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=5),
+        # rev-parse fails → returns None (transient git lock contention)
+        patch.object(mod, "_git", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+        caplog.at_level(logging.INFO, logger="kiro_crew.apps.builtins.dev_fleet.server"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=True)
+
+    assert result["ok"] is False
+    assert "cannot pin branch OID" in result["error"]
+    # Audit line must record the refused_unpinnable action
+    audit_lines = [r for r in caplog.records if "worktree_removal_audit" in r.message]
+    assert len(audit_lines) == 1
+    msg = audit_lines[0].message
+    assert "action=refused_unpinnable" in msg
+
+
+@pytest.mark.asyncio
+async def test_containment_pin_empty_string_refuses_unpinnable(caplog):
+    """Same as above but rev-parse returns empty string (another falsy form)."""
+    import logging
+
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=True),
+        patch.object(
+            mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "MERGED"},
+        ),
+        patch.object(mod, "_own_commits_count", new_callable=AsyncMock, return_value=5),
+        # rev-parse returns empty string (another failure mode)
+        patch.object(mod, "_git", new_callable=AsyncMock, return_value=""),
+        patch.object(mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+        caplog.at_level(logging.INFO, logger="kiro_crew.apps.builtins.dev_fleet.server"),
+    ):
+        result = await mod._worktree_remove("feat-x", force=True)
+
+    assert result["ok"] is False
+    assert "cannot pin branch OID" in result["error"]
+    audit_lines = [r for r in caplog.records if "worktree_removal_audit" in r.message]
+    assert len(audit_lines) == 1
+    assert "action=refused_unpinnable" in audit_lines[0].message
+
+
+@pytest.mark.asyncio
+async def test_dirty_unmerged_message_does_not_promise_force_override():
+    """Message regression: the non-forced dirty refusal no longer says
+    'use force to override' since force is also refused for dirty+unmerged."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    with (
+        patch.object(
+            mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(mod, "_own_checkout_path", return_value=None),
+        # Dirty tree, non-forced, PR not merged
+        patch.object(mod, "_real_dirty", new_callable=AsyncMock, return_value=True),
+    ):
+        result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is False
+    # Must NOT say "use force to override" — that's a dead-end promise
+    assert "use force to override" not in result["error"]
+    # Should mention uncommitted changes
+    assert "uncommitted changes" in result["error"]


### PR DESCRIPTION
<!-- pr-context:start -->
## Summary
This PR combines 2 related changes:
- **Dev Fleet worktree removal: refuse force on dirty+unmerged, ancestry-gate ref deletion, log verdicts**
- **PR 1840: fail-closed force guard (unknown dirty, fresh merged verdict) + squash-safe ref deletion**

## Changes and rationale

### Dev Fleet worktree removal: refuse force on dirty+unmerged, ancestry-gate ref deletion, log verdicts
**Problem:** Fixes #1554. A worktree whose PR was open and unmerged, with uncommitted changes, was removed with `--force` and its local branch ref deleted — the uncommitted work was unrecoverable (recovery only possible because the branch happened to be pushed).
**Why it matters:** This is unrecoverable data loss of user work (uncommitted edits + the only local ref to unpushed commits), reachable from the dashboard. The dirty-tree refusal built into `git worktree remove` is being explicitly overridden, so a single wrong verdict destroys work instead of producing an error message.
**Fix (symptoms → root cause → change):** In `_worktree_remove` (all three callers route through it — single remove handler, prune workers, auto-prune reaper): Never force-remove a dirty tree whose PR is unmerged: even when `force=True`, re-run `_real_dirty` and the merged verdict; if the tree is dirty AND the PR is not merged, return an error naming both facts instead of proceeding. (Force retains its meaning for the merged-dirty and diverged-OID overrides the existing messages point at.) Before `update-ref -d`, add a fail-closed ancestry gate: delete the
**Tests:** Regression pinning the incident: dirty worktree + unmerged PR + `force=True` -> removal refused, tree and branch ref intact. Fails on current main, passes after. Ancestry gate: merged-PR path unchanged (ref deleted); unmerged branch whose cached PR status wrongly says merged (mock `_pr_status_cached`) -> ref survives because `merge-base --is-ancestor` fails.
**Review focus:** backend, security boundaries, regression coverage

### PR 1840: fail-closed force guard (unknown dirty, fresh merged verdict) + squash-safe ref deletion
**Tests:** Regression (a): `_real_dirty` → None, force=True, PR OPEN → removal refused, error names the unverifiable state. Fails at f1183c0a, passes after. Regression (b): cached PR status MERGED but fresh `_fetch_pr_head_oid` returns None (stale cache / reused branch name), force=True, dirty=True → refused. Fails at f1183c0a (guard bypassed), passes after.…
**Review focus:** pr-maintenance

## Review map

| Change | Primary files |
|---|---|
| Dev Fleet worktree removal: refuse force on dirty+unmerged, ancestry-gate ref deletion, log verdicts | `src/kiro_crew/apps/builtins/dev_fleet/server.py`<br>`test/test_dev_fleet_app.py` |
| PR 1840: fail-closed force guard (unknown dirty, fresh merged verdict) + squash-safe ref deletion | `src/kiro_crew/apps/builtins/dev_fleet/server.py`<br>`test/test_dev_fleet_app.py` |

## Commits
- [`7715a6f`](https://github.com/kirodotdev/KiroCrew/pull/1840/commits/7715a6f3859f66aab79b1b4fd91f4253e34c5757) feat(server): dev fleet worktree removal: refuse force on dirty+unmer…

## Validation

Local build, static-analysis, and test gates completed before publication. Upstream CI and review checks on the current PR revision remain the authoritative merge signal.

<details><summary><strong>Changed files</strong> (2 files, +2205/-972)</summary>

- `src/kiro_crew/apps/builtins/dev_fleet/server.py` (+723/-350)
- `test/test_dev_fleet_app.py` (+1482/-622)

</details>

> This description updates automatically as related changes land; manually written text outside this block is preserved.
<!-- pr-context:end -->