### PR TITLE
fix(instances): pin ssh multiplexing off in supervised tunnels

### DIFF
--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -347,7 +347,8 @@ it is reachable only by an authenticated owner driving the API directly.
   `ExitOnForwardFailure=yes` so a forward that cannot bind is a detected failure
   rather than a silent hang. `-N` without `-f` is deliberate: `-f` would fork ssh
   into the background and leave the gateway unable to supervise or kill the real
-  forwarder.
+  forwarder. The multiplexing pins in §9 close the same hole from the
+  ssh_config side.
 - **No local shell.** `ssh` is always spawned with an argv list, so `ssh_host`
   cannot inject local shell syntax; `ssh_host`/`remote_bin` are
   injection-validated immediately before every command line is built (§11).
@@ -411,10 +412,32 @@ it is reachable only by an authenticated owner driving the API directly.
 The only thing that varies per remote is the **SSH host** you configure: the hub
 always runs a fixed `ssh <ssh_host> ...` argv (`BatchMode=yes`,
 `ExitOnForwardFailure=yes`, `ServerAliveInterval=30`, `ServerAliveCountMax=3`,
-`AddressFamily=inet`, `-L`/`-N`, plus `-C` when compression is on). Anything
-`ssh` can reach **non-interactively** works. `ssh_host` accepts `host`,
-`host.fqdn`, an `~/.ssh/config` alias, or `user@host`, and rejects any segment
-starting with `-` (ssh option-injection guard).
+`AddressFamily=inet`, `ControlPath=none`, `ControlMaster=no`, `-L`/`-N`, plus `-C` <!-- wokeignore:rule=master -->
+when compression is on). Anything `ssh` can reach **non-interactively** works.
+`ssh_host` accepts `host`, `host.fqdn`, an `~/.ssh/config` alias, or
+`user@host`, and rejects any segment starting with `-` (ssh option-injection
+guard).
+
+**Multiplexing is pinned off; everything else is inherited.** A tunnel is a
+supervised foreground child, and a forward the gateway cannot supervise or kill
+reports as `ssh exited with code 0` while it is in fact still serving. A
+multiplexed session does exactly that — ssh hands the forward to an existing
+shared connection and exits. `ControlPath=none` is the enforcement: with no path
+resolved there is no socket to join. `ControlMaster=no` states the policy, and <!-- wokeignore:rule=master -->
+is not sufficient alone — an inherited `ControlPath` still routes into a shared
+connection.
+
+Everything else per-host — `User`, `IdentityFile`, `Port`, `ProxyJump`,
+`ProxyCommand` — is still inherited from `~/.ssh/config`; the registry carries no
+inline equivalents and depends on that. **Pinning a directive the user may also
+set is not free**: ssh takes the first value obtained and reads the command line
+first, so a pinned `-o` silently discards theirs. The two multiplexing pins are
+safe because a supervised tunnel must never share a connection, but the same
+move on, say, `IgnoreUnknown` would drop the pattern a cross-platform config
+relies on and turn a working setup into `Bad configuration option`.
+
+The diagnostics probes are a different case and are left alone: they are
+one-shot commands whose exit status is the whole result, with no forward to own.
 
 ### Dev host / home server (primary)
 

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -16,7 +16,10 @@ Design note: a literal ``ssh -fN`` would make ssh fork into the background and
 the foreground process exit immediately, which would leave the gateway unable to
 supervise or kill the real forwarder. A gateway-supervised child must stay in the
 foreground, so we use ``-N`` (no remote command) *without* ``-f``, mirroring how
-``TunnelManager`` supervises its own child. ``ExitOnForwardFailure=yes`` ensures
+``TunnelManager`` supervises its own child. Connection multiplexing is pinned
+off in the argv (``ControlPath=none``) for the same reason: it lets a user's
+``~/.ssh/config`` recreate that fork-and-exit shape from outside this module.
+``ExitOnForwardFailure=yes`` ensures
 ssh exits if the local forward can't be bound, so a failed connect is detected
 rather than hanging. The SSM transport gets the equivalent detection from the
 generic ready-poll (:meth:`_Tunnel._wait_until_ready`) plus a post-hoc ownership
@@ -230,6 +233,19 @@ def _build_ssh_tunnel_argv(
         "ServerAliveCountMax=3",
         "-o",
         "AddressFamily=inet",  # force IPv4 loopback (dodge ::1 fallback)
+        # The forward must stay owned by the child this manager supervises.
+        # Multiplexing takes it away from the user's ssh_config: ssh hands the
+        # forward to an existing shared connection and exits 0, leaving it alive
+        # under a process the gateway never spawned, so a tunnel that is in fact
+        # serving is reported as dead.
+        #
+        # Routing and identity (`User`, `IdentityFile`, `Port`,
+        # `ProxyJump`/`ProxyCommand`) are deliberately still inherited -- the
+        # registry carries no inline equivalents. See §9 of the instances spec.
+        "-o",
+        "ControlPath=none",  # no socket to share -- this is what disables it
+        "-o",
+        "ControlMaster=no",  # policy; ControlPath alone suffices  # wokeignore:rule=master
         "-L",
         forward,
         ssh_host,

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -16,7 +16,9 @@ import asyncio
 import json
 import logging
 import os
+import shutil
 import socket
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -942,6 +944,166 @@ class TestSshTunnelArgvCompression:
         reg.add(name="CD2", ssh_host="cd-2-alias", instance_id="cd-2")
         assert (await mgr_on.connect("cd-2")).state == TunnelState.CONNECTED
         assert captured["compression"] is True
+
+
+requires_ssh = pytest.mark.skipif(shutil.which("ssh") is None, reason="ssh not available")
+
+
+def _ssh_effective_config(tmp_path, config_text: str, ssh_args: list[str], host: str) -> dict:
+    """Return ssh's OWN resolved settings (``ssh -G``) for *ssh_args* under a config.
+
+    Asks the real ssh binary how it would interpret the production command line,
+    rather than asserting on option strings: the point at issue is precedence
+    between the command line and ``~/.ssh/config``, which only ssh can answer.
+
+    *ssh_args* is everything between the ``ssh`` binary and the host, flags
+    included. Passing the whole thing rather than only the ``-o`` pairs matters:
+    some settings resolve differently depending on flags like ``-N``.
+    """
+    cfg = tmp_path / "ssh_config"
+    cfg.write_text(config_text.format(host=host, sock=str(tmp_path / "cm-%r@%h:%p")), "utf-8")
+    out = subprocess.run(
+        ["ssh", "-G", "-F", str(cfg), *ssh_args, host],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert out.returncode == 0, f"ssh -G failed: {out.stderr}"
+    # Repeated keys are accumulated, not overwritten: ssh prints one
+    # ``identityfile`` line per candidate, and how many appear varies by
+    # release and by whether the config named one.
+    resolved: dict[str, str] = {}
+    for line in out.stdout.splitlines():
+        key, _, value = line.partition(" ")
+        key, value = key.strip().lower(), value.strip()
+        resolved[key] = f"{resolved[key]}\n{value}" if key in resolved else value
+    return resolved
+
+
+def _ssh_args(argv: list[str]) -> list[str]:
+    """Everything between the ``ssh`` binary and the trailing host."""
+    return argv[1:-1]
+
+
+class TestSshTunnelMultiplexing:
+    """The supervised-child contract must survive a user's ssh_config.
+
+    Multiplexing moves the local forward off the child the gateway supervises:
+    ssh hands it to an existing shared connection and exits 0. That recreates
+    the fork-and-exit shape ``-N`` without ``-f`` exists to avoid, so a tunnel
+    that is genuinely serving reports ``ssh exited with code 0`` and is torn
+    down.
+    """
+
+    _HOST = "kc-test-multiplex-host"
+
+    #: A user config that enables multiplexing for the instance host.
+    _ADVERSARIAL_CONFIG = """\
+Host {host}
+  HostName 127.0.0.1
+  User probeuser
+  ControlMaster auto  # wokeignore:rule=master
+  ControlPath {sock}
+  ControlPersist 10m
+"""
+
+    def test_tunnel_argv_pins_multiplexing_off(self):
+        from kiro_crew.instances.ssh_tunnel_manager import _build_ssh_tunnel_argv
+
+        argv = _build_ssh_tunnel_argv("host-a", 7779, 7879)
+        assert "ControlPath=none" in argv
+        assert "ControlMaster=no" in argv  # wokeignore:rule=master
+        # Options, so they precede the -L forward and the positional host.
+        assert argv.index("ControlPath=none") < argv.index("-L")
+        assert argv.index("ControlMaster=no") < argv.index("-L")  # wokeignore:rule=master
+        assert argv[-1] == "host-a"
+
+    @requires_ssh
+    def test_user_ssh_config_cannot_re_enable_multiplexing(self, tmp_path):
+        """Ask the real ssh how it resolves the production argv, twice.
+
+        The pinned run must end up sharing nothing. The unpinned run over the
+        SAME config is the control: it shows ssh honouring the user's settings,
+        so the assertions above test the pins rather than restating ssh's
+        defaults.
+        """
+        from kiro_crew.instances.ssh_tunnel_manager import _build_ssh_tunnel_argv
+
+        args = _ssh_args(_build_ssh_tunnel_argv(self._HOST, 7779, 7879))
+        pinned = _ssh_effective_config(tmp_path, self._ADVERSARIAL_CONFIG, args, self._HOST)
+        assert pinned.get("controlpath") in (None, "none")
+        assert pinned.get("controlmaster") in ("no", "false")  # wokeignore:rule=master
+
+        bare = ["-N", "-L", "127.0.0.1:7779:127.0.0.1:7879"]
+        unpinned = _ssh_effective_config(tmp_path, self._ADVERSARIAL_CONFIG, bare, self._HOST)
+        assert unpinned.get("controlpath") not in (None, "none")
+        assert unpinned.get("controlmaster") == "auto"  # wokeignore:rule=master
+
+    @requires_ssh
+    def test_pins_do_not_override_a_user_ignoreunknown(self, tmp_path):
+        """A pinned `-o` must not displace a directive the user also sets.
+
+        ssh takes the FIRST value obtained for a directive and reads the command
+        line before ``~/.ssh/config``, so pinning a single-valued directive here
+        silently discards the user's own. ``IgnoreUnknown`` is the one that
+        bites: it is how a cross-platform config carries an option this ssh does
+        not recognise, and losing it turns a working config into ``Bad
+        configuration option`` -- every tunnel then fails where it used to
+        connect. Multiplexing is safe to pin because a supervised tunnel must
+        never share a connection; that reasoning does not generalise.
+
+        The keyword is invented so no OpenSSH release knows it, which keeps the
+        result independent of platform and version.
+        """
+        from kiro_crew.instances.ssh_tunnel_manager import _build_ssh_tunnel_argv
+
+        cfg = tmp_path / "ssh_config"
+        cfg.write_text(
+            "IgnoreUnknown UserPrivateOption\n"
+            "UserPrivateOption yes\n"
+            "\n"
+            f"Host {self._HOST}\n"
+            "  HostName 127.0.0.1\n",
+            "utf-8",
+        )
+        args = _ssh_args(_build_ssh_tunnel_argv(self._HOST, 7779, 7879))
+        out = subprocess.run(
+            ["ssh", "-G", "-F", str(cfg), *args, self._HOST],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert out.returncode == 0, f"production argv broke a working config: {out.stderr}"
+        assert "bad configuration option" not in out.stderr.lower()
+
+    @requires_ssh
+    def test_per_host_ssh_config_is_still_inherited(self, tmp_path):
+        """Only process ownership is overridden; connection coordinates are not.
+
+        The registry carries no inline `-i`/`-p`/`-J` fields and relies on the
+        ssh-config alias path for identity, port, and bastion reachability, so
+        pinning must not turn the argv into a general ssh_config override.
+        """
+        from kiro_crew.instances.ssh_tunnel_manager import _build_ssh_tunnel_argv
+
+        config = (
+            self._ADVERSARIAL_CONFIG
+            + "  Port 2222\n"
+            + "  IdentityFile ~/.ssh/some-key.pem\n"
+            + "  ProxyCommand /bin/true %h %p\n"
+        )
+        args = _ssh_args(_build_ssh_tunnel_argv(self._HOST, 7779, 7879))
+        resolved = _ssh_effective_config(tmp_path, config, args, self._HOST)
+
+        assert resolved.get("hostname") == "127.0.0.1"
+        assert resolved.get("user") == "probeuser"
+        assert resolved.get("port") == "2222"
+        assert "some-key.pem" in resolved.get("identityfile", "")
+        assert resolved.get("proxycommand", "").startswith("/bin/true")
+        # The argv's own pins are still in force alongside the inherited values.
+        assert resolved.get("batchmode") == "yes"
+        assert resolved.get("exitonforwardfailure") == "yes"
+        assert resolved.get("addressfamily") == "inet"
 
 
 class TestSshTunnelManager:


### PR DESCRIPTION
## Symptom

With connection multiplexing enabled for the instance host in `~/.ssh/config`, connecting a remote instance fails with `ssh exited with code 0` — while the forward is up and serving the remote dashboard.

## Root cause

The tunnel is a **supervised foreground child**. `_build_ssh_tunnel_argv` deliberately uses `-N` *without* `-f`, and the module docstring spells out why: `-f` would fork ssh into the background and leave the gateway unable to supervise or kill the real forwarder. `_wait_until_ready` correctly refuses to call a tunnel ready when its child is gone, even if the local port answers — a reachable port is not proof *this* child bound it.

`ControlMaster` recreates that fork-and-exit shape from outside the module: the slave hands the forward to an existing master and exits 0. The forward is live, owned by a process the gateway never spawned; the child being watched is gone. So a healthy tunnel is reported dead and torn down — and exit code 0 reads as success, with nothing pointing at ssh_config.

## The fix

```
-o ControlPath=none    # enforcement: no path resolved, so no socket to join
-o ControlMaster=no    # explicit no-multiplex policy
```

**`ControlMaster=no` alone would not fix this.** Real `ssh -G` against a config with `ControlMaster auto` + a `ControlPath`:

| Command-line pins | `controlmaster` | `controlpath` |
|---|---|---|
| *(none — current `main`)* | `auto` | `/…/cm-probeuser@127.0.0.1:22` |
| `ControlMaster=no` only | `false` | `/…/cm-…` ← **still joins a master** |
| `ControlPath=none` only | `auto` | *absent* ← sharing disabled |
| both | `false` | *absent* |

`ControlPath=none` is the enforcement; the `ControlMaster` pin states the policy.

## Connection coordinates stay with the user

`User`, `IdentityFile`, `Port`, `ProxyJump`, `ProxyCommand` are still inherited — the registry carries no inline `-i`/`-p`/`-J` fields and §9 of the instances spec depends on the alias path for bastion and SSM-proxied hosts. The boundary: *connection coordinates are user policy; who owns the forward is supervisor policy.*

**Pinning a directive the user may also set is not free.** ssh takes the first value obtained for a directive and reads the command line before `~/.ssh/config`, so a pinned `-o` silently discards theirs. Multiplexing is safe to pin because a supervised tunnel must never share a connection — but that reasoning does not generalise, and `test_pins_do_not_override_a_user_ignoreunknown` pins that it isn't generalised: a config carrying its own `IgnoreUnknown` pattern must keep working, since losing it turns an unrecognised option into a fatal `Bad configuration option` on every connect.

## Tests

4 cases in `TestSshTunnelMultiplexing`:

1. **argv contract** — both pins present, before the `-L` forward.
2. **adversarial ssh_config** (real `ssh -G`) — a config enabling multiplexing must end up sharing nothing. An unpinned run over the *same* config is the control, showing ssh honouring the user's settings.
3. **per-host inheritance preserved** — `HostName`/`User`/`Port`/`IdentityFile`/`ProxyCommand` still come from ssh_config, alongside the existing `BatchMode`/`ExitOnForwardFailure`/`AddressFamily` pins.
4. **user `IgnoreUnknown` guard** — a working cross-platform config must not become fatal. Uses an invented keyword so the result is independent of platform and OpenSSH version.

Tests requiring the binary are gated on `shutil.which("ssh")`, matching the existing `requires_git` convention.

Mutation-verified:

| Mutation | Result |
|---|---|
| both pins removed (= `main`) | 1 + 2 fail |
| `ControlPath=none` removed | 1 + 2 fail |
| a command-line `IgnoreUnknown` introduced | 4 fails |

## Out of scope

The **diagnostics probes** (`_probe_ssh`, the remote-dashboard curl) are unchanged. They are one-shot commands with no forward to own, and whether they *should* reuse a master is a separate question — a live master could mask a fresh-auth failure — that this fix does not need to answer.

Fixes #1975
