### PR TITLE
test(sandbox): fix stale 2-tuple _last_unshare_failure stub in docker guidance tests

### DIFF
--- a/test/test_sandbox_docker_detection.py
+++ b/test/test_sandbox_docker_detection.py
@@ -167,7 +167,7 @@ class TestWrapArgvDockerGuidance:
         monkeypatch.setattr(
             sandbox,
             "_last_unshare_failure",
-            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)"),
+            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)", ""),
         )
         # Stub SEL so no real I/O happens.
         fake_sel = MagicMock()
@@ -246,7 +246,7 @@ class TestWrapArgvDockerGuidance:
         monkeypatch.setattr(
             sandbox,
             "_last_unshare_failure",
-            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)"),
+            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)", ""),
         )
         fake_sel = MagicMock()
         fake_sel.return_value = fake_sel
@@ -281,7 +281,7 @@ class TestWrapArgvDockerGuidance:
         monkeypatch.setattr(
             sandbox,
             "_last_unshare_failure",
-            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)"),
+            (False, "unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)", ""),
         )
         fake_sel = MagicMock()
         fake_sel.return_value = fake_sel


### PR DESCRIPTION
## Problem
Six tests in `test/test_sandbox_docker_detection.py::TestWrapArgvDockerGuidance` fail on Linux/CI (Backend shard 3) with:

```
ValueError: not enough values to unpack (expected 3, got 2)
```

This has been a persistent red on `main`'s Backend shard 3, bleeding into unrelated open PRs (e.g. #1860). The module is `skipif(sys.platform != "linux")`, so it silently skips on macOS and only breaks on CI.

## Why it matters
A permanently-red base check masks real regressions and forces every PR author to hand-wave "it's red on main too". It is not flaky — it is a deterministic stale-test breakage that should just be fixed.

## Fix (symptoms → root cause → change)
- Symptom: three `TestWrapArgvDockerGuidance` helpers stub `sandbox._last_unshare_failure` with a 2-tuple `(False, "unshare(...) ...")`.
- Root cause: `_last_unshare_failure` was widened to a 3-tuple `(transient, reason, remedy)` in `src/kiro_crew/sandbox.py` (declared at line 260; unpacked at lines 2226/2373/2690 as `transient, probe_reason, probe_remedy = _last_unshare_failure or (False, ..., "")`). Because a stubbed 2-tuple is truthy, the `or (...)` default never fires, so unpacking 3 targets from a 2-tuple raises `ValueError`. Every other sandbox test file (`test_sandbox_argv.py`, `test_sandbox_backend_cache.py`, `test_sandbox_remedy.py`, `test_sandbox_probe.py`) was already migrated to the 3-tuple; this file was the sole straggler.
- Change: add the missing `remedy` element (`""`, matching the code's own fallback default) to all three stub sites. `remedy` only feeds the transient branch and the exception's `remedy=` field — neither is asserted by these tests — so the fix restores unpacking without altering any assertion.

## Tests
No new tests. Restores the six existing `TestWrapArgvDockerGuidance` cases (seccomp guidance, allow-unsandboxed guidance, no "install a supported sandbox backend" text, `no_backend` error kind, bare-metal generic guidance, AppArmor-restricted profile guidance) to a runnable, passing state on Linux.

## Manual verification
- macOS: `pytest test/test_sandbox_docker_detection.py -q` → 16 skipped (Linux guard), no collection/unpack error.
- `isort --check-only`, `flake8`, `mypy` on the changed file: all clean.
- Full Linux run happens on CI (Backend shards).

## Screenshots
N/A — test-only change, no user-visible UI.
