### PR TITLE
fix: gate mochi ambient chat pushes against live conversation

### DIFF
--- a/src/kiro_crew/apps/builtins/mochi/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/mochi/backend/routes.py
@@ -435,6 +435,12 @@ async def _handle_pet_event(request: web.Request) -> web.Response:
         )
     sm = _rt().state_manager
     sm.apply_event(event, _now())
+    # The runtime tracks foreground chat-turn activity from this SAME signal so
+    # an ambient pet push is not interleaved into a live turn (see
+    # MochiRuntime.note_chat_lifecycle). Using the route (foreground-only) rather
+    # than state_manager.current is deliberate: background spawns also drive the
+    # state machine, and must not count as the user conversing.
+    _rt().note_chat_lifecycle(event, _now())
     return web.json_response({"ok": True, "state": sm.current})
 
 

--- a/src/kiro_crew/apps/builtins/mochi/hooks.py
+++ b/src/kiro_crew/apps/builtins/mochi/hooks.py
@@ -214,6 +214,16 @@ class MochiRuntime:
         # recent-15 scan depth; the TIME window comes from the user's
         # `quietPeriodMins` setting at push time.
         self._recent_chat_pushes: deque[tuple[str, int]] = deque()
+        # Foreground chat-turn awareness for the conversation-interleave gate
+        # (see note_chat_lifecycle / _push_to_chat). An ambient pet push must
+        # not land between a user's message and the agent's reply, so a
+        # non-critical push is deferred while a turn is in flight (or within a
+        # short grace window after the last user input) and flushed when the
+        # turn ends. Fed by the /pet-event route — the SAME foreground-only
+        # signal that already drives the pet's thinking/working animation.
+        self._chat_turn_active = False
+        self._last_user_input_ms = 0
+        self._deferred_chat_pushes: list[dict[str, Any]] = []
         # Budget is re-resolved on every read so a tier change in Settings
         # takes effect on the next poll — same live-read contract as
         # silentSubagents. The ledger is the budget's persisted memory AND
@@ -344,6 +354,13 @@ class MochiRuntime:
             try:
                 # Cheap deadline-based ticks first (pure in-memory).
                 self.poller.tick(now)
+                # Time-based backstop for the conversation-interleave gate:
+                # deliver any chat push stranded past the busy window (a push
+                # buffered after the terminal flush, or a turn whose flag aged
+                # out with no terminal event). Runs every wake, ungated by shell
+                # presence — a deferred push must still drain when Mochi is not
+                # on screen. Pure in-memory unless there is a backlog to flush.
+                self._drain_deferred_chat_pushes(now)
                 # The pinned-file and watchlist ticks below each do blocking
                 # filesystem work — an os.stat per watched path, plus an
                 # atomic_write when a debounce fires — under a cross-process lock,
@@ -634,6 +651,25 @@ class MochiRuntime:
     #: original's `chatHistory.getRecent(15)` scan depth.
     _CHAT_PUSH_SCAN_DEPTH = 15
 
+    #: Grace window after the last user input during which a non-critical chat
+    #: push is still deferred, so a rapid back-and-forth reads as one live
+    #: conversation rather than a gap the pet can barge into. The observed
+    #: interleave landed ~4s before the next user turn began, inside exactly
+    #: such a gap — an "in-flight only" check would have missed it.
+    _CHAT_ACTIVE_GRACE_MS = 8_000
+
+    #: Hard ceiling on how long a single ``user_input`` keeps the turn "active".
+    #: ``_chat_turn_active`` is set by ``user_input`` and cleared only by a
+    #: terminal chat event on ``/pet-event`` (posted from the panel's WebSocket
+    #: chat_done handler). If the panel closes mid-turn or the socket drops
+    #: before chat_done, that terminal event never arrives and the flag would
+    #: wedge True for the runtime's lifetime — every non-critical push then
+    #: defers forever and the capped buffer silently discards the oldest. Bound
+    #: it by the timestamp already recorded: past this age the turn is treated
+    #: as ended even with the flag still set, so the drain can deliver the
+    #: backlog. Ten minutes comfortably exceeds any real single agent turn.
+    _CHAT_TURN_MAX_MS = 600_000
+
     def set_quiet(self, minutes: int) -> int:
         """Enter (minutes > 0) or leave (0) quiet mode. Returns silent-until ms.
 
@@ -687,11 +723,127 @@ class MochiRuntime:
         if isinstance(mood, str) and mood:
             self.state_manager.set_mood(mood, _now_ms())
 
+    def note_chat_lifecycle(self, event: str, now_ms: int) -> None:
+        """Track foreground chat-turn activity for the interleave gate.
+
+        Fed by the ``/pet-event`` route — the SAME signal that drives the pet's
+        thinking/working animation. That route carries only FOREGROUND chat
+        events (background spawns reach the state manager by another path, via
+        ``watch_spawn_completion``), which is exactly why it is the right seam:
+        it isolates the user's live turn, so a background check can't falsely
+        gate an ambient push.
+
+        ``user_input`` opens a turn; the terminal events (``task_complete``,
+        ``error``) close it and flush anything deferred while it was open.
+        ``approval_rejected`` is deliberately NOT terminal: unlike
+        ``task_complete``/``error`` (slot-filtered to the pet's own turn on the
+        panel WebSocket), the ``approval_resolved`` frame it derives from is
+        gateway-level and slotless, so a rejection answered on ANOTHER chat
+        surface would otherwise clear THIS turn's gate mid-conversation. A
+        rejected pet-slot turn still ends with a ``chat_done`` → ``task_complete``,
+        and the ``_CHAT_TURN_MAX_MS`` ceiling backstops any turn that ends with
+        no terminal frame at all. Other chat events (``tool_call``,
+        ``task_start``, ``approval_required``/``approval_granted``) neither open
+        nor close a turn — they occur mid-turn, when it is already active.
+        """
+        if event == "user_input":
+            self._chat_turn_active = True
+            self._last_user_input_ms = now_ms
+        elif event in ("task_complete", "error"):
+            self._chat_turn_active = False
+            self._flush_deferred_chat_pushes()
+
+    def _chat_turn_busy(self, now_ms: int) -> bool:
+        """True while a foreground chat turn is in flight, or within the grace
+        window after the last user input (rapid back-and-forth counts as one
+        live conversation).
+
+        The active flag is bounded by ``_CHAT_TURN_MAX_MS``: past that age a
+        turn whose terminal event never arrived (panel closed / socket dropped)
+        no longer counts as busy, so the drain can release its backlog rather
+        than deferring forever."""
+        if self._chat_turn_active and now_ms - self._last_user_input_ms < self._CHAT_TURN_MAX_MS:
+            return True
+        return now_ms - self._last_user_input_ms < self._CHAT_ACTIVE_GRACE_MS
+
+    def _drain_deferred_chat_pushes(self, now_ms: int) -> None:
+        """Time-based backstop that delivers deferred pushes with no further
+        pet-event.
+
+        The terminal chat events flush on turn end, but two paths strand a
+        deferred push with nothing left to release it:
+
+        * a push that arrives AFTER the terminal event but inside the grace
+          window — it is buffered after the only flush already ran; and
+        * a turn whose panel closed / socket dropped before any terminal frame
+          — the ``_chat_turn_active`` flag ages out via ``_CHAT_TURN_MAX_MS``
+          but no event fires to flush.
+
+        Driven by the owner loop's 1s cadence (see ``_loop``): once the busy
+        window has closed it clears any stale wedged flag and delivers the
+        backlog through the SAME dedup as a live push. Piggybacking on the
+        existing loop — rather than arming a per-push ``asyncio`` task from
+        ``notify_user`` — is the cleaner seam: it needs no task lifecycle
+        (arm/refresh/cancel) and sidesteps having to prove which loop
+        ``notify_user`` runs on, since the loop is unconditionally the gateway's.
+        Delivery is bounded by the grace/ceiling window plus at most one poll
+        interval, with no dependency on another pet-event arriving.
+        """
+        if not self._deferred_chat_pushes and not self._chat_turn_active:
+            return
+        if self._chat_turn_busy(now_ms):
+            return
+        # The window has closed (terminal event, grace expiry, or the ceiling
+        # aging out a wedged flag). Clear the flag so state stays honest, then
+        # deliver any backlog (a no-op when empty).
+        self._chat_turn_active = False
+        self._flush_deferred_chat_pushes()
+
+    def _flush_deferred_chat_pushes(self) -> None:
+        """Deliver pushes deferred during a chat turn, in arrival order.
+
+        Each goes through the SAME dedup as a live push (``_deliver_chat_push``),
+        so a deferred greeting that now duplicates the agent's own reply — or an
+        earlier accepted push — is still dropped rather than double-posted.
+        """
+        if not self._deferred_chat_pushes:
+            return
+        deferred, self._deferred_chat_pushes = self._deferred_chat_pushes, []
+        for action in deferred:
+            self._deliver_chat_push(action)
+
     def _push_to_chat(self, action: dict[str, Any]) -> None:
-        """Append a pet message to the panel transcript, deduplicated.
+        """Append a pet message to the panel transcript, gated and deduplicated.
 
         Content is `chatMessage` (detailed, no length limit) falling back to
         the bubble summary — the original's `action.chatMessage || summary`.
+
+        THE INTERLEAVE GATE. An ambient pet push (a scheduled greeting, a watch
+        result) must not land between the user's message and the agent's reply —
+        the reported bug was a "Good evening!" greeting injected mid-turn. While
+        a foreground chat turn is in flight, or within the grace window after the
+        last user input, a non-critical push is DEFERRED (buffered, capped at the
+        scan depth) and flushed when the turn ends (see note_chat_lifecycle).
+        `critical` priority (e.g. a "meeting in 5 minutes" reminder) bypasses the
+        gate and lands immediately. Deferring, not dropping, preserves the push,
+        and the durable activity-log entry `notify_user` writes is unaffected —
+        so an ambient message deferred right at the end of a conversation (no
+        following turn to flush it) is still recorded there immediately.
+
+        Delivery below the gate is unchanged — see `_deliver_chat_push`.
+        """
+        content = action.get("chatMessage") or action.get("summary")
+        if not isinstance(content, str) or not content:
+            return
+        if action.get("priority") != "critical" and self._chat_turn_busy(_now_ms()):
+            self._deferred_chat_pushes.append(action)
+            while len(self._deferred_chat_pushes) > self._CHAT_PUSH_SCAN_DEPTH:
+                self._deferred_chat_pushes.pop(0)
+            return
+        self._deliver_chat_push(action)
+
+    def _deliver_chat_push(self, action: dict[str, Any]) -> None:
+        """Dedup against recent accepted pushes, then broadcast `mochi:chat-push`.
 
         THE GUARD IS THE POINT. Watch-check agents are independent spawns and
         cannot see each other's output, so without it every poll cycle would

--- a/test/test_mochi_pet_events.py
+++ b/test/test_mochi_pet_events.py
@@ -277,6 +277,188 @@ class TestChatPush:
             assert len(self._pushes(seen)) == 2
 
 
+class TestChatPushConversationGate:
+    """notify_user's pushToChat must not interleave into a live chat turn.
+
+    The reported bug: a scheduled "Good evening! All quiet…" greeting from the
+    background planner landed between the user's message and the agent's reply,
+    because the chat-push path had no awareness of an in-flight (or just-ended)
+    foreground turn. The gate defers a non-critical push while a turn is active
+    or within a short grace window, and flushes it — through the SAME dedup — on
+    the terminal chat event. `critical` priority still lands immediately.
+    """
+
+    def _pushes(self, seen):
+        return [d for ch, d in seen if ch == "mochi:chat-push"]
+
+    @pytest.mark.asyncio
+    async def test_push_suppressed_while_turn_active(self, tmp_path):
+        async with _live_runtime(tmp_path) as runtime:
+            seen: list[tuple[str, dict]] = []
+            runtime.publish = lambda ch, data: seen.append((ch, data))  # type: ignore[assignment]
+            # A user turn is in flight (reported over the same /pet-event seam
+            # that animates the pet).
+            await routes._handle_pet_event(_post({"event": "user_input"}))
+            runtime.notify_user({"summary": "Good evening! All quiet 🌙", "pushToChat": True})
+            assert self._pushes(seen) == []
+
+    @pytest.mark.asyncio
+    async def test_deferred_push_flushes_once_on_task_complete(self, tmp_path):
+        async with _live_runtime(tmp_path) as runtime:
+            seen: list[tuple[str, dict]] = []
+            runtime.publish = lambda ch, data: seen.append((ch, data))  # type: ignore[assignment]
+            await routes._handle_pet_event(_post({"event": "user_input"}))
+            runtime.notify_user({"summary": "Good evening! All quiet 🌙", "pushToChat": True})
+            assert self._pushes(seen) == []
+            # The turn ends: the deferred greeting is delivered exactly once.
+            await routes._handle_pet_event(_post({"event": "task_complete"}))
+            pushed = self._pushes(seen)
+            assert len(pushed) == 1
+            assert pushed[0]["content"] == "Good evening! All quiet 🌙"
+
+    @pytest.mark.asyncio
+    async def test_grace_window_defers_then_delivers_after_expiry(self, tmp_path, monkeypatch):
+        async with _live_runtime(tmp_path) as runtime:
+            seen: list[tuple[str, dict]] = []
+            runtime.publish = lambda ch, data: seen.append((ch, data))  # type: ignore[assignment]
+            clock = {"now": 1_000_000}
+            monkeypatch.setattr(hooks, "_now_ms", lambda: clock["now"])
+            # A turn runs and completes; the grace window is now open.
+            runtime.note_chat_lifecycle("user_input", clock["now"])
+            runtime.note_chat_lifecycle("task_complete", clock["now"])
+            # A push arriving inside the grace window is still deferred — the gap
+            # before the next user message is where the real interleave landed.
+            runtime.notify_user({"summary": "Good evening! All quiet 🌙", "pushToChat": True})
+            assert self._pushes(seen) == []
+            # Past the grace window, a fresh push is delivered immediately.
+            clock["now"] += runtime._CHAT_ACTIVE_GRACE_MS + 1
+            runtime.notify_user({"summary": "Your build finished", "pushToChat": True})
+            pushed = self._pushes(seen)
+            assert len(pushed) == 1
+            assert pushed[0]["content"] == "Your build finished"
+
+    @pytest.mark.asyncio
+    async def test_critical_push_bypasses_the_gate(self, tmp_path):
+        async with _live_runtime(tmp_path) as runtime:
+            seen: list[tuple[str, dict]] = []
+            runtime.publish = lambda ch, data: seen.append((ch, data))  # type: ignore[assignment]
+            runtime.note_chat_lifecycle("user_input", hooks._now_ms())  # turn active
+            runtime.notify_user(
+                {"summary": "Meeting in 5 minutes", "pushToChat": True, "priority": "critical"}
+            )
+            assert len(self._pushes(seen)) == 1
+
+    @pytest.mark.asyncio
+    async def test_idle_path_delivers_immediately(self, tmp_path, monkeypatch):
+        """Regression guard for the common case: with no turn ever reported and
+        the clock well past any grace, a push is delivered without deferral."""
+        async with _live_runtime(tmp_path) as runtime:
+            seen: list[tuple[str, dict]] = []
+            runtime.publish = lambda ch, data: seen.append((ch, data))  # type: ignore[assignment]
+            clock = {"now": 5_000_000}
+            monkeypatch.setattr(hooks, "_now_ms", lambda: clock["now"])
+            runtime.notify_user({"summary": "Heads up: pipeline is green", "pushToChat": True})
+            assert len(self._pushes(seen)) == 1
+
+    @pytest.mark.asyncio
+    async def test_dedup_still_applies_on_flush(self, tmp_path, monkeypatch):
+        async with _live_runtime(tmp_path) as runtime:
+            seen: list[tuple[str, dict]] = []
+            runtime.publish = lambda ch, data: seen.append((ch, data))  # type: ignore[assignment]
+            clock = {"now": 2_000_000}
+            monkeypatch.setattr(hooks, "_now_ms", lambda: clock["now"])
+            # An identical push is accepted while idle (recorded in the guard).
+            runtime.notify_user({"summary": "CR-123 still pending review", "pushToChat": True})
+            assert len(self._pushes(seen)) == 1
+            # A turn starts; a duplicate arrives mid-turn and is deferred.
+            runtime.note_chat_lifecycle("user_input", clock["now"])
+            runtime.notify_user({"summary": "CR-123 still pending review", "pushToChat": True})
+            assert len(self._pushes(seen)) == 1
+            # The turn ends: the flush runs the SAME dedup, so the duplicate is
+            # dropped rather than double-posted.
+            runtime.note_chat_lifecycle("task_complete", clock["now"])
+            assert len(self._pushes(seen)) == 1
+
+    @pytest.mark.asyncio
+    async def test_wedged_turn_ages_out_via_ceiling(self, tmp_path, monkeypatch):
+        """Blocker 1: a turn whose terminal event never arrives (panel closed /
+        socket dropped) must not wedge the gate forever. Past the staleness
+        ceiling the flag ages out and the drain delivers the backlog — with NO
+        further pet-event. Pre-fix there was no ceiling (busy stayed True while
+        active) and no drain, so this could not pass."""
+        async with _live_runtime(tmp_path) as runtime:
+            seen: list[tuple[str, dict]] = []
+            runtime.publish = lambda ch, data: seen.append((ch, data))  # type: ignore[assignment]
+            clock = {"now": 3_000_000}
+            monkeypatch.setattr(hooks, "_now_ms", lambda: clock["now"])
+            # A turn opens; the terminal event never arrives.
+            runtime.note_chat_lifecycle("user_input", clock["now"])
+            runtime.notify_user({"summary": "Good evening! All quiet 🌙", "pushToChat": True})
+            assert self._pushes(seen) == []  # deferred: turn still "active"
+            assert runtime._chat_turn_active is True
+            # Advance past the ceiling and run the owner-loop drain directly
+            # (deterministic — no real sleep). The wedged flag ages out and the
+            # backlog is delivered exactly once.
+            clock["now"] += runtime._CHAT_TURN_MAX_MS + 1
+            runtime._drain_deferred_chat_pushes(clock["now"])
+            pushed = self._pushes(seen)
+            assert len(pushed) == 1
+            assert pushed[0]["content"] == "Good evening! All quiet 🌙"
+            # State is honest again after the age-out.
+            assert runtime._chat_turn_active is False
+
+    @pytest.mark.asyncio
+    async def test_stranded_push_after_terminal_drains_within_bound(self, tmp_path, monkeypatch):
+        """Blocker 2: a non-critical push that lands AFTER the terminal flush but
+        inside the grace window is buffered with nothing left to release it. The
+        time-based drain delivers it once the window closes, with no further
+        pet-event. Pre-fix the terminal flush was the sole flush, so this push
+        stranded until the next user_input."""
+        async with _live_runtime(tmp_path) as runtime:
+            seen: list[tuple[str, dict]] = []
+            runtime.publish = lambda ch, data: seen.append((ch, data))  # type: ignore[assignment]
+            clock = {"now": 4_000_000}
+            monkeypatch.setattr(hooks, "_now_ms", lambda: clock["now"])
+            runtime.note_chat_lifecycle("user_input", clock["now"])
+            runtime.note_chat_lifecycle("task_complete", clock["now"])  # flush runs (empty)
+            # Push arrives inside the grace window — deferred, but the only flush
+            # already ran.
+            runtime.notify_user({"summary": "Your build finished", "pushToChat": True})
+            assert self._pushes(seen) == []
+            # No further pet-event. Advance past the grace window and drain.
+            clock["now"] += runtime._CHAT_ACTIVE_GRACE_MS + 1
+            runtime._drain_deferred_chat_pushes(clock["now"])
+            pushed = self._pushes(seen)
+            assert len(pushed) == 1
+            assert pushed[0]["content"] == "Your build finished"
+            # Idempotent: a second drain with nothing newly deferred is a no-op.
+            runtime._drain_deferred_chat_pushes(clock["now"])
+            assert len(self._pushes(seen)) == 1
+
+    @pytest.mark.asyncio
+    async def test_approval_rejected_does_not_clear_the_gate(self, tmp_path):
+        """Finding 3: approval_rejected derives from a slotless, gateway-level
+        frame — a rejection answered on ANOTHER surface must not clear THIS
+        turn's gate. Only a real terminal event (task_complete/error) for this
+        turn releases the deferred backlog. Pre-fix approval_rejected was
+        terminal, so it flushed mid-turn."""
+        async with _live_runtime(tmp_path) as runtime:
+            seen: list[tuple[str, dict]] = []
+            runtime.publish = lambda ch, data: seen.append((ch, data))  # type: ignore[assignment]
+            runtime.note_chat_lifecycle("user_input", hooks._now_ms())
+            runtime.notify_user({"summary": "Good evening! All quiet 🌙", "pushToChat": True})
+            assert self._pushes(seen) == []
+            # A rejection from another surface arrives; it must NOT release us.
+            runtime.note_chat_lifecycle("approval_rejected", hooks._now_ms())
+            assert self._pushes(seen) == []
+            assert runtime._chat_turn_active is True
+            # A genuine terminal event for this turn releases the backlog.
+            runtime.note_chat_lifecycle("task_complete", hooks._now_ms())
+            pushed = self._pushes(seen)
+            assert len(pushed) == 1
+            assert pushed[0]["content"] == "Good evening! All quiet 🌙"
+
+
 class TestManifestDeclaresEveryPublishedEvent:
     """``permissions.events`` must cover every event name the backend publishes.
 


### PR DESCRIPTION
## Problem / Motivation

While I was chatting with Mochi, a scheduled "Good evening! All quiet — no watches, no reminders. Just here if you need me 🌙" greeting from the background planner dropped into the transcript *between* my message and the agent's reply. The panel rendered: my message → the pet's ambient greeting → the agent's actual answer. It reads like the pet talking over the conversation.

The ambient push comes from `perform_pet_action({action:"notify", pushToChat:true})` on the `mochi-bg` planner, and `_push_to_chat` broadcast it into the live transcript with no awareness that I was mid-turn. Here is the sanitized `gateway.log` timeline that shows it (2026-08-06 PDT): `21:44:22` the planner subagent `mochi-bg` spawns (running `mochi-plan`); `21:44:25` I am mid-conversation (chat slot=mochi, is_new=False); `21:45:00` the planner's `notify` fans out — `mochi:notify` → activity line "Good evening! All quiet…" → `mochi:chat-push` (the greeting injected into the transcript) → `mochi:mood`; `21:45:04` my next turn ("mmm…") is processed. The chat-push landed ~4s *before* my next turn started — in the brief gap between two of my messages.

## Why it matters

The chat transcript is the one surface where interleaving actually confuses the reader: an ambient message wedged between a user's line and the agent's reply looks like the agent said something it did not, or answered a question I did not ask. `notification_gate.py` already had burst-merge, quiet-mode, and critical-bypass gates, but none of them models "the user is actively conversing," so any proactive push could race into a live turn. This hits anyone using the Mochi chat panel while the background planner or a watch check fires — which is the normal, always-on case.

## What changed (motivation → approach → change)

Root cause: `_push_to_chat` had no notion of foreground chat activity. The runtime *does* already learn about my turn — the chat surface posts `user_input`/`tool_call`/`task_complete` to `POST /api/apps/mochi/pet-event`, which drives the pet's thinking/working animation — but `notify_user`/`_push_to_chat` never consulted that signal.

Approach: add a foreground-conversation gate to the chat-push path only. I add chat-turn tracking to `MochiRuntime` (`_chat_turn_active`, `_last_user_input_ms`, a capped `_deferred_chat_pushes` buffer, an 8s `_CHAT_ACTIVE_GRACE_MS`) and a `note_chat_lifecycle(event, now_ms)` method: `user_input` opens a turn; a terminal event closes it and flushes any deferred pushes. `_push_to_chat` now defers a non-critical push while a turn is in flight *or* within the grace window (I split the actual dedup+broadcast into `_deliver_chat_push`, which the flush reuses so a deferred greeting that now duplicates the agent's own reply is still dropped). `critical` priority (e.g. a "meeting in 5 minutes" reminder) bypasses the gate and lands immediately.

I wire the gate from `backend/routes.py` `_handle_pet_event`, calling `note_chat_lifecycle` right after `state_manager.apply_event`. Using the route rather than `state_manager.current` is deliberate: it is the *foreground-only* seam. Background spawns drive the same state machine through `watch_spawn_completion`, not this route, so a background check can never be mistaken for me conversing and falsely gate an ambient push.

Why the 8s grace rather than an in-flight-only check: the observed greeting arrived ~4s *before* my next turn began, in the gap between two messages. An "only while a turn is running" gate would have missed it; the short grace treats a rapid back-and-forth as one live conversation. Scope is intentionally narrow — only the chat-push surface (`mochi:chat-push`) is gated. The ambient bubble (`mochi:notify`) is genuinely transient and keeps replacing as before, and the durable activity-log entry `notify_user` writes is untouched, so a push deferred right at the end of a conversation (no following turn to flush it) is still recorded there immediately rather than lost.

### Review follow-ups: staleness ceiling, time-based drain, and the terminal tuple

Three findings on the first cut of the gate hardened its liveness guarantees. **Staleness ceiling (was: unbounded active flag).** `_chat_turn_active` was set by `user_input` and cleared *only* by a terminal event on `/pet-event` (posted from the panel's `chat_done` handler). If the panel closed mid-turn or the socket dropped before `chat_done`, the flag wedged `True` for the runtime's lifetime — every non-critical push then deferred forever and the capped buffer silently discarded the oldest. I bound it with a `_CHAT_TURN_MAX_MS` ceiling (10 min, comfortably longer than any real agent turn): `_chat_turn_busy` treats the turn as ended once the already-recorded `_last_user_input_ms` is older than the ceiling, even with the flag still set.

**Time-based drain (was: terminal events were the sole flush).** Because only the terminal events flushed, a non-critical push arriving *after* `task_complete` but inside the 8s grace was buffered *after* the only flush already ran, and never delivered — and likewise for a turn that ended with no terminal frame at all. I add `_drain_deferred_chat_pushes(now_ms)`, called every wake by the owner `_loop()` (ungated by shell presence, so a deferred push still drains when Mochi is off screen): once the busy window has closed it clears any stale wedged flag and delivers the backlog through the *same* dedup as a live push. I chose to piggyback the existing 1s owner loop rather than arm a per-push `asyncio` delayed-flush task from `notify_user`, because it is the cleaner seam — there is no task lifecycle to arm/refresh/cancel (nothing to leak, `stop()` already cancels the loop) and it sidesteps having to prove which event loop `notify_user` is called on (the `notify_gate` fan-out and the poller callbacks all tick inside this loop, but the drain does not have to depend on that). Delivery is bounded by the grace/ceiling window plus at most one poll interval, with no dependency on a further pet-event ever arriving — including after the ceiling ages out a wedged flag.

**`approval_rejected` is no longer terminal.** Unlike `task_complete`/`error`, which the panel WebSocket slot-filters to the pet's own turn (`data.slot !== MOCHI_SLOT` returns early before the `chat_done` switch), `approval_rejected` derives from the gateway-level `approval_resolved` frame, which is handled *before* the slot filter and carries no slot — so a rejection answered on another chat surface (the dashboard, say) would clear *this* pet turn's gate mid-conversation and flush an ambient push into it. I dropped it from the terminal tuple; the turn now closes only on `task_complete`/`error`. I verified in `panelBridge.ts` that a rejected pet-slot turn still ends with a `chat_done` → `task_complete` (that frame *is* slot-filtered to `MOCHI_SLOT`), so the gate still releases on the normal path; the one residual gap — a pet-slot turn that ends after a rejection with no `chat_done` emitted — is caught by the `_CHAT_TURN_MAX_MS` ceiling, which is exactly why the ceiling is the backstop.

## Tests

`TestChatPushConversationGate` in `test/test_mochi_pet_events.py` now has 9 cases, on the existing harness that fakes `publish` and drives `notify_user`/`_handle_pet_event`. Original six: (1) a push is suppressed while a turn is active; (2) the deferred push flushes exactly once on `task_complete`; (3) the grace window defers a push then a later push is delivered once the window expires; (4) `critical` priority bypasses the gate; (5) the idle path still delivers immediately (regression guard); (6) the flush runs the same dedup so a duplicate deferred push is dropped. Three added for the follow-ups, each driving the drain deterministically with the file's fake-clock/monkeypatch style (no real sleeps) and each failing against the pre-fix code: (7) a wedged turn with no terminal event ages out via the ceiling and the drain delivers the backlog; (8) a push stranded after the terminal flush but inside the grace window drains once the window closes, exactly once, with no further pet-event; (9) `approval_rejected` no longer clears the gate — only a real `task_complete`/`error` releases the deferred push.

## Manual verification

N/A — unit coverage is sufficient. The gate, the ceiling, and the drain are pure in-memory logic driven by the pet-event route, `notify_user`, and `_drain_deferred_chat_pushes` (which the owner loop calls), all exercised directly by the tests; there is no UI change to capture.

## Related Issues

N/A.

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behavior contract changed (the "durable somewhere" contract is preserved)
- [x] No secrets, credentials, or internal references in the diff
