### PR TITLE
fix(tests): plant the probe triple and translate the gate's ja keys

### DIFF
--- a/test/test_sandbox_docker_detection.py
+++ b/test/test_sandbox_docker_detection.py
@@ -164,10 +164,13 @@ class TestWrapArgvDockerGuidance:
         monkeypatch.setattr(sandbox, "_inside_kirocrew_sandbox", lambda: False)
         monkeypatch.setattr(sandbox, "_inside_macos_sandbox", lambda: False)
         monkeypatch.setattr(sandbox, "is_docker_container", lambda: True)
+        # The probe records (transient, reason, remedy) as ONE value. The remedy
+        # token is empty because it is only surfaced on the transient path, and
+        # every case here is a permanent failure.
         monkeypatch.setattr(
             sandbox,
             "_last_unshare_failure",
-            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)"),
+            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)", ""),
         )
         # Stub SEL so no real I/O happens.
         fake_sel = MagicMock()
@@ -246,7 +249,7 @@ class TestWrapArgvDockerGuidance:
         monkeypatch.setattr(
             sandbox,
             "_last_unshare_failure",
-            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)"),
+            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)", ""),
         )
         fake_sel = MagicMock()
         fake_sel.return_value = fake_sel
@@ -281,7 +284,7 @@ class TestWrapArgvDockerGuidance:
         monkeypatch.setattr(
             sandbox,
             "_last_unshare_failure",
-            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)"),
+            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)", ""),
         )
         fake_sel = MagicMock()
         fake_sel.return_value = fake_sel

--- a/website/src/i18n/locales/ja.json
+++ b/website/src/i18n/locales/ja.json
@@ -4105,7 +4105,18 @@
       "try_again": "もう一度試してください",
       "waiting": "待機中",
       "we_could_not_check_kiro_cli": "Kiro CLI を確認できませんでした。",
-      "your_crew_is_almost_ready": "クルーの準備がほぼ完了しました。"
+      "your_crew_is_almost_ready": "クルーの準備がほぼ完了しました。",
+      "copied": "コピーしました",
+      "copy_command": "コマンドをコピー",
+      "how_to_fix": "解決方法",
+      "if_this_keeps_happening": "問題が解決しない場合",
+      "linux_sandbox_guide": "Linux サンドボックスガイド",
+      "remedy_apparmor_service_install": "Kiro Crew をサービスとしてインストールします。その際、ユーザー名前空間の権限のみを Kiro Crew サービスに限定して許可する狭い AppArmor プロファイル (kirocrew-userns) も書き込まれます。マシン上の他の設定が緩められることはありません。",
+      "remedy_max_user_namespaces": "ユーザー名前空間の作成がユーザーごとの上限に達しました。通常これは、強化されたホストで user.max_user_namespaces が 0 になっていることを意味します。この値を引き上げ、再起動後も維持されるよう /etc/sysctl.d/ に永続化してください。",
+      "remedy_no_user_ns": "このカーネルはユーザー名前空間のサポート (CONFIG_USER_NS) なしでビルドされているため、変更できる設定はありません。別のカーネルを使用することが唯一の解決方法です。",
+      "remedy_userns_denied": "カーネルがユーザー名前空間の作成を拒否しました。Debian 系のホストではこのレガシー設定を確認し、再起動後も維持されるよう /etc/sysctl.d/ に永続化してください。コンテナ内では通常、コンテナ自身の seccomp フィルターが unshare を拒否しているため、ホストの設定ではなくコンテナの実行フラグで解決します。",
+      "run_kirocrew_doctor_on_the_gateway_host_for_a_ful": "サンドボックスのどのステップが失敗したかを含む前提条件の完全なレポートを取得するには、ゲートウェイホストでこれを実行してください。",
+      "this_host_allows_user_namespaces_but_the_kernel_d": "このホストはユーザー名前空間を許可していますが、カーネルがマウント名前空間を拒否しました。これは Ubuntu 23.10 以降の特徴で、ユーザー名前空間を作成したプロセスを制限付きの AppArmor プロファイルに移動させます。Kiro Crew は認証情報を危険にさらすよりも、隔離されていない状態でエージェントを実行することを拒否するため、プロファイルが適用されるまでブロックされたままになります。"
     },
     "linkPreview": {
       "copied": "コピー済み",


### PR DESCRIPTION
Main is red at `429cbad8c` and both causes trace to #1668 landing incomplete.

**Backend shards + namespace sandbox: `ValueError: not enough values to unpack (expected 3, got 2)`**

#1668 made the userns probe record its outcome as one `(transient, reason, remedy)` value so a remedy token can never outlive the failure it describes. `test_sandbox_docker_detection.py` still plants a 2-tuple at three sites, so `wrap_argv` raises while unpacking and six guidance tests fail. This file was rewritten by #1804 at almost the same time to pin the guidance branch instead of reading the host's AppArmor sysctl, which is how the two crossed — every other sandbox test file already plants the triple.

The remedy token is `""` in these fixtures rather than a sample string, because it is only surfaced on the transient path and all three cases are permanent failures. That matches what the production default records for a caller that reports a failure without probing.

**Frontend Tests: `catalog parity > ja > has no key missing relative to en`**

The eleven `kiroPrerequisiteGate` strings #1668 added to `en.manual.json` were never translated, so ja is missing 11 keys. Added, with the brand and host-mechanism terms (Kiro Crew, AppArmor, `kirocrew-userns`, `user.max_user_namespaces`, `CONFIG_USER_NS`, seccomp, `unshare`, `/etc/sysctl.d/`) left literal — the DNT gate scans for exactly those.

The Japanese is machine-written and would benefit from a native-speaker pass; it is accurate on the technical nouns, which is what these strings are mostly made of.

**Not in scope:** `Backend Lint & Type Check`, `De-Amazon Scrub Lint` and `Coverage Gate` were failing on the same run for an unrelated reason — `Failed to resolve action download info. Error: Bad Gateway / Service Unavailable`, a GitHub Actions incident, not code. Those should clear on a re-run.

**Verification.** With this branch the full backend suite returns to 31964 passed with only the 7 host-specific failures this machine always shows (playwright-needs-node-18, /proc probing, IPv6 parsing) — the six sandbox failures are gone. Frontend: `catalogParity` 70/70, full vitest 9625 passed with only the node-24-only `Intl.DurationFormat` case (CI runs node 20), `i18n:check` all gates ok including DNT 20 terms intact. isort and flake8 clean.

Revert-verified: restoring a 2-tuple at one site fails four of the six tests again.
