### PR TITLE
fix(deps): bump js-yaml override to 4.3.1 to clear GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -2402,9 +2402,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -21,7 +21,7 @@
   },
   "overrides": {
     "fast-uri": "3.1.5",
-    "js-yaml": "4.3.0"
+    "js-yaml": "4.3.1"
   },
   "build": {
     "appId": "com.amazon.kiro.crew",


### PR DESCRIPTION
## Problem

The **Production Dependency Vulnerability Gate** fails on `main`, so every open PR
inherits a red `Code Review / Dependency Audit / Audit Production Dependencies`
check regardless of what it changes:

```
ERROR: unexcepted high/critical production vulnerabilities:
  website/electron/package-lock.json: js-yaml GHSA-5p4m-2wfm-xmqj (high)
    - JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x)
```

## Why it matters

Two things, one of them ongoing:

- **A real high-severity vulnerability ships in the desktop app.** js-yaml is
  reached through `electron-updater`, which is a *production* dependency, so the
  affected parser is present in the packaged DMG, not just in build tooling.
  Quadratic CPU consumption on `!!omap` resolution is a denial-of-service vector
  wherever untrusted YAML is parsed.
- **It blocks unrelated work.** A gate that is red on `main` is red on every PR,
  which trains reviewers to ignore it — and hides the next genuine finding.

## Fix (symptom → root cause → change)

**Symptom.** The audit flags js-yaml 4.3.0 as a high-severity production
vulnerability in `website/electron/package-lock.json`.

**Root cause.** js-yaml is not a direct dependency of the electron package. It is
pulled in transitively and force-resolved by an `overrides` pin that was set to an
exact `4.3.0`. The advisory covers `>= 4.0.0, < 4.3.1`, so that pin holds the tree
on an affected version.

The advisory's *title* is misleading — it reads
`3.x and 4.x — CVE-2026-59870 fix not backported`, which suggests the 4.x line has
no fix and that the only way out is a major bump to 5.x. Its **structured data
says otherwise**:

```
vulnerable_version_range: ">= 4.0.0, < 4.3.1"
first_patched_version:    "4.3.1"
```

So 4.x *is* patched, at 4.3.1.

**Change.** Move the override from `4.3.0` to `4.3.1` — four lines, one patch
version.

This is deliberately the smallest fix that clears the advisory. Every consumer of
js-yaml in this tree declares `^4.1.0`:

| Consumer | Declares | In |
|---|---|---|
| `app-builder-lib` | `^4.1.0` | devDependency tree |
| `builder-util` | `^4.1.0` | devDependency tree |
| `dmg-builder` | `^4.1.0` | devDependency tree |
| `electron-updater` | `^4.1.0` | **production** dependency |

`4.3.1` satisfies `^4.1.0`, so no consumer is forced onto a version it never
declared support for. A bump to 5.x would override all four onto an undeclared
major — including the production auto-updater — for no additional security
benefit. Keeping the pin exact also preserves the style of its neighbour,
`"fast-uri": "3.1.5"`.

## Tests

No new test. This is a dependency-pin change with no source change, and the
condition it fixes is asserted by an existing CI gate
(`scripts/check_npm_audit.py`, run by `.github/workflows/dependency-vulnerability.yml`),
which is precisely the check that is currently red. That gate is the regression
test: if the pin regresses to an affected version, it goes red again.

## Manual verification

- `python3 scripts/check_npm_audit.py` → **passes**
  (`3 lockfiles, 2 governed exception(s)`); fails on `main` without this change.
- `npm install --package-lock-only` in `website/electron` → `found 0 vulnerabilities`.
- **Lockfile integrity verified against the registry** — the hand-edited
  `integrity` and `resolved` fields match `npm view js-yaml@4.3.1` byte for byte,
  so `npm ci` will not reject the lockfile:
  ```
  registry: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
  lockfile: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
  ```
- `node --test test/*.test.js` in `website/electron` → **635 passed, 0 failed**
  (covers `electron-updater`'s consumers, the closest available proof that the
  bump does not disturb the build/update path).

The diff is confined to two manifest files and carries no `"peer": true`
normalization churn, so the review surface is exactly the four lines that matter.

## Screenshots

N/A — no user-visible change.

## Note on the overlapping PR

#1925 targets this same defect by moving the override to `^5.2.3`. I'd suggest
this one instead: 5.x is an unnecessary major bump across four `^4.1.0` consumers
(one of them production), and `^5.2.3` loosens an exact pin to a caret range.
Happy to close this in favour of #1925 if maintainers prefer the 5.x line — the
advisory is cleared either way, so this is a blast-radius judgement, not a
correctness one.

## Related

This is one of three defects making `main` red at `429cbad8`. The other two —
the `_last_unshare_failure` tuple arity in `test_sandbox_docker_detection.py` and
the 11 untranslated `ja` `kiroPrerequisiteGate` keys — are both covered by #1873.
