### PR TITLE
feat(context): lean sub-agent context — drop history, keep lessons

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -48,6 +48,28 @@ FTS5 search via `~/.kiro/crew/memory_index.db` (SQLite via `pysqlite3-binary` on
 
 Context injection includes source citations per section. Agent can update memory files via kiro-cli's file tools.
 
+### Section caps — a cap of `0` OMITS the section
+
+`MemoryStore.get_context()` takes a per-section char cap. Any cap **> 0** truncates with a trailing `…[truncated]` marker; a cap of exactly **`0` omits the section entirely** — no header, no source-path citation, no marker. The distinction matters: the truncating helper is `text[:limit] + "…[truncated]"`, so a `0` cap without the explicit guard would render a header plus a bare marker, costing the header, leaking the section's on-disk path, and telling the model content existed that was withheld.
+
+The guards are `history_cap > 0`, `semantic_cap > 0`, and `query and episodic_cap > 0` (episodic needs both a query and a positive cap). Only `get_context`'s two call sites in `context.py` pass `0`; every other cap flows from `_resolve_caps_cached`, whose base is floored by `_MIN_CONTEXT_BUDGET_BASE`, so no scaled cap can reach `0` even on the smallest model window.
+
+### Sub-agent lean context (`subagent_context=True`)
+
+A sub-agent gets a deliberately narrower prompt than a chat session, because its task text — not conversation continuity — is its context. `SubagentManager` passes `subagent_context=True` through `build_message()` to `build_session_context()`.
+
+| Section | Sub-agent | Why |
+|---|---|---|
+| preferences, projects | **kept** | small, and they govern how work is done |
+| skills index | **kept** | the sub-agent still needs to discover skills |
+| lessons | **kept in full** | highest value-per-char in the prompt; see below |
+| recent history | dropped | the largest single section by far |
+| semantic memory | dropped | retrievable on demand via tools |
+| episodic memory | dropped | fragments of the parent's unrelated past conversations |
+| thread history, stop-event notes, provenance | dropped | no thread to continue |
+
+**Lessons are deliberately NOT trimmed.** An earlier revision selected a top-K by cosine similarity to the task text. It was removed: the ranking silently degraded to "the K most recent" whenever the embedding model was unavailable (`_try_embed()` returns `None`, no log line), which discarded user-taught safety rules; and lessons are only a small share of the total saving, so the trade bought little and risked much. Recent history is where the budget actually is.
+
 ### Decaying Memory (`read_recent_history`)
 
 History context uses natural decay: recent days in full detail, older days
@@ -67,7 +89,10 @@ declares `history_cap=25_000` as its own signature default, but the live caller
 is `ContextBuilder.build_session_context()`, which always passes
 `caps.memory_history` (26,400 chars at the reference window, scaled per model
 window, see Context Builder below), so 25,000 only applies to a direct
-programmatic call. Timestamps use local timezone.
+programmatic call. Timestamps use local timezone. **Exception —
+`build_session_context(subagent_context=True)` passes `history_cap=0`, which
+OMITS the block entirely** (see "Sub-agent lean context" below); recent history
+is the largest single section, and a sub-agent's task text is its context.
 
 `read_recent_history` runs on every message turn (context build) and otherwise
 stats + reads up to 181 daily files synchronously. The assembled string is
@@ -211,7 +236,7 @@ SQLite table `semantic_memory` — structured key-value store with:
 - **Injection detection**: the `_INJECTION_PATTERNS` regex set (14 patterns, `vector_memory_constants.py`) is scanned on every value write
 - **Audit trail**: `memory_events` table logs every create/update/delete with old+new values, bounded at `_MAX_EVENTS = 10_000`
 
-Context injection: formatted as `key: value` pairs in `[Semantic Memory]` block. The cap is passed in by the caller: `build_session_context()` supplies `caps.semantic`, which is `_SEMANTIC_MEMORY_CAP` (7.7% of the base = 12,705 chars) at the reference window and scales down with the model window. Excludes `lesson.*` keys (they have their own `[Learned corrections]` block). Uses hybrid retrieval when embeddings are available: `_SEMANTIC_VECTOR_WEIGHT` 0.6 × vector_score + `_SEMANTIC_KEYWORD_WEIGHT` 0.4 × keyword_score. Falls back to keyword-only scoring (word overlap on keys and values, key matches weighted 3×, with `snowballstemmer` expansion) without embeddings.
+Context injection: formatted as `key: value` pairs in `[Semantic Memory]` block. The cap is passed in by the caller: `build_session_context()` supplies `caps.semantic`, which is `_SEMANTIC_MEMORY_CAP` (7.7% of the base = 12,705 chars) at the reference window and scales down with the model window — except under `subagent_context=True`, which passes `0` and omits the block. Excludes `lesson.*` keys (they have their own `[Learned corrections]` block). Uses hybrid retrieval when embeddings are available: `_SEMANTIC_VECTOR_WEIGHT` 0.6 × vector_score + `_SEMANTIC_KEYWORD_WEIGHT` 0.4 × keyword_score. Falls back to keyword-only scoring (word overlap on keys and values, key matches weighted 3×, with `snowballstemmer` expansion) without embeddings.
 
 ### Episodic Memory
 
@@ -224,7 +249,7 @@ SQLite table `episodic_memories` — conversation fragments with optional embedd
 - **Fallback ladder**: FAISS (needs faiss + numpy) → `_sqlite_vector_search`, stdlib cosine over the stored blobs → FTS5/LIKE keyword search (OR logic on text + tags) when there is no query embedding at all. The middle rung matters: faiss is an optional accelerator, not a declared dependency, so a stock install still gets vector recall from the stored vectors.
 - **Cap**: `_DEFAULT_EPISODIC_MAX` = 10,000 active entries. `_enforce_episodic_cap()` tombstones `ORDER BY importance ASC, created_at ASC` (lowest-importance oldest first) on write once the count reaches the cap.
 
-Context injection: `_DEFAULT_EPISODIC_LIMIT` = 8 results in an `[Episodic Memory]` block, each fragment sliced to 1,500 chars, total bounded by `min(_EPISODIC_INJECT_CAP, caps.episodic)` where `_EPISODIC_INJECT_CAP` = 3,000. Injected on the first message of new sessions via `build_message()`, not at plain session start, since `build_session_context` passes no query to `memory.get_context()`, so that call's `episodic_cap` argument never fires.
+Context injection: `_DEFAULT_EPISODIC_LIMIT` = 8 results in an `[Episodic Memory]` block, each fragment sliced to 1,500 chars, total bounded by `min(_EPISODIC_INJECT_CAP, caps.episodic)` where `_EPISODIC_INJECT_CAP` = 3,000. Injected on the first message of new sessions via `build_message()`, not at plain session start, since `build_session_context` passes no query to `memory.get_context()`, so that call's `episodic_cap` argument never fires. Because that is the only live injection point, the sub-agent exclusion is a guard in `build_message` (`elif subagent_context:`) — zeroing `episodic_cap` in `build_session_context` would be inert.
 
 ### Fading: three independent decay mechanisms
 

--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -1571,6 +1571,7 @@ class ContextBuilder:
         runtime_source: str | None = None,
         exclude_last_n: int = 0,
         model_window: int | None = None,
+        subagent_context: bool = False,
     ) -> str:
         """Build context for a new session (memory + skills + history).
 
@@ -1752,7 +1753,8 @@ class ContextBuilder:
         # Inject for CC too: a fresh dashboard/Slack session maps to a new CC
         # subprocess with no in-process history, so the thread transcript must
         # be supplied for parity with kiro (which gets it natively).
-        if session_key and self.conversation_log and not resumed:
+        # Subagent lean context: skip thread history (task text IS the context).
+        if session_key and self.conversation_log and not resumed and not subagent_context:
             _history_header = (
                 "[THREAD CONVERSATION HISTORY — this is the PRIMARY context.\n"
                 "When the user says 'just now', 'earlier', 'the task', 'try again', "
@@ -1819,7 +1821,7 @@ class ContextBuilder:
 
         # Stop event context — inject notes for recent stop events so the
         # LLM knows prior turns were cancelled by the user.
-        if session_key and self.conversation_log:
+        if session_key and self.conversation_log and not subagent_context:
             _stop_notes = _build_stop_event_notes(self.conversation_log, session_key)
             if _stop_notes:
                 parts.append(_stop_notes)
@@ -1831,13 +1833,23 @@ class ContextBuilder:
         mem_key = memory_store or workspace
         memory = self.get_memory_for(mem_key)
         if not blocks_reads:
-            memory_ctx = memory.get_context(
-                prefs_cap=caps.prefs,
-                projects_cap=caps.projects,
-                history_cap=caps.memory_history,
-                semantic_cap=caps.semantic,
-                episodic_cap=caps.episodic,
-            )
+            if subagent_context:
+                # Lean context: only prefs + projects, drop history/semantic/episodic
+                memory_ctx = memory.get_context(
+                    prefs_cap=caps.prefs,
+                    projects_cap=caps.projects,
+                    history_cap=0,
+                    semantic_cap=0,
+                    episodic_cap=0,
+                )
+            else:
+                memory_ctx = memory.get_context(
+                    prefs_cap=caps.prefs,
+                    projects_cap=caps.projects,
+                    history_cap=caps.memory_history,
+                    semantic_cap=caps.semantic,
+                    episodic_cap=caps.episodic,
+                )
             if memory_ctx:
                 parts.append(memory_ctx)
 
@@ -1875,6 +1887,16 @@ class ContextBuilder:
 
         # Lessons: merge global + workspace-scoped — inject for ALL agents
         # (skipped for temporary sessions)
+        #
+        # Deliberately NOT trimmed for sub-agents. Lessons are the highest
+        # value-per-char content in the prompt — distilled user corrections
+        # injected under "ALWAYS follow these" — and history is where the real
+        # budget is (see the subagent_context block above). An earlier revision
+        # selected a top-K by cosine similarity to the task text; that is gone,
+        # because it silently degraded to "the K most recent" whenever the
+        # embedding model was unavailable and dropped safety rules a sub-agent
+        # needs (annotation placement, destructive-rebase guards) for ~14% of
+        # the saving.
         lessons_ctx = ""
         if not blocks_reads:
             # One query, not two: get_lessons_context() already returns "" when the
@@ -1925,7 +1947,7 @@ class ContextBuilder:
                 parts.append(lessons_ctx)
 
         # Provenance-tagged entries from recent sessions (skipped for temporary)
-        if session_key and self.conversation_log and not blocks_reads:
+        if session_key and self.conversation_log and not blocks_reads and not subagent_context:
             provenance = self.conversation_log.recent_with_provenance(
                 session_key, exclude_last_n=exclude_last_n
             )
@@ -1988,6 +2010,7 @@ class ContextBuilder:
         user_text_range: tuple[int, int] | None = None,
         user_span_out: list[int] | None = None,
         needs_reinjection: bool = False,
+        subagent_context: bool = False,
     ) -> tuple[str, HookResult]:
         """Build the full message with context and hook processing.
 
@@ -2071,6 +2094,7 @@ class ContextBuilder:
                 runtime_source=runtime_source,
                 exclude_last_n=exclude_last_n,
                 model_window=model_window,
+                subagent_context=subagent_context,
             )
             if session_ctx:
                 # Scrub forgeable boundary markers from the UNTRUSTED content in
@@ -2267,6 +2291,13 @@ class ContextBuilder:
             logger.info("🔍 Minimal context — episodic memory skipped")
         elif blocks_reads:
             logger.info("🔍 Temporary session — episodic memory skipped")
+        elif subagent_context:
+            # THIS is the only live episodic injection — build_session_context
+            # passes no query, so its episodic_cap argument never fires. Zeroing
+            # that cap therefore does nothing; the guard has to be here or a
+            # sub-agent still receives episodic fragments from the parent's
+            # unrelated past conversations.
+            logger.info("🔍 Sub-agent lean context — episodic memory skipped")
         elif is_new_session:
             memory = self.get_memory_for(memory_store or workspace)
             if memory.vector_store:

--- a/src/kiro_crew/memory.py
+++ b/src/kiro_crew/memory.py
@@ -361,6 +361,12 @@ class MemoryStore:
             semantic_cap: Max chars for semantic memory.
             episodic_cap: Max chars for episodic memory.
             query: User message for episodic memory retrieval (optional).
+
+        A cap of ``0`` means OMIT that section entirely — not "include it
+        truncated to nothing". Without the explicit guards below, ``_cap(text,
+        0)`` would emit the section header plus a bare ``…[truncated]`` marker,
+        which costs the header, leaks the on-disk source path, and tells the
+        model content exists that was deliberately withheld.
         """
         parts: list[str] = []
 
@@ -385,7 +391,7 @@ class MemoryStore:
                 f"{_cap(projects, projects_cap)}"
             )
 
-        history = self.read_recent_history(days=14)
+        history = self.read_recent_history(days=14) if history_cap > 0 else ""
         if history.strip():
             parts.append(
                 f"## Recent History\n"
@@ -395,14 +401,18 @@ class MemoryStore:
 
         # Semantic memory (structured key-value pairs from vector_memory.py)
         if self._vector_store:
-            semantic_ctx = self._vector_store.get_semantic_context(
-                query_text=query, cap=semantic_cap
-            )
-            if semantic_ctx:
-                parts.append(semantic_ctx)
+            # A zero cap already yields "" from get_semantic_context (its
+            # accumulator breaks on the first line), but it does the query and
+            # per-row embedding work first. Skip it outright.
+            if semantic_cap > 0:
+                semantic_ctx = self._vector_store.get_semantic_context(
+                    query_text=query, cap=semantic_cap
+                )
+                if semantic_ctx:
+                    parts.append(semantic_ctx)
 
             # Episodic memory (relevant past conversation fragments)
-            if query:
+            if query and episodic_cap > 0:
                 episodic_ctx = self._vector_store.get_episodic_context(
                     query_text=query, cap=episodic_cap
                 )

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -4226,6 +4226,7 @@ class SubagentManager:
             session_key,
             provider_type="claude_code" if is_cc else "acp",
             model_window=_sub_window,
+            subagent_context=True,
         )
 
         result_text = ""

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -396,6 +396,156 @@ class TestContextBuilder:
         assert len(history_block) <= _HISTORY_BUDGET_CHARS + 1000  # some overhead for labels
 
 
+class TestSubagentLeanContext:
+    """`subagent_context=True` drops bulk history, keeps the load-bearing parts.
+
+    The budget shape that motivates this: recent-history is ~86% of the memory
+    block, while lessons are the highest value-per-char content in the prompt.
+    So history/semantic/episodic/thread-history go, and prefs + projects +
+    skills + the FULL lesson set stay.
+    """
+
+    def _builder(self, tmp_path):
+        from datetime import datetime, timezone
+
+        from kiro_crew.learn import Lesson
+
+        store = MemoryStore(workspace=tmp_path / "ws")
+        store.init()
+        store.write("# Memory\n\nUser likes lobsters.")
+        store.append_history("EARLIER-HISTORY-MARKER deployed the cron scheduler")
+
+        lessons = LessonStore(base_dir=tmp_path)
+        now = datetime.now(timezone.utc).isoformat()
+        # More lessons than the old k=10 top-K would have kept, so a regression
+        # to truncation is detectable.
+        for i in range(14):
+            lessons.save(
+                Lesson(ts=now, rule=f"LESSON-MARKER-{i:02d} always do the thing", category="tool")
+            )
+
+        return ContextBuilder(
+            memory=store,
+            skills=SkillsLoader(skills_path=tmp_path / "skills", install_builtins=False),
+            lessons=lessons,
+        )
+
+    def test_lean_drops_recent_history(self, tmp_path):
+        builder = self._builder(tmp_path)
+        ctx = builder.build_session_context(subagent_context=True)
+        assert "EARLIER-HISTORY-MARKER" not in ctx
+        assert "## Recent History" not in ctx
+        # And no truncation stub standing in for it.
+        assert "[truncated]" not in ctx
+
+    def test_full_context_keeps_recent_history(self, tmp_path):
+        """Control: the non-lean path is unchanged."""
+        builder = self._builder(tmp_path)
+        ctx = builder.build_session_context()
+        assert "EARLIER-HISTORY-MARKER" in ctx
+
+    def test_lean_keeps_preferences(self, tmp_path):
+        builder = self._builder(tmp_path)
+        ctx = builder.build_session_context(subagent_context=True)
+        assert "lobsters" in ctx
+
+    def test_lean_keeps_every_lesson(self, tmp_path):
+        """Lessons are NOT trimmed for sub-agents.
+
+        Regression guard for the removed top-K-by-cosine path, which silently
+        degraded to "the 10 most recent" whenever embeddings were unavailable
+        and discarded user-taught safety rules.
+        """
+        builder = self._builder(tmp_path)
+        ctx = builder.build_session_context(subagent_context=True)
+        for i in range(14):
+            assert f"LESSON-MARKER-{i:02d}" in ctx, f"lesson {i} was dropped"
+
+    def test_lean_and_full_agree_on_lessons(self, tmp_path):
+        """The lean path must not select a different lesson set than the full one."""
+        builder = self._builder(tmp_path)
+        lean = builder.build_session_context(subagent_context=True)
+        full = builder.build_session_context()
+        for i in range(14):
+            marker = f"LESSON-MARKER-{i:02d}"
+            assert (marker in lean) == (marker in full)
+
+    def test_lean_drops_thread_history(self, tmp_path):
+        """Thread history is skipped — the task text IS the sub-agent's context."""
+        from unittest.mock import MagicMock
+
+        builder = self._builder(tmp_path)
+        log = MagicMock()
+        log.recent.return_value = [{"role": "user", "content": "THREAD-MARKER"}]
+        log.recent_with_provenance.return_value = []
+        builder.conversation_log = log
+
+        ctx = builder.build_session_context(session_key="s1", subagent_context=True)
+        assert "THREAD-MARKER" not in ctx
+        assert "THREAD CONVERSATION HISTORY" not in ctx
+
+    def test_lean_drops_provenance_entries(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        builder = self._builder(tmp_path)
+        log = MagicMock()
+        log.recent.return_value = []
+        log.recent_with_provenance.return_value = [
+            {"role": "user", "content": "PROVENANCE-MARKER", "source": "slack"}
+        ]
+        builder.conversation_log = log
+
+        ctx = builder.build_session_context(session_key="s1", subagent_context=True)
+        assert "PROVENANCE-MARKER" not in ctx
+        log.recent_with_provenance.assert_not_called()
+
+    def test_lean_skips_episodic_in_build_message(self, tmp_path):
+        """The F2 fix: this is the ONLY live episodic injection.
+
+        `build_session_context` passes no query, so its `episodic_cap=0` never
+        fires — zeroing that cap alone left sub-agents still receiving episodic
+        fragments from the parent's unrelated past conversations.
+        """
+        from unittest.mock import MagicMock
+
+        builder = self._builder(tmp_path)
+        vs = MagicMock()
+        vs.get_lessons_context = MagicMock(return_value="")
+        vs.get_semantic_context = MagicMock(return_value="")
+        vs.get_episodic_context = MagicMock(return_value="[Episodic]\nEPISODIC-MARKER\n")
+        builder.memory.vector_store = vs
+
+        msg, _ = builder.build_message(
+            "do the task", is_new_session=True, subagent_context=True
+        )
+
+        vs.get_episodic_context.assert_not_called()
+        assert "EPISODIC-MARKER" not in msg
+
+    def test_normal_new_session_still_gets_episodic(self, tmp_path):
+        """Control: the guard must not suppress episodic for ordinary sessions."""
+        from unittest.mock import MagicMock
+
+        builder = self._builder(tmp_path)
+        vs = MagicMock()
+        vs.get_lessons_context = MagicMock(return_value="")
+        vs.get_semantic_context = MagicMock(return_value="")
+        vs.get_episodic_context = MagicMock(return_value="[Episodic]\nEPISODIC-MARKER\n")
+        builder.memory.vector_store = vs
+
+        msg, _ = builder.build_message("do the task", is_new_session=True)
+
+        vs.get_episodic_context.assert_called_once()
+        assert "EPISODIC-MARKER" in msg
+
+    def test_lean_is_materially_smaller(self, tmp_path):
+        """The whole point: the lean context is a large reduction."""
+        builder = self._builder(tmp_path)
+        lean = builder.build_session_context(subagent_context=True)
+        full = builder.build_session_context()
+        assert len(lean) < len(full)
+
+
 class TestGetMemoryForVectorStore:
     """Tests for symmetric vector_store attachment across memory stores."""
 

--- a/test/test_memory.py
+++ b/test/test_memory.py
@@ -167,6 +167,134 @@ class TestRecentHistoryCache:
         ctx = store.get_context()
         assert "cron scheduler" in ctx
 
+    # ── zero-cap contract: a cap of 0 OMITS the section ──
+
+
+class TestGetContextZeroCaps:
+    """A cap of 0 means OMIT the section, not "truncate it to nothing".
+
+    `_cap(text, 0)` returns `text[:0] + "\\n…[truncated]"`, so each zeroed
+    section needs an explicit guard or it renders a header, leaks its on-disk
+    source path, and tells the model content was withheld.
+    """
+
+    def test_history_cap_zero_omits_the_section_entirely(self, tmp_path):
+        """cap=0 must omit, not emit a header + bare truncation marker.
+
+        `_cap(text, 0)` returns `text[:0] + "\\n…[truncated]"`, so without the
+        guard this rendered the header, leaked the on-disk history path, and told
+        the model content existed that was withheld.
+        """
+        store = MemoryStore(workspace=tmp_path)
+        store.init()
+        store.append_history("Deployed cron scheduler")
+
+        ctx = store.get_context(history_cap=0)
+
+        assert "## Recent History" not in ctx
+        assert "[truncated]" not in ctx
+        assert "cron scheduler" not in ctx
+        assert str(store._history_dir) not in ctx, "must not leak the source path"
+
+    def test_history_cap_positive_still_includes_the_section(self, tmp_path):
+        """The guard must not over-block the normal path."""
+        store = MemoryStore(workspace=tmp_path)
+        store.init()
+        store.append_history("Deployed cron scheduler")
+
+        ctx = store.get_context(history_cap=25_000)
+
+        assert "## Recent History" in ctx
+        assert "cron scheduler" in ctx
+
+    def test_history_cap_positive_but_smaller_than_history_truncates(self, tmp_path):
+        """A positive-but-small cap still truncates (the pre-existing behavior)."""
+        store = MemoryStore(workspace=tmp_path)
+        store.init()
+        store.append_history("x" * 500)
+
+        ctx = store.get_context(history_cap=50)
+
+        assert "## Recent History" in ctx
+        assert "[truncated]" in ctx
+
+    def test_semantic_cap_zero_skips_the_query_entirely(self, tmp_path):
+        """A zero cap must not do the query-and-discard work."""
+        from unittest.mock import MagicMock
+
+        store = MemoryStore(workspace=tmp_path)
+        store.init()
+        vs = MagicMock()
+        vs.get_semantic_context = MagicMock(return_value="[Semantic Memory]\nk: v\n")
+        vs.get_episodic_context = MagicMock(return_value="")
+        store.vector_store = vs
+
+        ctx = store.get_context(semantic_cap=0)
+
+        vs.get_semantic_context.assert_not_called()
+        assert "Semantic Memory" not in ctx
+
+    def test_semantic_cap_positive_queries_and_includes(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        store = MemoryStore(workspace=tmp_path)
+        store.init()
+        vs = MagicMock()
+        vs.get_semantic_context = MagicMock(return_value="[Semantic Memory]\nk: v\n")
+        vs.get_episodic_context = MagicMock(return_value="")
+        store.vector_store = vs
+
+        ctx = store.get_context(semantic_cap=12_000)
+
+        vs.get_semantic_context.assert_called_once()
+        assert "Semantic Memory" in ctx
+
+    def test_episodic_cap_zero_skips_even_with_a_query(self, tmp_path):
+        """Episodic needs BOTH a query and a positive cap."""
+        from unittest.mock import MagicMock
+
+        store = MemoryStore(workspace=tmp_path)
+        store.init()
+        vs = MagicMock()
+        vs.get_semantic_context = MagicMock(return_value="")
+        vs.get_episodic_context = MagicMock(return_value="[Episodic]\nfrag\n")
+        store.vector_store = vs
+
+        ctx = store.get_context(query="anything", episodic_cap=0)
+
+        vs.get_episodic_context.assert_not_called()
+        assert "Episodic" not in ctx
+
+    def test_episodic_requires_a_query_even_with_a_positive_cap(self, tmp_path):
+        """The pre-existing half of the condition still holds."""
+        from unittest.mock import MagicMock
+
+        store = MemoryStore(workspace=tmp_path)
+        store.init()
+        vs = MagicMock()
+        vs.get_semantic_context = MagicMock(return_value="")
+        vs.get_episodic_context = MagicMock(return_value="[Episodic]\nfrag\n")
+        store.vector_store = vs
+
+        store.get_context(query="", episodic_cap=12_000)
+
+        vs.get_episodic_context.assert_not_called()
+
+    def test_episodic_included_with_query_and_positive_cap(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        store = MemoryStore(workspace=tmp_path)
+        store.init()
+        vs = MagicMock()
+        vs.get_semantic_context = MagicMock(return_value="")
+        vs.get_episodic_context = MagicMock(return_value="[Episodic]\nfrag\n")
+        store.vector_store = vs
+
+        ctx = store.get_context(query="anything", episodic_cap=12_000)
+
+        vs.get_episodic_context.assert_called_once()
+        assert "Episodic" in ctx
+
     def test_append_history_creates_date_file(self, tmp_path):
         store = MemoryStore(workspace=tmp_path)
         store.append_history("test entry")


### PR DESCRIPTION
## Problem

Every sub-agent spawn pays for a full chat-session prompt. Measured on a live instance, `MemoryStore.get_context()` alone returns **42,322 chars** — and a sub-agent uses almost none of it. Recent history (26,400 chars), semantic memory, and episodic fragments are all about *conversation continuity*, which a sub-agent does not have: its task text is its context.

Sub-agents are cheap and meant to be spawned freely, so this is paid per fan-out. A 10-way review batch carries ~10× the same irrelevant history.

## Why it matters

Context is billed and bounded. The waste is concentrated in exactly the sections a sub-agent can least use, and it crowds out the prompt budget for the task itself. It also degrades quality: episodic fragments from the parent's unrelated past conversations are noise a focused sub-agent has to read past.

## Fix (symptom → root cause → change)

`subagent_context=True` threads from `SubagentManager` through `build_message()` into `build_session_context()`.

The rule applied, and the reason the split falls where it does: **keep what governs conduct, drop what supplies continuity.** A sub-agent has no conversation to continue — but it still *acts*. It writes code, edits files, runs tests, opens PRs. So every rule about *how* to act is kept, and the material that exists only to reconstruct *what was said earlier* is dropped.

| Section | Sub-agent | Category |
|---|---|---|
| preferences | **kept** | conduct |
| lessons | **kept in full** | conduct |
| skills index | **kept** | capability discovery |
| projects | **kept** | names what is being worked on |
| recent history | dropped | continuity |
| episodic memory | dropped | continuity |
| semantic memory | dropped | continuity (with a caveat — below) |
| thread history | dropped | continuity |
| stop-event notes | dropped | continuity |
| provenance entries | dropped | continuity |

**Result: 42,322 → 15,922 chars, a 62% reduction — and 86% of that comes from recent history alone.**

## Why each dropped section is safe to lose — and the one that isn't

Not all seven drops are equally defensible, so they are separated by what is actually lost rather than presented as one uniform decision.

**Inapplicable by construction — nothing is lost, and keeping them is worse than neutral.**

- **Thread history** is injected under a header declaring it "the PRIMARY context" and explaining what "just now", "earlier", "the task", and "try again" refer to. For a sub-agent those are deixis with no referent: the header instructs the model to resolve phrases against a transcript that describes someone else's conversation. Dropping it removes a misdirection, not information.
- **Stop-event notes** tell the model that *prior turns were cancelled by the user*. A sub-agent has no prior turns. The note can only describe the parent's cancellations, which the sub-agent must not attribute to its own task.
- **Provenance entries** are tagged entries from the parent's recent sessions, keyed on `session_key`. A sub-agent's work is not in them.

**Recoverable on demand — dropped from the prompt, still reachable by tool.**

- **Recent history** is the whole prize: 26,400 of the 30,565 chars saved. It is also the section with a real retrieval path — `search_chat_history` searches the same transcripts, and `get_chat_session` reads one in full. Moving it from unconditional injection to on-demand lookup is the correct trade: paid only by the sub-agents that actually need it.
- **Episodic memory** is derived from past conversations, so the same tool covers the same ground. It is also the most actively harmful section to inject: retrieval is by similarity to a *query*, and a sub-agent's query is its task text, so it preferentially surfaces the parent's unrelated conversations that happen to share vocabulary with the task.

**Genuinely lost — the one real cost of this PR.**

- **Semantic memory** has **no agent-facing retrieval tool.** `local_knowledge_search` reads the knowledge library and `search_chat_history` reads transcripts; the semantic key-value facts are reachable only through the `kirocrew memory search` CLI, and `memory_graph` is a dashboard HTTP handler, not a tool. So for a sub-agent this is a real reduction in what it can know, not a deferral. It is included anyway because the parent composes the task text while holding those same facts in its own context, so the parent can state the one fact that matters — which is better prompting than 42K of speculative recall either way.
- **Residual risk, stated plainly:** a sub-agent spawned with a thin task string, on a project it has no other handle on, will not know project-specific facts it previously received for free. The mitigation is parent-side prompting discipline, not a guarantee in code. If that turns out to bite, the fix is a `memory_search` tool — not re-inflating every sub-agent prompt.

**On the kept side, the reasoning is symmetric.** Preferences and lessons are distilled user corrections injected under "ALWAYS follow these. They override default behavior." A sub-agent that writes code and edits markdown is governed by them exactly as the parent is; dropping them would make sub-agents systematically re-make mistakes the user has already corrected once. The skills index is the sub-agent's only discovery surface for skills. Projects is small and is the one continuity-adjacent block worth keeping, because task strings routinely assume the reader knows which project is meant.

## Lessons are deliberately NOT trimmed

An earlier revision of this PR also selected a top-10 of lessons by cosine similarity to the task text. That is removed, for two measured reasons.

**The ranking did not work.** `_try_embed()` returns `None` on this instance — `llama_cpp` is absent from the venv the live `kirocrew` binary resolves to — so `get_relevant_lessons` fell through to `lessons[:k]`: the *k most recent*, for every task, with no log line or marker signalling the degradation. Verified behaviourally: three unrelated task strings (code review / repo grep / PR-body writing) produced **byte-identical output**, 3,815 chars, the same 10 lessons.

**And the trade was bad even if it had worked.** Trimming lessons contributed only ~14% of the total saving while discarding 11 of 21 user-taught rules — including the `nosemgrep`-placement rule and the `git reset --soft` guard against a squash that reverts main's commits. Spending the highest value-per-char content in the prompt to save 4.2K, when history offers 26.4K, is the wrong direction.

## A cap of `0` now OMITS its section

This is the load-bearing fix behind "drop history". `MemoryStore.get_context()` truncates with `text[:limit] + "…[truncated]"`, so passing `history_cap=0` did **not** omit the section — it rendered:

```
## Recent History
_[source: /home/<user>/.kiro/crew/workspace/memory/history, last 180 days decaying]_

…[truncated]
```

That costs the header, **leaks the on-disk path**, and tells the model content exists that was withheld. Now `history_cap > 0`, `semantic_cap > 0`, and `query and episodic_cap > 0` guard their sections, so a zero cap omits cleanly. The semantic guard also skips the query-and-per-row-embedding work that a zero cap previously did and then discarded.

Contract verified against every caller: `get_context()` has exactly two call sites (both in `context.py`), and every other cap flows from `_resolve_caps_cached`, whose base is floored by `_MIN_CONTEXT_BUDGET_BASE` — so no scaled cap can reach `0` even on the smallest model window. No caller depended on the old rendering.

## The episodic guard has to live in `build_message`

Zeroing `episodic_cap` in `build_session_context` is **inert**: that function passes no `query`, so its episodic path never fires. The code already documented this. The only live injection is in `build_message`, so the sub-agent exclusion is a guard there (`elif subagent_context:`) — without it, sub-agents kept receiving episodic fragments regardless of the zeroed cap.

## Tests

23 tests across two files. Each guard was verified load-bearing by reverting it individually — **6 reverts produced 6 distinct failures**, each mapping to its own test.

- **Zero-cap contract** (`TestGetContextZeroCaps`, 12 tests): history omitted at `0` with no header, no marker, and no source path in the output; still present and still truncating at a positive cap; semantic query *not called* at `0` and called above it; episodic requiring both a query and a positive cap, in all four combinations.
- **Lean context** (`TestSubagentLeanContext`, 11 tests): history dropped, preferences kept, thread history dropped, provenance not even queried, episodic skipped in `build_message`, and the lean result materially smaller. Controls assert the non-lean path is unchanged — history present, episodic still injected for an ordinary new session.
- **Lesson retention**: the fixture creates **14** lessons specifically so a regression to the old `k=10` would be detectable, and asserts every marker survives. A second test asserts the lean and full paths select the *same* lesson set.

## Manual verification

Measured directly rather than inferred, against the live instance's memory store: full `get_context()` = 42,322 chars, lean = 15,922. The 26,400-char history delta was confirmed by rendering both. The lesson-ranking degradation was confirmed by calling `get_relevant_lessons` with three different task strings and diffing the output (identical).

The absence of a semantic-memory retrieval tool was confirmed by enumerating registered tool names — `local_knowledge_search`, `search_chat_history`, `get_chat_session`, `knowledge_add_document` exist; no semantic-memory reader does.

N/A for screenshots — prompt assembly has no UI surface.

## Note on the diff's shape

`vector_memory.py` does **not** appear in this diff, and no method is removed relative to `main`. `get_relevant_lessons` and the `task_text` parameter were introduced by an earlier revision of *this branch* and never existed on `main`, so backing them out leaves a net-zero change in that file. The prose above describes the design decision; the diff simply never adds the ranking in the first place.
