### PR TITLE
fix(apps): resolve bare Python MCP commands through app venvs

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -77,6 +77,21 @@ that never installed it, and a dead HTTP entry there broke EVERY kiro session, n
 just the app's. KiroCrew sessions read only the agent config (`includeMcpJson` is
 pinned False in `agent.py`), so the narrower target is also sufficient.
 
+**A bare interpreter name is resolved before it is written.** kiro-cli spawns a
+stdio entry's `command`, so `python` / `python3` would be a `PATH` lookup on
+whatever host the session runs on — which need not hold an interpreter under that
+name, and where it does need not hold one new enough for the app's venv. Either
+way the server never starts, and a stdio MCP server that never starts is
+indistinguishable from an app that provides no tools. `_pin_app_python_command`
+substitutes `python_runtime.resolve_app_python` (the app's `.venv` interpreter,
+else the gateway's own), which is the policy the app's backend already applies to
+its own spawns — one module so the two spawn sites cannot drift again. The match
+is literal, like the host-CLI pin beside it: an absolute path, a versioned name,
+and any non-Python command are the author's explicit choice and are written as
+declared. Only the value of `command` changes; no key is added, because the entry
+is parsed by kiro-cli and its documented local-server properties are `command`,
+`args`, `env`, `disabled`, `autoApprove` and `disabledTools`.
+
 **Migration is finished at boot, not at disable.** `reconcile_enabled_app_resources`
 scrubs the app's entries out of the legacy shared file for every ENABLED app on
 every gateway start. Scrubbing only on deregister meant an already-enabled app

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -29,6 +29,7 @@ from kiro_crew.apps.execution import (
     shipped_builtin_module_path,
 )
 from kiro_crew.apps.manager import app_dir, get_app_manifest, list_apps
+from kiro_crew.apps.python_runtime import resolve_app_python
 from kiro_crew.apps.registry import minimal_env
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
@@ -860,13 +861,7 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
     elif backend_type == "asgi" or (
         not backend_type and _is_asgi_entry(entry)
     ):
-        venv_python = str(root / ".venv" / "bin" / "python3")
-        # Fall back to the gateway's own interpreter (sys.executable) rather than a bare
-        # "python3": a bare name relies on PATH, which isn't guaranteed (e.g. some
-        # build environments ship only a versioned interpreter, so execvp("python3") raises
-        # FileNotFoundError and the backend dies immediately). Matches the module-style
-        # branch above.
-        python_bin = venv_python if (root / ".venv" / "bin" / "python3").is_file() else sys.executable
+        python_bin = resolve_app_python(root)
         # Derive the module path for uvicorn (e.g. backend.app:app)
         rel = entry.relative_to(root)
         parts = list(rel.parts)
@@ -886,10 +881,7 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
 
     # --- Plain Python backend (default) ---
     else:
-        venv_python = str(root / ".venv" / "bin" / "python3")
-        # See the ASGI branch: prefer the venv python, else the gateway's own interpreter
-        # (sys.executable) — a bare "python3" relies on PATH and isn't always present.
-        python_bin = venv_python if (root / ".venv" / "bin" / "python3").is_file() else sys.executable
+        python_bin = resolve_app_python(root)
         cmd = [python_bin, entry_str]
         cwd = str(root)
 

--- a/src/kiro_crew/apps/bridges.py
+++ b/src/kiro_crew/apps/bridges.py
@@ -36,6 +36,7 @@ from kiro_crew.apps.manager import (
     list_apps,
 )
 from kiro_crew.apps.manifest import AppManifest
+from kiro_crew.apps.python_runtime import is_bare_python, resolve_app_python
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import (
     config_dir,
@@ -478,6 +479,26 @@ def _apply_agent_mcp_policy(
 
 #: The host CLI name a builtin app may declare as its MCP ``command``.
 _HOST_CLI_COMMAND = "kirocrew"
+
+
+def _pin_app_python_command(app_name: str, cfg: dict[str, Any]) -> dict[str, Any]:
+    """Resolve a stdio server's bare ``python``/``python3`` to the app's own venv.
+
+    The same app's backend already refuses to spawn on a bare name, and for the
+    same two reasons: ``PATH`` need not hold an interpreter under that name at
+    all, and where it does, a system interpreter older than the app's venv dies
+    on the app's own imports. Either way the server never starts, and a stdio MCP
+    server that never starts is indistinguishable from an app that provides no
+    tools — nothing is logged on this path.
+
+    The match is literal, like the host-CLI pin beside it: an absolute path, a
+    versioned name, and any non-Python binary are the author's explicit choice
+    and are written as declared.
+    """
+    if not is_bare_python(cfg.get("command")):
+        return cfg
+    cfg["command"] = resolve_app_python(app_dir(app_name))
+    return cfg
 
 
 def _pin_host_cli_command(app_name: str, cfg: dict[str, Any]) -> dict[str, Any]:
@@ -1791,6 +1812,10 @@ def _register_mcp_servers(
             if isinstance(cfg, dict):
                 cfg = _pin_host_cli_command(app_name, cfg)
             is_http = isinstance(cfg, dict) and bool(cfg.get("url"))
+            if isinstance(cfg, dict) and not is_http:
+                # stdio only: an HTTP server is reached over its url and has no
+                # command to resolve.
+                cfg = _pin_app_python_command(app_name, cfg)
             if is_http and not resolved_port:
                 # No live backend → registering the manifest's dead default-port URL would
                 # break every kiro session. Skip it AND scrub any stale entry so a prior

--- a/src/kiro_crew/apps/python_runtime.py
+++ b/src/kiro_crew/apps/python_runtime.py
@@ -1,0 +1,63 @@
+"""Which interpreter an App Kit app's own Python runs under.
+
+One policy, because an app has one set of dependencies but several spawn sites:
+its backend process and any stdio MCP server it declares. Resolving this at each
+site is how the two drifted apart — the backend refusing a bare ``python3`` while
+the MCP registration wrote one through.
+
+Kept in its own module rather than beside either caller: ``apps.backend`` and
+``apps.bridges`` already defer-import each other to break a cycle, so a helper
+either of them owned would have to be imported lazily by the other.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from kiro_crew import platform_compat
+
+#: Interpreter names that are resolved through ``PATH`` at spawn time rather than
+#: naming a file. ``py`` is the Windows launcher and belongs here for the same
+#: reason as the other two. Deliberately a closed set: a versioned name
+#: (``python3.13``) and an absolute path are the author's explicit choice.
+BARE_PYTHON_COMMANDS = frozenset({"python", "python3", "py"})
+
+
+def is_bare_python(command: object) -> bool:
+    """Whether *command* names an interpreter to be looked up rather than a file.
+
+    Case- and whitespace-insensitive: a manifest is hand-written JSON, and
+    ``"Python3"`` spawns the same launcher as ``"python3"`` on a case-insensitive
+    filesystem while failing an exact match here.
+    """
+    return isinstance(command, str) and command.strip().lower() in BARE_PYTHON_COMMANDS
+
+
+def app_venv_python(app_root: Path) -> Path | None:
+    """The app venv's interpreter, or ``None`` when the app has no usable venv.
+
+    A venv exposes its interpreter at ``bin/python3`` on POSIX and
+    ``Scripts/python.exe`` on Windows, so a single hardcoded layout resolves
+    nothing on the other platform and the caller falls through to the gateway's
+    interpreter — losing the app's dependencies without saying so.
+    """
+    subpath = ("Scripts", "python.exe") if platform_compat.IS_WINDOWS else ("bin", "python3")
+    candidate = app_root.joinpath(".venv", *subpath)
+    return candidate if candidate.is_file() else None
+
+
+def resolve_app_python(app_root: Path) -> str:
+    """Interpreter to run *app_root*'s own Python with.
+
+    The app's venv first, so its code runs against the dependencies installed for
+    it; the gateway's own interpreter otherwise. Never a bare ``python3``, which
+    is resolved through ``PATH`` at spawn time and so is not guaranteed to name an
+    interpreter at all (a host shipping only a versioned one raises
+    ``FileNotFoundError`` from ``execvp``) nor to name the right one (a system
+    interpreter older than the venv's dies on the app's imports). Both failures
+    are silent where they matter: the process never starts, and whatever it
+    provided is simply absent.
+    """
+    venv_python = app_venv_python(app_root)
+    return str(venv_python) if venv_python is not None else sys.executable

--- a/test/test_app_bridges.py
+++ b/test/test_app_bridges.py
@@ -805,6 +805,107 @@ class TestMCPRegistration:
             "mcpServers", {}
         )
 
+    def _register_stdio(self, tmp_path, app_env, monkeypatch, servers: dict) -> dict:
+        """Install an app declaring *servers* and return the config as written."""
+        import kiro_crew.apps.backend as backend_mod
+        import kiro_crew.apps.bridges as bmod
+
+        mcp_path = tmp_path / "mcp.json"
+        monkeypatch.setattr(bmod, "_mcp_json_path", lambda: mcp_path)
+        monkeypatch.setattr(backend_mod, "get_app_backend_port", lambda _n: 9000)
+        src = _make_app_source(tmp_path, mcpServers=servers)
+        install_app(src)
+        manifest = AppManifest.from_json_file(
+            app_env["home"] / "apps" / "test-app" / APP_MANIFEST_FILENAME
+        )
+        _register_mcp_servers("test-app", manifest)
+        return json.loads(mcp_path.read_text(encoding="utf-8"))["mcpServers"]
+
+    def test_a_bare_python_command_is_resolved_before_it_is_written(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # kiro-cli spawns this entry, so a bare name is a PATH lookup on whatever
+        # host it runs on. The same app's backend already refuses to do that.
+        written = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"tools": {"command": "python3", "args": ["-m", "pkg.mcp"]}},
+        )
+        entry = written["test-app:tools"]
+        assert entry["command"] != "python3", "a bare interpreter name reached the config"
+        assert Path(entry["command"]).is_absolute()
+        assert entry["args"] == ["-m", "pkg.mcp"], "args must survive untouched"
+
+    def test_only_the_command_is_touched(self, tmp_path, app_env, monkeypatch):
+        # The documented local-server properties are command/args/env/disabled/
+        # autoApprove/disabledTools. Adding a key outside that set would put an
+        # unknown property in front of an external parser, so the rewrite changes
+        # the value of one documented field and introduces nothing.
+        declared = {
+            "command": "python3",
+            "args": ["server.py"],
+            "env": {"APP_MODE": "stdio"},
+            "disabled": False,
+        }
+        written = self._register_stdio(tmp_path, app_env, monkeypatch, {"tools": dict(declared)})
+        entry = written["test-app:tools"]
+        assert set(entry) == set(declared), f"key set changed: {sorted(entry)}"
+        assert {k: v for k, v in entry.items() if k != "command"} == {
+            k: v for k, v in declared.items() if k != "command"
+        }
+
+    def test_the_app_venv_interpreter_is_preferred_over_the_gateways(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        import kiro_crew.apps.bridges as bmod
+        from kiro_crew.apps import python_runtime as pr
+        from kiro_crew.apps.manager import app_dir
+
+        monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", False)
+        self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"tools": {"command": "python3", "args": []}},
+        )
+        # install_app copies the source tree, so the venv is planted afterwards
+        # and picked up by a re-registration — which is also the real sequence:
+        # dependencies are installed after the app lands.
+        venv = app_dir("test-app") / ".venv" / "bin" / "python3"
+        venv.parent.mkdir(parents=True, exist_ok=True)
+        venv.write_text("", encoding="utf-8")
+        manifest = AppManifest.from_json_file(
+            app_env["home"] / "apps" / "test-app" / APP_MANIFEST_FILENAME
+        )
+        _register_mcp_servers("test-app", manifest)
+
+        written = json.loads(bmod._mcp_json_path().read_text(encoding="utf-8"))["mcpServers"]
+        assert written["test-app:tools"]["command"] == str(venv)
+
+    def test_an_absolute_interpreter_is_left_exactly_as_declared(
+        self, tmp_path, app_env, monkeypatch
+    ):
+        # The author resolved it themselves; overriding that is not ours to do.
+        written = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"tools": {"command": "/usr/local/bin/python3.13", "args": []}},
+        )
+        assert written["test-app:tools"]["command"] == "/usr/local/bin/python3.13"
+
+    def test_a_non_python_command_is_left_alone(self, tmp_path, app_env, monkeypatch):
+        written = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"tools": {"command": "node", "args": ["server.js"]}},
+        )
+        assert written["test-app:tools"]["command"] == "node"
+
+    def test_an_http_server_gains_no_command(self, tmp_path, app_env, monkeypatch):
+        # An HTTP server is reached over its url; there is no command to resolve,
+        # and inventing one would send kiro-cli spawning a local process for a
+        # remote server.
+        written = self._register_stdio(
+            tmp_path, app_env, monkeypatch,
+            {"api": {"url": "http://127.0.0.1:8000/mcp"}},
+        )
+        assert "command" not in written["test-app:api"]
+
     def test_stdio_mcp_server_always_registered_no_backend(self, tmp_path, app_env, monkeypatch):
         # A command/stdio MCP server (no url) has no port to be dead — it must always be
         # registered regardless of backend liveness (only HTTP url servers are gated).

--- a/test/test_app_python_runtime.py
+++ b/test/test_app_python_runtime.py
@@ -1,0 +1,93 @@
+"""Which interpreter an App Kit app's own Python runs under.
+
+A bare ``python3`` is resolved through ``PATH`` at spawn time, which need not
+hold an interpreter under that name at all, and where it does need not hold one
+new enough for the app's venv-installed dependencies. Both failures are silent at
+the point they matter, so the resolution happens once rather than at each spawn
+site — which is how the backend and the MCP registration drifted apart.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from kiro_crew.apps import python_runtime as pr
+
+
+def _plant(root: Path, *parts: str) -> Path:
+    p = root.joinpath(".venv", *parts)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("", encoding="utf-8")
+    return p
+
+
+class TestAppInterpreterResolution:
+    def test_the_posix_venv_interpreter_wins(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", False)
+        expected = _plant(tmp_path, "bin", "python3")
+        assert pr.resolve_app_python(tmp_path) == str(expected)
+
+    def test_the_windows_venv_interpreter_wins(self, tmp_path, monkeypatch):
+        # A venv exposes Scripts/python.exe there; resolving the POSIX layout
+        # finds nothing and the app's dependencies are silently dropped.
+        monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", True)
+        expected = _plant(tmp_path, "Scripts", "python.exe")
+        assert pr.resolve_app_python(tmp_path) == str(expected)
+
+    def test_the_other_platforms_layout_is_not_accepted(self, tmp_path, monkeypatch):
+        # The POSIX layout present while running as Windows must NOT resolve, or
+        # the caller is handed a path that cannot execute. Branching on the
+        # platform rather than probing both is what makes this hold.
+        monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", True)
+        _plant(tmp_path, "bin", "python3")
+        assert pr.resolve_app_python(tmp_path) == sys.executable
+
+    def test_no_venv_falls_back_to_the_gateway_interpreter(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", False)
+        assert pr.app_venv_python(tmp_path) is None
+        assert pr.resolve_app_python(tmp_path) == sys.executable
+
+    def test_a_directory_at_the_interpreter_path_is_not_a_venv(self, tmp_path, monkeypatch):
+        # is_file(), not exists(): a directory there is not runnable, and
+        # returning it would replace a PATH lookup with a guaranteed failure.
+        monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", False)
+        (tmp_path / ".venv" / "bin" / "python3").mkdir(parents=True)
+        assert pr.resolve_app_python(tmp_path) == sys.executable
+
+    def test_the_resolved_interpreter_is_never_a_bare_name(self, tmp_path, monkeypatch):
+        # The whole point: whatever comes back must name a file, because the
+        # caller writes it where something else will spawn it.
+        monkeypatch.setattr(pr.platform_compat, "IS_WINDOWS", False)
+        for planted in (True, False):
+            if planted:
+                _plant(tmp_path, "bin", "python3")
+            resolved = pr.resolve_app_python(tmp_path)
+            assert resolved not in pr.BARE_PYTHON_COMMANDS
+            assert Path(resolved).is_absolute()
+
+    def test_every_bare_launcher_is_recognised(self):
+        # `py` is the Windows launcher and is looked up on PATH like the other
+        # two, so it belongs to the same class.
+        for name in ("python", "python3", "py"):
+            assert pr.is_bare_python(name)
+
+    def test_a_bare_name_is_recognised_case_and_space_insensitively(self):
+        # A manifest is hand-written JSON: "Python3" spawns the same launcher on
+        # a case-insensitive filesystem but would slip past an exact match.
+        for name in ("Python3", " python3 ", "PY", "\tpython\n"):
+            assert pr.is_bare_python(name), name
+
+    def test_a_resolved_or_deliberate_command_is_not_bare(self):
+        for name in ("python3.13", "/usr/bin/python3", "node", "docker", "", "pythonic"):
+            assert not pr.is_bare_python(name), name
+        assert not pr.is_bare_python(None)
+
+    def test_the_backend_spawn_paths_use_the_shared_resolver(self):
+        # Both app-Python branches must go through one policy; a second inline
+        # copy is how the two spawn paths drifted apart to begin with.
+        import kiro_crew.apps.backend as backend_mod
+
+        source = Path(backend_mod.__file__).read_text(encoding="utf-8")
+        assert 'root / ".venv" / "bin"' not in source, "backend re-hardcodes a venv layout"
+        assert source.count("resolve_app_python(root)") == 2


### PR DESCRIPTION
Refs #1807 — the interpreter half. The working-directory half is deliberately not
addressed; see the end.

## Problem

An app's stdio MCP server declaring `command: "python3"` is written into the
agent config verbatim, so kiro-cli resolves it through `PATH` at spawn time. That
need not name an interpreter at all, and where it does it need not name one new
enough for the dependencies installed into the app's own venv. Either way the
server never starts, and a stdio MCP server that never starts is
indistinguishable from an app that provides no tools — nothing on this path logs
the difference.

The same app's backend already refuses a bare name for exactly these reasons. It
just refuses it in a way that only works on POSIX: `backend.py` hardcodes
`.venv/bin/python3` in both Python branches, so on Windows — where a venv exposes
`Scripts/python.exe` — the venv is never found and the launch falls through to the
gateway interpreter. The same silent substitution, one layer up.

## Overlap with #1013

**#1013 already fixes this defect**, in the same function and the same branch:
`resolve_stdio_command()` maps a bare launcher to `sys.executable`. Two things
from it are adopted here and are better than what I had — `py` belongs in the
bare set, and the match should be case- and whitespace-insensitive.

The difference is the resolution target:

| | #1013 | this |
|---|---|---|
| resolves to | `sys.executable` | app `.venv` first, else `sys.executable` |
| guarantees | the server can import `kiro_crew` | the server gets the app's own dependencies |
| backend | unchanged | both branches share the policy |
| Windows venv layout | — | `Scripts/python.exe` |
| scope | part of a 122-file feature PR | this |

The two agree whenever the app has no venv. They differ for a third-party app
that has one, which is the version-skew half of the report and the policy #1807
proposes. If #1013 lands first this should rebase onto it and replace that hunk
rather than leave two resolvers in one branch; I am happy to close this instead if
you would rather the venv-first policy were folded into #1013.

## Change

`apps/python_runtime` resolves the app venv's interpreter for the running
platform, falling back to `sys.executable`. Both `backend.py` Python branches and
the stdio registration use it — a net reduction in `backend.py`. Its own module
because `apps.backend` and `apps.bridges` already defer-import each other to break
a cycle, so a helper owned by either would have to be imported lazily by the other.

The match is literal, like the host-CLI pin beside it: an absolute path, a
versioned name (`python3.13`) and any non-Python binary are the author's explicit
choice and are written as declared. HTTP entries are untouched.

**Only the value of `command` changes; no key is added.** kiro-cli parses this
file, and the documented local-server properties are `command`, `args`, `env`,
`disabled`, `autoApprove`, `disabledTools`
(`docs/reference/kiro-cli/mcp/configuration.md`). A test pins the key set.

Not touched: venv creation, `python3 -m venv`, `bin/pip`, requirements
installation, manifest validation.

## Tests

`test_app_python_runtime.py` (new) — POSIX and Windows venv layouts; the other
platform's layout explicitly NOT accepted; no venv falls back; a directory at the
interpreter path is not a venv; the resolved value is never a bare name; every
bare launcher recognised; case/whitespace insensitivity; a versioned or absolute
name is not bare; both backend branches go through the resolver.

`test_app_bridges.py` — driving the real `_register_mcp_servers` and reading the
config back off disk: a bare command is resolved before it is written; the app
venv beats the gateway interpreter; the key set is unchanged; an absolute
interpreter, a `node` command and an HTTP entry are left alone.

**Fail-before / pass-after:** with the stdio resolution disabled and everything
else intact, **2 fail** (`a bare interpreter name reached the config`). The rest
are preservation guards on what must NOT change — they pass either way by design
and are not evidence of the fix.

## Validation

Targeted app suites: **302 passed, 19 skipped, 1 baseline Windows failure.** That
failure is `test_backend_entrypoint_escapes_app_root`, which fails with the same
`WinError 1314` on pristine `main` because this Windows account lacks the
symlink-creation privilege. The full repository suite was not run locally — the
environment is missing `defusedxml` — so CI is the authoritative matrix.

`flake8`, `mypy`, `isort`, `git diff --check`, docs-lint, scrub-lint and the
diff-scoped brand gate all clean. `app-kit-platform.md` documents the rewrite in
the same commit.

## What this does not fix

`#1807` also proposes an absolute `cwd` on the rewritten entry, so a relative
entry script resolves against the app. `cwd` is not among kiro-cli's documented
local-server properties and I could not verify locally whether an unknown key is
ignored or rejects the entry. If it rejects it, adding one would cause exactly the
failure this fixes — so it is left out, and the issue stays open for it.
