### PR TITLE
fix: load persisted voice settings on dashboard-only gateways

### DIFF
--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1359,9 +1359,7 @@ async def _start_unix_site(runner: web.AppRunner, port: int) -> Path | None:
         logger.info("dashboard internal API also listening on unix socket %s", path)
         return path
     except Exception as exc:
-        logger.warning(
-            "dashboard unix socket unavailable (%s); internal API stays TCP-only", exc
-        )
+        logger.warning("dashboard unix socket unavailable (%s); internal API stays TCP-only", exc)
         return None
 
 
@@ -2341,6 +2339,13 @@ async def start_dashboard(
         client_max_size=60 * 1024 * 1024
     )  # 60 MB: covers 50 MB upload + multipart overhead
     app["state"] = state
+    # Voice settings live in slack/handler's module state and are otherwise
+    # loaded only on the Slack startup path (set_orch_cfg) — without this a
+    # dashboard-only gateway (no Slack tokens) resets TTS to defaults on
+    # every restart (see load_voice_reply_config).
+    from kiro_crew.slack.handler import load_voice_reply_config
+
+    await asyncio.to_thread(load_voice_reply_config)
     # ── Tunnel teardown (FIRST cleanup hook, deliberately) ───────────────────
     # aiohttp dispatches ``on_cleanup`` in registration order and gateway
     # shutdown has a hard deadline, so this is registered ahead of every other
@@ -3296,6 +3301,13 @@ async def start_api_server(
         client_max_size=60 * 1024 * 1024
     )  # 60 MB: covers 50 MB upload + multipart overhead
     app["state"] = state
+    # Voice settings live in slack/handler's module state and are otherwise
+    # loaded only on the Slack startup path (set_orch_cfg) — without this a
+    # dashboard-only gateway (no Slack tokens) resets TTS to defaults on
+    # every restart (see load_voice_reply_config).
+    from kiro_crew.slack.handler import load_voice_reply_config
+
+    await asyncio.to_thread(load_voice_reply_config)
     from kiro_crew.kiro_prerequisite import KiroPrerequisiteService
 
     app["kiro_prerequisite_service"] = await asyncio.to_thread(

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -1184,8 +1184,20 @@ def set_orch_cfg(cfg: KiroCrewConfig) -> None:
     """Store a live reference to the orchestrator's config (called by events.py)."""
     global _orch_cfg
     _orch_cfg = cfg
+    load_voice_reply_config(cfg)
+
+
+def load_voice_reply_config(cfg: "KiroCrewConfig | None" = None) -> None:
+    """Populate the live voice state (``_vc``) from config's ``voice_reply``.
+
+    Callable without a Slack orchestrator: ``set_orch_cfg`` runs only on the
+    Slack startup path, so the dashboard app builders call this directly at
+    boot. Without that call a dashboard-only gateway (no Slack tokens) never
+    restores persisted voice settings — every restart silently resets TTS to
+    disabled while the dashboard's settings PUT keeps reporting success.
+    """
     # Load voice_reply defaults from config
-    _vr: dict = cfg.raw.get("voice_reply", {}) if hasattr(cfg, "raw") else {}
+    _vr: dict = cfg.raw.get("voice_reply", {}) if (cfg is not None and hasattr(cfg, "raw")) else {}
     if not _vr:
         try:
             with open(config_path()) as f:

--- a/test/test_set_orch_cfg_voice.py
+++ b/test/test_set_orch_cfg_voice.py
@@ -1,4 +1,4 @@
-"""Tests for set_orch_cfg voice_reply restore — covers auto_speak + peers."""
+"""Tests for the voice_reply restore — set_orch_cfg and the dashboard path."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from kiro_crew.slack import handler as handler_mod
-from kiro_crew.slack.handler import _vc, set_orch_cfg
+from kiro_crew.slack.handler import _vc, load_voice_reply_config, set_orch_cfg
 
 
 @pytest.fixture(autouse=True)
@@ -52,6 +52,7 @@ def test_set_orch_cfg_reads_auto_speak_from_raw(tmp_path, monkeypatch):
     set_orch_cfg(cfg)
     assert _vc.auto_speak is True
 
+
 # ── auto_reply_to_voice default follows enabled ─────────────────────────
 
 
@@ -74,7 +75,8 @@ def test_auto_reply_to_voice_defaults_true_when_enabled_true(tmp_path, monkeypat
 def test_auto_reply_to_voice_explicit_overrides_enabled_false(tmp_path, monkeypatch):
     """User can set ``auto_reply_to_voice=true`` while keeping ``enabled=false``."""
     _cfg_file(
-        tmp_path, monkeypatch,
+        tmp_path,
+        monkeypatch,
         {"enabled": False, "auto_reply_to_voice": True},
     )
     set_orch_cfg(SimpleNamespace())
@@ -85,7 +87,8 @@ def test_auto_reply_to_voice_explicit_overrides_enabled_false(tmp_path, monkeypa
 def test_auto_reply_to_voice_explicit_overrides_enabled_true(tmp_path, monkeypatch):
     """User can set ``auto_reply_to_voice=false`` while keeping ``enabled=true``."""
     _cfg_file(
-        tmp_path, monkeypatch,
+        tmp_path,
+        monkeypatch,
         {"enabled": True, "auto_reply_to_voice": False},
     )
     set_orch_cfg(SimpleNamespace())
@@ -125,8 +128,7 @@ def test_provider_typo_falls_back_to_polly_with_warning(tmp_path, monkeypatch, c
         set_orch_cfg(SimpleNamespace())
     assert _vc.provider == "polly"
     assert any(
-        "voice_reply.provider" in rec.message and "ploly" in rec.message
-        for rec in caplog.records
+        "voice_reply.provider" in rec.message and "ploly" in rec.message for rec in caplog.records
     ), "expected a warning log naming the bad provider value"
 
 
@@ -140,3 +142,47 @@ def test_provider_omitted_defaults_to_polly(tmp_path, monkeypatch):
     _cfg_file(tmp_path, monkeypatch, {})
     set_orch_cfg(SimpleNamespace())
     assert _vc.provider == "polly"
+
+
+# ── restore without a Slack orchestrator (dashboard-only gateway) ────────
+
+
+def test_load_voice_reply_config_restores_from_disk_without_cfg(tmp_path, monkeypatch):
+    """A gateway with no Slack tokens never calls set_orch_cfg, so the
+    loader must be callable with no config object and fall back to disk."""
+    _cfg_file(tmp_path, monkeypatch, {"enabled": True, "auto_speak": True})
+    load_voice_reply_config()
+    assert _vc.auto_speak is True
+    assert _vc.global_enabled is True
+    assert _vc.auto_reply_to_voice is True
+
+
+def test_load_voice_reply_config_keeps_defaults_when_config_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(handler_mod, "config_path", lambda: tmp_path / "missing.json")
+    load_voice_reply_config()
+    assert _vc.auto_speak is False
+    assert _vc.global_enabled is False
+
+
+def test_load_voice_reply_config_prefers_cfg_raw_over_disk(tmp_path, monkeypatch):
+    _cfg_file(tmp_path, monkeypatch, {"auto_speak": False})
+    load_voice_reply_config(SimpleNamespace(raw={"voice_reply": {"auto_speak": True}}))
+    assert _vc.auto_speak is True
+
+
+def test_dashboard_entrypoints_restore_voice_settings():
+    """Wiring pin: BOTH dashboard app builders must load persisted voice
+    settings at boot. On a dashboard-only gateway (no Slack tokens) nothing
+    else does — without this call every restart silently resets TTS to
+    disabled while the dashboard's settings PUT keeps reporting success."""
+    import inspect
+
+    from kiro_crew.dashboard import server as server_mod
+
+    for func, name in (
+        (server_mod.start_dashboard, "start_dashboard"),
+        (server_mod.start_api_server, "start_api_server"),
+    ):
+        assert "await asyncio.to_thread(load_voice_reply_config)" in inspect.getsource(
+            func
+        ), f"{name} must restore persisted voice settings without blocking the event loop"


### PR DESCRIPTION
## Problem / Motivation

On a gateway configured without Slack tokens (the documented dashboard-only mode), voice settings saved from the dashboard do not survive a restart: TTS silently resets to disabled while `PUT /api/voice/config` keeps reporting success.

## Why it matters

Dashboard-only deployments lose their voice configuration on every restart, with no error anywhere — the success response makes it look like user error rather than a bug.

## What changed (motivation → approach → change)

The only code that read the config's `voice_reply` block into the live voice state ran inside `set_orch_cfg` on the Slack startup path, which a dashboard-only gateway never executes — so saved settings existed on disk but were never applied. The loader is extracted into `load_voice_reply_config()` — callable with no config object, falling back to disk — and called from both dashboard app builders; the Slack path is unchanged (`set_orch_cfg` delegates to it).

## Tests

`test/test_set_orch_cfg_voice.py` extended: the restore-from-disk path with no orchestrator, the missing-config and `cfg.raw`-precedence cases, and a wiring pin that both `start_dashboard` and `start_api_server` call the loader.

```
# main without the fix
ImportError: cannot import name 'load_voice_reply_config' from 'kiro_crew.slack.handler'
(the wiring-pin test also fails on the missing dashboard call site)

# with the fix
17 passed, 1 warning in 0.29s
```

Touched files pass `flake8` and `isort`.

## Manual verification

On a dashboard-only gateway: enable TTS from the dashboard, restart — the setting is live again after restart. Slack-connected startup is unaffected (delegation only).

## Related Issues

Fixes #1890

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the template's CLA section is still a placeholder without agreement text.
