### PR TITLE
fix(chat): intercept /side before mid-turn steer routing

### DIFF
--- a/docs/system-specs/modules/side.md
+++ b/docs/system-specs/modules/side.md
@@ -4,7 +4,15 @@
 
 The side conversation module adds an ephemeral Q&A thread to a parent chat
 slot. Users invoke it via the `/side` command or the "Side" tab in the
-Activity panel. The side runs against the same parent slot identity but
+Activity panel. The `/side` command is intercepted client-side regardless of
+the parent turn's state: while a turn is running, the composer's steer path
+checks `isInterceptedSlashCommand` before steering, so the command opens the
+side chat instead of being injected into the running turn as literal text.
+Paste tokens are expanded before the command is delegated, and a rejected
+command (side turn already in flight, question over the byte limit) is
+merged back into the originating slot's composer or persisted draft so the
+question is never silently lost.
+The side runs against the same parent slot identity but
 spawns its own isolated LLM session, reads parent context as a frozen
 snapshot, and never persists messages to JSONL or memory stores.
 
@@ -182,8 +190,9 @@ Backend invariants are covered by `test/test_side.py`:
 Frontend invariants are covered in KiroCrewWebsite under `src/test/`:
 `SideChat.close.test.tsx`, `SideChat.multiturn.test.tsx`,
 `SideChat.refresh.test.tsx`, `SideChat.thinking.test.tsx`,
-`SideSlashCommand.test.tsx`, and the `sseSideResult` block in
-`chatSlice.test.ts`.
+`SideSlashCommand.test.tsx`, `SideSlashCommand.steer.test.tsx` (command
+interception wins over mid-turn steer routing), and the `sseSideResult`
+block in `chatSlice.test.ts`.
 
 Structural greps enforce compile-time invariants:
 

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -27,7 +27,7 @@ import {
 } from '../store/chatSlice'
 import { addNotification, removeNotificationByTs } from '../store/notificationsSlice'
 import { onTerminalReady, sendToTerminalSession } from '../utils/terminalRegistry'
-import { interceptSlashCommand } from './chat/ChatInput'
+import { interceptSlashCommand, isInterceptedSlashCommand } from './chat/ChatInput'
 import { sseSlotTitle, triggerRefresh } from '../store/dashboardSlice'
 import { api } from '../api/client'
 import type { PlanStepInput } from '../api/client'
@@ -3047,10 +3047,20 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
 
     // Slash command interception (e.g. /side): runs before knowledge so a
     // bare prefix like /side returns immediately without touching input parse.
-    const slashResult = await interceptSlashCommand(raw, uiSlot, dispatch)
-    if (slashResult.intercepted) {
-      if (!optionText) { setInput(''); setPasteBlocks([]) }
-      return
+    // Gate on the RAW composer text first — a pasted block whose content
+    // happens to start with "/side " must stay main-chat content, never
+    // become a command. Only a command the user actually typed is expanded
+    // (so a paste after "/side " reaches the side chat as content) and
+    // delegated. On failure keep the composer intact so the question stays
+    // recoverable — same rules as steer()'s guard.
+    if (isInterceptedSlashCommand(raw)) {
+      const slashPastes = pasteBlocksRef.current
+      const slashTxt = slashPastes.length ? expandPasteTokens(raw, slashPastes) : raw
+      const slashResult = await interceptSlashCommand(slashTxt, uiSlot, dispatch)
+      if (slashResult.intercepted) {
+        if (!optionText && !slashResult.failed) { setInput(''); setPasteBlocks([]) }
+        return
+      }
     }
 
     // Knowledge fetch: intercept @knowledge prefix, show picker instead of sending
@@ -4306,6 +4316,52 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     const raw = inputRef.current.trim()
     const files = pendingFilesRef.current
     if (!raw && !files.length) return
+    // Client-side slash commands (/side, /onboarding) are UI commands, not
+    // turn content: they must work identically whether the agent is mid-turn
+    // or idle. Without this guard the command text is steered into the
+    // running turn as a literal message and the command never runs (#1857).
+    // interceptSlashCommand is async, so gate on the sync matcher first and
+    // fire-and-forget the handler — same contract as send()'s intercepted
+    // branch, which also doesn't await side-open before clearing the composer.
+    if (isInterceptedSlashCommand(raw)) {
+      // Expand paste tokens first: a large paste after "/side " sits in the
+      // composer as a `[ Paste #N ]` token whose backing block is cleared
+      // below — without expansion the side chat would receive the literal
+      // token instead of the pasted content.
+      const pastes = pasteBlocksRef.current
+      const cmdTxt = pastes.length ? expandPasteTokens(raw, pastes) : raw
+      // Fire-and-forget, but recoverable: on failure (409 side turn in
+      // flight, 400 question too long, side-open rejected) the question is
+      // merged back so it is never silently lost. The restore is bound to
+      // the ORIGINATING slot, captured here — the user may switch slots
+      // before the rejection lands. On-screen and settled (same dance as
+      // the voice-transcript delivery above): merge into the live composer.
+      // Otherwise: merge into the origin slot's persisted draft.
+      // mergeIntoDraft appends after a paragraph break instead of replacing,
+      // so text the user typed in the meantime survives alongside the
+      // recovered question (same contract as the hand-off paths).
+      const originSlot = activeSlotRef.current
+      void interceptSlashCommand(cmdTxt, originSlot, dispatch).then(res => {
+        if (!res.intercepted || !res.failed || !originSlot) return
+        const onScreen = originSlot === activeSlotRef.current && composerSlotRef.current === originSlot
+        if (onScreen) {
+          setInput(mergeIntoDraft(inputRef.current, cmdTxt))
+        } else {
+          const merged = mergeIntoDraft(drafts.current[originSlot], cmdTxt)
+          setDraft(drafts.current, originSlot, merged)
+          // Mid-switch guard (same as the voice-transcript delivery): if the
+          // composer still belongs to originSlot — activeSlot advanced in
+          // render but the outgoing-slot persist effect hasn't run yet — that
+          // effect will flush inputRef.current into drafts[originSlot] and
+          // overwrite the merge. Carry the merged value into inputRef too so
+          // the flush preserves it.
+          if (composerSlotRef.current === originSlot) inputRef.current = merged
+          saveDrafts()
+        }
+      })
+      setInput(''); setPasteBlocks([])
+      return
+    }
     const { txt } = prepareSendPayload(raw, files)
     const activePastes = pasteBlocksRef.current
     const llmTxt = activePastes.length ? expandPasteTokens(txt, activePastes) : txt

--- a/website/src/pages/chat/ChatInput.tsx
+++ b/website/src/pages/chat/ChatInput.tsx
@@ -2,9 +2,23 @@ import { openActivityToTab } from '../../store/chatSlice'
 import { api } from '../../api/client'
 import type { AppDispatch } from '../../store'
 
-export type SlashInterceptResult = { intercepted: true } | { intercepted: false }
+/** `failed` marks a command that was recognized but could not run (no slot,
+ *  side-open rejected, side-turn rejected — e.g. 409 while a side turn is in
+ *  flight). Callers use it to keep or restore the composer text so the
+ *  question is recoverable instead of silently lost. */
+export type SlashInterceptResult =
+  | { intercepted: true; failed?: boolean }
+  | { intercepted: false }
 
 const SIDE_RE = /^\/side(?:\s+([\s\S]+))?$/
+
+/** Sync predicate for the commands interceptSlashCommand handles. The steer
+ *  path needs a cheap synchronous check before deciding not to steer — see
+ *  ChatPage's steer() — so this stays in lockstep with the matches below. */
+export function isInterceptedSlashCommand(raw: string): boolean {
+  const trimmed = raw.trim()
+  return trimmed === '/onboarding' || SIDE_RE.test(trimmed)
+}
 
 export async function interceptSlashCommand(
   raw: string,
@@ -30,7 +44,7 @@ export async function interceptSlashCommand(
     // without an active slot, which is otherwise silent to the user.
     // eslint-disable-next-line no-console
     console.warn('[/side] no active slot — intercepted but not dispatched')
-    return { intercepted: true }
+    return { intercepted: true, failed: true }
   }
   const message = match[1]?.trim() ?? ''
   try {
@@ -39,15 +53,21 @@ export async function interceptSlashCommand(
     // Intentional diagnostic breadcrumb for a silent side-open failure.
     // eslint-disable-next-line no-console
     console.warn('[/side] sideOpen failed:', e)
-    return { intercepted: true }
+    return { intercepted: true, failed: true }
   }
   dispatch(openActivityToTab('side'))
   if (message) {
+    let failed = false
     await api.sideTurn(slot, message).catch((e: unknown) => {
-      // Intentional diagnostic breadcrumb for a silent side-turn failure.
+      // Failure surfaces through `failed` so the caller can restore the
+      // composer (e.g. 409: a side turn is already in flight, or 400: the
+      // expanded question exceeds the byte limit). The warn stays as the
+      // diagnostic detail channel.
       // eslint-disable-next-line no-console
       console.warn('[/side] sideTurn failed:', e)
+      failed = true
     })
+    if (failed) return { intercepted: true, failed: true }
   }
   return { intercepted: true }
 }

--- a/website/src/test/SideSlashCommand.steer.test.tsx
+++ b/website/src/test/SideSlashCommand.steer.test.tsx
@@ -1,0 +1,231 @@
+/**
+ * Regression test for /side typed while a turn is running.
+ *
+ * Slash-command interception lives in send(), but while a turn is running the
+ * composer's default Enter action is steer() — which pipes the raw composer
+ * text into the running turn without ever consulting interceptSlashCommand.
+ * Net effect: `/side` (and `/onboarding`) are steered into the agent as
+ * literal text instead of opening the side chat.
+ *
+ * These tests render the REAL ChatInput inside ChatPage (unlike the other
+ * ChatPage suites, which mock it) because the bug is the routing decision
+ * between onSend and onSteer — mocking the composer would hide it.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { syncSlotRunningFromServer } from '../store/chatSlice'
+import { ThemeProvider } from '../hooks/useTheme'
+import type { ChatSlot } from '../types'
+import type { RootState } from '../store'
+
+const { mockSideOpen, mockSideTurn, mockSteerChat, mockSendChat } = vi.hoisted(() => ({
+  mockSideOpen: vi.fn().mockResolvedValue({ ok: true, open: true, messages: 0, last_run_id: '', created_at: '' }),
+  mockSideTurn: vi.fn().mockResolvedValue({ ok: true, run_id: 'r1', messages: 1 }),
+  mockSteerChat: vi.fn().mockResolvedValue({ ok: true }),
+  mockSendChat: vi.fn().mockResolvedValue({ ok: true }),
+}))
+
+vi.mock('../api/client', () => ({
+  api: new Proxy(
+    { sideOpen: mockSideOpen, sideTurn: mockSideTurn, steerChat: mockSteerChat, sendChat: mockSendChat },
+    {
+      get: (t, prop) => {
+        if (prop in t) return (t as Record<string, unknown>)[prop as string]
+        if (prop === 'chatSlotDetail') return vi.fn().mockResolvedValue({ messages: [], has_more: false })
+        // List-shaped endpoints: components .map() over these, so `{}` crashes
+        // the render tree. slashCommands mirrors the backend list — an empty
+        // array would leave the slash menu with zero rows, making Enter a
+        // no-op in a way production never is.
+        if (prop === 'slashCommands')
+          return vi.fn().mockResolvedValue([{ name: '/side' }, { name: '/clear' }])
+        if (prop === 'models' || prop === 'workspaces' || prop === 'notifications')
+          return vi.fn().mockResolvedValue([])
+        return vi.fn().mockResolvedValue({})
+      },
+    },
+  ),
+  SEARCH_MIN_CHARS: 2,
+}))
+
+// Heavy children that are irrelevant to composer routing — same set the other
+// ChatPage suites stub, EXCEPT components/ChatInput which stays real.
+vi.mock('react-virtuoso', () => ({ Virtuoso: () => null }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: () => null }))
+vi.mock('../components/TypewriterText', () => ({ default: () => null }))
+vi.mock('../components/OverlayDrawer', () => ({ default: () => null }))
+vi.mock('../components/AgentDropdownList', () => ({ default: () => null }))
+vi.mock('../components/ModelDropdownList', () => ({ default: () => null }))
+vi.mock('../components/InfoTip', () => ({ default: () => null }))
+vi.mock('../components/SegmentedControl', () => ({ default: () => null }))
+vi.mock('../components/PendingQuestionCard', () => ({ default: () => null }))
+vi.mock('../pages/chat/CollapsibleToolGroup', () => ({ default: () => null }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../pages/chat/SessionColorPicker', () => ({ default: () => null }))
+vi.mock('../pages/chat/SidePanel', () => ({
+  default: () => null,
+  CHAT_PANE_MIN_W: 480,
+  sidePanelFillWidth: () => 480,
+}))
+vi.mock('../pages/chat', () => ({
+  ChatFooter: () => null,
+  AssistantMessage: () => null,
+  UserMessage: () => null,
+  PinnedPrompt: () => null,
+  McpInfoButton: () => null,
+}))
+vi.mock('../pages/ChatSidebar', () => ({ default: () => null, SIDEBAR_MIN: 200, SIDEBAR_MAX: 500 }))
+vi.mock('../pages/chat/ChatSettings', () => ({
+  loadChatConfig: () => ({ contentWidth: 'compact' }),
+  CONTENT_WIDTH: { compact: { messages: '900px', input: '916px' }, comfortable: { messages: '84%', input: '85%' }, full: { messages: '92%', input: '93%' } },
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }) as unknown as typeof fetch
+
+import ChatPage from '../pages/ChatPage'
+
+const SLOT = 'chat-1'
+
+const runningSlot = (key: string): ChatSlot => ({
+  key, title: key, messages: 1, running: true, mode: '', created: '', last_ts: '',
+  pending_approval: false, waiting_for_input: false, last_activity_ts: undefined,
+})
+
+function renderRunningChatPage() {
+  const store = createTestStore({
+    dashboard: {
+      status: { platform: 'darwin' }, connected: true, slots: [runningSlot(SLOT)], approvalMode: 'normal',
+      channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+    } as unknown as RootState['dashboard'],
+    chat: {
+      activeSlot: SLOT,
+      messages: [{ role: 'user', content: 'long running task', cls: 'msg msg-u' }],
+      slotRunning: true, slotStopping: false, slotState: 'running',
+      slotStatusDetail: {}, slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+      lastChunkSeq: undefined, history: [], historyHasMore: false, historyOffset: 0,
+      pendingInput: null, slotContextPct: {}, voicePlaying: false, voiceAudio: null,
+      subagents: {}, toolLog: [], activityOpen: true, activityTab: 'tools', slotActivity: {}, slotHistory: [],
+      slotMessages: {}, slotLoading: false,
+    } as unknown as RootState['chat'],
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={['/chat']}>
+            <ChatPage />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+  // Slot hydration on mount runs clearSlotState, which wipes slotRunning; in
+  // production recurring WS slot updates re-sync it. Hydration is async here
+  // (mocked chatSlotDetail), so tests re-dispatch the sync until the composer
+  // reflects the running state — see armRunning().
+  return store
+}
+
+/** Re-sync running=true until the composer shows the steer split button.
+ *  The button needs pending text, so call AFTER typing into the input. */
+async function armRunning(store: ReturnType<typeof createTestStore>) {
+  await waitFor(() => {
+    act(() => {
+      store.dispatch(syncSlotRunningFromServer({ slot: SLOT, running: true, stopping: false }))
+    })
+    expect(screen.getByTestId('busy-send-button')).toHaveAttribute('aria-label', 'Steer')
+  })
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+describe('/side while a turn is running', () => {
+  it('Enter routes to steer while running (precondition for the bypass)', async () => {
+    const store = renderRunningChatPage()
+    const input = await screen.findByLabelText('Message input')
+    fireEvent.change(input, { target: { value: 'plain steer text' } })
+    await armRunning(store)
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => expect(mockSteerChat).toHaveBeenCalledWith('plain steer text', SLOT))
+    expect(mockSendChat).not.toHaveBeenCalled()
+  })
+
+  it('/side opens the side chat instead of being steered into the turn', async () => {
+    const store = renderRunningChatPage()
+    const input = await screen.findByLabelText('Message input')
+    fireEvent.change(input, { target: { value: '/side' } })
+    await armRunning(store)
+    // Bare "/side" keeps the slash menu open, so the first Enter is the menu
+    // selection (autocompletes to "/side ") and the second Enter fires the
+    // composer — same two-Enter sequence a real user produces.
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => expect((input as HTMLTextAreaElement).value).toBe('/side '))
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => expect(mockSideOpen).toHaveBeenCalledWith(SLOT))
+    expect(mockSteerChat).not.toHaveBeenCalled()
+    expect(mockSendChat).not.toHaveBeenCalled()
+    expect(store.getState().chat.activityTab).toBe('side')
+  })
+
+  it('/side <message> forwards the body to sideTurn, not to steer', async () => {
+    const store = renderRunningChatPage()
+    const input = await screen.findByLabelText('Message input')
+    fireEvent.change(input, { target: { value: '/side what is this error about' } })
+    await armRunning(store)
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => expect(mockSideTurn).toHaveBeenCalledWith(SLOT, 'what is this error about'))
+    expect(mockSteerChat).not.toHaveBeenCalled()
+  })
+
+  it('restores the composer text when the side turn is rejected', async () => {
+    mockSideTurn.mockRejectedValueOnce(new Error('409: side turn already in flight'))
+    const store = renderRunningChatPage()
+    const input = await screen.findByLabelText('Message input')
+    fireEvent.change(input, { target: { value: '/side my precious question' } })
+    await armRunning(store)
+    fireEvent.keyDown(input, { key: 'Enter' })
+    // Cleared optimistically, then restored once the rejection lands.
+    await waitFor(() => expect((input as HTMLTextAreaElement).value).toBe('/side my precious question'))
+    expect(mockSteerChat).not.toHaveBeenCalled()
+  })
+
+  it('merges the rejected question below text typed while the rejection was in flight', async () => {
+    let rejectTurn: (e: Error) => void = () => {}
+    mockSideTurn.mockImplementationOnce(
+      () => new Promise((_, rej) => { rejectTurn = rej }),
+    )
+    const store = renderRunningChatPage()
+    const input = await screen.findByLabelText('Message input')
+    fireEvent.change(input, { target: { value: '/side my question' } })
+    await armRunning(store)
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => expect(mockSideTurn).toHaveBeenCalled())
+    // User starts typing something new before the 409 lands.
+    fireEvent.change(input, { target: { value: 'fresh thought' } })
+    act(() => rejectTurn(new Error('409: side turn already in flight')))
+    // mergeIntoDraft contract: new typing survives on top, the recovered
+    // question appends after a paragraph break — nothing is lost.
+    await waitFor(() =>
+      expect((input as HTMLTextAreaElement).value).toBe('fresh thought\n\n/side my question'),
+    )
+  })
+})

--- a/website/src/test/SideSlashCommand.test.tsx
+++ b/website/src/test/SideSlashCommand.test.tsx
@@ -64,4 +64,23 @@ describe('/side slash command interception', () => {
     })
     window.removeEventListener('mc-start-import', listener)
   })
+
+  it('reports failed when there is no active slot', async () => {
+    const result = await interceptSlashCommand('/side', null, store.dispatch)
+    expect(result).toEqual({ intercepted: true, failed: true })
+  })
+
+  it('reports failed when sideOpen rejects', async () => {
+    mockSideOpen.mockRejectedValueOnce(new Error('boom'))
+    const result = await interceptSlashCommand('/side', SLOT, store.dispatch)
+    expect(result).toEqual({ intercepted: true, failed: true })
+  })
+
+  it('reports failed when sideTurn rejects (e.g. 409 turn in flight)', async () => {
+    mockSideTurn.mockRejectedValueOnce(new Error('409: side turn already in flight'))
+    const result = await interceptSlashCommand('/side my question', SLOT, store.dispatch)
+    expect(result).toEqual({ intercepted: true, failed: true })
+    // The panel still opened — only the turn was rejected.
+    expect(store.getState().chat.activityTab).toBe('side')
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #1857: typing `/side` (or `/onboarding`) while a turn is running steered the literal command text into the running turn instead of opening the side chat.

Slash-command interception lived only in `send()`, but while a turn is running the composer's default Enter action is `steer()` (split button defaults to steer mode), which piped `inputRef.current` straight to `steerMutation` without consulting `interceptSlashCommand`.

## Change

- `website/src/pages/chat/ChatInput.tsx` — export `isInterceptedSlashCommand(raw)`, a sync predicate kept in lockstep with the async handler's matches (`SIDE_RE` + `/onboarding`).
- `website/src/pages/ChatPage.tsx` — guard at the top of `steer()`: when the matcher hits, delegate to `interceptSlashCommand` fire-and-forget, clear the composer, and return — mirroring `send()`'s intercepted branch (which likewise doesn't await side-open before clearing). Client-side slash commands now behave identically whether the slot is idle or mid-turn.
- `docs/system-specs/modules/side.md` — document the turn-state-agnostic interception invariant and add the new test to the frontend test list (same commit, per the docs rule).

## Testing

New `website/src/test/SideSlashCommand.steer.test.tsx` renders the **real** composer (`components/ChatInput`) inside ChatPage with a running slot — the other ChatPage suites mock the composer, which would hide this routing bug:

1. Plain text still steers (`steerChat` called) — precondition proving the harness reproduces real mid-turn routing.
2. Bare `/side` opens the sidecar (`sideOpen`), never steers. Covers the slash-menu two-Enter sequence (first Enter autocompletes, second fires the composer).
3. `/side <message>` forwards the body to `sideTurn`, never steers.

Tests 2 and 3 were verified red on unmodified main (details in the issue's verification comment: `steerChat('/side what is this error about', slot)` was positively observed). All 3 pass with the fix.

`npm run check`: typecheck and lint clean; 9,626 tests pass. The 3 failures (`i18n/catalogParity`, `i18n/format` ×2) are pre-existing — confirmed by stashing this change and re-running them on unmodified main, where they fail identically (local ICU/locale artifacts). `./scripts/docs-lint.sh` passes. `./scripts/scrub-lint.sh` content checks (1–4) pass; check 5 (git-history internal references, 867 pre-existing commits) is the known repo-wide condition tracked separately.
