### PR TITLE
ci: resolve fork PRs by open-PR head SHA so readiness re-evaluates

### DIFF
--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -139,6 +139,8 @@ jobs:
           EVENT_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_PR: ${{ github.event.workflow_run.pull_requests[0].number }}
           RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          RUN_HEAD_REF: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
           case "$EVENT" in
@@ -149,12 +151,36 @@ jobs:
               # `workflow_run.pull_requests` is empty for a fork head AND for
               # the managed `dynamic` CodeQL runs, so it can never be the only
               # way in. Resolve the PR from the immutable head SHA instead.
+              #
+              # NOT via `repos/{repo}/commits/{sha}/pulls`: that endpoint only
+              # lists PRs whose head commit is reachable in THIS repo, and a
+              # fork PR's head commit is not reachable from any base-repo
+              # branch until it merges -- so it returns empty for every OPEN
+              # fork PR, skipping every re-evaluation and freezing the fork
+              # verdict at the `opened` snapshot (a premature red). Match the
+              # head SHA against the open-PR list instead: a PR object always
+              # carries its `head.sha` regardless of which repo the commit
+              # lives in, so this resolves fork and same-repo heads alike.
+              #
+              # A head SHA is not by itself unique -- two open PRs can point at
+              # the same commit (e.g. the same fork commit pushed to two
+              # branches). Disambiguate with the triggering run's head
+              # repository + branch (both populated on every workflow_run),
+              # exactly as the verdict step binds monitored runs below; fall
+              # back to SHA-only when either is absent.
               if [ -z "$PR" ]; then
-                associated="$(gh api "repos/$REPO/commits/$RUN_SHA/pulls")"
-                PR="$(jq -r --arg sha "$RUN_SHA" '
-                  [.[] | select(.state == "open" and .head.sha == $sha)]
-                  | first.number // empty
-                ' <<<"$associated")"
+                PR="$(gh api --paginate \
+                  "repos/$REPO/pulls?state=open&per_page=100" \
+                  | jq -rs \
+                      --arg sha "$RUN_SHA" \
+                      --arg repo "$RUN_HEAD_REPO" \
+                      --arg ref "$RUN_HEAD_REF" '
+                      first(.[][]
+                        | select(.head.sha == $sha
+                                 and ($repo == "" or .head.repo.full_name == $repo)
+                                 and ($ref  == "" or .head.ref == $ref))
+                        | .number) // empty
+                    ')"
               fi
               if [ -z "$PR" ]; then
                 {


### PR DESCRIPTION
## Problem
Fork PRs get stuck showing `PR Readiness` = **red / `readiness: action required`** even after every check (CI, Build, Code Review, and the Stage-2 fork Opus/GPT/Design/UX reviews) has gone green. The verdict freezes at the snapshot written when the PR was opened — while checks were still pending — and never updates. Recent examples: #1847 (needed a manual re-run to pass), and currently-open #1841, #1739, #1816 are all green yet frozen red.

## Why it matters
`PR Readiness` is the merge-gate signal. A stuck-red fork PR looks un-mergeable to maintainers and forces a manual `workflow_dispatch` re-run on every fork contribution — recurring toil and a bad contributor experience on exactly the external PRs we most want to keep frictionless. Every open fork PR is affected.

## Fix (symptoms → root cause → change)
- **Symptom:** fork readiness never recomputes after checks complete; internal PRs are fine.
- **Root cause:** readiness recomputes via its `workflow_run` trigger, whose resolve step maps the completed run back to a PR by head SHA. `github.event.workflow_run.pull_requests` is empty for fork heads, so it falls back to `GET /repos/{repo}/commits/{sha}/pulls`. That endpoint only lists PRs whose head commit is **reachable in the base repo**, and a fork PR's head commit is not reachable from any base-repo branch until it merges. So the fallback returns empty for every **open** fork PR → the resolve step hits `state=SKIP` → the verdict stays frozen at the `opened` snapshot (a premature red).
  - Proven reproducibly: `commits/{sha}/pulls` returns EMPTY for 5/5 open fork PRs but resolves 3/3 internal PRs; #1847's three post-completion re-evals all logged `No open pull request currently has workflow head <sha>` → SKIP; replaying the verdict algorithm against green fork #1739's current state yields `passed`, proving the published red is purely stale (the algorithm itself is correct).
- **Change:** replace the reachability-dependent fallback with an open-PR head.sha match — `GET /repos/{repo}/pulls?state=open` then select `.head.sha == RUN_SHA`. A PR object always carries its `head.sha` regardless of which repo the commit lives in, so this resolves fork and same-repo heads alike (and also covers the `dynamic` CodeQL runs the old comment noted). One `.github/workflows/pr-readiness.yml` change, resolve step only. The head SHA alone is not unique (two open PRs can share a commit), so the match is disambiguated by the triggering run's head repository + branch — the same key the verdict step already uses to bind monitored runs — falling back to SHA-only when either is absent.

## Tests
N/A — this is a GitHub Actions workflow shell step; the repo has no harness for the embedded `gh`/`jq` logic. Verified empirically instead (see Manual verification).

## Manual verification
- New resolution logic run live against current open PRs: fork #1841 → 1841, fork #1739 → 1739, internal #1855 → 1855 (all correct).
- Old fallback (`commits/{sha}/pulls`) confirmed EMPTY for 5/5 open fork PRs, non-empty for 3/3 internal — the exact failure this replaces.
- `jq -rs` slurp expression unit-checked on synthetic multi-page input.
- Change is confined to `.github/workflows/pr-readiness.yml`; no packaged code touched.
