### PR TITLE
fix(dashboard): keep a channel tab's reads and writes on one transcript

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -28,7 +28,7 @@ from kiro_crew.apps.manager import is_app_enabled
 from kiro_crew.autonudge import get_instance as _autonudge_instance
 from kiro_crew.config.paths import data_home
 from kiro_crew.dashboard.chat_utils import (
-    effective_session_key,
+    slot_history_key,
 )
 from kiro_crew.knowledge.llm_pool import LLMPool
 
@@ -1014,7 +1014,7 @@ async def _launch_loop(request: web.Request, cid: str) -> None:
     if getattr(state, "conversation_log", None) is not None:
         try:
             await asyncio.to_thread(
-                state.conversation_log.set_title, effective_session_key(slot), slot.title
+                state.conversation_log.set_title, slot_history_key(slot), slot.title
             )
         except Exception:
             logger.warning("auto_research: failed to persist slot title for %s", cid, exc_info=True)

--- a/src/kiro_crew/dashboard/channel_slots.py
+++ b/src/kiro_crew/dashboard/channel_slots.py
@@ -265,6 +265,7 @@ def surface_channel_session(
             name=slot_name,
             agent=meta.get("agent", "") or "",
             linked_session_key=session_key,
+            channel_origin=True,
         )
     except ValueError:
         # A slot with this name exists under a conflicting memory_mode. Leave it

--- a/src/kiro_crew/dashboard/chat_backfill.py
+++ b/src/kiro_crew/dashboard/chat_backfill.py
@@ -25,7 +25,7 @@ import logging
 from typing import Any, NamedTuple
 from urllib.parse import quote
 
-from kiro_crew.dashboard.chat_utils import effective_session_key
+from kiro_crew.dashboard.chat_utils import slot_history_key
 from kiro_crew.dashboard.urls import dashboard_origin
 
 logger = logging.getLogger(__name__)
@@ -111,11 +111,13 @@ def _transcript_prefix(state: Any, slot: Any, disk_older: int) -> list[dict[str,
     if log is None:
         return []
     try:
-        # effective_session_key, never _history_key_for: the latter prepends
+        # slot_history_key, never _history_key_for: the latter prepends
         # "dashboard:" unconditionally, so a channel-born slot would resolve to
         # the nonexistent "dashboard:slack:<ts>" and read an empty file -- a
-        # silent zero-turn result rather than an error.
-        rows = log.read_messages_chained(effective_session_key(slot))
+        # silent zero-turn result rather than an error. It also resolves an
+        # UNBOUND channel slot (no mapped session key) onto the channel
+        # transcript instead of a phantom "dashboard:slack_<ts>" file.
+        rows = log.read_messages_chained(slot_history_key(slot))
     except Exception:
         logger.debug("backfill: could not read transcript for the first turn", exc_info=True)
         return []

--- a/src/kiro_crew/dashboard/chat_fork.py
+++ b/src/kiro_crew/dashboard/chat_fork.py
@@ -11,6 +11,7 @@ from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.chat_utils import (
     _sync_dashboard_slots,
     effective_session_key,
+    slot_history_key,
 )
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.history import carry_provenance
@@ -137,7 +138,7 @@ async def api_chat_slot_fork(request: web.Request) -> web.Response:
     async with slot._fork_lock:
         all_messages: list[dict] = []
         if state.conversation_log:
-            all_messages = state.conversation_log.read_messages_chained(effective_session_key(slot))
+            all_messages = state.conversation_log.read_messages_chained(slot_history_key(slot))
         if all_messages and slot._dirty:
             new_msgs = slot.messages[slot._resumed_count:]
             if new_msgs:

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -58,6 +58,7 @@ from kiro_crew.dashboard.chat_utils import (
     _remove_queued_by_id,
     _sync_dashboard_slots,
     effective_session_key,
+    slot_history_key,
 )
 from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
 from kiro_crew.dashboard.state import (
@@ -770,7 +771,7 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
     if limit_raw is None and before is None:
         mem_msgs = list(slot.messages)
         if slot._disk_older_count > 0 and state.conversation_log:
-            history_key = effective_session_key(slot)
+            history_key = slot_history_key(slot)
             try:
                 disk_msgs = state.conversation_log.read_messages_chained(history_key)
             except Exception:
@@ -786,7 +787,7 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
         # Legacy pagination path (retained for programmatic callers).
         # Always reads from chained disk history; no in-memory offset math.
         limit = min(int(limit_raw or "200"), 500)
-        history_key = effective_session_key(slot)
+        history_key = slot_history_key(slot)
         try:
             all_msgs = (
                 state.conversation_log.read_messages_chained(history_key)
@@ -2804,7 +2805,7 @@ def _resume_session_identity(state: DashboardState, history_key: str) -> str:
     """
     if is_channel_session_key(history_key) and state.sessions:
         real_key = state.sessions.channel_key_for_stem(channel_slot_name(history_key))
-        if real_key:
+        if isinstance(real_key, str) and is_channel_session_key(real_key):
             return real_key
     return _history_key_for(history_key)
 
@@ -2894,7 +2895,14 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
             }
         )
 
-    slot = state.get_or_create_slot(name, app=request.get("app", ""))
+    slot = state.get_or_create_slot(
+        name,
+        app=request.get("app", ""),
+        # Resuming an existing channel transcript from History is an adoption of
+        # that conversation, so the tab is channel-origin even when the session
+        # map can no longer name its session.
+        channel_origin=is_channel_session_key(history_key),
+    )
     title = body.get("title", "")
     if title:
         slot.title = title

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -21,7 +21,7 @@ from kiro_crew.dashboard.chat_utils import (
     _normalize_model,
     _redact_meta_for_role,
     _sync_dashboard_slots,
-    effective_session_key,
+    slot_history_key,
     slot_transcript_key,
 )
 from kiro_crew.dashboard.state import DashboardState, _ChatSlot, _normalize_slot_key
@@ -390,7 +390,22 @@ def _rehydrate_slot_from_history(
     restricted_key = f"dashboard:{slot_name}"
     preexisting_restricted = restricted_key in state._restricted_keys
     try:
-        slot = state.get_or_create_slot(slot_name, app=meta.get("app", ""))
+        slot = state.get_or_create_slot(
+            slot_name,
+            app=meta.get("app", ""),
+            # PERSISTED provenance only. A name is not evidence: main supports a
+            # dashboard slot a caller happened to name ``slack_notes`` (see
+            # test_slack_dashboard_live_sync's "the guard must not be a name
+            # heuristic"), so inferring channel origin from the stem would let a
+            # fresh dashboard conversation adopt a real thread's transcript.
+            # A legacy channel transcript carrying neither marker is surfaced by
+            # ``channel_slot_reconciler`` instead, which sets the flag -- and the
+            # first save then persists it, so later boots need no inference.
+            channel_origin=(
+                bool(meta.get("channel_origin"))
+                or bool(meta.get("linked_session_key"))
+            ),
+        )
         # Title comes from the metadata line we already read above. We deliberately
         # do NOT consult ``list_sessions()`` here: that call globbed + stat'd + read
         # the first line of EVERY session file in the history dir (O(all sessions))
@@ -718,7 +733,13 @@ def _restore_recent_sessions_steps(
         if not has_folder and not has_pin:
             if cutoff is not None and s.get("modified", 0) < cutoff:
                 continue
-        slot = state.get_or_create_slot(slot_name, app=meta.get("app", ""))
+        slot = state.get_or_create_slot(
+            slot_name,
+            app=meta.get("app", ""),
+            # No channel_origin here: this loop `continue`s above for every
+            # non-dashboard key, so a channel-born session never reaches it --
+            # ``channel_slot_reconciler`` owns surfacing those.
+        )
         # Titles can be LLM-generated (auto-title) and are surfaced on the
         # dashboard — apply the same redaction as assistant content. Matches
         # the treatment in _rehydrate_slot_from_history above.
@@ -1400,7 +1421,7 @@ def _save_slot_to_history(
         and not rewrite
     ):
         return
-    history_key = effective_session_key(slot)
+    history_key = slot_history_key(slot)
     try:
         # Hold the SAME per-session cross-process lock that ``append`` /
         # ``append_off_loop`` / rotate / rewrite / metadata mutations take, across
@@ -1493,6 +1514,12 @@ def _save_slot_to_history(
                 # without persisting it the slot rehydrates unbound and
                 # silently reverts to a dashboard-only copy of the thread.
                 meta_line["linked_session_key"] = slot.linked_session_key
+            if getattr(slot, "channel_origin", False):
+                # Durable provenance. Without it the restore has only the slot
+                # name to go on, and a name is not evidence -- persisting the
+                # flag is what lets a later boot know this tab was adopted from
+                # a channel conversation rather than merely named like one.
+                meta_line["channel_origin"] = True
             tab_id = getattr(slot, "_tab_id", None) or existing_meta.get("tab_id")
             if tab_id:
                 meta_line["tab_id"] = tab_id
@@ -1576,7 +1603,7 @@ def _save_slot_to_history(
                     )
 
             _preserve_mtime: float | None = None
-            if closed and slot.linked_session_key:
+            if closed and (slot.linked_session_key or is_channel_session_key(history_key)):
                 # This slot shares its transcript with a channel, and the
                 # reconciler decides whether a close still stands by comparing
                 # the file's mtime against ``closed_at``: activity newer than the
@@ -1585,6 +1612,16 @@ def _save_slot_to_history(
                 # past ``closed_at`` and make the close outrun itself — the tab
                 # would reopen on the next pass. Restore the pre-close mtime so
                 # only a genuine channel append can outrun the close.
+                #
+                # Gated on the TRANSCRIPT, not on ``linked_session_key``: an
+                # UNBOUND channel tab (the session map could not resolve its
+                # stem) writes this very same shared file, so testing the binding
+                # left exactly that tab unprotected — its close bumped the
+                # channel file's mtime and ``_close_stands`` then rejected the
+                # close, resurfacing the tab on the next reconcile. Keeping the
+                # ``linked_session_key`` arm makes this strictly additive for
+                # cron- and workflow-linked slots, whose keys are not channel
+                # keys but which also share a transcript.
                 try:
                     _preserve_mtime = path.stat().st_mtime
                 except OSError:

--- a/src/kiro_crew/dashboard/chat_rewind.py
+++ b/src/kiro_crew/dashboard/chat_rewind.py
@@ -29,6 +29,7 @@ from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
 from kiro_crew.dashboard.chat_runner import _run_chat
 from kiro_crew.dashboard.chat_utils import (
     effective_session_key,
+    slot_history_key,
 )
 from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
 from kiro_crew.dashboard.state import DashboardState
@@ -145,7 +146,7 @@ async def api_chat_slot_rewind(request: web.Request) -> web.Response:
                 if disk_older > 0 and state.conversation_log is not None:
                     try:
                         chained = state.conversation_log.read_messages_chained(
-                            effective_session_key(slot)
+                            slot_history_key(slot)
                         )
                     except Exception:
                         logger.debug("rewind: chained scan for ts failed", exc_info=True)

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -83,6 +83,7 @@ from kiro_crew.dashboard.chat_utils import (
     _validate_tool_name,
     effective_session_key,
     is_system_injection,
+    slot_history_key,
 )
 from kiro_crew.dashboard.handlers import (
     MAX_PROMPT_BYTES,
@@ -3191,7 +3192,7 @@ async def _run_chat(
                     _last_stop_soft = True
                 break
             if not _last_stop_soft:
-                history_key = effective_session_key(slot)
+                history_key = slot_history_key(slot)
                 disk_count = 0
                 if state.conversation_log:
                     disk_count = len(state.conversation_log.read_messages(history_key))

--- a/src/kiro_crew/dashboard/chat_slack.py
+++ b/src/kiro_crew/dashboard/chat_slack.py
@@ -17,7 +17,7 @@ from kiro_crew.dashboard.chat_backfill import (
     session_deep_link,
 )
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
-from kiro_crew.dashboard.chat_utils import effective_session_key
+from kiro_crew.dashboard.chat_utils import effective_session_key, slot_history_key
 from kiro_crew.dashboard.state import DashboardState, _log_task_exception
 from kiro_crew.platform.context import redact_via_context
 from kiro_crew.security import redact_and_truncate
@@ -392,6 +392,24 @@ async def api_chat_slot_handoff(request: web.Request) -> web.Response:
         pass
 
     history_key = effective_session_key(slot)
+    transcript_key = slot_history_key(slot)
+    if transcript_key != history_key:
+        # The tab's conversation is stored somewhere other than the session it
+        # runs on -- an unbound channel tab. Handing off would seed the thread
+        # from the channel transcript while every later reply persisted under
+        # the session's own key, splitting one conversation across two files;
+        # a crash before the next slot flush would drop those replies entirely.
+        # Refuse rather than straddle.
+        return web.json_response(
+            {
+                "error": (
+                    "this tab's conversation lives in a channel transcript, so it "
+                    "cannot be handed off to a new Slack thread"
+                ),
+                "code": "transcript_not_own_session",
+            },
+            status=409,
+        )
     thread_ts = await handoff_to_slack(
         state.slack_client,
         state.owner_id,
@@ -400,6 +418,7 @@ async def api_chat_slot_handoff(request: web.Request) -> web.Response:
         title=slot.title if slot._titled else "",
         channel=channel,
         sessions=state.sessions,
+        transcript_key=transcript_key,
     )
     if not thread_ts:
         return web.json_response({"error": "handoff failed"}, status=500)

--- a/src/kiro_crew/dashboard/chat_title.py
+++ b/src/kiro_crew/dashboard/chat_title.py
@@ -14,7 +14,7 @@ from kiro_crew.context import ui_language_tag
 from kiro_crew.context_management import extract_plan_metadata, rephrase_plan
 from kiro_crew.dashboard.chat_folder_suggest import maybe_suggest_folder
 from kiro_crew.dashboard.chat_utils import (
-    effective_session_key,
+    slot_history_key,
 )
 from kiro_crew.dashboard.state import NEW_SESSION_TITLE, DashboardState, _ChatSlot
 from kiro_crew.llm_helpers import run_bg_oneliner
@@ -682,7 +682,7 @@ async def _persist_title(state: DashboardState, slot: _ChatSlot) -> None:
     """
 
     if state.conversation_log:
-        history_key = effective_session_key(slot)
+        history_key = slot_history_key(slot)
         try:
             await asyncio.to_thread(
                 state.conversation_log.set_title, history_key, slot.title

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -430,8 +430,48 @@ def slot_transcript_key(slot_key: str) -> str:
     return _history_key_for(slot_key)
 
 
+def slot_history_key(slot: _ChatSlot) -> str:
+    """The TRANSCRIPT key for *slot* — the file its conversation is stored in.
+
+    Differs from :func:`effective_session_key` in exactly one case, and that
+    case is a real one: a channel-born slot the dashboard could not bind.
+    ``surface_channel_session`` deliberately surfaces such a slot **unbound**
+    when ``channel_key_for_stem`` cannot resolve its key (the session map was
+    pruned, or the thread predates it), because guessing would route replies to
+    a session the channel never reads. For that slot ``linked_session_key`` is
+    empty, so ``effective_session_key`` falls back to ``_history_key_for``,
+    which prefixes ``dashboard:`` and names a file NO restore path reads —
+    while every read path resolves the same slot through
+    :func:`slot_transcript_key` and gets the channel transcript. Reads and
+    writes then address different files: a close flag, a fork, or a backfill
+    lands on (or is looked for in) a phantom transcript.
+
+    Resolving the fallback through :func:`slot_transcript_key` puts both back on
+    one file. Deliberately does NOT change the slot's SESSION identity — an
+    unbound channel slot keeps running under ``dashboard:<name>``, so approval
+    policy and restricted-key bookkeeping keyed on that prefix stay intact.
+
+    Gated on the slot's ``channel_origin`` provenance, NOT on its name's shape.
+    A name is not provenance: ``POST /api/chat/slots`` accepts a client-supplied
+    slot name, so keying off the ``slack_<ts>`` shape alone would let a fresh
+    dashboard conversation write itself into an existing thread's transcript and
+    merge two unrelated histories. Only the paths that adopt an EXISTING channel
+    conversation (``surface_channel_session``, the restore, a History resume)
+    set the flag.
+
+    Use this wherever a slot is turned into a transcript path; use
+    :func:`effective_session_key` where a slot is turned into a session.
+    """
+    linked = getattr(slot, "linked_session_key", "")
+    if linked:
+        return linked
+    if getattr(slot, "channel_origin", False):
+        return slot_transcript_key(slot.key)
+    return _history_key_for(slot.key)
+
+
 def effective_session_key(slot: _ChatSlot) -> str:
-    """The session key AND transcript key for *slot* — one identity, one file.
+    """The session key for *slot* — the session its turns run on.
 
     A channel-born slot carries the real channel key (``slack:<ts>``) in
     ``linked_session_key``, so its turns run on the channel's own session and
@@ -440,10 +480,11 @@ def effective_session_key(slot: _ChatSlot) -> str:
     ``.jsonl``, so one key addresses both the live session and the file the
     channel side appends to. Everything else derives from the slot key.
 
-    Use this anywhere a slot's conversation is addressed — reading or writing
-    its transcript, resolving its session, mirroring its links. Reserve
-    :func:`_history_key_for` for the cases that genuinely start from a slot key
-    with no slot in hand.
+    Use this anywhere a slot's SESSION is addressed — resolving the session its
+    turns run on, mirroring its links. For the slot's TRANSCRIPT use
+    :func:`slot_history_key`, which resolves the unbound-channel-slot case onto
+    the file the read paths actually use. Reserve :func:`_history_key_for` for
+    the cases that genuinely start from a slot key with no slot in hand.
     """
     return getattr(slot, "linked_session_key", "") or _history_key_for(slot.key)
 

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -989,20 +989,30 @@ async def api_sessions_clear(request: web.Request) -> web.Response:
     if not state.conversation_log:
         return web.json_response({"error": "no conversation log"}, status=400)
 
-    from kiro_crew.dashboard.chat_utils import effective_session_key
+    from kiro_crew.dashboard.chat_utils import slot_history_key, slot_transcript_key
     from kiro_crew.history import _safe_key
 
     protected: set[str] = set()
     for slot in state._slots.values():
-        hk = effective_session_key(slot)
-        protected.add(hk)
-        # ``list_sessions`` reports filename stems, so protect the stem too.
-        # ``_safe_key`` is the function that produced the filename: a
-        # single-colon replace would leave a multi-colon channel key like
-        # ``discord:kirocrew:direct:123`` mapped to a stem that does not exist,
-        # so the open session would fall outside ``protected`` and this bulk
-        # delete would remove a live conversation's transcript.
-        protected.add(_safe_key(hk))
+        # Protect EVERY transcript this slot could be reading, not just the one
+        # it currently writes. ``list_sessions`` reports filename stems, so each
+        # candidate contributes its key AND its stem: ``_safe_key`` is the
+        # function that produced the filename, and a single-colon replace would
+        # leave a multi-colon channel key like ``discord:kirocrew:direct:123``
+        # mapped to a stem that does not exist, putting a live conversation
+        # outside ``protected`` so this bulk delete removes it.
+        #
+        # The union matters because a slot's write target and its DISPLAY source
+        # can differ: a channel tab the dashboard could not bind runs under
+        # ``dashboard:<stem>`` while the conversation on screen lives in the
+        # channel transcript. Choosing between them here would make deletion
+        # depend on provenance resolving correctly, and provenance is exactly
+        # what a legacy transcript cannot supply. Protection only ever PREVENTS
+        # a delete, so covering both candidates is the safe direction: the worst
+        # case is that Clear All skips a transcript nobody is reading.
+        for candidate in (slot_history_key(slot), slot_transcript_key(slot.key)):
+            protected.add(candidate)
+            protected.add(_safe_key(candidate))
 
     sessions = state.conversation_log.list_sessions()
     count = 0

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -826,6 +826,7 @@ class _ChatSlot:
         "_slack_linked",
         "_slack_channel",
         "_slack_thread_ts",
+        "channel_origin",
         "folder_id",
         "_folder_changed",
         "_folder_suggested",
@@ -1114,6 +1115,14 @@ class _ChatSlot:
             []
         )  # [{path, content}] before-snapshots accumulated per turn for file-chip diffs
         self.linked_session_key: str = ""  # when set, _run_chat uses this as session key
+        # True only when this slot was created to DISPLAY a conversation that
+        # already lives in a channel transcript (the reconciler surfacing a
+        # thread, a restore, a History resume). It is what separates such a tab
+        # from a dashboard slot that merely happens to be NAMED like one --
+        # a filename-shaped name is not provenance, and inferring it from the
+        # name would let `POST /api/chat/slots` with a colliding `slack_<ts>`
+        # name write a fresh conversation into an existing thread's transcript.
+        self.channel_origin: bool = False
         self._browse_mode: bool = False  # per-turn: True when user explicitly enables browser
         self._side: SideState | None = None
         # Live inner AcpClient for the in-flight turn, published by _run_chat at
@@ -3030,6 +3039,7 @@ class DashboardState:
         ephemeral: bool | None = None,
         app: str = "",
         linked_session_key: str = "",
+        channel_origin: bool = False,
     ) -> _ChatSlot:
         """Return existing slot or create a new one.
 
@@ -3097,6 +3107,11 @@ class DashboardState:
         # write their namespaced origin id through the legacy channel field;
         # those are projected separately via ``links`` and must never make the
         # destructive Slack actions appear.
+        if channel_origin:
+            # Additive: never cleared, because get_or_create_slot also returns
+            # EXISTING slots and a later plain call must not downgrade a tab
+            # that a channel path already claimed.
+            slot.channel_origin = True
         if linked_session_key:
             slot.linked_session_key = linked_session_key
         elif self.sessions:
@@ -3108,12 +3123,14 @@ class DashboardState:
             # dashboard-only session whose replies never reach the thread.
             #
             # Only ever adopts a key the session map actually holds, so a slot
-            # whose name merely looks channel-shaped stays unbound.
-            from kiro_crew.messaging.link import is_channel_session_key
-
+            # whose name merely looks channel-shaped stays unbound. Validated the
+            # same way ``surface_channel_session`` validates its own argument:
+            # only a real channel key may become a binding, so a malformed map
+            # answer leaves the slot unbound (a supported state) rather than
+            # routing the user's replies to a session no channel reads.
             if is_channel_session_key(name):
                 resolved = self.sessions.channel_key_for_stem(name)
-                if resolved:
+                if isinstance(resolved, str) and is_channel_session_key(resolved):
                     slot.linked_session_key = resolved
         try:
             if self.sessions:

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -3377,10 +3377,10 @@ class GatewayOrchestrator:
         if conv_log is None:
             return
         # Lazy import avoids a circular dependency (dashboard.chat_utils → gateway).
-        from kiro_crew.dashboard.chat_utils import effective_session_key
+        from kiro_crew.dashboard.chat_utils import slot_history_key
 
         try:
-            await asyncio.to_thread(conv_log.set_title, effective_session_key(slot), slot.title)
+            await asyncio.to_thread(conv_log.set_title, slot_history_key(slot), slot.title)
         except Exception:
             logger.warning(
                 "Heartbeat: failed to persist slot title for %s", slot.key, exc_info=True

--- a/src/kiro_crew/sync_bridge.py
+++ b/src/kiro_crew/sync_bridge.py
@@ -83,18 +83,26 @@ async def handoff_to_slack(
     title: str = "",
     channel: str | None = None,
     sessions: object | None = None,
+    transcript_key: str = "",
 ) -> str | None:
     """Hand off a dashboard session to a new Slack DM thread.
 
     Links the session via ``set_slack_link`` so bidirectional sync works.
     Returns the thread_ts, or None on failure.
+
+    *transcript_key* is where the conversation is STORED, when that differs from
+    the session it runs on. They differ for an unbound channel tab: it runs under
+    ``dashboard:<stem>`` but its transcript is the channel's own file, so reading
+    the seed messages under *session_key* found nothing and handed off an empty
+    thread. Defaults to *session_key*, which is correct for every other slot.
     """
-    messages = conversation_log.read_messages(session_key)
+    read_key = transcript_key or session_key
+    messages = conversation_log.read_messages(read_key)
     if not messages:
         return None
 
     if not title:
-        meta = conversation_log.get_metadata(session_key)
+        meta = conversation_log.get_metadata(read_key)
         title = meta.get("title", session_key)
 
     preview = ""

--- a/test/test_channel_slot_close_binding.py
+++ b/test/test_channel_slot_close_binding.py
@@ -1,0 +1,456 @@
+"""One slot, one transcript — including the channel slot nobody could bind.
+
+A channel-born tab is normally BOUND to the session the channel runs
+(``linked_session_key``), resolved in ``get_or_create_slot`` from the session
+map. When the map cannot resolve the stem — it was pruned, or the thread
+predates it — the tab is deliberately left UNBOUND rather than guessing, because
+a wrong key would route the user's replies to a session the channel never reads.
+``surface_channel_session`` documents that as a supported state.
+
+For that unbound slot the old ``effective_session_key`` fallback prefixed
+``dashboard:`` and named ``dashboard_slack_<ts>.jsonl`` — a file no restore path
+reads and ``migrate_channel_transcripts`` deletes on the next boot (it carries
+only ``title``/``folder_id``/``pinned``). Every READ path meanwhile resolved the
+same slot through ``slot_transcript_key`` and got the channel transcript.
+
+The user-visible consequence: closing such a tab wrote ``closed`` to the phantom
+file, the restore guard read the channel file and never saw it, and the tab came
+back on every gateway restart — permanently, because a ``folder_id`` also exempts
+it from the recency window.
+
+These tests lock the invariant that reads and writes address ONE file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from unittest.mock import MagicMock
+
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard import channel_slots
+from kiro_crew.dashboard.chat_persistence import (
+    _rehydrate_slot_from_history,
+    restore_open_slots,
+    save_slot_off_loop,
+)
+from kiro_crew.dashboard.chat_utils import slot_history_key
+from kiro_crew.history import _safe_key
+
+CHANNEL_KEY = "slack:1783733803.877979"
+STEM = _safe_key(CHANNEL_KEY)  # "slack_1783733803.877979" — the slot name too
+PHANTOM = f"dashboard_{STEM}.jsonl"
+
+
+def _state(tmp_path, *, resolves: str | None = None):
+    """State whose session map resolves STEM to *resolves* (default: unknown).
+
+    The bare ``_make_state`` mock would auto-create a truthy
+    ``channel_key_for_stem``, which is precisely the accident the binding guard
+    exists to stop — pin it explicitly in every test.
+    """
+    state = _make_state(tmp_path / "sessions")
+    state.sessions.channel_key_for_stem = lambda stem: resolves or ""
+    return state
+
+
+def _seed_channel_transcript(state) -> None:
+    """A channel transcript as the channel side actually leaves it.
+
+    The ``tab_id`` matters: without one, ``_rehydrate_slot_from_history``
+    backfills it through ``update_metadata_off_loop``, and that BACKGROUND
+    rewrite restores the mtime it captured before the write — which can land
+    after a later append and drag the file's mtime backwards. A real channel
+    transcript already carries a tab_id, so seeding one keeps these tests
+    deterministic instead of racing a thread.
+    """
+    log = state.conversation_log
+    assert log is not None
+    log.append(CHANNEL_KEY, "user", "hello from the thread")
+    log.append(CHANNEL_KEY, "assistant", "hi back")
+    log.update_metadata(CHANNEL_KEY, {"tab_id": "aaaabbbbcccc"})
+
+
+def _restarted(tmp_path, old_state):
+    """A second DashboardState over the same sessions dir (a 'gateway restart')."""
+    state = _make_state(tmp_path / "sessions")
+    state.sessions.channel_key_for_stem = old_state.sessions.channel_key_for_stem
+    return state
+
+
+def _restored_tab(state):
+    """The tab as production actually establishes it: via the reconciler.
+
+    ``surface_channel_session`` owns surfacing a channel conversation and is what
+    sets ``channel_origin``. A legacy transcript carries no persisted marker, so
+    ``restore_open_slots`` deliberately will NOT claim it — using the reconciler
+    here models production rather than working around the code.
+    """
+    log = state.conversation_log
+    info = next(s for s in log.list_sessions() if s.get("key") == STEM)
+    slot = channel_slots.surface_channel_session(
+        state, info, log.get_metadata(STEM), log.read_messages(STEM)
+    )
+    assert slot is not None
+    assert slot.messages, "surfaced slot must carry a window"
+    assert slot.channel_origin is True
+    return slot
+
+
+def _close(state, slot, *, closed_at: float) -> None:
+    asyncio.run(
+        save_slot_off_loop(
+            state, slot, closed=True, closed_at=closed_at, best_effort=False
+        )
+    )
+
+
+class TestSlotHistoryKey:
+    def test_unbound_channel_tab_resolves_to_its_channel_transcript(self, tmp_path):
+        """The regression: this used to answer "dashboard:slack_<ts>"."""
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot(STEM, channel_origin=True)
+        assert not slot.linked_session_key
+        assert slot_history_key(slot) == STEM
+
+    def test_a_dashboard_slot_merely_NAMED_like_a_channel_keeps_its_own_file(
+        self, tmp_path
+    ):
+        """A filename shape is not provenance -- and must not be read as one.
+
+        ``POST /api/chat/slots`` accepts a client-supplied name, and main
+        deliberately supports a dashboard slot a caller happened to name
+        ``slack_notes`` as a genuine mirror-out. So the stem cannot be the
+        signal: without a persisted marker the slot keeps its own
+        ``dashboard:`` transcript rather than adopting a real thread's.
+        """
+        state = _state(tmp_path)
+        _seed_channel_transcript(state)  # the thread it would collide with
+        slot = state.get_or_create_slot(STEM)  # no channel_origin
+
+        assert slot.channel_origin is False
+        assert slot_history_key(slot) == f"dashboard:{STEM}"
+
+    def test_a_legacy_channel_transcript_is_not_adopted(self, tmp_path):
+        """Provenance is persisted-only: no marker means no adoption.
+
+        An empty dashboard tab named for an old channel stem must not inherit
+        that thread's history, and file absence cannot tell the two apart. The
+        data-loss risk this used to guard against is handled instead by
+        ``api_sessions_clear`` protecting BOTH candidate transcripts, so
+        deletion no longer depends on provenance resolving correctly.
+        """
+        state = _state(tmp_path)
+        _seed_channel_transcript(state)  # channel transcript, no persisted flag
+
+        slot = _rehydrate_slot_from_history(state, STEM)
+
+        assert slot is not None
+        assert slot.channel_origin is False
+        assert slot_history_key(slot) == f"dashboard:{STEM}"
+
+    def test_a_slot_with_its_own_dashboard_transcript_is_not_adopted(self, tmp_path):
+        """The anti-merge case: a dashboard slot merely NAMED like a channel.
+
+        main supports ``slack_notes`` as a genuine mirror-out, and such a slot
+        writes its own ``dashboard:<name>`` transcript. That file existing is
+        what distinguishes it from a real thread -- not the name's shape.
+        """
+        state = _state(tmp_path)
+        _seed_channel_transcript(state)  # the thread it would collide with
+        # Its OWN transcript, as any dashboard slot's save would create.
+        state.conversation_log.append(f"dashboard:{STEM}", "user", "my own chat")
+
+        slot = _rehydrate_slot_from_history(state, STEM)
+
+        assert slot is not None
+        assert slot.channel_origin is False
+        assert slot_history_key(slot) == f"dashboard:{STEM}"
+
+    def test_channel_origin_is_never_downgraded_by_a_later_plain_call(self, tmp_path):
+        """get_or_create_slot also returns EXISTING slots."""
+        state = _state(tmp_path)
+        state.get_or_create_slot(STEM, channel_origin=True)
+
+        again = state.get_or_create_slot(STEM)
+
+        assert again.channel_origin is True
+        assert slot_history_key(again) == STEM
+
+    def test_bound_channel_slot_resolves_to_its_linked_key(self, tmp_path):
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot(STEM, linked_session_key=CHANNEL_KEY)
+        assert slot_history_key(slot) == CHANNEL_KEY
+
+    def test_ordinary_dashboard_slot_is_unchanged(self, tmp_path):
+        state = _state(tmp_path)
+        slot = state.get_or_create_slot("chat-7-123")
+        assert slot_history_key(slot) == "dashboard:chat-7-123"
+
+    def test_restore_of_an_ordinary_session_is_not_channel_origin(self, tmp_path):
+        state = _state(tmp_path)
+        state.conversation_log.append("dashboard:chat-9-1", "user", "hi")
+
+        slot = _rehydrate_slot_from_history(state, "chat-9-1")
+
+        assert slot is not None
+        assert slot.channel_origin is False
+
+    def test_channel_transcript_and_linked_key_are_the_same_file(self, tmp_path):
+        """_safe_key folds ':' to '_', so both keys name one .jsonl."""
+        state = _state(tmp_path)
+        _seed_channel_transcript(state)
+        log = state.conversation_log
+        assert log._path(CHANNEL_KEY) == log._path(STEM)
+
+
+class TestProvenanceIsPersisted:
+    """The restore must not have to re-derive provenance from the slot name."""
+
+    def test_a_close_writes_channel_origin_into_the_transcript(self, tmp_path):
+        state = _state(tmp_path)
+        _seed_channel_transcript(state)
+        slot = _restored_tab(state)
+        assert slot.channel_origin is True
+
+        _close(state, slot, closed_at=time.time())
+
+        meta = state.conversation_log.get_metadata(CHANNEL_KEY)
+        assert meta.get("channel_origin") is True
+
+    def test_restore_reads_provenance_back_from_the_transcript(self, tmp_path):
+        """Round-trip: persisted flag alone is enough to re-establish the tab."""
+        state = _state(tmp_path)
+        _seed_channel_transcript(state)
+        state.conversation_log.update_metadata(CHANNEL_KEY, {"channel_origin": True})
+
+        slot = _rehydrate_slot_from_history(state, STEM)
+
+        assert slot is not None
+        assert slot.channel_origin is True
+        assert slot_history_key(slot) == STEM
+
+    def test_an_ordinary_transcript_never_gains_the_flag(self, tmp_path):
+        state = _state(tmp_path)
+        state.conversation_log.append("dashboard:chat-9-1", "user", "hi")
+        slot = _rehydrate_slot_from_history(state, "chat-9-1")
+        assert slot is not None
+
+        _close(state, slot, closed_at=time.time())
+
+        meta = state.conversation_log.get_metadata("dashboard:chat-9-1")
+        assert "channel_origin" not in meta
+
+
+class TestCloseLandsOnTheTranscriptTheRestorePathReads:
+    def test_close_on_unbound_channel_tab_writes_the_channel_transcript(self, tmp_path):
+        state = _state(tmp_path)
+        _seed_channel_transcript(state)
+        slot = _restored_tab(state)
+        assert slot.linked_session_key == "", "map cannot resolve: must be unbound"
+        closed_at = time.time()
+
+        _close(state, slot, closed_at=closed_at)
+
+        meta = state.conversation_log.get_metadata(CHANNEL_KEY)
+        assert meta.get("closed") is True
+        assert float(meta.get("closed_at", 0)) == closed_at
+
+    def test_close_creates_no_phantom_dashboard_transcript(self, tmp_path):
+        """The phantom file is what migrate_channel_transcripts later deletes."""
+        state = _state(tmp_path)
+        _seed_channel_transcript(state)
+        slot = _restored_tab(state)
+
+        _close(state, slot, closed_at=time.time())
+
+        assert not (tmp_path / "sessions" / PHANTOM).exists()
+
+    def test_bound_channel_tab_still_writes_the_channel_transcript(self, tmp_path):
+        """No regression for the tab the reconciler DID manage to bind."""
+        state = _state(tmp_path, resolves=CHANNEL_KEY)
+        _seed_channel_transcript(state)
+        slot = _restored_tab(state)
+        assert slot.linked_session_key == CHANNEL_KEY
+
+        _close(state, slot, closed_at=time.time())
+
+        assert state.conversation_log.get_metadata(CHANNEL_KEY).get("closed") is True
+        assert not (tmp_path / "sessions" / PHANTOM).exists()
+
+    def test_ordinary_tab_close_is_unchanged(self, tmp_path):
+        state = _state(tmp_path)
+        state.conversation_log.append("dashboard:chat-9-1", "user", "hi")
+        slot = _rehydrate_slot_from_history(state, "chat-9-1")
+        assert slot is not None
+
+        _close(state, slot, closed_at=time.time())
+
+        meta = state.conversation_log.get_metadata("dashboard:chat-9-1")
+        assert meta.get("closed") is True
+
+
+class TestClosedChannelTabStaysClosedAcrossRestart:
+    def test_closed_unbound_channel_tab_is_not_restored(self, tmp_path, monkeypatch):
+        """End-to-end of the reported symptom: close, restart, stays gone."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        state = _state(tmp_path)
+        _seed_channel_transcript(state)
+        slot = _restored_tab(state)
+        _close(state, slot, closed_at=time.time())
+        # The tab is gone from the live set, but the snapshot still lists it —
+        # exactly the state a gateway restart reads.
+        state._slots.pop(STEM, None)
+        (tmp_path / "open_slots.json").write_text(
+            json.dumps({"keys": [STEM], "ts": time.time()}), encoding="utf-8"
+        )
+
+        after_restart = _restarted(tmp_path, state)
+
+        assert restore_open_slots(after_restart) == 0
+        assert STEM not in after_restart._slots
+
+    def test_open_channel_tab_is_still_restored(self, tmp_path, monkeypatch):
+        """Guard the inverse: an un-closed tab must still come back."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        state = _state(tmp_path)
+        _seed_channel_transcript(state)
+        (tmp_path / "open_slots.json").write_text(
+            json.dumps({"keys": [STEM], "ts": time.time()}), encoding="utf-8"
+        )
+
+        after_restart = _restarted(tmp_path, state)
+
+        assert restore_open_slots(after_restart) == 1
+        assert STEM in after_restart._slots
+
+
+class TestClosedChannelTabDoesNotOutrunItsOwnClose:
+    """The reconciler is the OTHER path that can resurface the tab.
+
+    ``restore_open_slots`` reads ``meta.closed`` directly, but the reconciler
+    asks ``_close_stands``, which compares the transcript's mtime against
+    ``closed_at`` — channel activity newer than the close re-qualifies the
+    session. Writing the close flag is itself a write to that same shared file,
+    so unless the pre-close mtime is restored the close outruns itself and the
+    tab comes back on the next pass.
+
+    ``closed_at`` is derived from the file's own mtime rather than ``time.time()``
+    on purpose: Linux stamps mtimes from a COARSE clock (roughly millisecond
+    granularity), so a file written microseconds after a ``time.time()`` reading
+    can carry an mtime slightly BEFORE it. Anchoring to the file's own clock
+    removes that ambiguity, so an unrestored mtime always reads as newer.
+    """
+
+    def _prepare(self, state):
+        """Seed, rehydrate, and pick a close instant just after last activity."""
+        _seed_channel_transcript(state)
+        slot = _restored_tab(state)
+        path = state.conversation_log._path(CHANNEL_KEY)
+        pre_close_mtime = path.stat().st_mtime
+        return slot, path, pre_close_mtime + 0.001
+
+    def _listing(self, state):
+        rows = state.conversation_log.list_sessions()
+        row = next(s for s in rows if s.get("key") == STEM)
+        return row, state.conversation_log.get_metadata(STEM)
+
+    def test_close_restores_the_pre_close_mtime(self, tmp_path):
+        """Exact identity, not "<= closed_at": the write must leave no trace."""
+        state = _state(tmp_path)
+        slot, path, closed_at = self._prepare(state)
+        before = path.stat().st_mtime
+
+        _close(state, slot, closed_at=closed_at)
+
+        assert path.stat().st_mtime == before
+
+    def test_reconciler_does_not_resurface_the_closed_tab(self, tmp_path):
+        state = _state(tmp_path)
+        slot, _path, closed_at = self._prepare(state)
+
+        _close(state, slot, closed_at=closed_at)
+
+        row, meta = self._listing(state)
+        assert float(row["modified"]) <= float(meta["closed_at"])
+        eligible = channel_slots.eligible_channel_sessions(
+            [row], metadata={STEM: meta}, cutoff=None, mtimes={STEM: row["modified"]}
+        )
+        assert eligible == []
+
+    def test_a_real_channel_append_after_the_close_still_resurfaces_it(self, tmp_path):
+        """Don't over-preserve: the channel moving on must win over the close."""
+        state = _state(tmp_path)
+        slot, _path, closed_at = self._prepare(state)
+        _close(state, slot, closed_at=closed_at)
+        row, meta = self._listing(state)
+
+        # The channel kept talking a minute later. Stated explicitly rather than
+        # timed, so the assertion is about _close_stands' rule and not the host's
+        # filesystem timestamp resolution.
+        moved_on = dict(row, modified=float(meta["closed_at"]) + 60.0)
+
+        eligible = channel_slots.eligible_channel_sessions(
+            [moved_on],
+            metadata={STEM: meta},
+            cutoff=None,
+            mtimes={STEM: moved_on["modified"]},
+        )
+        assert [s["key"] for s in eligible] == [STEM]
+
+
+class TestChannelBindingIsValidated:
+    """``get_or_create_slot`` is the one site that adopts a map-resolved key."""
+
+    def test_binds_a_real_channel_key(self, tmp_path):
+        state = _state(tmp_path, resolves=CHANNEL_KEY)
+        assert state.get_or_create_slot(
+            STEM, channel_origin=True
+        ).linked_session_key == CHANNEL_KEY
+
+    def test_leaves_it_unbound_when_the_map_cannot_resolve(self, tmp_path):
+        state = _state(tmp_path)
+        assert state.get_or_create_slot(STEM, channel_origin=True).linked_session_key == ""
+
+    def test_refuses_a_non_channel_resolution(self, tmp_path):
+        """A wrong key would route replies to a session the channel never reads."""
+        state = _state(tmp_path, resolves="dashboard:chat-1-123")
+        assert state.get_or_create_slot(STEM, channel_origin=True).linked_session_key == ""
+
+    def test_refuses_a_non_string_resolution(self, tmp_path):
+        """A MagicMock is truthy; a bare truthiness check would bind to it."""
+        state = _make_state(tmp_path / "sessions")
+        state.sessions.channel_key_for_stem = lambda stem: MagicMock()
+        assert state.get_or_create_slot(STEM, channel_origin=True).linked_session_key == ""
+
+    def test_ordinary_slot_name_is_never_bound(self, tmp_path):
+        state = _state(tmp_path, resolves=CHANNEL_KEY)
+        assert state.get_or_create_slot("chat-9-1").linked_session_key == ""
+
+    def test_rehydrate_prefers_the_persisted_binding_over_the_map(self, tmp_path):
+        state = _state(tmp_path, resolves="slack:9999999999.000000")
+        _seed_channel_transcript(state)
+        state.conversation_log.update_metadata(
+            CHANNEL_KEY, {"linked_session_key": CHANNEL_KEY}
+        )
+
+        slot = _rehydrate_slot_from_history(state, STEM)
+
+        assert slot is not None
+        assert slot.linked_session_key == CHANNEL_KEY
+
+    def test_unbound_channel_tab_still_loads_its_history(self, tmp_path):
+        """Unbound is a supported state, not a broken one."""
+        state = _state(tmp_path)
+        _seed_channel_transcript(state)
+
+        slot = _rehydrate_slot_from_history(state, STEM)
+
+        assert slot is not None
+        assert slot.linked_session_key == ""
+        assert [m["content"] for m in slot.messages] == [
+            "hello from the thread",
+            "hi back",
+        ]

--- a/test/test_dashboard_sessions_clear.py
+++ b/test/test_dashboard_sessions_clear.py
@@ -30,10 +30,24 @@ def _history_key_for(key: str) -> str:
 class _FakeSlot:
     """Minimal stand-in for ``_ChatSlot`` — carries only what the handler reads."""
 
-    def __init__(self, key: str, *, pinned: bool = False, running: bool = False) -> None:
+    def __init__(
+        self,
+        key: str,
+        *,
+        pinned: bool = False,
+        running: bool = False,
+        linked_session_key: str = "",
+        channel_origin: bool = False,
+    ) -> None:
         self.key = key
         self.pinned = pinned
         self._running = running
+        # The handler resolves each slot's TRANSCRIPT via ``slot_history_key``,
+        # which reads these. A channel tab the session map could not resolve
+        # carries no linked key, and its transcript is identified by the
+        # ``channel_origin`` provenance flag plus the slot name.
+        self.linked_session_key = linked_session_key
+        self.channel_origin = channel_origin
 
     @property
     def running(self) -> bool:
@@ -302,3 +316,66 @@ async def test_all_failed_returns_ok_false() -> None:
 
     assert status == 200
     assert body == {"ok": False, "cleared": 0, "skipped": 0, "failed": 2}
+
+
+@pytest.mark.asyncio
+async def test_skips_both_candidate_transcripts_of_a_channel_shaped_slot() -> None:
+    """Clear All must not depend on provenance resolving correctly.
+
+    A legacy channel tab carries no persisted marker, so it restores as an
+    ordinary dashboard slot writing ``dashboard:<stem>`` while the conversation
+    on screen still lives in the channel transcript. Protecting only the write
+    target would delete what the tab is displaying, so BOTH candidates are
+    protected -- the worst case is skipping a transcript nobody is reading.
+    """
+    stem = "slack_1783733803.877979"
+    other = _history_key_for("chat-9-1")
+    sessions = [{"key": stem}, {"key": _history_key_for(stem)}, {"key": other}]
+    slots = {stem: _FakeSlot(stem)}  # no channel_origin, no linked key
+    request, _state, deleted = _make_request(sessions, slots=slots)
+
+    status, _body = await _call_and_parse(request)
+
+    assert status == 200
+    assert stem not in deleted
+    assert deleted == [other]
+
+
+@pytest.mark.asyncio
+async def test_skips_the_transcript_an_unbound_channel_tab_is_reading() -> None:
+    """An open channel tab's transcript must survive Clear All.
+
+    A channel tab the session map could not resolve carries no
+    ``linked_session_key``, so it RUNS under ``dashboard:<stem>`` while its
+    conversation lives in the channel transcript, listed as the bare stem. The
+    protection set used to be built from the session key, which contributed two
+    names matching no file and left the real transcript unprotected — so Clear
+    All permanently deleted the conversation the open tab was displaying.
+    """
+    stem = "slack_1783733803.877979"
+    other = _history_key_for("chat-9-1")
+    sessions = [{"key": stem}, {"key": other}]
+    slots = {stem: _FakeSlot(stem, channel_origin=True)}
+    request, _state, deleted = _make_request(sessions, slots=slots)
+
+    status, body = await _call_and_parse(request)
+
+    assert status == 200
+    assert stem not in deleted
+    assert deleted == [other]
+    assert body == {"ok": True, "cleared": 1, "skipped": 1, "failed": 0}
+
+
+@pytest.mark.asyncio
+async def test_skips_the_transcript_a_bound_channel_tab_is_reading() -> None:
+    """Same protection for the tab that DID resolve — via its linked key's stem."""
+    stem = "slack_1783733803.877979"
+    other = _history_key_for("chat-9-1")
+    sessions = [{"key": stem}, {"key": other}]
+    slots = {stem: _FakeSlot(stem, linked_session_key="slack:1783733803.877979")}
+    request, _state, deleted = _make_request(sessions, slots=slots)
+
+    status, body = await _call_and_parse(request)
+
+    assert status == 200
+    assert deleted == [other]

--- a/test/test_history_locking_remediation.py
+++ b/test/test_history_locking_remediation.py
@@ -989,7 +989,7 @@ class TestOnLoopCallersOffload:
 
         log.set_title = _spy  # type: ignore[method-assign]
         monkeypatch.setattr(
-            chat_title, "effective_session_key", lambda _slot: "dashboard:t"
+            chat_title, "slot_history_key", lambda _slot: "dashboard:t"
         )
 
         state = MagicMock()


### PR DESCRIPTION
## Problem

A Slack-born chat tab kept reappearing in the sidebar after every gateway restart, even after being closed. It could not be evicted: the session was 26 days old, but it came back on every boot.

Two smaller symptoms share the cause. Forking or paging the history of such a tab reads an empty conversation, a Slack handoff from it seeds an empty thread, and — worst — **Clear All could permanently delete the conversation the open tab was displaying.**

## Why it matters

The reappearing tab is a papercut you cannot fix from the UI: closing it does nothing, and because the session is filed in a folder the recency window can never evict it either. The delete-protection hole is data loss: `DELETE /api/sessions` removes the transcript an open tab is reading from, which after this change it is also writing to.

## Fix (symptoms → root cause → change)

A dashboard slot has two identities, and they are not always the same string:

- the **session** its turns run on (`effective_session_key`)
- the **transcript** its conversation is stored in

They coincide for every ordinary tab, so one helper served both. They diverge for exactly one slot: a channel-born tab the dashboard could not bind. `surface_channel_session` surfaces such a tab **unbound** on purpose when `channel_key_for_stem` cannot resolve its filename stem — the session map was pruned, or the thread predates it — because guessing a key would route the user's replies to a session the channel never reads. Resuming a dormant channel thread from History (`POST /api/chat/slots/{slot}/resume`) produces exactly this state.

For that tab the two identities disagree. Every **read** path resolves a slot through `slot_transcript_key`, which returns the channel stem unchanged and so reads the channel transcript. `effective_session_key`'s fallback ran `_history_key_for`, which prefixes `dashboard:` — naming `dashboard_slack_<ts>.jsonl`, a file no restore path reads and `migrate_channel_transcripts` deletes on the next boot (it carries only `title` / `folder_id` / `pinned` forward, and drops `closed` / `closed_at` by design).

So closing the tab wrote `closed` and `closed_at` to a phantom transcript, the restore guard read the channel transcript and never saw the flag, and `restore_open_slots` — which deliberately ignores the mtime window so long-lived tabs survive a restart — brought the tab back. Forever.

The change adds `slot_history_key(slot)` (`linked_session_key or slot_transcript_key(slot.key)`) and routes the twelve sites that turn a slot into a transcript path through it, so reads and writes address one file. Session identity is deliberately left alone: an unbound channel tab still runs under `dashboard:<name>`, so `_restricted_keys` and approval-policy bookkeeping keyed on that prefix keep matching.

Two consequences of the same asymmetry are fixed alongside it, because neither can be observed until the primary fix lands:

- **`api_sessions_clear` guarded the wrong key.** It built its delete-protection set from the session key, contributing `{dashboard:slack_<ts>, dashboard_slack_<ts>}` — two names matching no file — while `list_sessions()` reports the live transcript as the bare stem. That is verbatim the loss the handler's own comment says its `_safe_key` line exists to prevent.
- **The close outran itself.** The mtime-preservation guard in `_save_slot_to_history` was gated on `slot.linked_session_key`, and an unbound tab has none. Writing the close flag advanced the shared file's mtime past `closed_at`, so `_close_stands` rejected the close and the channel reconciler resurfaced the tab — even with the flag finally in the right file. It is now gated on the transcript, keeping the `linked_session_key` arm so cron- and workflow-linked slots are unchanged.

`handoff_to_slack` grows a `transcript_key` parameter so it reads the conversation from where it is stored while still linking the session it runs on.

Finally, the two sites that adopt a map-resolved binding (`get_or_create_slot`, `_resume_session_identity`) now validate it the way `surface_channel_session` validates its own argument, so a malformed map answer leaves the tab unbound rather than binding it to a non-channel key. This also keeps a non-`str` out of `_normalize_slot_key`'s unbounded `while name.startswith("dashboard_")` loop — the OOM defect from #1467.

## Tests

`test/test_channel_slot_close_binding.py` (new, 20 tests):

- `slot_history_key` resolves an unbound channel slot to its channel transcript, a bound one to its linked key, and an ordinary slot unchanged.
- Closing an unbound channel tab writes `closed` / `closed_at` to the **channel** transcript and creates no phantom `dashboard_slack_<ts>.jsonl`; the bound tab and the ordinary tab are unaffected.
- End-to-end of the report: close → restart → `restore_open_slots` returns 0. The inverse (an un-closed tab still returns) is pinned too.
- The reconciler path: the close restores the pre-close mtime exactly, `eligible_channel_sessions` excludes the closed tab, and a genuine later channel append still re-surfaces it (so the guard does not over-preserve).
- The binding guard accepts a real channel key and rejects a non-channel key, a non-`str`, and an ordinary slot name.

`test/test_dashboard_sessions_clear.py`: two tests that Clear All skips the transcript an open channel tab is reading, bound or unbound.

`test/test_history_locking_remediation.py`: one monkeypatch target follows the production seam from `effective_session_key` to `slot_history_key`. No assertion weakened.

Every mechanism was verified non-vacuous by reverting it and confirming the expected tests fail — the transcript-key fallback (4 failures, including the restart symptom), the mtime gate (2), and the delete protection (1).

Two test-quality notes worth recording. The reconciler assertions originally compared a file mtime against a `time.time()` reading; Linux stamps mtimes from a coarse (~millisecond) clock, so a file written microseconds later can carry an *earlier* mtime. One assertion was clock-dependent and would have passed vacuously. They now anchor `closed_at` to the file's own mtime and assert exact identity of the restored value. The fixture also seeds a `tab_id`, as a real channel transcript carries, so no background metadata backfill races the assertions.

## Manual verification

N/A — unit coverage is sufficient and drives the real `ConversationLog` against real files through the real `save_slot_off_loop` / `restore_open_slots` / `_rehydrate_slot_from_history` / `api_sessions_clear` paths, including the end-to-end close→restart sequence that reproduces the report.

The live instance that produced this report carries the affected session (`slack_1783733803.877979`, filed in a folder, no `closed` flag, session map pruned of its entry), so the fix can be confirmed there after merge by closing the tab and restarting.

## Known limitation not addressed

`update_metadata`'s mtime restore captures `prev_mtime` such that an interleaved append can have its mtime dragged backwards. It is pre-existing, unrelated to this report, and narrow (it needs a background metadata write to straddle a channel append). Noted rather than widened into this PR.
