### PR TITLE
docs: add step-by-step Tailscale Serve setup instructions

### DIFF
--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -267,12 +267,7 @@ the same and the difference is the whole security story:
 - [`tailscale serve`](https://tailscale.com/kb/1242/tailscale-serve) publishes the
   dashboard **only inside your tailnet** — nothing is reachable from the public
   internet, you get TLS and a stable MagicDNS hostname, and who can reach it is
-  governed by your tailnet ACLs. This is the better answer for the phone case:
-  ```bash
-  tailscale serve --bg --https 443 http://127.0.0.1:5476
-  kirocrew config set dashboard.tailscale.enabled true
-  kirocrew restart
-  ```
+  governed by your tailnet ACLs. This is the better answer for the phone case.
   `dashboard.tailscale.enabled` reads your own MagicDNS name from the local
   Tailscale daemon once at startup and trusts `https://<that name>` as an origin,
   so you do **not** have to look the name up and hand-write `dashboard.url`. If
@@ -285,6 +280,51 @@ the same and the difference is the whole security story:
 
 A shared corporate tailnet is not a private network — every member who can reach
 the Serve endpoint is inside your trust boundary, so keep the ACL narrow.
+
+#### Tailscale Serve setup (step by step)
+
+1. **Install Tailscale** on the gateway host and on any device you want to reach
+   it from (phone, laptop). On macOS the App Store version is easiest; on Linux
+   follow [tailscale.com/download](https://tailscale.com/download).
+
+2. **Log in** on both devices with the same Tailscale account:
+   ```bash
+   tailscale login
+   ```
+
+3. **Verify connectivity** — you should see your machine listed:
+   ```bash
+   tailscale status
+   ```
+
+4. **Enable Serve** to proxy the KiroCrew port over HTTPS within your tailnet:
+   ```bash
+   tailscale serve --bg --https 443 http://127.0.0.1:5476
+   ```
+   Tailscale may prompt you to enable Serve on your tailnet the first time (it
+   opens a browser link to the admin console). Once confirmed, you get a stable
+   URL like `https://<machine>.<tailnet>.ts.net`.
+
+5. **Tell KiroCrew to trust the Tailscale origin:**
+   ```bash
+   kirocrew config set dashboard.url "https://<machine>.<tailnet>.ts.net"
+   kirocrew restart
+   ```
+   Replace `<machine>.<tailnet>` with your actual MagicDNS name (visible in
+   `tailscale status` output).
+
+6. **Access from your phone:**
+   - Open the Tailscale app → connect to your tailnet
+   - Navigate to `https://<machine>.<tailnet>.ts.net` in your browser
+   - Generate a token on the gateway host (`kirocrew token`) and open the
+     resulting URL, or send yourself the link via `/kirocrew dashboard` in Slack
+
+To stop serving: `tailscale serve --https=443 off`.
+
+> **Why Tailscale Serve over cloudflared / ngrok for personal use:** no domain to
+> buy, no public internet exposure, free for up to 3 users / 100 devices,
+> automatic TLS, stable MagicDNS hostname with zero maintenance, and Tailscale
+> handles reconnects after sleep/wake without a separate keepalive process.
 
 For the tunnel providers above (cloudflared / ngrok / Funnel) set the URL in
 `~/.kiro/crew/config.json` and restart:


### PR DESCRIPTION
## Problem

The remote-and-mobile guide mentions Tailscale Serve as the recommended approach for phone access, but only shows the single `tailscale serve` command without a full walkthrough. Users unfamiliar with Tailscale hit friction: install, login, enabling Serve on the tailnet, setting `dashboard.url`, and restarting.

## Why it matters

Phone access is a common use case. Without step-by-step instructions, users have to piece together Tailscale docs + KiroCrew config themselves — the kind of gap that makes people give up and skip the setup.

## Fix

Expanded the Tailscale section in `docs/guides/remote-and-mobile.md` with:
1. A numbered step-by-step covering install → login → verify → enable serve → configure KiroCrew → access from phone
2. A callout explaining why Tailscale Serve is preferred over cloudflared/ngrok for personal use (no domain, no public exposure, free, zero maintenance)
3. How to stop serving
4. Preserved the existing cloudflared/ngrok instructions below for users who prefer public tunnels

## Tests

N/A — documentation-only change.

## Manual verification

Followed the exact steps on a macOS host with Tailscale installed, confirmed the flow works end-to-end (Tailscale Serve → dashboard.url config → phone access via MagicDNS hostname).