### PR TITLE
fix(cron): run a just-created job instead of 404ing for up to 30s

### DIFF
--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -474,8 +474,14 @@ async def api_cron_run(request: web.Request) -> web.Response:
     """POST /api/crons/{id}/run — trigger immediate execution."""
     state: DashboardState = request.app["state"]
     job_id = request.match_info["job_id"]
-    jobs = state.crons.list_jobs(include_disabled=True)
-    job = next((j for j in jobs if j.id == job_id), None)
+    # Freshness-guaranteed lookup: this endpoint is handed a job id minted by
+    # ANOTHER process (`kirocrew cron add`, the MCP cron_add tool), which writes
+    # crons.json directly. The cache-only `list_jobs()` would not see that job
+    # until the timer tick refreshes the in-memory snapshot (≤_TIMER_POLL_SECS),
+    # so triggering a just-created job 404'd for up to that long. Same rationale
+    # as the GET handler below; the read runs in a worker thread, so the loop is
+    # not blocked.
+    job = await state.crons.get_job_async(job_id)
     if not job:
         return web.json_response({"error": "job not found"}, status=404)
     # Reject if a run is already in flight. Overwriting _running_tasks[job_id]
@@ -483,7 +489,9 @@ async def api_cron_run(request: web.Request) -> web.Response:
     # tracked/cancelled/joined) and allow overlapping duplicate runs. The
     # check-and-set below is atomic: there is no await between the guard and the
     # assignment, so the single-threaded event loop cannot interleave a second
-    # request into this critical section.
+    # request into this critical section. (The lookup above awaits, so two
+    # concurrent requests can both reach the guard — but only one can pass it,
+    # because the guard and the assignment are not separated by an await.)
     if job_id in state.crons._running_tasks or state.crons.is_running(job_id):
         return web.json_response({"error": "job is already running"}, status=409)
     task = asyncio.create_task(state.crons.run_job(job_id))  # type: ignore[arg-type]

--- a/test/test_dashboard_cron_run_guard.py
+++ b/test/test_dashboard_cron_run_guard.py
@@ -8,6 +8,7 @@ must reject with 409 when a run is already in flight.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock
 
@@ -39,7 +40,13 @@ def _make_app(state) -> web.Application:
 def _make_state(job: CronJob | None, *, is_running: bool = False, running_tasks=None):
     state = MagicMock()
     state.crons = MagicMock()
-    state.crons.list_jobs.return_value = [job] if job else []
+    # The handler resolves the job through the freshness-guaranteed async form so
+    # a job written by another process (CLI / MCP `cron add`) is visible
+    # immediately. `list_jobs` is left mocked as an EMPTY cache on purpose: if the
+    # handler ever regresses to the cache-only lookup, every test here goes red
+    # rather than silently passing against a stale snapshot.
+    state.crons.list_jobs.return_value = []
+    state.crons.get_job_async = AsyncMock(return_value=job)
     state.crons.is_running.return_value = is_running
     state.crons._running_tasks = running_tasks if running_tasks is not None else {}
     state.crons.run_job = AsyncMock(return_value=True)
@@ -88,3 +95,52 @@ class TestApiCronRun:
         # The previously-running task reference must be preserved untouched.
         assert state.crons._running_tasks["j1"] is prior
         state.crons.run_job.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_run_finds_job_absent_from_the_cache_only_snapshot(self) -> None:
+        """A job created by another process must be runnable immediately.
+
+        `kirocrew cron add` and the MCP cron_add tool write crons.json from a
+        separate process. The gateway's in-memory snapshot only picks that up on
+        its timer tick, so resolving the id through the cache-only `list_jobs()`
+        made this endpoint 404 for up to _TIMER_POLL_SECS after creation. The
+        handler must use the freshness-guaranteed lookup instead.
+        """
+        state = _make_state(_make_job("just-created"))
+        # Explicitly model the stale gateway: the cache does not contain it yet.
+        state.crons.list_jobs.return_value = []
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/crons/just-created/run")
+            assert resp.status == 200
+        state.crons.get_job_async.assert_awaited_once_with("just-created")
+        state.crons.run_job.assert_called_once_with("just-created")
+
+    @pytest.mark.asyncio
+    async def test_concurrent_runs_still_yield_one_200_and_one_409(self) -> None:
+        """The added await must not weaken the check-and-set guard.
+
+        Resolving the job is now asynchronous, so two concurrent requests can
+        both get past the lookup — where previously the handler ran straight
+        through to the guard without suspending. Only one may still start a run,
+        because the guard and the `_running_tasks` assignment are not separated
+        by an await.
+        """
+        gate = asyncio.Event()
+
+        async def _blocked_run(_job_id: str) -> bool:
+            await gate.wait()
+            return True
+
+        state = _make_state(_make_job("j1"))
+        state.crons.run_job = AsyncMock(side_effect=_blocked_run)
+        try:
+            async with TestClient(TestServer(_make_app(state))) as client:
+                first, second = await asyncio.gather(
+                    client.post("/api/crons/j1/run"),
+                    client.post("/api/crons/j1/run"),
+                )
+                assert sorted([first.status, second.status]) == [200, 409]
+        finally:
+            gate.set()
+        # Exactly one run was started despite both requests passing the lookup.
+        state.crons.run_job.assert_called_once_with("j1")


### PR DESCRIPTION
## Problem

Trigger a cron job you have just created and it returns `404 job not found` —
for up to 30 seconds — even though the job exists.

Reproducible from either external creation path:

```
kirocrew cron add --name probe --every 3600 --message hi   # or the MCP cron_add tool
kirocrew cron trigger <the id it printed>                  # -> "Job not found: <id>"
# wait ~30s, run the same command again                    -> works
```

## Why it matters

The message is actively misleading: it says the job does not exist, when the
truth is "the gateway has not synced it yet". The natural reaction is to assume
creation silently failed and create it again — so the honest failure mode here is
duplicate cron jobs. It also breaks the obvious create-then-verify workflow, both
by hand and from a script.

## Fix (symptom → root cause → change)

**Symptom:** a just-created job is untriggerable, then starts working on its own.

**Root cause:** the handler resolved the job from the in-memory snapshot, which
by design never reads disk:

```
src/kiro_crew/dashboard/handlers/cron.py:477:    jobs = state.crons.list_jobs(include_disabled=True)
src/kiro_crew/dashboard/handlers/cron.py:478:    job = next((j for j in jobs if j.id == job_id), None)
```

`list_jobs`' own docstring (`src/kiro_crew/cron.py:1933`) says *"CACHE-ONLY,
never touches disk"* and states that cross-process freshness is maintained off
the loop by the timer tick. That tick is `_TIMER_POLL_SECS = 30`
(`src/kiro_crew/cron.py:112`). Both `kirocrew cron add` and the MCP `cron_add`
tool write `crons.json` from a **different process**, so their job is invisible
to this handler until the next tick — hence a 404 window of up to 30s.

**Change:** resolve through `get_job_async()`, which exists for exactly this
case — *"for the rare loop-side caller that must observe a write made by another
process (CLI/MCP) right now"* (`src/kiro_crew/cron.py:2039`). It offloads the
locked sync to a worker via `asyncio.to_thread`, so the event loop is not blocked
and the `no-blocking-call-on-event-loop` rule still holds. The GET handler in
this same file already made this switch (`handlers/cron.py:900`), with a comment
noting the other mutation handlers stayed on the cache-only read.

`get_job_async` snapshots with `include_disabled=True` internally, so a disabled
job remains triggerable exactly as before — no behaviour change there.

### Two things deliberately not changed

**Scope is this handler only.** `api_cron_cancel` and `api_cron_to_chat` also use
the cache-only lookup, but they act on a run already in flight *in this process*:
`cancel()` returns early on `if job_id not in self._executing`, and `_executing`
is loop-owned in-process state, so a job absent from the cache cannot be in it. A
fresh lookup there would only convert a 404 into a 409 — the same refusal.

**The atomicity invariant the handler documents is preserved.** The lookup is now
a suspension point where the handler previously ran straight through, so two
concurrent requests can both reach the already-running guard. Only one can pass
it, because the guard and the `_running_tasks` assignment are still not separated
by an await. The existing comment is extended to say so, and a new test pins it.

## Tests

`test/test_dashboard_cron_run_guard.py` — the file that already covers this
endpoint's 409 guard.

| Test | Locks in |
|---|---|
| `test_run_finds_job_absent_from_the_cache_only_snapshot` | a job missing from the stale snapshot returns 200, not 404 — the actual bug |
| `test_concurrent_runs_still_yield_one_200_and_one_409` | the added await did not weaken the check-and-set guard; exactly one run starts |
| existing 200 / 404 / 409 / no-clobber cases | unchanged behaviour on the paths that already worked |

The shared `_make_state` fixture now pins `list_jobs.return_value = []` on
purpose, modelling a stale gateway: if this handler ever regresses to the
cache-only lookup, every test in the class goes red instead of quietly passing
against a snapshot that happens to contain the job.

Verified non-tautological: **5 of the 6 fail** against the previous handler (the
survivor is the unknown-job 404, which is correct either way).

## Manual verification

Reproduced the original 404 window by the CLI path quoted under Problem —
`cron add` then an immediate `cron trigger` returns "Job not found", and the same
command succeeds after the tick. This is the behaviour the new test now covers at
unit level.

Gates run locally: `isort`, `flake8` clean; `mypy src/kiro_crew/` reports only 3
pre-existing `os.*xattr` errors in `hooks.py` (Linux-only attributes that macOS
mypy flags — identical count on unmodified `origin/main`); 185 passed across
`test_dashboard_cron_run_guard`, `test_cron`, `test_cron_cancel`,
`test_handler_cron_list`, `test_cron_gateway_integration`,
`test_dashboard_cron_to_chat_handler`, `test_cron_locking_regression`,
`test_cron_count_from_disk`. One failure in that set —
`test_cron_cancel.py::TestSubprocessRegistry::test_run_command_sandboxed_can_be_cancelled_mid_run`
— fails identically with this change reverted, so it is pre-existing and
unrelated (sandboxed subprocess cancellation, not this endpoint).

## Screenshots

N/A — no user-visible UI change. The fix is a single lookup call in a REST
handler; nothing rendered changes.
