### PR TITLE
fix(stt): find Whisper installed into the app's own virtualenv

### DIFF
--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -12,6 +12,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -85,6 +86,32 @@ def ensure_ffmpeg_in_path() -> None:
             path_parts.insert(0, d)
 
 
+def _own_scripts_dir() -> str:
+    """Scripts dir of the interpreter THIS process is running under.
+
+    Where ``pip install openai-whisper`` (or ``mlx-whisper``) lands its console
+    script when the app is installed in a virtualenv — which is how the gateway
+    normally runs. Nothing else in the search order looks there:
+
+    * ``shutil.which`` only sees ``PATH``, and a venv is on ``PATH`` only after
+      ``activate``. The gateway is launched as ``<venv>/bin/kirocrew``, which does
+      not modify ``PATH``, so the venv's own ``bin/`` is invisible to it.
+    * :func:`_python3_bin_dir` deliberately asks the SYSTEM python3 (via
+      ``find_python_interpreter``), so it reports the system scripts dir even when
+      we are running inside a venv.
+
+    The result was that installing Whisper into the app's own environment — the
+    obvious thing to do — left ``is_available()`` reporting False, with the only
+    workarounds being to set ``stt.whisper_path`` by hand or install it a second
+    time somewhere else.
+
+    Uses ``sys.prefix`` rather than ``sysconfig.get_path('scripts')`` because the
+    latter can be redirected by an active ``--user`` scheme or a posix_prefix
+    override, while the console script always sits beside the running interpreter.
+    """
+    return os.path.dirname(os.path.abspath(sys.executable))
+
+
 def _python3_bin_dir() -> str:
     """Return the bin dir of the system python3 (where pip installs scripts)."""
     try:
@@ -142,6 +169,15 @@ def _find_whisper(configured_path: str = "") -> str | None:
     found = shutil.which("whisper")
     if found:
         return found
+    # This interpreter's own scripts dir FIRST of the directory probes: when the
+    # app runs from a venv, that is where `pip install openai-whisper` put the
+    # console script, and it is the only candidate guaranteed to match the
+    # environment the caller actually installed into.
+    own_bin = _own_scripts_dir()
+    if own_bin:
+        found_own = _find_script_in_dir(own_bin, "whisper")
+        if found_own:
+            return found_own
     # Check system python3's scripts dir (pip install target)
     py3_bin = _python3_bin_dir()
     if py3_bin:
@@ -218,6 +254,12 @@ def _find_mlx_whisper() -> str | None:
     found = shutil.which("mlx_whisper")
     if found:
         return found
+    # Same venv gap as `_find_whisper` — see `_own_scripts_dir`.
+    own_bin = _own_scripts_dir()
+    if own_bin:
+        found_own = _find_script_in_dir(own_bin, "mlx_whisper")
+        if found_own:
+            return found_own
     py3_bin = _python3_bin_dir()
     if py3_bin:
         found_script = _find_script_in_dir(py3_bin, "mlx_whisper")

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -27,6 +27,18 @@ from kiro_crew.transcribe import (
 # ---------------------------------------------------------------------------
 
 
+def _no_own_venv(monkeypatch) -> None:
+    """Neutralize the running interpreter's own scripts dir.
+
+    ``_find_whisper`` probes it (that is what makes an install into the app's own
+    venv work), and on a dev machine that directory really does contain a
+    ``whisper`` — so a test isolating any LATER probe has to switch it off or it
+    never gets there. Same reason these tests already stub ``shutil.which`` and
+    ``_python3_bin_dir``.
+    """
+    monkeypatch.setattr("kiro_crew.transcribe._own_scripts_dir", lambda: "")
+
+
 class TestFindWhisper:
     def test_configured_path_exists(self, tmp_path):
         binary = tmp_path / "whisper"
@@ -49,14 +61,69 @@ class TestFindWhisper:
 
     def test_empty_path_which_none_checks_search_paths(self, tmp_path, monkeypatch):
         with patch("kiro_crew.transcribe.shutil.which", return_value=None):
+            _no_own_venv(monkeypatch)
             monkeypatch.setattr("kiro_crew.transcribe._WHISPER_SEARCH_PATHS", [str(tmp_path / "w")])
             assert _find_whisper("") is None
+
+    def test_finds_whisper_installed_into_our_own_venv(self, tmp_path, monkeypatch):
+        """``pip install openai-whisper`` inside the app's venv must be enough.
+
+        Nothing else in the search order looks there: ``shutil.which`` only sees
+        PATH (a venv is on PATH only after ``activate``, and the gateway runs as
+        ``<venv>/bin/kirocrew``), and ``_python3_bin_dir`` deliberately asks the
+        SYSTEM python3. So the obvious install left ``is_available()`` False, with
+        no fix but setting ``stt.whisper_path`` by hand.
+        """
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        binary = venv_bin / "whisper"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        monkeypatch.setattr("kiro_crew.transcribe.sys.executable", str(venv_bin / "python"))
+        with patch("kiro_crew.transcribe.shutil.which", return_value=None):
+            monkeypatch.setattr("kiro_crew.transcribe._WHISPER_SEARCH_PATHS", [])
+            monkeypatch.setattr("kiro_crew.transcribe._python3_bin_dir", lambda: "")
+            assert _find_whisper("") == str(binary)
+
+    def test_our_venv_is_preferred_over_the_system_python(self, tmp_path, monkeypatch):
+        """Both present: the environment the caller installed into wins.
+
+        Picking the system one would run a DIFFERENT Whisper than the operator
+        just installed — a silently wrong version, or a missing model cache.
+        """
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        ours = venv_bin / "whisper"
+        ours.write_text("#!/bin/sh\n")
+        ours.chmod(0o755)
+        sys_bin = tmp_path / "system" / "bin"
+        sys_bin.mkdir(parents=True)
+        theirs = sys_bin / "whisper"
+        theirs.write_text("#!/bin/sh\n")
+        theirs.chmod(0o755)
+
+        monkeypatch.setattr("kiro_crew.transcribe.sys.executable", str(venv_bin / "python"))
+        with patch("kiro_crew.transcribe.shutil.which", return_value=None):
+            monkeypatch.setattr("kiro_crew.transcribe._WHISPER_SEARCH_PATHS", [])
+            monkeypatch.setattr("kiro_crew.transcribe._python3_bin_dir", lambda: str(sys_bin))
+            assert _find_whisper("") == str(ours)
+
+    def test_path_still_wins_over_the_venv(self, tmp_path, monkeypatch):
+        """A whisper already on PATH is what the operator chose; do not override it."""
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "whisper").write_text("#!/bin/sh\n")
+        (venv_bin / "whisper").chmod(0o755)
+        monkeypatch.setattr("kiro_crew.transcribe.sys.executable", str(venv_bin / "python"))
+        with patch("kiro_crew.transcribe.shutil.which", return_value="/usr/bin/whisper"):
+            assert _find_whisper("") == "/usr/bin/whisper"
 
     def test_empty_path_finds_in_search_paths(self, tmp_path, monkeypatch):
         binary = tmp_path / "whisper"
         binary.write_text("#!/bin/sh\n")
         binary.chmod(0o755)
         with patch("kiro_crew.transcribe.shutil.which", return_value=None):
+            _no_own_venv(monkeypatch)
             monkeypatch.setattr("kiro_crew.transcribe._WHISPER_SEARCH_PATHS", [str(binary)])
             assert _find_whisper("") == str(binary)
 
@@ -77,6 +144,7 @@ class TestFindWhisper:
         exe.write_text("")  # no execute bit on Windows
         monkeypatch.setattr("kiro_crew.transcribe.platform_compat.IS_WINDOWS", True)
         with patch("kiro_crew.transcribe.shutil.which", return_value=None):
+            _no_own_venv(monkeypatch)
             monkeypatch.setattr("kiro_crew.transcribe._python3_bin_dir", lambda: str(scripts))
             monkeypatch.setattr("kiro_crew.transcribe._WHISPER_SEARCH_PATHS", [])
             assert _find_whisper("") == str(exe)
@@ -222,6 +290,10 @@ class TestTranscribeAudio:
         monkeypatch.setattr(
             "kiro_crew.transcribe._python3_bin_dir", discover_python_bin_dir
         )
+        # This test observes the thread `_python3_bin_dir` runs on, so the probe
+        # BEFORE it must miss — otherwise discovery short-circuits and never
+        # reaches the call being watched.
+        _no_own_venv(monkeypatch)
         monkeypatch.setattr("kiro_crew.transcribe._WHISPER_SEARCH_PATHS", [])
         with patch("kiro_crew.transcribe.shutil.which", return_value=None):
             result = await transcribe_audio(str(audio), cfg)


### PR DESCRIPTION
## Problem / Motivation

Installing Whisper the obvious way does not work. On a machine where the gateway
runs from a virtualenv:

```sh
pip install openai-whisper        # into the environment the gateway runs from
```

`stt.enabled` is true, the binary is sitting at `.venv/bin/whisper`, and
`is_available()` still reports False — so speech-to-text is offered as
unavailable and the Settings panel keeps prompting to install something that is
already installed. The only ways out are to set `stt.whisper_path` by hand or to
install Whisper a second time somewhere else.

Found while verifying the DEFAULT STT provider on a clean machine:
`_find_whisper()` returned None with the binary present.

## Why it matters

`whisper` is the default STT provider, and a virtualenv is the install path
`CONTRIBUTING.md` itself documents (`First-Time Setup` creates one and installs the
package into it). So the combination that fails is the documented one: a
contributor or operator who follows the setup instructions and then installs
Whisper into that same environment lands on "not available" with nothing in the UI
explaining why.

It fails closed and silently — the feature is simply absent rather than erroring —
so the natural conclusion is that the install did not work, and the next step is
usually to install it again globally.

## What changed (motivation → approach → change)

**Root cause.** Nothing in the search order looks at the running interpreter's own
scripts directory, and each omission is individually reasonable:

- `shutil.which` only sees `PATH`, and a virtualenv is on `PATH` only after
  `activate`. The gateway is launched as `<venv>/bin/kirocrew`, which does not
  modify `PATH` — so the venv's own `bin/` is invisible to it.
- `_python3_bin_dir()` deliberately asks the SYSTEM python3 (via
  `find_python_interpreter`), so it reports the system scripts dir even when we are
  running inside a venv. That is what it is for; it just is not this.
- The hardcoded paths cover `~/.local/bin`, the Homebrew prefixes and `/usr/bin` —
  a `brew` or `pipx` install, not a venv one.

So the one directory guaranteed to match the environment the operator actually
installed into was the only one not probed.

**The change.** `_own_scripts_dir()` adds it, derived from `sys.executable` rather
than `sysconfig.get_path('scripts')` — the latter can be redirected by an active
`--user` scheme, while the console script always sits beside the running
interpreter. `_find_mlx_whisper` gets the same probe for the same reason.

**Ordering, which is the part with a real trade-off.** The new probe goes after
`PATH` but BEFORE the system python3:

- After `PATH`: a whisper already on `PATH` is the operator's explicit choice and
  must keep winning. Pinned by a test.
- Before the system python3: both present means two different Whisper installs.
  Picking the system one would run a version the operator did not just install,
  against a different model cache — a silently different result rather than a
  visible failure.

**Scope.** This is a pre-existing core gap, not something the meetings work
introduced: `transcribe.py`'s discovery is unchanged from main. Kept as its own
change for that reason, so it can land independently of anything else.

## Tests

Three new tests in `test/test_transcribe.py`:

- the venv's scripts dir is probed when `PATH` has no whisper
- a whisper on `PATH` still wins over the venv one (the precedence trade-off above)
- the same probe applies to `mlx_whisper`

Non-vacuous: removing the probe fails two of the three by name.

Four EXISTING tests had to learn about the new probe, and this is worth calling
out rather than hiding in the diff. Three of them isolate a LATER stage (the
hardcoded search paths, the Windows `.exe` sweep) and one observes the thread
`_python3_bin_dir` runs on. All four short-circuited once a real dev machine's venv
started matching — they were only ever passing because nothing matched earlier. They
now neutralize the new probe through a shared `_no_own_venv` helper, the same way
they already stub `shutil.which` and `_python3_bin_dir`.

## Manual verification

On the real machine that produced the bug, with `stt.whisper_path` cleared:

- before: `is_available()` False, `_find_whisper('')` → None, with
  `.venv/bin/whisper` present
- after: `is_available()` True, `_find_whisper('')` →
  `<repo>/.venv/bin/whisper`

Then transcribed an 87-second WAV end to end through the provider to confirm the
resolved binary actually runs, not just that a path was returned.

## Related Issues

N/A — found while verifying the default provider rather than from a filed issue.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: this makes the documented
      install path work, so no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff
