### PR TITLE
fix(memory): make concurrent prompt assembly safe

### DIFF
--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -130,12 +130,29 @@ _MMR_MAX_POOL = 1000
 _SEMANTIC_VECTOR_WEIGHT = 0.6  # weight for vector score in hybrid semantic retrieval
 _SEMANTIC_KEYWORD_WEIGHT = 0.4  # weight for keyword score in hybrid semantic retrieval
 
-_snowball = _snowball_stemmer("english")
+# ``snowballstemmer``'s stemmer keeps its whole parse position on the instance
+# (``current``, ``cursor``, ``limit``, ``bra``/``ket``), so one shared instance is
+# NOT thread-safe: concurrent ``stemWords`` calls interleave those cursors and the
+# stemmer indexes past the end of another thread's word, raising
+# ``IndexError: string index out of range``. Prompt assembly reaches this from
+# ``get_semantic_context`` once per candidate row while other threads assemble
+# their own prompts, so the shared instance is reachable in normal operation.
+# One instance per thread costs a few KB and removes the shared state entirely.
+_snowball_local = threading.local()
+
+
+def _thread_snowball():
+    """Return this thread's own stemmer, creating it on first use."""
+    stemmer = getattr(_snowball_local, "stemmer", None)
+    if stemmer is None:
+        stemmer = _snowball_stemmer("english")
+        _snowball_local.stemmer = stemmer
+    return stemmer
 
 
 def _stem_words(words: set[str]) -> set[str]:
     """Stem a set of words, returning both original and stemmed forms."""
-    return words | set(_snowball.stemWords(list(words)))
+    return words | set(_thread_snowball().stemWords(list(words)))
 
 
 _BUILTIN_PREFIXES = [
@@ -460,6 +477,34 @@ class VectorMemoryStore:
             raise RuntimeError("VectorMemoryStore not initialized — call init() first")
         return self._db
 
+    # ── Locked read helpers ──
+    #
+    # The sqlite3 connection is a process-wide singleton opened with
+    # ``check_same_thread=False`` and shared by every caller: the dashboard
+    # session, each subagent, and history consolidation all assemble prompts on
+    # the same ``mc-embed`` thread pool (``run_in_embed_pool``), and every one of
+    # them reads semantic memory / lessons on the way. Two threads stepping one
+    # connection raise ``sqlite3.InterfaceError: bad parameter or other API
+    # misuse``, which for a subagent lands in prompt assembly and kills the run
+    # before its first turn.
+    #
+    # Writes were already serialized on ``_db_lock``; these helpers extend the
+    # same lock to the read paths. The cursor is drained INSIDE the lock — a
+    # cursor handed back un-fetched would keep stepping the connection after the
+    # lock was released, which is the bug all over again. Per the ``_db_lock``
+    # contract the lock is never held across a blocking embed call: callers embed
+    # before or after, never inside.
+
+    def _fetchall(self, sql: str, params: tuple = ()) -> list[sqlite3.Row]:
+        """Run a read query under ``_db_lock`` and return every row."""
+        with self._db_lock:
+            return self.db.execute(sql, params).fetchall()
+
+    def _fetchone(self, sql: str, params: tuple = ()) -> sqlite3.Row | None:
+        """Run a read query under ``_db_lock`` and return the first row."""
+        with self._db_lock:
+            return self.db.execute(sql, params).fetchone()
+
     # ── Key Validation ──
 
     def _validate_key(self, key: str) -> str | None:
@@ -531,9 +576,9 @@ class VectorMemoryStore:
 
     def get_semantic(self, key: str) -> dict | None:
         """Get a single semantic memory entry by key."""
-        row = self.db.execute(
+        row = self._fetchone(
             "SELECT * FROM semantic_memory WHERE key = ? AND is_deleted = 0", (key,)
-        ).fetchone()
+        )
         return dict(row) if row else None
 
     def get_all_semantic(self, limit: int | None = None, offset: int = 0) -> list[dict]:
@@ -550,7 +595,7 @@ class VectorMemoryStore:
         if limit is not None:
             sql += " LIMIT ? OFFSET ?"
             params = (int(limit), int(offset))
-        rows = self.db.execute(sql, params).fetchall()
+        rows = self._fetchall(sql, params)
         return [dict(r) for r in rows]
 
     @timed("vector", "write")
@@ -806,10 +851,10 @@ class VectorMemoryStore:
     @timed("vector", "search")
     def search_semantic(self, prefix: str) -> list[dict]:
         """Search semantic memory by key prefix."""
-        rows = self.db.execute(
+        rows = self._fetchall(
             "SELECT * FROM semantic_memory WHERE key LIKE ? AND is_deleted = 0 ORDER BY key",
             (prefix.rstrip("*").rstrip(".") + "%",),
-        ).fetchall()
+        )
         return [dict(r) for r in rows]
 
     # ── Context Injection ──
@@ -828,10 +873,10 @@ class VectorMemoryStore:
             query_words = _stem_words(set(re.findall(r"\w+", query_text.lower())))
             query_embedding = self._try_embed(query_text) if self.embed_fn else None
 
-            all_rows = self.db.execute(
+            all_rows = self._fetchall(
                 "SELECT key, value_json, updated_at FROM semantic_memory "
                 "WHERE is_deleted = 0 AND key NOT LIKE 'lesson.%'"
-            ).fetchall()
+            )
 
             scored_rows: list[tuple[float, dict]] = []
             for r in all_rows:
@@ -869,11 +914,11 @@ class VectorMemoryStore:
             rows = [r[1] for r in scored_rows[:max_rows]]
         else:
             # No query: recent entries
-            rows = self.db.execute(
+            rows = self._fetchall(
                 "SELECT key, value_json FROM semantic_memory WHERE is_deleted = 0 "
                 "AND key NOT LIKE 'lesson.%' ORDER BY updated_at DESC LIMIT ?",
                 (max_rows,),
-            ).fetchall()
+            )
 
         if not rows:
             return ""
@@ -928,10 +973,10 @@ class VectorMemoryStore:
 
     def get_events(self, limit: int = 50, offset: int = 0) -> list[dict]:
         """Return recent memory events with pagination."""
-        rows = self.db.execute(
+        rows = self._fetchall(
             "SELECT * FROM memory_events ORDER BY id DESC LIMIT ? OFFSET ?",
             (limit, offset),
-        ).fetchall()
+        )
         return [dict(r) for r in rows]
 
     def rotate_events(self, max_rows: int = _MAX_EVENTS) -> int:
@@ -957,10 +1002,10 @@ class VectorMemoryStore:
             return 0
         self._faiss_index = faiss.IndexFlatIP(self._embedding_dim)
         self._faiss_id_map = []
-        rows = self.db.execute(
+        rows = self._fetchall(
             "SELECT id, embedding FROM episodic_memories "
             "WHERE is_deleted = 0 AND embedding IS NOT NULL"
-        ).fetchall()
+        )
         skipped = 0
         for row in rows:
             vec = np.frombuffer(row["embedding"], dtype=np.float32).reshape(1, -1)
@@ -1548,12 +1593,12 @@ class VectorMemoryStore:
         else:
             tag_conds = ""
             tag_params = ()
-        rows = self.db.execute(
+        rows = self._fetchall(
             "SELECT id, conversation_id, text, tags, importance, created_at, last_accessed_at "
             f"FROM episodic_memories WHERE is_deleted = 0{tag_conds} "
             "ORDER BY created_at DESC LIMIT ? OFFSET ?",
             (*tag_params, limit, offset),
-        ).fetchall()
+        )
         return [dict(r) for r in rows]
 
     def delete_episodic(self, mem_id: str, source: str = "user_explicit") -> bool:
@@ -1608,7 +1653,7 @@ class VectorMemoryStore:
 
     def memory_stats(self) -> dict:
         """Return counts and sizes for dashboard display."""
-        row = self.db.execute(
+        row = self._fetchone(
             "SELECT "
             "(SELECT COUNT(*) FROM semantic_memory WHERE is_deleted=0) AS sem_active, "
             "(SELECT COUNT(*) FROM semantic_memory WHERE is_deleted=1) AS sem_deleted, "
@@ -1616,16 +1661,19 @@ class VectorMemoryStore:
             "(SELECT COUNT(*) FROM episodic_memories WHERE is_deleted=1) AS ep_deleted, "
             "(SELECT COUNT(*) FROM memory_events) AS events_count, "
             "(SELECT COUNT(*) FROM episodic_memories WHERE is_deleted=0 AND embedding IS NOT NULL) AS ep_with_vec"
-        ).fetchone()
+        )
+        # A bare aggregate SELECT always yields exactly one row, but _fetchone is
+        # typed Optional; fall back to zeros rather than raise on a stats read.
+        counts = row if row is not None else (0, 0, 0, 0, 0, 0)
         faiss_size = len(self._faiss_id_map) if self._faiss_id_map else 0
         return {
-            "semantic_active": row[0],
-            "semantic_deleted": row[1],
-            "episodic_active": row[2],
-            "episodic_deleted": row[3],
-            "events_count": row[4],
+            "semantic_active": counts[0],
+            "semantic_deleted": counts[1],
+            "episodic_active": counts[2],
+            "episodic_deleted": counts[3],
+            "events_count": counts[4],
             "faiss_index_size": faiss_size,
-            "embedded_count": row[5],
+            "embedded_count": counts[5],
         }
 
     # ── Episodic Helpers ──
@@ -1638,9 +1686,9 @@ class VectorMemoryStore:
         return bool(set(t.lower() for t in entry_tags) & set(t.lower() for t in tag_filter))
 
     def _get_episodic(self, mem_id: str) -> dict | None:
-        row = self.db.execute(
+        row = self._fetchone(
             "SELECT * FROM episodic_memories WHERE id = ? AND is_deleted = 0", (mem_id,)
-        ).fetchone()
+        )
         return dict(row) if row else None
 
     #: Columns returned for episodic search hits. Deliberately omits the
@@ -1662,11 +1710,11 @@ class VectorMemoryStore:
         if not mem_ids:
             return {}
         placeholders = ",".join("?" * len(mem_ids))
-        rows = self.db.execute(
+        rows = self._fetchall(
             f"SELECT {self._EPISODIC_SEARCH_COLUMNS} FROM episodic_memories "
             f"WHERE id IN ({placeholders}) AND is_deleted = 0",
             tuple(mem_ids),
-        ).fetchall()
+        )
         return {row["id"]: dict(row) for row in rows}
 
     #: Minimum interval between last_accessed_at writes for the same episodic row.
@@ -1991,9 +2039,9 @@ class VectorMemoryStore:
         )
         if limit is not None and limit > 0:
             sql += " LIMIT ?"
-            rows = self.db.execute(sql, (limit,)).fetchall()
+            rows = self._fetchall(sql, (limit,))
         else:
-            rows = self.db.execute(sql).fetchall()
+            rows = self._fetchall(sql)
         return [dict(r) for r in rows]
 
     def delete_lesson(self, rule_substring: str) -> bool:
@@ -2584,9 +2632,10 @@ class VectorMemoryStore:
                     else:
                         counts["skipped"] += 1
 
-        embedded_n = self.db.execute(
+        embedded_row = self._fetchone(
             "SELECT COUNT(*) FROM episodic_memories WHERE is_deleted=0 AND embedding IS NOT NULL"
-        ).fetchone()[0]
+        )
+        embedded_n = embedded_row[0] if embedded_row is not None else 0
         logger.info(
             "Migration complete: semantic=%d episodic=%d skipped=%d embedded=%d",
             counts["semantic"],
@@ -2670,11 +2719,11 @@ class VectorMemoryStore:
             return 0
 
         promoted = 0
-        rows = self.db.execute(
+        rows = self._fetchall(
             "SELECT id, text, embedding FROM episodic_memories "
             "WHERE is_deleted = 0 AND embedding IS NOT NULL "
             "ORDER BY importance DESC, created_at DESC LIMIT 500"
-        ).fetchall()
+        )
 
         # Cluster similar episodic memories
         clusters: dict[int, list[dict]] = {}
@@ -2739,13 +2788,13 @@ class VectorMemoryStore:
         FAISS dedup, so counting episodic there would conflate benign
         deduplication with policy rejections.
         """
-        rows = self.db.execute(
+        rows = self._fetchall(
             "SELECT event_type, COUNT(*) as count FROM memory_events "
             "WHERE event_type = 'injection_blocked' "
             "OR (memory_type = 'semantic' AND event_type IN "
             "('allowlist_reject', 'low_confidence', 'conflict_skip')) "
             "GROUP BY event_type"
-        ).fetchall()
+        )
         return {r["event_type"]: r["count"] for r in rows}
 
     def get_context_preview(self, query_text: str = "") -> dict:

--- a/test/test_vector_memory.py
+++ b/test/test_vector_memory.py
@@ -19,6 +19,7 @@ from kiro_crew.vector_memory import (
     _jaccard,
     _mmr_rerank,
     _stem_words,
+    _thread_snowball,
     _tokenize,
 )
 
@@ -815,6 +816,84 @@ class TestStemWords:
     def test_short_words_unchanged(self) -> None:
         result = _stem_words({"bug", "run", "fix"})
         assert {"bug", "run", "fix"} <= result
+
+    def test_stemmer_instance_is_per_thread(self) -> None:
+        """Each thread must get its own stemmer -- the deterministic guard.
+
+        ``snowballstemmer`` keeps its parse position on the instance
+        (``current``, ``cursor``, ``bra``/``ket``), so a module-level shared
+        stemmer is not thread-safe. This asserts the invariant directly rather
+        than waiting for contention to expose it.
+
+        The barrier keeps all four threads alive at once. Without it a thread
+        could exit before the next starts, and the assertion would be comparing
+        stemmers that never coexisted -- a shared instance would then look fine.
+
+        The stemmers themselves are retained, not their ``id()``: once a thread
+        exits its thread-local stemmer is freed and CPython reuses the address,
+        so comparing ids collected over time reports false collisions. Holding a
+        strong reference to each keeps every object alive, making identity
+        comparison sound.
+        """
+        n_threads = 4
+        barrier = threading.Barrier(n_threads)
+        stemmers: list[object | None] = [None] * n_threads
+
+        def grab(slot: int) -> None:
+            barrier.wait(timeout=10)
+            stemmers[slot] = _thread_snowball()
+
+        threads = [threading.Thread(target=grab, args=(i,)) for i in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert all(s is not None for s in stemmers), "a thread never reported"
+        distinct = {id(s) for s in stemmers}
+        assert len(distinct) == n_threads, (
+            "concurrent threads shared a stemmer instance: "
+            f"{len(distinct)} distinct for {n_threads} threads"
+        )
+        # Same thread, called twice -> cached, not rebuilt per call.
+        assert _thread_snowball() is _thread_snowball()
+
+    def test_concurrent_stemming_does_not_corrupt(self) -> None:
+        """Concurrent ``_stem_words`` must not raise or drop stems.
+
+        Against a shared stemmer this raised
+        ``IndexError: string index out of range`` -- one thread's cursor walked
+        off the end of another thread's word.
+        """
+        words = {
+            "consolidation",
+            "transactions",
+            "locking",
+            "findings",
+            "revisions",
+            "assembly",
+        }
+        expected = _stem_words(words)
+        errors: list[BaseException] = []
+        mismatches: list[set[str]] = []
+
+        def worker() -> None:
+            try:
+                for _ in range(300):
+                    got = _stem_words(set(words))
+                    if got != expected:
+                        mismatches.append(got)
+            except BaseException as exc:  # noqa: BLE001 - capture any thread crash
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(6)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"concurrent stemming raised: {errors!r}"
+        assert not mismatches, f"concurrent stemming produced wrong stems: {mismatches[:2]!r}"
 
 
 class TestEmbedFnLazyRebind:
@@ -2034,31 +2113,34 @@ class _AuditingConnection:
     transaction``. Holding ``_db_lock`` across every DML statement is what
     prevents it, so this proxy audits that discipline directly.
 
-    Reads are audited too, but only the two episodic-search fetches, which the
-    context-assembly path runs concurrently with memory writes. sqlite3 caches
-    prepared statements per connection, so a SELECT that overlaps another
-    statement can have its row iteration corrupted — that surfaced on Windows
-    CI as a NULL ``embedding`` from a query filtering ``embedding IS NOT NULL``,
-    raising ``TypeError`` on ``len()``. The other read methods are deliberately
-    NOT audited: they run unlocked by design and widening the audit to them
-    would assert an invariant this change does not establish.
-    """
+    Every statement routed through ``execute`` is audited, reads included.
+    sqlite3 caches prepared statements per connection, so a SELECT overlapping
+    another statement can have its row iteration corrupted or fail outright with
+    ``InterfaceError: bad parameter or other API misuse``. That is not
+    hypothetical: it killed subagents during prompt assembly, because the
+    dashboard session, every subagent and history consolidation all read
+    semantic memory and lessons on the same ``mc-embed`` thread pool over this
+    one shared connection. The read paths now go through
+    ``VectorMemoryStore._fetchall`` / ``_fetchone``, which take the lock and
+    drain the cursor inside it, so the invariant is total and this audit no
+    longer needs a read allowlist.
 
-    _DML = ("INSERT", "UPDATE", "DELETE", "REPLACE", "BEGIN")
-    _GUARDED_READS = ("embedding IS NOT NULL", "text LIKE ?")
+    Scope limit: only ``execute`` is proxied. ``executemany`` and ``commit``
+    fall through ``__getattr__`` unaudited, so a lock violation reaching sqlite
+    by those routes would not be reported here.
+
+    ``init()`` statements never reach this proxy — it is installed after
+    ``store.init()`` returns, and init runs before the store is published to
+    any other thread.
+    """
 
     def __init__(self, inner: object, lock: _TrackingLock, violations: list[str]) -> None:
         self._inner = inner
         self._lock = lock
         self._violations = violations
 
-    def _must_be_locked(self, sql: str) -> bool:
-        if sql.lstrip().upper().startswith(self._DML):
-            return True
-        return any(frag in sql for frag in self._GUARDED_READS)
-
     def execute(self, sql: str, *args: object, **kwargs: object) -> object:
-        if self._must_be_locked(sql) and not self._lock.held:
+        if not self._lock.held:
             self._violations.append(sql.strip()[:80])
         return self._inner.execute(sql, *args, **kwargs)  # type: ignore[attr-defined]
 
@@ -2119,6 +2201,110 @@ class TestSharedConnectionLockDiscipline:
         store.rotate_events(max_rows=1)
 
         assert violations == [], f"statement issued without _db_lock held: {violations}"
+
+    def test_prompt_assembly_reads_hold_db_lock(self, tmp_path: Path) -> None:
+        """Every read a prompt build performs must hold ``_db_lock``.
+
+        These are the methods on the subagent startup path
+        (``build_message`` -> ``build_session_context`` -> ``MemoryStore.get_context``
+        -> ``get_semantic_context`` / ``get_lessons``). They ran unlocked, so a
+        subagent whose prompt build overlapped another thread's statement on the
+        shared connection died with ``InterfaceError`` before its first turn.
+        The dashboard read paths are included: they share the same connection.
+        """
+        dim = 16
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db", embedding_dim=dim)
+        store.init()
+        embed = self._fake_embed(dim)
+        store.embed_fn = embed
+        store.set_semantic("project.alpha.status", "in progress", 0.9, "consolidation")
+        store.write_lesson("prefer explicit transactions over implicit ones")
+        text = "the findings doc for topic alpha was written to disk"
+        store.write_episodic(text, embedding=embed(text))
+
+        violations = self._instrument(store)
+
+        # Prompt-assembly reads.
+        store.get_semantic_context()
+        store.get_semantic_context(query_text="alpha status findings")
+        store.get_lessons()
+        store.get_lessons(limit=5)
+        store.get_semantic("project.alpha.status")
+        # Dashboard / maintenance reads on the same connection.
+        store.get_all_semantic()
+        store.get_all_semantic(limit=5, offset=0)
+        store.search_semantic("project.*")
+        store.get_events(limit=5)
+        store.get_episodic_list(limit=5)
+        store.memory_stats()
+        store.get_rejection_stats()
+        store.get_context_preview(query_text="alpha")
+        store.promote_episodic_patterns()
+
+        assert violations == [], f"read issued without _db_lock held: {violations}"
+
+    def test_concurrent_prompt_assembly_and_consolidation(self, tmp_path: Path) -> None:
+        """Prompt assembly must survive concurrent consolidation writes.
+
+        Several threads assemble prompts (``get_semantic_context`` +
+        ``get_lessons``, what ``build_message`` does off the ``mc-embed`` pool)
+        while another consolidates memory.
+
+        Load-dependent reproduction. Run alone against unlocked read paths it
+        usually passes -- the per-statement collision window is narrow. Run as
+        part of the full suite (xdist, machine under load) it failed on
+        ``AttributeError: 'NoneType' object has no attribute 'lower'``: an
+        overlapped SELECT handed back a row with NULL in ``value_json``, a column
+        the schema never allows to be NULL. That is the important half of the
+        bug -- the unlocked reads do not merely raise ``InterfaceError``, they
+        can return CORRUPT ROWS that callers then use as if valid.
+
+        Because it needs contention to trip, it is a supporting test, not the
+        guard. ``test_prompt_assembly_reads_hold_db_lock`` is the deterministic
+        guard: it asserts the lock invariant directly and fails every time a
+        read path is left unlocked.
+        """
+        dim = 16
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db", embedding_dim=dim)
+        store.init()
+        embed = self._fake_embed(dim)
+        store.embed_fn = embed
+        for i in range(20):
+            store.set_semantic(f"project.topic{i}.status", f"state {i}", 0.9, "consolidation")
+        for i in range(5):
+            store.write_lesson(f"lesson number {i} about explicit transactions and locking")
+
+        errors: list[BaseException] = []
+
+        def _prompt_builder() -> None:
+            try:
+                for _ in range(30):
+                    store.get_semantic_context(query_text="topic status project state")
+                    store.get_lessons()
+            except BaseException as exc:  # noqa: BLE001 - capture any thread crash
+                errors.append(exc)
+
+        def _consolidator() -> None:
+            try:
+                for i in range(30):
+                    store.set_semantic(
+                        "project.topic0.status", f"revision {i}", 0.9, "consolidation"
+                    )
+                    text = f"consolidated note {i} about topic status and project state"
+                    store.write_episodic(text, embedding=embed(text))
+            except BaseException as exc:  # noqa: BLE001 - capture any thread crash
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_prompt_builder) for _ in range(4)]
+        threads.append(threading.Thread(target=_consolidator))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"concurrent prompt assembly / consolidation raised: {errors!r}"
+        assert store.get_semantic("project.topic0.status") is not None
+        assert store.get_lessons()
 
     def test_concurrent_search_and_semantic_write(self, tmp_path: Path) -> None:
         """Consolidation-style writes must survive concurrent context assembly.


### PR DESCRIPTION
## Problem

Subagents died before their first turn. The failure looked like this, with
`turns=0` and no model output at all:

```
context.py:1802 build_message
  -> memory.py:396 get_context
    -> vector_memory.py:837 get_semantic_context
sqlite3.InterfaceError: bad parameter or other API misuse
```

In one local gateway log, 22 of 23 subagent failures carried this signature (24
occurrences total). It reproduces when a subagent's prompt assembly overlaps
another thread's use of the same `VectorMemoryStore` — most reliably while the
parent session is under memory/context pressure, because that is when it is
writing.

## Why it matters

Prompt assembly runs on the shared `mc-embed` thread pool, and the dashboard
session, every subagent, and history consolidation all read semantic memory and
lessons over **one shared sqlite connection**. A subagent that loses this race
never runs, and the parent waits on a completion event that never arrives.

The crash is the visible half. The worse half is silent: an overlapped `SELECT`
on a shared connection can return a **corrupt row** rather than raising. A
concurrency test caught `AttributeError: 'NoneType' object has no attribute
'lower'` from a row with `NULL` in `value_json` — a column the schema never
allows to be NULL. That path produces a prompt built from corrupt memory with no
error anywhere.

## Fix (symptom -> root cause -> change)

Two independent pieces of shared mutable state sit on this one code path. Both
had to go; fixing either alone leaves prompt assembly broken.

**1. The shared sqlite connection.** `InterfaceError` came from 16 of 58 db
access sites reading the connection without holding `_db_lock`. sqlite3 caches
prepared statements per connection, so a `SELECT` overlapping another statement
can have its row iteration corrupted or fail outright. Added locked
`_fetchall` / `_fetchone` helpers that execute **and drain the cursor** inside
the lock, and routed every read through them — a cursor obtained under the lock
but iterated after release is still unsafe, so materializing inside is the point.

**2. The shared Snowball stemmer.** With the lock in place the concurrency test
still failed, now with `IndexError: string index out of range`. Not sqlite at
all: `snowballstemmer`'s stemmer keeps its entire parse position on the instance
(`current`, `cursor`, `limit`, `bra`/`ket`), and the module held one singleton.
`get_semantic_context` stems **once per candidate row**, so concurrent prompt
builds interleaved those cursors and the stemmer indexed past the end of another
thread's word. Replaced with one instance per thread via `threading.local`.

Direct measurement of the singleton, 6 threads:

```
SHARED     errors=5   sample=[IndexError('string index out of range'), ...]
PER-THREAD errors=0
```

`threading.local` rather than a global lock because stemming is per-row — a lock
would serialize prompt assembly across all threads to protect a few KB of state.
Per-thread instances are released with their thread, and `snowballstemmer.stemmer()
returns a fresh object per call, so the instances are genuinely unshared.

Also: `memory_stats` and the markdown-migration count now have explicit `None`
branches. The new `_fetchone` is honestly typed `sqlite3.Row | None`, which mypy
correctly rejected at the indexing call sites. Both queries are bare aggregates
that always yield exactly one row, so the fallbacks are unreachable rather than
error-hiding.

## Tests

- **`test_prompt_assembly_reads_hold_db_lock`** — the deterministic guard. A
  connection proxy records any statement issued without `_db_lock` held, so it
  fails every time a read path is left unlocked, rather than waiting for
  contention. Covers the subagent startup path plus the dashboard reads that
  share the connection.
- **`test_concurrent_prompt_assembly_and_consolidation`** — supporting,
  load-dependent: four threads assemble prompts while one consolidates.
- **`test_stemmer_instance_is_per_thread`** — deterministic guard for the
  stemmer. A `Barrier` keeps all four threads alive simultaneously, and the
  stemmers themselves are retained rather than their `id()`: a thread's stemmer
  is freed when the thread exits and CPython reuses the address, so comparing ids
  gathered over time reports false collisions.
- **`test_concurrent_stemming_does_not_corrupt`** — reproduces the CI
  `IndexError`, and asserts the stems are *correct*, not merely non-raising.

Both new stemmer tests were verified to fail against the unfixed singleton and
pass after, so neither can pass vacuously.

Also restores **`test_concurrent_search_and_semantic_write`**: an earlier commit
on this branch deleted its `def` line, so its docstring and body were absorbed
into the test above it and pytest stopped collecting it. No deterministic gate
catches this — flake8 here has no bugbear (so no `B018` on the orphaned
docstring) and mypy does not cover `test/`. Verified by AST comparison against
the base ref: 136 tests collected = 132 base + exactly the 4 intentional
additions, **0 tests lost**, and the restored body is byte-identical to base's.

## Manual verification

N/A for UI. Behavioral verification beyond the unit tests:

- `mypy src/kiro_crew/` — 0 errors in `vector_memory.py`.
- `flake8` and `isort` clean.
- `test/test_vector_memory.py` — 126 passed / 10 skipped (pre-existing
  FAISS/numpy guards), stable across 5 consecutive runs.
- Wider neighborhood (18 files importing `vector_memory` / `get_semantic_context`
  / `memory_stats` / `_stem_words`) — 1569 passed. Three failures in
  `test_context.py` / `test_memory_smoke.py` were confirmed **pre-existing** by
  stash-and-compare against the base ref, and are local-macOS artifacts.

## Screenshots

N/A — no user-visible UI surface is touched. Both changed files are backend
Python (`src/kiro_crew/vector_memory.py`, `test/test_vector_memory.py`).
