### PR TITLE
test(test_brand_name_gate): stabilize brand-gate linearity ratio on noisy windows runners

### DIFF
--- a/test/test_brand_name_gate.py
+++ b/test/test_brand_name_gate.py
@@ -173,13 +173,21 @@ class TestUrlBoundary:
         # ratio assertion catches that where a wall-clock budget loose enough for a
         # loaded runner would not.
         #
+        # We only need to separate two regimes: a linear scan doubles the input for
+        # ~2x the time, while a quadratic one (slice/rescan the whole line per
+        # match) costs ~4x AND with a far larger constant that blows well past 4x
+        # at these sizes. The bound sits between them with headroom for a noisy
+        # runner, so real regressions are still caught.
+        #
         # Each size is measured as the MIN of N repetitions (the first call also
         # warms up caches). min() is the standard noise-robust estimator: scheduler
-        # preemptions only ever ADD time, so the minimum converges on the true cost
-        # while a genuinely quadratic _hits still blows past the bound on every
-        # repetition. Single-shot timing flaked twice on Windows CI at ~60ms base
-        # durations where one GC pause skewed the ratio past 3.0.
-        _REPS = 3
+        # preemptions and GC pauses only ever ADD time, so the minimum converges on
+        # the true cost while a genuinely quadratic _hits still blows past the
+        # bound. The base size is large enough that one fixed pause is a small
+        # fraction of it -- min-of-3 at a ~50ms/20k-match base was not, and flaked
+        # on Windows CI when a single pause skewed the ratio of two small timings
+        # past 3.0 (base 47ms / doubled 141ms == 3.0x on a linear scan).
+        _REPS = 5
 
         def best_of(count: int) -> tuple[float, int]:
             line = "!KiroCrew" * count
@@ -191,10 +199,10 @@ class TestUrlBoundary:
                 times.append(time.monotonic() - began)
             return min(times), found
 
-        base, base_found = best_of(20_000)
-        doubled, doubled_found = best_of(40_000)
-        assert (base_found, doubled_found) == (20_000, 40_000)
-        assert doubled / base < 3.0, f"doubling the input cost {doubled / base:.1f}x, want ~2x"
+        base, base_found = best_of(50_000)
+        doubled, doubled_found = best_of(100_000)
+        assert (base_found, doubled_found) == (50_000, 100_000)
+        assert doubled / base < 3.5, f"doubling the input cost {doubled / base:.1f}x, want ~2x"
 
     def test_many_backticks_stay_linear(self) -> None:
         line = "`x`" * 30_000 + " KiroCrew"


### PR DESCRIPTION
## Problem
`TestUrlBoundary::test_many_brand_names_on_one_line_stay_linear` flaked on Windows CI:

```
AssertionError: doubling the input cost 3.0x, want ~2x
assert (0.14100000000001955 / 0.04699999999996862) < 3.0
```

This is the second flake of the same test — the prior robustness pass (#1610) moved single-shot timing to min-of-3, which was still not enough.

## Why it matters
The test guards against a quadratic regression in `scan_line` (a per-match `line[:start]` slice or prefix rescan). A false failure here reds the whole backend suite and blocks every PR's merge, while teaching contributors to ignore the gate.

## Fix
Symptom → root cause → change:
- **Symptom:** ratio hit exactly 3.0x (base 47ms / doubled 141ms) on a linear algorithm.
- **Root cause:** the assertion is a ratio of two *small* wall-clock times. At a ~47ms base, a single GC/scheduler pause in one measurement is a large fraction of it, and min-of-3 at 20k matches did not sample often enough to floor it out. The algorithm itself is confirmed linear — per-line preprocessing, `bisect`-based `covered()`, and the match loop indexes into the line rather than slicing.
- **Change:** raise the base/doubled sizes to 50k/100k matches (so one fixed pause is a small fraction of the base), take the MIN of 5 reps instead of 3, and relax the bound from 3.0 → 3.5. We only need to separate the two regimes: a linear scan is ~2x, a genuine quadratic is ~4x with a far larger constant that blows well past 4x at these sizes. 3.5 sits between them with headroom for a noisy runner while still catching a real regression. Comment updated to record the failure signature and the reasoning.

## Tests
- `test/test_brand_name_gate.py::TestUrlBoundary` — 10/10 pass, run 3x consecutively, stable.
- Timed test call is ~0.8s (10 timed `scan_line` runs), well within the 2s budget the sibling long-line tests use.

## Manual verification
Ran the full `TestUrlBoundary` class three times back-to-back locally (macOS, shared venv); all green each time. The measured `doubled/base` ratio sits near ~2x, comfortably below the 3.5 bound.
