### PR TITLE
fix: make semantic context reads thread-safe under concurrent writers

### DIFF
--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -130,12 +130,27 @@ _MMR_MAX_POOL = 1000
 _SEMANTIC_VECTOR_WEIGHT = 0.6  # weight for vector score in hybrid semantic retrieval
 _SEMANTIC_KEYWORD_WEIGHT = 0.4  # weight for keyword score in hybrid semantic retrieval
 
-_snowball = _snowball_stemmer("english")
+# snowballstemmer's pure-Python stemmers keep the word being stemmed as
+# mutable instance state (set_current() -> _stem() -> get_current()), so a
+# single shared instance is NOT thread-safe: concurrent context builds
+# (parallel subagent spawns via run_in_embed_pool) interleave their cursor
+# state and crash with IndexError("string index out of range") — or silently
+# return the wrong stem. One instance per thread; construction is trivial
+# (~0.1 µs once the language module is imported).
+_snowball_local = threading.local()
+
+
+def _get_snowball():
+    stemmer = getattr(_snowball_local, "stemmer", None)
+    if stemmer is None:
+        stemmer = _snowball_stemmer("english")
+        _snowball_local.stemmer = stemmer
+    return stemmer
 
 
 def _stem_words(words: set[str]) -> set[str]:
     """Stem a set of words, returning both original and stemmed forms."""
-    return words | set(_snowball.stemWords(list(words)))
+    return words | set(_get_snowball().stemWords(list(words)))
 
 
 _BUILTIN_PREFIXES = [
@@ -828,10 +843,20 @@ class VectorMemoryStore:
             query_words = _stem_words(set(re.findall(r"\w+", query_text.lower())))
             query_embedding = self._try_embed(query_text) if self.embed_fn else None
 
-            all_rows = self.db.execute(
-                "SELECT key, value_json, updated_at FROM semantic_memory "
-                "WHERE is_deleted = 0 AND key NOT LIKE 'lesson.%'"
-            ).fetchall()
+            # Context assembly runs on executor threads (subagent context builds,
+            # run_in_embed_pool) concurrent with writers on worker threads. The
+            # shared connection's statement cache is not safe for unsynchronized
+            # cross-thread use — an unlocked SELECT racing a writer's implicit
+            # BEGIN surfaces as sqlite3.InterfaceError ("bad parameter or other
+            # API misuse"), and context.py does not guard this call, so the
+            # whole subagent run dies. Lock ONLY the fetch: fetchall()
+            # materializes the rows, and the scoring loop below issues blocking
+            # per-row embed calls that must never run under _db_lock.
+            with self._db_lock:
+                all_rows = self.db.execute(
+                    "SELECT key, value_json, updated_at FROM semantic_memory "
+                    "WHERE is_deleted = 0 AND key NOT LIKE 'lesson.%'"
+                ).fetchall()
 
             scored_rows: list[tuple[float, dict]] = []
             for r in all_rows:
@@ -868,12 +893,14 @@ class VectorMemoryStore:
             scored_rows.sort(key=lambda x: (-x[0], x[1]["updated_at"]))
             rows = [r[1] for r in scored_rows[:max_rows]]
         else:
-            # No query: recent entries
-            rows = self.db.execute(
-                "SELECT key, value_json FROM semantic_memory WHERE is_deleted = 0 "
-                "AND key NOT LIKE 'lesson.%' ORDER BY updated_at DESC LIMIT ?",
-                (max_rows,),
-            ).fetchall()
+            # No query: recent entries. Same serialization requirement as the
+            # query path above.
+            with self._db_lock:
+                rows = self.db.execute(
+                    "SELECT key, value_json FROM semantic_memory WHERE is_deleted = 0 "
+                    "AND key NOT LIKE 'lesson.%' ORDER BY updated_at DESC LIMIT ?",
+                    (max_rows,),
+                ).fetchall()
 
         if not rows:
             return ""
@@ -1989,11 +2016,18 @@ class VectorMemoryStore:
             "WHERE is_deleted = 0 AND key LIKE 'lesson.%' "
             "ORDER BY updated_at DESC"
         )
+        # On the same concurrent context-injection path as get_semantic_context
+        # (get_lessons_context runs on executor threads while lesson writes are
+        # offloaded to workers), so the fetch must be serialized on the shared
+        # connection. _db_lock is reentrant, so callers that already hold it
+        # remain safe.
         if limit is not None and limit > 0:
             sql += " LIMIT ?"
-            rows = self.db.execute(sql, (limit,)).fetchall()
+            with self._db_lock:
+                rows = self.db.execute(sql, (limit,)).fetchall()
         else:
-            rows = self.db.execute(sql).fetchall()
+            with self._db_lock:
+                rows = self.db.execute(sql).fetchall()
         return [dict(r) for r in rows]
 
     def delete_lesson(self, rule_substring: str) -> bool:

--- a/test/test_vector_memory.py
+++ b/test/test_vector_memory.py
@@ -1157,6 +1157,7 @@ class TestMmrRerankNegativeScores:
         assert len(out) == 2
 
 
+@pytest.mark.xdist_group("vector_memory_concurrency")
 class TestVectorStoreConcurrency:
     """Writes are offloaded to worker threads (consolidation, dashboard) while
     reads (search_episodic via context assembly) run on the event loop thread.
@@ -1283,6 +1284,156 @@ class TestVectorStoreConcurrency:
         ), f"store broken after stress (transient errors seen: {transient!r})"
         lessons = store.get_lessons()
         assert any("zeta functionality" in str(ls.get("value_json", "")) for ls in lessons)
+
+    def test_concurrent_semantic_write_and_context_no_errors(self, tmp_path) -> None:
+        """get_semantic_context runs on executor threads (subagent context builds
+        via run_in_embed_pool) concurrent with set_semantic writers on worker
+        threads. Its SELECTs used to hit the shared connection WITHOUT _db_lock,
+        racing writers' implicit transactions and the per-connection statement
+        cache — observed in production as sqlite3.InterfaceError ("bad parameter
+        or other API misuse") from get_semantic_context, which propagates
+        unguarded through memory.get_context -> context.build_session_context
+        and kills the whole subagent run.
+
+        Unlike the lesson stress above, readers here must raise NOTHING: with
+        the fetches locked, every db access on this path is serialized, and the
+        production caller has no try/except to absorb a transient.
+        """
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        # Seed rows so the reader's scoring loop has real work between fetches.
+        for i in range(20):
+            store.set_semantic(f"project.seed.k{i:02d}", f"alpha beta value {i}", 1.0, "tool")
+
+        start_barrier = threading.Barrier(4)
+        errors: list[BaseException] = []
+
+        def _writer(n: int, tag: str) -> None:
+            start_barrier.wait()
+            try:
+                for i in range(n):
+                    store.set_semantic(f"project.stress.{tag}{i:03d}", f"gamma {i}", 1.0, "tool")
+            except BaseException as exc:  # noqa: BLE001 - capture any thread crash
+                errors.append(exc)
+
+        def _context_reader(n: int) -> None:
+            start_barrier.wait()
+            try:
+                for i in range(n):
+                    # Alternate branches: query-scored path and recency path.
+                    if i % 2:
+                        store.get_semantic_context(query_text="alpha beta gamma")
+                    else:
+                        store.get_semantic_context()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=_writer, args=(60, "a")),
+            threading.Thread(target=_writer, args=(60, "b")),
+            threading.Thread(target=_context_reader, args=(80,)),
+            threading.Thread(target=_context_reader, args=(80,)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+        assert not any(t.is_alive() for t in threads), "stress threads deadlocked"
+        assert not errors, f"concurrent set_semantic/get_semantic_context raised: {errors!r}"
+
+        # Coherence: a post-stress read returns the seeded entries intact.
+        ctx = store.get_semantic_context(query_text="alpha beta")
+        assert "project.seed.k00" in ctx
+
+    def test_concurrent_lesson_write_and_get_lessons_context_no_reader_errors(
+        self, tmp_path
+    ) -> None:
+        """get_lessons_context feeds the same unguarded context-injection path
+        (context.py calls it with no try/except), so with get_lessons' fetch
+        now serialized the READERS must not raise. Writer-side transients are
+        tolerated as in the lesson stress above — write_lesson still has
+        unlocked segments outside the fetch (embed, dedup logic).
+        """
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        for i in range(10):
+            store.write_lesson(
+                rule=f"seed lesson number {i} about distinct topic {i}",
+                category="tool",
+                source="consolidation",
+            )
+
+        start_barrier = threading.Barrier(4)
+        reader_errors: list[BaseException] = []
+
+        def _lesson_writer(n: int, tag: str) -> None:
+            start_barrier.wait()
+            for i in range(n):
+                try:
+                    store.write_lesson(
+                        rule=f"stress lesson {tag}{i:03d} about unique subject {tag}{i}",
+                        category="tool",
+                        source="consolidation",
+                    )
+                except Exception:  # noqa: BLE001 - writer transients tolerated
+                    pass
+
+        def _lesson_reader(n: int) -> None:
+            start_barrier.wait()
+            try:
+                for _ in range(n):
+                    store.get_lessons_context()
+            except BaseException as exc:  # noqa: BLE001
+                reader_errors.append(exc)
+
+        threads = [
+            threading.Thread(target=_lesson_writer, args=(30, "a")),
+            threading.Thread(target=_lesson_writer, args=(30, "b")),
+            threading.Thread(target=_lesson_reader, args=(80,)),
+            threading.Thread(target=_lesson_reader, args=(80,)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+        assert not any(t.is_alive() for t in threads), "stress threads deadlocked"
+        assert not reader_errors, f"get_lessons_context raised: {reader_errors!r}"
+
+    def test_stem_words_thread_safe(self) -> None:
+        """_stem_words used to share ONE module-level snowballstemmer instance.
+        The pure-Python stemmer keeps the word under stem as mutable instance
+        state (set_current -> _stem -> get_current), so concurrent
+        get_semantic_context calls (parallel subagent context builds)
+        interleaved that cursor and raised IndexError("string index out of
+        range") — or silently produced wrong stems. Now one instance per
+        thread: hammering _stem_words from many threads must neither raise nor
+        diverge from the single-threaded result.
+        """
+        vocab = [
+            f"word{i} running jumped happily nationalization {i}" for i in range(50)
+        ]
+        word_sets = [set(v.split()) for v in vocab]
+        expected = [_stem_words(ws) for ws in word_sets]
+
+        start_barrier = threading.Barrier(8)
+        errors: list[BaseException] = []
+
+        def _stemmer_worker() -> None:
+            start_barrier.wait()
+            try:
+                for _ in range(40):
+                    for ws, exp in zip(word_sets, expected):
+                        assert _stem_words(ws) == exp
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_stemmer_worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+        assert not any(t.is_alive() for t in threads), "stemmer threads deadlocked"
+        assert not errors, f"concurrent _stem_words raised/diverged: {errors!r}"
 
 
 @pytest.mark.skipif(not _HAS_NUMPY, reason="numpy not available (Linux-compiled binary)")


### PR DESCRIPTION
## Problem / Motivation

One of my subagents died mid-run with `sqlite3.InterfaceError: bad parameter or other API misuse` raised from `VectorMemoryStore.get_semantic_context` (full traceback in my gateway.log). The error propagates unguarded through `memory.get_context` → `context.build_session_context`, so the whole subagent run is killed instead of degrading gracefully.

## Why it matters

Any user running concurrent sessions or parallel subagents can lose an entire run to this race — the subagent just dies with a database error that has nothing to do with its task. It's nondeterministic and load-dependent, so it's exactly the kind of failure that erodes trust in background agents and is nearly impossible for a user to diagnose from the outside.

## What changed (motivation → approach → change)

Symptom: context assembly runs on executor threads (`run_in_embed_pool`) while memory writers run on worker threads, all sharing one `check_same_thread=False` sqlite connection. `get_semantic_context` and `get_lessons` executed their SELECTs without taking `_db_lock`, while every writer serializes on it — the class's own constructor comment and the earlier `_sqlite_vector_search` fix both document that unsynchronized statements on this shared connection corrupt each other (per-connection statement cache + implicit transactions). An unlocked fetch racing a writer surfaces as `InterfaceError: bad parameter or other API misuse`.

The fix follows the exact pattern already established in `_sqlite_vector_search`: lock ONLY the `fetchall()` (rows are fully materialized by then), and keep the blocking per-row embed calls in the scoring loop outside the lock, per the constructor's "never hold this across a blocking embed call" invariant. `_db_lock` is an RLock, so callers that already hold it (e.g. `delete_lesson`) remain safe.

While stress-testing that fix I found a second race on the same code path: `_stem_words` shared a single module-level `snowballstemmer` instance. The pure-Python stemmer keeps the word being stemmed as mutable instance state (`set_current()` → `_stem()` → `get_current()`), so concurrent `get_semantic_context` calls from parallel subagent context builds interleave that cursor and crash with `IndexError: string index out of range` — or worse, silently return wrong stems and degrade retrieval. The stemmer is now one instance per thread via `threading.local()`; construction is ~0.1µs once the language module is imported, so there's no meaningful cost.

## Tests

Three regression tests added to `TestVectorStoreConcurrency` in `test/test_vector_memory.py`, and I verified each fails on the unpatched code with the exact production error before passing with the fix:

- `test_concurrent_semantic_write_and_context_no_errors` — writers racing `get_semantic_context` readers (both query and recency branches) must raise nothing, because the production caller (`context.py`) has no try/except on this path. On unpatched code this reproduces the production `InterfaceError`.
- `test_concurrent_lesson_write_and_get_lessons_context_no_reader_errors` — same guarantee for the `get_lessons_context` injection path; writer-side transients remain tolerated as in the existing lesson stress test, since `write_lesson` still has unlocked segments outside the fetch.
- `test_stem_words_thread_safe` — 8 threads hammering `_stem_words` must neither raise nor diverge from the single-threaded stems. On unpatched code this catches both the `IndexError` and the silent wrong-stem corruption.

I ran the concurrency test class 40 consecutive times under pytest-xdist with zero failures to check for residual flakiness.

## Manual verification

I reproduced the failure signature from my own gateway.log (subagent killed at `vector_memory.py` `get_semantic_context` during a context build) and confirmed the fixed code survives a 200-iteration standalone stress harness of the same write/read pattern with no errors. Full backend suite: 29,723 passed; the 11 failures are pre-existing on pristine `main` in my environment (installer-signature and platform-dependent tests, unrelated to this diff).

## Related Issues

N/A — found via my own gateway.log; no existing issue filed.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior-preserving thread-safety fix; invariants documented in code comments
- [x] No secrets, credentials, or internal references in the diff
