### PR TITLE
fix(build): install glibc-217 Node 20 on Amazon Linux 2 for vite 8

### DIFF
--- a/ensure-node.sh
+++ b/ensure-node.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Ensure Node.js is available for the build. Installs via mise (preferred) or nvm.
+# Ensure Node.js is available for the build. Installs via mise (preferred),
+# nvm, or the nodejs "unofficial-builds" glibc-217 tarball on old-glibc hosts.
 # Called by: setup.sh, kirocrew update, kirocrew gateway, Makefile (frontend)
 # Platforms: macOS, Amazon Linux 2 (glibc 2.26), Amazon Linux 2023, Linux
 #
@@ -10,19 +11,30 @@
 # NOT the pre-move "$HOME/.kirocrew", which the one-time data-home migration
 # deletes, so writing there would resurrect the legacy dir on every build.
 
-MIN_VERSION=18
+# The frontend build (vite 8 / rolldown) requires a Node in the bundler's own
+# declared support range: `vite@8.2.0` and `rolldown@1.2.3` both set
+# engines.node "^20.19.0 || >=22.12.0". Too-old Node fails in more than one
+# way; the first symptom on Node 16 is rolldown importing `styleText` from
+# `node:util` (added in 20.12.0), which aborts the build with
+#   "The requested module 'node:util' does not provide an export named 'styleText'".
+# See _version_meets_floor for the exact per-line cutoffs.
+MIN_VERSION="20.19"   # human-readable primary floor, for messages
 TARGET_VERSION=20
 
-# Amazon Linux 2 ships glibc 2.26, but official Node >= 18 binaries are linked
-# against glibc >= 2.28 and fail to load ("GLIBC_2.28 not found"). Official
-# Node 16 was built on a glibc-2.17 baseline, so it runs on AL2 for both x86_64
-# and aarch64 and is enough for the frontend build (tsc + vite). Test-only
-# tooling that wants >= 18 runs in CI, not on the AL2 build host. This mirrors
-# the sibling deployment's approach.
-AL2_NODE_VERSION=16
+# Amazon Linux 2 ships glibc 2.26, but the OFFICIAL Node >= 18 binaries are
+# linked against glibc >= 2.28 and fail to load ("GLIBC_2.28 not found"). The
+# official Node 16 build (glibc-2.17 baseline) runs on AL2 but is below the
+# >= 20.19 floor the frontend now needs. The nodejs "unofficial-builds" project
+# publishes a `glibc-217` variant compiled against glibc 2.17 that satisfies
+# both constraints on AL2 — x64 only (upstream ships no arm64 glibc-217 build).
+GLIBC217_VERSION=20.20.2
 
 _node_major() {
     node -v 2>/dev/null | sed 's/v//' | cut -d. -f1
+}
+
+_node_minor() {
+    node -v 2>/dev/null | sed 's/v//' | cut -d. -f2
 }
 
 # node is "usable" only if it is on PATH AND actually executes. A binary built
@@ -32,11 +44,44 @@ _node_usable() {
     command -v node >/dev/null 2>&1 && node -v >/dev/null 2>&1
 }
 
+# The floor is the frontend bundler's OWN declared support range, not just the
+# first symptom: `vite@8.2.0` and `rolldown@1.2.3` (website/package-lock.json)
+# both declare engines.node "^20.19.0 || >=22.12.0". So 20.19+ is supported on
+# the 20.x line, the whole 21.x line is not supported at all, and 22 needs
+# 22.12+. A missing `util.styleText` (added in 20.12.0) is only the first way a
+# too-old Node fails; gating on that export alone would still admit versions the
+# bundler rejects. Re-check this range when vite/rolldown are upgraded.
+_version_meets_floor() {   # $1=major $2=minor
+    local maj="$1" min="$2"
+    [ -n "$maj" ] && [ -n "$min" ] || return 1
+    if [ "$maj" -eq 20 ]; then [ "$min" -ge 19 ]; return; fi
+    if [ "$maj" -eq 22 ]; then [ "$min" -ge 12 ]; return; fi
+    if [ "$maj" -ge 23 ]; then return 0; fi
+    return 1   # 21.x is unsupported; so is anything below 20.19
+}
+
+# True (0) iff the node FIRST ON PATH runs and meets the floor. This is the
+# predicate for "is node good enough?" — used to decide install, to pick the
+# old-glibc fallback, and for final validation, so a runnable-but-too-old node
+# (Node 16/20.11/21.6 already on PATH) never masquerades as sufficient.
+_node_version_ok() {
+    _node_usable || return 1
+    _version_meets_floor "$(_node_major)" "$(_node_minor)"
+}
+
+# True (0) iff the given node BINARY runs and meets the floor. Used to test a
+# candidate without disturbing PATH.
+_node_bin_ok() {   # $1 = path to a node binary
+    local nb="$1" ver
+    [ -x "$nb" ] || return 1
+    ver="$("$nb" -v 2>/dev/null)" || return 1
+    ver="${ver#v}"
+    [ -n "$ver" ] || return 1
+    _version_meets_floor "${ver%%.*}" "$(printf '%s\n' "${ver#*.}" | cut -d. -f1)"
+}
+
 _needs_install() {
-    if ! _node_usable; then return 0; fi
-    local cur
-    cur=$(_node_major)
-    [ -z "$cur" ] || [ "$cur" -lt "$MIN_VERSION" ]
+    ! _node_version_ok
 }
 
 _get_platform() {
@@ -72,6 +117,168 @@ _source_nvm() {
     fi
 }
 
+# Every node bin dir this script knows about, most-preferred first. Printed one
+# per line; only existing, executable candidates are emitted.
+_candidate_node_bins() {
+    local d nb mise_bin nvm_versions v
+    d="$(_glibc217_node_dir)/bin"
+    # Same completeness requirement as _source_glibc217_node: node without npm is
+    # a half-written tree, not a usable toolchain.
+    [ -x "$d/node" ] && [ -x "$d/npm" ] && echo "$d"
+
+    if [ -x "$HOME/.local/bin/mise" ]; then
+        mise_bin="$HOME/.local/bin/mise"
+    elif command -v mise >/dev/null 2>&1; then
+        mise_bin="mise"
+    fi
+    if [ -n "$mise_bin" ]; then
+        nb="$("$mise_bin" which node 2>/dev/null)"
+        [ -n "$nb" ] && [ -x "$nb" ] && dirname "$nb"
+    fi
+
+    # nvm keeps every installed version side by side; try newest first. The "v"
+    # prefix must be stripped before sorting: with it, `sort -k1,1nr` reads "v20"
+    # as 0, every entry ties on the first field, and the order silently falls
+    # through to the MINOR number (v18.19.0 ahead of v20.12.0).
+    nvm_versions="${NVM_DIR:-$HOME/.nvm}/versions/node"
+    if [ -d "$nvm_versions" ]; then
+        for v in $(ls -1 "$nvm_versions" 2>/dev/null | sed 's/^v//' \
+                   | sort -t. -k1,1nr -k2,2nr -k3,3nr); do
+            [ -x "$nvm_versions/v$v/bin/node" ] && echo "$nvm_versions/v$v/bin"
+        done
+    fi
+}
+
+# PATH precedence is SOURCE ORDER, not version: whichever manager is sourced
+# last wins, so an nvm default of Node 18 can mask a Node 20 that mise or the
+# glibc-217 install just provided, and the run then fails validation with the
+# right node installed but not in front. When the node on PATH is below the
+# floor, promote the first candidate that meets it instead of trusting order.
+_promote_usable_node() {
+    _node_version_ok && return 0
+    local cand
+    while IFS= read -r cand; do
+        [ -n "$cand" ] || continue
+        if _node_bin_ok "$cand/node"; then
+            export PATH="$cand:$PATH"
+            return 0
+        fi
+    done <<EOF
+$(_candidate_node_bins)
+EOF
+    return 1
+}
+
+# Directory holding the unofficial glibc-217 Node install, under the data home.
+_glibc217_node_dir() {
+    echo "${KIROCREW_HOME:-$HOME/.kiro/crew}/node-glibc217"
+}
+
+# Put a previously-installed glibc-217 node on PATH (if present). Called LAST in
+# the source order so it takes precedence over any stale mise/nvm node. Requires
+# npm alongside node, matching the reuse check in _install_glibc217_node: a tree
+# left half-written by an older build has a runnable bin/node but no npm, and
+# putting that on PATH would satisfy the version gate while breaking `npm ci`.
+_source_glibc217_node() {
+    local bin
+    bin="$(_glibc217_node_dir)/bin"
+    [ -x "$bin/node" ] && [ -x "$bin/npm" ] && export PATH="$bin:$PATH"
+}
+
+# Install the nodejs "unofficial-builds" glibc-217 variant (glibc 2.17 baseline)
+# so a supported Node runs on old-glibc hosts (AL2 = glibc 2.26). x64 only.
+# On success exports PATH and returns 0; otherwise prints guidance and returns 1.
+_install_glibc217_node() {
+    local ver="$GLIBC217_VERSION"
+    local arch
+    arch="$(uname -m)"
+    if [ "$arch" != "x86_64" ]; then
+        echo "  ⚠️  $arch: upstream publishes no glibc-217 Node build."
+        echo "     The frontend build needs Node >= $MIN_VERSION (vite 8 / rolldown), and the"
+        echo "     official arm64 Node >= 18 needs glibc 2.28 (this host has less)."
+        echo "     Build Node from source, or run 'make build' on an x86_64 host / in CI."
+        return 1
+    fi
+
+    local dir tarball url tmp
+    dir="$(_glibc217_node_dir)"
+    tarball="node-v${ver}-linux-x64-glibc-217"
+    url="https://unofficial-builds.nodejs.org/download/release/v${ver}/${tarball}.tar.gz"
+
+    # Reuse an existing install only when it is COMPLETE (npm present) and meets
+    # the floor. A tree left behind by an interrupted extraction can have a
+    # runnable bin/node but no npm, and must be replaced rather than trusted.
+    if _node_bin_ok "$dir/bin/node" && [ -x "$dir/bin/npm" ]; then
+        export PATH="$dir/bin:$PATH"
+        return 0
+    fi
+
+    echo "  → Installing Node v${ver} (glibc-217, old-glibc compatible) from unofficial-builds…"
+    tmp="$(mktemp -d)" || return 1
+    if ! curl -fsSL "$url" -o "$tmp/node.tar.gz"; then
+        echo "  ⚠️  Download failed: $url"
+        rm -rf "$tmp"; return 1
+    fi
+
+    # Verify integrity against the published checksum before extracting. Both the
+    # manifest and the tarball come from one HTTPS origin, so this is corruption
+    # detection rather than an independent trust root — but it is fail-closed: a
+    # manifest we cannot fetch, a tool we do not have, or an absent entry all stop
+    # the install rather than silently extracting unverified bytes.
+    if ! curl -fsSL "https://unofficial-builds.nodejs.org/download/release/v${ver}/SHASUMS256.txt" -o "$tmp/SHASUMS256.txt"; then
+        echo "  ⚠️  Could not fetch SHASUMS256.txt for v${ver} — refusing to install unverified"
+        rm -rf "$tmp"; return 1
+    fi
+    local want got sha_cmd
+    if command -v sha256sum >/dev/null 2>&1; then sha_cmd="sha256sum";
+    elif command -v shasum >/dev/null 2>&1; then sha_cmd="shasum -a 256"; fi
+    if [ -z "$sha_cmd" ]; then
+        echo "  ⚠️  No sha256sum/shasum available — refusing to install unverified"
+        rm -rf "$tmp"; return 1
+    fi
+    want="$(awk -v f="${tarball}.tar.gz" '$2==f {print $1}' "$tmp/SHASUMS256.txt")"
+    got="$($sha_cmd "$tmp/node.tar.gz" | awk '{print $1}')"
+    # Empty want = the expected filename was absent from the manifest
+    # (wrong version / bad download); fail closed rather than skip.
+    if [ -z "$want" ] || [ "$want" != "$got" ]; then
+        echo "  ⚠️  Checksum verification failed for ${tarball}.tar.gz (want '$want' got '$got')"
+        rm -rf "$tmp"; return 1
+    fi
+
+    # Extract into a staging dir NEXT TO the destination — same filesystem, so the
+    # promote below is an atomic rename — then validate it and swap it in.
+    # Unpacking straight into $dir cannot be made safe: if the process is killed
+    # mid-tar, no cleanup runs and $dir is left as a partial tree for the next run
+    # to find. Staging means an interrupted run leaves $dir untouched.
+    local staging="${dir}.incoming.$$"
+    mkdir -p "$(dirname "$dir")"
+    rm -rf "$staging"
+    if ! mkdir -p "$staging"; then
+        echo "  ⚠️  Could not create staging dir $staging"
+        rm -rf "$tmp"; return 1
+    fi
+    if ! tar -xzf "$tmp/node.tar.gz" -C "$staging" --strip-components=1; then
+        echo "  ⚠️  Extraction failed"
+        rm -rf "$staging" "$tmp"; return 1
+    fi
+    rm -rf "$tmp"
+
+    # Validate the staged tree BEFORE it becomes the install, so $dir only ever
+    # holds a complete, runnable, floor-meeting Node.
+    if ! _node_bin_ok "$staging/bin/node" || [ ! -x "$staging/bin/npm" ]; then
+        echo "  ⚠️  Extracted Node tree is incomplete or does not meet Node >= $MIN_VERSION"
+        rm -rf "$staging"; return 1
+    fi
+
+    rm -rf "$dir"
+    if ! mv "$staging" "$dir"; then
+        echo "  ⚠️  Could not promote $staging to $dir"
+        rm -rf "$staging"; return 1
+    fi
+
+    export PATH="$dir/bin:$PATH"
+}
+
 # Record where node ended up so make / other callers can find it. Writes into
 # the data home ($KIROCREW_HOME, else ~/.kiro/crew) — never the legacy
 # ~/.kirocrew (see header).
@@ -85,15 +292,14 @@ _record_node_bin() {
 
 PLATFORM=$(_get_platform)
 
-# On Amazon Linux 2, target Node 16 (see AL2_NODE_VERSION note above).
-if [ "$PLATFORM" = "al2" ]; then
-    MIN_VERSION="$AL2_NODE_VERSION"
-    TARGET_VERSION="$AL2_NODE_VERSION"
-fi
-
-# Source existing managers first — node may already be installed but not in PATH
+# Source existing managers first — node may already be installed but not in PATH.
+# _promote_usable_node then puts a good-enough node in front regardless of which
+# manager was sourced last, so an already-present Node 20 is not reinstalled just
+# because an older nvm default masks it.
 _source_mise
 _source_nvm
+_source_glibc217_node
+_promote_usable_node
 
 if ! _needs_install; then
     echo "  ✅ node v$(_node_major) ($(which node))"
@@ -113,9 +319,13 @@ _ensure_mise() {
 }
 
 case $PLATFORM in
-    mac|al2|al2023)
-        # macOS + AL2023 use the default target (20); AL2 uses 16 (set above).
-        # All are official mise builds that run on the host's glibc.
+    al2)
+        # AL2 (glibc 2.26): the official Node >= 18 binaries won't load, so use
+        # the glibc-217 unofficial build (meets the vite 8 / rolldown range).
+        _install_glibc217_node
+        ;;
+    mac|al2023)
+        # macOS + AL2023 (glibc 2.34) run the official mise build for Node 20.
         _ensure_mise
         mise use -g "node@$TARGET_VERSION" 2>/dev/null
         ;;
@@ -133,34 +343,39 @@ case $PLATFORM in
             nvm install "$TARGET_VERSION" 2>/dev/null
             nvm alias default "$TARGET_VERSION" 2>/dev/null
         fi
-        # If the stock binary can't load (old glibc on a non-AL2-labelled host),
-        # fall back to Node 16, whose official build runs on glibc 2.17+.
+        # If the resulting node can't load OR is outside the supported range (an
+        # old glibc leaves official Node 20 unloadable, or a pre-existing
+        # nvm/mise Node 16/18 is runnable but too old), fall back to the
+        # glibc-217 unofficial build (x64), which runs on glibc 2.17+ and is
+        # within the range the frontend build requires.
         _source_mise
         _source_nvm
-        if ! _node_usable; then
-            echo "  → node@$TARGET_VERSION won't run here (likely old glibc); falling back to node@$AL2_NODE_VERSION…"
-            MIN_VERSION="$AL2_NODE_VERSION"
-            TARGET_VERSION="$AL2_NODE_VERSION"
-            if command -v mise &>/dev/null; then
-                mise use -g "node@$TARGET_VERSION" 2>/dev/null
-            else
-                _source_nvm
-                nvm install "$TARGET_VERSION" 2>/dev/null
-                nvm alias default "$TARGET_VERSION" 2>/dev/null
-            fi
+        # Promote before deciding: source order alone can leave an nvm default of
+        # Node 18 in front of the Node 20 mise just installed, and testing PATH
+        # as-is would download the unofficial build on a host that already has a
+        # supported toolchain.
+        _promote_usable_node
+        if ! _node_version_ok; then
+            echo "  → node@$TARGET_VERSION is unusable or < $MIN_VERSION here; trying glibc-217 build…"
+            _install_glibc217_node
         fi
         ;;
 esac
 
-# Re-source to pick up newly installed node
+# Re-source to pick up the newly installed node, then repair PATH precedence:
+# sourcing order alone would let an older manager's node sit in front of the one
+# just installed (see _promote_usable_node).
 _source_mise
 _source_nvm
+_source_glibc217_node
+_promote_usable_node
 
-if _node_usable && [ "$(_node_major)" -ge "$MIN_VERSION" ]; then
+if _node_version_ok; then
     echo "  ✅ node $(node -v) installed ($(which node))"
     _record_node_bin
 else
-    echo "  ⚠️  Node install failed — frontend will use legacy fallback"
-    echo "     Install manually: curl https://mise.run | sh && mise use -g node@$TARGET_VERSION"
+    echo "  ⚠️  Node install failed — frontend build needs Node >= $MIN_VERSION"
+    echo "     macOS / AL2023 / modern Linux: curl https://mise.run | sh && mise use -g node@$TARGET_VERSION"
+    echo "     Amazon Linux 2 (x86_64): re-run 'bash ensure-node.sh' (installs the glibc-217 Node build)"
     exit 1
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -73,6 +73,18 @@ if [ -x "$_kirocrew_dir/ensure-node.sh" ]; then
     elif command -v mise >/dev/null 2>&1; then
         eval "$(mise activate bash 2>/dev/null)" 2>/dev/null || true
     fi
+    # On a host where no version manager can serve a supported Node -- Amazon
+    # Linux 2, whose glibc 2.26 cannot load the official builds -- ensure-node.sh
+    # installs a private toolchain that neither nvm nor mise owns, so the
+    # re-sourcing above cannot surface it. It records the directory it settled on;
+    # consume that marker the way the Makefile and kiro_crew.env.node_bin_dirs()
+    # already do. Without this the checks below miss the node just installed and
+    # the frontend build plus the agent-backend install are skipped.
+    _nbd="$(cat "${KIROCREW_HOME:-$HOME/.kiro/crew}/node-bin-dir" 2>/dev/null || true)"
+    if [ -n "$_nbd" ] && [ -x "$_nbd/node" ]; then
+        export PATH="$_nbd:$PATH"
+    fi
+    unset _nbd
     if _check node; then
         echo "  ✅ node ($(which node))"
     else


### PR DESCRIPTION
## Problem
`make build` fails on Amazon Linux 2 during the frontend step:

```
node_modules/rolldown/dist/shared/create-bundler-option-*.mjs:8
import { formatWithOptions, styleText } from "node:util";
                            ^^^^^^^^^
SyntaxError: The requested module 'node:util' does not provide an export named 'styleText'
make: *** [frontend] Error 1
```

## Why it matters
AL2 is a supported build / remote-crew host. With the frontend build broken there, `make build` cannot produce the dashboard on AL2 at all, blocking gateway setup and remote-crew installs on those hosts.

## Fix (symptom → root cause → change)
- **Symptom:** rolldown (vite 8's bundler) imports `styleText` from `node:util`, which the running Node does not export.
- **Root cause:** the vite 5→8 bump raised the frontend's Node requirement well above what that shortcut provides. `vite@8.2.0` and `rolldown@1.2.3` both declare `engines.node: "^20.19.0 || >=22.12.0"`; `styleText` (added in Node 20.12.0) is simply the first symptom Node 16 hits. Meanwhile `ensure-node.sh` installs **Node 16** on AL2 (`AL2_NODE_VERSION=16`), because official Node ≥18 is linked against glibc ≥2.28 while AL2 ships glibc 2.26.
- **Change:** on AL2 (and the generic old-glibc x64 Linux fallback), install the nodejs **unofficial-builds `glibc-217`** Node 20.20.2 tarball — compiled against glibc 2.17, so it runs on AL2's 2.26, and inside the supported range — verify its SHA256, extract to `~/.kiro/crew/node-glibc217`, and record `node-bin-dir` so the Makefile's frontend target puts it on PATH.
  - **Version gating follows the bundler's declared range** (`_version_meets_floor`, shared by `_node_version_ok` for the node on PATH and `_node_bin_ok` for a candidate binary): accept 20.19+ on the 20.x line and 22.12+, reject all of 21.x. Gating on `styleText` alone would still admit 20.12–20.18, 21.x and 22.0–22.11, which the bundler rejects.
  - **PATH resolution is version-aware, not source-order-aware.** Sourcing mise/nvm/glibc-217 in sequence means the last one sourced wins, so an nvm default of Node 18 could mask a supported Node that mise had just installed and fail validation with the right Node present. `_promote_usable_node` promotes the first candidate meeting the floor (`_candidate_node_bins`, newest nvm version first).
  - **The glibc-217 install is fail-closed and atomic.** An unfetchable `SHASUMS256.txt`, a missing `sha256sum`/`shasum`, an absent manifest entry, or a hash mismatch all abort instead of installing unverified bytes. Extraction goes to a same-filesystem staging dir which is validated (runnable `node` meeting the floor **and** an `npm`) and only then renamed into place, so a run killed mid-`tar` leaves the destination untouched; the reuse check likewise requires a complete tree rather than just a runnable `bin/node`.
  - **arm64 AL2** has no upstream glibc-217 build, so it fails with an explicit message (build from source, or build on x86_64 / in CI) rather than silently installing an unusable Node.
  - **`setup.sh` consumes the `node-bin-dir` marker.** A toolchain owned by no version manager is reachable only through the marker `ensure-node.sh` records. The `Makefile` frontend target already consumed it; `setup.sh` only re-sourced nvm/mise, so on AL2 its `_check node` guard failed and it silently skipped both the frontend build and the `npm i -g` agent-backend install. It now reads the marker the same way (absent marker degrades to "whatever node is on PATH").

**Deliberately out of scope:** `kirocrew`'s Python callers (`env.augmented_path`, `cli._node_ok`, `frontend.py`) resolve node via bare `PATH` / the version-manager glob and so cannot see a manager-less toolchain either. That is **pre-existing on every platform** — it is why `kiro_crew.env.find_node_tool()` exists — and an earlier revision of this PR that routed them through the marker put `node_bin_dirs()`'s filesystem walk onto async call paths (`acp/runtime`, `mcp_discovery`, `dashboard/handlers/agents`, and `cli_server._gateway`), which the `no-blocking-call-on-event-loop` rule correctly rejects. Closing that gap needs the walk moved off the event loop, so it belongs in its own change rather than riding along with a build-script fix.

**Windows:** unaffected. `build-windows.yml` provisions Node with `actions/setup-node` (`node-version: 20`) and never invokes `ensure-node.sh`, which has no Windows branch in `_get_platform` at all.

## Tests
No automated test — `ensure-node.sh` is host-provisioning shell with no existing test harness. Verified with `bash -n` (syntax) plus targeted checks of the new pure helpers:
- `_version_meets_floor` across `16.20 / 18.19 / 20.11 / 20.12 / 20.18 / 20.19 / 20.20 / 21.0 / 21.7 / 21.9 / 22.0 / 22.11 / 22.12 / 23.1 / 24.3` — accepts exactly `^20.19.0 || >=22.12.0`, matching vite/rolldown's declared engines, and the pinned `GLIBC217_VERSION=20.20.2` qualifies.
- `_node_bin_ok` against stub binaries reporting `v20.11.1 / v20.12.0 / v21.6.2 / v21.7.0 / v16.20.2 / v22.1.0`, and a nonexistent path (rejected).
- `_promote_usable_node` against the reported masking case — an nvm Node 18.19.0 ahead of a mise Node 20.20.2 on PATH resolves to `v20.20.2`.
- nvm candidate ordering is newest-first (`v22.1.0 v20.20.2 v20.12.0 v18.19.0 v16.20.2`).
- `setup.sh`'s new marker step: with a marker pointing at a private bin dir, a parent shell resolves `node` from it; with the marker absent, PATH is left untouched and no error is raised.

The repo's two `ensure-node.sh`-related suites — `test/test_dev_fleet_node_toolchain.py` and `test/test_node_toolchain_resolution.py` (64 tests) — pass; they exercise the `node-bin-dir` marker contract in Python, which this change preserves. No Python is modified by this PR.

## Manual verification
On an AL2 x86_64 host (nobita):
```bash
cd ~/workspace/KiroCrew/ && rm -f ~/.kiro/crew/node-bin-dir && bash ensure-node.sh && make build
```
Expected: `ensure-node.sh` reports `✅ node v20.20.2`, and the frontend build completes without the `styleText` error. macOS / AL2023 / modern Linux are unaffected (still official mise `node@20`).

## Screenshots
N/A — no user-visible UI change (build-tooling shell script only).
