### PR TITLE
fix(slack): point the setup-guide link at the packaged doc

### DIFF
--- a/scripts/docs_lint.py
+++ b/scripts/docs_lint.py
@@ -158,12 +158,12 @@ _EXTERNAL_REPO_MARKERS: tuple[str, ...] = ("KiroCrewPublishCDK", "electron.git")
 # coupling is a one-line change here and is impossible to forget silently.
 CODE_COUPLED_DOCS: dict[str, tuple[str, ...]] = {
     "src/kiro_crew/docs/discord-integration.md": ("website/src/pages/settings/DiscordPanel.tsx",),
+    "src/kiro_crew/docs/slack-integration.md": ("website/src/pages/settings/SlackPanel.tsx",),
     "src/kiro_crew/docs/teams-integration.md": ("website/src/pages/settings/TeamsPanel.tsx",),
     "src/kiro_crew/docs/telegram-integration.md": ("website/src/pages/settings/TelegramPanel.tsx",),
     "src/kiro_crew/docs/webex-integration.md": ("website/src/pages/settings/WebexPanel.tsx",),
     "src/kiro_crew/docs/wecom-integration.md": ("website/src/pages/settings/WeComPanel.tsx",),
     "src/kiro_crew/docs/weixin-integration.md": ("website/src/pages/settings/WeixinPanel.tsx",),
-    "docs/guides/slack-setup.md": ("website/src/pages/settings/SlackPanel.tsx",),
     "docs/architecture/security-deep-dive.md": ("website/src/pages/settings/SecurityPanel.tsx",),
     "website/docs/theming-contract.md": ("website/scripts/check-theme-colors.mjs",),
 }

--- a/website/src/pages/settings/SlackPanel.tsx
+++ b/website/src/pages/settings/SlackPanel.tsx
@@ -9,7 +9,7 @@ import { api, type SlackConfigData, type SlackConfigSave } from '../../api/clien
 
 import { i18nT } from '../../i18n/t'
 import ErrorNotice from '../../components/ErrorNotice'
-const SETUP_GUIDE = 'https://github.com/kirodotdev/KiroCrew/blob/main/docs/guides/slack-setup.md'
+const SETUP_GUIDE = 'https://github.com/kirodotdev/KiroCrew/blob/main/src/kiro_crew/docs/slack-integration.md'
 
 type Draft = {
   owner_id: string


### PR DESCRIPTION
## Problem / Motivation

The Slack settings panel's `SETUP_GUIDE` link points to a broken link (https://github.com/kirodotdev/KiroCrew/blob/main/docs/slack-setup.md). The settings panel should instead direct users to the packaged Slack integration documentation.

The docs-lint coupling entry also tracks the existing link target, so it
needs to remain aligned with the document referenced by `SlackPanel`.

## Why it matters

Users who open the setup guide from the Slack settings panel should land
on the Slack integration documentation that ships with Kiro Crew and
describes the integration in the context of the installed product.
