### PR TITLE
fix: guard page-context Notification construction on Android Chrome

### DIFF
--- a/website/src/hooks/useNativeNotification.ts
+++ b/website/src/hooks/useNativeNotification.ts
@@ -29,15 +29,23 @@ export function useNativeNotification(botName: string, avatar: string) {
           const body =
             latestNotif?.body ||
             (delta > 1 ? `${delta} new notifications` : 'New notification')
-          new Notification(title, {
-            body,
-            icon: avatar,
-            tag:
-              latestNotif?.approval_id ||
-              latestNotif?.job_id ||
-              latestNotif?.task_id ||
-              'kirocrew-notif',
-          })
+          // Android Chrome throws "Illegal constructor" here even with
+          // permission granted (page-context Notification is desktop-only);
+          // the in-app notification center still shows the event, so the
+          // native toast is best-effort.
+          try {
+            new Notification(title, {
+              body,
+              icon: avatar,
+              tag:
+                latestNotif?.approval_id ||
+                latestNotif?.job_id ||
+                latestNotif?.task_id ||
+                'kirocrew-notif',
+            })
+          } catch {
+            /* unsupported platform */
+          }
         } else if (Notification.permission === 'default') {
           Notification.requestPermission()
         }

--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -746,7 +746,14 @@ export function useWebSocket() {
             }
             // Browser notification when tab not focused (permission must be granted via UI interaction elsewhere)
             if (typeof Notification !== 'undefined' && document.hidden && Notification.permission === 'granted') {
-              new Notification(i18nT('hooks.useWebSocket.approval_required'), { body: data.tool || i18nT('hooks.useWebSocket.a_task_needs_your_decision'), tag: 'kirocrew-approval' })
+              // Android Chrome throws "Illegal constructor" for page-context
+              // Notification; an uncaught throw here kills the whole message
+              // handler, so the native toast is best-effort.
+              try {
+                new Notification(i18nT('hooks.useWebSocket.approval_required'), { body: data.tool || i18nT('hooks.useWebSocket.a_task_needs_your_decision'), tag: 'kirocrew-approval' })
+              } catch {
+                /* unsupported platform */
+              }
             }
             dispatch(addNotification({
               kind: 'approval',

--- a/website/src/test/notificationConstructorGuard.test.ts
+++ b/website/src/test/notificationConstructorGuard.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Page-context `new Notification()` is desktop-only: Android Chrome throws
+ * "Illegal constructor" even with permission granted (the platform requires
+ * ServiceWorkerRegistration.showNotification, and this app registers no
+ * service worker). The native toast is best-effort — a throwing constructor
+ * must never take down the code around it:
+ *
+ * - on the WebSocket approval path, an uncaught throw kills the rest of the
+ *   message handler, so the approval never reaches the notification feed;
+ * - in useNativeNotification, it kills the effect that watches the feed.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createTestStore } from './helpers'
+import { useWebSocket } from '../hooks/useWebSocket'
+import { useNativeNotification } from '../hooks/useNativeNotification'
+import { addNotification } from '../store/notificationsSlice'
+import type { Notification as AppNotification } from '../types'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() { WS_INSTANCES.push(this) }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+}
+
+/** What Android Chrome does: permission is granted, construction throws. */
+class ThrowingNotification {
+  static permission = 'granted'
+  static requestPermission = vi.fn()
+  constructor() {
+    throw new TypeError('Illegal constructor')
+  }
+}
+
+describe('page-context Notification construction is best-effort', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.stubGlobal('Notification', ThrowingNotification)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    // Restore the prototype getter shadowed by the per-test own property.
+    delete (document as { hidden?: boolean }).hidden
+  })
+
+  function mountWs(store: ReturnType<typeof createTestStore>) {
+    function wrapper({ children }: { children: React.ReactNode }) {
+      return createElement(Provider, { store },
+        createElement(QueryClientProvider, { client: queryClient }, children))
+    }
+    const hook = renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    return { hook, ws }
+  }
+
+  it('an approval frame still reaches the notification feed when the toast constructor throws', () => {
+    // The hidden-tab + permission-granted branch is the only one that
+    // constructs a Notification on the approval path.
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => true })
+    const store = createTestStore()
+    const { ws } = mountWs(store)
+
+    act(() => {
+      ws.simulateMessage({
+        type: 'approval',
+        data: { id: 'ap-android-1', source: 'cron', tool: 'Bash', tool_input: '{}', ts: 1.0 },
+      })
+    })
+
+    const match = store.getState().notifications.items.find(n => n.approval_id === 'ap-android-1')
+    expect(match).toBeDefined()
+    expect(match!.kind).toBe('approval')
+  })
+
+  it('useNativeNotification survives a throwing toast constructor', () => {
+    const store = createTestStore()
+    function wrapper({ children }: { children: React.ReactNode }) {
+      return createElement(Provider, { store }, children)
+    }
+    renderHook(() => useNativeNotification('Kiro Crew', '/avatar.png'), { wrapper })
+
+    // A new unacked notification triggers the toast effect; the throw must
+    // stay inside it.
+    expect(() => {
+      act(() => {
+        store.dispatch(addNotification({
+          kind: 'approval',
+          title: 'Tool approval',
+          body: 'Bash',
+          ts: '1.0',
+          approval_id: 'ap-android-2',
+        } as AppNotification))
+      })
+    }).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

On Android Chrome the dashboard breaks the moment a notification toast is attempted: `new Notification()` throws `TypeError: Illegal constructor` even with permission granted. The uncaught throw kills more than the toast — on the WebSocket path it aborts the rest of the message handler, so an approval arriving while the tab is hidden never reaches the in-app notification feed, and in `useNativeNotification` it kills the effect watching the feed (the dashboard-breaks-at-load symptom reported in #1828).

## Why it matters

Any Android user who grants notification permission gets a broken dashboard: failure at load, and lost feed entries exactly when the tab is hidden — the one moment a notification matters.

## What changed (motivation → approach → change)

Page-context notifications are desktop-only: Android requires `ServiceWorkerRegistration.showNotification()`, and the dashboard registers no service worker, so the constructor itself throws. The in-app notification center already carries every event, so the native toast can be best-effort: both construction sites (the `useWebSocket.ts` message handler and the `useNativeNotification.ts` effect) are wrapped so a platform that cannot show a page-context toast skips it instead of killing the surrounding code.

## Tests

`website/src/test/notificationConstructorGuard.test.ts` (new) stubs a throwing `Notification` constructor — what Android Chrome does — and pins:

- an approval frame still reaches the notification feed when the toast constructor throws
- the `useNativeNotification` effect survives a throwing toast constructor

```
# main without the fix
 × an approval frame still reaches the notification feed when the toast constructor throws
 × useNativeNotification survives a throwing toast constructor
   'TypeError: Illegal constructor' was thrown
 Tests  2 failed (2)

# with the fix
 Tests  2 passed (2)
```

`npx tsc -b` and `npx eslint` over the touched files pass.

## Manual verification

Reproduced on Android Chrome against a dashboard-only gateway (permission granted, tab hidden, approval sent): without the fix the console shows the TypeError and the feed misses the event; with the fix the feed receives it (no toast, by platform limitation). Desktop toast behavior unchanged.

## Related Issues

Fixes #1828

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the template's CLA section is still a placeholder without agreement text.
