### PR TITLE
feat(i18n): interpolate the product name via defaultVariables

### DIFF
--- a/website/docs/extension-seams.md
+++ b/website/docs/extension-seams.md
@@ -374,6 +374,29 @@ mounts `App`; registering after mount does not appear until an unrelated
 re-render. Builtin routes are the one relaxed case, because they resolve lazily on
 navigation.
 
+## Product name: exported setter, not a registry
+
+The i18n catalogs interpolate `{{productName}}` instead of hardcoding the
+displayed product name (authoring rules:
+[i18n-catalog](i18n-catalog.md#the-product-name-is-an-interpolation-variable)).
+`initI18n()` feeds the variable to i18next as `interpolation.defaultVariables`,
+defaulting to `Kiro Crew`, so the stock build renders unchanged text.
+
+An edition rebrands by calling `setProductName('…')` (exported from
+`src/i18n`) in its composition root. The root is imported before `main.tsx`
+calls `initI18n()`, so the ordering holds by construction; a call after init
+throws in dev rather than half-applying (in production it returns silently
+rather than crash the shell). Like the API transport above, this is
+a single exported function rather than a registry: the core consumes the value
+itself, there is nothing to enumerate, and a whole-catalog transform hook would
+hand an edition the power to break any string for what is a one-variable
+substitution.
+
+Scope: catalog strings only. The `apps.<id>.manifest.*` keys mirror the
+Python-side `app.json` prose byte-for-byte and keep the literal name; the
+shell logo and welcome mark are the theme-branding seam's job; the chat bot
+display name stays `dashboard.bot_name`.
+
 ## API methods: exported transport, not a registry
 
 There is no registrar for edition API methods. The core never *consumes* them:

--- a/website/docs/i18n-catalog.md
+++ b/website/docs/i18n-catalog.md
@@ -84,6 +84,40 @@ like "`fr` is unsupported, so it falls back" silently inverts the moment French
 ships. Use a language the project has no plans for for negative cases, and derive
 positive cases from `SUPPORTED_CODES` so a new language is covered automatically.
 
+## The product name is an interpolation variable
+
+Catalog values never hardcode the displayed product name. They interpolate
+`{{productName}}`, which `initI18n()` supplies to i18next as
+`interpolation.defaultVariables` with the stock value `Kiro Crew`, so the stock
+build renders exactly what a literal would. The indirection exists for
+downstream editions: overriding one variable rebrands every catalog string,
+instead of forking 13 locale files through every upstream sync (see
+[extension-seams](extension-seams.md)).
+
+> Transitional note: the mechanical conversion of pre-existing catalog values
+> is landing in follow-up PRs (the full-catalog diff exceeds the reviewable
+> size limit). The rules below bind new copy immediately; the catalog-wide
+> no-literal invariant test ships with the final conversion chunk.
+
+Authoring rules that follow:
+
+- **New copy naming the product writes `{{productName}}`, not the literal.**
+  A translation must carry the same placeholder — `catalogParity.test.ts`
+  placeholder parity fails the catalog that drops it.
+- **The `apps.<id>.manifest.*` keys are the deliberate exception.** They must
+  stay byte-identical to the Python-side `app.json` prose (`[manifest-sync]`
+  is a hard zero), so they keep the literal English name.
+- **A call-time variable of the same name wins** over the default, per
+  i18next's merge order — useful when a string names a *different* crew.
+- German compounds hyphenate through the placeholder
+  (`{{productName}}-Katalog`), matching how the literal compound was written.
+
+`setProductName()` (exported beside `initI18n`) is the edition override. It
+must run before `initI18n()`; the edition composition root is imported first
+in `main.tsx`, so that ordering holds by construction. A late call throws in
+dev rather than half-applying; in production it returns silently rather
+than crash the shell.
+
 ## Counts: never concatenate a plural suffix
 
 **Never append a plural marker outside the translate call.** This is a bug:

--- a/website/scripts/settingsExtract.ts
+++ b/website/scripts/settingsExtract.ts
@@ -168,7 +168,14 @@ function extractStringProp(source: string, propName: string): string | undefined
     'g',
   )
   const tMatch = tCall.exec(source)
-  if (tMatch) return getEnCatalog()[tMatch[1]]
+  // `{{productName}}` is resolved to its stock default here, mirroring what
+  // i18next's `defaultVariables` renders at runtime. The registry is a SEARCH
+  // corpus: leaving the raw placeholder in would make a user's query for the
+  // product name stop matching these entries. The literal deliberately
+  // duplicates DEFAULT_PRODUCT_NAME in `src/i18n/index.ts`: importing that
+  // module here would drag i18next and every catalog into a build-time
+  // script for one constant.
+  if (tMatch) return getEnCatalog()[tMatch[1]]?.replaceAll('{{productName}}', 'Kiro Crew')
   return undefined
 }
 

--- a/website/src/i18n/index.ts
+++ b/website/src/i18n/index.ts
@@ -127,6 +127,40 @@ export const CATALOGS: Record<string, { translation: Record<string, unknown> }> 
     : AUTHORED_CATALOGS
 
 /**
+ * The product name rendered by `{{productName}}` in catalog values.
+ *
+ * Catalog strings never hardcode the displayed product name; they interpolate
+ * this variable, supplied to i18next as `interpolation.defaultVariables`. The
+ * stock build resolves it to "Kiro Crew", so rendered output is identical to a
+ * hardcoded literal — the indirection exists for downstream editions.
+ *
+ * The `apps.<id>.manifest.*` keys are the deliberate exception: they must stay
+ * byte-identical to the Python-side `app.json` prose (the manifest-sync gate),
+ * so they keep the literal.
+ */
+const DEFAULT_PRODUCT_NAME = 'Kiro Crew'
+let productName = DEFAULT_PRODUCT_NAME
+
+/**
+ * Override the product name an edition renders. Call it from the edition
+ * composition root (`extensions.tsx`), which `main.tsx` imports BEFORE
+ * `initI18n()` runs — after init the variable has already been handed to
+ * i18next, so a late call cannot take effect and is refused loudly in dev
+ * rather than half-applying.
+ */
+export function setProductName(name: string): void {
+  if (i18next.isInitialized) {
+    if (import.meta.env.DEV) {
+      throw new Error('setProductName() must be called before initI18n()')
+    }
+    return
+  }
+  // Stored trimmed: accidental edge whitespace would render into every string.
+  const trimmed = name.trim()
+  if (trimmed) productName = trimmed
+}
+
+/**
  * Initialize i18next exactly once.
  *
  * Called from `main.tsx` before render, and from the vitest setup file so
@@ -144,9 +178,14 @@ export function initI18n(initialLanguage?: string): typeof i18next {
     lng,
     fallbackLng: DEFAULT_LANGUAGE,
     supportedLngs: [...SUPPORTED_CODES],
-    // React escapes interpolated values already; escaping here would
-    // double-encode (`&amp;amp;`) any string containing & < > " '.
-    interpolation: { escapeValue: false },
+    interpolation: {
+      // React escapes interpolated values already; escaping here would
+      // double-encode (`&amp;amp;`) any string containing & < > " '.
+      escapeValue: false,
+      // Resolves `{{productName}}` in every catalog value. A call-time
+      // variable of the same name still wins, per i18next merge order.
+      defaultVariables: { productName },
+    },
     // A missing key renders its English fallback, never an empty string, so a
     // gap in a translation degrades to readable English instead of blank UI.
     returnEmptyString: false,

--- a/website/src/i18n/productName.test.ts
+++ b/website/src/i18n/productName.test.ts
@@ -1,0 +1,55 @@
+/**
+ * The `{{productName}}` contract.
+ *
+ * Catalog values will interpolate the product name instead of hardcoding it,
+ * so a downstream edition can rebrand by overriding one variable from its
+ * composition root instead of forking every locale file. These tests pin the
+ * three properties the arrangement rests on: the stock default renders the
+ * exact same English a hardcoded literal would, the variable is wired as an
+ * i18next `defaultVariables` (so it survives the planned lazy-catalog
+ * migration untouched), and a call-time variable still wins.
+ *
+ * The tests interpolate against an injected resource rather than a shipped
+ * catalog key: the mechanical catalog rewrite lands in follow-up PRs (the
+ * full-catalog diff exceeds the reviewable size limit), and this contract
+ * must hold independently of how much of the catalog has been converted.
+ * The catalog-wide "no non-manifest value hardcodes the literal" invariant
+ * ships with the final rewrite chunk, where it can actually pass.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { initI18n, i18next, setProductName } from './index'
+
+// No-op — the vitest setup file already initialized i18n. Explicit so this
+// file also works standalone, and so the late-override test below is
+// self-evidently running against an initialized instance.
+initI18n()
+
+// A value shaped exactly like the rewritten catalog strings will be. Injected
+// under a test-only key so the assertion is independent of the rewrite's
+// progress through the real catalogs.
+i18next.addResource('en', 'translation', 'test.updating_product', 'Updating {{productName}}…')
+
+describe('productName interpolation variable', () => {
+  it('defaults to the stock product name', () => {
+    expect(i18next.options.interpolation?.defaultVariables).toMatchObject({
+      productName: 'Kiro Crew',
+    })
+  })
+
+  it('renders a placeholder-bearing value identically to the old literal', () => {
+    expect(i18next.t('test.updating_product')).toBe('Updating Kiro Crew…')
+  })
+
+  it('lets a call-time variable win over the default', () => {
+    expect(i18next.t('test.updating_product', { productName: 'Acme' })).toBe('Updating Acme…')
+  })
+
+  it('refuses a late override rather than half-applying it', () => {
+    // After init the variable has been handed to i18next; silently accepting
+    // the call would leave the UI unchanged while the caller believes it
+    // rebranded. Vitest runs with import.meta.env.DEV true, so this throws.
+    expect(() => setProductName('Acme')).toThrow(/before initI18n/)
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

Implements the seam for #1957. The i18n catalogs hardcode the displayed product name in ~1,500 strings across 14 locales, and none of the frontend extension seams covers catalog content, so a downstream edition build (`KIROCREW_EDITION_DIR`) that wants a different product name is pushed into forking every locale file through every upstream sync. The only in-tree alternative — mutating the exported `CATALOGS` object before `initI18n()` — is an undocumented accident of import ordering that the planned lazy-catalog migration would silently break.

> **Restructured per triage feedback ([comment](https://github.com/kirodotdev/KiroCrew/pull/1964#issuecomment-5290638548)):** this PR previously also carried the mechanical rewrite of all catalog values, which put the diff at ~1.4 MB — over the 1 MB limit the AI review lanes enforce, so they failed closed on every push. It is now the logic-only seam (~11 KB); the mechanical rewrite follows in two follow-up PRs, each under the limit, chunked by key subset across *all* locales (not by locale — `catalogParity` enforces placeholder parity per key across locales, so each chunk must rewrite a key's value in every catalog at once). The catalog-wide "no non-manifest literal" invariant test lands in the final chunk, where it can pass.

## Why it matters

The extension-seams architecture (#296) promises editions composition without forking core files, and `dashboard.bot_name` / `registerThemeBranding.botName` already set the precedent for overriding the visible name — they just don't reach the catalog strings, which is where most of the name lives. Closing the gap keeps editions on the supported seam path instead of on `sed` over built artifacts or a fork of every locale file.

## What changed (motivation → approach → change)

Goal: one overridable variable, zero rendered change in the stock build. Approach chosen over a `registerCatalogTransform()` seam (overpowered: a whole-catalog hook can break any string), an i18next postProcessor (runs on every `t()` call, string-replaces resolved output), and documenting `CATALOGS` mutation (freezes an import-ordering accident into a contract). Details in #1957.

* `initI18n()` now passes `interpolation.defaultVariables: { productName: 'Kiro Crew' }`; a catalog value carrying `{{productName}}` renders byte-identical to the old literal in the stock build. With no catalog carrying the placeholder yet, the variable is inert — this PR merges standalone with zero rendered change.
* `setProductName()` (exported beside `initI18n`) is the edition override. The edition composition root is imported before `main.tsx` calls `initI18n()`, so the ordering holds by construction; a late call throws in dev rather than half-applying. A call-time variable of the same name still wins, per i18next merge order.
* The settings-registry extractor resolves `{{productName}}` to the stock name, so the palette's search corpus keeps matching what users see once conversion begins. `settingsRegistry.gen.ts` is unchanged (no catalog carries the placeholder yet).
* `apps.*.manifest.*` keys are permanently excluded: `[manifest-sync]` requires them byte-identical to the Python-side `app.json` prose.
* Docs: a "product name" section in `website/docs/i18n-catalog.md` (authoring rules, with a transitional note while conversion is in flight) and an "exported setter, not a registry" section in `website/docs/extension-seams.md`.

## Tests

* `src/i18n/productName.test.ts` (4 tests) pins the contract against an injected resource, so it is independent of the catalog conversion's progress: the stock default renders the identical English a literal would, the variable is wired as `defaultVariables`, a call-time variable wins, and a post-init `setProductName()` throws in dev.
* Full frontend suite green on this diff: 21,116 passed. `npx tsc -b`, `npm run build`, `i18n:check`, `lint:i18n` all clean.

## Manual verification

N/A — unit coverage sufficient: no catalog value interpolates the variable yet, so the stock build is bit-identical by construction, which is exactly what the contract tests pin.

## Related Issues

Refs #1957 (closes when the final conversion chunk lands)

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
