### PR TITLE
fix(file-explorer): open at home dir instead of /opt on macOS

### DIFF
--- a/src/kiro_crew/apps/builtins/file_explorer/server.py
+++ b/src/kiro_crew/apps/builtins/file_explorer/server.py
@@ -76,13 +76,27 @@ if _HOME == Path(_HOME.anchor):  # home resolved to the filesystem root — unus
 
 # The system temp dir is /tmp on POSIX and %TEMP% on Windows.
 _TMP = Path(tempfile.gettempdir()).resolve()
-ALLOWED_ROOTS = [_HOME, _TMP]
-if platform_compat.IS_POSIX:
-    # /home and /opt are POSIX-only conventions; on Windows they resolve to
-    # nonexistent C:\home / C:\opt and would be dropped by the exists() filter.
-    ALLOWED_ROOTS += [Path("/home").resolve(), Path("/opt").resolve()]
-# De-dupe and only keep ones that exist
-ALLOWED_ROOTS = list({p for p in ALLOWED_ROOTS if p.exists()})
+
+
+def _compute_allowed_roots(home: Path, tmp: Path) -> list[Path]:
+    """Ordered allow-list of browsing roots: home, tmp, then POSIX conventions.
+
+    Order matters — the health endpoint serves this list and the frontend
+    falls back to roots[0] as its default folder, so the dedupe must preserve
+    insertion order (home first) rather than use a set, whose iteration order
+    varies between interpreter runs.
+    """
+    roots = [home, tmp]
+    if platform_compat.IS_POSIX:
+        # /home and /opt are POSIX-only conventions; on Windows they resolve
+        # to nonexistent C:\home / C:\opt and would be dropped by the
+        # exists() filter.
+        roots += [Path("/home").resolve(), Path("/opt").resolve()]
+    # De-dupe and only keep ones that exist
+    return list(dict.fromkeys(p for p in roots if p.exists()))
+
+
+ALLOWED_ROOTS = _compute_allowed_roots(_HOME, _TMP)
 
 # Default ignore patterns for tree + search
 IGNORE_DIRS = {
@@ -874,9 +888,13 @@ class FileExplorerHandler(BaseHTTPRequestHandler):
                 {
                     "status": "ok",
                     "app": APP_NAME,
-                    "version": "0.2.0",
+                    "version": "0.2.1",
                     "rg": _has_rg(),
                     "allowedRoots": [str(p) for p in ALLOWED_ROOTS],
+                    # The user's home dir (resolved) — the frontend opens here
+                    # by default instead of guessing from allowedRoots, which
+                    # picked /opt on macOS (home is /Users/<u>, not /home/<u>).
+                    "home": str(_HOME),
                     "maxReadBytes": MAX_READ_BYTES,
                 },
             )

--- a/test/test_file_explorer_app.py
+++ b/test/test_file_explorer_app.py
@@ -384,6 +384,32 @@ class TestHTTPHandler:
         assert code == 200
         assert body["status"] == "ok"
 
+    def test_health_reports_home_dir(self, tmp_tree):
+        """Health payload carries the resolved home dir so the frontend can
+        open there by default instead of guessing from allowedRoots (the old
+        heuristic picked /opt on macOS)."""
+        responses = self._make_request("/health")
+        code, body = responses[0]
+        assert code == 200
+        assert body["home"] == str(tmp_tree)
+        assert body["home"] in body["allowedRoots"]
+
+    def test_allowed_roots_order_is_deterministic_home_first(self, tmp_path):
+        """_compute_allowed_roots must preserve insertion order (home first) —
+        the frontend falls back to roots[0], so a set-based dedupe would make
+        the default root random across restarts."""
+        home = tmp_path / "home-dir"
+        tmp = tmp_path / "tmp-dir"
+        for d in (home, tmp):
+            d.mkdir()
+        roots = server._compute_allowed_roots(home, tmp)
+        assert roots[0] == home
+        assert roots[1] == tmp
+        # Dedupe keeps first occurrence: home==tmp collapses to one entry.
+        same = server._compute_allowed_roots(home, home)
+        assert same[0] == home
+        assert same.count(home) == 1
+
     def test_resolve_endpoint(self, tmp_tree):
         responses = self._make_request(f"/resolve?path={tmp_tree}/file.txt")
         assert responses[0][0] == 200

--- a/website/src/apps/file-explorer/FileExplorerPage.tsx
+++ b/website/src/apps/file-explorer/FileExplorerPage.tsx
@@ -57,12 +57,14 @@ export default function FileExplorerPage() {
   useEffect(() => {
     if (!healthData || initialized) return
     const roots = healthData.allowedRoots || []
-    let defaultRoot = roots[0] || '/'
-    if (roots.length > 1) {
-      const home = roots.find((r) => r.includes('/home/'))
-      if (home) defaultRoot = home
-      else defaultRoot = roots.reduce((a, b) => a.length <= b.length ? a : b)
-    }
+    // Open at the user's home dir. Prefer the backend-reported `home` (must be
+    // an allowed root); for older backends that don't send it, recognize
+    // home-style roots on Linux (/home/<u>) and macOS (/Users/<u>). Never fall
+    // back to "shortest root" — on macOS that picked /opt over /Users/<u>.
+    const home =
+      (healthData.home && roots.includes(healthData.home) ? healthData.home : undefined) ??
+      roots.find((r) => r.includes('/home/') || r.startsWith('/Users/'))
+    const defaultRoot = home || roots[0] || '/'
     const saved = loadState()
     if (saved && saved.folderTabs?.length) {
       const ft = saved.folderTabs.map((t: Partial<FolderTab>) => ({ ...newFolderTab(t.rootPath, t.label), id: t.id!, expanded: t.expanded || { [t.rootPath!]: true } }))

--- a/website/src/apps/file-explorer/api.ts
+++ b/website/src/apps/file-explorer/api.ts
@@ -11,7 +11,7 @@ async function get<T>(path: string): Promise<T> {
 }
 
 export const fileExplorerApi = {
-  health: () => get<{ allowedRoots: string[] }>(`${API_BASE}/health`),
+  health: () => get<{ allowedRoots: string[]; home?: string }>(`${API_BASE}/health`),
 
   tree: (path: string, depth = 1) =>
     get<{ entries: TreeEntry[] }>(`${API_BASE}/tree?path=${encodeURIComponent(path)}&depth=${depth}`),

--- a/website/src/test/fileExplorerComponents.test.tsx
+++ b/website/src/test/fileExplorerComponents.test.tsx
@@ -126,6 +126,51 @@ describe('FileExplorerPage', () => {
     await waitFor(() => expect(document.querySelector('.mc-fe-root')).toBeInTheDocument())
     expect(screen.queryByText('src')).not.toBeInTheDocument()
   })
+
+  it('opens at the backend-reported home dir, not the shortest root', async () => {
+    // macOS shape: /opt is the shortest allowed root; home must still win.
+    vi.mocked(fileExplorerApi.health).mockResolvedValue({
+      allowedRoots: ['/Users/u', '/private/tmp', '/home', '/opt'],
+      home: '/Users/u',
+    })
+    vi.mocked(fileExplorerApi.tree).mockResolvedValue({ entries: [] })
+    vi.mocked(fileExplorerApi.gitStatus).mockResolvedValue(null)
+    renderPage()
+    await waitFor(() => expect(fileExplorerApi.tree).toHaveBeenCalledWith('/Users/u', 2))
+  })
+
+  it('recognizes a macOS /Users home from an older backend without `home`', async () => {
+    // Regression: the old heuristic matched only '/home/' and fell back to
+    // the shortest root, which opened /opt on macOS.
+    vi.mocked(fileExplorerApi.health).mockResolvedValue({
+      allowedRoots: ['/Users/u', '/private/tmp', '/home', '/opt'],
+    })
+    vi.mocked(fileExplorerApi.tree).mockResolvedValue({ entries: [] })
+    vi.mocked(fileExplorerApi.gitStatus).mockResolvedValue(null)
+    renderPage()
+    await waitFor(() => expect(fileExplorerApi.tree).toHaveBeenCalledWith('/Users/u', 2))
+  })
+
+  it('still opens the Linux /home/<user> root without `home`', async () => {
+    vi.mocked(fileExplorerApi.health).mockResolvedValue({
+      allowedRoots: ['/home/user', '/tmp', '/home', '/opt'],
+    })
+    vi.mocked(fileExplorerApi.tree).mockResolvedValue({ entries: [] })
+    vi.mocked(fileExplorerApi.gitStatus).mockResolvedValue(null)
+    renderPage()
+    await waitFor(() => expect(fileExplorerApi.tree).toHaveBeenCalledWith('/home/user', 2))
+  })
+
+  it('ignores a `home` that is not an allowed root and uses roots[0]', async () => {
+    vi.mocked(fileExplorerApi.health).mockResolvedValue({
+      allowedRoots: ['/tmp', '/opt'],
+      home: '/nonexistent',
+    })
+    vi.mocked(fileExplorerApi.tree).mockResolvedValue({ entries: [] })
+    vi.mocked(fileExplorerApi.gitStatus).mockResolvedValue(null)
+    renderPage()
+    await waitFor(() => expect(fileExplorerApi.tree).toHaveBeenCalledWith('/tmp', 2))
+  })
 })
 
 // ─── TreeNode ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- Fill in each section below. -->

## Problem / Motivation

I opened the Files app on my Mac and it started at `/opt` — showing homebrew and a couple of vendor directories — instead of my home directory. My home dir (`/Users/<me>`), where all my actual files live, is in the allow-list but is never chosen.

## Why it matters

Every macOS user gets `/opt` as their first impression of the Files app, which looks broken ("why is my file browser showing homebrew internals?") and forces manual navigation to home on first use. The first-run default is also nondeterministic on the fallback path, so different installs can land in different roots.

## What changed (motivation → approach → change)

Symptom: the app opens at `/opt` on macOS. Root cause is two-fold. (1) The frontend's default-root heuristic in `FileExplorerPage.tsx` only recognizes Linux-style homes (`roots.find(r => r.includes('/home/'))`) and otherwise falls back to the *shortest* allowed root — on macOS home is `/Users/<u>`, so the `/home/` match never hits and `/opt` (4 chars) beats `/Users/<u>`, `/private/tmp`, and `/home`. (2) The backend dedupes `ALLOWED_ROOTS` through a set comprehension, so the order the frontend sees (and its `roots[0]` fallback) is nondeterministic across restarts.

Rather than patching the guess with more path patterns, the backend now tells the frontend where home is: the `/health` payload gains a `home` field (the already-resolved `_HOME`), and the frontend prefers it after validating it is a member of `allowedRoots`. For older backends that don't send `home`, the frontend falls back to recognizing home-style roots on both Linux (`/home/<u>`) and macOS (`/Users/<u>`), then `roots[0]` — the shortest-root heuristic is gone. On the backend I extracted the root computation into a pure `_compute_allowed_roots(home, tmp)` helper that dedupes with `dict.fromkeys`, preserving insertion order with home first, so `roots[0]` is deterministic and sensible. Path-safety semantics are unchanged: membership in the allow-list is identical (same `exists()` filter) and containment checks are order-independent.

## Tests

- `test_health_reports_home_dir` (backend): `/health` carries the resolved home dir and it is a member of `allowedRoots`.
- `test_allowed_roots_order_is_deterministic_home_first` (backend): `_compute_allowed_roots` preserves insertion order (home first) and dedupes to the first occurrence.
- `opens at the backend-reported home dir, not the shortest root` (frontend): macOS-shaped roots with `home` present → tree opens at `/Users/u`, not `/opt`.
- `recognizes a macOS /Users home from an older backend without home` (frontend): regression for the exact reported bug via the fallback path.
- `still opens the Linux /home/<user> root without home` (frontend): Linux behavior preserved.
- `ignores a home that is not an allowed root and uses roots[0]` (frontend): the allow-list membership guard.

## Manual verification

Reproduced the bug on macOS (Files app opened at `/opt` with roots `/Users/<u>`, `/private/tmp`, `/home`, `/opt`) and traced both root causes in source. The fixed selection logic is locked in by the frontend tests above using the exact macOS root shape from my machine; the backend payload change is covered by the health-endpoint test. Note for existing installs: the first-run default is what changed — a previously persisted `/opt` folder tab (localStorage) is intentionally left untouched; close the tab or reset to pick up home.

## Screenshots / video

N/A — no visual/layout change; the fix only changes which directory the existing tree view opens at on first run.

## Related Issues

None filed; bug found and fixed in the same session.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior documented in code comments
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR. -->
