### PR TITLE
fix: show the message action footer on touch devices

### DIFF
--- a/website/src/pages/chat/AssistantMessage.tsx
+++ b/website/src/pages/chat/AssistantMessage.tsx
@@ -275,7 +275,7 @@ const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, 
       </div>
     )}
     {!isStreaming && showFooter && (
-      <div className="flex items-center gap-1 mt-0.5 opacity-0 transition-opacity duration-300 delay-100 group-hover/msg:opacity-100 group-hover/msg:delay-300 group-focus-within/msg:opacity-100 group-focus-within/msg:delay-300">
+      <div className="flex items-center gap-1 mt-0.5 opacity-0 transition-opacity duration-300 delay-100 group-hover/msg:opacity-100 group-hover/msg:delay-300 group-focus-within/msg:opacity-100 group-focus-within/msg:delay-300 [@media(hover:none)]:opacity-100">
         {/* No `font-mono`: a formatted date is prose, and Tailwind's `font-mono`
             pins `var(--mono)` — a token the Font Family setting never writes, so
             it overrode the user's choice and put JetBrains Mono (no CJK

--- a/website/src/test/AssistantMessage.test.tsx
+++ b/website/src/test/AssistantMessage.test.tsx
@@ -225,6 +225,27 @@ describe('AssistantMessage', () => {
 
 })
 
+describe('action footer on touch devices', () => {
+  // The footer is opacity-0 until group-hover, and a touch pointer never
+  // hovers — without the hover:none override the actions (copy, speak,
+  // regenerate, fork) are permanently invisible on phones. happy-dom does not
+  // evaluate media queries, so pin the utility class itself.
+  const footer = () => screen.getByTitle('Copy').closest('div') as HTMLElement
+
+  it('reveals the footer where the pointer cannot hover', () => {
+    render(<AssistantMessage content="Hello world" isStreaming={false} slotRunning={false} />)
+    expect(footer().className).toContain('[@media(hover:none)]:opacity-100')
+  })
+
+  it('keeps the footer hover-revealed for hover-capable pointers', () => {
+    render(<AssistantMessage content="Hello world" isStreaming={false} slotRunning={false} />)
+    const cls = footer().className
+    expect(cls).toContain('opacity-0')
+    expect(cls).toContain('group-hover/msg:opacity-100')
+    expect(cls).toContain('group-focus-within/msg:opacity-100')
+  })
+})
+
 describe('parseOptions', () => {
   it('parses [OPTIONS: a|b|c] multi syntax', () => {
     const { options, multi, isPlan } = parseOptions('Pick one [OPTIONS: Alpha|Beta|Gamma]')


### PR DESCRIPTION
## Problem / Motivation

On phones and tablets the message action footer (copy, speak, regenerate, fork) is unreachable: it is `opacity-0` until `group-hover`, and a touch pointer never hovers, so the actions are permanently invisible.

## Why it matters

Mobile users cannot copy, re-run, fork, or speak any reply — a whole action row exists in the DOM but can never be seen or used.

## What changed (motivation → approach → change)

Hover-gated reveal assumes a pointer that can hover; under `@media (hover: none)` the trigger can never fire. This adds Tailwind's arbitrary variant `[@media(hover:none)]:opacity-100` to the footer so it is always visible where the pointer cannot hover, while hover-capable pointers keep the existing reveal-on-hover behavior. CSS-only; no layout or handler changes.

## Tests

`website/src/test/AssistantMessage.test.tsx` extended: pins the hover-none override and the retained hover/focus-within classes (happy-dom does not evaluate media queries, so the utility class itself is asserted).

```
# main without the fix
 × reveals the footer where the pointer cannot hover
 Tests  1 failed | 57 passed (58)

# with the fix
 Tests  58 passed (58)
```

`npx tsc -b` and `npx eslint` over the touched files pass.

## Manual verification

Android Chrome: the footer is visible at rest under each assistant message and all four actions are tappable. Desktop: unchanged — hidden at rest, revealed on hover/focus-within.

## Screenshots / video

The visual delta on a touch device is the footer rendered at rest, identical to its desktop hover state (no new surface or layout). Happy to attach Android screenshots if useful for review — kept out of the branch for now to preserve the single, focused commit.

## Related Issues

Fixes #1894

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the template's CLA section is still a placeholder without agreement text.
