### PR TITLE
test(e2e): disambiguate 'Knowledge Library' locator in help-dialog spec

### DIFF
--- a/website/playwright/knowledge.spec.ts
+++ b/website/playwright/knowledge.spec.ts
@@ -116,7 +116,10 @@ test.describe('Knowledge Page E2E Tests', () => {
   })
 
   test('help dialog opens and closes', async ({ page }) => {
-    await expect(page.getByText('Knowledge Library')).toBeVisible({ timeout: 10000 })
+    // exact: true — the onboarding heading also contains "Knowledge Library"
+    // ("Welcome to the Knowledge Library"), so a substring match resolves to two
+    // elements and trips strict mode (see the same guard above).
+    await expect(page.getByText('Knowledge Library', { exact: true })).toBeVisible({ timeout: 10000 })
 
     // Click the Help button
     await page.getByRole('button', { name: /Help/i }).click()


### PR DESCRIPTION
## Problem
The `E2E (stub ACP backend, offline)` job fails deterministically on `test/test_playwright_e2e.py::test_dashboard_playwright_suite` at `playwright/knowledge.spec.ts:119` (`help dialog opens and closes`):

```
Error: strict mode violation: getByText('Knowledge Library') resolved to 2 elements:
  1) <div ...>Knowledge Library</div>              (page title)
  2) <h3 ...>Welcome to the Knowledge Library</h3>  (onboarding card heading)
```

This is red on `main`, so it blocks the E2E gate on every open PR.

## Why it matters
E2E is part of `PR Readiness`. A base-level red here darkens the readiness rollup for all PRs, forcing manual re-runs and masking real regressions behind a known-failing check.

## Fix (symptom -> root cause -> change)
- **Symptom:** strict-mode violation — the locator matches two elements.
- **Root cause:** the Knowledge page renders both the title `Knowledge Library` and the onboarding heading `Welcome to the Knowledge Library`, which contains the same substring. A substring `getByText('Knowledge Library')` therefore resolves to both.
- **Change:** add `{ exact: true }` so the assertion matches only the title. This mirrors the identical guard already present at `knowledge.spec.ts:52` (with the same explanatory comment) — line 119 was simply missed when that fix was applied. Playwright's own error output labels the title as `aka getByText('Knowledge Library', { exact: true })`, confirming exact matching disambiguates uniquely.

## Tests
No new test — this repairs an existing E2E assertion. The `help dialog opens and closes` Playwright test now loads the page cleanly before exercising the dialog.

## Manual verification
N/A — the fix is a locator disambiguation identical to the working guard at line 52 in the same file; correctness is confirmed by Playwright's own strict-mode diagnostic. Full validation is the E2E job on this PR.

## Screenshots
N/A — test-only change, no user-visible UI change.
