### PR TITLE
refactor(memory): serialize all VectorMemoryStore reads through a locked fetch helper

### DIFF
--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -902,9 +902,9 @@ async def api_lessons_delete(request: web.Request) -> web.Response:
     scope = body.get("scope", "global")
     # Delete from vector store if active, else JSONL
     vs = _get_memory(state).vector_store
-    vs_lessons = vs.get_lessons() if vs else None
+    vs_lessons = await asyncio.to_thread(vs.get_lessons) if vs else None
     if vs_lessons:
-        ok = vs.delete_lesson(rule_sub)
+        ok = await asyncio.to_thread(vs.delete_lesson, rule_sub)
     else:
         if scope == "workspace":
             ws = body.get("workspace")
@@ -1104,7 +1104,7 @@ async def api_lessons(request: web.Request) -> web.Response:
     workspace = request.query.get("workspace")
     # Read from vector store if it has lessons, else JSONL
     vs = _get_memory(state).vector_store
-    vs_lessons = vs.get_lessons() if vs else None
+    vs_lessons = await asyncio.to_thread(vs.get_lessons) if vs else None
     if vs_lessons:
         data = []
         for e in vs_lessons[-50:]:

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -212,7 +212,11 @@ async def api_memory_semantic(request: web.Request) -> web.Response:
     except (ValueError, TypeError):
         return web.json_response({"error": "limit/offset must be integers"}, status=400)
     entries = []
-    for e in store.get_all_semantic(limit=limit, offset=offset):
+    # Offload: the fetch serializes on the store's _db_lock (#1947), and a
+    # worker holding it (e.g. backfill's locked FAISS rebuild) would otherwise
+    # block the gateway event loop here.
+    rows = await asyncio.to_thread(store.get_all_semantic, limit=limit, offset=offset)
+    for e in rows:
         d = {k: v for k, v in dict(e).items() if not isinstance(v, (bytes, memoryview))}
         entries.append(_redact_memory_field(d))
     return web.json_response({"entries": entries})
@@ -280,7 +284,8 @@ async def api_memory_semantic_delete(request: web.Request) -> web.Response:
         return web.json_response({"error": "Memory writes are not allowed in this session mode."}, status=403)
     store = _get_vector_store(request.app["state"])
     key = request.match_info["key"]
-    ok = store.delete_semantic(key, source="user_explicit")
+    # Offload: acquires _db_lock internally (#1947) — see api_memory_semantic.
+    ok = await asyncio.to_thread(store.delete_semantic, key, source="user_explicit")
     if not ok:
         return web.json_response({"error": "not found"}, status=404)
     return web.json_response({"ok": True})
@@ -294,7 +299,9 @@ async def api_memory_events(request: web.Request) -> web.Response:
         offset = int(request.query.get("offset", "0"))
     except (ValueError, TypeError):
         return web.json_response({"error": "limit/offset must be integers"}, status=400)
-    return web.json_response({"events": store.get_events(limit=limit, offset=offset)})
+    # Offload: serializes on _db_lock (#1947) — see api_memory_semantic.
+    events = await asyncio.to_thread(store.get_events, limit=limit, offset=offset)
+    return web.json_response({"events": events})
 
 
 _embedding_setup_status: dict[str, object] = {"step": "idle", "error": ""}
@@ -1016,9 +1023,16 @@ async def api_memory_episodic_search(request: web.Request) -> web.Response:
         else None
     )
     results = []
-    for e in store.search_episodic(
-        query_embedding=emb, query_text=query, limit=limit, tag_filter=tag_filter
-    ):
+    # Offload: search_episodic serializes on _db_lock (#1947) — see
+    # api_memory_semantic.
+    hits = await asyncio.to_thread(
+        store.search_episodic,
+        query_embedding=emb,
+        query_text=query,
+        limit=limit,
+        tag_filter=tag_filter,
+    )
+    for e in hits:
         d = {k: v for k, v in dict(e).items() if not isinstance(v, (bytes, memoryview))}
         results.append(_redact_memory_field(d))
     return web.json_response({"results": results})
@@ -1033,10 +1047,11 @@ async def api_memory_episodic_list(request: web.Request) -> web.Response:
     except (ValueError, TypeError):
         return web.json_response({"error": "limit/offset must be integers"}, status=400)
     tag_filter = [t.strip() for t in request.query.get("tags", "").split(",") if t.strip()] or None
-    entries = [
-        _redact_memory_field(dict(e))
-        for e in store.get_episodic_list(limit=limit, offset=offset, tag_filter=tag_filter)
-    ]
+    # Offload: serializes on _db_lock (#1947) — see api_memory_semantic.
+    rows = await asyncio.to_thread(
+        store.get_episodic_list, limit=limit, offset=offset, tag_filter=tag_filter
+    )
+    entries = [_redact_memory_field(dict(e)) for e in rows]
     return web.json_response({"entries": entries})
 
 
@@ -1044,7 +1059,8 @@ async def api_memory_episodic_delete(request: web.Request) -> web.Response:
     """DELETE /api/memory/episodic/{id} — tombstone an episodic memory."""
     store = _get_vector_store(request.app["state"])
     mem_id = request.match_info["id"]
-    ok = store.delete_episodic(mem_id)
+    # Offload: acquires _db_lock internally (#1947) — see api_memory_semantic.
+    ok = await asyncio.to_thread(store.delete_episodic, mem_id)
     if not ok:
         return web.json_response({"error": "not found"}, status=404)
     return web.json_response({"ok": True})
@@ -1053,7 +1069,8 @@ async def api_memory_episodic_delete(request: web.Request) -> web.Response:
 async def api_memory_stats(request: web.Request) -> web.Response:
     """GET /api/memory/stats — memory system statistics."""
     store = _get_vector_store(request.app["state"])
-    stats = store.memory_stats()
+    # Offload: serializes on _db_lock (#1947) — see api_memory_semantic.
+    stats = await asyncio.to_thread(store.memory_stats)
     # Add embedding status
     from kiro_crew.config.loader import KiroCrewConfig  # noqa: F811
 
@@ -1119,7 +1136,9 @@ async def api_memory_context_preview(request: web.Request) -> web.Response:
     """GET /api/memory/context-preview?q=... — preview what gets injected into prompts."""
     store = _get_vector_store(request.app["state"])
     query = request.query.get("q", "")[:500]
-    semantic_ctx = store.get_semantic_context()
+    # Offload: the fetch serializes on _db_lock (#1947) — see api_memory_semantic.
+    # (No query_text is passed, so this is the recency path — no embed calls.)
+    semantic_ctx = await asyncio.to_thread(store.get_semantic_context)
     # Filter semantic context by query if provided
     if query and semantic_ctx:
         lines = semantic_ctx.split("\n")
@@ -1173,8 +1192,9 @@ async def api_memory_observability(request: web.Request) -> web.Response:
     """GET /api/memory/observability — memory health metrics and context preview."""
     store = _get_vector_store(request.app["state"])
     query = request.query.get("q", "")[:500]
-    stats = store.memory_stats()
-    rejections = store.get_rejection_stats()
+    # Offload: both serialize on _db_lock (#1947) — see api_memory_semantic.
+    stats = await asyncio.to_thread(store.memory_stats)
+    rejections = await asyncio.to_thread(store.get_rejection_stats)
     # get_context_preview with a query embeds the query AND every non-lesson
     # semantic row (blocking urllib per row) — the worst on-loop amplification
     # in the store; offload so it can't stall the gateway event loop.

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -3597,7 +3597,11 @@ class HistoryConsolidator:
             # Structured memory extraction (when vector store is available)
             has_vector = self._vector_store is not None
             if has_vector and self._vector_store is not None:
-                current_semantic = self._vector_store.get_all_semantic()
+                # Offload: the fetch serializes on the store's _db_lock (#1947),
+                # and this coroutine runs on the gateway event loop — a worker
+                # holding the lock (backfill's FAISS rebuild, reconcile's bulk
+                # UPDATEs) would otherwise block the whole loop here.
+                current_semantic = await asyncio.to_thread(self._vector_store.get_all_semantic)
                 semantic_json = (
                     json.dumps(
                         [

--- a/src/kiro_crew/slack/events.py
+++ b/src/kiro_crew/slack/events.py
@@ -1180,7 +1180,7 @@ async def _publish_home_tab(orch: GatewayOrchestrator, user_id: str) -> None:
         vs = getattr(orch, "vector_memory", None)
         if vs is not None and callable(getattr(vs, "get_lessons", None)):
             try:
-                all_vs = vs.get_lessons()
+                all_vs = await asyncio.to_thread(vs.get_lessons)
             except Exception:
                 all_vs = None
                 logger.debug("Vector store lesson read failed, trying JSONL", exc_info=True)

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -18,6 +18,7 @@ import math
 import re
 import struct
 import threading
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from enum import Enum
 from fnmatch import fnmatch
@@ -475,6 +476,33 @@ class VectorMemoryStore:
             raise RuntimeError("VectorMemoryStore not initialized — call init() first")
         return self._db
 
+    # ── Locked fetch helpers ──
+    #
+    # The single ``check_same_thread=False`` connection is shared across the
+    # event loop, executor threads (context assembly via run_in_embed_pool) and
+    # worker threads (consolidation, dashboard handlers). sqlite3 caches
+    # prepared statements per connection, so an unsynchronized statement racing
+    # another thread's implicit transaction corrupts the statement cache —
+    # observed in production as sqlite3.InterfaceError ("bad parameter or other
+    # API misuse") and DatabaseError ("another row available") — or silently
+    # corrupts row iteration. EVERY statement on ``self.db`` must therefore be
+    # serialized on ``_db_lock`` (enforced by an AST guard in
+    # test_vector_memory.py). Route plain SELECTs through these helpers; only
+    # read-modify-write sections that must be atomic should take the lock
+    # explicitly. Both helpers materialize results before releasing the lock,
+    # so callers never iterate a live cursor unlocked — and per the lock's
+    # contract, never call a blocking embed while holding it.
+
+    def _fetch_all_locked(self, sql: str, params: Sequence[object] = ()) -> list[sqlite3.Row]:
+        """Run a SELECT serialized on ``_db_lock``; return materialized rows."""
+        with self._db_lock:
+            return self.db.execute(sql, params).fetchall()
+
+    def _fetch_one_locked(self, sql: str, params: Sequence[object] = ()) -> sqlite3.Row | None:
+        """Run a SELECT serialized on ``_db_lock``; return the first row or None."""
+        with self._db_lock:
+            return self.db.execute(sql, params).fetchone()
+
     # ── Key Validation ──
 
     def _validate_key(self, key: str) -> str | None:
@@ -546,9 +574,9 @@ class VectorMemoryStore:
 
     def get_semantic(self, key: str) -> dict | None:
         """Get a single semantic memory entry by key."""
-        row = self.db.execute(
+        row = self._fetch_one_locked(
             "SELECT * FROM semantic_memory WHERE key = ? AND is_deleted = 0", (key,)
-        ).fetchone()
+        )
         return dict(row) if row else None
 
     def get_all_semantic(self, limit: int | None = None, offset: int = 0) -> list[dict]:
@@ -565,7 +593,7 @@ class VectorMemoryStore:
         if limit is not None:
             sql += " LIMIT ? OFFSET ?"
             params = (int(limit), int(offset))
-        rows = self.db.execute(sql, params).fetchall()
+        rows = self._fetch_all_locked(sql, params)
         return [dict(r) for r in rows]
 
     @timed("vector", "write")
@@ -821,10 +849,10 @@ class VectorMemoryStore:
     @timed("vector", "search")
     def search_semantic(self, prefix: str) -> list[dict]:
         """Search semantic memory by key prefix."""
-        rows = self.db.execute(
+        rows = self._fetch_all_locked(
             "SELECT * FROM semantic_memory WHERE key LIKE ? AND is_deleted = 0 ORDER BY key",
             (prefix.rstrip("*").rstrip(".") + "%",),
-        ).fetchall()
+        )
         return [dict(r) for r in rows]
 
     # ── Context Injection ──
@@ -844,19 +872,16 @@ class VectorMemoryStore:
             query_embedding = self._try_embed(query_text) if self.embed_fn else None
 
             # Context assembly runs on executor threads (subagent context builds,
-            # run_in_embed_pool) concurrent with writers on worker threads. The
-            # shared connection's statement cache is not safe for unsynchronized
-            # cross-thread use — an unlocked SELECT racing a writer's implicit
-            # BEGIN surfaces as sqlite3.InterfaceError ("bad parameter or other
-            # API misuse"), and context.py does not guard this call, so the
-            # whole subagent run dies. Lock ONLY the fetch: fetchall()
-            # materializes the rows, and the scoring loop below issues blocking
-            # per-row embed calls that must never run under _db_lock.
-            with self._db_lock:
-                all_rows = self.db.execute(
-                    "SELECT key, value_json, updated_at FROM semantic_memory "
-                    "WHERE is_deleted = 0 AND key NOT LIKE 'lesson.%'"
-                ).fetchall()
+            # run_in_embed_pool) concurrent with writers on worker threads, and
+            # context.py does not guard this call — an unserialized fetch here
+            # used to kill the whole subagent run (see the locked-fetch helper
+            # contract). The helper materializes the rows; the scoring loop
+            # below issues blocking per-row embed calls that must never run
+            # under _db_lock.
+            all_rows = self._fetch_all_locked(
+                "SELECT key, value_json, updated_at FROM semantic_memory "
+                "WHERE is_deleted = 0 AND key NOT LIKE 'lesson.%'"
+            )
 
             scored_rows: list[tuple[float, dict]] = []
             for r in all_rows:
@@ -895,12 +920,11 @@ class VectorMemoryStore:
         else:
             # No query: recent entries. Same serialization requirement as the
             # query path above.
-            with self._db_lock:
-                rows = self.db.execute(
-                    "SELECT key, value_json FROM semantic_memory WHERE is_deleted = 0 "
-                    "AND key NOT LIKE 'lesson.%' ORDER BY updated_at DESC LIMIT ?",
-                    (max_rows,),
-                ).fetchall()
+            rows = self._fetch_all_locked(
+                "SELECT key, value_json FROM semantic_memory WHERE is_deleted = 0 "
+                "AND key NOT LIKE 'lesson.%' ORDER BY updated_at DESC LIMIT ?",
+                (max_rows,),
+            )
 
         if not rows:
             return ""
@@ -955,10 +979,10 @@ class VectorMemoryStore:
 
     def get_events(self, limit: int = 50, offset: int = 0) -> list[dict]:
         """Return recent memory events with pagination."""
-        rows = self.db.execute(
+        rows = self._fetch_all_locked(
             "SELECT * FROM memory_events ORDER BY id DESC LIMIT ? OFFSET ?",
             (limit, offset),
-        ).fetchall()
+        )
         return [dict(r) for r in rows]
 
     def rotate_events(self, max_rows: int = _MAX_EVENTS) -> int:
@@ -984,10 +1008,10 @@ class VectorMemoryStore:
             return 0
         self._faiss_index = faiss.IndexFlatIP(self._embedding_dim)
         self._faiss_id_map = []
-        rows = self.db.execute(
+        rows = self._fetch_all_locked(
             "SELECT id, embedding FROM episodic_memories "
             "WHERE is_deleted = 0 AND embedding IS NOT NULL"
-        ).fetchall()
+        )
         skipped = 0
         for row in rows:
             vec = np.frombuffer(row["embedding"], dtype=np.float32).reshape(1, -1)
@@ -1334,14 +1358,13 @@ class VectorMemoryStore:
 
     def has_episodic_text(self, text: str) -> bool:
         """Return whether an active episodic memory exactly matches *text*."""
-        with self._db_lock:
-            return (
-                self.db.execute(
-                    "SELECT 1 FROM episodic_memories WHERE is_deleted = 0 AND text = ? LIMIT 1",
-                    (text,),
-                ).fetchone()
-                is not None
+        return (
+            self._fetch_one_locked(
+                "SELECT 1 FROM episodic_memories WHERE is_deleted = 0 AND text = ? LIMIT 1",
+                (text,),
             )
+            is not None
+        )
 
     @timed("vector", "search")
     def _episodic_relevance_threshold(self, text: str) -> float:
@@ -1500,19 +1523,16 @@ class VectorMemoryStore:
         q = [x / norm for x in query_embedding] if norm > 0 else query_embedding
         q_len = len(q)
 
-        # The fetch is serialized with every other statement on this shared
-        # connection. sqlite3 caches prepared statements per connection, so two
-        # threads running a statement at the same time can corrupt each other's
-        # row iteration — observed as DatabaseError("another row available") and,
-        # on Windows CI, a NULL value for a column the WHERE clause excludes
-        # (`embedding IS NOT NULL` returning None, TypeError on len()). Only the
-        # fetch is locked: the scoring loop below works on materialized rows.
-        with self._db_lock:
-            rows = self.db.execute(
-                "SELECT id, conversation_id, text, tags, importance, created_at, "
-                "last_accessed_at, embedding FROM episodic_memories "
-                "WHERE is_deleted = 0 AND embedding IS NOT NULL"
-            ).fetchall()
+        # Serialized via the locked helper — two threads running a statement at
+        # the same time used to corrupt each other's row iteration (observed as
+        # DatabaseError("another row available") and, on Windows CI, a NULL
+        # value for a column the WHERE clause excludes). Only the fetch is
+        # locked: the scoring loop below works on materialized rows.
+        rows = self._fetch_all_locked(
+            "SELECT id, conversation_id, text, tags, importance, created_at, "
+            "last_accessed_at, embedding FROM episodic_memories "
+            "WHERE is_deleted = 0 AND embedding IS NOT NULL"
+        )
 
         logger.debug(
             "Episodic SQLite vector search: query=%s… rows_with_emb=%d",
@@ -1575,12 +1595,12 @@ class VectorMemoryStore:
         else:
             tag_conds = ""
             tag_params = ()
-        rows = self.db.execute(
+        rows = self._fetch_all_locked(
             "SELECT id, conversation_id, text, tags, importance, created_at, last_accessed_at "
             f"FROM episodic_memories WHERE is_deleted = 0{tag_conds} "
             "ORDER BY created_at DESC LIMIT ? OFFSET ?",
             (*tag_params, limit, offset),
-        ).fetchall()
+        )
         return [dict(r) for r in rows]
 
     def delete_episodic(self, mem_id: str, source: str = "user_explicit") -> bool:
@@ -1635,7 +1655,7 @@ class VectorMemoryStore:
 
     def memory_stats(self) -> dict:
         """Return counts and sizes for dashboard display."""
-        row = self.db.execute(
+        row = self._fetch_one_locked(
             "SELECT "
             "(SELECT COUNT(*) FROM semantic_memory WHERE is_deleted=0) AS sem_active, "
             "(SELECT COUNT(*) FROM semantic_memory WHERE is_deleted=1) AS sem_deleted, "
@@ -1643,7 +1663,8 @@ class VectorMemoryStore:
             "(SELECT COUNT(*) FROM episodic_memories WHERE is_deleted=1) AS ep_deleted, "
             "(SELECT COUNT(*) FROM memory_events) AS events_count, "
             "(SELECT COUNT(*) FROM episodic_memories WHERE is_deleted=0 AND embedding IS NOT NULL) AS ep_with_vec"
-        ).fetchone()
+        )
+        assert row is not None  # a scalar-subquery SELECT always returns one row
         faiss_size = len(self._faiss_id_map) if self._faiss_id_map else 0
         return {
             "semantic_active": row[0],
@@ -1665,9 +1686,9 @@ class VectorMemoryStore:
         return bool(set(t.lower() for t in entry_tags) & set(t.lower() for t in tag_filter))
 
     def _get_episodic(self, mem_id: str) -> dict | None:
-        row = self.db.execute(
+        row = self._fetch_one_locked(
             "SELECT * FROM episodic_memories WHERE id = ? AND is_deleted = 0", (mem_id,)
-        ).fetchone()
+        )
         return dict(row) if row else None
 
     #: Columns returned for episodic search hits. Deliberately omits the
@@ -1689,11 +1710,14 @@ class VectorMemoryStore:
         if not mem_ids:
             return {}
         placeholders = ",".join("?" * len(mem_ids))
-        rows = self.db.execute(
+        # The FAISS search path calls this while already holding _db_lock;
+        # the helper's re-acquire is safe (RLock) and keeps the site covered
+        # when reached from any future unlocked caller.
+        rows = self._fetch_all_locked(
             f"SELECT {self._EPISODIC_SEARCH_COLUMNS} FROM episodic_memories "
             f"WHERE id IN ({placeholders}) AND is_deleted = 0",
             tuple(mem_ids),
-        ).fetchall()
+        )
         return {row["id"]: dict(row) for row in rows}
 
     #: Minimum interval between last_accessed_at writes for the same episodic row.
@@ -2036,11 +2060,9 @@ class VectorMemoryStore:
         # remain safe.
         if limit is not None and limit > 0:
             sql += " LIMIT ?"
-            with self._db_lock:
-                rows = self.db.execute(sql, (limit,)).fetchall()
+            rows = self._fetch_all_locked(sql, (limit,))
         else:
-            with self._db_lock:
-                rows = self.db.execute(sql).fetchall()
+            rows = self._fetch_all_locked(sql)
         return [dict(r) for r in rows]
 
     def delete_lesson(self, rule_substring: str) -> bool:
@@ -2172,8 +2194,7 @@ class VectorMemoryStore:
 
     def _read_meta(self, key: str) -> str | None:
         """Read a ``memory_meta`` value, or None when absent."""
-        with self._db_lock:
-            row = self.db.execute("SELECT value FROM memory_meta WHERE key = ?", (key,)).fetchone()
+        row = self._fetch_one_locked("SELECT value FROM memory_meta WHERE key = ?", (key,))
         return str(row["value"]) if row is not None else None
 
     def _write_meta(self, key: str, value: str) -> None:
@@ -2404,11 +2425,10 @@ class VectorMemoryStore:
         self._backfill_lesson_embeddings(progress)
         if not _HAS_NUMPY:
             return 0
-        with self._db_lock:
-            rows = self.db.execute(
-                "SELECT id, text FROM episodic_memories "
-                "WHERE is_deleted = 0 AND embedding IS NULL"
-            ).fetchall()
+        rows = self._fetch_all_locked(
+            "SELECT id, text FROM episodic_memories "
+            "WHERE is_deleted = 0 AND embedding IS NULL"
+        )
         if not rows:
             return 0
         embedded = 0
@@ -2483,11 +2503,10 @@ class VectorMemoryStore:
         """
         if self.embed_fn is None:
             return 0
-        with self._db_lock:
-            rows = self.db.execute(
-                "SELECT key, value_json FROM semantic_memory "
-                "WHERE is_deleted = 0 AND embedding IS NULL AND key LIKE 'lesson.%'"
-            ).fetchall()
+        rows = self._fetch_all_locked(
+            "SELECT key, value_json FROM semantic_memory "
+            "WHERE is_deleted = 0 AND embedding IS NULL AND key LIKE 'lesson.%'"
+        )
         if not rows:
             return 0
         embedded = 0
@@ -2631,9 +2650,10 @@ class VectorMemoryStore:
                     else:
                         counts["skipped"] += 1
 
-        embedded_n = self.db.execute(
+        embedded_row = self._fetch_one_locked(
             "SELECT COUNT(*) FROM episodic_memories WHERE is_deleted=0 AND embedding IS NOT NULL"
-        ).fetchone()[0]
+        )
+        embedded_n = embedded_row[0] if embedded_row is not None else 0
         logger.info(
             "Migration complete: semantic=%d episodic=%d skipped=%d embedded=%d",
             counts["semantic"],
@@ -2696,13 +2716,12 @@ class VectorMemoryStore:
             params.extend(f'%"{t.lower()}"%' for t in tag_filter)
         # Serialized for the same reason as the vector fallback above: this runs
         # on the context-assembly path, concurrently with memory writes.
-        with self._db_lock:
-            rows = self.db.execute(
-                f"SELECT id, conversation_id, text, tags, importance, created_at, last_accessed_at "
-                f"FROM episodic_memories WHERE is_deleted = 0 AND ({conditions}) "
-                f"ORDER BY created_at DESC LIMIT ?",
-                (*params, limit),
-            ).fetchall()
+        rows = self._fetch_all_locked(
+            f"SELECT id, conversation_id, text, tags, importance, created_at, last_accessed_at "
+            f"FROM episodic_memories WHERE is_deleted = 0 AND ({conditions}) "
+            f"ORDER BY created_at DESC LIMIT ?",
+            (*params, limit),
+        )
         return [dict(r) for r in rows]
 
     # ── Episodic Promotion ──
@@ -2717,11 +2736,11 @@ class VectorMemoryStore:
             return 0
 
         promoted = 0
-        rows = self.db.execute(
+        rows = self._fetch_all_locked(
             "SELECT id, text, embedding FROM episodic_memories "
             "WHERE is_deleted = 0 AND embedding IS NOT NULL "
             "ORDER BY importance DESC, created_at DESC LIMIT 500"
-        ).fetchall()
+        )
 
         # Cluster similar episodic memories
         clusters: dict[int, list[dict]] = {}
@@ -2786,13 +2805,13 @@ class VectorMemoryStore:
         FAISS dedup, so counting episodic there would conflate benign
         deduplication with policy rejections.
         """
-        rows = self.db.execute(
+        rows = self._fetch_all_locked(
             "SELECT event_type, COUNT(*) as count FROM memory_events "
             "WHERE event_type = 'injection_blocked' "
             "OR (memory_type = 'semantic' AND event_type IN "
             "('allowlist_reject', 'low_confidence', 'conflict_skip')) "
             "GROUP BY event_type"
-        ).fetchall()
+        )
         return {r["event_type"]: r["count"] for r in rows}
 
     def get_context_preview(self, query_text: str = "") -> dict:

--- a/test/test_slack_handler.py
+++ b/test/test_slack_handler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 
 import pytest
 
@@ -3076,18 +3077,20 @@ class TestToolElapsedTimer:
         slack = MockSlackClient()
         slack._stream_enabled = True
 
-        # We need to track when _tool_start_time gets set
-        # The simplest way: wrap the original and track based on call count
-        # From debug: ~20 calls happen. The timer start is around call 7-8
-        # and elapsed calc around call 18. We need start to be early, elapsed late.
+        # Advance the clock by >60s on EVERY monotonic() call. The elapsed
+        # calc always runs at least one call after _start_tool_timer, so the
+        # computed elapsed is >= one step regardless of how many unrelated
+        # monotonic() calls precede the timer start. (A fixed call-count
+        # threshold here was order-dependent: module caches touched by earlier
+        # tests in this file change the pre-timer call count, so the test
+        # broke whenever a pytest-split shard boundary landed inside this
+        # class.)
         calls = [0]
         base = handler.time.monotonic()
 
         def fake_monotonic():
             calls[0] += 1
-            # Calls 1-10 return base (timer sets _tool_start_time here)
-            # Calls 11+ return base + 75.5 (elapsed calculation)
-            return base if calls[0] <= 10 else base + 75.5
+            return base + calls[0] * 75.5
 
         monkeypatch.setattr(handler.time, "monotonic", fake_monotonic)
         provider = FakeProvider(
@@ -3102,9 +3105,13 @@ class TestToolElapsedTimer:
         task_appends = [a for a in slack.actions if a[0] == "append_task"]
         complete_tasks = [t for t in task_appends if t[1].get("status") == "complete"]
         # Elapsed time is shown in the TITLE (Slack replaces title on same
-        # task_id; details would APPEND and accumulate ⏱ stamps).
+        # task_id; details would APPEND and accumulate ⏱ stamps). Elapsed is
+        # N*75.5s for some N>=1, so assert the minutes FORMAT rather than a
+        # specific minute count.
         title_list = [str(t[1].get("title", "")) for t in complete_tasks]
-        assert any("1m" in t for t in title_list), f"Expected '1m' in title but got: {title_list}"
+        assert any(
+            re.search(r"⏱ \d+m \d+(\.\d+)?s", t) for t in title_list
+        ), f"Expected minutes-format elapsed in title but got: {title_list}"
         # Regression guard: elapsed must NOT be in details (append bug)
         details_list = [str(t[1].get("details", "")) for t in complete_tasks]
         assert all("⏱" not in d for d in details_list), f"⏱ leaked into details: {details_list}"
@@ -3167,9 +3174,11 @@ class TestToolElapsedTimer:
 
         def fake_monotonic():
             calls[0] += 1
-            # Early calls (tool 1 timer start) return base; later calls
-            # (transition completion elapsed calc) return base + 42s.
-            return base if calls[0] <= 10 else base + 42.0
+            # Advance >1s per call: the transition's elapsed calc always runs
+            # after the first tool's timer start, so elapsed >= one 42s step.
+            # (A fixed call-count threshold was order-dependent — see
+            # test_elapsed_time_shows_minutes_format.)
+            return base + calls[0] * 42.0
 
         monkeypatch.setattr(handler.time, "monotonic", fake_monotonic)
         provider = FakeProvider(

--- a/test/test_vector_memory.py
+++ b/test/test_vector_memory.py
@@ -2338,3 +2338,439 @@ class TestSharedConnectionLockDiscipline:
         entry = store.get_semantic("pref.editor")
         assert entry is not None
         assert entry["value_json"] == '"emacs"'
+
+
+class TestLockedFetchHelpers:
+    """The locked fetch helpers (#1947) — the single route for plain SELECTs."""
+
+    def test_fetch_all_locked_returns_materialized_rows(self, tmp_path: Path) -> None:
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        store.set_semantic("pref.editor", "vim", 0.9, "user_explicit")
+        store.set_semantic("pref.shell", "zsh", 0.9, "user_explicit")
+        rows = store._fetch_all_locked(
+            "SELECT key FROM semantic_memory WHERE key LIKE ? AND is_deleted = 0 ORDER BY key",
+            ("pref.%",),
+        )
+        # A materialized list (not a live cursor), safe to iterate unlocked.
+        assert isinstance(rows, list)
+        assert [r["key"] for r in rows] == ["pref.editor", "pref.shell"]
+
+    def test_fetch_one_locked_hit_and_miss(self, tmp_path: Path) -> None:
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        store.set_semantic("pref.editor", "vim", 0.9, "user_explicit")
+        row = store._fetch_one_locked(
+            "SELECT value_json FROM semantic_memory WHERE key = ?", ("pref.editor",)
+        )
+        assert row is not None and row["value_json"] == '"vim"'
+        assert (
+            store._fetch_one_locked(
+                "SELECT value_json FROM semantic_memory WHERE key = ?", ("pref.nope",)
+            )
+            is None
+        )
+
+    def test_helpers_are_reentrant_under_held_lock(self, tmp_path: Path) -> None:
+        """_db_lock is an RLock: locked write sections may call readers that
+        route through the helpers (e.g. search_episodic -> _get_episodic_batch)
+        without deadlocking."""
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        store.set_semantic("pref.editor", "vim", 0.9, "user_explicit")
+        with store._db_lock:
+            rows = store._fetch_all_locked("SELECT key FROM semantic_memory")
+        assert len(rows) == 1
+
+
+class TestDbLockGuard:
+    """AST guard for the #1947 invariant: EVERY statement on the shared
+    ``check_same_thread=False`` connection must be serialized on ``_db_lock``.
+
+    The contract used to be enforced by convention only and failed twice
+    (the _sqlite_vector_search locked-fetch fix, then #1859's
+    get_semantic_context/get_lessons production InterfaceError). This test
+    makes a raw unlocked ``self.db.execute(...)`` in vector_memory.py a CI
+    failure instead of a code-review catch: new fetches must route through
+    ``_fetch_all_locked``/``_fetch_one_locked`` (which lock internally) or sit
+    inside an explicit ``with self._db_lock:`` read-modify-write section.
+    """
+
+    #: Methods allowed to touch the raw ``self._db`` attribute unlocked:
+    #: they run before/after the store is shared across threads.
+    _RAW_DB_ALLOWED = {"init", "close", "db"}
+
+    @staticmethod
+    def _is_self_attr(node: object, attr: str) -> bool:
+        import ast
+
+        return (
+            isinstance(node, ast.Attribute)
+            and node.attr == attr
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "self"
+        )
+
+    @classmethod
+    def _find_unserialized_statements(cls, tree) -> list[str]:
+        """Return a violation string per sqlite statement not serialized on
+        ``_db_lock``. Shared by the real guard and its self-test below."""
+        import ast
+
+        violations: list[str] = []
+        guard = cls
+
+        class Visitor(ast.NodeVisitor):
+            def __init__(self) -> None:
+                self.lock_depth = 0
+                self.func_stack: list[str] = []
+
+            def visit_With(self, node: ast.With) -> None:
+                locked = any(
+                    guard._is_self_attr(item.context_expr, "_db_lock") for item in node.items
+                )
+                self.lock_depth += 1 if locked else 0
+                self.generic_visit(node)
+                self.lock_depth -= 1 if locked else 0
+
+            def visit_ClassDef(self, node) -> None:
+                self.func_stack.append(node.name)
+                self.generic_visit(node)
+                self.func_stack.pop()
+
+            def _visit_func(self, node) -> None:
+                self.func_stack.append(node.name)
+                saved = self.lock_depth
+                self.lock_depth = 0  # function body runs at call time, not here
+                self.generic_visit(node)
+                self.lock_depth = saved
+                self.func_stack.pop()
+
+            visit_FunctionDef = _visit_func
+            visit_AsyncFunctionDef = _visit_func
+
+            def visit_Call(self, node: ast.Call) -> None:
+                func = node.func
+                if isinstance(func, ast.Attribute) and func.attr in (
+                    "execute",
+                    "executemany",
+                    "executescript",
+                ):
+                    where = ".".join(self.func_stack) or "<module>"
+                    if guard._is_self_attr(func.value, "db") and self.lock_depth == 0:
+                        violations.append(
+                            f"line {node.lineno} ({where}): self.db.{func.attr}() outside "
+                            "`with self._db_lock:` — use _fetch_all_locked/_fetch_one_locked "
+                            "for reads or take the lock explicitly for writes"
+                        )
+                    elif guard._is_self_attr(func.value, "_db") and not (
+                        self.func_stack and self.func_stack[-1] in guard._RAW_DB_ALLOWED
+                    ):
+                        violations.append(
+                            f"line {node.lineno} ({where}): raw self._db.{func.attr}() outside "
+                            f"{sorted(guard._RAW_DB_ALLOWED)} — go through self.db under _db_lock"
+                        )
+                self.generic_visit(node)
+
+        Visitor().visit(tree)
+        return violations
+
+    def test_every_db_statement_is_lock_serialized(self) -> None:
+        import ast
+        import inspect
+
+        from kiro_crew import vector_memory
+
+        source = inspect.getsource(vector_memory)
+        tree = ast.parse(source)
+        violations = self._find_unserialized_statements(tree)
+        assert not violations, "unserialized sqlite statement(s):\n" + "\n".join(violations)
+
+    def test_guard_catches_a_seeded_violation(self) -> None:
+        """The guard itself must fail on an unlocked fetch — otherwise a refactor
+        that breaks its With/function tracking would silently disarm it."""
+        import ast
+
+        seeded = ast.parse(
+            "class S:\n"
+            "    def bad(self):\n"
+            "        return self.db.execute('SELECT 1').fetchone()\n"
+            "    def good(self):\n"
+            "        with self._db_lock:\n"
+            "            return self.db.execute('SELECT 1').fetchone()\n"
+            "    def sneaky(self):\n"
+            "        with self._db_lock:\n"
+            "            def inner():\n"
+            "                return self.db.execute('SELECT 1').fetchone()\n"
+            "            return inner\n"
+            "    def raw(self):\n"
+            "        return self._db.execute('SELECT 1').fetchone()\n"
+        )
+        violations = self._find_unserialized_statements(seeded)
+        # `bad` is a plain unlocked fetch; `sneaky`'s inner function is defined
+        # under the lock but runs at call time; `raw` bypasses the property
+        # outside the allowed lifecycle methods. `good` must not be flagged.
+        assert len(violations) == 3
+        flagged = "\n".join(violations)
+        assert "(S.bad)" in flagged
+        assert "(S.sneaky.inner)" in flagged
+        assert "(S.raw)" in flagged
+        assert "S.good" not in flagged
+
+
+@pytest.mark.xdist_group("vector_memory_concurrency")
+class TestReaderConcurrency1947:
+    """Stress the readers that ran UNLOCKED on the shared connection before
+    #1947 (get_semantic, get_all_semantic, search_semantic, get_events,
+    get_episodic_list, memory_stats, _get_episodic, get_rejection_stats)
+    against concurrent writers.
+
+    Same defect class as #1859: an unserialized statement racing a writer's
+    implicit transaction corrupts the per-connection statement cache
+    (sqlite3.InterfaceError "bad parameter or other API misuse") or silently
+    corrupts row iteration. With every fetch routed through the locked helper,
+    readers must raise NOTHING — dashboard/API callers surface any exception
+    as a 500.
+    """
+
+    def test_previously_unlocked_readers_survive_concurrent_writes(self, tmp_path: Path) -> None:
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        # Seed both tables plus the event log so every reader has real rows.
+        seeded_episodic_ids: list[str] = []
+        for i in range(10):
+            store.set_semantic(f"project.seed.k{i:02d}", f"alpha value {i}", 1.0, "tool")
+            store.write_episodic(f"seeded episodic memory {i} about alpha beta topics")
+        seeded_episodic_ids = [m["id"] for m in store.get_episodic_list(limit=10)]
+
+        start_barrier = threading.Barrier(4)
+        errors: list[BaseException] = []
+
+        def _writer(n: int, tag: str) -> None:
+            start_barrier.wait()
+            try:
+                for i in range(n):
+                    store.set_semantic(f"project.stress.{tag}{i:03d}", f"gamma {i}", 1.0, "tool")
+                    store.write_episodic(f"stress episodic {tag}{i:03d} gamma delta {i}")
+            except BaseException as exc:  # noqa: BLE001 - capture any thread crash
+                errors.append(exc)
+
+        def _reader(n: int) -> None:
+            start_barrier.wait()
+            try:
+                for i in range(n):
+                    store.get_semantic("project.seed.k00")
+                    store.get_all_semantic(limit=20)
+                    store.search_semantic("project.")
+                    store.get_events(limit=20)
+                    store.get_episodic_list(limit=20)
+                    store.memory_stats()
+                    store._get_episodic(seeded_episodic_ids[i % len(seeded_episodic_ids)])
+                    store.get_rejection_stats()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=_writer, args=(40, "a")),
+            threading.Thread(target=_writer, args=(40, "b")),
+            threading.Thread(target=_reader, args=(30,)),
+            threading.Thread(target=_reader, args=(30,)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=120)
+        assert not any(t.is_alive() for t in threads), "stress threads deadlocked"
+        assert not errors, f"concurrent reader/writer stress raised: {errors!r}"
+
+        # Post-stress coherence: counts add up and a fresh read round-trips.
+        stats = store.memory_stats()
+        assert stats["semantic_active"] >= 90  # 10 seed + 2×40 stress writers
+        assert store.get_semantic("project.stress.a000") is not None
+
+
+class TestHandlerOffload1947:
+    """Async code must not call lock-serialized store methods inline on the
+    event loop.
+
+    #1947 made every plain fetch serialize on ``_db_lock``. A worker thread can
+    hold that lock for seconds (backfill's locked FAISS rebuild, reconcile's
+    bulk UPDATEs), so an async function that calls a locked method inline would
+    freeze the whole gateway event loop — chat, heartbeats, every request — for
+    the duration (GPT fork-review P1 on PR #1971). Async callers must offload
+    via ``asyncio.to_thread`` / ``run_in_executor`` / ``run_in_embed_pool``.
+
+    Both the method set and the caller set are DERIVED, not hand-listed
+    (design review on PR #1971 — a hand-maintained list re-introduces
+    enforcement-by-convention one level up): the methods come from
+    ``vector_memory.py``'s AST (public methods that reach
+    ``with self._db_lock:`` directly or transitively through other ``self``
+    calls), and the scan covers every module in the ``kiro_crew`` package.
+    """
+
+    #: Lock-reaching methods exempt from the inline-call scan. ``init`` is the
+    #: one-time lifecycle call made before the store is shared across threads
+    #: (startup paths call it inline by design), and its name collides with
+    #: unrelated ``.init()`` methods across the package.
+    _EXEMPT = {"init"}
+
+    @staticmethod
+    def _package_root() -> Path:
+        import kiro_crew
+
+        return Path(kiro_crew.__file__).resolve().parent
+
+    @classmethod
+    def _derive_locked_methods(cls) -> set[str]:
+        """Public ``VectorMemoryStore`` methods that acquire ``_db_lock``,
+        directly or transitively through other ``self`` method calls."""
+        import ast
+
+        source = (cls._package_root() / "vector_memory.py").read_text(encoding="utf-8")
+        klass = next(
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.ClassDef) and node.name == "VectorMemoryStore"
+        )
+
+        callees: dict[str, set[str]] = {}
+        direct: set[str] = set()
+        for node in klass.body:
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            called: set[str] = set()
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.withitem) and TestDbLockGuard._is_self_attr(
+                    sub.context_expr, "_db_lock"
+                ):
+                    direct.add(node.name)
+                if isinstance(sub, ast.Call):
+                    func = sub.func
+                    if (
+                        isinstance(func, ast.Attribute)
+                        and isinstance(func.value, ast.Name)
+                        and func.value.id == "self"
+                    ):
+                        called.add(func.attr)
+            callees[node.name] = called
+
+        # Fixpoint over the self-call graph: a method that calls a
+        # lock-reaching method is itself lock-reaching.
+        reaching = set(direct)
+        changed = True
+        while changed:
+            changed = False
+            for name, called in callees.items():
+                if name not in reaching and called & reaching:
+                    reaching.add(name)
+                    changed = True
+
+        return {name for name in reaching if not name.startswith("_")} - cls._EXEMPT
+
+    @classmethod
+    def _find_inline_calls(cls, tree, locked: set[str], label: str) -> list[str]:
+        """Violation string per inline call of a locked method inside an
+        ``async def``. Shared by the real guard and its seeded self-test."""
+        import ast
+
+        violations: list[str] = []
+
+        class Visitor(ast.NodeVisitor):
+            def __init__(self) -> None:
+                self.async_stack: list[str] = []
+
+            def visit_AsyncFunctionDef(self, node) -> None:
+                self.async_stack.append(node.name)
+                self.generic_visit(node)
+                self.async_stack.pop()
+
+            def visit_FunctionDef(self, node) -> None:
+                # A sync def's body runs wherever it is CALLED from; handlers
+                # that offload a sync helper (run_in_executor on
+                # _build_memory_graph) are the compliant pattern, so sync
+                # bodies are out of scope here.
+                saved, self.async_stack = self.async_stack, []
+                self.generic_visit(node)
+                self.async_stack = saved
+
+            def visit_Call(self, node: ast.Call) -> None:
+                func = node.func
+                # Direct attribute call: <expr>.<method>(...) — inline execution.
+                # Offloaded forms pass the method as an OBJECT
+                # (asyncio.to_thread(store.get_events, ...)), which is an
+                # Attribute argument, not a Call, so they do not match here.
+                if (
+                    self.async_stack
+                    and isinstance(func, ast.Attribute)
+                    and func.attr in locked
+                ):
+                    violations.append(
+                        f"{label} line {node.lineno} "
+                        f"(async {self.async_stack[-1]}): inline .{func.attr}() call — "
+                        "offload with asyncio.to_thread to keep a contended _db_lock "
+                        "from blocking the event loop"
+                    )
+                self.generic_visit(node)
+
+        Visitor().visit(tree)
+        return violations
+
+    def test_derived_method_set_is_sound(self) -> None:
+        """The derivation must stay non-vacuous: known lock-takers present
+        (direct AND transitive), known lock-free methods absent."""
+        locked = self._derive_locked_methods()
+        # Direct: write_episodic takes the lock in its own body. Transitive:
+        # build_faiss_index and delete_semantic reach it only through other
+        # self calls (get_all_semantic / get_semantic locked fetches).
+        assert {
+            "get_lessons",
+            "write_episodic",
+            "build_faiss_index",
+            "delete_semantic",
+            "memory_stats",
+        } <= locked
+        # Lock-free public methods must not be flagged, or the guard would
+        # force pointless offloads.
+        assert not {"embed_lesson", "validate_semantic", "close"} & locked
+        assert "init" not in locked  # exempt lifecycle call
+
+    def test_guard_catches_seeded_violation(self) -> None:
+        """The scanner must flag a known-bad inline call, so a visitor
+        regression cannot silently turn the guard vacuous."""
+        import ast
+        import textwrap
+
+        seeded = textwrap.dedent(
+            """
+            async def handler(store):
+                return store.get_lessons()
+
+            def sync_helper(store):
+                return store.get_lessons()  # sync def: out of scope
+
+            async def compliant(store):
+                import asyncio
+                return await asyncio.to_thread(store.get_lessons)
+            """
+        )
+        violations = self._find_inline_calls(
+            ast.parse(seeded), {"get_lessons"}, "<seeded>"
+        )
+        assert len(violations) == 1
+        assert "async handler" in violations[0]
+        assert ".get_lessons()" in violations[0]
+
+    def test_async_callers_offload_locked_methods(self) -> None:
+        import ast
+
+        locked = self._derive_locked_methods()
+        root = self._package_root()
+        violations: list[str] = []
+        for path in sorted(root.rglob("*.py")):
+            if path.name == "vector_memory.py":
+                continue  # the store may call its own methods inline
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            violations.extend(
+                self._find_inline_calls(tree, locked, str(path.relative_to(root)))
+            )
+        assert not violations, "\n".join(violations)


### PR DESCRIPTION
## Problem / Motivation

`VectorMemoryStore` shares one `check_same_thread=False` SQLite connection across the event loop, executor threads (context assembly via `run_in_embed_pool`), and worker threads (consolidation, dashboard handlers), with a documented contract that every statement serializes on `_db_lock`. That contract was enforced by convention only, and it failed twice: once in `_sqlite_vector_search` (fixed earlier with a locked fetch) and once in `get_semantic_context`/`get_lessons` (#1859, after a production `sqlite3.InterfaceError: bad parameter or other API misuse` killed a subagent run mid-context-build). The call-site audit in #1859 found ten more readers still executing unlocked on the shared connection: `get_semantic`, `get_all_semantic`, `search_semantic`, `get_events`, `get_episodic_list`, `memory_stats`, `_get_episodic`, `migrate_from_markdown`, `promote_episodic_patterns`, and `get_rejection_stats`. While implementing this I found two additional unlocked readers the audit missed: `build_faiss_index` and `_get_episodic_batch`.

Closes #1947.

## Why it matters

Any of these readers racing a writer's implicit transaction can corrupt the per-connection statement cache and raise the same `InterfaceError`, or silently corrupt row iteration. Most of them serve dashboard/API/CLI paths where the crash surfaces as a 500; the FAISS index-build path can additionally produce a corrupt index. Patching one crash site per production incident (which is how the last two fixes happened) leaves the recurrence pattern in place — the defect class needed retiring, not another spot fix.

## What changed (motivation → approach → change)

I took shape 1 from the issue (a locked fetch helper), which preserves the single-connection design and keeps the "never hold the lock across a blocking embed" invariant explicit in one place — per-thread connections (shape 2) would have changed transaction visibility semantics and still needed `_db_lock` for the FAISS index.

- Added two helpers next to the `db` property: `_fetch_all_locked(sql, params)` and `_fetch_one_locked(sql, params)`. Both take `_db_lock`, execute, and return materialized results, so callers never iterate a live cursor unlocked. The helper docstring block now carries the full serialization contract (previously spread across per-site comments).
- Routed every plain SELECT through the helpers: the twelve previously-unlocked readers above, plus the already-locked pure fetches (`get_semantic_context` both branches, `get_lessons`, `_sqlite_vector_search`, `has_episodic_text`, `_read_meta`, both backfill row scans, `_fts5_episodic_search`) so the file has one idiom for reads.
- Left explicit `with self._db_lock:` blocks only where they guard an atomic read-modify-write section (`set_semantic_if_absent`, `_write_semantic`, `rotate_events`, `write_episodic`, `_touch_last_accessed`, `reconcile_embedding_space`, backfill UPDATE loops, etc.). The Opus review pass verified no converted site lost atomicity it previously had, and that `_db_lock` being an `RLock` keeps the helpers safe when called under an already-held lock (`search_episodic` → `_get_episodic_batch`, backfill → `build_faiss_index`).
- Made the invariant mechanically verifiable, as the issue requested: a new AST guard test parses `vector_memory.py` and fails on any `self.db.execute/executemany/executescript` call outside a `with self._db_lock:` block (the helpers pass naturally), and on any raw `self._db` statement outside `init`/`close`. The guard resets lock scope at function boundaries, so a nested function defined under a lock but invoked later is still flagged.
- Kept the gateway event loop out of lock contention (raised by the fork GPT review on the first revision): now that these readers acquire `_db_lock`, an async dashboard handler calling one inline would block the event loop whenever a worker holds the lock — worst case the locked FAISS rebuild at the end of `backfill_missing_embeddings`, which would freeze chat and heartbeats for its whole duration. All seven inline call sites in `src/kiro_crew/dashboard/handlers/memory.py` (`get_all_semantic`, `get_events`, `get_episodic_list`, `memory_stats` ×2, `get_rejection_stats`, `search_episodic`, `get_semantic_context`) now offload via `await asyncio.to_thread(...)`, matching the module's existing pattern, as does the `_consolidate` coroutine in `src/kiro_crew/history.py` (flagged by the fork Design review — it called the newly locked `get_all_semantic` inline on the gateway loop), and — after the maintainer review pulled in the remaining sites — the four inline calls in `dashboard/handlers/cron.py` (`api_lessons`, `api_lessons_delete`: `get_lessons` ×2 + `delete_lesson`) and `slack/events.py` (`_publish_home_tab`: `get_lessons`). A second AST guard test makes any future inline locked-method call in an async function a CI failure — and per the Design review, nothing about it is hand-maintained: the locked-method set is derived from `vector_memory.py`'s AST (methods that reach `with self._db_lock:` directly or transitively through the self-call graph — which also caught six methods the earlier hand list missed), and the scan covers every module in the `kiro_crew` package instead of a hand-listed module tuple. The one exemption (`init`) is a documented lifecycle call made before the store is shared across threads.

**Residual scope:** none — the follow-up scope originally deferred to #1998 (the three remaining inline `get_lessons()` async call sites and the mechanical derivation of the guard's method set) was pulled into this PR at the maintainer's request.

## Tests

- `TestDbLockGuard::test_every_db_statement_is_lock_serialized` — the AST guard; makes a raw unlocked statement in `vector_memory.py` a CI failure instead of a code-review catch.
- `TestDbLockGuard::test_guard_catches_a_seeded_violation` — self-test on a seeded AST (plain violation, nested-def-under-lock, raw `self._db` bypass, and a correctly-locked negative), so a refactor that breaks the guard's traversal can't silently disarm it.
- `TestReaderConcurrency1947::test_previously_unlocked_readers_survive_concurrent_writes` — 2 writer threads (semantic + episodic + event-log writes) against 2 reader threads cycling all eight public previously-unlocked readers; readers must raise nothing, and post-stress counts must be coherent. Same shape as #1859's regression tests, in the same `xdist_group`.
- `TestHandlerOffload1947::test_async_callers_offload_locked_methods` — AST guard over the whole `kiro_crew` package: any inline call of a `_db_lock`-acquiring store method inside an async function fails CI, locking in the event-loop-safety fix above. The method set is derived from `vector_memory.py`'s AST (lock statements + fixpoint over the self-call graph), not hand-listed; `test_derived_method_set_is_sound` pins known direct/transitive lock-takers in and known lock-free methods out, and `test_guard_catches_seeded_violation` proves the scanner flags a seeded inline call (with sync defs and `to_thread` forms as negatives), so neither the derivation nor the visitor can silently go vacuous.
- `TestLockedFetchHelpers` (3 tests) — helpers return materialized rows, `fetch_one` hit/miss, and reentrancy under a held lock.

- Fixed two order-dependent tests in `test/test_slack_handler.py` (`TestToolElapsedTimer`) that faked `time.monotonic` with hardcoded call-count thresholds: this PR's added tests shifted the count-based pytest-split shard boundary, which exposed them as a deterministic failure on CI shard `Backend Tests (3.10, 4)`. They now use per-call advancing clocks, so they pass in any shard composition.

Full backend suite: 32,851 passed; the 21 failures are pre-existing environment failures (builtins app tests + 2 env-sensitive tests), verified unrelated by re-running them with this change stashed.

## Manual verification

N/A — the failure mode is a data race, which the deterministic AST guard plus the stress tests cover better than manual poking; no user-visible behavior changes.





