### PR TITLE
feat(acp): report unconsumed _kiro.dev/metadata fields at debug level

### DIFF
--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -131,6 +131,70 @@ def set_model_params(session_id: str, model_id: str) -> dict[str, Any]:
     return {"sessionId": session_id, "modelId": model_id}
 
 
+#: Top-level ``_kiro.dev/metadata`` params this parser consumes. ``sessionId`` is
+#: consumed a layer up — ``AcpRuntime`` routes every notification by it to the
+#: right per-session queue — so reporting it would mislabel a load-bearing routing
+#: field as an unhandled discovery on the first frame of every shared-runtime
+#: session.
+_KNOWN_METADATA_KEYS = frozenset({"contextUsagePercentage", "meteringUsage", "sessionId"})
+
+#: ``meteringUsage`` entry keys this parser knows, and the one ``unit`` value the
+#: credit sum reads. An entry with any other unit contributes nothing.
+_KNOWN_METERING_KEYS = frozenset({"unit", "unitPlural", "value"})
+_KNOWN_METERING_UNITS = frozenset({"credit"})
+
+#: Field names already reported, so a stream of per-turn notifications logs each
+#: novel shape once per process rather than on every frame. Two threads racing
+#: here can only duplicate a log line, so the hot path takes no lock.
+_reported_metadata_fields: set[str] = set()
+
+
+def _log_unrecognized_metadata_fields(params: dict[str, Any]) -> None:
+    """Report ``_kiro.dev/metadata`` fields this parser drops, once each.
+
+    kiro-cli owns the metadata payload, so a field it begins sending — prompt-cache
+    counters being the case in point, since ``AcpPromptStats`` already carries
+    ``cache_read_tokens``/``cache_creation_tokens`` slots that nothing fills — is
+    otherwise discarded with no way to notice.
+
+    What reaches the log is deliberately narrow: field NAMES and value TYPES, plus
+    — for ``meteringUsage`` units alone — the unit LABEL itself, because there the
+    label IS the signal (``unit=cacheRead`` is the discovery; ``unit:str`` conveys
+    nothing, since the unit is always a string). A unit is a low-cardinality
+    dimension name drawn from kiro's own billing vocabulary, never a quantity,
+    alias, or identifier, so no billing detail reaches the log.
+    """
+    novel: list[str] = []
+    for key, value in params.items():
+        if key in _KNOWN_METADATA_KEYS or key in _reported_metadata_fields:
+            continue
+        _reported_metadata_fields.add(key)
+        novel.append(f"{key}:{type(value).__name__}")
+
+    metering = params.get("meteringUsage")
+    if isinstance(metering, list):
+        for entry in metering:
+            if not isinstance(entry, dict):
+                continue
+            for key, value in entry.items():
+                name = f"meteringUsage[].{key}"
+                if key in _KNOWN_METERING_KEYS or name in _reported_metadata_fields:
+                    continue
+                _reported_metadata_fields.add(name)
+                novel.append(f"{name}:{type(value).__name__}")
+            unit = entry.get("unit")
+            # A non-credit unit is silently dropped by the credit sum, so naming it
+            # is the only signal that kiro started reporting a new usage dimension.
+            if isinstance(unit, str) and unit not in _KNOWN_METERING_UNITS:
+                name = f"meteringUsage[].unit={unit}"
+                if name not in _reported_metadata_fields:
+                    _reported_metadata_fields.add(name)
+                    novel.append(name)
+
+    if novel:
+        logger.debug("acp metadata: unconsumed field(s) %s", ", ".join(sorted(novel)))
+
+
 def parse_metadata(params: dict[str, Any]) -> tuple[float | None, float]:
     """Parse a ``_kiro.dev/metadata`` notification's params.
 
@@ -140,7 +204,16 @@ def parse_metadata(params: dict[str, Any]) -> tuple[float | None, float]:
     ``AcpClient`` and ``AcpSessionHandle`` call this so the credit-capture
     logic has a single source of truth. The caller applies the values to its own
     ``last_prompt_stats`` (credits are accumulated across the turn).
+
+    Fields outside the two consumed keys are reported once each at debug level by
+    :func:`_log_unrecognized_metadata_fields`.
     """
+    try:
+        _log_unrecognized_metadata_fields(params)
+    except Exception:
+        # A diagnostic must never break a turn.
+        logger.debug("acp metadata: field scan failed", exc_info=True)
+
     pct = params.get("contextUsagePercentage")
     try:
         pct_val = float(pct) if pct is not None else None

--- a/test/test_acp_metadata_fields.py
+++ b/test/test_acp_metadata_fields.py
@@ -1,0 +1,127 @@
+"""``_kiro.dev/metadata`` unconsumed-field reporting.
+
+``parse_metadata`` reads two keys and drops everything else. These tests pin the
+diagnostic that names what was dropped, so a field kiro-cli starts sending (a
+prompt-cache counter, a new billing unit) becomes visible instead of silent.
+"""
+
+import logging
+
+import pytest
+
+from kiro_crew.acp import _dispatch
+from kiro_crew.acp._dispatch import parse_metadata
+
+
+@pytest.fixture(autouse=True)
+def _clear_reported_fields():
+    """Reset the once-per-process report set so each test starts cold."""
+    _dispatch._reported_metadata_fields.clear()
+    yield
+    _dispatch._reported_metadata_fields.clear()
+
+
+def _debug_lines(caplog):
+    # getMessage() interpolates args; LogRecord.message only exists once a
+    # Formatter has run, which caplog does not do.
+    return [r.getMessage() for r in caplog.records]
+
+
+class TestConsumedFieldsStaySilent:
+    def test_known_params_report_nothing(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger=_dispatch.logger.name):
+            pct, credits = parse_metadata(
+                {
+                    "contextUsagePercentage": 41.0,
+                    "meteringUsage": [{"unit": "credit", "unitPlural": "credits", "value": 0.5}],
+                }
+            )
+        assert (pct, credits) == (41.0, 0.5)
+        assert not [ln for ln in _debug_lines(caplog) if "unconsumed field" in ln]
+
+    def test_empty_params_report_nothing(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger=_dispatch.logger.name):
+            assert parse_metadata({}) == (None, 0.0)
+        assert not [ln for ln in _debug_lines(caplog) if "unconsumed field" in ln]
+
+    def test_session_id_is_not_reported(self, caplog):
+        # AcpRuntime routes every notification by params["sessionId"], so a
+        # shared-runtime frame always carries it. Reporting it would mislabel a
+        # consumed routing field on the first frame of every session.
+        with caplog.at_level(logging.DEBUG, logger=_dispatch.logger.name):
+            parse_metadata({"sessionId": "sess-abc", "contextUsagePercentage": 12})
+        assert not [ln for ln in _debug_lines(caplog) if "unconsumed field" in ln]
+
+
+class TestUnconsumedFieldsAreNamed:
+    def test_unknown_top_level_key_is_named_with_its_type(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger=_dispatch.logger.name):
+            parse_metadata({"contextUsagePercentage": 10, "cacheReadTokens": 2048})
+        line = next(ln for ln in _debug_lines(caplog) if "unconsumed field" in ln)
+        assert "cacheReadTokens:int" in line
+
+    def test_value_is_never_logged(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger=_dispatch.logger.name):
+            parse_metadata({"accountId": "super-secret-value"})
+        line = next(ln for ln in _debug_lines(caplog) if "unconsumed field" in ln)
+        assert "accountId:str" in line
+        assert "super-secret-value" not in line
+
+    def test_non_credit_metering_unit_is_named(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger=_dispatch.logger.name):
+            _, credits = parse_metadata(
+                {"meteringUsage": [{"unit": "cacheRead", "value": 4096}]}
+            )
+        # The unit is not "credit", so it still contributes nothing to the sum.
+        assert credits == 0.0
+        line = next(ln for ln in _debug_lines(caplog) if "unconsumed field" in ln)
+        assert "meteringUsage[].unit=cacheRead" in line
+
+    def test_unknown_metering_entry_key_is_named(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger=_dispatch.logger.name):
+            parse_metadata(
+                {"meteringUsage": [{"unit": "credit", "value": 1.0, "cachedTokens": 900}]}
+            )
+        line = next(ln for ln in _debug_lines(caplog) if "unconsumed field" in ln)
+        assert "meteringUsage[].cachedTokens:int" in line
+
+
+class TestReportedOncePerProcess:
+    def test_repeat_notification_does_not_re_report(self, caplog):
+        params = {"cacheReadTokens": 2048}
+        with caplog.at_level(logging.DEBUG, logger=_dispatch.logger.name):
+            parse_metadata(params)
+            first = len([ln for ln in _debug_lines(caplog) if "unconsumed field" in ln])
+            parse_metadata(params)
+            second = len([ln for ln in _debug_lines(caplog) if "unconsumed field" in ln])
+        assert (first, second) == (1, 1)
+
+    def test_a_newly_appearing_field_still_reports(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger=_dispatch.logger.name):
+            parse_metadata({"cacheReadTokens": 1})
+            parse_metadata({"cacheReadTokens": 1, "cacheWriteTokens": 2})
+        lines = [ln for ln in _debug_lines(caplog) if "unconsumed field" in ln]
+        assert len(lines) == 2
+        assert "cacheWriteTokens:int" in lines[1]
+        assert "cacheReadTokens" not in lines[1]
+
+
+class TestDiagnosticNeverBreaksParsing:
+    def test_malformed_metering_entries_are_tolerated(self):
+        pct, credits = parse_metadata(
+            {
+                "contextUsagePercentage": "77",
+                "meteringUsage": ["not-a-dict", None, {"unit": "credit", "value": 2}],
+            }
+        )
+        assert (pct, credits) == (77.0, 2.0)
+
+    def test_a_scan_failure_leaves_parsing_intact(self, monkeypatch):
+        def _boom(_params):
+            raise RuntimeError("scan exploded")
+
+        monkeypatch.setattr(_dispatch, "_log_unrecognized_metadata_fields", _boom)
+        pct, credits = parse_metadata(
+            {"contextUsagePercentage": 12.5, "meteringUsage": [{"unit": "credit", "value": 3}]}
+        )
+        assert (pct, credits) == (12.5, 3.0)


### PR DESCRIPTION
## What

`parse_metadata` in `src/kiro_crew/acp/_dispatch.py` reads exactly two keys out of a
`_kiro.dev/metadata` notification — `contextUsagePercentage` and `meteringUsage` — and
silently discards everything else. This adds a debug-level report naming the fields
that were dropped, once per distinct field per process.

Three shapes are reported:

- unrecognized top-level params
- unrecognized `meteringUsage` entry keys
- `meteringUsage` `unit` values other than `credit` (the only unit the credit sum consumes)

What reaches the log is deliberately narrow: field **names** and **value types**, plus —
for `meteringUsage` units alone — the unit **label** itself, because there the label is the
signal (`unit=cacheRead` is the discovery; `unit:str` is a tautology). A unit is a
low-cardinality dimension name from kiro's own billing vocabulary, never a quantity, alias,
or identifier, so no billing detail reaches the log.

## Why

kiro-cli owns the metadata payload, so a field it starts sending is dropped here with no
way to notice. That matters concretely for prompt-cache accounting, where the display
pipeline is already fully built and entirely unfed:

- `AcpPromptStats.cache_creation_tokens` / `cache_read_tokens` — `src/kiro_crew/acp/types.py:251`
- `stats.inc_cache_creation_tokens()` / `inc_cache_read_tokens()` — `src/kiro_crew/stats.py:89`
- `cache_create` / `cache_read` served by the usage API — `src/kiro_crew/dashboard/handlers/usage.py:934`

Those two `inc_*` methods have **zero call sites in the tree**, and `parse_metadata` is the
only place ACP metadata is interpreted. So today there is no way to distinguish "kiro-cli
does not send cache counters" from "kiro-cli sends them and we throw them away." This log
line settles that from a single debug run. If the counters turn out to be present, wiring
them to the existing slots is a small follow-up; if absent, it becomes a concrete upstream
ask instead of a hypothesis.

Context for why this is worth knowing: images inflate the per-turn context that drives
`SessionManager.check_context_usage` against `session.autocompact_pct`, and compaction
rewrites history, which is a guaranteed prompt-cache prefix miss. Tuning any of that
requires being able to see `cacheRead` / `cacheWrite`, which KiroCrew currently cannot.

## Design notes

- **Quantities are never logged.** Names and types only, so token counts, credit amounts
  and account fields stay out of logs. `meteringUsage` unit labels are the one deliberate
  exception, because the label is the finding itself.
- **Once per process, no lock.** Metadata notifications arrive many times per turn; logging
  every frame would be unusable. A thread race can only duplicate one log line, so the hot
  path takes no lock.
- **Fails open.** The scan is wrapped in `try/except` — a diagnostic must never break a turn.
- **Debug level**, so this is silent in normal operation.

## Testing

`test/test_acp_metadata_fields.py` — 10 tests covering: consumed-only params stay silent;
each of the three unrecognized shapes is named with its type; values are not logged; the
report fires once per process but a newly appearing field still reports; malformed
`meteringUsage` entries are tolerated; and a scan failure leaves parsing intact.

Verified locally: pytest 10 passed, flake8 clean, isort clean, mypy clean on the changed file.

Two gaps to flag honestly. The local mypy was 2.3.0 rather than the version pinned in
`pyproject.toml`'s dev group, so it is not strict CI parity. And a numpy build failure in my
scratch venv meant pytest ran the test file outside the repo `conftest.py`, so repo-wide
fixtures were not applied — CI is the first run with the real conftest and the pinned
toolchain. Frontend gates are not applicable (backend-only change).
