### PR TITLE
feat(dashboard): accept this machine's own tailnet origin without hand-writing dashboard.url

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -3951,6 +3951,9 @@
       "enumValues": null,
       "defaultValue": {
         "url": "",
+        "tailscale": {
+          "enabled": false
+        },
         "restore_sessions": false,
         "restore_window_minutes": 30,
         "surface_channel_sessions": true,
@@ -4006,6 +4009,36 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": ""
+    },
+    {
+      "path": "dashboard.tailscale",
+      "kind": "core",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Tailscale",
+      "help": "Reach the dashboard over your tailnet via `tailscale serve`.",
+      "hasChildren": true,
+      "enumValues": null,
+      "defaultValue": {
+        "enabled": false
+      }
+    },
+    {
+      "path": "dashboard.tailscale.enabled",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Tailnet Access",
+      "help": "Accept this machine's own MagicDNS name as a dashboard origin, so `tailscale serve` works without hand-writing dashboard.url. Reads the local Tailscale daemon once at startup; contributes nothing if Tailscale is absent, stopped, or MagicDNS is off. Does NOT widen the network bind and does NOT change authentication — every request still needs a dashboard session.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": false
     },
     {
       "path": "dashboard.restore_sessions",

--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -270,9 +270,15 @@ the same and the difference is the whole security story:
   governed by your tailnet ACLs. This is the better answer for the phone case:
   ```bash
   tailscale serve --bg --https 443 http://127.0.0.1:5476
+  kirocrew config set dashboard.tailscale.enabled true
+  kirocrew restart
   ```
-  Then set `dashboard.url` to `https://<machine>.<tailnet>.ts.net` (below) so the
-  origin allowlist and the `Host` barrier accept it.
+  `dashboard.tailscale.enabled` reads your own MagicDNS name from the local
+  Tailscale daemon once at startup and trusts `https://<that name>` as an origin,
+  so you do **not** have to look the name up and hand-write `dashboard.url`. If
+  Tailscale is absent, stopped, or MagicDNS is off it contributes nothing and the
+  dashboard starts exactly as before. It does not widen the network bind and does
+  not change authentication — every request still needs a dashboard session.
 - [Tailscale Funnel](https://tailscale.com/kb/1223/funnel) does the opposite: it
   puts the service **on the public internet**, like cloudflared and ngrok. Use it
   only if you actually want public ingress.
@@ -280,7 +286,8 @@ the same and the difference is the whole security story:
 A shared corporate tailnet is not a private network — every member who can reach
 the Serve endpoint is inside your trust boundary, so keep the ACL narrow.
 
-Then set the URL in `~/.kiro/crew/config.json` and restart:
+For the tunnel providers above (cloudflared / ngrok / Funnel) set the URL in
+`~/.kiro/crew/config.json` and restart:
 
 ```json
 {

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1804,12 +1804,37 @@ class PublishConfig:
 
 
 @dataclass
+class TailscaleConfig:
+    """Tailnet access for the dashboard (RFC: rfc-tailnet-dashboard-access)."""
+
+    enabled: bool = field(
+        default=False,
+        metadata=_meta(
+            "Tailnet Access",
+            "Accept this machine's own MagicDNS name as a dashboard origin, so "
+            "`tailscale serve` works without hand-writing dashboard.url. Reads "
+            "the local Tailscale daemon once at startup; contributes nothing if "
+            "Tailscale is absent, stopped, or MagicDNS is off. Does NOT widen the "
+            "network bind and does NOT change authentication — every request "
+            "still needs a dashboard session.",
+        ),
+    )
+
+
+@dataclass
 class DashboardConfig:
     url: str = field(
         default="",
         metadata=_meta(
             "Dashboard URL",
             "Public URL for the dashboard (used in Slack links).",
+        ),
+    )
+    tailscale: TailscaleConfig = field(
+        default_factory=TailscaleConfig,
+        metadata=_meta(
+            "Tailscale",
+            "Reach the dashboard over your tailnet via `tailscale serve`.",
         ),
     )
     restore_sessions: bool = field(
@@ -4853,6 +4878,11 @@ class KiroCrewConfig:
             ),
             dashboard=DashboardConfig(
                 url=dashboard_data.get("url", ""),
+                tailscale=TailscaleConfig(
+                    enabled=_safe_bool(
+                        _safe_dict(dashboard_data.get("tailscale")).get("enabled"), False
+                    ),
+                ),
                 restore_sessions=dashboard_data.get("restore_sessions", False),
                 restore_window_minutes=dashboard_data.get("restore_window_minutes", 30),
                 surface_channel_sessions=dashboard_data.get("surface_channel_sessions", True),

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -41,6 +41,7 @@ from kiro_crew.dashboard import (
     handlers_project,
     openai_compat,
     stt_stream,
+    tailnet,
     ws,
 )
 from kiro_crew.dashboard.crash_dump_store import (
@@ -2927,7 +2928,22 @@ async def start_dashboard(
                 raise
         return await handler(request)  # type: ignore[operator]
 
-    app["allowed_origins"] = build_allowed_origins(port, local_only, configured_host)
+    # Tailnet origin (RFC §4): this machine's own MagicDNS name, so
+    # `tailscale serve` works without the operator hand-writing dashboard.url.
+    # Off by default; resolved in a thread so the daemon call cannot stall the
+    # loop; "" whenever Tailscale is absent, stopped, or produced nothing that
+    # validated.
+    _tailnet_host = await tailnet.resolve_tailnet_host(
+        KiroCrewConfig.load().dashboard.tailscale.enabled
+    )
+    if _tailnet_host:
+        logger.info(
+            "tailnet access enabled: trusting origin https://%s (bind and auth unchanged)",
+            _tailnet_host,
+        )
+    app["allowed_origins"] = build_allowed_origins(
+        port, local_only, configured_host, tailnet_host=_tailnet_host
+    )
     # Exposed to handlers (e.g. knowledge.pick_folder) that only make sense when
     # the browser and gateway are co-located on localhost.
     app["local_only"] = local_only
@@ -3011,7 +3027,7 @@ async def start_dashboard(
         _has_token_auth = any(getattr(mw, "_is_token_auth", False) for mw in app.middlewares)
         if _has_token_auth:
             app["allowed_origins"] = build_allowed_origins(
-                port, local_only, configured_host, dashboard_url
+                port, local_only, configured_host, dashboard_url, tailnet_host=_tailnet_host
             )
             logger.info(
                 "dashboard_url=%s: added to CSRF allowed origins (token auth verified)",
@@ -3445,7 +3461,14 @@ async def start_api_server(
     # The MCP route surface is identical to the dashboard's, so the middleware
     # chain must be too. Host-allowlist source of truth is shared with the CSRF
     # Origin check via build_allowed_origins/build_allowed_hosts (see origin.py).
-    app["allowed_origins"] = build_allowed_origins(port, local_only, configured_host)
+    app["allowed_origins"] = build_allowed_origins(
+        port,
+        local_only,
+        configured_host,
+        tailnet_host=await tailnet.resolve_tailnet_host(
+            KiroCrewConfig.load().dashboard.tailscale.enabled
+        ),
+    )
     app["local_only"] = local_only
 
     # Per-session internal secret for machine-to-machine (mcp-core, cron) auth.

--- a/src/kiro_crew/dashboard/tailnet.py
+++ b/src/kiro_crew/dashboard/tailnet.py
@@ -1,0 +1,245 @@
+"""Read-only interface to the local Tailscale daemon.
+
+Answers one question for now: *what MagicDNS name does this machine have on its
+tailnet?* — so the dashboard can accept its own tailnet origin without the
+operator hand-writing ``dashboard.url``. RFC:
+``docs/request-for-change/rfc-tailnet-dashboard-access.md`` §4.
+
+Two properties are load-bearing and neither is optional:
+
+**Nothing here raises.** A missing binary, a stopped daemon, a timeout, a
+non-zero exit, malformed JSON, an unexpected schema — every one returns ``None``.
+The dashboard must start on a host that has never heard of Tailscale, so this
+module is a pure enrichment: it either contributes a name or contributes nothing.
+
+**The name is validated before it is returned.** It arrives from a subprocess and
+its destination is the CSRF origin allowlist and the DNS-rebinding ``Host``
+barrier, so an unvalidated value would be an origin-injection primitive. See
+:func:`_valid_magicdns_name`: structure is checked as a strict allowlist, and the
+name must additionally sit under the tailnet's own MagicDNS suffix *as the daemon
+reports it* — not a suffix hardcoded here, because upstream documents the suffix
+as tailnet-specific (its own example is ``userfoo.tailscale.net``, not
+``ts.net``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import subprocess
+from typing import Any
+
+from kiro_crew.sandbox import scrub_env
+
+logger = logging.getLogger(__name__)
+
+#: Hard ceiling on a daemon call. Startup path, so this is latency the user
+#: waits through — it must be short, and it must be a real timeout rather than a
+#: hope, because `tailscale status` blocks while the daemon is starting up.
+_CLI_TIMEOUT_SECS = 3.0
+
+#: Where the CLI is accepted from — **vetted absolute paths only, never ``PATH``**.
+#: A ``PATH`` lookup would make the binary itself attacker-selectable: an agent
+#: that can write into any writable ``PATH`` entry (``~/.local/bin`` is on PATH on
+#: a normal dev box) could plant a ``tailscale`` executable, and the next gateway
+#: start with this feature enabled would execute it. The arguments were never
+#: agent-influenced, but the *binary* was — so resolution is pinned to the
+#: locations the official packages install into, all of which need root to write:
+#:
+#: * ``/usr/bin`` — Linux distro packages
+#: * ``/usr/local/bin`` — Linux tarball, macOS Homebrew on Intel
+#: * ``/opt/homebrew/bin`` — macOS Homebrew on Apple silicon
+#: * the app bundle — the macOS app ships the binary inside and does not always
+#:   symlink it
+#: * ``C:\Program Files\Tailscale`` — the Windows installer
+#:
+#: A non-standard install is not auto-derived. That is the deliberate trade: it
+#: keeps using explicit ``dashboard.url``, which is the path it uses today.
+_CLI_CANDIDATE_PATHS = (
+    "/usr/bin/tailscale",
+    "/usr/local/bin/tailscale",
+    "/opt/homebrew/bin/tailscale",
+    "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+    r"C:\Program Files\Tailscale\tailscale.exe",
+)
+
+#: MagicDNS names are DNS labels joined by dots, all lowercase. Deliberately
+#: strict: no scheme, no port, no path, no userinfo, no whitespace, no trailing
+#: dot (stripped before the match), no uppercase.
+_DNS_LABEL = r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?"
+_MAGICDNS_RE = re.compile(rf"^{_DNS_LABEL}(?:\.{_DNS_LABEL})+$")
+
+
+def _cli_path() -> str | None:
+    """Locate the ``tailscale`` CLI, or ``None`` if it is not installed.
+
+    Deliberately does **not** consult ``PATH`` — see ``_CLI_CANDIDATE_PATHS``.
+    """
+    for candidate in _CLI_CANDIDATE_PATHS:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def _run_json(args: list[str]) -> Any | None:
+    """Run the CLI and parse stdout as JSON. ``None`` on ANY failure.
+
+    Deliberately broad: the caller's contract is "a name or nothing", and every
+    failure mode here (no binary, daemon down, timeout, non-zero exit, non-JSON
+    output) means the same thing to it. Failures are logged at debug so a host
+    without Tailscale does not emit noise on every start.
+    """
+    cli = _cli_path()
+    if not cli:
+        logger.debug("tailscale CLI not found; skipping tailnet origin derivation")
+        return None
+    try:
+        proc = subprocess.run(  # noqa: S603 - vetted absolute binary, fixed argv, no shell
+            [cli, *args],
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT_SECS,
+            check=False,
+            # Defence in depth behind the pinned binary above: even a legitimate
+            # `tailscale` has no business reading the gateway's credentials out of
+            # the inherited environment. Uses the repo's own scrubber rather than a
+            # second, narrower allowlist, so this spawn cannot drift away from the
+            # policy every other spawn follows — and so it stays cross-OS safe.
+            env=scrub_env(),
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.debug("tailscale %s failed to run: %s", " ".join(args), exc)
+        return None
+    if proc.returncode != 0:
+        logger.debug(
+            "tailscale %s exited %d: %s",
+            " ".join(args),
+            proc.returncode,
+            (proc.stderr or "").strip()[:200],
+        )
+        return None
+    try:
+        return json.loads(proc.stdout or "")
+    except (json.JSONDecodeError, ValueError) as exc:
+        logger.debug("tailscale %s produced non-JSON output: %s", " ".join(args), exc)
+        return None
+
+
+def _valid_magicdns_name(raw: object, magic_dns_suffix: object) -> str | None:
+    """Return *raw* as a trusted MagicDNS name, or ``None`` if it is not one.
+
+    Two independent checks, and they defend different things.
+
+    **Structure** is the injection defense. An allowlist, not a denylist: the
+    destination is the CSRF origin set and the ``Host`` barrier, so the question
+    is not "does this look dangerous" but "is this provably a bare hostname".
+    Rejected — a non-string, empty, over 253 bytes, or anything carrying a
+    scheme / port / path / credentials / whitespace / uppercase.
+
+    **Suffix self-consistency** is the "is this actually ours" check. The name
+    must sit under the tailnet's own MagicDNS suffix *as reported by the same
+    status output* (``CurrentTailnet.MagicDNSSuffix``). Checking against the
+    daemon's own answer rather than a hardcoded suffix matters: upstream
+    documents the suffix as tailnet-specific and its own example is
+    ``userfoo.tailscale.net``, not ``ts.net``, so a hardcoded list would reject
+    legitimate tailnets and would rot as Tailscale adds suffixes. It also means a
+    self-hosted control plane works without a special case. ``CurrentTailnet`` is
+    nil when the node is not connected, which lands here as a missing suffix and
+    is refused — no tailnet means no origin to add.
+    """
+    if not isinstance(raw, str) or not isinstance(magic_dns_suffix, str):
+        return None
+    name = raw.strip().rstrip(".")
+    # Upstream documents MagicDNSSuffix as carrying "no surrounding dots", but
+    # normalise rather than trust the shape of a value we did not build.
+    suffix = magic_dns_suffix.strip().strip(".").lower()
+    if not name or not suffix or len(name) > 253:
+        return None
+    # Cheap structural rejections before the regex, so the reason is obvious in
+    # a debug log rather than a bare "did not match".
+    if any(ch in name for ch in "/:@?# \t\r\n\\"):
+        return None
+    if name != name.lower():
+        return None
+    # Must be a host UNDER the suffix, not the suffix itself and not a name that
+    # merely contains it (`desk.tail.ts.net.evil.com` must not pass).
+    if not name.endswith(f".{suffix}"):
+        return None
+    if not _MAGICDNS_RE.match(name):
+        return None
+    return name
+
+
+def self_dns_name() -> str | None:
+    """This machine's MagicDNS name on its tailnet, or ``None``.
+
+    ``None`` covers every "not applicable" case as well as every failure:
+    Tailscale absent, daemon not running, machine not logged in (``CurrentTailnet``
+    is nil), MagicDNS disabled for the tailnet, or a name that does not validate
+    against the tailnet's own suffix.
+    """
+    status = _run_json(["status", "--json"])
+    if not isinstance(status, dict):
+        return None
+    self_node = status.get("Self")
+    if not isinstance(self_node, dict):
+        return None
+    # CurrentTailnet is nil when the node is not connected to a tailnet. The
+    # legacy top-level MagicDNSSuffix is upstream-deprecated, so it is only a
+    # fallback for an older daemon, never the primary read.
+    tailnet = status.get("CurrentTailnet")
+    suffix: object = None
+    if isinstance(tailnet, dict):
+        suffix = tailnet.get("MagicDNSSuffix")
+    if not isinstance(suffix, str) or not suffix.strip():
+        suffix = status.get("MagicDNSSuffix")
+    name = _valid_magicdns_name(self_node.get("DNSName"), suffix)
+    if name is None:
+        logger.debug("tailscale status returned no usable Self.DNSName for this tailnet")
+    return name
+
+
+def tailnet_origin() -> str | None:
+    """The HTTPS origin to trust for this machine's tailnet name, or ``None``.
+
+    No port: ``tailscale serve`` fronts the dashboard on 443, so the browser's
+    ``Origin`` carries no port component.
+    """
+    name = self_dns_name()
+    return f"https://{name}" if name else None
+
+
+async def resolve_tailnet_host(enabled: bool) -> str:
+    """Async entry point for the startup path: the name, or ``""``.
+
+    Exists so the **blocking subprocess never runs on the event loop**.
+    :func:`self_dns_name` shells out with a multi-second timeout, and
+    ``tailscale status`` genuinely blocks while the daemon is coming up; running
+    that inline would stall every other session and can trip the loop-stall
+    watchdog. Offloaded to a thread, and short-circuited before the thread hop
+    when the feature is off so a host without Tailscale pays nothing.
+
+    Takes *enabled* as an argument rather than reading config, to keep this
+    module free of a config import (and the import cycle that would invite).
+    """
+    if not enabled:
+        return ""
+    name: str | None = await asyncio.to_thread(self_dns_name)
+    if not name:
+        # Debug-level silence is right for a host that never opted in, but the
+        # operator who set ``dashboard.tailscale.enabled`` gets the same bare 403
+        # this feature exists to remove, with nothing above debug saying why.
+        # The common cause is a boot race: the gateway resolves once at startup
+        # and tailscaled has not answered yet.
+        logger.warning(
+            "dashboard.tailscale.enabled is on, but no tailnet name could be "
+            "resolved, so no tailnet origin was added and `tailscale serve` will "
+            "still fail the Origin/Host check. Check `tailscale status`; if the "
+            "daemon was still starting, restart the gateway once it reports "
+            "Running."
+        )
+        return ""
+    return name

--- a/src/kiro_crew/dashboard/urls.py
+++ b/src/kiro_crew/dashboard/urls.py
@@ -380,13 +380,25 @@ def format_dashboard_urls(
 
 
 def build_allowed_origins(
-    port: int, local_only: bool, configured_host: str = "", dashboard_url: str = ""
+    port: int,
+    local_only: bool,
+    configured_host: str = "",
+    dashboard_url: str = "",
+    tailnet_host: str = "",
 ) -> set[str]:
     """Compute the set of allowed origins for the dashboard.
 
     When *dashboard_url* is provided, its origin (scheme + host + port)
     is added as-is so that reverse-proxy setups (e.g. Caddy with TLS on
     a custom domain) pass the CSRF check without code changes.
+
+    *tailnet_host* is this machine's MagicDNS name when tailnet access is
+    enabled, and adds ``https://<name>`` — no port, because ``tailscale serve``
+    fronts the dashboard on 443. Kept as a **parameter rather than a lookup** so
+    this function stays pure and testable: the caller owns the daemon call and
+    the validation (``dashboard/tailnet.py``), and passes "" when Tailscale is
+    disabled, absent, or produced nothing trustworthy. Nothing here re-validates
+    it, so nothing may pass an unvalidated value in.
     """
     origins: set[str] = {
         f"http://127.0.0.1:{port}",
@@ -402,6 +414,11 @@ def build_allowed_origins(
         origin = dashboard_origin(dashboard_url)
         if origin:
             origins.add(origin)
+    # Tailnet origin (§4). Already validated by dashboard/tailnet.py — see the
+    # docstring: this function must not be the place that decides whether a
+    # subprocess-derived hostname is trustworthy.
+    if tailnet_host:
+        origins.add(f"https://{tailnet_host}")
     if not local_only:
         mh = machine_hostname()
         if mh:

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -180,6 +180,38 @@ def test_sandbox_allow_unsandboxed_exec_loads_from_config() -> None:
     assert enabled.agent.sandbox_allow_unsandboxed_exec is True
 
 
+def test_dashboard_tailscale_hydrates_and_survives_a_round_trip() -> None:
+    """The opt-in must survive ``load()`` and a later ``save()``.
+
+    ``DashboardConfig`` is built field-by-field in ``load()``, so a nested
+    section that nobody wires up is silently dropped: the documented
+    ``kirocrew config set dashboard.tailscale.enabled true`` would land in
+    config.json, read back as ``False``, and — because ``to_dict()`` re-serializes
+    the default — be rewritten to ``false`` by the next unrelated ``save()``.
+    That makes the whole feature inert while looking configured, so both halves
+    are pinned here: hydration, and the round trip that would erase it.
+    """
+    assert KiroCrewConfig().dashboard.tailscale.enabled is False
+    assert _load_from_dict({}).dashboard.tailscale.enabled is False
+
+    enabled = _load_from_dict({"dashboard": {"tailscale": {"enabled": True}}})
+    assert enabled.dashboard.tailscale.enabled is True
+
+    # A save() built from the loaded config must not drop the operator's value.
+    assert _load_from_dict(enabled.to_dict()).dashboard.tailscale.enabled is True
+
+    # A malformed section degrades to the default instead of raising.
+    for bad in ("yes", 1, [], None):
+        assert _load_from_dict({"dashboard": {"tailscale": bad}}).dashboard.tailscale.enabled is (
+            False
+        ), bad
+    assert (
+        _load_from_dict({"dashboard": {"tailscale": {"enabled": "true"}}})
+        .dashboard.tailscale.enabled
+        is False
+    )
+
+
 def test_sandbox_allow_unsandboxed_exec_default_is_platform_independent(monkeypatch) -> None:
     """No platform may flip this default on its own.
 

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -168,6 +168,20 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # version into versions.txt. The binary name is a module constant; a
         # resource ceiling / sandbox adds nothing to a `--version` call.
         "diagnostics.py::_kiro_cli_version",
+        # Tailnet origin derivation (RFC: rfc-tailnet-dashboard-access): one
+        # fixed argv, ``["<tailscale>", "status", "--json"]``, with a 3s timeout,
+        # no shell and no cwd. The binary is resolved from a vetted absolute
+        # allowlist (``_CLI_CANDIDATE_PATHS``) and NOT from ``PATH`` — a ``PATH``
+        # lookup made the executable itself agent-selectable even though the
+        # arguments never were, since ``~/.local/bin`` is both on ``PATH`` and
+        # agent-writable. The child also gets ``sandbox.scrub_env()`` rather than
+        # the inherited environment. Deliberately NOT routed through
+        # ``sandboxed_spawn_argv``: this is a read-only query of the local daemon
+        # on the dashboard's startup path, and the module's load-bearing property
+        # is that *nothing raises* so the gateway still boots on a host with no
+        # Tailscale. Routing it would make dashboard startup depend on sandbox
+        # availability, which is exactly the failure that property rules out.
+        "dashboard/tailnet.py::_run_json",
         "apps/backend.py::_proc_start_time",
         "apps/backend.py::_resolve_nvm_path",
         "apps/backend.py::stop_app_backend",

--- a/test/test_tailnet_origin.py
+++ b/test/test_tailnet_origin.py
@@ -1,0 +1,339 @@
+"""Tailnet origin derivation: a name that reaches the allowlist must be earned.
+
+The value under test travels from a subprocess into the CSRF origin set and the
+DNS-rebinding ``Host`` barrier, so the tests are weighted accordingly:
+
+* :class:`TestValidation` is an injection-rejection suite, not a formatting one.
+  Anything carrying a scheme, port, path, credentials, whitespace or uppercase
+  must be refused, and so must a plausible hostname outside ``*.ts.net`` —
+  "looks like a hostname" is not "is a tailnet name".
+* :class:`TestFailureModes` pins that **nothing raises**. A host that has never
+  installed Tailscale, a stopped daemon, a timeout, a non-zero exit and garbage
+  on stdout all have to degrade to "contributes nothing", because the dashboard
+  has to start regardless.
+* :class:`TestOriginSet` pins that the contribution lands as `https://` with no
+  port, and that the ``Host`` allowlist follows without a second change.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.dashboard import tailnet
+from kiro_crew.dashboard.urls import build_allowed_hosts, build_allowed_origins
+
+_GOOD = "desk.tail1a2b3c.ts.net"
+_SUFFIX = "tail1a2b3c.ts.net"
+
+
+def _status(dns_name: object, suffix: object = _SUFFIX, *, current_tailnet: bool = True) -> str:
+    body: dict = {"Self": {"DNSName": dns_name}}
+    if current_tailnet:
+        body["CurrentTailnet"] = {"MagicDNSSuffix": suffix}
+    return json.dumps(body)
+
+
+def _fake_proc(stdout: str = "", returncode: int = 0, stderr: str = ""):
+    return subprocess.CompletedProcess(args=["tailscale"], returncode=returncode,
+                                       stdout=stdout, stderr=stderr)
+
+
+class TestValidation:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (_GOOD, _GOOD),
+            (f"{_GOOD}.", _GOOD),          # upstream documents the trailing dot
+            (f"  {_GOOD}  ", _GOOD),       # surrounding whitespace is trimmed
+        ],
+    )
+    def test_accepts_a_name_under_the_reported_suffix(self, raw: str, expected: str) -> None:
+        assert tailnet._valid_magicdns_name(raw, _SUFFIX) == expected
+
+    def test_accepts_a_non_ts_net_tailnet(self) -> None:
+        """Upstream's own suffix example is ``userfoo.tailscale.net``.
+
+        A hardcoded ``.ts.net`` requirement would reject this legitimate tailnet,
+        which is why the check is self-consistency against the reported suffix.
+        """
+        assert (
+            tailnet._valid_magicdns_name("desk.userfoo.tailscale.net", "userfoo.tailscale.net")
+            == "desk.userfoo.tailscale.net"
+        )
+
+    def test_accepts_a_self_hosted_suffix(self) -> None:
+        """Falls out of the same rule — no special case for Headscale."""
+        assert (
+            tailnet._valid_magicdns_name("desk.net.example.org", "net.example.org")
+            == "desk.net.example.org"
+        )
+
+    @pytest.mark.parametrize("suffix", [_SUFFIX, f".{_SUFFIX}.", f"  {_SUFFIX}  "])
+    def test_suffix_shape_is_normalised_not_trusted(self, suffix: str) -> None:
+        assert tailnet._valid_magicdns_name(_GOOD, suffix) == _GOOD
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "https://desk.tail1a2b3c.ts.net",   # scheme
+            "desk.tail1a2b3c.ts.net:8443",      # port
+            "desk.tail1a2b3c.ts.net/admin",     # path
+            "user@desk.tail1a2b3c.ts.net",      # userinfo
+            "desk.tail1a2b3c.ts.net?x=1",       # query
+            "desk.tail1a2b3c.ts.net#f",         # fragment
+            "desk tail1a2b3c.ts.net",           # space
+            "desk\ttail1a2b3c.ts.net",          # tab
+            "desk\ntail1a2b3c.ts.net",          # newline
+            "desk\\tail1a2b3c.ts.net",          # backslash
+            "DESK.tail1a2b3c.ts.net",           # uppercase
+            "-bad.tail1a2b3c.ts.net",           # label may not start with a hyphen
+            "",
+            "   ",
+        ],
+    )
+    def test_rejects_structurally_bad_names(self, raw: str) -> None:
+        assert tailnet._valid_magicdns_name(raw, _SUFFIX) is None
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "evil.example.com",                     # different domain entirely
+            "desk.tail1a2b3c.ts.net.evil.com",      # suffix present but not a suffix
+            "tail1a2b3c.ts.net",                    # the bare suffix, no host label
+            "desk.other9z8y7x.ts.net",              # a DIFFERENT tailnet's suffix
+        ],
+    )
+    def test_rejects_names_outside_the_reported_suffix(self, raw: str) -> None:
+        assert tailnet._valid_magicdns_name(raw, _SUFFIX) is None
+
+    @pytest.mark.parametrize("suffix", [None, "", "   ", 42, [], {}])
+    def test_rejects_a_missing_or_non_string_suffix(self, suffix: object) -> None:
+        """No tailnet reported means no origin to add."""
+        assert tailnet._valid_magicdns_name(_GOOD, suffix) is None
+
+    @pytest.mark.parametrize("raw", [None, 42, [], {}, True])
+    def test_rejects_non_strings(self, raw: object) -> None:
+        assert tailnet._valid_magicdns_name(raw, _SUFFIX) is None
+
+    def test_rejects_an_over_long_name(self) -> None:
+        assert tailnet._valid_magicdns_name("a" * 250 + f".{_SUFFIX}", _SUFFIX) is None
+
+
+class TestFailureModes:
+    """Every one of these must return None, and none may raise."""
+
+    def test_cli_absent(self) -> None:
+        with patch.object(tailnet, "_cli_path", return_value=None):
+            assert tailnet.self_dns_name() is None
+
+    def test_timeout(self) -> None:
+        with patch.object(tailnet, "_cli_path", return_value="/usr/bin/tailscale"), patch(
+            "subprocess.run", side_effect=subprocess.TimeoutExpired("tailscale", 3.0)
+        ):
+            assert tailnet.self_dns_name() is None
+
+    def test_oserror_on_exec(self) -> None:
+        with patch.object(tailnet, "_cli_path", return_value="/usr/bin/tailscale"), patch(
+            "subprocess.run", side_effect=OSError("permission denied")
+        ):
+            assert tailnet.self_dns_name() is None
+
+    def test_non_zero_exit(self) -> None:
+        with patch.object(tailnet, "_cli_path", return_value="/usr/bin/tailscale"), patch(
+            "subprocess.run", return_value=_fake_proc(returncode=1, stderr="not running")
+        ):
+            assert tailnet.self_dns_name() is None
+
+    @pytest.mark.parametrize(
+        "stdout",
+        [
+            "",                      # empty
+            "not json at all",       # garbage
+            "[]",                    # JSON, wrong top-level type
+            '"a string"',            # JSON, wrong top-level type
+            "{}",                    # no Self
+            '{"Self": null}',        # Self present but not a dict
+            '{"Self": {}}',          # Self present, no DNSName
+        ],
+    )
+    def test_unusable_output(self, stdout: str) -> None:
+        with patch.object(tailnet, "_cli_path", return_value="/usr/bin/tailscale"), patch(
+            "subprocess.run", return_value=_fake_proc(stdout=stdout)
+        ):
+            assert tailnet.self_dns_name() is None
+
+    def test_logged_out_node_has_no_tailnet_and_so_no_origin(self) -> None:
+        """``CurrentTailnet`` is nil until the node joins a tailnet."""
+        with patch.object(tailnet, "_cli_path", return_value="/usr/bin/tailscale"), patch(
+            "subprocess.run",
+            return_value=_fake_proc(stdout=_status(f"{_GOOD}.", current_tailnet=False)),
+        ):
+            assert tailnet.self_dns_name() is None
+
+    def test_falls_back_to_the_deprecated_top_level_suffix(self) -> None:
+        """An older daemon reports only the deprecated top-level MagicDNSSuffix."""
+        legacy = json.dumps({"Self": {"DNSName": f"{_GOOD}."}, "MagicDNSSuffix": _SUFFIX})
+        with patch.object(tailnet, "_cli_path", return_value="/usr/bin/tailscale"), patch(
+            "subprocess.run", return_value=_fake_proc(stdout=legacy)
+        ):
+            assert tailnet.self_dns_name() == _GOOD
+
+    def test_name_from_a_different_tailnet_than_reported_is_refused(self) -> None:
+        with patch.object(tailnet, "_cli_path", return_value="/usr/bin/tailscale"), patch(
+            "subprocess.run",
+            return_value=_fake_proc(stdout=_status("desk.other9z8y7x.ts.net.", _SUFFIX)),
+        ):
+            assert tailnet.self_dns_name() is None
+
+    def test_a_hostile_name_in_otherwise_valid_output_is_refused(self) -> None:
+        """The daemon is trusted to be the daemon, not to be well-behaved."""
+        with patch.object(tailnet, "_cli_path", return_value="/usr/bin/tailscale"), patch(
+            "subprocess.run",
+            return_value=_fake_proc(stdout=_status("evil.example.com:1234/x")),
+        ):
+            assert tailnet.self_dns_name() is None
+
+    def test_happy_path(self) -> None:
+        with patch.object(tailnet, "_cli_path", return_value="/usr/bin/tailscale"), patch(
+            "subprocess.run", return_value=_fake_proc(stdout=_status(f"{_GOOD}."))
+        ):
+            assert tailnet.self_dns_name() == _GOOD
+            assert tailnet.tailnet_origin() == f"https://{_GOOD}"
+
+
+class TestResolveEntryPoint:
+    @pytest.mark.asyncio
+    async def test_disabled_never_touches_the_daemon(self) -> None:
+        """Short-circuits before the thread hop, so a non-user pays nothing."""
+        with patch.object(tailnet, "self_dns_name") as probe:
+            assert await tailnet.resolve_tailnet_host(False) == ""
+        probe.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enabled_resolves_off_the_event_loop(self) -> None:
+        """The subprocess must not run inline — it blocks for seconds."""
+        import asyncio
+
+        loop_thread = None
+
+        def _record() -> str:
+            nonlocal loop_thread
+            import threading
+
+            loop_thread = threading.current_thread()
+            return _GOOD
+
+        main_thread = __import__("threading").current_thread()
+        with patch.object(tailnet, "self_dns_name", side_effect=_record):
+            assert await tailnet.resolve_tailnet_host(True) == _GOOD
+        assert loop_thread is not None and loop_thread is not main_thread
+        assert asyncio.get_running_loop() is not None
+
+    @pytest.mark.asyncio
+    async def test_enabled_but_unresolvable_yields_empty_string(self) -> None:
+        with patch.object(tailnet, "self_dns_name", return_value=None):
+            assert await tailnet.resolve_tailnet_host(True) == ""
+
+    @pytest.mark.asyncio
+    async def test_enabled_but_unresolvable_warns(self, caplog) -> None:
+        """An explicit opt-in that resolves to nothing must not fail silently.
+
+        Debug-level silence is correct for a host that never opted in; for one
+        that did, it reproduces the bare 403 this feature removes with nothing
+        above debug explaining it.
+        """
+        with patch.object(tailnet, "self_dns_name", return_value=None):
+            with caplog.at_level("WARNING", logger=tailnet.logger.name):
+                assert await tailnet.resolve_tailnet_host(True) == ""
+        assert any(r.levelname == "WARNING" for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_disabled_stays_silent(self, caplog) -> None:
+        """The off path must emit nothing — that is what keeps the warning useful."""
+        with caplog.at_level("WARNING", logger=tailnet.logger.name):
+            assert await tailnet.resolve_tailnet_host(False) == ""
+        assert not caplog.records
+
+
+class TestSpawnHardening:
+    """The binary is pinned and the environment is scrubbed.
+
+    Both defend the same reachable path: the feature is enabled, the dashboard
+    starts, and whatever ``_run_json`` executes runs inside the gateway process.
+    """
+
+    def test_path_is_never_consulted(self) -> None:
+        """A planted binary on ``PATH`` must not be selected.
+
+        ``~/.local/bin`` is on ``PATH`` on a normal dev box and is agent-writable,
+        so resolving through ``PATH`` would let an agent choose the executable the
+        gateway runs at startup. Arguments were never agent-influenced; the binary
+        was.
+        """
+        with patch("shutil.which", return_value="/tmp/planted/tailscale") as which:
+            with patch("os.path.isfile", return_value=False):
+                assert tailnet._cli_path() is None
+        which.assert_not_called()
+
+    def test_candidates_are_absolute_and_vetted(self) -> None:
+        for candidate in tailnet._CLI_CANDIDATE_PATHS:
+            assert candidate.startswith(("/", "C:\\")), candidate
+            assert "tailscale" in candidate.lower(), candidate
+
+    def test_credentials_are_not_inherited(self) -> None:
+        """The child gets a scrubbed environment, not ``os.environ``."""
+        witness = "AWS_SECRET_ACCESS_KEY"
+        with patch.dict(os.environ, {witness: "must-not-leak"}, clear=False):
+            with patch.object(tailnet, "_cli_path", return_value="/usr/bin/tailscale"):
+                with patch("subprocess.run") as run:
+                    run.return_value = SimpleNamespace(returncode=0, stdout="{}", stderr="")
+                    tailnet._run_json(["status", "--json"])
+        passed_env = run.call_args.kwargs["env"]
+        assert witness not in passed_env
+        # Still a real environment, not an empty one — over-scrubbing breaks the
+        # macOS and Windows CLIs, which need HOME / SystemRoot to find the daemon.
+        assert passed_env
+
+
+class TestOriginSet:
+    def test_absent_by_default(self) -> None:
+        """Passing ``tailnet_host`` adds exactly one origin and nothing else.
+
+        Stated as set arithmetic rather than a substring scan over each origin:
+        the difference pins both halves at once — the default set contributes
+        nothing tailnet-ish, and the opt-in contributes no second entry.
+        """
+        baseline = build_allowed_origins(5476, local_only=True)
+        contributed = build_allowed_origins(5476, local_only=True, tailnet_host=_GOOD)
+        assert contributed - baseline == {f"https://{_GOOD}"}
+
+    def test_contributed_as_https_without_a_port(self) -> None:
+        origins = build_allowed_origins(5476, local_only=True, tailnet_host=_GOOD)
+        assert f"https://{_GOOD}" in origins
+        assert f"https://{_GOOD}:5476" not in origins
+
+    def test_host_barrier_follows_without_a_second_change(self) -> None:
+        """build_allowed_hosts derives from the origin set — the RFC's invariant."""
+        origins = build_allowed_origins(5476, local_only=True, tailnet_host=_GOOD)
+        assert _GOOD in build_allowed_hosts(origins)
+
+    def test_coexists_with_dashboard_url(self) -> None:
+        """A re-derivation for dashboard_url must not drop the tailnet origin."""
+        origins = build_allowed_origins(
+            5476,
+            local_only=True,
+            dashboard_url="https://crew.example.com",
+            tailnet_host=_GOOD,
+        )
+        assert origins.issuperset({f"https://{_GOOD}", "https://crew.example.com"})
+
+    def test_loopback_floor_is_untouched(self) -> None:
+        origins = build_allowed_origins(5476, local_only=True, tailnet_host=_GOOD)
+        assert "http://127.0.0.1:5476" in origins
+        assert "http://localhost:5476" in origins


### PR DESCRIPTION
Phase 2 of the tailnet RFC (`docs/request-for-change/rfc-tailnet-dashboard-access.md` §4). Off by default. **Does not widen the network bind and does not touch authentication.**

## Problem

`tailscale serve` is the right way to reach the dashboard from a phone — tailnet-only, TLS, a stable MagicDNS hostname, access governed by tailnet ACLs. Phase 1 (#1761) documented it. But making it work still takes a manual step that fails obscurely when skipped:

```bash
tailscale serve --bg --https 443 http://127.0.0.1:5476
# ...then open https://desk.tail1a2b3c.ts.net and get a bare 403
```

The `403` comes from `check_host()`, the DNS-rebinding barrier. The origin allowlist is built from loopback plus `dashboard.url`, so a tailnet name is not in it. The response does not say which allowlist rejected the request or how to extend it — the user has to know to look up their own MagicDNS name and hand-write it into `dashboard.url`.

## Why it matters

This is the one remote-access path that is private by construction, and the friction to reach it is "find a hostname you don't know, put it in a config file you haven't opened, and decode a 403 that names nothing". The RFC calls this out as Problem 3.

## Fix (symptom → root cause → change)

The symptom is an unexplained `403`. The root cause is that the origin set has no way to learn a name the local Tailscale daemon already knows. So the daemon is asked, once, at startup.

**`dashboard/tailnet.py`** (new) — a read-only interface to the daemon. Two properties carry the whole design:

**1. Nothing raises.** Missing binary, stopped daemon, timeout, non-zero exit, malformed JSON, unexpected schema — every path returns `None`. The dashboard must start on a host that has never heard of Tailscale, so this is pure enrichment: it contributes a name or contributes nothing.

**2. The name is validated before it is returned.** It arrives from a subprocess and its destination is the CSRF origin set *and* the `Host` barrier, so an unvalidated value is an origin-injection primitive. `_valid_magicdns_name()` is an **allowlist**, not a denylist — the question is not "does this look dangerous" but "is this provably a bare tailnet hostname":

| Rejected | Why |
|---|---|
| non-string, empty, >253 bytes | not a hostname |
| anything with `/ : @ ? #`, whitespace, backslash | scheme / port / path / userinfo / injection |
| any uppercase | MagicDNS names are lowercase; a mixed-case value did not come from where we think |
| `evil.example.com`, `desk.tail.ts.net.evil.com` | valid hostnames, **not** tailnet names |
| `-bad.tail.ts.net`, `ts.net` | malformed label / bare suffix |

The second check is **suffix self-consistency, not a hardcoded `.ts.net`**: the name must sit under the tailnet's own `CurrentTailnet.MagicDNSSuffix` *as reported by the same `status` output*. Upstream documents that suffix as tailnet-specific and its own example is `userfoo.tailscale.net`, so a hardcoded list would reject legitimate tailnets and would rot as Tailscale adds suffixes. A consequence worth stating plainly: **a self-hosted control plane (Headscale) on its own suffix is accepted**, with no special case — `test_accepts_a_self_hosted_suffix` pins that. `CurrentTailnet` is nil when the node is not connected, which lands here as a missing suffix and is refused: no tailnet means no origin to add.

**`build_allowed_origins()` stays a pure function.** It gains a `tailnet_host` **parameter**, not a lookup — the caller owns the daemon call and the validation. The docstring says so explicitly, so the next reader does not move the subprocess into it and so nothing may pass an unvalidated value in. `build_allowed_hosts()` is **unmodified**: the `Host` allowlist derives from the origin set, so the barrier follows for free. That is the RFC's single-source-of-truth invariant and a test pins it.

**The daemon call never runs on the event loop.** `resolve_tailnet_host()` short-circuits before the thread hop when the feature is off, and offloads to `asyncio.to_thread` when it is on. `tailscale status` genuinely blocks while the daemon is coming up, and a multi-second inline stall would freeze every other session and can trip the loop-stall watchdog. A test asserts the probe runs on a non-main thread.

**Both startup paths wired** — `start_dashboard` and `start_api_server`. The `dashboard_url` re-derivation inside `start_dashboard` also passes `tailnet_host`; without that it would silently drop the tailnet origin for anyone who sets both.

## What is deliberately NOT here

- **The inferred opt-in.** The RFC's §4 signal 2 (infer from `tailscale serve status` instead of a config flag) is gated on an open question — whether every widening of the origin allowlist must be explicit config. Only the explicit `dashboard.tailscale.enabled` flag ships, which the RFC says can land without that answer.
- **Phase 3.** The session pin is still inert behind every same-host tunnel (issue #1762). This PR does not change any auth decision, binding, comparison, or TTL. Phase 1's posture row and guide warning remain the honest signal until Phase 3 lands.
- **Any bind change.** `is_local_only()` still returns `True`; the gateway still binds loopback. `tailscale serve` proxies to it.

## Tests

`test/test_tailnet_origin.py`, 47 tests, weighted toward the security surface:

- **Validation as an injection-rejection suite** — 17 rejected forms above, each named for what it represents rather than lumped into one parametrize; plus non-strings and the length cap.
- **Failure modes all return `None` and none raise** — CLI absent, `TimeoutExpired`, `OSError` on exec, non-zero exit, and seven shapes of unusable stdout (empty, garbage, wrong top-level type, no `Self`, `Self` not a dict, no `DNSName`). One test specifically feeds a *hostile* name through otherwise-valid output: the daemon is trusted to be the daemon, not to be well-behaved.
- **Entry point** — disabled never touches the daemon (asserted via `assert_not_called`, so the short-circuit can't rot into a wasted thread hop); enabled resolves off the event loop; enabled-but-unresolvable yields `""`.
- **Origin set** — absent by default; contributed as `https://` with no port; the `Host` allowlist follows; coexists with `dashboard.url`; the loopback floor is untouched. Absence is stated as set arithmetic (`contributed - baseline == {…}`), which also pins that the opt-in adds exactly one origin and no stray `:port` variant.
- **The config opt-in actually survives load and save** (`test/test_config_loader.py`) — `DashboardConfig` is built field-by-field, so a nested section nobody wires up is dropped silently: the documented `config set dashboard.tailscale.enabled true` would read back `False` and then be rewritten to `false` by the next unrelated `save()`, leaving the feature inert while looking configured. Both halves are pinned, plus malformed-section degradation.
- **An explicit opt-in that resolves to nothing warns** — debug-level silence is right for a host that never opted in, but for one that did it reproduces the same bare 403 with nothing above debug saying why. The off path is separately asserted to stay silent, which is what keeps the warning meaningful.

## Manual verification

**N/A on this host, and worth stating plainly: this dev desk has no Tailscale installed**, so the happy path is exercised only against a mocked daemon. What that leaves unverified is the real shape of `tailscale status --json` on a live tailnet — the code reads `Self.DNSName`, and if a future CLI moved it the result is `None` (feature silently contributes nothing), not a crash. Everything else — the validator, every failure mode, the threading, and the origin/host wiring — is covered above.

## Gates

`pytest` 436 passed (new file + `test_dashboard_origin` / `test_config_loader` / `test_config_baseline` / `test_config_schema` / `test_spawn_audit`), `isort`, `flake8 -j 1`, `mypy` 1.14.1 (732 files) — clean. `docs-lint`, `brand-lint`, `scrub-lint` green. `config-baseline.json` regenerated; the diff is only the two new entries.

`test_spawn_audit.py` requires every `subprocess` spawn under `src/kiro_crew` to route through `sandboxed_spawn_argv` or be listed in `BENIGN_SPAWNS` with a justification. `dashboard/tailnet.py::_run_json` is listed rather than routed, because routing it would make dashboard startup depend on sandbox availability — precisely the failure this module's "nothing raises" property exists to rule out. Being listed is not a free pass, so the spawn is hardened on both axes it could be reached through:

- **The binary is pinned, not looked up.** Resolution walks a vetted absolute allowlist (`/usr/bin`, `/usr/local/bin`, `/opt/homebrew/bin`, the macOS app bundle, the Windows install dir) and never consults `PATH`. A `PATH` lookup made the *executable* attacker-selectable even though the arguments never were: `~/.local/bin` is both on `PATH` and agent-writable, so a planted `tailscale` would be executed by the next gateway start, in-process, with the gateway's environment. A non-standard install is therefore not auto-derived and keeps using explicit `dashboard.url`.
- **The environment is scrubbed.** `env=sandbox.scrub_env()` rather than inheriting `os.environ` — the repo's own scrubber, not a second policy invented here, so it cannot drift and stays cross-OS safe.

One fixed argv (`status --json`), 3s timeout, no shell, no cwd. `TestSpawnHardening` pins all of it, including that `shutil.which` is never called and that the passed env is non-empty (an over-scrub that strips `HOME` / `SystemRoot` breaks the macOS and Windows CLIs).


