### PR TITLE
fix(dashboard): seed the context meter for cron-created sessions

### DIFF
--- a/src/kiro_crew/dashboard/cron_inject.py
+++ b/src/kiro_crew/dashboard/cron_inject.py
@@ -6,6 +6,7 @@ gateway.py and dashboard.handlers.
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.dashboard.state import DashboardState
@@ -16,11 +17,70 @@ if TYPE_CHECKING:
     from kiro_crew.cron import CronJob
 
 
+def context_meter_reading(client: object) -> dict[str, Any] | None:
+    """Best-effort context-meter reading from a live provider, or ``None``.
+
+    The cron executor resets its agent session the moment the run finishes, so
+    by the time the user opens the injected ``cron-{id}`` slot there is no
+    resident provider for the slot-detail open path to read and no snapshot
+    either — ``broadcast_context_usage`` (the meter's single writer) is only
+    reached by dashboard-driven turns. The bar therefore rendered 0% for a
+    session with a full transcript. This helper captures the reading while the
+    provider is still alive; :func:`inject_cron_result_to_dashboard` routes it
+    through the single writer so the open path serves it like any other
+    cold-session snapshot.
+
+    Mirrors ``chat_runner._context_usage_payload``'s accessor discipline: the
+    provider's PUBLIC accessors only (``last_prompt_stats`` lives on the inner
+    AcpClient and would always miss on the pooled provider), and token counts
+    ship only when both are measured — ``used == 0`` means "not measured", and
+    asserting a false "0 / W tokens" is worse than omitting the pair.
+
+    Returns ``None`` when nothing was measured (``pct <= 0``): a provider that
+    just ran a turn always occupies context (the prompt itself), so a
+    zero/absent pct here means "not reported", never "measured empty" — the
+    same contract as ``_context_reading`` on the read side. Skipping the write
+    also deliberately preserves an earlier run's real snapshot rather than
+    overwriting it with an unmeasured zero (which would recreate the 0%-bar
+    symptom this helper exists to fix); the genuine post-compaction 0% reset
+    frame is emitted by the session manager's compact callback for live
+    sessions, not by this capture path. Never raises — this feeds best-effort
+    display state and must not fail the cron delivery that calls it.
+    """
+    try:
+        # Deferred: dashboard.handlers.__init__ imports this module, so a
+        # top-level import of handlers.usage would close a circular import.
+        from kiro_crew.dashboard.handlers.usage import read_context_tokens
+
+        pct_fn = getattr(client, "context_usage_pct", None)
+        pct = float(pct_fn()) if callable(pct_fn) else 0.0
+        if not math.isfinite(pct) or pct <= 0:
+            return None
+        used, window = read_context_tokens(client)
+        reading: dict[str, Any] = {"pct": round(pct, 1)}
+        if used > 0 and window > 0:
+            reading["used_tokens"] = used
+            reading["window_tokens"] = window
+        return reading
+    except Exception:
+        return None
+
+
 def inject_cron_result_to_dashboard(
     state: DashboardState, job: "CronJob", result_text: str,
     history: list[dict[str, Any]] | None = None,
+    context_reading: dict[str, Any] | None = None,
 ) -> None:
-    """Inject cron result into linked dashboard chat slot (shared by to-chat and auto-inject)."""
+    """Inject cron result into linked dashboard chat slot (shared by to-chat and auto-inject).
+
+    ``context_reading`` is the run's context-meter reading captured by
+    :func:`context_meter_reading` while the cron's provider was still resident.
+    When present it is routed through ``broadcast_context_usage`` — the meter's
+    single writer — so an open tab updates live and the slot-detail open path
+    can serve it after the executor resets the session. ``None`` (the to-chat
+    replay path, or a run that measured nothing) records nothing and keeps
+    whatever snapshot an earlier run stored.
+    """
     slot_name = f"cron-{job.id}"
     slot = state.get_or_create_slot(name=slot_name, agent=job.agent_id or "")
     safe_name, _ = redact_exfiltration_urls(job.name)
@@ -70,6 +130,18 @@ def inject_cron_result_to_dashboard(
                     context,
                     agent=job.agent_id or None,
                 )
+    if context_reading:
+        # Same frame shape as chat_runner._context_usage_payload. `reset` when
+        # the counts are unknown is load-bearing: the frontend stores pct and
+        # token counts in independent slices, and a bare {slot, pct} frame
+        # would leave stale counts beside a fresh percentage.
+        payload: dict[str, Any] = {"slot": slot.key, "pct": context_reading["pct"]}
+        if context_reading.get("window_tokens"):
+            payload["used_tokens"] = context_reading.get("used_tokens", 0)
+            payload["window_tokens"] = context_reading["window_tokens"]
+        else:
+            payload["reset"] = True
+        state.broadcast_context_usage(slot.key, payload)
     state.push_slots_update()
 
 

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -83,7 +83,10 @@ from kiro_crew.dashboard import start_dashboard
 from kiro_crew.dashboard.chat_persistence import rehydrate_slot_from_history_async
 from kiro_crew.dashboard.chat_runner import _run_chat
 from kiro_crew.dashboard.chat_utils import dashboard_slot_key
-from kiro_crew.dashboard.cron_inject import inject_cron_result_to_dashboard
+from kiro_crew.dashboard.cron_inject import (
+    context_meter_reading,
+    inject_cron_result_to_dashboard,
+)
 from kiro_crew.dashboard.handlers import MAX_PROMPT_BYTES
 from kiro_crew.dashboard.handlers.autonudge import render_nudge_message
 from kiro_crew.dashboard.handlers.messaging import _rehydrate_slot_from_history
@@ -2235,6 +2238,12 @@ class GatewayOrchestrator:
 
                 job.last_result = result_text
 
+                # Context-meter reading for the dashboard slot, captured NOW:
+                # the finally block below resets this session, so the open
+                # path can never read the provider live. Routed through
+                # broadcast_context_usage by inject_cron_result_to_dashboard.
+                _ctx_reading = context_meter_reading(client)
+
                 # ── Per-turn usage row: attribute background spend. ──
                 # Best-effort; must never fail the cron turn.
                 try:
@@ -2310,7 +2319,10 @@ class GatewayOrchestrator:
                             and not job.hide_in_chat
                             and self.dashboard_state.has_slot(f"cron-{job.id}")
                         ):
-                            inject_cron_result_to_dashboard(self.dashboard_state, job, result_text)
+                            inject_cron_result_to_dashboard(
+                                self.dashboard_state, job, result_text,
+                                context_reading=_ctx_reading,
+                            )
                         return result_text
 
                 if job.silent:
@@ -2329,7 +2341,10 @@ class GatewayOrchestrator:
                         and not job.hide_in_chat
                         and self.dashboard_state.has_slot(f"cron-{job.id}")
                     ):
-                        inject_cron_result_to_dashboard(self.dashboard_state, job, result_text)
+                        inject_cron_result_to_dashboard(
+                            self.dashboard_state, job, result_text,
+                            context_reading=_ctx_reading,
+                        )
                     return result_text
 
                 if self.dashboard_state:
@@ -2356,7 +2371,8 @@ class GatewayOrchestrator:
                             else []
                         )
                         inject_cron_result_to_dashboard(
-                            self.dashboard_state, job, result_text, history=history
+                            self.dashboard_state, job, result_text, history=history,
+                            context_reading=_ctx_reading,
                         )
                     redacted_for_dash, _ = redact_exfiltration_urls(result_text)
                     redacted_for_dash, _ = redact_credentials(redacted_for_dash)

--- a/test/test_cron_context_meter_seed.py
+++ b/test/test_cron_context_meter_seed.py
@@ -1,0 +1,201 @@
+"""Cron-created sessions must open with a real context-meter reading, not 0%.
+
+The cron executor resets its agent session the moment a run finishes, so the
+slot-detail open path can never read the provider live — and the snapshot
+fallback was only ever written by dashboard-driven turns. Opening a
+``cron-{id}`` slot therefore rendered a 0% bar over a full transcript.
+
+Covered here: the capture helper (``context_meter_reading``), the injection
+wiring that routes the reading through ``broadcast_context_usage`` (the
+meter's single writer), and the end-to-end read-back — inject, then open the
+slot with no resident provider and get the stale reading the run recorded.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_app, _make_state
+
+from kiro_crew.acp.types import AcpPromptStats
+from kiro_crew.dashboard.cron_inject import (
+    context_meter_reading,
+    inject_cron_result_to_dashboard,
+)
+from kiro_crew.providers.acp import AcpProvider
+
+
+def _provider(used: int, window: int, pct: float) -> AcpProvider:
+    with patch("kiro_crew.providers.acp.AcpClient"):
+        provider = AcpProvider()
+    provider._client = MagicMock()
+    provider._client.last_prompt_stats = AcpPromptStats(
+        context_pct=pct,
+        context_used_tokens=used,
+        context_window_tokens=window,
+    )
+    return provider
+
+
+def _make_job(job_id="abc123", name="test-cron"):
+    job = MagicMock()
+    job.id = job_id
+    job.name = name
+    job.agent_id = ""
+    return job
+
+
+@pytest.fixture(autouse=True)
+def _isolate_snapshot_file(tmp_path, monkeypatch):
+    """Point the snapshot sidecar at tmp_path — same isolation as
+    test_context_bar_reopen, so a stray entry in the developer's real
+    ~/.kiro/crew/context_snapshots.json cannot change what we observe."""
+    monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+
+
+# ── context_meter_reading: capture from a live provider ────────────────────
+
+
+def test_reading_carries_pct_and_counts():
+    reading = context_meter_reading(_provider(88000, 200000, 44.0))
+    assert reading == {"pct": 44.0, "used_tokens": 88000, "window_tokens": 200000}
+
+
+def test_reading_pct_alone_when_counts_unmeasured():
+    # The common kiro-cli case: contextUsagePercentage with no usage_update.
+    reading = context_meter_reading(_provider(0, 0, 11.4))
+    assert reading == {"pct": 11.4}
+
+
+def test_reading_omits_counts_when_used_unmeasured():
+    # used == 0 with a known window is the post-compaction state — shipping
+    # {used: 0, window: W} would assert a false "0 / W tokens".
+    reading = context_meter_reading(_provider(0, 200000, 12.0))
+    assert reading == {"pct": 12.0}
+
+
+def test_no_reading_when_nothing_measured():
+    assert context_meter_reading(_provider(0, 0, 0.0)) is None
+
+
+def test_no_reading_for_non_finite_pct():
+    assert context_meter_reading(_provider(0, 0, float("nan"))) is None
+    assert context_meter_reading(_provider(0, 0, float("inf"))) is None
+
+
+def test_no_reading_without_accessors():
+    assert context_meter_reading(object()) is None
+
+
+def test_no_reading_when_accessor_raises():
+    client = MagicMock()
+    client.context_usage_pct.side_effect = RuntimeError("gone")
+    assert context_meter_reading(client) is None
+
+
+# ── inject wiring: route through the single writer ─────────────────────────
+
+
+def test_inject_records_reading_via_single_writer():
+    state = MagicMock()
+    slot = MagicMock()
+    slot.key = "cron-abc123"
+    slot.linked_session_key = "cron:abc123"
+    slot.messages = []
+    state.get_or_create_slot.return_value = slot
+    state.conversation_log = None
+
+    inject_cron_result_to_dashboard(
+        state, _make_job(), "result",
+        context_reading={"pct": 61.2, "used_tokens": 122400, "window_tokens": 200000},
+    )
+
+    state.broadcast_context_usage.assert_called_once_with(
+        "cron-abc123",
+        {"slot": "cron-abc123", "pct": 61.2,
+         "used_tokens": 122400, "window_tokens": 200000},
+    )
+
+
+def test_inject_pct_only_reading_signals_reset():
+    # A bare {slot, pct} frame would leave stale token counts beside a fresh
+    # percentage in the frontend's independent slices — reset moves them together.
+    state = MagicMock()
+    slot = MagicMock()
+    slot.key = "cron-abc123"
+    slot.linked_session_key = "cron:abc123"
+    slot.messages = []
+    state.get_or_create_slot.return_value = slot
+    state.conversation_log = None
+
+    inject_cron_result_to_dashboard(
+        state, _make_job(), "result", context_reading={"pct": 33.0}
+    )
+
+    state.broadcast_context_usage.assert_called_once_with(
+        "cron-abc123", {"slot": "cron-abc123", "pct": 33.0, "reset": True}
+    )
+
+
+def test_inject_without_reading_records_nothing():
+    # The to-chat replay path (no client in hand) must not clobber whatever
+    # snapshot an earlier run stored.
+    state = MagicMock()
+    slot = MagicMock()
+    slot.key = "cron-abc123"
+    slot.linked_session_key = "cron:abc123"
+    slot.messages = []
+    state.get_or_create_slot.return_value = slot
+    state.conversation_log = None
+
+    inject_cron_result_to_dashboard(state, _make_job(), "result")
+
+    state.broadcast_context_usage.assert_not_called()
+
+
+# ── end to end: the reported bug ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cron_slot_opens_with_stale_reading_not_zero(tmp_path):
+    """Inject with a reading, then open the slot with no resident provider:
+    the detail response must carry the run's percentage flagged stale —
+    previously it carried nothing and the bar rendered 0%."""
+    state = _make_state(tmp_path)
+    state.sessions.get_provider = MagicMock(return_value=None)
+
+    inject_cron_result_to_dashboard(
+        state, _make_job(), "cron result",
+        context_reading={"pct": 57.3, "used_tokens": 114600, "window_tokens": 200000},
+    )
+
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.get("/api/chat/slots/cron-abc123")
+        assert resp.status == 200
+        body = await resp.json()
+
+    assert body["context_pct"] == 57.3
+    assert body["context_stale"] is True
+    assert body["context_window_tokens"] == 200000
+    # A stale reading omits `used` — no process measured it for THIS session
+    # incarnation; the tooltip derives a ~ approximation from pct instead.
+    assert "context_used_tokens" not in body
+
+
+@pytest.mark.asyncio
+async def test_cron_slot_reading_survives_model_check(tmp_path):
+    """The snapshot records the slot's model at injection time, so the
+    read-side model comparison passes for an untouched cron slot."""
+    state = _make_state(tmp_path)
+    state.sessions.get_provider = MagicMock(return_value=None)
+
+    inject_cron_result_to_dashboard(
+        state, _make_job(job_id="xyz789"), "cron result",
+        context_reading={"pct": 12.5},
+    )
+    slot = state.get_or_create_slot(name="cron-xyz789")
+    snapshot = state._context_snapshots["cron-xyz789"]
+    assert snapshot["pct"] == 12.5
+    assert snapshot["model"] == slot.model

--- a/test/test_cron_thread_routing.py
+++ b/test/test_cron_thread_routing.py
@@ -470,7 +470,10 @@ class TestCronCallbackDashboardChat:
             "kiro_crew.slack.gateway.inject_cron_result_to_dashboard"
         ) as mock_inject:
             _run_callback(gateway, job, stream_result="cron output")
-            mock_inject.assert_called_once_with(gateway.dashboard_state, job, "cron output", history=ANY)
+            mock_inject.assert_called_once_with(
+                gateway.dashboard_state, job, "cron output", history=ANY,
+                context_reading=ANY,
+            )
 
     def test_persistent_session_without_slot_still_injects(self) -> None:
         gateway = _make_gateway()
@@ -481,7 +484,10 @@ class TestCronCallbackDashboardChat:
             "kiro_crew.slack.gateway.inject_cron_result_to_dashboard"
         ) as mock_inject:
             _run_callback(gateway, job, stream_result="cron output")
-            mock_inject.assert_called_once_with(gateway.dashboard_state, job, "cron output", history=ANY)
+            mock_inject.assert_called_once_with(
+                gateway.dashboard_state, job, "cron output", history=ANY,
+                context_reading=ANY,
+            )
 
     def test_non_persistent_session_does_not_inject(self) -> None:
         gateway = _make_gateway()
@@ -527,7 +533,7 @@ class TestCronCallbackDashboardChat:
         ) as mock_inject:
             _run_callback(gateway, job, stream_result="silent output")
             mock_inject.assert_called_once_with(
-                gateway.dashboard_state, job, "silent output"
+                gateway.dashboard_state, job, "silent output", context_reading=ANY
             )
 
     def test_silent_cron_no_slot_does_not_inject(self) -> None:
@@ -568,7 +574,8 @@ class TestCronCallbackDashboardChat:
         ) as mock_inject:
             _run_callback(gateway, job, stream_result="shown output")
             mock_inject.assert_called_once_with(
-                gateway.dashboard_state, job, "shown output", history=ANY
+                gateway.dashboard_state, job, "shown output", history=ANY,
+                context_reading=ANY,
             )
 
     def test_hide_in_chat_suppresses_inject_even_with_existing_slot(self) -> None:


### PR DESCRIPTION
## Problem / Motivation

Opening a dashboard session that a cron job created shows the context-window meter at 0% even though the session carries a full transcript. I hit this after a cron run injected a long result into a `Cron: …` session — the bottom bar read `0%` next to the model name while the conversation was clearly holding tens of thousands of tokens.

## Why it matters

The context meter is the session-death early warning: it exists so the user can see a session approaching compaction before a follow-up turn lands. For cron-created sessions — often the longest-running, most context-heavy sessions in a workspace — the meter is silently wrong in the most misleading direction, telling the user there is unlimited headroom right before a follow-up turn inherits a nearly-full window.

## What changed (motivation → approach → change)

Symptom: the cron slot's detail response carries no context fields, so the frontend falls back to its `?? 0` default (`ChatPane.tsx`) and renders 0%. Root cause is a two-part gap on the open path: (1) the cron executor resets its agent session the moment a run finishes (`gateway.py` finally block), so `_context_snapshot_fields` never finds a resident provider to read live; and (2) the cold-session fallback — the snapshot recorded by `broadcast_context_usage` — is only ever written by dashboard-driven turns, which a cron run never takes. Both tiers come up empty, `{}` goes on the wire, and the bar defaults to zero.

The fix captures the reading at the only moment it exists and routes it through the meter's designed single writer. A new `context_meter_reading()` helper in `cron_inject.py` reads the provider's public accessors (`context_usage_pct` / `context_used_tokens` / `context_window_tokens`, mirroring `_context_usage_payload`'s accessor discipline) right after the cron turn in `gateway.py`, while the provider is still resident. `inject_cron_result_to_dashboard` takes the reading as a new optional `context_reading` parameter and passes it to `state.broadcast_context_usage` once the slot exists — so an open tab updates live, and the reopen path serves it as a stale snapshot exactly like any other cold session. A reading with `pct <= 0` is treated as "not reported" (a provider that just ran a turn always occupies context, so zero cannot mean "measured empty") and records nothing, preserving any earlier run's real snapshot; token counts ship only when both are measured, otherwise the frame carries `reset: True` so the frontend's independent pct/token slices move together.

## Tests

New `test/test_cron_context_meter_seed.py` (12 tests): `context_meter_reading` capture semantics (pct+counts, pct-only, used-unmeasured omits counts, nothing-measured → None, non-finite pct → None, missing accessors → None, raising accessor → None); injection wiring (reading routed through `broadcast_context_usage` with the exact frame shape, pct-only frame carries `reset: True`, no reading records nothing so the to-chat replay path can't clobber an earlier snapshot); and the end-to-end regression — inject with a reading, open the slot with no resident provider, and the detail response carries the pct flagged `context_stale` with the window tokens, instead of nothing. Four exact-signature assertions in `test/test_cron_thread_routing.py` updated for the new `context_reading` kwarg.

## Manual verification

Full backend suite run locally on macOS: 31,888 passed; the only failures (`test_cli_manifest_signature.py`, spec_builder `test_routes`, `test_pid_sweep_helpers`, `test_module_loader`, one pty-integration timeout) reproduce identically on unmodified `origin/main` in the same environment, verified by stashing the change and re-running each. isort / flake8 / mypy clean on the touched files.

## Screenshots / video

N/A — the change adds no new UI; it feeds the existing context bar the reading it already knows how to render (live frame + stale-snapshot styling both exercised by the end-to-end test).
