### PR TITLE
fix: re-check cron governance at execution, not just cron_add

### DIFF
--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -650,8 +650,14 @@ read-your-writes should add it deliberately, with its own tests.
   is authoritative; KiroCrew does not regenerate `~/.kiro/agents/*.json`.
 - **Plane C — out-of-band executors**: the cron `command` (runs via `sh -c`
   outside the ACP flow) is gated in `mcp_cron._vet_command_governance`; the
-  cron *capability* on/off gate in `mcp_cron._vet_cron_capability_governance`
-  (at `cron_add`); the sandbox ordinal floor is clamped in `sandbox.wrap_argv`;
+  cron *capability* on/off gate in `mcp_cron._vet_cron_capability_governance`.
+  Both run at `cron_add` (authoring) AND again at fire time, in
+  `slack.gateway._cron_callback`, immediately before the sandboxed subprocess
+  is spawned — a policy tightened after a job was scheduled denies that job's
+  next run instead of only affecting jobs authored after the change. Denial at
+  fire time marks the run `last_status="error"` and does not delete or pause
+  the job, so a later policy loosening lets it resume on its own; the sandbox
+  ordinal floor is clamped in `sandbox.wrap_argv`;
   spawn in `subagent._vet_spawn_governance`; outbound messaging in
   `mcp_core._vet_messaging_governance` plus the per-transport `channels` check
   in `mcp_core._vet_channel_governance`; dashboard cross-surface mirror creation

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -1768,6 +1768,38 @@ class GatewayOrchestrator:
                         logger.debug(
                             "SEL logging failed in cron command invoked path", exc_info=True
                         )
+                    # Re-run governance at fire time, not just at cron_add authoring
+                    # time. A job vetted when it was scheduled can outlive a later
+                    # policy tightening: mcp_cron._vet_cron_capability_governance and
+                    # _vet_command_governance only run once, at authoring, so a
+                    # ceiling change has no effect on an already-scheduled job until
+                    # someone notices and re-authors it. Denial here does not delete
+                    # the job, so a later policy loosening lets it resume on its own.
+                    from kiro_crew.mcp_cron import (
+                        _vet_command_governance,
+                        _vet_cron_capability_governance,
+                    )
+
+                    gate_reason = _vet_cron_capability_governance() or _vet_command_governance(
+                        job.command
+                    )
+                    if gate_reason:
+                        job.last_status = "error"
+                        job.last_error = redact(gate_reason)
+                        job.record_failure()
+                        try:
+                            sel().log_tool_invocation(
+                                session_key=f"cron:{job.id}",
+                                tool_name="cron_command_exec",
+                                tool_kind="cron_command",
+                                outcome="denied",
+                            )
+                        except Exception:
+                            logger.debug(
+                                "SEL logging failed in cron command fire-time deny path",
+                                exc_info=True,
+                            )
+                        return None
                     cmd_timeout = job.timeout or 300
                     result = await asyncio.wait_for(
                         asyncio.get_running_loop().run_in_executor(

--- a/test/test_cron_gateway_integration.py
+++ b/test/test_cron_gateway_integration.py
@@ -270,6 +270,52 @@ class TestCommandExecution:
         assert args[0] == "echo hello"
         assert args[1] == 120  # the timeout value
 
+    @pytest.mark.asyncio
+    async def test_fire_time_command_deny_blocks_execution(self):
+        # A policy tightened after this job was scheduled must still block it at
+        # fire time, not just at cron_add authoring time.
+        gw = _make_gw()
+        job = _make_command_job()
+        with patch("kiro_crew.mcp_cron._vet_cron_capability_governance", return_value=None), \
+             patch(
+                 "kiro_crew.mcp_cron._vet_command_governance",
+                 return_value="Error: cron command blocked by governance policy: denied",
+             ):
+            result, mock_run = await _run_command_callback(
+                gw, job, {"status": "ok", "output": "hello\n", "exit_code": 0}
+            )
+        assert result is None
+        assert job.last_status == "error"
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fire_time_capability_deny_blocks_execution(self):
+        # capabilities.cron can be disabled after the job was scheduled too.
+        gw = _make_gw()
+        job = _make_command_job()
+        with patch(
+            "kiro_crew.mcp_cron._vet_cron_capability_governance",
+            return_value="Error: cron scheduling blocked by governance policy: disabled",
+        ):
+            result, mock_run = await _run_command_callback(
+                gw, job, {"status": "ok", "output": "hello\n", "exit_code": 0}
+            )
+        assert result is None
+        assert job.last_status == "error"
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fire_time_governance_allow_still_executes(self):
+        gw = _make_gw()
+        job = _make_command_job()
+        with patch("kiro_crew.mcp_cron._vet_cron_capability_governance", return_value=None), \
+             patch("kiro_crew.mcp_cron._vet_command_governance", return_value=None):
+            result, mock_run = await _run_command_callback(
+                gw, job, {"status": "ok", "output": "hello\n", "exit_code": 0}
+            )
+        assert job.last_status == "ok"
+        mock_run.assert_called_once()
+
 
 class TestTimeoutPersistence:
     """Test that timeout field survives save/load cycle."""


### PR DESCRIPTION
## Problem / Motivation

Cron command jobs are only governance-vetted once, at `cron_add` authoring time. If a policy is tightened after a job is already scheduled, the job keeps running under the old rules until someone notices and manually re-authors it.

## Why it matters

Anyone relying on the governance ceiling to bound what a scheduled job can do has a real gap here: tightening the `commands` scope or disabling `capabilities.cron` for a surface has no effect on jobs that were already scheduled before the change. On a deployment where policy is expected to take effect promptly, that's a meaningful drift window between "policy says no" and the system actually stopping.

## What changed (motivation → approach → change)

Observed: the deny-by-default `capabilities.cron` gate and the `commands` ceiling are only evaluated in `mcp_cron._vet_cron_capability_governance` / `_vet_command_governance`, both called from `cron_add`, and never again after that.

Root cause: the cron command executes via `sh -c` outside the ACP hook flow (documented in `mcp_cron.py`'s own comments), so `hooks.on_tool_call` never re-runs on it, and nothing else re-checks governance at execution time either.

Change: re-run both governance checks in the gateway's `_cron_callback`, immediately before `run_command_sandboxed` is dispatched. A deny at fire time marks the run `last_status="error"` and leaves the job in place (not deleted, not paused), so a later policy loosening lets it resume without needing to be re-authored.

## Tests

Added 3 tests in `test_cron_gateway_integration.py::TestCommandExecution`: a fire-time command-governance deny blocks execution and marks the run failed, a fire-time capability deny does the same, and a control test confirming the allow path still executes and delivers output normally.

## Manual verification

N/A — unit coverage sufficient. The change is a synchronous pre-check ahead of an already-covered dispatch path, and the new tests exercise both the deny and allow branches directly against the real gateway callback.

## Related Issues

Related to #1881 (this is Phase 1 of that issue's proposal).

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (`governance.md`'s Plane C description)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
