### PR TITLE
fix(apps): forward KIROCREW_DEVFLEET_REPO to app backends

### DIFF
--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -737,6 +737,15 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
         # backend can detect an edition but never manufacture consent to compile
         # one.
         _platform_extra["KIROCREW_EDITION_DIR"] = os.environ["KIROCREW_EDITION_DIR"]
+    if os.environ.get("KIROCREW_DEVFLEET_REPO"):
+        # Operator-declared main-checkout override (same trust class as the
+        # KIROCREW_DEVFLEET_BIN_* overrides below). dev-fleet reads it as the
+        # highest-priority repo discovery hint, ahead of KIROCREW_PROJECT_DIR
+        # — which packaged installs point at the app bundle (no .git), leaving
+        # only the ~/kirocrew fallback. minimal_env() strips the var, so
+        # without this forward the documented override silently never reaches
+        # the backend and the fleet renders empty. A path, not a secret.
+        _platform_extra["KIROCREW_DEVFLEET_REPO"] = os.environ["KIROCREW_DEVFLEET_REPO"]
     for _k, _v in os.environ.items():
         # Operator-declared trusted-binary overrides (unit-file owned):
         # backends resolve credential-bearing tools through these instead of

--- a/test/test_app_backend.py
+++ b/test/test_app_backend.py
@@ -1392,3 +1392,53 @@ class TestHealthGatedMcpRegistration:
         finally:
             with bmod._lock:
                 bmod._processes.clear()
+
+
+# =============================================================================
+# KIROCREW_DEVFLEET_REPO forwarding (silent-empty-fleet fix)
+# =============================================================================
+
+
+def test_devfleet_repo_survives_the_app_backend_env_allowlist(monkeypatch):
+    """The documented dev-fleet repo override must be ABLE to reach the backend.
+
+    The dev-fleet backend runs as a separate process started with
+    ``apps.registry.minimal_env()``, which passes only a fixed safe-key set.
+    ``KIROCREW_DEVFLEET_REPO`` is dev-fleet's highest-priority repo discovery
+    hint, but until it is added to the explicit platform extras the allowlist
+    strips it — the operator sets the documented override, the backend never
+    sees it, and the fleet silently renders empty (the remaining hints are
+    ``KIROCREW_PROJECT_DIR``, which packaged installs point at the app bundle
+    with no ``.git``, and a hardcoded ``~/kirocrew`` fallback).
+    """
+    from pathlib import Path
+
+    import kiro_crew.apps.backend as bmod
+    from kiro_crew.apps.registry import minimal_env
+
+    monkeypatch.setenv("KIROCREW_DEVFLEET_REPO", "/opt/checkouts/kirocrew")
+    # The generic allowlist does NOT carry it — that is the trap this guards.
+    assert "KIROCREW_DEVFLEET_REPO" not in minimal_env()
+
+    # apps/backend.py must therefore add it to the explicit platform extras
+    # (same mechanism that carries KIROCREW_PROJECT_DIR and the
+    # KIROCREW_DEVFLEET_BIN_* trusted-binary overrides).
+    body = Path(bmod.__file__).read_text()
+    assert '_platform_extra["KIROCREW_DEVFLEET_REPO"]' in body, \
+        "the KIROCREW_DEVFLEET_REPO override no longer reaches app backends"
+
+
+def test_devfleet_repo_env_wins_repo_discovery(monkeypatch, tmp_path):
+    """dev-fleet honors the forwarded override ahead of every other hint."""
+    from kiro_crew.apps.builtins.dev_fleet import server as dfmod
+
+    proj = tmp_path / "proj"
+    (proj / ".git").mkdir(parents=True)
+    monkeypatch.setenv("KIROCREW_DEVFLEET_REPO", "/opt/checkouts/kirocrew")
+    monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(proj))
+    assert dfmod._default_main_repo() == "/opt/checkouts/kirocrew"
+
+    # Without the override the chain falls through to PROJECT_DIR (with .git),
+    # and then to the ~/kirocrew fallback — the packaged-install trap.
+    monkeypatch.delenv("KIROCREW_DEVFLEET_REPO")
+    assert dfmod._default_main_repo() == str(proj)


### PR DESCRIPTION
## Problem / Motivation

The Dev Fleet app documents `KIROCREW_DEVFLEET_REPO` as the highest-priority hint for locating the main checkout, but setting it on the gateway has no effect: app backends are spawned with `minimal_env()`, whose fixed safe-key allowlist strips the variable before the dev-fleet process ever starts. I hit this on my packaged install — the fleet page rendered "No worktrees found" with 12 worktrees on disk, and the documented override was a dead knob.

## Why it matters

On packaged (Electron) installs the remaining discovery hints both fail: `KIROCREW_PROJECT_DIR` points at the app bundle's Resources directory (no `.git`), and the hardcoded `~/kirocrew` fallback only works if the checkout happens to live exactly there. That makes the env override the *only* sanctioned escape hatch for anyone developing KiroCrew from a non-default checkout location — and it silently doesn't work. Dev Fleet is "built for people developing KiroCrew itself", so its primary audience is exactly the population that hits this.

## What changed (motivation → approach → change)

Symptom: fleet always empty on packaged installs regardless of the override. Root cause: `_start_app_backend_body()` builds the backend env via `minimal_env()` plus an explicit `_platform_extra` dict, and `KIROCREW_DEVFLEET_REPO` was never added to the extras — so the allowlist strips it. Change: forward the variable through `_platform_extra`, the same mechanism that already carries `KIROCREW_PROJECT_DIR`, `KIROCREW_EDITION_DIR`, and the `KIROCREW_DEVFLEET_BIN_*` trusted-binary overrides. It is an operator-declared filesystem path in the same trust class as those neighbors — a path, not a secret — and its consumer runs it only as the value of `git -C <path>`, where a leading-dash value cannot be parsed as an option.

## Tests

- `test_devfleet_repo_survives_the_app_backend_env_allowlist` — locks in both halves of the contract: `minimal_env()` alone still strips the var (documenting the trap), and `apps/backend.py` forwards it via the platform extras (same pattern as the existing `KIROCREW_EDITION_DIR` allowlist test).
- `test_devfleet_repo_env_wins_repo_discovery` — locks in dev-fleet's discovery precedence: the override beats `KIROCREW_PROJECT_DIR`, and removing it falls back to the documented chain.

## Manual verification

Confirmed the failure chain on my live packaged install before writing the fix: the running dev-fleet backend's env showed `KIROCREW_PROJECT_DIR=/Applications/KiroCrew.app/Contents/Resources` and no `KIROCREW_DEVFLEET_REPO`, discovery fell through to a nonexistent `~/kirocrew`, and `/api/fleet` returned an empty list while `git -C <real checkout> worktree list` returned 12 worktrees.

## Screenshots / video

N/A — no UI change; this is env plumbing in the backend spawner.

Related: a sibling PR makes dev-fleet surface repo-discovery failures in the UI instead of rendering a misleading empty state; the two are independent but this one makes the remedy named there actually work.
