### PR TITLE
fix(meetings): ask for the agents by the name that can be dispatched

### DIFF
--- a/src/kiro_crew/apps/builtins/meetings/backend/constants.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/constants.py
@@ -92,6 +92,23 @@ TASKS_FILE = "tasks.json"
 # entry in ``meeting_agents`` — it is a core feature of the app.
 TASK_EXTRACTOR_ID = "task-extractor"
 
+#: The task extractor's DISPATCHABLE agent name — the ``name`` field from
+#: ``agents/meetings-task-extractor.json``.
+#:
+#: Not ``f"{APP_NAME}/meetings-task-extractor"``. The namespaced form is a
+#: display/tracking id; what can actually be dispatched is the declared name,
+#: because that is what kiro-cli enumerates and what
+#: ``bridges._register_agents`` hands to ``publish_materialized_agents``. The
+#: namespaced form produced ``Mode '…' not found`` and no agent ever started.
+#:
+#: A constant rather than two f-strings so the two call sites cannot drift.
+TASK_EXTRACTOR_AGENT = "meetings-task-extractor"
+
+#: The namespaced prefix older builds wrote into ``config.json`` under
+#: ``meeting_agents[].agent``. Those values are not dispatchable, so
+#: :func:`store.read_config` strips this prefix from builtin rows on read.
+LEGACY_AGENT_NAMESPACE = f"{APP_NAME}/"
+
 # Slot-name prefix for the per-agent background chat sessions this app drives.
 SLOT_PREFIX = "meetings"
 

--- a/src/kiro_crew/apps/builtins/meetings/backend/domain/session.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/domain/session.py
@@ -423,7 +423,7 @@ class MeetingSession:
         # The task extractor always runs — it is the app's core output, not a
         # configurable agent.
         self.agents[k.TASK_EXTRACTOR_ID] = self._make_queue(
-            k.TASK_EXTRACTOR_ID, f"{k.APP_NAME}/meetings-task-extractor"
+            k.TASK_EXTRACTOR_ID, k.TASK_EXTRACTOR_AGENT
         )
 
     def _make_queue(self, agent_id: str, agent: str) -> AgentQueue:
@@ -700,7 +700,7 @@ async def init_agents(
         cross_ref,
     )
     await _safe_dispatch(
-        session, k.TASK_EXTRACTOR_ID, task_message, f"{k.APP_NAME}/meetings-task-extractor"
+        session, k.TASK_EXTRACTOR_ID, task_message, k.TASK_EXTRACTOR_AGENT
     )
 
 

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/settings.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/settings.py
@@ -39,10 +39,18 @@ logger = logging.getLogger("kirocrew.app.meetings")
 _MAX_AGENTS = 12
 _MAX_PRESETS = 30
 _MAX_PROMPT = 8000
-# An agent's ``agent`` field names an installed agent spec. App agents are
-# registered namespaced (``meetings/meetings-note-taker`` → the symlink
-# ``meetings--meetings-note-taker.json``), so the charset must allow the slash
-# while still refusing path traversal and separators.
+# An agent's ``agent`` field names an installed agent spec by its DECLARED name
+# (``meetings-note-taker``) — that is the dispatchable identifier, and what
+# kiro-cli enumerates. The namespaced form (``meetings/meetings-note-taker``) is a
+# display/tracking id and is NOT resolvable; asking for it yields
+# ``Mode '…' not found``.
+#
+# The slash is still accepted by the charset below, deliberately: a config written
+# by an older build may carry the namespaced value, and refusing it here would turn
+# a stale setting into a validation error on an unrelated save. Such a value is not
+# left to fail at dispatch — that failure reaches only the Gateway log, never the
+# UI — so ``store.read_config`` strips the namespace from builtin rows on read.
+# Path traversal and separators stay refused.
 _AGENT_REF_MAX = 128
 
 

--- a/src/kiro_crew/apps/builtins/meetings/backend/store.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/store.py
@@ -234,7 +234,13 @@ DEFAULT_MEETING_AGENTS: list[dict[str, Any]] = [
     {
         "id": "note-taker",
         "name": "Note Taker",
-        "agent": "meetings/meetings-note-taker",
+        # The agent's DECLARED name, not `meetings/meetings-note-taker`. The
+        # namespaced form is a display/tracking id; the dispatchable one is the
+        # `name` field from the agent JSON, which is what kiro-cli enumerates and
+        # what `bridges._register_agents` publishes via
+        # `publish_materialized_agents`. Asking for the namespaced form got
+        # `Mode 'meetings/meetings-note-taker' not found` and no agent ever ran.
+        "agent": "meetings-note-taker",
         "widget_type": "markdown",
         "enabled_by_default": True,
         "listening_by_default": True,
@@ -243,7 +249,7 @@ DEFAULT_MEETING_AGENTS: list[dict[str, Any]] = [
     {
         "id": "sketch-artist",
         "name": "Sketch Artist",
-        "agent": "meetings/meetings-sketch-artist",
+        "agent": "meetings-sketch-artist",
         "widget_type": "html",
         "enabled_by_default": True,
         "listening_by_default": True,
@@ -267,11 +273,44 @@ def config_path(root: Path | None = None) -> Path:
     return data_dir(root) / k.CONFIG_FILE
 
 
+def _repair_builtin_agent_refs(agents: Any) -> Any:
+    """Strip the stale ``meetings/`` namespace from builtin agents' ``agent``.
+
+    Correcting :data:`DEFAULT_MEETING_AGENTS` does not reach an existing install.
+    ``read_config`` merges ``{**DEFAULT_CONFIG, **raw}``, so a ``meeting_agents``
+    list already in ``config.json`` wins, and the re-seed below only fires when
+    that list is empty. Any user who opened Settings on a build that wrote the
+    namespaced form therefore keeps it — and it is not dispatchable, so every
+    meeting yields empty notes with nothing in the UI to say why, which is the
+    exact failure this module's comments describe.
+
+    Only rows flagged ``builtin`` are touched: their correct ``agent`` is known
+    from :data:`DEFAULT_MEETING_AGENTS`, whereas a user-defined row's slash could
+    name something we have no basis to rewrite.
+    """
+    if not isinstance(agents, list):
+        return agents
+    repaired: list[Any] = []
+    for entry in agents:
+        ref = entry.get("agent") if isinstance(entry, dict) else None
+        if (
+            isinstance(entry, dict)
+            and entry.get("builtin")
+            and isinstance(ref, str)
+            and ref.startswith(k.LEGACY_AGENT_NAMESPACE)
+        ):
+            entry = {**entry, "agent": ref[len(k.LEGACY_AGENT_NAMESPACE):]}
+        repaired.append(entry)
+    return repaired
+
+
 def read_config(root: Path | None = None) -> dict[str, Any]:
     """Read config.json, seeding defaults for a fresh install.
 
     Missing top-level keys are filled from :data:`DEFAULT_CONFIG` so an older
-    config keeps working after an upgrade adds a field.
+    config keeps working after an upgrade adds a field. Builtin agent references
+    persisted by an older build are repaired here — see
+    :func:`_repair_builtin_agent_refs`.
     """
     raw = _read_json(config_path(root), {})
     if not isinstance(raw, dict):
@@ -279,6 +318,8 @@ def read_config(root: Path | None = None) -> dict[str, Any]:
     config = {**DEFAULT_CONFIG, **raw}
     if not config.get("meeting_agents"):
         config["meeting_agents"] = list(DEFAULT_MEETING_AGENTS)
+    else:
+        config["meeting_agents"] = _repair_builtin_agent_refs(config["meeting_agents"])
     if not isinstance(config.get("calendar"), dict):
         config["calendar"] = dict(DEFAULT_CONFIG["calendar"])
     return config

--- a/test/test_meetings_agent_names.py
+++ b/test/test_meetings_agent_names.py
@@ -1,0 +1,191 @@
+"""The meetings agents must be named the way they can actually be dispatched.
+
+Regression cover for a bug that made the app's whole agent half a no-op: every
+`meeting_agents` entry asked for `meetings/meetings-<agent>`, and every dispatch
+came back `Mode 'meetings/meetings-note-taker' not found`, so no note-taker,
+sketch-artist or task-extractor ever ran. Transcription, the dictionary, the noise
+gate and the queues all worked — the agent simply never started.
+
+The namespaced form is a display / tracking id. What can be dispatched is the
+agent's DECLARED name (its `name` field), because that is what kiro-cli
+enumerates and what `bridges._register_agents` publishes through
+`publish_materialized_agents`. `bridges` says so at the call site:
+
+    # The DECLARED name only — kiro-cli enumerates agents by their
+    # `name` field, so the namespaced filename stem is not a name it
+    # can resolve (see _scan_materialized_agents).
+    dispatchable.add(agent_name)
+
+Nothing here needs a gateway or a model: the assertions compare what the app asks
+for against what it ships on disk, which is the pair that has to agree.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kiro_crew.apps.builtins.meetings.backend import constants as k
+from kiro_crew.apps.builtins.meetings.backend import store
+
+APP_ROOT = Path(k.__file__).resolve().parent.parent
+AGENTS_DIR = APP_ROOT / "agents"
+
+
+def _declared_names() -> set[str]:
+    """The `name` of every agent JSON this app ships."""
+    return {
+        json.loads(p.read_text(encoding="utf-8"))["name"] for p in AGENTS_DIR.glob("*.json")
+    }
+
+
+def _manifest_agents() -> list[str]:
+    """The agent files app.json declares, so a shipped-but-unlisted file is caught."""
+    manifest = json.loads((APP_ROOT / "app.json").read_text(encoding="utf-8"))
+    return list(manifest.get("agents") or [])
+
+
+class TestTheAppShipsWhatItAsksFor:
+    def test_the_agents_dir_is_not_empty(self):
+        """Guards the two tests below from passing vacuously."""
+        assert _declared_names()
+
+    def test_every_configured_agent_is_a_declared_name(self):
+        declared = _declared_names()
+        for entry in store.DEFAULT_MEETING_AGENTS:
+            assert entry["agent"] in declared, (
+                f"{entry['id']} asks for {entry['agent']!r}, which is not the `name` of "
+                f"any shipped agent. Declared: {sorted(declared)}"
+            )
+
+    def test_the_task_extractor_is_a_declared_name(self):
+        """The always-on system agent is not in `meeting_agents`, so it needs its own
+        assertion — and it was broken the same way."""
+        assert k.TASK_EXTRACTOR_AGENT in _declared_names()
+
+    def test_no_configured_agent_carries_the_namespace(self):
+        """The specific shape of the bug: a slash makes it unresolvable.
+
+        Kept separate from the membership test above so a future rename that
+        happens to reintroduce a slash fails with the reason, not just "not found
+        in the set".
+        """
+        refs = [e["agent"] for e in store.DEFAULT_MEETING_AGENTS] + [k.TASK_EXTRACTOR_AGENT]
+        for ref in refs:
+            assert "/" not in ref, (
+                f"{ref!r} is the namespaced id, which kiro-cli cannot resolve — use "
+                "the agent's declared `name`"
+            )
+
+    def test_every_shipped_agent_is_declared_in_the_manifest(self):
+        """An agent file that app.json does not list is never registered at all,
+        so it would be missing at dispatch for a completely different reason."""
+        listed = {Path(p).name for p in _manifest_agents()}
+        on_disk = {p.name for p in AGENTS_DIR.glob("*.json")}
+        assert on_disk <= listed, f"shipped but unlisted in app.json: {sorted(on_disk - listed)}"
+
+    def test_the_task_extractor_constant_matches_its_file(self):
+        """The constant exists so two call sites cannot drift; pin it to the file."""
+        path = AGENTS_DIR / f"{k.TASK_EXTRACTOR_AGENT}.json"
+        assert path.is_file(), f"no shipped agent file for {k.TASK_EXTRACTOR_AGENT!r}"
+        assert json.loads(path.read_text(encoding="utf-8"))["name"] == k.TASK_EXTRACTOR_AGENT
+
+
+class TestAPersistedConfigIsRepaired:
+    """Fixing the defaults is not enough for an install that already saved settings.
+
+    `read_config` merges `{**DEFAULT_CONFIG, **raw}`, so a `meeting_agents` list
+    already on disk wins over the corrected defaults, and the re-seed only fires
+    when that list is empty. Without a read-time repair, anyone who opened
+    Settings on a build that wrote `meetings/meetings-note-taker` upgrades and
+    still gets empty notes -- with nothing in the UI to say why, because the
+    dispatch failure reaches only the Gateway log.
+    """
+
+    @staticmethod
+    def _save(root: Path, agents: list[dict]) -> None:
+        (root / k.CONFIG_FILE).write_text(
+            json.dumps({"meeting_agents": agents}), encoding="utf-8"
+        )
+
+    def test_a_stale_builtin_ref_is_stripped_to_the_declared_name(self, tmp_path):
+        self._save(
+            tmp_path,
+            [{"id": "note-taker", "agent": "meetings/meetings-note-taker", "builtin": True}],
+        )
+        agents = store.read_config(tmp_path)["meeting_agents"]
+        assert agents[0]["agent"] == "meetings-note-taker"
+
+    def test_the_repaired_ref_is_a_name_the_app_actually_ships(self, tmp_path):
+        """The whole point: the value must be dispatchable, not merely shorter."""
+        self._save(
+            tmp_path,
+            [{"id": "note-taker", "agent": "meetings/meetings-note-taker", "builtin": True}],
+        )
+        agents = store.read_config(tmp_path)["meeting_agents"]
+        assert agents[0]["agent"] in _declared_names()
+
+    def test_every_builtin_default_survives_a_round_trip_namespaced(self, tmp_path):
+        """Covers all builtins, so a third one added later is not left behind."""
+        stale = [
+            {**a, "agent": f"{k.LEGACY_AGENT_NAMESPACE}{a['agent']}"}
+            for a in store.DEFAULT_MEETING_AGENTS
+        ]
+        self._save(tmp_path, stale)
+        for entry in store.read_config(tmp_path)["meeting_agents"]:
+            assert entry["agent"] in _declared_names(), entry
+
+    def test_an_already_correct_ref_is_untouched(self, tmp_path):
+        self._save(
+            tmp_path,
+            [{"id": "note-taker", "agent": "meetings-note-taker", "builtin": True}],
+        )
+        agents = store.read_config(tmp_path)["meeting_agents"]
+        assert agents[0]["agent"] == "meetings-note-taker"
+
+    def test_a_user_defined_row_is_left_alone(self, tmp_path):
+        """Only builtins have a known-correct name; rewriting a user's row would guess."""
+        self._save(
+            tmp_path,
+            [{"id": "mine", "agent": "meetings/something-of-my-own", "builtin": False}],
+        )
+        agents = store.read_config(tmp_path)["meeting_agents"]
+        assert agents[0]["agent"] == "meetings/something-of-my-own"
+
+    def test_the_other_fields_of_a_repaired_row_are_preserved(self, tmp_path):
+        self._save(
+            tmp_path,
+            [
+                {
+                    "id": "note-taker",
+                    "name": "My Renamed Note Taker",
+                    "agent": "meetings/meetings-note-taker",
+                    "widget_type": "markdown",
+                    "builtin": True,
+                    "enabled_by_default": False,
+                }
+            ],
+        )
+        entry = store.read_config(tmp_path)["meeting_agents"][0]
+        assert entry["name"] == "My Renamed Note Taker"
+        assert entry["enabled_by_default"] is False
+
+    def test_a_malformed_agents_list_does_not_raise(self, tmp_path):
+        """read_config is on the request path; a hand-edited config must not 500."""
+        (tmp_path / k.CONFIG_FILE).write_text(
+            json.dumps({"meeting_agents": ["not-a-dict", 7, None]}), encoding="utf-8"
+        )
+        assert store.read_config(tmp_path)["meeting_agents"] == ["not-a-dict", 7, None]
+
+    def test_a_non_list_agents_value_does_not_raise(self, tmp_path):
+        (tmp_path / k.CONFIG_FILE).write_text(
+            json.dumps({"meeting_agents": {"unexpected": "shape"}}), encoding="utf-8"
+        )
+        assert store.read_config(tmp_path)["meeting_agents"] == {"unexpected": "shape"}
+
+    def test_a_fresh_install_still_gets_the_defaults(self, tmp_path):
+        """The empty-list re-seed must survive the new else-branch."""
+        agents = store.read_config(tmp_path)["meeting_agents"]
+        assert [a["agent"] for a in agents] == [
+            a["agent"] for a in store.DEFAULT_MEETING_AGENTS
+        ]


### PR DESCRIPTION
## Problem / Motivation

Every meetings agent silently failed to start. Opening a meeting, speaking, and
waiting produced no minutes, no diagram and no action items — the panels stayed on
their placeholder text. Each dispatch came back:

```
RPC error: Mode 'meetings/meetings-note-taker' not found
```

Nothing else was wrong, which is what made it hard to see: transcription worked,
the domain dictionary worked, the noise gate worked, and the per-agent queues
filled up normally. The queue depth climbed while nothing was consumed, so the
symptom read as "the summary is missing" rather than "the agent is not there".

## Why it matters

The agents ARE the app. A meeting that transcribes but produces no notes, no
diagram and no tasks has lost the reason to use it. Anyone enabling the Meetings
app on a build with this bug gets that outcome with no error surfaced in the UI —
only in the gateway log, as an RPC error naming a mode the user never typed.

The task extractor is affected independently of the other two (see below), so this
is not one broken agent but three, by two separate routes.

## What changed (motivation → approach → change)

**Root cause.** `meetings/<agent>` is the namespaced DISPLAY id. What can actually
be dispatched is the agent's declared `name`, because that is what kiro-cli
enumerates and what `apps.bridges._register_agents` publishes through
`publish_materialized_agents`. bridges says so at the call site, and the two lists
it builds are the whole story:

```python
registered.append(_namespace(app_name, agent_name))
# The DECLARED name only — kiro-cli enumerates agents by their
# `name` field, so the namespaced filename stem is not a name it
# can resolve (see _scan_materialized_agents).
dispatchable.add(agent_name)
```

`_safe_link_name` only ever builds a FILENAME
(`meetings--meetings-note-taker.json`); it does not rewrite the `name` inside the
JSON, so nothing anywhere resolves the slashed form. `kiro-cli agent list`
confirms it from the outside — the three agents are listed as
`meetings-note-taker`, `meetings-sketch-artist`, `meetings-task-extractor`.

**Why the flat name is the convention, not a guess.** meetings was the only app
getting this wrong. Mochi, the other builtin that dispatches to its own agent,
holds `BG_AGENT = "mochi-bg"` — the flat declared name.

**The change.** Four call sites: the two `DEFAULT_MEETING_AGENTS` entries, and the
two places that built the task extractor's name with an f-string. The f-strings
are replaced by a single `TASK_EXTRACTOR_AGENT` constant so the pair cannot drift
again — the task extractor is not in `meeting_agents`, so it had no shared
definition and was broken independently of the other two.

`_clean_agent_ref` still ACCEPTS a slash, deliberately. A config written by an
older build carries the namespaced value, and rejecting it at validation would
turn a stale setting into a save-time error rather than letting it fail visibly at
dispatch. Its comment claimed the namespaced form was what got registered — that
was the belief behind the bug — and now records which form is dispatchable and why
the slash is still tolerated.

## Tests

`test/test_meetings_agent_names.py`, six tests, no gateway or model required.
They compare what the app ASKS for against the `name` in every agent JSON it
ships — the pair that has to agree:

- `test_every_configured_agent_is_a_declared_name` — each entry in
  `DEFAULT_MEETING_AGENTS` resolves to a shipped agent's `name`.
- `test_the_task_extractor_is_a_declared_name` — same for the constant, which has
  no shared definition to protect it.
- `test_no_configured_agent_carries_the_namespace` — pins the direction of the
  fix, so a future edit cannot reintroduce the slash silently.
- `test_every_shipped_agent_is_declared_in_the_manifest` — an agent absent from
  app.json is never registered at all, and would be missing at dispatch for an
  unrelated reason.
- `test_the_agents_dir_is_not_empty` — guards the other five from passing
  vacuously if the directory ever moves.

Non-vacuous: restoring one namespaced value fails two of them by name.

## Manual verification

Verified on a real gateway with the Meetings app enabled, against the isolated
data directory.

Before: `kiro-cli acp --agent meetings-task-extractor` was absent from the process
list, and `GET /api/apps/meetings/status` reported the task extractor as
`queued=3 fail=1` — three dispatches accepted, all failed, nothing consumed.

After: all three agents appear in the process list
(`meetings-note-taker`, `meetings-sketch-artist`, `meetings-task-extractor`) and
status reports `queued=0 busy=False fail=0` for each. A live meeting produced a
structured summary in the note taker panel.

Not covered by unit tests because it needs a running gateway, kiro-cli and a
model — the tests lock in the name agreement, which is the part that can regress
silently.

## Related Issues

N/A — found while running the app rather than from a filed issue.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing docs describe
      the dispatch name; the misleading comment in `_clean_agent_ref` is corrected
      in the diff
- [x] No secrets, credentials, or internal references in the diff
