### PR TITLE
fix(dev-fleet): gate background tasks off by default in tests

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -4015,6 +4015,18 @@ _refresher_task: asyncio.Task | None = None
 _warm_task: asyncio.Task | None = None
 _reaper_task: asyncio.Task | None = None
 
+# Test-only escape hatch: a test that boots the real app via ``create_app()``
+# (e.g. to exercise the HMAC middleware) would otherwise start a genuine
+# network ``git fetch`` inside ``_status_refresher`` with nothing stubbed,
+# leaking a live background task into whichever test runs next. Unset in
+# production; ``test/conftest.py`` sets it for every test by default.
+_DISABLE_BACKGROUND_ENV = "KIROCREW_DEVFLEET_NO_BACKGROUND"
+
+
+def _background_tasks_disabled() -> bool:
+    return os.environ.get(_DISABLE_BACKGROUND_ENV) == "1"
+
+
 # Auto-prune reaper (opt-in via dev_fleet.auto_prune.enabled). The poll interval
 # is floored so a misconfigured tiny value can't hammer gh/git every cycle.
 _AUTO_PRUNE_MIN_INTERVAL_S = 300
@@ -4485,6 +4497,8 @@ async def dev_fleet_startup(app: web.Application) -> None:
     # Resolve the node build toolchain here, on the executor, so no request
     # handler ever pays for the filesystem scan (NFS homes make it slow).
     await _warm_build_path()
+    if _background_tasks_disabled():
+        return
     if _refresher_task is None or _refresher_task.done():
         _refresher_task = asyncio.create_task(_status_refresher())
     if _reaper_task is None or _reaper_task.done():

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -785,6 +785,21 @@ def _reset_reasoning_effort_globals():
 
 
 @pytest.fixture(autouse=True)
+def _disable_dev_fleet_background_tasks(monkeypatch):
+    """Stop dev-fleet's app-startup hook from starting its background loops.
+
+    A test that boots the real app via ``dev_fleet.server.create_app()`` (to
+    exercise middleware, for instance) otherwise starts ``_status_refresher``,
+    a genuine network ``git fetch``, as a fire-and-forget task. That task can
+    still be running when the test's client tears down, and cancelling it then
+    is what leaked into unrelated tests and flaked ``Gateway Tests (macOS)``
+    (issue #1832). A test that wants the real refresher overrides this itself
+    via ``monkeypatch.setattr(mod, "_background_tasks_disabled", lambda: False)``.
+    """
+    monkeypatch.setenv("KIROCREW_DEVFLEET_NO_BACKGROUND", "1")
+
+
+@pytest.fixture(autouse=True)
 def _isolate_kiro_window_cache():
     """Give every test an EMPTY ``model_registry._KIRO_WINDOWS``, then restore it.
 

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -5618,6 +5618,39 @@ async def test_hmac_invalid_signature_denial_is_audited(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_startup_skips_background_tasks_when_disabled(monkeypatch):
+    """``dev_fleet_startup`` must not start the refresher/reaper/warm tasks
+    when background tasks are disabled, so tests that boot the real app via
+    ``create_app()`` (e.g. the HMAC tests above) never drag in a live network
+    ``git fetch``. See issue #1832: an unstubbed ``_status_refresher`` leaked
+    into unrelated tests and flaked ``Gateway Tests (macOS)``."""
+    monkeypatch.setattr(mod, "_load_app_secret", lambda: "sekrit")
+    monkeypatch.setattr(mod, "_background_tasks_disabled", lambda: True)
+    app = mod.create_app()
+    async with TestClient(TestServer(app)):
+        assert mod._refresher_task is None
+        assert mod._reaper_task is None
+        assert mod._warm_task is None
+
+
+@pytest.mark.asyncio
+async def test_startup_starts_background_tasks_when_enabled(monkeypatch):
+    """The opposite of the above: with the gate off (production default),
+    startup still creates all three background tasks."""
+    monkeypatch.setattr(mod, "_load_app_secret", lambda: "sekrit")
+    monkeypatch.setattr(mod, "_background_tasks_disabled", lambda: False)
+    monkeypatch.setattr(mod, "_upstream_remote", AsyncMock(return_value="origin"))
+    monkeypatch.setattr(mod, "_run_cmd", AsyncMock(return_value=(0, "", "")))
+    monkeypatch.setattr(mod, "_fleet_refresh", AsyncMock(return_value=None))
+    monkeypatch.setattr(mod, "_auto_prune_reaper", AsyncMock(return_value=None))
+    app = mod.create_app()
+    async with TestClient(TestServer(app)):
+        assert mod._refresher_task is not None
+        assert mod._reaper_task is not None
+        assert mod._warm_task is not None
+
+
+@pytest.mark.asyncio
 async def test_prunable_merged_unverified_when_oid_lookup_fails():
     """OID verification unavailable -> never a prune candidate (preview must
     match the removal path, which would refuse anyway)."""


### PR DESCRIPTION
## Problem / Motivation

`dev_fleet_startup` starts three background tasks on app startup, including `_status_refresher`, which does a real network `git fetch` every 60s. A test that boots the real app via `create_app()` to exercise something unrelated (the HMAC middleware tests) also starts these tasks with nothing stubbed. The task can still be running when the test's client tears down, and cancelling a live network task there is what leaked into unrelated tests and flaked `Gateway Tests (macOS)`.

## Why it matters

The leaked live `git fetch` task makes `Gateway Tests (macOS)` non-deterministically red for every contributor (issue #1832): CI failures land on unrelated PRs, wasting rerun cycles and eroding trust in the gate. Any future test that boots the real dev-fleet app would re-introduce the same leak without this fix.

## What changed (motivation → approach → change)

Symptom: unrelated tests flake after a test boots the real dev-fleet app. Root cause: `dev_fleet_startup` unconditionally fires three `asyncio.create_task` background loops, one of which performs real network I/O, and test teardown cancels them mid-flight, leaking into whichever test runs next. Change:

- Added `_background_tasks_disabled()`, a small env-gated check (`KIROCREW_DEVFLEET_NO_BACKGROUND=1`), before the three `create_task` calls in `dev_fleet_startup`. Unset in production, so production behavior is unchanged.
- Added an autouse fixture in `test/conftest.py` that sets the gate for every test by default. A test that wants the real refresher can override it with `monkeypatch.setattr(mod, "_background_tasks_disabled", lambda: False)`.

## Tests

- `test_startup_skips_background_tasks_when_disabled` — locks in that with the gate on, startup creates none of the refresher/reaper/warm tasks.
- `test_startup_starts_background_tasks_when_enabled` — locks in the production default: with the gate off, all three background tasks are created.
- `test/test_dev_fleet_app.py` full file: 235 passed.
- Full backend suite: 28,935 passed, 0 failures (one pre-existing, unrelated flock/fork test excluded, confirmed failing identically on unmodified `main`).

## Manual verification

N/A — unit coverage sufficient: the change is a startup-path gate with both states locked in by the two regression tests above; there is no UI or external-service surface.

## Related Issues

Fixes #1832

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
