### PR TITLE
fix(browser): resolve native-panel session key from host_pid for warm-pool proxies

### DIFF
--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -1872,8 +1872,11 @@ async def api_browser_command(request: web.Request) -> web.Response:
     """POST /api/browser/command — run one op against the native browser panel.
 
     Called by the Playwright MCP proxy. Body:
-    ``{"session_key": str, "op": str, "args": object, "timeout_ms"?: int}``.
-    Enqueues the op on the command bus and awaits the native panel's result.
+    ``{"op": str, "host_pid": int, "session_key"?: str, "args"?: object, "timeout_ms"?: int}``.
+    The session is resolved from ``host_pid`` (signed session_pid sidecar, same as
+    ``api_browser_frame``); ``session_key`` is only a fallback for per-session
+    spawns. Enqueues the op on the command bus and awaits the native panel's
+    result.
 
     Responses:
     - 200 ``{"id", "ok": true, "result": <any>}`` — op ran and succeeded;
@@ -1913,23 +1916,55 @@ async def api_browser_command(request: web.Request) -> web.Response:
             resources="invalid-json",
         )
         return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
-    session_key = body.get("session_key")
+    fallback_key = body.get("session_key")
     op = body.get("op")
     args = body.get("args")
     timeout_ms = body.get("timeout_ms")
-    if not isinstance(session_key, str) or not session_key or not isinstance(op, str) or not op:
+    if not isinstance(op, str) or not op:
         _sel().log_tool_invocation(
             session_key="dashboard",
             tool_name="browser_command",
             outcome="invalid_input",
             downstream_service="browser",
-            resources="missing session_key/op",
+            resources="missing op",
         )
-        return web.json_response({"error": "session_key and op required", "code": "session_key_and_op_required"}, status=400)
+        return web.json_response({"error": "op required", "code": "op_required"}, status=400)
     if args is not None and not isinstance(args, dict):
         return web.json_response({"error": "args must be an object", "code": "args_must_be_object"}, status=400)
     if not isinstance(timeout_ms, int) or isinstance(timeout_ms, bool) or timeout_ms <= 0:
         timeout_ms = DEFAULT_COMMAND_TIMEOUT_MS
+    # Resolve the AUTHORITATIVE session key from the posting proxy's host pid
+    # (gateway-signed session_pid sidecar), overriding the proxy's frozen-env key
+    # which is EMPTY under the warm pool -- the same resolution api_browser_frame
+    # does. Strip the "dashboard:" prefix so the key matches the BARE slot key the
+    # Electron panel registers via command-drain and dispatches on (see
+    # api_browser_frame for the identical normalization). The proxy-provided
+    # session_key is only a fallback for per-session spawns whose pid does not
+    # resolve.
+    resolved_key = await asyncio.to_thread(
+        _resolve_browse_session_key,
+        body.get("host_pid"),
+    )
+    if resolved_key:
+        session_key = resolved_key.removeprefix("dashboard:")
+    elif isinstance(fallback_key, str):
+        session_key = fallback_key
+    else:
+        session_key = ""
+    if not session_key:
+        # No identifiable session -> no panel we could address. Answer like the
+        # no-panel case (503) so the proxy falls back to Playwright, NOT 400: a
+        # 400 surfaces a hard MCP error to the agent instead of the graceful
+        # mirror path, and a warm-pool worker on a remote/non-Electron host (no
+        # sidecar to resolve) legitimately reaches here on every browser_* call.
+        _sel().log_tool_invocation(
+            session_key="dashboard",
+            tool_name="browser_command",
+            outcome="no_panel",
+            downstream_service="browser",
+            resources=op,
+        )
+        return web.json_response({"error": "no-native-panel", "code": "no_native_panel"}, status=503)
     bus = get_command_bus()
     try:
         outcome = await bus.submit(session_key, op, args or {}, timeout_ms=timeout_ms)

--- a/src/kiro_crew/mcp_playwright_proxy.py
+++ b/src/kiro_crew/mcp_playwright_proxy.py
@@ -811,15 +811,17 @@ def _try_native_tool_call(msg: dict[str, Any]) -> dict[str, Any] | None:
         # Not a browser tool (e.g. tools/list plumbing) -- never our concern.
         return None
 
+    # The frozen-env key is correct for per-session spawns but EMPTY for a
+    # warm-pool worker (pre-spawned before a slot is assigned, so
+    # KIROCREW_SESSION_KEY was never set). We do NOT bail on an empty key here:
+    # the command POST also carries this proxy's ``host_pid``, from which the
+    # GATEWAY resolves the AUTHORITATIVE session key by walking our process
+    # ancestry to the kiro-cli worker and verifying its signed session_pid
+    # sidecar -- the same mechanism the frame path already uses to make the live
+    # mirror work under the warm pool. When no native panel is registered for the
+    # resolved session the gateway answers 503 and we fall back to Playwright
+    # below, so attempting the POST costs nothing on a remote/non-Electron host.
     session_key = _SESSION_KEY
-    if not session_key:
-        # A warm-pool worker never had KIROCREW_SESSION_KEY frozen in, so we
-        # cannot say which panel to drive and native routing is INACTIVE for this
-        # session. Fall everything back to Playwright -- with nothing going
-        # native there is no split brain to guard against. (The frame path
-        # resolves the key from the session_pid sidecar via the gateway; doing
-        # the same here is a follow-up.)
-        return None
 
     op = _NATIVE_OPS.get(name)
     if op is None:
@@ -849,7 +851,12 @@ def _try_native_tool_call(msg: dict[str, Any]) -> dict[str, Any] | None:
         # fall back and silently mis-target on Playwright.
         return _native_error(msg.get("id"), arg_error)
 
-    body = json.dumps({"session_key": session_key, "op": op, "args": args}).encode()
+    # ``host_pid`` lets the gateway resolve the authoritative session key when
+    # ``session_key`` is empty (warm pool); ``session_key`` stays as the fallback
+    # for per-session spawns. Same pair the frame ingress accepts.
+    body = json.dumps(
+        {"session_key": session_key, "host_pid": os.getpid(), "op": op, "args": args}
+    ).encode()
     req = urllib.request.Request(
         _gateway_command_url(),
         data=body,

--- a/test/test_browser_command_bus.py
+++ b/test/test_browser_command_bus.py
@@ -261,8 +261,47 @@ async def test_handlers_reject_loopback_cookie_caller(fresh_bus) -> None:
 
 @pytest.mark.asyncio
 async def test_handler_command_missing_fields_400(fresh_bus) -> None:
-    resp = await msg.api_browser_command(_req({"op": "navigate"}))
+    # ``op`` is the only hard-required field now; a missing session identity is a
+    # graceful 503 (below), not a 400.
+    resp = await msg.api_browser_command(_req({"session_key": "s1"}))
     assert resp.status == 400
+    assert _body(resp)["code"] == "op_required"
+
+
+@pytest.mark.asyncio
+async def test_handler_command_no_session_identity_is_503_not_400(fresh_bus) -> None:
+    """op present but no resolvable session (no host_pid, empty fallback) ->
+    answer like no-panel (503) so the proxy falls back to Playwright, rather than
+    surfacing a hard 400 MCP error to the agent."""
+    resp = await msg.api_browser_command(_req({"op": "navigate", "args": {}}))
+    assert resp.status == 503
+    assert _body(resp)["error"] == "no-native-panel"
+
+
+@pytest.mark.asyncio
+async def test_handler_command_resolves_session_from_host_pid(fresh_bus, monkeypatch) -> None:
+    """The gateway resolves the authoritative key from host_pid, OVERRIDING the
+    proxy's empty frozen-env fallback, and strips the "dashboard:" prefix to
+    match the bare slot key the Electron panel registers via command-drain."""
+    monkeypatch.setattr(msg, "_resolve_browse_session_key", lambda _pid: "dashboard:chat-9")
+    # Panel registers under the BARE slot key (what Electron's listPanelIds yields).
+    drain_task = asyncio.create_task(
+        msg.api_browser_command_drain(_req({"session_keys": ["chat-9"], "wait_ms": 2000}))
+    )
+    await _wait_registered(fresh_bus, "chat-9")
+    # Warm-pool proxy: empty session_key, but host_pid resolves to chat-9.
+    submit_task = asyncio.create_task(
+        msg.api_browser_command(
+            _req({"session_key": "", "host_pid": 4242, "op": "navigate", "args": {"url": "http://x"}})
+        )
+    )
+    drain_resp = await drain_task
+    assert drain_resp.status == 200
+    assert _body(drain_resp)["session_key"] == "chat-9", "resolved+stripped key drives the panel"
+    await msg.api_browser_command_result(_req({"id": _body(drain_resp)["id"], "ok": True, "result": "ok"}))
+    submit_resp = await submit_task
+    assert submit_resp.status == 200
+    assert _body(submit_resp)["ok"] is True
 
 
 @pytest.mark.asyncio

--- a/test/test_browser_native_routing.py
+++ b/test/test_browser_native_routing.py
@@ -251,10 +251,65 @@ def test_transport_failure_does_fall_back() -> None:
         assert proxy._try_native_tool_call(_call()) is None
 
 
-def test_missing_session_key_falls_back_rather_than_guessing() -> None:
-    with patch.object(proxy, "_SESSION_KEY", ""):
-        # Mapped and unmapped alike fall back when native routing is inactive.
+def test_empty_session_key_delegates_resolution_to_gateway_via_host_pid() -> None:
+    """Warm pool: the frozen-env key is empty, so the proxy does NOT bail. It
+    sends its ``host_pid`` and lets the GATEWAY resolve the authoritative session
+    key (signed session_pid sidecar) -- the same mechanism the frame path uses.
+    A mapped op therefore still ATTEMPTS the native POST; only a transport gap
+    (503 / timeout) sends it to Playwright."""
+    import os as _os
+
+    seen: dict = {}
+
+    def _capture(req, timeout=None):
+        seen["body"] = json.loads(req.data.decode())
+        return _ok("navigated")
+
+    with patch.object(proxy, "_SESSION_KEY", ""), patch.object(
+        proxy.urllib.request, "urlopen", side_effect=_capture
+    ):
+        out = proxy._try_native_tool_call(_call())
+    assert out is not None and "result" in out, "an empty key must not short-circuit to Playwright"
+    assert seen["body"]["host_pid"] == _os.getpid(), "the proxy's pid is sent for gateway resolution"
+    assert seen["body"]["session_key"] == "", "the frozen-env key rides along as an empty fallback"
+
+
+def test_host_pid_is_sent_even_when_session_key_is_known() -> None:
+    """Per-session spawns also carry host_pid, so the gateway can prefer the
+    authoritative resolution and the two paths behave identically."""
+    seen: dict = {}
+
+    def _capture(req, timeout=None):
+        seen["body"] = json.loads(req.data.decode())
+        return _ok("navigated")
+
+    with _session("dashboard:chat-1"), patch.object(
+        proxy.urllib.request, "urlopen", side_effect=_capture
+    ):
+        assert proxy._try_native_tool_call(_call()) is not None
+    assert "host_pid" in seen["body"] and isinstance(seen["body"]["host_pid"], int)
+    assert seen["body"]["session_key"] == "dashboard:chat-1"
+
+
+def test_empty_session_key_still_falls_back_on_no_panel() -> None:
+    """When the gateway cannot resolve a panel it answers 503, and THAT (a
+    transport gap) is what routes the op to Playwright -- never a client guess."""
+    import urllib.error
+
+    err = urllib.error.HTTPError(
+        "http://127.0.0.1/api/browser/command", 503, "no-native-panel", {}, None  # type: ignore[arg-type]
+    )
+    with patch.object(proxy, "_SESSION_KEY", ""), patch.object(
+        proxy.urllib.request, "urlopen", side_effect=err
+    ):
         assert proxy._try_native_tool_call(_call()) is None
+
+
+def test_unmapped_tool_falls_back_until_a_panel_is_proven() -> None:
+    """An unmapped ``browser_*`` tool still falls back while no native panel has
+    answered, regardless of the session key -- the split-brain refusal only
+    engages once a panel is proven live."""
+    with patch.object(proxy, "_SESSION_KEY", ""), _panel_seen(False):
         assert proxy._try_native_tool_call(_call("browser_drag", {})) is None
 
 


### PR DESCRIPTION
## Problem

The merged native embedded browser panel never actually drove the page from
chat: every `browser_*` call fell back to the Playwright screenshot mirror. On
this install, navigating `www.amazon.com` produced only `browser_frame` / `pump`
SEL events and zero `browser_command` events — the native command path was never
exercised.

## Why it matters

The native panel (in-process `WebContentsView` + CDP control) is the whole point
of the embedded-browser work: real paint, real input, downloads, video. As long
as the agent silently routes through the Playwright mirror instead, that feature
is dead code for the common case, and future agent-drive-the-browser work has no
working substrate underneath it.

## Fix (symptom → root cause → change)

- **Symptom:** `browser_*` always uses Playwright; the native command endpoint is
  never called.
- **Root cause:** `mcp_playwright_proxy._try_native_tool_call` bailed out
  (`return None`) whenever its frozen-env `KIROCREW_SESSION_KEY` was empty — which
  is *always* the case for warm-pool proxy workers (pre-spawned before a slot is
  assigned, so the key was never injected). With no session key it could not name
  a panel, so it never even attempted native routing. This is the exact
  empty-key-under-warm-pool condition the **frame path already works around**
  server-side (`api_browser_frame` resolves the key from the proxy's `host_pid`),
  but the command path had that resolution as an unfinished follow-up.
- **Change:** mirror the frame path.
  - Proxy (`mcp_playwright_proxy.py`): stop returning early on an empty key; send
    `host_pid = os.getpid()` on every native command (the frozen key rides along
    only as a fallback for per-session spawns).
  - Gateway (`dashboard/handlers/messaging.py`, `api_browser_command`): resolve
    the **authoritative** session key from `host_pid` via
    `_resolve_browse_session_key` (the signed `session_pid` sidecar, identical to
    `api_browser_frame`), strip the `dashboard:` prefix so it matches the **bare**
    slot key the Electron panel registers under (`listPanelIds`), fall back to the
    body `session_key`, and — when nothing resolves — return **503 no-native-panel**
    (a graceful Playwright fallback) rather than 400, so a warm-pool worker on a
    remote/non-Electron host still degrades cleanly on every call. `op` is now the
    only hard-required field.

Net behavior: warm-pool proxies now drive the native panel; remote/non-Electron
and no-panel cases still fall back to Playwright exactly as before (503/504 →
fallback); no split-brain regression (the `_native_panel_seen` gate is untouched).

## Tests

- `test/test_browser_native_routing.py`: replaced the old "empty key falls back"
  test with (a) empty key now sends `host_pid` and still attempts native routing,
  (b) `host_pid` is sent even when the key is known, (c) a 503 from the gateway is
  what triggers Playwright fallback, (d) an unmapped `browser_*` tool still falls
  back until a panel is proven.
- `test/test_browser_command_bus.py`: `op`-missing → 400; op-present but no
  resolvable session → graceful 503 (not 400); and a new end-to-end test that the
  gateway resolves the key from `host_pid`, strips `dashboard:`, and drives the
  registered bare-key panel (overriding an empty body key).

Local gate: 112 backend tests pass; isort / flake8 clean; mypy clean on the two
changed source files (the only repo-wide mypy hits are pre-existing macOS
`os.*xattr` stub quirks in `hooks.py`, green on Linux CI). No `website/` changes,
so frontend gates are N/A.

## Manual verification

N/A for a rebuild-required live check in this session — unit coverage exercises
both the proxy (host_pid emission + fallback) and the gateway (resolution + strip
+ 503) halves. Live confirmation after a rebuild is: reopen the Browser panel,
navigate, and observe a `browser_command` SEL event with the screenshot pump
quiet, instead of the `browser_frame`/`pump` stream.

## Screenshots

N/A — backend routing change only, no user-visible UI surface.

## Security review note (documented rebuttal)

A local GPT review pass raised a **blocking High**: that resolving the session key
from `host_pid` could let a subagent's ancestor-walk reach the *parent* session's
signed sidecar and thereby drive the parent's native panel. After validation I am
**rebutting this as a false positive** (the parallel Opus pass reached the same
non-blocking conclusion independently). Evidence:

1. **Resolution is confined to the caller's own spawning session.**
   `_resolve_browse_session_key` walks *process ancestry* only. Subagents are
   either session-shared (running *inside the parent's* runtime — same session) or
   fresh gateway-child processes that never publish a `session_pid` sidecar
   (`publish_turn_identity` is only called from the chat/transport turn paths), so
   their walk terminates at the gateway → resolves to `""` → 503 → Playwright.
   There is **no process-ancestry path from one session's subagent to an unrelated
   session's sidecar**, so no cross-session escalation is reachable.
2. **Every native op is double-gated server-side** (`website/electron/main.js`
   dispatch): a command runs only against a **registered** panel for the resolved
   key (missing → absent-marker → Playwright fallback) **and** only when that
   panel's `agentAct` ("let the agent act") is enabled — the `navigate` bootstrap
   explicitly throws `agent-act-not-authorized`, and every other op goes through
   `setOwner(LIGHT, entry.gate())` which enforces the same.
3. **No new capability, parity with merged code.** A session-shared subagent
   already shares the parent runtime's MCP tools, so it could already issue
   `browser_*` calls; this only changes *where* the same call executes (native vs
   Playwright), gated identically. It is the exact resolution mechanism the
   already-merged `api_browser_frame` uses; the command path merely adds the
   `agentAct` gate on top.

The GPT-suggested remediation (restore the empty-key early return) would revert
the fix entirely, so it is declined in favor of this evidence-based rebuttal — no
correct code is contorted to silence the finding.
