### PR TITLE
fix(browser): publish browse-mode changes to the specs kiro-cli launches

### DIFF
--- a/src/kiro_crew/browser/setup.py
+++ b/src/kiro_crew/browser/setup.py
@@ -94,6 +94,10 @@ _LEGACY_DIRECT_PLAYWRIGHT_KEY = "npm:@playwright/mcp"
 _OWNED_KIRO_AGENT_FILES = OWNED_KIRO_AGENT_FILES
 _OWNED_CC_AGENT_FILES = OWNED_CC_AGENT_FILES
 
+# The env var carrying the Chrome-extension connection token. Named once so the
+# writer that ADDS it and the merge that must DROP it on mode-down agree.
+_EXTENSION_TOKEN_ENV = "PLAYWRIGHT_MCP_EXTENSION_TOKEN"
+
 
 def is_playwright_installed() -> bool:
     """Check whether the Playwright MCP package is resolvable on PATH (OSS stub).
@@ -144,16 +148,6 @@ def get_extension_token() -> str | None:
     return None
 
 
-def get_playwright_mcp_env() -> dict[str, str]:
-    """Return env vars needed for Playwright MCP (extension token if set)."""
-    env: dict[str, str] = {}
-    if has_playwright_extension():
-        token = get_extension_token()
-        if token:
-            env["PLAYWRIGHT_MCP_EXTENSION_TOKEN"] = token
-    return env
-
-
 def generate_playwright_config() -> Path:
     """Generate ``<config_dir>/playwright-config.json`` with absolute paths.
 
@@ -163,7 +157,17 @@ def generate_playwright_config() -> Path:
     config_path = config_dir() / "playwright-config.json"
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
-    storage_state = str(config_dir() / "playwright-storage-state.json")
+    storage_state = config_dir() / "playwright-storage-state.json"
+
+    # ``storageState`` is only wired in when the file is actually present.
+    # Playwright treats a missing storage-state path as a hard error and fails
+    # context creation, which surfaces to the agent as an opaque HTTP 400 on
+    # EVERY browser call — indistinguishable from a broken install. Auth is
+    # optional (public sites need none), so an absent cookie jar must degrade to
+    # an anonymous context rather than disable browsing altogether.
+    context_options: dict[str, Any] = {}
+    if storage_state.exists():
+        context_options["storageState"] = str(storage_state)
 
     config = {
         "browser": {
@@ -174,14 +178,12 @@ def generate_playwright_config() -> Path:
                 # Run headless: the live mirror in the dashboard Browser panel is
                 # the intended view surface, so a separate visible OS window is
                 # redundant (and breaks on display-less Linux hosts). Auth is
-                # seeded via ``storageState`` below, so no interactive SSO window
-                # is needed.
+                # seeded via ``storageState`` when present, so no interactive SSO
+                # window is needed.
                 "headless": True,
                 "args": [],
             },
-            "contextOptions": {
-                "storageState": storage_state,
-            },
+            "contextOptions": context_options,
         },
         "capabilities": ["network", "storage"],
     }
@@ -218,24 +220,6 @@ def refresh_storage_state() -> dict[str, Any]:
         "count": len(cookies),
         "expired": len(expired),
     }
-
-
-def get_playwright_mcp_args() -> list[str]:
-    """Return Playwright MCP launch args based on platform and mode.
-
-    Extension mode (--extension): attaches to user's running Chrome with existing auth.
-    Config mode (--config): launches separate Chromium with cookie injection.
-    """
-    args = ["@playwright/mcp"]
-    if has_playwright_extension():
-        args.append("--extension")
-        return args
-    config_path = config_dir() / "playwright-config.json"
-    if config_path.exists():
-        args.extend(["--config", str(config_path)])
-    if is_headed():
-        args.append("--headed")
-    return args
 
 
 def _kirocrew_bin() -> str:
@@ -324,6 +308,30 @@ def migrate_owned_playwright_registration() -> None:
     _migrate_owned_kiro_registration()
     _converge_kirocrew_mcp_json()
     _converge_playwright_agent_files()
+    _heal_browse_mode_drift()
+
+
+def _heal_browse_mode_drift() -> None:
+    """Re-apply the recorded browse mode to the owned agent specs on boot.
+
+    The converge steps above collapse DUPLICATE and legacy proxy keys. None of
+    them notices a single canonical entry whose ``args`` are stale for the mode
+    the user actually chose, so an install wired before the mode write-path was
+    fixed keeps launching the wrong browser across upgrade and restart — and the
+    dashboard already shows the mode they picked, so nothing prompts them to
+    re-toggle it.
+
+    Scoped to the agent specs on purpose: kiro's global ``mcp.json`` is already
+    converged by :func:`_migrate_owned_kiro_registration`, and the specs are the
+    files kiro-cli actually launches from — the drifted shape in practice is a
+    correct ``mcp.json`` beside a stale spec. Delegating to
+    :func:`_sync_agent_specs_proxy_entry` inherits its invariants unchanged: only
+    owned files, only entries whose launch target is already this proxy (so
+    Playwright is never ADDED and a user's own server is never rewritten),
+    change-detected so a healthy install performs no write, and declined outright
+    from a worktree or isolated home.
+    """
+    _sync_agent_specs_proxy_entry(_proxy_entry_for_mode())
 
 
 def _migrate_owned_kiro_registration() -> None:
@@ -691,9 +699,49 @@ def _kiro_mcp_locked() -> Iterator[None]:
 
 def _patch_mcp_extension_unlocked(token: str) -> None:
     """Write the ``--extension`` proxy entry. Caller MUST hold ``_kiro_mcp_locked``."""
+    _write_proxy_entry_unlocked(
+        {
+            "command": _kirocrew_bin(),
+            "args": ["mcp-playwright-proxy", "--extension"],
+            "env": {_EXTENSION_TOKEN_ENV: token},
+        }
+    )
+
+
+def _patch_mcp_headless_unlocked() -> None:
+    """Write the headless-config proxy entry. Caller MUST hold ``_kiro_mcp_locked``."""
+    _write_proxy_entry_unlocked(
+        {
+            "command": _kirocrew_bin(),
+            "args": [
+                "mcp-playwright-proxy",
+                "--config",
+                str(config_dir() / "playwright-config.json"),
+            ],
+        }
+    )
+
+
+def _write_proxy_entry_unlocked(entry: dict[str, Any]) -> None:
+    """Publish *entry* as the product's Playwright server everywhere it is read.
+
+    Two files matter, and writing only the first is a silent no-op:
+
+    * ``~/.kiro/settings/mcp.json`` — kiro's global registry.
+    * ``~/.kiro/agents/*.json`` — what kiro-cli ACTUALLY launches MCP servers
+      from. ``rebuild_agent_config`` merges the global file with ``setdefault``,
+      so a spec that already declares a Playwright server keeps its OLD entry
+      forever. Updating the global file alone therefore leaves the browse mode
+      the agent really gets unchanged.
+
+    Both receive the SAME spec, so the launch shape cannot drift between them.
+
+    Caller MUST hold ``_kiro_mcp_locked``.
+    """
     mcp_json = _kiro_mcp_json_path()
     if not mcp_json.exists():
         return
+    canonical = mcp_server_alias(_PLAYWRIGHT_MCP_PACKAGE)
     try:
         data = json.loads(mcp_json.read_text(encoding="utf-8"))
         # A user-owned mcp.json may hold valid JSON that isn't an object (e.g.
@@ -706,66 +754,230 @@ def _patch_mcp_extension_unlocked(token: str) -> None:
         servers = data.setdefault("mcpServers", {})
         if not isinstance(servers, dict):
             servers = data["mcpServers"] = {}
-        entry = {
-            "command": _kirocrew_bin(),
-            "args": ["mcp-playwright-proxy", "--extension"],
-            "env": {"PLAYWRIGHT_MCP_EXTENSION_TOKEN": token},
-        }
-        canonical = mcp_server_alias(_PLAYWRIGHT_MCP_PACKAGE)
         _drop_superseded_playwright(servers, canonical)
         servers[canonical] = entry
         mcp_json.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        # 0600 unconditionally: the entry carries the extension token in
+        # extension mode, and the file holds other servers' credentials in both.
         platform_compat.chmod_safe(str(mcp_json), 0o600)
         _record_owned_mcp_key(canonical)
     except (json.JSONDecodeError, OSError):
-        pass
+        return
+    _sync_agent_specs_proxy_entry(entry)
 
 
-def _patch_mcp_headless_unlocked() -> None:
-    """Write the headless-config proxy entry. Caller MUST hold ``_kiro_mcp_locked``."""
-    mcp_json = _kiro_mcp_json_path()
-    if not mcp_json.exists():
+def _proxy_entry_for_mode() -> dict[str, Any]:
+    """Return the proxy spec for the recorded browse mode.
+
+    Extension mode needs a token to be usable, so a flagged-but-tokenless
+    install resolves to the headless config rather than an entry whose
+    ``PLAYWRIGHT_MCP_EXTENSION_TOKEN`` would be empty. Single source of the mode
+    decision, shared by the mcp.json patch path and the boot-time heal, so the
+    two cannot disagree about which mode is in effect.
+    """
+    if has_playwright_extension():
+        token = get_extension_token() or ""
+        if token:
+            return {
+                "command": _kirocrew_bin(),
+                "args": ["mcp-playwright-proxy", "--extension"],
+                "env": {_EXTENSION_TOKEN_ENV: token},
+            }
+    return {
+        "command": _kirocrew_bin(),
+        "args": [
+            "mcp-playwright-proxy",
+            "--config",
+            str(config_dir() / "playwright-config.json"),
+        ],
+    }
+
+
+def _merge_proxy_launch_fields(existing: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]:
+    """Return *existing* with only the MODE-dependent fields taken from *entry*.
+
+    A browse-mode change decides how the server is launched — nothing else. Every
+    sibling key is policy the user or the dashboard set (``disabled``,
+    ``disabledTools``, ``autoApprove``, tool filters), so replacing the whole
+    object would silently re-enable a tool someone deliberately turned off.
+
+    ``command`` is deliberately NOT synced. ``_kirocrew_bin`` degrades to a bare
+    ``"kirocrew"`` when PATH cannot resolve it — which a GUI/desktop launch that
+    inherits no shell profile routinely cannot — so copying it over would replace
+    a working absolute interpreter path with a name that fails at the next spawn.
+    The spec's resolved command is refreshed by ``rebuild_agent_config``, whose
+    job that is; here it is only filled in when the entry has none at all.
+
+    ``env`` is merged key-wise rather than swapped: the entry contributes only
+    ``PLAYWRIGHT_MCP_EXTENSION_TOKEN``, and any other variable on the server
+    belongs to whoever put it there. Leaving extension mode drops the token key
+    specifically — a stale secret must not linger in the spec — and removes an
+    ``env`` map that this leaves empty.
+    """
+    merged = dict(existing)
+    if not merged.get("command"):
+        merged["command"] = entry["command"]
+    merged["args"] = list(entry["args"])
+
+    env_in = entry.get("env")
+    env_out = dict(merged["env"]) if isinstance(merged.get("env"), dict) else {}
+    if isinstance(env_in, dict) and env_in:
+        env_out.update(env_in)
+    else:
+        env_out.pop(_EXTENSION_TOKEN_ENV, None)
+    if env_out:
+        merged["env"] = env_out
+    else:
+        merged.pop("env", None)
+    return merged
+
+
+def _tighten_secret_bearing_spec(path: Path, servers: dict[str, Any]) -> None:
+    """chmod *path* to 0600 when one of its proxy entries carries the secret.
+
+    Judged from what is ON DISK, not from the entry being applied: the exposure
+    is a property of the file's current contents. Only narrows, and only when
+    group or other actually hold a bit, so a spec already at 0600 is untouched
+    and a secret-free headless spec keeps whatever permissions its owner chose.
+    """
+    if not any(
+        _spec_is_proxy(s) and isinstance(s, dict) and (s.get("env") or {}).get(_EXTENSION_TOKEN_ENV)
+        for s in servers.values()
+    ):
         return
     try:
-        data = json.loads(mcp_json.read_text(encoding="utf-8"))
-        # See _patch_mcp_extension_unlocked: guard a non-object mcp.json /
-        # non-dict mcpServers so setdefault/servers[...] can't raise an uncaught
-        # AttributeError/TypeError.
-        if not isinstance(data, dict):
-            data = {}
-        servers = data.setdefault("mcpServers", {})
-        if not isinstance(servers, dict):
-            servers = data["mcpServers"] = {}
-        config_path = str(config_dir() / "playwright-config.json")
-        entry = {
-            "command": _kirocrew_bin(),
-            "args": ["mcp-playwright-proxy", "--config", config_path],
-        }
-        canonical = mcp_server_alias(_PLAYWRIGHT_MCP_PACKAGE)
-        _drop_superseded_playwright(servers, canonical)
-        servers[canonical] = entry
-        mcp_json.write_text(json.dumps(data, indent=2), encoding="utf-8")
-        _record_owned_mcp_key(canonical)
-    except (json.JSONDecodeError, OSError):
-        pass
+        if stat.S_IMODE(path.stat().st_mode) & 0o077:
+            platform_compat.chmod_safe(str(path), 0o600)
+    except OSError:
+        return
+
+
+def _sync_agent_specs_proxy_entry(entry: dict[str, Any]) -> int:
+    """Repoint every Kiro Crew-owned agent spec declaring the proxy at *entry*.
+
+    Scoped to the EXACT filenames in ``_OWNED_KIRO_AGENT_FILES`` /
+    ``_OWNED_CC_AGENT_FILES`` — an allowlist, not a glob. A user's own agents
+    live in the same directories (even one named ``kirocrew-custom.json``) and
+    may carry intentionally distinct Playwright args or env, so matching
+    generated filenames is what keeps a mode change from rewriting a spec this
+    product did not author. Mirrors ``_converge_playwright_agent_files``.
+
+    Within those files, updates each owning key IN PLACE — no renames, no
+    deletions — so existing ``@<server>`` references in ``tools`` /
+    ``allowedTools`` keep resolving. Only entries whose launch target is the
+    proxy are touched, so a hand-authored Playwright server under a canonical
+    key is left alone, and Playwright is never ADDED to an agent that declared
+    none.
+
+    Returns the number of spec files updated.
+    """
+    # Function-local import: ``agent`` imports this module's package, so a
+    # top-level import here is a circular import. Only the shared-agent-home
+    # guard is needed, and only at call time.
+    from kiro_crew.agent import _decline_shared_agent_home
+
+    # An instance booted from a git worktree or its own isolated home is
+    # throwaway, but these specs are shared with the real install — repointing
+    # them at this tree would make the live gateway launch code that is about to
+    # disappear. Same guard, same reason, as ``rebuild_agent_config``'s.
+    if _decline_shared_agent_home() is not None:
+        return 0
+
+    spec_paths: list[Path] = []
+    kiro_dir = kiro_agents_dir()
+    for name in _OWNED_KIRO_AGENT_FILES:
+        p = kiro_dir / name
+        if p.is_file():
+            spec_paths.append(p)
+    cc_dir = Path.home() / ".claude" / "agents"
+    # The Claude sidecar lives at a HOST-absolute path that no isolation variable
+    # relocates: KIROCREW_HOME moves the data home and KIRO_HOME moves the kiro
+    # agents dir, but ``Path.home()/.claude`` is the real user's either way. An
+    # instance running on its own data home would therefore stamp ITS config path
+    # into the host's sidecar, and a pod's teardown then leaves the host launching
+    # a browser against a deleted file. The shared-agent-home guard above cannot
+    # catch this — it reasons about ``kiro_agents_dir()``, a different directory —
+    # so skip the sidecar whenever the data home is not the ambient default.
+    if not (os.environ.get("KIROCREW_HOME") or os.environ.get("KIROCREW_POD")):
+        for name in _OWNED_CC_AGENT_FILES:
+            p = cc_dir / name
+            if p.is_file():
+                spec_paths.append(p)
+
+    updated = 0
+    for path in spec_paths:
+        # Serialize on the SAME sidecar the app bridges use for this file. The
+        # read-modify-write below is otherwise racy against app registration:
+        # whichever side writes second wins wholesale, so an app's MCP server
+        # entry can silently disappear (see ``_kiro_mcp_locked`` for the same
+        # hazard on kiro's global mcp.json). The spec is re-read INSIDE the lock
+        # so a concurrent registration is never overwritten with a stale copy.
+        #
+        # Function-local import: ``apps.bridges`` pulls in the app runtime, so a
+        # top-level import here is a circular import.
+        from kiro_crew.apps.bridges import _mcp_lock
+
+        with _mcp_lock(target=path):
+            try:
+                spec = json.loads(path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError, ValueError):
+                continue
+            if not isinstance(spec, dict):
+                continue
+            servers = spec.get("mcpServers")
+            if not isinstance(servers, dict):
+                continue
+            changed = False
+            for name, existing in list(servers.items()):
+                if not _spec_is_proxy(existing):
+                    continue
+                merged = _merge_proxy_launch_fields(existing, entry)
+                if merged != existing:
+                    servers[name] = merged
+                    changed = True
+            if not changed:
+                # Content already matches, but the FILE can still be group- or
+                # world-readable while holding the connection secret: another
+                # writer landing at the umask default creates exactly that state,
+                # and returning early here would leave it that way — now on every
+                # boot, since the heal reaches this path unattended. Tighten in
+                # place; no content rewrite, and a no-op for an already-0600 spec.
+                _tighten_secret_bearing_spec(path, servers)
+                continue
+            if entry.get("env"):
+                # This entry carries the extension token. A spec left at the
+                # umask default (commonly 0644) would publish that secret to
+                # every local account, so tighten rather than inherit — the
+                # token is new to the file, and 0600 only ever narrows access.
+                mode: int | None = 0o600
+            else:
+                # No secret introduced: preserve whatever the file already had
+                # rather than imposing a permission decision (mirrors
+                # ``_converge_playwright_agent_files``).
+                try:
+                    mode = stat.S_IMODE(path.stat().st_mode)
+                except OSError:
+                    mode = None
+            try:
+                # Atomic write: a live kiro-cli session reads these specs to
+                # spawn MCP servers, so a torn write could be parsed as a
+                # corrupt config and take the ACP process down.
+                atomic_write(path, json.dumps(spec, indent=2), mode=mode)
+            except OSError:
+                continue
+            updated += 1
+    return updated
 
 
 def _patch_mcp_for_mode_unlocked() -> None:
     """Write the proxy entry matching the configured browse mode.
 
-    Extension mode needs a token to be usable, so a flagged-but-tokenless install
-    falls back to the headless config rather than writing an entry whose
-    ``PLAYWRIGHT_MCP_EXTENSION_TOKEN`` is empty. Every registration path shares
-    this dispatch so the mode decision cannot drift between them.
+    Delegates the mode decision to :func:`_proxy_entry_for_mode` so this path and
+    the boot-time heal cannot disagree about which mode is in effect.
 
     Caller MUST hold ``_kiro_mcp_locked``.
     """
-    if has_playwright_extension():
-        token = get_extension_token() or ""
-        if token:
-            _patch_mcp_extension_unlocked(token)
-            return
-    _patch_mcp_headless_unlocked()
+    _write_proxy_entry_unlocked(_proxy_entry_for_mode())
 
 
 def patch_mcp_extension(token: str) -> None:

--- a/src/kiro_crew/cli_setup.py
+++ b/src/kiro_crew/cli_setup.py
@@ -356,8 +356,12 @@ def _setup(agent_only: bool = False, electron_only: bool = False, clean: bool = 
 
     # Always regenerate config and register proxy in mcp.json (preserve extension mode)
     try:
-        generate_playwright_config()
+        # Storage state FIRST: generate_playwright_config only wires
+        # contextOptions.storageState when the jar is already on disk, so
+        # generating the config first leaves a fresh install with no auth until
+        # something regenerates it later.
         refresh_storage_state()
+        generate_playwright_config()
         # register_playwright_proxy owns the shared mcp.json lock, the
         # user-entry guard, and the create-when-absent path — the patch
         # primitives have none of those.

--- a/test/test_browser_mcp_write_guard.py
+++ b/test/test_browser_mcp_write_guard.py
@@ -205,10 +205,12 @@ class TestWritesHappenUnderTheLock:
         observed: list[bool] = []
 
         monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
+        # Observe at the single write helper the mode dispatch now delegates to;
+        # the assertion is unchanged — the write must see the lock already held.
         monkeypatch.setattr(
             setup_mod,
-            "_patch_mcp_headless_unlocked",
-            lambda: observed.append(_try_lock_noblock(lock_path)),
+            "_write_proxy_entry_unlocked",
+            lambda entry: observed.append(_try_lock_noblock(lock_path)),
         )
         setup_mod._migrate_owned_kiro_registration()
 

--- a/test/test_browser_setup.py
+++ b/test/test_browser_setup.py
@@ -26,7 +26,6 @@ from kiro_crew.browser.setup import (
     converge_playwright_servers,
     ensure_playwright_installed,
     generate_playwright_config,
-    get_playwright_mcp_args,
     inject_cookies_via_playwright,
     is_headed,
     is_playwright_installed,
@@ -91,22 +90,6 @@ class TestIsHeaded:
         # Chromium window like macOS, not the Linux headless mode.
         monkeypatch.setattr("platform.system", lambda: "Windows")
         assert is_headed() is True
-
-
-class TestGetPlaywrightMcpArgs:
-    def test_includes_headed_on_macos(self, monkeypatch):
-        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
-        monkeypatch.setattr(setup_mod, "is_headed", lambda: True)
-        args = get_playwright_mcp_args()
-        assert "--headed" in args
-        assert "@playwright/mcp" in args
-
-    def test_no_headed_on_linux(self, monkeypatch):
-        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: False)
-        monkeypatch.setattr(setup_mod, "is_headed", lambda: False)
-        args = get_playwright_mcp_args()
-        assert "--headed" not in args
-        assert "@playwright/mcp" in args
 
 
 # ── TestInjectCookiesViaPlaywright ───────────────────────────────────────────
@@ -192,7 +175,9 @@ class TestGeneratePlaywrightConfig:
         assert "browser" in config
         assert "capabilities" in config
         assert config["browser"]["browserName"] == "chromium"
-        assert "storageState" in config["browser"]["contextOptions"]
+        # contextOptions is always present; ``storageState`` is conditional on the
+        # cookie jar existing (see TestGeneratePlaywrightConfigStorageState).
+        assert isinstance(config["browser"]["contextOptions"], dict)
 
     def test_storage_state_path_is_absolute(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         # The config path now derives from config_dir(), which reads KIROCREW_HOME
@@ -200,6 +185,10 @@ class TestGeneratePlaywrightConfig:
         # resolves from the patched Path.home -> ~/.kiro/crew under tmp_path.
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # ``storageState`` is only emitted when the jar is on disk, so create it.
+        jar = tmp_path / ".kiro" / "crew" / "playwright-storage-state.json"
+        jar.parent.mkdir(parents=True, exist_ok=True)
+        jar.write_text('{"cookies": [], "origins": []}')
         config_path = generate_playwright_config()
         config = json.loads(config_path.read_text(encoding="utf-8"))
         storage_state = config["browser"]["contextOptions"]["storageState"]
@@ -373,33 +362,38 @@ class TestRefreshStorageState:
         assert isinstance(result["expired"], int)
 
 
-# ── TestGetPlaywrightMcpArgsWithConfig ───────────────────────────────────────
+# ── TestGeneratePlaywrightConfigStorageState ─────────────────────────────────
 
 
-class TestGetPlaywrightMcpArgsWithConfig:
-    def test_includes_config_flag_when_file_exists(
+class TestGeneratePlaywrightConfigStorageState:
+    """``storageState`` must only be wired in when the cookie jar exists.
+
+    Playwright fails context creation on a missing storage-state path, which the
+    agent sees as an opaque HTTP 400 on every browser call.
+    """
+
+    def _ctx_options(self, tmp_path: Path) -> dict:
+        cfg = json.loads((tmp_path / ".kiro" / "crew" / "playwright-config.json").read_text())
+        return cfg["browser"]["contextOptions"]
+
+    def test_omitted_when_storage_state_absent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
-        # Data home moved to ~/.kiro/crew (config_dir()); clear KIROCREW_HOME so
-        # config_dir() resolves from the patched Path.home under tmp_path.
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.setattr(setup_mod, "is_headed", lambda: False)
-        # Create the config file
-        config_path = tmp_path / ".kiro" / "crew" / "playwright-config.json"
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-        config_path.write_text("{}")
-        args = get_playwright_mcp_args()
-        assert "--config" in args
-        assert str(config_path) in args
+        generate_playwright_config()
+        assert "storageState" not in self._ctx_options(tmp_path)
 
-    def test_no_config_flag_when_file_absent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    def test_included_when_storage_state_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.setattr(setup_mod, "is_headed", lambda: False)
-        args = get_playwright_mcp_args()
-        assert "--config" not in args
-        assert "@playwright/mcp" in args
+        state = tmp_path / ".kiro" / "crew" / "playwright-storage-state.json"
+        state.parent.mkdir(parents=True, exist_ok=True)
+        state.write_text('{"cookies": [], "origins": []}')
+        generate_playwright_config()
+        assert self._ctx_options(tmp_path)["storageState"] == str(state)
 
 
 # ── TestPatchWritesCanonicalKey ──────────────────────────────────────────────
@@ -1161,3 +1155,400 @@ class TestConvergeForensics:
 
         assert agent_mod.AGENT_FILENAME == agent_files.AGENT_FILENAME
         assert agent_mod.AGENT_FILENAME in agent_files.OWNED_KIRO_AGENT_FILES
+
+
+# ── TestSyncAgentSpecsProxyEntry ─────────────────────────────────────────────
+
+
+class TestSyncAgentSpecsProxyEntry:
+    """kiro-cli launches MCP servers from ``~/.kiro/agents/*.json``.
+
+    A mode change that only reaches ``~/.kiro/settings/mcp.json`` is invisible to
+    the agent, because ``rebuild_agent_config`` merges the global file with
+    ``setdefault`` and so preserves whatever the spec already declared.
+    """
+
+    EXT_ENTRY = {
+        "command": "/opt/kirocrew",
+        "args": ["mcp-playwright-proxy", "--extension"],
+        "env": {"PLAYWRIGHT_MCP_EXTENSION_TOKEN": "tok"},
+    }
+
+    def _agents_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        agents = tmp_path / ".kiro" / "agents"
+        agents.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(setup_mod, "kiro_agents_dir", lambda: agents)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        import kiro_crew.agent as agent_mod
+
+        monkeypatch.setattr(agent_mod, "_decline_shared_agent_home", lambda **_: None)
+        return agents
+
+    STALE = {
+        "command": "/opt/kirocrew",
+        "args": ["mcp-playwright-proxy", "--config", "/tmp/pw.json"],
+    }
+
+    def _write_spec(self, agents: Path, name: str, servers: dict) -> Path:
+        p = agents / name
+        p.write_text(json.dumps({"name": name.removesuffix(".json"), "mcpServers": servers}))
+        return p
+
+    def _servers(self, path: Path) -> dict:
+        return json.loads(path.read_text())["mcpServers"]
+
+    def test_replaces_stale_config_entry_with_new_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        spec = self._write_spec(agents, "kirocrew.json", {"playwright-mcp": dict(self.STALE)})
+        assert setup_mod._sync_agent_specs_proxy_entry(self.EXT_ENTRY) == 1
+        assert self._servers(spec)["playwright-mcp"] == self.EXT_ENTRY
+
+    def test_updates_legacy_key_in_place_preserving_refs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A legacy key is repointed, never renamed/removed, so an existing
+        # ``@playwright-proxy-mcp`` reference in tools/allowedTools still resolves.
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        spec = self._write_spec(agents, "kirocrew.json", {"playwright-proxy-mcp": dict(self.STALE)})
+        setup_mod._sync_agent_specs_proxy_entry(self.EXT_ENTRY)
+        servers = self._servers(spec)
+        assert servers["playwright-proxy-mcp"] == self.EXT_ENTRY
+        assert "playwright-mcp" not in servers
+
+    def test_leaves_user_authored_agent_file_alone(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A hand-authored agent sharing the name prefix is NOT an owned file, so
+        # its deliberately-distinct Playwright wiring must survive a mode change.
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        custom = self._write_spec(
+            agents, "kirocrew-custom.json", {"playwright-mcp": dict(self.STALE)}
+        )
+        assert setup_mod._sync_agent_specs_proxy_entry(self.EXT_ENTRY) == 0
+        assert self._servers(custom)["playwright-mcp"] == self.STALE
+
+    def test_leaves_user_authored_non_proxy_server_alone(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        user_entry = {"command": "npx", "args": ["@playwright/mcp", "--headed"]}
+        spec = self._write_spec(agents, "kirocrew.json", {"playwright-mcp": dict(user_entry)})
+        assert setup_mod._sync_agent_specs_proxy_entry(self.EXT_ENTRY) == 0
+        assert self._servers(spec)["playwright-mcp"] == user_entry
+
+    def test_never_adds_playwright_to_an_agent_without_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        spec = self._write_spec(agents, "kirocrew-lite.json", {"kirocrew-core": {"command": "x"}})
+        assert setup_mod._sync_agent_specs_proxy_entry(self.EXT_ENTRY) == 0
+        assert "playwright-mcp" not in self._servers(spec)
+
+    def test_preserves_resolved_command_against_unresolved_bare_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # _kirocrew_bin() degrades to a bare "kirocrew" when PATH cannot resolve
+        # it (a GUI launch inherits no shell profile). A mode toggle must not
+        # trade the spec's working absolute path for a name that fails to spawn.
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        existing = {
+            "command": "/opt/venv/bin/kirocrew",
+            "args": ["mcp-playwright-proxy", "--config", "/tmp/pw.json"],
+        }
+        spec = self._write_spec(agents, "kirocrew.json", {"playwright-mcp": existing})
+        bare = {
+            "command": "kirocrew",
+            "args": ["mcp-playwright-proxy", "--extension"],
+            "env": {"PLAYWRIGHT_MCP_EXTENSION_TOKEN": "tok"},
+        }
+        assert setup_mod._sync_agent_specs_proxy_entry(bare) == 1
+        got = self._servers(spec)["playwright-mcp"]
+        assert got["command"] == "/opt/venv/bin/kirocrew"
+        assert got["args"] == ["mcp-playwright-proxy", "--extension"]
+
+    def test_fills_in_command_when_spec_has_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        spec = self._write_spec(
+            agents,
+            "kirocrew.json",
+            {"playwright-mcp": {"args": ["mcp-playwright-proxy", "--config", "/tmp/pw.json"]}},
+        )
+        assert setup_mod._sync_agent_specs_proxy_entry(self.EXT_ENTRY) == 1
+        assert self._servers(spec)["playwright-mcp"]["command"] == self.EXT_ENTRY["command"]
+
+    def test_preserves_per_server_policy_fields(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A mode change decides HOW the server launches. Sibling keys are policy
+        # someone set deliberately — wiping disabledTools would silently
+        # re-enable a tool that was turned off.
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        existing = dict(self.STALE)
+        existing.update(
+            {
+                "disabled": False,
+                "disabledTools": ["browser_evaluate"],
+                "autoApprove": ["browser_navigate"],
+            }
+        )
+        spec = self._write_spec(agents, "kirocrew.json", {"playwright-mcp": existing})
+        assert setup_mod._sync_agent_specs_proxy_entry(self.EXT_ENTRY) == 1
+        got = self._servers(spec)["playwright-mcp"]
+        assert got["args"] == self.EXT_ENTRY["args"]
+        assert got["disabledTools"] == ["browser_evaluate"]
+        assert got["autoApprove"] == ["browser_navigate"]
+        assert got["disabled"] is False
+
+    def test_leaving_extension_mode_drops_the_token(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A stale secret must not linger once the mode no longer uses it, while an
+        # unrelated env var the user set is left in place.
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        existing = {
+            "command": "/opt/kirocrew",
+            "args": ["mcp-playwright-proxy", "--extension"],
+            "env": {"PLAYWRIGHT_MCP_EXTENSION_TOKEN": "tok", "HTTP_PROXY": "http://p:8080"},
+        }
+        spec = self._write_spec(agents, "kirocrew.json", {"playwright-mcp": existing})
+        headless = {
+            "command": "/opt/kirocrew",
+            "args": ["mcp-playwright-proxy", "--config", "/tmp/pw.json"],
+        }
+        assert setup_mod._sync_agent_specs_proxy_entry(headless) == 1
+        env = self._servers(spec)["playwright-mcp"]["env"]
+        assert "PLAYWRIGHT_MCP_EXTENSION_TOKEN" not in env
+        assert env["HTTP_PROXY"] == "http://p:8080"
+
+    def test_no_write_when_merge_is_a_noop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        # Already on the target mode: nothing to change, so no rewrite at all.
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        spec = self._write_spec(agents, "kirocrew.json", {"playwright-mcp": dict(self.EXT_ENTRY)})
+        before = spec.stat().st_mtime_ns
+        assert setup_mod._sync_agent_specs_proxy_entry(self.EXT_ENTRY) == 0
+        assert spec.stat().st_mtime_ns == before
+
+    def test_syncs_the_cc_sidecar_on_a_default_data_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.delenv("KIROCREW_POD", raising=False)
+        cc = tmp_path / ".claude" / "agents"
+        cc.mkdir(parents=True, exist_ok=True)
+        sidecar = cc / "kirocrew.mcp.json"
+        sidecar.write_text(json.dumps({"mcpServers": {"playwright-mcp": dict(self.STALE)}}))
+        assert agents.exists()
+        assert setup_mod._sync_agent_specs_proxy_entry(self.EXT_ENTRY) == 1
+        assert self._servers(sidecar)["playwright-mcp"]["args"] == self.EXT_ENTRY["args"]
+
+    @pytest.mark.parametrize("var", ["KIROCREW_HOME", "KIROCREW_POD"])
+    def test_leaves_the_host_cc_sidecar_alone_from_an_isolated_instance(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, var: str
+    ):
+        # ``Path.home()/.claude`` is host-absolute — no isolation variable moves
+        # it — so an instance on its own data home must not stamp its config path
+        # into the host's sidecar, which teardown would leave dangling.
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.delenv("KIROCREW_POD", raising=False)
+        monkeypatch.setenv(var, str(tmp_path / "isolated"))
+        cc = tmp_path / ".claude" / "agents"
+        cc.mkdir(parents=True, exist_ok=True)
+        sidecar = cc / "kirocrew.mcp.json"
+        sidecar.write_text(json.dumps({"mcpServers": {"playwright-mcp": dict(self.STALE)}}))
+        assert agents.exists()
+        assert setup_mod._sync_agent_specs_proxy_entry(self.EXT_ENTRY) == 0
+        assert self._servers(sidecar)["playwright-mcp"] == self.STALE
+
+    @pytest.mark.skipif(not IS_POSIX, reason="POSIX permission bits only")
+    def test_tightens_a_world_readable_secret_spec_even_when_content_matches(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Another writer can land a token-bearing spec at the umask default. The
+        # content then already matches, so the no-op path must still narrow the
+        # file rather than leaving the secret readable by other local accounts.
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        spec = self._write_spec(agents, "kirocrew.json", {"playwright-mcp": dict(self.EXT_ENTRY)})
+        os.chmod(spec, 0o644)
+        body_before = spec.read_text()
+        assert setup_mod._sync_agent_specs_proxy_entry(self.EXT_ENTRY) == 0
+        assert stat.S_IMODE(spec.stat().st_mode) == 0o600
+        assert spec.read_text() == body_before
+
+    @pytest.mark.skipif(not IS_POSIX, reason="POSIX permission bits only")
+    def test_does_not_tighten_a_secret_free_spec(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # No secret on disk, so the owner's permission choice is left alone.
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        headless = {
+            "command": "/opt/kirocrew",
+            "args": ["mcp-playwright-proxy", "--config", "/tmp/pw.json"],
+        }
+        spec = self._write_spec(agents, "kirocrew.json", {"playwright-mcp": dict(headless)})
+        os.chmod(spec, 0o644)
+        assert setup_mod._sync_agent_specs_proxy_entry(headless) == 0
+        assert stat.S_IMODE(spec.stat().st_mode) == 0o644
+
+    @pytest.mark.skipif(not IS_POSIX, reason="POSIX permission bits only")
+    def test_token_bearing_spec_is_tightened_not_inherited(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The entry carries the extension token, so a spec sitting at the umask
+        # default must NOT inherit 0644 — that would publish the token to every
+        # local account.
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        spec = self._write_spec(agents, "kirocrew.json", {"playwright-mcp": dict(self.STALE)})
+        os.chmod(spec, 0o644)
+        assert setup_mod._sync_agent_specs_proxy_entry(self.EXT_ENTRY) == 1
+        assert stat.S_IMODE(spec.stat().st_mode) == 0o600
+
+    @pytest.mark.skipif(not IS_POSIX, reason="POSIX permission bits only")
+    def test_headless_entry_preserves_existing_bits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # No secret is introduced by a headless entry, so the file's own
+        # permission decision is left alone.
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        ext_spec = {
+            "command": "/opt/kirocrew",
+            "args": ["mcp-playwright-proxy", "--extension"],
+            "env": {"PLAYWRIGHT_MCP_EXTENSION_TOKEN": "tok"},
+        }
+        spec = self._write_spec(agents, "kirocrew.json", {"playwright-mcp": ext_spec})
+        os.chmod(spec, 0o640)
+        headless = {
+            "command": "/opt/kirocrew",
+            "args": ["mcp-playwright-proxy", "--config", "/tmp/pw.json"],
+        }
+        assert setup_mod._sync_agent_specs_proxy_entry(headless) == 1
+        assert stat.S_IMODE(spec.stat().st_mode) == 0o640
+
+    def test_declines_from_worktree_or_isolated_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        spec = self._write_spec(agents, "kirocrew.json", {"playwright-mcp": dict(self.STALE)})
+        import kiro_crew.agent as agent_mod
+
+        monkeypatch.setattr(agent_mod, "_decline_shared_agent_home", lambda **_: spec)
+        assert setup_mod._sync_agent_specs_proxy_entry(self.EXT_ENTRY) == 0
+        assert self._servers(spec)["playwright-mcp"] == self.STALE
+
+    def test_malformed_spec_is_skipped_not_fatal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        agents = self._agents_dir(tmp_path, monkeypatch)
+        (agents / "kirocrew-lite.json").write_text("{not json")
+        good = self._write_spec(agents, "kirocrew.json", {"playwright-mcp": dict(self.STALE)})
+        assert setup_mod._sync_agent_specs_proxy_entry(self.EXT_ENTRY) == 1
+        assert self._servers(good)["playwright-mcp"] == self.EXT_ENTRY
+
+
+# ── TestHealBrowseModeDrift ──────────────────────────────────────────────────
+
+
+class TestHealBrowseModeDrift:
+    """Gateway boot must re-apply the recorded mode, not just collapse duplicates.
+
+    The converge sweeps key off duplicate/legacy keys, so an install with exactly
+    one canonical proxy carrying stale args stayed broken across restart while the
+    dashboard showed the mode the user had already chosen.
+    """
+
+    def _wire(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        agents = tmp_path / ".kiro" / "agents"
+        agents.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(setup_mod, "kiro_agents_dir", lambda: agents)
+        import kiro_crew.agent as agent_mod
+
+        monkeypatch.setattr(agent_mod, "_decline_shared_agent_home", lambda **_: None)
+        mcp = tmp_path / ".kiro" / "settings" / "mcp.json"
+        mcp.parent.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(setup_mod, "_kiro_mcp_json_path", lambda: mcp)
+        # Extension mode recorded, with a token, so the mode resolves to --extension.
+        monkeypatch.setattr(setup_mod, "has_playwright_extension", lambda: True)
+        monkeypatch.setattr(setup_mod, "get_extension_token", lambda: "tok")
+        monkeypatch.setattr(setup_mod, "_kirocrew_bin", lambda: "/opt/kirocrew")
+        return mcp, agents
+
+    def _spec_args(self, path: Path) -> list:
+        return json.loads(path.read_text())["mcpServers"]["playwright-mcp"]["args"]
+
+    def test_heals_stale_agent_spec_even_when_mcp_json_is_correct(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The real-world broken shape: the global file already says --extension,
+        # so anything keying off mcp.json alone concludes the install is healthy.
+        mcp, agents = self._wire(tmp_path, monkeypatch)
+        correct = {
+            "command": "/opt/kirocrew",
+            "args": ["mcp-playwright-proxy", "--extension"],
+            "env": {"PLAYWRIGHT_MCP_EXTENSION_TOKEN": "tok"},
+        }
+        mcp.write_text(json.dumps({"mcpServers": {"playwright-mcp": correct}}))
+        spec = agents / "kirocrew.json"
+        spec.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "playwright-mcp": {
+                            "command": "/opt/kirocrew",
+                            "args": ["mcp-playwright-proxy", "--config", "/tmp/pw.json"],
+                        }
+                    }
+                }
+            )
+        )
+        setup_mod._heal_browse_mode_drift()
+        assert self._spec_args(spec) == ["mcp-playwright-proxy", "--extension"]
+
+    def test_no_write_when_already_consistent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Runs on every boot, so a healthy install must not be rewritten.
+        mcp, agents = self._wire(tmp_path, monkeypatch)
+        entry = {
+            "command": "/opt/kirocrew",
+            "args": ["mcp-playwright-proxy", "--extension"],
+            "env": {"PLAYWRIGHT_MCP_EXTENSION_TOKEN": "tok"},
+        }
+        mcp.write_text(json.dumps({"mcpServers": {"playwright-mcp": entry}}, indent=2))
+        spec = agents / "kirocrew.json"
+        spec.write_text(json.dumps({"mcpServers": {"playwright-mcp": dict(entry)}}))
+        mcp_before = mcp.stat().st_mtime_ns
+        spec_before = spec.stat().st_mtime_ns
+        setup_mod._heal_browse_mode_drift()
+        assert mcp.stat().st_mtime_ns == mcp_before
+        assert spec.stat().st_mtime_ns == spec_before
+
+    def test_never_adds_playwright_to_a_spec_without_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Runs unattended on every boot, so the "never add" invariant matters more
+        # here than on an explicit user action.
+        mcp, agents = self._wire(tmp_path, monkeypatch)
+        spec = agents / "kirocrew.json"
+        spec.write_text(json.dumps({"mcpServers": {"kirocrew-core": {"command": "x"}}}))
+        setup_mod._heal_browse_mode_drift()
+        assert "playwright-mcp" not in json.loads(spec.read_text())["mcpServers"]
+        assert not mcp.exists()
+
+    def test_boot_migration_invokes_the_heal(self, monkeypatch: pytest.MonkeyPatch):
+        calls: list[str] = []
+        for name in (
+            "_migrate_owned_kiro_registration",
+            "_converge_kirocrew_mcp_json",
+            "_converge_playwright_agent_files",
+            "_heal_browse_mode_drift",
+        ):
+            monkeypatch.setattr(setup_mod, name, lambda n=name: calls.append(n))
+        setup_mod.migrate_owned_playwright_registration()
+        assert calls[-1] == "_heal_browse_mode_drift"


### PR DESCRIPTION
## Problem

Turning on Chrome-extension mode (Settings → Browser, or `kirocrew browse extension on`) appeared to succeed but changed nothing. The agent kept browsing in the bundled Chromium, so every site the user was logged into came back **logged out** — and the toggle reported success, which sent debugging toward Chrome, the extension, and cookie export instead of the config.

A second, independent fault made the fallback path fail too: with no cookie jar on disk, *every* browser call failed with an opaque `HTTP 400` before any page loaded.

## Why it matters

Authenticated browsing is unusable and the failure actively misleads. Nothing surfaces the real cause: the mode flag file exists, `settings/mcp.json` shows `--extension`, and `browse setup` prints success — while the process actually running carries `--config`. The only way to see it is `ps`.

## Fix (symptoms → root cause → change)

**Symptom:** extension mode on, but the running proxy has `--config` and a fresh Chromium spawns.

**Root cause:** kiro-cli launches MCP servers from `~/.kiro/agents/*.json`, **not** `~/.kiro/settings/mcp.json`. Both the dashboard toggle and `browse setup` write only the global file, via `register_playwright_proxy`. `rebuild_agent_config` merges that file with **`setdefault`** (`agent.py:2240`), so an agent spec that already declares a Playwright server keeps its old entry forever. Writing the global file alone is a silent no-op.

**Change:** both mode patches now hand the *same* entry to one writer, `_write_proxy_entry_unlocked`, which publishes it to kiro's `mcp.json` **and** to the owned agent specs. One spec object to both files means the launch shape cannot drift. Because this sits at the existing mode-dispatch chokepoint, the dashboard toggle and the `browse setup` CLI are both fixed with no change to either caller.

Safety properties of the agent-spec sync:
- Scoped to the **exact filenames** in `OWNED_KIRO_AGENT_FILES` / `OWNED_CC_AGENT_FILES` — an allowlist, not a glob — mirroring `_converge_playwright_agent_files`. A user's own agent in the same directory (even one named `kirocrew-custom.json`) may carry deliberately distinct Playwright wiring and is never rewritten.
- Only the **mode-dependent** fields are taken from the new entry: `args` and the connection env var. Sibling policy keys (`disabled`, `disabledTools`, `autoApprove`, tool filters) are preserved — a full swap would silently re-enable a tool someone turned off.
- `command` is **not** synced. The binary resolver degrades to a bare name when PATH cannot resolve it (routine for a GUI launch inheriting no shell profile), so copying it would trade a working absolute path for a name that fails at the next spawn. Refreshing that value is `rebuild_agent_config`'s job; it is filled in here only when the spec has none.
- `env` is merged key-wise so an unrelated variable survives, and **leaving** extension mode drops the connection key specifically, so a stale secret cannot linger.
- Owning keys are updated **in place** — no rename, no delete — so existing `@<server>` references keep resolving. Identity is by **launch target**, so a hand-authored Playwright server under a canonical key is left alone, and Playwright is **never added** to an agent that declared none.
- Writes are **atomic**, since a live kiro-cli session reads these specs to spawn MCP servers and a torn write could take the ACP process down. An entry carrying the extension secret forces mode `0600` rather than inheriting the file's bits — the secret is new to the file, so a spec at the umask default would otherwise expose it to every local account. A headless entry introduces no secret and preserves the existing bits.
- Each spec's read-modify-write runs under the **same lock sidecar the app bridges use for that file**, re-reading inside the lock, so a concurrent app registration is not clobbered — the hazard `_kiro_mcp_locked`'s docstring already documents for the global file.
- Worktree and isolated-home instances **decline**, reusing `rebuild_agent_config`'s existing guard.

**Already-broken installs self-heal.** Fixing the write path alone would have left every install *already* in the broken state needing a manual re-toggle of a mode the dashboard already shows as on — which is exactly the state that produced this report. The boot converge steps key off duplicate and legacy keys; none notices a single canonical entry whose `args` are stale for the recorded mode. Gateway boot now re-applies the recorded mode to the owned agent specs (`_heal_browse_mode_drift`, called from `migrate_owned_playwright_registration`). It delegates to the same spec sync, so it inherits every invariant above unchanged — including never adding Playwright and never touching a user's own server, which the pre-existing boot-migration tests caught when an earlier draft called the writer directly. The mode decision now lives in one helper (`_proxy_entry_for_mode`) shared by the patch path and the heal, so the two cannot disagree about which mode is in effect.

**Setup ordering.** `refresh_storage_state()` now runs **before** `generate_playwright_config()`. The config only wires `contextOptions.storageState` when the jar is already on disk, so generating it first left a fresh install with no auth until something regenerated it later.

**`storageState` no longer emitted when the jar is absent.** Playwright treats a missing storage-state path as a hard error and fails context creation. Auth is optional — public sites need none — so an absent cookie jar now degrades to an anonymous context instead of disabling browsing entirely.

**Dead helpers removed.** `get_playwright_mcp_args` / `get_playwright_mcp_env` were unreachable from production and returned a direct `["@playwright/mcp", ...]` invocation, contradicting the `mcp-playwright-proxy` command every real entry uses. They read like the mode-aware source of truth, so the tempting "fix" is to wire them in — which would write a launch command that cannot work.

## Tests

`TestSyncAgentSpecsProxyEntry` (11) covers the regression and each safety property: stale `--config` replaced; legacy key repointed in place so `@ref`s survive; a hand-authored `kirocrew-custom.json` untouched; a non-proxy server under the canonical key untouched; never added to an agent without it; policy fields (`disabled`/`disabledTools`/`autoApprove`) preserved while `args` update; token dropped on mode-down with an unrelated `HTTP_PROXY` preserved; no write when the merge is a no-op; a resolved absolute `command` preserved against an unresolved bare name; `command` filled in when the spec has none; 0600 forced for a token-bearing spec and existing bits preserved for a headless one (the two permission cases are `IS_POSIX`-gated).

`TestHealBrowseModeDrift` (4) covers boot healing: a stale agent spec healed even when `mcp.json` is already correct (the real-world shape), no write when already consistent, never adding Playwright to a spec without it, and the dispatcher actually invoking the heal.

`TestGeneratePlaywrightConfigStorageState` (2) covers `storageState` omitted when the jar is absent and present when it exists.

Removed `TestGetPlaywrightMcpArgs` and `TestGetPlaywrightMcpArgsWithConfig` (4 cases) with the functions they covered.

Two existing `TestGeneratePlaywrightConfig` cases that assumed `storageState` is unconditional were updated; `test_storage_state_path_is_absolute` now creates the jar first, preserving its intent. One pre-existing lock-guard test (`test_boot_migration_holds_lock_across_read_and_write`) now observes `_write_proxy_entry_unlocked` instead of `_patch_mcp_headless_unlocked`, because the mode dispatch delegates there — the assertion is unchanged: the write must see the lock already held.

**Not covered by a dedicated test:** the setup ordering change. The enclosing function is the interactive setup wizard, and the only test shapes available were a source-text scan or a near-full-wizard harness; the behaviour it protects is already pinned by `TestGeneratePlaywrightConfigStorageState`, and the call site carries a comment explaining why the order matters. Calling that out rather than implying coverage that isn't there.

## Manual verification

Verified end-to-end on macOS against real Chrome. Before: the proxy ran `mcp-playwright-proxy --config`, a separate "Google Chrome for Testing" process spawned, and a logged-in site rendered its logged-out marketing page with only an anonymous session cookie. After correcting the agent spec: the proxy runs `--extension`, the attached target is a `chrome-extension://…` page served from the real Chrome process (default profile, no `--user-data-dir`), and **zero** Chrome-for-Testing processes spawn. A bundled-Chromium fallback cannot produce that URL, since the extension exists only in the real profile.

Gates: full `pytest` 33032 passed with the same 9 failures as a clean `origin/main` baseline (33016 passed there); `isort`, `flake8` and the brand-name gate clean; `mypy` reports the same 3 pre-existing `os.*xattr` errors as main (macOS typeshed, `hooks.py`, untouched here). Backend-only change, so `tsc`/`vitest` do not apply.

## Screenshots

N/A — no user-visible UI change. The dashboard toggle's markup and behaviour are unchanged; only what it writes to disk differs.

## Deliberately not in this PR

The remaining Design Review item: the owned specs' Playwright entry is maintained by three writers (rebuild's `setdefault` merge, the boot converge sweep, this mode sync). Promoting the proxy to a mode-aware managed server in `rebuild_agent_config` would collapse them to one and subsume the boot heal above, but `_MANAGED_MCP_SERVERS` is a static dict and Playwright's spec is mode-dependent, so it means changing the managed-server contract and its consumers — a refactor on a path every session start depends on, and its own PR.

Also deferred: the durable half of the `storageState` fix. The existence check is still a snapshot at config-write time, so a jar deleted *later* can still resurrect the `HTTP 400`. The robust form is checking the jar at proxy launch rather than at write time, which is a different mechanism in `mcp_playwright_proxy.py` and interacts with `browser_set_storage_state`.
