### PR TITLE
fix(i18n): add the ja plural form that breaks catalog parity on main

### DIFF
--- a/website/src/i18n/locales/ja.json
+++ b/website/src/i18n/locales/ja.json
@@ -4572,7 +4572,8 @@
     "pastedChip": {
       "collapse_paste": "ペーストを折りたたむ",
       "expand_paste": "ペーストを展開",
-      "paste_lines_other": "[ ペースト #{{seq}} · {{count}} 行 ]"
+      "paste_lines_other": "[ ペースト #{{seq}} · {{count}} 行 ]",
+      "preview_more_lines_other": "… 他 {{count}} 行"
     },
     "privacyChapter": {
       "continue": "続行",


### PR DESCRIPTION
## Problem

`catalogParity.test.ts > catalog parity > ja > provides every plural form its
own language requires` fails on `main` itself:

```
missing 1 plural form(s) for categories [other],
e.g. components.pastedChip.preview_more_lines_other
```

Every PR branched off main inherits the red check, so the failure gets charged
to whoever opened the next PR rather than to the change that caused it.

## Why it matters

The plural gate is one of the few whole-repo checks allowed to BLOCK a PR (it is
a hard-zero gate, not a stored-count report), so this is not cosmetic — nothing
can go green until it is fixed. And the underlying user-visible bug is real: with
the key absent, i18next falls through to English, so a Japanese user reading a
collapsed paste chip sees "… 3 more lines" in the middle of a Japanese UI.

## Fix (symptom -> root cause -> change)

`components.pastedChip` gained `preview_more_lines_{one,other}` in
`en.manual.json`, and 9 of the 11 translated catalogs were updated with it —
`zh-CN`, `de`, `fr`, `es`, `ru`, `pt`, `it`, `hi` and `bn` all carry
`preview_more_lines_other`. Only `ja` was missed. Japanese has a single
`Intl.PluralRules` category (`other`), so exactly one key is missing.

Added `"preview_more_lines_other": "… 他 {{count}} 行"`, using ja.json's own
existing rendering of a line count (`paste_lines_other` already says
`{{count}} 行`) rather than inventing a new unit.

## Tests

No new test — `catalogParity.test.ts` is the test, and it already covers this
exact case per-language against that language's own `Intl.PluralRules`. It goes
from failing to passing (70/70 in that file).

## Manual verification

N/A -- the gate is the verification. Also confirmed `en-XA.json` already carried
the key (it is generated from English, which was never missing it), so
`gen-pseudolocale.mjs` is a no-op here and the file is untouched.

## Screenshots

N/A -- a catalog key with no layout change.

## Noted separately, NOT fixed here

`ja.json` contains **11 duplicate JSON keys** (`how_to_fix`, `copied`,
`copy_command`, `remedy_*`, ...), where a later object literally repeats an
earlier key. `JSON.parse` keeps the last occurrence, so the earlier copies are
dead weight that no reader ever sees — but they are also a trap for any tooling
that round-trips the catalog through a dict, which silently collapses them and
produces a large spurious diff. No other catalog has any. Left alone to keep
this fix a two-line unblock; worth its own cleanup.

