### PR TITLE
fix(dev-fleet): surface repo-discovery failures instead of an empty fleet

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -716,6 +716,12 @@ def _invalidate_toolchain_cache() -> None:
 # arbitrarily long stderr.
 _SANDBOX_ERR_MAX = 900
 
+# Upper bound on a propagated generic git-discovery error. Git's own failure
+# messages are short ("fatal: not a git repository", "cannot change to ..."),
+# so a tight cap keeps the Discovery Error banner readable while still bounding
+# an arbitrarily long stderr from a broken repo.
+_GIT_ERR_MAX = 300
+
 
 def _trusted_bin(name: str) -> str | None:
     """Resolve *name* to a canonical executable in a system or Homebrew bin dir.
@@ -1494,7 +1500,35 @@ async def _discover_worktrees() -> list[dict]:
             # swallow the fix. Keep a generous bound purely to stop an unbounded
             # stderr reaching the UI.
             raise RuntimeError(raw[:_SANDBOX_ERR_MAX])  # already prefixed by _run_cmd
-        return []
+        # Every other git failure was previously swallowed into a silent [] —
+        # which the UI renders as the "No worktrees found / Nothing under the
+        # worktrees root yet" empty state. When MAIN_REPO is wrong that empty
+        # state is a lie: the fleet is not empty, it is unreadable. This is the
+        # default condition on packaged installs, where KIROCREW_PROJECT_DIR
+        # points at the app bundle (no .git) and discovery falls through to the
+        # hardcoded ~/kirocrew — raise instead, so api_dev_fleet_fleet's
+        # existing error path renders the Discovery Error banner with the path
+        # it tried and the remedy.
+        # The .git probe is a filesystem stat — on a wedged network mount it
+        # can block indefinitely, and this branch is reachable precisely when
+        # the checkout is unhealthy (git already failed or timed out against
+        # it). Same "Blocking — executor only" convention as _is_checkout().
+        loop = asyncio.get_running_loop()
+        repo_is_git = await loop.run_in_executor(
+            subprocess_executor(), (Path(MAIN_REPO) / ".git").exists
+        )
+        if not repo_is_git:
+            raise RuntimeError(
+                f"main checkout not found: {MAIN_REPO} is missing or not a git "
+                "checkout. Set KIROCREW_DEVFLEET_REPO to your Kiro Crew checkout, "
+                "or clone it to ~/kirocrew."
+            )
+        # The repo exists but git failed for some other reason (corrupt repo,
+        # permissions): surface git's own message, redacted and bounded.
+        raise RuntimeError(
+            f"git worktree discovery failed in {MAIN_REPO}: "
+            f"{_redact(raw)[:_GIT_ERR_MAX] or 'unknown git error'}"
+        )
     entries = _parse_worktree_porcelain(stdout)
     # `git worktree list --porcelain` always lists the primary checkout
     # first — that is the authoritative main, regardless of whether

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -1458,13 +1458,53 @@ async def test_discover_worktrees_sandbox_error_is_still_bounded():
 
 
 @pytest.mark.asyncio
-async def test_discover_worktrees_normal_failure_returns_empty():
-    """Non-sandbox git failures return empty list (existing behavior)."""
-    with patch.object(mod, "_run_cmd", new=AsyncMock(
-        return_value=(128, "", "fatal: not a git repository")
-    )):
-        result = await mod._discover_worktrees()
-        assert result == []
+async def test_discover_worktrees_missing_repo_raises_actionable_error(tmp_path):
+    """A missing/non-git MAIN_REPO raises with the path and the remedy.
+
+    This used to return a silent [] — which the UI renders as the
+    "No worktrees found" empty state. On packaged installs (where
+    KIROCREW_PROJECT_DIR points at the app bundle and discovery falls through
+    to the hardcoded ~/kirocrew) that empty state told users they had no
+    worktrees when the app was simply looking at a path that does not exist.
+    """
+    missing = tmp_path / "does-not-exist"
+    with patch.object(mod, "MAIN_REPO", str(missing)), \
+         patch.object(mod, "_run_cmd", new=AsyncMock(
+             return_value=(128, "", f"fatal: cannot change to '{missing}'")
+         )):
+        with pytest.raises(RuntimeError) as exc:
+            await mod._discover_worktrees()
+    msg = str(exc.value)
+    assert str(missing) in msg  # names the path it tried
+    assert "KIROCREW_DEVFLEET_REPO" in msg  # names the remedy
+
+
+@pytest.mark.asyncio
+async def test_discover_worktrees_git_failure_raises_with_stderr(tmp_path):
+    """When the repo exists but git fails, git's own message is surfaced."""
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    with patch.object(mod, "MAIN_REPO", str(repo)), \
+         patch.object(mod, "_run_cmd", new=AsyncMock(
+             return_value=(128, "", "fatal: index file corrupt")
+         )):
+        with pytest.raises(RuntimeError, match="index file corrupt"):
+            await mod._discover_worktrees()
+
+
+@pytest.mark.asyncio
+async def test_discover_worktrees_git_failure_is_bounded(tmp_path):
+    """An unbounded git stderr is clipped before reaching the UI."""
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    with patch.object(mod, "MAIN_REPO", str(repo)), \
+         patch.object(mod, "_run_cmd", new=AsyncMock(
+             return_value=(128, "", "fatal: " + "x" * 5000)
+         )):
+        with pytest.raises(RuntimeError) as exc:
+            await mod._discover_worktrees()
+    # bounded: the git portion is clipped to _GIT_ERR_MAX plus the fixed prefix
+    assert len(str(exc.value)) <= mod._GIT_ERR_MAX + 200
 
 
 # =============================================================================
@@ -1582,6 +1622,31 @@ async def test_fleet_handler_sandbox_error_returns_error_payload():
             body = await resp.json()
             assert body["worktrees"] == []
             assert "sandbox unavailable" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_fleet_handler_missing_repo_returns_error_payload():
+    """The missing-repo RuntimeError reaches the client as the error payload
+    (the frontend renders it as the Discovery Error banner), not a silent
+    empty fleet."""
+    async def boom():
+        raise RuntimeError(
+            "main checkout not found: /nope/kirocrew is missing or not a git "
+            "checkout. Set KIROCREW_DEVFLEET_REPO to your Kiro Crew checkout, "
+            "or clone it to ~/kirocrew."
+        )
+
+    with patch.object(mod, "_fleet_refresh", new=boom), \
+         patch.object(mod, "_fleet_cached", new=boom):
+        app = web.Application()
+        app.router.add_get("/api/fleet", mod.api_dev_fleet_fleet)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/api/fleet")
+            assert resp.status == 200
+            body = await resp.json()
+            assert body["worktrees"] == []
+            assert "main checkout not found" in body["error"]
+            assert "KIROCREW_DEVFLEET_REPO" in body["error"]
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem / Motivation

Dev Fleet renders "No worktrees found — Nothing under the worktrees root yet" even when the machine has a dozen worktrees. I hit this on my packaged install: `_discover_worktrees()` swallows every non-sandbox git failure into a silent empty list, so when the app is looking at the wrong repo path (or a broken repo) the UI is indistinguishable from a genuinely empty fleet. There is zero diagnostic output anywhere — not in the UI, not in the payload.

## Why it matters

On packaged (Electron) installs the wrong-path case is the default: `KIROCREW_PROJECT_DIR` points at the app bundle (no `.git`), so discovery falls through to the hardcoded `~/kirocrew`, which most contributors don't have. Every such user sees a confident, misleading empty state that says "you have no worktrees" when the truth is "I can't read the repo I'm pointed at". The empty state actively sends the user down the wrong trail (creating worktrees, refreshing) instead of the actual fix (pointing the app at their checkout).

## What changed (motivation → approach → change)

Symptom: misleading empty fleet. Root cause: the `rc != 0` branch of `_discover_worktrees()` raises only for sandbox errors and returns `[]` for everything else — and the UI renders `[]` as the empty state. Change: follow the sandbox-error precedent the rest of the way and raise a `RuntimeError` for every discovery failure. The surfacing pipeline already exists end-to-end: `api_dev_fleet_fleet` catches `RuntimeError` and returns `{worktrees: [], error}`, and the frontend already renders a payload error as the Discovery Error banner — so lighting it up needs no frontend change.

- A missing/non-git `MAIN_REPO` gets a purpose-built message naming the path it tried and the remedy (`KIROCREW_DEVFLEET_REPO` or a `~/kirocrew` clone). The `.git` probe runs through `subprocess_executor()` — this branch is reachable precisely when the checkout is unhealthy (git already failed or timed out against it), and a synchronous stat on a wedged network mount would freeze the event loop; same "Blocking — executor only" convention as `_is_checkout()`.
- Any other git failure (corrupt repo, permissions) surfaces git's own stderr, redacted and bounded by a new `_GIT_ERR_MAX = 300` cap (the sandbox branch keeps its wider `_SANDBOX_ERR_MAX` bound, which exists to carry the sandbox layer's long remedy sentence).

Blast radius: the sandbox `RuntimeError` already propagated through every `_discover_worktrees()` caller before this change, so no caller meets a novel exception type; the destructive consumers fail closed and the background tasks (disk usage, auto-prune reaper) hold broad excepts.

## Tests

- `test_discover_worktrees_missing_repo_raises_actionable_error` — the missing-repo raise names the path it tried and the `KIROCREW_DEVFLEET_REPO` remedy.
- `test_discover_worktrees_git_failure_raises_with_stderr` — repo exists but git fails → git's own message is surfaced.
- `test_discover_worktrees_git_failure_is_bounded` — a 5000-char stderr is clipped before reaching the UI.
- `test_fleet_handler_missing_repo_returns_error_payload` — the raise reaches the client as the `{worktrees: [], error}` payload the Discovery Error banner renders.
- Replaces `test_discover_worktrees_normal_failure_returns_empty`, which locked in the silent-`[]` behavior this PR removes — that test was the bug's guardian.

## Manual verification

Reproduced the symptom on my live packaged install before the fix: dev-fleet backend env pointed discovery at a nonexistent `~/kirocrew`, `/api/fleet` returned an empty list, UI showed "No worktrees found" while `git worktree list` against the real checkout returned 12 worktrees. The frontend banner path is exercised by the existing sandbox-error flow in production today; the new handler test locks in the payload shape it consumes.

## Screenshots / video

N/A — no frontend change; the Discovery Error banner this lights up is existing, already-shipped UI (previously reachable only via sandbox errors).

Related: a sibling PR (kirodotdev/KiroCrew#1966) forwards `KIROCREW_DEVFLEET_REPO` through the app-backend env allowlist so the remedy this error message names actually works on packaged installs. Independent changes; either lands cleanly without the other.
