### PR TITLE
docs: add Trendshift daily-ranking badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/103032" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/103032/daily?language=Python" alt="Kiro Crew on Trendshift" width="250" height="55"></a>
+</p>
+
+<p align="center">
   Kiro Crew is an open source development workspace that runs locally or remotely on
   your hardware. It is persistent, self-learning, and self-evolving. Work with it
   from the desktop app, web dashboard, and CLI, or continue the same work through


### PR DESCRIPTION
## What

Adds the [Trendshift](https://trendshift.io/repositories/103032) daily-ranking badge to the README, on its own centered line under the tagline so it does not disrupt the existing flat-square shields row (the Trendshift badge is 55px tall, the shields are 20px).

## Notes

- Badge endpoint verified live: `https://trendshift.io/api/badge/trendshift/repositories/103032/daily?language=Python` returns 200 `image/svg+xml`, `aria-label="Trendshift: number 18 Python repository of the day"`. The image is dynamic — the rank updates daily.
- `alt` text is `Kiro Crew on Trendshift` rather than the vendor snippet's `kirodotdev%2FKiroCrew | Trendshift`: percent-encoded prose reads poorly to a screen reader, and the rank is not baked into the alt because the image changes daily.
- Kept `target="_blank" rel="noopener noreferrer"` from the vendor snippet; dropped the UTM query params from the link href since they only tag traffic back to the badge itself.
- Brand-name gate passes on added lines; `scripts/docs-lint.sh` passes (it does not cover README, but ran it anyway).

Docs-only change — no code, no tests affected.
