### PR TITLE
fix(cli): gate, audit, and answer tool permission requests

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -76,6 +76,17 @@ cancelled caller still lets the worker settle).
 
 `PermissionOption` field names differ between backends — kiro-cli uses `id`/`label`, claude-agent-acp uses `optionId`/`name` (per the public ACP spec). `_build_permission_event` reads both and remembers the optionIds keyed by `kind` (`allow_once`/`allow_always`/`reject_once`/`reject_always`) on the request id — recording an entry when **either** an allow option (for `approve_tool`) **or** a reject option (for a clean `reject_tool`) was advertised. `approve_tool(request_id, *, always=False)` echoes the matching allow id back, so the host doesn't need to know whether it's talking to kiro (`"allow_once"`/`"allow_always"`) or claude-agent-acp (`"allow"`/`"allow_always"`). `reject_tool` prefers a **clean reject**: if a reject optionId was advertised it sends `outcome: "selected"` with that id. Both backends advertise one — claude-agent-acp as `{kind:"reject_once", optionId:"reject"}` (→ `behavior:"deny"`), kiro-cli as `{kind:"reject_once", optionId:"reject_once"}` — and the fallback to `outcome: "cancelled"` therefore only applies to a backend that advertises no reject option at all. The distinction is load-bearing, not cosmetic: a clean reject resolves the tool call to `status:"failed"` with kiro-cli's fixed content `"User denied tool execution"` and the turn continues to the next model-inference boundary (`stopReason: "end_turn"`), whereas `cancelled` ends the turn immediately with `stopReason: "refusal"` and no text — and drops any queued `_session/steer` as `AgentExecutionUserMessageCleared`. That is why the host's in-band deny notice (`_steer_policy_notice`) can only be folded in on the clean-reject path, and why `stopReason: "refusal"` is NOT by itself evidence of a model-side content refusal.
 
+Both the shared runtime and the legacy direct `AcpClient` route permission
+frames through `_dispatch.build_permission_event`, including the same provenance
+flags. A shell-cache hit whose value is `False` sets `shell_classified=True` —
+it is a resolved non-shell call, not a cache miss — and a structured-params
+cache hit sets `raw_params_trusted=True`. The raw-params cache is read without
+consuming it, so a repeated permission frame for the same `toolCallId` keeps the
+original tool-call arguments authoritative instead of falling back to the
+permission frame's agent-authored inline input. A genuine miss may carry inline
+data for display, but both provenance flags remain false and consumers that
+need trusted arguments fail closed.
+
 The host always sends one-shot approvals (`always=False`, the default). KiroCrew — not the agent — owns the trust scope (`slot._trust`, `slot._trust_reads`, `slot._trusted_patterns`, `safety_override`, `channel.trusted`, parent session `approval_policy`). Per-call `session/request_permission` is required so KiroCrew's PreToolUse hooks (`auto_deny_tools`, sensitive-path checks, credential redaction) fire on every tool invocation. The `always=True` path is reserved for a future "skip KiroCrew hooks for this exact tool" feature; no caller passes it today.
 
 The handshake also branches on the backend:

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -507,6 +507,211 @@ All write paths emit SEL audit events (`config_get`, `config_set`, `config_set_f
 - Exit: `exit`, `quit`, `/exit`, `/quit`, `:q`, Ctrl+D
 - Streaming output printed as chunks arrive
 
+### Tool permission requests
+
+A backend that routes tool decisions over ACP holds the turn open until it gets
+an answer, so the stream consumer must respond — an ignored request is not a
+missed prompt, it is a turn that never ends.
+
+Answering one is an **authorization decision**, so the CLI is a security
+surface, not just a prompt. Every request runs the same ladder, in this order:
+
+```
+permission_request
+  → HookManager.on_tool_call        (sensitive paths, denied commands, ceiling ∩ profile)
+      deny → SEL "denied" → reject_tool → stderr notice          [not overridable]
+  → may this invocation ask?        (command mode AND both streams a TTY)
+      no   → SEL "denied" → reject_tool → stderr notice
+  → prompt the human
+      exactly "a" → SEL "allowed" → approve_tool(always=False)
+      anything else → SEL "denied" → reject_tool
+```
+
+The gate is fed the event's non-model-authored fields (`tool_kind`,
+`raw_tool_params`, `shell_command`, `is_shell`, `mcp_server_name`, `tool_name`),
+not just `title`: for a shell tool the title may be an LLM-authored
+description, so a dangerous command behind a benign label is exactly what
+keying on the title alone lets through. The CLI identifies itself as
+`session_key="cli_chat"` (SEL source `cli`) with the resolved agent, which is
+what lets the gate resolve `ceiling ∩ profile` rather than the ceiling alone.
+No second copy of the sensitive-path or denied-command rules lives in the CLI.
+
+The hook result is used as a **deny ceiling only**: `TOOL_DENY` rejects, and
+both `TOOL_ALLOW` and `TOOL_AUTO_APPROVE` still ask the human. This consumer
+answers permission requests; it does not carry the dashboard's trust and
+auto-approval semantics, and honouring `TOOL_AUTO_APPROVE` here would add a
+second execution path with no human confirmation. Asking more often than the
+dashboard is the safe direction.
+
+| Mode | stdin+stdout TTY | Behaviour |
+|---|---|---|
+| interactive REPL | yes | Prompt. Exactly `a` allows once; anything else denies. |
+| interactive REPL | no | Deny automatically, notice on stderr, stdin untouched. |
+| `-m` single message | either | Deny automatically, notice on stderr, stdin untouched. |
+
+Both conditions are required, and neither implies the other. `-m` is documented
+as `Single message (non-interactive)`, so a terminal does not license a prompt
+there — a script wrapped in a pty would otherwise block on a question nobody is
+watching for. And a prompt nobody can see is a hang, not consent, so the REPL
+still needs a real terminal on both ends. The mode is passed explicitly rather
+than inferred from a TTY check, because only the caller knows which mode runs.
+
+A shell call shows the command it is asking about:
+
+```
+Permission required: Run a helpful script
+Command: git status --short
+   [a] allow once  [d] deny (default):
+```
+
+`title` is LLM-authored prose, so approving on it alone is consent to a
+description rather than to what runs — the same reason the gate keys on
+`shell_command`. The command is redacted with the two `security` helpers,
+collapsed to one line, and capped with an explicit `... [truncated]`. Local
+paths are deliberately **not** redacted here: this is the operator's own
+terminal, and seeing the real path is part of the consent.
+
+**A call that names a file discloses that file.** A trusted tool identity says
+WHICH tool runs, not what it runs against, so `fs_write` under a benign title is
+consent to a verb:
+
+```
+Permission required: Tidy up the notes
+Tool: fs_write
+Path: /home/tester/thesis.md
+   [a] allow once  [d] deny (default):
+```
+
+The path is read from the request's own `raw_tool_params`, under the same
+`path` / `file_path` / `filePath` spellings `hooks._SEARCH_DENY_ARG_KEYS`
+accepts. Sharing the spellings is the point: the gate already denies a
+*sensitive* path or a write-protected config path read from those keys, so what
+is left for a human to judge is exactly the ordinary valuable file no rule
+speaks for — and a prompt reading a different field than the gate inspects would
+let the two disagree about what the target is. Rendered like the command
+(sanitised, one line, capped), and shown for any call that carries a path rather
+than only an `edit`-kind one, because the kind is agent-influenced and
+disclosure can only inform the decision.
+
+Absence of a path is **not** a refusal. Most builtin calls legitimately act on no
+file — a memory write, a tag creation — so denying whenever a path cannot be
+found would refuse them all to close a gap that exists only for tools which name
+one. A non-string value is treated as absent rather than raised on: raising would
+leave the request unanswered, which is the hang this path exists to end.
+
+Beyond the command and the path, the whole tool input is still **not** shown —
+this is the question, not a detail panel.
+
+**Terminal controls are neutralised on this surface.** Every untrusted string
+the permission UI prints — the title, the command, and a gate reason — goes
+through `_for_consent`, which redacts as above and then replaces ESC, the C0 set
+(`U+0000`–`U+001F`), DEL (`U+007F`), and the C1 set (`U+0080`–`U+009F`) with
+spaces before collapsing whitespace, so the result is always a single line. Lone
+UTF-16 surrogate code points (`U+D800`–`U+DFFF`) are removed by the same boundary:
+they are not Unicode scalar values, so even a strict UTF-8 stream cannot encode
+them. The result is then round-tripped through the destination stream's codec
+with `backslashreplace`. UTF-8 terminals retain ordinary Unicode; a strict cp1252
+or other legacy Windows stream sees inert ASCII escapes for characters it cannot
+represent. This is an authorization surface: OSC 52 writes the clipboard, and
+CSI can move the cursor and erase what is drawn, so a model-authored title could
+otherwise repaint the question a human is answering and hide what is being approved.
+Scope is the permission prompt only — ordinary streamed model output is printed
+raw by `_send_and_print` and is unchanged, which is a surface-wide rendering
+question rather than part of answering a permission request.
+
+**An authorization-boundary failure is itself a refusal.** If the shared gate
+raises, the CLI records `gate_failed` best-effort and rejects the request. If TTY
+detection, prompt rendering, or prompt reading raises, it records `prompt_failed`
+best-effort and rejects. The transport response is sent before any explanatory
+notice, so a closed or unencodable output stream cannot leave the backend waiting.
+This does not change cancellation: Ctrl-C still aborts the session and provider
+teardown owns the pending request, because waiting on a possibly wedged rejection
+transport would swallow the cancellation.
+
+**The audit write never runs on the event loop.** `sel()` opens the audit log
+and replays it to recover the running HMAC chain, so the first permission of a
+fresh chat pays a filesystem cost inside the call — an unbounded one on slow or
+corrupt storage. The decision coroutine shares its loop with the ACP reader and
+stderr-drain tasks, exactly as the gate call does, so the audit is awaited
+through `asyncio.to_thread` for the same reason: a blocking write here would
+stop draining the backend and freeze the turn the audit is about. The one
+exception is the cancellation teardown, which keeps the synchronous call because
+awaiting anything there would swallow the `CancelledError` being delivered.
+
+**There is no "always allow".** A persistent approval asks the backend to stop
+sending permission requests for matching calls, and a request that is never sent
+is a call this ladder never runs and never audits. The dashboard offers it
+because its tool pipeline re-gates every call; this consumer does not.
+
+The answer is matched **exactly**, not by first letter: a prefix match reads
+`abort` as an allow. Blank line, EOF, and any unrecognised word all deny.
+
+Denial is **not** an error: the request is answered, the turn runs to completion,
+and the exit code is unchanged. Only the existing transport failures
+(`AcpTimeoutError`, `AcpError`) exit non-zero.
+
+Every decision is written to the SEL log **before** the matching
+`approve_tool`/`reject_tool`, so a transport failure cannot erase a decision
+already made:
+
+| decision | `outcome` | `error` |
+|---|---|---|
+| gate denied | `denied` | `hook_deny` |
+| gate raised before a verdict | `denied` | `gate_failed` |
+| execute-kind request has no verified command | `denied` | `unverified_shell` |
+| nobody to ask | `denied` | `noninteractive` |
+| prompt availability/render/read failed | `denied` | `prompt_failed` |
+| user allowed | `allowed` | — |
+| user allowed but the critical audit failed | `denied` | `audit_unwritable` |
+| user denied / blank / EOF / unrecognised | `denied` | `user_denied` |
+| session cancelled with the question open | `denied` | `session_aborted` |
+
+`error` is a stable machine code, never the gate's reason: a reason names the
+path or command that triggered it, and an audit record must not restate the
+thing it protects (`log_tool_invocation` does not redact for its callers). The
+audited `tool_name` is the canonical `_meta.kiro` identity when the backend
+supplies one, falling back to a redacted `title` — an audit trail keyed on prose
+the model wrote can be steered by the model being audited.
+
+Responses go through `provider.approve_tool()` / `provider.reject_tool()`. The
+CLI never reads the advertised `options`: those ids are backend-specific and the
+ACP layer owns the mapping.
+
+#### stdin ownership
+
+The prompt is read on an owned daemon thread through a private duplicate of the
+stdin descriptor, not on the event loop and not through `sys.stdin`. The turn is
+parked inside an active stream — the ACP runtime holds a reader task on the
+backend's stdout and a drain task on its stderr — so a read on the loop thread
+would stop draining those pipes until the human answers.
+
+**A cancelled prompt ends the session.** A blocking terminal read cannot be
+retracted: cancelling the await frees the coroutine, not the thread, and that
+reader stays parked and takes the next line the user types. So cancellation
+marks stdin poisoned and propagates; `_require_usable_stdin` then refuses at
+every later entry point — a second permission prompt and the REPL's own `you>`
+alike — rather than racing the abandoned reader for keystrokes. There is no
+input broker and no recovery path: the abandoned reader can only outlive the
+session, never compete with a live prompt.
+
+Teardown **must not await the backend.** The request in flight is left
+unanswered and audited as `session_aborted`, because answering it means awaiting
+a transport: `CancelledError` has already been raised once and nothing
+re-delivers it, so a wedged `reject_tool` would leave the Ctrl-C that asked for
+the teardown unable to land. The provider is shut down with the session, so the
+unanswered request dies with it. `StdinPoisonedError` carries the same rule.
+
+That last sentence is a guarantee, not an expectation: `provider.start()` hands
+back a live backend process, so `_chat` runs the whole message/REPL lifecycle
+under `try` and calls `provider.shutdown()` from `finally`. A normal return, an
+exception, and a cancellation raised through a permission prompt all tear the
+backend down; without it a Ctrl-C at the prompt would exit leaving the backend
+running with nothing owning it. Cleanup never swallows the cancellation — a
+failing `shutdown()` is logged rather than raised, because replacing the
+exception already propagating would discard the very `CancelledError` the
+teardown exists to clean up after — and `gc.collect()` is nested inside its own
+`finally` so a raising shutdown cannot skip it.
+
 ### Context Tracking
 
 After each message, checks `provider.context_usage_pct()`:

--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -675,7 +675,37 @@ read-your-writes should add it deliberately, with its own tests.
   profile, title)` (governance, incl. the `commands` scope, and MCP titles
   `mcp__server__tool` converted to `@server/tool`) → first-party app-own MCP
   server auto-approve → read-only auto-approve →
-  user `auto_approve_tools` loop**. A governance deny wins over a user
+  user `auto_approve_tools` loop**. **Canonical MCP identity.** For a call
+  carrying BOTH trusted `_meta.kiro` fields, the gate reconstructs
+  `mcp__<mcp_server_name>__<mcp_tool_name>` once on the common path and runs the
+  deny-floor and `gate_decision` against it **in addition to** the display title
+  and raw command — never instead of them. `select_tool_title` prefers the
+  model's prose `description`, so an ordinary MCP call whose per-tool rule names
+  the real tool would otherwise miss the ceiling and reach interactive approval,
+  where a human "allow" runs a policy-denied tool. The two are not competing
+  spellings of one fact: the canonical name is the trusted, non-model-authored
+  statement of WHICH tool is invoked and is what a per-tool rule matches, while
+  the title and raw command carry the path/command/content signals that a tool
+  identity does not express. Each covers a security dimension the other cannot,
+  so a deny on EITHER denies the call: a `~/.aws/credentials` title still denies
+  behind a harmless canonical name, and a denied canonical name still denies
+  behind benign prose. **Server-only identity.** When the backend proves the
+  server but not the tool (no `_meta.kiro.toolName`, or an uncached permission
+  event), `gate_decision` is asked about `mcp__<mcp_server_name>` instead. That
+  is a complete question for this plane and only this plane: `mcp_title_to_ref`
+  maps it to `@server`, and an `@server` rule is defined to cover every tool
+  under that server, so a `deny @github` ceiling binds on a call whose tool
+  cannot be named — without it, governance sees only the model-authored title
+  and the call reaches a human who can approve a server the policy forbids. It
+  is deliberately NOT added to the deny-floor targets: that plane matches raw
+  text and operator regexes, where `mcp__<server>` is a different string from
+  the canonical identity a rule is written against rather than a broader form of
+  it. A server-only identity never satisfies auto-approval. Because this
+  enforcement is
+  on the common path, the first-party app-own auto-approve below does **not**
+  repeat it; what remains load-bearing there is the identity requirement itself
+  (an absent `mcp_tool_name` leaves the canonical name empty, so the tool cannot
+  be identified and is not auto-approved). A governance deny wins over a user
   auto-approve, and the read-only auto-approve fast-path runs strictly AFTER
   both the deny-floor and `gate_decision`, so a read-only classification can
   never re-admit a denied/governed call. **First-party app-own MCP server

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -37,6 +37,7 @@ from kiro_crew import agent_scratch, model_registry, platform_compat
 from kiro_crew.acp._dispatch import (
     _kiro_mcp_server_name,
     _kiro_tool_name,
+    build_permission_event,
     derive_edit_diff,
     extract_tool_purpose,
     make_unified_diff,
@@ -63,7 +64,6 @@ from kiro_crew.acp.types import (
     EVENT_MCP_OAUTH_REQUEST,
     EVENT_MCP_SERVER_INIT_FAILURE,
     EVENT_MCP_SERVER_INITIALIZED,
-    EVENT_PERMISSION_REQUEST,
     EVENT_SUBAGENT_ACTIVITY,
     EVENT_SUBAGENT_LIST,
     EVENT_TEXT_CHUNK,
@@ -886,17 +886,6 @@ _WAIT_RESPONSE_MAX_TIMEOUT = 600.0  # 10 min absolute ceiling
 # and must never gate tool dispatch, so a wedged SEL backend is abandoned (the
 # worker thread may leak, which is survivable) after this timeout.
 _SEL_AUDIT_TIMEOUT_SECONDS = 5.0
-# Legacy kiro permission options omit the spec-mandated `kind` field. Only
-# synthesize a kind for these well-known literals — unknown ids stay empty
-# so we don't fabricate intent the agent didn't express.
-_LEGACY_OPTION_KIND: dict[str, str] = {
-    OPTION_ALLOW_ONCE: "allow_once",
-    "allow": "allow_once",
-    OPTION_ALLOW_ALWAYS: "allow_always",
-    "reject_once": "reject_once",
-    "reject_always": "reject_always",
-}
-
 # Canonical ACP tool-kind value for shell/exec tools. kiro-cli and
 # claude-agent-acp both report shell commands with kind="execute". This is the
 # ONE place the ACP shell literal lives — _is_shell_kind() maps it to the
@@ -5578,174 +5567,35 @@ class AcpClient:
         return results
 
     def _build_permission_event(self, msg: JsonRpcMessage) -> AcpEvent:
-        request_id = msg.id if msg.id is not None else ""
-        params = msg.params or {}
-        # The permission payload comes straight from the agent process. A
-        # malformed toolCall (null/list/string) or options (null/dict/string,
-        # or non-dict entries) would raise AttributeError/TypeError here — and
-        # this runs inside the prompt-turn event generator, so the crash tears
-        # down the whole turn instead of degrading to the default options.
-        tool_call = params.get("toolCall", {})
-        if not isinstance(tool_call, dict):
-            tool_call = {}
-        title = tool_call.get("title", "unknown")
-        # The ACP toolCall carries a `kind` ("execute" for Bash, "read"/"edit"/
-        # …). Carry it onto the event as display/telemetry metadata. NOTE: the
-        # tool-name length-cap exemption does NOT key off this value — it uses
-        # the is_shell flag resolved below from the trusted tool_call cache, not
-        # the agent-influenced permission payload. Missing/empty stays "".
-        tool_kind = tool_call.get("kind", "")
-        # ACP spec uses optionId/name + kind ("allow_once"|"allow_always"|
-        # "reject_once"|"reject_always"); kiro-cli uses id/label
-        # with id values "allow_once"/"allow_always". Accept both shapes and
-        # remember the actual optionIds keyed by kind so approve_tool/
-        # reject_tool can echo the exact id the agent advertised.
-        options: list[dict[str, str]] = []
-        kind_to_id: dict[str, str] = {}
-        raw_options = params.get("options", [])
-        if not isinstance(raw_options, list):
-            raw_options = []
-        for o in raw_options:
-            if not isinstance(o, dict):
-                continue
-            opt_id = o.get("optionId") or o.get("id") or ""
-            opt_label = o.get("name") or o.get("label") or ""
-            opt_kind = o.get("kind") or ""
-            # A non-string id would crash opt_id.lower() below (and non-string
-            # label/kind would leak into the typed options list) — skip them.
-            if not isinstance(opt_id, str) or not opt_id:
-                continue
-            if not isinstance(opt_label, str):
-                opt_label = ""
-            if not isinstance(opt_kind, str):
-                opt_kind = ""
-            options.append({"id": opt_id, "label": opt_label})
-            if not opt_kind:
-                # Only synthesize a kind for well-known literals; unknown ids
-                # leave kind empty so we don't mis-classify agent intent.
-                opt_kind = _LEGACY_OPTION_KIND.get(opt_id.lower(), "")
-            if opt_kind:
-                kind_to_id.setdefault(opt_kind, opt_id)
-        if not options:
-            options = [
-                {"id": OPTION_ALLOW_ONCE, "label": "Allow once"},
-                {"id": OPTION_ALLOW_ALWAYS, "label": "Allow always"},
-            ]
-            kind_to_id = {"allow_once": OPTION_ALLOW_ONCE, "allow_always": OPTION_ALLOW_ALWAYS}
-        # Record optionIds the agent advertised so approve_tool / reject_tool
-        # can echo the exact ids. We record when EITHER an allow option (for
-        # approve) OR a reject option (for a clean reject) was advertised.
-        # Both backends advertise a reject option — claude-agent-acp as
-        # {kind:"reject_once", optionId:"reject"}, kiro-cli as
-        # {kind:"reject_once", optionId:"reject_once"} — and sending it is far
-        # better than a "cancelled" outcome: kiro-cli resolves a clean reject to
-        # a FAILED tool call and lets the turn continue to a model-inference
-        # boundary, whereas "cancelled" ends the turn outright with
-        # stopReason:"refusal" (and the claude adapter turns it into the cryptic
-        # "Tool use aborted"). reject_tool falls back to "cancelled" only for a
-        # backend that advertised no reject option at all.
-        any_allow = kind_to_id.get("allow_once") or kind_to_id.get("allow_always")
-        any_reject = kind_to_id.get("reject_once") or kind_to_id.get("reject_always")
-        if request_id != "" and (any_allow is not None or any_reject is not None):
-            recorded: dict[str, str] = {}
-            if any_allow is not None:
-                recorded["once"] = kind_to_id.get("allow_once") or any_allow
-                recorded["always"] = kind_to_id.get("allow_always") or any_allow
-            if any_reject is not None:
-                recorded["reject"] = any_reject
-            self._permission_options[request_id] = recorded
+        """Build one permission event through the transport-shared parser.
 
-        # Resolve full tool input — the preceding ToolCall session/notification
-        # carries the complete params that we cache by toolCallId.  The
-        # request_permission message only has a truncated human-readable title.
-        tool_input = ""
-        tool_call_id = tool_call.get("toolCallId", "")
-
-        # 1. Look up cached input from the ToolCall notification
-        if tool_call_id and tool_call_id in self._tool_call_inputs:
-            tool_input = self._tool_call_inputs.pop(tool_call_id)
-
-        # Recover the STRUCTURED raw params cached at the ToolCall notification
-        # (or carried inline on this permission message) so the governance gate
-        # can evaluate the filesystem.write (edit path) / network.egress (fetch
-        # url) scopes — the title alone cannot carry these.
-        raw_params: dict | None = None
-        if tool_call_id and tool_call_id in self._tool_call_params:
-            raw_params = self._tool_call_params.pop(tool_call_id)
-
-        # 2. Fallback: check if toolCall itself carries input/params
-        if not tool_input:
-            raw_input = tool_call.get("input") or tool_call.get("params")
-            if raw_input:
-                tool_input = (
-                    json.dumps(raw_input, indent=2)
-                    if isinstance(raw_input, (dict, list))
-                    else str(raw_input)
-                )
-                if raw_params is None and isinstance(raw_input, dict):
-                    raw_params = raw_input
-        elif raw_params is None:
-            # tool_input came from the cache; the permission message may still
-            # carry an inline params dict the gate can use.
-            inline = tool_call.get("input") or tool_call.get("params")
-            if isinstance(inline, dict):
-                raw_params = inline
-
-        # Resolve the canonical shell signal. SECURITY (deny-by-default): the
-        # ONLY trusted source is the value cached from the preceding tool_call
-        # notification (keyed by toolCallId). We deliberately do NOT fall back
-        # to the permission payload's own `kind`: that field is agent/LLM-
-        # influenced, and trusting it to waive the tool-name length cap on the
-        # very name being validated would let a malicious agent set
-        # kind="execute" on the permission payload to bypass the check. On a
-        # cache miss is_shell stays False and the length cap is enforced.
-        #
-        # Use .get() (not .pop()): a later tool_call_update refinement for the
-        # same toolCallId reads this same cache, so popping here would make that
-        # refinement wrongly report is_shell=False if it arrives after the
-        # permission event. The per-turn dispatch-loop .clear() handles cleanup.
-        cached_shell = self._tool_call_is_shell.get(tool_call_id) if tool_call_id else None
-        is_shell = bool(cached_shell)
-        if cached_shell is None and tool_input:
-            # Input resolved but the shell signal did not — the cache invariant
-            # (tool_call precedes permission) did not hold. Surface it so the
-            # miss is observable rather than silently enforcing the length cap.
-            logger.info(
-                "Permission event resolved tool_input but missed is_shell cache "
-                "(req=%s tool_call_id=%s)",
-                request_id,
-                tool_call_id,
-            )
-
-        logger.info("Permission requested for tool: %s (req=%s)", title, request_id)
-        if logger.isEnabledFor(logging.DEBUG):
-            _tc_redacted = repr(tool_call)
-            _tc_redacted, _ = redact_exfiltration_urls(_tc_redacted)
-            _tc_redacted, _ = redact_credentials(_tc_redacted)
-            logger.debug("Permission toolCall payload: %s", _tc_redacted)
-        return AcpEvent(
-            kind=EVENT_PERMISSION_REQUEST,
-            request_id=request_id,
-            title=title,
-            tool_kind=tool_kind,
-            options=options,
-            tool_input=tool_input,
-            tool_call_id=tool_call_id,
-            raw_tool_params=raw_params,
-            is_shell=is_shell,
-            # Trusted MCP server identity recovered from the preceding tool_call
-            # (the permission payload has no _meta). .get() mirrors the is_shell
-            # cache-read; empty on a miss (fail-closed for app-own auto-approve).
-            mcp_server_name=(
-                self._tool_call_mcp_server.get(tool_call_id, "") if tool_call_id else ""
-            ),
-            # Trusted tool name recovered from the preceding tool_call, mirroring
-            # mcp_server_name — lets the app-own-server auto-approve govern the
-            # canonical mcp__<server>__<tool> on this permission path.
-            tool_name=(
-                self._tool_call_tool_name.get(tool_call_id, "") if tool_call_id else ""
-            ),
+        The legacy direct client owns the same provenance caches as the shared
+        runtime. Routing them through one parser keeps a cached ``False`` shell
+        classification distinguishable from a cache miss and preserves cached
+        raw parameters across repeated permission frames for the same tool call.
+        """
+        event, recorded = build_permission_event(
+            msg,
+            tool_input_cache=self._tool_call_inputs,
+            shell_cache=self._tool_call_is_shell,
+            raw_params_cache=self._tool_call_params,
+            mcp_server_name_cache=self._tool_call_mcp_server,
+            tool_name_cache=self._tool_call_tool_name,
         )
+        if recorded is not None:
+            self._permission_options[event.request_id] = recorded
+        logger.info(
+            "Permission requested for tool: %s (req=%s)", event.title, event.request_id
+        )
+        if logger.isEnabledFor(logging.DEBUG):
+            params = msg.params if isinstance(msg.params, dict) else {}
+            tool_call = params.get("toolCall", {})
+            tool_call = tool_call if isinstance(tool_call, dict) else {}
+            redacted_payload = repr(tool_call)
+            redacted_payload, _ = redact_exfiltration_urls(redacted_payload)
+            redacted_payload, _ = redact_credentials(redacted_payload)
+            logger.debug("Permission toolCall payload: %s", redacted_payload)
+        return event
 
     def _backfill_context_window(self, pct: float) -> None:
         """Derive window/used tokens from a percentage-only reading.

--- a/src/kiro_crew/cli_chat.py
+++ b/src/kiro_crew/cli_chat.py
@@ -7,11 +7,15 @@ import asyncio
 import gc
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
+import threading
+from dataclasses import dataclass
 from pathlib import Path
 
+from kiro_crew.acp._dispatch import is_shell_kind
 from kiro_crew.acp.client import AcpError, AcpTimeoutError
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import (
@@ -23,9 +27,241 @@ from kiro_crew.config.loader import (
     write_config_atomically,
 )
 from kiro_crew.constants import BANNER, DATA_WARNING, MIN_NODE_MAJOR
-from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMProvider
+from kiro_crew.hooks import (
+    TOOL_DENY,
+    HookManager,
+    hooks_config_from_config_dict,
+    mcp_identity_ref,
+    target_paths,
+)
+from kiro_crew.providers.base import (
+    EVENT_COMPLETE,
+    EVENT_PERMISSION_REQUEST,
+    EVENT_TEXT_CHUNK,
+    LLMEvent,
+    LLMProvider,
+)
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
+
+#: Session key this surface presents everywhere it is identified: to the
+#: provider factory, to the PreToolUse gate, and to the SEL audit log. It is the
+#: value ``sel._infer_source`` and ``validation`` already recognise as the CLI,
+#: so the three must not drift apart.
+_CLI_SESSION_KEY = "cli_chat"
+
+#: The ACP runtime's canonical identity when no agent is configured.  The
+#: provider normalizes an empty agent to this name; the governance gate must see
+#: the same value so a task-bound ``kirocrew`` profile cannot be skipped merely
+#: because the CLI relied on the provider's default.
+_DEFAULT_KIRO_AGENT = "kirocrew"
+
+#: The audit ``source`` ``_CLI_SESSION_KEY`` maps to. Passed explicitly so a
+#: record is attributed to the CLI even if the key ever gains a suffix.
+_CLI_SEL_SOURCE = "cli"
+
+#: The only answer that approves a tool call, and the key advertised for
+#: refusing one. Matched exactly -- see :func:`_prompt_allows`.
+_ALLOW_KEY = "a"
+_DENY_KEY = "d"
+
+#: Audit codes. Stable and machine-readable, mirroring the dashboard's own
+#: ``error="hook_deny"``: an audit record must not restate the path or command a
+#: gate reason names.
+_HOOK_DENY_CODE = "hook_deny"
+_NONINTERACTIVE_CODE = "noninteractive"
+_USER_DENY_CODE = "user_denied"
+#: An ``execute``-kind request the trusted shell cache never confirmed, so no
+#: command could be recovered to gate on. Distinct from ``hook_deny``: the gate
+#: did not reject it, we refused to ASK about it.
+_UNVERIFIED_SHELL_CODE = "unverified_shell"
+#: The authorization gate itself could not produce a verdict. A broken gate is
+#: not permission to run, so the request is refused and answered under its own
+#: code rather than being left pending.
+_GATE_FAILURE_CODE = "gate_failed"
+#: The attended consent surface could not be rendered or read. A question the
+#: operator could not reliably see and answer is a denial, never implicit consent.
+_PROMPT_FAILURE_CODE = "prompt_failed"
+#: The session died with the question unanswered -- distinct from a user who
+#: said no, which is what an audit reader needs to be able to tell apart.
+_ABORTED_CODE = "session_aborted"
+#: The human allowed the call but the decision could not be persisted, so the
+#: allow was downgraded to a refusal. Distinct from ``user_denied``: the operator
+#: said yes, and an audit reader must not read this as a human refusal.
+_UNAUDITABLE_CODE = "audit_unwritable"
+
+#: Cap for the command line echoed above a permission prompt. Wide enough to
+#: read a real command, narrow enough that a generated one-liner cannot flood
+#: the terminal the question is being asked on.
+_MAX_COMMAND_DISPLAY = 240
+
+
+#: True once a prompt's await was cancelled. See :func:`_require_usable_stdin`.
+_stdin_poisoned = False
+
+
+class StdinPoisonedError(RuntimeError):
+    """Raised when stdin is read after an abandoned prompt was left on it.
+
+    A blocking terminal read cannot be retracted: cancelling the coroutine frees
+    the coroutine, not the thread, and that reader still takes the next line the
+    user types. So a cancelled prompt leaves no recoverable session -- every
+    later entry point refuses rather than racing it for keystrokes.
+    """
+
+
+def _require_usable_stdin() -> None:
+    """Guard every read of the terminal. Raises once a prompt was abandoned."""
+    if _stdin_poisoned:
+        raise StdinPoisonedError(
+            "stdin was abandoned by a cancelled permission prompt; "
+            "this session cannot read the terminal again"
+        )
+
+
+def _redacted(text: str) -> str:
+    """Strip credentials and exfiltration URLs from text that leaves this turn.
+
+    ``log_tool_invocation`` does not redact for its callers, so anything derived
+    from model-authored prose or from a real command is scrubbed here before it
+    reaches the audit log or the terminal.
+    """
+    text, _ = redact_exfiltration_urls(text or "")
+    text, _ = redact_credentials(text)
+    return text
+
+
+def _for_audit(text: str) -> str:
+    """Redact text and replace non-scalar Unicode before SEL persistence."""
+    return _redacted(text).encode("utf-8", errors="backslashreplace").decode("utf-8")
+
+
+#: ESC, the C0 set, DEL, the C1 set, and lone UTF-16 surrogate code points. The
+#: controls can be interpreted as terminal protocol. A lone surrogate is not a
+#: Unicode scalar value and cannot be encoded by UTF-8 or legacy Windows console
+#: codecs, so letting one reach ``print`` can abandon the pending request with a
+#: ``UnicodeEncodeError``.
+_TERMINAL_CONTROLS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f\ud800-\udfff]")
+
+
+#: Emitted immediately before the permission prompt. Ordered, and every part is
+#: load-bearing:
+#:
+#: 1. ``CAN`` (``\x18``) ABORTS any OSC/DCS/APC/PM string the previous output
+#:    left OPEN. Ordinary streamed model output is printed raw, so a turn can end
+#:    mid-sequence -- and while a string is open the terminal consumes everything
+#:    that follows as its payload, which would swallow the rest of this reset AND
+#:    the prompt itself. Resetting modes first would therefore reset nothing.
+#:    Aborting is required rather than merely closing: a String Terminator
+#:    (``ESC \``) would COMPLETE the pending string, so an unterminated ``OSC 52``
+#:    in model output would be handed to the terminal as a finished command and
+#:    set the user's clipboard. CAN discards the partial sequence instead, so the
+#:    payload never executes. It is a no-op with no string open, so it is safe to
+#:    send unconditionally, and unlike BEL it does not beep when nothing is open.
+#: 2. SGR reset undoes concealed, inverted or colour-matched text.
+#: 3. Show-cursor undoes a hidden cursor.
+#:
+#: This stays scoped to the authorization boundary rather than becoming a
+#: rendering policy for all streamed output: it makes the question visible
+#: without changing how anything else is displayed.
+_PROMPT_TERMINAL_RESET = "\x18\x1b[0m\x1b[?25h"
+
+
+def _terminal_reset() -> str:
+    """The reset to emit before the permission prompt, or ``""`` when not a TTY.
+
+    Escape sequences written to a pipe or a redirected file are literal bytes in
+    someone's log, so the reset is emitted only when stdout is a terminal that
+    can act on it.
+    """
+    try:
+        return _PROMPT_TERMINAL_RESET if sys.stdout.isatty() else ""
+    except (ValueError, OSError):
+        # A detached or closed stream cannot be interrogated; treat it as not a
+        # terminal rather than letting the check itself break the prompt.
+        return ""
+
+
+def _for_consent(text: str, *, stream: object | None = None) -> str:
+    """Render untrusted text safe to show in a permission prompt.
+
+    A permission prompt is the one place a human decides whether a tool may run,
+    and the strings on it -- the tool title especially -- are model-authored. An
+    escape sequence reaching the terminal from there is not merely cosmetic: OSC
+    52 writes the clipboard, and CSI can move the cursor and overwrite what has
+    already been drawn, so a title could repaint the question the user is
+    answering and hide what is being approved. Neutralising controls keeps the
+    prompt showing what it says it shows.
+
+    Each control or lone surrogate becomes a space, then whitespace collapses,
+    so the result is always a single line: a prompt is a question, and a title
+    that spans lines can push it off screen just as an escape sequence can redraw
+    it. The final text is round-tripped through the destination stream's codec
+    with ``backslashreplace``. That preserves ordinary Unicode on UTF-8 terminals
+    and renders unrepresentable characters as inert ASCII escapes on cp1252 and
+    other legacy Windows codepages, even when the stream itself is strict.
+
+    This is the authorization surface only. Ordinary streamed model output is
+    printed raw by ``_send_and_print`` and is unchanged here -- that is a
+    surface-wide rendering question, not part of answering a permission request.
+    """
+    rendered = " ".join(_TERMINAL_CONTROLS_RE.sub(" ", _redacted(text)).split())
+    destination = stream if stream is not None else sys.stdout
+    try:
+        encoding_value = getattr(destination, "encoding", None)
+    except Exception:
+        encoding_value = None
+    encoding = encoding_value if isinstance(encoding_value, str) and encoding_value else "utf-8"
+    try:
+        return rendered.encode(encoding, errors="backslashreplace").decode(encoding)
+    except (LookupError, UnicodeError):
+        # A detached/custom stream can advertise a broken codec. ASCII escapes
+        # are the narrowest portable fallback; if the stream itself is unusable,
+        # the caller converts that render failure into an explicit rejection.
+        return rendered.encode("ascii", errors="backslashreplace").decode("ascii")
+
+
+def _print_permission_notice(message: str) -> None:
+    """Best-effort stderr notice after a permission request is already answered.
+
+    A closed or broken terminal must not turn a completed rejection back into a
+    failed turn. Callers sanitise every interpolated field with ``_for_consent``
+    before constructing ``message``; this helper owns only the output failure.
+    """
+    try:
+        print(message, file=sys.stderr)
+    except Exception:
+        logger.warning("Could not render the CLI permission notice", exc_info=True)
+
+
+@dataclass(frozen=True)
+class _ToolGate:
+    """Kiro Crew's own PreToolUse gate, plus the identity it is asked under.
+
+    ``session_key`` and ``agent`` are what let the gate resolve the governance
+    ceiling ∩ profile for this surface; without them it can only apply the
+    ceiling, and a profile narrowing (say) ``filesystem.write`` would silently
+    not be enforced for tools the CLI approves.
+    """
+
+    hooks: HookManager
+    session_key: str = _CLI_SESSION_KEY
+    agent: str = ""
+
+
+def _build_tool_gate(agent: str = "") -> _ToolGate:
+    """Load the security gate for this CLI process.
+
+    Opt-out state comes from the keystone ``denied_commands.json`` rather than
+    the config's hooks section, so this mirrors the gateway's own construction
+    instead of assembling a weaker manager.
+    """
+    return _ToolGate(
+        hooks=HookManager(hooks_config_from_config_dict(KiroCrewConfig.load().hooks)),
+        agent=agent,
+    )
 
 
 def _tui(args: argparse.Namespace) -> None:
@@ -108,23 +344,45 @@ async def _chat(message: str | None, model: str | None, agent: str | None = None
     if model:
         cfg.agent.model = model
     channel_id = os.environ.get("KIROCREW_CHANNEL_ID") or None
-    agent_name = agent or cfg.agent.default_agent or None
+    # Keep the provider and governance gate on one canonical identity.  ACP
+    # resolves an omitted agent to ``kirocrew``; passing an empty string only to
+    # the gate would therefore run that agent while bypassing its task profile.
+    agent_name = agent or cfg.agent.default_agent or _DEFAULT_KIRO_AGENT
     provider: LLMProvider = build_provider_factory(cfg)(
-        "cli_chat", agent=agent_name, channel_id=channel_id
+        _CLI_SESSION_KEY, agent=agent_name, channel_id=channel_id
     )
+    # Built once per process, not per request: a permission request must not
+    # depend on a config read succeeding while the turn is parked.
+    gate = _build_tool_gate(agent_name or "")
+    # A permission prompt cancelled at the terminal raises through the turn by
+    # design (the request is deliberately left unanswered, see
+    # `_answer_permission`), so the teardown belongs in `finally` rather than on
+    # the success path -- a Ctrl-C there would leave the backend running with
+    # nothing owning it. `start()` is inside the try because it spawns the
+    # backend before the handshake completes: a failure partway through leaves a
+    # process that only `shutdown()` ends.
     try:
         await provider.start()
 
         if message:
-            await _send_and_print(provider, message)
+            # `-m` is documented as a non-interactive single message, so this
+            # path never stops to ask -- a permission request is denied rather
+            # than blocking a caller that may be a script.
+            await _send_and_print(provider, message, interactive=False, gate=gate)
         else:
-            await _interactive(provider, cfg)
+            await _interactive(provider, cfg, gate=gate)
     finally:
         try:
             await provider.shutdown()
+        except Exception:  # pragma: no cover - cleanup must not mask the outcome
+            # A failed teardown is not worth replacing the exception that is
+            # already propagating: raising here would discard the very
+            # CancelledError the shutdown exists to clean up after.
+            logger.debug("Provider shutdown failed during teardown", exc_info=True)
         finally:
             # Force GC so subprocess transports are collected while the loop is
-            # still open, avoiding "Event loop is closed" noise on exit.
+            # still open, avoiding "Event loop is closed" noise on exit. Nested
+            # so a raising shutdown cannot skip it.
             gc.collect()
 
 
@@ -136,12 +394,622 @@ def _run_chat(message: str | None, model: str | None, agent: str | None = None) 
         print("\nBye! 👻")
 
 
-async def _send_and_print(provider: LLMProvider, message: str) -> None:
-    """Stream a single message to stdout, handling errors and timeouts."""
+def _can_prompt(interactive: bool) -> bool:
+    """True when this invocation may stop and ask a human.
+
+    Two conditions, and both are load-bearing. ``-m`` is documented as
+    ``Single message (non-interactive)``, so it must never block on stdin even
+    from a terminal -- a script wrapped in a pty would otherwise hang on a
+    question nobody is watching for. And a prompt nobody can see is a hang, not
+    consent, so the interactive REPL still needs a real terminal on both ends.
+    """
+    return interactive and sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _read_line_blocking(prompt: str) -> str:
+    """Read one line from the controlling terminal. Blocks the calling thread.
+
+    The single blocking seam of the permission prompt, kept off the event loop
+    by :func:`_read_line`. It reads through a PRIVATE file object over a dup of
+    the stdin descriptor rather than ``sys.stdin``: an abandoned read parks here
+    forever, and a thread parked inside ``sys.stdin`` holds a buffer lock the
+    interpreter must acquire to finalize it, aborting the process when it
+    cannot. A private buffer is nobody else's to finalize.
+    """
+    sys.stdout.write(prompt)
+    sys.stdout.flush()
+    with open(
+        os.dup(sys.stdin.fileno()),
+        "r",
+        encoding=sys.stdin.encoding or "utf-8",
+        errors="replace",
+        closefd=True,
+    ) as stream:
+        return stream.readline()
+
+
+async def _read_line(prompt: str) -> str:
+    """Await one line of terminal input without stalling the event loop.
+
+    The request is answered from INSIDE an active provider stream, not at an
+    idle REPL: the ACP runtime is holding a reader task on the backend's stdout
+    and a drain task on its stderr, and a read on the loop thread stops draining
+    both for as long as the human takes to answer. The read runs on an owned
+    daemon thread rather than the default executor, which ``asyncio.run`` joins
+    at shutdown -- a worker still parked in ``read`` would wedge the interpreter.
+
+    Cancelling this await does not retract the thread, so it poisons stdin (see
+    :class:`StdinPoisonedError`) and re-raises. Returns ``""`` on EOF or any read
+    failure, which every caller must treat as a deny.
+    """
+    _require_usable_stdin()
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[str] = loop.create_future()
+
+    def _worker() -> None:
+        try:
+            line = _read_line_blocking(prompt)
+        except BaseException:  # EOF, a stdin with no descriptor to dup, a decode failure
+            line = ""
+
+        def _deliver() -> None:
+            if not future.done():
+                future.set_result(line)
+
+        try:
+            loop.call_soon_threadsafe(_deliver)
+        except RuntimeError:
+            # The loop is already closed: this prompt was abandoned and the
+            # answer has nowhere to go. Dropping it is correct -- nothing is
+            # waiting, and no tool may be approved on it.
+            pass
+
+    threading.Thread(target=_worker, daemon=True, name="kirocrew-permission-prompt").start()
+    try:
+        return await future
+    except asyncio.CancelledError:
+        global _stdin_poisoned
+        _stdin_poisoned = True
+        raise
+
+
+def _display_command(command: str) -> str:
+    """Render what will actually run, for the human deciding whether it may.
+
+    Collapsed to one line and capped: the value is a real shell command, which
+    may be a multi-line heredoc or a generated one-liner long enough to push the
+    question itself off the screen.
+    """
+    text = _for_consent(command)
+    if len(text) > _MAX_COMMAND_DISPLAY:
+        text = f"{text[:_MAX_COMMAND_DISPLAY]}... [truncated]"
+    return text
+
+
+def _target_path(event: LLMEvent) -> str:
+    """The file path this call acts on, from the request's own arguments.
+
+    ``raw_tool_params`` is the argument dict the backend sent for the call, not
+    model prose about it, so it is the same class of trusted signal as
+    ``shell_command`` -- and it is where the gate reads a path from to deny
+    ``~/.ssh`` or a write-protected config.
+
+    Resolved through ``hooks.target_paths``, the SAME helper the gate uses, so the
+    two cannot drift about which argument names carry a target. An earlier revision
+    duplicated the spellings here and claimed parity in a comment; the gate's
+    sensitive-path keystone was in fact reading two of the three, so a
+    ``filePath`` target was displayed as vetted while never having been gated.
+
+    The FIRST path is shown when a call carries several. The gate denies on ANY of
+    them, so anything forbidden has already been refused before this runs; what is
+    left is a disclosure choice, and a prompt is a question rather than a manifest.
+
+    Returns ``""`` when the call carries no path, which is the ordinary case for
+    a tool that acts on no file. That is deliberately NOT a refusal: most builtin
+    calls (a memory write, a tag creation) legitimately have no path, so denying
+    on absence would refuse them all to close a gap that only exists for tools
+    which DO name a file.
+    """
+    found = target_paths(event.raw_tool_params)
+    return found[0] if found else ""
+
+
+def _display_path(path: str) -> str:
+    """Render a target path for the human deciding whether it may be written.
+
+    Capped and collapsed like a command, and for the same reason: the value is
+    attacker-influenceable text on an authorization prompt, so it must not be
+    able to push the question off the screen.
+
+    Local paths are NOT redacted, matching the command line above it -- this is
+    the operator's own terminal and seeing the real path IS the consent. Only
+    credential and exfiltration-URL shapes are scrubbed, by ``_for_consent``.
+    """
+    text = _for_consent(path)
+    if len(text) > _MAX_COMMAND_DISPLAY:
+        text = f"{text[:_MAX_COMMAND_DISPLAY]}... [truncated]"
+    return text
+
+
+def _unverifiable_shell(event: LLMEvent) -> bool:
+    """True when the request claims to execute a command we cannot verify.
+
+    ``is_shell`` is set ONLY from the trusted cache the preceding ``tool_call``
+    populated, so a cache miss leaves it False even for a real shell call --
+    and ``shell_command`` returns None whenever ``is_shell`` is False. Gating
+    that on the title alone is exactly the bypass the gate exists to prevent:
+    the title may be LLM-authored prose over a sensitive command.
+
+    The payload's own ``tool_kind`` is agent-influenced, so it must never WAIVE
+    a check -- but reading it to DENY is sound, because an agent that forges
+    ``execute`` only earns a refusal. That asymmetry is why the trusted cache
+    stays the only thing that can set ``is_shell`` True.
+
+    The cost is a refused call when the cache genuinely missed. For an
+    authorization gate that is the correct direction: a refusal the user can
+    retry, rather than a command approved on a description of itself.
+    """
+    if event.is_shell:
+        # Trusted signal: the gate's own deny-by-default backstop covers an
+        # unrecoverable command from here.
+        return False
+    # No classification happened AT ALL: the preceding ``tool_call`` carried no
+    # resolvable ``kind``, so nothing was cached and ``is_shell`` is the miss
+    # default rather than a resolved "not a shell tool". Reading the payload's own
+    # ``kind`` here would let an uncached shell request labelled ``read`` past the
+    # check, and the human would then be asked to approve a title with no command
+    # behind it. An absent classification is not a negative one -- the same
+    # distinction ``child_low_fidelity`` already draws on this flag.
+    if not event.shell_classified:
+        return True
+    # Normalised before the shared check so a cosmetic variant still denies --
+    # widening a fail-closed test is safe in a way widening an allow is not.
+    # ``tool_kind`` is relayed verbatim from ACP, so a backend may supply a
+    # non-string (``kind: 1``); coerced here rather than trusted, because an
+    # AttributeError on this path would abort the turn without answering the
+    # permission request.
+    return is_shell_kind(_kind_text(event))
+
+
+def _kind_text(event: LLMEvent) -> str:
+    """The ACP tool kind as comparable text, or ``""`` when it is not usable.
+
+    ACP relays ``toolCall.kind`` verbatim, so the value is agent-influenced and
+    need not be a string. Every consumer here compares it as text, and an
+    unusable kind must read as absent rather than raise: a raise would leave the
+    permission request unanswered, which is the hang this path exists to end.
+    An absent kind cannot match the read-only allow-list, so the human is asked.
+    """
+    kind = event.tool_kind
+    return kind.strip().lower() if isinstance(kind, str) else ""
+
+
+async def _prompt_allows(event: LLMEvent) -> bool:
+    """Ask the human, and return True ONLY for the exact allow token.
+    Matched exactly rather than by first letter: a prefix match reads ``abort``
+    as an allow, which is the opposite of what the person typing it means.
+    Anything else -- an unrecognised word, a blank line, EOF -- denies, so the
+    safe answer is the one a user gets by doing nothing.
+
+    A shell call also shows its command, and any call with a trusted identity
+    shows that identity. ``title`` is LLM-authored prose, so approving on it
+    alone asks the user to consent to a description rather than to what runs --
+    the same reason the security gate keys on ``shell_command`` and
+    ``mcp_server_name`` rather than the title. Only those non-model-authored
+    fields are shown, never the whole tool input: this is the question, not a
+    detail panel.
+    """
+    print(
+        f"{_terminal_reset()}\nPermission required: "
+        f"{_for_consent(event.title, stream=sys.stdout) or 'tool call'}"
+    )
+    command = event.shell_command if event.is_shell else None
+    if command:
+        print(f"Command: {_display_command(command)}")
+    # kiro-cli sets these from ``_meta`` for MCP-served calls only, so unlike
+    # the title they cannot be chosen by the model to describe the call as
+    # something milder than it is.
+    if event.mcp_server_name:
+        server = _for_consent(event.mcp_server_name, stream=sys.stdout)
+        tool = _for_consent(event.tool_name, stream=sys.stdout) or "unnamed tool"
+        print(f"MCP tool: {server} / {tool}")
+    elif event.tool_name:
+        # A builtin (non-MCP) call has no server to name, but ``tool_name`` is
+        # still the trusted ``_meta.kiro`` identity rather than model prose. Left
+        # unshown, a file-write reaches the human as its title alone, which is
+        # the description-not-substance problem the shell and MCP lines exist to
+        # avoid.
+        print(f"Tool: {_for_consent(event.tool_name, stream=sys.stdout)}")
+    # The trusted identity says WHICH tool runs; it does not say what it runs
+    # against. ``fs_write`` under a benign title is consent to a verb, and a
+    # write to an ordinary valuable file is not disclosed by the verb alone --
+    # the gate's sensitive-path and write-protected-config denials cover the
+    # named-dangerous paths, so what is left for the human is exactly the file
+    # no rule speaks for. Printed for any call that carries a path, not just an
+    # edit-kind one: the kind is agent-influenced, and disclosure can only ever
+    # inform the decision.
+    target = _target_path(event)
+    if target:
+        print(f"Path: {_display_path(target)}")
+    answer = await _read_line(f"   [{_ALLOW_KEY}] allow once  [{_DENY_KEY}] deny (default): ")
+    return answer.strip().lower() == _ALLOW_KEY
+
+
+async def _audit_off_loop(
+    gate: _ToolGate, event: LLMEvent, outcome: str, *, error: str = "", critical: bool = False
+) -> None:
+    """Await :func:`_audit` on a worker thread.
+
+    ``critical`` selects SEL's audit-or-deny contract: the event is written
+    synchronously and a persistence failure is RE-RAISED so the caller can refuse
+    the action rather than let it run unaudited. Only the approval path passes it
+    -- see :func:`_answer_permission`.
+
+    ``sel()`` initializes the audit log on first use -- opening it, and reading
+    it to recover the running HMAC chain -- so the first permission of a fresh
+    chat pays a filesystem cost inside this call, and slow or corrupt storage
+    makes it an unbounded one. This coroutine shares its loop with the ACP
+    reader and stderr-drain tasks, exactly as ``on_tool_call`` does, so the same
+    off-loop treatment applies for the same reason: a blocking write here stops
+    draining the backend and freezes the turn the audit is about.
+
+    Used on EVERY decision path, including the cancellation teardown, which wraps
+    it in :func:`asyncio.shield` so the record still lands if another
+    cancellation arrives mid-write. No caller audits synchronously on the loop.
+    """
+    await asyncio.to_thread(_audit, gate, event, outcome, error=error, critical=critical)
+
+
+async def _audit_refusal(gate: _ToolGate, event: LLMEvent, *, error: str) -> None:
+    """Audit a REFUSAL without letting the audit become the outcome.
+
+    Every caller goes on to ``reject_tool``, and that call is what ends the turn:
+    the backend holds it open until the request is answered. So an exception from
+    the audit must not escape, or it skips the rejection and abandons the request
+    unanswered -- the hang this whole path exists to end, reached by way of the
+    bookkeeping rather than the decision.
+
+    ``critical`` is deliberately NOT used here, and the asymmetry with the approval
+    path is the point. Audit-or-deny only has meaning where the alternative is
+    EXECUTION; a refusal is already refusing, so a lost record cannot authorize
+    anything. Refusal paths therefore fail safe when bookkeeping is unavailable.
+    """
+    try:
+        await _audit_off_loop(gate, event, "denied", error=error)
+    except Exception:
+        # Warning, not debug: an audit sink that cannot record refusals is an
+        # operational fault worth seeing, even though it must not stop the refusal.
+        logger.warning("SEL audit failed for a refusal; refusing anyway", exc_info=True)
+
+
+async def _reject_internal_failure(
+    provider: LLMProvider,
+    gate: _ToolGate,
+    event: LLMEvent,
+    *,
+    error: str,
+    notice: str,
+) -> None:
+    """Answer a request whose gate or consent UI failed before a decision.
+
+    The audit is best-effort because the safe outcome is already a refusal. The
+    transport response comes before the notice so a broken output stream cannot
+    leave the backend waiting on a question nobody can answer.
+    """
+    await _audit_refusal(gate, event, error=error)
+    await provider.reject_tool(event.request_id)
+    _print_permission_notice(notice)
+
+
+def _audit(
+    gate: _ToolGate, event: LLMEvent, outcome: str, *, error: str = "", critical: bool = False
+) -> None:
+    """Record a permission decision in the SEL audit log.
+
+    ``critical`` is SEL's audit-or-deny flag: it writes synchronously and raises
+    on a persistence failure instead of swallowing it in the background writer.
+
+    Callers on the event loop must go through :func:`_audit_off_loop`; this
+    function performs blocking I/O.
+
+    Called BEFORE the matching ``approve_tool``/``reject_tool``: a transport
+    failure must not be able to erase the record of a security decision that was
+    already made.
+
+    ``error`` is a stable machine code, never a gate reason: a reason carries
+    the path or command that triggered it, and an audit record is not a place to
+    copy the thing being protected.
+
+    The tool identity prefers ``event.tool_name`` -- the canonical,
+    non-model-authored name from ``_meta.kiro`` -- and falls back to the
+    LLM-authored title only when the backend supplies none.
+
+    For an MCP call that name is unique only WITHIN its server, so two servers
+    exposing the same tool name would otherwise produce indistinguishable
+    records. The canonical ``@server/tool`` reference carries both halves. It is
+    used in preference to an ``mcp__server__tool`` composition because that form
+    re-splits on the last ``__``, so a server or tool name containing ``__``
+    collapses two distinct identities onto one string.
+
+    Whichever identity wins is scrubbed before it is logged, as is the kind:
+    these fields are served over ``/api/sel/events`` and the SEL writer does not
+    redact for its callers, so a credential embedded in a tool name would
+    otherwise be persisted and exposed.
+    """
+    identity = mcp_identity_ref(event.mcp_server_name, event.tool_name)
+    # Redact whatever identity wins, not just the title branch. These fields reach
+    # ``/api/sel/events``, and ``log_tool_invocation`` does not scrub for its
+    # callers, so a credential-bearing tool name or kind would be persisted
+    # verbatim. Scrubbing is lossless for an ordinary identity -- it only rewrites
+    # credential and exfiltration-URL shapes -- so the canonical ``@server/tool``
+    # precision is preserved. The kind is normalised first: it is relayed verbatim
+    # from ACP and may not even be a string.
+    subject = _for_audit(identity or event.tool_name or event.title)
+    sel().log_tool_invocation(
+        session_key=gate.session_key,
+        agent=gate.agent or _DEFAULT_KIRO_AGENT,
+        source=_CLI_SEL_SOURCE,
+        tool_name=subject or "unknown",
+        tool_kind=_for_audit(_kind_text(event)),
+        outcome=outcome,
+        request_id=event.request_id,
+        error=error,
+        critical=critical,
+    )
+
+
+async def _answer_permission(
+    provider: LLMProvider,
+    event: LLMEvent,
+    *,
+    interactive: bool,
+    gate: _ToolGate | None = None,
+) -> None:
+    """Answer a pending permission request so the backend can resume the turn.
+
+    Answering one is an authorization decision, so Kiro Crew's own PreToolUse
+    gate runs first and a human is asked only about what survives it. That gate
+    is the shared :class:`~kiro_crew.hooks.HookManager` -- sensitive paths, the
+    built-in denied commands, the governance ceiling -- never a second copy of
+    those rules living here. It is fed the event's NON-model-authored fields,
+    not just ``title``: for a shell tool the title may be an LLM-authored
+    description, so a dangerous command behind a benign label is exactly what
+    keying on the title alone would let through (see ``AcpEvent.shell_command``).
+
+    Its verdict is a deny CEILING: ``TOOL_AUTO_APPROVE`` still asks, because
+    honouring it here would add a second path that runs a tool with no human
+    confirmation. There is no persistent-approval option either -- ``always``
+    asks the backend to stop SENDING these requests, and a request never sent is
+    a call this gate never sees and never audits.
+
+    The answer always goes through the provider's ``approve_tool`` /
+    ``reject_tool``: the ACP layer records the option ids the agent advertised
+    for this request, and those differ per backend.
+
+    Every interpolated field is made representable in its destination stream by
+    :func:`_for_consent`, independently of the stream's configured error handler.
+    This covers strict UTF-8 and legacy Windows codepages as well as CPython's
+    usual ``backslashreplace`` stderr. A gate, prompt, render, or audit failure
+    always becomes an explicit rejection; only cancellation keeps the existing
+    session-abort contract, where provider teardown owns the pending request.
+    """
+    gate = gate or _build_tool_gate()
+    title = event.title or "tool call"
+
+    # Off-loop: the gate resolves the active governance profile, which stats and
+    # reads ``profiles/`` on the way to a verdict. That is a filesystem walk, not
+    # computation, and this coroutine shares its loop with the ACP reader and
+    # drain tasks -- on slow or network storage a synchronous call here stalls the
+    # whole session, not just this prompt.
+    try:
+        decision = await asyncio.to_thread(
+            gate.hooks.on_tool_call,
+            event.title,
+            session_key=gate.session_key,
+            agent=gate.agent,
+            tool_kind=_kind_text(event),
+            raw_params=event.raw_tool_params,
+            command=event.shell_command,
+            is_shell=event.is_shell,
+            mcp_server_name=event.mcp_server_name,
+            mcp_tool_name=event.tool_name,
+        )
+    except Exception:
+        logger.warning("CLI permission gate failed; refusing the request", exc_info=True)
+        await _reject_internal_failure(
+            provider,
+            gate,
+            event,
+            error=_GATE_FAILURE_CODE,
+            notice=(
+                "\nDenied automatically: the security gate could not verify this tool call.\n"
+                "   Fix the gate error, then retry the tool call."
+            ),
+        )
+        return
+    if decision.action == TOOL_DENY:
+        # Not a question for the user: a policy denial is not theirs to
+        # override from here. The audit carries a stable code; the reason is
+        # for the person at the terminal, and is sanitised on the way there.
+        await _audit_refusal(gate, event, error=_HOOK_DENY_CODE)
+        await provider.reject_tool(event.request_id)
+        try:
+            reason = (
+                _for_consent(decision.reason, stream=sys.stderr) or "blocked by security policy"
+            )
+            safe_title = _for_consent(title, stream=sys.stderr)
+            _print_permission_notice(f"\nBlocked by security policy: {safe_title} -- {reason}")
+        except Exception:
+            logger.warning("Could not prepare the CLI policy-denial notice", exc_info=True)
+        return
+
+    if _unverifiable_shell(event):
+        # Refusing to ASK, not a gate rejection: with no trusted shell signal
+        # the only thing left to show the human is the LLM-authored title, and
+        # consent to a description is not consent to what runs.
+        await _audit_refusal(gate, event, error=_UNVERIFIED_SHELL_CODE)
+        await provider.reject_tool(event.request_id)
+        try:
+            safe_title = _for_consent(title, stream=sys.stderr)
+            _print_permission_notice(
+                f"\nDenied automatically: {safe_title} claims to run a command, "
+                "but its command could not be verified.\n"
+                "   Ask the agent to retry the tool call."
+            )
+        except Exception:
+            logger.warning("Could not prepare the CLI shell-denial notice", exc_info=True)
+        return
+
+    try:
+        can_prompt = _can_prompt(interactive)
+    except Exception:
+        logger.warning("CLI permission prompt availability check failed", exc_info=True)
+        await _reject_internal_failure(
+            provider,
+            gate,
+            event,
+            error=_PROMPT_FAILURE_CODE,
+            notice=(
+                "\nDenied automatically: the permission prompt could not be opened.\n"
+                "   Retry from a usable terminal."
+            ),
+        )
+        return
+
+    if not can_prompt:
+        await _audit_refusal(gate, event, error=_NONINTERACTIVE_CODE)
+        await provider.reject_tool(event.request_id)
+        try:
+            safe_title = _for_consent(title, stream=sys.stderr)
+            _print_permission_notice(
+                f"\nDenied automatically: {safe_title} needs approval, "
+                "and this invocation cannot ask.\n"
+                "   Run `kirocrew chat` from a terminal to approve tool calls."
+            )
+        except Exception:
+            logger.warning("Could not prepare the CLI noninteractive-denial notice", exc_info=True)
+        return
+
+    try:
+        allowed = await _prompt_allows(event)
+    except (StdinPoisonedError, asyncio.CancelledError):
+        # The BACKEND is deliberately not answered here. Answering means awaiting
+        # a transport, and a wedged one would park this teardown on a call that
+        # may never return, so the Ctrl-C that asked for it could never land. The
+        # provider is torn down with the session, so the unanswered request dies
+        # with it.
+        #
+        # The AUDIT is a different matter, and an earlier version of this comment
+        # wrongly generalised the transport rule to cover it. It is not a
+        # transport: it is local SEL I/O with a bounded caller, and running it
+        # synchronously here blocks the loop -- which still owns the ACP reader
+        # and stderr-drain tasks -- for as long as the audit store takes. Cold
+        # ``sel()`` initialization replays the log to recover the HMAC chain, so
+        # on slow storage that is exactly the freeze this whole path exists to
+        # end, just relocated to the exit.
+        #
+        # Shielded because this record is the one that distinguishes "the session
+        # died with the question unanswered" from "the user said no", and that is
+        # the harder of the two for an audit reader to reconstruct. A plain await
+        # would be re-cancelled the moment another cancellation arrives and the
+        # record would be dropped; the shield lets the write run to completion on
+        # its worker thread regardless. ``CancelledError`` from the shielded wait
+        # is therefore expected rather than exceptional -- it is caught so the
+        # bare ``raise`` below still re-delivers the ORIGINAL cancellation.
+        try:
+            await asyncio.shield(_audit_off_loop(gate, event, "denied", error=_ABORTED_CODE))
+        except asyncio.CancelledError:
+            logger.debug("SEL audit outlived the cancelled turn; it completes off-loop")
+        except Exception:  # pragma: no cover - an audit failure must not mask it
+            logger.debug("SEL audit failed during teardown", exc_info=True)
+        raise
+    except Exception:
+        logger.warning("CLI permission prompt failed; refusing the request", exc_info=True)
+        await _reject_internal_failure(
+            provider,
+            gate,
+            event,
+            error=_PROMPT_FAILURE_CODE,
+            notice=(
+                "\nDenied automatically: the permission prompt could not be rendered or read.\n"
+                "   Retry the tool call from a usable terminal."
+            ),
+        )
+        return
+
+    if allowed:
+        # AUDIT-OR-DENY, and only here. ``critical=True`` writes the record
+        # synchronously and re-raises a persistence failure (read-only SEL file,
+        # full disk) instead of letting the background writer swallow it. Without
+        # it an unwritable log means the tool RUNS while the only record that a
+        # human authorized it is silently dropped -- the one outcome on this
+        # surface that cannot be reconstructed afterwards, because the consent was
+        # a keystroke that left no other trace.
+        #
+        # The failure is converted to a REFUSAL here rather than allowed to
+        # propagate. Letting it escape ``_answer_permission`` would abandon the
+        # request unanswered, and the backend holds the turn open until it is
+        # answered -- the exact hang this whole path exists to end. So an audit
+        # failure denies the call, which is the same direction the gate fails in.
+        #
+        # ``error`` is a distinct code, not ``user_denied``: the operator said
+        # yes, and an audit reader must not be told they refused. That record is
+        # best-effort by necessity -- the writer that just failed is the only one
+        # available -- so it is attempted and its own failure only logged.
+        try:
+            await _audit_off_loop(gate, event, "allowed", critical=True)
+        except Exception:
+            logger.warning("SEL audit unwritable; refusing the approved call", exc_info=True)
+            await _audit_refusal(gate, event, error=_UNAUDITABLE_CODE)
+            await provider.reject_tool(event.request_id)
+            try:
+                safe_title = _for_consent(title, stream=sys.stderr)
+                _print_permission_notice(
+                    f"\nDenied automatically: {safe_title} was approved, but the "
+                    "decision could not be recorded.\n"
+                    "   Fix the security event log, then retry the tool call."
+                )
+            except Exception:
+                logger.warning("Could not prepare the CLI audit-denial notice", exc_info=True)
+            return
+        await provider.approve_tool(event.request_id)
+    else:
+        # Deliberately NOT critical, and the asymmetry is the point: this call is
+        # already being refused, so a lost record cannot authorize anything. Making
+        # the deny paths audit-or-deny would trade availability for no security
+        # gain -- it would turn a refusal into an error. Fail-closed only has
+        # meaning where the alternative is execution.
+        await _audit_refusal(gate, event, error=_USER_DENY_CODE)
+        await provider.reject_tool(event.request_id)
+
+
+async def _send_and_print(
+    provider: LLMProvider,
+    message: str,
+    *,
+    interactive: bool = False,
+    gate: _ToolGate | None = None,
+) -> None:
+    """Stream a single message to stdout, handling errors and timeouts.
+
+    ``interactive`` says whether the caller is the REPL, which may stop and ask
+    a human, or single-message mode, which may not. It is passed explicitly
+    rather than inferred from a TTY check: only the caller knows which command
+    mode is running, and ``-m`` is non-interactive even from a terminal.
+
+    ``gate`` is the security gate permission requests are decided against. None
+    builds the process default on first use, so a caller that never sees a
+    request pays nothing for it.
+    """
     try:
         async for event in provider.stream(message):
             if event.kind == EVENT_TEXT_CHUNK:
                 print(event.text, end="", flush=True)
+            elif event.kind == EVENT_PERMISSION_REQUEST:
+                # The backend holds the turn open until this is answered, so an
+                # unhandled request is not a missed prompt -- it is a turn that
+                # never ends.
+                await _answer_permission(provider, event, interactive=interactive, gate=gate)
             elif event.kind == EVENT_COMPLETE:
                 break
         print()  # final newline
@@ -155,7 +1023,9 @@ async def _send_and_print(provider: LLMProvider, message: str) -> None:
         sys.exit(1)
 
 
-async def _interactive(provider: LLMProvider, cfg: KiroCrewConfig) -> None:
+async def _interactive(
+    provider: LLMProvider, cfg: KiroCrewConfig, *, gate: _ToolGate | None = None
+) -> None:
     """REPL loop — read user input, stream responses, auto-compact at configured threshold."""
     print(BANNER)
     print(DATA_WARNING)
@@ -164,6 +1034,10 @@ async def _interactive(provider: LLMProvider, cfg: KiroCrewConfig) -> None:
     print("Type your message (Ctrl+D or 'exit' to quit)\n")
 
     while True:
+        # A cancelled permission prompt left a reader on stdin that this call
+        # would race for the user's keystrokes, so the session ends here instead
+        # of silently losing lines to it.
+        _require_usable_stdin()
         try:
             message = input("you> ").strip()
         except (EOFError, KeyboardInterrupt):
@@ -176,7 +1050,7 @@ async def _interactive(provider: LLMProvider, cfg: KiroCrewConfig) -> None:
             print("Bye! 👻")
             break
 
-        await _send_and_print(provider, message)
+        await _send_and_print(provider, message, interactive=True, gate=gate)
 
         # Check context usage — compact and restart if needed
         pct = provider.context_usage_pct()

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -506,14 +506,31 @@ class HookManager:
         default, or a backend that omits ``_meta.kiro``) fails closed: no match.
 
         ``mcp_tool_name`` is the sibling NON-model-authored tool identity from
-        ``_meta.kiro.toolName`` (``AcpEvent.tool_name``), set by kiro-cli
-        alongside ``mcp_server_name`` for MCP-served calls. It is used to
-        reconstruct the canonical ``mcp__<server>__<tool>`` name and govern the
-        REAL tool before the app-own-server auto-approve — because the ``tool_name``
-        title above is LLM-authored prose (``select_tool_title`` prefers the
-        model's ``description``) and may not carry the canonical form a per-tool
-        MCP policy matches on. Empty (no ``_meta.kiro.toolName``) means the tool
-        cannot be identified for governance, so the own-server auto-approve does
+        ``_meta.kiro.toolName`` (``AcpEvent.tool_name``). Despite the name it is
+        NOT MCP-only: kiro-cli sets it for every tool call it serves, built-ins
+        included, and sets ``mcp_server_name`` only for MCP-served ones. It is
+        therefore evaluated on the deny and governance planes whenever present,
+        server or no server -- otherwise a built-in's real name (``fs_write``)
+        reaches no check at all and a deny/ceiling rule naming it is bypassable
+        behind a benign model-authored title. With both present the
+        gate reconstructs the canonical ``mcp__<server>__<tool>`` name and runs
+        the effective deny set AND the governance ceiling against it as well as
+        against the title — because the ``tool_name`` title above is LLM-authored
+        prose (``select_tool_title`` prefers the model's ``description``) and may
+        not carry the canonical form a per-tool MCP policy matches on. Without
+        this, an ordinary MCP call whose policy-denied tool arrives under a benign
+        description would pass the gate and reach the human prompt, where an
+        "allow" would run a tool the ceiling forbids.
+
+        The canonical name is ADDED to those checks, never SUBSTITUTED for the
+        title: the two carry different security signals. The canonical name is
+        the trusted statement of WHICH MCP tool is being invoked, and is what a
+        per-tool ceiling or deny rule matches. The title and raw command carry
+        the path, command and content signals that a tool identity does not
+        express — ``~/.aws/credentials`` read through an innocuously named MCP
+        tool is denied by the title, not by the identity. Different dimensions,
+        so a deny on EITHER denies the call. Empty (no ``_meta.kiro.toolName``)
+        means the tool cannot be identified, so the own-server auto-approve does
         NOT fire (fall through to interactive approval — fail-closed).
         """
         # Deny-by-default: a shell tool whose command could not be recovered
@@ -573,10 +590,15 @@ class HookManager:
         # trust-root files (security_policy.json / profiles) is blocked even when
         # the title hides it. This is the keystone the governance model leans on
         # (agent-cannot-rewrite-its-own-ceiling), so it must not be title-gated.
+        # EVERY accepted spelling, and a deny on any of them denies: a backend that
+        # sends ``filePath`` (the camel-case form the search plane has always
+        # accepted) reached NEITHER of the two snake_case reads this used to do, so
+        # a write to ~/.ssh under that key was never gated and the human was asked
+        # to approve a path the keystone should have refused outright.
         if raw_params:
-            real_path = raw_params.get("path") or raw_params.get("file_path")
-            if isinstance(real_path, str) and real_path and is_sensitive_path(real_path):
-                return ToolHookResult.deny(f"Blocked: access to sensitive path: {real_path}")
+            for real_path in target_paths(raw_params):
+                if is_sensitive_path(real_path):
+                    return ToolHookResult.deny(f"Blocked: access to sensitive path: {real_path}")
         # Config files are WRITE-protected (reads stay allowed): block the agent's
         # file-EDIT tool from modifying config.json / config.local.json so a
         # prompt-injected agent cannot rewrite its own resource ceilings
@@ -600,11 +622,14 @@ class HookManager:
         # ``edit``); not hard-denying them keeps the two write-gates from drifting
         # into a read regression, and the bash gate covers the shell surface.
         if tool_kind == _EDIT_TOOL_KIND and raw_params:
-            wpath = raw_params.get("path") or raw_params.get("file_path")
-            if isinstance(wpath, str) and wpath and is_sensitive_write_path(wpath):
-                return ToolHookResult.deny(
-                    f"Blocked: modification of write-protected config path: {wpath}"
-                )
+            # Same spelling coverage as the sensitive-path keystone above, for the
+            # same reason: the write-protected tier is worthless if a config edit
+            # can name its target under a key the check never reads.
+            for wpath in target_paths(raw_params):
+                if is_sensitive_write_path(wpath):
+                    return ToolHookResult.deny(
+                        f"Blocked: modification of write-protected config path: {wpath}"
+                    )
         # Built-in security deny list (always enforced).  Route through the
         # active PlatformContext's PolicyAuthority so the Amazon companion's
         # ADD-only deny overlay (+ internal patterns) applies when loaded.  The
@@ -619,6 +644,62 @@ class HookManager:
         denied_regexes = self._effective_denied(ctx)
         denied_notes = self._denied_notes()
         deny_targets = [normalized, tool_name]
+        # The canonical ``mcp__<server>__<tool>`` identity, when kiro-cli supplied
+        # BOTH trusted ``_meta.kiro`` fields. ``select_tool_title`` prefers the
+        # model's prose ``description``, so ``tool_name`` for an MCP call may be
+        # "Look up the weather" rather than the canonical form a per-tool deny
+        # rule or MCP policy matches on. Reconstructing it here — on the COMMON
+        # path, before the deny floor and governance — is what makes a rule keyed
+        # on the real tool identity bind for every consumer of this gate, not
+        # only for the first-party own-server auto-approve below.
+        #
+        # ADDITIVE, never a substitution: the display title and the raw command
+        # stay in every check they were already in. They are not competing
+        # spellings of one fact — the canonical name is the trusted statement of
+        # WHICH tool runs, which is what a per-tool rule matches, while the title
+        # and command carry the path/command/content signals that identity does
+        # not express. Each covers a security dimension the other cannot, so both
+        # are evaluated and a deny on either denies. Both fields empty (a non-MCP
+        # call, or a backend that omits ``_meta.kiro``) leaves every target
+        # exactly as before.
+        canonical_mcp_name = (
+            f"mcp__{mcp_server_name}__{mcp_tool_name}" if mcp_server_name and mcp_tool_name else ""
+        )
+        if canonical_mcp_name:
+            deny_targets.append(canonical_mcp_name)
+        # The trusted tool identity on its own, which is the ONLY form a built-in
+        # carries: kiro-cli sets ``_meta.kiro.toolName`` for every tool call but
+        # ``mcpServerName`` only for MCP-served ones, so the canonical form above
+        # is empty for a built-in and its real name would otherwise reach no check
+        # at all -- leaving ``deny = ["fs_write"]`` bypassable behind a benign
+        # model-authored title. Appended whenever present, MCP or not, because a
+        # deny target can only ever DENY: an identity the model could influence
+        # cannot waive a rule here, at most it matches one it did not need to.
+        if mcp_tool_name and mcp_tool_name not in deny_targets:
+            deny_targets.append(mcp_tool_name)
+        # What the GOVERNANCE plane is asked about, which is NOT the same string,
+        # because that plane has a SERVER level the deny plane does not and it
+        # matches canonical references rather than raw titles.
+        #
+        # The ``mcp__<server>__<tool>`` title is a LOSSY encoding: the parser that
+        # reads it splits on the LAST ``__``, so it can carry any server name but
+        # never a tool name containing ``__``. ``@github`` + ``repo__delete``
+        # encodes to ``mcp__github__repo__delete`` and reads back as server
+        # ``github__repo`` with tool ``delete``, so a ``deny @github/repo__delete``
+        # ceiling never binds and a human is asked to approve a tool the policy
+        # forbids. No spelling of that title fixes it -- the ambiguity is in the
+        # format -- so the trusted fields are composed straight into the canonical
+        # ``@server/tool`` form the matcher documents, where ``/`` separates and
+        # neither segment can contain it. A server with no proven tool asks the
+        # server-level question ``@server``, which a ``@server`` rule matches and
+        # a ``@server/tool`` rule correctly does not.
+        #
+        # Deliberately NOT added to ``deny_targets``: that plane matches raw text
+        # and operator regexes, where a canonical reference is a DIFFERENT string
+        # from the raw identity a rule is written against rather than a broader
+        # form of it, and feeding it there would widen matching by accident
+        # instead of by grammar.
+        governance_mcp_ref = mcp_identity_ref(mcp_server_name, mcp_tool_name)
         if command:
             deny_targets.append(command)
         for target in deny_targets:
@@ -665,13 +746,42 @@ class HookManager:
         # Governance ceiling ∩ active profile (Level 1 ∩ Level 2).  Runs BEFORE
         # the auto-approve loop so a governance deny wins over a user
         # auto-approve and is never bypassed.  This is the layer that denies a
-        # tool/MCP call even when the kiro agent config granted it: the title for
-        # an MCP tool arrives as ``mcp__server__tool`` and is governed by name
-        # here regardless of kiro's allowedTools.  No-op on a standalone host
-        # with no policy and no bound profile (gate_decision permits), so today's
+        # tool/MCP call even when the kiro agent config granted it, by name,
+        # regardless of kiro's allowedTools.  No-op on a standalone host with no
+        # policy and no bound profile (gate_decision permits), so today's
         # behavior is preserved unless governance is configured.
+        #
+        # Governed under BOTH identities for the reason spelled out at
+        # ``canonical_mcp_name``: a ceiling/profile rule naming the real MCP tool
+        # must bind even when the title is model-authored prose, and a rule
+        # naming the title must still bind. Tightest-wins, so evaluating both and
+        # denying on either preserves the governance contract. The MCP identity
+        # is ``governance_mcp_name``, which falls back to the server alone when
+        # that is all the backend proved.
+        # Governance is asked about the display title AND, separately, the trusted
+        # MCP identity. The identity travels as a canonical reference rather than a
+        # title because the title grammar cannot round-trip every name (see
+        # ``mcp_identity_ref``); a deny on either is final. An absent identity
+        # (a non-MCP call) is not asked about at all -- an empty title classifies
+        # to the unprefixed scopes, where it is a queryable item rather than a
+        # no-op, so querying it could deny on a rule it has nothing to do with.
+        # ONE query, every identity. The title, the trusted tool name and the MCP
+        # reference are all asked against a SINGLE resolved profile: asking them
+        # as separate calls re-resolved the active profile each time, so a profile
+        # hot-reloaded mid-call could answer each question from a different
+        # snapshot and permit a tool that both complete profiles deny -- and each
+        # extra call walked ``profiles/`` synchronously on the event loop.
+        # Tightest-wins is preserved: a deny on any identity denies the call.
         gov_reason = _governance_denial(
-            ctx, tool_name, session_key, agent, app, tool_kind, raw_params
+            ctx,
+            tool_name,
+            session_key,
+            agent,
+            app,
+            tool_kind,
+            raw_params,
+            mcp_ref=governance_mcp_ref,
+            extra_titles=(mcp_tool_name,) if mcp_tool_name and mcp_tool_name != tool_name else (),
         )
         if gov_reason:
             return ToolHookResult.deny_policy(gov_reason)
@@ -740,40 +850,21 @@ class HookManager:
             and _is_first_party_app(owner_app)
             and _is_declared_builtin_mcp_server(mcp_server_name)
         ):
-            # Govern the REAL tool by its TRUSTED _meta.kiro identity before
-            # granting the intra-app auto-approve. ``select_tool_title`` prefers
-            # the model's prose ``description``, so ``tool_name`` (and thus the
-            # ``_governance_denial`` above) may not carry the canonical
-            # ``mcp__server__tool`` a per-tool policy matches on — a ceiling /
-            # profile that denies ONE tool of this server would otherwise be
-            # skipped here and the tool auto-executed. Reconstruct the canonical
-            # title from the NON-model-authored server + tool names (mirroring
-            # the ``mcp__<server>__<tool>`` form ``mcp_title_to_ref`` parses) and
-            # re-check governance. A missing trusted tool name (a backend without
-            # ``_meta.kiro.toolName``, or an uncached permission event) means we
-            # cannot prove WHICH tool this is, so we do NOT auto-approve — fall
-            # through to interactive approval (fail-closed), never silent execute.
-            if mcp_tool_name:
-                canonical_mcp_name = f"mcp__{mcp_server_name}__{mcp_tool_name}"
-                # Re-apply the always-on deny floor to the canonical name too:
-                # the top-of-method ``authority.is_denied`` ran against the prose
-                # title / command, so a configured deny rule (``auto_deny_tools``
-                # or a denied regex) keyed on the canonical ``mcp__server__tool``
-                # would have MISSED — and this auto-approve must never re-admit a
-                # tool the deny floor forbids. Mirrors the governance re-check.
-                deny_reason = authority.is_denied(
-                    canonical_mcp_name,
-                    self._config.auto_deny_tools,
-                    denied_regexes=denied_regexes,
-                    reason_notes=denied_notes,
-                )
-                if deny_reason:
-                    return ToolHookResult.deny(deny_reason)
-                gov_reason = _governance_denial(
-                    ctx, canonical_mcp_name, session_key, agent, app, tool_kind, raw_params
-                )
-                if gov_reason:
-                    return ToolHookResult.deny_policy(gov_reason)
+            # The deny floor has already run against ``canonical_mcp_name`` and
+            # governance against ``governance_mcp_name`` on the common path above,
+            # so a ceiling or profile denying ONE tool of this server — or the
+            # server as a whole — has returned a deny and cannot reach this
+            # auto-approve. Those checks live there only, so there is one copy to
+            # keep in step rather than two.
+            #
+            # The identity requirement is what this branch enforces: a missing
+            # trusted tool name (a backend without ``_meta.kiro.toolName``, or an
+            # uncached permission event) leaves ``canonical_mcp_name`` empty,
+            # which means WHICH tool this is cannot be proven — and an
+            # unidentifiable tool must not be auto-approved on the strength of its
+            # server alone. Fall through to interactive approval (fail-closed),
+            # never silent execute.
+            if canonical_mcp_name:
                 return ToolHookResult.auto_approve()
 
         # Auto-approve — match against both the original title (preserves
@@ -1054,8 +1145,16 @@ def _governance_denial(
     app: str,
     tool_kind: str = "",
     raw_params: dict | None = None,
+    mcp_ref: str = "",
+    extra_titles: tuple[str, ...] = (),
 ) -> str | None:
     """Return a denial reason if governance forbids *tool_name*, else None.
+
+    *mcp_ref* is an already-canonical ``@server`` / ``@server/tool`` reference
+    for the trusted MCP identity, evaluated in addition to (or instead of) the
+    display title. It is passed as a reference rather than folded into
+    *tool_name* because the title grammar cannot encode every identity; both are
+    empty for a non-MCP call with no title, which governs nothing.
 
     Resolves the active profile (Level 2) for the calling surface and intersects
     it with the boot-frozen ceiling (Level 1).  Fast no-op when the host has
@@ -1080,10 +1179,20 @@ def _governance_denial(
         if ceiling is None and profile is None:
             return None
         decision = gate_decision(
-            ceiling, profile, tool_name, tool_kind=tool_kind, raw_params=raw_params
+            ceiling,
+            profile,
+            tool_name,
+            tool_kind=tool_kind,
+            raw_params=raw_params,
+            mcp_ref=mcp_ref,
+            extra_titles=extra_titles,
         )
         if not decision.permitted:
-            _audit_governance(session_key, agent, tool_name, decision)
+            # The denied identity when the decision names one -- with the title,
+            # the trusted tool name and the MCP reference all in one query, the
+            # subject is whichever of them the rule matched, not always the title.
+            subject = getattr(decision, "item", "") or tool_name or mcp_ref
+            _audit_governance(session_key, agent, subject, decision)
             return f"Blocked by governance policy: {decision.reason}"
         return None
     except PlatformCompositionError:
@@ -1353,6 +1462,38 @@ _RECURSIVE_SEARCH_OPERATIONS: frozenset[str] = frozenset(
 # number and needs no such treatment.
 _SEARCH_PATH_FIELD = "path"
 
+#: EVERY argument name a tool may carry its target file path under. Public because
+#: it is shared with the consent prompt in ``cli_chat``: a prompt that disclosed a
+#: path the gate did not inspect would let the two disagree about what the target
+#: is, and the surface asking a human would be reading the weaker field. One tuple
+#: is what makes that parity structural instead of a comment claiming it.
+#:
+#: The camel-case spelling is not hypothetical -- ``_SEARCH_DENY_ARG_KEYS`` has
+#: accepted it for the search plane all along, while the sensitive-path keystone
+#: below read only the two snake_case forms.
+TARGET_PATH_KEYS: tuple[str, ...] = ("path", "file_path", "filePath")
+
+
+def target_paths(raw_params: Mapping | None) -> list[str]:
+    """Every non-empty string path in *raw_params*, under any accepted spelling.
+
+    Returns ALL of them rather than the first match, and callers deny if ANY is
+    forbidden. That is deliberately different from "normalize the aliases onto one
+    key and reject conflicts": a conflict rule has to decide which spelling wins,
+    and picking wrong is how a sensitive path slips past. Checking every value
+    present cannot be gamed by adding a second, innocent-looking alias, and needs
+    no adjudication.
+    """
+    if not isinstance(raw_params, Mapping):
+        return []
+    found: list[str] = []
+    for key in TARGET_PATH_KEYS:
+        value = raw_params.get(key)
+        if isinstance(value, str) and value.strip() and value not in found:
+            found.append(value)
+    return found
+
+
 # The SCOPE-bearing arguments of a file search as ``(canonical, accepted spellings)``,
 # in a fixed order so the synthesized target is deterministic. Scope is the root walked
 # and the depth cap — NOT what is being looked for. ``pattern`` and ``include`` are
@@ -1522,6 +1663,30 @@ def _is_search_shaped(raw_params: Mapping) -> bool:
         return True
     operation = raw_params.get("operation")
     return isinstance(operation, str) and operation in _RECURSIVE_SEARCH_OPERATIONS
+
+
+def mcp_identity_ref(mcp_server_name: str, mcp_tool_name: str) -> str:
+    """The canonical MCP reference governance is asked about, or ``""``.
+
+    Composes the trusted fields straight into the ``@server`` / ``@server/tool``
+    form :func:`_match_mcp` documents, instead of encoding them into an
+    ``mcp__<server>__<tool>`` title and having the parser split it back apart.
+    That round trip is lossy in one direction: the split takes the LAST ``__``,
+    so any tool name containing ``__`` re-parses into a different server and
+    tool, and a per-tool ceiling written against the real identity stops binding.
+    Composing the reference directly cannot mis-split, because the segments are
+    joined by ``/`` and neither an MCP server nor an MCP tool name contains one.
+
+    A server with no proven tool yields the server-level ``@server``: a
+    ``@server`` rule covers every tool under it, while a ``@server/tool`` rule
+    does not match it, so an unproven tool is never denied by a rule naming a
+    specific one.
+    """
+    if not mcp_server_name:
+        return ""
+    if not mcp_tool_name:
+        return f"@{mcp_server_name}"
+    return f"@{mcp_server_name}/{mcp_tool_name}"
 
 
 def _search_deny_target(raw_params: dict | None) -> str:

--- a/src/kiro_crew/platform/governance.py
+++ b/src/kiro_crew/platform/governance.py
@@ -41,7 +41,7 @@ import json
 import logging
 import os
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import (
     Callable,
@@ -440,6 +440,24 @@ _KIND_READ = "read"
 _KIND_EDIT = "edit"
 _KIND_FETCH = "fetch"
 
+_PATH_ARG_KEYS = ("path", "file_path", "filePath")
+
+
+def _tool_arg_paths(raw_params: Mapping[str, object]) -> Tuple[str, ...]:
+    """Return every distinct, non-empty path carried under a supported alias.
+
+    Tool backends use all three spellings, sometimes in the same payload.  Every
+    value must be governed: choosing the first truthy alias would let a benign
+    ``path`` mask a sensitive ``filePath`` (and a truthy non-string value could
+    mask every later alias entirely).
+    """
+    paths: list[str] = []
+    for key in _PATH_ARG_KEYS:
+        value = raw_params.get(key)
+        if isinstance(value, str) and value.strip() and value not in paths:
+            paths.append(value)
+    return tuple(paths)
+
 
 def classify_tool_args(
     tool_kind: str, raw_params: Optional[Mapping[str, object]]
@@ -452,8 +470,10 @@ def classify_tool_args(
     authoritative signal.  Used by the gate to enforce the path/host scopes that a
     title cannot carry:
 
-    * ``kind == "edit"`` with a ``path`` → ``("filesystem.write", "<path>")``.
-    * ``kind == "read"`` with a ``path`` → ``("filesystem.read", "<path>")``
+    * ``kind == "edit"`` with a path argument →
+      ``("filesystem.write", "<path>")``.
+    * ``kind == "read"`` with a path argument →
+      ``("filesystem.read", "<path>")``
       (redundant with the ``Reading`` title path, harmless — both must permit).
     * ``kind == "fetch"`` with a ``url`` → ``("network.egress", "<host>")`` —
       the host is extracted from the URL so the ``host`` matcher applies.
@@ -462,7 +482,7 @@ def classify_tool_args(
     ACP backends omit it, so it arrives ``""``).**  When the kind is not one of
     the known fs/fetch kinds, we infer from the param SHAPE so an edit/fetch is
     still governed: a ``url``/``uri`` (and no shell ``command``) → egress; a
-    ``path``/``file_path`` (and no shell ``command``) → BOTH read and write
+    ``path``/``file_path``/``filePath`` (and no shell ``command``) → BOTH read and write
     (we cannot tell read from write without the kind, so we apply both ceilings —
     an ungoverned one permits, so this only tightens and never misroutes a shell
     command, which carries ``command`` and is governed by the ``commands`` scope).
@@ -473,14 +493,14 @@ def classify_tool_args(
     if not raw_params or not isinstance(raw_params, Mapping):
         return ()
     pairs: list = []
-    path = raw_params.get("path") or raw_params.get("file_path")
+    paths = _tool_arg_paths(raw_params)
     url = raw_params.get("url") or raw_params.get("uri")
     has_command = bool(raw_params.get("command"))  # a shell tool → commands scope
     if tool_kind == _KIND_EDIT:
-        if isinstance(path, str) and path:
+        for path in paths:
             pairs.append(("filesystem.write", path))
     elif tool_kind == _KIND_READ:
-        if isinstance(path, str) and path:
+        for path in paths:
             pairs.append(("filesystem.read", path))
     elif tool_kind == _KIND_FETCH:
         if isinstance(url, str) and url:
@@ -494,7 +514,7 @@ def classify_tool_args(
             host = _url_host(url)
             if host:
                 pairs.append(("network.egress", host))
-        if isinstance(path, str) and path:
+        for path in paths:
             # Can't distinguish read from write without the kind → apply both
             # ceilings (tightest-wins; an ungoverned scope permits).
             pairs.append(("filesystem.read", path))
@@ -625,6 +645,12 @@ class Decision:
     reason: str
     rule: str = ""  # rule1-allow | rule1-deny | rule2-intersect | ordinal | gate | default
     layer: str = ""  # policy | profile | both | default
+    # The governed item this outcome is ABOUT. One gate query can carry several
+    # identities for a single call (a prose title plus a trusted tool name plus an
+    # MCP reference), so a denial has to say WHICH one it denied or the audit
+    # record names the wrong subject. Empty when the caller asked about one item
+    # and already knows it.
+    item: str = ""
 
 
 # A control that can answer "is this item permitted?" for ONE level.  Both
@@ -2279,6 +2305,8 @@ def gate_decision(
     *,
     tool_kind: str = "",
     raw_params: Optional[Mapping[str, object]] = None,
+    mcp_ref: str = "",
+    extra_titles: Tuple[str, ...] = (),
 ) -> Decision:
     """Resolve a PreToolUse gate title against the governance ceiling ∩ profile.
 
@@ -2291,9 +2319,43 @@ def gate_decision(
     permitted here — an ungoverned scope permits.  When BOTH levels are
     ungoverned the result permits (the standalone default), so a host with no
     policy + no profile behaves exactly as today.
+
+    ``mcp_ref`` supplies an ALREADY-canonical ``@server`` / ``@server/tool``
+    reference for a caller that holds the server and tool as separate trusted
+    fields; it is checked in the ``mcp`` scope alongside anything the title maps
+    to.  Taking the reference directly is what makes such a call exact: the
+    ``mcp__<server>__<tool>`` title form is read by splitting on the LAST ``__``,
+    so it cannot represent a tool name containing ``__``, and a caller holding
+    the untangled fields must not be made to encode them into a form that loses
+    the distinction.
+
+    ``extra_titles`` carries any further NON-model-authored names the caller holds
+    for the SAME call (the trusted ``_meta.kiro.toolName`` beside a prose display
+    title). They belong in this one call rather than a second one: a separate call
+    re-resolves the active profile, so a hot reload between the two could answer
+    each question from a different snapshot and permit a tool that both complete
+    profiles deny. Empty entries are ignored.
     """
     pairs = list(classify_tool_title(tool_title))
+    # Additional NON-model-authored titles the caller holds for the same call --
+    # e.g. the trusted ``_meta.kiro.toolName`` beside an LLM-authored display
+    # title. They are classified here, in ONE decision, rather than asked as
+    # separate calls: each separate call would resolve the active profile again,
+    # so a profile hot-reloaded mid-call could serve a DIFFERENT snapshot to each
+    # question and a tool denied by both complete profiles could be permitted by
+    # every individual lookup. One snapshot, every target, deny if any denies.
+    # Empty entries are skipped: an empty title classifies to the unprefixed
+    # scopes as a real queryable item (``('tools', '')``), not a no-op, so it
+    # could match a rule it has nothing to do with.
+    for extra in extra_titles:
+        if extra:
+            pairs.extend(classify_tool_title(extra))
     pairs.extend(classify_tool_args(tool_kind, raw_params))
+    if mcp_ref:
+        pairs.append(("mcp", mcp_ref))
+    # Order-preserving dedupe -- a caller whose title already equals its trusted
+    # identity must not pay the same resolve twice.
+    pairs = list(dict.fromkeys(pairs))
     if not pairs:
         return Decision(True, "title not name-gate-governed", rule="default")
     # Deny if ANY governed scope the title/args map to denies it (the unprefixed
@@ -2302,7 +2364,10 @@ def gate_decision(
     for scope, item in pairs:
         decision = resolve(ceiling, profile, scope, item)
         if not decision.permitted:
-            return decision
+            # Name the identity that actually denied: with several targets in one
+            # query the caller cannot infer it, and an audit naming the prose
+            # title instead of the trusted tool name is a misleading record.
+            return replace(decision, item=item)
     return Decision(True, "permitted by all mapped scopes", rule="rule2-intersect")
 
 

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1115,6 +1115,15 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         "imessage/client.py",
         "imessage/transport.py",
         "imessage/transport_dispatch.py",
+        # The tool-permission prompt and its SEL record. Neither crosses a
+        # machine boundary: the prompt is written to the operator's OWN terminal
+        # in their own process, and the audit line goes to the local SEL log. The
+        # scrubbing there is targeted hygiene — a credential the model echoed
+        # into a tool title must not be copied into the audit record, and
+        # `log_tool_invocation` does not redact for its callers — not an egress
+        # pass. Local paths are deliberately NOT redacted in the prompt, because
+        # seeing the real path is part of what the operator is consenting to.
+        "cli_chat.py",
         "acp/_dispatch.py",
         "acp/client.py",
         # Redacts the tool title in the auto-rejected-permission WARNING (a

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,12 +1,15 @@
 """Tests for CLI module."""
 
 import argparse
+import asyncio
 import contextlib
 import hashlib
 import json
 import os
 import subprocess
 import sys
+import threading
+import types
 import urllib.error
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -5584,3 +5587,1680 @@ class TestBannerBranding:
         # The 'Cl' of Claw is `/ __| |` + `(__| / _`; Crew is `/ __|_ _` + `(__| '_/`.
         for name, b in (("cli", MAIN), ("cli_chat", CHAT), ("cloud", CLOUD)):
             assert "(__| / _`" not in b, f"{name} banner still spells Claw"
+
+
+class TestChatPermissionRequest:
+    """`kirocrew chat` must ANSWER a permission request, and answering one is an
+    authorization decision.
+
+    Every case drives the real ``_send_and_print`` against a provider whose
+    stream cannot finish until the request is answered, and against a real
+    ``HookManager`` -- not a stub returning the verdict the test wants.
+    """
+
+    #: Bounds a stalled turn so the suite fails instead of hanging. Never
+    #: reached when the request is answered.
+    _TIMEOUT = 10.0
+
+    class _StrictTextStream:
+        """A TTY-like stream that raises on anything its codec cannot encode."""
+
+        errors = "strict"
+
+        def __init__(self, encoding):
+            self.encoding = encoding
+            self._chunks = []
+
+        def write(self, text):
+            text.encode(self.encoding, errors=self.errors)
+            self._chunks.append(text)
+            return len(text)
+
+        def flush(self):
+            return None
+
+        def isatty(self):
+            return True
+
+        def getvalue(self):
+            return "".join(self._chunks)
+
+    @pytest.fixture(autouse=True)
+    def _fresh_stdin_state(self, monkeypatch):
+        """Poisoning is process-wide state; monkeypatch restores it per test."""
+        import kiro_crew.cli_chat as cli_chat
+
+        monkeypatch.setattr(cli_chat, "_stdin_poisoned", False)
+
+    @staticmethod
+    def _event(
+        *,
+        title="Terminal",
+        command=None,
+        tool_name="",
+        mcp_server_name="",
+        tool_kind=None,
+        shell_classified=True,
+        raw_params=None,
+    ):
+        """A permission request in the shape the wire delivers.
+
+        ``tool_input`` rather than ``raw_tool_params`` carries the command,
+        because that is where a permission_request puts it -- the fallback the
+        gate depends on to recover what really executes.
+
+        ``tool_kind`` defaults to ``execute`` only when a command is supplied.
+        An execute-kind request with no recoverable command is the cache-miss
+        anomaly ``_unverifiable_shell`` refuses outright, so it must not be the
+        default shape for tests about display, teardown or stdin -- those need a
+        request that actually reaches the prompt. Pass ``tool_kind`` explicitly
+        to exercise the anomaly.
+
+        ``shell_classified`` defaults True for the same reason: the normal wire
+        shape is a preceding ``tool_call`` that carried a resolvable ``kind``, so
+        the shell cache was populated and ``is_shell`` is a RESOLVED answer. The
+        miss -- where nothing was classified and the gate must refuse rather than
+        read the payload's own kind -- is opted into explicitly.
+        """
+        from kiro_crew.providers.base import EVENT_PERMISSION_REQUEST, LLMEvent
+
+        return LLMEvent(
+            kind=EVENT_PERMISSION_REQUEST,
+            request_id=7,
+            title=title,
+            tool_kind=tool_kind if tool_kind is not None else ("execute" if command else "read"),
+            is_shell=command is not None,
+            shell_classified=shell_classified,
+            tool_input=json.dumps({"command": command}) if command else "",
+            tool_name=tool_name,
+            raw_tool_params=raw_params,
+            mcp_server_name=mcp_server_name,
+            # Advertised by a real backend; the CLI must NOT read these -- option
+            # ids are backend-specific and the ACP layer owns the mapping.
+            options=[{"id": "allow", "label": "Allow Once"}],
+        )
+
+    @staticmethod
+    def _direct_tool_call(client, *, path="notes.md", tool_call_id="tc-direct"):
+        """Populate the real direct-client provenance caches for an edit call."""
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        event = client._extract_tool_event(
+            JsonRpcMessage(
+                method="session/update",
+                params={
+                    "update": {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": tool_call_id,
+                        "title": "Edit notes",
+                        "kind": "edit",
+                        "rawInput": {"path": path, "content": "updated"},
+                        "_meta": {"kiro": {"toolName": "fs_write"}},
+                    }
+                },
+            )
+        )
+        assert event is not None
+
+    @staticmethod
+    def _direct_permission_message(*, tool_call_id="tc-direct", inline_path=None):
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        tool_call: dict[str, object] = {
+            "toolCallId": tool_call_id,
+            "title": "Edit notes",
+            "kind": "edit",
+        }
+        if inline_path is not None:
+            tool_call["input"] = {"path": inline_path, "content": "inline"}
+        return JsonRpcMessage(
+            id="req-direct",
+            method="session/request_permission",
+            params={
+                "toolCall": tool_call,
+                "options": [
+                    {"optionId": "allow", "name": "Allow once", "kind": "allow_once"},
+                    {"optionId": "reject", "name": "Deny", "kind": "reject_once"},
+                ],
+            },
+        )
+
+    class _GatedProvider:
+        """Cannot finish its turn until the permission is answered.
+
+        Provider calls and audit records land in ONE ``trace`` so their relative
+        order is observable, not just their presence.
+        """
+
+        def __init__(self, event, trace):
+            self._event, self.trace = event, trace
+            self.answered = asyncio.Event()
+
+        @property
+        def calls(self):
+            return [t for t in self.trace if t[0] in ("approve", "reject")]
+
+        async def stream(self, message):
+            from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="I'll check that. ")
+            yield self._event
+            await self.answered.wait()
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="done")
+            yield LLMEvent(kind=EVENT_COMPLETE)
+
+        async def approve_tool(self, request_id, *, always: bool = False):
+            self.trace.append(("approve", request_id, always))
+            self.answered.set()
+
+        async def reject_tool(self, request_id):
+            self.trace.append(("reject", request_id, False))
+            self.answered.set()
+
+        def context_usage_pct(self):
+            return 0.0
+
+    @staticmethod
+    def _gate():
+        """A gate carrying the REAL HookManager: the built-in sensitive-path and
+        denied-command rules are the thing under test in several cases."""
+        import kiro_crew.cli_chat as cli_chat
+        from kiro_crew.hooks import HookManager, HooksConfig
+
+        return cli_chat._ToolGate(hooks=HookManager(HooksConfig.from_dict({})), agent="cli-tester")
+
+    @staticmethod
+    def _patch_env(monkeypatch, *, tty=True, trace=None, answer="d"):
+        """Wire the seams every case shares. Returns the stdin-read record.
+
+        The blocking read is patched at ``_read_line_blocking`` -- the single
+        blocking seam -- NOT at the choice helper or the gate, so the exact-match
+        rule, the daemon-thread plumbing, the gate call and the audit ordering
+        all run as production code.
+        """
+        import kiro_crew.cli_chat as cli_chat
+
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: tty, raising=False)
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: tty, raising=False)
+        monkeypatch.setattr(
+            cli_chat,
+            "sel",
+            lambda: types.SimpleNamespace(
+                log_tool_invocation=lambda **kw: (
+                    trace.append(("sel", kw)) if trace is not None else None
+                )
+            ),
+        )
+        reads = {"n": 0, "prompts": []}
+
+        def fake_read(prompt=""):
+            reads["n"] += 1
+            reads["prompts"].append(prompt)
+            if answer is EOFError:
+                raise EOFError
+            return answer
+
+        monkeypatch.setattr(cli_chat, "_read_line_blocking", fake_read)
+        return reads
+
+    async def _drive(self, monkeypatch, *, event=None, interactive=True, tty=True, answer="d"):
+        """Run one gated turn. Returns (provider, sel records, stdin reads).
+
+        ``interactive`` is the command mode the caller passes and ``tty`` is
+        patched onto the real streams, so the production ``_can_prompt`` decides
+        -- patching that helper would test the stub rather than the rule.
+        """
+        import kiro_crew.cli_chat as cli_chat
+
+        trace: list = []
+        provider = self._GatedProvider(event or self._event(), trace)
+        reads = self._patch_env(monkeypatch, tty=tty, trace=trace, answer=answer)
+        await asyncio.wait_for(
+            cli_chat._send_and_print(
+                provider, "run it", interactive=interactive, gate=self._gate()
+            ),
+            timeout=self._TIMEOUT,
+        )
+        return provider, [t[1] for t in trace if t[0] == "sel"], reads
+
+    # ── The security gate ────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_a_benign_title_cannot_hide_a_sensitive_command(self, monkeypatch, capsys):
+        """The gate judges what executes, not what the model called it.
+
+        ``title`` for a shell tool is an LLM-authored description, so a
+        credential read labelled "List project files" is the bypass that keying
+        on the title alone would let through. The user is never even asked.
+        """
+        provider, sels, reads = await self._drive(
+            monkeypatch,
+            event=self._event(title="List project files", command="cat ~/.ssh/id_rsa"),
+            answer="a",  # the user WOULD have allowed it
+        )
+        assert provider.calls == [("reject", 7, False)]
+        assert reads["n"] == 0
+        # A stable code, not the gate's reason: the reason names the very path
+        # being protected, and an audit record must not restate it.
+        assert sels[0]["error"] == "hook_deny"
+        assert ".ssh" not in json.dumps(sels[0])
+        # The reason still reaches the terminal, and it has to be the REAL one:
+        # `is_shell` with no command also denies, via the gate's deny-by-default
+        # backstop, so "it was denied" would pass just as well when the command
+        # is never forwarded at all.
+        err = capsys.readouterr().err
+        assert "sensitive credential path" in err
+        assert "could not be verified" not in err
+
+    @pytest.mark.asyncio
+    async def test_a_denied_command_is_not_the_users_to_override(self, monkeypatch):
+        provider, sels, reads = await self._drive(
+            monkeypatch,
+            event=self._event(title="Tidy the workspace", command="rm -rf /"),
+            answer="a",
+        )
+        assert provider.calls == [("reject", 7, False)]
+        assert reads["n"] == 0
+        assert [s["outcome"] for s in sels] == ["denied"]
+
+    # ── The audit record ─────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "event_kw,answer,order,code",
+        [
+            (dict(title="x", command="rm -rf /"), "a", ["sel", "reject"], "hook_deny"),
+            ({}, "a", ["sel", "approve"], ""),
+            ({}, "d", ["sel", "reject"], "user_denied"),
+        ],
+    )
+    async def test_the_audit_precedes_the_transport(
+        self, monkeypatch, event_kw, answer, order, code
+    ):
+        """A transport failure must not erase the decision, and the code stays a
+        stable token so the log is queryable and quotes nothing.
+
+        Asserting the interleaved trace, rather than two separate lists, is what
+        makes this an ordering test.
+        """
+        provider, sels, _ = await self._drive(
+            monkeypatch, event=self._event(**event_kw), answer=answer
+        )
+        assert [t[0] for t in provider.trace] == order
+        assert sels[0]["error"] == code
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "event_kw,expected,forbidden",
+        [
+            # The canonical `_meta.kiro` identity wins over LLM prose.
+            (
+                dict(title="do something friendly", tool_name="mcp__files__read"),
+                "mcp__files__read",
+                "friendly",
+            ),
+            # No canonical name: the title is all there is, so scrub it -- SEL
+            # does not redact for its callers.
+            (dict(title="deploy with AKIAIOSFODNN7EXAMPLE"), None, "AKIAIOSFODNN7EXAMPLE"),
+        ],
+    )
+    async def test_the_audited_identity_is_not_model_authored(
+        self, monkeypatch, event_kw, expected, forbidden
+    ):
+        _, sels, _ = await self._drive(monkeypatch, event=self._event(**event_kw), answer="a")
+        if expected is not None:
+            assert sels[0]["tool_name"] == expected
+        assert forbidden not in sels[0]["tool_name"]
+
+    # ── The human decision ───────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "answer,call,outcome",
+        [("a", ("approve", 7, False), "allowed"), ("d", ("reject", 7, False), "denied")],
+    )
+    async def test_the_turn_completes_whatever_the_human_answers(
+        self, monkeypatch, capsys, answer, call, outcome
+    ):
+        """Denial answers the gate; it must not abandon the turn."""
+        provider, sels, reads = await self._drive(monkeypatch, answer=answer)
+        assert provider.calls == [call]
+        assert reads["n"] == 1
+        assert [s["outcome"] for s in sels] == [outcome]
+        assert "done" in capsys.readouterr().out  # text after the gate reached stdout
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "answer,allows",
+        # A prefix match reads `abort` as an allow -- the opposite of intent.
+        # The other rejects are what a person types when a single-key prompt did
+        # not register, plus the do-nothing answers.
+        [(a, True) for a in ("a", "A", " a ", "a\n")]
+        + [(a, False) for a in ("abort", "allow", "always", "wait", "ad", "x", "", EOFError)],
+    )
+    async def test_only_the_exact_allow_token_approves(self, monkeypatch, answer, allows):
+        provider, sels, _ = await self._drive(monkeypatch, answer=answer)
+        assert provider.calls == [("approve", 7, False) if allows else ("reject", 7, False)]
+        assert [s["outcome"] for s in sels] == ["allowed" if allows else "denied"]
+
+    @pytest.mark.asyncio
+    async def test_no_answer_grants_a_persistent_approval(self, monkeypatch):
+        """There is no "always allow": a backend that records one stops sending
+        permission requests for matching calls, and a request never sent is a
+        call this ladder never runs and never audits."""
+        for answer in ("a", "w", "always"):
+            provider, _, reads = await self._drive(monkeypatch, answer=answer)
+            assert all(not always for kind, _, always in provider.calls if kind == "approve")
+        # The prompt must not advertise an option the responder cannot honour.
+        assert "always" not in reads["prompts"][0].lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "interactive,tty",
+        [
+            # `-m` is documented as non-interactive, so a terminal does not
+            # license a prompt: a script under a pty would block on a question
+            # nobody is watching for.
+            (False, True),
+            # And a prompt nobody can see is a hang, not consent.
+            (True, False),
+        ],
+    )
+    async def test_a_prompt_nobody_can_answer_denies_without_reading_stdin(
+        self, monkeypatch, capsys, interactive, tty
+    ):
+        provider, sels, reads = await self._drive(
+            monkeypatch, interactive=interactive, tty=tty, answer="a"
+        )
+        assert provider.calls == [("reject", 7, False)]
+        assert reads["n"] == 0
+        assert sels[0]["error"] == "noninteractive"
+        captured = capsys.readouterr()
+        assert "done" in captured.out  # the turn still finished
+        assert "Denied automatically" in captured.err
+        # The notice's own wording stays ASCII, which is a legibility choice: a
+        # redirected stream encodes with the locale codec, and an escaped
+        # character reads as noise mid-sentence. This case supplies an ASCII
+        # title, so the whole captured notice is ASCII.
+        #
+        # It is NOT a safety property, and the title is not covered by it — see
+        # TestDenialNoticeEncoding, which drives a real child process to pin what
+        # actually protects an arbitrary-Unicode title.
+        captured.err.encode("ascii")
+
+    # ── What the human is shown ──────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "command,expected,absent",
+        [
+            ("git status --short", "Command: git status --short", None),
+            # Collapsed to one line: a heredoc must not reflow the question.
+            ("printf 'a\\n\\tb'\nwc -l", "Command: printf 'a\\n\\tb' wc -l", None),
+            # Capped, with the cut made explicit.
+            ("echo " + "x" * 400, "... [truncated]", "x" * 400),
+            # Redacted on the way to the screen.
+            ("deploy --key AKIAIOSFODNN7EXAMPLE", None, "AKIAIOSFODNN7EXAMPLE"),
+            # Nothing to show for a non-shell call.
+            (None, None, "Command:"),
+        ],
+    )
+    async def test_a_shell_prompt_shows_what_will_actually_run(
+        self, monkeypatch, capsys, command, expected, absent
+    ):
+        """Approving on an LLM-authored title alone is consent to a description.
+
+        The gate already keys on ``shell_command``; the human deciding needs the
+        same ground truth.
+        """
+        await self._drive(
+            monkeypatch,
+            event=self._event(title="Run a helpful script", command=command),
+            answer="a",
+        )
+        out = capsys.readouterr().out
+        # Non-vacuous control: for a shell call the line must have been printed
+        # at all, or an "absent" assertion passes for a request that never
+        # reached the prompt.
+        assert ("Command:" in out) is (command is not None)
+        if expected:
+            assert expected in out
+        if absent:
+            assert absent not in out
+
+    # ── stdin lifecycle ──────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_the_event_loop_keeps_running_while_the_prompt_waits(self, monkeypatch):
+        """The turn is parked INSIDE an active stream, not at an idle REPL.
+
+        The blocking read does not return until a loop-side ticker has advanced,
+        so a synchronous implementation deadlocks and this times out rather than
+        passing quietly.
+        """
+        import kiro_crew.cli_chat as cli_chat
+
+        ticks, released = {"n": 0}, threading.Event()
+
+        async def _ticker():
+            while True:
+                await asyncio.sleep(0.01)
+                ticks["n"] += 1
+                if ticks["n"] >= 3:
+                    released.set()
+
+        def blocking_read(prompt=""):
+            # Waits for the LOOP to progress: only reachable off the loop thread.
+            assert released.wait(timeout=self._TIMEOUT), "event loop was blocked"
+            return "a"
+
+        self._patch_env(monkeypatch)
+        monkeypatch.setattr(cli_chat, "_read_line_blocking", blocking_read)
+        provider = self._GatedProvider(self._event(), [])
+        ticker = asyncio.create_task(_ticker())
+        try:
+            await asyncio.wait_for(
+                cli_chat._send_and_print(provider, "run it", interactive=True, gate=self._gate()),
+                timeout=self._TIMEOUT,
+            )
+        finally:
+            ticker.cancel()
+        assert provider.calls == [("approve", 7, False)]
+
+    @pytest.mark.asyncio
+    async def test_a_poisoned_session_never_starts_a_second_reader(self, monkeypatch):
+        """No later entry point may race the abandoned reader for keystrokes --
+        not a second permission prompt, and not the REPL."""
+        import kiro_crew.cli_chat as cli_chat
+
+        self._patch_env(monkeypatch)
+        monkeypatch.setattr(cli_chat, "_stdin_poisoned", True)
+
+        def never(prompt=""):
+            raise AssertionError("a poisoned session read stdin")
+
+        monkeypatch.setattr(cli_chat, "_read_line_blocking", never)
+        monkeypatch.setattr("builtins.input", never)
+
+        provider = self._GatedProvider(self._event(), [])
+        with pytest.raises(cli_chat.StdinPoisonedError):
+            await cli_chat._send_and_print(provider, "run it", interactive=True, gate=self._gate())
+        with pytest.raises(cli_chat.StdinPoisonedError):
+            await cli_chat._interactive(provider, types.SimpleNamespace())
+
+    @pytest.mark.asyncio
+    async def test_teardown_never_awaits_the_backend(self, monkeypatch):
+        """Cancelling frees the coroutine, not the reader thread, and a wedged
+        transport must not swallow the cancellation being delivered.
+
+        The abandoned reader stays parked and takes the next line the user types
+        -- measured -- so stdin has to be marked unusable. And ``CancelledError``
+        has already been raised once with nothing to re-deliver it, so awaiting a
+        ``reject_tool`` that never returns would leave the Ctrl-C that asked for
+        this teardown unable to land.
+        """
+        import kiro_crew.cli_chat as cli_chat
+
+        entered = threading.Event()
+
+        class _HungReject(self._GatedProvider):
+            async def reject_tool(self, request_id):
+                self.trace.append(("reject", request_id, False))
+                await asyncio.Event().wait()  # never returns
+
+        def blocking_read(prompt=""):
+            entered.set()
+            threading.Event().wait(timeout=self._TIMEOUT)
+            return "a"
+
+        trace: list = []
+        self._patch_env(monkeypatch, trace=trace)
+        monkeypatch.setattr(cli_chat, "_read_line_blocking", blocking_read)
+        provider = _HungReject(self._event(), trace)
+        task = asyncio.create_task(
+            cli_chat._send_and_print(provider, "run it", interactive=True, gate=self._gate())
+        )
+        await asyncio.get_running_loop().run_in_executor(None, entered.wait, 5.0)
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=self._TIMEOUT)
+        assert cli_chat._stdin_poisoned is True
+        assert provider.calls == []  # nothing was awaited on the way out
+        assert [s[1]["error"] for s in trace if s[0] == "sel"] == ["session_aborted"]
+
+    @pytest.mark.asyncio
+    async def test_the_teardown_audit_also_runs_off_the_event_loop(self, monkeypatch):
+        """The exit path is the one where blocking the loop hurts most: the loop
+        still owns the ACP reader and stderr-drain tasks, and cold ``sel()``
+        initialization replays the audit log to recover the HMAC chain. Auditing
+        synchronously here would relocate the freeze this path exists to end.
+
+        Shielded, so the record still lands if another cancellation arrives
+        mid-write -- ``session_aborted`` is the outcome an audit reader can least
+        afford to lose, because it is what distinguishes a died-unanswered turn
+        from a user who said no.
+        """
+        import kiro_crew.cli_chat as cli_chat
+
+        entered = threading.Event()
+        threads: list = []
+        trace: list = []
+
+        def blocking_read(prompt=""):
+            entered.set()
+            threading.Event().wait(timeout=self._TIMEOUT)
+            return "a"
+
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(cli_chat, "_read_line_blocking", blocking_read)
+
+        def _record(**kw):
+            threads.append(threading.current_thread())
+            trace.append(("sel", kw))
+
+        monkeypatch.setattr(
+            cli_chat, "sel", lambda: types.SimpleNamespace(log_tool_invocation=_record)
+        )
+
+        provider = self._GatedProvider(self._event(), trace)
+        task = asyncio.create_task(
+            cli_chat._send_and_print(provider, "run it", interactive=True, gate=self._gate())
+        )
+        await asyncio.get_running_loop().run_in_executor(None, entered.wait, 5.0)
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=self._TIMEOUT)
+
+        assert [s[1]["error"] for s in trace if s[0] == "sel"] == ["session_aborted"]
+        assert threads[0] is not threading.main_thread(), (
+            "the teardown SEL write ran on the event loop thread; a slow audit "
+            "store would stall ACP draining while the turn is being torn down"
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_approval_that_cannot_be_audited_is_refused(self, monkeypatch):
+        """AUDIT-OR-DENY on the allow path. An unwritable SEL log otherwise means
+        the tool RUNS while the only record that a human authorized it is dropped
+        by the background writer -- and on this surface the consent was a
+        keystroke, so nothing else can reconstruct it afterwards.
+
+        Refused rather than raised: letting the failure escape would abandon the
+        request unanswered, and the backend holds the turn open until it is
+        answered, which is the hang this path exists to end.
+        """
+        import kiro_crew.cli_chat as cli_chat
+
+        trace: list = []
+
+        def _explode(**kw):
+            trace.append(("sel", kw))
+            if kw.get("critical"):
+                raise OSError("SEL log is read-only")
+
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(cli_chat, "_read_line_blocking", lambda prompt="": "a")
+        monkeypatch.setattr(
+            cli_chat, "sel", lambda: types.SimpleNamespace(log_tool_invocation=_explode)
+        )
+
+        provider = self._GatedProvider(self._event(), trace)
+        await asyncio.wait_for(
+            cli_chat._send_and_print(
+                provider, "run it", interactive=True, gate=self._gate()
+            ),
+            timeout=self._TIMEOUT,
+        )
+
+        assert provider.calls == [("reject", 7, False)], "the tool must not run unaudited"
+        outcomes = [(s[1]["outcome"], s[1].get("error", "")) for s in trace if s[0] == "sel"]
+        assert ("allowed", "") in outcomes, "the critical attempt must have been made"
+        assert ("denied", "audit_unwritable") in outcomes, (
+            "the downgrade must be recorded under its OWN code -- the operator said "
+            "yes, so an audit reader must not be told they refused"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_allow_audit_is_critical_and_the_deny_audit_is_not(self, monkeypatch):
+        """The asymmetry is deliberate. Fail-closed only has meaning where the
+        alternative is EXECUTION: a deny is already refusing, so a lost record
+        cannot authorize anything, and making it audit-or-deny would turn a
+        refusal into an error for no security gain."""
+        import kiro_crew.cli_chat as cli_chat
+
+        seen: dict = {}
+
+        async def _drive(answer, key):
+            trace: list = []
+            self._patch_env(monkeypatch, trace=trace, answer=answer)
+            provider = self._GatedProvider(self._event(), trace)
+            await asyncio.wait_for(
+                cli_chat._send_and_print(
+                    provider, "run it", interactive=True, gate=self._gate()
+                ),
+                timeout=self._TIMEOUT,
+            )
+            seen[key] = [s[1].get("critical", False) for s in trace if s[0] == "sel"]
+
+        await _drive("a", "allow")
+        await _drive("d", "deny")
+
+        assert seen["allow"] == [True], "the approval must be audit-or-deny"
+        assert seen["deny"] == [False], "a refusal must not be gated on its own audit"
+
+    @pytest.mark.asyncio
+    async def test_the_prompt_and_the_gate_share_one_set_of_path_spellings(self, monkeypatch):
+        """A ``filePath`` target used to be DISPLAYED as though it had been vetted
+        while the keystone never read that key. Both sides now resolve through
+        ``hooks.target_paths``, so the parity is structural rather than asserted in
+        a comment -- and a sensitive value under any spelling is refused by the
+        gate before a human is ever asked.
+        """
+        provider, sels, reads = await self._drive(
+            monkeypatch,
+            event=self._event(
+                title="Tidy up the notes",
+                tool_name="fs_write",
+                tool_kind="edit",
+                raw_params={"filePath": "~/.ssh/id_rsa"},
+            ),
+            answer="a",
+        )
+        assert provider.calls == [("reject", 7, False)], "the keystone must refuse it"
+        assert reads["n"] == 0, "a policy denial is not the user's to override"
+        assert [s["error"] for s in sels] == ["hook_deny"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "answer,tty,interactive,expected_error",
+        [
+            ("d", True, True, "user_denied"),
+            ("a", False, True, "noninteractive"),
+        ],
+    )
+    async def test_a_refusal_survives_its_own_audit_failing(
+        self, monkeypatch, answer, tty, interactive, expected_error
+    ):
+        """The audit is bookkeeping; ``reject_tool`` is what ends the turn. If a
+        raising audit skipped the rejection, the backend would hold the turn open
+        on an unanswered request -- the hang this path exists to end, reached
+        through the bookkeeping instead of the decision.
+
+        Parametrised across two different refusal reasons so this pins the CLASS,
+        not the single call site: every refusal path shares one helper.
+        """
+        import kiro_crew.cli_chat as cli_chat
+
+        trace: list = []
+
+        def _explode(**kw):
+            trace.append(("sel", kw))
+            raise ValueError("invalid SEL key")
+
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: tty, raising=False)
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: tty, raising=False)
+        monkeypatch.setattr(cli_chat, "_read_line_blocking", lambda prompt="": answer)
+        monkeypatch.setattr(
+            cli_chat, "sel", lambda: types.SimpleNamespace(log_tool_invocation=_explode)
+        )
+
+        provider = self._GatedProvider(self._event(), trace)
+        await asyncio.wait_for(
+            cli_chat._send_and_print(
+                provider, "run it", interactive=interactive, gate=self._gate()
+            ),
+            timeout=self._TIMEOUT,
+        )
+
+        assert provider.calls == [("reject", 7, False)], (
+            "the audit failure swallowed the rejection; the backend would wait "
+            "forever on an unanswered permission request"
+        )
+        assert [s[1].get("error") for s in trace if s[0] == "sel"] == [expected_error]
+
+    @pytest.mark.asyncio
+    async def test_a_policy_denial_survives_its_own_audit_failing(self, monkeypatch):
+        """The gate-deny path is the one a prompt-injected agent is most likely to
+        reach, so it must not be the one where a broken audit sink turns a refusal
+        into an abandoned turn."""
+        import kiro_crew.cli_chat as cli_chat
+
+        trace: list = []
+
+        def _explode(**kw):
+            trace.append(("sel", kw))
+            raise ValueError("invalid SEL key")
+
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(cli_chat, "_read_line_blocking", lambda prompt="": "a")
+        monkeypatch.setattr(
+            cli_chat, "sel", lambda: types.SimpleNamespace(log_tool_invocation=_explode)
+        )
+
+        event = self._event(
+            title="Tidy up", tool_name="fs_write", tool_kind="edit",
+            raw_params={"path": "~/.ssh/id_rsa"},
+        )
+        provider = self._GatedProvider(event, trace)
+        await asyncio.wait_for(
+            cli_chat._send_and_print(
+                provider, "run it", interactive=True, gate=self._gate()
+            ),
+            timeout=self._TIMEOUT,
+        )
+
+        assert provider.calls == [("reject", 7, False)]
+        assert [s[1].get("error") for s in trace if s[0] == "sel"] == ["hook_deny"]
+
+    @pytest.mark.asyncio
+    async def test_a_gate_exception_is_explicitly_rejected(self, monkeypatch, capsys):
+        """A broken authorization gate cannot become an unanswered request."""
+        import kiro_crew.cli_chat as cli_chat
+
+        trace: list = []
+        event = self._event(title="Check it", tool_name="fs_read")
+        provider = self._GatedProvider(event, trace)
+        reads = self._patch_env(monkeypatch, tty=True, trace=trace, answer="a")
+        gate = self._gate()
+
+        def broken_gate(*args, **kwargs):
+            raise ValueError("malformed tool input")
+
+        monkeypatch.setattr(gate.hooks, "on_tool_call", broken_gate)
+        await asyncio.wait_for(
+            cli_chat._send_and_print(provider, "run it", interactive=True, gate=gate),
+            timeout=self._TIMEOUT,
+        )
+
+        assert provider.calls == [("reject", 7, False)]
+        assert reads["n"] == 0
+        assert [s[1].get("error") for s in trace if s[0] == "sel"] == ["gate_failed"]
+        captured = capsys.readouterr()
+        assert "done" in captured.out
+        assert "security gate could not verify" in captured.err
+
+    # ── Unchanged behaviour ──────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_stream_without_a_permission_request_is_unchanged(self, capsys):
+        import kiro_crew.cli_chat as cli_chat
+        from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+        class _PlainProvider(self._GatedProvider):
+            async def stream(self, message):
+                yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="hello ")
+                yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="world")
+                yield LLMEvent(kind=EVENT_COMPLETE)
+
+        provider = _PlainProvider(self._event(), [])
+        await cli_chat._send_and_print(provider, "hi")
+        assert capsys.readouterr().out == "hello world\n"
+        assert provider.calls == []
+
+    # ── Terminal controls on the consent surface ─────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_osc52_title_cannot_reach_the_terminal(self, monkeypatch, capsys):
+        # An OSC 52 sequence in a model-authored title writes the user's
+        # clipboard if it reaches the terminal. Neither ESC nor BEL -- the
+        # sequence's introducer and terminator -- may survive to the prompt.
+        # The prompt's own terminal reset is fixed, trusted bytes rather than
+        # anything a title can influence, so it is subtracted before asserting
+        # that NOTHING else escaped: that keeps this a whole-output guarantee
+        # instead of narrowing it to one line.
+        import kiro_crew.cli_chat as cli_chat
+
+        title = "Read file\x1b]52;c;aGVsbG8=\x07 please"
+        await self._drive(monkeypatch, event=self._event(title=title))
+        out = capsys.readouterr().out
+        untrusted = out.replace(cli_chat._PROMPT_TERMINAL_RESET, "")
+        assert "\x1b" not in untrusted and "\x07" not in untrusted
+        assert "]52;c;aGVsbG8=" in out  # neutralised to inert text, not dropped
+        assert "Read file" in out
+
+    @pytest.mark.asyncio
+    async def test_csi_sequence_cannot_reach_the_terminal(self, monkeypatch, capsys):
+        # CSI can move the cursor and erase what is already drawn, so a title
+        # could repaint the question the user is answering. The newline is part
+        # of the same class: a multi-line title pushes the prompt off screen.
+        title = "Delete\x1b[2K\x1b[1Anothing\nimportant"
+        await self._drive(monkeypatch, event=self._event(title=title))
+        out = capsys.readouterr().out
+        line = next(ln for ln in out.splitlines() if ln.startswith("Permission required:"))
+        assert "\x1b" not in line
+        assert line == "Permission required: Delete [2K [1Anothing important"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("encoding", ["utf-8", "cp1252"])
+    async def test_malicious_unicode_title_and_tool_input_are_answered(
+        self, monkeypatch, encoding
+    ):
+        """Strict UTF-8 rejects lone surrogates; strict cp1252 rejects wider Unicode.
+
+        Drive the whole pending-request flow through a strict destination stream
+        so either case raises before ``approve_tool`` when the render boundary is
+        missing. ``tool_input`` is used because that is the permission-request
+        wire shape ``shell_command`` decodes.
+        """
+        stream = self._StrictTextStream(encoding)
+        monkeypatch.setattr(sys, "stdout", stream)
+        bomb = chr(0x1F4A3)
+        command = f"printf '{chr(0xDFFF)} {bomb}'"
+        event = self._event(title=f"Run safely {chr(0xD800)} 刪除 {bomb}", command=command)
+        provider, sels, reads = await self._drive(monkeypatch, event=event, answer="a")
+
+        assert provider.calls == [("approve", 7, False)]
+        assert reads["n"] == 1
+        assert [record["outcome"] for record in sels] == ["allowed"]
+        rendered = stream.getvalue()
+        rendered.encode(encoding, errors="strict")
+        assert "\ud800" not in rendered and "\udfff" not in rendered
+        assert "Permission required:" in rendered and "Command:" in rendered
+        if encoding == "cp1252":
+            assert "\\u522a\\u9664" in rendered
+            assert "\\U0001f4a3" in rendered
+        else:
+            assert "刪除" in rendered and bomb in rendered
+
+    @pytest.mark.asyncio
+    async def test_a_prompt_render_failure_is_explicitly_rejected(self, monkeypatch, capsys):
+        """A render bug is not allowed to escape between request and response."""
+        import kiro_crew.cli_chat as cli_chat
+
+        async def broken_prompt(event):
+            raise UnicodeEncodeError("utf-8", "\ud800", 0, 1, "surrogate")
+
+        monkeypatch.setattr(cli_chat, "_prompt_allows", broken_prompt)
+        provider, sels, reads = await self._drive(
+            monkeypatch,
+            event=self._event(title="Render \ud800", tool_name="fs_write"),
+            answer="a",
+        )
+
+        assert provider.calls == [("reject", 7, False)]
+        assert reads["n"] == 0
+        assert [record["error"] for record in sels] == ["prompt_failed"]
+        captured = capsys.readouterr()
+        assert "done" in captured.out
+        assert "could not be rendered or read" in captured.err
+
+    @pytest.mark.asyncio
+    async def test_control_characters_in_a_command_are_neutralised(self, monkeypatch, capsys):
+        # The shell command is untrusted display text on the same surface, and
+        # keeps its existing one-line collapse contract.
+        event = self._event(title="Run it", command="echo \x1b]52;c;x\x07hi\nls")
+        await self._drive(monkeypatch, event=event)
+        out = capsys.readouterr().out
+        line = next(ln for ln in out.splitlines() if ln.startswith("Command:"))
+        assert "\x1b" not in line and "\x07" not in line
+        assert line == "Command: echo ]52;c;x hi ls"
+
+    @pytest.mark.asyncio
+    async def test_an_unverifiable_execute_request_is_never_put_to_the_user(
+        self, monkeypatch, capsys
+    ):
+        """``is_shell`` comes only from the trusted preceding-tool_call cache.
+
+        On a cache miss it stays False, and ``shell_command`` returns None
+        whenever it is False -- so a real command would be gated on nothing but
+        its LLM-authored title. The request is refused instead of asked about,
+        even though the user would have allowed it.
+        """
+        provider, sels, reads = await self._drive(
+            monkeypatch,
+            event=self._event(title="List project files", tool_kind="execute"),
+            answer="a",  # the user WOULD have allowed it
+        )
+        assert provider.calls == [("reject", 7, False)]
+        assert reads["n"] == 0  # never prompted
+        assert sels[0]["outcome"] == "denied"
+        # Its own code: the gate did not reject this, we refused to ask.
+        assert sels[0]["error"] == "unverified_shell"
+        assert "could not be verified" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_a_cosmetic_kind_variant_still_refuses(self, monkeypatch):
+        # Widening a fail-closed test is safe, so casing/padding must not be a
+        # way to present an unverifiable command as an ordinary tool call.
+        provider, sels, _ = await self._drive(
+            monkeypatch,
+            event=self._event(title="List files", tool_kind="  Execute "),
+            answer="a",
+        )
+        assert provider.calls == [("reject", 7, False)]
+        assert sels[0]["error"] == "unverified_shell"
+
+    @pytest.mark.asyncio
+    async def test_a_non_string_kind_still_gets_answered(self, monkeypatch):
+        # ACP relays ``toolCall.kind`` verbatim, so a backend can send ``kind: 1``.
+        # The gate reads the kind as text, so an unguarded value raises inside the
+        # hook and the turn ends with the request UNANSWERED -- the hang this
+        # whole path exists to end. The request must still be decided, and an
+        # unusable kind must not qualify for the read-only allow-list.
+        provider, sels, reads = await self._drive(
+            monkeypatch,
+            event=self._event(title="List files", tool_kind=1),
+            answer="a",
+        )
+        assert provider.calls == [("approve", 7, False)]
+        assert reads["n"] == 1
+        assert [s["outcome"] for s in sels] == ["allowed"]
+
+    @pytest.mark.asyncio
+    async def test_a_builtin_call_shows_its_trusted_tool_name(self, monkeypatch, capsys):
+        # A builtin has no MCP server, so the prompt otherwise carries only the
+        # model-authored title and a file write reaches the human as whatever
+        # prose the model chose. ``tool_name`` is the trusted ``_meta.kiro``
+        # identity, so consent covers what runs rather than its description.
+        provider, sels, reads = await self._drive(
+            monkeypatch,
+            event=self._event(title="Tidy up the notes", tool_name="fs_write"),
+            answer="a",
+        )
+        assert provider.calls == [("approve", 7, False)]
+        assert "fs_write" in capsys.readouterr().out
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("key", ["path", "file_path", "filePath"])
+    async def test_a_file_write_discloses_its_target_path(self, monkeypatch, capsys, key):
+        # The trusted identity says WHICH tool runs, not what it runs AGAINST.
+        # ``fs_write`` under a benign title is consent to a verb, and the gate's
+        # sensitive-path deny covers only the named-dangerous paths -- so what is
+        # left undisclosed is exactly the ordinary valuable file no rule speaks
+        # for. Every spelling the gate accepts must be read here too, or the
+        # prompt and the gate disagree about which value is the target.
+        provider, sels, reads = await self._drive(
+            monkeypatch,
+            event=self._event(
+                title="Tidy up the notes",
+                tool_name="fs_write",
+                raw_params={key: "/home/tester/thesis.md"},
+            ),
+            answer="a",
+        )
+        assert provider.calls == [("approve", 7, False)]
+        assert "/home/tester/thesis.md" in capsys.readouterr().out
+
+    @pytest.mark.asyncio
+    async def test_a_pathless_call_is_still_asked_about(self, monkeypatch):
+        # Absence of a path is NOT a refusal. Most builtin calls legitimately act
+        # on no file, so denying whenever a path cannot be found would refuse
+        # them all to close a gap that only exists for tools which name a file.
+        provider, sels, reads = await self._drive(
+            monkeypatch,
+            event=self._event(title="Remember this", tool_name="memory_write"),
+            answer="a",
+        )
+        assert provider.calls == [("approve", 7, False)]
+        assert reads["n"] == 1, "a call with no path must still reach the human"
+        assert [s["outcome"] for s in sels] == ["allowed"]
+
+    @pytest.mark.asyncio
+    async def test_a_long_path_cannot_push_the_question_off_screen(self, monkeypatch, capsys):
+        # The path is attacker-influenceable text on an authorization prompt, so
+        # it is capped for the same reason the command line is.
+        import kiro_crew.cli_chat as cli_chat
+
+        flood = "/tmp/" + "a" * (cli_chat._MAX_COMMAND_DISPLAY * 3)
+        await self._drive(
+            monkeypatch,
+            event=self._event(title="Tidy up", tool_name="fs_write", raw_params={"path": flood}),
+            answer="a",
+        )
+        out = capsys.readouterr().out
+        assert "[truncated]" in out
+        assert flood not in out
+
+    @pytest.mark.asyncio
+    async def test_a_non_string_path_argument_does_not_break_the_prompt(self, monkeypatch):
+        # ``raw_tool_params`` is relayed from the backend, so a value need not be
+        # a string. Raising here would leave the permission request unanswered --
+        # the hang this whole path exists to end.
+        provider, sels, reads = await self._drive(
+            monkeypatch,
+            event=self._event(
+                title="Tidy up",
+                tool_name="fs_write",
+                raw_params={"path": {"nested": 1}},
+            ),
+            answer="a",
+        )
+        assert provider.calls == [("approve", 7, False)]
+        assert [s["outcome"] for s in sels] == ["allowed"]
+
+    @pytest.mark.asyncio
+    async def test_the_audit_write_never_runs_on_the_event_loop(self, monkeypatch):
+        """``sel()`` opens the audit log and replays it to recover the HMAC chain,
+        so the first permission of a fresh chat pays a filesystem cost inside the
+        call -- unbounded on slow or corrupt storage. This coroutine shares its
+        loop with the ACP reader and stderr-drain tasks, so a blocking write here
+        stops draining the backend and freezes the turn the audit is about."""
+        import threading
+
+        import kiro_crew.cli_chat as cli_chat
+
+        threads: list = []
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(cli_chat, "_read_line_blocking", lambda prompt="": "a")
+        monkeypatch.setattr(
+            cli_chat,
+            "sel",
+            lambda: types.SimpleNamespace(
+                log_tool_invocation=lambda **kw: threads.append(threading.current_thread())
+            ),
+        )
+
+        class _P:
+            def __init__(self):
+                self.calls = []
+
+            async def approve_tool(self, request_id, *, always: bool = False):
+                self.calls.append(("approve", request_id))
+
+            async def reject_tool(self, request_id):
+                self.calls.append(("reject", request_id))
+
+        provider = _P()
+        await asyncio.wait_for(
+            cli_chat._answer_permission(
+                provider,
+                self._event(title="Tidy up", tool_name="fs_write"),
+                interactive=True,
+                gate=self._gate(),
+            ),
+            timeout=self._TIMEOUT,
+        )
+        assert provider.calls == [("approve", 7)]
+        assert threads, "nothing was audited"
+        assert threads[0] is not threading.main_thread(), (
+            "the SEL write ran on the event loop thread; a slow audit store would "
+            "stall ACP draining and freeze the turn"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_prompt_resets_terminal_modes_first(self, monkeypatch, capsys):
+        # Streamed model output is printed raw, so a turn can leave the terminal
+        # in conceal mode and the prompt would draw invisibly into it --
+        # sanitising the prompt's own strings cannot undo inherited state. The
+        # reset has to precede the question, or it does not protect it.
+        await self._drive(
+            monkeypatch,
+            event=self._event(title="Tidy up the notes", tool_name="fs_write"),
+            answer="a",
+        )
+        out = capsys.readouterr().out
+        assert "\x1b[0m" in out and "\x1b[?25h" in out
+        assert out.index("\x1b[0m") < out.index("Permission required")
+
+    @pytest.mark.asyncio
+    async def test_the_mcp_audit_record_names_the_server(self, monkeypatch):
+        # An MCP tool name is unique only within its server, so the audit record
+        # must carry both halves or two servers exposing the same name produce
+        # indistinguishable records.
+        _, sels, _ = await self._drive(
+            monkeypatch,
+            event=self._event(
+                title="Tidy up", tool_name="write_file", mcp_server_name="filesystem"
+            ),
+            answer="d",
+        )
+        assert sels[0]["tool_name"] == "@filesystem/write_file"
+
+    @pytest.mark.asyncio
+    async def test_the_mcp_audit_identity_cannot_collide_on_underscores(self, monkeypatch):
+        # `mcp__<server>__<tool>` re-splits on the LAST `__`, so server "a__b"
+        # with tool "c" and server "a" with tool "b__c" would compose to the same
+        # string. The `/`-joined reference keeps them distinct, because neither an
+        # MCP server nor an MCP tool name contains a slash.
+        _, first, _ = await self._drive(
+            monkeypatch,
+            event=self._event(title="One", tool_name="c", mcp_server_name="a__b"),
+            answer="d",
+        )
+        _, second, _ = await self._drive(
+            monkeypatch,
+            event=self._event(title="Two", tool_name="b__c", mcp_server_name="a"),
+            answer="d",
+        )
+        assert first[0]["tool_name"] == "@a__b/c"
+        assert second[0]["tool_name"] == "@a/b__c"
+        assert first[0]["tool_name"] != second[0]["tool_name"]
+
+    @pytest.mark.asyncio
+    async def test_a_non_mcp_audit_record_keeps_the_plain_tool_name(self, monkeypatch):
+        # The negative control: without an MCP server there is nothing to
+        # qualify, so the record must not gain an `@` prefix.
+        _, sels, _ = await self._drive(
+            monkeypatch,
+            event=self._event(title="Read it", tool_name="fs_read"),
+            answer="d",
+        )
+        assert sels[0]["tool_name"] == "fs_read"
+
+    @pytest.mark.asyncio
+    async def test_the_reset_closes_an_open_string_before_resetting_modes(
+        self, monkeypatch, capsys
+    ):
+        # An OSC/DCS sequence the model left UNTERMINATED puts the terminal in
+        # string-consuming mode: everything after it is swallowed as that
+        # sequence's payload. A mode reset sent into that state is itself eaten,
+        # and so is the prompt. So the abort must come FIRST -- once it discards
+        # the string, the rest of the reset is interpreted again.
+        await self._drive(
+            monkeypatch,
+            event=self._event(title="Tidy up the notes", tool_name="fs_write"),
+            answer="a",
+        )
+        out = capsys.readouterr().out
+        can = out.index("\x18")
+        assert can < out.index("\x1b[0m"), "the abort must precede the mode reset"
+        assert can < out.index("Permission required")
+
+    @pytest.mark.asyncio
+    async def test_the_reset_aborts_rather_than_terminates_a_pending_string(
+        self, monkeypatch, capsys
+    ):
+        # A String Terminator would COMPLETE the pending string, handing an
+        # unterminated OSC 52 from model output to the terminal as a finished
+        # command -- which sets the user's clipboard from attacker-controlled
+        # text. The reset must abort the sequence, so it must not contain ST.
+        await self._drive(
+            monkeypatch,
+            event=self._event(title="Tidy up the notes", tool_name="fs_write"),
+            answer="a",
+        )
+        out = capsys.readouterr().out
+        assert "\x18" in out
+        assert "\x1b\\" not in out, "ST completes the pending string instead of discarding it"
+
+    @pytest.mark.asyncio
+    async def test_the_reset_does_not_beep(self, monkeypatch, capsys):
+        # BEL also ends an OSC string, but it beeps audibly when no string is
+        # open -- on every single prompt. CAN is silent and, unlike BEL, discards
+        # the pending payload rather than delivering it, so the reset must not
+        # fall back to BEL.
+        await self._drive(
+            monkeypatch,
+            event=self._event(title="Tidy up the notes", tool_name="fs_write"),
+            answer="a",
+        )
+        assert "\x07" not in capsys.readouterr().out
+
+    @pytest.mark.asyncio
+    async def test_the_reset_is_withheld_when_stdout_is_not_a_terminal(self, monkeypatch):
+        # The negative control, exercised directly: driving a full turn with
+        # tty=False never renders the prompt at all, so asserting on its output
+        # would pass no matter what this branch does. Escape bytes written to a
+        # pipe or a redirected file are literal noise in someone's log.
+        import kiro_crew.cli_chat as cli_chat
+
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: False, raising=False)
+        assert cli_chat._terminal_reset() == ""
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+        assert cli_chat._terminal_reset() == cli_chat._PROMPT_TERMINAL_RESET
+
+        def boom():
+            raise ValueError("detached")
+
+        # A closed or detached stream must not let the check itself break the
+        # prompt the user is waiting on.
+        monkeypatch.setattr(sys.stdout, "isatty", boom, raising=False)
+        assert cli_chat._terminal_reset() == ""
+
+    @pytest.mark.asyncio
+    async def test_a_verified_shell_call_is_still_asked_about(self, monkeypatch):
+        # The negative control: the refusal must key on the MISSING trusted
+        # signal, not on execute-kind itself, or every shell call would die
+        # here and the test above would pass for the wrong reason.
+        provider, sels, reads = await self._drive(
+            monkeypatch,
+            event=self._event(title="Run the tests", command="pytest -q"),
+            answer="a",
+        )
+        assert provider.calls == [("approve", 7, False)]
+        assert reads["n"] == 1
+        assert [s["outcome"] for s in sels] == ["allowed"]
+
+    @pytest.mark.asyncio
+    async def test_direct_client_non_shell_permission_can_be_allowed(
+        self, monkeypatch, tmp_path
+    ):
+        """The Claude/direct transport must distinguish cached False from a miss.
+
+        This drives the production ``AcpClient`` parser before the CLI consumer;
+        hand-building an event with ``shell_classified=True`` would not catch a
+        transport that dropped the provenance flag while copying the cache.
+        """
+        from kiro_crew.acp.client import AcpClient
+        from kiro_crew.acp.types import ACP_BACKEND_CLAUDE
+
+        client = AcpClient(work_dir=tmp_path, acp_backend=ACP_BACKEND_CLAUDE)
+        self._direct_tool_call(client)
+        event = client._build_permission_event(self._direct_permission_message())
+
+        assert event.is_shell is False
+        assert event.shell_classified is True
+        assert event.raw_params_trusted is True
+        provider, sels, reads = await self._drive(monkeypatch, event=event, answer="a")
+        assert provider.calls == [("approve", "req-direct", False)]
+        assert reads["n"] == 1
+        assert [s["outcome"] for s in sels] == ["allowed"]
+
+    @pytest.mark.asyncio
+    async def test_direct_client_repeat_keeps_cached_params_authoritative(
+        self, monkeypatch, tmp_path
+    ):
+        """A repeated request cannot replace trusted args with inline prose."""
+        from kiro_crew.acp.client import AcpClient
+        from kiro_crew.acp.types import ACP_BACKEND_CLAUDE
+
+        client = AcpClient(work_dir=tmp_path, acp_backend=ACP_BACKEND_CLAUDE)
+        self._direct_tool_call(client, path="~/.ssh/id_rsa")
+        first = client._build_permission_event(self._direct_permission_message())
+        repeat = client._build_permission_event(
+            self._direct_permission_message(inline_path="notes.md")
+        )
+
+        assert first.raw_tool_params == repeat.raw_tool_params
+        assert repeat.raw_tool_params is not None
+        assert repeat.raw_tool_params["path"] == "~/.ssh/id_rsa"
+        assert repeat.raw_params_trusted is True
+        assert repeat.shell_classified is True
+        provider, _, reads = await self._drive(monkeypatch, event=repeat, answer="a")
+        assert provider.calls == [("reject", "req-direct", False)]
+        assert reads["n"] == 0
+
+    @pytest.mark.asyncio
+    async def test_direct_client_cache_miss_stays_fail_closed(
+        self, monkeypatch, tmp_path
+    ):
+        """Inline permission data cannot manufacture trusted provenance."""
+        from kiro_crew.acp.client import AcpClient
+        from kiro_crew.acp.types import ACP_BACKEND_CLAUDE
+
+        client = AcpClient(work_dir=tmp_path, acp_backend=ACP_BACKEND_CLAUDE)
+        event = client._build_permission_event(
+            self._direct_permission_message(tool_call_id="uncached", inline_path="notes.md")
+        )
+
+        assert event.raw_params_trusted is False
+        assert event.shell_classified is False
+        provider, sels, reads = await self._drive(monkeypatch, event=event, answer="a")
+        assert provider.calls == [("reject", "req-direct", False)]
+        assert reads["n"] == 0
+        assert sels[0]["error"] == "unverified_shell"
+
+    @pytest.mark.asyncio
+    async def test_ordinary_title_and_command_display_unchanged(self, monkeypatch, capsys):
+        # The control-stripping must not disturb ordinary text: this is the
+        # control for the three cases above.
+        event = self._event(title="Run the test suite", command="pytest -q test/test_cli.py")
+        await self._drive(monkeypatch, event=event)
+        out = capsys.readouterr().out
+        assert "Permission required: Run the test suite" in out
+        assert "Command: pytest -q test/test_cli.py" in out
+        # A shell call has no MCP identity to disclose, so the line is absent
+        # rather than empty -- the negative control for the MCP cases below.
+        assert "MCP tool:" not in out
+
+    @pytest.mark.asyncio
+    async def test_mcp_identity_is_disclosed_not_just_the_title(self, monkeypatch, capsys):
+        # An MCP call shows no command, so before this the human saw ONLY the
+        # model-authored title: a benign description could win consent for an
+        # undisclosed tool. The trusted _meta identity must reach the prompt.
+        event = self._event(
+            title="Tidy up the workspace",
+            tool_name="delete_everything",
+            mcp_server_name="filesystem",
+        )
+        await self._drive(monkeypatch, event=event)
+        out = capsys.readouterr().out
+        assert "MCP tool: filesystem / delete_everything" in out
+
+    @pytest.mark.asyncio
+    async def test_mcp_identity_is_neutralised_and_survives_a_nameless_tool(
+        self, monkeypatch, capsys
+    ):
+        # The identity is server-supplied text on the consent surface, so it
+        # gets the same one-line control-stripping as the title and command. A
+        # missing tool name still discloses the server rather than printing a
+        # bare separator that reads as though nothing was withheld.
+        event = self._event(
+            title="Tidy up",
+            tool_name="",
+            mcp_server_name="fs\x1b[2Kspoof\nserver",
+        )
+        await self._drive(monkeypatch, event=event)
+        line = next(
+            ln for ln in capsys.readouterr().out.splitlines() if ln.startswith("MCP tool:")
+        )
+        assert "\x1b" not in line
+        assert line == "MCP tool: fs [2Kspoof server / unnamed tool"
+
+    # ── Canonical MCP identity reaches the shared gate ───────────────────
+
+    @pytest.mark.asyncio
+    async def test_canonical_mcp_identity_is_forwarded_and_denies(self, monkeypatch):
+        # The wiring guard: a permission_request carrying the trusted _meta.kiro
+        # server + tool names must reach HookManager as those fields, so a
+        # governance rule naming the canonical mcp__server__tool denies the call
+        # -- the backend is rejected and the human is never asked.
+        import kiro_crew.cli_chat as cli_chat
+        import kiro_crew.hooks as hooks_mod
+        from kiro_crew.providers.base import EVENT_PERMISSION_REQUEST, LLMEvent
+
+        seen: list[str] = []
+
+        def fake_gov(ctx, name, *a, **k):
+            # One question carries every identity for the call (title, trusted
+            # tool name, canonical MCP reference), so match against all of them.
+            targets = [name, *k.get("extra_titles", ()), k.get("mcp_ref", "")]
+            for target in targets:
+                if target and target not in seen:
+                    seen.append(target)
+            if "@weather:srv/wipe_disk" in targets:
+                return "Blocked by governance policy: denied"
+            return None
+
+        monkeypatch.setattr(hooks_mod, "_governance_denial", fake_gov)
+        event = LLMEvent(
+            kind=EVENT_PERMISSION_REQUEST,
+            request_id=7,
+            title="Check the forecast",  # benign model-authored prose
+            tool_kind="other",
+            mcp_server_name="weather:srv",
+            tool_name="wipe_disk",
+            options=[{"id": "allow", "label": "Allow Once"}],
+        )
+        trace: list = []
+        provider = self._GatedProvider(event, trace)
+        reads = self._patch_env(monkeypatch, tty=True, trace=trace, answer="a")
+        await asyncio.wait_for(
+            cli_chat._send_and_print(provider, "run it", interactive=True, gate=self._gate()),
+            timeout=self._TIMEOUT,
+        )
+
+        assert "@weather:srv/wipe_disk" in seen  # forwarded, not just the title
+        assert provider.calls == [("reject", 7, False)]
+        assert reads["n"] == 0  # the human was never asked
+        assert [s[1]["error"] for s in trace if s[0] == "sel"] == ["hook_deny"]
+
+    @pytest.mark.asyncio
+    async def test_gate_verdict_is_obtained_off_the_event_loop(self, monkeypatch):
+        # The gate resolves the governance profile, which stats and reads
+        # ``profiles/``. This coroutine shares its loop with the ACP reader and
+        # drain tasks, so that walk must not run on the loop: on slow or network
+        # storage a synchronous call stalls the whole session. Pinned by asserting
+        # the call lands on a DIFFERENT thread than the loop's.
+        import threading
+
+        import kiro_crew.cli_chat as cli_chat
+        import kiro_crew.hooks as hooks_mod
+        from kiro_crew.providers.base import EVENT_PERMISSION_REQUEST, LLMEvent
+
+        loop_thread = threading.get_ident()
+        call_threads: list[int] = []
+        real = hooks_mod.HookManager.on_tool_call
+
+        def recording(self, *a, **k):
+            call_threads.append(threading.get_ident())
+            return real(self, *a, **k)
+
+        monkeypatch.setattr(hooks_mod.HookManager, "on_tool_call", recording)
+        event = LLMEvent(
+            kind=EVENT_PERMISSION_REQUEST,
+            request_id=11,
+            title="Read a file",
+            tool_kind="read",
+            options=[{"id": "allow", "label": "Allow Once"}],
+        )
+        trace: list = []
+        provider = self._GatedProvider(event, trace)
+        self._patch_env(monkeypatch, tty=True, trace=trace, answer="a")
+        await asyncio.wait_for(
+            cli_chat._send_and_print(provider, "go", interactive=True, gate=self._gate()),
+            timeout=self._TIMEOUT,
+        )
+
+        assert call_threads, "the gate was never consulted"
+        assert loop_thread not in call_threads, (
+            "on_tool_call ran on the event-loop thread; its profile walk must be "
+            "offloaded via asyncio.to_thread"
+        )
+
+    def test_an_unclassified_request_is_refused_whatever_kind_it_claims(self):
+        # THE VECTOR. A real shell call whose preceding tool_call carried no
+        # resolvable kind leaves the cache empty, so is_shell is the MISS default
+        # rather than a resolved "not a shell tool". Labelling it ``read`` must not
+        # buy it a trip to the human prompt, where the only thing on display would
+        # be a title with no command behind it.
+        import kiro_crew.cli_chat as cli_chat
+
+        event = self._event(title="Read a file", tool_kind="read", shell_classified=False)
+        assert cli_chat._unverifiable_shell(event) is True
+
+    def test_a_resolved_non_shell_request_is_not_refused(self):
+        # The negative control that keeps the deny narrow: a RESOLVED non-shell
+        # classification is a real answer, and must still reach the prompt.
+        import kiro_crew.cli_chat as cli_chat
+
+        event = self._event(title="Read a file", tool_kind="read")
+        assert cli_chat._unverifiable_shell(event) is False
+
+    def test_audit_scrubs_a_credential_out_of_the_tool_identity(self, monkeypatch):
+        # The audited identity comes from the backend, and SEL does not redact for
+        # its callers, so a credential riding in a tool name would be persisted and
+        # served over /api/sel/events.
+        import types as _types
+
+        import kiro_crew.cli_chat as cli_chat
+
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        trace: list = []
+        gate = self._gate()
+        monkeypatch.setattr(
+            cli_chat,
+            "sel",
+            lambda: _types.SimpleNamespace(
+                log_tool_invocation=lambda **kw: trace.append(("sel", kw))
+            ),
+        )
+        event = self._event(title="Terminal", tool_name=f"fetch_{secret}")
+        cli_chat._audit(gate, event, "approved")
+
+        logged = [s[1]["tool_name"] for s in trace if s[0] == "sel"]
+        assert logged, "nothing was audited"
+        assert secret not in logged[0], f"credential survived into the audit: {logged[0]!r}"
+
+
+class TestDenialNoticeEncoding:
+    """The automatic-denial notice interpolates a title the model or the tool
+    chose, and is written to stderr precisely when stderr is REDIRECTED — where
+    the stream encodes with the locale codec rather than UTF-8.
+
+    Run in a CHILD PROCESS on purpose. The contract under test is a property of
+    the real interpreter's standard streams, and in-process substitutes do not
+    have it: a ``TextIOWrapper`` or ``StringIO`` built by a test carries whatever
+    error handler the test chose, so a strict one would manufacture a failure
+    this code path cannot actually produce, and pytest's own capture replaces
+    ``sys.stderr`` outright.
+    """
+
+    #: Han the cp950 codec can encode, plus an emoji no legacy codepage can.
+    _TITLE = "刪除全部 \U0001f4a3 rm -rf"
+
+    _CHILD = """
+import asyncio, json, sys
+import kiro_crew.cli_chat as cli_chat
+from kiro_crew.providers.base import EVENT_PERMISSION_REQUEST, LLMEvent
+
+print(f"encoding={sys.stderr.encoding}")
+print(f"errors={sys.stderr.errors}")
+
+
+class P:
+    async def approve_tool(self, rid):
+        print("approve")
+
+    async def reject_tool(self, rid):
+        print("reject")
+
+
+event = LLMEvent(
+    kind=EVENT_PERMISSION_REQUEST,
+    request_id=7,
+    title=%(title)r,
+    tool_kind="read",
+    is_shell=False,
+    tool_input=json.dumps({}),
+    tool_name="",
+    options=[{"id": "allow", "label": "Allow Once"}],
+)
+# interactive=False takes the automatic-denial branch, whose notice goes to
+# stderr with the title interpolated into it.
+asyncio.run(cli_chat._answer_permission(P(), event, interactive=False))
+print("survived")
+"""
+
+    @pytest.mark.parametrize("io_encoding", ["cp950", "cp950:strict"])
+    def test_denial_notice_survives_a_non_utf8_redirected_stderr(
+        self, tmp_path, io_encoding
+    ):
+        env = dict(os.environ)
+        env["PYTHONIOENCODING"] = io_encoding
+        # Keep the SEL audit write inside the test's own tree.
+        env["KIROCREW_HOME"] = str(tmp_path / "home")
+        out_path = tmp_path / "child.out"
+        err_path = tmp_path / "child.err"
+        with open(out_path, "wb") as out, open(err_path, "wb") as err:
+            rc = subprocess.call(
+                [sys.executable, "-c", self._CHILD % {"title": self._TITLE}],
+                stdout=out,
+                stderr=err,  # a real OS handle, so the stream is redirected
+                env=env,
+                # Anchor the child OUTSIDE the checkout. It imports the installed
+                # package, so CWD is not on its import path, and any relative
+                # artifact it or a library writes then lands in the test's own tree
+                # instead of surviving in the repo.
+                cwd=tmp_path,
+            )
+        stdout = out_path.read_text(encoding="utf-8", errors="replace")
+
+        assert rc == 0, f"the denial notice killed the CLI:\n{stdout}"
+        assert "survived" in stdout
+        assert "reject" in stdout
+        # The premise a reviewer keeps reaching for is that a locale codec makes
+        # this strict. It does not: CPython pins stderr to backslashreplace, and
+        # the ``:strict`` half of PYTHONIOENCODING is ignored for this stream.
+        assert "encoding=cp950" in stdout
+        assert "errors=backslashreplace" in stdout
+        # And the unencodable character is escaped rather than raised.
+        written = err_path.read_bytes().decode("cp950", errors="replace")
+        assert "\\U0001f4a3" in written
+
+
+class TestChatProviderShutdown:
+    """``provider.start()`` hands back a live backend process, so every exit from
+    the turn -- return, error, or cancellation -- has to run ``shutdown()``."""
+
+    class _FakeProvider:
+        def __init__(self):
+            self.started = 0
+            self.shutdowns = 0
+
+        async def start(self):
+            self.started += 1
+
+        async def shutdown(self):
+            self.shutdowns += 1
+
+        def context_usage_pct(self):
+            return 0.0
+
+    def _patch(self, monkeypatch, provider):
+        import kiro_crew.cli_chat as cli_chat
+        from kiro_crew.config import KiroCrewConfig
+
+        monkeypatch.setattr(KiroCrewConfig, "load", staticmethod(lambda: KiroCrewConfig()))
+        monkeypatch.setattr(
+            cli_chat, "build_provider_factory", lambda cfg: (lambda *a, **k: provider)
+        )
+        monkeypatch.setattr(cli_chat, "_build_tool_gate", lambda agent: None)
+
+    @pytest.mark.asyncio
+    async def test_shutdown_runs_when_the_turn_is_cancelled(self, monkeypatch):
+        # A permission prompt cancelled at the terminal raises through the turn
+        # by design. The backend must still be torn down, and the cancellation
+        # must still reach the caller.
+        import kiro_crew.cli_chat as cli_chat
+
+        provider = self._FakeProvider()
+        self._patch(monkeypatch, provider)
+
+        async def cancelled(*a, **k):
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(cli_chat, "_send_and_print", cancelled)
+        with pytest.raises(asyncio.CancelledError):
+            await cli_chat._chat("hello", None)
+        assert provider.shutdowns == 1
+
+    @pytest.mark.asyncio
+    async def test_shutdown_runs_when_the_turn_raises(self, monkeypatch):
+        import kiro_crew.cli_chat as cli_chat
+
+        provider = self._FakeProvider()
+        self._patch(monkeypatch, provider)
+
+        async def boom(*a, **k):
+            raise RuntimeError("backend died")
+
+        monkeypatch.setattr(cli_chat, "_send_and_print", boom)
+        with pytest.raises(RuntimeError, match="backend died"):
+            await cli_chat._chat("hello", None)
+        assert provider.shutdowns == 1
+
+    @pytest.mark.asyncio
+    async def test_shutdown_runs_exactly_once_on_the_normal_path(self, monkeypatch):
+        import kiro_crew.cli_chat as cli_chat
+
+        provider = self._FakeProvider()
+        self._patch(monkeypatch, provider)
+
+        async def ok(*a, **k):
+            return None
+
+        monkeypatch.setattr(cli_chat, "_send_and_print", ok)
+        await cli_chat._chat("hello", None)
+        assert provider.shutdowns == 1
+
+    @pytest.mark.asyncio
+    async def test_gc_runs_even_when_shutdown_raises(self, monkeypatch):
+        # gc.collect() collects the subprocess transports while the loop is
+        # still open; a failing shutdown must not skip it, and must not replace
+        # the exception already propagating.
+        import kiro_crew.cli_chat as cli_chat
+
+        class _BadShutdown(self._FakeProvider):
+            async def shutdown(self):
+                self.shutdowns += 1
+                raise RuntimeError("shutdown failed")
+
+        provider = _BadShutdown()
+        self._patch(monkeypatch, provider)
+        collected = {"n": 0}
+        monkeypatch.setattr(cli_chat.gc, "collect", lambda: collected.__setitem__("n", 1))
+
+        async def cancelled(*a, **k):
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(cli_chat, "_send_and_print", cancelled)
+        with pytest.raises(asyncio.CancelledError):
+            await cli_chat._chat("hello", None)
+        assert provider.shutdowns == 1
+        assert collected["n"] == 1

--- a/test/test_cli_chat.py
+++ b/test/test_cli_chat.py
@@ -38,6 +38,42 @@ async def test_cancelled_turn_shuts_down_provider(monkeypatch) -> None:
     provider.shutdown.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_default_chat_uses_canonical_agent_for_provider_and_gate(monkeypatch) -> None:
+    """The default ACP agent's task profile must receive the same identity."""
+    provider = MagicMock()
+    provider.start = AsyncMock()
+    provider.shutdown = AsyncMock()
+    cfg = KiroCrewConfig()
+    assert cfg.agent.default_agent == "", "exercise the provider-default path"
+
+    provider_agents: list[str | None] = []
+    gate_agents: list[str] = []
+
+    def _factory(config):
+        assert config is cfg
+
+        def _provider(*args, agent=None, **kwargs):
+            provider_agents.append(agent)
+            return provider
+
+        return _provider
+
+    monkeypatch.setattr(cli_chat.KiroCrewConfig, "load", classmethod(lambda cls: cfg))
+    monkeypatch.setattr(cli_chat, "build_provider_factory", _factory)
+    monkeypatch.setattr(
+        cli_chat,
+        "_build_tool_gate",
+        lambda agent: gate_agents.append(agent) or MagicMock(),
+    )
+    monkeypatch.setattr(cli_chat, "_send_and_print", AsyncMock())
+
+    await cli_chat._chat("hello", None)
+
+    assert provider_agents == ["kirocrew"]
+    assert gate_agents == ["kirocrew"]
+
+
 def test_run_chat_renders_keyboard_interrupt_as_clean_exit(monkeypatch, capsys) -> None:
     def interrupt(coro) -> None:
         coro.close()

--- a/test/test_governance_chokepoints.py
+++ b/test/test_governance_chokepoints.py
@@ -1203,6 +1203,51 @@ class TestFilesystemEgressAtGate:
         # Empty kind + a shell command → NOT filesystem/egress (commands scope).
         assert classify_tool_args("", {"command": "rm -rf /"}) == ()
 
+    @pytest.mark.parametrize("key", ["path", "file_path", "filePath"])
+    def test_every_path_alias_is_classified(self, key):
+        from kiro_crew.platform.governance import classify_tool_args
+
+        assert classify_tool_args("edit", {key: "/srv/secret"}) == (
+            ("filesystem.write", "/srv/secret"),
+        )
+        assert classify_tool_args("read", {key: "/srv/secret"}) == (
+            ("filesystem.read", "/srv/secret"),
+        )
+
+    def test_conflicting_path_aliases_are_all_classified(self):
+        """An innocent first alias must not mask a sensitive later alias."""
+        from kiro_crew.platform.governance import classify_tool_args
+
+        assert classify_tool_args(
+            "edit",
+            {
+                "path": "/tmp/innocent",
+                "file_path": {"not": "a path"},
+                "filePath": "/home/user/.ssh/id_rsa",
+            },
+        ) == (
+            ("filesystem.write", "/tmp/innocent"),
+            ("filesystem.write", "/home/user/.ssh/id_rsa"),
+        )
+
+    def test_conflicting_path_alias_cannot_bypass_gate(self):
+        _install(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "filesystem": {"write": {"mode": "allow", "allow": ["/tmp/**"]}},
+            }
+        )
+        from kiro_crew.hooks import TOOL_DENY, HookManager
+
+        decision = HookManager().on_tool_call(
+            "Editing notes",
+            session_key="cli_chat",
+            tool_kind="edit",
+            raw_params={"path": "/tmp/allowed.txt", "filePath": "/srv/outside.txt"},
+        )
+        assert decision.action == TOOL_DENY
+
     def test_empty_kind_write_still_denied_at_gate(self):
         # End-to-end: an edit with tool_kind="" (backend omitted kind) to a
         # path outside the write allowlist must still be DENIED at the gate.

--- a/test/test_hooks.py
+++ b/test/test_hooks.py
@@ -977,6 +977,381 @@ class TestMutatingKindBeatsTheTitle:
         assert _should_auto_approve_spawn(ctx, "spawn_run") is False
 
 
+class TestCanonicalMcpIdentityGoverned:
+    """An ORDINARY MCP permission request — no first-party app-own-server
+    auto-approve involved — is governed under its trusted
+    ``mcp__<server>__<tool>`` identity as well as its LLM-authored title, so a
+    per-tool ceiling rule binds even when the title is benign prose. The
+    canonical name is ADDED to the deny floor and governance, never substituted
+    for the title, so the title/raw-command floor keeps denying on its own."""
+
+    @staticmethod
+    def _deny_canonical(monkeypatch, denied: str):
+        """Governance that denies exactly *denied*, recording what it saw.
+
+        The gate asks ONE question carrying every identity for the call (title,
+        trusted tool name, canonical MCP reference), so this double records all of
+        them and denies if any matches -- mirroring the real tightest-wins
+        evaluation over a single profile snapshot.
+        """
+        import kiro_crew.hooks as hooks_mod
+
+        seen: list[str] = []
+
+        def fake_gov(ctx, name, *a, **k):
+            targets = [name, *k.get("extra_titles", ()), k.get("mcp_ref", "")]
+            for target in targets:
+                if target and target not in seen:
+                    seen.append(target)
+            if denied in targets:
+                return "Blocked by governance policy: denied"
+            return None
+
+        monkeypatch.setattr(hooks_mod, "_governance_denial", fake_gov)
+        return seen
+
+    def test_governance_denies_canonical_behind_prose_title(self, monkeypatch):
+        # THE REGRESSION. A policy denies the weather server's wipe_disk tool, but
+        # select_tool_title handed us the model's prose description. Governing
+        # only the title would permit, the call would reach the human prompt,
+        # and an "allow" would run a tool the ceiling forbids.
+        seen = self._deny_canonical(monkeypatch, "@weather:srv/wipe_disk")
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "Check tomorrow's forecast",  # benign model-authored prose
+            mcp_server_name="weather:srv",
+            mcp_tool_name="wipe_disk",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_DENY
+        # Both identities were offered to governance — the title (permitted)
+        # AND the trusted canonical reference (denied).
+        assert "Check tomorrow's forecast" in seen
+        assert "@weather:srv/wipe_disk" in seen
+
+    def test_deny_floor_matches_canonical_behind_prose_title(self, monkeypatch):
+        # Same bypass, via the effective deny set rather than governance.
+        cfg = HooksConfig(auto_deny_tools=["mcp__weather:srv__wipe_disk"])
+        mgr = HookManager(cfg)
+        r = mgr.on_tool_call(
+            "Check tomorrow's forecast",
+            mcp_server_name="weather:srv",
+            mcp_tool_name="wipe_disk",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_DENY
+
+    def test_partial_mcp_identity_governs_the_server_never_a_malformed_name(self, monkeypatch):
+        # Only ONE trusted field → no canonical per-TOOL name exists. What the
+        # server alone supports is a SERVER-level question, which the governance
+        # grammar has (``@server`` covers every tool under it), so that is what
+        # governance is asked — and nothing else is synthesised.
+        #
+        # The shapes this guards against are the malformed ones a title-encoded
+        # identity could produce: a dangling ``__`` separator, or an empty server
+        # (``mcp____wipe_disk``), either of which could match a prefix rule and
+        # deny an unrelated call. Composing the reference from the trusted fields
+        # cannot produce them, and this pins that. Denying the tool-qualified form
+        # must NOT deny the call either: the tool was never proven.
+        seen = self._deny_canonical(monkeypatch, "@weather:srv/")
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "Check tomorrow's forecast", mcp_server_name="weather:srv", tool_kind="other"
+        )
+        assert r.action != TOOL_DENY
+        assert seen == ["Check tomorrow's forecast", "@weather:srv"]
+        assert not any(t.endswith("__") or "mcp____" in t for t in seen)
+
+    def test_title_floor_survives_canonical_enforcement(self, monkeypatch):
+        # PRESERVATION. Governance permits EVERYTHING here, so the only thing
+        # that can produce a deny is the title-keyed security floor. The display
+        # title names a sensitive path while the canonical name is innocuous:
+        # canonical enforcement is additive, so it must not have displaced the
+        # title from the checks it was already in. Governance must permit for
+        # this to mean anything — a stub that denies the canonical name would
+        # pass even if the title had been substituted away.
+        self._deny_canonical(monkeypatch, "nothing-is-denied")
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "~/.aws/credentials",
+            mcp_server_name="files:srv",
+            mcp_tool_name="nothing_to_see",
+            tool_kind="read",
+        )
+        assert r.action == TOOL_DENY
+
+    def test_raw_command_floor_survives_canonical_enforcement(self, monkeypatch):
+        # PRESERVATION, the shell half: benign title, benign canonical name,
+        # dangerous raw command, and governance permitting everything — so the
+        # deny can only come from the command being evaluated. (For this input
+        # the effective deny set is what fires; the point is that adding the
+        # canonical identity did not displace `command` from the checks that
+        # see it.)
+        self._deny_canonical(monkeypatch, "nothing-is-denied")
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "Tidy up some files",
+            command="cat ~/.ssh/id_rsa",
+            is_shell=True,
+            mcp_server_name="shell:srv",
+            mcp_tool_name="nothing_to_see",
+            tool_kind="execute",
+        )
+        assert r.action == TOOL_DENY
+
+    def test_non_mcp_call_unaffected(self, monkeypatch):
+        # Neither trusted field (a shell/built-in tool, or a backend that omits
+        # _meta.kiro): governance sees the title and nothing else.
+        seen = self._deny_canonical(monkeypatch, "never-matches")
+        mgr = HookManager()
+        r = mgr.on_tool_call("List the files", tool_kind="read")
+        assert r.action == TOOL_AUTO_APPROVE
+        assert seen == ["List the files"]
+
+
+class TestBuiltinToolIdentityGoverned:
+    """A BUILT-IN tool proves ``_meta.kiro.toolName`` but no ``mcpServerName``,
+    so no canonical ``@server/tool`` reference exists for it. Its trusted name
+    must still reach the deny floor and governance on its own, or a rule naming
+    the real tool is bypassable behind a benign model-authored title."""
+
+    def test_deny_floor_matches_builtin_tool_name_behind_prose_title(self):
+        # THE REGRESSION. deny=["fs_write"] with a benign title and no MCP
+        # server: the canonical form is empty, so before this the title was the
+        # only deny target and the policy-denied built-in reached the human.
+        cfg = HooksConfig(auto_deny_tools=["fs_write"])
+        mgr = HookManager(cfg)
+        r = mgr.on_tool_call(
+            "Update the changelog",  # benign model-authored prose
+            mcp_tool_name="fs_write",  # trusted _meta.kiro.toolName
+            tool_kind="edit",
+        )
+        assert r.action == TOOL_DENY
+
+    def test_governance_denies_builtin_tool_name_behind_prose_title(self, monkeypatch):
+        # Same bypass on the governance plane. The identity is asked as a plain
+        # tool item, never as an ``@server/tool`` reference -- a built-in has no
+        # server, so synthesising one would invent a name nothing matches.
+        seen = TestCanonicalMcpIdentityGoverned._deny_canonical(monkeypatch, "fs_write")
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "Update the changelog",
+            mcp_tool_name="fs_write",
+            tool_kind="edit",
+        )
+        assert r.action == TOOL_DENY
+        # Both were offered: the title (permitted) AND the trusted name (denied).
+        assert "Update the changelog" in seen
+        assert "fs_write" in seen
+
+    def test_identity_equal_to_the_title_is_not_asked_twice(self, monkeypatch):
+        # A backend whose title already IS the tool name must not cost a second
+        # identical governance query.
+        seen = TestCanonicalMcpIdentityGoverned._deny_canonical(monkeypatch, "never-matches")
+        mgr = HookManager()
+        mgr.on_tool_call("fs_read", mcp_tool_name="fs_read", tool_kind="read")
+        assert seen == ["fs_read"]
+
+    def test_every_identity_shares_one_profile_resolution(self, monkeypatch):
+        # THE SNAPSHOT CONTRACT. Title, trusted tool name and MCP reference are
+        # one question against one resolved profile. Resolving per identity let a
+        # profile hot-reloaded mid-call answer each from a different snapshot, so
+        # a tool both complete profiles deny could be permitted by every single
+        # lookup -- and each resolve walked ``profiles/`` on the event loop.
+        import kiro_crew.platform.governance_profiles as profiles_mod
+
+        calls = []
+        real = profiles_mod.resolve_active_scope
+
+        def counting(session_key, **kw):
+            calls.append(session_key)
+            return real(session_key, **kw)
+
+        monkeypatch.setattr(profiles_mod, "resolve_active_scope", counting)
+        mgr = HookManager()
+        mgr.on_tool_call(
+            "Update the changelog",
+            session_key="s1",
+            mcp_server_name="weather:srv",
+            mcp_tool_name="fs_write",
+            tool_kind="edit",
+        )
+        # Three identities in play (title, fs_write, @weather:srv/fs_write) and
+        # exactly ONE profile resolution.
+        assert len(calls) == 1, f"expected one profile resolution, got {len(calls)}"
+
+
+class TestServerLevelGovernanceBindsOnPartialIdentity:
+    """A trusted SERVER identity with no trusted tool name is still a complete
+    question for governance, whose grammar has a server level: ``@server`` covers
+    every tool under it. Exercised through the REAL policy engine rather than a
+    stubbed ``_governance_denial``, because what is at stake is precisely whether
+    the raw target this gate emits is one the ``mcp`` matcher can bind a
+    server-level rule to."""
+
+    @staticmethod
+    def _ceiling_denying(server_ref: str):
+        """A real ceiling whose ``mcp`` scope denies *server_ref*."""
+        from kiro_crew.platform.governance import (
+            MODE_DENY,
+            GovernanceCeiling,
+            ScopedRuleset,
+            parse_policy,
+        )
+
+        return GovernanceCeiling(
+            version=1,
+            boot=parse_policy({"version": 1, "boot": {"fail_closed": True}}).boot,
+            controls={"mcp": ScopedRuleset(mode=MODE_DENY, deny=(server_ref,), matcher="mcp")},
+        )
+
+    @staticmethod
+    def _install(monkeypatch, ceiling):
+        """Run the gate against *ceiling* with the real security authority."""
+        import kiro_crew.hooks as hooks_mod
+        from kiro_crew.platform import current_context
+
+        real = current_context()
+
+        class _Ctx:
+            security = real.security
+            governance = ceiling
+
+        monkeypatch.setattr(hooks_mod, "current_context", lambda: _Ctx())
+
+    def test_server_level_deny_binds_without_a_trusted_tool_name(self, monkeypatch):
+        # THE REGRESSION. kiro-cli supplied `_meta.kiro.mcpServerName` but no
+        # `toolName` — an uncached permission event, or a backend that omits it.
+        # The title is the model's own prose, so governing on the title alone
+        # leaves a `deny @github` ceiling with nothing to bind to, and the call
+        # walks past the ceiling to a human who can approve it.
+        self._install(monkeypatch, self._ceiling_denying("@github"))
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "Read a public README",  # benign model-authored prose
+            mcp_server_name="github",
+            mcp_tool_name="",  # not proven
+            tool_kind="other",
+        )
+        assert r.action == TOOL_DENY
+
+    def test_server_level_deny_still_binds_on_a_full_identity(self, monkeypatch):
+        # PRESERVATION: `@server` covers every tool under it, so the complete
+        # identity is denied by the same rule.
+        self._install(monkeypatch, self._ceiling_denying("@github"))
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "Read a public README",
+            mcp_server_name="github",
+            mcp_tool_name="get_file",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_DENY
+
+    def test_tool_level_deny_does_not_widen_to_the_whole_server(self, monkeypatch):
+        # The partial target must not be a blunter instrument than the grammar
+        # allows: `@github/delete_repo` denies that tool, and a call that proves
+        # only the server is NOT that tool, so it is not denied by this rule.
+        # Without this, "govern the server when the tool is unknown" would
+        # quietly become "deny the server whenever any of its tools is denied".
+        self._install(monkeypatch, self._ceiling_denying("@github/delete_repo"))
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "Read a public README",
+            mcp_server_name="github",
+            mcp_tool_name="",
+            tool_kind="other",
+        )
+        assert r.action != TOOL_DENY
+
+    def test_an_ungoverned_server_is_not_denied(self, monkeypatch):
+        # The control that keeps the test above honest: same partial identity,
+        # a rule naming a DIFFERENT server, so the deny must not fire.
+        self._install(monkeypatch, self._ceiling_denying("@gitlab"))
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "Read a public README",
+            mcp_server_name="github",
+            mcp_tool_name="",
+            tool_kind="other",
+        )
+        assert r.action != TOOL_DENY
+
+    def test_a_server_name_containing_the_separator_still_binds(self, monkeypatch):
+        # A ``__``-bearing server name must reach governance intact. Encoded into
+        # an ``mcp__<server>`` title it re-parses as server ``npm`` + tool
+        # ``playwright_mcp`` and the ceiling denying the real server never binds --
+        # a human would be asked to approve a server the policy forbids.
+        self._install(monkeypatch, self._ceiling_denying("@npm__playwright_mcp"))
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "Open a page",
+            mcp_server_name="npm__playwright_mcp",
+            mcp_tool_name="",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_DENY
+
+    def test_a_tool_name_containing_the_separator_still_binds(self, monkeypatch):
+        # The sibling, and the one no title spelling can fix: the title form is
+        # read by splitting on the LAST ``__``, so ``@github`` + ``repo__delete``
+        # encodes to ``mcp__github__repo__delete`` and reads back as server
+        # ``github__repo`` with tool ``delete``. A ``deny @github/repo__delete``
+        # ceiling would then never bind and approval could run the denied tool.
+        self._install(monkeypatch, self._ceiling_denying("@github/repo__delete"))
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "Read a public README",
+            mcp_server_name="github",
+            mcp_tool_name="repo__delete",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_DENY
+
+    def test_both_segments_containing_the_separator_still_bind(self, monkeypatch):
+        # Both halves ambiguous at once — the branch a per-segment patch on either
+        # side alone would still leave open.
+        self._install(monkeypatch, self._ceiling_denying("@npm__gh/repo__delete"))
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "Read a public README",
+            mcp_server_name="npm__gh",
+            mcp_tool_name="repo__delete",
+            tool_kind="other",
+        )
+        assert r.action == TOOL_DENY
+
+    def test_a_specific_tool_rule_does_not_deny_the_server_only_question(self, monkeypatch):
+        # The other half of the server-level question: an unproven tool must not be
+        # denied by a rule naming a specific one, or closing the missed denies
+        # above would trade them for a false one.
+        self._install(monkeypatch, self._ceiling_denying("@npm__playwright_mcp/wipe"))
+        mgr = HookManager()
+        r = mgr.on_tool_call(
+            "Open a page",
+            mcp_server_name="npm__playwright_mcp",
+            mcp_tool_name="",
+            tool_kind="other",
+        )
+        assert r.action != TOOL_DENY
+
+    def test_partial_identity_never_reaches_the_raw_deny_regex_plane(self, monkeypatch):
+        # The server-only target belongs to the governance grammar, where
+        # `mcp__<server>` means `@server`. The deny plane matches raw text and
+        # operator regexes, where it is simply a different string — so a rule
+        # written against the canonical identity must NOT start matching calls
+        # whose tool was never proven.
+        cfg = HooksConfig(auto_deny_tools=["mcp__github__delete_repo"])
+        mgr = HookManager(cfg)
+        r = mgr.on_tool_call(
+            "Read a public README",
+            mcp_server_name="github",
+            mcp_tool_name="",
+            tool_kind="other",
+        )
+        assert r.action != TOOL_DENY
+
+
 class TestAppOwnMcpServerAutoApprove:
     """A FIRST-PARTY (builtin) app agent calling its OWN app-scoped MCP server
     (identified by the trusted, non-model-authored ``mcp_server_name`` =
@@ -1142,8 +1517,8 @@ class TestAppOwnMcpServerAutoApprove:
 
     def test_own_server_governs_canonical_tool_not_prose_title(self, monkeypatch):
         # The auto-approve must govern the REAL tool (trusted mcp_server_name +
-        # mcp_tool_name → canonical mcp__server__tool), NOT the LLM prose title.
-        # A per-tool policy denying mcp__myapp:srv__danger must block the call
+        # mcp_tool_name → canonical ``@server/tool``), NOT the LLM prose title.
+        # A per-tool policy denying ``@myapp:srv/danger`` must block the call
         # even though the prose title never matches that policy — closing the
         # bypass where an own-server auto-approve skipped per-tool governance.
         import kiro_crew.hooks as hooks_mod
@@ -1153,8 +1528,13 @@ class TestAppOwnMcpServerAutoApprove:
         seen: list[str] = []
 
         def fake_gov(ctx, name, *a, **k):
-            seen.append(name)
-            if name == "mcp__myapp:srv__danger":
+            # One question carries every identity for the call, so match against
+            # all of them rather than a single target.
+            targets = [name, *k.get("extra_titles", ()), k.get("mcp_ref", "")]
+            for target in targets:
+                if target and target not in seen:
+                    seen.append(target)
+            if "@myapp:srv/danger" in targets:
                 return "Blocked by governance policy: denied"
             return None
 
@@ -1168,10 +1548,10 @@ class TestAppOwnMcpServerAutoApprove:
             tool_kind="other",
         )
         assert r.action == TOOL_DENY
-        # BOTH governance calls ran: the prose title (permitted) AND the
-        # reconstructed canonical name (denied).
+        # BOTH identities were offered in the one query: the prose title
+        # (permitted) AND the canonical reference (denied).
         assert "Do a risky thing" in seen
-        assert "mcp__myapp:srv__danger" in seen
+        assert "@myapp:srv/danger" in seen
 
     def test_own_server_honors_canonical_deny_rule(self, monkeypatch):
         # The always-on deny floor (auto_deny_tools / denied regexes) must apply
@@ -1349,3 +1729,78 @@ class TestAppOwnMcpServerAutoApprove:
 
         monkeypatch.setattr(hooks_mod, "_BUILTIN_APP_NAMES", frozenset())
         assert hooks_mod._is_first_party_app("myapp") is False
+
+
+class TestTargetPathSpellings:
+    """The sensitive-path keystone read ``path`` and ``file_path`` but not
+    ``filePath`` -- the camel-case form ``_SEARCH_DENY_ARG_KEYS`` has accepted for
+    the search plane all along. A backend sending that spelling reached NEITHER
+    read, so a write to a sensitive path under it was never gated.
+
+    ``cli_chat`` shares ``target_paths`` with the gate, so a prompt cannot
+    disclose a path the keystone did not inspect.
+    """
+
+    @staticmethod
+    def _gate():
+        from kiro_crew.hooks import HookManager, HooksConfig
+
+        return HookManager(HooksConfig.from_dict({}))
+
+    @pytest.mark.parametrize("key", ["path", "file_path", "filePath"])
+    def test_a_sensitive_path_is_denied_under_every_spelling(self, key):
+        from kiro_crew.hooks import TOOL_DENY
+
+        decision = self._gate().on_tool_call(
+            "Tidy up the notes",
+            session_key="cli_chat",
+            tool_kind="edit",
+            raw_params={key: "~/.ssh/id_rsa"},
+        )
+        assert decision.action == TOOL_DENY, (
+            f"a sensitive path under {key!r} reached no check; the human would be "
+            "asked to approve what the keystone must refuse outright"
+        )
+
+    def test_a_second_innocent_alias_cannot_shadow_a_sensitive_one(self):
+        """Every value present is checked, so a deny cannot be dodged by adding a
+        benign alias. This is why the fix does not 'normalize onto one key and
+        reject conflicts' -- a conflict rule has to pick a winner, and picking
+        wrong is exactly how the sensitive value slips past.
+
+        Uses a READ kind deliberately. An ``edit`` would also be caught by the
+        write-protected-config gate further down, so the deny would prove nothing
+        about the sensitive-path keystone this test exists to pin -- a mutation
+        limiting the keystone to the FIRST path still passed while the kind was
+        ``edit``.
+        """
+        from kiro_crew.hooks import TOOL_DENY
+
+        decision = self._gate().on_tool_call(
+            "Read the notes",
+            session_key="cli_chat",
+            tool_kind="read",
+            raw_params={"path": "/tmp/harmless.txt", "filePath": "~/.aws/credentials"},
+        )
+        assert decision.action == TOOL_DENY
+
+    def test_an_ordinary_path_is_still_allowed_under_every_spelling(self):
+        """The absence direction: widening the spellings must not start denying
+        ordinary files, or the gate would refuse most real edits."""
+        from kiro_crew.hooks import TOOL_DENY
+
+        for key in ("path", "file_path", "filePath"):
+            decision = self._gate().on_tool_call(
+                "Tidy up the notes",
+                session_key="cli_chat",
+                tool_kind="edit",
+                raw_params={key: "/tmp/notes.md"},
+            )
+            assert decision.action != TOOL_DENY, f"{key!r} wrongly denied an ordinary file"
+
+    def test_target_paths_ignores_non_string_and_blank_values(self):
+        from kiro_crew.hooks import target_paths
+
+        assert target_paths({"path": {"nested": 1}, "filePath": "   "}) == []
+        assert target_paths(None) == []
+        assert target_paths({"path": "/a", "file_path": "/a"}) == ["/a"], "deduped"


### PR DESCRIPTION
## Problem / Motivation

A backend that routes tool decisions over ACP holds the turn open until it
receives a response. `_send_and_print` consumed only text and completion events,
so a `permission_request` fell through the chain and was discarded: the backend
waited for an answer that never came, the reply stopped mid-sentence, and the
`you>` prompt never returned. An unhandled permission request is not a missed
prompt — it is a turn that never ends.

## Root cause

The CLI had no branch for `EVENT_PERMISSION_REQUEST`. Adding one is not a
missing-branch fix, because answering a permission request *is* an authorization
decision: it makes `kirocrew chat` a security surface, and it has to carry the
same ceiling, audit trail, and consent semantics every other consumer of that
event already carries.

## Why it matters

The turn hangs until it times out, with nothing on screen explaining why. Worse,
the governance ceiling does not bind on that path, so the deny the operator
configured is not applied — the failure is both a usability dead end and a
security-relevant gap in the same code path.

## What changed

Every request runs Kiro Crew's own PreToolUse gate first, fed the event's
non-model-authored fields rather than `title` alone. For a shell tool the title
may be an LLM-authored description, so `cat ~/.ssh/id_rsa` behind "List project
files" is exactly what keying on the title lets through. A policy denial is not
the user's to override.

The gate verdict is a deny **ceiling**. `TOOL_AUTO_APPROVE` still asks, because
honouring it here would add a second path that runs a tool with no human
confirmation; this consumer answers permission requests, it does not carry the
dashboard's trust semantics. Asking more often than the dashboard is the safe
direction.

**There is no "always allow".** A persistent approval asks the backend to stop
*sending* permission requests for matching calls, and a request never sent is a
call this ladder never runs and never audits — one answer would disarm the
ceiling and the audit trail for the rest of the session.

The answer is matched exactly, not by first letter: a prefix match reads `abort`
as an allow. Blank line, EOF and any unrecognised word deny, so the safe answer
is the one a user gets by doing nothing.

Every decision is SEL-logged before the matching transport call, so a transport
failure cannot erase a decision already made. The audited `error` is a stable
code (`hook_deny`, 
oninteractive`, `user_denied`, `session_aborted`), never
the gate's reason: a reason names the path it protects, and
`log_tool_invocation` does not redact for its callers.

### Governing the real MCP tool

`HookManager.on_tool_call` takes the display title as `tool_name`, and
`select_tool_title` prefers the model's prose `description` — so an MCP call
arrives titled "Check the forecast" rather than `mcp__weather:srv__wipe_disk`.
The trusted `_meta.kiro` server and tool names were reconstructed into a
canonical name only inside the first-party app-own-server auto-approve, so a
per-tool ceiling rule missed an ordinary MCP call, which then reached the human
prompt where an "allow" runs a tool the ceiling forbids.

The gate now builds `mcp__<server>__<tool>` once on the common path when both
trusted fields are present, and evaluates it in the effective deny set and the
governance ceiling **in addition to** the title and raw command. The two are not
competing spellings of one fact: the canonical name is the trusted,
non-model-authored statement of *which tool* is invoked and is what a per-tool
rule matches, while the title and raw command carry the path, command and
content signals that a tool identity does not express. Each covers a security
dimension the other cannot, so a deny on either denies the call. With
enforcement on the common path the own-server auto-approve no longer repeats
those two checks — one copy to keep in step instead of two — and what it still
requires is the complete identity.

When the backend proves the **server but not the tool** (no
`_meta.kiro.toolName`, or an uncached permission event), governance is asked
about `mcp__<server>` instead. That is a complete question for that plane and
only that plane: `mcp_title_to_ref` maps it to `@server` and an `@server` rule
covers every tool beneath it, so a `deny @github` ceiling binds on a call whose
tool cannot be named — without it governance sees the model-authored title alone
and a human is asked to approve a server the policy forbids. It is deliberately
NOT added to the deny-floor targets, which match raw text and operator regexes
where `mcp__<server>` is a different string from the canonical identity a rule
is written against rather than a broader form of it. A server-only identity can
never satisfy the own-server auto-approve; once governance permits it, an
incomplete tool identity falls through to interactive approval.

### What the human is shown

A shell call shows its command — redacted, collapsed to one line, capped —
because approving on a title alone is consent to a description rather than to
what runs. Local paths are deliberately not redacted there: this is the
operator's own terminal, and seeing the real path is part of the consent.

Every untrusted string the permission UI prints also has terminal controls
neutralised: ESC, C0 (`U+0000`–`U+001F`), DEL (`U+007F`) and C1
(`U+0080`–`U+009F`) and lone surrogates (`U+D800`–`U+DFFF`) become spaces before whitespace collapses. The result is made representable in the destination stream codec with `backslashreplace`, so strict UTF-8 and legacy Windows codepages cannot strand the request. This is an
authorization surface — OSC 52 writes the clipboard and CSI can move the cursor
and erase what is drawn, so a model-authored title could otherwise repaint the
question a human is answering and hide what is being approved.

Authorization-boundary failures are also refusals: if the security gate, TTY detection, prompt rendering/reading, or critical audit fails, the CLI best-effort audits the stable failure code and explicitly rejects the tool before rendering any explanatory notice. Cancellation retains the teardown contract below.

## stdin and cancellation contract

The prompt is read on an owned daemon thread through a private duplicate of the
stdin descriptor. Four things were measured rather than reasoned about. A read
on the loop thread freezes it while the ACP runtime holds reader and drain tasks
on the backend's pipes. `asyncio.to_thread` wedges the interpreter, because
`asyncio.run` joins default-executor workers at shutdown. A thread parked inside
`sys.stdin` holds a buffer lock whose acquisition failure aborts the process.
And a blocking terminal read cannot be retracted at all: an abandoned reader
consumes a line typed *after* the cancellation completed and silently discards
it.

So a cancelled prompt does not leave a recoverable session. It poisons stdin and
propagates; every later entry point — a second permission prompt and the REPL's
own read alike — refuses rather than racing the abandoned reader for keystrokes.
Teardown does not answer the backend: `CancelledError` has already been raised
once with nothing to re-deliver it, so awaiting a wedged `reject_tool` would
leave the Ctrl-C that asked for the teardown unable to land.

The unanswered request dies with the provider, and that is a guarantee rather
than an expectation: `provider.start()` hands back a live backend process, so
`_chat` runs the whole message/REPL lifecycle under `try` and calls
`provider.shutdown()` from `finally`. Normal return, exception and cancellation
all tear the backend down; otherwise a Ctrl-C at the prompt would exit leaving it
running with nothing owning it. Cleanup never swallows the cancellation — a
failing `shutdown()` is logged rather than raised, since replacing the
propagating exception would discard the very `CancelledError` the teardown
exists to clean up after — and `gc.collect()` is nested in its own `finally` so
a raising shutdown cannot skip it.

Because the prompt and the audit line call the redactors, `cli_chat` is
classified in `NON_EGRESS_REDACTION_MODULES` with its reason. Neither crosses a
machine boundary — the prompt is the operator's own terminal and the audit line
is the local SEL log — so it is not a `redaction_paths` egress sink. The drift
guard in `test_security_posture` requires every redactor call site to be one or
the other, which is what makes "every output path" an honest claim.

### Direct ACP event parity

The legacy/direct `AcpClient` path now reuses the shared permission-event builder. Cached non-shell classifications are explicitly authoritative, cached structured parameters remain trusted across repeated prompts, and an inline cache miss stays fail-closed. This prevents normal non-shell tools from being rejected before the CLI prompt while preserving the security boundary.

## Tests

`TestChatPermissionRequest` (42 cases) drives the real `_send_and_print`
against a provider whose stream cannot finish until the request is answered,
and against a real `HookManager` — not a stub returning the verdict the test
wants. It includes the wiring guard that a `permission_request` carrying the
trusted `_meta.kiro` fields reaches the gate as those fields, so a governance
rule naming the canonical tool rejects the call without ever asking the human;
and four consent-surface cases: OSC 52 and CSI titles cannot put ESC or BEL on
the terminal, control characters in a command are neutralised inside its
existing collapse/truncate contract, and ordinary text displays unchanged.

`TestChatProviderShutdown` (4 cases) pins the teardown at the caller: return,
exception, cancellation, and a raising `shutdown()` that must not skip
`gc.collect()` or mask the propagating `CancelledError`.

`TestCanonicalMcpIdentityGoverned` (6 cases) covers the gate: governance and the
effective deny set each denying a canonical name behind a benign prose title, a
partial identity governing the server rather than synthesising a malformed name,
a non-MCP call unchanged, and two preservation cases holding the title and
raw-command floor active with governance permitting everything.

`TestServerLevelGovernanceBindsOnPartialIdentity` (5 cases) drives the REAL
policy engine rather than a stubbed `_governance_denial`, because what is at
stake is whether the raw target this gate emits is one the `mcp` matcher can
bind a server-level rule to: the regression itself, the same rule still binding
on a full identity, a tool-level rule NOT widening to the whole server, an
ungoverned server not denied, and the server-only form staying out of the deny
regex plane.

Mutation-verified. The original 15 each caught: skipping the gate, gating on the
title only, auditing after the transport, copying the raw reason into the audit,
auditing the model-authored title, prefix-matching, re-adding persistent
approval, dropping the non-interactive denial, reading on the loop thread,
dropping the poison flag, unguarding the REPL, awaiting the backend during
teardown, and hiding or failing to sanitise the command. Four more for the
checks above: dropping the canonical name from the gate fails the two new
regressions *and* the two pre-existing own-server tests, so removing the
duplicated enforcement lost no coverage; substituting it for the title lets a
`~/.aws/credentials` read reach auto-approve; not forwarding
`mcp_server_name` leaves only the title at the gate; and removing the `try` /
`finally` or un-nesting `gc.collect()` each drop the teardown.

Latest validation on this head: post-rebase permission/direct-AcpClient regression passed 78 tests with 2 platform skips; the broader final audit passed 231 tests with 7 skips; the complete CLI suite previously passed 340 tests with 14 skipped; Black baseline, isort, flake8, production mypy, subprocess-encoding, harness parity, and diff-check passed.

## Out of scope

Ordinary streamed model output (`EVENT_TEXT_CHUNK`) is printed raw and is
unchanged here. Terminal-control handling for general model output is a
surface-wide rendering question, not part of answering a permission request —
this PR does not claim to have fixed terminal injection in the CLI, only that
the untrusted display text on the authorization prompt is neutralised.

Fixes #1666


