### PR TITLE
fix(dev-fleet): restart the macOS gateway with a domain-targeted launchctl kill

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/gateway_service.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/gateway_service.py
@@ -22,9 +22,10 @@ concern              systemd                                     launchd
 ===================  ==========================================  ==================================================
 manageable           ``systemctl --user cat <unit>`` rc == 0      ``launchctl print gui/<uid>/<label>`` rc == 0
 start identity       ``ExecMainStartTimestampMonotonic``          the job's PID (launchd exposes no monotonic stamp)
-detached restart     ``systemd-run --user --collect systemctl     ``launchctl stop <label>`` returns immediately;
-                     --user restart <unit>``                      ``KeepAlive`` respawns after graceful SIGTERM,
-                                                                  with ``ExitTimeOut`` as the SIGKILL ceiling
+detached restart     ``systemd-run --user --collect systemctl     ``launchctl kill TERM gui/<uid>/<label>`` returns
+                     --user restart <unit>``                      immediately; ``KeepAlive`` respawns after the
+                                                                  graceful SIGTERM, with ``ExitTimeOut`` as the
+                                                                  SIGKILL ceiling
 stage a new target   a drop-in overriding ExecStart,             atomically rewrite the ``live-gateway`` launcher
                      WorkingDirectory and PATH, then             script the agent's ProgramArguments executes
                      ``daemon-reload``
@@ -38,7 +39,7 @@ definition and never re-reads the file). ``bootout`` kills us, so the
 ``bootstrap`` half would never run: the gateway would stop and never come back.
 
 So the plist never changes. It points permanently at a generated launcher script
-and staging is an atomic rewrite of that script plus ``launchctl stop``.
+and staging is an atomic rewrite of that script plus a restart request.
 launchd owns the stop and respawn; rollback restores the previous script if the
 restart request is rejected.
 
@@ -334,9 +335,9 @@ class SystemdBackend:
 class LaunchdBackend:
     """``launchctl`` backend for the per-user gateway LaunchAgent.
 
-    Uses ``print`` for state and launchd's non-blocking ``stop`` transaction for
-    restart. ``unload`` + ``load`` is unsafe because unload can terminate the
-    process that would issue load.
+    Uses ``print`` for state and a domain-targeted ``kill TERM`` for the
+    non-blocking restart transaction. ``unload`` + ``load`` is unsafe because
+    unload can terminate the process that would issue load.
     """
 
     kind = "launchd"
@@ -451,7 +452,22 @@ class LaunchdBackend:
         return None if rc != 0 else self._parse_pid(out)
 
     async def restart_detached(self) -> tuple[bool, str]:
-        """Schedule a bounded graceful restart through launchd."""
+        """Schedule a bounded graceful restart through launchd.
+
+        Addresses the job by its ``gui/<uid>/<label>`` service target rather
+        than through launchctl's legacy label-only ``stop``. That is a hard
+        requirement, not a style preference: every Dev Fleet spawn is wrapped in
+        ``sandbox-exec`` (see ``server._run_cmd``), and launchd refuses the
+        legacy stop routine for a sandboxed caller with "Not privileged to stop
+        service." regardless of the seatbelt profile's contents. The
+        domain-targeted verbs are unaffected.
+
+        ``kill TERM`` — not ``kickstart -k`` — because the restart must stay
+        graceful: launchd delivers SIGTERM, the gateway runs its shutdown, and
+        ``KeepAlive`` respawns it, with ``ExitTimeOut`` bounding how long the
+        SIGTERM has before SIGKILL. This is safe to call from inside the process
+        being restarted, since launchd performs both the signal and the respawn.
+        """
         if not restart_contract_current(self.plist_path()):
             return False, (
                 "launchd agent restart contract is outdated; re-run "
@@ -466,9 +482,9 @@ class LaunchdBackend:
                 "`kirocrew service install`"
             )
         rc, _out, stderr = await self._run(
-            ["launchctl", "stop", self._label()], timeout=10
+            ["launchctl", "kill", "TERM", self.target()], timeout=10
         )
-        return (rc == 0, "" if rc == 0 else (stderr.strip()[:200] or "launchctl stop failed"))
+        return (rc == 0, "" if rc == 0 else (stderr.strip()[:200] or "launchctl kill failed"))
 
     # -- staging --
     def plan(self, worktree: Path, kcbin: Path) -> dict:

--- a/src/kiro_crew/service/common.py
+++ b/src/kiro_crew/service/common.py
@@ -23,7 +23,7 @@ def launchd_live_program() -> "os.PathLike[str]":
     only re-reads a plist on ``bootout`` + ``bootstrap`` (``kickstart`` restarts
     the in-memory job definition), and ``bootout`` kills the very process that
     would have to run the ``bootstrap``. The gateway would stop and never come
-    back. Rewriting THIS file plus ``launchctl stop`` leaves nothing for a dying
+    back. Rewriting THIS file plus a restart signal leaves nothing for a dying
     process to do.
 
     It is a generated launcher SCRIPT rather than a symlink to the binary

--- a/src/kiro_crew/service/macos.py
+++ b/src/kiro_crew/service/macos.py
@@ -2,9 +2,8 @@
 
 The plist lives at ``~/Library/LaunchAgents/dev.kirocrew.gateway.plist``
 and is loaded via ``launchctl load -w``. It keeps the gateway continuously
-running. Dev Fleet's ``launchctl stop`` restart is launchd-owned: SIGTERM first,
-then SIGKILL only after the finite ``ExitTimeOut`` if cooperative shutdown does
-not finish.
+running. Dev Fleet's restart is launchd-owned: SIGTERM first, then SIGKILL only
+after the finite ``ExitTimeOut`` if cooperative shutdown does not finish.
 """
 
 from __future__ import annotations
@@ -143,7 +142,7 @@ def loaded_restart_contract_current(printed: str) -> bool:
 
 
 def restart_contract_current(path: Path | None = None) -> bool:
-    """Return whether *path* has the expected ``launchctl stop`` contract."""
+    """Return whether *path* has the expected graceful-restart contract."""
     payload = _plist_payload(path or PLIST_PATH)
     if payload is None:
         return False
@@ -423,8 +422,9 @@ def is_active() -> bool:
 def stop() -> None:
     """Stop the agent without triggering its ``KeepAlive`` restart.
 
-    Dev Fleet restarts with ``launchctl stop``; operator stop unloads the job
-    from the current domain while leaving it enabled for the next login.
+    Dev Fleet restarts by signalling the job so ``KeepAlive`` respawns it;
+    operator stop unloads the job from the current domain while leaving it
+    enabled for the next login.
     """
     if PLIST_PATH.exists():
         _launchctl("unload", str(PLIST_PATH))

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -2534,7 +2534,14 @@ async def test_make_live_unsafe_path_returns_code(monkeypatch, tmp_path):
 
 @pytest.mark.asyncio
 async def test_restart_gateway_darwin_requests_graceful_stop(monkeypatch):
-    """macOS restart asks launchd for a bounded SIGTERM-first stop."""
+    """macOS restart asks launchd for a bounded SIGTERM-first stop.
+
+    Pinned as a DOMAIN-TARGETED ``kill TERM``, not launchctl's legacy label-only
+    ``stop``: Dev Fleet spawns every command inside ``sandbox-exec``, and launchd
+    refuses the legacy stop routine for a sandboxed caller ("Not privileged to
+    stop service.") whatever the seatbelt profile allows. A regression to the
+    legacy form makes Restart fail on every Mac, so the shape is asserted here.
+    """
     monkeypatch.setattr(mod, "sys", MagicMock(platform="darwin"))
     monkeypatch.setattr(
         mod, "shutil", MagicMock(which=MagicMock(return_value="/bin/launchctl"))
@@ -2561,8 +2568,15 @@ async def test_restart_gateway_darwin_requests_graceful_stop(monkeypatch):
     # The PID stands in for systemd's monotonic start stamp: it changes on every
     # respawn, which is the edge the frontend handshake waits for.
     assert res["start_id"] == "4242"
-    assert ["launchctl", "stop", mod._gateway_label()] in calls
+    # Addressed via the backend's own domain helper rather than a second copy of
+    # the uid logic (which would also break on Windows, where getuid is absent).
+    domain = mod.gateway_service.LaunchdBackend.domain()
+    assert ["launchctl", "kill", "TERM", f"{domain}/{mod._gateway_label()}"] in calls
+    # `kickstart -k` would restart it too, but as a hard kill rather than the
+    # graceful SIGTERM the ExitTimeOut budget is sized for.
     assert not any(c[:2] == ["launchctl", "kickstart"] for c in calls)
+    # The legacy verb is what the sandbox blocks — it must not reappear.
+    assert not any(c[:2] == ["launchctl", "stop"] for c in calls)
 
 
 @pytest.mark.asyncio
@@ -2587,7 +2601,7 @@ async def test_restart_gateway_darwin_refuses_stale_loaded_contract(monkeypatch)
     res = await mod._restart_gateway()
     assert res["ok"] is False
     assert "loaded launchd restart contract is outdated" in res["error"]
-    assert not any(c[:2] == ["launchctl", "stop"] for c in calls)
+    assert not any(c[:3] == ["launchctl", "kill", "TERM"] for c in calls)
 
 
 @pytest.mark.asyncio
@@ -2647,7 +2661,7 @@ async def test_make_live_darwin_writes_pointer_and_stops_agent(monkeypatch, tmp_
     import json as _json
     data = _json.loads(ptr_file.read_text())
     assert Path(data["checkout"]).resolve() == wt.resolve()
-    assert any(c[:2] == ["launchctl", "stop"] for c in calls)
+    assert any(c[:3] == ["launchctl", "kill", "TERM"] for c in calls)
     assert not any(c[:2] == ["launchctl", "kickstart"] for c in calls)
     assert not any("bootout" in c or "bootstrap" in c for c in calls)
 
@@ -2670,8 +2684,8 @@ async def test_make_live_darwin_rolls_back_pointer_on_restart_failure(
     async def fake_run_cmd(cmd, **kw):
         if cmd[:2] == ["launchctl", "print"]:
             return (0, "  pid = 99\n", "")
-        if cmd[:2] == ["launchctl", "stop"]:
-            return (1, "", "stop refused")
+        if cmd[:3] == ["launchctl", "kill", "TERM"]:
+            return (1, "", "restart refused")
         return (0, "", "")
 
     monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)


### PR DESCRIPTION
## Problem

Dev Fleet's **Restart** control fails on every Mac. Pressing it returns:

```
Not privileged to stop service.
```

The gateway is never restarted — the launchd job's `runs` counter does not
advance and its PID is unchanged. The message is launchd's own error string (it
lives in `/bin/launchctl`, not in this repository), so it surfaces to the user
verbatim with no indication of what to do about it.

## Why it matters

Restart, and the Make live cutover that depends on it, are the mechanism by
which a macOS developer applies a Pull + build. With this broken, the only way
to pick up new code is to leave the dashboard and run a `launchctl` command by
hand. The failure is unconditional on macOS, and the error text points at a
permissions problem the user does not have and cannot fix.

## Fix (symptoms → root cause → change)

`LaunchdBackend.restart_detached()` asked launchd for a graceful stop through
launchctl's **legacy, label-only** verb:

```python
["launchctl", "stop", self._label()]
```

Every Dev Fleet spawn is wrapped in `sandbox-exec` by `server._run_cmd`, and
launchd **refuses the legacy stop routine for a sandboxed caller** — independent
of what the seatbelt profile permits. The profile KiroCrew generates for this
tier is `(allow default)` and the call is still denied, so no profile change
could have fixed it. launchd's *domain-targeted* verbs are unaffected.

Measured against a throwaway LaunchAgent, wrapped in the same
`sandbox-exec -f <profile>` prefix `_run_cmd` builds, versus running plain:

| command | wrapped | plain |
|---|---|---|
| `stop <label>` (legacy) | **rc=1** `Not privileged to stop service.` | rc=0 |
| `print gui/<uid>/<label>` | rc=0 | rc=0 |
| `kickstart -k gui/<uid>/<label>` | rc=0 | rc=0 |
| `kill TERM gui/<uid>/<label>` | rc=0 | rc=0 |

That isolates the cause to the legacy verb's implicit domain resolution, not to
the sandbox profile, not to `KeepAlive` (all three KeepAlive shapes stop fine),
and not to the caller being a descendant of the job it is stopping (a child
stopping its own agent succeeds).

So the job is now addressed by its `gui/<uid>/<label>` service target, which the
backend already computes for `print` via `target()`:

```python
["launchctl", "kill", "TERM", self.target()]
```

`kill TERM` rather than `kickstart -k` because the restart must stay **graceful**:
launchd delivers SIGTERM, the gateway runs its cooperative shutdown, `KeepAlive`
respawns it, and `ExitTimeOut` bounds the window before SIGKILL — exactly the
contract the installed plist encodes and `restart_contract_current()` verifies.
`kickstart -k` would restart the job too, but as a hard kill that skips that
budget.

Three docstrings that named the old mechanism are corrected alongside the code so
the described contract matches what runs.

**Linux is not affected and is deliberately untouched.** Its backend drives a
`systemctl --user` unit (`kirocrew-gateway.service`), which exists only in a
session context — and that is the same context that supplies the session-bus
locators. Where those locators are absent, no such `--user` unit exists either,
and `status()` already reports `no_user_unit`, which is the correct answer rather
than a failure. Forwarding bus locators to `_run_cmd` to "fix" that would hand a
live user-bus address to every subprocess it spawns, including the ones running
worktree-controlled code — which `sandbox.py` documents as a sandbox-escape
vector.

## Tests

`test/test_dev_fleet_app.py`:

- `test_restart_gateway_darwin_requests_graceful_stop` — pins the emitted command
  to the domain-targeted `["launchctl", "kill", "TERM", "gui/<uid>/<label>"]`,
  built from the backend's own `domain()` helper rather than a second copy of the
  uid logic (which would break on Windows, where `getuid` is absent). It also
  keeps the existing negative assertion against `kickstart` and **adds one
  against the legacy `stop`** — that verb is what the sandbox blocks, so a
  regression to it must fail the suite rather than fail on users' machines.
- `test_restart_gateway_darwin_refuses_stale_loaded_contract` — still asserts that
  a stale loaded contract short-circuits before any restart is requested, now
  keyed on the new verb.
- `test_make_live_darwin_writes_pointer_and_stops_agent` and
  `test_make_live_darwin_rolls_back_pointer_on_restart_failure` — the macOS
  cutover's success and rollback paths, re-keyed so the rollback case still
  exercises a *rejected* restart request.

## Manual verification

The sandbox interaction cannot be reproduced by a unit test — the suite fakes
`_run_cmd`, so it can pin the command *shape* but never launchd's answer to it.
Verified directly on macOS 26.5.2 against throwaway LaunchAgents, never the live
gateway:

1. **Reproduced the failure**: built the wrapped argv through the real
   `sandboxed_spawn_argv(...)`, ran the legacy `stop` against a probe agent →
   `rc=1`, `Not privileged to stop service.`; the same command unwrapped → `rc=0`.
   Also dumped the generated profile and confirmed it is `(allow default)`.
2. **Verb matrix**: the table above, each verb wrapped and plain.
3. **Verified the fix end to end**: a probe agent with `KeepAlive=true` and a
   `TERM` trap, signalled by the sandbox-wrapped `kill TERM gui/<uid>/<label>` →
   `rc=0`, the trap fired (so the stop was a graceful SIGTERM, not SIGKILL), and
   launchd respawned the job under a new PID.

Local gates on the final commit: `isort` and `flake8` clean; `pytest` 31904
passed with 7 failures, all of which reproduce on a clean `origin/main` checkout
of this host (`KIROCREW_PORT` leakage per #1702, a test that assumes no launchd
agent is installed, macOS `sysctl`, and the wall-clock brand-gate timing test per
#1711). `mypy` reports 3 pre-existing macOS-only errors in `src/kiro_crew/hooks.py`
(`os.setxattr`), a file this PR does not touch. Frontend gates were not run
locally because the diff contains no frontend change.

Out of scope, tracked separately: `service.macos.restart()` (the
`kirocrew service restart` CLI path) still uses `kickstart -k`. It is not
sandboxed and so not affected by this bug; its hard-kill semantics are #1562.

## Behavior note: a loaded-but-not-running agent

The two verbs disagree on one edge, and the new one is the more honest of the
two. Measured on a loaded agent that had already exited (`RunAtLoad` +
`/usr/bin/true`, no `KeepAlive`, so it is registered with no live pid):

| verb | rc | stderr |
|---|---|---|
| `stop <label>` (old) | **0** | *(silent success)* |
| `kill TERM gui/<uid>/<label>` (new) | **3** | `No process to signal.` |

`stop` reported success for a restart that did not happen. `kill TERM` reports
the truth.

This is reachable only through the Make live cutover, whose
`can_restart = svc is not None and unit_status == "ok"`
(`src/kiro_crew/apps/builtins/dev_fleet/server.py`) does not require a live pid.
The consequence of the change there is that such a cutover now **refuses and
rolls the pointer back** (`restart_failed`) instead of leaving a new pointer
staged behind a restart it only claimed to have performed — the rollback path
already covered by
`test_make_live_darwin_rolls_back_pointer_on_restart_failure`.

The Restart button itself is unaffected either way: `_restart_gateway` gates on
`await svc.active()`, which requires a pid.
