### PR TITLE
fix(acp): enforce the per-image byte cap on the encoded payload

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -411,14 +411,17 @@ The `audit_source` constructor param (default `None`) tags an `AcpClient` that r
 
 1. Reads the file (paths over `MAX_IMAGE_BYTES` = 10 MB stay as text, not inlined)
 2. Downscales so the longest edge is <= `MAX_IMAGE_EDGE_PX` (2000 px), preserving aspect ratio and re-encoding to the same format (an oversized GIF becomes a PNG still frame)
-3. Base64-encodes the (possibly downscaled) bytes
-4. Appends an image content block: `{"type": "image", "data": "<base64>", "mimeType": "image/png"}`
-5. Replaces the path in the text with `[image: filename.png]`
-6. Sends both text and image blocks in the `prompt` array
+3. Shrinks further while the base64 payload still exceeds `MAX_IMAGE_B64_BYTES` (5 MiB), stopping at `MIN_IMAGE_EDGE_PX` (256 px)
+4. Base64-encodes the (possibly downscaled) bytes
+5. Appends an image content block: `{"type": "image", "data": "<base64>", "mimeType": "image/png"}`
+6. Replaces the path in the text with `[image: filename.png]`
+7. Sends both text and image blocks in the `prompt` array
 
 This leverages kiro-cli's `promptCapabilities.image: true` capability. The LLM receives the image inline — no tool call needed.
 
 **Dimension backstop** (`build_prompt_blocks` in `acp/prompt_blocks.py`). This shared builder is the single funnel every channel's images cross before reaching kiro-cli, so the `MAX_IMAGE_EDGE_PX` (2000 px) downscale runs for all of them — dashboard upload/paste/screenshot, Slack, Discord. Anthropic rejects the ENTIRE request when a many-image conversation (>20 images) carries any image over 2000 px on a side; because kiro-cli replays the full message history every turn, one oversized image would otherwise sit at a fixed history index and wedge the session permanently (a follow-up resize cannot evict the original). The browser's client-side resize (1568 px, `website/src/utils/resizeImage.ts`) is a token-cost optimization on top; this server-side cap is the correctness guarantee that still holds when that resize is skipped or bypassed (e.g. the native `/api/screenshot` capture, or non-dashboard channels).
+
+**Encoded-size backstop** (`_fit_encoded_budget`, same module). The dimension cap alone does not bound the payload: a raster can sit well inside 2000 px and still encode past the backend's per-image byte ceiling. `MAX_IMAGE_B64_BYTES` is **5 MiB, read out of the backend's own rejection** rather than derived from which provider kiro-cli routes through (which we treat as opaque) — the error names the limit in bytes, `image exceeds 5 MB maximum: 6714372 bytes > 5242880`, and 5242880 is exactly 5 × 1024 × 1024. Anthropic's published per-image ceiling for Bedrock and Google Cloud agrees, which is corroboration rather than the basis. The check must run on the ENCODED payload AFTER any downscale: `MAX_IMAGE_BYTES` measures the file before the re-encode and cannot see base64's 4/3 inflation, so a ~3.9 MiB raster passes every pre-encode gate and is still rejected on the wire. Because a rejected image is replayed from a fixed history index on every later turn, this has the same wedge-the-session consequence as the dimension case. Erring low merely ships a smaller image while erring high ships a refused payload, so the cap is set to the observed value and callers can override it via `max_image_b64_bytes` if a backend ever reports a different number. `_fit_encoded_budget` applies the dimension cap, then keeps shrinking (0.8 per pass, up to 6 passes, from the rendition's OWN long edge so an already-in-cap image still makes progress) until the encoding fits. If nothing fits above `MIN_IMAGE_EDGE_PX` (256 px) it fails CLOSED — the path stays in the text and no image block is emitted, because inlining a payload the backend refuses is strictly worse than sending a reference a tool-capable agent can open.
 
 
 ## AcpRuntime & AcpSessionHandle (session multiplexing)

--- a/src/kiro_crew/acp/prompt_blocks.py
+++ b/src/kiro_crew/acp/prompt_blocks.py
@@ -74,6 +74,54 @@ MAX_IMAGE_BYTES = 10 * 1024 * 1024
 #: 1568px pre-upload downscale, which only ever covers dashboard uploads.
 MAX_IMAGE_EDGE_PX = 2000
 
+#: Longest base64-encoded payload (bytes) allowed for a single inlined image.
+#: The dimension cap above is not sufficient: a raster can sit well inside 2000px
+#: and still encode past the backend's per-image byte ceiling.
+#:
+#: 5 MiB is the value the backend itself reports. It is not derived from which
+#: provider kiro-cli happens to route through, which we treat as opaque, but read
+#: straight out of its rejection, which names the limit in bytes:
+#:
+#:     image exceeds 5 MB maximum: 6714372 bytes > 5242880
+#:
+#: 5242880 is exactly 5 * 1024 * 1024. (Anthropic's published per-image ceiling
+#: for Bedrock and Google Cloud agrees, which is corroboration rather than the
+#: basis.) base64 inflates by 4/3, so a ~3.9 MiB raster already exceeds it while
+#: passing every pre-encode check.
+#:
+#: Note this is a DIFFERENT quantity from the limit kiro-cli documents. Its docs
+#: state "images must be under 10MB in size" -- a FILE-size rule, which
+#: ``MAX_IMAGE_BYTES`` implements -- and say nothing about the encoded payload.
+#: Both hold at once: a 5.04 MiB file is under 10 MB yet encodes to 6.71 MiB and
+#: is refused. So the encoded ceiling is undocumented but enforced, which is why
+#: it has to be observed rather than looked up.
+#:
+#: Being wrong here is safe in one direction only, which is why the cap is set to
+#: the observed value rather than a guess: too LOW merely ships a smaller image,
+#: while too HIGH ships a payload the backend refuses. Callers can override it
+#: via ``build_prompt_blocks(max_image_b64_bytes=...)`` if a backend ever reports
+#: a different number.
+#:
+#: This is enforced on the ENCODED payload, after any downscale, because that is
+#: the only quantity the backend measures: ``MAX_IMAGE_BYTES`` reads the file
+#: size before the re-encode and cannot see the encoding overhead. Getting this
+#: wrong is not a one-turn error -- a rejected image sits at a fixed history
+#: index that kiro-cli replays on every subsequent turn, so one oversized
+#: attachment wedges the session permanently.
+MAX_IMAGE_B64_BYTES = 5 * 1024 * 1024
+
+#: Floor for the encoded-budget shrink loop. Below ~200px Claude's own guidance
+#: says accuracy degrades badly, so an image that still will not fit is dropped
+#: to a path reference instead of being shrunk into uselessness.
+MIN_IMAGE_EDGE_PX = 256
+
+#: Per-attempt edge multiplier and attempt cap for the encoded-budget shrink.
+#: Encoded size falls roughly with area, so 0.8 on the edge sheds ~36% per pass
+#: and 6 passes span a 4x linear reduction -- enough to bring any image that the
+#: dimension cap admitted under a 5 MiB encoding.
+_ENCODE_SHRINK_FACTOR = 0.8
+_MAX_ENCODE_ATTEMPTS = 6
+
 #: mime -> Pillow save format for a re-encoded downscale. GIF collapses to a PNG
 #: first frame: vision models read frame 0 only (animation is invisible to them)
 #: and rescaling a palette image is lossy, so a lossless still is faithful.
@@ -202,12 +250,75 @@ def _downscale_within_limits(raw_bytes: bytes, mime: str, max_edge: int) -> tupl
         return None
 
 
+def _b64_len(raw_len: int) -> int:
+    """Exact base64 length for *raw_len* bytes (4 chars per 3-byte group, padded)."""
+    return 4 * ((raw_len + 2) // 3)
+
+
+def _long_edge(raw_bytes: bytes) -> int | None:
+    """Longest edge of *raw_bytes* in px, or ``None`` if it cannot be read.
+
+    Header-only read -- no decompression -- so this is cheap enough to call on
+    the shrink path without paying for a decode.
+    """
+    if not _HAS_PIL:
+        return None
+    try:
+        with Image.open(io.BytesIO(raw_bytes)) as img:
+            return max(img.width, img.height)
+    except Exception:
+        return None
+
+
+def _fit_encoded_budget(
+    raw_bytes: bytes, mime: str, max_edge: int, max_b64_bytes: int
+) -> tuple[bytes, str] | None:
+    """Render *raw_bytes* so it obeys BOTH the dimension and encoded-size caps.
+
+    Applies the dimension cap first, then keeps shrinking while the base64
+    encoding still exceeds *max_b64_bytes*. Returns the ``(bytes, mime)`` pair to
+    inline, or ``None`` when no compliant rendition exists -- the caller must then
+    leave the path as text, since inlining a payload the backend rejects poisons
+    every later turn in the session.
+
+    The shrink target is derived from the rendition's OWN long edge rather than
+    from *max_edge*: :func:`_downscale_within_limits` is a deliberate no-op for an
+    image already inside the cap, so an oversized-but-small-dimension file (the
+    exact case that trips the 5 MiB ceiling) would otherwise loop without ever
+    making progress.
+    """
+    fitted = _downscale_within_limits(raw_bytes, mime, max_edge)
+    if fitted is None:
+        return None
+    out_bytes, out_mime = fitted
+    if max_b64_bytes <= 0 or _b64_len(len(out_bytes)) <= max_b64_bytes:
+        return out_bytes, out_mime
+
+    edge = _long_edge(out_bytes)
+    if edge is None:
+        # Dimensions unknown (no Pillow, or an undecodable raster): the encoded
+        # size is known to be over budget and cannot be reduced, so fail closed.
+        return None
+    for _ in range(_MAX_ENCODE_ATTEMPTS):
+        edge = max(MIN_IMAGE_EDGE_PX, int(edge * _ENCODE_SHRINK_FACTOR))
+        fitted = _downscale_within_limits(raw_bytes, mime, edge)
+        if fitted is None:
+            return None
+        out_bytes, out_mime = fitted
+        if _b64_len(len(out_bytes)) <= max_b64_bytes:
+            return out_bytes, out_mime
+        if edge <= MIN_IMAGE_EDGE_PX:
+            break
+    return None
+
+
 def build_prompt_blocks(
     message: str,
     *,
     allow_image: bool = True,
     max_image_bytes: int = MAX_IMAGE_BYTES,
     max_image_edge: int = MAX_IMAGE_EDGE_PX,
+    max_image_b64_bytes: int = MAX_IMAGE_B64_BYTES,
 ) -> list[dict]:
     """Return ACP prompt blocks for *message*.
 
@@ -224,7 +335,9 @@ def build_prompt_blocks(
     Inlined images are downscaled so their longest edge is at most
     ``max_image_edge`` px -- the server-side backstop for Anthropic's many-image
     dimension limit, applied for EVERY channel here regardless of any
-    client-side resize that was skipped or bypassed.
+    client-side resize that was skipped or bypassed -- and then shrunk further if
+    needed so the base64 payload stays within ``max_image_b64_bytes``, the
+    backend's per-image byte ceiling.
     """
     text = message
     images: list[dict] = []
@@ -265,14 +378,17 @@ def build_prompt_blocks(
                 # stays in the text; it is NOT inlined.
                 logger.warning("acp prompt: image read refused for %s", path.name)
                 continue
-            downscaled = _downscale_within_limits(raw_bytes, mime, max_image_edge)
+            downscaled = _fit_encoded_budget(
+                raw_bytes, mime, max_image_edge, max_image_b64_bytes
+            )
             if downscaled is None:
-                # Oversized and un-shrinkable (decompression-bomb / undecodable):
-                # leave the path as text rather than inline a >2000px payload that
-                # would poison the session. A tool-capable agent can still open it.
+                # Oversized and un-shrinkable (decompression-bomb / undecodable /
+                # still over the encoded ceiling at the minimum edge): leave the
+                # path as text rather than inline a payload the backend rejects on
+                # this and every later turn. A tool-capable agent can still open it.
                 logger.warning(
-                    "acp prompt: image %s exceeds the dimension cap and could not be "
-                    "downscaled - sending path, not inline",
+                    "acp prompt: image %s could not be rendered within the "
+                    "dimension and encoded-size caps - sending path, not inline",
                     path.name,
                 )
                 continue

--- a/test/test_acp_prompt_blocks.py
+++ b/test/test_acp_prompt_blocks.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import base64
 import io
 import os
+import random
 
 import pytest
 
@@ -398,3 +399,79 @@ class TestImageDownscale:
             assert 0x0112 not in out.getexif()  # tag baked away, not carried
             assert h > w  # rotation applied to the pixels -> portrait
             assert max(w, h) <= MAX_IMAGE_EDGE_PX
+
+
+def _noise_image(tmp_path, w, h, name="noise.png", fmt="PNG"):
+    """An image that resists compression, so its encoded size tracks pixel count."""
+    pil = pytest.importorskip("PIL.Image")
+    rnd = random.Random(1234)
+    img = pil.new("RGB", (w, h))
+    img.putdata([(rnd.randrange(256), rnd.randrange(256), rnd.randrange(256)) for _ in range(w * h)])
+    p = tmp_path / name
+    img.save(p, format=fmt)
+    return p
+
+
+class TestImageEncodedBudget:
+    """The per-image ENCODED byte ceiling.
+
+    The dimension cap alone is not enough: Bedrock rejects a single image over
+    5 MiB base64, and a raster can sit well inside 2000px while encoding past
+    that. A rejected image is replayed from history every later turn, so letting
+    one through wedges the whole session.
+    """
+
+    def test_default_cap_is_5_mib(self):
+        assert prompt_blocks.MAX_IMAGE_B64_BYTES == 5 * 1024 * 1024
+
+    def test_b64_len_matches_real_encoding(self):
+        for n in (0, 1, 2, 3, 4, 100, 1023, 4096):
+            assert prompt_blocks._b64_len(n) == len(base64.b64encode(b"x" * n))
+
+    def test_image_inside_dimension_cap_but_over_budget_is_shrunk(self, tmp_path):
+        """The exact production defect: dimensions are already legal, so the
+        dimension pass is a no-op, yet the payload still exceeds the wire limit.
+        """
+        p = _noise_image(tmp_path, 900, 900)
+        budget = len(base64.b64encode(p.read_bytes())) // 3
+        blocks = build_prompt_blocks(f"see {p}", max_image_b64_bytes=budget)
+        assert [b["type"] for b in blocks] == ["text", "image"]
+        assert len(blocks[1]["data"]) <= budget
+        # Shrunk, not passed through: the bug was inlining the original here.
+        assert base64.b64decode(blocks[1]["data"]) != p.read_bytes()
+        assert max(_decoded_size(blocks[1])) < 900
+
+    def test_image_within_budget_is_byte_identical(self, tmp_path):
+        p = _sized_image(tmp_path, 100, 80)
+        original = p.read_bytes()
+        blocks = build_prompt_blocks(f"see {p}")
+        assert base64.b64decode(blocks[1]["data"]) == original
+
+    def test_unshrinkable_image_falls_back_to_a_path(self, tmp_path):
+        """Fail CLOSED: a budget no rendition can meet must leave the path as
+        text rather than inline a payload the backend will reject forever."""
+        p = _noise_image(tmp_path, 400, 400)
+        blocks = build_prompt_blocks(f"see {p}", max_image_b64_bytes=8)
+        assert [b["type"] for b in blocks] == ["text"]
+        assert str(p) in blocks[0]["text"]
+
+    def test_zero_budget_disables_the_check(self, tmp_path):
+        p = _noise_image(tmp_path, 120, 120)
+        original = p.read_bytes()
+        blocks = build_prompt_blocks(f"see {p}", max_image_b64_bytes=0)
+        assert base64.b64decode(blocks[1]["data"]) == original
+
+    def test_budget_applies_after_the_dimension_cap(self, tmp_path):
+        """Both caps hold at once -- shrinking for bytes must not reintroduce an
+        over-dimension rendition, and vice versa."""
+        p = _noise_image(tmp_path, 2400, 2400, name="big.jpg", fmt="JPEG")
+        blocks = build_prompt_blocks(f"see {p}", max_image_b64_bytes=400_000)
+        assert max(_decoded_size(blocks[1])) <= MAX_IMAGE_EDGE_PX
+        assert len(blocks[1]["data"]) <= 400_000
+
+    def test_shrink_floor_is_respected(self, tmp_path):
+        """The loop never grinds an image below the usable-accuracy floor; it
+        gives up and hands back a path instead."""
+        p = _noise_image(tmp_path, 1000, 1000)
+        blocks = build_prompt_blocks(f"see {p}", max_image_b64_bytes=64)
+        assert [b["type"] for b in blocks] == ["text"]


### PR DESCRIPTION
## 1. What is the problem?

The per-image byte gate measures the wrong quantity. `acp/prompt_blocks.py` checks `MAX_IMAGE_BYTES` (10 MB) against the **file size before the re-encode**, and never re-checks the base64 output:

```python
size = path.stat().st_size
if size > max_image_bytes:      # 10 MB, on the ORIGINAL file
    continue
raw_bytes = safe_read_file_bytes(str(path))
downscaled = _downscale_within_limits(raw_bytes, mime, max_image_edge)   # dimensions only
data = base64.b64encode(out_bytes)                                      # never re-checked
```

Three things compound:

* **The limit is 2x too permissive for this backend.** Anthropic's direct API allows 10 MiB base64 per image, but [the vision docs](https://docs.claude.com/en/docs/build-with-claude/vision) cap a single image at **5 MiB base64** on Amazon Bedrock and Google Cloud. More to the point, **the backend states the number in its own rejection** (`... > 5242880`, exactly 5 MiB), so the cap here is observed rather than looked up — see the [black-box discussion](https://github.com/kirodotdev/KiroCrew/pull/1941#issuecomment-5212387254).
* **The check sits on the wrong side of the encoding.** base64 inflates by 4/3, so a ~3.9 MiB raster already exceeds 5 MiB encoded while passing a 10 MB pre-read gate.
* **The downscale only looks at dimensions.** An image inside the 2000 px cap is returned byte-identical, so nothing downstream reduces its size.
* **Kiro's own docs describe a different quantity.** [Working with images](https://kiro.dev/docs/cli/chat/images/) states "images must be under 10MB in size" — a FILE-size rule, which `MAX_IMAGE_BYTES` implements correctly — and says nothing about the encoded payload. Both hold at once: a 5.04 MiB file is under 10 MB, encodes to 6.71 MiB, and is refused.

## 2. Why this issue matters to the user

This is a **hard failure with no recovery path**, not a slowdown or a cost regression. kiro-cli replays the full history every turn, so a rejected image sits at a fixed index and fails again on every subsequent request. The live gateway log shows exactly that — the same image, **19 times**:

```
image exceeds 5 MB maximum: 6714372 bytes > 5242880
```

One attachment wedges the session permanently. Re-sending a smaller copy does not help, because the original stays at its history index; the only escape is rewinding before the message or starting a new chat. Nothing warns beforehand that the attachment will be refused.

This is the same failure shape the `MAX_IMAGE_EDGE_PX` dimension cap was added to prevent — on the axis that was left unguarded.

## 3. How our fix solves it

Walking from symptom to cause: the payload the backend measures is the base64 encoding, but the only byte check ran on the pre-encode file size, so the encoding's 4/3 inflation was never accounted for — and the 10 MB threshold was itself calibrated for the direct API rather than the Bedrock path this build uses. Compounding it, `_downscale_within_limits` returns an in-cap image byte-identical, so no later step reduced size either.

`_fit_encoded_budget` adds the missing constraint: apply the dimension cap, then keep shrinking while the base64 encoding still exceeds `MAX_IMAGE_B64_BYTES` (5 MiB).

Two details are load-bearing:

* **The shrink target comes from the rendition's own long edge, not from `max_image_edge`.** `_downscale_within_limits` is a deliberate no-op for an image already inside the cap, so shrinking against the cap would loop without ever making progress — and an already-in-cap image is *precisely* the case that trips this ceiling.
* **It fails CLOSED.** If nothing fits above `MIN_IMAGE_EDGE_PX` (256 px), the path stays in the text and no image block is emitted. A reference a tool-capable agent can open is strictly better than a payload the backend refuses on this and every later turn.

## 4. What tests we did

**8 new cases** in `test/test_acp_prompt_blocks.py`: default cap is 5 MiB; `_b64_len` matches real encoding across boundary sizes; an image inside the dimension cap but over budget **is shrunk** (the exact production defect); an in-budget image stays byte-identical (no needless re-encode); an unshrinkable image falls back to a path; a zero budget disables the check; both caps hold simultaneously; the shrink floor is respected.

**Mutation-verified.** Restoring the old `_downscale_within_limits(...)` call at the inline site fails 4 of the 8.

**Gates.** `isort`, `flake8`, `mypy` (731 files), brand gate and docs lint all clean; 333 tests across the affected files pass. No frontend files changed. The full backend run's failures are all in unrelated modules (sandbox, service, dev-fleet, ops-mission-control, code-review-sage) and reproduce identically on `kirocrew/main` with the same venv (**19 failed / 981 passed** on the sampled subset), confirming they are pre-existing environment failures.

## 5. Any other suggestions on the work

**The conversation-log bloat half of #1940 was removed from this PR, and the reason is worth recording.** An earlier revision added a watchdog hook that stripped image bytes from orphaned kiro-cli conversation logs, reclaiming ~22.5 GB of the 27.3 GB in `<kiro sessions>/cli`. GPT and Design Review independently landed on the same objection: that directory belongs to **kiro-cli**, not to us, so any "this log is abandoned" rule we can express is proxy evidence — a session the user started by running kiro-cli directly is absent from our session map yet still resumable there, and stripping it is irreversible.

That objection is correct and, on measurement, the whole approach was aimed at the wrong directory. Kiro Crew's **own** session store carries no image payload at all — 126 files, 156.7 MB, **zero** raw byte arrays and zero long base64 runs. All 27.3 GB of image bloat lives in kiro-cli's directory. So the sweep had no target Kiro Crew can legitimately claim, and it is dropped rather than narrowed.

Follow-ups worth filing separately:

* **Four gaps between what kiro-cli documents and what it enforces**, all found while chasing this. Recorded because they are the reason a caller obeying the published limits still hits both failures seen here:
  1. [Working with images](https://kiro.dev/docs/cli/chat/images/) documents a 10 MB **file** limit but not the ~5 MiB **encoded** ceiling the backend actually rejects on — the defect this PR fixes.
  2. That page documents no **dimension** limit at all, yet a >2000 px image in a many-image request is rejected outright (the constraint `MAX_IMAGE_EDGE_PX` already guards).
  3. That page says "up to 10 images in a single request", but the many-image dimension error only fires above **20** image blocks, so receiving it proves at least 21 reached one request. The documented number must mean *ten per attachment*; history replay accumulates past it and the docs do not cover that.
  4. [Built-in tools](https://kiro.dev/docs/reference/built-in-tools/) describes `read` as "Reads files, folders and images" and documents only `allowedPaths` / `deniedPaths` — **no image limits on the read path at all**, which is where most images in a screenshot-heavy session actually enter.
* **The log bloat itself remains unfixed and is upstream-shaped.** kiro-cli stores an image as a JSON array of decimal byte values (~3.6 chars per byte vs 1.33 for base64) and never reclaims it; 98% of the largest single log was byte arrays. Worth noting [Session management](https://kiro.dev/docs/cli/chat/session-management/) describes storage as "a SQLite database in `~/.kiro/`" and lists "auto-save to database only (not files)" as a limitation, while on disk `~/.kiro/sessions` is 28 GB of per-session JSONL files with no SQLite present — and neither a retention policy nor unbounded growth appears anywhere in that page's Limitations. `--delete-session <ID>` is the only reclaim, manual and one session at a time.
* **Three things this PR deliberately does not claim.** Total request size: no size-related failure appears in the log, so it is not targeted. Memory: real image bytes in resumable sessions total ~120 MB, at most ~18 MB in any one, against a 500 MiB recycle ceiling — images are not what drives the multi-GB RSS growth noted in `acp/runtime.py`. Pointer forms: Anthropic's `file_id` and Bedrock Converse's `s3Location` both have the service fetch the bytes and feed the model identical pixels, so neither reduces visual tokens or context occupancy, and neither is reachable on the Messages-over-Bedrock path this build uses.

Refs #1940
