### PR TITLE
fix(skills): truncate index descriptions, drop dir, disable trigger matcher

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -1596,7 +1596,7 @@
       "hasChildren": true,
       "enumValues": null,
       "defaultValue": {
-        "max_triggered": 3,
+        "max_triggered": 0,
         "lazy_load": false,
         "auto_create_from_sessions": false,
         "auto_refine_on_deviation": false,
@@ -1621,10 +1621,10 @@
       "sensitive": false,
       "tags": [],
       "label": "Max Triggered",
-      "help": "Maximum number of skills a single message may flag as relevant (≥0). Each match injects that skill's full content, unless the skill sets inject_on_trigger: false in its frontmatter, in which case it contributes a one-line pointer naming it and its path and the agent reads the file if the skill applies. Set to 0 to stop flagging entirely and rely only on the Available Skills index, $skillname, and skill_search.",
+      "help": "Maximum number of skills to load per message (≥0). Defaults to 0 (disabled); set to a positive integer to re-enable per-turn trigger matching.",
       "hasChildren": false,
       "enumValues": null,
-      "defaultValue": 3
+      "defaultValue": 0
     },
     {
       "path": "skills.lazy_load",

--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -630,7 +630,7 @@ class MessagingConfig:
 
 @dataclass
 class SkillsConfig:
-    max_triggered: int = 3         # max skills loaded per message (>=1)
+    max_triggered: int = 0         # max skills loaded per message (>=0)
     lazy_load: bool = False        # inject only a usage-ranked top-K of on-demand skills (long tail via skill_search / $skillname / triggers); off = legacy full skills dump
     # ... auto_create_from_sessions / auto_refine_on_deviation / extra_paths
 

--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -609,7 +609,7 @@ Skills with auxiliary files (scripts, assets) include `dir` path so the LLM can 
 - **OFF** (`get_context(budget=None)`): the byte-for-byte legacy full dump — every on-demand skill summarized, unranked and untruncated, under the flat 165k `_CONTEXT_BUDGET_BASE`.
 - **ON** (`get_context(budget)`): `always: true` pinned skills are injected in full, plus a usage-ranked **top-K** of on-demand skills filled up to `budget`. Ranking is by `_rank_key` (`skills.py`) — `(usage_hits, effective_recency)` from the `SkillUsageLedger`, with a recency boost so freshly-added skills escape cold start. The long tail is left discoverable via the `skill_search` tool, the `$skillname` inline token, `cat`, and the per-message trigger auto-loader.
 
-**Usage ledger (`skill_usage.py`, `SkillUsageLedger`):** in-memory per-skill hit tally with debounced, atomic persistence to `skill-usage.json` (`SKILL_USAGE_FILENAME`, co-located with the Kiro Crew home). Entries older than a 30-day TTL (`_MAX_AGE_SECS`) are dropped on load/flush so a stale skill stops occupying a top-K slot. Hits are recorded in `get_triggered_skills` (`_record_use`) and `resolve_dollar_skills` **regardless of the `lazy_load` flag**, so ranking data accrues even while the feature is off. Best-effort: ledger init failure falls back to recency-only / unweighted ranking without breaking skill loading.
+**Usage ledger (`skill_usage.py`, `SkillUsageLedger`):** in-memory per-skill hit tally with debounced, atomic persistence to `skill-usage.json` (`SKILL_USAGE_FILENAME`, co-located with the Kiro Crew home). Entries older than a 30-day TTL (`_MAX_AGE_SECS`) are dropped on load/flush so a stale skill stops occupying a top-K slot. Hits are recorded in two places: the **body-delivery loop** in `context.py` (`_record_use`, called only after `load_skill` succeeds and the body is appended to the prompt) and in `resolve_dollar_skills`. However, since `max_triggered` defaults to 0 the body-delivery recorder is inactive in stock config — `$skillname` is the only source of hits, so lazy-load ranking is effectively recency-only unless the trigger matcher is re-enabled (`max_triggered > 0`). A trigger match alone does NOT earn a hit — only actual delivery does, so pointer-only skills and false-positive matches do not inflate the ranking. Best-effort: ledger init failure falls back to recency-only / unweighted ranking without breaking skill loading.
 
 **`skill_search` MCP tool (`kirocrew-core`):** greps skill name/description then, only on a metadata miss, the skill body (bounded, tool-call only — never per message). Schema in `mcp_core.py`, validated against `SKILL_SEARCH_SCHEMA` (`validation.py`). Does NOT record usage — searching is not using. Scope is **locally installed skills only**.
 
@@ -778,8 +778,9 @@ setting that the runtime reads must be added to that carry list, or an unrelated
 approval will silently undo it.
 
 Unchanged: `always: true` pinned skills (skipped by the matcher entirely) and the
-explicit `$skillname` token. Set `skills.max_triggered = 0` to stop flagging
-altogether and rely only on the index, `$skillname`, and `skill_search`. The
+explicit `$skillname` token. `skills.max_triggered` defaults to 0 (disabled): the
+trigger matcher does not fire in stock config, so the agent relies only on the
+index, `$skillname`, and `skill_search`. Set to a positive integer to re-enable. The
 pointer block is attributed as `skill_hint` in the per-turn context breakdown, so
 it is never folded into whatever precedes it.
 
@@ -796,14 +797,7 @@ opt-out is stateless and has neither failure mode. Dedup remains a legitimate
 future addition — it is orthogonal, since re-sending a body ACP already replays
 does nothing for enforcement even on a skill that must be enforced.
 
-**What `_record_use` counts.** A trigger match, which is what it has always
-counted — the call sits in `get_triggered_skills` ahead of any delivery decision,
-as it did when delivery was unconditional. Decoupling delivery does make the
-consequence plainer: the lazy-load hotness ledger accrues hits for skills the
-agent may never read, so a matcher false positive still earns ranking weight.
-That is pre-existing, and cheaper to correct now that a false positive costs a
-line rather than a body — measuring the matcher's false-positive rate is the
-prerequisite, not a change to the ledger.
+**What `_record_use` counts.** Actual body delivery — the call now sits in the body-delivery loop in `context.py`, after `load_skill` confirms the content and the body is appended to the prompt. Only skills whose body is actually injected earn a hit; pointer-only skills (`inject_on_trigger: false`) and undelivered false positives contribute nothing to the ranking. The `resolve_dollar_skills` path also records, since `$skillname` is an intentional user action. With `max_triggered` defaulting to 0 in stock config, this recorder is inactive — only `resolve_dollar_skills` contributes hits unless the trigger matcher is re-enabled. This ensures the lazy-load hotness ledger ranks by actual utility to the agent, not by how often the word-overlap matcher fires on common words.
 
 **CRUD operations** (via `SkillsLoader`):
 - `create_skill(name, content)` — creates `{name}/SKILL.md`, supports nested paths
@@ -991,7 +985,7 @@ Opt-in secondary flag, gated by `auto_create_from_sessions`. When on, the consol
 ```json
 {
   "skills": {
-    "max_triggered": 3,
+    "max_triggered": 0,
     "auto_create_from_sessions": false,
     "approval_required": true,
     "auto_refine_on_deviation": false,

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2234,16 +2234,16 @@ class ExternalRegistryConfig:
 @dataclass
 class SkillsConfig:
     max_triggered: int = field(
-        default=3,
+        default=0,
         metadata=_meta(
             "Max Triggered",
             "Maximum number of skills a single message may flag as relevant (≥0). "
             "Each match injects that skill's full content, unless the skill sets "
-            "inject_on_trigger: false in its frontmatter, in which case it "
-            "contributes a one-line pointer naming it and its path and the agent "
-            "reads the file if the skill applies. Set to 0 to stop flagging "
-            "entirely and rely only on the Available Skills index, $skillname, "
-            "and skill_search.",
+            "inject_on_trigger: false (pointer-only; requires max_triggered > 0 to "
+            "have any effect). Defaults to 0 (disabled): the agent discovers skills "
+            "from the Available Skills index and reads them on demand via cat, "
+            "$skillname, or skill_search. Set to a positive integer to re-enable "
+            "per-turn word-overlap trigger matching.",
         ),
     )
     # ── Lazy skill injection (opt-in, like MCP prewarm) ──
@@ -5096,7 +5096,7 @@ class KiroCrewConfig:
             ),
             heartbeat=HeartbeatConfig(default_deliver=heartbeat_default_deliver),
             skills=SkillsConfig(
-                max_triggered=_safe_int(skills_data.get("max_triggered", 3), 3),
+                max_triggered=_safe_int(skills_data.get("max_triggered", 0), 0),
                 lazy_load=bool(skills_data.get("lazy_load", False)),
                 auto_create_from_sessions=bool(skills_data.get("auto_create_from_sessions", False)),
                 auto_refine_on_deviation=bool(skills_data.get("auto_refine_on_deviation", False)),

--- a/src/kiro_crew/docs/configuration.md
+++ b/src/kiro_crew/docs/configuration.md
@@ -96,7 +96,7 @@ Set via `kirocrew config set agent.sandbox auto`.
     "history_max_days": 365
   },
   "skills": {
-    "max_triggered": 3
+    "max_triggered": 0
   },
   "knowledge": {
     "auto_ingest_artifacts": true,
@@ -205,7 +205,7 @@ them, so there is no enable switch here: only knobs for *which* model runs.
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `skills.max_triggered` | Maximum skills loaded per message (at least 1) | `3` |
+| `skills.max_triggered` | Maximum skills loaded per message (>=0) | `0` |
 | `skills.lazy_load` | Inject only a usage-ranked top-K of on-demand skills at session start and leave the long tail discoverable via search, so a large skills set cannot crowd out memory and lessons | `false` |
 
 ### Knowledge Library

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -61,8 +61,13 @@ def _matches_any(path: str, globs: list[str]) -> bool:
 # affords a bounded slice of the context budget, so on-demand skills are ranked
 # by usage and summarized top-down; the tail is discoverable via `skill_search`.
 # Per-skill description is truncated to this many chars in the summary line so a
-# few verbose descriptions can't dominate the block.
-_SHORT_DESC_CHARS = 160
+# few verbose descriptions can't dominate the block. Sized as a guardrail against
+# a pathological description rather than a routine trim: the description is the
+# only signal the model has for deciding whether to load a skill, so the cap sits
+# above the typical length (~290 chars across the built-in set) and bites only the
+# outliers. Descriptions also arrive from the public registry, where their length
+# is not ours to control — hence a cap rather than hand-trimming.
+_SHORT_DESC_CHARS = 300
 # A skill whose file mtime is within this window gets a recency boost in the
 # ranking so a freshly-added, never-used skill still surfaces instead of being
 # starved by the rich-get-richer usage ordering.
@@ -2534,12 +2539,9 @@ class SkillsLoader:
             if skill_file is None:
                 continue
             meta = self._cached_frontmatter(skill_file)
-            desc = (meta.get("description", "") or name).strip()
-            if len(desc) > _SHORT_DESC_CHARS:
-                desc = desc[:_SHORT_DESC_CHARS].rstrip() + "…"
+            desc = self._short_desc(meta.get("description", "") or name, suffix="…")
             lines.append(
-                f"- **{meta.get('name', name)}**: {desc} → `{skill_file}` "
-                f"(dir: `{skill_file.parent}`)"
+                f"- **{meta.get('name', name)}**: {desc} → `{skill_file}`"
             )
         if not lines:
             return ""
@@ -2647,7 +2649,7 @@ class SkillsLoader:
             for s in ranked:
                 line = (
                     f"- **{s['name']}**: {self._short_desc(s['description'])} "
-                    f"-> `{s['path']}` (dir: `{s['dir']}`)"
+                    f"-> `{s['path']}`"
                 )
                 if (
                     budget is not None
@@ -2701,12 +2703,12 @@ class SkillsLoader:
                 "",
                 "If a user request relates to any skill below, read the full "
                 "skill file first with `cat <path>` before responding.",
-                "To run a skill's scripts, `cd` into its directory first.",
+                "To run a skill's scripts, `cd` into the directory containing its `SKILL.md`.",
                 "",
             ]
             for s in on_demand:
                 summary_lines.append(
-                    f"- **{s['name']}**: {s['description']} → `{s['path']}` (dir: `{s['dir']}`)"
+                    f"- **{s['name']}**: {self._short_desc(s['description'])} → `{s['path']}`"
                 )
             parts.append("\n".join(summary_lines))
         return "[Skills:]\n" + "\n\n---\n\n".join(parts) + "\n[End of skills]\n\n"
@@ -2739,12 +2741,21 @@ class SkillsLoader:
         return self._usage.score(s["key"], recency_boost=boost)
 
     @staticmethod
-    def _short_desc(desc: str) -> str:
-        """Collapse whitespace and truncate a description for the summary line."""
+    def _short_desc(desc: str, suffix: str = "...") -> str:
+        """Collapse whitespace and truncate a description for the summary line.
+
+        Cuts on a word boundary when one falls in the last fifth of the budget so
+        the line ends on a readable word instead of mid-token; a description with
+        no such boundary (one very long token) is cut hard.
+        """
         d = " ".join((desc or "").split())
-        if len(d) > _SHORT_DESC_CHARS:
-            return d[:_SHORT_DESC_CHARS].rstrip() + "..."
-        return d
+        if len(d) <= _SHORT_DESC_CHARS:
+            return d
+        cut = d[:_SHORT_DESC_CHARS]
+        space = cut.rfind(" ")
+        if space >= _SHORT_DESC_CHARS * 4 // 5:
+            cut = cut[:space]
+        return cut.rstrip() + suffix
 
     def search_skills(self, query: str, limit: int = 20) -> list[dict]:
         """Grep skills by keyword for on-demand discovery (the skill_search tool).

--- a/test/test_crystallize_skill.py
+++ b/test/test_crystallize_skill.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+from kiro_crew.config.loader import KiroCrewConfig, SkillsConfig
 from kiro_crew.skills import SkillsLoader
 
 
 def test_crystallize_builtin_present_and_triggers(tmp_path):
-    loader = SkillsLoader(skills_path=tmp_path / "skills", install_builtins=True)
+    # max_triggered defaults to 0 (matcher off) and is snapshotted at
+    # construction, so the trigger assertions below need a positive cap.
+    loader = SkillsLoader(
+        skills_path=tmp_path / "skills",
+        install_builtins=True,
+        config=KiroCrewConfig(skills=SkillsConfig(max_triggered=3)),
+    )
     keys = {s["key"] for s in loader.list_skills()}
     assert "crystallize" in keys
 

--- a/test/test_skill_trigger_pointer.py
+++ b/test/test_skill_trigger_pointer.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from kiro_crew.config.loader import KiroCrewConfig, SkillsConfig
 from kiro_crew.context import ContextBuilder
 from kiro_crew.context_blocks import split_blocks
 from kiro_crew.memory import MemoryStore
@@ -47,13 +48,27 @@ def _builder(tmp_path: Path, skills: SkillsLoader) -> ContextBuilder:
     return ContextBuilder(memory=MemoryStore(workspace=tmp_path / "ws"), skills=skills)
 
 
+def _loader(skills_path: Path, *, cap: int = 3) -> SkillsLoader:
+    """Build a loader with the trigger matcher enabled.
+
+    ``max_triggered`` defaults to 0 (matcher off) and is snapshotted at
+    construction, so every test in this file — whose whole subject is
+    trigger-match delivery — must inject a positive cap via ``config=``.
+    """
+    return SkillsLoader(
+        skills_path=skills_path,
+        install_builtins=False,
+        config=KiroCrewConfig(skills=SkillsConfig(max_triggered=cap)),
+    )
+
+
 class TestDefaultIsInjection:
     """Forgetting the field must not silently stop a skill being delivered."""
 
     def test_absent_field_injects_the_full_body(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"
         _write_skill(skills, "foundation")
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        loader = _loader(skills)
 
         msg, _ = _builder(tmp_path, loader).build_message("zebra quokka", is_new_session=False)
 
@@ -64,7 +79,7 @@ class TestDefaultIsInjection:
     def test_absent_field_splits_as_body(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"
         _write_skill(skills, "plain")
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        loader = _loader(skills)
 
         assert loader.split_triggered(["plain"]) == (["plain"], [])
 
@@ -73,7 +88,7 @@ class TestDefaultIsInjection:
         """Anything that is not `false` means inject — the safe direction."""
         skills = tmp_path / "skills"
         _write_skill(skills, "foundation", inject=value)
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        loader = _loader(skills)
 
         assert loader.split_triggered(["foundation"]) == (["foundation"], [])
 
@@ -81,7 +96,7 @@ class TestDefaultIsInjection:
     def test_false_is_case_and_space_insensitive(self, tmp_path: Path, value: str) -> None:
         skills = tmp_path / "skills"
         _write_skill(skills, "foundation", inject=value)
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        loader = _loader(skills)
 
         assert loader.split_triggered(["foundation"]) == ([], ["foundation"])
 
@@ -90,7 +105,7 @@ class TestOptedOutSkill:
     def test_body_stays_out_of_the_message(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"
         path = _write_skill(skills, "foundation", inject="false")
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        loader = _loader(skills)
 
         msg, _ = _builder(tmp_path, loader).build_message("zebra quokka", is_new_session=False)
 
@@ -101,7 +116,7 @@ class TestOptedOutSkill:
     def test_hint_names_the_skill_and_its_path(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"
         path = _write_skill(skills, "foundation", inject="false")
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        loader = _loader(skills)
 
         hint = loader.trigger_hint(["foundation"])
 
@@ -119,7 +134,7 @@ class TestOptedOutSkill:
         """
         skills = tmp_path / "skills"
         _write_skill(skills, "foundation", inject="false")
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        loader = _loader(skills)
 
         assert "already appears earlier in this conversation" in loader.trigger_hint(["foundation"])
 
@@ -128,7 +143,7 @@ class TestOptedOutSkill:
         _write_skill(
             skills, "verbose", inject="false", description="x" * (_SHORT_DESC_CHARS + 200)
         )
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        loader = _loader(skills)
 
         hint = loader.trigger_hint(["verbose"])
 
@@ -137,11 +152,11 @@ class TestOptedOutSkill:
         assert "…" in hint
 
     def test_unknown_name_yields_no_block(self, tmp_path: Path) -> None:
-        loader = SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False)
+        loader = _loader(tmp_path / "skills")
         assert loader.trigger_hint(["does-not-exist"]) == ""
 
     def test_empty_selection_yields_no_block(self, tmp_path: Path) -> None:
-        loader = SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False)
+        loader = _loader(tmp_path / "skills")
         assert loader.trigger_hint([]) == ""
 
 
@@ -150,7 +165,7 @@ class TestMixedAndUnchangedPaths:
         skills = tmp_path / "skills"
         _write_skill(skills, "mandated")
         _write_skill(skills, "offered", inject="false", body="POINTER ONLY BODY")
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        loader = _loader(skills)
 
         msg, _ = _builder(tmp_path, loader).build_message("zebra quokka", is_new_session=False)
 
@@ -163,7 +178,7 @@ class TestMixedAndUnchangedPaths:
         _write_skill(skills, "a-ptr", inject="false")
         _write_skill(skills, "b-body")
         _write_skill(skills, "c-ptr", inject="false")
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        loader = _loader(skills)
 
         assert loader.split_triggered(["a-ptr", "b-body", "c-ptr"]) == (
             ["b-body"],
@@ -171,21 +186,21 @@ class TestMixedAndUnchangedPaths:
         )
 
     def test_unknown_name_is_dropped_from_both_sides(self, tmp_path: Path) -> None:
-        loader = SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False)
+        loader = _loader(tmp_path / "skills")
         assert loader.split_triggered(["ghost"]) == ([], [])
 
     def test_always_skill_keeps_its_full_body(self, tmp_path: Path) -> None:
         """Pinning is untouched — the matcher skips `always: true` entirely."""
         skills = tmp_path / "skills"
         _write_skill(skills, "pinned", triggers=None, always=True)
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        loader = _loader(skills)
 
         assert BODY_SENTINEL in _builder(tmp_path, loader).build_session_context()
 
     def test_no_match_emits_nothing(self, tmp_path: Path) -> None:
         skills = tmp_path / "skills"
         _write_skill(skills, "foundation", inject="false")
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        loader = _loader(skills)
 
         msg, _ = _builder(tmp_path, loader).build_message(
             "unrelated wording", is_new_session=False
@@ -199,7 +214,7 @@ class TestMixedAndUnchangedPaths:
         """The floor lift is what makes the whole path switchable off."""
         skills = tmp_path / "skills"
         _write_skill(skills, "foundation")
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        loader = _loader(skills)
         loader._max_triggered = cap
 
         msg, _ = _builder(tmp_path, loader).build_message("zebra quokka", is_new_session=False)
@@ -220,7 +235,7 @@ class TestDeliveryIsAuditable:
         skills = tmp_path / "skills"
         _write_skill(skills, "mandated")
         _write_skill(skills, "offered", inject="false")
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        loader = _loader(skills)
 
         captured: dict[str, str] = {}
 

--- a/test/test_skills.py
+++ b/test/test_skills.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from kiro_crew.config.loader import KiroCrewConfig, SkillsConfig
-from kiro_crew.skills import SkillsLoader
+from kiro_crew.skills import _SHORT_DESC_CHARS, SkillsLoader
 
 
 @pytest.fixture(autouse=True)
@@ -212,7 +212,8 @@ class TestRepoScope:
     ) -> None:
         skills = tmp_path / "skills"
         self._write_skill(skills, "repo-only", "src/kiro_crew")
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        cfg = KiroCrewConfig(skills=SkillsConfig(max_triggered=3))
+        loader = SkillsLoader(skills_path=skills, install_builtins=False, config=cfg)
         repo = tmp_path / "checkout"
         (repo / "src" / "kiro_crew").mkdir(parents=True)
         subdir = repo / "website"
@@ -225,7 +226,8 @@ class TestRepoScope:
     ) -> None:
         skills = tmp_path / "skills"
         self._write_skill(skills, "anywhere", None)
-        loader = SkillsLoader(skills_path=skills, install_builtins=False)
+        cfg = KiroCrewConfig(skills=SkillsConfig(max_triggered=3))
+        loader = SkillsLoader(skills_path=skills, install_builtins=False, config=cfg)
         outside = tmp_path / "elsewhere"
         outside.mkdir()
         monkeypatch.chdir(outside)
@@ -332,7 +334,8 @@ class TestTriggeredSkills:
             "tiny-url",
             f"---\nname: tiny-url\ndescription: Shorten URLs\ntriggers: {triggers}\n---\n# Tiny URL\n",
         )
-        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False)
+        cfg = KiroCrewConfig(skills=SkillsConfig(max_triggered=3))
+        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False, config=cfg)
         if monkeypatch is not None:
             from unittest.mock import MagicMock
 
@@ -518,11 +521,9 @@ class TestTriggerMatching:
             "weather",
             "---\nname: weather\ndescription: Get weather info\ntriggers: weather forecast\n---\n",
         )
-        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False)
+        cfg = KiroCrewConfig(skills=SkillsConfig(max_triggered=3))
+        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False, config=cfg)
 
-        mock_config = MagicMock()
-        mock_config.skills.max_triggered = 3
-        monkeypatch.setattr("kiro_crew.config.loader.KiroCrewConfig.load", lambda: mock_config)
         monkeypatch.setattr("kiro_crew.skills.sel", lambda: MagicMock())
 
         result = loader.get_triggered_skills("what's the weather forecast today")
@@ -538,11 +539,9 @@ class TestTriggerMatching:
             "code-search",
             "---\nname: code-search\ndescription: Search code\ntriggers: search code, !search examples\n---\n",
         )
-        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False)
+        cfg = KiroCrewConfig(skills=SkillsConfig(max_triggered=3))
+        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False, config=cfg)
 
-        mock_config = MagicMock()
-        mock_config.skills.max_triggered = 3
-        monkeypatch.setattr("kiro_crew.config.loader.KiroCrewConfig.load", lambda: mock_config)
         monkeypatch.setattr("kiro_crew.skills.sel", lambda: MagicMock())
 
         # Positive match without negative words
@@ -586,11 +585,9 @@ class TestTriggerMatching:
             "better",
             "---\nname: better\ndescription: Better\ntriggers: alpha beta gamma\n---\n",
         )
-        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False)
+        cfg = KiroCrewConfig(skills=SkillsConfig(max_triggered=5))
+        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False, config=cfg)
 
-        mock_config = MagicMock()
-        mock_config.skills.max_triggered = 5
-        monkeypatch.setattr("kiro_crew.config.loader.KiroCrewConfig.load", lambda: mock_config)
         monkeypatch.setattr("kiro_crew.skills.sel", lambda: MagicMock())
 
         result = loader.get_triggered_skills("alpha beta gamma")
@@ -606,11 +603,9 @@ class TestTriggerMatching:
             skills_dir, "always", "---\nname: always\nalways: true\ntriggers: test\n---\n"
         )
         _create_skill(skills_dir, "normal", "---\nname: normal\ntriggers: test\n---\n")
-        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False)
+        cfg = KiroCrewConfig(skills=SkillsConfig(max_triggered=5))
+        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False, config=cfg)
 
-        mock_config = MagicMock()
-        mock_config.skills.max_triggered = 5
-        monkeypatch.setattr("kiro_crew.config.loader.KiroCrewConfig.load", lambda: mock_config)
         monkeypatch.setattr("kiro_crew.skills.sel", lambda: MagicMock())
 
         result = loader.get_triggered_skills("test")
@@ -627,11 +622,9 @@ class TestTriggerMatching:
             "tiny-url",
             "---\nname: tiny-url\ndescription: Shorten URLs\ntriggers: shorten url, create tiny link, make short url\n---\n",
         )
-        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False)
+        cfg = KiroCrewConfig(skills=SkillsConfig(max_triggered=3))
+        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False, config=cfg)
 
-        mock_config = MagicMock()
-        mock_config.skills.max_triggered = 3
-        monkeypatch.setattr("kiro_crew.config.loader.KiroCrewConfig.load", lambda: mock_config)
         monkeypatch.setattr("kiro_crew.skills.sel", lambda: MagicMock())
 
         assert "tiny-url" in loader.get_triggered_skills("please shorten this url")
@@ -1180,7 +1173,11 @@ class TestTriggerPerformance:
             "pipeline",
             "---\nname: pipeline\ndescription: d\ntriggers: pipeline health\n---\n# x\n",
         )
-        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False)
+        loader = SkillsLoader(
+            skills_path=skills_dir,
+            install_builtins=False,
+            config=KiroCrewConfig(skills=SkillsConfig(max_triggered=3)),
+        )
 
         fake_sel = MagicMock()
         monkeypatch.setattr("kiro_crew.skills.sel", lambda: fake_sel)
@@ -1513,10 +1510,13 @@ class TestLazyLoadContext:
                 "---\nname: core-pinned\ndescription: core\nalways: true\n---\n# CorePinned\nAlways here.",
             )
         for i in range(n_on_demand):
+            # Description is sized off the cap so it always exceeds it — a fixed
+            # repetition count silently stops testing truncation if the cap rises.
+            verbose = ("word%d " % i) * (_SHORT_DESC_CHARS // 4)
             _create_skill(
                 skills_dir,
                 f"od{i}",
-                f"---\nname: od{i}\ndescription: {'word%d ' % i * 40}\n---\n# OD{i}\nBody {i}.",
+                f"---\nname: od{i}\ndescription: {verbose}\n---\n# OD{i}\nBody {i}.",
             )
         return SkillsLoader(skills_path=skills_dir, install_builtins=False)
 
@@ -1562,12 +1562,34 @@ class TestLazyLoadContext:
         loader = self._make(tmp_path, n_on_demand=1)
         # Description truncation applies only on the opt-in (integer-budget) path.
         ctx = loader.get_context(budget=100_000)
-        # The verbose 'word0 '*40 description is truncated with an ellipsis.
+        # The verbose description is truncated with an ellipsis.
         assert "..." in ctx
+
+    def test_short_desc_cuts_on_a_word_boundary(self, tmp_path):
+        loader = self._make(tmp_path, n_on_demand=1)
+        # A space falls in the last fifth of the budget, so the cut lands there
+        # and the line does not end mid-word.
+        desc = "alpha " * 200
+        out = loader._short_desc(desc)
+        assert out.endswith("alpha...")
+        assert len(out) <= _SHORT_DESC_CHARS + len("...")
+
+    def test_short_desc_hard_cuts_a_single_long_token(self, tmp_path):
+        loader = self._make(tmp_path, n_on_demand=1)
+        # No word boundary to cut on -- fall back to a hard cut rather than
+        # returning the whole token or an empty string.
+        out = loader._short_desc("x" * (_SHORT_DESC_CHARS + 50))
+        assert out == "x" * _SHORT_DESC_CHARS + "..."
+
+    def test_short_desc_leaves_a_description_under_the_cap_alone(self, tmp_path):
+        loader = self._make(tmp_path, n_on_demand=1)
+        # The cap is a guardrail: a typical-length description is untouched.
+        desc = "Drive a change to a review-ready pull request."
+        assert loader._short_desc(desc) == desc
 
     def test_budget_none_is_legacy_full_dump(self, tmp_path):
         # Opt-in OFF (budget=None): legacy block — old header, every skill shown,
-        # no top-K / tail-pointer, no skill_search. Byte-for-byte pre-feature.
+        # no top-K / tail-pointer, no skill_search.
         loader = self._make(tmp_path, n_on_demand=3)
         ctx = loader.get_context(budget=None)
         assert "If a user request relates to any skill below" in ctx
@@ -1576,6 +1598,25 @@ class TestLazyLoadContext:
         assert "skill_search" not in ctx
         for i in range(3):
             assert f"**od{i}**" in ctx
+
+    def test_skills_config_max_triggered_default_is_zero(self):
+        assert SkillsConfig().max_triggered == 0
+
+    def test_budget_none_truncates_long_description(self, tmp_path):
+        # On the budget=None (legacy) path, an over-cap description is truncated.
+        skills_dir = tmp_path / "skills"
+        long_desc = "x" * (_SHORT_DESC_CHARS + 40)
+        _create_skill(
+            skills_dir,
+            "longdesc",
+            f"---\nname: longdesc\ndescription: {long_desc}\n---\n# LD\nBody.",
+        )
+        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False)
+        ctx = loader.get_context(budget=None)
+        # The full description should NOT appear verbatim.
+        assert long_desc not in ctx
+        # Truncated with ellipsis.
+        assert "..." in ctx or "…" in ctx
 
 
 class TestSearchSkills:


### PR DESCRIPTION
## Problem

Two independent defects in how skills reach the model.

**The one that actually costs context:** the per-turn word-overlap trigger matcher (`max_triggered=3`) force-injected up to **3 full skill bodies** (8–34 KB each) on every turn its keywords matched. Because it matches on bare word overlap, the three skills it picks are frequently *unrelated to the task* — `computer-use` (22 KB) fires on the word "click". There is no upper bound on repetition: the same bodies are re-injected turn after turn for as long as the keyword keeps appearing.

**The one that is merely untidy:** the session-start index cost 17,481 chars for 35 skills despite containing **zero skill bodies and zero `always: true` skills** — it was 100% metadata. `_legacy_context()` (the default path) emitted raw descriptions while the ranked path already truncated them, and every line carried a redundant `(dir: ...)` suffix that was literally `path` minus `/SKILL.md`.

## Why it matters

Context is billed and bounded. On the measured instance skill bodies were 48% of assembled context, and the matcher was the mechanism putting them there — up to 102 KB in a single turn, none of it requested by the model. That is what drives sessions into early compaction, which is what makes the agent forget earlier conversation.

The index, by contrast, is sent once and replayed by ACP, so its cost is amortized across the session rather than paid per turn. Both are worth fixing, but they are not the same order of problem, and the framing below reflects that.

## Fix (symptom → root cause → change)

1. **Default `max_triggered` to 0** — disables per-turn matching. This is the substantive change. The model instead discovers skills from the `## Available Skills` index and loads bodies on demand, so what gets loaded is *chosen* rather than keyword-matched. Because the parse fallback *is* the default, users who never set the key get the new behavior on upgrade; only an explicit positive integer keeps the matcher.
2. **Call `_short_desc()` in `_legacy_context()`** — the truncation the ranked path already applied, so the two renderers stop disagreeing.
3. **Drop `(dir: ...)` from all three renderers** — zero information loss; the header now says to `cd` into the directory containing the `SKILL.md`. (−2.2 K)

**Result:** per-turn body re-injection eliminated in stock config. Session-start index 17.5 K → **11,547 chars** (measured render, not an estimate).

## Findings: how skills actually reach the model

This PR is grounded in an audit of every delivery path. The load-bearing conclusion is that **the index plus `cat` is the primary mechanism, and it is self-sufficient** — every entry already carries the absolute path to its `SKILL.md` and an explicit instruction to read it:

```
- **prepare-pr**: End-to-end drives working-tree changes to a review-ready… → `/…/skills/kirocrew-dev/prepare-pr/SKILL.md`
```

| Path | Who initiates | Still needed after this PR? |
|---|---|---|
| `## Available Skills` index + `cat <path>` | model | **Yes — this is the mechanism.** Complete when `lazy_load=false` (the default). |
| `$skillname` | user | Yes — shorthand for forcing a load |
| `skill_search` | model | Rarely. It exists to recover the tail that `lazy_load` truncates; with a complete index it can only add body-text grep. |
| word-overlap trigger matcher | neither — regex on the message | **No.** Disabled by this PR. |

Two supporting facts, because they defuse the obvious objections:

- **ACP replays native conversation history every turn**, so the turn-1 index is already in the window on every later turn. Re-injecting it per turn would double the cost, not replace it. The only loss vector is compaction (see Known remaining gap).
- **`skill_search` greps the full frontmatter description, not the rendered index** (`s['description']` is the raw value; `_short_desc()` applies only at render time). Capping the index does not reduce searchability.

This also converges KiroCrew onto kiro-cli's documented progressive-disclosure model — name + description at startup, full instructions loaded on demand — rather than deviating from it.

## The description cap is a guardrail, not a trim (160 → 300)

An earlier revision of this PR reused the existing `_SHORT_DESC_CHARS = 160`. That was too aggressive, for a reason that matters: **descriptions are what the model uses to decide whether a skill is relevant**, and now that the matcher is off, the index is the *only* discovery surface. Cutting the median skill's description in half to save context is trading accuracy for a saving the amortized index does not need.

Measured across 36 skills (median 289, mean 346, max 1,106, total 12,466 chars):

| Cap | Skills truncated | Chars recovered |
|---|---|---|
| 160 (previous revision) | 29 / 36 | 7,036 |
| **300 (this PR)** | **17 / 36** | **~3,900** |
| No cap; hand-trim the worst offender only | 1 / 36 | 946 |

300 leaves the typical skill untouched while still bounding the outliers. A cap is still the right shape rather than hand-trimming `prepare-pr`: the bloat is distributional (29 of 36 exceed 160), and descriptions also arrive from `skill_discover` / the public registry, where their length is not this repo's to control.

Two related cleanups in the same helper:

- **`_short_desc` now cuts on a word boundary** when one falls in the last fifth of the budget, instead of mid-token (`"...KEEPS RUNNING IN-SESS…"`). A description with no such boundary — one very long token — still hard-cuts.
- **The third renderer's inline duplicate of the truncation logic now calls `_short_desc`.** It had drifted: same cap, different ellipsis character. The helper takes a `suffix` parameter so each caller keeps its existing character and both existing assertions stay valid.

## Tests

- `assert SkillsConfig().max_triggered == 0` — locks the new default. The `__post_init__` clamp is `< 0 → 0`, so 0 survives it (upstream's `≥ 1` clamp was already relaxed in this fork; had it survived, this PR would have been a no-op).
- Three new tests on `_short_desc`: word-boundary cut, hard-cut fallback for a single long token, and passthrough for an under-cap description.
- **Truncation fixtures are now sized off `_SHORT_DESC_CHARS`** rather than hardcoded. Raising the cap silently stopped two tests from exercising truncation at all (their 240- and 200-char fixtures fell under 300) — they passed while testing nothing. Deriving the fixture from the constant makes that failure mode impossible on a future cap change.
- **5 tests inherited the `max_triggered=0` default and were repaired**, since `SkillsLoader.__init__` snapshots the value at construction: `test_crystallize_skill.py::test_crystallize_builtin_present_and_triggers` plus 4 in `test_skill_trigger_pointer.py`. Each now injects `config=KiroCrewConfig(skills=SkillsConfig(max_triggered=3))`, the pattern `test_skills.py` already used; that file's 17 construction sites route through a new `_loader(skills_path, *, cap=3)` helper.
- `test_max_triggered_zero_disables_the_path` still sets `_max_triggered` post-construction, so the off case stays explicitly covered.

Verified: 195 passed across the 5 directly-affected files; **3,025 passed / 0 failed** across `-k "skill or trigger or context or config"`. flake8 + isort clean.

## Manual verification

Measured on a live instance:

- Before: 17,481 chars for 35 skills — 100% metadata, zero bodies, zero `always: true`.
- Per-turn body injection: 0 after fix 1 (previously up to 102 KB/turn on a measured session).
- Index after fixes 2+3 at the 300 cap: **11,547 chars**, measured by rendering `get_context(budget=None)` against the live skills directory (36 skills; the same render confirms `(dir:` is absent). The baseline 17,481 was measured at 35 skills, so the corpus grew by one between the two measurements — the comparison is close but not strictly apples-to-apples.
- Per-skill description recovery figures in the cap table are computed from measured per-skill description lengths.
- Invariants re-checked with `max_triggered=0`: `get_triggered_skills` returns `scored[:0] == []` so the injection block never runs; the negative-trigger DENY audit still fires (`if triggered or negated_skills:`); `get_always_skills()`, the index listing, `resolve_dollar_skills`, `skill_search`, and agent `cat` reads are unaffected.

## Provenance: the trigger matcher's real history

Recorded because an earlier revision of this description mis-attributed it, and the correction bears on how much deference the mechanism is owed.

- **[`e1fc206b`](https://code.amazon.com/packages/MeshClaw/commits/e1fc206b) (2026-02-15)** — `get_triggered_skills` is born for one narrow purpose: replacing a hardcoded `cron_context` that had been injected into *every* prompt with a built-in cron skill carrying hand-curated `triggers:` (cron, schedule, remind). A cost optimization for a single skill with curated keywords — not a general discovery mechanism.
- **[`fe384a10`](https://code.amazon.com/packages/MeshClaw/commits/fe384a10) (2026-04-07)** — generalized to embedding-based semantic matching with progressive loading. `max_triggered` is introduced here, defaulting to 3.
- **[`8de565d3`](https://code.amazon.com/packages/MeshClaw/commits/8de565d3) (2026-04-09)** — two days later the entire embedding tier is removed on review feedback ([CR-265599314](https://code.amazon.com/reviews/CR-265599314)) in favor of "a simpler approach that works for all users without external dependencies." That simpler approach is the word-overlap matcher being disabled here.

So the matcher **was** code-reviewed, and word-overlap was a deliberate choice over embeddings. What changed since is the surrounding context: the index, `$skillname`, and `skill_search` all shipped later ([`255ef0b8`](https://code.amazon.com/packages/MeshClaw/commits/255ef0b8), 2026-07-03, for the latter), each letting the *model* choose. Nobody turned the matcher off when its role was superseded. It is preserved and reversible via config, just no longer the default.

`inject_on_trigger` ships with zero consumers on the measured instance, and with `max_triggered=0` it is unreachable (`split_triggered()` is only called on a non-empty `get_triggered_skills()` result). Its help text now states that it requires `max_triggered > 0` to have any effect.

## Known remaining gap

Compaction can drop the session-start index, and what is lost is specifically the **paths** — without which the model does not know skills exist or where they live. `skill_search` still works as a fallback but the primary mechanism is gone, and `is_new` is one-shot so nothing re-arms. Addressed separately in #1866 (`set_compact_callback` is single-slot and already claimed by `DashboardState`, so the fix threads a flag through the existing `_on_compacted` success branch).
