### PR TITLE
fix(stt): gate --fp16 flag to openai-whisper only

### DIFF
--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -699,12 +699,32 @@ async def _transcribe_apple(audio_path: str, stt_config) -> str | None:  # type:
     return text
 
 
+def _is_openai_whisper(whisper_bin: str) -> bool:
+    """True when *whisper_bin* is the reference openai-whisper CLI.
+
+    ``--fp16`` is an openai-whisper-only flag (it silences the "FP16 is not
+    supported on CPU" warning). Drop-in replacements advertised as
+    openai-whisper-compatible — e.g. ``whisper-ctranslate2`` — do not implement
+    it and exit ``rc=2`` (``unrecognized arguments: --fp16``), which surfaces to
+    the user as a silent empty transcript. openai-whisper's console script is
+    always named ``whisper`` (``whisper`` / ``whisper.exe``), so gating on the
+    resolved binary's stem lets a compatible engine work through the existing
+    ``stt.whisper_path`` setting with no extra config. Getting this wrong for a
+    genuine openai-whisper install only restores a harmless CPU warning; wrongly
+    passing the flag to an engine that rejects it breaks transcription outright,
+    so the check errs toward omitting the flag when unsure.
+    """
+    return Path(whisper_bin).stem.lower() == "whisper"
+
+
 async def _transcribe_native(audio_path: str, stt_config) -> str | None:  # type: ignore[no-untyped-def]
-    """Transcribe using the native openai-whisper binary."""
+    """Transcribe using the native openai-whisper (or a compatible) binary."""
     whisper_bin = await asyncio.to_thread(_find_whisper, stt_config.whisper_path)
     if not whisper_bin:
         logger.error("whisper not found — install: pip install openai-whisper")
         return None
+
+    add_fp16 = _is_openai_whisper(whisper_bin)
 
     return await _run_whisper_cli(
         whisper_bin,
@@ -718,8 +738,9 @@ async def _transcribe_native(audio_path: str, stt_config) -> str | None:  # type
             out_dir,
             "--output_format",
             "txt",
-            "--fp16",
-            "False",
+            # ``--fp16`` is openai-whisper-only; omit it for compatible engines
+            # (e.g. whisper-ctranslate2) that would reject it with rc=2.
+            *(["--fp16", "False"] if add_fp16 else []),
         ],
         stt_config.timeout_secs,
         label="whisper",

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -16,6 +16,7 @@ from kiro_crew.transcribe import (
     BREW_PATH_DIRS,
     _find_mlx_whisper,
     _find_whisper,
+    _is_openai_whisper,
     _ProfileCredentialResolver,
     find_brew,
     is_available,
@@ -148,6 +149,89 @@ class TestFindWhisper:
             monkeypatch.setattr("kiro_crew.transcribe._python3_bin_dir", lambda: str(scripts))
             monkeypatch.setattr("kiro_crew.transcribe._WHISPER_SEARCH_PATHS", [])
             assert _find_whisper("") == str(exe)
+
+
+# ---------------------------------------------------------------------------
+# _is_openai_whisper — the --fp16 gate (issue #1896)
+# ---------------------------------------------------------------------------
+
+
+class TestIsOpenaiWhisper:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "whisper",
+            "/usr/bin/whisper",
+            "/opt/homebrew/bin/whisper",
+            "whisper.exe",  # Windows console script — .stem drops the suffix
+            "/usr/bin/WHISPER",  # case-insensitive
+        ],
+    )
+    def test_reference_binary_is_openai(self, path):
+        assert _is_openai_whisper(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "whisper-ctranslate2",
+            "/usr/local/bin/whisper-ctranslate2",
+            "/home/u/.local/bin/faster-whisper",
+            "/usr/bin/whisperx",
+            "/opt/whisper-cpp/main",
+        ],
+    )
+    def test_dropin_engines_are_not_openai(self, path):
+        assert _is_openai_whisper(path) is False
+
+
+# ---------------------------------------------------------------------------
+# _transcribe_native --fp16 gating end-to-end (issue #1896)
+# ---------------------------------------------------------------------------
+
+
+class TestNativeFp16Gating:
+    """``--fp16 False`` must reach openai-whisper but never a drop-in engine.
+
+    Passing it to whisper-ctranslate2 makes the CLI exit rc=2 and the user sees
+    a silent empty transcript, so the flag is gated on the resolved binary name.
+    """
+
+    async def _run_native(self, tmp_path, whisper_bin: str) -> list:
+        audio = tmp_path / "test.webm"
+        audio.write_text("fake audio")
+        cfg = SttConfig(enabled=True, provider="whisper", timeout_secs=10)
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        captured: dict = {}
+
+        async def fake_exec(*args, **kwargs):
+            captured["args"] = list(args)
+            out_dir = args[args.index("--output_dir") + 1]
+            Path(out_dir).joinpath("test.txt").write_text("hello world")
+            return mock_proc
+
+        with patch("kiro_crew.transcribe._find_whisper", return_value=whisper_bin):
+            with patch(
+                "kiro_crew.transcribe.asyncio.create_subprocess_exec", side_effect=fake_exec
+            ):
+                result = await transcribe_audio(str(audio), cfg)
+        assert result == "hello world"
+        return captured["args"]
+
+    @pytest.mark.asyncio
+    async def test_openai_whisper_gets_fp16(self, tmp_path):
+        args = await self._run_native(tmp_path, "/usr/bin/whisper")
+        assert "--fp16" in args
+        assert args[args.index("--fp16") + 1] == "False"
+
+    @pytest.mark.asyncio
+    async def test_dropin_engine_omits_fp16(self, tmp_path):
+        args = await self._run_native(tmp_path, "/usr/local/bin/whisper-ctranslate2")
+        assert "--fp16" not in args
+        # The rest of the invocation is unchanged — the engine still gets its model/output flags.
+        assert "--model" in args and "--output_format" in args
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1896

## Problem / Motivation

`_transcribe_native` in `src/kiro_crew/transcribe.py` unconditionally appended `--fp16 False` to the whisper CLI invocation. `--fp16` is an **openai-whisper-only** flag (it silences the "FP16 is not supported on CPU" warning). Engines advertised as drop-in openai-whisper replacements — e.g. `whisper-ctranslate2`, pointed at via the existing `stt.whisper_path` setting — do not implement it and exit `rc=2` (`unrecognized arguments: --fp16`). The failure surfaces to the user only as a **silent empty transcript**; the rc/stderr detail is buried in the gateway log.

## Why it matters

Users who set `stt.whisper_path` to a faster CPU-friendly whisper-compatible engine (the documented way to swap engines) get empty transcripts with no visible error. The setting looks supported but silently produces nothing, which is hard to diagnose.

## What changed (motivation → approach → change)

- **Symptom:** empty transcript from any whisper-compatible engine that rejects `--fp16`.
- **Root cause:** the flag was appended for every engine, not just openai-whisper.
- **Approach:** gate the flag on the resolved binary. openai-whisper's console script is always named `whisper` (`whisper` / `whisper.exe`), so a name probe lets compatible engines work through the existing `stt.whisper_path` setting **with no new config**. I chose the name probe over a config knob (which users would have to discover) or a detect-rejection-and-retry (which costs every affected engine a wasted run). The check errs toward *omitting* the flag when unsure: wrongly omitting it for real openai-whisper only restores a harmless CPU warning, whereas wrongly passing it breaks transcription outright.
- **Change:** new `_is_openai_whisper(bin)` helper; `_transcribe_native` appends `--fp16 False` only when it returns True.

**Known limitation:** symlinking a non-openai engine to the name `whisper` would defeat the probe. Noted here as a maintainer call — a `stt.whisper_fp16` config knob or rejection-retry could be layered on later if that case matters.

## Tests

New in `test/test_transcribe.py`:
- `TestIsOpenaiWhisper` — parametrized unit tests: reference `whisper` paths (incl. `whisper.exe`, uppercase) → True; drop-in engine names (`whisper-ctranslate2`, `faster-whisper`, `whisperx`, `whisper-cpp/main`) → False.
- `TestNativeFp16Gating` — end-to-end via the existing subprocess-capture pattern: asserts `--fp16 False` **is** in the args for `/usr/bin/whisper`, and **is not** for `whisper-ctranslate2` (while `--model`/`--output_format` remain).

Full `test/test_transcribe.py` suite: 66 passed, 1 skipped. `isort` and `mypy 1.14.1` clean.

## Manual verification

N/A — the bug is entirely in subprocess argument construction, which the new tests assert exactly. The third-party engine's `rc=2` behavior on `--fp16` is already established in the issue's repro; I did not re-run the real binaries.

## Related Issues

Closes #1896

## Checklist

- [x] Single commit with a Conventional Commits title (`fix(stt): gate --fp16 flag to openai-whisper only`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: internal behavior fix, no user-facing docs affected
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR. -->