### PR TITLE
fix(history): stamp transcript metadata timestamps offset-aware

### DIFF
--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -606,10 +606,12 @@ def transcript_sort_key(ts: str) -> tuple[int, float]:
     Shared by every path that has to put two independently written streams of
     transcript lines into one chronological order.
 
-    Timestamps in one transcript are not written in one format. The dashboard
-    path stores offset-aware values; the channel path stores
-    ``datetime.now().isoformat()``, which is local and naive. Comparing those as
-    STRINGS orders them by their text, so on any host that is not UTC a naive
+    Timestamps in one transcript are not guaranteed to share one format. Both
+    the dashboard and the channel path now write offset-aware values (message
+    rows via :func:`monotonic_transcript_ts`, metadata via
+    :func:`metadata_now_iso`), but transcripts written by older builds still
+    hold naive ``datetime.now().isoformat()`` rows. Comparing those as STRINGS
+    orders them by their text, so on any host that is not UTC a naive
     ``10:00:00`` sorts before an aware ``09:30:00+00:00`` that actually happened
     later — and this merge deletes the source file afterwards, so the wrong order
     is what survives.
@@ -638,6 +640,26 @@ def _parse_transcript_ts(ts: str) -> datetime | None:
         return datetime.fromisoformat(ts.strip().replace("Z", "+00:00"))
     except (ValueError, AttributeError):
         return None
+
+
+def metadata_now_iso() -> str:
+    """Offset-aware ISO-8601 stamp for a transcript metadata timestamp.
+
+    A transcript's metadata line carries absolute-instant fields --
+    ``created_at``, ``updated_at``, ``compacted_at``, ``rotated_at`` -- that are
+    read back as points in time, not wall clocks: the dashboard renders a
+    session's ``created_at`` as a local-time timestamp, and
+    :func:`transcript_sort_key` orders lines against it. A bare
+    ``datetime.now().isoformat()`` records naive local wall-clock with no
+    offset, so a reader (the browser, or a merge running on another host) has no
+    way to know which timezone produced it -- the dashboard then renders it
+    verbatim, showing a Slack/channel session's creation time in UTC instead of
+    the viewer's local zone (issue #1948). Resolving to an absolute instant with
+    ``astimezone()`` records the offset, matching the message-row convention in
+    :func:`monotonic_transcript_ts` so both the metadata line and the rows below
+    it speak the same, unambiguous format.
+    """
+    return datetime.now().astimezone().isoformat()
 
 
 def monotonic_transcript_ts(previous: str | None, now: datetime) -> str:
@@ -1307,7 +1329,7 @@ class ConversationLog:
                 self._dir.mkdir(parents=True, exist_ok=True)
                 meta: dict = {
                     "_type": "metadata",
-                    "created_at": datetime.now().isoformat(),
+                    "created_at": metadata_now_iso(),
                     "last_consolidated": 0,
                 }
                 if agent:
@@ -1628,7 +1650,7 @@ class ConversationLog:
             else:
                 safe_offset = offset
             meta["last_consolidated"] = safe_offset
-            meta["updated_at"] = datetime.now().isoformat()
+            meta["updated_at"] = metadata_now_iso()
             lines[0] = json.dumps(meta) + "\n"
             # Reduce lock hold for this one-line metadata rewrite: skip the
             # fsync (fsync=False). ``last_consolidated`` is recoverable
@@ -2264,7 +2286,7 @@ class ConversationLog:
             self._dir.mkdir(parents=True, exist_ok=True)
             meta = {
                 "_type": "metadata",
-                "created_at": datetime.now().isoformat(),
+                "created_at": metadata_now_iso(),
                 "last_consolidated": 0,
             }
             lines = [""]  # placeholder; replaced below
@@ -2777,9 +2799,9 @@ class ConversationLog:
         orig_meta = self.get_metadata(key) or {}
         meta = {
             "_type": "metadata",
-            "created_at": orig_meta.get("created_at", datetime.now().isoformat()),
+            "created_at": orig_meta.get("created_at", metadata_now_iso()),
             "last_consolidated": orig_meta.get("last_consolidated", 0),
-            "compacted_at": datetime.now().isoformat(),
+            "compacted_at": metadata_now_iso(),
         }
         # Carry the rotation generation forward so a compaction (which is NOT a
         # rotation) doesn't reset it to 0 and spuriously trip the generation
@@ -2860,7 +2882,7 @@ class ConversationLog:
             try:
                 meta = json.loads(meta_line)
                 meta["last_consolidated"] = 0
-                meta["rotated_at"] = datetime.now().isoformat()
+                meta["rotated_at"] = metadata_now_iso()
                 meta["rotation_generation"] = int(meta.get("rotation_generation", 0) or 0) + 1
                 meta_line = json.dumps(meta) + "\n"
             except json.JSONDecodeError:

--- a/test/test_channel_transcript_timezone.py
+++ b/test/test_channel_transcript_timezone.py
@@ -1,0 +1,87 @@
+"""Regression tests for issue #1948 — channel-session timestamps in UTC.
+
+A Slack/channel conversation persists to a session transcript whose first line
+is a metadata record carrying ``created_at`` (and, later, ``updated_at`` /
+``compacted_at`` / ``rotated_at``). The dashboard renders a session's
+``created_at`` as a local-time timestamp, and the frontend does that conversion
+by parsing the stored string as an *instant*: an offset-aware value
+(``…-04:00`` / ``…+00:00``) is converted to the viewer's zone, but a naive value
+(``2026-08-07T03:35:00`` with no offset) is read verbatim, so a message the user
+sent at 11:35 PM EDT showed as 03:35 AM — its UTC wall clock.
+
+The message ROWS were already offset-aware (``monotonic_transcript_ts``); these
+tests lock in that the metadata timestamps are too, so the whole transcript
+speaks one unambiguous format regardless of the host timezone.
+
+Deliberately timezone-independent: the guarantee asserted is "the stored string
+carries an offset", which holds on any host (including a UTC CI runner, where
+the offset is simply ``+00:00``). A naive value has ``tzinfo is None`` and fails
+here — which is exactly the regression.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from kiro_crew.history import ConversationLog, metadata_now_iso
+
+CHANNEL_KEY = "slack:1785370133.085469"
+
+
+def _assert_offset_aware(value: str) -> datetime:
+    """Parse *value* and assert it is an unambiguous, offset-aware instant."""
+    assert isinstance(value, str) and value, f"missing timestamp: {value!r}"
+    parsed = datetime.fromisoformat(value)
+    # The crux of #1948: a naive string (no offset) parses to tzinfo=None and
+    # the frontend renders it verbatim as if UTC. An offset-aware string carries
+    # the information needed to convert to the viewer's local zone.
+    assert parsed.tzinfo is not None, f"timestamp is naive (no offset): {value!r}"
+    assert parsed.utcoffset() is not None
+    # Coherence check: it represents roughly now, not a parsing artefact.
+    now = datetime.now(timezone.utc)
+    assert abs(parsed - now) < timedelta(minutes=5), f"timestamp not ~now: {value!r}"
+    return parsed
+
+
+class TestChannelTranscriptTimezone:
+    def test_metadata_now_iso_is_offset_aware(self):
+        """The metadata stamp helper always records an offset."""
+        _assert_offset_aware(metadata_now_iso())
+
+    def test_channel_session_created_at_is_offset_aware(self, tmp_path):
+        """A freshly created channel session's created_at carries an offset."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.append(CHANNEL_KEY, "user", "sent at 11:35 PM local")
+
+        created_at = log.get_metadata(CHANNEL_KEY).get("created_at")
+        _assert_offset_aware(created_at)
+
+    def test_whole_transcript_speaks_one_format(self, tmp_path):
+        """Metadata line AND message rows are all offset-aware.
+
+        This is what makes the dashboard render every timestamp in the viewer's
+        zone: the reader never has to guess a timezone for any line in the file.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append(CHANNEL_KEY, "user", "hello from slack")
+        log.append(CHANNEL_KEY, "assistant", "hi there")
+
+        meta = log.get_metadata(CHANNEL_KEY)
+        created = _assert_offset_aware(meta["created_at"])
+
+        rows = log.read_messages(CHANNEL_KEY)
+        assert rows, "expected message rows"
+        row_instants = [_assert_offset_aware(m["ts"]) for m in rows]
+
+        # Ordered as written, and the metadata (session creation) is not after
+        # the first row — proves the two format families are comparable as
+        # instants rather than as raw strings.
+        assert row_instants == sorted(row_instants)
+        assert created <= row_instants[0] + timedelta(seconds=1)
+
+    def test_update_metadata_created_at_is_offset_aware(self, tmp_path):
+        """update_metadata's create path also stamps an offset-aware created_at."""
+        log = ConversationLog(base_dir=tmp_path)
+        log.update_metadata(CHANNEL_KEY, {"agent": "kirocrew"})
+
+        _assert_offset_aware(log.get_metadata(CHANNEL_KEY).get("created_at"))


### PR DESCRIPTION
## Problem / Motivation

Timestamps for Slack (and other channel) sessions render in UTC instead of my local timezone in the dashboard. I sent a Slack message at 11:35 PM EDT and the dashboard session list labeled it 03:35 AM — exactly its UTC wall clock. The instant stored is correct; only the presentation drops the local-timezone conversion. Reported in #1948.

## Why it matters

Every Slack/Discord/Teams user reading their conversations in the dashboard sees creation timestamps that are hours off (4–5h for US Eastern, more elsewhere), which is confusing and makes "when did this happen" unanswerable at a glance. The same naive value also feeds cross-session chronological sorting, so channel sessions can order incorrectly relative to dashboard sessions.

## What changed (motivation → approach → change)

I traced the timestamps the dashboard renders. Message ROWS were already stored offset-aware (`monotonic_transcript_ts`, fixed earlier in #1690/#1768), and the frontend converts an offset-aware string to the viewer's local zone correctly. The gap was the transcript's METADATA line: a channel session's `created_at` (and `updated_at`/`compacted_at`/`rotated_at`) were written with `datetime.now().isoformat()` — naive local wall-clock with no offset. The frontend parses `created_at` as an instant, so a naive value is read verbatim and shown as UTC (this is precisely the "channel path stores `datetime.now().isoformat()`, which is local and naive" wart the `transcript_sort_key` docstring already called out). The correct fix is to persist an unambiguous instant rather than format a local string, so I added a `metadata_now_iso()` helper that returns `datetime.now().astimezone().isoformat()` (offset-aware) and routed all metadata-timestamp writes through it. Now the whole transcript — metadata line and message rows — speaks one unambiguous format, the dashboard converts every timestamp to the viewer's local zone, and cross-session sorting compares real instants. I verified the one backend consumer that parses `created_at` (`chat_handlers.py` stale-session archival) already normalizes naive→UTC before use, so an offset-aware value cannot introduce a naive/aware comparison error.

## Tests

I added `test/test_channel_transcript_timezone.py` with four regression tests, all timezone-independent (they assert the stored string carries an offset, which holds on any host including a UTC CI runner where the offset is `+00:00`; a naive value has `tzinfo is None` and fails — exactly the regression): `metadata_now_iso()` is offset-aware; a freshly created `slack:` session's `created_at` is offset-aware; the whole transcript (metadata line + message rows) is uniformly offset-aware and orders correctly as instants; and `update_metadata`'s create path also stamps an offset-aware `created_at`.

## Manual verification

Before the fix, `ConversationLog.append('slack:…', 'user', …)` then `get_metadata()` returned `created_at='2026-08-06T21:46:46.631907'` (naive) — which `new Date(...)` in the browser renders as UTC digits. After the fix it returns `'2026-08-06T21:46:46.631907-07:00'` (offset-aware), which the frontend converts to local time. Backend-only change, no UI code touched, so the existing frontend formatter (already correct for offset-aware values) needs no change.

## Related Issues

Fixes #1948

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — updated the `transcript_sort_key` docstring to reflect that both paths now write offset-aware
- [x] No secrets, credentials, or internal references in the diff
