### PR TITLE
docs: say who each release channel is for in the README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,6 +199,10 @@ nightlies sort above what just shipped, and **merge the branch's fixes back into
 Nightly installs **side by side** as its own app. Insider and stable are two
 update lanes of **one** production app, switchable in Settings.
 
+The user-facing version of this table — same audiences, more detail on
+switching — is [Release channels](README.md#release-channels) in the README.
+Keep the two in step.
+
 ### Cutting a release
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -59,6 +59,35 @@ remote Gateway over an SSH tunnel. See the
 - **Linux**: [Stable](https://download.crew.kiro.dev/desktop/stable/latest/KiroCrew-x86_64.AppImage) | [Insider](https://download.crew.kiro.dev/desktop/insider/latest/KiroCrew-x86_64.AppImage) | [Nightly](https://download.crew.kiro.dev/desktop/nightly/latest/KiroCrew-x86_64.AppImage)
 - **Windows**: no desktop build yet, so run the Gateway from a [source install](#build-from-source) and open the dashboard in your browser
 
+Take Stable unless you have a reason not to — the table below says who each
+channel is for.
+
+### Release channels
+
+Every install path — desktop app, CLI, Docker image — offers the same three
+channels. Pick by how much churn you can absorb, not by version number:
+
+| Channel | Who it's for | Built from | Cadence |
+|---------|--------------|------------|---------|
+| **Stable** | Everyone. The default on every install path. | The Insider build that baked long enough to be promoted | On promotion, no calendar commitment |
+| **Insider** | Power users who want features days to weeks early and accept the new bugs that come with them | Release-branch release-candidate tags | Every RC |
+| **Nightly** | Us and contributors. Untested `main` HEAD — expect breakage. | `main`, 06:00 UTC daily | Daily |
+
+Stable and Insider are two update lanes of the **same** app. The desktop app
+switches between them in Settings → About, a CLI install switches by re-running
+the installer with `--channel`, and a container switches by pulling a different
+tag. Either way, the other lane's current version then arrives as an ordinary
+update.
+
+Nightly is a separate app with its own name and icon, so it installs *alongside*
+a Stable or Insider one rather than replacing it. It is not a sandbox, though: it
+reads the same `~/.kiro/crew` data home unless you point it elsewhere with
+`KIROCREW_HOME`.
+
+Running Insider or Nightly is a real contribution. When something looks wrong,
+please [open an issue](https://github.com/kirodotdev/KiroCrew/issues) so it gets
+fixed before it reaches Stable.
+
 ### One-line install
 
 Install the prebuilt, SHA-256-verified wheel from the release CDN without
@@ -70,7 +99,8 @@ Stable, the default:
 curl -fsSL https://download.crew.kiro.dev/cli.sh | sh
 ```
 
-Track a faster channel, `insider` or `nightly`:
+Track a faster channel, `insider` or `nightly` (see
+[Release channels](#release-channels) for who each one is for):
 
 ```bash
 curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --channel insider

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -29,7 +29,9 @@ Or with compose: copy [`docker/compose.yaml`](../../docker/compose.yaml) and run
 
 `linux/amd64` and `linux/arm64` are published under every tag. Version tags
 are never repointed once published; pin a version tag (or a digest) for
-reproducible deployments. Every published manifest carries SLSA build
+reproducible deployments. See
+[Release channels](../../README.md#release-channels) for who each channel is
+for. Every published manifest carries SLSA build
 provenance — verify with:
 
 ```

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -82,6 +82,13 @@ curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --channel insider
 curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --version 0.1.0
 ```
 
+`stable` suits everyone, `insider` is for power users who want features days to
+weeks early and accept the new bugs that arrive with them, and `nightly` is
+untested `main` HEAD for us and contributors. The
+[Release channels](../../README.md#release-channels) table has the full
+comparison; re-running the installer with a different `--channel` is how a CLI
+install moves between lanes.
+
 The installer verifies the wheel's digest against the signed manifest and
 refuses to install on a mismatch; there is no checksum-only fallback. It uses
 `pipx` when available, otherwise it creates a managed venv **beside** the data


### PR DESCRIPTION
## Problem

The README offers Stable, Insider and Nightly as three equal-looking download
links and then says only "track a faster channel" — nothing about who each one
is for, or that Nightly is untested `main` HEAD. The audience table existed only
in `CONTRIBUTING.md`, which is the one readership that least needs it. A user who
never opens CONTRIBUTING got no steer at all.

The in-app About panel does explain Stable vs Insider, but it is visible only
*after* you have already installed something, and it says nothing about Nightly.

## Change

Docs only.

- **README** — new `### Release channels` section right after the download links:
  audience / built-from / cadence table for all three channels, how switching
  works on each install shape (desktop toggle, `--channel` re-run, different
  image tag), the fact that Nightly installs alongside but shares the
  `~/.kiro/crew` data home, and a nudge to file issues when running early builds.
  A one-line "take Stable unless you have a reason not to" steer sits with the
  download links, and the one-line install section links to the table.
- **docs/guides/install.md** — one-paragraph audience summary next to
  `--channel`, linking to the README table.
- **docs/guides/docker.md** — pointer to the same table from the tag list.
- **CONTRIBUTING.md** — pointer from the existing contributor table to the
  user-facing one so the two do not drift.

## Verification

- `scripts/docs-lint.sh` — 185 files scanned, all checks passed
- `scripts/check_brand_name.py` on the four touched files — clean
- Claims checked against source rather than assumed: nightly cadence from
  `nightly.yml`'s `0 6 * * *`, the shared-appId / distinct-productName
  side-by-side behaviour from `packaging/build-desktop.sh`, the desktop-only
  Stable/Insider segmented control from `AboutPanel.tsx`, and the absence of any
  channel component in the data-home resolution in `src/kiro_crew/config/paths.py`
  (hence "not a sandbox" rather than a claim of isolation).
