### PR TITLE
fix(config): report restart_required for startup-read subagent settings

### DIFF
--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -1071,6 +1071,38 @@ async def api_security_posture(_request: web.Request) -> web.Response:
 # caller raising it arbitrarily (e.g. {"subagent_auto_max": 9999}) to bypass
 # the concurrency limit.
 
+# Agent settings whose ENFORCED effect is fixed at gateway startup.
+# ``SubagentManager`` is constructed with ``max_subagents`` and
+# ``subagent_max_turns`` and never re-reads the config afterwards;
+# ``max_concurrent`` is stored once with no setter, and ``subagent_auto_max``
+# only reaches that enforced value as the ``hard_cap`` inside
+# ``compute_max_subagents``, which the same construction calls.
+#
+# Precisely: persisting one of these does NOT change what the running gateway
+# ENFORCES. It is not inert, though — the advisory cap advertised to the model
+# re-resolves from config on each read, so after a write the reported cap can
+# move while the enforced one stays put. That divergence is pre-existing and
+# deliberate (overflow queues, so the advertised number is guidance rather than
+# a limit); this constant describes only the enforced side, which is what the
+# restart is for.
+#
+# ``dynamic-subagent-sizing.md`` states the contract this mirrors: "The cap is
+# computed once per gateway start. Restart to recompute." The ``restart_required``
+# response field is the existing convention for exactly this case — the channel
+# config handlers already return it for settings read at boot, and the frontend
+# API client already types it.
+#
+# ``conductor_skill`` is deliberately absent: it is applied inline by this
+# handler (the skill file is regenerated/removed in-request), so it takes effect
+# immediately and must not raise the restart hint.
+_STARTUP_READ_AGENT_KEYS = frozenset(
+    {
+        "max_subagents",
+        "subagent_max_turns",
+        "subagent_auto_max",
+    }
+)
+
 
 async def api_kirocrew_config(request: web.Request) -> web.Response:
     """GET/PUT /api/config/kirocrew — read or update KiroCrew config."""
@@ -1109,6 +1141,13 @@ async def api_kirocrew_config(request: web.Request) -> web.Response:
         if not isinstance(data.get("agent"), dict):
             data["agent"] = {}
         agent = data["agent"]
+        # Snapshot the persisted values BEFORE any mutation. The dashboard sends
+        # all four settings on every save and enables Save whenever any one is
+        # dirty, so "was applied" is not "was changed" -- keying the restart hint
+        # off the raw applied list would flag a restart for a conductor-only save.
+        # Same truthfulness guard as handlers/messaging.py (see its no-op-save
+        # comments) so the flag stays trustworthy enough to act on.
+        before = dict(agent)
         # subagent_max_turns keeps the generic 1..N validation; max_subagents is
         # special — 0 is the "auto-size" sentinel and its upper bound is the
         # configured hard cap (dynamic-subagent-sizing.md §5.5/§6).
@@ -1209,7 +1248,13 @@ async def api_kirocrew_config(request: web.Request) -> web.Response:
                         p.unlink()
                 except Exception:
                     logger.exception("Failed to clean up conductor skill")
-        return web.json_response({"ok": True})
+        # A startup-read key that was merely re-sent with its existing value did
+        # not change the enforced cap, so it must not raise the hint.
+        restart_required = any(
+            key in _STARTUP_READ_AGENT_KEYS and agent.get(key) != before.get(key)
+            for key in applied
+        )
+        return web.json_response({"ok": True, "restart_required": restart_required})
 
     cfg = KiroCrewConfig.load()
     return web.json_response(_masked_config_dict(cfg))

--- a/test/test_api_server.py
+++ b/test/test_api_server.py
@@ -567,6 +567,135 @@ class TestApiKirocrewConfig:
             assert saved["agent"]["subagent_auto_max"] == 32
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "settings",
+        [
+            {"max_subagents": 8},
+            {"subagent_max_turns": 50},
+            {"subagent_auto_max": 32},
+        ],
+    )
+    async def test_put_flags_restart_required_for_startup_read_keys(
+        self, settings, tmp_path, monkeypatch
+    ):
+        # These are read once when SubagentManager is constructed at gateway
+        # start, so changing them does nothing to what the running gateway
+        # enforces. The response must say so instead of a bare success the user
+        # cannot tell apart from a change that took effect. Each parametrized
+        # value differs from the persisted one below, so each is a real change.
+        monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: tmp_path / "config.json")
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: MagicMock())
+        (tmp_path / "config.json").write_text('{"agent": {"subagent_auto_max": 16}}')
+        async with TestClient(TestServer(self._make_app(tmp_path))) as c:
+            resp = await c.put("/api/config/kirocrew", json={"agent": settings})
+            assert resp.status == 200
+            assert (await resp.json())["restart_required"] is True
+
+    @pytest.mark.asyncio
+    async def test_put_no_restart_when_startup_key_resent_unchanged(self, tmp_path, monkeypatch):
+        # The dashboard sends all four settings on every save and enables Save
+        # whenever ANY one is dirty, so a conductor-only save re-sends the three
+        # startup-read keys at their existing values. That changed nothing the
+        # gateway enforces, so it must NOT ask the user to restart.
+        monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: tmp_path / "config.json")
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: MagicMock())
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.agents._regen_conductor", lambda: None, raising=False
+        )
+        (tmp_path / "config.json").write_text(
+            '{"agent": {"max_subagents": 8, "subagent_max_turns": 50, '
+            '"subagent_auto_max": 32, "conductor_skill": false}}'
+        )
+        async with TestClient(TestServer(self._make_app(tmp_path))) as c:
+            resp = await c.put(
+                "/api/config/kirocrew",
+                json={
+                    "agent": {
+                        "max_subagents": 8,
+                        "subagent_max_turns": 50,
+                        "subagent_auto_max": 32,
+                        "conductor_skill": True,
+                    }
+                },
+            )
+            assert resp.status == 200
+            assert (await resp.json())["restart_required"] is False
+
+    @pytest.mark.asyncio
+    async def test_put_restart_required_when_one_startup_key_actually_changes(
+        self, tmp_path, monkeypatch
+    ):
+        # Same all-four payload, but max_subagents genuinely differs -> the hint
+        # must fire even though the other two are unchanged re-sends.
+        monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: tmp_path / "config.json")
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: MagicMock())
+        (tmp_path / "config.json").write_text(
+            '{"agent": {"max_subagents": 8, "subagent_max_turns": 50, '
+            '"subagent_auto_max": 32}}'
+        )
+        async with TestClient(TestServer(self._make_app(tmp_path))) as c:
+            resp = await c.put(
+                "/api/config/kirocrew",
+                json={
+                    "agent": {
+                        "max_subagents": 12,
+                        "subagent_max_turns": 50,
+                        "subagent_auto_max": 32,
+                    }
+                },
+            )
+            assert resp.status == 200
+            assert (await resp.json())["restart_required"] is True
+
+    @pytest.mark.asyncio
+    async def test_put_flags_restart_when_startup_key_set_for_the_first_time(
+        self, tmp_path, monkeypatch
+    ):
+        # Absent-then-set must count as a change, not as an unchanged re-send.
+        monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: tmp_path / "config.json")
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: MagicMock())
+        (tmp_path / "config.json").write_text('{"agent": {}}')
+        async with TestClient(TestServer(self._make_app(tmp_path))) as c:
+            resp = await c.put("/api/config/kirocrew", json={"agent": {"subagent_max_turns": 40}})
+            assert resp.status == 200
+            assert (await resp.json())["restart_required"] is True
+
+    @pytest.mark.asyncio
+    async def test_put_does_not_flag_restart_for_live_keys(self, tmp_path, monkeypatch):
+        # conductor_skill is applied inline by the handler (the skill file is
+        # regenerated in-request), so it takes effect immediately and must NOT
+        # raise the restart hint — otherwise the hint becomes noise users learn
+        # to ignore.
+        monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: tmp_path / "config.json")
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: MagicMock())
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.agents._regen_conductor", lambda: None, raising=False
+        )
+        (tmp_path / "config.json").write_text('{"agent": {}}')
+        async with TestClient(TestServer(self._make_app(tmp_path))) as c:
+            resp = await c.put("/api/config/kirocrew", json={"agent": {"conductor_skill": True}})
+            assert resp.status == 200
+            assert (await resp.json())["restart_required"] is False
+
+    @pytest.mark.asyncio
+    async def test_put_restart_required_tracks_only_applied_keys(self, tmp_path, monkeypatch):
+        # A mixed request reports restart_required once any startup-read key is
+        # applied — the flag describes the request, not each field.
+        monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: tmp_path / "config.json")
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: MagicMock())
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.agents._regen_conductor", lambda: None, raising=False
+        )
+        (tmp_path / "config.json").write_text('{"agent": {}}')
+        async with TestClient(TestServer(self._make_app(tmp_path))) as c:
+            resp = await c.put(
+                "/api/config/kirocrew",
+                json={"agent": {"conductor_skill": True, "subagent_max_turns": 40}},
+            )
+            assert resp.status == 200
+            assert (await resp.json())["restart_required"] is True
+
+    @pytest.mark.asyncio
     async def test_put_rejects_subagent_auto_max_above_ceiling(self, tmp_path, monkeypatch):
         monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: tmp_path / "config.json")
         monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: MagicMock())

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -1384,7 +1384,7 @@ export const api = {
   defaultAgent: () => fetch('/api/config/default-agent').then(j),
   setDefaultAgent: (agent: string) => put('/api/config/default-agent', { agent }).then(j),
   kirocrewConfig: () => fetch('/api/config/kirocrew').then(j),
-  saveKirocrewConfig: (agent: object) => put('/api/config/kirocrew', { agent }).then(j),
+  saveKirocrewConfig: (agent: object) => put('/api/config/kirocrew', { agent }).then(j) as Promise<{ ok?: boolean; restart_required?: boolean; error?: string }>,
   patchConfig: (path: string, value: unknown) => fetch('/api/config/kirocrew', { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ path, value }) }).then(j),
   // Optional integrations — backend endpoints are graceful no-ops on a public
   // install (AIM / kiro usage are stubbed). Kept so the UI compiles and


### PR DESCRIPTION
## Problem

Changing the concurrent sub-agent cap in the dashboard reports success and does
not change what the running gateway enforces, with nothing in the response to
say so.

`PUT /api/config/kirocrew` accepts four agent settings. Three of them —
`max_subagents`, `subagent_max_turns`, `subagent_auto_max` — have their
**enforced** effect fixed at gateway startup, and the handler persisted all three
and returned a bare `{"ok": true}`.

## Why it matters

The user sets a cap, is told "Saved", and the gateway keeps enforcing the old
one until it restarts. Nothing distinguishes that from a change that took effect.

The same settings page is already inconsistent with itself:
`website/src/pages/overview/KiroCrewCfgTab.tsx:262` shows a *restart required to
apply changes* string for the Warm Pool card, while the sub-agent section beside
it reports a plain "Saved".

## Fix (symptom → root cause → change)

**Symptom:** the dashboard's sub-agent cap edit appears to succeed but does not
take effect.

**Root cause:** `SubagentManager` is constructed with these values and never
re-reads the config:

```
src/kiro_crew/slack/gateway.py:4813:            max_concurrent=resolve_max_subagents(self._cfg),
src/kiro_crew/slack/gateway.py:4814:            default_turn_limit=self._cfg.agent.subagent_max_turns,
```

`self._max_concurrent = max_concurrent` (`subagent.py:1065`) is the only write in
the file — every other reference is a read — and there is no setter.
`subagent_auto_max` reaches that enforced value only as the `hard_cap` inside
`compute_max_subagents` (`subagent.py:685`), which the same construction calls.

This is intended behaviour, and this PR does **not** change it.
`dynamic-subagent-sizing.md` states the contract:

> The cap is computed once per gateway start. Restart to recompute (e.g. after
> the host's resources change).

What was missing is the API telling the truth about it.

**Change:** return `restart_required`, the convention this repository already
uses for settings read at boot — the channel-config handlers in
`dashboard/handlers/messaging.py` return it, the frontend API client already
types it, and `SlackPanel` / `TeamsPanel` / `WebexPanel` / `BotChannelPanel`
already surface it.

Two details that matter for the flag being trustworthy:

- It keys off keys whose value actually **changed**, not merely which keys were
  applied. `KiroCrewCfgTab.tsx` sends all four settings on every save and enables
  Save whenever *any* one is dirty, so keying off the applied list alone would
  demand a restart for a conductor-only save. `handlers/messaging.py` already
  applies this same no-op-save guard to this field ("staging an unchanged value
  would flag restart_required on every config-only save").
- `conductor_skill` is excluded: this handler applies it inline (the skill file is
  regenerated/removed in-request), so it takes effect immediately and must not
  raise the hint.

### Scope note: these settings are not inert between restarts

Worth stating precisely, because the naive claim is wrong. The advisory cap
advertised to the model re-resolves from config on every read
(`mcp_core.py:237`, `mcp_core.py:3906`, `context.py:1389`), so after a write the
*reported* cap can move while the *enforced* one stays put. That divergence is
pre-existing and documented as acceptable at `mcp_core.py:231-235` (overflow
queues, so the advertised number is guidance rather than a limit). This PR
touches neither side of it and describes only the enforced side, which is what
the restart is for.

## Tests

Eight cases in `test/test_api_server.py::TestApiKirocrewConfig`, beside the
existing `max_subagents` validation tests:

| Case | Locks in |
|---|---|
| parametrized over all three startup-read keys, each genuinely changed | the hint fires for every startup-read key |
| all three re-sent at persisted values + `conductor_skill` flipped | a conductor-only save does **not** demand a restart |
| `max_subagents` 8→12 among two unchanged re-sends | one real change among no-ops still fires |
| key absent then set | absent-then-set counts as a change, not an equal compare |
| `conductor_skill` alone | an inline-applied key never raises the hint |
| mixed applied set | the flag describes the request, not each field |

Verified meaningful rather than tautological: under the previous
`intersection(applied)` logic the unchanged-re-send case returns `True` against
an asserted `False`, and with the source change stashed the original five cases
all fail.

## Manual verification

N/A — unit coverage is sufficient. The change is a response field on a JSON
endpoint with no UI consumer yet (see below), and every branch of the new
predicate is covered by the table above, including the absent-key and
no-op-resend edges.

Gates run locally: `isort`, `flake8` clean; `mypy src/kiro_crew/` reports only 3
pre-existing `os.*xattr` errors in `hooks.py` (Linux-only attributes that macOS
mypy flags — identical count on unmodified `origin/main`); `tsc -b` clean;
`vitest` 73 passed including all 70 `i18n/catalogParity` cases; the scoped pytest
set around this handler (`test_api_server`, `test_config_loader`,
`test_config_patch`, `test_config_extra_sections`, `test_api_health`,
`test_subagent_sizing`, `test_kirocrew_config_validator`, `test_spawn_audit`,
`test_token_auth`) is 688 passed / 1 skipped.

## Screenshots

N/A — no user-visible UI change. The only frontend edit widens a return type in
`website/src/api/client.ts`; nothing rendered changes, so there is no surface to
capture.

## Deliberately out of scope

Surfacing the hint in `KiroCrewCfgTab` needs a new i18n key in all 13 locales to
keep `website/src/i18n/catalogParity.test.ts` green (it asserts no locale may
lack a key present in `en`). That belongs with the i18n remediation program
(#1004) rather than bundled into a behaviour fix, so this PR stops at the API
contract plus the client-side type.

Two related surfaces left alone, each needing its own freshness audit rather than
a guess:

- `PATCH /api/config/kirocrew` (`api_kirocrew_config_patch`) — its
  `_EDITABLE_CONFIG` allowlist contains none of these three keys, but it does
  contain other plausibly startup-read ones (e.g. `session.pool_size`, the
  `pool_reserve` term in the same formula).
- The reported-vs-enforced cap divergence described above, which the code
  already documents as a deliberate trade-off.
