### PR TITLE
feat(dashboard): auto-tag sessions with their project name in the background

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1435,
+    "missing_code": 1415,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 453,
+  "_compliant": 545,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -59,9 +59,6 @@
     },
     "dashboard/chat_slack.py": {
       "missing_code": 9
-    },
-    "dashboard/chat_tags.py": {
-      "missing_code": 20
     },
     "dashboard/chat_title.py": {
       "missing_code": 5

--- a/src/kiro_crew/dashboard/chat_auto_tag.py
+++ b/src/kiro_crew/dashboard/chat_auto_tag.py
@@ -1,0 +1,136 @@
+"""Background auto-tagging — derive a tag from the session's project directory.
+
+Mirrors the pattern of ``_maybe_auto_title`` in ``chat_title.py``: a fire-once
+background task that never raises, guards on idempotency, and runs alongside the
+first-message title generation.
+
+v1 derivation is DETERMINISTIC: the tag name is ``os.path.basename(slot.project)``
+(the repo/directory name). This requires zero LLM calls — if the project is
+set, the tag is derived immediately.
+
+# Future work: use a cheap model to extract 1–2 topic tags from the first
+# user message (similar to how auto-title calls the LLM). That would add
+# semantic tags like "oncall", "debugging", "code-review" alongside the
+# deterministic project-name tag.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
+from kiro_crew.dashboard.chat_tags import (
+    _NAME_MAX,
+    create_tag_definition,
+    persist_tags_snapshot_unlocked,
+    tags_write_lock,
+)
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+logger = logging.getLogger(__name__)
+
+
+async def maybe_auto_tag(state: Any, slot: Any) -> None:
+    """Derive a tag from the slot's project directory and apply it.
+
+    Never raises — all failures are debug-logged. Guards:
+    - Once-per-slot: ``slot._auto_tagged`` flag (mirrors ``_titled`` pattern)
+    - Non-empty ``slot.project`` that isn't trivial (".", "~")
+    - Idempotent: if the derived tag id is already in slot.tags, no-op
+    """
+    # Once-guard: never re-run after the first attempt (even if the user
+    # manually removes the tag later — respect the removal).
+    if getattr(slot, "_auto_tagged", False):
+        return
+    try:
+        await _auto_tag_inner(state, slot)
+    finally:
+        # Mark attempted regardless of success/failure (same as _titled).
+        slot._auto_tagged = True
+    return
+
+
+async def _auto_tag_inner(state: Any, slot: Any) -> None:
+    # Note: no slot-kind guard needed here — the only call site
+    # (chat_handlers message path) fires exclusively for dashboard chat
+    # slots, same as ``_maybe_auto_title``. Slot keys are BARE names; the
+    # ``dashboard:`` prefix exists only on the derived session key
+    # (``dashboard:{slot.key}``), never on ``slot.key`` itself.
+
+    # Guard: must have a meaningful project
+    project = getattr(slot, "project", "") or ""
+    if not project:
+        return
+    tag_name = os.path.basename(project)
+    if not tag_name or tag_name in (".", "~"):
+        return
+
+    # Redact credential/exfiltration patterns from derived name, then apply
+    # the SAME normalization create_tag_definition uses (strip + _NAME_MAX
+    # truncation) BEFORE matching — otherwise two long basenames that differ
+    # only past the truncation point would each miss the lookup and create
+    # duplicate definitions with identical persisted names.
+    safe_name, _ = redact_exfiltration_urls(tag_name)
+    safe_name, _ = redact_credentials(safe_name)
+    safe_name = safe_name.strip()[:_NAME_MAX]
+    if not safe_name:
+        return
+
+    async with tags_write_lock(state):
+        # Build case-insensitive lookup
+        existing_by_lower: dict[str, dict] = {}
+        for t in state._tags:
+            name_lower = (t.get("name") or "").lower()
+            if name_lower and name_lower not in existing_by_lower:
+                existing_by_lower[name_lower] = t
+
+        lower = safe_name.lower()
+        existing = existing_by_lower.get(lower)
+
+        if existing:
+            # NEVER apply status/workflow tags
+            if existing.get("status"):
+                return
+            tag_id = existing["id"]
+        else:
+            # Create new tag definition (never status=True)
+            new_tag = create_tag_definition(state, safe_name, status=False)
+            tag_id = new_tag["id"]
+            try:
+                await persist_tags_snapshot_unlocked(state)
+            except Exception:
+                # Roll back the in-memory append: a definition that never
+                # reached disk must not stay visible in the vocabulary
+                # (retries are suppressed by the once-flag, so it would
+                # otherwise linger unassigned until restart).
+                state._tags = [t for t in state._tags if t.get("id") != tag_id]
+                logger.debug(
+                    "auto_tag: tag snapshot persist failed; rolled back %s",
+                    tag_id,
+                    exc_info=True,
+                )
+                return
+
+        # Idempotency: already tagged? no-op
+        current_tags: list[str] = list(getattr(slot, "tags", None) or [])
+        if tag_id in current_tags:
+            return
+
+        # Additive merge. Set the once-flag BEFORE persisting: the slot save
+        # below writes the metadata line, and the flag must be on it —
+        # otherwise a restart loses the flag and a later message re-runs
+        # auto-tag, silently re-adding a tag the user removed.
+        current_tags.append(tag_id)
+        slot.tags = current_tags
+        slot._auto_tagged = True
+        await save_slot_off_loop(state, slot, force=True)
+
+        # Push update to connected clients
+        push = getattr(state, "push_slots_update", None)
+        if push is not None:
+            try:
+                push()
+            except Exception:
+                logger.debug("push_slots_update failed in auto_tag", exc_info=True)

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -29,6 +29,7 @@ from kiro_crew.config.loader import (
     resolve_agent_bindings,
 )
 from kiro_crew.dashboard.channel_slots import channel_slot_name, note_slot_closed
+from kiro_crew.dashboard.chat_auto_tag import maybe_auto_tag
 from kiro_crew.dashboard.chat_folders import _unhide_folder
 from kiro_crew.dashboard.chat_orchestrator import _stage_loop
 from kiro_crew.dashboard.chat_persistence import (
@@ -543,6 +544,13 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         state._background_tasks.add(_tt)
         _tt.add_done_callback(state._background_tasks.discard)
 
+    # Auto-tag: derive a tag from the session's project directory (deterministic,
+    # no LLM). Fire-and-forget, same pattern as auto-title.
+    if not getattr(slot, "_auto_tagged", False):
+        _at = asyncio.create_task(maybe_auto_tag(state, slot))
+        state._background_tasks.add(_at)
+        _at.add_done_callback(state._background_tasks.discard)
+
     # Edition message observer (CPP seam). Fire-and-forget, fail-safe: a
     # companion uses this to auto-ingest doc links pasted into chat. The public
     # Default is a no-op. Guarded so an observer error never blocks the turn;
@@ -643,9 +651,7 @@ def _finite_number(value: Any) -> float | None:
     return float(value) if math.isfinite(value) else None
 
 
-def _context_reading(
-    pct: Any, used: Any, window: Any, *, stale: bool
-) -> dict[str, Any]:
+def _context_reading(pct: Any, used: Any, window: Any, *, stale: bool) -> dict[str, Any]:
     """Assemble the context fields from a (pct, used, window) triple.
 
     ``pct`` is the PRIMARY signal and the only one the bar needs: kiro-cli
@@ -721,16 +727,8 @@ async def _context_snapshot_fields_inner(
     if provider is not None:
         return _context_reading(
             provider.context_usage_pct(),
-            (
-                provider.context_used_tokens()
-                if hasattr(provider, "context_used_tokens")
-                else 0
-            ),
-            (
-                provider.context_window_tokens()
-                if hasattr(provider, "context_window_tokens")
-                else 0
-            ),
+            (provider.context_used_tokens() if hasattr(provider, "context_used_tokens") else 0),
+            (provider.context_window_tokens() if hasattr(provider, "context_window_tokens") else 0),
             stale=False,
         )
     # Readings from a previous process live in a file, so the first read is
@@ -951,9 +949,7 @@ async def api_chat_slot_create(request: web.Request) -> web.Response:
             # One code for BOTH reasons on purpose: a distinct code per reason
             # would turn this 404 into an existence oracle for slots the caller
             # may not know about. The prose stays in `error` for logs.
-            return web.json_response(
-                {"error": "not found", "code": "slot_not_found"}, status=404
-            )
+            return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
         # Pin title if explicitly provided (prevents auto-title from overwriting)
         title = (body.get("title") or "").strip()[:200] if isinstance(body, dict) else ""
         if title:
@@ -1065,14 +1061,10 @@ def _unblock_pending_waits(state: DashboardState, slot: _ChatSlot) -> None:
     _reject_pending_approvals(slot)
     cancelled = state.cancel_questions_for_slot(slot.key)
     if cancelled:
-        logger.info(
-            "Stop: cancelled %d pending question(s) on slot %s", cancelled, slot.key
-        )
+        logger.info("Stop: cancelled %d pending question(s) on slot %s", cancelled, slot.key)
 
 
-async def _reset_slot_session(
-    state: DashboardState, slot: _ChatSlot, session_key: str
-) -> None:
+async def _reset_slot_session(state: DashboardState, slot: _ChatSlot, session_key: str) -> None:
     """Reset a slot's agent session, releasing anything blocked on the old one.
 
     The switch handlers (agent, model, bulk model, reasoning effort, workspace)
@@ -1410,7 +1402,8 @@ async def api_chat_slot_continue(request: web.Request) -> web.Response:
             source="app_isolation",
             resources=f"slot={slot.key}",
             error=(
-                "app cannot access unscoped slots" if not slot._app
+                "app cannot access unscoped slots"
+                if not slot._app
                 else "app does not own this slot"
             ),
         )
@@ -1927,9 +1920,7 @@ async def api_chat_slot_delete(request: web.Request) -> web.Response:
         except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
             pass
     try:
-        await save_slot_off_loop(
-            state, slot, closed=True, closed_at=closed_at, best_effort=False
-        )
+        await save_slot_off_loop(state, slot, closed=True, closed_at=closed_at, best_effort=False)
     except Exception:
         # Save failed — restore slot so data isn't lost
         logger.error("Failed to save slot %s to history, restoring", name, exc_info=True)
@@ -2355,9 +2346,7 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
         # to make this call, so there is no pre-emptive gate here to go stale.
         slot.model = prior_model
         logger.warning("Slot %s model rejected: %s", name, exc)
-        return web.json_response(
-            {"error": str(exc), "code": "model_unavailable"}, status=400
-        )
+        return web.json_response({"error": str(exc), "code": "model_unavailable"}, status=400)
     if went_live:
         _broadcast_context_reset(state, slot.key, provider)
     else:
@@ -2986,6 +2975,22 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
         # so a tampered/legacy JSONL can't seed a malformed sha that later
         # crashes the compare.
         slot.theme_consent_sha = normalize_theme_consent_sha(meta.get("theme_consent_sha"))
+    # Restore tags + the auto-tag once-flag (mirrors the persistence loaders).
+    # Without the flag, resuming a session whose auto-tag the user removed
+    # would re-run maybe_auto_tag on the next message and silently re-add it.
+    raw_tags = meta.get("tags")
+    if isinstance(raw_tags, list):
+        slot.tags = [str(t) for t in raw_tags if isinstance(t, str) and t]
+        # Prune ids missing from the vocabulary (crash-atomic delete leaves
+        # dangling ids on disk; see api_chat_tag_delete). FAIL-OPEN only when
+        # the vocabulary is UNKNOWN (tags.json parse/I/O failure) — pruning
+        # then would wipe every assignment. A legitimately-empty vocabulary
+        # is authoritative and must prune dangling ids.
+        if getattr(state, "_tags_authoritative", True):
+            known = {t.get("id") for t in state._tags}
+            slot.tags = [t for t in slot.tags if t in known]
+    if meta.get("auto_tagged"):
+        slot._auto_tagged = True
     mm = meta.get("memory_mode", "persistent")
     slot.memory_mode = mm
     if mm != "persistent":

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -478,6 +478,20 @@ def _rehydrate_slot_from_history(
         raw_tags = meta.get("tags")
         if isinstance(raw_tags, list):
             slot.tags = [str(t) for t in raw_tags if isinstance(t, str) and t]
+            # Prune ids missing from the vocabulary: tag deletion commits the
+            # vocab write first (crash-atomic), so a crash mid-delete can
+            # leave dangling ids on the persisted slot line. load_tags() runs
+            # before any slot restore, so state._tags is authoritative here.
+            # FAIL-OPEN only when the vocabulary is UNKNOWN (tags.json parse
+            # or I/O failure): pruning then would wipe EVERY assignment and
+            # the next save persists the loss. A legitimately-empty vocabulary
+            # (user deleted the last tag) IS authoritative and must prune —
+            # otherwise a crash mid-delete resurrects the dangling id forever.
+            if getattr(state, "_tags_authoritative", True):
+                known = {t.get("id") for t in state._tags}
+                slot.tags = [t for t in slot.tags if t in known]
+        if meta.get("auto_tagged"):
+            slot._auto_tagged = True
         mm = meta.get("memory_mode", "persistent")
         slot.memory_mode = mm
         if mm != "persistent":
@@ -814,6 +828,20 @@ def _restore_recent_sessions_steps(
         raw_tags = meta.get("tags")
         if isinstance(raw_tags, list):
             slot.tags = [str(t) for t in raw_tags if isinstance(t, str) and t]
+            # Prune ids missing from the vocabulary: tag deletion commits the
+            # vocab write first (crash-atomic), so a crash mid-delete can
+            # leave dangling ids on the persisted slot line. load_tags() runs
+            # before any slot restore, so state._tags is authoritative here.
+            # FAIL-OPEN only when the vocabulary is UNKNOWN (tags.json parse
+            # or I/O failure): pruning then would wipe EVERY assignment and
+            # the next save persists the loss. A legitimately-empty vocabulary
+            # (user deleted the last tag) IS authoritative and must prune —
+            # otherwise a crash mid-delete resurrects the dangling id forever.
+            if getattr(state, "_tags_authoritative", True):
+                known = {t.get("id") for t in state._tags}
+                slot.tags = [t for t in slot.tags if t in known]
+        if meta.get("auto_tagged"):
+            slot._auto_tagged = True
         mm = meta.get("memory_mode", "persistent")
         slot.memory_mode = mm
         if mm != "persistent":
@@ -1523,6 +1551,11 @@ def _save_slot_to_history(
                 meta_line["color_theme"] = slot.color_theme
             if slot.tags:
                 meta_line["tags"] = list(slot.tags)
+            if getattr(slot, "_auto_tagged", False):
+                # Once-flag for project auto-tagging: without it a restart
+                # re-runs maybe_auto_tag and silently re-adds a tag the user
+                # removed (see chat_auto_tag.maybe_auto_tag).
+                meta_line["auto_tagged"] = True
             if slot.forked_from is not None:
                 meta_line["forked_from"] = slot.forked_from
             if slot.linked_session_key:

--- a/src/kiro_crew/dashboard/chat_tags.py
+++ b/src/kiro_crew/dashboard/chat_tags.py
@@ -9,15 +9,18 @@ carry a single status tag as filter reassigns the card's status tag.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 import uuid
-from typing import Any
+import weakref
+from typing import Any, Callable, TypeVar
 
 from aiohttp import web
 
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
@@ -26,6 +29,73 @@ _NAME_MAX = 60
 _COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
 _DEFAULT_COLOR = "#6b7280"
 _VALID_MODES = {"any", "all", "none"}
+
+_T = TypeVar("_T")
+
+
+# Per-state tag-write lock. Serializes ALL mutations to state._tags + disk
+# persistence so concurrent creates/updates/deletes cannot race the atomic
+# fsync/os.replace sequence. Keyed weakly so a discarded state's lock is
+# collectable (mirrors _RECONCILE_LOCKS in channel_slots.py).
+_TAGS_WRITE_LOCKS: weakref.WeakKeyDictionary[Any, asyncio.Lock] = weakref.WeakKeyDictionary()
+
+
+def _tags_write_lock(state: Any) -> asyncio.Lock:
+    """Return (lazily create) the per-state asyncio.Lock for tag writes."""
+    lock = _TAGS_WRITE_LOCKS.get(state)
+    if lock is None:
+        lock = asyncio.Lock()
+        _TAGS_WRITE_LOCKS[state] = lock
+    return lock
+
+
+# Public accessor — used by the tags/boards HTTP handlers in this module and by
+# chat_auto_tag.maybe_auto_tag to hold the lock across an entire
+# resolve→merge→persist critical section.
+tags_write_lock = _tags_write_lock
+
+
+async def _mutate_tags_locked(state: DashboardState, mutate: Callable[[], _T]) -> _T:
+    """Serialize a tag mutation + persistence under a shared async lock.
+
+    ``mutate`` is a sync callable that modifies ``state._tags`` in place and
+    returns a result. After it runs, an immutable snapshot is atomically written
+    to disk inside a worker thread (mirrors DashboardState._atomic_write_json).
+    The lock is NON-REENTRANT — callers must never nest.
+
+    Raises on persist failure (caller must catch to surface HTTP 5xx).
+    The in-memory state is rolled back to the pre-mutate snapshot on failure.
+    """
+    async with _tags_write_lock(state):
+        pre_snapshot = [dict(t) for t in state._tags]
+        result = mutate()
+        snapshot = [dict(t) for t in state._tags]
+        try:
+            await asyncio.to_thread(_write_tags_snapshot, state, snapshot)
+        except Exception:
+            # Roll back to pre-mutate state.
+            state._tags = pre_snapshot
+            raise
+        return result
+
+
+def _write_tags_snapshot(state: DashboardState, snapshot: list[dict]) -> None:
+    """Persist a pre-captured tag snapshot (runs in worker thread).
+
+    Delegates to ``state.save_tags_snapshot`` so the file location resolves
+    through ``kiro_crew.dashboard.state.config_dir`` exactly like
+    ``save_tags`` (and stays patchable in tests)."""
+    state.save_tags_snapshot(snapshot)
+
+
+async def persist_tags_snapshot_unlocked(state: DashboardState) -> None:
+    """Persist the current state._tags to disk without acquiring the lock.
+
+    Callers MUST hold `tags_write_lock(state)` themselves. Exported for use in
+    cross-module critical sections (e.g. chat_auto_tag.maybe_auto_tag).
+    """
+    snapshot = [dict(t) for t in state._tags]
+    await asyncio.to_thread(_write_tags_snapshot, state, snapshot)
 
 
 def _valid_color(value: str) -> str:
@@ -36,7 +106,71 @@ def _tag_by_id(state: DashboardState, tag_id: str) -> dict | None:
     return next((t for t in state._tags if t.get("id") == tag_id), None)
 
 
+def create_tag_definition(
+    state: DashboardState,
+    name: str,
+    color: str | None = None,
+    *,
+    status: bool = False,
+) -> dict:
+    """Create a new tag definition (sync, no lock).
+
+    Shared by the async locked callers. Mutates state._tags in place.
+    Returns the created tag dict.
+    """
+    clean_name = name.strip()[:_NAME_MAX]
+    if not clean_name:
+        raise ValueError("tag name must not be empty")
+    clean_color = _valid_color(str(color or _DEFAULT_COLOR))
+    tag = {
+        "id": uuid.uuid4().hex[:12],
+        "name": clean_name,
+        "color": clean_color,
+        "order": len(state._tags),
+        "status": bool(status),
+    }
+    state._tags.append(tag)
+    return tag
+
+
+async def create_tag_definition_off_loop(
+    state: DashboardState,
+    name: str,
+    color: str | None = None,
+    *,
+    status: bool = False,
+) -> dict:
+    """Async wrapper: creates a tag definition under the shared write lock.
+
+    Acquires the per-state tag-write lock (shared with update/delete) so
+    concurrent callers creating the same missing tag name produce exactly one
+    definition. The sync fsync write runs in a worker thread while the lock is
+    held.
+
+    Raises on persist failure so the caller can surface HTTP 5xx.
+    """
+    async with _tags_write_lock(state):
+        # Re-check under lock: another caller may have just created it.
+        lower = name.strip().lower()
+        existing = next(
+            (t for t in state._tags if (t.get("name") or "").lower() == lower),
+            None,
+        )
+        if existing:
+            return existing
+        tag = create_tag_definition(state, name, color, status=status)
+        snapshot = [dict(t) for t in state._tags]
+        try:
+            await asyncio.to_thread(_write_tags_snapshot, state, snapshot)
+        except Exception:
+            # Roll back in-memory mutation.
+            state._tags = [t for t in state._tags if t.get("id") != tag["id"]]
+            raise
+        return tag
+
+
 # ── Tag vocabulary ─────────────────────────────────────────────────────────
+
 
 async def api_chat_tags(request: web.Request) -> web.Response:
     """GET /api/chat/tags — list all tag definitions."""
@@ -50,127 +184,247 @@ async def api_chat_tag_create(request: web.Request) -> web.Response:
     try:
         body = await request.json()
     except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    name = (body.get("name") or "").strip()[:_NAME_MAX]
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
+    # Redact credential / exfiltration patterns from the user-supplied name
+    # BEFORE truncation — truncating first can slice a credential that
+    # straddles the length cut into a fragment the scanners no longer
+    # recognize, persisting a raw prefix. Same boundary pattern as other
+    # LLM-authored sinks.
+    name = (body.get("name") or "").strip()
+    name, _ = redact_exfiltration_urls(name)
+    name, _ = redact_credentials(name)
+    name = name.strip()[:_NAME_MAX]
     if not name:
-        return web.json_response({"error": "name required"}, status=400)
-    color = _valid_color(str(body.get("color") or _DEFAULT_COLOR))
-    tag = {
-        "id": uuid.uuid4().hex[:12],
-        "name": name,
-        "color": color,
-        "order": len(state._tags),
-        "status": bool(body.get("status", False)),
-    }
-    state._tags.append(tag)
-    state.save_tags()
+        return web.json_response({"error": "name required", "code": "name_required"}, status=400)
+    color = str(body.get("color") or _DEFAULT_COLOR)
+    status = bool(body.get("status", False))
+    try:
+        tag = await create_tag_definition_off_loop(state, name, color, status=status)
+    except Exception:
+        logger.warning("tag create failed to persist: %s", name)
+        return web.json_response({"error": "persist failed", "code": "persist_failed"}, status=500)
     state.push_slots_update()
     sel().log_api_access(
-        caller="dashboard", operation="chat.tag_create",
-        outcome="allowed", source="dashboard", resources=str(tag["id"]),
+        caller="dashboard",
+        operation="chat.tag_create",
+        outcome="allowed",
+        source="dashboard",
+        resources=str(tag["id"]),
     )
     return web.json_response(tag, status=201)
 
 
 async def api_chat_tag_update(request: web.Request) -> web.Response:
-    """PATCH /api/chat/tags/{id} — rename / recolor / reorder."""
+    """PATCH /api/chat/tags/{id} — rename / recolor / reorder.
+
+    Resolution of the tag dict happens INSIDE the write lock so a concurrent
+    DELETE cannot remove the tag between lookup and mutation (preventing a
+    silent lost update on a detached dict).
+    """
     state: DashboardState = request.app["state"]
     tid = request.match_info["id"]
-    tag = _tag_by_id(state, tid)
-    if not tag:
-        return web.json_response({"error": "not found"}, status=404)
+    # Early unlocked check for fast 404 on obviously invalid ids (avoids
+    # JSON parse + lock contention for non-existent tags).
+    if not _tag_by_id(state, tid):
+        return web.json_response({"error": "not found", "code": "not_found"}, status=404)
     try:
         body = await request.json()
     except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
     if "name" in body:
         new_name = str(body["name"]).strip()[:_NAME_MAX]
         if not new_name:
-            return web.json_response({"error": "name required"}, status=400)
-        tag["name"] = new_name
-    if "color" in body:
-        tag["color"] = _valid_color(str(body["color"]))
-    if "order" in body:
+            return web.json_response(
+                {"error": "name required", "code": "name_required"}, status=400
+            )
+
+    async with _tags_write_lock(state):
+        # Re-resolve under lock — a concurrent DELETE may have removed it.
+        tag = _tag_by_id(state, tid)
+        if not tag:
+            return web.json_response({"error": "not found", "code": "not_found"}, status=404)
+
+        pre_snapshot = [dict(t) for t in state._tags]
+
+        if "name" in body:
+            # Redact BEFORE truncation (same reasoning as tag create).
+            safe_name = str(body["name"]).strip()
+            safe_name, _ = redact_exfiltration_urls(safe_name)
+            safe_name, _ = redact_credentials(safe_name)
+            safe_name = safe_name.strip()[:_NAME_MAX]
+            if not safe_name:
+                # Parity with create: never persist an empty name (e.g. the
+                # whole input was a redacted credential).
+                return web.json_response(
+                    {"error": "name required", "code": "name_required"}, status=400
+                )
+            tag["name"] = safe_name
+        if "color" in body:
+            tag["color"] = _valid_color(str(body["color"]))
+        if "order" in body:
+            try:
+                tag["order"] = int(body["order"])
+            except (TypeError, ValueError, OverflowError):
+                pass
+        if "status" in body:
+            tag["status"] = bool(body["status"])
+
+        snapshot = [dict(t) for t in state._tags]
         try:
-            tag["order"] = int(body["order"])
-        except (TypeError, ValueError, OverflowError):
-            pass
-    if "status" in body:
-        tag["status"] = bool(body["status"])
-    state.save_tags()
+            await asyncio.to_thread(_write_tags_snapshot, state, snapshot)
+        except Exception:
+            state._tags = pre_snapshot
+            logger.warning("tag update failed to persist: %s", tid)
+            return web.json_response(
+                {"error": "persist failed", "code": "persist_failed"}, status=500
+            )
+        updated = tag
+
     state.push_slots_update()
     sel().log_api_access(
-        caller="dashboard", operation="chat.tag_update",
-        outcome="allowed", source="dashboard", resources=tid,
+        caller="dashboard",
+        operation="chat.tag_update",
+        outcome="allowed",
+        source="dashboard",
+        resources=tid,
     )
-    return web.json_response(tag)
+    return web.json_response(updated)
 
 
 async def api_chat_tag_delete(request: web.Request) -> web.Response:
-    """DELETE /api/chat/tags/{id} — delete a tag; strip it from all slots."""
+    """DELETE /api/chat/tags/{id} — delete a tag; strip it from all slots.
+
+    Holds the per-state tag-write lock across the ENTIRE sequence so a
+    concurrent tag_session directive cannot resolve the tag between the
+    vocabulary removal and the slot strip.
+
+    CRASH-ATOMIC ordering: the vocabulary (``tags.json``) is persisted FIRST.
+    Once that single write commits, the deletion is durable — a crash at any
+    later point leaves only dangling tag ids on slots/boards, which are
+    harmless and pruned on the next load (see ``_prune_unknown_tag_ids``).
+    If the vocabulary write fails, nothing else has been touched, so the
+    in-memory removal is simply rolled back and 500 returned. No multi-write
+    compensation is needed in either direction.
+    """
     state: DashboardState = request.app["state"]
     tid = request.match_info["id"]
     if not _tag_by_id(state, tid):
-        return web.json_response({"error": "not found"}, status=404)
-    state._tags = [t for t in state._tags if t.get("id") != tid]
-    # Strip from slots
-    for slot in state._slots.values():
-        if tid in slot.tags:
-            slot.tags = [t for t in slot.tags if t != tid]
-            await save_slot_off_loop(state, slot, force=True)
-    # Strip from sidebar columns (flat list of column dicts).
-    changed_boards = False
-    for col in state._tag_boards:
-        tag_ids = col.get("tag_ids") or []
-        filtered = [t for t in tag_ids if t != tid]
-        if len(filtered) != len(tag_ids):
-            col["tag_ids"] = filtered
-            changed_boards = True
-    if changed_boards:
-        state.save_tag_boards()
-    state.save_tags()
+        return web.json_response({"error": "not found", "code": "not_found"}, status=404)
+
+    async with _tags_write_lock(state):
+        # Re-check under lock — another concurrent delete may have won.
+        removed_tag = _tag_by_id(state, tid)
+        if not removed_tag:
+            return web.json_response({"error": "not found", "code": "not_found"}, status=404)
+
+        # ── Single durable commit: remove from vocabulary and persist ────
+        state._tags = [t for t in state._tags if t.get("id") != tid]
+        snapshot = [dict(t) for t in state._tags]
+        try:
+            await asyncio.to_thread(_write_tags_snapshot, state, snapshot)
+        except Exception:
+            # Nothing else has been written — restore memory and abort.
+            state._tags.append(removed_tag)
+            logger.warning("tag delete: vocab persist failed for %s", tid)
+            return web.json_response(
+                {"error": "persist failed", "code": "persist_failed"}, status=500
+            )
+
+        # ── Best-effort cleanup: strip the (now nonexistent) id ──────────
+        # Failures here are tolerable: a dangling id on disk is pruned on
+        # the next load; mark the slot dirty so the periodic flush retries.
+        for slot in state._slots.values():
+            if tid in slot.tags:
+                slot.tags = [t for t in slot.tags if t != tid]
+                try:
+                    await save_slot_off_loop(state, slot, force=True, best_effort=False)
+                except Exception:
+                    slot._dirty = True
+                    logger.warning(
+                        "tag delete: slot strip persist failed for %s; "
+                        "marked dirty for periodic-flush retry",
+                        getattr(slot, "key", "?"),
+                        exc_info=True,
+                    )
+
+        # Strip from sidebar columns (flat list of column dicts).
+        changed_boards = False
+        for col in state._tag_boards:
+            tag_ids = col.get("tag_ids") or []
+            filtered = [t for t in tag_ids if t != tid]
+            if len(filtered) != len(tag_ids):
+                col["tag_ids"] = filtered
+                changed_boards = True
+        if changed_boards:
+            try:
+                boards_snapshot = [dict(c) for c in state._tag_boards]
+                await asyncio.to_thread(state.save_tag_boards_snapshot, boards_snapshot)
+            except Exception:
+                # Dangling board reference — pruned on next load.
+                logger.warning("tag delete: board strip persist failed for %s", tid, exc_info=True)
+
     state.push_slots_update()
     sel().log_api_access(
-        caller="dashboard", operation="chat.tag_delete",
-        outcome="allowed", source="dashboard", resources=tid,
+        caller="dashboard",
+        operation="chat.tag_delete",
+        outcome="allowed",
+        source="dashboard",
+        resources=tid,
     )
     return web.json_response({"ok": True})
 
 
 # ── Slot tag assignment ────────────────────────────────────────────────────
 
+
 async def api_chat_slot_tags(request: web.Request) -> web.Response:
-    """PUT /api/chat/slots/{slot}/tags — replace the slot's tag list."""
+    """PUT /api/chat/slots/{slot}/tags — replace the slot's tag list.
+
+    Holds the tags write lock across validate→assign→persist so a concurrent
+    DELETE cannot remove a tag id between validation and slot persistence
+    (preventing dangling references).
+    """
     state: DashboardState = request.app["state"]
     name = request.match_info["slot"]
     slot = state._slots.get(name)
     if not slot:
-        return web.json_response({"error": "not found"}, status=404)
+        return web.json_response({"error": "not found", "code": "not_found"}, status=404)
     try:
         body = await request.json()
     except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
     raw_ids = body.get("tags")
     if not isinstance(raw_ids, list):
-        return web.json_response({"error": "tags must be an array"}, status=400)
-    valid_ids = {t.get("id") for t in state._tags}
-    new_tags: list[str] = []
-    for tid in raw_ids:
-        if isinstance(tid, str) and tid in valid_ids and tid not in new_tags:
-            new_tags.append(tid)
-    slot.tags = new_tags
-    await save_slot_off_loop(state, slot, force=True)
+        return web.json_response(
+            {"error": "tags must be an array", "code": "tags_not_array"}, status=400
+        )
+
+    async with _tags_write_lock(state):
+        valid_ids = {t.get("id") for t in state._tags}
+        new_tags: list[str] = []
+        for tid in raw_ids:
+            if isinstance(tid, str) and tid in valid_ids and tid not in new_tags:
+                new_tags.append(tid)
+        slot.tags = new_tags
+        await save_slot_off_loop(state, slot, force=True)
+
     state.push_slots_update()
     sel().log_api_access(
-        caller="dashboard", operation="chat.slot_tags",
-        outcome="allowed", source="dashboard", resources=name,
+        caller="dashboard",
+        operation="chat.slot_tags",
+        outcome="allowed",
+        source="dashboard",
+        resources=name,
     )
     return web.json_response({"ok": True, "tags": slot.tags})
 
 
 # ── Sidebar columns (Trello-style filtered lanes) ──────────────────────────
 
-def _normalize_column(state: DashboardState, raw: Any, *, existing: dict | None = None) -> dict | None:
+
+def _normalize_column(
+    state: DashboardState, raw: Any, *, existing: dict | None = None
+) -> dict | None:
     """Validate + coerce a column payload. Returns None if invalid."""
     if not isinstance(raw, dict):
         return None
@@ -217,16 +471,30 @@ async def api_chat_tag_column_create(request: web.Request) -> web.Response:
     try:
         body = await request.json()
     except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    column = _normalize_column(state, {**body, "order": len(state._tag_boards)})
-    if column is None:
-        return web.json_response({"error": "invalid column payload"}, status=400)
-    column["id"] = uuid.uuid4().hex[:12]
-    state._tag_boards.append(column)
-    state.save_tag_boards()
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
+    async with _tags_write_lock(state):
+        column = _normalize_column(state, {**body, "order": len(state._tag_boards)})
+        if column is None:
+            return web.json_response(
+                {"error": "invalid column payload", "code": "invalid_column_payload"}, status=400
+            )
+        column["id"] = uuid.uuid4().hex[:12]
+        state._tag_boards.append(column)
+        boards_snap = [dict(c) for c in state._tag_boards]
+        try:
+            await asyncio.to_thread(state.save_tag_boards_snapshot, boards_snap)
+        except Exception:
+            state._tag_boards = [c for c in state._tag_boards if c.get("id") != column["id"]]
+            logger.warning("tag column create failed to persist: %s", column["id"])
+            return web.json_response(
+                {"error": "persist failed", "code": "persist_failed"}, status=500
+            )
     sel().log_api_access(
-        caller="dashboard", operation="chat.tag_column_create",
-        outcome="allowed", source="dashboard", resources=str(column["id"]),
+        caller="dashboard",
+        operation="chat.tag_column_create",
+        outcome="allowed",
+        source="dashboard",
+        resources=str(column["id"]),
     )
     return web.json_response(column, status=201)
 
@@ -237,19 +505,39 @@ async def api_chat_tag_column_update(request: web.Request) -> web.Response:
     cid = request.match_info["id"]
     column = next((c for c in state._tag_boards if c.get("id") == cid), None)
     if not column:
-        return web.json_response({"error": "not found"}, status=404)
+        return web.json_response({"error": "not found", "code": "not_found"}, status=404)
     try:
         body = await request.json()
     except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
-    merged = _normalize_column(state, body, existing=column)
-    if merged is None:
-        return web.json_response({"error": "invalid column payload"}, status=400)
-    column.update(merged)
-    state.save_tag_boards()
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
+    async with _tags_write_lock(state):
+        # Re-check under lock (column may have been deleted concurrently).
+        column = next((c for c in state._tag_boards if c.get("id") == cid), None)
+        if not column:
+            return web.json_response({"error": "not found", "code": "not_found"}, status=404)
+        merged = _normalize_column(state, body, existing=column)
+        if merged is None:
+            return web.json_response(
+                {"error": "invalid column payload", "code": "invalid_column_payload"}, status=400
+            )
+        original = dict(column)
+        column.update(merged)
+        boards_snap = [dict(c) for c in state._tag_boards]
+        try:
+            await asyncio.to_thread(state.save_tag_boards_snapshot, boards_snap)
+        except Exception:
+            column.clear()
+            column.update(original)
+            logger.warning("tag column update failed to persist: %s", cid)
+            return web.json_response(
+                {"error": "persist failed", "code": "persist_failed"}, status=500
+            )
     sel().log_api_access(
-        caller="dashboard", operation="chat.tag_column_update",
-        outcome="allowed", source="dashboard", resources=cid,
+        caller="dashboard",
+        operation="chat.tag_column_update",
+        outcome="allowed",
+        source="dashboard",
+        resources=cid,
     )
     return web.json_response(column)
 
@@ -259,12 +547,28 @@ async def api_chat_tag_column_delete(request: web.Request) -> web.Response:
     state: DashboardState = request.app["state"]
     cid = request.match_info["id"]
     if not any(c.get("id") == cid for c in state._tag_boards):
-        return web.json_response({"error": "not found"}, status=404)
-    state._tag_boards = [c for c in state._tag_boards if c.get("id") != cid]
-    state.save_tag_boards()
+        return web.json_response({"error": "not found", "code": "not_found"}, status=404)
+    async with _tags_write_lock(state):
+        # Re-check under lock.
+        removed = [c for c in state._tag_boards if c.get("id") == cid]
+        if not removed:
+            return web.json_response({"error": "not found", "code": "not_found"}, status=404)
+        state._tag_boards = [c for c in state._tag_boards if c.get("id") != cid]
+        boards_snap = [dict(c) for c in state._tag_boards]
+        try:
+            await asyncio.to_thread(state.save_tag_boards_snapshot, boards_snap)
+        except Exception:
+            state._tag_boards.extend(removed)
+            logger.warning("tag column delete failed to persist: %s", cid)
+            return web.json_response(
+                {"error": "persist failed", "code": "persist_failed"}, status=500
+            )
     sel().log_api_access(
-        caller="dashboard", operation="chat.tag_column_delete",
-        outcome="allowed", source="dashboard", resources=cid,
+        caller="dashboard",
+        operation="chat.tag_column_delete",
+        outcome="allowed",
+        source="dashboard",
+        resources=cid,
     )
     return web.json_response({"ok": True})
 
@@ -275,31 +579,53 @@ async def api_chat_tag_columns_reorder(request: web.Request) -> web.Response:
     try:
         body = await request.json()
     except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
     ids = body.get("ids")
     if not isinstance(ids, list):
-        return web.json_response({"error": "ids must be an array"}, status=400)
-    order_map = {str(cid): i for i, cid in enumerate(ids)}
-    # Push columns not present in the reorder payload past the explicit
-    # ordering so they don't collide with the new sequential indices.
-    next_order = len(order_map)
-    for col in state._tag_boards:
-        cid = col.get("id")
-        if cid in order_map:
-            col["order"] = order_map[cid]
-        else:
-            col["order"] = next_order
-            next_order += 1
-    state._tag_boards.sort(key=lambda c: c.get("order", 0))
-    state.save_tag_boards()
+        return web.json_response(
+            {"error": "ids must be an array", "code": "ids_not_array"}, status=400
+        )
+    async with _tags_write_lock(state):
+        original_order = [(col.get("id"), col.get("order", 0)) for col in state._tag_boards]
+        order_map = {str(cid): i for i, cid in enumerate(ids)}
+        # Push columns not present in the reorder payload past the explicit
+        # ordering so they don't collide with the new sequential indices.
+        next_order = len(order_map)
+        for col in state._tag_boards:
+            cid = col.get("id")
+            if cid in order_map:
+                col["order"] = order_map[cid]
+            else:
+                col["order"] = next_order
+                next_order += 1
+        state._tag_boards.sort(key=lambda c: c.get("order", 0))
+        boards_snap = [dict(c) for c in state._tag_boards]
+        try:
+            await asyncio.to_thread(state.save_tag_boards_snapshot, boards_snap)
+        except Exception:
+            # Restore original order.
+            for col in state._tag_boards:
+                for cid, order in original_order:
+                    if col.get("id") == cid:
+                        col["order"] = order
+                        break
+            state._tag_boards.sort(key=lambda c: c.get("order", 0))
+            logger.warning("tag columns reorder failed to persist")
+            return web.json_response(
+                {"error": "persist failed", "code": "persist_failed"}, status=500
+            )
     sel().log_api_access(
-        caller="dashboard", operation="chat.tag_columns_reorder",
-        outcome="allowed", source="dashboard", resources=",".join(str(x) for x in ids[:10]),
+        caller="dashboard",
+        operation="chat.tag_columns_reorder",
+        outcome="allowed",
+        source="dashboard",
+        resources=",".join(str(x) for x in ids[:10]),
     )
     return web.json_response({"ok": True})
 
 
 # ── Drag-drop: move a session between columns (reassigns status tags) ──────
+
 
 async def api_chat_slot_drop(request: web.Request) -> web.Response:
     """POST /api/chat/slots/{slot}/drop — move a session into a column.
@@ -313,15 +639,17 @@ async def api_chat_slot_drop(request: web.Request) -> web.Response:
     name = request.match_info["slot"]
     slot = state._slots.get(name)
     if not slot:
-        return web.json_response({"error": "not found"}, status=404)
+        return web.json_response({"error": "not found", "code": "not_found"}, status=404)
     try:
         body = await request.json()
     except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
     column_id = str(body.get("column_id") or "")
     column = next((c for c in state._tag_boards if c.get("id") == column_id), None)
     if not column:
-        return web.json_response({"error": "column not found"}, status=404)
+        return web.json_response(
+            {"error": "column not found", "code": "column_not_found"}, status=404
+        )
     tag_index = {t["id"]: t for t in state._tags}
     col_tags = [tag_index[t] for t in column.get("tag_ids") or [] if t in tag_index]
     status_tags = [t for t in col_tags if t.get("status")]
@@ -331,18 +659,26 @@ async def api_chat_slot_drop(request: web.Request) -> web.Response:
         # (covers both the unfiltered and the multi-status filter cases).
         # Audit the rejected drop so the SEL trail captures every attempt.
         sel().log_api_access(
-            caller="dashboard", operation="chat.slot_drop",
-            outcome="rejected", source="dashboard",
-            resources=f"{name}->{column_id}", error="column is not a status lane",
+            caller="dashboard",
+            operation="chat.slot_drop",
+            outcome="rejected",
+            source="dashboard",
+            resources=f"{name}->{column_id}",
+            error="column is not a status lane",
         )
-        return web.json_response({"ok": False, "reason": "column is not a status lane", "tags": slot.tags})
+        return web.json_response(
+            {"ok": False, "reason": "column is not a status lane", "tags": slot.tags}
+        )
     target_id = status_tags[0]["id"]
     kept = [t for t in slot.tags if t in tag_index and not tag_index[t].get("status")]
     slot.tags = kept + [target_id]
     await save_slot_off_loop(state, slot, force=True)
     state.push_slots_update()
     sel().log_api_access(
-        caller="dashboard", operation="chat.slot_drop",
-        outcome="allowed", source="dashboard", resources=f"{name}->{column_id}",
+        caller="dashboard",
+        operation="chat.slot_drop",
+        outcome="allowed",
+        source="dashboard",
+        resources=f"{name}->{column_id}",
     )
     return web.json_response({"ok": True, "tags": slot.tags})

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -814,6 +814,7 @@ class _ChatSlot:
         "_trust_reads",
         "_trusted_patterns",
         "_titled",
+        "_auto_tagged",
         "_title_in_flight",
         "_title_retry_pending",
         "_artifact",
@@ -926,6 +927,7 @@ class _ChatSlot:
         self._trust_reads: bool = False  # auto-approve read-only bash commands
         self._trusted_patterns: set[str] = set()  # session-scoped fnmatch globs
         self._titled: bool = False  # True once a title has been assigned
+        self._auto_tagged: bool = False  # True once auto-tag has been attempted
         # Guards against concurrent LLM auto-title attempts (on-send trigger vs
         # the end-of-turn chat_done trigger racing on the same slot).
         self._title_in_flight: bool = False
@@ -1104,7 +1106,9 @@ class _ChatSlot:
         # no-blocking-call-on-event-loop rule forbids. Refreshed at the save
         # boundary, where the lock is already held and the foreign lines are
         # already parsed.
-        self._disk_tail_ts: str | None = None        # Cached frozen-prefix bytes for the append-safe save model.
+        self._disk_tail_ts: str | None = (
+            None  # Cached frozen-prefix bytes for the append-safe save model.
+        )
         # The session file is FROZEN-PREFIX (the first _disk_older_count on-disk
         # message lines, OLDER than the in-memory window) + a fresh re-serialize
         # of the whole window. The prefix is never rewritten, so a restart that
@@ -1986,6 +1990,12 @@ class DashboardState:
         self._cron_folders: list[dict[str, Any]] = []  # cron job folder groupings
         # Tag vocabulary: list of {id, name, color, order}. User-managed.
         self._tags: list[dict[str, Any]] = []
+        # True once load_tags() parsed tags.json successfully (or seeded a
+        # fresh install). False means the vocabulary state is UNKNOWN (parse
+        # or I/O failure) — restore-time pruning must fail open then, because
+        # a legitimately-empty vocabulary (user deleted every tag) must still
+        # prune dangling ids while an unreadable one must not wipe anything.
+        self._tags_authoritative: bool = False
         # Sidebar columns — flat list of {id, name, tag_ids, mode, order, include_untagged}
         self._tag_boards: list[dict[str, Any]] = []
         self._background_tasks: set[asyncio.Task] = set()  # type: ignore[type-arg]
@@ -3020,9 +3030,7 @@ class DashboardState:
                 # The previous owner's slot may already be gone; fall back to
                 # deriving its key from the name in that case.
                 old_key = (
-                    effective_session_key(old_slot)
-                    if old_slot
-                    else _history_key_for(old_owner)
+                    effective_session_key(old_slot) if old_slot else _history_key_for(old_owner)
                 )
                 self.sessions.set_slack_link(old_key, "", "")
         slot._slack_linked = True
@@ -3033,9 +3041,7 @@ class DashboardState:
         if self.sessions:
             from kiro_crew.dashboard.chat_utils import effective_session_key
 
-            self.sessions.set_slack_link(
-                effective_session_key(slot), thread_ts, channel_id
-            )
+            self.sessions.set_slack_link(effective_session_key(slot), thread_ts, channel_id)
         self.push_slots_update()
 
     def get_or_create_slot(
@@ -3480,14 +3486,27 @@ class DashboardState:
         tags_path = config_dir() / self._TAGS_FILE
         file_existed = tags_path.exists()
         try:
+            vocab_ok = True
             if file_existed:
                 raw = json.loads(tags_path.read_text(encoding="utf-8"))
                 if isinstance(raw, list):
                     self._tags = [t for t in raw if isinstance(t, dict) and t.get("id")]
+                else:
+                    # Valid JSON but not a list (e.g. {}): the vocabulary
+                    # state is UNKNOWN, same as a parse failure — do not let
+                    # restore-time pruning wipe assignments against it.
+                    vocab_ok = False
+                    logger.warning("tags.json is not a list; treating vocabulary as unknown")
+            # Authoritative only when the file is missing (fresh install,
+            # seeded below) or parsed as a list — INCLUDING a legitimately-
+            # empty [] — so restore-time pruning of dangling ids is safe.
+            self._tags_authoritative = vocab_ok
         except Exception:
             logger.warning("Failed to load tags", exc_info=True)
             # Treat a parse error like a present file: do not re-seed.
             file_existed = True
+            # Vocabulary state unknown — restore-time pruning must fail open.
+            self._tags_authoritative = False
         # Back-fill the status flag for legacy tags saved before the field existed.
         # The 5 seed ids are canonical status tags; everything else defaults to False.
         seed_ids = {t["id"] for t in self._DEFAULT_TAGS}
@@ -3518,9 +3537,37 @@ class DashboardState:
         """Persist tag vocabulary to disk (atomic write)."""
         self._atomic_write_json(config_dir() / self._TAGS_FILE, self._tags)
 
+    def save_tags_snapshot(self, snapshot: list[dict]) -> None:
+        """Persist a pre-captured tag snapshot to disk (strict -- raises on failure).
+
+        Used by the serialized tag-write path in chat_tags.py: the snapshot is
+        captured on the event loop under the tags write lock, then this write
+        runs in a worker thread. Lives here (not in chat_tags.py) so the file
+        location resolves through this module's ``config_dir`` exactly like
+        ``save_tags`` -- keeping tests that patch it working unchanged.
+
+        Raises on I/O failure so callers can roll back in-memory state and
+        surface HTTP 5xx rather than silently losing data.
+        """
+        self._atomic_write_json_strict(config_dir() / self._TAGS_FILE, snapshot)
+
     def save_tag_boards(self) -> None:
         """Persist sidebar column layout to disk (atomic write)."""
         self._atomic_write_json(config_dir() / self._TAG_BOARDS_FILE, self._tag_boards)
+
+    def save_tag_boards_snapshot(self, snapshot: list[dict]) -> None:
+        """Persist a pre-captured boards snapshot to disk (strict -- raises on failure).
+
+        Used by the tag-delete path in chat_tags.py: the snapshot is captured
+        on the event loop under the tags write lock, then this write runs in a
+        worker thread. Lives here (not in chat_tags.py) so the file location
+        resolves through this module's ``config_dir`` exactly like
+        ``save_tag_boards`` -- keeping tests that patch it working unchanged.
+
+        Raises on I/O failure so callers can roll back in-memory state and
+        surface HTTP 5xx rather than silently losing data.
+        """
+        self._atomic_write_json_strict(config_dir() / self._TAG_BOARDS_FILE, snapshot)
 
     @staticmethod
     def _atomic_write_json_strict(path: Path, data: Any) -> None:

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -612,6 +612,22 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "exfiltration-URL scanners plus a sensitive-header pass before anything is "
         "written into the archive.",
     ),
+    (
+        "Tag definitions (HTTP + auto-tag)",
+        "dashboard/chat_tags.py",
+        "Tag names supplied by both the POST /api/chat/tags HTTP handler and the "
+        "background auto-tag task are LLM-authored or project-derived and persist "
+        "to tags.json, the dashboard sidebar, and Slack notifications. Both paths "
+        "redact credentials and exfiltration URLs before creation/persistence.",
+    ),
+    (
+        "Background auto-tag (project-derived names)",
+        "dashboard/chat_auto_tag.py",
+        "The background auto-tag task derives tag names from the slot's project "
+        "path and persists them to tags.json and the dashboard sidebar via the "
+        "shared tag-creation path. Names are passed through redact_credentials "
+        "and redact_exfiltration_urls before resolution or persistence.",
+    ),
 )
 
 # Modules that call a redactor but are NOT an output egress boundary, so they do

--- a/test/test_chat_tags.py
+++ b/test/test_chat_tags.py
@@ -8,6 +8,7 @@ import pytest
 from aiohttp.test_utils import TestClient, TestServer
 from chat_test_helpers import _make_state, _make_tags_app
 
+from kiro_crew.dashboard import chat_tags as chat_tags_module
 from kiro_crew.dashboard.chat_tags import _normalize_column, _valid_color
 from kiro_crew.dashboard.state import _ChatSlot
 
@@ -96,7 +97,14 @@ class TestNormalizeColumn:
 
     def test_existing_values_preserved_when_keys_absent(self, tmp_path):
         state = self._state_with_tags(tmp_path)
-        existing = {"id": "c1", "name": "Keep", "tag_ids": ["t1"], "mode": "all", "order": 7, "include_untagged": True}
+        existing = {
+            "id": "c1",
+            "name": "Keep",
+            "tag_ids": ["t1"],
+            "mode": "all",
+            "order": 7,
+            "include_untagged": True,
+        }
         col = _normalize_column(state, {"name": "Updated"}, existing=existing)
         assert col is not None
         assert col["id"] == "c1"
@@ -145,7 +153,9 @@ class TestTagVocabulary:
         state = _make_state(tmp_path)
         app = _make_tags_app(state)
         async with TestClient(TestServer(app)) as client:
-            resp = await client.post("/api/chat/tags", json={"name": "Spike", "color": "#22c55e", "status": False})
+            resp = await client.post(
+                "/api/chat/tags", json={"name": "Spike", "color": "#22c55e", "status": False}
+            )
             assert resp.status == 201
             tag = await resp.json()
             assert tag["name"] == "Spike"
@@ -179,7 +189,9 @@ class TestTagVocabulary:
         state = _make_state(tmp_path)
         app = _make_tags_app(state)
         async with TestClient(TestServer(app)) as client:
-            resp = await client.post("/api/chat/tags", data="not json", headers={"Content-Type": "application/json"})
+            resp = await client.post(
+                "/api/chat/tags", data="not json", headers={"Content-Type": "application/json"}
+            )
             assert resp.status == 400
 
     @pytest.mark.asyncio
@@ -189,8 +201,10 @@ class TestTagVocabulary:
         app = _make_tags_app(state)
         async with TestClient(TestServer(app)) as client:
             tag = await (await client.post("/api/chat/tags", json={"name": "Old"})).json()
-            resp = await client.patch(f"/api/chat/tags/{tag['id']}",
-                                      json={"name": "New", "color": "#00ff00", "order": 9, "status": True})
+            resp = await client.patch(
+                f"/api/chat/tags/{tag['id']}",
+                json={"name": "New", "color": "#00ff00", "order": 9, "status": True},
+            )
             assert resp.status == 200
             data = await resp.json()
             assert data["name"] == "New"
@@ -234,9 +248,94 @@ class TestTagVocabulary:
         app = _make_tags_app(state)
         async with TestClient(TestServer(app)) as client:
             tag = await (await client.post("/api/chat/tags", json={"name": "X"})).json()
-            resp = await client.patch(f"/api/chat/tags/{tag['id']}",
-                                      data="not json", headers={"Content-Type": "application/json"})
+            resp = await client.patch(
+                f"/api/chat/tags/{tag['id']}",
+                data="not json",
+                headers={"Content-Type": "application/json"},
+            )
             assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_update_tag_redacts_credentials_in_name(self, tmp_path, monkeypatch):
+        """PATCH a tag name containing an AWS key — the credential is redacted."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        async with TestClient(TestServer(app)) as client:
+            tag = await (await client.post("/api/chat/tags", json={"name": "Safe"})).json()
+            resp = await client.patch(
+                f"/api/chat/tags/{tag['id']}",
+                json={"name": "key-AKIAIOSFODNN7EXAMPLE"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert "AKIAIOSFODNN7EXAMPLE" not in data["name"]
+
+    @pytest.mark.asyncio
+    async def test_update_tag_redacts_credential_straddling_truncation(self, tmp_path, monkeypatch):
+        """Redaction must run BEFORE truncation: a credential crossing the
+        60-char cut would otherwise be sliced into a fragment the scanners
+        no longer recognize, persisting a raw key prefix."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        async with TestClient(TestServer(app)) as client:
+            tag = await (await client.post("/api/chat/tags", json={"name": "Redact"})).json()
+            resp = await client.patch(
+                f"/api/chat/tags/{tag['id']}",
+                json={"name": "x" * 50 + "AKIAIOSFODNN7EXAMPLE"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert "AKIA" not in data["name"]
+
+    @pytest.mark.asyncio
+    async def test_create_tag_redacts_credential_straddling_truncation(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post(
+                "/api/chat/tags",
+                json={"name": "x" * 50 + "AKIAIOSFODNN7EXAMPLE"},
+            )
+            assert resp.status == 201
+            data = await resp.json()
+            assert "AKIA" not in data["name"]
+
+    @pytest.mark.asyncio
+    async def test_delete_tag_persists_vocab_before_slots(self, tmp_path, monkeypatch):
+        """Crash-atomic ordering: tags.json is the single durable commit and
+        must be written BEFORE any slot strip — a crash after it leaves only
+        harmless dangling slot ids (pruned on load), never lost assignments
+        with a still-live tag."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        call_order: list[str] = []
+
+        async def _tracking_save(st, slot, *, force=False, best_effort=True):
+            call_order.append("save_slot")
+
+        original_write = __import__(
+            "kiro_crew.dashboard.chat_tags", fromlist=["_write_tags_snapshot"]
+        )._write_tags_snapshot
+
+        def _tracking_write(st, snapshot):
+            call_order.append("write_tags_snapshot")
+            return original_write(st, snapshot)
+
+        async with TestClient(TestServer(app)) as client:
+            tag = await (await client.post("/api/chat/tags", json={"name": "Del"})).json()
+            slot = _ChatSlot("s1")
+            slot.tags = [tag["id"]]
+            state._slots["s1"] = slot
+            with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop", _tracking_save):
+                with patch("kiro_crew.dashboard.chat_tags._write_tags_snapshot", _tracking_write):
+                    resp = await client.delete(f"/api/chat/tags/{tag['id']}")
+            assert resp.status == 200
+            # Vocabulary removal must be committed BEFORE slot persistence.
+            assert call_order.index("write_tags_snapshot") < call_order.index("save_slot")
 
     @pytest.mark.asyncio
     async def test_delete_tag_strips_from_slots_and_columns(self, tmp_path, monkeypatch):
@@ -249,9 +348,12 @@ class TestTagVocabulary:
             slot = _ChatSlot("s1")
             slot.tags = [tag["id"], other["id"]]
             state._slots["s1"] = slot
-            col = await (await client.post(
-                "/api/chat/tag-columns", json={"tag_ids": [tag["id"], other["id"]], "mode": "any"}
-            )).json()
+            col = await (
+                await client.post(
+                    "/api/chat/tag-columns",
+                    json={"tag_ids": [tag["id"], other["id"]], "mode": "any"},
+                )
+            ).json()
             with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop"):
                 resp = await client.delete(f"/api/chat/tags/{tag['id']}")
             assert resp.status == 200
@@ -269,6 +371,72 @@ class TestTagVocabulary:
         async with TestClient(TestServer(app)) as client:
             resp = await client.delete("/api/chat/tags/ghost")
             assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_strips_all_slots_despite_partial_save_failure(
+        self, tmp_path, monkeypatch
+    ):
+        """A failing slot save during the post-commit strip must not abort
+        stripping the remaining slots; the failed one is marked dirty."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        async with TestClient(TestServer(app)) as client:
+            tag = await (await client.post("/api/chat/tags", json={"name": "Partial"})).json()
+            slot_a = _ChatSlot("s1")
+            slot_a.tags = [tag["id"]]
+            slot_b = _ChatSlot("s2")
+            slot_b.tags = [tag["id"]]
+            state._slots["s1"] = slot_a
+            state._slots["s2"] = slot_b
+
+            saves: list[str] = []
+
+            async def _partial_failing_save(state_arg, slot_arg, **kwargs):
+                saves.append(slot_arg.key)
+                if slot_arg.key == "s1":
+                    raise IOError("disk full")
+
+            with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop", _partial_failing_save):
+                resp = await client.delete(f"/api/chat/tags/{tag['id']}")
+            assert resp.status == 200
+            assert all(t["id"] != tag["id"] for t in state._tags)
+            # BOTH slots stripped in memory despite s1's save failing:
+            assert tag["id"] not in slot_a.tags
+            assert tag["id"] not in slot_b.tags
+            assert "s1" in saves and "s2" in saves  # s2 not aborted by s1
+            assert getattr(slot_a, "_dirty", False) is True
+
+    @pytest.mark.asyncio
+    async def test_delete_succeeds_despite_board_persist_failure(self, tmp_path, monkeypatch):
+        """Board strip failure after the vocab commit is tolerated: deletion
+        succeeds; the dangling board reference is pruned on next load."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        async with TestClient(TestServer(app)) as client:
+            tag = await (await client.post("/api/chat/tags", json={"name": "BoardFail"})).json()
+            col = await (
+                await client.post(
+                    "/api/chat/tag-columns",
+                    json={"tag_ids": [tag["id"]], "mode": "any"},
+                )
+            ).json()
+            slot = _ChatSlot("s1")
+            slot.tags = [tag["id"]]
+            state._slots["s1"] = slot
+
+            def _failing_boards(snapshot):
+                raise IOError("disk full")
+
+            with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop"):
+                with patch.object(state, "save_tag_boards_snapshot", _failing_boards):
+                    resp = await client.delete(f"/api/chat/tags/{tag['id']}")
+            assert resp.status == 200
+            assert all(t["id"] != tag["id"] for t in state._tags)
+            assert tag["id"] not in slot.tags
+            updated_col = next(c for c in state._tag_boards if c["id"] == col["id"])
+            assert tag["id"] not in updated_col["tag_ids"]  # stripped in memory
 
 
 # ── Slot tag assignment ──
@@ -312,7 +480,9 @@ class TestSlotTags:
         app = _make_tags_app(state)
         async with TestClient(TestServer(app)) as client:
             resp = await client.put(
-                "/api/chat/slots/s1/tags", data="not json", headers={"Content-Type": "application/json"}
+                "/api/chat/slots/s1/tags",
+                data="not json",
+                headers={"Content-Type": "application/json"},
             )
             assert resp.status == 400
 
@@ -376,7 +546,9 @@ class TestColumns:
         app = _make_tags_app(state)
         async with TestClient(TestServer(app)) as client:
             resp = await client.post(
-                "/api/chat/tag-columns", data="not json", headers={"Content-Type": "application/json"}
+                "/api/chat/tag-columns",
+                data="not json",
+                headers={"Content-Type": "application/json"},
             )
             assert resp.status == 400
 
@@ -387,8 +559,9 @@ class TestColumns:
         app = _make_tags_app(state)
         async with TestClient(TestServer(app)) as client:
             col = await (await client.post("/api/chat/tag-columns", json={"name": "Old"})).json()
-            resp = await client.patch(f"/api/chat/tag-columns/{col['id']}",
-                                      json={"name": "New", "include_untagged": True})
+            resp = await client.patch(
+                f"/api/chat/tag-columns/{col['id']}", json={"name": "New", "include_untagged": True}
+            )
             assert resp.status == 200
             data = await resp.json()
             assert data["name"] == "New"
@@ -421,7 +594,9 @@ class TestColumns:
         async with TestClient(TestServer(app)) as client:
             col = await (await client.post("/api/chat/tag-columns", json={})).json()
             resp = await client.patch(
-                f"/api/chat/tag-columns/{col['id']}", data="not json", headers={"Content-Type": "application/json"}
+                f"/api/chat/tag-columns/{col['id']}",
+                data="not json",
+                headers={"Content-Type": "application/json"},
             )
             assert resp.status == 400
 
@@ -479,7 +654,9 @@ class TestColumns:
         app = _make_tags_app(state)
         async with TestClient(TestServer(app)) as client:
             resp = await client.put(
-                "/api/chat/tag-columns/order", data="not json", headers={"Content-Type": "application/json"}
+                "/api/chat/tag-columns/order",
+                data="not json",
+                headers={"Content-Type": "application/json"},
             )
             assert resp.status == 400
 
@@ -503,15 +680,23 @@ class TestDrop:
         state = _make_state(tmp_path)
         app = _make_tags_app(state)
         async with TestClient(TestServer(app)) as client:
-            todo = await (await client.post("/api/chat/tags", json={"name": "ToDo", "status": True})).json()
-            done = await (await client.post("/api/chat/tags", json={"name": "Done", "status": True})).json()
-            spike = await (await client.post("/api/chat/tags", json={"name": "spike", "status": False})).json()
+            todo = await (
+                await client.post("/api/chat/tags", json={"name": "ToDo", "status": True})
+            ).json()
+            done = await (
+                await client.post("/api/chat/tags", json={"name": "Done", "status": True})
+            ).json()
+            spike = await (
+                await client.post("/api/chat/tags", json={"name": "spike", "status": False})
+            ).json()
             slot = _ChatSlot("s1")
             slot.tags = [todo["id"], spike["id"]]
             state._slots["s1"] = slot
-            col = await (await client.post(
-                "/api/chat/tag-columns", json={"tag_ids": [done["id"]], "mode": "any"}
-            )).json()
+            col = await (
+                await client.post(
+                    "/api/chat/tag-columns", json={"tag_ids": [done["id"]], "mode": "any"}
+                )
+            ).json()
             with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop"):
                 resp = await client.post("/api/chat/slots/s1/drop", json={"column_id": col["id"]})
             data = await resp.json()
@@ -526,13 +711,15 @@ class TestDrop:
         state = _make_state(tmp_path)
         app = _make_tags_app(state)
         async with TestClient(TestServer(app)) as client:
-            todo = await (await client.post("/api/chat/tags", json={"name": "ToDo", "status": True})).json()
+            todo = await (
+                await client.post("/api/chat/tags", json={"name": "ToDo", "status": True})
+            ).json()
             slot = _ChatSlot("s1")
             slot.tags = [todo["id"]]
             state._slots["s1"] = slot
-            col = await (await client.post(
-                "/api/chat/tag-columns", json={"tag_ids": [], "mode": "any"}
-            )).json()
+            col = await (
+                await client.post("/api/chat/tag-columns", json={"tag_ids": [], "mode": "any"})
+            ).json()
             resp = await client.post("/api/chat/slots/s1/drop", json={"column_id": col["id"]})
             data = await resp.json()
             assert data["ok"] is False
@@ -565,7 +752,9 @@ class TestDrop:
         app = _make_tags_app(state)
         async with TestClient(TestServer(app)) as client:
             resp = await client.post(
-                "/api/chat/slots/s1/drop", data="not json", headers={"Content-Type": "application/json"}
+                "/api/chat/slots/s1/drop",
+                data="not json",
+                headers={"Content-Type": "application/json"},
             )
             assert resp.status == 400
 
@@ -576,14 +765,21 @@ class TestDrop:
         state = _make_state(tmp_path)
         app = _make_tags_app(state)
         async with TestClient(TestServer(app)) as client:
-            todo = await (await client.post("/api/chat/tags", json={"name": "ToDo", "status": True})).json()
-            done = await (await client.post("/api/chat/tags", json={"name": "Done", "status": True})).json()
+            todo = await (
+                await client.post("/api/chat/tags", json={"name": "ToDo", "status": True})
+            ).json()
+            done = await (
+                await client.post("/api/chat/tags", json={"name": "Done", "status": True})
+            ).json()
             slot = _ChatSlot("s1")
             slot.tags = [todo["id"]]
             state._slots["s1"] = slot
-            col = await (await client.post(
-                "/api/chat/tag-columns", json={"tag_ids": [todo["id"], done["id"]], "mode": "any"}
-            )).json()
+            col = await (
+                await client.post(
+                    "/api/chat/tag-columns",
+                    json={"tag_ids": [todo["id"], done["id"]], "mode": "any"},
+                )
+            ).json()
             resp = await client.post("/api/chat/slots/s1/drop", json={"column_id": col["id"]})
             data = await resp.json()
             assert data["ok"] is False
@@ -665,20 +861,221 @@ class TestDropOnMixedColumn:
         state = _make_state(tmp_path)
         app = _make_tags_app(state)
         async with TestClient(TestServer(app)) as client:
-            todo = await (await client.post("/api/chat/tags", json={"name": "ToDo", "status": True})).json()
-            done = await (await client.post("/api/chat/tags", json={"name": "Done", "status": True})).json()
-            spike = await (await client.post("/api/chat/tags", json={"name": "spike", "status": False})).json()
+            todo = await (
+                await client.post("/api/chat/tags", json={"name": "ToDo", "status": True})
+            ).json()
+            done = await (
+                await client.post("/api/chat/tags", json={"name": "Done", "status": True})
+            ).json()
+            spike = await (
+                await client.post("/api/chat/tags", json={"name": "spike", "status": False})
+            ).json()
             slot = _ChatSlot("s1")
             slot.tags = [todo["id"]]
             state._slots["s1"] = slot
             # Column is "Done AND spike" — exactly one status tag in the filter.
-            col = await (await client.post(
-                "/api/chat/tag-columns",
-                json={"tag_ids": [done["id"], spike["id"]], "mode": "all"},
-            )).json()
+            col = await (
+                await client.post(
+                    "/api/chat/tag-columns",
+                    json={"tag_ids": [done["id"], spike["id"]], "mode": "all"},
+                )
+            ).json()
             with patch("kiro_crew.dashboard.chat_tags.save_slot_off_loop"):
                 resp = await client.post("/api/chat/slots/s1/drop", json={"column_id": col["id"]})
             data = await resp.json()
             assert data["ok"] is True
             assert done["id"] in data["tags"]
             assert todo["id"] not in data["tags"]
+
+
+# ── F1: DELETE fail-closed propagation from save_slot_off_loop ──
+
+
+class TestDeleteSlotPersistPropagatesFromUnderlying:
+    """Crash-atomic contract: an underlying slot write failure during the
+    post-commit strip does NOT fail the deletion — the vocab commit already
+    made it durable; the slot is marked dirty for periodic-flush retry."""
+
+    @pytest.mark.asyncio
+    async def test_delete_succeeds_despite_underlying_write_failure(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        async with TestClient(TestServer(app)) as client:
+            tag = await (await client.post("/api/chat/tags", json={"name": "Under"})).json()
+            slot = _ChatSlot("s1")
+            slot.tags = [tag["id"]]
+            state._slots["s1"] = slot
+
+            async def _failing_save(state_arg, slot_arg, **kwargs):
+                raise IOError("disk full")
+
+            with patch.object(chat_tags_module, "save_slot_off_loop", _failing_save):
+                resp = await client.delete(f"/api/chat/tags/{tag['id']}")
+            assert resp.status == 200
+            # Tag removed from vocabulary; slot stripped in memory; the
+            # failed write left the slot dirty so the flush retries it.
+            assert all(t["id"] != tag["id"] for t in state._tags)
+            assert tag["id"] not in slot.tags
+            assert getattr(slot, "_dirty", False) is True
+
+
+# ── F2: Tag create surfaces persist failure and rolls back ──
+
+
+class TestTagCreatePersistFailure:
+    """F2: save_tags_snapshot now uses strict writes; a create that fails to
+    persist must return 5xx and NOT leave the tag in state._tags."""
+
+    @pytest.mark.asyncio
+    async def test_create_returns_500_and_rolls_back_on_write_failure(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        async with TestClient(TestServer(app)) as client:
+            with patch.object(
+                state.__class__,
+                "_atomic_write_json_strict",
+                side_effect=IOError("disk full"),
+            ):
+                resp = await client.post("/api/chat/tags", json={"name": "Ghost"})
+            assert resp.status == 500
+            body = await resp.json()
+            assert body["code"] == "persist_failed"
+            # Tag must NOT be in state
+            assert not any(t.get("name") == "Ghost" for t in state._tags)
+
+
+# ── F3: Board column create concurrency test ──
+
+
+class TestBoardColumnConcurrency:
+    """F3: Two concurrent column creates must both appear in state and the
+    final snapshot (lock serializes them)."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_column_creates_both_persisted(self, tmp_path, monkeypatch):
+        import asyncio
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+
+        snapshots_written: list[list[dict]] = []
+        _real_save = state.save_tag_boards_snapshot
+
+        def _recording_save(snapshot):
+            snapshots_written.append(snapshot)
+            _real_save(snapshot)
+
+        async with TestClient(TestServer(app)) as client:
+            with patch.object(state, "save_tag_boards_snapshot", _recording_save):
+                results = await asyncio.gather(
+                    client.post("/api/chat/tag-columns", json={"mode": "any"}),
+                    client.post("/api/chat/tag-columns", json={"mode": "any"}),
+                )
+            assert all(r.status == 201 for r in results)
+            col_ids = [await r.json() for r in results]
+            ids_created = {c["id"] for c in col_ids}
+            # Both columns in state
+            state_ids = {c["id"] for c in state._tag_boards}
+            assert ids_created.issubset(state_ids)
+            # Final snapshot (last written) contains both
+            assert len(snapshots_written) >= 2
+            final_snap_ids = {c["id"] for c in snapshots_written[-1]}
+            assert ids_created.issubset(final_snap_ids)
+
+
+# ── F1-ext: Delete vocab-write failure triggers compensating rollback ──
+
+
+class TestDeleteVocabWriteCompensation:
+    """Crash-atomic contract: the vocabulary write is the single durable
+    commit. If it fails, NOTHING else has been touched — slots are never
+    stripped and no compensation writes are needed."""
+
+    @pytest.mark.asyncio
+    async def test_vocab_write_failure_leaves_slots_untouched(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        async with TestClient(TestServer(app)) as client:
+            tag = await (await client.post("/api/chat/tags", json={"name": "VocabFail"})).json()
+            slot = _ChatSlot("s1")
+            slot.tags = [tag["id"]]
+            state._slots["s1"] = slot
+
+            slot_saves: list[str] = []
+
+            async def _recording_save(state_arg, slot_arg, **kwargs):
+                slot_saves.append(slot_arg.key)
+
+            with patch.object(chat_tags_module, "save_slot_off_loop", _recording_save):
+                with patch.object(
+                    chat_tags_module, "_write_tags_snapshot", side_effect=IOError("disk full")
+                ):
+                    resp = await client.delete(f"/api/chat/tags/{tag['id']}")
+            assert resp.status == 500
+            body = await resp.json()
+            assert body["code"] == "persist_failed"
+            # Vocabulary restored in memory; slot NEVER touched (no strip, no
+            # save) — the failed vocab write is the only attempted mutation.
+            assert any(t["id"] == tag["id"] for t in state._tags)
+            assert tag["id"] in slot.tags
+            assert slot_saves == []
+
+
+# ── F2-ext: Update race with concurrent DELETE ──
+
+
+class TestUpdateDeleteRace:
+    """F2: The PATCH handler must resolve the tag INSIDE the write lock.
+    A concurrent DELETE that wins the lock first must cause PATCH to 404
+    (not silently mutate a detached dict)."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_delete_causes_update_to_404(self, tmp_path, monkeypatch):
+        import asyncio as _asyncio
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        app = _make_tags_app(state)
+        async with TestClient(TestServer(app)) as client:
+            tag = await (await client.post("/api/chat/tags", json={"name": "Race"})).json()
+            tid = tag["id"]
+
+            # Make _write_tags_snapshot slow so the DELETE holds the lock long
+            # enough for PATCH to queue behind it.
+            original_write = __import__(
+                "kiro_crew.dashboard.chat_tags", fromlist=["_write_tags_snapshot"]
+            )._write_tags_snapshot
+
+            def _slow_write(st, snap):
+                __import__("time").sleep(0.15)
+                return original_write(st, snap)
+
+            # Run DELETE and PATCH concurrently.
+            # DELETE wins the lock; PATCH waits, then re-resolves -> 404.
+            with patch(
+                "kiro_crew.dashboard.chat_tags._write_tags_snapshot",
+                side_effect=_slow_write,
+            ):
+                delete_task = _asyncio.ensure_future(client.delete(f"/api/chat/tags/{tid}"))
+                # Small delay so DELETE grabs the lock first.
+                await _asyncio.sleep(0.01)
+                patch_task = _asyncio.ensure_future(
+                    client.patch(f"/api/chat/tags/{tid}", json={"name": "Updated"})
+                )
+
+                delete_resp, patch_resp = await _asyncio.gather(delete_task, patch_task)
+
+            # DELETE should succeed.
+            assert delete_resp.status == 200
+
+            # PATCH must 404 (tag deleted under the lock before PATCH could resolve it).
+            assert patch_resp.status == 404
+            patch_body = await patch_resp.json()
+            assert patch_body["code"] == "not_found"
+
+            # The tag must NOT be in state (no silent ghost mutation).
+            assert not any(t["id"] == tid for t in state._tags)

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -174,9 +174,7 @@ class TestChatSlot:
         assert payload["source_links_total"] == 1
         assert payload["source_links"][0]["url"] == url
 
-    @pytest.mark.parametrize(
-        "role", ["chunk", "done", "streaming", "queued", "permission"]
-    )
+    @pytest.mark.parametrize("role", ["chunk", "done", "streaming", "queued", "permission"])
     def test_pr_source_links_ignore_non_durable_roles(self, role):
         slot = _ChatSlot("s1")
         slot.append(role, "https://github.com/acme/widgets/pull/12")
@@ -406,9 +404,7 @@ class TestBroadcastCompactionResultBackoff:
 
         # Still within cooldown: suppressed.
         fake_now[0] += 1.0
-        assert (
-            chat_utils._broadcast_compaction_result(state, slot, self._failed_event()) is None
-        )
+        assert chat_utils._broadcast_compaction_result(state, slot, self._failed_event()) is None
 
         # Cooldown elapses: next failure collapses the streak into one message.
         fake_now[0] += chat_utils._COMPACTION_FAIL_COOLDOWN_SECS + 1.0
@@ -451,9 +447,7 @@ class TestBroadcastCompactionResultBackoff:
         _broadcast_compaction_result(state, slot, self._completed_event())
 
         resets = [
-            c
-            for c in state.broadcast_ws.call_args_list
-            if c.args and c.args[0] == "context_usage"
+            c for c in state.broadcast_ws.call_args_list if c.args and c.args[0] == "context_usage"
         ]
         assert resets, "completed compaction must broadcast a context_usage event"
         payload = resets[0].args[1]
@@ -468,9 +462,7 @@ class TestBroadcastCompactionResultBackoff:
         _broadcast_compaction_result(state, slot, self._failed_event())
 
         assert not [
-            c
-            for c in state.broadcast_ws.call_args_list
-            if c.args and c.args[0] == "context_usage"
+            c for c in state.broadcast_ws.call_args_list if c.args and c.args[0] == "context_usage"
         ]
 
 
@@ -526,9 +518,7 @@ class TestApiChatMemoryModeForwarding:
         async def fake_run_chat(st, sl, msg):
             sl.append("chunk", "ack", "chunk")
 
-        monkeypatch.setattr(
-            "kiro_crew.dashboard.chat_handlers._run_chat", fake_run_chat
-        )
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers._run_chat", fake_run_chat)
 
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.post(
@@ -556,9 +546,7 @@ class TestApiChatMemoryModeForwarding:
         async def fake_run_chat(st, sl, msg):
             sl.append("chunk", "ack", "chunk")
 
-        monkeypatch.setattr(
-            "kiro_crew.dashboard.chat_handlers._run_chat", fake_run_chat
-        )
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers._run_chat", fake_run_chat)
 
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.post(
@@ -582,9 +570,7 @@ class TestApiChatMemoryModeForwarding:
         async def fake_run_chat(st, sl, msg):
             sl.append("chunk", "ack", "chunk")
 
-        monkeypatch.setattr(
-            "kiro_crew.dashboard.chat_handlers._run_chat", fake_run_chat
-        )
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers._run_chat", fake_run_chat)
 
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.post(
@@ -607,6 +593,7 @@ class TestApiChatMemoryModeForwarding:
 
     async def test_mismatched_memory_mode_on_existing_slot_returns_409(self, tmp_path, monkeypatch):
         from unittest.mock import MagicMock
+
         mock_sel = MagicMock()
         monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.sel", lambda: mock_sel)
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
@@ -629,8 +616,9 @@ class TestApiChatMemoryModeForwarding:
             assert "memory_mode" in data["error"]
 
         # SEL audit event for the denial
-        denied_calls = [c for c in mock_sel.log_api_access.call_args_list
-                        if c[1].get("outcome") == "denied"]
+        denied_calls = [
+            c for c in mock_sel.log_api_access.call_args_list if c[1].get("outcome") == "denied"
+        ]
         assert len(denied_calls) == 1
         kw = denied_calls[0][1]
         assert kw["operation"] == "chat_send"
@@ -841,9 +829,7 @@ class TestSlotLifecycle:
         assert callback == state.push_slots_update
 
     @pytest.mark.asyncio
-    async def test_list_slots_omits_status_and_refresh_for_non_owner(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_list_slots_omits_status_and_refresh_for_non_owner(self, tmp_path, monkeypatch):
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         from kiro_crew.dashboard import state as state_module
         from kiro_crew.dashboard.handlers import source_providers
@@ -1848,7 +1834,10 @@ class TestInMemoryAuthority:
 
         # sessA got its new turn; sessB is byte-for-byte untouched.
         assert [m["content"] for m in log.read_messages("dashboard:sessA")] == [
-            "A0", "A1", "A2", "A-new"
+            "A0",
+            "A1",
+            "A2",
+            "A-new",
         ]
         assert log.read_messages("dashboard:sessB") == b_before
 
@@ -1908,9 +1897,7 @@ class TestInMemoryAuthority:
 
         disk = log.read_messages("dashboard:s11")
         # Frozen prefix preserved + kept window head; dropped tail archived.
-        assert [m["content"] for m in disk] == [
-            "old 0", "old 1", "old 2", "old 3", "old 4"
-        ]
+        assert [m["content"] for m in disk] == ["old 0", "old 1", "old 2", "old 3", "old 4"]
         archives = list((tmp_path / "archive").glob("dashboard_s11__*.jsonl"))
         assert len(archives) == 1
         content = archives[0].read_text(encoding="utf-8")
@@ -2142,6 +2129,108 @@ class TestSessionRename:
             slot = state._slots["s1"]
             assert slot.title == "My Custom Title"
             assert slot._titled is True
+
+    @pytest.mark.asyncio
+    async def test_resumed_session_restores_tags_and_auto_tagged(self, tmp_path, monkeypatch):
+        """Regression: resume must restore tags AND the auto-tag once-flag.
+        Without the flag, resuming a session whose auto-tag the user removed
+        re-runs maybe_auto_tag on the next message and silently re-adds it."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        log = state.conversation_log
+        log.append("dashboard:s1", "user", "hello")
+        # The id must exist in the vocabulary — resume prunes unknown ids
+        # (crash-atomic delete can leave dangling ids on disk).
+        state._tags.append({"id": "tag-abc", "name": "ABC", "color": "#6b7280", "order": 0})
+        log.update_metadata(
+            "dashboard:s1",
+            {"tags": ["tag-abc"], "auto_tagged": True, "project": "/x/repos/MyRepo"},
+        )
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/resume",
+                json={"key": "dashboard:s1"},
+            )
+            assert resp.status == 200
+            slot = state._slots["s1"]
+            assert slot.tags == ["tag-abc"]
+            assert slot._auto_tagged is True
+
+    @pytest.mark.asyncio
+    async def test_resume_unreadable_vocab_does_not_wipe_tags(self, tmp_path, monkeypatch):
+        """FAIL-OPEN: if tags.json failed to load (vocabulary UNKNOWN), resume
+        must NOT prune — pruning against an unknown vocab would wipe every
+        assignment and the next save persists the loss."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state._tags = []
+        state._tags_authoritative = False  # load_tags() hit a parse/I/O error
+        log = state.conversation_log
+        log.append("dashboard:s1", "user", "hello")
+        log.update_metadata("dashboard:s1", {"tags": ["tag-abc"], "auto_tagged": True})
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/resume", json={"key": "dashboard:s1"})
+            assert resp.status == 200
+            slot = state._slots["s1"]
+            assert slot.tags == ["tag-abc"]  # preserved, not wiped
+            assert slot._auto_tagged is True
+
+    @pytest.mark.asyncio
+    async def test_resume_empty_authoritative_vocab_prunes_dangling_ids(
+        self, tmp_path, monkeypatch
+    ):
+        """A legitimately-empty vocabulary (last tag deleted, tags.json parsed
+        fine as []) IS authoritative: resume must prune the dangling id, or a
+        crash between the vocab commit and slot cleanup would resurrect the
+        deleted tag id on this slot forever."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state._tags = []
+        state._tags_authoritative = True  # tags.json parsed OK as []
+        log = state.conversation_log
+        log.append("dashboard:s1", "user", "hello")
+        log.update_metadata("dashboard:s1", {"tags": ["tag-abc"], "auto_tagged": True})
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/resume", json={"key": "dashboard:s1"})
+            assert resp.status == 200
+            slot = state._slots["s1"]
+            assert slot.tags == []  # dangling id pruned
+            assert slot._auto_tagged is True
+
+    def test_load_tags_sets_authoritative_flag(self, tmp_path, monkeypatch):
+        """load_tags() marks the vocabulary authoritative on a clean parse
+        (including a legitimately-empty []) and NOT authoritative on a parse
+        failure — the signal the restore-time pruning fail-open relies on."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+
+        # Legitimately-empty vocabulary: parsed OK -> authoritative.
+        (tmp_path / "tags.json").write_text("[]", encoding="utf-8")
+        state._tags = []
+        state._tags_authoritative = False
+        state.load_tags()
+        assert state._tags_authoritative is True
+        assert state._tags == []
+
+        # Corrupt file: parse failure -> NOT authoritative, data untouched.
+        (tmp_path / "tags.json").write_text("{not json", encoding="utf-8")
+        state._tags = [{"id": "keep-me", "name": "Keep", "status": False}]
+        state._tags_authoritative = True
+        state.load_tags()
+        assert state._tags_authoritative is False
+        assert state._tags[0]["id"] == "keep-me"  # not re-seeded, not wiped
+
+        # Valid JSON but NOT a list (e.g. {}): vocabulary state is unknown,
+        # same as a parse failure -- NOT authoritative, data untouched.
+        (tmp_path / "tags.json").write_text("{}", encoding="utf-8")
+        state._tags = [{"id": "keep-me", "name": "Keep", "status": False}]
+        state._tags_authoritative = True
+        state.load_tags()
+        assert state._tags_authoritative is False
+        assert state._tags[0]["id"] == "keep-me"
 
 
 # ── Session color tests ──
@@ -2992,15 +3081,37 @@ class TestRunChatNativeSubagentAttribution:
             # 1) crew list → spawn one card
             LLMEvent(kind=EVENT_SUBAGENT_LIST, subagents=[_sub("working")]),
             # 2) private-channel activity maps the inner toolCallId → this card
-            LLMEvent(kind=EVENT_SUBAGENT_ACTIVITY, sub_session_id="sess-1", tool_call_id="tc-1", title="read"),
+            LLMEvent(
+                kind=EVENT_SUBAGENT_ACTIVITY,
+                sub_session_id="sess-1",
+                tool_call_id="tc-1",
+                title="read",
+            ),
             # 3) flat tool_call (full title) → attributed to the card
-            LLMEvent(kind=EVENT_TOOL_CALL, title="Reading foo.py:1", tool_kind="read", tool_call_id="tc-1"),
+            LLMEvent(
+                kind=EVENT_TOOL_CALL,
+                title="Reading foo.py:1",
+                tool_kind="read",
+                tool_call_id="tc-1",
+            ),
             # 4) flat tool_result (real output) → attributed + accumulated
-            LLMEvent(kind=EVENT_TOOL_RESULT, tool_call_id="tc-1", tool_output="file body XYZ", tool_final=True),
+            LLMEvent(
+                kind=EVENT_TOOL_RESULT,
+                tool_call_id="tc-1",
+                tool_output="file body XYZ",
+                tool_final=True,
+            ),
             # 5) duplicate tool_result (kiro sends content + rawOutput) → deduped
-            LLMEvent(kind=EVENT_TOOL_RESULT, tool_call_id="tc-1", tool_output="file body XYZ", tool_final=True),
+            LLMEvent(
+                kind=EVENT_TOOL_RESULT,
+                tool_call_id="tc-1",
+                tool_output="file body XYZ",
+                tool_final=True,
+            ),
             # 5b) sub-agent text streamed on the private channel (agent_message_chunk)
-            LLMEvent(kind=EVENT_SUBAGENT_ACTIVITY, sub_session_id="sess-1", text="thinking out loud"),
+            LLMEvent(
+                kind=EVENT_SUBAGENT_ACTIVITY, sub_session_id="sess-1", text="thinking out loud"
+            ),
             # 6) crew list terminal → done with accumulated feed
             LLMEvent(kind=EVENT_SUBAGENT_LIST, subagents=[_sub("terminated")]),
             LLMEvent(kind=EVENT_COMPLETE),
@@ -3025,10 +3136,12 @@ class TestRunChatNativeSubagentAttribution:
         assert spawns[0]["task"] == "explore acp"
 
         # Tool call + output streamed onto the card.
-        chunks = [d.get("text", "") for t, d in calls if t == "subagent_chunk" and d.get("id") == card]
+        chunks = [
+            d.get("text", "") for t, d in calls if t == "subagent_chunk" and d.get("id") == card
+        ]
         joined = "".join(chunks)
         assert "Reading foo.py:1" in joined  # full tool title from flat tool_call
-        assert "file body XYZ" in joined     # real tool output
+        assert "file body XYZ" in joined  # real tool output
         assert "thinking out loud" in joined  # sub-agent text (agent_message_chunk)
 
         # Dedupe: the duplicate tool_result must NOT double-print the output.
@@ -3154,9 +3267,7 @@ class TestRunChatCompactDeferredWait:
         # provider's counts were just dropped, so a payload broadcast would
         # claim "0 used" of a window nothing has re-measured yet.
         usage_calls = [
-            c
-            for c in state.broadcast_ws.call_args_list
-            if c.args and c.args[0] == "context_usage"
+            c for c in state.broadcast_ws.call_args_list if c.args and c.args[0] == "context_usage"
         ]
         assert {"slot": slot.key, "pct": 0.0, "reset": True} in [c.args[1] for c in usage_calls]
         # No later broadcast may resurrect the stale pre-compaction meter.
@@ -3195,9 +3306,7 @@ class TestRunChatCompactDeferredWait:
         await _run_chat(state, slot, "/compact")
 
         usage_calls = [
-            c
-            for c in state.broadcast_ws.call_args_list
-            if c.args and c.args[0] == "context_usage"
+            c for c in state.broadcast_ws.call_args_list if c.args and c.args[0] == "context_usage"
         ]
         assert usage_calls
         expected = {
@@ -3236,9 +3345,7 @@ class TestRunChatCompactDeferredWait:
         await _run_chat(state, slot, "/compact")
 
         usage_calls = [
-            c
-            for c in state.broadcast_ws.call_args_list
-            if c.args and c.args[0] == "context_usage"
+            c for c in state.broadcast_ws.call_args_list if c.args and c.args[0] == "context_usage"
         ]
         assert usage_calls
         payload = usage_calls[-1].args[1]
@@ -3524,9 +3631,7 @@ class TestKiroBackfillProfileGuard:
 
         events = [LLMEvent(kind=EVENT_COMPLETE, usage=TurnUsage(input_tokens=3, output_tokens=4))]
 
-        state = TestTokenPersistenceBackfill._make_state_for_run_chat(
-            tmp_path, monkeypatch
-        )
+        state = TestTokenPersistenceBackfill._make_state_for_run_chat(tmp_path, monkeypatch)
         slot = state.get_or_create_slot("s1")
         slot.model = ""  # user picked nothing explicit on this turn
 
@@ -3580,9 +3685,7 @@ class TestPinnedModelWithheld:
     @staticmethod
     def _client(advertised, *, claude_backend=False):
         client = MagicMock()
-        client.available_models = MagicMock(
-            return_value=[{"modelId": m} for m in advertised]
-        )
+        client.available_models = MagicMock(return_value=[{"modelId": m} for m in advertised])
         client.is_claude_backend = claude_backend
         return client
 
@@ -3695,23 +3798,19 @@ class TestPinnedModelWithheld:
             for c in state.broadcast_ws.call_args_list
             if c.args and c.args[0] == "activity_event" and c.args[1].get("kind") == "session"
         ]
-        assert any(f.get("spawned") is True for f in session_frames), (
-            f"a new session must report spawned=True, got {session_frames}"
-        )
-        assert all("claude-opus-5" not in f.get("text", "") for f in session_frames), (
-            f"the session line must report the effective model, got {session_frames}"
-        )
-        assert any("auto" in f.get("text", "") for f in session_frames), (
-            f"expected the effective model on the session line, got {session_frames}"
-        )
+        assert any(
+            f.get("spawned") is True for f in session_frames
+        ), f"a new session must report spawned=True, got {session_frames}"
+        assert all(
+            "claude-opus-5" not in f.get("text", "") for f in session_frames
+        ), f"the session line must report the effective model, got {session_frames}"
+        assert any(
+            "auto" in f.get("text", "") for f in session_frames
+        ), f"expected the effective model on the session line, got {session_frames}"
         # But the user must be able to learn why their model is not being used, and
         # that explanation has to survive a reload the same way the pin does — so
         # it is a persisted transcript row, not a transient activity line.
-        notices = [
-            m.get("content", "")
-            for m in slot.messages
-            if m.get("role") == "notice"
-        ]
+        notices = [m.get("content", "") for m in slot.messages if m.get("role") == "notice"]
         assert any(
             "claude-opus-5" in t and "isn't offered right now" in t for t in notices
         ), f"expected a persisted notice naming the withheld model, got {notices}"
@@ -3752,9 +3851,7 @@ class TestPinnedModelWithheld:
                 raise ValueError("config became unreadable mid-turn")
             return real_cfg
 
-        monkeypatch.setattr(
-            "kiro_crew.dashboard.chat_runner.KiroCrewConfig.load", load_then_break
-        )
+        monkeypatch.setattr("kiro_crew.dashboard.chat_runner.KiroCrewConfig.load", load_then_break)
 
         client = AsyncMock()
         client.context_usage_pct = MagicMock(return_value=10.0)
@@ -3835,13 +3932,13 @@ class TestPinnedModelWithheld:
             for c in state.broadcast_ws.call_args_list
             if c.args and c.args[0] == "activity_event" and c.args[1].get("kind") == "session"
         ]
-        assert any("claude-opus-5" in f.get("text", "") for f in session_frames), (
-            f"an entitled pin must still be named on the session line, got {session_frames}"
-        )
+        assert any(
+            "claude-opus-5" in f.get("text", "") for f in session_frames
+        ), f"an entitled pin must still be named on the session line, got {session_frames}"
         notices = [m.get("content", "") for m in slot.messages if m.get("role") == "notice"]
-        assert not any("isn't offered right now" in t for t in notices), (
-            f"nothing was withheld, so there must be no notice, got {notices}"
-        )
+        assert not any(
+            "isn't offered right now" in t for t in notices
+        ), f"nothing was withheld, so there must be no notice, got {notices}"
 
     @pytest.mark.asyncio
     async def test_run_chat_stays_quiet_on_a_warm_session(self, tmp_path, monkeypatch):
@@ -3883,14 +3980,10 @@ class TestPinnedModelWithheld:
 
         await _run_chat(state, slot, "hello")
 
-        notices = [
-            m.get("content", "")
-            for m in slot.messages
-            if m.get("role") == "notice"
-        ]
-        assert not any("isn't offered right now" in t for t in notices), (
-            f"the withhold notice must not repeat every turn, got {notices}"
-        )
+        notices = [m.get("content", "") for m in slot.messages if m.get("role") == "notice"]
+        assert not any(
+            "isn't offered right now" in t for t in notices
+        ), f"the withhold notice must not repeat every turn, got {notices}"
         assert slot.model == "claude-opus-5"
         # A warm turn respawns nothing, so the session frame must say so: the
         # frontend refetches the entitlement-narrowed model list on `spawned`,
@@ -3902,9 +3995,9 @@ class TestPinnedModelWithheld:
             if c.args and c.args[0] == "activity_event" and c.args[1].get("kind") == "session"
         ]
         assert session_frames, "the session frame is emitted on warm turns too"
-        assert all(f.get("spawned") is False for f in session_frames), (
-            f"warm turn must not claim a spawn, got {session_frames}"
-        )
+        assert all(
+            f.get("spawned") is False for f in session_frames
+        ), f"warm turn must not claim a spawn, got {session_frames}"
 
     @pytest.mark.asyncio
     async def test_run_chat_keeps_an_entitled_pin(self, tmp_path, monkeypatch):
@@ -4322,9 +4415,7 @@ class TestRuntimeWiring:
         assert build_message_calls[0]["kwargs"].get("memory_store") == "oncall-mem"
 
     @pytest.mark.asyncio
-    async def test_run_chat_forwards_and_clears_the_reinjection_flag(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_run_chat_forwards_and_clears_the_reinjection_flag(self, tmp_path, monkeypatch):
         """A compaction flags the session; the NEXT _run_chat must forward
         needs_reinjection=True to build_message and clear the flag so the turn
         after that does not re-inject again.
@@ -5760,9 +5851,9 @@ class TestOrchestratorPlanGateArming:
 
         assert calls == 1, "loop must stop after the plan shrank, not over-run"
         seps = [m["content"] for m in slot.messages if "stage-sep" in m.get("cls", "")]
-        assert not any("Stage 2" in s or "Stage 3" in s for s in seps), (
-            "no phantom stage beyond the live plan size may be built"
-        )
+        assert not any(
+            "Stage 2" in s or "Stage 3" in s for s in seps
+        ), "no phantom stage beyond the live plan size may be built"
 
     # ── P0 hardening: stage turn ceiling + subagent wait cap ──
 
@@ -5810,9 +5901,7 @@ class TestOrchestratorPlanGateArming:
                 swallowed = True
                 return None
 
-        monkeypatch.setattr(
-            "kiro_crew.dashboard.chat_orchestrator._run_chat", _hang_and_swallow
-        )
+        monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _hang_and_swallow)
 
         await asyncio.wait_for(_stage_loop(state, slot, auto_run=True), timeout=30)
 
@@ -5822,9 +5911,7 @@ class TestOrchestratorPlanGateArming:
             "timed out" in m.get("content", "") for m in slot.messages
         ), "the user must see a timeout card, not a silently-advanced stage"
         seps = [m["content"] for m in slot.messages if "stage-sep" in m.get("cls", "")]
-        assert not any("Stage 2" in s for s in seps), (
-            "a cut stage must NOT advance to the next one"
-        )
+        assert not any("Stage 2" in s for s in seps), "a cut stage must NOT advance to the next one"
 
     @pytest.mark.asyncio
     async def test_stage_loop_disabled_timeout_does_not_abort_instantly(
@@ -7240,9 +7327,7 @@ class TestFolderCRUD:
             )
             assert resp.status == 201
             assert (await resp.json())["color"] == "#ef4444"
-            bad = await client.post(
-                "/api/chat/folders", json={"name": "Bad", "color": "#123456"}
-            )
+            bad = await client.post("/api/chat/folders", json={"name": "Bad", "color": "#123456"})
             assert bad.status == 400
             assert (await bad.json())["code"] == "color_invalid"
 
@@ -7257,7 +7342,10 @@ class TestFolderCRUD:
 
         catalog = (
             Path(__file__).resolve().parent.parent
-            / "website" / "src" / "components" / "folderColorCatalog.tsx"
+            / "website"
+            / "src"
+            / "components"
+            / "folderColorCatalog.tsx"
         )
         frontend = set(re.findall(r"#[0-9a-f]{6}", catalog.read_text(encoding="utf-8")))
         assert frontend == set(_FOLDER_COLOR_PALETTE)
@@ -7480,7 +7568,9 @@ class TestFolderCRUD:
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         state = _make_state(tmp_path)
         state.get_or_create_slot("myslot")
-        state._folders = [{"id": "f1", "name": "Test", "order": 0, "collapsed": False, "hidden": True}]
+        state._folders = [
+            {"id": "f1", "name": "Test", "order": 0, "collapsed": False, "hidden": True}
+        ]
         app = _make_folder_app(state)
         async with TestClient(TestServer(app)) as client:
             # Moving a session into a hidden folder re-engages it (Model B) → un-hides.
@@ -7500,7 +7590,9 @@ class TestFolderCRUD:
 
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         state = _make_state(tmp_path)
-        state._folders = [{"id": "f1", "name": "Test", "order": 0, "collapsed": False, "hidden": True}]
+        state._folders = [
+            {"id": "f1", "name": "Test", "order": 0, "collapsed": False, "hidden": True}
+        ]
         # Create a session filed in f1, persist it to history, then drop the active
         # slot so resume loads it fresh from history (the revive path).
         slot = state.get_or_create_slot("revive1")
@@ -7853,8 +7945,15 @@ class TestGenerateEmojiForName:
         state.save_folders = MagicMock()
         state.push_slots_update = MagicMock()
 
-        with patch("kiro_crew.dashboard.chat_folders.redact_exfiltration_urls", return_value=("🔥", False)) as mock_url, \
-             patch("kiro_crew.dashboard.chat_folders.redact_credentials", return_value=("🔥", False)) as mock_cred:
+        with (
+            patch(
+                "kiro_crew.dashboard.chat_folders.redact_exfiltration_urls",
+                return_value=("🔥", False),
+            ) as mock_url,
+            patch(
+                "kiro_crew.dashboard.chat_folders.redact_credentials", return_value=("🔥", False)
+            ) as mock_cred,
+        ):
             icon = await generate_emoji_for_name(state, "Oncall")
             assert icon == "🔥"
             mock_url.assert_called_once()
@@ -8353,9 +8452,7 @@ class TestRegenerateAndVariants:
         state.get_or_create_slot("s1")
         app = web.Application()
         app["state"] = state
-        app.router.add_post(
-            "/api/chat/slots/{slot}/edit-resend", api_chat_slot_edit_resend
-        )
+        app.router.add_post("/api/chat/slots/{slot}/edit-resend", api_chat_slot_edit_resend)
         async with TestClient(TestServer(app)) as client:
             for bad in ("[1, 2]", '"hi"', "42"):
                 resp = await client.post(
@@ -8643,9 +8740,7 @@ class TestForkSlot:
         failing_save = AsyncMock(side_effect=RuntimeError("lock timeout"))
         app = _make_app(state)
         async with TestClient(TestServer(app)) as client:
-            with patch(
-                "kiro_crew.dashboard.chat_fork.save_slot_off_loop", failing_save
-            ):
+            with patch("kiro_crew.dashboard.chat_fork.save_slot_off_loop", failing_save):
                 resp = await client.post("/api/chat/slots/src/fork", json={})
                 assert resp.status == 503
 
@@ -8718,9 +8813,7 @@ class TestForkSlot:
         slot.append("user", "plain msg", "msg msg-u")
         slot.append("assistant", "plain reply", "msg msg-a")
         slot.drain()
-        parent_meta = [
-            m.get("meta") for m in slot.messages if m["role"] in ("user", "assistant")
-        ]
+        parent_meta = [m.get("meta") for m in slot.messages if m["role"] in ("user", "assistant")]
 
         app = _make_app(state)
         async with TestClient(TestServer(app)) as client:
@@ -9532,7 +9625,9 @@ class TestInstalledPackConsentInjection:
             return_value=self.PERSONA,
         ):
             result = _maybe_inject_persona(
-                "hello", "custom-mypack", True,
+                "hello",
+                "custom-mypack",
+                True,
                 theme_consent_sha=self._sha(self.PERSONA),
             )
         assert "[THEME PERSONA]" in result
@@ -9548,7 +9643,9 @@ class TestInstalledPackConsentInjection:
             return_value=self.PERSONA,
         ):
             result = _maybe_inject_persona(
-                "hello", "custom-mypack", True,
+                "hello",
+                "custom-mypack",
+                True,
                 theme_consent_sha=self._sha("OLD PERSONA THE USER CONSENTED TO"),
             )
         assert result == "hello"
@@ -9574,7 +9671,10 @@ class TestInstalledPackConsentInjection:
             return_value=self.PERSONA,
         ):
             result = _maybe_inject_persona(
-                "hello", "custom-mypack", True, theme_consent_sha=None,
+                "hello",
+                "custom-mypack",
+                True,
+                theme_consent_sha=None,
             )
         assert result == "hello"
 
@@ -9586,7 +9686,9 @@ class TestInstalledPackConsentInjection:
             return_value=self.PERSONA,
         ):
             result = _maybe_inject_persona(
-                "hello", "custom-mypack", False,
+                "hello",
+                "custom-mypack",
+                False,
                 theme_consent_sha=self._sha(self.PERSONA),
             )
         assert result == "hello"
@@ -9601,14 +9703,14 @@ class TestInstalledPackConsentInjection:
 
         valid = self._sha(self.PERSONA)
         malformed = [
-            "é",                 # non-ASCII -> would TypeError in compare_digest
-            valid.upper(),       # uppercase hex (raw, un-normalized) -> not 64-lower
-            valid[:-1],          # 63 chars
-            valid + "a",         # 65 chars
-            "",                  # empty
-            "  ",                # whitespace only
-            12345,               # non-str
-            None,                # absent
+            "é",  # non-ASCII -> would TypeError in compare_digest
+            valid.upper(),  # uppercase hex (raw, un-normalized) -> not 64-lower
+            valid[:-1],  # 63 chars
+            valid + "a",  # 65 chars
+            "",  # empty
+            "  ",  # whitespace only
+            12345,  # non-str
+            None,  # absent
             valid[:-2] + "gg",  # non-hex chars
         ]
         with patch(
@@ -9618,7 +9720,10 @@ class TestInstalledPackConsentInjection:
             for bad in malformed:
                 # The call must not raise for any malformed input...
                 result = _maybe_inject_persona(
-                    "hello", "custom-mypack", True, theme_consent_sha=bad,
+                    "hello",
+                    "custom-mypack",
+                    True,
+                    theme_consent_sha=bad,
                 )
                 # ...and must not inject the persona.
                 assert result == "hello", f"unexpected injection for {bad!r}"
@@ -9647,7 +9752,10 @@ class TestInstalledPackConsentInjection:
         ):
             norm = normalize_theme_consent_sha("  " + valid.upper() + "\n")
             result = _maybe_inject_persona(
-                "hello", "custom-mypack", True, theme_consent_sha=norm,
+                "hello",
+                "custom-mypack",
+                True,
+                theme_consent_sha=norm,
             )
         assert "[THEME PERSONA]" in result
 
@@ -9905,7 +10013,9 @@ class TestStopTurnSlotState:
 
         captured_states: list[str] = []
 
-        async def fake_stop_turn(key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None):
+        async def fake_stop_turn(
+            key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None
+        ):
             captured_states.append(slot._stop_state)
             if on_soft:
                 await on_soft()
@@ -9929,7 +10039,9 @@ class TestStopTurnSlotState:
         slot = state.get_or_create_slot("s1")
         slot.task = asyncio.ensure_future(asyncio.sleep(999))
 
-        async def fake_stop_turn(key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None):
+        async def fake_stop_turn(
+            key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None
+        ):
             if on_hard:
                 await on_hard()
             return "hard"
@@ -9954,7 +10066,9 @@ class TestStopTurnSlotState:
 
         force_called = []
 
-        async def fake_stop_turn(key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None):
+        async def fake_stop_turn(
+            key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None
+        ):
             force_called.append(force)
             if on_hard:
                 await on_hard()
@@ -9985,7 +10099,9 @@ class TestStopTurnSlotState:
 
         force_called = []
 
-        async def fake_stop_turn(key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None):
+        async def fake_stop_turn(
+            key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None
+        ):
             force_called.append(force)
             if on_hard:
                 await on_hard()
@@ -10012,7 +10128,9 @@ class TestStopTurnSlotState:
         slot.task = asyncio.ensure_future(asyncio.sleep(999))
         slot._queue.extend(["msg1", "msg2"])
 
-        async def fake_stop_turn(key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None):
+        async def fake_stop_turn(
+            key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None
+        ):
             assert preserve_queue is True
             if on_soft:
                 await on_soft()
@@ -10036,7 +10154,9 @@ class TestStopTurnSlotState:
         slot._stop_state = "soft_pending"
         slot._queue.extend(["msg1", "msg2", "msg3"])
 
-        async def fake_stop_turn(key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None):
+        async def fake_stop_turn(
+            key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None
+        ):
             if on_hard:
                 await on_hard()
             return "hard"
@@ -10058,7 +10178,9 @@ class TestStopTurnSlotState:
         slot.task = asyncio.ensure_future(asyncio.sleep(999))
         assert len(slot._queue) == 0
 
-        async def fake_stop_turn(key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None):
+        async def fake_stop_turn(
+            key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None
+        ):
             assert preserve_queue is True
             if on_soft:
                 await on_soft()
@@ -10082,7 +10204,9 @@ class TestStopTurnSlotState:
         slot._stop_state = "soft_pending"
         assert len(slot._queue) == 0
 
-        async def fake_stop_turn(key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None):
+        async def fake_stop_turn(
+            key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None
+        ):
             if on_hard:
                 await on_hard()
             return "hard"
@@ -10114,7 +10238,9 @@ class TestStopTurnSlotState:
         slot = state.get_or_create_slot("s1")
         slot.task = asyncio.ensure_future(asyncio.sleep(999))
 
-        async def fake_stop_turn(key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None):
+        async def fake_stop_turn(
+            key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None
+        ):
             if on_soft:
                 await on_soft()
             return "soft"
@@ -10152,7 +10278,9 @@ class TestStopTurnSlotState:
         slot = state.get_or_create_slot("s1")
         slot.task = asyncio.ensure_future(asyncio.sleep(999))
 
-        async def fake_stop_turn(key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None):
+        async def fake_stop_turn(
+            key, *, force=False, preserve_queue=False, on_soft=None, on_hard=None
+        ):
             # Verify the stop_event was inserted before callbacks
             stop_msgs = [m for m in slot.messages if _is_stop_event(m)]
             assert len(stop_msgs) == 1
@@ -10300,9 +10428,12 @@ class TestAcpProcessDiedRecovery:
         # ALSO explicitly broadcast over chat_message (slot.append already emits it
         # once via _on_message). A redundant broadcast_ws renders a second card.
         dup_broadcasts = [
-            c for c in state.broadcast_ws.call_args_list
-            if c.args and c.args[0] == "chat_message"
-            and len(c.args) > 1 and "retrying" in c.args[1].get("content", "")
+            c
+            for c in state.broadcast_ws.call_args_list
+            if c.args
+            and c.args[0] == "chat_message"
+            and len(c.args) > 1
+            and "retrying" in c.args[1].get("content", "")
         ]
         assert dup_broadcasts == [], "retry card must not be double-emitted via broadcast_ws"
 
@@ -10522,7 +10653,9 @@ class TestAcpProcessDiedRecovery:
         assert any("Session busy" in m.get("content", "") for m in error_msgs)
 
     @pytest.mark.asyncio
-    async def test_acperror_process_exited_depth_gt0_resets_no_requeue(self, tmp_path: Path) -> None:
+    async def test_acperror_process_exited_depth_gt0_resets_no_requeue(
+        self, tmp_path: Path
+    ) -> None:
         """A pipe-death AcpError ('process exited') at _prompt_depth>0 must STILL reset
         the dead session and increment the pipe-death counter (mirrors AcpProcessDied /
         PromptBusyExhaustedError), and surface a 'Connection lost — please retry' card —
@@ -10599,15 +10732,15 @@ class TestEmptyResponseRetry:
             calls.append(a)
             return orig(self_slot, *a, **kw)
 
-        with patch.object(_ChatSlot, "queue_insert", spy), patch(
-            "kiro_crew.dashboard.chat_runner.save_slot_off_loop"
-        ) as mock_save, patch(
-            "kiro_crew.dashboard.chat_runner._maybe_consolidate"
-        ) as mock_consolidate, patch(
-            "kiro_crew.dashboard.chat_runner._flush_file_changes"
-        ) as mock_flush, patch(
-            "kiro_crew.dashboard.chat_runner._start_next_queued_turn",
-            new=AsyncMock(return_value=False),
+        with (
+            patch.object(_ChatSlot, "queue_insert", spy),
+            patch("kiro_crew.dashboard.chat_runner.save_slot_off_loop") as mock_save,
+            patch("kiro_crew.dashboard.chat_runner._maybe_consolidate") as mock_consolidate,
+            patch("kiro_crew.dashboard.chat_runner._flush_file_changes") as mock_flush,
+            patch(
+                "kiro_crew.dashboard.chat_runner._start_next_queued_turn",
+                new=AsyncMock(return_value=False),
+            ),
         ):
             # The behavior under test is the re-queue itself. Keep the queued
             # item in the slot, but stop the finally block from immediately
@@ -10636,7 +10769,9 @@ class TestEmptyResponseRetry:
         assert mock_flush.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_empty_response_at_depth_gt0_shows_error_immediately(self, tmp_path: Path) -> None:
+    async def test_empty_response_at_depth_gt0_shows_error_immediately(
+        self, tmp_path: Path
+    ) -> None:
         """At _prompt_depth>0 an empty response is NOT silently retried — it shows the
         terminal empty-response notice card on the FIRST empty. The silent
         re-queue is intentionally depth-0 only (nested tool-use turns must not silently
@@ -10711,9 +10846,7 @@ class TestEmptyResponseRetry:
             except Exception:
                 pass
 
-        nudge_msgs = [
-            m for m in slot.messages if m.get("content") == _EMPTY_AUTO_CONTINUE_MSG
-        ]
+        nudge_msgs = [m for m in slot.messages if m.get("content") == _EMPTY_AUTO_CONTINUE_MSG]
         assert nudge_msgs, "drained nudge never reached the transcript"
         # The nudge must NEVER carry the user role (that would persist an
         # internal instruction as user-authored history and mirror it to
@@ -10751,12 +10884,8 @@ class TestEmptyResponseRetry:
         # rather than patching the gate function (which would pass even if the
         # loader dropped the field — the exact regression this test guards).
         cfg_file = tmp_path / "flag-off-config.json"
-        cfg_file.write_text(
-            '{"session": {"empty_response_auto_continue": false}}'
-        )
-        with patch(
-            "kiro_crew.config.loader.config_path", return_value=cfg_file
-        ):
+        cfg_file.write_text('{"session": {"empty_response_auto_continue": false}}')
+        with patch("kiro_crew.config.loader.config_path", return_value=cfg_file):
             await _run_chat(state, slot, "test message")
 
         notice_msgs = [m for m in slot.messages if m.get("role") == "notice"]
@@ -10858,9 +10987,7 @@ class TestExpandDollarSkills:
         from kiro_crew.platform.defaults import DefaultMcpToolingProvider
         from kiro_crew.skills import SkillsLoader
 
-        monkeypatch.setattr(
-            DefaultMcpToolingProvider, "extra_skills", lambda self: []
-        )
+        monkeypatch.setattr(DefaultMcpToolingProvider, "extra_skills", lambda self: [])
         skills_dir = tmp_path / "skills"
         for name, body in skills:
             self._make_skill(skills_dir, name, body)
@@ -10990,9 +11117,7 @@ class TestRunChatTransientRetry:
     backend 5xx WITHOUT resetting the live session, guarded so a partial
     (already-streamed) response is never re-run."""
 
-    _TRANSIENT = (
-        "Prompt error: {'message': 'Internal error: API Error: Internal server error'}"
-    )
+    _TRANSIENT = "Prompt error: {'message': 'Internal error: API Error: Internal server error'}"
     _AUTH = "Bedrock authentication failed. Run 'ada credentials update'"
 
     @staticmethod
@@ -11046,9 +11171,7 @@ class TestRunChatTransientRetry:
         return [m["content"] for m in slot.messages if m.get("role") == "assistant"]
 
     @pytest.mark.asyncio
-    async def test_transient_pre_token_retries_then_recovers_no_reset(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_transient_pre_token_retries_then_recovers_no_reset(self, tmp_path, monkeypatch):
         """A transient 5xx before any token streams is retried on the SAME live
         session (no reset); the second attempt succeeds."""
         from kiro_crew.acp.client import AcpError
@@ -11138,15 +11261,14 @@ class TestRunChatTransientRetry:
         assert any("ok-result" in t for t in assistant), "continued answer must append below"
         # The RE-QUEUED prompt is the CONTINUE instruction, NOT the original.
         assert len(captured) == 2
-        assert "Continue from where it stopped" in captured[1], (
-            "the retry must re-queue the continue instruction, not the original prompt"
-        )
+        assert (
+            "Continue from where it stopped" in captured[1]
+        ), "the retry must re-queue the continue instruction, not the original prompt"
         assert "hello" not in captured[1], "the original prompt must NOT be re-queued"
         # No chat_stream_reset broadcast — that frontend reconcile event was
         # removed entirely by the append-only rework.
         assert not any(
-            c.args and c.args[0] == "chat_stream_reset"
-            for c in state.broadcast_ws.call_args_list
+            c.args and c.args[0] == "chat_stream_reset" for c in state.broadcast_ws.call_args_list
         ), "chat_stream_reset must no longer be broadcast"
         # Live session was NOT reset. The one-shot allowance stays consumed
         # (True) across the synthetic recovery turn — it is refreshed only at the
@@ -11156,9 +11278,7 @@ class TestRunChatTransientRetry:
         assert slot._posttoken_retry_used is True
 
     @pytest.mark.asyncio
-    async def test_transient_post_token_suppressed_preserves_partial(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_transient_post_token_suppressed_preserves_partial(self, tmp_path, monkeypatch):
         """When Stop is active (_should_suppress_requeue True) during a post-token
         transient 5xx, the partial assistant text is PRESERVED (persisted as an
         assistant message) and the message is NOT re-queued. Under the
@@ -11207,8 +11327,7 @@ class TestRunChatTransientRetry:
         assert not any(t.startswith("❌") for t in self._err_texts(slot))
         # No chat_stream_reset broadcast — that event was removed entirely.
         assert not any(
-            c.args and c.args[0] == "chat_stream_reset"
-            for c in state.broadcast_ws.call_args_list
+            c.args and c.args[0] == "chat_stream_reset" for c in state.broadcast_ws.call_args_list
         )
         # Transient path never resets the (still-alive) session.
         state.sessions.reset.assert_not_awaited()
@@ -11266,12 +11385,10 @@ class TestRunChatTransientRetry:
         assert any("Backend hiccup" in t for t in self._err_texts(slot))
         assert not any(t.startswith("❌") for t in self._err_texts(slot))
         # The partial text is preserved and the continued answer appended below.
-        assert any("working" in t for t in self._assistant_texts(slot)), (
-            "partial must be preserved"
-        )
-        assert any("ok-result" in t for t in self._assistant_texts(slot)), (
-            "continued answer must append below"
-        )
+        assert any("working" in t for t in self._assistant_texts(slot)), "partial must be preserved"
+        assert any(
+            "ok-result" in t for t in self._assistant_texts(slot)
+        ), "continued answer must append below"
         # The CONTINUE instruction — not the original prompt — was re-queued.
         assert len(captured) == 2
         assert "Continue from where it stopped" in captured[1]
@@ -11339,9 +11456,7 @@ class TestRunChatTransientRetry:
         assert not any(t.startswith("❌") for t in self._err_texts(slot))
 
     @pytest.mark.asyncio
-    async def test_posttoken_recovery_turn_refailure_does_not_loop(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_posttoken_recovery_turn_refailure_does_not_loop(self, tmp_path, monkeypatch):
         """Finding #3(b): a post-token transient that re-fires DURING the
         synthetic recovery turn must NOT recover again (no infinite re-queue).
         The recovery turn inherits the already-consumed allowance (it is not
@@ -11455,9 +11570,7 @@ class TestRunChatTransientRetry:
         assert slot._transient_5xx_retries == 0
 
     @pytest.mark.asyncio
-    async def test_transient_budget_refreshed_after_terminal_error(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_transient_budget_refreshed_after_terminal_error(self, tmp_path, monkeypatch):
         """Regression: a cycle that EXHAUSTS the transient budget and surfaces
         the terminal ❌ must refresh the budget for the NEXT cycle. The
         happy-path reset only runs when a cycle COMPLETES, so before the fix
@@ -11520,9 +11633,7 @@ class TestRunChatTransientRetry:
         state.sessions.reset.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_transient_after_thinking_only_retries(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_transient_after_thinking_only_retries(self, tmp_path, monkeypatch):
         """A transient 5xx that lands AFTER reasoning streamed but before any
         answer token or tool call is still retried: thinking is ephemeral,
         broadcast-only output, so it does NOT flip _turn_emitted. This pins the
@@ -11666,9 +11777,7 @@ class TestSourceLinkUrlsExcludeIssues:
         state = _make_state(tmp_path)
         slot = state.get_or_create_slot("source")
         pr = "https://github.com/acme/widgets/pull/12"
-        slot.append(
-            "assistant", f"{pr} and https://github.com/acme/widgets/issues/13"
-        )
+        slot.append("assistant", f"{pr} and https://github.com/acme/widgets/issues/13")
 
         assert state.source_link_urls() == [pr]
         assert state.source_link_urls_for_slot("source") == [pr]
@@ -11684,9 +11793,7 @@ class TestSourceLinkUrlsExcludeIssues:
         state.owner_id = "U_OWNER"
         slot = state.get_or_create_slot("source")
         pr = "https://github.com/acme/widgets/pull/12"
-        slot.append(
-            "assistant", f"{pr} and https://github.com/acme/widgets/issues/13"
-        )
+        slot.append("assistant", f"{pr} and https://github.com/acme/widgets/issues/13")
 
         app = _make_app(state)
 
@@ -11747,9 +11854,7 @@ class TestBulkModelSwitch:
         state.push_slots_update = MagicMock()  # mock after creation: get_or_create_slot pushes
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/model", json={"model": "claude-opus-4.8"}
-            )
+            resp = await client.post("/api/chat/slots/model", json={"model": "claude-opus-4.8"})
             data = await resp.json()
 
         assert resp.status == 200
@@ -11770,9 +11875,7 @@ class TestBulkModelSwitch:
         self._mark_running(busy)
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/model", json={"model": "claude-opus-4.8"}
-            )
+            resp = await client.post("/api/chat/slots/model", json={"model": "claude-opus-4.8"})
             data = await resp.json()
 
         assert resp.status == 200
@@ -11811,9 +11914,7 @@ class TestBulkModelSwitch:
         state.push_slots_update = MagicMock()  # mock after creation: get_or_create_slot pushes
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/model", json={"model": "claude-opus-4.8"}
-            )
+            resp = await client.post("/api/chat/slots/model", json={"model": "claude-opus-4.8"})
             data = await resp.json()
 
         assert resp.status == 200
@@ -11834,9 +11935,7 @@ class TestBulkModelSwitch:
         state.push_slots_update = MagicMock()  # mock after creation: get_or_create_slot pushes
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/model", json={"model": "claude-opus-4.8"}
-            )
+            resp = await client.post("/api/chat/slots/model", json={"model": "claude-opus-4.8"})
             data = await resp.json()
 
         assert resp.status == 200
@@ -11867,9 +11966,7 @@ class TestBulkModelSwitch:
         app_obj.middlewares.insert(0, inject_app)
 
         async with TestClient(TestServer(app_obj)) as client:
-            resp = await client.post(
-                "/api/chat/slots/model", json={"model": "claude-opus-4.8"}
-            )
+            resp = await client.post("/api/chat/slots/model", json={"model": "claude-opus-4.8"})
             data = await resp.json()
 
         assert resp.status == 200
@@ -11896,9 +11993,7 @@ class TestBulkModelSwitch:
         bare_app.router.add_post("/api/chat/slots/model", api_chat_slots_model)
 
         async with TestClient(TestServer(bare_app)) as client:
-            resp = await client.post(
-                "/api/chat/slots/model", json={"model": "claude-opus-4.8"}
-            )
+            resp = await client.post("/api/chat/slots/model", json={"model": "claude-opus-4.8"})
 
         assert resp.status == 403
         assert state._slots["a"].model == "claude-opus-4.6"
@@ -11925,9 +12020,7 @@ class TestBulkModelSwitch:
         app_obj.router.add_post("/api/chat/slots/model", api_chat_slots_model)
 
         async with TestClient(TestServer(app_obj)) as client:
-            resp = await client.post(
-                "/api/chat/slots/model", json={"model": "claude-opus-4.8"}
-            )
+            resp = await client.post("/api/chat/slots/model", json={"model": "claude-opus-4.8"})
             data = await resp.json()
 
         assert resp.status == 200
@@ -11958,9 +12051,7 @@ class TestBulkModelSwitch:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/model", json={"model": "fable-5-1m"}
-            )
+            resp = await client.post("/api/chat/slots/model", json={"model": "fable-5-1m"})
             data = await resp.json()
 
         assert resp.status == 400
@@ -11990,9 +12081,7 @@ class TestSlotModelGuard:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "fable-5-1m"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "fable-5-1m"})
             data = await resp.json()
 
         assert resp.status == 400
@@ -12040,9 +12129,7 @@ class TestSlotModelGuard:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "claude-opus-4.8"})
 
         assert resp.status == 200
         assert state._slots["a"].model == "claude-opus-4.8"
@@ -12102,9 +12189,7 @@ class TestSlotModelLiveSwitch:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"})
 
         assert resp.status == 200
         assert state._slots["a"].model == "gpt-5.6-sol"
@@ -12125,9 +12210,7 @@ class TestSlotModelLiveSwitch:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "claude-opus-4.8"})
 
         assert resp.status == 200
         sent = provider.client.set_model.await_args.args[0]
@@ -12147,9 +12230,7 @@ class TestSlotModelLiveSwitch:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"})
 
         assert resp.status == 200
         provider.client.set_model.assert_not_awaited()
@@ -12166,9 +12247,7 @@ class TestSlotModelLiveSwitch:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"})
 
         # The slot still lands on the new model, via the reset path.
         assert resp.status == 200
@@ -12240,9 +12319,7 @@ class TestSlotModelLiveSwitch:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "claude-opus-4.8"})
 
         assert resp.status == 200
         sent = provider.client.set_model.await_args.args[0]
@@ -12260,9 +12337,7 @@ class TestSlotModelLiveSwitch:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"})
 
         assert resp.status == 200
         assert state._slots["a"].model == "gpt-5.6-sol"
@@ -12278,9 +12353,7 @@ class TestSlotModelLiveSwitch:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"})
 
         assert resp.status == 200
         provider.client.set_model.assert_not_awaited()
@@ -12303,9 +12376,7 @@ class TestSlotModelLiveSwitch:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "claude-opus-4.8"})
 
         assert resp.status == 200
         provider.change_effort.assert_awaited_once_with("high")
@@ -12324,9 +12395,7 @@ class TestSlotModelLiveSwitch:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "claude-opus-4.8"})
 
         assert resp.status == 200
         state.sessions.reset.assert_awaited_once()
@@ -12343,9 +12412,7 @@ class TestSlotModelLiveSwitch:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "claude-opus-4.8"})
 
         assert resp.status == 200
         state.sessions.reset.assert_awaited_once()
@@ -12363,9 +12430,7 @@ class TestSlotModelLiveSwitch:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "claude-haiku-4.5"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "claude-haiku-4.5"})
 
         assert resp.status == 200
         provider.change_effort.assert_not_awaited()
@@ -12387,9 +12452,7 @@ class TestSlotModelLiveSwitch:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "claude-opus-4.8"})
 
         assert resp.status == 200
         provider.clear_effort.assert_awaited_once()
@@ -12420,9 +12483,7 @@ class TestSlotModelLiveSwitch:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "claude-opus-4.8"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "claude-opus-4.8"})
             body = await resp.json()
 
         assert resp.status == 400
@@ -12471,9 +12532,7 @@ class TestSlotModelSwitchContextBroadcast:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"})
 
         assert resp.status == 200
         events = self._find_context_events(state.broadcast_ws)
@@ -12499,9 +12558,7 @@ class TestSlotModelSwitchContextBroadcast:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"})
 
         assert resp.status == 200
         state.sessions.reset.assert_awaited_once()
@@ -12518,9 +12575,7 @@ class TestSlotModelSwitchContextBroadcast:
         state.push_slots_update = MagicMock()
 
         async with TestClient(TestServer(self._app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"}
-            )
+            resp = await client.post("/api/chat/slots/a/model", json={"model": "gpt-5.6-sol"})
 
         assert resp.status == 200
         assert state._slots["a"].model == "gpt-5.6-sol"
@@ -12547,9 +12602,7 @@ class TestForkSlotTail:
         the B1 gate test below overrides this to False for its own assertion."""
         mock_cfg = MagicMock()
         mock_cfg.dashboard.tail_fork_enabled = True
-        monkeypatch.setattr(
-            "kiro_crew.dashboard.chat_fork.KiroCrewConfig.load", lambda: mock_cfg
-        )
+        monkeypatch.setattr("kiro_crew.dashboard.chat_fork.KiroCrewConfig.load", lambda: mock_cfg)
 
     @pytest.mark.asyncio
     async def test_tail_fork_keeps_messages_after_index(self, tmp_path):
@@ -12671,9 +12724,7 @@ class TestForkSlotTail:
         """B1 gate (D1): tail_fork_enabled=False silently downgrades tail -> head."""
         mock_cfg = MagicMock()
         mock_cfg.dashboard.tail_fork_enabled = False
-        monkeypatch.setattr(
-            "kiro_crew.dashboard.chat_fork.KiroCrewConfig.load", lambda: mock_cfg
-        )
+        monkeypatch.setattr("kiro_crew.dashboard.chat_fork.KiroCrewConfig.load", lambda: mock_cfg)
         state = _make_state(tmp_path)
         _make_tail_fork_slot(state)
 

--- a/test/test_tag_session.py
+++ b/test/test_tag_session.py
@@ -1,0 +1,465 @@
+"""Tests for the background auto-tag task (chat_auto_tag.maybe_auto_tag).
+
+Covers:
+- Derives tag from slot.project basename (project=/x/repos/MyRepo -> tag 'MyRepo')
+- No project -> no-op
+- Second call -> no extra write (idempotency)
+- Status-name collision -> skipped
+- Creates missing tag definitions
+- Reuses existing tags case-insensitively
+- Merges without duplication (dedup)
+- Credential redaction in derived tag name
+- Concurrent calls race-safe (one definition only)
+- Non-dashboard slot -> no-op
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.dashboard.chat_auto_tag import maybe_auto_tag
+
+
+def _make_state(tags=None):
+    """Build a minimal mock DashboardState for testing."""
+    from kiro_crew.dashboard.state import DashboardState
+
+    state = MagicMock()
+    state._tags = list(tags or [])
+    state._TAGS_FILE = "chat_tags.json"
+    state.save_tags = MagicMock()
+    state._atomic_write_json = DashboardState._atomic_write_json
+    state._atomic_write_json_strict = DashboardState._atomic_write_json_strict
+    state.save_tags_snapshot = lambda snapshot: DashboardState.save_tags_snapshot(state, snapshot)
+    state.push_slots_update = MagicMock()
+    return state
+
+
+def _make_slot(project="", tags=None):
+    """Build a minimal mock slot.
+
+    Real ``_ChatSlot.key`` values are BARE names (the ``dashboard:`` prefix
+    exists only on the derived session key), so the mock uses a bare key to
+    match production shape.
+    """
+    slot = SimpleNamespace(
+        tags=list(tags or []),
+        key="test-slot",
+        project=project,
+    )
+    return slot
+
+
+@pytest.fixture
+def patch_save_slot(tmp_path):
+    mock = AsyncMock()
+    # chat_auto_tag binds save_slot_off_loop at import time (module-level
+    # import), so the patch target must be chat_auto_tag's binding — patching
+    # chat_persistence would be a silent no-op.
+    with patch(
+        "kiro_crew.dashboard.chat_auto_tag.save_slot_off_loop",
+        mock,
+    ):
+
+        async def _sync_to_thread(fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        with patch("kiro_crew.dashboard.chat_tags.asyncio.to_thread", side_effect=_sync_to_thread):
+            with patch("kiro_crew.dashboard.state.config_dir", return_value=tmp_path):
+                yield mock
+
+
+# ── Core derivation ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAutoTagDerivation:
+    """Derive tag name from slot.project basename."""
+
+    async def test_project_basename_becomes_tag(self, patch_save_slot, tmp_path):
+        state = _make_state()
+        slot = _make_slot(project="/x/repos/MyRepo")
+
+        await maybe_auto_tag(state, slot)
+
+        # Tag definition created with project basename
+        assert len(state._tags) == 1
+        assert state._tags[0]["name"] == "MyRepo"
+        assert state._tags[0]["status"] is False
+        # Tag id assigned to slot
+        assert state._tags[0]["id"] in slot.tags
+        # Persistence
+        tags_file = tmp_path / "chat_tags.json"
+        assert tags_file.exists()
+        written = json.loads(tags_file.read_text())
+        assert len(written) == 1
+        assert written[0]["name"] == "MyRepo"
+
+    async def test_no_project_is_noop(self, patch_save_slot):
+        state = _make_state()
+        slot = _make_slot(project="")
+
+        await maybe_auto_tag(state, slot)
+
+        assert len(state._tags) == 0
+        assert len(slot.tags) == 0
+        patch_save_slot.assert_not_awaited()
+
+    async def test_dot_project_is_noop(self, patch_save_slot):
+        state = _make_state()
+        slot = _make_slot(project=".")
+
+        await maybe_auto_tag(state, slot)
+
+        assert len(state._tags) == 0
+        assert len(slot.tags) == 0
+
+    async def test_tilde_project_is_noop(self, patch_save_slot):
+        state = _make_state()
+        slot = _make_slot(project="~")
+
+        await maybe_auto_tag(state, slot)
+
+        assert len(state._tags) == 0
+        assert len(slot.tags) == 0
+
+    async def test_nested_path_uses_basename(self, patch_save_slot):
+        state = _make_state()
+        slot = _make_slot(project="/home/user/workspace/src/DisapereBackend")
+
+        await maybe_auto_tag(state, slot)
+
+        assert len(state._tags) == 1
+        assert state._tags[0]["name"] == "DisapereBackend"
+
+
+# ── Idempotency ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAutoTagIdempotency:
+    """Second call with same project does not produce extra writes."""
+
+    async def test_second_call_is_noop(self, patch_save_slot):
+        """After the first attempt sets _auto_tagged, second call short-circuits."""
+        state = _make_state()
+        slot = _make_slot(project="/x/repos/MyRepo")
+
+        await maybe_auto_tag(state, slot)
+        assert slot._auto_tagged is True
+        assert len(slot.tags) == 1
+        patch_save_slot.reset_mock()
+
+        # Second call: flag already set -> immediate return
+        await maybe_auto_tag(state, slot)
+        patch_save_slot.assert_not_awaited()
+
+    async def test_manual_removal_not_retagged(self, patch_save_slot):
+        """If user removes auto-tag manually, flag prevents re-tagging."""
+        state = _make_state()
+        slot = _make_slot(project="/x/repos/MyRepo")
+
+        # First call: tag is applied
+        await maybe_auto_tag(state, slot)
+        assert slot._auto_tagged is True
+        assert len(slot.tags) == 1
+
+        # Simulate user removing the tag manually
+        slot.tags = []
+
+        # Second call: flag prevents re-tagging
+        patch_save_slot.reset_mock()
+        await maybe_auto_tag(state, slot)
+        assert slot.tags == []
+        patch_save_slot.assert_not_awaited()
+
+
+# ── Case-insensitive reuse ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAutoTagCaseInsensitive:
+    """Reuses existing tag case-insensitively."""
+
+    async def test_reuses_existing_case_insensitively(self, patch_save_slot):
+        existing = {
+            "id": "abc123",
+            "name": "myrepo",
+            "color": "#6b7280",
+            "order": 0,
+            "status": False,
+        }
+        state = _make_state(tags=[existing])
+        slot = _make_slot(project="/x/repos/MyRepo")
+
+        await maybe_auto_tag(state, slot)
+
+        # No new tag created
+        assert len(state._tags) == 1
+        # Existing id assigned
+        assert "abc123" in slot.tags
+
+
+# ── Status tag collision ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAutoTagStatusSkip:
+    """Status/workflow tags with same name are skipped."""
+
+    async def test_status_tag_collision_skipped(self, patch_save_slot):
+        status_tag = {
+            "id": "status-id",
+            "name": "MyRepo",
+            "color": "#22c55e",
+            "order": 0,
+            "status": True,
+        }
+        state = _make_state(tags=[status_tag])
+        slot = _make_slot(project="/x/repos/MyRepo")
+
+        await maybe_auto_tag(state, slot)
+
+        # No tag assigned (status tag skipped)
+        assert "status-id" not in slot.tags
+        assert len(slot.tags) == 0
+        patch_save_slot.assert_not_awaited()
+
+
+# ── Credential redaction ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAutoTagRedaction:
+    """Credential patterns in derived tag name are redacted."""
+
+    async def test_credential_in_project_name_is_redacted(self, patch_save_slot):
+        state = _make_state()
+        # This extreme case: project dir named with an AWS key
+        slot = _make_slot(project="/x/deploy-AKIAIOSFODNN7EXAMPLE")
+
+        await maybe_auto_tag(state, slot)
+
+        # Credential must NOT survive into the tag definition name
+        if state._tags:
+            tag_name = state._tags[0]["name"]
+            assert "AKIAIOSFODNN7EXAMPLE" not in tag_name
+
+
+# ── Production-shaped slot keys ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAutoTagBareSlotKey:
+    """Real ``_ChatSlot.key`` values are BARE names — the ``dashboard:``
+    prefix exists only on the derived session key. Regression: an early
+    guard that required a ``dashboard:`` prefix made auto-tagging a
+    permanent no-op for every real slot (the once-flag was still set,
+    suppressing retries)."""
+
+    async def test_bare_key_slot_gets_tagged(self, patch_save_slot):
+        state = _make_state()
+        slot = _make_slot(project="/x/repos/MyRepo")
+        slot.key = "chat-1712793600123"  # production shape: bare, no prefix
+
+        await maybe_auto_tag(state, slot)
+
+        assert [t["name"] for t in state._tags] == ["MyRepo"]
+        assert len(slot.tags) == 1
+        patch_save_slot.assert_awaited()
+
+
+# ── Once-flag persisted with the slot save ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAutoTagFlagSetBeforeSave:
+    """The once-flag must be True at the moment the slot is persisted — the
+    save writes the metadata line, so a flag set only afterwards (e.g. in a
+    ``finally``) never reaches disk; after a restart the flag is lost and a
+    later message re-adds a tag the user removed."""
+
+    async def test_flag_is_set_when_slot_is_saved(self, tmp_path, monkeypatch):
+        state = _make_state()
+        slot = _make_slot(project="/x/repos/MyRepo")
+
+        flag_at_save: list[bool] = []
+
+        async def _recording_save(state_arg, slot_arg, **kwargs):
+            flag_at_save.append(bool(getattr(slot_arg, "_auto_tagged", False)))
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_auto_tag.save_slot_off_loop", _recording_save)
+
+        async def _sync_to_thread(fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        with patch("kiro_crew.dashboard.chat_tags.asyncio.to_thread", side_effect=_sync_to_thread):
+            with patch("kiro_crew.dashboard.state.config_dir", return_value=tmp_path):
+                await maybe_auto_tag(state, slot)
+
+        assert flag_at_save == [True]
+        assert len(slot.tags) == 1
+
+
+# ── Concurrent calls produce one definition ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAutoTagConcurrency:
+    """Concurrent maybe_auto_tag calls for the same project yield one definition."""
+
+    async def test_concurrent_creates_one_definition(self, patch_save_slot):
+        state = _make_state()
+        slot_a = _make_slot(project="/x/repos/ConcurrentRepo")
+        slot_b = _make_slot(project="/x/repos/ConcurrentRepo")
+
+        await asyncio.gather(
+            maybe_auto_tag(state, slot_a),
+            maybe_auto_tag(state, slot_b),
+        )
+
+        # Exactly one definition
+        matching = [t for t in state._tags if t["name"].lower() == "concurrentrepo"]
+        assert len(matching) == 1
+        # Both slots have the tag
+        the_id = matching[0]["id"]
+        assert the_id in slot_a.tags
+        assert the_id in slot_b.tags
+
+
+# ── Delete race ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAutoTagDeleteRace:
+    """Concurrent auto_tag + tag delete must not leave dangling references."""
+
+    async def test_no_dangling_reference(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.chat_tags import api_chat_tag_delete
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+
+        async def _sync_to_thread(fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        violations = 0
+        iterations = 20
+
+        for _ in range(iterations):
+            state = _make_state()
+            tag_t = {
+                "id": "race_tag_id",
+                "name": "RaceRepo",
+                "color": "#6b7280",
+                "order": 0,
+                "status": False,
+            }
+            state._tags = [tag_t]
+            state._slots = {}
+            state._tag_boards = []
+            state.save_tag_boards = MagicMock()
+            slot = _make_slot(project="/x/repos/RaceRepo")
+            slot.tags = []
+            state._slots["test-slot"] = slot
+
+            with patch(
+                "kiro_crew.dashboard.chat_tags.asyncio.to_thread", side_effect=_sync_to_thread
+            ):
+                with patch(
+                    "kiro_crew.dashboard.chat_tags.save_slot_off_loop", new_callable=AsyncMock
+                ):
+                    with patch(
+                        "kiro_crew.dashboard.chat_persistence.save_slot_off_loop",
+                        new_callable=AsyncMock,
+                    ):
+
+                        async def do_tag():
+                            await maybe_auto_tag(state, slot)
+
+                        async def do_delete():
+                            mock_request = MagicMock()
+                            mock_request.app = {"state": state}
+                            mock_request.match_info = {"id": "race_tag_id"}
+                            await api_chat_tag_delete(mock_request)
+
+                        await asyncio.gather(do_tag(), do_delete())
+
+            tag_exists = any(t.get("id") == "race_tag_id" for t in state._tags)
+            slot_has_tag = "race_tag_id" in slot.tags
+            if not tag_exists and slot_has_tag:
+                violations += 1
+
+        assert violations == 0, f"Dangling reference in {violations}/{iterations} iterations"
+
+
+# ── Trigger integration ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAutoTagTrigger:
+    """Verify chat_handlers imports and fires maybe_auto_tag."""
+
+    async def test_import_succeeds(self):
+        """chat_handlers can import maybe_auto_tag without cycle."""
+        from kiro_crew.dashboard.chat_handlers import maybe_auto_tag as imported
+
+        assert callable(imported)
+
+
+# ── Persist-failure rollback ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAutoTagPersistFailureRollback:
+    """If the tags.json snapshot write fails after the definition was
+    appended in memory, the append must be rolled back — the once-flag
+    suppresses retries, so an undurable definition would otherwise linger
+    visible and unassigned until restart."""
+
+    async def test_snapshot_failure_rolls_back_definition(self, patch_save_slot, monkeypatch):
+        state = _make_state()
+        slot = _make_slot(project="/x/repos/MyRepo")
+
+        async def _failing_persist(st):
+            raise IOError("disk full")
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_auto_tag.persist_tags_snapshot_unlocked",
+            _failing_persist,
+        )
+        await maybe_auto_tag(state, slot)
+
+        assert state._tags == []  # rolled back
+        assert slot.tags == []  # never assigned
+        patch_save_slot.assert_not_awaited()
+        assert slot._auto_tagged is True  # attempt still consumed
+
+
+# ── Truncation before matching ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestAutoTagTruncationBeforeMatch:
+    """Names must be normalized (strip + _NAME_MAX truncation) BEFORE the
+    case-insensitive match, or two >60-char basenames differing only past
+    the cut would create duplicate definitions with identical names."""
+
+    async def test_long_basenames_reuse_one_definition(self, patch_save_slot):
+        from kiro_crew.dashboard.chat_auto_tag import _NAME_MAX
+
+        state = _make_state()
+        base = "x" * _NAME_MAX
+        slot_a = _make_slot(project=f"/repos/{base}AAAA")
+        slot_b = _make_slot(project=f"/repos/{base}BBBB")
+
+        await maybe_auto_tag(state, slot_a)
+        await maybe_auto_tag(state, slot_b)
+
+        assert len(state._tags) == 1  # single definition, no duplicate
+        assert state._tags[0]["name"] == base
+        assert slot_a.tags == slot_b.tags == [state._tags[0]["id"]]


### PR DESCRIPTION
Closes #1861

## What

Auto-tags chat sessions with the name of the project/repo they are working in, via a **background task** -- no new tool is added to any chat's toolset.

> **Reworked per review feedback**: the original design exposed a `tag_session` directive tool in `kirocrew-core`, which would have influenced all chats. That surface is now fully removed; tagging happens in a background task modeled on the existing auto-title flow, with deterministic (zero-LLM) derivation.


## Demo

Attach a project, send the first message — the session tags itself:

![session auto-tags demo](https://github.com/RohanK6/KiroCrew/releases/download/demo-pr-1880/session-auto-tags-demo.gif)

<sub>[mp4 version](https://github.com/RohanK6/KiroCrew/releases/download/demo-pr-1880/session-auto-tags-demo.mp4)</sub>

## How

- **`chat_auto_tag.py` (new)**: `maybe_auto_tag(state, slot)` fires as a fire-and-forget async task alongside `_maybe_auto_title` on the first user message. Guards: dashboard slots only, non-empty `slot.project`, idempotent (no-op when the derived tag is already assigned), never raises. The tag name is derived deterministically from the project directory basename -- a cheap-model topic pass is possible future work.
- **Tag application**: name is passed through `redact_credentials`/`redact_exfiltration_urls`, resolved case-insensitively against the vocabulary; missing definitions are auto-created (never as workflow/status tags -- those are skipped); the merge is additive, preserving manual tags. The whole resolve->create->assign->persist sequence holds the tags write lock, so it cannot interleave with concurrent tag deletion.
- **`chat_tags.py` hardening (kept)**: all `tags.json` mutations (create/update/delete) serialize under one per-state lock with the fsync write offloaded to a worker thread on an immutable snapshot; POST/PATCH redact user-supplied names; DELETE is crash-atomic: the vocabulary write (`tags.json`) is the single durable commit, done first; slot/board strips are best-effort cleanup afterward, and dangling ids self-heal on the next load.

## Frontend

Zero frontend changes: `push_slots_update()` already broadcasts `slot.tags` and the sidebar renders the pills.

## Tests

Backend suites cover: deterministic derivation from the slot project, idempotency, no-project no-op, status-tag skip, credential redaction, case-insensitive reuse, concurrent create dedup, assign/delete race (repeated interleavings), delete ordering, and the error-code contract baseline.

