### PR TITLE
docs: add a reference egress defense-in-depth security_policy.json

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -14,7 +14,9 @@ system is built, see [../architecture/](../architecture/README.md).
 | [slack-setup.md](slack-setup.md) | Creating and configuring the Slack app. |
 
 `assets/` holds the copy-pasteable service unit, launchd plist, and setup script
-that [remote-and-mobile.md](remote-and-mobile.md) refers to.
+that [remote-and-mobile.md](remote-and-mobile.md) refers to, plus an example
+`security_policy.json` that
+[governance.md](../system-specs/modules/governance.md) refers to.
 
 End-user feature documentation is not here: it ships in the package under
 [`../../src/kiro_crew/docs/`](../../src/kiro_crew/docs/README.md).

--- a/docs/guides/assets/security-policy.example.json
+++ b/docs/guides/assets/security-policy.example.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "boot": {
+    "fail_closed": true
+  },
+  "network": {
+    "egress": {
+      "mode": "allow",
+      "allow": [
+        "*.amazonaws.com",
+        "*.kiro.dev",
+        "management.*.kiro.dev",
+        "runtime.*.kiro.dev"
+      ]
+    }
+  },
+  "commands": {
+    "mode": "deny",
+    "deny": [
+      "curl*://*",
+      "wget*://*",
+      "nc *",
+      "ncat *"
+    ]
+  }
+}

--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -935,6 +935,22 @@ denials leave the same forensic trail.
   relevant `commands` patterns. This is the same plane split the rest of the
   model uses (a shell command is a `commands` item, never re-parsed into its
   sub-effects).
+  [`docs/guides/assets/security-policy.example.json`](../../guides/assets/security-policy.example.json)
+  shows both scopes set together, but read it as **egress defense-in-depth,
+  not a bounded egress guarantee**: a `commands` deny list is a finite set of
+  known patterns, not an allow-shaped ceiling, so it cannot enumerate every
+  network-capable tool (`python`, `ssh`, `git`, `pip`, `openssl s_client`, a
+  `curl` invocation with no `://` in it, or a piped/absolute-path
+  invocation of any of the above), and it says nothing about the web terminal
+  PTY, which is an ungoverned plane by design (see below). A deployment that
+  needs an actual bound on where the host can reach should treat the example
+  as a starting point for defense-in-depth, not as sufficient on its own.
+  Separately: once a `commands` deny pattern is adopted into policy, it
+  becomes a force-pin via `resolve_pinned_commands` (ceiling pins ∪ profile
+  pins, union not override) — a user cannot locally opt out of a pinned rule
+  the way they can an unpinned one, so an operator copying the example should
+  expect its deny rows to be effectively permanent for anyone bound by that
+  policy, not something end users can narrow per-rule.
 - **Per-app profile binding via MCP chokepoints is best-effort.** The managed
   `kirocrew-core` MCP server is spawned by kiro-cli, not by an app backend, so
   `KIROCREW_APP_NAME` is absent there — `learn_add`/`send_message` resolve the


### PR DESCRIPTION
## Problem / Motivation

Operators asking how to bound where the local agent process can reach, for a residency-sensitive deployment or just tighter defense-in-depth, have no starting point today beyond reading the governance scope catalog from scratch and inferring the right shape of a `security_policy.json`.

## Why it matters

Without a working reference, an operator either skips network governance entirely or writes an incomplete policy that only covers one of the two egress paths. `governance.md` already documents that `network.egress` governs the dedicated fetch tool only, and that shell-based egress needs the separate `commands` scope, but that split is easy to miss without an example showing both used together.

## What changed (motivation → approach → change)

Goal: give operators a real, copy-editable starting point for bounding local-agent network reach.

Approach considered and chosen: rather than adding a new config field or scope (an engine/schema change and a bigger ask), I used the two existing scopes together in one example, since that's genuinely sufficient to cover both egress paths without touching any code.

Change: added `docs/guides/assets/security-policy.example.json` (an allow list for the fetch tool plus a deny list for common shell-based egress commands like curl/wget/nc), linked it from `governance.md`'s existing scope-boundaries note, and indexed it in `docs/guides/README.md`.

## Tests

N/A — config-only, no code path changes.

## Manual verification

Ran `parse_policy()` directly against the example file's contents and checked `.permits(...)` on representative allowed/denied hosts and commands; all matched intent (allowed hosts and benign commands permitted, other hosts and the listed shell-egress patterns denied). Ran `scripts/docs_lint.py`, passes.

## Related Issues

Related to #1881 (this is Phase 2 of that issue's proposal).

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality — N/A, config/docs-only, no code path to test; see Manual verification for how the example itself was validated
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (`governance.md` and `docs/guides/README.md`)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
