### PR TITLE
perf(search): memoize snippet sources and put a byte ceiling on both search memos

### DIFF
--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -18,7 +18,7 @@ import re
 import threading
 import time as _time
 from collections import OrderedDict
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Container, Iterator
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Generic, TypeVar
@@ -415,6 +415,29 @@ def update_metadata_off_loop(
 SEARCH_MIN_CHARS = 2  # shortest query string that triggers backend search
 _TITLE_BOOST = 10  # field-boost multiplier for title matches in search_sessions
 _SEARCH_SCAN_WINDOW = 500  # cap files scanned per search to bound I/O
+
+# Hard ceilings on the memory the two search memos may hold, in real retained
+# bytes as reported by ``str.__sizeof__`` — NOT in characters.
+#
+# ``len()`` is the wrong unit and dangerously so: CPython stores a ``str`` in the
+# narrowest width its contents allow, so one character is 1 byte for latin-1, 2
+# for the BMP, and 4 for astral planes. A ceiling of 160 MB counted in characters
+# retains 168 MB of ASCII, 336 MB of CJK, or 671 MB of emoji — and CJK is the
+# ordinary case for a non-English corpus, not a pathological one. The sizers
+# therefore call ``__sizeof__`` per string, and the snippet memo also charges for
+# its list container.
+#
+# Why bytes and not an entry count: a session is read up to
+# ``_SESSION_MAX_BYTES`` (2 MB), so ``_SEARCH_SCAN_WINDOW`` entries is anywhere
+# from a few MB to ~1 GB depending on the corpus. An entry count therefore
+# bounds nothing that matters; it only *looked* safe because real sessions are
+# small (a 171 MB / 230-session corpus folds to ~8 MB).
+#
+# The two are separate rather than one shared pool so a corpus that blows the
+# snippet budget cannot starve the fold, which is the one that keeps matching
+# off the critical path. Their sum is the ceiling to reason about.
+_SEARCH_FOLD_BUDGET_BYTES = 96 * 1024 * 1024
+_SEARCH_SNIPPET_BUDGET_BYTES = 64 * 1024 * 1024
 
 # Canonical set of memory_mode values that mark a session private — never
 # searchable/listable/summarizable. Single source of truth shared by the MCP
@@ -858,6 +881,163 @@ class _LRUCache(Generic[_V]):
             self._data.clear()
 
 
+class _SearchTextCache(Generic[_V]):
+    """Byte-budgeted memo for the two derived corpora ``search_sessions`` needs.
+
+    Distinct from :class:`_LRUCache` because the access pattern is different in
+    the one way that decides an eviction policy. A search walks
+    ``_SEARCH_SCAN_WINDOW`` sessions **in the same recency order every query**,
+    so the working set is cyclic. Under LRU a cyclic scan larger than the cache
+    evicts each entry exactly one step before its next read: the hit rate does
+    not degrade, it collapses to zero, and it does so for the users with the
+    most sessions — the ones the memo exists for. ``_folded_cache`` was sized
+    ``max(cache_max, _SEARCH_SCAN_WINDOW)`` for precisely that reason.
+
+    An entry *count* is the wrong bound to carry that guarantee, though: 500
+    entries is 37 MB on one corpus and could be far more on another, because a
+    session is read up to ``_SESSION_MAX_BYTES``. The bound here is therefore
+    **bytes**, which is what actually has to fit in the gateway's RSS.
+
+    A byte budget reintroduces the cliff, so eviction is replaced by
+    **admission control**: when a new entry would exceed the budget it is simply
+    not stored, and the entries already held are kept. For a cyclic scan that
+    turns 0% into (whatever fraction fits)% — and because ``search_sessions``
+    walks most-recent-first, the fraction that stays cached is the most recently
+    active sessions, which is the half worth keeping. Existing entries are still
+    replaced in place on a content change (same key, new value), so a session
+    that is being written to never gets stuck on a stale value.
+
+    ``max_bytes <= 0`` disables the bound (behaves like a plain dict).
+
+    Thread safety mirrors :class:`_LRUCache`: one lock, every method atomic, no
+    method calls another locked method.
+    """
+
+    def __init__(self, max_bytes: int, sizer: Callable[[_V], int], label: str = "") -> None:
+        self._max_bytes = max_bytes
+        self._sizer = sizer
+        self._label = label
+        self._data: dict[str, _V] = {}
+        self._bytes = 0
+        self._admitted = 0
+        self._refused = 0
+        self._refused_since_prune = 0
+        self._warned = False
+        self._lock = threading.Lock()
+
+    def get(self, key: str, default: _V | None = None) -> _V | None:
+        with self._lock:
+            return self._data.get(key, default)
+
+    def __setitem__(self, key: str, value: _V) -> None:
+        cost = self._sizer(value)
+        with self._lock:
+            previous = self._data.get(key)
+            if previous is not None:
+                # Replacement, not growth: release the old cost first so a
+                # session that keeps being appended to cannot inflate the
+                # accounting or be refused admission for its own new value.
+                self._bytes -= self._sizer(previous)
+                del self._data[key]
+            if self._max_bytes > 0 and self._bytes + cost > self._max_bytes:
+                self._refused += 1
+                self._refused_since_prune += 1
+                warn = not self._warned
+                self._warned = True
+                if warn:
+                    # Say it once, at the moment the ceiling starts binding.
+                    # Without this the degradation is observable only under a
+                    # debugger, which makes "diagnosable" an empty claim.
+                    logger.warning(
+                        "search memo %s hit its %d MB ceiling (%d entries, %d "
+                        "admitted); sessions past it fall back to re-reading "
+                        "their file, so warm search will be slower on this "
+                        "corpus",
+                        self._label or "cache",
+                        self._max_bytes // (1024 * 1024),
+                        len(self._data),
+                        self._admitted,
+                    )
+                return
+            self._data[key] = value
+            self._bytes += cost
+            self._admitted += 1
+
+    def pop(self, key: str, default: _V | None = None) -> _V | None:
+        with self._lock:
+            if key in self._data:
+                value = self._data.pop(key)
+                self._bytes -= self._sizer(value)
+                return value
+            return default
+
+    def retain(self, live_keys: Container[str]) -> int:
+        """Drop every entry whose key is not in *live_keys*; return how many.
+
+        The release valve that keeps admission control from becoming a one-way
+        ratchet. Without it, a cache that fills freezes on whatever it happened
+        to hold first: entries that have since aged out of the scan window keep
+        their budget forever (only invalidation or a stat failure pops them),
+        while every newly created session is refused — so the newest and most
+        searched sessions become exactly the cold ones, and warm latency
+        regresses over process lifetime until a restart.
+
+        Safe against the LRU cliff this class exists to avoid, because it only
+        drops entries a search can no longer reach: ``search_sessions`` walks the
+        ``_SEARCH_SCAN_WINDOW`` most recent sessions, so anything outside that
+        window is dead weight by construction rather than an entry one step from
+        its next read.
+
+        Called only under pressure (see ``refused_since_prune``) so an
+        uncontended cache never pays for the scan.
+        """
+        with self._lock:
+            doomed = [k for k in self._data if k not in live_keys]
+            for k in doomed:
+                self._bytes -= self._sizer(self._data.pop(k))
+            self._refused_since_prune = 0
+            return len(doomed)
+
+    def refused_since_prune(self) -> int:
+        """Admissions turned away since the last :meth:`retain`.
+
+        Nonzero means the budget is binding right now, which is the signal to
+        spend a prune. Distinct from the cumulative ``refused`` in
+        :meth:`stats`, which never resets so it stays useful for diagnosis.
+        """
+        with self._lock:
+            return self._refused_since_prune
+
+    def __contains__(self, key: object) -> bool:
+        with self._lock:
+            return key in self._data
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._data)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._data.clear()
+            self._bytes = 0
+
+    def stats(self) -> dict[str, int]:
+        """Observability for the budget: how full it is and what it turned away.
+
+        ``refused`` rising while ``entries`` is flat is the signal that the
+        budget is smaller than the working set, i.e. that searches on this
+        corpus are paying the cold cost for the sessions that did not fit.
+        """
+        with self._lock:
+            return {
+                "entries": len(self._data),
+                "bytes": self._bytes,
+                "max_bytes": self._max_bytes,
+                "admitted": self._admitted,
+                "refused": self._refused,
+            }
+
+
 class ConversationLog:
     """Append-only JSONL conversation store with provenance and rotation."""
 
@@ -912,7 +1092,7 @@ class ConversationLog:
         #: staleness (an append bumps the file mtime, so the entry is
         #: recomputed on the next call). Own ``_LRUCache`` → own internal lock.
         self._recent_cache: _LRUCache[tuple[float, list[dict]]] = _LRUCache(cache_max)
-        #: Bounded, mtime-keyed LRU of ``(mtime, doc_chars, casefolded_blob)``
+        #: Bounded, mtime-keyed memo of ``(mtime, doc_chars, casefolded_blob)``
         #: per session, consumed only by :meth:`search_sessions`.
         #:
         #: Folding is the dominant cost of a search: the substring count itself
@@ -922,17 +1102,33 @@ class ConversationLog:
         #: corpus does not change between the keystrokes of one search, so the
         #: fold is memoized here and each query pays only the count.
         #:
-        #: Sized to cover the ENTIRE scan window, never ``cache_max``. A search
-        #: walks ``_SEARCH_SCAN_WINDOW`` sessions in the same order every query,
-        #: so an LRU smaller than that window is evicted exactly one step ahead
-        #: of its next read: the hit rate collapses to zero rather than
-        #: degrading, and the memoization silently stops working for the users
-        #: with the most sessions — the ones it exists for. ``max`` rather than a
-        #: bare constant so a caller shrinking ``cache_max`` cannot reintroduce
-        #: that cliff; this cache holds derived strings, which are far smaller
-        #: than the parsed transcripts ``cache_max`` is tuned for.
-        self._folded_cache: _LRUCache[tuple[float, int, str]] = _LRUCache(
-            max(cache_max, _SEARCH_SCAN_WINDOW)
+        #: Bounded by BYTES, not entries — see ``_SEARCH_FOLD_BUDGET_BYTES``. The
+        #: previous ``max(cache_max, _SEARCH_SCAN_WINDOW)`` entry bound existed to
+        #: stop an LRU from collapsing to a zero hit rate against the cyclic scan
+        #: order; :class:`_SearchTextCache` keeps that guarantee by refusing
+        #: admission instead of evicting, so the sessions that fit stay cached
+        #: and the bound is now a real memory ceiling rather than a proxy for one.
+        self._folded_cache: _SearchTextCache[tuple[float, int, str]] = _SearchTextCache(
+            _SEARCH_FOLD_BUDGET_BYTES, lambda v: v[2].__sizeof__(), "fold"
+        )
+        #: session key → (mtime, raw message texts) for snippet extraction.
+        #:
+        #: The fold above answers "does this session match"; this answers "show me
+        #: the line". Without it every returned row re-opened its file and
+        #: re-parsed JSONL until the first hit, which profiling showed to be 92%
+        #: of a warm query (55% in ``json.raw_decode`` alone, ~7.2k parses per
+        #: query on a 230-session corpus). The cost is not the match count but how
+        #: deep the first hit sits, which is why a 21-hit query measured 189 ms
+        #: while a 50-hit query measured 81 ms.
+        #:
+        #: Filled by :meth:`_build_folded`, which already materializes exactly
+        #: this list to build the fold — so the second corpus costs one extra
+        #: reference, never an extra read. Raw (not folded) because the snippet is
+        #: displayed to the user; the fold cannot be reused for it.
+        self._snippet_cache: _SearchTextCache[tuple[float, list[str]]] = _SearchTextCache(
+            _SEARCH_SNIPPET_BUDGET_BYTES,
+            lambda v: v[1].__sizeof__() + sum(t.__sizeof__() for t in v[1]),
+            "snippet",
         )
         #: tab_id → [session keys] chain index. ``None`` means "stale, rebuild
         #: on next chained read"; a dict is an authoritative snapshot. Rebuilt
@@ -1821,7 +2017,9 @@ class ConversationLog:
         needle = query.casefold()
         # (score, -rank, meta, needs_snippet)
         scored: list[tuple[float, int, dict, bool]] = []
-        for rank, meta in enumerate(self.list_sessions()[:_SEARCH_SCAN_WINDOW]):
+        window = self.list_sessions()[:_SEARCH_SCAN_WINDOW]
+        self._prune_search_memos({m["key"] for m in window})
+        for rank, meta in enumerate(window):
             doc_chars, folded = self._folded_content(meta["key"])
             content_hits = folded.count(needle) if folded else 0
             title_hits = (meta.get("title") or "").casefold().count(needle)
@@ -1865,6 +2063,7 @@ class ConversationLog:
             mtime = path.stat().st_mtime
         except OSError:
             self._folded_cache.pop(key, None)
+            self._snippet_cache.pop(key, None)
             return (0, "")
         cached = self._folded_cache.get(key)
         if cached and cached[0] == mtime:
@@ -1890,11 +2089,12 @@ class ConversationLog:
                 mtime = path.stat().st_mtime
             except OSError:
                 self._folded_cache.pop(key, None)
+                self._snippet_cache.pop(key, None)
                 return (0, "")
             cached = self._folded_cache.get(key)
             if cached and cached[0] == mtime:
                 return (cached[1], cached[2])
-            built = self._build_folded(key)
+            built = self._build_folded(key, mtime)
             if built is None:
                 # The read failed rather than finding no content. Caching that
                 # would be keyed by an mtime the file still has, so a session
@@ -1907,7 +2107,27 @@ class ConversationLog:
             self._folded_cache[key] = (mtime, built[0], built[1])
             return built
 
-    def _build_folded(self, key: str) -> tuple[int, str] | None:
+    def _prune_search_memos(self, live_keys: set[str]) -> None:
+        """Free budget held by sessions that have left the scan window.
+
+        Only runs for a memo that is currently refusing admissions, so an
+        uncontended cache never pays the scan. Entries outside *live_keys* are
+        unreachable by any future search (it walks only the
+        ``_SEARCH_SCAN_WINDOW`` most recent sessions), so dropping them cannot
+        cost a hit — which is what makes this safe where an LRU eviction would
+        not be.
+
+        Called before the walk, so a refusal raised *during* a walk is released
+        on the NEXT query rather than that one: the prune needs the scan window,
+        which the walk computes. The lag is one query (~20 ms for a keystroke
+        caller) and self-clearing; what it prevents is budget staying pinned by
+        aged-out sessions for the life of the process.
+        """
+        for cache in (self._folded_cache, self._snippet_cache):
+            if cache.refused_since_prune():
+                cache.retain(live_keys)
+
+    def _build_folded(self, key: str, mtime: float) -> tuple[int, str] | None:
         """Parse *key* and fold its content — the cache-miss half of
         :meth:`_folded_content`.
 
@@ -1948,6 +2168,11 @@ class ConversationLog:
             return None
         if not texts:
             return (0, "")
+        # Hand the same list to the snippet memo. The caller has already stat'ed
+        # under ``_file_lock`` and passes that mtime, so both memos are keyed by
+        # one observation of the file and cannot disagree about which revision
+        # they hold. Storing here is why the second corpus costs no extra read.
+        self._snippet_cache[key] = (mtime, texts)
         return (sum(len(t) for t in texts), "\x00".join(texts).casefold())
 
     def _iter_message_texts(self, key: str) -> Iterator[str]:
@@ -1985,6 +2210,37 @@ class ConversationLog:
     #: Hard cap on a returned snippet.
     _SNIPPET_MAX = 200
 
+    def _snippet_texts(self, key: str) -> Iterator[str]:
+        """Yield *key*'s message texts for snippet extraction, memo first.
+
+        Prefers ``_snippet_cache`` — filled by :meth:`_build_folded` from the same
+        read that produced the fold — and falls back to re-reading the file.
+
+        The memo is validated against the file's current mtime, so it degrades to
+        the file read rather than serving a stale snippet. That check is cheap
+        relative to the parse it avoids, and unlike the fold this path does NOT
+        need ``_file_lock``: a snippet is display-only, so the worst case for a
+        preserved-mtime rewrite racing here is one stale preview line, not a
+        session that stops matching. The fold — which decides whether a row
+        appears at all — keeps the lock.
+
+        Falls back for three reasons, all of which must stay non-fatal: the entry
+        was refused admission by the byte budget, the fold cached ``(0, "")`` for
+        a session with no text and so stored nothing, or the file changed since
+        the fold. Propagates ``OSError`` from the fallback read, which
+        :meth:`_content_snippet` already treats as "no snippet".
+        """
+        cached = self._snippet_cache.get(key)
+        if cached is not None:
+            try:
+                if cached[0] == self._path(key).stat().st_mtime:
+                    return iter(cached[1])
+            except OSError:
+                # Let the fallback read raise the OSError the caller handles,
+                # rather than deciding here what a vanished file means.
+                pass
+        return self._iter_message_texts(key)
+
     def _content_snippet(self, key: str, query: str) -> str:
         """Return a match-centered window of *key*'s content around *query*.
 
@@ -2014,7 +2270,7 @@ class ConversationLog:
         if not needle:
             return ""
         try:
-            for text in self._iter_message_texts(key):
+            for text in self._snippet_texts(key):
                 pos = text.casefold().find(needle)
                 if pos < 0:
                     continue
@@ -2557,6 +2813,12 @@ class ConversationLog:
         # exactly when they do. Its own mtime guard is not enough here: the
         # housekeeping rewrites below restore the pre-write mtime.
         self._folded_cache.pop(key, None)
+        # Same reasoning for the snippet source: it is the raw form of what the
+        # fold is derived from, so it goes stale at exactly the same moment. Its
+        # own mtime check would miss the preserved-mtime rewrites below, and a
+        # missed invalidation here shows the user a preview line quoting text
+        # that is no longer in the session.
+        self._snippet_cache.pop(key, None)
         # Also drop any memoized recent() windows for this key. Necessary
         # because housekeeping rewrites (mark_consolidated/update_metadata/
         # rewrite_session/rotation) restore the pre-write mtime via

--- a/test/test_search_sessions_cost.py
+++ b/test/test_search_sessions_cost.py
@@ -38,9 +38,9 @@ def counting_log(tmp_path, monkeypatch):
     calls: list[str] = []
     original = ConversationLog._build_folded
 
-    def counted(self, key: str):
+    def counted(self, key: str, mtime: float):
         calls.append(key)
-        return original(self, key)
+        return original(self, key, mtime)
 
     monkeypatch.setattr(ConversationLog, "_build_folded", counted)
     return log, calls
@@ -147,25 +147,50 @@ class TestSearchFoldingIsMemoized:
 
 
 class TestFoldCacheCoversTheScanWindow:
-    """An LRU smaller than the scan window would hit 0%, not degrade.
+    """A bound smaller than the scan window would hit 0%, not degrade.
 
     ``search_sessions`` walks ``_SEARCH_SCAN_WINDOW`` sessions in the same order
-    on every query. If the cache holds fewer entries than that, each session is
-    evicted one step before its next read, so the hit rate collapses to zero and
-    the memoization silently stops working — precisely for the users with the
-    most sessions, who need it most.
+    on every query. If the cache cannot hold them, each session is dropped one
+    step before its next read, so the hit rate collapses to zero and the
+    memoization silently stops working — precisely for the users with the most
+    sessions, who need it most.
+
+    The bound is BYTES rather than entries, because a session is read up to
+    ``_SESSION_MAX_BYTES``: an entry count of 500 was anywhere from a few MB to
+    ~1 GB depending on the corpus, so it bounded memory only by accident.
+    ``_SearchTextCache`` preserves the no-collapse guarantee by refusing
+    admission instead of evicting.
     """
 
-    def test_cache_is_sized_to_at_least_the_scan_window(self, tmp_path):
+    def test_fold_cache_is_bounded_by_bytes_not_entries(self, tmp_path):
         log = ConversationLog(base_dir=tmp_path)
-        assert log._folded_cache._maxsize >= history._SEARCH_SCAN_WINDOW
+        stats = log._folded_cache.stats()
+        assert stats["max_bytes"] == history._SEARCH_FOLD_BUDGET_BYTES
+        assert stats["max_bytes"] > 0, "the ceiling must actually be enforced"
 
-    def test_a_small_cache_max_cannot_shrink_it_below_the_window(self, tmp_path):
-        """The fold cache holds derived strings, not the parsed transcripts
-        ``cache_max`` is tuned for, so it must not follow that knob down."""
+    def test_a_small_cache_max_cannot_shrink_the_search_budgets(self, tmp_path):
+        """The search memos hold derived text, not the parsed transcripts
+        ``cache_max`` is tuned for, so they must not follow that knob down."""
         log = ConversationLog(base_dir=tmp_path, cache_max=8)
-        assert log._folded_cache._maxsize >= history._SEARCH_SCAN_WINDOW
+        assert log._folded_cache.stats()["max_bytes"] == history._SEARCH_FOLD_BUDGET_BYTES
+        assert log._snippet_cache.stats()["max_bytes"] == history._SEARCH_SNIPPET_BUDGET_BYTES
         assert log._msg_cache._maxsize == 8, "the transcript cache still honors cache_max"
+
+    def test_the_budget_holds_a_full_scan_window_of_ordinary_sessions(self, tmp_path):
+        """The ceiling has to be generous enough to not be the common case.
+
+        A budget tight enough to refuse ordinary corpora would reintroduce the
+        very cliff this class exists to prevent, just measured in bytes. Pinned
+        against a deliberately roomy per-session estimate so the assertion fails
+        if someone tightens the budget without re-reasoning about the window.
+        """
+        generous_session_chars = 64 * 1024
+        capacity = history._SEARCH_FOLD_BUDGET_BYTES // generous_session_chars
+        assert capacity >= history._SEARCH_SCAN_WINDOW, (
+            f"the fold budget holds only {capacity} sessions of "
+            f"{generous_session_chars} chars, fewer than the "
+            f"{history._SEARCH_SCAN_WINDOW}-session scan window"
+        )
 
     def test_no_thrash_across_a_corpus_larger_than_the_transcript_cache(
         self, tmp_path, monkeypatch
@@ -185,9 +210,9 @@ class TestFoldCacheCoversTheScanWindow:
         calls: list[str] = []
         original = ConversationLog._build_folded
 
-        def counted(self, key: str):
+        def counted(self, key: str, mtime: float):
             calls.append(key)
-            return original(self, key)
+            return original(self, key, mtime)
 
         monkeypatch.setattr(ConversationLog, "_build_folded", counted)
 
@@ -252,7 +277,7 @@ class TestFoldDoesNotPinParsedTranscripts:
         mtime = log._path("s0").stat().st_mtime
         log._msg_cache["s0"] = (mtime, [{"role": "user", "content": "phantom text"}])
 
-        built = log._build_folded("s0")
+        built = log._build_folded("s0", mtime)
         assert built is not None
         assert built[1] == "on disk only", "the fold must come from the file"
         assert "phantom" not in built[1]
@@ -293,9 +318,9 @@ class TestFoldDoesNotPinParsedTranscripts:
         real_build = ConversationLog._build_folded
         observed: list[int] = []
 
-        def observing(self, key: str):
+        def observing(self, key: str, mtime: float):
             observed.append(depth[0])
-            return real_build(self, key)
+            return real_build(self, key, mtime)
 
         log = ConversationLog(base_dir=tmp_path)
         for i in range(3):
@@ -401,7 +426,7 @@ class TestFoldDoesNotPinParsedTranscripts:
 
     def test_unreadable_file_signals_failure_rather_than_empty(self, tmp_path):
         log = ConversationLog(base_dir=tmp_path)
-        assert log._build_folded("never-existed") is None
+        assert log._build_folded("never-existed", 0.0) is None
 
     def test_both_halves_of_a_query_share_one_definition_of_searchable_text(
         self, tmp_path, monkeypatch
@@ -410,8 +435,15 @@ class TestFoldDoesNotPinParsedTranscripts:
 
         They are two readers of the same on-disk format; divergent skip rules
         would let a query count a match the snippet cannot then locate (an empty
-        snippet on a matched row), or vice versa. Pinned by routing both through
-        ``_iter_message_texts``.
+        snippet on a matched row), or vice versa.
+
+        The guarantee is now structural rather than conventional: the fold hands
+        the snippet memo the very list it folded, so a single traversal of
+        ``_iter_message_texts`` serves both halves and there is no second
+        traversal that could apply different rules. One call, not two — the
+        second call is what this used to assert, and its disappearance is the
+        optimization. The fallback path (memo refused or stale) still routes
+        through the shared iterator; see ``TestSnippetSourceIsMemoized``.
         """
         log = ConversationLog(base_dir=tmp_path)
         log.append("s0", "user", "the wombat entry")
@@ -428,8 +460,13 @@ class TestFoldDoesNotPinParsedTranscripts:
 
         assert [h["key"] for h in hits] == ["s0"]
         assert "wombat" in hits[0]["snippet"]
-        assert callers == ["s0", "s0"], (
-            f"fold and snippet must both go through the shared iterator, saw {callers}"
+        assert callers == ["s0"], (
+            "one traversal must serve both the fold and the snippet, "
+            f"saw {callers}"
+        )
+        stored = log._snippet_cache.get("s0")
+        assert stored is not None and stored[1] == ["the wombat entry"], (
+            "the snippet memo must hold exactly what the fold read"
         )
 
     def test_the_shared_iterator_skips_metadata_and_unparseable_lines(self, tmp_path):
@@ -539,3 +576,367 @@ class TestSearchResultsUnchangedByMemoization:
         hits = log.search_sessions("needle", 50)
         assert "needle" in hits[0]["snippet"]
         assert "filler" not in hits[0]["snippet"], "window must stay in the matching message"
+
+
+class TestSearchTextCacheByteBudget:
+    """The bound is bytes, and it is a ceiling rather than an eviction trigger.
+
+    An entry count bounded nothing that mattered: a session is read up to
+    ``_SESSION_MAX_BYTES``, so ``_SEARCH_SCAN_WINDOW`` entries ranged from a few
+    MB to ~1 GB depending on whose corpus it was.
+    """
+
+    def _cache(self, max_bytes: int) -> history._SearchTextCache[str]:
+        return history._SearchTextCache(max_bytes, len)
+
+    def test_entry_that_would_exceed_the_budget_is_refused_not_evicted(self):
+        """Admission control, not LRU eviction.
+
+        A search walks the scan window in the same recency order every query, so
+        the working set is cyclic. Evicting to make room for the newcomer would
+        drop the entry needed one step later — the hit rate collapses to zero
+        instead of degrading. Refusing the newcomer keeps whatever fits.
+        """
+        cache = self._cache(10)
+        cache["a"] = "1234567890"  # exactly fills the budget
+
+        cache["b"] = "x"
+
+        assert cache.get("a") == "1234567890", "the entry that fit must survive"
+        assert cache.get("b") is None, "the entry that did not fit is refused"
+        assert cache.stats()["refused"] == 1
+
+    def test_partial_fill_still_serves_the_sessions_that_fit(self):
+        cache = self._cache(6)
+        for name in ("a", "b", "c", "d"):
+            cache[name] = "xxx"  # 3 bytes each: only two fit
+
+        held = [n for n in ("a", "b", "c", "d") if cache.get(n) is not None]
+        assert held == ["a", "b"], "the earliest (most recent sessions) stay cached"
+        assert cache.stats()["bytes"] == 6
+
+    def test_replacing_a_key_releases_the_old_cost_first(self):
+        """A session being appended to must not inflate the accounting.
+
+        Without releasing the previous value the byte total would grow on every
+        rewrite of the same key, and the session would eventually be refused
+        admission for its OWN new value while still counting against the budget.
+        """
+        cache = self._cache(10)
+        cache["a"] = "12345"
+        cache["a"] = "67890"
+
+        assert cache.get("a") == "67890"
+        assert cache.stats()["bytes"] == 5, "the old value's cost is released"
+        assert cache.stats()["refused"] == 0
+
+    def test_pop_releases_the_budget(self):
+        cache = self._cache(10)
+        cache["a"] = "1234567890"
+        cache.pop("a", None)
+
+        assert cache.stats()["bytes"] == 0
+        cache["b"] = "1234567890"
+        assert cache.get("b") is not None, "the freed budget is reusable"
+
+    def test_pop_of_an_absent_key_does_not_corrupt_the_accounting(self):
+        cache = self._cache(10)
+        cache["a"] = "123"
+        cache.pop("missing", None)
+
+        assert cache.stats()["bytes"] == 3, "a miss must not subtract anything"
+
+    def test_zero_budget_disables_the_bound(self):
+        cache = self._cache(0)
+        cache["a"] = "x" * 10_000
+        assert cache.get("a") is not None
+        assert cache.stats()["refused"] == 0
+
+
+class TestSnippetSourceIsMemoized:
+    """The snippet is 92% of a warm query unless its source is memoized.
+
+    Matching is already cheap (the fold cache). What was not cheap: every
+    returned row re-opened its file and re-parsed JSONL until the first hit.
+    """
+
+    def test_warm_query_builds_snippets_without_reading_any_file(
+        self, tmp_path, monkeypatch
+    ):
+        log = ConversationLog(base_dir=tmp_path)
+        _seed(log, sessions=3)
+        log.search_sessions("deployment", 50)  # warm both memos
+
+        reads: list[str] = []
+        original = ConversationLog._iter_message_texts
+
+        def counted(self, key: str):
+            reads.append(key)
+            return original(self, key)
+
+        monkeypatch.setattr(ConversationLog, "_iter_message_texts", counted)
+
+        results = log.search_sessions("deployment", 50)
+
+        assert results, "the query must still return rows"
+        assert all(r.get("snippet") for r in results), "each row still has its snippet"
+        assert reads == [], "a warm query must not re-read any session file"
+
+    def test_snippet_falls_back_to_the_file_when_the_memo_has_no_entry(
+        self, tmp_path, monkeypatch
+    ):
+        """The budget may refuse admission, so the memo is an optimization only.
+
+        With a zero-byte budget nothing is ever stored, which is the same state
+        as a refused entry — and the snippet must still be produced.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        _seed(log, sessions=2)
+        monkeypatch.setattr(log, "_snippet_cache", history._SearchTextCache(1, lambda v: 10**9))
+
+        results = log.search_sessions("deployment", 50)
+
+        assert results
+        assert all(r.get("snippet") for r in results), "fallback still yields snippets"
+
+    def test_a_write_that_preserves_mtime_still_drops_the_snippet_memo(self, tmp_path):
+        """The case the memo's own mtime check cannot see.
+
+        Housekeeping writes restore the pre-write mtime (``_restore_mtime``) so
+        consolidation does not float stale sessions to the top of
+        ``list_sessions``. After one of those the file's mtime still matches what
+        the memo recorded, so the mtime guard in :meth:`_snippet_texts` is blind
+        and ``_invalidate_cache`` is the only thing standing between the user and
+        a preview quoting text the session no longer contains.
+
+        Asserted on the memo directly rather than through a snippet, because a
+        content-changing rewrite bumps the mtime and would pass on the guard
+        alone — which is exactly the false confidence this test exists to avoid.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("s0", "user", "the original wording mentions deployment")
+        log.search_sessions("deployment", 50)
+        assert log._snippet_cache.get("s0") is not None, "precondition: memo warm"
+        before = log._path("s0").stat().st_mtime
+
+        log.mark_consolidated("s0", 1)
+
+        assert log._path("s0").stat().st_mtime == before, (
+            "precondition: this write path preserves mtime, so the guard is blind"
+        )
+        assert log._snippet_cache.get("s0") is None, (
+            "the memo must be dropped by invalidation, not left to the mtime guard"
+        )
+
+    def test_no_stale_preview_survives_a_content_rewrite(self, tmp_path):
+        """End-to-end check that the two defences together hold.
+
+        This one passes on the mtime guard alone; the preserved-mtime case above
+        is what pins the invalidation.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("s0", "user", "the original wording mentions deployment")
+        log.search_sessions("deployment", 50)  # memoize the original text
+
+        log.rewrite_session("s0", [{"role": "user", "content": "replaced deployment text"}])
+
+        results = log.search_sessions("deployment", 50)
+        assert results, "the session still matches after the rewrite"
+        assert "original wording" not in results[0]["snippet"], "no stale preview"
+        assert "replaced" in results[0]["snippet"]
+
+    def test_a_changed_mtime_falls_back_rather_than_serving_a_stale_snippet(
+        self, tmp_path
+    ):
+        """Defence in depth behind ``_invalidate_cache``.
+
+        If a write path ever forgets to drop the memo, the stored mtime must
+        still stop the snippet from being served from it.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("s0", "user", "first deployment wording")
+        log.search_sessions("deployment", 50)
+
+        stored = log._snippet_cache.get("s0")
+        assert stored is not None, "precondition: the memo holds this session"
+        # Poison the memo, keeping its (now wrong) mtime.
+        log._snippet_cache["s0"] = (stored[0], ["poisoned deployment content"])
+        # Make the file's mtime disagree with the memo's.
+        path = log._path("s0")
+        os.utime(path, (stored[0] + 10, stored[0] + 10))
+
+        snippet = log._content_snippet("s0", "deployment")
+        assert "poisoned" not in snippet, "a stale mtime must not be trusted"
+        assert "first deployment wording" in snippet
+
+    def test_unreadable_session_drops_both_memos_together(self, tmp_path):
+        """The two memos are two views of one file; they must never disagree.
+
+        A stat failure invalidates the fold, and leaving the snippet source
+        behind would let a later query pair a fresh fold with a stale preview.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("s0", "user", "deployment notes")
+        log.search_sessions("deployment", 50)
+        assert log._snippet_cache.get("s0") is not None
+
+        log._path("s0").unlink()
+        log._folded_content("s0")
+
+        assert log._folded_cache.get("s0") is None
+        assert log._snippet_cache.get("s0") is None, "both memos drop together"
+
+
+class TestBudgetCountsRealBytesNotCharacters:
+    """``len()`` would undercount the ceiling by up to 4x.
+
+    CPython stores a ``str`` at the narrowest width its contents allow, so one
+    character is 1 byte for latin-1, 2 for the BMP and 4 for astral planes. A
+    ceiling counted in characters retains 168 MB of ASCII, 336 MB of CJK or
+    671 MB of emoji at a nominal 160 MB — and CJK is the ordinary case for a
+    non-English corpus, so this is not a pathological-input concern.
+    """
+
+    def test_wide_characters_consume_more_budget_than_narrow_ones(self, tmp_path):
+        log = ConversationLog(base_dir=tmp_path)
+        sizer = log._folded_cache._sizer
+
+        narrow = sizer((0.0, 0, "a" * 1000))
+        wide = sizer((0.0, 0, "\U0001f600" * 1000))
+
+        assert wide > narrow * 3, (
+            f"a 4-byte-per-char string must cost ~4x a 1-byte one, "
+            f"got narrow={narrow} wide={wide}"
+        )
+
+    def test_a_wide_string_is_refused_where_the_same_length_of_ascii_fits(self):
+        """The behavioural consequence: the ceiling holds regardless of script."""
+        budget = "x" * 2000
+        cache: history._SearchTextCache[str] = history._SearchTextCache(
+            budget.__sizeof__(), lambda v: v.__sizeof__()
+        )
+
+        cache["ascii"] = "y" * 2000
+        assert cache.get("ascii") is not None, "same-width content of equal length fits"
+
+        cache.clear()
+        cache["emoji"] = "\U0001f600" * 2000
+        assert cache.get("emoji") is None, (
+            "the same CHARACTER count of astral text is ~4x the bytes and must not fit"
+        )
+
+    def test_the_snippet_sizer_charges_for_its_list_container(self, tmp_path):
+        """Many small strings make the list itself a real share of the cost."""
+        log = ConversationLog(base_dir=tmp_path)
+        sizer = log._snippet_cache._sizer
+
+        texts = ["x" * 10 for _ in range(500)]
+        charged = sizer((0.0, texts))
+        strings_only = sum(t.__sizeof__() for t in texts)
+
+        assert charged > strings_only, "the list container must be charged too"
+        assert charged == strings_only + texts.__sizeof__()
+
+
+class TestAdmissionControlIsNotAOneWayRatchet:
+    """A full cache must not freeze on its first-fill set.
+
+    Admission control avoids the LRU cliff, but on its own it means entries
+    persist forever once admitted: sessions that age out of the scan window keep
+    holding budget while every newly created session is refused. The newest and
+    most-searched sessions would become exactly the cold ones, and warm latency
+    would regress over process lifetime until a restart.
+    """
+
+    def test_retain_frees_entries_outside_the_live_set(self):
+        cache: history._SearchTextCache[str] = history._SearchTextCache(100, len)
+        cache["old"] = "x" * 40
+        cache["new"] = "y" * 40
+
+        dropped = cache.retain({"new"})
+
+        assert dropped == 1
+        assert cache.get("old") is None
+        assert cache.get("new") is not None
+        assert cache.stats()["bytes"] == 40, "the freed budget is accounted"
+
+    def test_retain_resets_the_pressure_signal(self):
+        cache: history._SearchTextCache[str] = history._SearchTextCache(10, len)
+        cache["a"] = "x" * 10
+        cache["b"] = "y"  # refused
+        assert cache.refused_since_prune() == 1
+
+        cache.retain({"a"})
+
+        assert cache.refused_since_prune() == 0, "a prune clears the signal it acted on"
+        assert cache.stats()["refused"] == 1, "the cumulative count survives for diagnosis"
+
+    def test_a_session_that_left_the_window_stops_holding_budget(self, tmp_path, monkeypatch):
+        """End-to-end: an aged-out session's budget becomes reusable.
+
+        The valve fires from ``search_sessions`` only when a memo is refusing, and
+        a refusal happens *during* the walk while the prune runs *before* it — so
+        the release lands on the NEXT query, not the one that discovered the
+        pressure. That one-query lag is deliberate and bounded: the prune needs
+        the scan window, which is computed at the top of the walk, and a query
+        costs ~20 ms against a keystroke-driven caller. What must not happen is
+        the budget staying pinned forever, which is what this asserts.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        monkeypatch.setattr(history, "_SEARCH_SCAN_WINDOW", 1)
+        # Equal-length content so the budget freed by one exactly admits the other,
+        # which is what proves the valve restored service rather than just freeing.
+        log.append("older", "user", "mentions deployment nine")
+        log.search_sessions("deployment", 50)
+        assert log._folded_cache.get("older") is not None, "precondition: cached"
+
+        # A newer session displaces the older one from a 1-session window.
+        log.append("newer", "user", "mentions deployment ten!")
+        # Shrink the budget so admitting "newer" is refused while "older" holds it.
+        log._folded_cache._max_bytes = log._folded_cache.stats()["bytes"]
+
+        log.search_sessions("deployment", 50)  # discovers the pressure
+        assert log._folded_cache.refused_since_prune() > 0, "precondition: refusing"
+        assert log._folded_cache.get("newer") is None, "precondition: newer was refused"
+
+        log.search_sessions("deployment", 50)  # acts on it
+
+        assert log._folded_cache.get("older") is None, (
+            "a session outside the scan window must not keep holding budget"
+        )
+        assert log._folded_cache.get("newer") is not None, (
+            "the freed budget must admit the session that is actually in the window"
+        )
+
+    def test_an_uncontended_cache_is_never_pruned(self, tmp_path, monkeypatch):
+        """The scan is only worth paying under pressure."""
+        log = ConversationLog(base_dir=tmp_path)
+        _seed(log, sessions=3)
+        log.search_sessions("deployment", 50)
+
+        calls: list[int] = []
+        original = history._SearchTextCache.retain
+
+        def counted(self, live_keys):
+            calls.append(1)
+            return original(self, live_keys)
+
+        monkeypatch.setattr(history._SearchTextCache, "retain", counted)
+        log.search_sessions("deployment", 50)
+
+        assert calls == [], "no refusals means no prune"
+
+    def test_first_refusal_is_logged_once(self, caplog):
+        """``refused`` in stats() is only diagnosable if something surfaces it."""
+        cache: history._SearchTextCache[str] = history._SearchTextCache(
+            10, len, "test-memo"
+        )
+        cache["a"] = "x" * 10
+
+        with caplog.at_level("WARNING"):
+            cache["b"] = "y"
+            cache["c"] = "z"
+
+        hits = [r for r in caplog.records if "test-memo" in r.getMessage()]
+        assert len(hits) == 1, f"warn once, not per refusal; saw {len(hits)}"
+        assert "ceiling" in hits[0].getMessage()


### PR DESCRIPTION
## 1. What is the problem?

Two problems in `ConversationLog.search_sessions`, both found by profiling the palette after #1827 shipped the fold cache.

**A warm query spends 92% of its time rebuilding snippets from disk.** Matching is memoized; the preview line under each result is not. Every returned row re-opens its session file and re-parses JSONL until the first hit. Profiling three queries on the live 230-session / 171 MB corpus:

```
21720 calls  0.389s  json/decoder.py:344(raw_decode)     <- 55% of total
21666 calls  0.093s  history.py:_iter_message_texts
  768 calls  0.027s  {method 'count' of 'str' objects}    <- matching is 4%
   63 calls  0.653s  history.py:_content_snippet          <- cumtime, 92%
```

~7,200 JSON parses per query. The cost tracks **how deep the first hit sits**, not the hit count — which is why a 21-hit query measured 189 ms and a 50-hit query measured 81 ms.

**The fold cache is bounded by entry count, which bounds nothing that matters.** It was sized `max(cache_max, _SEARCH_SCAN_WINDOW)` = 500 entries. A session is read up to `_SESSION_MAX_BYTES` (2 MB), so 500 entries is a few MB or ~1 GB depending on whose corpus it is.

## 2. Why this issue matters to the user

The 12x spread is what a user feels, not the average. 80 ms reads as fine; the same search bar taking 15 ms for one word and 190 ms for another reads as stuttering. That variance is entirely the snippet path.

| query | before | after |
|---|---|---|
| `palette` | 25.8 ms | **10.8 ms** |
| `provider` | 74.0 ms | **13.4 ms** |
| `fleet` | 80.8 ms | **14.7 ms** |
| `sandbox` | 136.7 ms | **16.5 ms** |
| `ja` | **189.3 ms** | **21.4 ms** |

The unbounded memo is latent rather than present, but it is the kind that surfaces as an unexplained gateway RSS climb on exactly the largest corpora — the users the memoization exists for.

## 3. How our fix solves it

**Symptom** — a warm query stalls for up to 190 ms. **Cause** — `_content_snippet` streams the file through `_iter_message_texts` on every call, and JSON parsing dominates. **Root** — the fold and the snippet each read the file independently, even though `_build_folded` already materializes the exact list the snippet needs.

So `_build_folded` now hands that list to a second memo, and `_content_snippet` reads it through a new `_snippet_texts` accessor. **One traversal serves both halves** — the second corpus costs one extra reference, never an extra read. When the memo is absent (refused by the budget, session has no text, file changed) it falls back to the file, so the memo is an optimization and never a correctness dependency.

For the ceiling, both memos move from `_LRUCache` to a new `_SearchTextCache` bounded by **real retained bytes** (`str.__sizeof__`, plus the list container for the snippet memo — see §5 for why `len()` is the wrong unit).

Three properties make that bound safe:

**Admission control instead of eviction.** `search_sessions` walks the scan window **in the same recency order every query**, so the working set is cyclic. Under LRU a cyclic scan larger than the cache evicts each entry exactly one step before its next read — the hit rate does not degrade, it collapses to zero. (That cliff is why the old bound was `max(cache_max, _SEARCH_SCAN_WINDOW)`.) A byte budget would reintroduce it, so an entry that would exceed the budget is simply not stored and what is already held stays.

**A release valve, so admission control is not a one-way ratchet.** On its own, a full cache freezes on whatever it held first: entries that age out of the scan window keep their budget forever while every newly created session is refused, so the newest and most-searched sessions become exactly the cold ones and warm latency regresses over process lifetime. `retain(live_keys)` drops entries outside the current scan window — unreachable by construction, since a search only walks the 500 most recent — and `search_sessions` calls it only for a memo that is actually refusing. The release lands on the query after the one that discovered the pressure (the prune needs the window, which the walk computes); that lag is one query and self-clearing.

**Invalidation, not the mtime guard, is the correctness mechanism.** Both memos are dropped together in `_invalidate_cache` and on either stat failure, because they are two views of one file and must never disagree. `_snippet_texts` also validates the stored mtime, but that guard is explicitly *not* the protection: housekeeping writes restore the pre-write mtime (`_restore_mtime`), so it is blind to exactly the writes that matter.

One asymmetry, deliberate: `_snippet_texts` does not take `_file_lock`, while the fold still does. The fold decides whether a row appears at all, so a lost race there makes a session unsearchable for the life of the process. A snippet is display-only, so the same race costs one stale preview line.

## 4. What tests we did

`test/test_search_sessions_cost.py` — **47 pass** (was 31; 16 added, 6 updated). Wider suites: `test_history.py`, `test_history_atomic_rewrite.py`, `test_history_locking_remediation.py`, `test_dashboard_sessions_search.py` — **249 pass**. `isort` / `flake8` / `mypy` clean.

New coverage:
- byte budget refuses admission rather than evicting; the entries that fit survive; a partially-filled budget still serves them
- replacing a key releases the old cost first (else a session being appended to inflates the accounting until refused admission for its own value)
- `pop` releases budget; `pop` of an absent key does not corrupt accounting; `max_bytes <= 0` disables the bound
- **wide characters consume proportionally more budget**, and the same character count of astral text is refused where ASCII fits
- **the snippet sizer charges for its list container**
- **`retain` frees out-of-window entries, resets the pressure signal, and the freed budget admits the session actually in the window**
- **an uncontended cache is never pruned**; the first refusal is logged exactly once
- a warm query builds every snippet **without reading any file**; the snippet falls back when the memo holds nothing
- a write that **preserves mtime** still drops the memo; a changed mtime falls back rather than serving stale; an unreadable session drops both memos together

**Mutations verified (5).** Each applied, suite confirmed red, then reverted:
1. evict LRU-style instead of refusing admission → 2 failures (`the entry that fit must survive`)
2. drop a replaced entry without releasing its accounted cost → `the old value's cost is released`
3. omit `_snippet_cache.pop` from `_invalidate_cache` → `the memo must be dropped by invalidation, not left to the mtime guard`
4. size the fold by `len()` instead of `__sizeof__()` → `a 4-byte-per-char string must cost ~4x a 1-byte one`
5. disable the release valve → `a session outside the scan window must not keep holding budget`

Mutation 3 is worth calling out because **my first version of that test did not catch it.** It asserted no-stale-preview through `rewrite_session`, which bumps the mtime — so the guard alone made it pass and the test proved nothing about invalidation. It was rewritten to use `mark_consolidated`, a write path that preserves mtime, and asserts the memo directly. The original end-to-end check is kept, relabelled as what it actually is.

The valve test also **caught a real ordering defect in my own fix**: the prune ran before the walk while refusals happen during it, so the valve was silently one query late. That lag turned out to be inherent (the prune needs the window the walk computes), so it is now documented and the test pins that it is bounded to one query rather than permanent.

Six existing tests were updated rather than deleted. Two pinned the old **mechanism** (`_folded_cache._maxsize >= _SEARCH_SCAN_WINDOW`) and now pin the new one plus a guard that the budget holds a full scan window of generously-sized sessions, so tightening it fails loudly. Three needed the new `_build_folded(key, mtime)` signature. One asserted fold and snippet each call `_iter_message_texts` once; that invariant (no divergent skip rules) is now **structurally** stronger — they share one list — so it asserts one call and that the memo holds exactly what the fold read.

## 5. Any other suggestions on the work

- **`len()` was the wrong unit, and the miss was 4x on this very corpus.** CPython stores a `str` at the narrowest width its contents allow: 1 byte/char for latin-1, 2 for the BMP, 4 for astral. A ceiling counted in characters retains 168 MB of ASCII, **336 MB of CJK**, or 671 MB of emoji at a nominal 160 MB. That is not a pathological-input concern — the corpus these numbers come from is heavily CJK, and switching to `__sizeof__` moved the measured fold from a reported 7.9 MB to an actual **31.4 MB**. Credit to the GPT review for catching it before merge.
- **Observed usage on the 171 MB corpus:** fold 31.4 MB / 96 MB, snippet 22.3 MB / 64 MB, `refused=0`. The budgets are ceilings, not targets — sized so the pathological case is bounded, not to be reached.
- **The refusal warning has a consumer now.** `stats()` alone was an empty diagnosability claim (nothing surfaced it), so the first refusal logs a warning naming the memo and its ceiling. Credit to the Design review for pointing that out.
- **Cold query is untouched and still ~605 ms.** That is the initial fold walk across the scan window, a different problem; #1827's future-work section already names a persistent index as the fix. Deliberately out of scope.
- Peak RSS is unchanged (105.0 MB vs 106.3 MB before), because the snippet memo's cost is offset by no longer allocating a fresh parse per returned row.

Fixes #1986
