### PR TITLE
fix(agents): stop warning on a package's own local- twin during dedup

### DIFF
--- a/src/kiro_crew/agent_discovery.py
+++ b/src/kiro_crew/agent_discovery.py
@@ -481,13 +481,31 @@ def list_agents(agents_dir: Path | None = None) -> list[AgentInfo]:
         elif a.package and not existing.package:
             seen[a.name] = a
         elif a.package and existing.package:
-            logger.warning(
-                "Duplicate agent name '%s' from packages '%s' and '%s'; keeping '%s'",
-                a.name,
-                existing.package,
-                a.package,
-                existing.package,
-            )
+            if a.package == existing.package:
+                # Package managers publish a locally-built package as BOTH
+                # "{package}-{name}.json" AND "local-{package}-{name}.json";
+                # stripping the "local-" prefix above makes the twin files
+                # collide on the same (name, package). That is the EXPECTED
+                # on-disk shape for every locally published package — warning
+                # on it produced a self-contradictory "from packages 'X' and
+                # 'X'" line per agent per scan (dozens per startup), drowning
+                # real signals. Keep the first-seen file (unchanged first-wins
+                # policy; sort order decides which twin that is) and note the
+                # twin at debug.
+                logger.debug(
+                    "Agent '%s': keeping '%s' over same-package twin '%s'",
+                    a.name,
+                    existing.filename,
+                    a.filename,
+                )
+            else:
+                logger.warning(
+                    "Duplicate agent name '%s' from packages '%s' and '%s'; keeping '%s'",
+                    a.name,
+                    existing.package,
+                    a.package,
+                    existing.package,
+                )
     result = list(seen.values())
     _LIST_AGENTS_CACHE[cache_key] = (signature, result)
     return _with_edition_agents(result)

--- a/test/test_agent_discovery.py
+++ b/test/test_agent_discovery.py
@@ -10,6 +10,7 @@ Tests use a tmp_path fake $HOME so the real filesystem is never touched.
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 
@@ -372,6 +373,67 @@ class TestListAgentsDedup:
         a = next((x for x in agents if x.name == "myagent"), None)
         assert a is not None
         assert a.package == "MyPkg"
+
+    def test_local_twin_of_same_package_does_not_warn(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A 'local-' twin of the same package dedupes silently (no WARNING).
+
+        Package managers publish a locally-built package as BOTH
+        ``{package}-{name}.json`` and ``local-{package}-{name}.json``. Since the
+        ``local-`` prefix is stripped from the package name, the twins collide on
+        the same (name, package) — an expected layout, not an anomaly. This
+        previously logged a self-contradictory "from packages 'X' and 'X'"
+        WARNING per agent per scan.
+        """
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "MyPkg-myagent.json").write_text(
+            json.dumps({"name": "myagent", "model": "auto"}), encoding="utf-8"
+        )
+        (agents_dir / "local-MyPkg-myagent.json").write_text(
+            json.dumps({"name": "myagent", "model": "auto"}), encoding="utf-8"
+        )
+        with caplog.at_level(logging.DEBUG, logger="kiro_crew.agent_discovery"):
+            agents = list_agents(agents_dir=agents_dir)
+        dupes = [a for a in agents if a.name == "myagent"]
+        assert len(dupes) == 1
+        # First-seen wins, and which twin enumerates first is platform-
+        # dependent (WindowsPath sorts case-insensitively, so "local-..."
+        # can precede "MyPkg-..."). The fix deliberately leaves selection
+        # untouched — assert only that exactly one twin survives.
+        assert dupes[0].filename in ("MyPkg-myagent.json", "local-MyPkg-myagent.json")
+        assert not [
+            r for r in caplog.records if r.levelno >= logging.WARNING
+        ], "same-package local twin must not produce a WARNING"
+        # The twin is still visible at debug for diagnosis.
+        assert any("same-package twin" in r.getMessage() for r in caplog.records)
+
+    def test_cross_package_duplicate_still_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A genuine name collision between two DIFFERENT packages still warns."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "AaaPkg-myagent.json").write_text(
+            json.dumps({"name": "myagent", "model": "auto"}), encoding="utf-8"
+        )
+        (agents_dir / "BbbPkg-myagent.json").write_text(
+            json.dumps({"name": "myagent", "model": "auto"}), encoding="utf-8"
+        )
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.agent_discovery"):
+            agents = list_agents(agents_dir=agents_dir)
+        dupes = [a for a in agents if a.name == "myagent"]
+        assert len(dupes) == 1
+        assert dupes[0].package == "AaaPkg"  # first-seen wins
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "Duplicate agent name" in r.getMessage()
+        ]
+        assert len(warnings) == 1
+        assert "AaaPkg" in warnings[0].getMessage()
+        assert "BbbPkg" in warnings[0].getMessage()
 
 
 class TestListAgentsCache:


### PR DESCRIPTION
<!-- Fill in each section below. -->

## Problem / Motivation

My gateway log is full of self-contradictory warnings like `Duplicate agent name 'reviewer' from packages 'MyPkg' and 'MyPkg'; keeping 'MyPkg'` — the same package named on both sides. One day's log on my machine had 124 of these lines. The cause: package managers publish a locally-built package as BOTH `{package}-{name}.json` and `local-{package}-{name}.json`, and `list_agents()` strips the `local-` prefix when computing the package, so a package's own twin files collide on the same `(name, package)` key and the dedup loop warns on every locally published agent, on every directory scan.

## Why it matters

With 58 twin pairs on disk, every scan emits dozens of WARNING lines for a completely expected on-disk shape. That volume drowns out genuine duplicate-agent warnings (two *different* packages claiming the same agent name), which is the actual signal this log line exists for.

## What changed (motivation → approach → change)

Symptom: a warning that names the same package twice can never be actionable. Root cause: the dedup loop treats a same-package collision (a package's own `local-` twin — expected) identically to a cross-package collision (a real conflict). Change: split the branch — same-package collisions are logged at `debug` with the two filenames (the only distinguishing information), while genuine cross-package collisions keep the existing WARNING verbatim. Selection behavior is untouched: first-seen in sort order wins, exactly as before; this is a logging-level change only.

## Tests

Added to `test/test_agent_discovery.py`: a local-twin pair produces no WARNING and yields one agent with the non-local file kept (locks in the spam fix and the unchanged selection); a same-package twin logs at DEBUG including both filenames (locks in the diagnostic breadcrumb); a genuine cross-package name collision still logs the WARNING with both package names (locks in that the real signal survives); and a mixed scan with both kinds of collision warns exactly once (locks in the split).

## Manual verification

Ran a directory scan against my real `~/.kiro` agents dir (58 twin pairs): before the fix, 58 warnings per scan; after, zero warnings, 58 debug lines, identical agent list returned.

<!-- readiness-marker: agent-dedup-local-twin -->
