### PR TITLE
feat(dashboard): recover from PreToolUse hook blocks

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -1067,16 +1067,17 @@ The Agents page context window section shows per-session info:
 ### Tool-Refusal Recovery
 
 When `_run_chat` refuses a tool call for a **recoverable, system-side** reason —
-a host-gate policy deny (`hooks.on_tool_call` → `TOOL_DENY`) or the read-only
-bash safety gate (`is_read_only_bash` / `unsafe_bash_reason`) — kiro-cli ends
-the turn early by emitting the attribution-free marker `Tool uses were
-interrupted, waiting for the next user prompt`. Historically the refusal reason
-reached only the dashboard pill and the SEL audit log, never the model, so the
-agent stalled and the user had to manually prompt it to continue (and the model,
-lacking any cause in its context, often misattributed the stop to the user).
+a host-gate policy deny (`hooks.on_tool_call` → `TOOL_DENY`), the read-only
+bash safety gate (`is_read_only_bash` / `unsafe_bash_reason`), or a PreToolUse
+script hook block (`exit 2` → `BLOCKED:<hook>:<stderr>`) — kiro-cli ends the
+turn early by emitting the attribution-free marker `Tool uses were interrupted,
+waiting for the next user prompt`. Without recovery, the reason reaches only the
+dashboard pill and SEL audit log, so the model cannot adapt.
 
-`_run_chat` now records each recoverable refusal as a redacted `(title, reason)`
-tuple in a per-turn `_refusal_reasons` list. When the turn ends — and the user
+`_run_chat` records each recoverable refusal as a redacted `(title, reason)`
+tuple in a per-turn `_refusal_reasons` list. PreToolUse block reasons use the
+first non-empty hook STDERR value and fall back to a generic policy-hook reason
+for deny-by-default malformed results. When the turn ends — and the user
 did **not** stop it (`slot._stopping` is false) and no session reset is already
 re-queuing — it builds a continuation via `context.build_refusal_recovery_prompt`,
 prepends `REFUSAL_RECOVERY_PREFIX`, and `queue_insert(0, …)`s it. The existing
@@ -1088,9 +1089,9 @@ as user input (`_is_recovery` guard).
 
 By design there is **no retry cap**: the model decides when to stop, and the
 user's Stop button remains the hard breaker (a stop clears the queue and aborts
-the chain). Scope is the two reason-bearing gates above; pre-tool-use hook
-`BLOCKED:` results are not yet wired for recovery (consistent treatment across
-all three hook branches is a follow-up).
+the chain). All four permission paths that can process PreToolUse script hooks
+(declarative auto-approve, normal gating, trusted/YOLO, and interactive approval)
+route `BLOCKED:` reasons through the same recovery funnel.
 
 ### Design
 

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -319,6 +319,68 @@ def _pre_tool_hooks_should_block(pre_hook_results: Any) -> bool:
     return any(not isinstance(r, str) or r.startswith("BLOCKED:") for r in pre_hook_results)
 
 
+def _pre_tool_block_reason(pre_hook_results: Any) -> str:
+    """Return the first hook-authored block reason, or a safe fallback."""
+    if isinstance(pre_hook_results, list):
+        for result in pre_hook_results:
+            if isinstance(result, str) and result.startswith("BLOCKED:"):
+                parts = result.split(":", 2)
+                reason = parts[2].strip() if len(parts) == 3 else ""
+                if reason:
+                    return reason
+    return "blocked by a PreToolUse policy hook"
+
+
+def _redacted_hook_block(event: Any, pre_hook_results: Any) -> tuple[str, str]:
+    """Build a redacted ``(tool title, hook reason)`` recovery entry."""
+    title, _ = redact_exfiltration_urls(event.title)
+    title, _ = redact_credentials(title)
+    reason, _ = redact_exfiltration_urls(_pre_tool_block_reason(pre_hook_results))
+    reason, _ = redact_credentials(reason)
+    return title, reason
+
+
+async def _reject_hook_blocked(
+    client: Any,
+    slot: Any,
+    event: Any,
+    *,
+    session_key: str,
+    pre_hook_results: Any,
+    refusal_reasons: list[tuple[str, str]],
+    metadata: dict | None = None,
+) -> None:
+    """Deny a tool a PreToolUse hook blocked, and record WHY for the model.
+
+    Four things have to happen together: reject the call, show the user a blocked
+    row, audit the denial, and append the hook's reason to ``refusal_reasons`` so
+    the recovery nudge tells the model what it did wrong. Doing the first three
+    without the fourth is the defect this fixes — the turn dies silently and the
+    model stalls with no reason to adapt to, while every other signal looks
+    correct. They live here rather than at each permission path so a path added
+    later cannot deny by omission.
+    """
+    # event.title prefers the model's own `description` field (_select_tool_title),
+    # so it is LLM-controlled display text. Redact once up front and use that
+    # everywhere: the row is broadcast to the dashboard AND persisted to the
+    # ConversationLog, and the sibling reject path (_safe_reject_title) redacts for
+    # both that row and the audit.
+    title, reason = _redacted_hook_block(event, pre_hook_results)
+    await client.reject_tool(event.request_id)
+    slot.append("tool", f"🚫 {title} (hook blocked)", "msg msg-tool")
+    sel().log_tool_invocation(
+        session_key=session_key,
+        agent=slot.agent or "kirocrew",
+        source="dashboard",
+        tool_name=title,
+        tool_kind=event.tool_kind,
+        outcome="hook_blocked",
+        request_id=event.request_id,
+        metadata=metadata,
+    )
+    refusal_reasons.append((title, reason))
+
+
 def _is_bedrock_profile_id(model: str) -> bool:
     """True if *model* is a concrete Bedrock inference-profile id rather than a
     portable model alias.
@@ -4097,20 +4159,13 @@ async def _run_chat(
                                 )
                                 continue
                             if _pre_tool_hooks_should_block(pre_hook_results):
-                                await client.reject_tool(event.request_id)
-                                slot.append(
-                                    "tool",
-                                    f"🚫 {event.title} (hook blocked)",
-                                    "msg msg-tool",
-                                )
-                                sel().log_tool_invocation(
+                                await _reject_hook_blocked(
+                                    client,
+                                    slot,
+                                    event,
                                     session_key=session_key,
-                                    agent=slot.agent or "kirocrew",
-                                    source="dashboard",
-                                    tool_name=event.title,
-                                    tool_kind=event.tool_kind,
-                                    outcome="hook_blocked",
-                                    request_id=event.request_id,
+                                    pre_hook_results=pre_hook_results,
+                                    refusal_reasons=_refusal_reasons,
                                 )
                                 continue
                             await client.approve_tool(event.request_id)
@@ -4181,16 +4236,13 @@ async def _run_chat(
                         )
                         continue
                     if _pre_tool_hooks_should_block(pre_hook_results):
-                        await client.reject_tool(event.request_id)
-                        slot.append("tool", f"🚫 {event.title} (hook blocked)", "msg msg-tool")
-                        sel().log_tool_invocation(
+                        await _reject_hook_blocked(
+                            client,
+                            slot,
+                            event,
                             session_key=session_key,
-                            agent=slot.agent or "kirocrew",
-                            source="dashboard",
-                            tool_name=event.title,
-                            tool_kind=event.tool_kind,
-                            outcome="hook_blocked",
-                            request_id=event.request_id,
+                            pre_hook_results=pre_hook_results,
+                            refusal_reasons=_refusal_reasons,
                         )
                         continue
                     _pre_tool_hooks_fired = True
@@ -4394,16 +4446,13 @@ async def _run_chat(
                             )
                             continue
                         if _pre_tool_hooks_should_block(pre_hook_results):
-                            await client.reject_tool(event.request_id)
-                            slot.append("tool", f"🚫 {event.title} (hook blocked)", "msg msg-tool")
-                            sel().log_tool_invocation(
+                            await _reject_hook_blocked(
+                                client,
+                                slot,
+                                event,
                                 session_key=session_key,
-                                agent=slot.agent or "kirocrew",
-                                source="dashboard",
-                                tool_name=event.title,
-                                tool_kind=event.tool_kind,
-                                outcome="hook_blocked",
-                                request_id=event.request_id,
+                                pre_hook_results=pre_hook_results,
+                                refusal_reasons=_refusal_reasons,
                             )
                             continue
                     # always=False — KiroCrew owns trust scope; per-call request_permission
@@ -4644,16 +4693,13 @@ async def _run_chat(
                         )
                         break
                     if _pre_tool_hooks_should_block(pre_hook_results):
-                        await client.reject_tool(event.request_id)
-                        slot.append("tool", f"🚫 {event.title} (hook blocked)", "msg msg-tool")
-                        sel().log_tool_invocation(
+                        await _reject_hook_blocked(
+                            client,
+                            slot,
+                            event,
                             session_key=session_key,
-                            agent=slot.agent or "kirocrew",
-                            source="dashboard",
-                            tool_name=event.title,
-                            tool_kind=event.tool_kind,
-                            outcome="hook_blocked",
-                            request_id=event.request_id,
+                            pre_hook_results=pre_hook_results,
+                            refusal_reasons=_refusal_reasons,
                             metadata={"reason": "interactive"},
                         )
                     else:

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -575,10 +575,11 @@ def build_refusal_recovery_prompt(refusals: list[tuple[str, str]]) -> str:
     """Build the body of an automatic continuation after a recoverable tool refusal.
 
     When a tool call is refused for a recoverable, system-side reason — a
-    host-gate policy deny or the read-only bash safety gate — kiro-cli ends the
-    turn early with an attribution-free "tool uses were interrupted" marker. The
-    refusal reason is otherwise surfaced only to the dashboard pill and the SEL
-    audit log, never to the model, so the agent stalls and waits for the user.
+    host-gate policy deny, the read-only bash safety gate, or a PreToolUse policy
+    hook block — kiro-cli ends the turn early with an attribution-free
+    "tool uses were interrupted" marker. The refusal reason is otherwise surfaced
+    only to the dashboard pill and the SEL audit log, never to the model, so the
+    agent stalls and waits for the user.
 
     ``refusals`` is a list of ``(tool_title, reason)`` tuples recorded during the
     turn (already redacted by the caller). The returned text hands those reasons

--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import contextmanager
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from chat_test_helpers import _make_ready_kiro_prerequisite
 
+from kiro_crew.dashboard import chat_runner
 from kiro_crew.dashboard.chat import _run_chat
 from kiro_crew.dashboard.state import (
     REFUSAL_RECOVERY_PREFIX,
@@ -60,6 +62,83 @@ def _make_hook_store() -> MagicMock:
     hs = MagicMock()
     hs.fire = AsyncMock(return_value=[])
     return hs
+
+
+def _blocking_hook_store(reason: str, hook_name: str = "policy-hook") -> MagicMock:
+    """Hook store whose PreToolUse fire blocks (exit 2) with *reason* on stderr."""
+    hs = _make_hook_store()
+    hs.fire = AsyncMock(
+        return_value=[
+            MagicMock(exit_code=2, stderr=reason, stdout="", hook_name=hook_name)
+        ]
+    )
+    return hs
+
+
+async def _drive_hook_blocked_turn(
+    state, client, slot, *, approve_prompt: bool = False, title: str = "fs_write"
+) -> None:
+    """Run one turn whose only tool call is blocked by a PreToolUse script hook.
+
+    Only the first stream yields a permission request, so the automatic recovery
+    continuation completes instead of blocking again. ``approve_prompt`` answers
+    the interactive permission future, which is the only way to reach the hook
+    fire that happens after the user approves.
+    """
+    client.context_usage_pct = MagicMock(return_value=0.0)
+    client._client = client
+    client.last_prompt_stats = None
+    calls = {"n": 0}
+
+    def _stream(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _async_iter([_permission_event(title=title), _complete_event()])
+        return _async_iter([_complete_event()])
+
+    client.stream = MagicMock(side_effect=_stream)
+
+    approver = None
+    if approve_prompt:
+
+        async def _answer() -> None:
+            for _ in range(600):
+                fut = slot._approval_futures.get("req-1")
+                if fut is not None:
+                    if not fut.done():
+                        fut.set_result("approved")
+                    return
+                await asyncio.sleep(0.01)
+
+        approver = asyncio.get_event_loop().create_task(_answer())
+
+    with _patch_stats():
+        await _run_chat(state, slot, "hello")
+        if slot.task:
+            await slot.task
+
+    if approver is not None:
+        await _drain(approver)
+
+
+def _assert_block_reason_recovered(slot, client, reason: str) -> None:
+    """Assert the call was rejected and *reason* reached a recovery continuation.
+
+    Selected by content, not position: a turn can also enqueue the
+    empty-response nudge, so the last inject is not reliably the recovery one.
+    """
+    client.reject_tool.assert_called_once()
+    recoveries = [
+        message.get("content", "")
+        for message in slot.messages
+        if message.get("role") == "inject"
+        and message.get("content", "").startswith(REFUSAL_RECOVERY_PREFIX)
+    ]
+    assert recoveries, (
+        "Script-hook block must trigger refusal-recovery; injects were "
+        f"{[m.get('content', '')[:40] for m in slot.messages if m.get('role') == 'inject']}"
+    )
+    assert any(reason.lower() in recovery.lower() for recovery in recoveries)
 
 
 def _make_state(
@@ -1013,3 +1092,136 @@ class TestInteractiveDenyDoesNotTriggerRecovery:
         recovery = injects[-1]["content"]
         assert recovery.startswith(REFUSAL_RECOVERY_PREFIX)
         assert "security policy" in recovery.lower()
+
+
+class TestPreToolUseHookBlockRecovery:
+    """A PreToolUse script-hook block feeds its reason into refusal recovery.
+
+    Four permission paths can fire PreToolUse hooks and they are not
+    interchangeable: the gating path latches ``_pre_tool_hooks_fired``, so the
+    trust and interactive paths only fire hooks themselves when no context
+    builder ran first. Each path therefore needs its own fixture.
+    """
+
+    @pytest.mark.asyncio
+    async def test_declarative_auto_approve_block_enqueues_recovery(self, tmp_path):
+        """A declarative auto-approve verdict still routes a block to recovery."""
+        reason = "Read the whole SKILL.md - this was a truncated slice"
+        state, client = _make_state(
+            tmp_path,
+            context_builder=_context_builder(ToolHookResult.auto_approve()),
+            hook_store=_blocking_hook_store(reason, hook_name="skill-truncation"),
+        )
+        slot = _make_slot()
+
+        await _drive_hook_blocked_turn(state, client, slot)
+
+        _assert_block_reason_recovered(slot, client, reason)
+
+    @pytest.mark.asyncio
+    async def test_gated_path_block_enqueues_recovery(self, tmp_path):
+        """A block raised while gating a normal tool call routes to recovery."""
+        reason = "Gating hook refused this command"
+        state, client = _make_state(
+            tmp_path,
+            context_builder=_context_builder(),
+            hook_store=_blocking_hook_store(reason),
+        )
+        slot = _make_slot()
+
+        await _drive_hook_blocked_turn(state, client, slot)
+
+        _assert_block_reason_recovered(slot, client, reason)
+
+    @pytest.mark.asyncio
+    async def test_trusted_path_block_enqueues_recovery(self, tmp_path):
+        """Trust mode fires the hook itself and must route its block to recovery."""
+        reason = "Trusted calls still respect policy"
+        state, client = _make_state(tmp_path, hook_store=_blocking_hook_store(reason))
+        slot = _make_slot(trust=True)
+
+        await _drive_hook_blocked_turn(state, client, slot)
+
+        _assert_block_reason_recovered(slot, client, reason)
+
+    @pytest.mark.asyncio
+    async def test_interactive_approved_block_enqueues_recovery(self, tmp_path):
+        """A block landing after the user approves must route to recovery."""
+        reason = "Approved by the user but refused by policy"
+        state, client = _make_state(tmp_path, hook_store=_blocking_hook_store(reason))
+        slot = _make_slot()
+
+        await _drive_hook_blocked_turn(state, client, slot, approve_prompt=True)
+
+        _assert_block_reason_recovered(slot, client, reason)
+
+    def test_every_hook_deny_path_routes_through_the_shared_helper(self) -> None:
+        """A fifth permission path must not be able to deny without recording the reason.
+
+        The four cases above each cover one existing path behaviourally. This one is
+        structural, and it is why the helper exists: rejecting, showing the blocked row
+        and auditing WITHOUT appending the hook's reason is precisely the defect this
+        change fixes -- the model stalls with no idea what it did wrong, while every
+        other assertion still passes. One helper makes that omission unrepresentable.
+        """
+        source = Path(chat_runner.__file__).read_text(encoding="utf-8")
+        deny_branches = source.count("if _pre_tool_hooks_should_block(pre_hook_results):")
+        helper_calls = source.count("await _reject_hook_blocked(")
+
+        assert deny_branches >= 4, "expected at least the four known PreToolUse deny paths"
+        assert helper_calls == deny_branches, (
+            f"{deny_branches} hook-deny branch(es) but {helper_calls} helper call(s) -- "
+            "a deny path that inlines reject/row/audit can silently drop the reason"
+        )
+        # The audit lives in the helper and nowhere else, so an inlined deny path
+        # cannot reappear without this failing.
+        assert source.count('outcome="hook_blocked"') == 1, (
+            "hook_blocked is audited in more than one place -- a deny path was inlined "
+            "again instead of routed through the helper"
+        )
+
+    @pytest.mark.asyncio
+    async def test_blocked_row_and_audit_redact_the_model_authored_title(
+        self, tmp_path
+    ) -> None:
+        """A credential the model put in the tool title must not reach either surface.
+
+        ``event.title`` prefers the model's own ``description`` field
+        (``_select_tool_title``), so it is LLM-controlled display text. The sibling
+        reject path redacts it before both the transcript row and the audit
+        (``_safe_reject_title``); this path published it verbatim, and the row is both
+        broadcast to the dashboard and persisted to the ConversationLog.
+        """
+        # Assembled at runtime, never written as one literal: the redactor only
+        # fires on credential-SHAPED input (a plain sentinel passes through
+        # untouched, so this test would prove nothing), but a real key shape
+        # sitting in the source trips the source-text scanners --
+        # `scripts/scrub-lint.sh` and Semgrep's
+        # `detected-aws-access-key-id-value`. Splitting satisfies both, and
+        # matches the existing sentinels in code_review_sage's tests.
+        secret = "AKIA" + "1234567890ABCDEF"
+        state, client = _make_state(
+            tmp_path,
+            context_builder=_context_builder(),
+            hook_store=_blocking_hook_store("Gating hook refused this command"),
+        )
+        slot = _make_slot()
+
+        with patch("kiro_crew.dashboard.chat_runner.sel") as mock_sel:
+            audit = MagicMock()
+            mock_sel.return_value = audit
+            await _drive_hook_blocked_turn(
+                state, client, slot, title=f"Deploy with {secret} now"
+            )
+
+        rows = [m.get("content", "") for m in slot.messages]
+        assert not any(secret in row for row in rows), rows
+        assert any("[REDACTED: credential]" in row and "hook blocked" in row for row in rows), rows
+
+        blocked = [
+            call.kwargs
+            for call in audit.log_tool_invocation.call_args_list
+            if call.kwargs.get("outcome") == "hook_blocked"
+        ]
+        assert blocked, "expected a hook_blocked audit record"
+        assert all(secret not in c.get("tool_name", "") for c in blocked), blocked


### PR DESCRIPTION
## Problem / Motivation

Recoverable tool refusals already feed their reason into an automatic
continuation, but a PreToolUse script hook that blocks with `exit 2` was never
wired in. The turn ended on the attribution-free "tool uses were interrupted"
marker with no cause in the model's context, so the agent stalled and the user had
to prompt it to continue — and the model, lacking any reason, could misread the
stop as a user cancellation.

The owning doc recorded this as known-missing work: *"pre-tool-use hook `BLOCKED:`
results are not yet wired for recovery."* This is that follow-up.

## Why it matters

A policy hook exists to redirect the agent, but a block whose reason never reaches
the agent is just a dead turn: the operator writes a hook with an actionable message and the
agent never sees it. Every blocked call costs a manual nudge, and the wrong
attribution ("the user stopped me") pollutes the model's view of the session.

## What changed (motivation -> approach -> change)

Symptom: hook blocks stall the turn silently. Root cause: the block path rejected
the tool and logged it, but never appended to the per-turn `_refusal_reasons`
list that drives the recovery continuation.

Change: record the hook's block reason as a redacted refusal alongside the
host-gate and read-only-bash reasons, so it flows through the existing
refusal-recovery funnel unchanged. The reason comes from the first blocking hook —
its stderr truncated to 200 characters, or `hook denied` when stderr is empty. When no
usable `BLOCKED:` reason exists at all — including for malformed deny-by-default output
— recovery uses a generic policy-hook reason rather than an empty string. Title and reason both pass through
the existing exfiltration-URL and credential redaction. Because the reason joins
that funnel, the continuation renders through the existing `RecoveryCard` refusal
path, which this change does not modify — so there is no new or changed UI.

All four permission paths that can process PreToolUse hooks route through the one
funnel: declarative auto-approve, normal gating, trusted/YOLO, and interactive
approval.

The deny itself is one helper, `_reject_hook_blocked()`. Four things have to happen
together — reject the call, show the user a blocked row, audit the denial, and append the
hook's reason — and the first three without the fourth IS this defect. That failure is
invisible: the turn ends, the model stalls with no reason to adapt to, and every other
signal (the rejection, the row, the audit record) looks correct. Keeping the four steps
at each permission path meant a fifth path could reintroduce it by omission, so they now
live in one place and the `hook_blocked` audit exists in exactly one location.

That consolidation also made a redaction gap a one-line fix. `event.title` prefers the
model's own `description` field (`_select_tool_title`), so it is LLM-controlled display
text — a Bash description embedding a credential reached `slot.messages`, which is
broadcast to the dashboard and persisted to the `ConversationLog`, and reached the SEL
record verbatim. A redacted copy of the same string was being computed two lines later
for the recovery reason. The helper now redacts once up front and uses that value for the
row, for `tool_name`, and for the reason, matching the sibling reject path
(`_safe_reject_title`), which already redacts for both surfaces. This was pre-existing at
four deny sites on mainline; one helper meant fixing it once.

## Tests

`TestPreToolUseHookBlockRecovery` covers each permission path with its own
fixture, because they are not interchangeable — the gating path latches
`_pre_tool_hooks_fired`, so the trusted and interactive paths only fire hooks
themselves when no context builder ran first:

- `test_declarative_auto_approve_block_enqueues_recovery`
- `test_gated_path_block_enqueues_recovery`
- `test_trusted_path_block_enqueues_recovery`
- `test_interactive_approved_block_enqueues_recovery`

Each asserts the call was rejected and the hook's reason reached a
refusal-recovery continuation. The assertion selects the recovery inject by
content rather than position, since a turn can also enqueue the empty-response
nudge.

Path coverage was verified by mutation rather than assumed: neutering each of the
four call sites in turn fails exactly one test, so no two tests ride the same
branch.

`test_every_hook_deny_path_routes_through_the_shared_helper` is structural rather than
behavioural, and it is the reason the helper exists: it asserts every
`_pre_tool_hooks_should_block` branch calls `_reject_hook_blocked`, and that the
`hook_blocked` audit appears exactly once in the module. Re-inlining one deny path
(reject + row + audit, reason dropped) fails it — and also fails that path's behavioural
test, so the guard and the behaviour agree about what regressed.

`test_blocked_row_and_audit_redact_the_model_authored_title` drives a real blocked turn
whose title carries a credential and asserts it appears in neither the transcript row nor
the `hook_blocked` audit. Reverting either surface to `event.title` fails it
independently.

## Manual verification

Still required: install a real PreToolUse hook script that exits 2 with a message
on stderr, trigger a tool call under each approval mode, and confirm the agent
receives the reason and continues on its own. The tests mock the hook store, so
they do not prove a real hook subprocess's stderr survives the path.

Several described behaviours are outside the four tests' reach, because all four
fixtures supply one short, non-empty plain stderr reason. Unexercised: the generic
fallback for a malformed deny-by-default result; redaction of an exfiltration URL or
credential in the title/reason; first-blocker-wins ordering when more than one hook
blocks; truncation of stderr longer than 200 characters; and the `hook denied`
substitution when stderr is empty.

## Known pre-existing gap (not addressed here)

Seven sibling `slot.append` sites still interpolate the raw `event.title` — four on the
invalid-tool-input path (`(invalid: {e})`) and three on the hook-execution-error path
(`(hook error)`) — carrying the same LLM-controlled text to the same two surfaces.
Mainline has ten such sites; this change removes the hook-block ones. The rest are a
separate pre-existing class on paths this PR does not otherwise touch, each needing its
own test, so they are recorded here rather than folded in.

## Related Issues

N/A — no tracking issue; the gap was recorded as a follow-up in
`docs/system-specs/modules/learn-cron-dashboard.md`, which this PR updates.

## Checklist

- [x] Single commit with a Conventional Commits title
- [ ] Existing tests pass and new tests added for new functionality — new tests are
      added (see Tests) and the targeted suites pass against base `e7bf693e`: 48
      `test/test_dashboard_approval.py` tests pass; flake8 clean. Left unchecked because the repository's full existing
      suite has not been confirmed locally; CI is the authoritative signal. Re-verified after
      the helper extraction: 49 tests pass, `isort`, `flake8` and `mypy` clean.
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated — `docs/system-specs/modules/learn-cron-dashboard.md`
      (removes the stale "not yet wired" follow-up note)
- [x] No secrets, credentials, or internal references in the diff
      (`scrub-lint.sh`, `check_brand_name.py` both clean)

## Contribution License Agreement

<!-- PLACEHOLDER: awaiting OSPO/Legal wording. -->
