### PR TITLE
fix(instances): make connect_timeout_secs user-configurable

### DIFF
--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -232,6 +232,7 @@ Defaults live in `kiro_crew.instances.constants` and are referenced from the
 | `instances.warm_set_cap` | `5` | Max instances kept warm at once (bounds memory/sockets; each warm instance is a full dashboard SPA). Clamped up to 1. |
 | `instances.tunnel_base_port` | `7778` | First local loopback port the allocator hands out. Out-of-range values fall back to the default. |
 | `instances.ssh_compression` | `true` | Add `-C` to the tunnel argv. See §5.2. |
+| `instances.connect_timeout_secs` | `15.0` | How long (secs) to wait for the local forward port to accept connections before declaring a connect attempt failed. Hosts behind a ProxyCommand or jump host need longer (the proxy handshake runs before ssh begins the forward). The SSM transport uses its own higher default (25s) unless this value is explicitly set. Clamped to [1, 120]. |
 | `instances.max_recovery_attempts` | `8` | Consecutive self-heal attempts before the tunnel is left disconnected. Below 1 falls back to the default; above `MAX_RECOVERY_ATTEMPTS_CEILING` (100) is clamped with a warning, so a pathological setting cannot turn bounded self-heal into a near-infinite retry loop. |
 | `instances.recover_backoff_max_secs` | `30.0` | Cap on the per-attempt backoff. Non-positive falls back to the default; above `RECOVER_BACKOFF_MAX_CEILING_SECS` (300) is clamped, bounding the worst-case wall-clock recovery window. |
 | `instances.probe_failure_threshold` | `3` | Consecutive health-probe failures before a non-forwarding tunnel is torn down. Below 1 falls back to the default. |
@@ -239,11 +240,12 @@ Defaults live in `kiro_crew.instances.constants` and are referenced from the
 ```bash
 kirocrew config set instances.warm_set_cap 3
 kirocrew config set instances.ssh_compression false
+kirocrew config set instances.connect_timeout_secs 45
 ```
 
 Constants that are **not** user-configurable: the probe interval (30s), the token
-refresh fraction (0.8), the stored-token probe timeout (2s), the connect
-readiness timeout (15s), and the mint timeout (30s).
+refresh fraction (0.8), the stored-token probe timeout (2s), and the mint
+timeout (30s).
 
 ### 5.2 `instances.ssh_compression`
 

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -98,6 +98,8 @@ from kiro_crew.config.validation import (  # noqa: F401
 )
 from kiro_crew.config.validation import validate_config_data as _validate_config_data  # noqa: F401
 from kiro_crew.effort import EFFORT_LEVELS, is_valid_effort, model_supports_effort
+from kiro_crew.instances.constants import CONNECT_TIMEOUT_CEILING_SECS as _CONNECT_TIMEOUT_CEILING
+from kiro_crew.instances.constants import DEFAULT_CONNECT_TIMEOUT_SECS as _DEFAULT_CONNECT_TIMEOUT
 from kiro_crew.instances.constants import DEFAULT_MAX_RECOVERY_ATTEMPTS as _DEFAULT_MAX_RECOVERY
 from kiro_crew.instances.constants import DEFAULT_PROBE_FAILURE_THRESHOLD as _DEFAULT_PROBE_FAILS
 from kiro_crew.instances.constants import DEFAULT_RECOVER_BACKOFF_MAX_SECS as _DEFAULT_BACKOFF_MAX
@@ -4259,6 +4261,20 @@ class InstancesConfig:
             "on a fast/local link where compression CPU outweighs the bandwidth win.",
         ),
     )
+    connect_timeout_secs: float = field(
+        default=_DEFAULT_CONNECT_TIMEOUT,
+        metadata=_meta(
+            "Connect Timeout (secs)",
+            "How long to wait for the local forward port to accept connections "
+            "before declaring a connect attempt failed. The default (15s) is "
+            "sufficient for a direct ssh TCP connect, but hosts behind a "
+            "ProxyCommand or jump host routinely need longer (the proxy handshake "
+            "runs before ssh begins the forward). Raise this if connecting a "
+            "remote instance times out while the same ssh forward succeeds by hand. "
+            "The SSM transport uses its own higher default (25s) unless this value "
+            "is explicitly set. Clamped to [1, 120].",
+        ),
+    )
     max_recovery_attempts: int = field(
         default=_DEFAULT_MAX_RECOVERY,
         metadata=_meta(
@@ -4298,6 +4314,21 @@ class InstancesConfig:
                 _DEFAULT_TUNNEL_BASE_PORT,
             )
             object.__setattr__(self, "tunnel_base_port", _DEFAULT_TUNNEL_BASE_PORT)
+        if self.connect_timeout_secs < 1.0:
+            logger.warning(
+                "instances.connect_timeout_secs %s < 1, using %s",
+                self.connect_timeout_secs,
+                _DEFAULT_CONNECT_TIMEOUT,
+            )
+            object.__setattr__(self, "connect_timeout_secs", _DEFAULT_CONNECT_TIMEOUT)
+        elif self.connect_timeout_secs > _CONNECT_TIMEOUT_CEILING:
+            logger.warning(
+                "instances.connect_timeout_secs %s > %s, clamping to %s",
+                self.connect_timeout_secs,
+                _CONNECT_TIMEOUT_CEILING,
+                _CONNECT_TIMEOUT_CEILING,
+            )
+            object.__setattr__(self, "connect_timeout_secs", _CONNECT_TIMEOUT_CEILING)
         if self.max_recovery_attempts < 1:
             logger.warning(
                 "instances.max_recovery_attempts %d < 1, using %d",
@@ -6329,6 +6360,10 @@ class KiroCrewConfig:
                 ),
                 ssh_compression=bool(
                     instances_data.get("ssh_compression", _DEFAULT_SSH_COMPRESSION)
+                ),
+                connect_timeout_secs=_safe_float(
+                    instances_data.get("connect_timeout_secs", _DEFAULT_CONNECT_TIMEOUT),
+                    _DEFAULT_CONNECT_TIMEOUT,
                 ),
                 max_recovery_attempts=_safe_int(
                     instances_data.get("max_recovery_attempts", _DEFAULT_MAX_RECOVERY),

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1743,6 +1743,7 @@ def _register_instances_hooks(app: web.Application, state: DashboardState, port:
         manager = SshTunnelManager(
             registry,
             base_port=_cfg.instances.tunnel_base_port,
+            connect_timeout_secs=_cfg.instances.connect_timeout_secs,
             ssh_compression=_cfg.instances.ssh_compression,
             max_recovery_attempts=_cfg.instances.max_recovery_attempts,
             recover_backoff_max_secs=_cfg.instances.recover_backoff_max_secs,

--- a/src/kiro_crew/instances/constants.py
+++ b/src/kiro_crew/instances/constants.py
@@ -67,6 +67,27 @@ DEFAULT_RECOVER_BACKOFF_MAX_SECS: float = 30.0
 # case is ~MAX_RECOVERY_ATTEMPTS_CEILING * this (~8h).
 RECOVER_BACKOFF_MAX_CEILING_SECS: float = 300.0
 
+# How long (secs) to wait for the local forward port to start accepting
+# connections before declaring a connect attempt failed. A direct ``ssh -L``
+# needs only a TCP handshake, so 15s is generous for most hosts. However, hosts
+# behind a ProxyCommand (jump host, WSSH, corporate proxy) routinely spend
+# 12-16s on the proxy handshake alone before ssh even begins the forward, so
+# this timeout becomes the binding constraint. Exposed as a user-tunable via
+# ``kirocrew config set instances.connect_timeout_secs <value>`` so operators on
+# slow-proxy hosts can raise it without patching the installed package.
+DEFAULT_CONNECT_TIMEOUT_SECS: float = 15.0
+
+# SSM's ``session-manager-plugin`` completes a WebSocket handshake with the SSM
+# service before it binds the local port — routinely slower than a direct ssh
+# TCP connect. This higher default mirrors that reality. When the user supplies
+# an explicit ``connect_timeout_secs`` override, it wins for both transports.
+DEFAULT_SSM_CONNECT_TIMEOUT_SECS: float = 25.0
+
+# Upper bound (secs) on a user-configured instances.connect_timeout_secs. Keeps
+# a pathological value from making the connect path hang indefinitely. 120s is
+# generous enough for any realistic proxy chain while still bounding the wait.
+CONNECT_TIMEOUT_CEILING_SECS: float = 120.0
+
 # Proactively re-mint each instance's dashboard token at this fraction of its
 # TTL, before the 20h cap. 0.8 = refresh at 80% elapsed.
 DEFAULT_TOKEN_REFRESH_FRACTION: float = 0.8

--- a/src/kiro_crew/instances/ssh_tunnel_manager.py
+++ b/src/kiro_crew/instances/ssh_tunnel_manager.py
@@ -65,6 +65,9 @@ from kiro_crew.cloud import ssm as cloud_ssm
 # be framed by this desktop app on whatever KIROCREW_PORT it runs on (no
 # hardcoded port, no wildcard). See server._extra_frame_ancestors.
 from kiro_crew.config.loader import DASHBOARD_PORT as _LOCAL_DASHBOARD_PORT
+from kiro_crew.instances.constants import (
+    DEFAULT_CONNECT_TIMEOUT_SECS as _DEFAULT_CONNECT_TIMEOUT_SECS,
+)
 from kiro_crew.instances.constants import DEFAULT_MAX_RECOVERY_ATTEMPTS as _MAX_RECOVERY
 from kiro_crew.instances.constants import DEFAULT_PROBE_FAILURE_THRESHOLD as _PROBE_FAILS
 from kiro_crew.instances.constants import DEFAULT_PROBE_INTERVAL_SECS as _PROBE_INTERVAL
@@ -72,6 +75,9 @@ from kiro_crew.instances.constants import (
     DEFAULT_RECOVER_BACKOFF_MAX_SECS as _RECOVER_BACKOFF_MAX_SECS,
 )
 from kiro_crew.instances.constants import DEFAULT_SESSION_TRANSFER_TIMEOUT_SECS as _TRANSFER_TIMEOUT
+from kiro_crew.instances.constants import (
+    DEFAULT_SSM_CONNECT_TIMEOUT_SECS as _DEFAULT_SSM_CONNECT_TIMEOUT_SECS,
+)
 from kiro_crew.instances.constants import DEFAULT_TOKEN_PROBE_TIMEOUT_SECS as _TOKEN_PROBE_TIMEOUT
 from kiro_crew.instances.constants import DEFAULT_TOKEN_REFRESH_FRACTION as _REFRESH_FRACTION
 from kiro_crew.instances.constants import (
@@ -107,12 +113,6 @@ logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 _LOOPBACK = "127.0.0.1"
-# How long to wait for the local forward port to start accepting connections
-# before declaring the connect attempt failed. SSM's session-manager-plugin
-# needs longer to establish (WebSocket handshake to the SSM service) than a
-# direct ssh TCP connect, so the SSM transport uses a longer timeout below.
-_DEFAULT_CONNECT_TIMEOUT_SECS = 15.0
-_DEFAULT_SSM_CONNECT_TIMEOUT_SECS = 25.0
 # Poll cadence while waiting for the forward to come up.
 _READY_POLL_INTERVAL_SECS = 0.25
 # Bound on retained stderr so a chatty/looping ssh can't grow memory unbounded.

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -32,6 +32,7 @@ class TestConfig:
     def test_defaults_off_and_tunables(self):
         from kiro_crew.config.loader import InstancesConfig
         from kiro_crew.instances.constants import (
+            DEFAULT_CONNECT_TIMEOUT_SECS,
             DEFAULT_TUNNEL_BASE_PORT,
             DEFAULT_WARM_SET_CAP,
         )
@@ -40,6 +41,7 @@ class TestConfig:
         assert c.enabled is False
         assert c.warm_set_cap == DEFAULT_WARM_SET_CAP == 5
         assert c.tunnel_base_port == DEFAULT_TUNNEL_BASE_PORT == 7778
+        assert c.connect_timeout_secs == DEFAULT_CONNECT_TIMEOUT_SECS == 15.0
 
     def test_clamps_out_of_range(self):
         from kiro_crew.config.loader import InstancesConfig
@@ -58,6 +60,7 @@ class TestConfig:
             "warm_set_cap": 5,
             "tunnel_base_port": 7778,
             "ssh_compression": True,
+            "connect_timeout_secs": 15.0,
             "max_recovery_attempts": 8,
             "recover_backoff_max_secs": 30.0,
             "probe_failure_threshold": 3,
@@ -69,6 +72,7 @@ class TestConfig:
             "instances.warm_set_cap",
             "instances.tunnel_base_port",
             "instances.ssh_compression",
+            "instances.connect_timeout_secs",
             "instances.max_recovery_attempts",
             "instances.recover_backoff_max_secs",
             "instances.probe_failure_threshold",
@@ -141,6 +145,50 @@ class TestConfig:
             ).recover_backoff_max_secs
             == RECOVER_BACKOFF_MAX_CEILING_SECS
         )
+
+    def test_connect_timeout_default_and_clamps(self):
+        from kiro_crew.config.loader import InstancesConfig
+        from kiro_crew.instances.constants import (
+            CONNECT_TIMEOUT_CEILING_SECS,
+            DEFAULT_CONNECT_TIMEOUT_SECS,
+        )
+
+        # Default value matches the constant.
+        c = InstancesConfig()
+        assert c.connect_timeout_secs == DEFAULT_CONNECT_TIMEOUT_SECS == 15.0
+
+        # Explicit override is honored.
+        c = InstancesConfig(connect_timeout_secs=45.0)
+        assert c.connect_timeout_secs == 45.0
+
+        # Below 1 falls back to the default.
+        c = InstancesConfig(connect_timeout_secs=0.5)
+        assert c.connect_timeout_secs == DEFAULT_CONNECT_TIMEOUT_SECS
+
+        c = InstancesConfig(connect_timeout_secs=-10.0)
+        assert c.connect_timeout_secs == DEFAULT_CONNECT_TIMEOUT_SECS
+
+        # Above the ceiling is clamped.
+        assert CONNECT_TIMEOUT_CEILING_SECS == 120.0
+        c = InstancesConfig(connect_timeout_secs=999.0)
+        assert c.connect_timeout_secs == CONNECT_TIMEOUT_CEILING_SECS
+
+        # Boundary value itself is left untouched.
+        c = InstancesConfig(connect_timeout_secs=CONNECT_TIMEOUT_CEILING_SECS)
+        assert c.connect_timeout_secs == CONNECT_TIMEOUT_CEILING_SECS
+
+    def test_connect_timeout_parses_from_config_file(self, tmp_path, monkeypatch):
+        import json
+
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(
+            json.dumps({"instances": {"connect_timeout_secs": 45.0}})
+        )
+        monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: cfg_file)
+        cfg = KiroCrewConfig.load()
+        assert cfg.instances.connect_timeout_secs == 45.0
 
 
 # ── PortAllocator ───────────────────────────────────────────────────────────
@@ -3696,6 +3744,7 @@ class TestStartupRevive:
                 enabled=True,
                 tunnel_base_port=53400,
                 ssh_compression=False,
+                connect_timeout_secs=15.0,
                 max_recovery_attempts=8,
                 recover_backoff_max_secs=30.0,
                 probe_failure_threshold=3,


### PR DESCRIPTION
## Summary

Exposes the SSH tunnel connect-readiness timeout as a user-configurable field (`instances.connect_timeout_secs`), fixing the only numeric tunable in the Instances feature that was hardcoded rather than settable via `kirocrew config set`.

Closes #1974

---

## Problem

The 15s connect timeout is too short for hosts behind a `ProxyCommand`, jump host, or corporate proxy — their handshake alone routinely takes 12–16s, leaving no budget for the forward itself. Every connect attempt times out, even though the same `ssh -L` command succeeds by hand. The only workaround today is patching the installed package.

## Fix

| File | Change |
|------|--------|
| `src/kiro_crew/instances/constants.py` | Add `DEFAULT_CONNECT_TIMEOUT_SECS` (15.0), `DEFAULT_SSM_CONNECT_TIMEOUT_SECS` (25.0), `CONNECT_TIMEOUT_CEILING_SECS` (120.0) |
| `src/kiro_crew/config/loader.py` | Add `connect_timeout_secs` field to `InstancesConfig` with two-sided validation [1, 120] |
| `src/kiro_crew/dashboard/server.py` | Wire the config value into `SshTunnelManager` |
| `src/kiro_crew/instances/ssh_tunnel_manager.py` | Replace hardcoded constants with imports from `constants.py` |
| `docs/system-specs/modules/instances.md` | Document the new config key |
| `test/test_instances.py` | Tests for default, override, clamps, config-file parse, schema |

## Behavior

```bash
# A user on a slow-proxy host can now fix it themselves:
kirocrew config set instances.connect_timeout_secs 45
```

- **Default unchanged** — existing users see no change (15s for SSH, 25s for SSM).
- **Explicit override wins for both transports** — matches the existing `_connect_timeout_for` logic.
- **Clamped to [1, 120]** — below 1 falls back to default with a warning; above 120 is clamped.
- **SSM default preserved** — when no explicit override is set, SSM still uses its own 25s default.

## Testing

- `pytest test/test_instances.py` — **174 passed**
- `pytest test/test_config_api.py` — **19 passed**
- New tests cover: default value, explicit override, lower-bound clamp, upper-bound clamp, boundary value, round-trip from `config.json`, schema registry presence.

## Checklist

- [x] One focused change, one commit
- [x] Conventional Commits format
- [x] Doc updated in the same commit
- [x] Tests pass locally
- [x] No new dependencies