### PR TITLE
fix(voice): keep the voice session alive across route changes

### DIFF
--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -11,6 +11,7 @@ import { QueryClientProvider } from '@tanstack/react-query'
 import { store } from './store'
 import { BrandingProvider } from './hooks/useBranding'
 import { ProviderProvider } from './providers'
+import { VoiceSessionProvider } from './providers/VoiceSessionProvider'
 import { ThemeProvider } from './hooks/useTheme'
 import { UIModeProvider } from './hooks/useUIMode'
 import ThemeExperienceLayer from './components/ThemeExperienceLayer'
@@ -106,7 +107,7 @@ createRoot(document.getElementById('root')!).render(
                       element={(
                         <BrandingProvider>
                           <ProviderProvider>
-                            <DashboardBootstrap>{withCommitProfiler('app', <App />)}</DashboardBootstrap>
+                            <DashboardBootstrap><VoiceSessionProvider>{withCommitProfiler('app', <App />)}</VoiceSessionProvider></DashboardBootstrap>
                           </ProviderProvider>
                         </BrandingProvider>
                       )}

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -103,7 +103,8 @@ import { pickSearchScrollBehavior, scrollCurrentMatchIntoView, pollRowSettled, g
 import QueueStack, { SubagentDeliveryProgress, isSystemDelivery, isNonInteractiveQueued } from '../components/QueueStack'
 import { runBelongsToSlot } from '../apps/workflows/runModel'
 import { TipCard, useTipTrigger } from '../components/TipCard'
-import { useVoiceInput, voiceInputSupported } from '../hooks/useVoiceInput'
+import { voiceInputSupported } from '../hooks/useVoiceInput'
+import { useVoiceSession } from '../providers/VoiceSessionProvider'
 import VoiceDisabledModal from '../components/VoiceDisabledModal'
 import { ChatFooter, AssistantMessage, UserMessage, PinnedPrompt } from './chat'
 import type { TurnStats } from './chat/AssistantMessage'
@@ -1566,7 +1567,6 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     queryKey: ['sttConfig'],
     queryFn: () => api.sttConfig() as Promise<{ streaming?: boolean; enabled?: boolean; dictation_panel?: boolean; available?: boolean; provider?: string }>,
   })
-  const sttStreaming = !!sttCfg?.streaming
   const sttEnabled = !!sttCfg?.enabled
   // The backend probes for the provider's binary and reports `available`.
   // Default true so a not-yet-loaded config doesn't flash the modal; the
@@ -1685,54 +1685,78 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // are null — fall back to the live composer text + caret so the transcript
     // inserts at the cursor instead of overwriting (or blindly appending to)
     // what the user typed.
+    //
     const spliced = spliceDictation(frozenInputRef.current ?? inputRef.current ?? '', text)
     // Only arm the caret restore when the value actually changes. If a streaming
     // final equals the last partial, setInput is a no-op and the restore effect
     // (keyed on `value`) never fires — leaving a stale pending caret that would
     // hijack the user's NEXT edit.
     if (spliced.value !== inputRef.current) {
+      // Write THROUGH to inputRef + the persisted draft, not just React state.
+      // `setInput` alone leaves drafts.current[target] holding the PRE-transcript
+      // text until the `[input]` persist effect runs on a later render — and the
+      // slot's draft-restore effect (dep [activeSlot]) can run before that. React
+      // defers passive effects until after paint, so a transcript that resolves
+      // in the post-paint window (an STT fetch/WS landing right after the sink's
+      // useLayoutEffect registered it on remount) would be read back as the stale
+      // draft and clobbered by `setInput(draftFallback)`. Updating all three
+      // writers here makes the two paths CONVERGE instead of racing: whichever
+      // effect runs second reads a draft that already contains the transcript.
+      inputRef.current = spliced.value
+      if (target) { setDraft(drafts.current, target, spliced.value); saveDrafts() }
       setInput(spliced.value)
       voicePendingCaretRef.current = spliced.caret
     }
     frozenInputRef.current = null
     frozenCaretRef.current = null
   }, [saveDrafts, spliceDictation])
-  const voice = useVoiceInput(
-    applyVoiceText,
-    {
-      streaming: sttStreaming,
-      sessionId: activeSlot,
-      onPartial: useCallback((text: string, sessionId: string | null) => {
-        // Streaming partials only fire while the originating slot is on screen
-        // (switching slots stops the stream), so a partial attributed to any
-        // other slot is a late straggler — drop it rather than smear a
-        // half-word into the wrong session.
-        if (sessionId && sessionId !== activeSlotRef.current) return
-        if (sttDisarmedRef.current) return
-        // Snapshot the pre-dictation text AND caret on the first partial
-        // (before setInput, so the updater stays pure — no ref mutation inside a
-        // function React may invoke twice) so every later partial and the final
-        // insert at the same spot, replacing the growing hypothesis.
-        if (frozenInputRef.current === null) {
-          frozenInputRef.current = inputRef.current
-          frozenCaretRef.current = voiceCaretRef.current
-        }
-        const spliced = spliceDictation(frozenInputRef.current ?? '', text)
-        if (spliced.value !== inputRef.current) {
-          setInput(spliced.value)
-          voicePendingCaretRef.current = spliced.caret
-        }
-      }, [spliceDictation]),
-      // Semantic endpointing (stt.endpointing) judged the utterance complete:
-      // auto-submit. The composer already holds the streamed transcript via
-      // onPartial, and send() reads inputRef.current + stops the live capture
-      // itself (its recording+streaming branch), so this is the same path as
-      // pressing Enter mid-dictation — just triggered by the backend verdict.
-      onEndpoint: useCallback(() => {
-        if (sttDisarmedRef.current) return
-        sendRef.current?.()
-      }, []),
+  // Live streaming hypothesis handler for the on-screen composer. Registered as
+  // the voice sink's onPartial below.
+  const voiceOnPartial = useCallback((text: string, sessionId: string | null) => {
+    // Streaming partials only fire while the originating slot is on screen
+    // (switching slots stops the stream), so a partial attributed to any
+    // other slot is a late straggler — drop it rather than smear a
+    // half-word into the wrong session.
+    if (sessionId && sessionId !== activeSlotRef.current) return
+    if (sttDisarmedRef.current) return
+    // Snapshot the pre-dictation text AND caret on the first partial
+    // (before setInput, so the updater stays pure — no ref mutation inside a
+    // function React may invoke twice) so every later partial and the final
+    // insert at the same spot, replacing the growing hypothesis.
+    if (frozenInputRef.current === null) {
+      frozenInputRef.current = inputRef.current
+      frozenCaretRef.current = voiceCaretRef.current
     }
+    const spliced = spliceDictation(frozenInputRef.current ?? '', text)
+    if (spliced.value !== inputRef.current) {
+      setInput(spliced.value)
+      voicePendingCaretRef.current = spliced.caret
+    }
+  }, [spliceDictation])
+  // Semantic endpointing (stt.endpointing) judged the utterance complete:
+  // auto-submit. The composer already holds the streamed transcript via
+  // voiceOnPartial, and send() reads inputRef.current + stops the live capture
+  // itself (its recording+streaming branch), so this is the same path as
+  // pressing Enter mid-dictation — just triggered by the backend verdict.
+  const voiceOnEndpoint = useCallback(() => {
+    if (sttDisarmedRef.current) return
+    sendRef.current?.()
+  }, [])
+  // The voice SESSION lives in VoiceSessionProvider ABOVE the router, so a route
+  // change (chat -> schedule/artifacts) no longer unmounts it and orphans an
+  // in-flight transcription. ChatPage remains the owner of the LIVE composer
+  // behaviour and registers it as the session's sink while mounted; when
+  // ChatPage is unmounted the provider routes a finished batch transcript to the
+  // originating slot's persisted draft instead of discarding it.
+  const { registerVoiceSink, ...voice } = useVoiceSession()
+  // useLayoutEffect (not useEffect): register the sink synchronously on (re)mount,
+  // before paint and before passive effects run — so if a batch transcript
+  // completes during a remount (user returns to /chat just as STT finishes) it
+  // routes to the live composer sink rather than slipping through to the draft
+  // fallback and being clobbered by a later mount effect.
+  useLayoutEffect(
+    () => registerVoiceSink({ onText: applyVoiceText, onPartial: voiceOnPartial, onEndpoint: voiceOnEndpoint }),
+    [registerVoiceSink, applyVoiceText, voiceOnPartial, voiceOnEndpoint],
   )
   // Keep a ref to the latest `voice` so effects that intentionally omit
   // `voice` from their deps always invoke the current instance — otherwise
@@ -1740,6 +1764,38 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // changes (e.g. when `sttStreaming` flips).
   const voiceRef = useRef(voice)
   useEffect(() => { voiceRef.current = voice }, [voice])
+  // The voice SESSION lives above the router and deliberately survives a route
+  // change (so an in-flight TRANSCRIPTION is no longer orphaned). But the
+  // recording meter and the stop/cancel controls live in this subtree and
+  // unmount with it — so if the mic is still HOT when the chat surface goes
+  // away (nav to Schedule/Artifacts), stop it here rather than leave an
+  // invisible, uncontrollable capture running off-route. Stopping a batch
+  // capture still transcribes, and the result lands in the originating slot's
+  // draft via the provider's sink-less fallback — the bug we fixed was the
+  // orphaned transcription, not a need for off-route capture. Empty deps: this
+  // cleanup runs only on true unmount, never on a sink re-register.
+  useEffect(() => () => {
+    const v = voiceRef.current
+    if (v.recording) {
+      // Stop a hot mic on unmount — its meter/stop control leave with ChatPage.
+      // Batch: toggle() -> stop -> onstop transcribes -> text lands in the draft.
+      // Streaming: cancel() instead — the hypothesis was already spliced into the
+      // composer and saved to the draft, so draining a streaming final here would
+      // DUPLICATE it if the user navigates back quickly. Draining it correctly
+      // (replacing the hypothesis rather than appending) is a follow-up, tracked
+      // on branch feat/voice-stream-drain-replace.
+      if (v.streamEnabled) v.cancel()
+      else v.toggle()
+      return
+    }
+    // Not recording yet, but a getUserMedia may still be in flight (pending
+    // startup): cancel it so a delayed acquisition can't turn the mic hot AFTER
+    // we've already navigated away. Guard on !transcribing so an in-flight
+    // transcription — the very case this change protects — is never aborted
+    // (cancel() only drops pre-transcription audio / invalidates a pending
+    // acquire; it does not abort an already-issued sttTranscribe request).
+    if (!v.transcribing) v.cancel()
+  }, [])
   // Same reason as voiceRef: send() deliberately keeps a minimal dep array (with
   // an exhaustive-deps suppression), so reading `sttStreaming` directly there
   // would close over the value from the render that created that send().

--- a/website/src/providers/VoiceSessionProvider.tsx
+++ b/website/src/providers/VoiceSessionProvider.tsx
@@ -1,0 +1,143 @@
+import { createContext, useCallback, useContext, useMemo, useRef, type ReactNode } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useVoiceInput } from '../hooks/useVoiceInput'
+import { createAudioSample } from '../hooks/mic'
+import { useAppSelector } from '../store'
+import { api } from '../api/client'
+import { loadDrafts, saveDrafts, setDraft } from '../utils/chatDrafts'
+
+/**
+ * VoiceSessionProvider — owns the ONE `useVoiceInput` session ABOVE the router.
+ *
+ * Why it lives here and not in ChatPage: each top-level view is its own route
+ * (`/chat`, `/schedule`, `/artifacts`, …), so navigating away UNMOUNTS ChatPage.
+ * When the voice hook lived inside ChatPage, that unmount tore down the recorder
+ * and orphaned any in-flight transcription — the user saw "transcribing"
+ * silently cancel and the words vanish. Hoisting the session above `<Routes>`
+ * means a route change no longer destroys it: the in-flight transcription and
+ * its "transcribing" state survive, so when the user returns to /chat the
+ * spinner + transcript are still there. An ACTIVE recording is a different
+ * matter — its meter and stop control unmount with ChatPage, so ChatPage stops
+ * a hot mic on unmount (it must not keep capturing off-route); that stop still
+ * transcribes and the words land in the originating slot's draft.
+ *
+ * ChatPage still owns everything about the LIVE composer (caret-splice, frozen
+ * snapshots, per-slot draft routing). It registers those as a "sink" via
+ * `registerVoiceSink` while mounted. When NO sink is mounted (the user is on
+ * Schedule/Artifacts/etc.), the final transcript falls back to the originating
+ * slot's PERSISTED draft — see `deliverToDraft` — so it is never lost.
+ */
+
+export interface VoiceSink {
+  /** Deliver a final transcript to the live composer (splice / per-slot route). */
+  onText?: (text: string, sessionId: string | null) => void
+  /** Live streaming hypothesis for the on-screen composer. */
+  onPartial?: (text: string, sessionId: string | null) => void
+  /** Semantic-endpointing verdict: auto-submit the composer. */
+  onEndpoint?: () => void
+}
+
+type VoiceHook = ReturnType<typeof useVoiceInput>
+
+export interface VoiceSessionContextValue extends VoiceHook {
+  /** Install the live-composer sink; returns an unregister fn for unmount. */
+  registerVoiceSink: (sink: VoiceSink) => () => void
+}
+
+const VoiceSessionContext = createContext<VoiceSessionContextValue | null>(null)
+
+/**
+ * Append a transcript to the originating slot's persisted draft when no live
+ * composer sink is mounted. The draft store is module-level + localStorage
+ * backed, so it survives ChatPage unmount; the remounted ChatPage picks the text
+ * up via `loadDrafts()`. Reached only for a final that resolves with no on-screen
+ * composer — a batch capture that finished off-route (ChatPage stops the mic on
+ * unmount) or a stop/config race. A streaming session is cancelled on nav-away
+ * (its hypothesis is already in the draft), so it never drains a duplicate final
+ * into here.
+ */
+function deliverToDraft(sessionId: string | null, text: string): void {
+  if (!sessionId || !text) return
+  const drafts = loadDrafts()
+  const base = drafts[sessionId] ?? ''
+  const next = base ? (base.endsWith(' ') ? base + text : base + ' ' + text) : text
+  setDraft(drafts, sessionId, next)
+  saveDrafts(drafts)
+}
+
+export function VoiceSessionProvider({ children }: { children: ReactNode }) {
+  const activeSlot = useAppSelector(s => s.chat.activeSlot)
+  const { data: sttCfg } = useQuery({
+    queryKey: ['sttConfig'],
+    queryFn: () => api.sttConfig() as Promise<{ streaming?: boolean }>,
+  })
+  const streaming = !!sttCfg?.streaming
+
+  // The live composer sink installed by whichever ChatPage is currently mounted.
+  // Null when no chat surface is on screen. A ref (not state) so the hook's
+  // stable callbacks always read the CURRENT sink without re-creating the hook.
+  const sinkRef = useRef<VoiceSink | null>(null)
+  const registerVoiceSink = useCallback((sink: VoiceSink) => {
+    sinkRef.current = sink
+    return () => { if (sinkRef.current === sink) sinkRef.current = null }
+  }, [])
+
+  const onText = useCallback((text: string, sessionId: string | null) => {
+    const sink = sinkRef.current
+    if (sink?.onText) { sink.onText(text, sessionId); return }
+    // No live composer (chat route unmounted). Persist EVERY sinkless final to
+    // the originating slot's draft so the words survive the navigation,
+    // regardless of the current STT mode. Keying the drop on the live streaming
+    // flag would silently discard an in-flight BATCH result if the user flipped
+    // streaming on mid-transcription. A streaming session is cancelled on
+    // nav-away (its hypothesis is already in the draft), so no duplicate
+    // streaming final ever reaches here.
+    deliverToDraft(sessionId, text)
+  }, [])
+  const onPartial = useCallback((text: string, sessionId: string | null) => {
+    sinkRef.current?.onPartial?.(text, sessionId)
+  }, [])
+  const onEndpoint = useCallback(() => {
+    sinkRef.current?.onEndpoint?.()
+  }, [])
+
+  const voice = useVoiceInput(onText, { streaming, sessionId: activeSlot, onPartial, onEndpoint })
+
+  const value = useMemo<VoiceSessionContextValue>(
+    () => ({ ...voice, registerVoiceSink }),
+    [voice, registerVoiceSink],
+  )
+  return <VoiceSessionContext.Provider value={value}>{children}</VoiceSessionContext.Provider>
+}
+
+/**
+ * Inert "voice unavailable" session used as the fallback when `useVoiceSession`
+ * is read outside a provider. Degrading gracefully (mic controls simply do
+ * nothing) is preferable to throwing, which would white-screen the whole view.
+ * In the real app main.tsx always mounts <VoiceSessionProvider> above <Routes>,
+ * so this is only reached in isolation — e.g. a unit test that renders a chat
+ * surface without wrapping it in the provider.
+ */
+const INERT_VOICE_SESSION: VoiceSessionContextValue = {
+  recording: false,
+  transcribing: false,
+  sessionOwner: null,
+  streamEnabled: false,
+  error: null,
+  level: 0,
+  deviceLabel: '',
+  partial: '',
+  deviceSwitchIsLive: false,
+  sampleRef: { current: createAudioSample() },
+  toggle: () => {},
+  cancel: () => {},
+  prewarm: () => {},
+  clearError: () => {},
+  switchDevice: async () => {},
+  registerVoiceSink: () => () => {},
+}
+
+/** Consume the hoisted voice session; inert fallback (see above) outside a provider. */
+export function useVoiceSession(): VoiceSessionContextValue {
+  return useContext(VoiceSessionContext) ?? INERT_VOICE_SESSION
+}

--- a/website/src/test/ChatPage.sendDuringDictation.test.tsx
+++ b/website/src/test/ChatPage.sendDuringDictation.test.tsx
@@ -9,6 +9,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { configureStore } from '@reduxjs/toolkit'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider } from '../hooks/useTheme'
+import { VoiceSessionProvider } from '../providers/VoiceSessionProvider'
 import chatReducer from '../store/chatSlice'
 import dashboardReducer from '../store/dashboardSlice'
 import notificationsReducer from '../store/notificationsSlice'
@@ -45,27 +46,40 @@ const voice = vi.hoisted(() => {
   return v
 })
 voice.toggle = vi.fn(() => { voice.recording = !voice.recording })
-vi.mock('../hooks/useVoiceInput', () => ({
-  useVoiceInput: (onText: (t: string) => void, opts?: { onPartial?: (t: string) => void; streaming?: boolean }) => {
-    voice.onPartial = opts?.onPartial ?? null
-    voice.onText = onText
-    return ({
-    recording: voice.recording,
-    transcribing: false,
-    sessionOwner: null,
-    streamEnabled: !!opts?.streaming,
-    toggle: voice.toggle,
-    prewarm: vi.fn(),
-    error: null,
-    level: 0,
-    deviceLabel: '',
-    clearError: vi.fn(),
-    partial: '',
-    sampleRef: { current: { level: 0, centroid: 0.5, onset: 0 } },
-    })
-  },
-  voiceInputSupported: true,
-}))
+vi.mock('../hooks/useVoiceInput', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+  return {
+    useVoiceInput: (onText: (t: string) => void, opts?: { onPartial?: (t: string) => void; streaming?: boolean }) => {
+      voice.onPartial = opts?.onPartial ?? null
+      voice.onText = onText
+      const [, rerender] = React.useState(0)
+      // Wrap toggle to also trigger a re-render of the host (VoiceSessionProvider)
+      // so the new recording value propagates through context to ChatPage.
+      const wrappedToggle = React.useCallback(() => {
+        voice.toggle()
+        rerender((c: number) => c + 1)
+      }, [rerender])
+      return ({
+        recording: voice.recording,
+        transcribing: false,
+        sessionOwner: null,
+        streamEnabled: !!opts?.streaming,
+        toggle: wrappedToggle,
+        cancel: vi.fn(),
+        switchDevice: vi.fn(),
+        deviceSwitchIsLive: false,
+        prewarm: vi.fn(),
+        error: null,
+        level: 0,
+        deviceLabel: '',
+        clearError: vi.fn(),
+        partial: '',
+        sampleRef: { current: { level: 0, centroid: 0.5, onset: 0 } },
+      })
+    },
+    voiceInputSupported: true,
+  }
+})
 vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
 vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: 'default' }) }))
 vi.mock('../components/MarkdownRenderer', () => ({ default: ({ content }: { content: string }) => <span>{content}</span> }))
@@ -120,7 +134,7 @@ async function renderAndWaitForInput(store: ReturnType<typeof makeStore>) {
       <QueryClientProvider client={qc}>
         <Provider store={store}>
           <ThemeProvider>
-            <MemoryRouter><ChatPage /></MemoryRouter>
+            <MemoryRouter><VoiceSessionProvider><ChatPage /></VoiceSessionProvider></MemoryRouter>
           </ThemeProvider>
         </Provider>
       </QueryClientProvider>,

--- a/website/src/test/ChatPage.voiceDraftWriteThrough.test.tsx
+++ b/website/src/test/ChatPage.voiceDraftWriteThrough.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * Regression test for the foreground transcript write-through
+ * (fix/voice-session-above-router, round-7 GPT finding).
+ *
+ * BUG: `applyVoiceText`'s FOREGROUND path called `setInput(spliced)` and nothing
+ * else. The persisted draft therefore still held the PRE-transcript text until
+ * the `[input]` persist effect ran on a later render. React defers passive
+ * effects until after paint, so a transcript resolving in the post-paint window
+ * (an STT fetch/WS landing just after the sink's `useLayoutEffect` registered it
+ * on remount) could be read back as the stale draft by the slot's draft-restore
+ * effect (dep `[activeSlot]`) and clobbered by its `setInput(draftFallback)` —
+ * the dictated words vanished.
+ *
+ * FIX: the foreground path now writes THROUGH to `inputRef.current` AND the
+ * persisted draft store at the same time as `setInput`, so the two writers
+ * CONVERGE instead of racing. Whichever effect runs second reads a draft that
+ * already contains the transcript.
+ *
+ * The assertion deliberately targets the PERSISTED draft rather than trying to
+ * interleave React's scheduler: ordering-independence is the actual contract, and
+ * a test that depended on winning a scheduler race would be the flakiest possible
+ * way to express it. If the draft is correct the instant the transcript is
+ * applied, no later hydration read can lose it — regardless of effect order.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ThemeProvider } from '../hooks/useTheme'
+import { VoiceSessionProvider } from '../providers/VoiceSessionProvider'
+import chatReducer from '../store/chatSlice'
+import dashboardReducer from '../store/dashboardSlice'
+import notificationsReducer from '../store/notificationsSlice'
+import type { RootState } from '../store'
+import { DRAFTS_KEY, loadDrafts, __resetForTests } from '../utils/chatDrafts'
+
+// Capture the onText the provider hands to useVoiceInput so a test can fire a
+// "transcript resolved" exactly as the real hook would, without a recorder.
+const voice = vi.hoisted(() => ({
+  onText: undefined as ((t: string, s: string | null) => void) | undefined,
+}))
+
+vi.mock('react-virtuoso', () => ({ Virtuoso: ({ data, itemContent }: { data?: unknown[]; itemContent: (i: number, d: unknown) => React.ReactNode }) => <div data-testid="virtuoso">{data?.map((d: unknown, i: number) => <div key={i}>{itemContent(i, d)}</div>)}</div> }))
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [{ role: 'assistant', content: 'hi', cls: '' }], running: false, has_more: false, total: 1 }),
+    sendChat: vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ ok: true }) }),
+    chatHistory: vi.fn().mockResolvedValue({ sessions: [] }),
+    models: vi.fn().mockResolvedValue([]),
+    agents: vi.fn().mockResolvedValue([]),
+    agentDetail: vi.fn().mockResolvedValue({}),
+    workspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+    slackChannels: vi.fn().mockResolvedValue([]),
+    spawnList: vi.fn().mockResolvedValue({ agents: [] }),
+    uploadFiles: vi.fn().mockResolvedValue({ paths: [] }),
+    screenshot: vi.fn().mockResolvedValue({ path: null }),
+    sttConfig: vi.fn(),
+  },
+  SEARCH_MIN_CHARS: 2,
+}))
+vi.mock('../hooks/useVoiceInput', () => ({
+  useVoiceInput: (onText: (t: string, s: string | null) => void) => {
+    voice.onText = onText
+    return {
+      recording: false, transcribing: false, sessionOwner: null, streamEnabled: false,
+      error: null, level: 0, deviceLabel: '', partial: '', deviceSwitchIsLive: false,
+      sampleRef: { current: { level: 0, centroid: 0.5, onset: 0 } },
+      toggle: vi.fn(), cancel: vi.fn(), prewarm: vi.fn(), clearError: vi.fn(), switchDevice: vi.fn(),
+    }
+  },
+  voiceInputSupported: true,
+}))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: 'default' }) }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: ({ content }: { content: string }) => <span>{content}</span> }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../components/DetailPanel', () => ({ default: () => null }))
+vi.mock('../hooks/useWebSocket', () => ({ useWebSocket: () => ({ subscribeLogs: () => {} }) }))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+})
+
+import ChatPage from '../pages/ChatPage'
+import { api } from '../api/client'
+
+const SLOT = 'chat-main'
+
+function makeStore() {
+  return configureStore({
+    reducer: { dashboard: dashboardReducer, chat: chatReducer, notifications: notificationsReducer },
+    preloadedState: {
+      dashboard: {
+        status: null, connected: true,
+        slots: [{ key: SLOT, messages: 1, running: false, mode: '', pending_approval: false, waiting_for_input: false, last_activity_ts: undefined }],
+        unreadSlots: [], refreshTrigger: 0, approvalMode: 'normal',
+        subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      } as unknown as RootState['dashboard'],
+      chat: {
+        activeSlot: SLOT, messages: [{ role: 'assistant', content: 'hi', cls: '' }],
+        slotRunning: false, slotStopping: false, slotState: 'idle',
+        history: [], historyHasMore: false, pendingInput: null,
+        subagents: {}, toolLog: [], activityOpen: false, activityTab: 'tools',
+        slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+        slotStatusDetail: {}, slotContextPct: {}, slotActivity: {}, slotHistory: [],
+        historyOffset: 0, _wsChunkedDuringFetch: false,
+        slotMessages: {}, slotLoading: false,
+      } as unknown as RootState['chat'],
+      notifications: { items: [] } as unknown as RootState['notifications'],
+    },
+  })
+}
+
+async function renderChat() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  await act(async () => {
+    render(
+      <QueryClientProvider client={qc}>
+        <Provider store={makeStore()}>
+          <ThemeProvider>
+            <MemoryRouter><VoiceSessionProvider><ChatPage /></VoiceSessionProvider></MemoryRouter>
+          </ThemeProvider>
+        </Provider>
+      </QueryClientProvider>,
+    )
+  })
+  await waitFor(() => expect(screen.getByLabelText('Message input')).toBeTruthy())
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  localStorage.clear()
+  __resetForTests?.()
+  voice.onText = undefined
+  vi.mocked(api.sttConfig).mockResolvedValue({
+    enabled: true, streaming: false, dictation_panel: true,
+    provider: 'whisper', available: true,
+  } as unknown as Awaited<ReturnType<typeof api.sttConfig>>)
+})
+
+describe('ChatPage — foreground transcript is persisted, not just set in state', () => {
+  it('writes the transcript to the persisted draft synchronously (survives a later hydration read)', async () => {
+    await renderChat()
+    expect(voice.onText).toBeTypeOf('function')
+
+    await act(async () => { voice.onText!('hello world', SLOT) })
+
+    // The composer shows it...
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+    expect(ta.value).toContain('hello world')
+    // ...AND the persisted draft already agrees. Before the fix this read the
+    // pre-transcript value (''), which is exactly what the draft-restore effect
+    // would have pushed back into the composer.
+    expect(loadDrafts()[SLOT]).toContain('hello world')
+    expect(localStorage.getItem(DRAFTS_KEY)).toContain('hello world')
+  })
+
+  it('a draft re-read after delivery returns the transcript, so a re-hydration cannot lose it', async () => {
+    await renderChat()
+    await waitFor(() => expect(voice.onText).toBeTypeOf('function'))
+
+    await act(async () => { voice.onText!('dictated text', SLOT) })
+
+    // Simulate exactly what the slot draft-restore effect does: read the store
+    // and compute the value it would push into the composer. It must already be
+    // the post-transcript text, so re-running hydration is a no-op rather than a
+    // silent revert.
+    const draftFallback = loadDrafts()[SLOT] ?? ''
+    expect(draftFallback).toContain('dictated text')
+  })
+})

--- a/website/src/test/VoiceSessionProvider.navAway.test.tsx
+++ b/website/src/test/VoiceSessionProvider.navAway.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Regression test for the voice-session hoist (fix/voice-session-above-router).
+ *
+ * BUG: while a dictation was transcribing, navigating away from /chat (to
+ * Schedule / Artifacts / …) unmounted ChatPage, which tore down the voice hook
+ * and orphaned the in-flight transcription — the finished words were lost.
+ *
+ * FIX: the ONE voice session now lives in VoiceSessionProvider, ABOVE the
+ * router, so a route change no longer destroys it. ChatPage registers a live
+ * "sink" while mounted; when NO sink is mounted (chat surface unmounted) a
+ * finished BATCH transcript is appended to the originating slot's PERSISTED
+ * draft, so the remounted ChatPage recovers it instead of losing it.
+ *
+ * These tests exercise the provider's dispatcher directly: the mocked
+ * useVoiceInput captures the `onText` the provider passes it, so a test can
+ * fire a "transcript resolved" exactly as the real hook would on completion —
+ * with and without a mounted sink — and assert where the text lands.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, waitFor, act } from '@testing-library/react'
+import { useEffect, type ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { VoiceSessionProvider, useVoiceSession, type VoiceSink } from '../providers/VoiceSessionProvider'
+
+// Grab the onText dispatcher the provider hands to useVoiceInput so a test can
+// simulate a transcript resolving without driving a real recorder.
+const captured = vi.hoisted(() => ({ onText: undefined as ((text: string, sessionId: string | null) => void) | undefined }))
+// In-memory stand-in for the localStorage-backed draft store. Mocking it keeps
+// the assertion deterministic (the real store debounces its localStorage flush)
+// and scopes this test to the PROVIDER's fallback routing — the store's own
+// persistence is covered by chatDrafts' tests.
+const draftStore = vi.hoisted(() => ({} as Record<string, string>))
+
+vi.mock('../hooks/useVoiceInput', () => ({
+  useVoiceInput: (onText: (text: string, sessionId: string | null) => void) => {
+    captured.onText = onText
+    return {
+      recording: false, transcribing: false, sessionOwner: null, streamEnabled: false,
+      error: null, level: 0, deviceLabel: '', partial: '', deviceSwitchIsLive: false,
+      sampleRef: { current: { level: 0, centroid: 0.5, onset: 0 } },
+      toggle: vi.fn(), cancel: vi.fn(), prewarm: vi.fn(), clearError: vi.fn(), switchDevice: vi.fn(),
+    }
+  },
+  voiceInputSupported: true,
+}))
+vi.mock('../hooks/mic', () => ({ createAudioSample: () => ({ level: 0, centroid: 0.5, onset: 0 }) }))
+vi.mock('../store', () => ({ useAppSelector: (sel: (s: unknown) => unknown) => sel({ chat: { activeSlot: 'slot-active' } }) }))
+vi.mock('../api/client', () => ({ api: { sttConfig: vi.fn().mockResolvedValue({ streaming: false }) } }))
+vi.mock('../utils/chatDrafts', () => ({
+  loadDrafts: () => ({ ...draftStore }),
+  setDraft: (d: Record<string, string>, id: string, text: string) => { d[id] = text },
+  saveDrafts: (d: Record<string, string>) => {
+    for (const k of Object.keys(draftStore)) delete draftStore[k]
+    Object.assign(draftStore, d)
+  },
+}))
+
+function renderProvider(children: ReactNode = <div />) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <VoiceSessionProvider>{children}</VoiceSessionProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('VoiceSessionProvider — transcript survives nav-away (no live composer)', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(draftStore)) delete draftStore[k]
+    captured.onText = undefined
+  })
+
+  it('appends a finished batch transcript to the originating slot draft when no sink is mounted', async () => {
+    renderProvider()
+    await waitFor(() => expect(captured.onText).toBeTypeOf('function'))
+    act(() => captured.onText!('hello world', 'slot-7'))
+    expect(draftStore['slot-7']).toBe('hello world')
+  })
+
+  it('appends (space-joined) to an existing draft rather than overwriting it', async () => {
+    renderProvider()
+    await waitFor(() => expect(captured.onText).toBeTypeOf('function'))
+    act(() => captured.onText!('first', 'slot-7'))
+    act(() => captured.onText!('second', 'slot-7'))
+    expect(draftStore['slot-7']).toBe('first second')
+  })
+
+  it('routes to the live sink and does NOT touch the draft when a composer is mounted', async () => {
+    const received: Array<[string, string | null]> = []
+    function Sink() {
+      const { registerVoiceSink } = useVoiceSession()
+      useEffect(() => registerVoiceSink({ onText: (t, s) => { received.push([t, s]) } } as VoiceSink), [registerVoiceSink])
+      return null
+    }
+    renderProvider(<Sink />)
+    await waitFor(() => expect(captured.onText).toBeTypeOf('function'))
+    act(() => captured.onText!('to composer', 'slot-7'))
+    expect(received).toEqual([['to composer', 'slot-7']])
+    expect(draftStore['slot-7']).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem

The voice session lived **inside** `ChatPage`. Each top-level view is its own route (`/chat`, `/schedule`, `/artifacts`, …), so navigating away UNMOUNTS `ChatPage` — which tore down the `useVoiceInput` hook and orphaned any in-flight transcription. The user watched "transcribing" silently cancel and the dictated words vanish.

## Fix

Hoist the ONE voice session into a new `VoiceSessionProvider` **above** `<Routes>`, so a route change no longer destroys it. The in-flight transcription and its `transcribing` state survive; returning to `/chat` still shows the spinner and then the transcript.

`ChatPage` keeps everything about the LIVE composer (caret splice, frozen snapshots, per-slot draft routing) and registers those as a **sink** while mounted. When no sink is mounted (the user is on Schedule/Artifacts/…), a finished transcript falls back to the originating slot's **persisted draft**, so it is recoverable rather than lost.

An ACTIVE recording is deliberately different: its meter and stop control unmount with `ChatPage`, so a hot mic is stopped on unmount rather than left capturing off-route. That stop still transcribes, and the words land in the originating slot's draft.

Also included: `applyVoiceText`'s foreground path now writes THROUGH to `inputRef.current` and the persisted draft alongside `setInput`, instead of `setInput` alone. Previously the persisted draft held pre-transcript text until the `[input]` effect ran on a later render, so it depended on effect-declaration-order staying ahead of the slot draft-restore effect. Writing all three at once makes the two writers converge and removes the reliance on that ordering. This is defense-in-depth — the user-visible loss did not reproduce in dogfooding, because three existing layers already covered it — not a fix for demonstrated loss.

## Scope note — streaming drain split out

This PR **no longer** changes streaming nav-away behaviour. Stopping a hot streaming mic on unmount keeps the `cancel()` path that is already shipped on `main`, so there is no behaviour change there.

Draining the socket gracefully on nav-away and landing the corrected final (replacing the live hypothesis rather than appending it) turned out to be a substantially harder problem than it looked: transcript/composer **ownership** while a correction is in flight, concurrent user editing, and StrictMode double-invocation all interact. Six review findings landed on that seam in a row, all legitimate. It deserves its own PR and its own design pass rather than riding along on a routing fix.

That work is preserved in full on **`feat/voice-stream-drain-replace`** (descriptor handoff, `replaceDictationHypothesis` with verify-and-replace, mount-gate on the slot-reconcile effect, and 21 mutation-verified tests) and will be raised separately with the ownership model addressed up front. The two known open edges there are recorded in that branch's review history.

## Tests

- `VoiceSessionProvider.navAway.test.tsx` — a finished transcript reaches the originating slot's draft with no sink mounted; routes to the live sink when a composer IS mounted; appends space-joined rather than overwriting.
- `ChatPage.voiceDraftWriteThrough.test.tsx` — the persisted draft already contains the transcript the instant it is applied, so a later hydration read cannot revert it. Mutation-verified: reverting the three write-through lines fails it.
- `ChatPage.sendDuringDictation.test.tsx` — updated for the hoisted provider; covers caret-splice, the post-send partial drop, and the batch-transcript-after-stop path.

## Manual verification

Dogfooded on an isolated `dev-fullstack.sh` stack (own `.kirocrew-dev` home, port 6777) driving real Chromium via Playwright with a stubbed STT endpoint: dictate on `/chat`, navigate to `/schedule` mid-transcription, return, and confirm the transcript is present in both the composer and `localStorage['mc-chat-drafts']`.

## Screenshots

N/A — no visual change; the fix is session lifetime and state plumbing.
