### PR TITLE
fix: resolve tool-approval prompt on "Request a Feature" button click

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -86,7 +86,7 @@ import { getBuiltinIcon } from './apps/builtinIcons'
 import { getThemeBranding } from './themeBranding'
 import { getTopBarWidgets } from './apps/topBarWidgets'
 import { getCapsuleSegments } from './apps/capsuleSegments'
-import { FEATURE_REQUEST_PROMPT } from './prompts/featureRequest'
+import { FEATURE_REQUEST_PROMPT_WITH_SKILL, FEATURE_REQUEST_PROMPT_FALLBACK } from './prompts/featureRequest'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { useInstanceShortcuts } from './hooks/useInstanceShortcuts'
 import { useCommandPalette } from './hooks/useCommandPalette'
@@ -1488,10 +1488,18 @@ export default function App() {
   }, [])
 
   const requestFeature = useCallback(async () => {
+    // Resolve skill availability in the dashboard so the agent never needs
+    // to probe the filesystem (which would trigger a tool-approval prompt).
+    let msg = FEATURE_REQUEST_PROMPT_FALLBACK
+    try {
+      const skills: { name: string }[] = await api.skills()
+      if (skills.some(s => s.name === 'feature-request')) {
+        msg = FEATURE_REQUEST_PROMPT_WITH_SKILL
+      }
+    } catch { /* skill list unavailable — use the self-contained fallback */ }
     const result = await dispatch(createSlot(undefined)).unwrap()
     const slot = result.key
     navigate('/chat')
-    const msg = FEATURE_REQUEST_PROMPT
     dispatch(appendMessage({ role: 'user', content: i18nT('app.i_d_like_to_request_a_feature'), cls: '', ts: new Date().toISOString() }))
     dispatch(setSlotRunning(true))
     try {

--- a/website/src/prompts/featureRequest.ts
+++ b/website/src/prompts/featureRequest.ts
@@ -1,8 +1,24 @@
 export const FEATURE_REQUEST_URL = 'https://github.com/kirodotdev/KiroCrew/issues/new'
 
-export const FEATURE_REQUEST_PROMPT = [
+/**
+ * Prompt used when the dashboard has already confirmed that the
+ * `feature-request` skill is installed. The ``$feature-request`` token is
+ * resolved server-side by the chat runner (``resolve_dollar_skills``) and
+ * injected into the message before the agent sees it — no tool call, no
+ * filesystem probe, no approval prompt.
+ */
+export const FEATURE_REQUEST_PROMPT_WITH_SKILL = [
   'The user clicked "Request a Feature".',
-  'If the `feature-request` skill is available, load and follow it. Otherwise follow this self-contained workflow:',
+  'Follow the $feature-request skill.',
+].join('\n')
+
+/**
+ * Self-contained fallback prompt used when the `feature-request` skill is
+ * NOT installed. Contains the full conversational workflow inline so the
+ * agent never needs to probe for the skill.
+ */
+export const FEATURE_REQUEST_PROMPT_FALLBACK = [
+  'The user clicked "Request a Feature".',
   '',
   "Greet the user warmly and ask what they'd like — a feature request or a bug report. Keep it casual; don't present a form.",
   'Guide them conversationally (two to three exchanges) to describe: what they want or what is broken, why it matters, and any context.',
@@ -21,3 +37,11 @@ export const FEATURE_REQUEST_PROMPT = [
   '',
   'Be casual and helpful. This is a conversation, not a form.',
 ].join('\n')
+
+/**
+ * Backward-compatible alias — points at the fallback so any consumer that
+ * imported the old name keeps working. New code should use
+ * {@link FEATURE_REQUEST_PROMPT_WITH_SKILL} or
+ * {@link FEATURE_REQUEST_PROMPT_FALLBACK} explicitly.
+ */
+export const FEATURE_REQUEST_PROMPT = FEATURE_REQUEST_PROMPT_FALLBACK

--- a/website/src/test/featureRequestLabels.test.ts
+++ b/website/src/test/featureRequestLabels.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-import { FEATURE_REQUEST_PROMPT } from '../prompts/featureRequest'
+import { FEATURE_REQUEST_PROMPT_FALLBACK } from '../prompts/featureRequest'
 
 // The "Request a Feature" flow has two copies of the same instructions: the
-// `feature-request` skill (preferred) and this prompt (self-contained fallback
+// `feature-request` skill (preferred) and the fallback prompt (self-contained
 // when the skill is unavailable). Both read the live label list via
 // `gh label list` rather than baking `enhancement`/`bug` in as the entire label
 // vocabulary, so issues filed through the flow carry the repo's grouping labels
@@ -28,7 +28,7 @@ const CONCRETE_GROUPING_LABEL = /(area|platform)(:\s*|%3A%20)[a-z]/i
 
 describe('feature-request label selection', () => {
   describe.each([
-    ['prompt fallback', FEATURE_REQUEST_PROMPT],
+    ['prompt fallback', FEATURE_REQUEST_PROMPT_FALLBACK],
     ['skill', skill],
   ])('%s', (_name, text) => {
     it('tells the agent to read the live label list', () => {
@@ -62,12 +62,12 @@ describe('feature-request label selection', () => {
   })
 
   it('no longer pins the pre-filled URL to a single label', () => {
-    expect(FEATURE_REQUEST_PROMPT).not.toMatch(/labels=enhancement/)
+    expect(FEATURE_REQUEST_PROMPT_FALLBACK).not.toMatch(/labels=enhancement/)
     expect(skill).not.toMatch(/labels=enhancement/)
   })
 
   it('no longer pins the gh create command to a single label', () => {
-    expect(FEATURE_REQUEST_PROMPT).not.toMatch(/--label enhancement/)
+    expect(FEATURE_REQUEST_PROMPT_FALLBACK).not.toMatch(/--label enhancement/)
     expect(skill).not.toMatch(/--label enhancement/)
   })
 })


### PR DESCRIPTION
## What

Clicking "Request a Feature" no longer surfaces a tool-approval prompt before the
agent speaks.

Closes #1844

## Why

The seed prompt told the agent _"If the `feature-request` skill is available, load
and follow it"_ — the agent had to probe the filesystem to check, triggering a
tool-approval dialog before it could even greet the user. For most users (who don't
have the skill installed), this was a confusing dead-end permission request about a
skill they've never heard of.

## How

Moved the skill-existence check from the agent (runtime tool call) to the dashboard
(pre-flight `GET /api/skills`), and split the prompt into two variants:

| Scenario | Prompt sent | Tool approval? |
|---|---|---|
| Skill **not** installed | `FEATURE_REQUEST_PROMPT_FALLBACK` — full self-contained workflow, no skill mention | No |
| Skill **installed** | `FEATURE_REQUEST_PROMPT_WITH_SKILL` — uses `$feature-request` inline token, resolved server-side by `resolve_dollar_skills` | No |
| `api.skills()` **fails** | Falls back to `FEATURE_REQUEST_PROMPT_FALLBACK` | No |

## Changed files

- `website/src/prompts/featureRequest.ts` — split into `_WITH_SKILL` / `_FALLBACK` variants
- `website/src/App.tsx` — `requestFeature` pre-checks skill availability via `api.skills()`
- `website/src/test/featureRequestLabels.test.ts` — updated imports to new export name

## Testing

- All 14 tests in `featureRequestLabels.test.ts` pass
- No AUTOSDE blocking rules triggered
- Backward-compatible: `FEATURE_REQUEST_PROMPT` alias preserved
