### PR TITLE
fix(meetings): poll while a start is initializing

### DIFF
--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/meeting_lifecycle.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/meeting_lifecycle.py
@@ -139,10 +139,24 @@ async def handle_get_meeting(request: web.Request) -> web.Response:
             {"error": "meeting not found", "code": "meeting_not_found"}, status=404
         )
     live = ACTIVE.get(meeting_id)
+    live_payload = None
+    if live is not None:
+        live_payload = live.status()
+        # Whether a dispatch sent NOW would be admitted, from the same holder flag
+        # ``get_for_dispatch`` reads. The status is persisted ``active`` before
+        # ``init_agents`` runs, so status alone overstates readiness for the whole
+        # initialization window (~tens of seconds) while every dispatch 409s. The
+        # frontend polls this endpoint to decide when to open the microphone, and
+        # this field is the only per-poll answer to "would speech land?" — the
+        # start response alone cannot be, because it can be lost in transit while
+        # the server side succeeded. Plain attribute read on the single-threaded
+        # loop, same as the ``ACTIVE.get`` above; the value is a snapshot and may
+        # change by the next poll, which is exactly what a poll is for.
+        live_payload["accepting_dispatches"] = ACTIVE.accepting_dispatches
     return web.json_response(
         {
             "meta": meta,
-            "live": live.status() if live is not None else None,
+            "live": live_payload,
         }
     )
 

--- a/test/test_meetings_routes.py
+++ b/test/test_meetings_routes.py
@@ -407,6 +407,30 @@ class TestMeetingLifecycleRoutes:
             assert body["live"] is None
 
     @pytest.mark.asyncio
+    async def test_get_meeting_reports_dispatch_admission(self, app, fake_sessions):
+        """The poll payload carries the same admission flag dispatch checks.
+
+        The frontend opens the microphone off this field, so it must track the
+        holder's ``accepting_dispatches`` — not merely whether a session is
+        installed. A completed start reports it open; suspending ingress (the
+        state the whole ~46s initialization window is in, and what reviewing
+        does) reports it closed while ``live`` itself is still present.
+        """
+        async with client_for(app) as client:
+            await _start(client)
+            body = await (await client.get(f"{BASE}/meetings/standup")).json()
+            assert body["live"] is not None
+            assert body["live"]["accepting_dispatches"] is True
+
+            # Ingress closed but session installed — what a poll observes while
+            # a start is mid-initialization, here reached via the same holder
+            # call the start handler uses.
+            _common.ACTIVE.suspend_dispatches(_common.ACTIVE.get("standup"))
+            body = await (await client.get(f"{BASE}/meetings/standup")).json()
+            assert body["live"] is not None
+            assert body["live"]["accepting_dispatches"] is False
+
+    @pytest.mark.asyncio
     async def test_delete_removes_the_meeting_and_all_outputs(self, app, root: Path):
         async with client_for(app) as client:
             await client.post(f"{BASE}/meetings/standup/init", json={"title": "Standup"})

--- a/website/src/apps/meetings/api.ts
+++ b/website/src/apps/meetings/api.ts
@@ -122,6 +122,10 @@ export interface LiveStatus {
   agents: Record<string, AgentQueueStatus>
   agents_paused: boolean
   expired: boolean
+  /** Whether a dispatch sent now would be admitted (transcript ingress open).
+   *  Present on the meeting poll (`GET /meetings/{id}`), whose consumer gates
+   *  the microphone on it; absent from the bare `/status` endpoint. */
+  accepting_dispatches?: boolean
 }
 
 export interface Task {

--- a/website/src/apps/meetings/hooks/useMeetingSession.ts
+++ b/website/src/apps/meetings/hooks/useMeetingSession.ts
@@ -28,6 +28,16 @@ import { useMeetingTranscription } from './useMeetingTranscription'
 const DEDUP_WINDOW_MS = 5000
 
 /**
+ * Poll cadence while a start is in flight.
+ *
+ * Deliberately faster than `poll_interval_active`: this window is short and the
+ * whole point is to notice `active` promptly, so the Live badge and the meeting
+ * controls come alive instead of looking dead. Not configurable, because it is
+ * not a steady-state cost — at most a handful of requests, once per start.
+ */
+const START_POLL_MS = 1000
+
+/**
  * Transcription failure code -> catalog key.
  *
  * FILE SCOPE, not inline in the handler that indexes it: `check-i18n-keys.mjs`
@@ -143,8 +153,81 @@ export const ALLOWED_TRANSITIONS: Record<MeetingStatus, MeetingStatus[]> = {
   ended: ['active'],
 }
 
+/**
+ * Poll cadence for a meeting's metadata query, or `false` for "do not poll".
+ *
+ * The `startInFlight` rule is the load-bearing one. `POST /start` does not answer
+ * until EVERY agent has been initialized, and that is a sequence of awaited agent
+ * dispatches — tens of seconds with the default roster (measured: ~46s for three).
+ * The meeting is already `active` on the server for almost all of that, because the
+ * status is persisted up front, BEFORE the dispatches begin. So the wait gates
+ * nothing except this client's knowledge of it.
+ *
+ * Without the rule that was enough to look like a broken button: polling is off
+ * while `idle`, so with no poll and no resolved mutation the UI sat on a stale
+ * `idle` for the whole initialization — Start greyed out (it is disabled while the
+ * mutation is pending), no Live badge, and, because the microphone is bound to
+ * `status`, no permission prompt and no capture at all. The only way through was a
+ * manual reload, whose fresh fetch saw `active` and brought the meeting to life.
+ * Users reasonably concluded that recording does not start without a reload.
+ *
+ * Checked LAST so a known status always wins: once a poll lands and `status` is
+ * `active`, the caller's configured cadence takes over and this rule goes quiet on
+ * its own.
+ */
+export function metaPollInterval(opts: {
+  status: MeetingStatus | undefined
+  startInFlight: boolean
+  activeMs?: number
+  idleMs?: number
+}): number | false {
+  const { status, startInFlight, activeMs, idleMs } = opts
+  if (status === 'active') return activeMs ?? 5000
+  if (status === 'paused' || status === 'reviewing') return idleMs ?? 30_000
+  if (startInFlight) return START_POLL_MS
+  return false
+}
+
 export function canTransition(from: MeetingStatus, to: MeetingStatus): boolean {
   return ALLOWED_TRANSITIONS[from]?.includes(to) ?? false
+}
+
+/**
+ * Whether the microphone may open for an `active` meeting.
+ *
+ * `status === 'active'` alone is NOT dispatch readiness. `POST /start` persists
+ * `active` up front and then initializes agents with transcript ingress
+ * SUSPENDED — every dispatch in that window is rejected with a 409
+ * (`no_active_meeting`, see the backend's `get_for_dispatch`). The fast start
+ * poll exists to observe `active` early, so without a readiness gate it opened
+ * the microphone tens of seconds before ingress: early finals burned through
+ * the short dispatch retry schedule (~4.6s) against a ~46s initialization and
+ * were PERMANENTLY lost from the notes and tasks.
+ *
+ * `ingressReady` is the server's own admission flag, `accepting_dispatches`,
+ * reported on every meta poll — the same holder flag the dispatch endpoint
+ * itself checks. Gating on the POLLED value rather than on the start
+ * mutation's lifecycle makes every client-side inference hole unreachable at
+ * once, because the mutation's outcome is not evidence about ingress in either
+ * direction: an error settlement can hide a server-side success (the ~46s
+ * request is exactly the shape a proxy timeout kills), and a success response
+ * can be lost in transit. With the polled flag, the mic simply follows what
+ * the server reports: closed while initialization holds ingress shut, open on
+ * the first poll after `resume_dispatches` — whatever became of the start
+ * request itself. A reload or a second tab lands on the same rule, which also
+ * closes the pre-existing hole where a tab that never started the meeting
+ * opened its mic mid-initialization.
+ *
+ * The Live badge and controls still key off `status` and appear within ~1s of
+ * Start; only capture waits for the server to report ingress open.
+ */
+export function canOpenTranscription(opts: {
+  status: MeetingStatus
+  ingressReady: boolean
+  transcriptFull: boolean
+}): boolean {
+  const { status, ingressReady, transcriptFull } = opts
+  return status === 'active' && ingressReady && !transcriptFull
 }
 
 interface Options {
@@ -190,21 +273,36 @@ export function useMeetingSession({ eventId, fallbackTitle, config, notify }: Op
     retry: 1,
   })
 
+  // Whether a start is waiting on the server. Drives the poll that lets the UI see
+  // `active` while `POST /start` is still initializing agents — see
+  // `metaPollInterval`, which explains why that wait is long and why it matters.
+  // The MICROPHONE deliberately does not key off this flag: it follows the polled
+  // `live.accepting_dispatches` instead (see `canOpenTranscription`), so the
+  // mutation's fate — settled, failed, or its response lost in transit — cannot
+  // wedge capture in either direction.
+  const [startInFlight, setStartInFlight] = useState(false)
+
   const metaQuery = useQuery({
     queryKey: [...scope, 'meta'],
     queryFn: () => meetingsApi.meeting(meetingId),
     enabled: initQuery.isSuccess,
-    refetchInterval: query => {
-      const status = query.state.data?.meta?.status
-      if (status === 'active') return config?.poll_interval_active ?? 5000
-      if (status === 'paused' || status === 'reviewing') return config?.poll_interval_idle ?? 30_000
-      return false
-    },
+    refetchInterval: query =>
+      metaPollInterval({
+        status: query.state.data?.meta?.status,
+        startInFlight,
+        activeMs: config?.poll_interval_active,
+        idleMs: config?.poll_interval_idle,
+      }),
   })
 
   const meta: MeetingMeta | undefined = metaQuery.data?.meta
   const status: MeetingStatus = meta?.status ?? 'idle'
   const live = metaQuery.data?.live ?? null
+  // The server's own dispatch-admission flag, straight off the poll. `=== true`
+  // rather than truthy-or-default: a missing `live` (no session installed — a
+  // gateway restart left the meeting `active` on disk with nothing live) means a
+  // dispatch CANNOT land, so unknown must read as not-ready.
+  const ingressReady = live?.accepting_dispatches === true
 
   const outputsQuery = useQuery({
     queryKey: [...scope, 'outputs'],
@@ -345,7 +443,9 @@ export function useMeetingSession({ eventId, fallbackTitle, config, notify }: Op
     onError: onTranscriptionError,
   })
 
-  // Bind the microphone to the meeting's status: recording exactly while active.
+  // Bind the microphone to the meeting's status: recording exactly while active
+  // AND dispatch-ready — see `canOpenTranscription` for why `active` alone is not
+  // enough while a start is still initializing agents.
   //
   // Keyed on `transcription.active` as WELL as `status`. Keying on `status` alone
   // made the binding one-directional: if the socket dropped while the meeting was
@@ -363,13 +463,14 @@ export function useMeetingSession({ eventId, fallbackTitle, config, notify }: Op
   transcriptionRef.current = transcription
   const transcriptionActive = transcription.active
   useEffect(() => {
-    if (status === 'active' && !transcriptFull && !transcriptionRef.current.active) {
+    const mayOpen = canOpenTranscription({ status, ingressReady, transcriptFull })
+    if (mayOpen && !transcriptionRef.current.active) {
       void transcriptionRef.current.start()
     }
-    if ((status !== 'active' || transcriptFull) && transcriptionRef.current.active) {
+    if (!mayOpen && transcriptionRef.current.active) {
       transcriptionRef.current.stop()
     }
-  }, [status, transcriptFull, transcriptionActive])
+  }, [status, ingressReady, transcriptFull, transcriptionActive])
 
   // ── mutations ─────────────────────────────────────────────────────────────
 
@@ -406,6 +507,15 @@ export function useMeetingSession({ eventId, fallbackTitle, config, notify }: Op
         muted_agents: mutedAgents,
         restart: opts.restart,
       }),
+    // Opens the polling window BEFORE the request goes out, so the status is
+    // observable for the entire time the server spends initializing agents.
+    onMutate: () => setStartInFlight(true),
+    // `onSettled`, not `onSuccess`: a start that 409s or fails must close the window
+    // too, or a meeting that never started would be polled forever. This flag only
+    // drives poll cadence — the microphone follows the polled
+    // `live.accepting_dispatches`, so nothing here needs to reason about whether an
+    // outcome reflects the server's true state.
+    onSettled: () => setStartInFlight(false),
     onSuccess: () => {
       notify(i18nT('apps.meetings.session.started'), { type: 'success' })
       invalidate()

--- a/website/src/test/MeetingsSessionLogic.test.ts
+++ b/website/src/test/MeetingsSessionLogic.test.ts
@@ -8,9 +8,11 @@ import { describe, it, expect } from 'vitest'
 
 import {
   ALLOWED_TRANSITIONS,
+  canOpenTranscription,
   canTransition,
   isDuplicateSegment,
   mergeTranscriptSegments,
+  metaPollInterval,
   newSegmentText,
   reconcileTranscriptPage,
   resolveEnabledAgents,
@@ -629,5 +631,123 @@ describe('the live caption shows the newest speech, not the meeting opening', ()
   it('bounds the browser-only final segment buffer', () => {
     expect(CAPTION_FINALS_LIMIT).toBeGreaterThan(1)
     expect(TranscriptionSource).toContain('finalsRef.current.splice(')
+  })
+})
+
+describe('the meeting is polled while a start is still initializing agents', () => {
+  // `POST /start` awaits one dispatch per agent before it answers, so it can take
+  // tens of seconds, while the server persists `active` up front. Without a poll in
+  // that window the UI held a stale `idle`: Start disabled, no Live badge, and no
+  // microphone — the mic is bound to `status` — so recording appeared not to start
+  // until the user reloaded by hand.
+
+  it('polls on a short cadence while the start is in flight', () => {
+    expect(metaPollInterval({ status: 'idle', startInFlight: true })).toBe(1000)
+    // `undefined` is the same situation: meta has not arrived, nothing says active.
+    expect(metaPollInterval({ status: undefined, startInFlight: true })).toBe(1000)
+  })
+
+  it('does not poll an idle meeting that nobody is starting', () => {
+    expect(metaPollInterval({ status: 'idle', startInFlight: false })).toBe(false)
+    expect(metaPollInterval({ status: 'ended', startInFlight: false })).toBe(false)
+  })
+
+  it('hands back to the configured cadence as soon as a status is known', () => {
+    // The start rule is checked last, so a landed poll ends the fast window even
+    // while the mutation is still pending — that is what makes it self-limiting.
+    expect(metaPollInterval({ status: 'active', startInFlight: true, activeMs: 5000 })).toBe(5000)
+    expect(metaPollInterval({ status: 'paused', startInFlight: true, idleMs: 30_000 })).toBe(30_000)
+    expect(metaPollInterval({ status: 'reviewing', startInFlight: true, idleMs: 30_000 })).toBe(30_000)
+  })
+
+  it('falls back to the shipped defaults when the config has not loaded', () => {
+    expect(metaPollInterval({ status: 'active', startInFlight: false })).toBe(5000)
+    expect(metaPollInterval({ status: 'reviewing', startInFlight: false })).toBe(30_000)
+  })
+
+  it('respects a configured cadence over the defaults', () => {
+    expect(metaPollInterval({ status: 'active', startInFlight: false, activeMs: 250 })).toBe(250)
+    expect(metaPollInterval({ status: 'paused', startInFlight: false, idleMs: 60_000 })).toBe(60_000)
+  })
+
+  it('opens the window before the request and closes it however the start ends', () => {
+    // Guards the wiring, not the rule: a window opened in `onSuccess` would miss the
+    // wait entirely, and one closed there would poll a failed start forever.
+    const startCall = SessionSource.match(/const startMutation[\s\S]*?\n  \}\)/)
+    expect(startCall, 'no startMutation found').not.toBeNull()
+    const mutateBlock = startCall![0].slice(
+      startCall![0].indexOf('onMutate:'),
+      startCall![0].indexOf('onSettled:'),
+    )
+    expect(mutateBlock).toContain('setStartInFlight(true)')
+    expect(startCall![0]).toContain('onSettled: () => setStartInFlight(false)')
+  })
+
+  it('feeds the query from the shared rule rather than an inline copy', () => {
+    expect(SessionSource).toContain('refetchInterval: query =>')
+    expect(SessionSource).toContain('metaPollInterval({')
+  })
+})
+
+describe('the microphone waits for transcript ingress, not just for `active`', () => {
+  // `POST /start` persists `active` up front and then initializes agents with
+  // transcript ingress SUSPENDED — every dispatch in that window 409s. The fast
+  // start poll observes `active` within ~1s of Start, so binding the microphone
+  // to `status` alone opened it tens of seconds before ingress: early finals
+  // exhausted the short dispatch retry schedule and were permanently lost from
+  // the notes and tasks. The gate follows the server's own admission flag,
+  // `live.accepting_dispatches`, reported on every meta poll — client-side
+  // inference from the start mutation's outcome cannot be trusted in either
+  // direction (an error can hide a server-side success; a success response can
+  // be lost in transit).
+
+  it('keeps the mic closed while the poll sees `active` but ingress is not open', () => {
+    expect(canOpenTranscription({
+      status: 'active', ingressReady: false, transcriptFull: false,
+    })).toBe(false)
+  })
+
+  it('opens the mic once the poll reports ingress open on an active meeting', () => {
+    expect(canOpenTranscription({
+      status: 'active', ingressReady: true, transcriptFull: false,
+    })).toBe(true)
+  })
+
+  it('never opens the mic for a meeting that is not active, ingress or not', () => {
+    for (const status of ['idle', 'paused', 'reviewing', 'ended'] as const) {
+      expect(canOpenTranscription({ status, ingressReady: true, transcriptFull: false })).toBe(false)
+      expect(canOpenTranscription({ status, ingressReady: false, transcriptFull: false })).toBe(false)
+    }
+  })
+
+  it('a full transcript keeps the mic closed regardless of readiness', () => {
+    expect(canOpenTranscription({
+      status: 'active', ingressReady: true, transcriptFull: true,
+    })).toBe(false)
+  })
+
+  it('the status binding actually consults the readiness rule', () => {
+    // Guards the wiring: the effect must gate BOTH the open and the close branch on
+    // the shared rule, so a poll reporting ingress open flips the mic on without a
+    // status change and a fast poll observing `active` early cannot race one on.
+    const binding = SessionSource.match(/const mayOpen = canOpenTranscription\(\{[\s\S]*?\n  \}, \[status, ingressReady, transcriptFull, transcriptionActive\]\)/)
+    expect(binding, 'status binding no longer gates on canOpenTranscription').not.toBeNull()
+    expect(binding![0]).toContain('if (mayOpen && !transcriptionRef.current.active)')
+    expect(binding![0]).toContain('if (!mayOpen && transcriptionRef.current.active)')
+  })
+
+  it('readiness comes from the POLLED server flag, and unknown reads as not-ready', () => {
+    // Guards the two properties that make the whole failure class unreachable:
+    // (1) the gate's input is the server's own admission flag off the poll — not
+    // client-side inference from the start mutation's lifecycle, which round-trips
+    // through outcomes that can misrepresent the server (lost success, ambiguous
+    // error); (2) strict `=== true`, so a null `live` (meeting `active` on disk
+    // with no session installed) keeps the mic closed rather than dispatching
+    // into guaranteed 409s.
+    expect(SessionSource).toContain('live?.accepting_dispatches === true')
+    // And the mutation callbacks do not manipulate any mic gate.
+    const startCall = SessionSource.match(/const startMutation[\s\S]*?\n  \}\)/)
+    expect(startCall, 'no startMutation found').not.toBeNull()
+    expect(startCall![0]).not.toContain('Ingress')
   })
 })

--- a/website/src/test/UseMeetingSessionCoverage.test.tsx
+++ b/website/src/test/UseMeetingSessionCoverage.test.tsx
@@ -304,12 +304,40 @@ describe('useMeetingSession preset selection', () => {
 })
 
 describe('useMeetingSession transcription binding', () => {
-  it('starts the microphone when the meeting is active', async () => {
-    apiMocks.meeting.mockResolvedValue({ meta: meta({ status: 'active' }), live: null })
+  it('starts the microphone when the meeting is active and ingress is open', async () => {
+    apiMocks.meeting.mockResolvedValue({
+      meta: meta({ status: 'active' }),
+      live: { accepting_dispatches: true },
+    })
     await mountLoaded()
 
     await waitFor(() => expect(stt.start).toHaveBeenCalled())
     expect(stt.stop).not.toHaveBeenCalled()
+  })
+
+  it('keeps the microphone closed while the server holds ingress shut', async () => {
+    // `POST /start` persists `active` before initializing agents, and every
+    // dispatch in that window 409s — the poll says so via
+    // `accepting_dispatches: false`, and the mic must believe it or early
+    // finals burn the retry schedule and are lost.
+    apiMocks.meeting.mockResolvedValue({
+      meta: meta({ status: 'active' }),
+      live: { accepting_dispatches: false },
+    })
+    const view = await mountLoaded()
+    await waitFor(() => expect(view.result.current.status).toBe('active'))
+
+    expect(stt.start).not.toHaveBeenCalled()
+  })
+
+  it('keeps the microphone closed when the meeting is active with no live session', async () => {
+    // `active` on disk with `live: null` (a gateway restart dropped the
+    // session) means a dispatch CANNOT land; unknown must read as not-ready.
+    apiMocks.meeting.mockResolvedValue({ meta: meta({ status: 'active' }), live: null })
+    const view = await mountLoaded()
+    await waitFor(() => expect(view.result.current.status).toBe('active'))
+
+    expect(stt.start).not.toHaveBeenCalled()
   })
 
   it('stops the microphone when the meeting is not active', async () => {
@@ -323,7 +351,10 @@ describe('useMeetingSession transcription binding', () => {
 
   it('restarts a socket that dropped while the meeting stayed active', async () => {
     stt.active = true
-    apiMocks.meeting.mockResolvedValue({ meta: meta({ status: 'active' }), live: null })
+    apiMocks.meeting.mockResolvedValue({
+      meta: meta({ status: 'active' }),
+      live: { accepting_dispatches: true },
+    })
     const view = await mountLoaded()
     await waitFor(() => expect(view.result.current.status).toBe('active'))
     expect(stt.start).not.toHaveBeenCalled()


### PR DESCRIPTION
## Problem / Motivation

Pressing **Start** on a meeting appeared to do nothing for tens of seconds, and
recording only began after a manual page reload.

Nothing in the UI moved: Start stayed greyed out, no Live badge appeared, and the
microphone permission prompt never fired — so even waiting it out produced a
meeting with no audio. Reloading the page was the only way through.

## Why it matters

Start is the app's entry point; it is the first thing anyone does with a meeting.
It fails in the shape that reads as "broken" rather than "slow" — no spinner, no
state change, no feedback of any kind — and the recovery (reload the page) is not
discoverable.

Worse than a cosmetic delay: because microphone acquisition is bound to the
meeting's `status`, a user who patiently waited still got nothing captured. The
feature looks like it ran and silently recorded no audio.

## What changed (motivation → approach → change)

**Root cause,** in four steps that are each individually reasonable:

- `POST /start` does not answer until every agent has been initialized, and that
  is a sequence of awaited agent dispatches — measured at ~46s for the default
  three-agent roster.
- The meeting is already `active` on the server for almost all of that window,
  because the status is persisted up front, before the dispatches begin. **So the
  wait gated nothing except the client's knowledge of it.**
- The metadata query does not poll while `idle`. With no poll and no resolved
  mutation, the UI held a stale `idle` for the whole initialization.
- Hence all three symptoms at once: Start is disabled while the mutation is
  pending, the Live badge is driven by `status`, and the microphone is bound to
  `status` too — so the permission prompt never fired. A reload worked only
  because its fresh fetch saw `active`.

**The change.** Poll on a short cadence while a start is in flight. The window
opens in `onMutate`, so it covers the entire server-side wait, and closes in
`onSettled`, so a start that 409s or fails is not polled forever.

The rule is checked *after* the known-status branches, which makes it
self-limiting: the first poll that lands moves `status` to `active` and the
configured cadence takes over. An idle meeting nobody is starting still costs no
requests.

```ts
if (status === 'active') return activeMs ?? 5000
if (status === 'paused' || status === 'reviewing') return idleMs ?? 30_000
if (startInFlight) return START_POLL_MS
return false
```

`START_POLL_MS` is 1000 — deliberately faster than `poll_interval_active`, because
this window is short and the whole point is to notice `active` promptly. It is not
configurable: it is not a steady-state cost, at most a handful of requests once per
start.

**The microphone does NOT open on the polled `active` alone.** During
initialization the server keeps transcript ingress suspended (`get_for_dispatch`
answers 409 until `resume_dispatches` runs), so a mic opened as soon as the fast
poll observed `active` would dispatch early finals into 409s until the short
retry schedule (~4.6s) was exhausted — permanently losing that speech from the
notes and tasks. The meeting poll now carries the server's own dispatch-admission
flag (`live.accepting_dispatches`, the same holder flag the dispatch endpoint
checks), and the status→microphone binding is gated on that **polled** value via
`canOpenTranscription`. Inferring readiness from the start mutation's outcome is
unsound in both directions — an error settlement can hide a server-side success
(a ~46s request is exactly what a proxy timeout kills), and a success response
can be lost in transit, wedging the mic closed on a live meeting. The polled flag
has neither hole: the mic is closed while initialization holds ingress shut, and
opens on the first poll after the server resumes dispatches, whatever became of
the start request itself. A reload or a second tab lands on the same rule, which
also closes the pre-existing hole where a tab that never started the meeting
opened its mic mid-initialization. Strict `=== true` means a meeting `active` on
disk with no live session (a gateway restart) keeps the mic closed instead of
dispatching into guaranteed 409s. The Live badge and controls still come alive
within ~1s of Start; only capture waits for the server's word.

**Why not shorten the server-side wait instead?** That is the real fix for the
latency, but it is a separate change with a different risk profile — it means not
awaiting agent dispatches before answering, which changes what `POST /start`
guarantees on return. This PR fixes the part that is unambiguously a bug: the
client not observing a state the server had already committed.

The decisions are extracted as `metaPollInterval` and `canOpenTranscription` and
exported, so the tests bind to the shipping rules rather than copies that can
drift — the convention the other pure functions in this hook already follow.

## Tests

Fourteen new tests (13 frontend in `website/src/test/MeetingsSessionLogic.test.ts`, 1 backend).

Polling window (7):

- polls on a short cadence while the start is in flight
- does **not** poll an idle meeting that nobody is starting — the cost guarantee
- hands back to the configured cadence as soon as a status is known — the
  self-limiting property above
- falls back to the shipped defaults when the config has not loaded
- respects a configured cadence over the defaults
- opens the window before the request and closes it however the start ends —
  covers the 409/failure path, so a failed start cannot poll forever
- feeds the query from the shared rule rather than an inline copy — the anti-drift
  guard that makes the other six meaningful

Ingress-readiness gating (6):

- keeps the mic closed while the poll sees `active` but ingress is not open —
  the "early finals lost to 409s" race
- opens the mic once the poll reports ingress open on an active meeting
- never opens the mic for a meeting that is not active, ingress or not
- a full transcript keeps the mic closed regardless of readiness
- the status binding actually consults the readiness rule — wiring guard: both
  the open and the close branch gate on `canOpenTranscription`, with
  `ingressReady` in the effect deps
- readiness comes from the POLLED server flag, and unknown reads as not-ready —
  pins the two properties that make the whole inference failure class
  unreachable

Backend (1, in `test/test_meetings_routes.py`):

- the poll payload's `accepting_dispatches` tracks the holder's admission flag
  through suspend/resume, not merely whether a session is installed

## Manual verification

On the real app, default three-agent roster:

- **before** — pressed Start; UI unchanged for the full initialization; no
  permission prompt; a page reload was required before recording began
- **server-side gap** — the audit log puts the start request at `14:02:55` and the
  agents ready at `14:03:52`, so the meeting sat `active`-but-unobserved for ~57s
  on that run
- **after** — the Live badge appears about a second after Start; the microphone
  prompt fires when `POST /start` answers (agents initialized, ingress open), and
  the meeting records without a reload

<!-- no-visual-delta -->
**Why no screenshot:** no new or changed component — the visible artefacts
(greyed-out Start, missing Live badge, permission prompt) are existing UI in
existing states; what changed is *when* they update, and the timings above are
the evidence.

## Related Issues

N/A — found by running the app while verifying the meeting lifecycle, not from a
filed issue.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no documented behaviour or
      configuration changes; `START_POLL_MS` is deliberately not a config field
- [x] No secrets, credentials, or internal references in the diff


