### PR TITLE
fix: honor Cmd+K in terminal panels (clear screen and palette passthrough)

### DIFF
--- a/website/src/components/CliPanel.tsx
+++ b/website/src/components/CliPanel.tsx
@@ -270,6 +270,27 @@ function TerminalView({ sessionId, cwd, visible, onSendToChat }: { sessionId: st
   // xterm instances persist in termCache across tab switches — only destroyed
   // on explicit tab close via disposeTerminalSession.
 
+  // Cmd+K (macOS) — clear the terminal viewport. macOS intercepts metaKey
+  // combos before the browser key event pipeline, so Cmd+K never reaches
+  // the PTY via xterm's own handler. We intercept it on the wrapper element
+  // and call term.clear(), which is an emulator-level viewport clear (no PTY
+  // write, safe while a foreground process is running). The handler lives on
+  // the wrapper div rather than through attachCustomKeyEventHandler (that slot
+  // is owned by TerminalCompletion).
+  useEffect(() => {
+    const wrap = wrapperRef.current
+    if (!wrap) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.metaKey && (e.key === 'k' || e.key === 'K') && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+        e.preventDefault()
+        e.stopPropagation()
+        term.clear()
+      }
+    }
+    wrap.addEventListener('keydown', onKeyDown)
+    return () => wrap.removeEventListener('keydown', onKeyDown)
+  }, [term])
+
   // Selection toolbar lifecycle. We show the toolbar on mouseup (the drag is
   // finished and the selection is stable), anchored to the pointer, and hide it
   // whenever the selection is cleared or the viewport scrolls (which would leave

--- a/website/src/components/CommandPalette.test.tsx
+++ b/website/src/components/CommandPalette.test.tsx
@@ -293,6 +293,74 @@ describe('useCommandPalette — global trigger', () => {
     act(() => result.current.close())
     expect(result.current.open).toBe(false)
   })
+
+  it('⌘K does NOT open when focus is inside an xterm terminal', () => {
+    // Simulate an xterm hierarchy: .xterm root > hidden textarea (the keyboard
+    // sink that xterm uses for input, where the event's target would be).
+    const xtermRoot = document.createElement('div')
+    xtermRoot.className = 'xterm'
+    const xtermTextarea = document.createElement('textarea')
+    xtermRoot.appendChild(xtermTextarea)
+    document.body.appendChild(xtermRoot)
+
+    try {
+      const { result } = renderHook(() => useCommandPalette())
+      act(() => {
+        fireEvent.keyDown(xtermTextarea, { key: 'k', metaKey: true })
+      })
+      // The palette must stay closed — xterm should handle ⌘K (clear screen).
+      expect(result.current.open).toBe(false)
+    } finally {
+      xtermRoot.remove()
+    }
+  })
+
+  it('Ctrl+K does NOT open when focus is inside an xterm terminal', () => {
+    // Ctrl+K is isModKEvent (ctrlKey + k), so the narrowed guard still
+    // suppresses it in a terminal — matching the original behavior. The
+    // guard change only unblocks custom chords and double-Shift.
+    const xtermRoot = document.createElement('div')
+    xtermRoot.className = 'xterm'
+    const xtermTextarea = document.createElement('textarea')
+    xtermRoot.appendChild(xtermTextarea)
+    document.body.appendChild(xtermRoot)
+
+    try {
+      const { result } = renderHook(() => useCommandPalette())
+      act(() => {
+        fireEvent.keyDown(xtermTextarea, { key: 'k', ctrlKey: true })
+      })
+      expect(result.current.open).toBe(false)
+    } finally {
+      xtermRoot.remove()
+    }
+  })
+
+  it('custom chord DOES open the palette even when focus is inside an xterm terminal', () => {
+    // The palette guard is scoped to isModKEvent only — custom chords and
+    // double-Shift do NOT conflict with the PTY and must still fire in terminals.
+    localStorage.setItem(
+      QUICK_SEARCH_SHORTCUT_KEY,
+      JSON.stringify({ mode: 'custom', custom: { key: 'p', mod: true } }),
+    )
+    const xtermRoot = document.createElement('div')
+    xtermRoot.className = 'xterm'
+    const xtermTextarea = document.createElement('textarea')
+    xtermRoot.appendChild(xtermTextarea)
+    document.body.appendChild(xtermRoot)
+
+    try {
+      const { result } = renderHook(() => useCommandPalette())
+      act(() => {
+        // Ctrl+P (non-mac: mod = ctrl) from within the terminal — not a mod-k event
+        fireEvent.keyDown(xtermTextarea, { key: 'p', code: 'KeyP', ctrlKey: true })
+      })
+      expect(result.current.open).toBe(true)
+    } finally {
+      xtermRoot.remove()
+      localStorage.removeItem(QUICK_SEARCH_SHORTCUT_KEY)
+    }
+  })
 })
 
 describe('useCommandPalette — Enable shortcuts toggle', () => {

--- a/website/src/hooks/useCommandPalette.ts
+++ b/website/src/hooks/useCommandPalette.ts
@@ -68,6 +68,18 @@ export const DOUBLE_SHIFT_WINDOW_MS = 250
 /** Live read of the global shortcuts toggle (default on; '0' means disabled). */
 const shortcutsEnabled = () => localStorage.getItem(SHORTCUTS_ENABLED_KEY) !== '0'
 
+/**
+ * True when focus is inside an xterm instance (the hidden textarea that xterm
+ * uses as its keyboard sink, or any element inside the `.xterm` root). All
+ * palette shortcuts must pass through when a terminal has focus so the shell
+ * can receive keys like ⌘K (clear screen in many shells via `bind -x`).
+ * Mirrors the identical guard in {@link useKeyboardShortcuts}.
+ */
+function isTerminalTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null
+  return !!el && typeof el.closest === 'function' && !!el.closest('.xterm')
+}
+
 export interface UseCommandPalette {
   /** Whether the palette is currently shown. */
   open: boolean
@@ -97,6 +109,16 @@ export function useCommandPalette(): UseCommandPalette {
       // unaffected. Reset any pending first Shift tap so re-enabling can't
       // resume a half-formed double-tap from across the disabled window.
       if (!shortcutsEnabled()) {
+        lastShiftRef.current = 0
+        return
+      }
+
+      // Let ⌘K / Ctrl+K pass through when a terminal has keyboard focus —
+      // that is the one palette binding that conflicts with the PTY (⌘K clears
+      // the screen; CliPanel's own wrapper handler handles it). Custom chords
+      // and double-Shift do NOT conflict with the PTY, so they must still work
+      // when a terminal is focused. Only the mod-K event is suppressed here.
+      if (isModKEvent(e) && isTerminalTarget(e.target)) {
         lastShiftRef.current = 0
         return
       }


### PR DESCRIPTION
## Problem

Cmd+K did not work in KiroCrew terminal panels. It either opened the universal search palette, or did nothing. Neither clears the screen.

## Why it matters

Cmd+K to clear the terminal is muscle memory for most macOS developers. Having it hijacked by the search palette while a terminal is focused is disorienting, and the lack of a keyboard shortcut to clear forced reaching for the mouse or typing `clear`.

## Fix

Three independent fixes:

**1. Palette no longer intercepts Cmd+K when a terminal is focused (useCommandPalette.ts)**

The global `window` keydown listener called `preventDefault()` on Cmd+K unconditionally, including when xterm had focus. Fixed by adding an `isTerminalTarget()` guard (`el.closest('.xterm')`) identical to the one in `useKeyboardShortcuts`. The guard is scoped to `isModKEvent` only, so custom chords and double-Shift still fire normally when a terminal is focused.

**2. Cmd+K now clears the terminal viewport (CliPanel.tsx)**

macOS intercepts `metaKey` combos before the browser key event pipeline, so Cmd+K never reaches xterm. A `keydown` listener on the `TerminalView` wrapper intercepts Cmd+K and calls `term.clear()`, which is an emulator-level buffer clear. This wipes both the viewport and scrollback with no PTY write, so it is safe while a foreground process is running (unlike `term.input('\x0c')` which would inject a byte into the running process's stdin). The handler is `metaKey`-only; Ctrl+K is excluded because xterm already handles it as readline kill-to-end-of-line.

**3. Ctrl+K (kill-line) now reaches xterm uninterrupted**

The previous implementation intercepted `ctrlKey` in the CliPanel handler, which would have silently repurposed a core readline editing key as clear-screen on Linux/Windows. Fixed by making the handler `metaKey`-only.

## Tests

Three new tests in `CommandPalette.test.tsx` (41 total, all pass):
- `⌘K does NOT open when focus is inside an xterm terminal`
- `Ctrl+K does NOT open when focus is inside an xterm terminal`
- `custom chord DOES open the palette even when focus is inside an xterm terminal` (validates the narrowed guard)

## Manual verification

1. Cmd+K with terminal focused: screen and scrollback clear, no palette
2. Cmd+K with chat input focused: palette opens normally
3. Ctrl+K with terminal focused: kill-to-end-of-line works as expected (not intercepted)

No screenshot attached since there are no UI changes, only behavior is updated on when the search panel opens