### PR TITLE
fix(i18n): add the 11 missing ja keys for the Kiro prerequisite gate

### DIFF
--- a/website/src/i18n/locales/ja.json
+++ b/website/src/i18n/locales/ja.json
@@ -4105,7 +4105,18 @@
       "try_again": "もう一度試してください",
       "waiting": "待機中",
       "we_could_not_check_kiro_cli": "Kiro CLI を確認できませんでした。",
-      "your_crew_is_almost_ready": "クルーの準備がほぼ完了しました。"
+      "your_crew_is_almost_ready": "クルーの準備がほぼ完了しました。",
+      "copied": "コピーしました",
+      "copy_command": "コマンドをコピー",
+      "how_to_fix": "解決方法",
+      "if_this_keeps_happening": "問題が続く場合",
+      "linux_sandbox_guide": "Linux サンドボックスガイド",
+      "remedy_apparmor_service_install": "Kiro Crew をサービスとしてインストールしてください。ユーザー名前空間の権限のみを許可する狭い範囲の AppArmor プロファイル (kirocrew-userns) も Kiro Crew サービスに限定して書き込まれます。マシン上の他の部分の制限が緩められることはありません。",
+      "remedy_max_user_namespaces": "ユーザー名前空間の作成がユーザーごとの上限に達しました。通常これは、要塞化されたホストで user.max_user_namespaces が 0 になっていることを意味します。値を引き上げ、再起動後も維持されるよう /etc/sysctl.d/ に保存してください。",
+      "remedy_no_user_ns": "このカーネルはユーザー名前空間のサポート (CONFIG_USER_NS) なしでビルドされているため、変更できる設定はありません。別のカーネルを使うことが唯一の解決策です。",
+      "remedy_userns_denied": "カーネルがユーザー名前空間の作成を拒否しました。Debian 系のホストではこのレガシー設定を確認し、再起動後も維持されるよう /etc/sysctl.d/ に値を保存してください。コンテナ内の場合は通常、コンテナ自身の seccomp フィルターが unshare を拒否しているため、ホストの設定ではなく コンテナの実行フラグで解決します。",
+      "run_kirocrew_doctor_on_the_gateway_host_for_a_ful": "どのサンドボックスの手順が失敗したかを含む完全な前提条件レポートを得るには、これをゲートウェイホストで実行してください。",
+      "this_host_allows_user_namespaces_but_the_kernel_d": "このホストはユーザー名前空間を許可していますが、カーネルがマウント名前空間を拒否しました。これは Ubuntu 23.10 以降の特徴で、ユーザー名前空間を作成したプロセスを制限付きの AppArmor プロファイルに移動させます。Kiro Crew は認証情報を露出させるよりも、隔離されていない状態で エージェントを実行することを拒否するため、プロファイルが設定されるまでブロックされたままになります。"
     },
     "linkPreview": {
       "copied": "コピー済み",


### PR DESCRIPTION
# What

`components.kiroPrerequisiteGate` gained 11 strings in `en.manual.json` that never reached `ja.json`. `catalogParity` is a hard gate, so it fails on `main` for **every** PR that runs the frontend suite:

```
FAIL  src/i18n/catalogParity.test.ts > catalog parity > ja > has no key missing relative to en
AssertionError: missing 11 key(s), e.g. components.kiroPrerequisiteGate.copied,
components.kiroPrerequisiteGate.copy_command, components.kiroPrerequisiteGate.how_to_fix, ...
```

# Why it is not any one PR's fault

Reproduced with the locale directory checked out at `origin/main` and nothing else changed:

| locale files | `catalogParity` |
|---|---|
| `origin/main` (pristine) | **1 failed** \| 69 passed |
| this branch | 70 passed |

So the gap predates the PRs currently sitting red on it.

# What changed

The 11 missing keys, translated, appended in the English catalog's own key order rather than sorted — the added block then reads in the same sequence as its source, and the diff is one contiguous hunk.

```
copied · copy_command · how_to_fix · if_this_keeps_happening · linux_sandbox_guide
remedy_apparmor_service_install · remedy_max_user_namespaces · remedy_no_user_ns
remedy_userns_denied · run_kirocrew_doctor_on_the_gateway_host_for_a_ful
this_host_allows_user_namespaces_but_the_kernel_d
```

The four `remedy_*` strings and the two long diagnostics are the user-facing sandbox remediation copy, so they are translated in full rather than left as fragments. Product nouns stay untranslated (`Kiro Crew`, `AppArmor`, `CONFIG_USER_NS`, `seccomp`, `unshare`, `/etc/sysctl.d/`, `user.max_user_namespaces`, `kirocrew-userns`), matching how `ja.json` already handles them elsewhere.

# Tested

- `catalogParity.test.ts` + `englishIdentity.test.ts` — 81 passed (was 1 failing).
- No source changes, so nothing else can be affected: the diff is one JSON file.

# Not in scope

Why the keys were added to `en.manual.json` without a translator pass is a process question, not fixed here. Worth a follow-up on whether the parity gate should run on the PR that adds an English key rather than surfacing on the next unrelated PR.
