### PR TITLE
fix(test): give the unshare-failure stub its third element

### DIFF
--- a/test/test_sandbox_docker_detection.py
+++ b/test/test_sandbox_docker_detection.py
@@ -167,7 +167,11 @@ class TestWrapArgvDockerGuidance:
         monkeypatch.setattr(
             sandbox,
             "_last_unshare_failure",
-            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)"),
+            # Three elements, matching what the probe actually stores
+            # (transient, reason, remedy) and what `wrap_argv` unpacks. A
+            # two-element stand-in raises ValueError inside the code under test,
+            # so the assertions below never run.
+            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)", ""),
         )
         # Stub SEL so no real I/O happens.
         fake_sel = MagicMock()
@@ -246,7 +250,11 @@ class TestWrapArgvDockerGuidance:
         monkeypatch.setattr(
             sandbox,
             "_last_unshare_failure",
-            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)"),
+            # Three elements, matching what the probe actually stores
+            # (transient, reason, remedy) and what `wrap_argv` unpacks. A
+            # two-element stand-in raises ValueError inside the code under test,
+            # so the assertions below never run.
+            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)", ""),
         )
         fake_sel = MagicMock()
         fake_sel.return_value = fake_sel
@@ -281,7 +289,11 @@ class TestWrapArgvDockerGuidance:
         monkeypatch.setattr(
             sandbox,
             "_last_unshare_failure",
-            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)"),
+            # Three elements, matching what the probe actually stores
+            # (transient, reason, remedy) and what `wrap_argv` unpacks. A
+            # two-element stand-in raises ValueError inside the code under test,
+            # so the assertions below never run.
+            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)", ""),
         )
         fake_sel = MagicMock()
         fake_sel.return_value = fake_sel


### PR DESCRIPTION
# What is broken

`TestWrapArgvDockerGuidance` stubs `sandbox._last_unshare_failure` with a **two**-element tuple. The probe stores **three** (`transient, reason, remedy` — `sandbox.py:678`) and `wrap_argv` unpacks three (`sandbox.py:2690`), so the stub makes the code under test raise before reaching a single assertion:

```
ValueError: not enough values to unpack (expected 3, got 2)
src/kiro_crew/sandbox.py:2690
```

Six tests in that class fail on `main`. They land on **Backend Tests shards 2 and 3, for both py3.10 and py3.12** — so this is charged to every open PR, including ones whose diff contains no Python at all.

# Why it is this stub and not the source

Every other place that sets the same module global already uses the three-element form:

| file | form |
|---|---|
| `test_sandbox_backend_cache.py` | 3-tuple |
| `test_sandbox_argv.py` | 3-tuple |
| `test_sandbox_remedy.py` | 3-tuple |
| `test_sandbox_probe.py` | 3-tuple |
| `src/kiro_crew/sandbox.py:678` (the real writer) | 3-tuple |
| **`test_sandbox_docker_detection.py`** (3 sites) | **2-tuple** |

So `remedy` was added to the tuple and these three monkeypatch sites were missed. The source is right; the stub is stale.

# The fix

Supply the empty remedy the real EPERM path carries, at all three sites, with a comment naming the failure mode — because a short tuple here does not weaken an assertion, it stops the assertions from running at all, which is a much quieter way to fail.

# Tested

- `test_sandbox_docker_detection.py`: **16 passed** (was 6 failed / 10 passed).
- `test_sandbox_{docker_detection,argv,remedy,probe,backend_cache}.py` + `test_spawn_audit.py`: **234 passed**, 1 skipped.
- `flake8` + `isort` clean. Test-only diff, one file.

Unblocks the Backend Tests failures currently red on #1927 and #1930.
