### PR TITLE
fix(dashboard): refresh transient-5xx retry budget after terminal error

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -5588,6 +5588,21 @@ async def _run_chat(
                 f"⏱️ {_err_text}" if "timed out" in _msg else f"❌ {_err_text}",
                 "msg msg-err",
             )
+            # This branch ENDS the retry cycle: the error is terminal and
+            # nothing is re-queued. Refresh the transient-5xx budget now so the
+            # NEXT cycle — the Continue press this very error message invites
+            # ("retry in a moment"), or a new user message — gets the designed
+            # TRANSIENT_RETRIES fresh attempts. Without this, the budget
+            # consumed by a failed cycle leaks into every later cycle (the
+            # happy-path reset only runs when a cycle COMPLETES), so after one
+            # exhaustion ❌ a single further 5xx fails instantly with zero
+            # retries until some turn happens to finish cleanly. Loop safety is
+            # unchanged: the reset happens only on a NO-REQUEUE exit, so a new
+            # budget always requires a new user- or system-initiated cycle —
+            # automatic retry chains within a cycle stay bounded at
+            # TRANSIENT_RETRIES. (_posttoken_retry_used needs no counterpart
+            # here: it is already refreshed at genuine-turn start.)
+            slot._transient_5xx_retries = 0
     except Exception as exc:
         logger.exception("Dashboard chat error in slot %s", slot.key)
         _err_text, _ = redact_exfiltration_urls(str(exc))

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -11017,9 +11017,77 @@ class TestRunChatTransientRetry:
 
         # Initial attempt + TRANSIENT_RETRIES re-prompts, then it gives up.
         assert call_count == TRANSIENT_RETRIES + 1
-        assert slot._transient_5xx_retries == TRANSIENT_RETRIES
         # Clean error surfaced; session left resumable (no reset).
         assert any(t.startswith("❌") for t in self._err_texts(slot))
+        state.sessions.reset.assert_not_awaited()
+        # The terminal ❌ ENDS the cycle, so the budget is refreshed for the
+        # next one — the Continue press the error message invites must get the
+        # full ladder again, not inherit an exhausted counter.
+        assert slot._transient_5xx_retries == 0
+
+    @pytest.mark.asyncio
+    async def test_transient_budget_refreshed_after_terminal_error(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression: a cycle that EXHAUSTS the transient budget and surfaces
+        the terminal ❌ must refresh the budget for the NEXT cycle. The
+        happy-path reset only runs when a cycle COMPLETES, so before the fix
+        the exhausted counter leaked into every later cycle: the very next
+        5xx — e.g. right after the Continue press the ❌ message itself
+        invites ("retry in a moment") — failed instantly with ZERO retries
+        until some turn happened to finish cleanly."""
+        from kiro_crew.acp.client import AcpError
+        from kiro_crew.dashboard.chat import _run_chat
+        from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+        # ── Cycle 1: persistent 5xx exhausts the budget → terminal ❌. ──
+        async def _always_fail(msg):
+            raise AcpError(self._TRANSIENT)
+            yield  # pragma: no cover
+
+        state = self._make_state(tmp_path, monkeypatch)
+        client = self._client(_always_fail)
+        self._wire_sessions(state, client)
+        slot = state.get_or_create_slot("s1")
+        slot._titled = True
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _run_chat(state, slot, "first question")
+            await self._drain_bg(state)
+
+        assert any(t.startswith("❌") for t in self._err_texts(slot))
+        assert slot._transient_5xx_retries == 0
+        n_before = len(slot.messages)
+
+        # ── Cycle 2: a 5xx on the next turn retries again (fresh budget). ──
+        call_count = 0
+
+        async def _fail_once_then_ok(msg):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise AcpError(self._TRANSIENT)
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="ok-result")
+            yield LLMEvent(kind=EVENT_COMPLETE)
+
+        client.stream = _fail_once_then_ok
+        client.stream_command = _fail_once_then_ok
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _run_chat(state, slot, "second question")
+            await self._drain_bg(state)
+
+        # Before the fix: 3 < TRANSIENT_RETRIES was False on the first 5xx, so
+        # cycle 2 died instantly (call_count == 1, a second ❌, no answer).
+        assert call_count == 2
+        tail = slot.messages[n_before:]
+        tail_errs = [m["content"] for m in tail if m.get("role") == "error"]
+        tail_answers = [m["content"] for m in tail if m.get("role") == "assistant"]
+        assert any("Backend hiccup" in t for t in tail_errs)
+        assert not any(t.startswith("❌") for t in tail_errs)
+        assert any("ok-result" in t for t in tail_answers)
+        # Completed cycle → budget back to 0 via the happy-path reset.
+        assert slot._transient_5xx_retries == 0
         state.sessions.reset.assert_not_awaited()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem / Motivation

After a laptop sleep/wake severed an in-flight model stream (surfacing as a burst of transient connection/5xx-class errors), I watched a session's transient recovery get weaker with every failure. The retry ladder is designed to give each turn cycle `TRANSIENT_RETRIES` (3) pre-token re-prompts plus one post-token recovery, but my session visibly got only two "⟳ Backend hiccup — retrying…" attempts before the terminal "❌ The model backend hit a transient error (HTTP 5xx)… retry in a moment" error. Worse, after one exhaustion the next cycle — including the Continue press that the ❌ message itself invites — had zero retry protection: a single further 5xx failed instantly with no retry at all.

## Why it matters

Transient backend errors cluster: exactly when the retry ladder is most needed (a multi-minute 5xx incident), it degrades to nothing after the first exhausted cycle and stays that way until some turn happens to complete cleanly. The user experience contradicts the product's own promise — the terminal error says "retry in a moment", but the retry it invites runs with an already-spent budget. Long-running work sessions hit by an outage burst end up needing many manual Continue presses instead of the designed automatic recovery.

## What changed (motivation → approach → change)

Symptom: fewer retries than designed after any prior failure, and instant terminal errors after an exhaustion. Root cause: `slot._transient_5xx_retries` is only reset when a turn cycle COMPLETES through the happy path (the "Reset ALL retry budgets once the cycle completes … so each new user turn gets fresh budgets" block). A cycle that exhausts the budget surfaces the terminal ❌ from the `except AcpError` handler's else branch, which skips that reset — so the consumed budget leaks into every subsequent cycle. Change: reset the counter in that terminal else branch. That branch ends the cycle with no re-queue, so loop safety is unchanged — a fresh budget is only ever usable by a new user- or system-initiated cycle, and automatic retry chains within a cycle stay bounded at `TRANSIENT_RETRIES`. `_posttoken_retry_used` needs no counterpart: it is already refreshed at genuine-turn start. The subagent parity copy (`_stream_with_transient_retry`) uses a local per-turn attempts counter and does not have this bug.

Two pre-existing same-class leaks exist on lines this PR does not touch (the `_should_suppress_requeue` pass arm and the depth>0 arm inside the transient elif both increment without a later reset when the turn dies elsewhere); they are rarer, and I kept this PR scoped to the observed exhaustion path.

## Tests

- `test_transient_budget_refreshed_after_terminal_error` (new): cycle 1 exhausts the budget and surfaces the terminal ❌; asserts the counter is 0 afterwards, then runs a second cycle whose first attempt 5xxes and asserts it RETRIES and recovers (before the fix: instant second ❌, no retry, no answer).
- `test_transient_exhausts_budget_then_clean_error_resumable` (updated): the post-exhaustion assertion flips from `_transient_5xx_retries == TRANSIENT_RETRIES` (pinning the leak) to `== 0` (pinning the refresh).

## Manual verification

N/A — unit coverage sufficient: the regression test drives the real `_run_chat` ladder end-to-end through exhaustion and the follow-up cycle, exactly the sequence I observed in the dashboard.

## Related Issues

None filed; observed live in my dashboard session after a laptop sleep/wake severed the in-flight stream (any burst of transient-classified errors triggers the same leak).

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behavior comment added inline at the fix site
- [x] No secrets, credentials, or internal references in the diff

