### PR TITLE
fix(acp): classify expired sessions as auth, not transient 5xx

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -780,6 +780,35 @@ _RE_5XX_STATUS = re.compile(r"(?:HTTP|status)\s*(?:code\s*)?(?:50[0234]|529)\b",
 # a transport envelope, not a signal about the failure inside it; classification
 # now reads the inner detail (see _provider_detail).
 _RE_5XX_HINT = re.compile(r"(please try again)", re.IGNORECASE)
+# Session expiry, by HTTP status. An expired session is rejected with 401/403,
+# and nothing else in this module recognised those codes: the error fell through
+# to the 5xx family (a co-occurring DispatchFailure/ConnectionReset from the
+# aborted request is enough to match) and the user was told to retry or switch
+# models, neither of which can succeed against an expired login. Status is the
+# primary signal because the rejection carries no explanatory wording.
+_RE_AUTH_STATUS = re.compile(r"(?:HTTP|status)\s*(?:code\s*)?(?:401|403)\b", re.IGNORECASE)
+# Session expiry, by wording. Complements the status match for backends that
+# describe the expiry in prose without a machine-readable code. Deliberately
+# excludes Bedrock's named exceptions, which _RE_AUTH already owns.
+_RE_SESSION_EXPIRED = re.compile(
+    r"\b(?:session\s+(?:has\s+)?expired|session\s+timed?\s*out"
+    r"|login\s+(?:has\s+)?expired|authentication\s+(?:has\s+)?expired"
+    r"|not\s+logged\s+in|not\s+authenticated"
+    r"|re-?authenticate|login\s+required|auth(?:entication)?\s+required)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_session_expired(haystack: str) -> bool:
+    """True when the failure is an expired session rather than a backend fault.
+
+    Both signals are terminal: retrying cannot refresh a login. Checked before
+    the 5xx family so an aborted request's transport error does not shadow the
+    real cause.
+    """
+    return bool(_RE_AUTH_STATUS.search(haystack) or _RE_SESSION_EXPIRED.search(haystack))
+
+
 # Account/plan capacity is EXHAUSTED — terminal. Distinct from a throttle: a
 # throttle clears in seconds and a retry is the right move, whereas a spent
 # monthly allowance does not come back until it resets, so retrying only adds
@@ -901,6 +930,9 @@ def _is_transient_raw_error(
         return True
     if _RE_AUTH.search(haystack):
         # Auth is terminal — a retry can't fix an expired/denied credential.
+        return False
+    if _is_session_expired(haystack):
+        # Session expiry is terminal — retrying can't refresh an expired login.
         return False
     return bool(
         _RE_5XX_NAMED.search(haystack)
@@ -1093,6 +1125,17 @@ def _format_acp_error(error: object, available_models: Sequence[str] | None = No
                 "(e.g. re-run your SSO/login or 'aws sso login'), then retry. If "
                 "the failure persists, check that the configured AWS profile has "
                 "Bedrock InvokeModel access."
+                f"{req_id_suffix}"
+            )
+        elif _is_session_expired(haystack):
+            # Session expiry (401/403, or prose saying as much) — distinct from
+            # the Bedrock credential errors above. Retrying or switching models
+            # cannot succeed, so the message must not suggest either.
+            formatted = (
+                "Your session has expired. Run `kiro-cli login` in your "
+                "terminal to sign back in, then start a new chat. "
+                "Retrying or switching models will not help — this is a "
+                "sign-in issue, not a backend error."
                 f"{req_id_suffix}"
             )
         elif (

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -6813,6 +6813,86 @@ class TestFormatAcpError:
         assert "transient error" not in out.lower()
         assert "ValidationException: input contains an unsupported field 'foo'" in out
 
+    def test_session_expired_rewrite(self):
+        """An expired session gets actionable sign-in guidance rather than the
+        misleading transient-5xx retry advice."""
+        err = {
+            "code": -32603,
+            "message": "Internal error",
+            "data": "DispatchFailure: session expired",
+        }
+        out = _format_acp_error(err)
+        assert "session has expired" in out.lower() or "session expired" in out.lower()
+        assert "kiro-cli login" in out.lower()
+        assert "retry" in out.lower() and "will not help" in out.lower()
+        # Must NOT show the misleading 5xx message.
+        assert "transient error" not in out.lower()
+        assert "retry in a moment" not in out.lower()
+
+    def test_session_expired_by_http_status(self):
+        """A bare 401/403 is the shape an expired session actually arrives in:
+        the rejection carries no explanatory wording, so status alone must
+        drive the classification."""
+        for status in ("HTTP 401", "HTTP 403", "status code 401", "status 403"):
+            err = {"code": -32603, "message": "Internal error", "data": status}
+            out = _format_acp_error(err)
+            assert "kiro-cli login" in out.lower(), f"No sign-in guidance for: {status!r}"
+            assert "transient error" not in out.lower(), f"Misclassified: {status!r}"
+
+    def test_session_expired_401_with_transport_error(self):
+        """The reported failure mode: an aborted request leaves a transport
+        error alongside the 401, and the 5xx family used to win and tell the
+        user to retry."""
+        err = {
+            "code": -32603,
+            "message": "Encountered an error in the response stream",
+            "data": "DispatchFailure ConnectionResetError: HTTP 401",
+        }
+        out = _format_acp_error(err)
+        assert "kiro-cli login" in out.lower()
+        assert "transient error" not in out.lower()
+        assert "retry in a moment" not in out.lower()
+
+    def test_genuine_5xx_still_transient_with_auth_absent(self):
+        """The new auth-status branch must not swallow real 5xx errors."""
+        err = {
+            "code": -32603,
+            "message": "Internal error",
+            "data": "ServiceUnavailableException: HTTP 503",
+        }
+        out = _format_acp_error(err)
+        assert "transient" in out.lower()
+        assert "kiro-cli login" not in out.lower()
+
+    def test_session_expired_variants(self):
+        """Various kiro-cli session-expiry error shapes are all classified."""
+        variants = [
+            "not logged in",
+            "session has expired",
+            "login expired",
+            "authentication required",
+            "session timed out",
+            "not authenticated",
+            "login required",
+        ]
+        for text in variants:
+            err = {"code": -32603, "message": "Internal error", "data": text}
+            out = _format_acp_error(err)
+            assert "transient error" not in out.lower(), f"Failed for: {text!r}"
+            assert "kiro-cli login" in out.lower(), f"No login guidance for: {text!r}"
+
+    def test_session_expired_with_5xx_token_wins(self):
+        """Session expiry checked before 5xx: a DispatchFailure wrapping a
+        session-expired message must surface as auth, not transient."""
+        err = {
+            "code": -32603,
+            "message": "Internal error",
+            "data": "DispatchFailure ConnectionResetError: session expired",
+        }
+        out = _format_acp_error(err)
+        assert "transient error" not in out.lower()
+        assert "kiro-cli login" in out.lower()
+
 
 class TestIsTransientRawError:
     """_is_transient_raw_error classifies retryability from the RAW JSON-RPC
@@ -6881,6 +6961,54 @@ class TestIsTransientRawError:
         )
         assert _is_transient_raw_error(None) is False
         assert _is_transient_raw_error("boom") is False
+
+    def test_session_expired_is_not_transient(self):
+        """Regression test: kiro-cli session expiry must be terminal.
+
+        These error shapes previously fell through to the 5xx branch (when they
+        also carried DispatchFailure/ConnectionResetError), telling the user to
+        retry when re-authentication was required.
+        """
+        from kiro_crew.acp.client import _is_transient_raw_error
+
+        # Direct session-expired wording from kiro-cli.
+        assert _is_transient_raw_error({"data": "session expired"}) is False
+        assert _is_transient_raw_error({"data": "session has expired"}) is False
+        assert _is_transient_raw_error({"data": "not logged in"}) is False
+        assert _is_transient_raw_error({"data": "not authenticated"}) is False
+        assert _is_transient_raw_error({"data": "login required"}) is False
+        assert _is_transient_raw_error({"data": "authentication required"}) is False
+        assert _is_transient_raw_error({"data": "re-authenticate"}) is False
+        assert _is_transient_raw_error({"message": "session timed out", "data": ""}) is False
+        # Session expiry with a co-occurring 5xx token: the session-expiry
+        # branch must win (checked first).
+        assert (
+            _is_transient_raw_error(
+                {"data": "DispatchFailure: session expired", "message": ""}
+            )
+            is False
+        )
+        assert (
+            _is_transient_raw_error(
+                {"data": "ConnectionResetError: not logged in", "message": ""}
+            )
+            is False
+        )
+        # A bare 401/403 — the shape an expired session actually arrives in.
+        assert _is_transient_raw_error({"data": "HTTP 401"}) is False
+        assert _is_transient_raw_error({"data": "HTTP 403"}) is False
+        assert _is_transient_raw_error({"data": "status code 401"}) is False
+        # 401 alongside the transport error left by the aborted request: the
+        # 5xx family must not reclaim it and re-arm the retry ladder.
+        assert (
+            _is_transient_raw_error(
+                {"data": "DispatchFailure ConnectionResetError: HTTP 401", "message": ""}
+            )
+            is False
+        )
+        # Real 5xx stays retryable — the auth-status branch must not overreach.
+        assert _is_transient_raw_error({"data": "ServiceUnavailableException"}) is True
+        assert _is_transient_raw_error({"data": "HTTP 503"}) is True
 
     def test_kiro_generic_generation_failure_is_transient(self):
         from kiro_crew.acp.client import _is_transient_raw_error


### PR DESCRIPTION
## Problem / Motivation

When a session expires while the dashboard is open, every subsequent action fails behind a misleading banner:

> ❌ The model backend hit a transient error (HTTP 5xx). This is usually momentary — retry in a moment. If it keeps happening, switch to a different model in the picker.

The UI still looks functional — modals open, Allow responds, the model picker works — but nothing goes through, and the message points at two fixes that cannot possibly work. In the reported case the user stepped away for a couple of minutes, came back to an approval modal, clicked Allow, saw nothing happen, then repeatedly re-asked and swapped models *on the app's own advice* before realising the session had simply expired.

## Root cause

An expired session is rejected with **401/403**, and nothing in the ACP error classifier recognised those codes:

- `_RE_AUTH` matches only Bedrock's *named* exceptions (`AccessDeniedException`, `ExpiredTokenException`, …) — a bare status code carries none of them.
- `_RE_5XX_STATUS` matches 5xx only.

The aborted request leaves a transport error (`DispatchFailure` / `ConnectionResetError`) next to the rejection, and the 5xx family matched *that* first. So the failure was classified transient: the user got retry advice, and `_is_transient_raw_error` re-armed the retry ladder on an error no retry can clear.

## What changed

- **`_RE_AUTH_STATUS`** — detects HTTP 401/403. This is the primary signal, because the rejection arrives with no explanatory wording.
- **`_RE_SESSION_EXPIRED`** — prose fallback (`session expired`, `not logged in`, `login required`, …) for backends that describe the expiry in words instead of a code.
- **`_is_session_expired()`** — both signals behind one helper, used by *both* the message formatter and the retry classifier, so the two cannot drift (the same drift hazard the surrounding comments already warn about).
- Evaluated **after** `_RE_AUTH` and **before** the 5xx family, so a transport error from the aborted request no longer shadows the real cause.
- The message now names the remedy and closes off the dead ends: *"Run `kiro-cli login` … Retrying or switching models will not help — this is a sign-in issue, not a backend error."* Wording matches the existing `_NOT_LOGGED_IN_MESSAGE`.

## Testing

`473 passed` in `test/test_acp_client.py`; `269 passed` across `test_acp_session_provider.py` + `test_acp_runtime.py` (no regressions). isort / flake8 / mypy clean.

Six new/extended tests, **mutation-verified against pristine `main`** — all six fail without the change:

| Test | Covers |
|---|---|
| `test_session_expired_by_http_status` | bare `HTTP 401` / `403` / `status code 401` |
| `test_session_expired_401_with_transport_error` | **the reported failure mode** — 401 + `DispatchFailure ConnectionResetError` |
| `test_session_expired_rewrite` | prose expiry gets sign-in guidance, not 5xx advice |
| `test_session_expired_variants` | 7 wording variants |
| `test_session_expired_with_5xx_token_wins` | ordering: expiry beats 5xx |
| `test_session_expired_is_not_transient` | retry classifier treats expiry as terminal |

`test_genuine_5xx_still_transient_with_auth_absent` is the overreach guard — it **passes on `main`** as well as here, confirming real 5xx errors stay retryable and the new branch is not swallowing them.

## Scope

Closes the misclassification half of the issue (item 1). The issue also asks for a **"Sign back in" affordance in the UI** (item 2) — that is a frontend change and is deliberately **not** in this PR; the corrected backend message is what unblocks the user today. Filing that separately keeps this diff reviewable.

The branch name mentions #1940 and #1835 — both turned out to be already handled (#1940 merged via #1941, #1835 open as #1841), so **this PR contains only the #1942 fix**.
