### PR TITLE
fix(deps): bump the electron js-yaml override to 4.3.1

### DIFF
--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -2402,9 +2402,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -21,7 +21,7 @@
   },
   "overrides": {
     "fast-uri": "3.1.5",
-    "js-yaml": "4.3.0"
+    "js-yaml": "4.3.1"
   },
   "build": {
     "appId": "com.amazon.kiro.crew",


### PR DESCRIPTION
# What is broken

`Dependency Audit / Audit Production Dependencies` fails on `main`, so on every open PR:

```
ERROR: unexcepted high/critical production vulnerabilities:
  website/electron/package-lock.json: js-yaml GHSA-5p4m-2wfm-xmqj (high)
  - JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x)
    — CVE-2026-59870 fix not backported
```

# Why `npm update` cannot fix it

js-yaml is transitive here (via `electron-builder` / `electron-updater`), and `website/electron/package.json` **already pins it through `overrides`** from an earlier advisory — at `4.3.0`, exactly one release below the fix:

```json
"overrides": {
  "fast-uri": "3.1.5",
  "js-yaml": "4.3.0"
}
```

The override is what holds it back, so the fix is to move the pin, not to run an update.

| | affected range | first patched |
|---|---|---|
| [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | `>= 4.0.0, < 4.3.1` | **4.3.1** |
| | `>= 3.0.0, < 3.15.1` | 3.15.1 |

4.3.1 is published on npm. `website/package-lock.json` is already resolved to it, which is why the audit named only the electron tree.

# The fix

Bump the override to the advisory's `first_patched_version` and regenerate the lockfile. The pin stays exact, matching the file's existing style.

```diff
-    "js-yaml": "4.3.0"
+    "js-yaml": "4.3.1"
```

# Tested

- `npm install --package-lock-only` in `website/electron`: **`found 0 vulnerabilities`**.
- Resolved version moves `4.3.0` → `4.3.1`.
- Two files, four lines. No source changes, no direct-dependency changes, no `package.json` dependency edits — so nothing can shift in the app bundle beyond the patch itself.

Unblocks the `Dependency Audit` failure currently red on #1927, #1930 and #1932.
