### PR TITLE
docs(rfc): wheel managed-venv replacement invariants + apply-consent open question

### DIFF
--- a/docs/request-for-change/rfc-update-architecture.md
+++ b/docs/request-for-change/rfc-update-architecture.md
@@ -417,6 +417,95 @@ capability check it never had.
   running gateway holds live sessions; the helper is what makes the swap
   survivable.
 
+  **Managed-venv replacement mechanics (invariants, not a settled design).**
+  `cli.sh` has two install branches, and only one of them is pipx. The other —
+  the default when pipx is absent — is a fixed-path managed venv
+  (`${KIROCREW_HOME}-venv`, `cli.sh:331`) upgraded **in place** today. For that
+  shape the promising direction is *versioned trees with atomic promotion*:
+  build `crew-venv-<version>` completely while the old gateway keeps serving,
+  then promote a stable path to point at it, then restart. (Precedent:
+  Claude Code's native installer keeps per-version binaries under
+  `~/.local/share/claude/versions/` behind one symlink; Codex CLI instead
+  detects the owning package manager and delegates.) A cross-vendor
+  adversarial council reviewed a concrete version of this design
+  (2026-08-06, GPT 5.6 / DeepSeek 3.2 / GLM 5 — REVISE / REJECT / REVISE)
+  and reduced it to the following **invariants any Phase 2 implementation
+  must satisfy**, with the mechanism itself left to the implementation PR:
+
+  - **Promotion must be actually atomic.** `ln -sfn` is unlink + create — a
+    missing-path window — and is not atomic on NFS at all. Atomic promotion is
+    a sibling symlink replaced via `rename(2)` / `os.replace`.
+  - **Every persisted launch path must resolve through the stable path.** At
+    least four exist today: `KIROCREW_SERVICE_BIN`, the `kirocrew_bin()` value
+    systemd renders into `ExecStart`, the generated macOS live-gateway
+    launcher, and the non-service restart in `updates.py`, which re-execs
+    `sys.executable` — the old version-specific interpreter. Fixing only the
+    service unit resurrects the old tree on every other path.
+  - **The old-inode guarantee holds only for versioned trees.** A Python
+    process imports lazily; after a flip, not-yet-imported modules resolve from
+    the new tree. "The running gateway is unaffected" is true only once the
+    running gateway was itself started from an immutable versioned directory —
+    which makes the **first migration** (moving off today's fixed real
+    directory without breaking the live venv's absolute shebangs) a protocol
+    of its own. That protocol is now defined:
+
+    **First-migration protocol.** The existing `${KIROCREW_HOME}-venv` real
+    directory is **never renamed, moved, or converted in place** — renaming it
+    breaks its own absolute shebangs while a gateway may still be running from
+    it, and a non-empty directory cannot be atomically replaced by a symlink
+    anyway. Instead the stable path is a **new name** that has always been a
+    symlink:
+
+    1. The helper builds `crew-venv-<version>` fresh and verifies it
+       (provenance per this section, hash-pinned dependencies, import check).
+    2. It creates `crew-venv-current → crew-venv-<version>` atomically
+       (sibling symlink + `rename(2)`; trivially safe because the name did not
+       previously exist).
+    3. The installer rewrites **all four persisted launch paths** (above) to
+       resolve through `crew-venv-current`, re-rendering the service unit and
+       the generated macOS launcher.
+    4. Drain per §5, restart via the supervisor, then the post-restart
+       health + version handshake.
+    5. **On a failed handshake**, launch paths are pointed back at the old
+       fixed directory — which still works, because it was never touched. This
+       is a *fallback to a still-functional tree*, not a rollback protocol,
+       and is consistent with rollback remaining a non-goal.
+    6. The old fixed directory is pruned only after N consecutive verified
+       boots (suggested N=3), and a pruning failure never fails an update.
+
+    The load-bearing property: **no tree that a live process might be using is
+    ever moved or deleted**, and the atomicity problem of replacing a real
+    directory with a symlink is dodged entirely by putting the symlink at a
+    fresh name. Subsequent updates are pure symlink flips on
+    `crew-venv-current` and never revisit this protocol.
+  - **A fresh venv re-resolves the dependency graph.** `setup.cfg` carries wide
+    ranges; a rebuilt environment downloads packages covered by nobody's
+    signature. The install step needs locked, hash-pinned constraints (or a
+    wheelhouse) inside the verified payload, or the provenance story covers
+    only the Kiro Crew wheel itself.
+  - **Provenance must bind more than a digest.** The feed is unsigned; an
+    actor who controls it can point at a *different* artifact with valid
+    provenance from the same repo. Verification must check workflow, commit
+    lineage and channel policy against the client-pinned root — and the SLSA
+    requirement above is unconditional; no "or" fallbacks.
+  - **pipx delegation is not a safety property.** `pipx install --force`
+    mutates the fixed pipx environment in place while the old gateway is using
+    it — the torn-runtime hazard this section exists to avoid. If Phase 2
+    ships a pipx apply path at all, it drains first, accepts the downtime, and
+    documents rollback as unsupported for that shape. Which branch owns a
+    given install is also **not derivable at update time** (pipx presence now
+    proves nothing about install time); the installer must persist the branch
+    it took.
+  - **Rollback stays a non-goal.** Retained old trees are *manual recovery
+    targets*, nothing more; any pruning policy must never delete the tree the
+    running process was started from, and cleanup failures must not fail the
+    update.
+  - **macOS TCC identity across path rotation is an open compatibility test,
+    not a solved problem.** The console script's shebang names the rotating
+    versioned interpreter, so a stable outer symlink may not preserve grants
+    (Claude Code hit exactly this: anthropics/claude-code#76246, #77081,
+    #80899).
+
   The checksum is necessary and not sufficient. `SHA256SUMS` is served from the
   same CDN as the wheel, so an actor who can replace one can replace both —
   `publish-cli.yml:85-87` says this in as many words ("integrity, not
@@ -444,9 +533,12 @@ post-restart verification.
 | source | notify only | same | same |
 
 **"Explicit" means a deliberate user action, not necessarily a terminal.** An
-in-app Apply button is as explicit as typing the command, and since the backend
-can invoke the install helper it can serve both — which is why `wheel` carries
-`can_apply: true` after Phase 2. What is ruled out for the CLI shape is the
+in-app Apply button and `kirocrew update` in a terminal both qualify, and since
+the backend can invoke the install helper it can serve both — which is why
+`wheel` carries `can_apply: true` after Phase 2. They are **not equivalent in
+authority**, however: the in-app path additionally requires the host-local
+step-up resolved in Open Question 7, because a dashboard session is weaker
+authority than a shell on the host. What is ruled out for the CLI shape is the
 *silent* path: no background download-and-swap, no apply without the user asking
 for it in one of those two places.
 
@@ -706,6 +798,32 @@ see §4.
    `unavailable_reason` by §2 but not yet expressed as `check_status`. Unifying
    them is right in principle and may not be worth a Phase 1b churn on a lane
    that currently works.
+7. **RESOLVED — the dashboard session is NOT sufficient authority to install
+   code; Apply requires a gateway-enforced, host-local step-up.** The button
+   turns an update into a network-reachable code-install trigger for anyone
+   holding a dashboard session — including sessions arriving through tunnels
+   (Tailscale serve / cloudflared). This repository has already documented
+   (issue #1762) that IP pinning is broken under every same-host proxy, making
+   the session effectively a transferable bearer for remote access. A
+   credential with that mobility is acceptable authority for chat and
+   operations; it is not acceptable authority for replacing the gateway's own
+   code. A frontend confirmation dialog changes nothing: the SPA is served
+   from the CDN and a compromised SPA can dismiss its own modal.
+
+   **Mechanism.** Apply from the SPA *arms* a pending update request (single-
+   use nonce; TTL ≈ 10 minutes; recorded with target version, channel,
+   artifact digest, attempt id, and request source). Approval requires an
+   action the SPA cannot perform for itself: `kirocrew update approve` run on
+   the gateway host, whose identity comes from loopback + filesystem access
+   rather than the dashboard session. Only an armed-and-approved request may
+   enter §5's drain-then-swap. The audit record gains the approval's origin
+   and outcome; an expired or unapproved request decays without side effects.
+
+   **What this rules out and keeps.** One-click remote apply is deliberately
+   ruled out in Phase 2. A future policy key could relax the step-up for
+   fleets that accept the reduced posture, but it is not part of this design
+   and would need its own review. `kirocrew update` run in a terminal on the
+   host already *is* the step-up, so the CLI path needs no extra ceremony.
 
 ## Provenance
 
@@ -785,4 +903,30 @@ independently; sources in the session record):
   which walks up to any ancestor repo) is itself an instance of the failure
   these two walk-backs describe, which is why OQ5 requires the equality check
   rather than the exit status alone.
+
+### Managed-venv mechanics review (2026-08-06, same day, second panel)
+
+A second adversarial panel (`gpt-5.6-sol`, `deepseek-3.2`, `glm-5`; a fourth
+member failed twice on an upstream error) red-teamed a concrete
+versioned-venv-plus-symlink-flip design for the wheel shape, drawn from a
+comparison against Claude Code's native installer (per-version binaries behind
+one symlink) and Codex CLI (detect the owning package manager and delegate).
+Verdicts: REVISE / REJECT / REVISE. The direction survived; the specific
+guarantees did not — `ln -sfn` is not atomic, the old-inode claim ignores lazy
+imports, four persisted launch paths exist rather than one, a rebuilt venv
+re-resolves unsigned dependencies, digest-only provenance admits
+artifact-substitution from an unsigned feed, and pipx delegation re-creates the
+in-place torn-runtime hazard. Per the panel's convergent placement finding, the
+outcome entered §3 as **invariants plus a first-migration open problem**, and
+the consent exposure as Open Question 7 — not as a settled mechanism. The
+mechanism itself is Phase 2 implementation-PR territory.
+
+Human review (rajpratham1, 2026-08-07) then required both open boundaries to be
+resolved before Phase 2 implementation. This revision resolves them: the
+first-migration protocol is defined in §3 (fresh stable symlink name; the
+existing fixed directory is never moved and remains a functional fallback), and
+Open Question 7 is resolved to a gateway-enforced, host-local step-up for the
+in-app Apply — the dashboard session alone is explicitly not sufficient
+authority to install code, on the strength of the documented tunnel-pin
+breakage (issue #1762).
 


### PR DESCRIPTION
## Problem

The RFC's §3 wheel-engine entry says only "perform the pipx replacement from an
external helper process" — but `cli.sh`'s **default** branch (when pipx is
absent) is a fixed-path managed venv upgraded in place, and the RFC says
nothing about how that shape gets replaced safely under a running gateway.
Separately, the Phase 2 in-app Apply button turns updating into a
network-reachable code-install trigger, and the RFC's consent model never
addresses the session-holder-via-tunnel adversary.

## Why it matters

Phase 2 (wheel apply path) is the next implementation step. Without recorded
constraints, the obvious design — versioned venvs behind a symlink, flipped
with `ln -sfn` — ships with real defects: `ln -sfn` is not atomic, only one of
four persisted launch paths would follow the flip, a rebuilt venv silently
re-resolves unsigned dependencies, and an unsigned feed admits
artifact-substitution against digest-only provenance checks.

## Fix (symptoms → root cause → change)

A concrete versioned-venv + symlink-flip design (drawn from a Claude Code /
Codex CLI comparison) was adversarially reviewed by a second cross-vendor
panel (`gpt-5.6-sol` REVISE / `deepseek-3.2` REJECT / `glm-5` REVISE). The
direction survived; the specific guarantees did not. Per the panel's
convergent placement finding, the outcome enters the RFC as **constraints,
not a settled mechanism**:

- **§3 wheel engine** — a "managed-venv replacement mechanics" subsection
  recording eight invariants any Phase 2 implementation must satisfy:
  atomic promotion via `rename(2)`/`os.replace` (never `ln -sfn`); all four
  persisted launch paths (`KIROCREW_SERVICE_BIN`, systemd `ExecStart`, the
  generated macOS launcher, the non-service `sys.executable` re-exec) must
  resolve through the stable path; the old-inode guarantee holds only for
  versioned trees, making the first migration its own protocol; hash-pinned
  dependency constraints inside the verified payload; provenance binding
  workflow/commit/channel rather than digest alone; pipx delegation is not a
  safety property; rollback stays a non-goal (retained trees are manual
  recovery targets); macOS TCC across path rotation is an open compatibility
  test.
- **Open Question 7** — what consent the in-app Apply requires, given any
  dashboard-session holder (including via tunnels) can reach the endpoint and
  a frontend confirmation cannot bind that adversary.
- **Provenance** — the second-panel record (roster, verdicts, and why this
  lands as invariants + open problem).

Docs-only; +94 lines on one file. Follows #1797 (merged as `48a8765a`), which
this extends with the same fold-learnings-back-into-the-RFC intent.

## Tests

N/A — documentation-only. Gates run locally: `scripts/docs-lint.sh` (all
checks passed) and the diff-scoped brand gate
(`BRAND_BASE_REF=origin/main scripts/check_brand_name.py`, no misspellings in
added lines).

## Manual verification

Every code claim in the added text was verified against the tree before
writing: `cli.sh:331` (managed-venv branch), `cli.sh:164,245` (signature
verification lives in the installer), `updates.py`'s non-service re-exec of
`sys.executable`, and `service/` restart mechanics. External precedent claims
(Claude Code versioned binaries + TCC issues #76246/#77081/#80899, Codex CLI
delegation) are cited to their sources in the Provenance section.

## Screenshots

N/A — no user-visible UI change.
