### PR TITLE
fix(dashboard): route subagent events to cron/channel-born tabs

### DIFF
--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -406,9 +406,50 @@ def dashboard_slot_key(session_key: str) -> str:
     receive it: routing a notice, addressing a card, honouring a dashboard-only
     directive.
     """
+    if session_key.startswith("cron:"):
+        # A cron-born tab is named ``cron-<job_id>`` (see cron_inject.py), which
+        # is NOT the session key folded: ``_normalize_slot_key`` turns
+        # ``cron:<id>`` into ``cron_<id>`` (underscore), a slot that has never
+        # existed. Consumers that trusted the fold — sub-agent completion
+        # injection, compaction/recycle notices — silently missed the open cron
+        # tab ("parent slot cron_<id> gone, notification only"), so agent
+        # results reached the bell icon but never the conversation.
+        #
+        # Per-run execution keys carry extra segments — ``cron:<job_id>:<run_id>``
+        # for stateless jobs, ``cron:<job_id>:<agent>`` for agent sequences —
+        # while the surface registry only ever holds the slot's linked key
+        # (``cron:<job_id>``), so the surface gate is checked against both
+        # spellings. Whichever matched, the displaying tab is the job's own.
+        job_id = session_key.removeprefix("cron:").split(":", 1)[0]
+        if not (
+            has_dashboard_surface(session_key) or has_dashboard_surface(f"cron:{job_id}")
+        ):
+            return ""
+        return _normalize_slot_key(f"cron-{job_id}")
     if not has_dashboard_surface(session_key):
         return ""
     return _normalize_slot_key(session_key)
+
+
+def subagent_event_slot(parent_session_key: str) -> str:
+    """The ``slot`` value a per-slot WS event must carry for *parent_session_key*.
+
+    The frontend routes ``subagent_*`` / ``batch_finished`` frames by EXACT
+    match between the frame's ``slot`` and the tab's slot key, so a bare
+    ``removeprefix("dashboard:")`` breaks every non-dashboard parent: a
+    cron-born tab is named ``cron-<id>`` while its session key is
+    ``cron:<id>``, and a channel-born tab is named by its transcript stem
+    (``slack_<ts>``) while its session key stays ``slack:<ts>``. Frames tagged
+    with those raw keys route to a slot no tab reads — the Subagents panel
+    showed "No subagents running" for the entire life of every agent spawned
+    from such a session.
+
+    :func:`dashboard_slot_key` owns the real mapping; fall back to the old
+    prefix-strip when it answers ``""`` (no open tab — nothing routes anywhere
+    either way, but keeping the raw key preserves the historical payload for
+    external WS consumers and log lines).
+    """
+    return dashboard_slot_key(parent_session_key) or parent_session_key.removeprefix("dashboard:")
 
 
 def slot_transcript_key(slot_key: str) -> str:

--- a/src/kiro_crew/dashboard/cron_inject.py
+++ b/src/kiro_crew/dashboard/cron_inject.py
@@ -93,6 +93,16 @@ def inject_cron_result_to_dashboard(
         else:
             messages = history
         hydrate_slot_from_history(slot, messages)
+    # Publish the (possibly just-created) tab to the dashboard-surface registry
+    # BEFORE anything routes against it. Every gate that asks "does this session
+    # have a tab?" — dashboard_slot_key for sub-agent event routing and
+    # completion injection, widget/question/approval delivery — reads that
+    # registry, and a created-but-unpublished slot silently fails those gates
+    # until some unrelated slot change happens to republish. (Same invariant as
+    # channel_slots.reconcile — see the comment there.)
+    from kiro_crew.dashboard.chat_utils import _sync_dashboard_slots
+
+    _sync_dashboard_slots(state)
     if result_text:
         safe_result, _ = redact_exfiltration_urls(result_text)
         safe_result, _ = redact_credentials(safe_result)

--- a/src/kiro_crew/dashboard/ws.py
+++ b/src/kiro_crew/dashboard/ws.py
@@ -12,6 +12,7 @@ from aiohttp import WSMsgType, web
 
 from kiro_crew import __version__ as _local_version
 from kiro_crew import shutdown_event
+from kiro_crew.dashboard.chat_utils import subagent_event_slot
 from kiro_crew.dashboard.origin import check_origin
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -332,7 +333,7 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                         if state.subagents:
                             for a in state.subagents.running:
                                 try:
-                                    slot = a.parent_session_key.removeprefix("dashboard:")
+                                    slot = subagent_event_slot(a.parent_session_key)
                                     _replay.append(
                                         {
                                             "type": "subagent_snapshot",
@@ -356,7 +357,11 @@ async def api_ws(request: web.Request) -> web.WebSocketResponse:
                             for a in state.subagents.all_agents:
                                 if not a.done:
                                     continue
-                                slot = a.parent_session_key.removeprefix("dashboard:")
+                                # Same slot mapping as the live frames — a raw
+                                # prefix-strip tags replayed cards with a slot
+                                # no tab reads, so the panel rehydrated empty
+                                # after every reconnect for cron/channel tabs.
+                                slot = subagent_event_slot(a.parent_session_key)
                                 try:
                                     _replay.append(
                                         {

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -84,7 +84,7 @@ from kiro_crew.cron_script import resolve_script_path, run_command_sandboxed, ru
 from kiro_crew.dashboard import start_dashboard
 from kiro_crew.dashboard.chat_persistence import rehydrate_slot_from_history_async
 from kiro_crew.dashboard.chat_runner import _run_chat
-from kiro_crew.dashboard.chat_utils import dashboard_slot_key
+from kiro_crew.dashboard.chat_utils import dashboard_slot_key, subagent_event_slot
 from kiro_crew.dashboard.cron_inject import (
     context_meter_reading,
     inject_cron_result_to_dashboard,
@@ -3670,12 +3670,20 @@ class GatewayOrchestrator:
     def _init_subagents(self) -> None:
         """Initialize the subagent manager."""
 
+        # Per-slot WS events route by EXACT slot-key match in the frontend —
+        # `subagent_event_slot` maps a parent session key to the tab that
+        # displays it (cron-born tabs are `cron-<id>`, channel-born tabs their
+        # transcript stem), falling back to the legacy prefix-strip when no
+        # tab is open. A raw `removeprefix("dashboard:")` here left the
+        # Subagents panel permanently empty for cron/channel-born sessions.
+        _event_slot = subagent_event_slot
+
         async def _broadcast_subagent_status(info: SubagentInfo, event: str) -> None:
             """Broadcast subagent status change via WS for per-slot tracking."""
             if not self.dashboard_state:
                 return
             try:
-                slot = info.parent_session_key.removeprefix("dashboard:")
+                slot = _event_slot(info.parent_session_key)
                 agents = (
                     self.subagent_mgr.running_agents_for(info.parent_session_key)
                     if self.subagent_mgr
@@ -4098,7 +4106,7 @@ class GatewayOrchestrator:
                                 "batch_finished",
                                 {
                                     "batch_id": _batch_id,
-                                    "slot": parent_key.removeprefix("dashboard:"),
+                                    "slot": _event_slot(parent_key),
                                     "total": bp["total"],
                                     "ok": bp["ok"],
                                     "err": bp["err"],
@@ -4776,7 +4784,7 @@ class GatewayOrchestrator:
             agent_id = request_id.removeprefix("spawn:")
             info = self.subagent_mgr.get(agent_id) if self.subagent_mgr is not None else None
             slot = (
-                info.parent_session_key.removeprefix("dashboard:")
+                _event_slot(info.parent_session_key)
                 if info and info.parent_session_key
                 else ""
             )
@@ -4825,7 +4833,7 @@ class GatewayOrchestrator:
         async def _subagent_event(etype: str, info: SubagentInfo, extra: dict) -> None:
             if not self.dashboard_state:
                 return
-            slot_name = info.parent_session_key.removeprefix("dashboard:")
+            slot_name = _event_slot(info.parent_session_key)
             base = {"id": info.id, "slot": slot_name}
             # Batch identity rides every frame when present so the UI can
             # group/aggregate a wave without a lookup table. (Type guard:

--- a/test/test_dashboard_cron_to_chat.py
+++ b/test/test_dashboard_cron_to_chat.py
@@ -4,13 +4,29 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from kiro_crew.dashboard.cron_inject import inject_cron_result_to_dashboard
+from kiro_crew.session_surface import set_dashboard_surfaced
+
+
+@pytest.fixture(autouse=True)
+def _reset_surface_registry():
+    """inject_cron_result_to_dashboard publishes to the process-global
+    dashboard-surface registry; reset it so keys from these mock states
+    never leak into other tests."""
+    set_dashboard_surfaced(())
+    yield
+    set_dashboard_surfaced(())
 
 
 def _make_state(history_messages=None):
     """Create a mock DashboardState with conversation_log."""
     state = MagicMock()
     slots = {}
+    # Real dict: inject_cron_result_to_dashboard publishes the surface registry
+    # via _sync_dashboard_slots, which iterates state._slots.values().
+    state._slots = slots
 
     def get_or_create_slot(name=None, agent=""):
         if name not in slots:
@@ -113,6 +129,31 @@ class TestInjectCronResultToDashboard:
         job = _make_job()
         inject_cron_result_to_dashboard(state, job, "result")
         state.push_slots_update.assert_called_once()
+
+    def test_publishes_the_tab_to_the_surface_registry(self):
+        """Regression: the cron tab must be surfaced the moment it is created.
+
+        Every gate that asks "does this session have a tab?" — sub-agent event
+        routing, completion injection, widget/question delivery — reads the
+        surface registry via has_dashboard_surface. A created-but-unpublished
+        slot fails those gates until some unrelated slot change republishes,
+        so the first cron run's sub-agents stayed invisible and their results
+        were never injected."""
+        from kiro_crew.dashboard.chat_utils import dashboard_slot_key
+        from kiro_crew.session_surface import (
+            has_dashboard_surface,
+            set_dashboard_surfaced,
+        )
+
+        set_dashboard_surfaced(())
+        try:
+            state = _make_state()
+            job = _make_job(job_id="188f71e5")
+            inject_cron_result_to_dashboard(state, job, "result")
+            assert has_dashboard_surface("cron:188f71e5") is True
+            assert dashboard_slot_key("cron:188f71e5") == "cron-188f71e5"
+        finally:
+            set_dashboard_surfaced(())
 
 
 class TestPersistsResultToConversationLog:

--- a/test/test_one_conversation_one_session.py
+++ b/test/test_one_conversation_one_session.py
@@ -23,6 +23,7 @@ from kiro_crew.dashboard.chat_utils import (
     dashboard_slot_key,
     effective_session_key,
     slot_transcript_key,
+    subagent_event_slot,
 )
 from kiro_crew.history import ConversationLog, _safe_key
 from kiro_crew.session_surface import has_dashboard_surface, set_dashboard_surfaced
@@ -337,11 +338,77 @@ class TestSurfaceRegistry:
         assert has_dashboard_surface("cron:nightly") is False
         assert dashboard_slot_key("cron:nightly") == ""
 
+    def test_a_cron_session_resolves_to_its_actual_slot_name(self):
+        """A cron-born tab is named ``cron-<id>`` (cron_inject.py), NOT the
+        session key folded (``cron_<id>``). Resolving the fold sent sub-agent
+        completions to a slot that never existed — "parent slot cron_<id>
+        gone, notification only" — so results reached the bell icon but never
+        the open conversation."""
+        set_dashboard_surfaced({"cron:188f71e5"})
+        assert dashboard_slot_key("cron:188f71e5") == "cron-188f71e5"
+
+    def test_a_cron_per_run_key_resolves_to_the_job_tab(self):
+        """Stateless jobs run under ``cron:<job_id>:<run_id>`` and agent
+        sequences under ``cron:<job_id>:<agent>``, but the surface registry
+        only ever holds the slot's linked key (``cron:<job_id>``) — the base
+        key must be retried or those runs stay invisible."""
+        set_dashboard_surfaced({"cron:188f71e5"})
+        assert dashboard_slot_key("cron:188f71e5:a1b2c3") == "cron-188f71e5"
+        assert dashboard_slot_key("cron:188f71e5:worker") == "cron-188f71e5"
+
+    def test_a_cron_session_with_no_tab_still_resolves_to_nothing(self):
+        set_dashboard_surfaced(())
+        assert dashboard_slot_key("cron:188f71e5") == ""
+        assert dashboard_slot_key("cron:188f71e5:a1b2c3") == ""
+
     def test_an_empty_registry_degrades_to_the_prefix_test(self):
         """Fail-safe: no worse than the behaviour it replaced."""
         set_dashboard_surfaced(())
         assert has_dashboard_surface("dashboard:chat-1-99") is True
         assert has_dashboard_surface(SLACK_KEY) is False
+
+
+class TestSubagentEventSlotRouting:
+    """The ``slot`` a per-slot WS event carries must be the TAB's key.
+
+    The frontend routes ``subagent_spawn/tool/done`` (and the reconnect
+    replay) by exact string match against the tab's slot key. A raw
+    ``removeprefix("dashboard:")`` tags frames from cron/channel-born parents
+    with the raw session key, which no tab uses — the Subagents panel then
+    reads "No subagents running" for the entire life of every agent those
+    sessions spawn.
+    """
+
+    def setup_method(self):
+        set_dashboard_surfaced(())
+
+    def teardown_method(self):
+        set_dashboard_surfaced(())
+
+    def test_dashboard_born_parent_keeps_its_slot_key(self):
+        assert subagent_event_slot("dashboard:chat-3-1754") == "chat-3-1754"
+
+    def test_cron_born_parent_routes_to_the_cron_tab(self):
+        """Regression: agents spawned from a cron-born session were invisible
+        in the panel (events carried ``cron:<id>``, the tab is ``cron-<id>``)."""
+        set_dashboard_surfaced({"cron:188f71e5"})
+        assert subagent_event_slot("cron:188f71e5") == "cron-188f71e5"
+
+    def test_cron_per_run_parent_routes_to_the_job_tab(self):
+        """A stateless run's ``cron:<job_id>:<run_id>`` parent must reach the
+        job's tab too — only the linked ``cron:<job_id>`` is ever surfaced."""
+        set_dashboard_surfaced({"cron:188f71e5"})
+        assert subagent_event_slot("cron:188f71e5:a1b2c3") == "cron-188f71e5"
+
+    def test_channel_born_parent_routes_to_its_transcript_stem_tab(self):
+        set_dashboard_surfaced({SLACK_KEY})
+        assert subagent_event_slot(SLACK_KEY) == SLACK_STEM
+
+    def test_no_tab_falls_back_to_the_legacy_raw_key(self):
+        """No tab open: nothing can route anywhere, but external WS consumers
+        and log lines keep the historical payload shape."""
+        assert subagent_event_slot("cron:188f71e5") == "cron:188f71e5"
+        assert subagent_event_slot(SLACK_KEY) == SLACK_KEY
 
 
 class TestA6NoLostOrOutOfOrderTurn:

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -4179,6 +4179,34 @@ class TestRetriggerRecovery:
         await on_event("subagent_started", info, {})
         orch.dashboard_state.broadcast_ws.assert_called()
 
+    @pytest.mark.asyncio
+    async def test_subagent_event_routes_cron_parent_to_the_cron_tab(self):
+        """Regression: a cron-born parent's events must carry the TAB's slot
+        key (``cron-<id>``), not the raw session key (``cron:<id>``). The
+        frontend routes frames by exact slot match, so the raw key left the
+        Subagents panel permanently on "No subagents running" for every agent
+        spawned from a cron-born session."""
+        from kiro_crew.session_surface import set_dashboard_surfaced
+
+        orch, mock_sm = self._setup()
+        on_event = mock_sm.call_args[1]["on_event"]
+
+        info = MagicMock()
+        info.id = "agent-cron"
+        info.parent_session_key = "cron:188f71e5"
+        info.batch_id = ""
+
+        set_dashboard_surfaced({"cron:188f71e5"})
+        try:
+            await on_event("subagent_spawn", info, {"task": "t", "agent": "a"})
+        finally:
+            set_dashboard_surfaced(())
+
+        orch.dashboard_state.broadcast_ws.assert_called()
+        etype, payload = orch.dashboard_state.broadcast_ws.call_args[0]
+        assert etype == "subagent_spawn"
+        assert payload["slot"] == "cron-188f71e5"
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Tests: run() signal handling and bg session


### PR DESCRIPTION
## Problem / Motivation

The Subagents panel never shows agents spawned from a cron-born session (or a channel-born one) — it reads "No subagents running" for the entire life of every agent those sessions spawn. I hit this on my own dashboard: a cron-born session ("Cron job bug fixes investigation") spawned research agents, the inline chat card showed them running, but the Subagents side panel stayed empty the whole time. Worse, the agents' results were never injected back into the conversation — my gateway.log shows `Subagent 51a539bb: parent slot cron_188f71e5 gone, notification only`, so the completion went to the bell icon and the "I'll report what it finds" follow-up never happened.

## Why it matters

Anyone who continues a cron job's session in the dashboard (a very natural flow — cron finds something, you open its tab and keep working) silently loses both sub-agent observability and sub-agent results. The work isn't lost (the agents run and finish), but the panel lies ("No subagents running") and the results dead-end in a notification instead of the conversation that spawned them. The same routing break applies to channel-born tabs (Slack/Discord sessions opened in the dashboard).

## What changed (motivation → approach → change)

Symptom → root cause: the frontend routes `subagent_spawn/tool/done` WS frames (and the reconnect replay) by exact match between the frame's `slot` and the tab's slot key. A cron-born tab is named `cron-<id>` (`cron_inject.py`) while its session key is `cron:<id>`, and a channel-born tab is named by its transcript stem (`slack_<ts>`) while its key stays `slack:<ts>`. The event emitters tagged frames with `parent_session_key.removeprefix("dashboard:")` — the raw key, which no tab uses — so every frame routed to a slot nothing reads. Independently, `dashboard_slot_key()` folded `cron:<id>` to `cron_<id>` (underscore — a slot that has never existed), so completion injection missed the open tab too. Three spellings of the same identity (`cron:` / `cron-` / `cron_`) and no single owner of the mapping.

The change makes `dashboard_slot_key()` own the mapping and routes everything through it:

- `dashboard_slot_key()` now maps `cron:<job_id>` → `cron-<job_id>` (mirroring the slot naming in `cron_inject.py`), and retries the surface gate against the base `cron:<job_id>` for per-run execution keys (`cron:<job_id>:<run_id>` stateless runs, `cron:<job_id>:<agent>` sequences), since only the linked base key is ever published to the surface registry.
- New `subagent_event_slot()` helper is used by the live event bridge (`_subagent_event`), the per-slot status broadcast, the `batch_finished` frame, the spawn-approval slot resolver, and the WS reconnect replay — falling back to the legacy prefix-strip when no tab is open (nothing routes anywhere either way; external WS consumers keep the historical payload shape).
- `inject_cron_result_to_dashboard()` now publishes the freshly created cron tab to the surface registry (`_sync_dashboard_slots`) before anything routes against it — previously the first run's tab existed but was unpublished until some unrelated slot change, so the gate failed exactly when the fix was needed (found by review).

One consequence worth naming: cron tabs now resolve for scoped trust, so a Trust toggle on a cron tab reaches the job's own unattended runs. This converges with the approval-card Trust path, which already granted the equivalent via `set_approval_policy(cron:<id>, "auto")` — it does not invent a new grant.

## Tests

- `test_a_cron_session_resolves_to_its_actual_slot_name` — `dashboard_slot_key("cron:<id>")` returns the real `cron-<id>` tab key when surfaced (the exact "parent slot cron_<id> gone" regression).
- `test_a_cron_per_run_key_resolves_to_the_job_tab` — per-run keys (`:<run_id>`, `:<agent>`) resolve to the job's tab via the base-key retry.
- `test_a_cron_session_with_no_tab_still_resolves_to_nothing` — the surface gate still fails closed with no tab.
- `TestSubagentEventSlotRouting` (4 tests) — `subagent_event_slot` keeps dashboard-born keys, maps cron-born and channel-born parents to their tab keys, and preserves the legacy raw-key fallback when no tab is open.
- `test_subagent_event_routes_cron_parent_to_the_cron_tab` — end-to-end through the real `_subagent_event` closure: a cron parent's `subagent_spawn` frame carries `slot == "cron-<id>"`.
- `test_publishes_the_tab_to_the_surface_registry` — `inject_cron_result_to_dashboard` publishes the tab to the surface registry at creation time.

Full backend suite: 30,043 passed locally; the 12 failures on my machine are environment-specific and identical on a clean origin/main checkout (verified by stashing the diff and re-running them).

## Manual verification

Root cause was confirmed against my live gateway's log before writing the fix: `Subagent 51a539bb: parent slot cron_188f71e5 gone, notification only` (completion injection missing the open tab) and `subagent_status WS: event=done slot=cron:188f71e5` frames that the frontend can't route (my `open_slots.json` shows the real tab key is `cron-188f71e5`). The unit tests pin the mapping at every consumer, so I didn't re-run a live cron end-to-end.

## Screenshots / video

N/A — backend-only change (event payloads and key mapping); no frontend code touched. The panel is expected to populate through the existing, already-tested frontend routing once frames carry the right slot key.

## Related Issues

None filed — found while investigating my own dashboard showing "No subagents running" during active spawns.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior fix; comments/docstrings updated in place
- [x] No secrets, credentials, or internal references in the diff
