### PR TITLE
fix(cron): publish turn identity so spawn_run resolves its parent

### DIFF
--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -147,6 +147,7 @@ from kiro_crew.mcp_gateway.rewriter import (
     rewrite_agents,
 )
 from kiro_crew.memory import MemoryStore
+from kiro_crew.messaging.identity import publish_turn_identity
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.platform import boot_platform
 from kiro_crew.platform.context import (
@@ -2110,6 +2111,18 @@ class GatewayOrchestrator:
                         )
                         _seq_downgraded = _seq_downgraded or _downgraded
                         _acq = True
+                        # Publish this turn's session identity so managed MCP
+                        # tools resolve their parent session. The cron path was
+                        # the ONE turn-running surface that skipped this (every
+                        # other surface publishes — see messaging.identity), and
+                        # under session sharing the runtime env carries no
+                        # KIROCREW_SESSION_KEY and macOS sets no
+                        # KIROCREW_HOST_PID, so the ancestor PID-walk over the
+                        # per-turn pidfile mapping is the only identity source
+                        # left. Without the publish, spawn_run resolved an
+                        # empty parent ("notification only (parent=)") unless an
+                        # unrelated surface happened to be mid-turn.
+                        await publish_turn_identity(self.sessions, agent_session_key)
                         # Off-loop: build_message embeds the episodic query.
                         full_message, _ = await run_in_embed_pool(
                             self.ctx_builder.build_message,
@@ -2170,9 +2183,33 @@ class GatewayOrchestrator:
                     finally:
                         if _acq:
                             self.sessions.release(agent_session_key)
-                            await self.sessions.reset(agent_session_key)
-                            if self.cron_svc is not None:
-                                self.cron_svc.clear_active_session_key(job.id)
+                            # Mirror the single-agent finally below: defer the
+                            # reset when this agent's sub-agents are still
+                            # running, QUEUED behind the concurrency/stagger
+                            # gate, or mid-injection — _subagent_done resets
+                            # after the last one. Now that this path publishes
+                            # turn identity, a non-final agent's spawn_run
+                            # resolves a REAL parent key, so an unconditional
+                            # reset here would tear down the session a pending
+                            # completion is about to inject into (cold-starting
+                            # a context-free replacement) and the completion's
+                            # own cleanup would clear the reaper registration
+                            # for the NEXT agent's still-in-flight turn.
+                            _has_pending = bool(
+                                self.subagent_mgr
+                                and self.subagent_mgr.has_pending_work_for(agent_session_key)
+                            )
+                            _has_injecting = self._cron_injecting.get(agent_session_key, 0) > 0
+                            if _has_pending or _has_injecting:
+                                logger.info(
+                                    "Cron '%s': deferring reset of %s, subagents pending",
+                                    job.name,
+                                    agent_session_key,
+                                )
+                            else:
+                                await self.sessions.reset(agent_session_key)
+                                if self.cron_svc is not None:
+                                    self.cron_svc.clear_active_session_key(job.id)
                 if _seq_downgraded:
                     result_text = _annotate_model_downgrade(result_text)
                 job.last_result = result_text
@@ -2192,6 +2229,10 @@ class GatewayOrchestrator:
                     session_key, job.agent_id or None
                 )
                 _acquired = True
+                # Same identity publish as the sequential site above — the
+                # single-agent cron turn must publish its pidfile mapping or
+                # spawn_run's parent resolution has no source to walk to.
+                await publish_turn_identity(self.sessions, session_key)
                 if job.acked_items:
                     msg += (
                         "\n\n[User has seen and acknowledged ALL of the following — "
@@ -2620,10 +2661,12 @@ class GatewayOrchestrator:
                 assert self.sessions is not None
                 if _acquired:
                     self.sessions.release(session_key)
-                    # Defer session reset if subagents are still running or
+                    # Defer session reset if subagents are still running,
+                    # queued behind the concurrency/stagger gate, or
                     # mid-injection — _subagent_done will reset after the last one.
-                    has_pending = self.subagent_mgr and any(
-                        a.parent_session_key == session_key for a in self.subagent_mgr.running
+                    has_pending = bool(
+                        self.subagent_mgr
+                        and self.subagent_mgr.has_pending_work_for(session_key)
                     )
                     has_injecting = self._cron_injecting.get(session_key, 0) > 0
                     if has_pending or has_injecting:
@@ -4513,10 +4556,17 @@ class GatewayOrchestrator:
                             "Subagent %s: failed to deliver cron response to Slack",
                             info.id,
                         )
-                # Reset only when no subagents running AND no injections pending
-                still_running = self.subagent_mgr and any(
-                    a.parent_session_key == parent_key and a.id != info.id
-                    for a in self.subagent_mgr.running
+                # Reset only when no subagents running or QUEUED AND no
+                # injections pending. Queued spawns (behind the concurrency /
+                # stagger gate) have no SubagentInfo in `running` yet — a
+                # sibling completing while the rest of the wave is still
+                # queued must not reset the parent out from under them.
+                still_running = self.subagent_mgr and (
+                    any(
+                        a.parent_session_key == parent_key and a.id != info.id
+                        for a in self.subagent_mgr.running
+                    )
+                    or self.subagent_mgr.queued_count_for(parent_key) > 0
                 )
                 still_injecting = self._cron_injecting.get(parent_key, 0) > 0
                 if not still_running and not still_injecting:
@@ -4531,11 +4581,20 @@ class GatewayOrchestrator:
                         # still be alive — reaper must be able to target it).
                         # parent_key is "cron:{job_id}" (persistent) or
                         # "cron:{job_id}:{run_id}" (ephemeral); job_id is the
-                        # second colon-separated segment in both cases.
+                        # second colon-separated segment in both cases. Clear
+                        # ONLY when the registration still points at the session
+                        # just reset: an agent-sequence job re-registers the
+                        # NEXT agent's key (cron:{job_id}:{agent}) while a prior
+                        # agent's deferred reset is still pending, and an
+                        # unconditional clear here would strip the reaper's
+                        # handle on that still-in-flight turn.
                         cron_svc = getattr(self, "cron_svc", None)
                         if cron_svc is not None:
                             parts = parent_key.split(":", 2)
-                            if len(parts) >= 2:
+                            if (
+                                len(parts) >= 2
+                                and cron_svc.get_active_session_key(parts[1]) == parent_key
+                            ):
                                 cron_svc.clear_active_session_key(parts[1])
                     except Exception:
                         logger.exception(

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -3955,6 +3955,28 @@ class SubagentManager:
         behind the concurrency cap / stagger gate, not yet started)."""
         return sum(1 for q in self._queue if q.get("parent_session_key", "") == parent_session_key)
 
+    def queued_count_for(self, parent_session_key: str) -> int:
+        """Public queued-spawn count for *parent_session_key*.
+
+        Spawns accepted behind the concurrency cap / stagger gate sit in
+        ``_queue`` with no ``SubagentInfo`` yet, so ``running``-based checks
+        read "no pending work" during exactly the window a wave is ramping.
+        Reset-deferral guards must consult this alongside ``running``.
+        """
+        return self._queued_depth(parent_session_key)
+
+    def has_pending_work_for(self, parent_session_key: str) -> bool:
+        """True while *parent_session_key* has sub-agents RUNNING or QUEUED.
+
+        The reset-deferral guards must consult this, not ``running`` alone —
+        see :meth:`queued_count_for` for why. A parent session reset while a
+        spawn is still queued strands that agent's completion on a
+        cold-started, context-free replacement session.
+        """
+        if self._queued_depth(parent_session_key) > 0:
+            return True
+        return any(a.parent_session_key == parent_session_key for a in self.running)
+
     def _emit_queue_depth(self, parent_session_key: str, batch_id: str = "") -> None:
         """Emit the current queued depth for *parent_session_key* as a
         ``subagent_queued`` lifecycle event.

--- a/test/test_cron_approval_mode.py
+++ b/test/test_cron_approval_mode.py
@@ -470,6 +470,7 @@ class TestCronSubagentInjection:
                 captured_done = kwargs["on_done"]
                 mgr = MagicMock()
                 mgr.running = []
+                mgr.queued_count_for = MagicMock(return_value=0)
                 return mgr
 
             mock_cls.side_effect = capture_mgr
@@ -587,6 +588,7 @@ class TestCronSubagentInjection:
 
         # .running is empty, but another subagent is mid-injection
         gw.subagent_mgr.running = []
+        gw.subagent_mgr.queued_count_for = MagicMock(return_value=0)
         gw._cron_injecting["cron:daily-prep"] = 1
 
         info = SubagentInfo(

--- a/test/test_cron_thread_routing.py
+++ b/test/test_cron_thread_routing.py
@@ -32,6 +32,7 @@ def _make_gateway():
     gateway._no_crons = False
     gateway.subagent_mgr = MagicMock()
     gateway.subagent_mgr.running = []
+    gateway.subagent_mgr.queued_count_for = MagicMock(return_value=0)
     gateway.sessions.get_or_create = AsyncMock(return_value=(MagicMock(), True, False))
     gateway.sessions.release = MagicMock()
     gateway.sessions.reset = AsyncMock()
@@ -99,6 +100,7 @@ def _capture_subagent_done(gateway):
             captured_done = kw["on_done"]
             mgr = MagicMock()
             mgr.running = []
+            mgr.queued_count_for = MagicMock(return_value=0)
             gateway.subagent_mgr = mgr
             return mgr
 

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -1063,6 +1063,324 @@ class TestInitCron:
         assert job.last_result == "cron result"
 
     @pytest.mark.asyncio
+    async def test_cron_callback_publishes_turn_identity(self):
+        """Regression: the cron turn must publish session_pid_<pid>.txt.
+
+        The cron path was the one turn-running surface that never called
+        publish_turn_identity. Under session sharing the runtime env carries
+        no KIROCREW_SESSION_KEY and macOS sets no KIROCREW_HOST_PID, so the
+        ancestor PID-walk over session_pid files is the ONLY parent-identity
+        source for spawn_run — without the publish, sub-agents spawned from a
+        cron turn resolved an empty parent ('notification only (parent=)')
+        unless an unrelated surface happened to be mid-turn."""
+        orch = _make_orchestrator(slack_enabled=True, owner_id="U1")
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.build_message = MagicMock(return_value=("full msg", None))
+        orch.ctx_builder.hooks = MagicMock()
+        orch.subagent_mgr = MagicMock()
+        orch.subagent_mgr.running = []
+        orch.dashboard_state = _mock_dashboard_state()
+        orch.slack = MagicMock()
+        orch.slack.open_dm = AsyncMock(return_value="D_U1")
+        orch.slack.post_blocks = AsyncMock(return_value="ts1")
+        orch.slack.post_message = AsyncMock()
+
+        with patch("kiro_crew.slack.gateway.CronService") as mock_cs:
+            mock_cs_inst = MagicMock()
+            mock_cs_inst.start = AsyncMock()
+            mock_cs_inst.start_reaper = MagicMock()
+            mock_cs_inst.register_active_session_key = MagicMock()
+            mock_cs_inst.clear_active_session_key = MagicMock()
+            mock_cs.return_value = mock_cs_inst
+            mock_cs.create = AsyncMock(return_value=mock_cs_inst)
+            await orch._init_cron()
+
+        callback = mock_cs.create.call_args[1]["on_job"]
+
+        job = MagicMock()
+        job.script = ""
+        job.command = ""
+        job.id = "j1"
+        job.name = "test-job"
+        job.persistent_session = True
+        job.agent_sequence = []
+        job.agent_id = None
+        job.channel = ""
+        job.created_by = "U1"
+        job.approval_mode = "auto"
+        job.env = None
+        job.acked_items = []
+        job.silent = False
+        job.thread_ts = None
+        job.last_posted_hash = ""
+        job.consecutive_dupes = 0
+        job.last_posted_at = 0.0
+        job.last_failure_hash = ""
+        job.last_failure_at = 0.0
+        job.consecutive_failures = 0
+
+        publish_events: list[str] = []
+
+        async def _publish(sessions, key):
+            publish_events.append(f"publish:{key}")
+
+        async def _stream(*a, **k):
+            # Identity must already be published when the model turn starts —
+            # spawn_run can fire at any point inside it.
+            publish_events.append("stream")
+            return "cron result"
+
+        with patch("kiro_crew.slack.gateway.publish_turn_identity", side_effect=_publish):
+            with patch("kiro_crew.slack.gateway.stream_and_collect", side_effect=_stream):
+                with patch(
+                    "kiro_crew.slack.gateway.build_cron_session_context",
+                    return_value=("cron:j1", "run task"),
+                ):
+                    await callback(job)
+
+        # Ordering is the contract: the publish must precede the model turn.
+        assert publish_events == ["publish:cron:j1", "stream"]
+
+    @pytest.mark.asyncio
+    async def test_cron_callback_publishes_identity_per_sequence_agent(self):
+        """Each agent in an agent_sequence runs on its own per-agent session
+        key (cron:<job>:<agent>) — identity must be re-published for each."""
+        orch = _make_orchestrator(slack_enabled=True, owner_id="U1")
+        orch.sessions = _mock_sessions()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.build_message = MagicMock(return_value=("full msg", None))
+        orch.ctx_builder.hooks = MagicMock()
+        orch.subagent_mgr = MagicMock()
+        orch.subagent_mgr.running = []
+        orch.dashboard_state = _mock_dashboard_state()
+        orch.slack = MagicMock()
+        orch.slack.open_dm = AsyncMock(return_value="D_U1")
+        orch.slack.post_blocks = AsyncMock(return_value="ts1")
+        orch.slack.post_message = AsyncMock()
+
+        with patch("kiro_crew.slack.gateway.CronService") as mock_cs:
+            mock_cs_inst = MagicMock()
+            mock_cs_inst.start = AsyncMock()
+            mock_cs_inst.start_reaper = MagicMock()
+            mock_cs_inst.register_active_session_key = MagicMock()
+            mock_cs_inst.clear_active_session_key = MagicMock()
+            mock_cs.return_value = mock_cs_inst
+            mock_cs.create = AsyncMock(return_value=mock_cs_inst)
+            await orch._init_cron()
+
+        callback = mock_cs.create.call_args[1]["on_job"]
+
+        job = MagicMock()
+        job.script = ""
+        job.command = ""
+        job.id = "j1"
+        job.name = "test-job"
+        job.persistent_session = True
+        job.agent_sequence = ["planner", "worker"]
+        job.agent_id = None
+        job.channel = ""
+        job.created_by = "U1"
+        job.approval_mode = "auto"
+        job.env = None
+        job.acked_items = []
+        job.silent = False
+        job.thread_ts = None
+        job.last_posted_hash = ""
+        job.consecutive_dupes = 0
+        job.last_posted_at = 0.0
+        job.last_failure_hash = ""
+        job.last_failure_at = 0.0
+        job.consecutive_failures = 0
+
+        publish = AsyncMock()
+        with patch("kiro_crew.slack.gateway.publish_turn_identity", publish):
+            with patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="cron result",
+            ):
+                with patch(
+                    "kiro_crew.slack.gateway.build_cron_session_context",
+                    return_value=("cron:j1", "run task"),
+                ):
+                    await callback(job)
+
+        assert publish.await_count == 2
+        published_keys = [c.args[1] for c in publish.await_args_list]
+        assert published_keys == ["cron:j1:planner", "cron:j1:worker"]
+
+    @pytest.mark.asyncio
+    async def test_sequence_agent_reset_deferred_while_subagents_pending(self):
+        """The sequential finally must mirror the single-agent deferral.
+
+        Now that the sequence path publishes turn identity, a non-final
+        agent's spawn_run resolves a REAL parent key. An unconditional reset
+        at the end of that agent's turn would tear down the session a pending
+        sub-agent completion is about to inject into (cold-starting a
+        context-free replacement) and strip the reaper registration for the
+        NEXT agent's still-in-flight turn."""
+        orch = _make_orchestrator(slack_enabled=True, owner_id="U1")
+        orch.sessions = _mock_sessions()
+        orch.sessions.reset = AsyncMock()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.build_message = MagicMock(return_value=("full msg", None))
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch.slack = MagicMock()
+        orch.slack.open_dm = AsyncMock(return_value="D_U1")
+        orch.slack.post_blocks = AsyncMock(return_value="ts1")
+        orch.slack.post_message = AsyncMock()
+
+        # A sub-agent of the FIRST sequence agent is still running when its
+        # turn ends; the second agent has no pending sub-agents.
+        pending = MagicMock()
+        pending.parent_session_key = "cron:j1:planner"
+        orch.subagent_mgr = MagicMock()
+        orch.subagent_mgr.running = [pending]
+        # Real predicate semantics: pending work == a running agent with this
+        # parent (no queued spawns in this scenario).
+        orch.subagent_mgr.queued_count_for = MagicMock(return_value=0)
+        orch.subagent_mgr.has_pending_work_for = MagicMock(
+            side_effect=lambda key: any(
+                a.parent_session_key == key for a in orch.subagent_mgr.running
+            )
+        )
+
+        with patch("kiro_crew.slack.gateway.CronService") as mock_cs:
+            mock_cs_inst = MagicMock()
+            mock_cs_inst.start = AsyncMock()
+            mock_cs_inst.start_reaper = MagicMock()
+            mock_cs_inst.register_active_session_key = MagicMock()
+            mock_cs_inst.clear_active_session_key = MagicMock()
+            mock_cs.return_value = mock_cs_inst
+            mock_cs.create = AsyncMock(return_value=mock_cs_inst)
+            await orch._init_cron()
+
+        callback = mock_cs.create.call_args[1]["on_job"]
+
+        job = MagicMock()
+        job.script = ""
+        job.command = ""
+        job.id = "j1"
+        job.name = "test-job"
+        job.persistent_session = True
+        job.agent_sequence = ["planner", "worker"]
+        job.agent_id = None
+        job.channel = ""
+        job.created_by = "U1"
+        job.approval_mode = "auto"
+        job.env = None
+        job.acked_items = []
+        job.silent = False
+        job.thread_ts = None
+        job.last_posted_hash = ""
+        job.consecutive_dupes = 0
+        job.last_posted_at = 0.0
+        job.last_failure_hash = ""
+        job.last_failure_at = 0.0
+        job.consecutive_failures = 0
+
+        with patch("kiro_crew.slack.gateway.publish_turn_identity", new_callable=AsyncMock):
+            with patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="cron result",
+            ):
+                with patch(
+                    "kiro_crew.slack.gateway.build_cron_session_context",
+                    return_value=("cron:j1", "run task"),
+                ):
+                    await callback(job)
+
+        # planner's reset deferred (sub-agent pending); worker's reset ran.
+        reset_keys = [c.args[0] for c in orch.sessions.reset.await_args_list]
+        assert "cron:j1:planner" not in reset_keys
+        assert "cron:j1:worker" in reset_keys
+        # The reaper registration is cleared only by the agent that actually
+        # reset — one clear, not two.
+        assert mock_cs_inst.clear_active_session_key.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_sequence_agent_reset_deferred_while_subagents_queued(self):
+        """A spawn accepted behind the concurrency/stagger gate is in the
+        manager's QUEUE, not `running` — the deferral must see it anyway.
+        A `running`-only guard reads "no pending work" during exactly the
+        window a wave is ramping, and the reset strands the queued agent's
+        completion on a cold-started, context-free replacement session."""
+        orch = _make_orchestrator(slack_enabled=True, owner_id="U1")
+        orch.sessions = _mock_sessions()
+        orch.sessions.reset = AsyncMock()
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.build_message = MagicMock(return_value=("full msg", None))
+        orch.ctx_builder.hooks = MagicMock()
+        orch.dashboard_state = _mock_dashboard_state()
+        orch.slack = MagicMock()
+        orch.slack.open_dm = AsyncMock(return_value="D_U1")
+        orch.slack.post_blocks = AsyncMock(return_value="ts1")
+        orch.slack.post_message = AsyncMock()
+
+        # Nothing RUNNING for planner — but one spawn is QUEUED for it.
+        orch.subagent_mgr = MagicMock()
+        orch.subagent_mgr.running = []
+        orch.subagent_mgr.queued_count_for = MagicMock(
+            side_effect=lambda key: 1 if key == "cron:j1:planner" else 0
+        )
+        orch.subagent_mgr.has_pending_work_for = MagicMock(
+            side_effect=lambda key: key == "cron:j1:planner"
+        )
+
+        with patch("kiro_crew.slack.gateway.CronService") as mock_cs:
+            mock_cs_inst = MagicMock()
+            mock_cs_inst.start = AsyncMock()
+            mock_cs_inst.start_reaper = MagicMock()
+            mock_cs_inst.register_active_session_key = MagicMock()
+            mock_cs_inst.clear_active_session_key = MagicMock()
+            mock_cs.return_value = mock_cs_inst
+            mock_cs.create = AsyncMock(return_value=mock_cs_inst)
+            await orch._init_cron()
+
+        callback = mock_cs.create.call_args[1]["on_job"]
+
+        job = MagicMock()
+        job.script = ""
+        job.command = ""
+        job.id = "j1"
+        job.name = "test-job"
+        job.persistent_session = True
+        job.agent_sequence = ["planner", "worker"]
+        job.agent_id = None
+        job.channel = ""
+        job.created_by = "U1"
+        job.approval_mode = "auto"
+        job.env = None
+        job.acked_items = []
+        job.silent = False
+        job.thread_ts = None
+        job.last_posted_hash = ""
+        job.consecutive_dupes = 0
+        job.last_posted_at = 0.0
+        job.last_failure_hash = ""
+        job.last_failure_at = 0.0
+        job.consecutive_failures = 0
+
+        with patch("kiro_crew.slack.gateway.publish_turn_identity", new_callable=AsyncMock):
+            with patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="cron result",
+            ):
+                with patch(
+                    "kiro_crew.slack.gateway.build_cron_session_context",
+                    return_value=("cron:j1", "run task"),
+                ):
+                    await callback(job)
+
+        reset_keys = [c.args[0] for c in orch.sessions.reset.await_args_list]
+        assert "cron:j1:planner" not in reset_keys
+        assert "cron:j1:worker" in reset_keys
+
+    @pytest.mark.asyncio
     async def test_cron_name_is_redacted_before_delivery(self):
         """A cron NAME is LLM-authored text on its way to Slack.
 
@@ -2265,6 +2583,8 @@ class TestSubagentDone:
                 mock_sm_inst = MagicMock()
                 mock_sm_inst.start_reaper = MagicMock()
                 mock_sm_inst.running = []
+                mock_sm_inst.queued_count_for = MagicMock(return_value=0)
+                mock_sm_inst.has_pending_work_for = MagicMock(return_value=False)
                 mock_sm_inst.running_agents_for = MagicMock(return_value=[])
                 mock_sm_inst.get = MagicMock(return_value=None)
                 mock_sm_inst.notify_injection_failed = MagicMock()
@@ -2767,6 +3087,8 @@ class TestSubagentSlackInjection:
                 mock_sm_inst = MagicMock()
                 mock_sm_inst.start_reaper = MagicMock()
                 mock_sm_inst.running = []
+                mock_sm_inst.queued_count_for = MagicMock(return_value=0)
+                mock_sm_inst.has_pending_work_for = MagicMock(return_value=False)
                 mock_sm_inst.running_agents_for = MagicMock(return_value=[])
                 mock_sm_inst.get = MagicMock(return_value=None)
                 mock_sm_inst.notify_injection_failed = MagicMock()
@@ -3334,6 +3656,8 @@ class TestInjectWithRetry:
                 mock_sm_inst = MagicMock()
                 mock_sm_inst.start_reaper = MagicMock()
                 mock_sm_inst.running = []
+                mock_sm_inst.queued_count_for = MagicMock(return_value=0)
+                mock_sm_inst.has_pending_work_for = MagicMock(return_value=False)
                 mock_sm_inst.running_agents_for = MagicMock(return_value=[])
                 mock_sm_inst.get = MagicMock(return_value=None)
                 mock_sm_inst.notify_injection_failed = MagicMock()
@@ -3420,6 +3744,8 @@ class TestOrchestrationGuard:
                 mock_sm_inst = MagicMock()
                 mock_sm_inst.start_reaper = MagicMock()
                 mock_sm_inst.running = []
+                mock_sm_inst.queued_count_for = MagicMock(return_value=0)
+                mock_sm_inst.has_pending_work_for = MagicMock(return_value=False)
                 mock_sm_inst.running_agents_for = MagicMock(return_value=[])
                 mock_sm_inst.get = MagicMock(return_value=None)
                 mock_sm_inst.notify_injection_failed = MagicMock()
@@ -3786,6 +4112,8 @@ class TestRetriggerRecovery:
                 mock_sm_inst = MagicMock()
                 mock_sm_inst.start_reaper = MagicMock()
                 mock_sm_inst.running = []
+                mock_sm_inst.queued_count_for = MagicMock(return_value=0)
+                mock_sm_inst.has_pending_work_for = MagicMock(return_value=False)
                 mock_sm_inst.running_agents_for = MagicMock(return_value=[])
                 mock_sm_inst.get = MagicMock(return_value=None)
                 mock_sm_inst.notify_injection_failed = MagicMock()
@@ -4230,6 +4558,8 @@ class TestSlackSubagentCompletionPersistence:
                 mock_sm_inst = MagicMock()
                 mock_sm_inst.start_reaper = MagicMock()
                 mock_sm_inst.running = []
+                mock_sm_inst.queued_count_for = MagicMock(return_value=0)
+                mock_sm_inst.has_pending_work_for = MagicMock(return_value=False)
                 mock_sm_inst.running_agents_for = MagicMock(return_value=[])
                 mock_sm_inst.get = MagicMock(return_value=None)
                 mock_sm_inst.notify_injection_failed = MagicMock()

--- a/test/test_subagent.py
+++ b/test/test_subagent.py
@@ -204,6 +204,32 @@ class TestSpawnWithoutApprovalCallback:
         assert manager._queue[0]["_preassigned_id"] == second.id
         assert first.queued is False
 
+    @pytest.mark.asyncio
+    async def test_queued_spawn_counts_as_pending_work(self) -> None:
+        """A spawn waiting behind the concurrency cap is in `_queue`, not
+        `running` — the reset-deferral predicates must see it anyway, or a
+        parent session is reset while its wave is still ramping and the queued
+        agent's completion lands on a cold-started replacement session."""
+        approval_callback = AsyncMock(return_value=True)
+        manager = SubagentManager(
+            sessions=_mock_sessions(),
+            ctx_builder=_mock_ctx_builder(),
+            max_concurrent=1,
+            on_spawn_approval=approval_callback,
+        )
+
+        with patch("kiro_crew.subagent.Stats"), patch("kiro_crew.subagent.sel"):
+            manager.spawn("task one", parent_session_key="cron:j1")
+            queued = manager.spawn("task two", parent_session_key="cron:j1")
+
+        assert queued is not None and queued.queued is True
+        # The queued member is invisible to `running`-based checks...
+        assert not any(a.parent_session_key == "cron:j1" and a.queued is False and a.id == queued.id for a in manager.running)
+        # ...but the pending-work predicates must still report it.
+        assert manager.queued_count_for("cron:j1") == 1
+        assert manager.has_pending_work_for("cron:j1") is True
+        assert manager.queued_count_for("cron:other") == 0
+
 
 class TestSpawnWithApprovalCallback:
     """When on_spawn_approval is set, spawns are gated behind approval."""


### PR DESCRIPTION
## Problem / Motivation

Sub-agents spawned from a cron turn intermittently resolve an EMPTY parent session key. When that happens their WS events carry `slot=""` (so they're invisible in every dashboard tab) and their completions are delivered as a bell notification only — my gateway.log shows `Subagent 2f6c779b → notification only (parent=)` for agents whose results should have been injected back into the cron session that spawned them. The failure is intermittent in the most confusing way: the same job's spawns resolved fine at 14:33 and came back empty at 14:15, with no code or config change in between.

## Why it matters

Cron jobs that fan work out to sub-agents (research, review mirrors, monitoring) silently lose their results on an unpredictable subset of runs. The agent session keeps waiting for a completion event that never arrives, the user sees "no subagents running", and the only trace is a bell notification. Because it depends on unrelated concurrent activity, it looks like flaky infrastructure rather than what it is — a deterministic identity gap.

## What changed (motivation → approach → change)

Symptom → root cause: `mcp_core._resolve_session_key()` has four identity sources, and on the cron turn path all four are simultaneously unavailable. (0) gatewayd caller injection is off by default (`mcp_gateway.enabled=False`); (1) under session sharing, `AcpRuntime.spawn()` deliberately sets no `KIROCREW_SESSION_KEY` — the runtime is multiplexed across sessions, so a single baked env key would be wrong for the others; (2) `KIROCREW_HOST_PID` is only exported by the Linux sandbox launcher, not on macOS; (3) the ancestor PID-walk needs a per-turn pidfile mapping written by `publish_turn_identity()` — and the cron dispatcher is the ONE turn-running surface that never called it (dashboard, native Slack, the Slack/Discord/Telegram transport dispatchers, and messaging dispatch all do). Resolution therefore only succeeded when some unrelated surface happened to be mid-turn and had published a reachable pidfile — exactly the observed intermittency.

The change publishes turn identity in `_cron_callback` after session acquisition and before `stream_and_collect`, at both model-turn sites: the single-agent path (the job's stable or per-run key) and the agent-sequence path (each per-agent key). `publish_turn_identity` is fail-safe by design (errors swallowed, filesystem work offloaded to the maintenance executor), so the cron turn cannot be broken by it. Script/command-mode jobs execute out-of-process with no model turn, so they need no publish.

Review of the sequence path surfaced a consequence worth fixing in the same change: once a sequence agent's `spawn_run` resolves a real parent, the sequential `finally`'s unconditional reset would tear down the session a pending sub-agent completion is about to inject into (cold-starting a context-free replacement), and the post-injection cleanup's unconditional `clear_active_session_key(job_id)` would strip the reaper registration for the NEXT sequence agent's still-in-flight turn. So the sequential `finally` now mirrors the single-agent deferral (skip the reset while that agent's sub-agents are running or mid-injection — `_subagent_done` resets after the last one), and the post-injection cleanup clears the reaper registration only when it still points at the session just reset. The fork GPT review then caught that all the reset guards were blind to spawns still QUEUED behind the concurrency/stagger gate (they sit in the manager's queue with no entry in `running` yet), so the deferral read "no pending work" during exactly the window a wave ramps: I added public `SubagentManager.queued_count_for()` / `has_pending_work_for()` and consult them at all three guard sites — the sequential finally, the single-agent finally (same pre-existing blind spot), and `_subagent_done`'s last-completion reset.

## Tests

- `test_cron_callback_publishes_turn_identity` — pins ordering with a single ordered event list: the identity publish happens strictly BEFORE the model turn starts (`["publish:cron:j1", "stream"]`), since `spawn_run` can fire at any point inside the turn.
- `test_cron_callback_publishes_identity_per_sequence_agent` — each agent in an `agent_sequence` runs on its own `cron:<job>:<agent>` key and gets its own publish (`["cron:j1:planner", "cron:j1:worker"]`).
- `test_queued_spawn_counts_as_pending_work` — real manager at `max_concurrent=1`: the second spawn is queued, invisible to `running`, and still counted by `queued_count_for` / `has_pending_work_for`.
- `test_sequence_agent_reset_deferred_while_subagents_queued` — nothing running but one spawn queued for the first sequence agent: its reset is deferred; the next agent's reset still runs.
- `test_sequence_agent_reset_deferred_while_subagents_pending` — with a sub-agent still parented to the first sequence agent: that agent's reset is deferred, the next agent's reset still runs, and the reaper registration is cleared exactly once.

The resolver side (ancestor walk over pidfiles, env precedence, symlink/cycle hardening) was already pinned by `test/test_resolve_session_key.py`; this PR closes the publish gap that left the walk with nothing to find.

Full backend suite: 30,038 passed locally; the 12 failures on my machine are environment-specific and identical on a clean origin/main checkout, plus one PTY-timing flake (`TestTerminalWsIntegration`) that passes in isolation.

## Manual verification

Root cause was established against my live gateway's log: two spawns at 14:15 from a cron session's kiro-cli (cold-started 13:59, no concurrent dashboard/Slack turn) resolved `parent=` empty, while the same session's spawns at 14:33 (after an unrelated dashboard session cold-started at 14:25 and published a reachable pidfile) resolved `parent=cron:188f71e5` correctly. That contrast is the race this PR removes. I did not re-run a live multi-hour cron soak; the ordering-pinned unit tests plus the pre-existing resolver tests cover the contract.

## Screenshots / video

N/A — backend-only change (session identity publication on the cron turn path); no UI code touched.

## Related Issues

None filed — found while investigating sub-agents spawned by my own cron jobs going invisible; sibling PR https://github.com/kirodotdev/KiroCrew/pull/1952 fixes the separate slot-key mismatch that hides cron sub-agents even when the parent key resolves.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior fix; comments document the invariant in place
- [x] No secrets, credentials, or internal references in the diff

