### PR TITLE
feat: auto-add merged-PR authors to the README Contributors list

### DIFF
--- a/.github/contributors-optout.txt
+++ b/.github/contributors-optout.txt
@@ -1,0 +1,14 @@
+# Contributors opt-out list.
+#
+# One GitHub login per line. Any login here is NEVER added to the README
+# Contributors block by the Add Contributor workflow
+# (.github/workflows/add-contributor.yml), even though that workflow rebuilds
+# the list from every merged pull request on each run.
+#
+# This is what keeps the README's removal promise ("if you contributed and would
+# like to be ... removed, please open an issue or a pull request") enforceable:
+# without it, a full rebuild would re-add a contributor who asked to be removed.
+# To remove someone: delete their <a> entry from the README AND add their login
+# here in the same pull request, so the next rebuild does not bring them back.
+#
+# Blank lines and text after a '#' are ignored; matching is case-insensitive.

--- a/.github/workflows/add-contributor.yml
+++ b/.github/workflows/add-contributor.yml
@@ -1,0 +1,221 @@
+name: Add Contributor
+
+# Add the authors of merged pull requests to the README Contributors block.
+# main is a protected branch, so this never commits directly -- it stages the
+# README edit on a single rolling feature branch, opens (or updates) one PR, and
+# arms GitHub auto-merge on it, like test-durations.yml. Auto-merge lets the
+# rolling PR land without a manual click once the repo's own required checks +
+# reviews pass; it never bypasses branch protection, so where protection requires
+# a human approval GitHub still waits for it.
+#
+# Why bespoke instead of an off-the-shelf tool (all-contributors bot, a
+# contrib.rocks embed): this repo's block is hand-curated with human display
+# names, credits by PULL-REQUEST-MERGE semantics (not the broader "contribution"
+# an embed counts), preserves maintainer-added entries verbatim, and must honor
+# an opt-out for removal requests. Those constraints are exactly what the generic
+# tools do not give, which is why the ~1k lines here earn their keep -- do not
+# replace this with the one-liner embed without re-checking all four.
+#
+# Trigger choice: a daily cron (plus manual dispatch), NOT pull_request_target.
+# Each run re-derives the complete author set by paginating every merged PR (see
+# below), so a per-merge trigger would do the exact same full sweep only sooner --
+# it buys at most 24h of immediacy while permanently carrying a write token in the
+# trusted base-repo context, where any future edit that touched a PR's title, body,
+# or head ref would inherit that privilege. A once-a-day batch also avoids
+# force-pushing the rolling branch on every merge (which would reset its review
+# approval and keep auto-merge from firing). Cron-only keeps the same result with
+# a smaller, static risk surface.
+#
+# Why the rolling branch is rebuilt from base every run AND we enumerate ALL
+# merged-PR authors: the branch is rebuilt from the protected branch each run so
+# it never drifts or carries a stale conflict. A rebuild is only safe if the
+# collection re-derives the COMPLETE set of authors who should appear, so it
+# paginates every merged PR -- not a recent-days window, which would silently drop
+# an author whose contributors PR stayed open past the window while newer PRs
+# merged. The script dedups against the README (which already holds everyone
+# previously credited), so scanning all merged PRs is cheap in effect: only
+# genuinely-new authors ever change the file.
+
+on:
+  schedule:
+    # Daily: credit the previous day's merged-PR authors.
+    - cron: "37 6 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write # only to open/update the failure-tracking issue (see last step)
+
+concurrency:
+  # One rolling branch, so serialize every run onto it -- do NOT cancel in
+  # progress, or a run could be aborted mid-push and skip a rebuild.
+  group: add-contributor
+  cancel-in-progress: false
+
+jobs:
+  add:
+    name: Add merged-PR authors to README
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Check out the default branch. github.event.repository is absent on
+      # schedule/workflow_dispatch payloads, so fall back to github.ref_name
+      # (the default branch on both triggers). We only read/write tracked files.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch || github.ref_name }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Collect merged-PR authors
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Enumerate EVERY merged PR's author (paginated), not a recent window:
+          # the branch is rebuilt from base each run, so the collection must
+          # re-derive the complete set or an author whose rolling PR outlived a
+          # bounded window would be dropped. The script dedups against the README,
+          # so only genuinely-new authors ever change the file.
+          #
+          # Guard .user != null first: a deleted account returns a null user, and
+          # a bare filter would emit {login: null} and inject a github.com/None
+          # entry. .user.type == "User" then excludes bots (dependabot, renovate,
+          # github-actions, ...), whose type is "Bot". `merged_at != null`
+          # distinguishes a merged PR from one merely closed.
+          gh api --paginate "repos/$REPO/pulls?state=closed&per_page=100&sort=updated&direction=desc" \
+            --jq '.[] | select(.merged_at != null and .user != null and .user.type == "User")
+                      | .user.login' \
+            | sort -u >/tmp/logins.txt
+
+          # A coarse set of logins already mentioned in the README, lowercased.
+          # Used ONLY to skip the display-name lookup for authors already
+          # present, so a steady-state daily run makes ~0 extra API calls while
+          # new entries still get the curated "Full Name" convention. The add/skip
+          # decision itself is the script's job (precise regex); over-matching
+          # here at worst falls a genuinely-new author back to login-as-name, so
+          # this greedy grep needs no repo-link exclusion.
+          grep -oiE 'https?://(www\.)?github\.com/[A-Za-z0-9][A-Za-z0-9-]*' README.md \
+            | sed -E 's#.*/##' | tr '[:upper:]' '[:lower:]' | sort -u >/tmp/known.txt
+
+          # Build records. Name is passed via jq --arg (safe JSON encoding, never
+          # shell-eval'd); the script validates the login and HTML-escapes the
+          # name. `.name // .login` covers users with no display name set.
+          : >/tmp/records.jsonl
+          while IFS= read -r login; do
+            [ -n "$login" ] || continue
+            if grep -qixF "$login" /tmp/known.txt; then
+              name="$login"
+            else
+              name="$(gh api "users/$login" --jq '.name // .login' 2>/dev/null || printf '%s' "$login")"
+            fi
+            jq -cn --arg l "$login" --arg n "$name" '{login: $l, name: $n}' >>/tmp/records.jsonl
+          done </tmp/logins.txt
+          jq -s '.' /tmp/records.jsonl >/tmp/records.json
+
+          echo "Collected $(jq 'length' /tmp/records.json) candidate author(s)."
+
+      - name: Update README
+        id: update
+        run: |
+          set -euo pipefail
+          python3 scripts/update_contributors.py </tmp/records.json
+          if git diff --quiet -- README.md; then
+            echo "changed=false" >>"$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update the contributors PR
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          BRANCH=chore/add-contributors
+          # Resolve the base from the repo itself, not the event payload -- the
+          # payload's repository object is absent on schedule/dispatch runs, and
+          # `gh pr create --base ""` would then fail.
+          BASE="$(gh repo view "$REPO" --json defaultBranchRef --jq .defaultBranchRef.name)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Rebuild the rolling branch from the current base each run so it never
+          # drifts behind the protected branch or carries a stale conflict. The
+          # collection above enumerates all merged authors, so the rebuild is
+          # complete and loses none.
+          git checkout -B "$BRANCH"
+          git add README.md
+          git commit -m "docs: add new contributors to README"
+
+          # Skip the push when the rolling branch's TREE already matches the
+          # remote branch's tip. Without this, rebuilding from a moved base each
+          # day mints a new commit for identical content, and every force-push
+          # dismisses the open PR's stale-review approvals and re-runs CI -- which
+          # can perpetually starve auto-merge where a human approval is required.
+          # Comparing trees (not commit SHAs) ignores the base rebase, so a push
+          # happens only when the README content actually changed. Fetch the
+          # remote branch first (absent on the first-ever run, hence `|| true`).
+          git fetch origin "$BRANCH" 2>/dev/null || true
+          remote_commit="$(git rev-parse --verify --quiet FETCH_HEAD || true)"
+          if [ -n "$remote_commit" ] \
+            && [ "$(git rev-parse HEAD^{tree})" = "$(git rev-parse "$remote_commit^{tree}")" ]; then
+            echo "Rolling branch tree unchanged; skipping push (no README delta since last run)."
+            exit 0
+          fi
+          git push --force-with-lease origin "$BRANCH"
+
+          if gh pr view "$BRANCH" --repo "$REPO" --json state --jq .state 2>/dev/null | grep -q OPEN; then
+            echo "PR already open for $BRANCH; updated in place."
+          else
+            gh pr create --repo "$REPO" --base "$BASE" --head "$BRANCH" \
+              --title "docs: add new contributors to README" \
+              --body "Automated update of the README Contributors block for authors of recently merged pull requests. Generated by the Add Contributor workflow (\`.github/workflows/add-contributor.yml\`); entries are inserted in sorted order and existing lines are preserved verbatim."
+          fi
+
+          # Arm GitHub auto-merge so the rolling PR lands ONCE the repo's own
+          # required checks + reviews pass. This never bypasses branch
+          # protection -- GitHub still enforces every required gate. The entries
+          # carry user-chosen display names and avatars, so a HUMAN review is the
+          # safeguard against an offensive name/avatar reaching the front page:
+          # main requires an approving review, so auto-merge waits for it. If a
+          # repo ever drops that requirement, the human look goes with it -- keep
+          # the required review, or drop this auto-merge step so the rolling PR
+          # always waits for a manual merge. Non-fatal: if "Allow auto-merge" is
+          # disabled or a branch rule forbids it, log and continue.
+          if ! gh pr merge "$BRANCH" --repo "$REPO" --auto --squash; then
+            echo "Could not arm auto-merge (allow-auto-merge disabled or blocked by a branch rule); PR remains open for manual merge."
+          fi
+
+      # A scheduled workflow that fails is easy to miss. If any step above failed
+      # (e.g. the script fails loud on a corrupted, non-contiguous block), open or
+      # update a single tracking issue so a human actually sees it. Deduped by a
+      # fixed title so repeated daily failures do not spam new issues.
+      - name: Surface failure as an issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="Add Contributor workflow is failing"
+          existing="$(gh issue list --repo "$REPO" --state open --search "in:title \"$TITLE\"" \
+            --json number --jq '.[0].number // empty')"
+          body="The scheduled \`add-contributor.yml\` run failed: $RUN_URL
+
+          A common cause is the README Contributors block no longer being a single
+          contiguous run of \`<a>\` entries (the script fails loud rather than
+          corrupt it). Check the run log, fix the block, and re-run."
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body "Still failing: $RUN_URL"
+          else
+            gh issue create --repo "$REPO" --title "$TITLE" --body "$body"
+          fi

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -62,7 +62,13 @@ Out-of-band lanes that never gate a PR:
   (a model picks `type:` / `area:` / `platform:` labels from the repository's own
   live label set, because keyword rules mislabel often enough to be worse than no
   label), `pr-merge-conflict-label.yml` and `fork-pr-label.yml` (both mirror a fact
-  GitHub does not surface in the `/pulls` list onto a label).
+  GitHub does not surface in the `/pulls` list onto a label), and
+  `add-contributor.yml` (a daily cron, plus manual dispatch, adds each merged
+  PR's author to the README Contributors block via
+  `scripts/update_contributors.py`; because the default branch is protected it
+  opens a rolling PR rather than committing directly, like `test-durations.yml`.
+  A login in `.github/contributors-optout.txt` is never added, which keeps the
+  README's removal promise enforceable against the full-rebuild collector).
 
 ## `ci.yml`: correctness
 

--- a/scripts/update_contributors.py
+++ b/scripts/update_contributors.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Insert merged-PR authors into the README Contributors block.
+
+Usage:
+    # Add contributors read as JSON from stdin ([{"login", "name"}, ...]).
+    # This is the path the workflow uses:
+    gh api ... | python3 scripts/update_contributors.py
+
+    # Add a single contributor from flags (a manual/debug convenience):
+    python3 scripts/update_contributors.py --login octocat --name "The Octocat"
+
+    # Self-test (no repository or network needed):
+    python3 scripts/update_contributors.py --test
+
+Exit codes:
+    0  README updated (or already up to date — idempotent no-op)
+    1  malformed input / README block not found / validation failure
+    2  environment error (README unreadable)
+
+The script is pure and network-free: the caller (the workflow) does all
+``gh``/GitHub I/O and pipes the resulting author records here. Contributor
+data is PR-controlled, so every login is validated against GitHub's username
+grammar and every display name is HTML-escaped before it reaches the README.
+Existing entries are preserved byte-for-byte, so hand-curated display names and
+inline comments (e.g. a ``wokeignore`` marker) survive a re-run untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_README = _REPO_ROOT / "README.md"
+
+# The Contributors block is a contiguous run of one-entry-per-line anchor tags,
+# sorted by GitHub login case-insensitively. New entries are inserted at their
+# sorted position; existing lines are never moved or rewritten, so a name a
+# maintainer added by hand (even out of strict order) is left exactly in place.
+# We locate the run by these anchors rather than by heading text so the block
+# can move within the file.
+_ENTRY_RE = re.compile(
+    r'^<a href="https://github\.com/(?P<login>[^"/]+)" title=".*?">'
+    r'<img src="https://github\.com/[^"]+\.png\?size=64"'
+    r' width="64" height="64" alt=".*?" /></a>'
+)
+
+# GitHub usernames: 1-39 chars, alphanumeric or single hyphens, no leading/
+# trailing hyphen. We reject anything else rather than escape it — a login that
+# is not a real GitHub handle cannot resolve to a real avatar or profile, so
+# admitting it would only inject a broken (or hostile) link.
+_LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$")
+
+# Any link to a GitHub PROFILE anywhere in the README, in whatever form a human
+# might type it: an ``<a href>`` or bare text, with or without scheme/``www.``,
+# and with an optional trailing slash, query, or fragment. This is how we
+# recognize a contributor a maintainer credited by hand OUTSIDE the sorted block
+# (a prose "thanks, see github.com/x", a second entry sharing a line, a
+# non-standard anchor) so we never re-add someone already credited in any form.
+# The login is one whole path segment: the trailing ``/?`` allows a single
+# trailing slash, and the negative lookahead then rejects a DEEPER segment, so a
+# repository or badge link (``…/owner/repo/releases``, ``…/owner/repo/``) is
+# never mistaken for a profile (which would wrongly skip a real new author of
+# that repo-owner's name).
+_PROFILE_HREF_RE = re.compile(
+    r"(?:https?://)?(?:www\.)?github\.com/" r"([A-Za-z0-9][A-Za-z0-9-]{0,38})/?(?![A-Za-z0-9/-])",
+    re.IGNORECASE,
+)
+
+
+def _entry_line(login: str, name: str) -> str:
+    """Render one contributor anchor line.
+
+    ``name`` is the human display text (falls back to the login) and is
+    HTML-escaped for both the ``title`` and ``alt`` attributes. ``login`` is
+    already validated against ``_LOGIN_RE`` so it needs no escaping. The workflow
+    supplies each author's real display name (from the GitHub user profile), so
+    the escaping and whitespace-collapse below run on live, user-controlled
+    input — they are a hard floor guaranteeing one well-formed single-line entry
+    regardless of what a name contains.
+
+    Whitespace is collapsed to single spaces first. This is a hard invariant,
+    not cosmetics: one entry MUST render to exactly one line, but a display name
+    can carry a line-boundary character (``\\n``, ``\\r``, U+2028/U+2029, NEL,
+    vertical tab, form feed) that ``str.splitlines()`` — used to re-parse the
+    block — would split on and ``html.escape`` does NOT neutralize. A multi-line
+    entry would break the contiguous-run invariant and wedge every later run.
+    """
+    display = " ".join(name.split()) or login
+    esc = html.escape(display, quote=True)
+    return (
+        f'<a href="https://github.com/{login}" title="{esc}">'
+        f'<img src="https://github.com/{login}.png?size=64"'
+        f' width="64" height="64" alt="{esc}" /></a>'
+    )
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` atomically, preserving line endings.
+
+    A plain ``open(path, "w")`` truncates the file before the write, so a
+    failure partway through (full disk) would leave the README truncated or
+    empty. Instead we write a temp file in the same directory (so ``os.replace``
+    is a same-filesystem atomic rename) and swap it in only after a clean close;
+    the original is untouched on any failure. ``newline=""`` keeps CRLF/LF
+    exactly as ``add_contributors`` produced them.
+    """
+    directory = path.parent
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".contributors-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+    except OSError:
+        # Leave the original intact and don't leak the temp file.
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _find_block(lines: list[str]) -> tuple[int, int]:
+    """Return the [start, end) line span of the contributor anchor run.
+
+    Raises ``ValueError`` if no contributor block is present, so the caller
+    fails loud rather than silently appending to the wrong place.
+    """
+    start = end = -1
+    for i, line in enumerate(lines):
+        if _ENTRY_RE.match(line):
+            if start == -1:
+                start = i
+            end = i + 1
+    if start == -1:
+        raise ValueError("no contributor anchor block found in README")
+    # The block must be a single contiguous run; a gap means our anchor regex is
+    # matching something unrelated and we should not guess where to insert.
+    for line in lines[start:end]:
+        if not _ENTRY_RE.match(line):
+            raise ValueError("contributor block is not a contiguous run of entries")
+    return start, end
+
+
+def _coerce_records(raw: object) -> list[dict[str, str]]:
+    """Normalize parsed JSON into a list of ``{"login", "name"}`` dicts."""
+    if not isinstance(raw, list):
+        raise ValueError("input must be a JSON array of contributor objects")
+    records: list[dict[str, str]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError("each contributor must be a JSON object")
+        # A JSON null login must become "" (dropped by _LOGIN_RE), NOT the
+        # string "None" — str(None) would pass the grammar and inject a
+        # github.com/None entry. A null author reaches here from a deleted PR
+        # account that slipped past an upstream filter.
+        login = str(item.get("login") or "").strip()
+        name = str(item.get("name") or "").strip()
+        records.append({"login": login, "name": name})
+    return records
+
+
+def _load_optout(path: Path) -> set[str]:
+    """Load lowercased opt-out logins from a file (one per line, ``#`` comments).
+
+    A missing file means an empty opt-out set — the feature is opt-in and its
+    absence must not break the run. Blank lines and ``#`` comments are ignored.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return set()
+    out: set[str] = set()
+    for line in raw.splitlines():
+        entry = line.split("#", 1)[0].strip()
+        if entry:
+            out.add(entry.lower())
+    return out
+
+
+def add_contributors(
+    text: str,
+    records: list[dict[str, str]],
+    optout: set[str] | None = None,
+) -> tuple[str, list[str]]:
+    """Return (new_text, added_logins).
+
+    Inserts each novel contributor into the block at its case-insensitive
+    sorted position, preserving every existing line verbatim. Idempotent:
+    logins already credited ANYWHERE in the README (compared case-insensitively)
+    are skipped, so a name a maintainer added by hand — inside or outside the
+    sorted block, in any anchor form — is never duplicated. Invalid logins are
+    dropped. Returns the text unchanged when nothing is new.
+
+    ``optout`` is a set of lowercased logins that must NEVER be added. This is
+    what makes the README's removal promise keepable: because a full rebuild
+    re-derives every merged author and dedups only against README PRESENCE, a
+    contributor removed on request would otherwise reappear on the next run. A
+    login on the opt-out list is skipped even when absent from the README.
+    """
+    optout = optout or set()
+    # Preserve the file's original newline style and trailing-newline state.
+    newline = "\r\n" if "\r\n" in text else "\n"
+    had_trailing_newline = text.endswith(("\n", "\r"))
+    lines = text.splitlines()
+
+    start, end = _find_block(lines)
+    # Seed the dedup set from EVERY GitHub profile link in the whole README, not
+    # just the canonical block — a maintainer may credit someone in prose or a
+    # differently-shaped anchor, and re-adding them would double-credit.
+    existing: set[str] = {lg.lower() for lg in _PROFILE_HREF_RE.findall(text)}
+
+    # Dedupe within the incoming batch too, keeping the first occurrence.
+    seen: set[str] = set()
+    added: list[str] = []
+    for rec in records:
+        login = rec["login"]
+        if not _LOGIN_RE.match(login):
+            continue
+        # Skip GitHub bot accounts (login ends in "[bot]" — already excluded by
+        # _LOGIN_RE since "[" is invalid — and the "-bot"/"[bot]" author type is
+        # filtered by the caller; this is a defense-in-depth belt).
+        key = login.lower()
+        if key in existing or key in seen or key in optout:
+            continue
+        seen.add(key)
+        added.append(login)
+
+    if not added:
+        return text, []
+
+    # Insert each new entry at its case-insensitive sorted position WITHOUT
+    # reordering existing lines. Existing rows never move relative to each
+    # other, so a name added by hand (even one out of strict sort order) is
+    # left exactly where a maintainer put it — automation only ever inserts,
+    # never rewrites. The block is treated as sorted for placement, and when it
+    # is not (a hand-added row out of order), we fall back to appending, which
+    # still never disturbs an existing line.
+    pending = set(added)
+    new_block = list(lines[start:end])
+    for rec in records:
+        login = rec["login"]
+        # Consume each new login exactly once, so a login repeated within the
+        # incoming batch is inserted a single time.
+        if login not in pending:
+            continue
+        pending.discard(login)
+        entry = _entry_line(login, rec["name"])
+        key = login.lower()
+        pos = len(new_block)
+        for i, line in enumerate(new_block):
+            m = _ENTRY_RE.match(line)
+            if m and m.group("login").lower() > key:
+                pos = i
+                break
+        new_block.insert(pos, entry)
+
+    new_lines = lines[:start] + new_block + lines[end:]
+    result = newline.join(new_lines)
+    if had_trailing_newline:
+        result += newline
+    return result, added
+
+
+# --------------------------------------------------------------------------- #
+# Self-test — runs without a repository or network (``--test``).
+# --------------------------------------------------------------------------- #
+def _self_test() -> int:
+    sample = (
+        "## Contributors\n\n"
+        "intro\n\n"
+        '<a href="https://github.com/0V" title="G2">'
+        '<img src="https://github.com/0V.png?size=64" width="64" height="64" alt="G2" /></a>\n'
+        '<a href="https://github.com/bob" title="Bob">'
+        '<img src="https://github.com/bob.png?size=64" width="64" height="64" alt="Bob" /></a>\n'
+        "\ntrailer\n"
+    )
+    failures = 0
+
+    def check(name: str, cond: bool) -> None:
+        nonlocal failures
+        if not cond:
+            failures += 1
+            print(f"FAIL: {name}")
+        else:
+            print(f"ok:   {name}")
+
+    # Insert in the middle, preserving alpha-fold order.
+    out, added = add_contributors(sample, [{"login": "amy", "name": "Amy"}])
+    check("added amy", added == ["amy"])
+    logins = [m.group("login") for m in (_ENTRY_RE.match(ln) for ln in out.splitlines()) if m]
+    check("order after amy", logins == ["0V", "amy", "bob"])
+
+    # Idempotent: re-adding an existing login (any case) is a no-op.
+    out2, added2 = add_contributors(out, [{"login": "AMY", "name": "Amy"}])
+    check("idempotent case-insensitive", added2 == [] and out2 == out)
+
+    # Existing lines preserved byte-for-byte (bob keeps its exact text).
+    check(
+        "bob line preserved",
+        any(
+            ln == '<a href="https://github.com/bob" title="Bob">'
+            '<img src="https://github.com/bob.png?size=64" width="64" height="64" alt="Bob" /></a>'
+            for ln in out.splitlines()
+        ),
+    )
+
+    # HTML injection in the display name is escaped.
+    out3, _ = add_contributors(sample, [{"login": "carol", "name": '"><script>x</script>'}])
+    check("name escaped", "<script>" not in out3 and "&lt;script&gt;" in out3)
+
+    # Invalid logins are dropped.
+    _, added4 = add_contributors(
+        sample,
+        [
+            {"login": "bad login", "name": "x"},
+            {"login": "-bad", "name": "x"},
+            {"login": "github-actions[bot]", "name": "bot"},
+        ],
+    )
+    check("invalid logins dropped", added4 == [])
+
+    # Empty display name falls back to the login.
+    out5, _ = add_contributors(sample, [{"login": "dave", "name": ""}])
+    check("empty name -> login", 'title="dave"' in out5)
+
+    # Batch insert stays sorted and deduped.
+    out6, added6 = add_contributors(
+        sample,
+        [
+            {"login": "zed", "name": "Zed"},
+            {"login": "AAA", "name": "Triple A"},
+            {"login": "zed", "name": "dup"},
+        ],
+    )
+    check("batch dedup", sorted(added6) == ["AAA", "zed"])
+    logins6 = [m.group("login") for m in (_ENTRY_RE.match(ln) for ln in out6.splitlines()) if m]
+    # Digits sort before letters case-insensitively, so "0V" precedes "AAA".
+    check("batch order", logins6 == ["0V", "AAA", "bob", "zed"])
+
+    # Missing block fails loud.
+    try:
+        add_contributors("# No contributors here\n", [{"login": "x", "name": "x"}])
+        check("missing block raises", False)
+    except ValueError:
+        check("missing block raises", True)
+
+    # A line-boundary char in the display name must not create a multi-line
+    # entry (which would break the contiguous-run invariant on the next run).
+    out7, _ = add_contributors(sample, [{"login": "erin", "name": "Er in"}])
+    entry7 = [ln for ln in out7.splitlines() if 'github.com/erin"' in ln]
+    check("boundary char collapsed to one line", len(entry7) == 1)
+    _, added7b = add_contributors(out7, [{"login": "erin", "name": "Er in"}])
+    check("boundary entry idempotent", added7b == [])
+
+    # A null login (deleted PR author) is dropped, never "None".
+    _, added8 = add_contributors(sample, _coerce_records([{"login": None, "name": None}]))
+    check("null login dropped", added8 == [])
+
+    # A name credited by hand OUTSIDE the sorted block is not re-added.
+    prose = sample.replace("intro\n", 'intro — thanks <a href="https://github.com/gus">Gus</a>\n')
+    _, added9 = add_contributors(prose, [{"login": "gus", "name": "Gus"}])
+    check("manual credit outside block not re-added", added9 == [])
+
+    # An opt-out login is never added, even when absent from the README, so a
+    # removal request survives a full rebuild.
+    _, added10 = add_contributors(sample, [{"login": "quinn", "name": "Quinn"}], optout={"quinn"})
+    check("opt-out login not added", added10 == [])
+
+    print("\nPASS" if not failures else f"\n{failures} FAILURE(S)")
+    return 1 if failures else 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Add merged-PR authors to the README Contributors block."
+    )
+    parser.add_argument("--test", action="store_true", help="run the built-in self-test and exit")
+    parser.add_argument("--login", help="single contributor login (alternative to JSON on stdin)")
+    parser.add_argument("--name", default="", help="single contributor display name (with --login)")
+    parser.add_argument(
+        "--readme", default=str(_README), help="path to README.md (default: repo root)"
+    )
+    parser.add_argument(
+        "--optout",
+        default=str(_REPO_ROOT / ".github" / "contributors-optout.txt"),
+        help="path to the opt-out login list (one login per line, # comments)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.test:
+        return _self_test()
+
+    if args.login is not None:
+        records = [{"login": args.login.strip(), "name": args.name.strip()}]
+    else:
+        try:
+            raw = json.load(sys.stdin)
+            records = _coerce_records(raw)
+        except (json.JSONDecodeError, ValueError) as exc:
+            print(f"::error::update_contributors: {exc}", file=sys.stderr)
+            return 1
+
+    readme_path = Path(args.readme)
+    try:
+        # newline="" disables universal-newline translation on BOTH read and
+        # write, so a CRLF file's line endings reach add_contributors intact
+        # (which preserves them) instead of being silently rewritten to LF.
+        with open(readme_path, encoding="utf-8", newline="") as fh:
+            text = fh.read()
+    except OSError as exc:
+        print(f"::error::update_contributors: cannot read {readme_path}: {exc}", file=sys.stderr)
+        return 2
+
+    optout = _load_optout(Path(args.optout))
+    try:
+        new_text, added = add_contributors(text, records, optout=optout)
+    except ValueError as exc:
+        print(f"::error::update_contributors: {exc}", file=sys.stderr)
+        return 1
+
+    if not added:
+        print("No new contributors; README already up to date.")
+        return 0
+
+    try:
+        _atomic_write(readme_path, new_text)
+    except OSError as exc:
+        # Same environment-error contract as the read path: a write failure
+        # (unwritable path, full disk) is exit 2, not an uncaught traceback, and
+        # the atomic write leaves the original README intact.
+        print(f"::error::update_contributors: cannot write {readme_path}: {exc}", file=sys.stderr)
+        return 2
+    print(f"Added {len(added)} contributor(s): {', '.join(added)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/test/test_update_contributors.py
+++ b/test/test_update_contributors.py
@@ -1,0 +1,398 @@
+"""Unit tests for scripts/update_contributors.py.
+
+The script edits the public README's Contributors block from PR-controlled
+author data, so the invariants that matter are: existing entries survive
+byte-for-byte (hand-curated names and inline comments must not be clobbered),
+insertion keeps the block's case-insensitive login order, the operation is
+idempotent, and no display name can inject HTML. Each gets a test here; the
+script's own ``--test`` mode covers the same families for a repo-free smoke run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SCRIPT_PATH = os.path.join(_REPO_ROOT, "scripts", "update_contributors.py")
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("update_contributors", _SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["update_contributors"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+uc = _load()
+
+
+def _entry(login: str, name: str) -> str:
+    return (
+        f'<a href="https://github.com/{login}" title="{name}">'
+        f'<img src="https://github.com/{login}.png?size=64"'
+        f' width="64" height="64" alt="{name}" /></a>'
+    )
+
+
+def _readme(*logins_and_names: tuple[str, str]) -> str:
+    body = "\n".join(_entry(lg, nm) for lg, nm in logins_and_names)
+    return f"## Contributors\n\nintro paragraph\n\n{body}\n\ntrailer\n"
+
+
+def _logins(text: str) -> list[str]:
+    return [m.group("login") for m in (uc._ENTRY_RE.match(line) for line in text.splitlines()) if m]
+
+
+def test_inserts_at_sorted_position():
+    text = _readme(("0V", "G2"), ("bob", "Bob"))
+    out, added = uc.add_contributors(text, [{"login": "amy", "name": "Amy"}])
+    assert added == ["amy"]
+    assert _logins(out) == ["0V", "amy", "bob"]
+
+
+def test_idempotent_case_insensitive():
+    text = _readme(("amy", "Amy"), ("bob", "Bob"))
+    out, added = uc.add_contributors(text, [{"login": "AMY", "name": "whatever"}])
+    assert added == []
+    assert out == text
+
+
+def test_existing_lines_preserved_byte_for_byte():
+    # A hand-curated entry with a trailing inline comment (like the repo's
+    # wokeignore marker) must survive untouched when a new entry is inserted.
+    curated = _entry("bob", "Bob The Great") + " <!-- keep me -->"
+    text = f"## Contributors\n\nintro\n\n{_entry('0V', 'G2')}\n{curated}\n\ntail\n"
+    out, added = uc.add_contributors(text, [{"login": "amy", "name": "Amy"}])
+    assert added == ["amy"]
+    assert curated in out.splitlines()
+
+
+def test_html_in_display_name_is_escaped():
+    text = _readme(("bob", "Bob"))
+    payload = '"><script>alert(1)</script>'
+    out, _ = uc.add_contributors(text, [{"login": "carol", "name": payload}])
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+    assert "&quot;&gt;" in out
+
+
+@pytest.mark.parametrize(
+    "login",
+    ["bad login", "-lead", "trail-", "has_underscore", "github-actions[bot]", "", "a" * 40],
+)
+def test_invalid_logins_dropped(login):
+    text = _readme(("bob", "Bob"))
+    out, added = uc.add_contributors(text, [{"login": login, "name": "x"}])
+    assert added == []
+    assert out == text
+
+
+def test_valid_login_edges():
+    text = _readme(("bob", "Bob"))
+    ok = ["a", "A1", "abc-def", "a" * 39, "0", "user-name-1"]
+    out, added = uc.add_contributors(text, [{"login": lg, "name": lg} for lg in ok])
+    assert sorted(added) == sorted(ok)
+
+
+def test_empty_name_falls_back_to_login():
+    text = _readme(("bob", "Bob"))
+    out, _ = uc.add_contributors(text, [{"login": "dave", "name": ""}])
+    assert 'title="dave"' in out
+    assert 'alt="dave"' in out
+
+
+def test_batch_dedup_and_order():
+    text = _readme(("0V", "G2"), ("bob", "Bob"))
+    out, added = uc.add_contributors(
+        text,
+        [
+            {"login": "zed", "name": "Zed"},
+            {"login": "AAA", "name": "Triple A"},
+            {"login": "zed", "name": "dup ignored"},
+        ],
+    )
+    assert sorted(added) == ["AAA", "zed"]
+    # Digits sort before letters under case-folding, so 0V leads.
+    assert _logins(out) == ["0V", "AAA", "bob", "zed"]
+
+
+def test_manual_out_of_order_entry_is_not_moved():
+    # A maintainer added "mZebra" by hand between "amy" and "bob" (out of strict
+    # sort order). Automation must leave it exactly there and never reorder it.
+    manual = _entry("mZebra", "Manual Zebra Add")
+    text = (
+        "## Contributors\n\nintro\n\n"
+        f"{_entry('amy', 'Amy')}\n"
+        f"{manual}\n"
+        f"{_entry('bob', 'Bob')}\n"
+        "\ntail\n"
+    )
+    out, added = uc.add_contributors(text, [{"login": "carl", "name": "Carl"}])
+    assert added == ["carl"]
+    out_lines = out.splitlines()
+    # The manual line survives byte-for-byte and keeps its relative position.
+    assert manual in out_lines
+    assert out_lines.index(_entry("amy", "Amy")) < out_lines.index(manual)
+    assert out_lines.index(manual) < out_lines.index(_entry("bob", "Bob"))
+
+
+def test_manually_added_name_not_re_added():
+    # A name a maintainer added by hand must not be duplicated when the same
+    # author later shows up in the automated sweep (case-insensitive match).
+    manual = _entry("Jane-Doe", "Jane Doe (hand-added)")
+    text = f"## Contributors\n\nintro\n\n{manual}\n\ntail\n"
+    out, added = uc.add_contributors(text, [{"login": "jane-doe", "name": "jane-doe"}])
+    assert added == []
+    assert out == text
+
+
+@pytest.mark.parametrize(
+    "credit",
+    [
+        '<a href="https://github.com/gus">Gus</a>',  # anchor
+        "see https://github.com/gus).",  # bare url, punctuation after
+        "see https://github.com/gus/ for art",  # trailing slash
+        "profile https://github.com/gus?tab=repositories",  # query string
+        "profile https://github.com/gus#readme",  # fragment
+        "shorthand github.com/gus mentioned",  # no scheme
+        "https://www.github.com/gus",  # www host
+        "http://github.com/gus",  # http scheme
+    ],
+)
+def test_manual_credit_outside_block_not_re_added(credit):
+    # A contributor credited by hand ANYWHERE in the README, in ANY reasonable
+    # URL form, must not be re-added into the sorted block (dedup is by profile
+    # link across the whole file, not just canonical block entries).
+    text = f"## Contributors\n\nintro {credit}\n\n{_entry('amy', 'Amy')}\n{_entry('zoe', 'Zoe')}\n\ntail\n"
+    out, added = uc.add_contributors(text, [{"login": "gus", "name": "Gus"}])
+    assert added == []
+    assert out == text
+
+
+@pytest.mark.parametrize(
+    "repo_link",
+    [
+        'See <a href="https://github.com/kirodotdev/KiroCrew/releases">releases</a>.',
+        "docs at https://github.com/kirodotdev/KiroCrew/",  # trailing slash on a repo
+        "https://github.com/kirodotdev/KiroCrew#install",  # repo + fragment
+    ],
+)
+def test_repo_and_deep_links_are_not_treated_as_contributors(repo_link):
+    # A deeper path (repo, releases, ...) must never be read as a profile, or a
+    # real new contributor named like the repo owner would be wrongly skipped.
+    text = f"## Contributors\n\n{repo_link}\n\n{_entry('amy', 'Amy')}\n\ntail\n"
+    out, added = uc.add_contributors(text, [{"login": "kirodotdev", "name": "Kiro"}])
+    assert added == ["kirodotdev"]
+
+
+def test_optout_login_never_added_even_when_absent():
+    # The removal promise: a login on the opt-out list must not be re-added by a
+    # full rebuild, even though it is absent from the README.
+    text = _readme(("amy", "Amy"))
+    out, added = uc.add_contributors(
+        text,
+        [{"login": "quinn", "name": "Quinn"}, {"login": "rob", "name": "Rob"}],
+        optout={"quinn"},
+    )
+    assert added == ["rob"]
+    assert "github.com/quinn" not in out
+
+
+def test_optout_is_case_insensitive():
+    text = _readme(("amy", "Amy"))
+    out, added = uc.add_contributors(text, [{"login": "Quinn", "name": "Quinn"}], optout={"quinn"})
+    assert added == []
+    assert out == text
+
+
+def test_load_optout_parses_comments_and_blanks(tmp_path):
+    f = tmp_path / "optout.txt"
+    f.write_text(
+        "# a comment\n\nAlice\nbob   # trailing note\n\n  Carol  \n",
+        encoding="utf-8",
+    )
+    assert uc._load_optout(f) == {"alice", "bob", "carol"}
+
+
+def test_load_optout_missing_file_is_empty(tmp_path):
+    # A missing opt-out file must not break the run; the feature is opt-in.
+    assert uc._load_optout(tmp_path / "does-not-exist.txt") == set()
+
+
+def test_main_honors_optout_file(tmp_path):
+    readme = tmp_path / "README.md"
+    readme.write_text(_readme(("amy", "Amy")), encoding="utf-8")
+    optout = tmp_path / "optout.txt"
+    optout.write_text("quinn\n", encoding="utf-8")
+    rc = uc.main(
+        ["--login", "quinn", "--name", "Quinn", "--readme", str(readme), "--optout", str(optout)]
+    )
+    # Nothing added -> exit 0, README unchanged.
+    assert rc == 0
+    assert "github.com/quinn" not in readme.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("boundary", ["\n", "\r", "\u2028", "\u2029", "\x85", "\x0b", "\x0c"])
+def test_line_boundary_in_name_stays_single_line_and_idempotent(boundary):
+    # A display name carrying a line-boundary char must render exactly one line;
+    # otherwise the block becomes non-contiguous and every later run wedges.
+    text = _readme(("bob", "Bob"))
+    name = f"Ca{boundary}rol"
+    out, added = uc.add_contributors(text, [{"login": "carol", "name": name}])
+    assert added == ["carol"]
+    carol_lines = [ln for ln in out.splitlines() if 'github.com/carol"' in ln]
+    assert len(carol_lines) == 1
+    # And re-running is a clean no-op (block stayed contiguous).
+    out2, added2 = uc.add_contributors(out, [{"login": "carol", "name": name}])
+    assert added2 == []
+    assert out2 == out
+
+
+def test_null_login_is_dropped_not_stringified():
+    # A deleted PR author yields a null login; it must be dropped, never turned
+    # into the string "None" and injected as github.com/None.
+    text = _readme(("bob", "Bob"))
+    records = uc._coerce_records([{"login": None, "name": None}, {"login": "real", "name": "Real"}])
+    out, added = uc.add_contributors(text, records)
+    assert added == ["real"]
+    assert "github.com/None" not in out
+
+
+def test_coerce_records_null_login_becomes_empty():
+    recs = uc._coerce_records([{"login": None, "name": None}])
+    assert recs == [{"login": "", "name": ""}]
+
+
+def test_missing_block_raises():
+    with pytest.raises(ValueError):
+        uc.add_contributors("# README\n\nno contributors here\n", [{"login": "x", "name": "x"}])
+
+
+def test_non_contiguous_block_raises():
+    # An anchor run split by a stray line is ambiguous — refuse rather than guess.
+    text = (
+        "## Contributors\n\n"
+        f"{_entry('0V', 'G2')}\n"
+        "stray line in the middle\n"
+        f"{_entry('bob', 'Bob')}\n"
+    )
+    with pytest.raises(ValueError):
+        uc.add_contributors(text, [{"login": "amy", "name": "Amy"}])
+
+
+def test_preserves_trailing_newline_and_crlf():
+    text = _readme(("bob", "Bob"))
+    out, _ = uc.add_contributors(text, [{"login": "amy", "name": "Amy"}])
+    assert out.endswith("\n")
+
+    crlf = text.replace("\n", "\r\n")
+    out_crlf, _ = uc.add_contributors(crlf, [{"login": "amy", "name": "Amy"}])
+    assert "\r\n" in out_crlf
+    assert "\n\n" not in out_crlf.replace("\r\n", "")
+
+
+def test_no_change_returns_original_text():
+    text = _readme(("amy", "Amy"))
+    out, added = uc.add_contributors(text, [])
+    assert added == []
+    assert out == text
+
+
+def test_coerce_records_rejects_non_list():
+    with pytest.raises(ValueError):
+        uc._coerce_records({"login": "x"})
+
+
+def test_coerce_records_normalizes():
+    recs = uc._coerce_records([{"login": " amy ", "name": " Amy "}, {"login": "bob"}])
+    assert recs == [{"login": "amy", "name": "Amy"}, {"login": "bob", "name": ""}]
+
+
+def test_self_test_passes():
+    assert uc._self_test() == 0
+
+
+def test_main_single_flag_updates_readme(tmp_path):
+    readme = tmp_path / "README.md"
+    readme.write_text(_readme(("bob", "Bob")), encoding="utf-8")
+    rc = uc.main(["--login", "amy", "--name", "Amy", "--readme", str(readme)])
+    assert rc == 0
+    assert 'title="Amy"' in readme.read_text(encoding="utf-8")
+
+
+def test_main_missing_block_exits_one(tmp_path):
+    readme = tmp_path / "README.md"
+    readme.write_text("# no block\n", encoding="utf-8")
+    rc = uc.main(["--login", "amy", "--name", "Amy", "--readme", str(readme)])
+    assert rc == 1
+
+
+def test_main_preserves_crlf_end_to_end(tmp_path):
+    # A CRLF README must survive a real file round-trip: reading with universal
+    # newlines would strip \r before the CRLF-preserving logic ever saw it, then
+    # rewrite the whole file as LF. Read/write with newline="" prevents that.
+    readme = tmp_path / "README.md"
+    crlf = _readme(("bob", "Bob")).replace("\n", "\r\n")
+    readme.write_bytes(crlf.encode("utf-8"))
+    before_crlf = readme.read_bytes().count(b"\r\n")
+
+    rc = uc.main(["--login", "amy", "--name", "Amy", "--readme", str(readme)])
+    assert rc == 0
+
+    raw = readme.read_bytes()
+    # The inserted line adds one CRLF; crucially, none are lost/converted to LF.
+    assert raw.count(b"\r\n") == before_crlf + 1
+    assert b"\n" not in raw.replace(b"\r\n", b"")  # no bare LF introduced
+    assert b'title="Amy"' in raw
+
+
+def test_main_preserves_lf_end_to_end(tmp_path):
+    # The mirror case: a pure-LF README must not gain any CR.
+    readme = tmp_path / "README.md"
+    readme.write_bytes(_readme(("bob", "Bob")).encode("utf-8"))
+    rc = uc.main(["--login", "amy", "--name", "Amy", "--readme", str(readme)])
+    assert rc == 0
+    assert b"\r" not in readme.read_bytes()
+
+
+def test_main_unreadable_readme_exits_two(tmp_path):
+    # A missing/unreadable --readme is an environment error (exit 2), not a
+    # crash and not "no findings".
+    rc = uc.main(["--login", "amy", "--name", "Amy", "--readme", str(tmp_path / "nope.md")])
+    assert rc == 2
+
+
+def test_main_unwritable_readme_exits_two_and_preserves_original(tmp_path, monkeypatch):
+    # A write failure after a successful read must honor the exit-2
+    # environment-error contract AND leave the original README intact (atomic
+    # write): a partial/truncated file would be worse than no update. Simulate a
+    # mid-write failure by making the final atomic rename raise.
+    readme = tmp_path / "README.md"
+    original = _readme(("bob", "Bob"))
+    readme.write_text(original, encoding="utf-8")
+
+    def failing_replace(src, dst, *args, **kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(uc.os, "replace", failing_replace)
+    rc = uc.main(["--login", "amy", "--name", "Amy", "--readme", str(readme)])
+    assert rc == 2
+    # Original content is untouched, and no temp file was left behind.
+    assert readme.read_text(encoding="utf-8") == original
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name != "README.md"]
+    assert leftovers == []
+
+
+def test_atomic_write_leaves_no_temp_and_preserves_newlines(tmp_path):
+    # Happy path: the atomic write replaces the file, preserves CRLF, and leaves
+    # no .contributors-*.tmp sibling.
+    target = tmp_path / "README.md"
+    uc._atomic_write(target, "line1\r\nline2\r\n")
+    assert target.read_bytes() == b"line1\r\nline2\r\n"
+    assert [p.name for p in tmp_path.iterdir()] == ["README.md"]


### PR DESCRIPTION
## Problem
The README "Contributors" block is maintained by hand. When someone lands their
first pull request, nothing adds them to that list, so recognizing new
contributors is a manual, easily-forgotten chore and the list drifts behind the
actual merge history.

## Why it matters
Contributor recognition is the one concrete reward an open-source project offers,
and the README block is where Kiro Crew gives it. A contributor who lands a PR and
never appears has effectively been dropped; relying on a maintainer to remember
means the list is chronically stale. Automating it makes recognition reliable and
removes recurring toil.

## Fix (symptoms → root cause → change)
Symptom: merged authors are missing from the README block. Root cause: there is
no automation tying "PR merged" to "author added". Change: a new
`add-contributor.yml` workflow runs on a **daily cron** (plus manual
`workflow_dispatch`), enumerates the real-user authors of all merged PRs, and
runs a small, pure, well-tested Python script that inserts each novel author into
the README block.

Design choices, and why:
- **Cron-only trigger, not `pull_request_target`.** Because collection re-derives
  the complete author set every run (see below), a per-merge trigger would do the
  identical full sweep only sooner. That immediacy (at most 24h) is not worth
  permanently holding a `contents: write` token in the trusted base-repo context,
  where a future edit touching a PR's title, body, or head ref would inherit that
  privilege. A daily batch also avoids force-pushing the rolling branch on every
  merge (which would reset its review approval and keep auto-merge from firing).
- **Rolling PR + auto-merge, not a direct commit.** The default branch is
  protected, so the workflow stages the edit on one rolling
  `chore/add-contributors` branch, opens/updates a single PR (like
  `test-durations.yml`), and arms GitHub auto-merge so it lands without a manual
  click once the repo's own required checks + reviews pass. Auto-merge never
  bypasses branch protection; where protection requires a human approval, GitHub
  still waits for it. Arming is non-fatal if the repo disallows auto-merge. The
  daily rebuild **skips the push entirely when the README content is unchanged**
  (tree comparison), so an open PR is not churned with no-op commits that would
  dismiss its approvals.
- **Complete rebuild, so no author is lost.** The rolling branch is rebuilt from
  the base each run (never drifts, never carries a stale conflict). That is only
  safe if collection re-derives the full set, so it paginates every merged PR
  rather than a recent-days window (which would drop an author whose PR outlived
  the window). The script dedups against the README, so only genuinely-new
  authors ever change the file.
- **Insert-only, never rewrite.** Each new entry is inserted at its
  case-insensitive sorted position; existing lines are never moved or rewritten,
  so a name a maintainer adds by hand (even out of strict order) is left exactly
  in place. Dedup scans **every** GitHub profile link in the whole README, in any
  form (block entry, prose mention, bare URL, with/without scheme/`www`/trailing
  slash), so a manual credit is never duplicated; repository/badge deep links are
  not mistaken for a contributor.
- **Untrusted input is contained.** Every login is validated against GitHub's
  username grammar and every display name is HTML-escaped before it reaches the
  README; author records are passed to the script as data (stdin), never
  interpolated into a shell command. A deleted PR author (null login) is dropped
  rather than injected as `github.com/None`, and a line-boundary character in a
  display name is collapsed so one entry always renders as one line. The script
  writes atomically (temp file + `os.replace`), so a failed write can never leave
  the README truncated.

The script (`scripts/update_contributors.py`) is stdlib-only, network-free, and
has a `--test` self-test; the workflow does all `gh`/network I/O and pipes author
records in. Docs updated in the same change: `docs/ci/ci-and-reviews.md` lists the
new out-of-band lane.

## Tests
`test/test_update_contributors.py` (50 tests) locks in: sorted-position
insertion; case-insensitive idempotency (byte-identical re-run); batch dedup;
**a hand-added out-of-order entry is never moved or duplicated** and **a manual
credit anywhere in the README (prose, bare URL, trailing slash, query, fragment,
no-scheme, www, http) is not re-added**; repository/badge deep links are not
treated as contributors; byte-for-byte preservation of existing lines including
inline comments (e.g. the `wokeignore` marker); HTML-escaping of injected display
names; line-boundary characters collapsed so an entry stays single-line and
idempotent; a null login dropped rather than stringified to `None`; login-grammar
validation; empty-name fallback to login; CRLF and trailing-newline preservation
end-to-end through the CLI; **atomic write preserves the original on a failed
write and leaves no temp file**; block-not-found and non-contiguous-block error
paths; unreadable/unwritable README both exit 2; and the CLI entry points. The
script's `--test` mode gives a repo-free smoke run.

## Manual verification
N/A for the script: unit coverage is sufficient (the mutation logic is pure and
fully covered), and it was additionally exercised against the real README block
(existing author gives a no-op; a brand-new author adds exactly one line at the
sorted position; every real entry is matched by the parser). The workflow's
author collection and the tree-unchanged push-skip were validated by simulating
the `gh api`/`jq` pipeline and the git tree comparison locally, and the YAML
parses. The workflow itself first runs on the next daily cron (or manual
dispatch) after this lands. No user-visible UI changes.
