### PR TITLE
fix(i18n): add 11 missing kiroPrerequisiteGate keys to ja catalog

### DIFF
--- a/website/src/i18n/locales/ja.json
+++ b/website/src/i18n/locales/ja.json
@@ -4105,7 +4105,18 @@
       "try_again": "もう一度試してください",
       "waiting": "待機中",
       "we_could_not_check_kiro_cli": "Kiro CLI を確認できませんでした。",
-      "your_crew_is_almost_ready": "クルーの準備がほぼ完了しました。"
+      "your_crew_is_almost_ready": "クルーの準備がほぼ完了しました。",
+      "copied": "コピーしました",
+      "copy_command": "コマンドをコピー",
+      "how_to_fix": "解決方法",
+      "if_this_keeps_happening": "問題が解決しない場合",
+      "linux_sandbox_guide": "Linux サンドボックスガイド",
+      "remedy_apparmor_service_install": "Kiro Crew をサービスとしてインストールします。その際、ユーザー名前空間の権限のみを付与する限定的な AppArmor プロファイル (kirocrew-userns) が Kiro Crew サービスに対してのみ書き込まれます。マシン上の他の要素の制限が緩められることはありません。",
+      "remedy_max_user_namespaces": "ユーザー名前空間の作成がユーザーごとの上限に達しました。これは通常、強化されたホストで user.max_user_namespaces が 0 になっていることを意味します。値を引き上げ、再起動後も維持されるように /etc/sysctl.d/ に永続化してください。",
+      "remedy_no_user_ns": "このカーネルはユーザー名前空間のサポート (CONFIG_USER_NS) なしでビルドされているため、変更できる設定はありません。別のカーネルを使用することが唯一の解決策です。",
+      "remedy_userns_denied": "カーネルがユーザー名前空間の作成を拒否しました。Debian 系のホストではこのレガシー設定を確認し、再起動後も維持されるように /etc/sysctl.d/ に永続化してください。コンテナ内の場合は通常、コンテナ自身の seccomp フィルターが unshare を拒否していることが原因で、ホストの設定ではなくコンテナの実行フラグで修正します。",
+      "run_kirocrew_doctor_on_the_gateway_host_for_a_ful": "ゲートウェイホストでこれを実行すると、どのサンドボックスステップが失敗したかを含む、前提条件の完全なレポートが得られます。",
+      "this_host_allows_user_namespaces_but_the_kernel_d": "このホストはユーザー名前空間を許可していますが、カーネルがマウント名前空間を拒否しました。これは Ubuntu 23.10 以降の特徴で、ユーザー名前空間を作成したプロセスを制限付きの AppArmor プロファイルに移動させます。Kiro Crew は認証情報を露出させるよりも分離されていない状態でエージェントを実行することを拒否するため、プロファイルが適用されるまでブロックされたままになります。"
     },
     "linkPreview": {
       "copied": "コピー済み",


### PR DESCRIPTION
## Problem
`catalogParity.test.ts > ja > has no key missing relative to en` fails on `origin/main`: the `ja` locale is missing 11 keys under `components.kiroPrerequisiteGate` (`copied`, `copy_command`, `how_to_fix`, `if_this_keeps_happening`, `linux_sandbox_guide`, `remedy_apparmor_service_install`, `remedy_max_user_namespaces`, `remedy_no_user_ns`, `remedy_userns_denied`, `run_kirocrew_doctor_on_the_gateway_host_for_a_ful`, `this_host_allows_user_namespaces_but_the_kernel_d`).

## Why it matters
This is a base breakage on `main`, not confined to one branch — every open PR inherits the red Frontend Tests shard and cannot go green until `ja` reaches parity. Japanese users also see raw key fallbacks for the sandbox-prerequisite gate UI.

## Fix
- **Symptom:** `catalogParity` reports 11 keys present in the en source but absent from `ja`.
- **Root cause:** these `kiroPrerequisiteGate` strings (sandbox user-namespace remedy copy) are authored in `en.manual.json`, the manual source of truth. When they were added, all translated locales (`de`, `ru`, `zh-CN`, `pt`, `it`, `fr`, `hi`, `es`, `bn`, `en-XA`) received them — `ja` alone was skipped.
- **Change:** add the 11 keys with Japanese translations to `website/src/i18n/locales/ja.json`. Insertion-only; no existing key reordered or modified.

## Tests
- `npx vitest run src/i18n/catalogParity.test.ts src/i18n/deadKeys.test.ts` → 73 passed (70 parity + 3 deadKeys). deadKeys baseline unaffected (these keys are referenced by `KiroPrerequisiteGate.tsx`, so no new unreferenced keys).

## Manual verification
- Confirmed against `origin/main` (51d045b2e) that `ja` was the only translated locale missing these keys; `de` and siblings already had all 62.