### PR TITLE
docs: add Chris Boomhower to contributor list

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,7 @@ make this tool possible:
 <a href="https://github.com/ChaonengQuan" title="ChaonengQuan"><img src="https://github.com/ChaonengQuan.png?size=64" width="64" height="64" alt="ChaonengQuan" /></a>
 <a href="https://github.com/chenmingwei23" title="Raymond Chen"><img src="https://github.com/chenmingwei23.png?size=64" width="64" height="64" alt="Raymond Chen" /></a>
 <a href="https://github.com/chenyjade" title="Yu Cheng"><img src="https://github.com/chenyjade.png?size=64" width="64" height="64" alt="Yu Cheng" /></a>
+<a href="https://github.com/ChrisBoomhower" title="Chris Boomhower"><img src="https://github.com/ChrisBoomhower.png?size=64" width="64" height="64" alt="Chris Boomhower" /></a>
 <a href="https://github.com/chrispaton" title="Chris Paton"><img src="https://github.com/chrispaton.png?size=64" width="64" height="64" alt="Chris Paton" /></a>
 <a href="https://github.com/Christian-Sidak" title="Christian Sidak"><img src="https://github.com/Christian-Sidak.png?size=64" width="64" height="64" alt="Christian Sidak" /></a>
 <a href="https://github.com/cixuuz" title="cixuuuuuuuuz"><img src="https://github.com/cixuuz.png?size=64" width="64" height="64" alt="cixuuuuuuuuz" /></a>


### PR DESCRIPTION
Adds **@ChrisBoomhower** to the README **Contributors** list, inserted in alphabetical order by GitHub username (between `chenyjade` and `chrispaton`).

The Contributors section explicitly invites this:
> If you contributed and would like to be added, corrected, or removed, please open an issue or a pull request.

### Contributions
- MeshClaw core CRs (merged internally)
- PR #1481 — `fix(cron): add timeout to post-kill proc.communicate() to prevent executor pool deadlock`

### Notes
- Single commit, based on current `main` HEAD (0 commits behind), single-file diff — keeps PR Hygiene / single-commit enforcement green.