### PR TITLE
fix(mcp-gateway): detect dead stub transports so their backends can be reclaimed

### DIFF
--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -826,10 +826,18 @@ async def _heartbeat_sweeper(
     stop_event: asyncio.Event,
     backends_pidfile: Optional[Path] = None,
 ) -> None:
-    """Probe every pooled backend's liveness once per ``interval`` and recycle
-    any that are gone or wedged, until ``stop_event`` is set.
+    """Probe stub transports and every pooled backend once per ``interval``,
+    until ``stop_event`` is set.
 
-    For each backend, :meth:`Backend._heartbeat_once` classifies it:
+    Two independent responsibilities, in this order:
+
+    1. **Stub transports** (:func:`_probe_stub_transports`) -- write a keepalive
+       to every live stub connection. A half-open transport is invisible to the
+       parked reader and surfaces only on a write, so without this probe a stub
+       that died mid-session never detaches and its backend's refcount never
+       reaches 0 -- putting it permanently out of reach of the idle sweep. A
+       failed write cancels that stub's handler, whose teardown detaches it.
+    2. **Backends** -- :meth:`Backend._heartbeat_once` classifies each one:
 
     * ``"gone"`` / ``"wedged"`` -- the classify call has already errored every
       attached stub (via ``_broadcast_backend_gone``); the sweeper evicts the
@@ -851,6 +859,14 @@ async def _heartbeat_sweeper(
                 pass
             try:
                 now = time.monotonic()
+                # Probe stub transports FIRST. A dead stub detected here
+                # detaches on this same sweep, so the backend sweep below and
+                # the idle sweep see the corrected refcount immediately rather
+                # than one interval late.
+                try:
+                    await _probe_stub_transports()
+                except Exception:  # pragma: no cover — defensive
+                    logger.exception("stub transport probe crashed")
                 for key, backend in await pool.snapshot():
                     try:
                         state = await backend._heartbeat_once(now)
@@ -1227,6 +1243,123 @@ class _StubConn:
 #: without usable PIDs (old stubs) are simply not indexed — they keep the
 #: recaller-poll fallback.
 _CONN_INDEX: dict[int, set[_StubConn]] = {}
+
+# --- Stub-connection liveness probe -----------------------------------------
+#
+# A stub whose transport dies without a clean close leaves its connection
+# handler parked in ``reader.readuntil()``. The handler's ``finally`` — which
+# owns ``detach_stub`` — therefore never runs, the backend's refcount never
+# drops, and the idle sweep (which keys on ``refcount == 0``) can never reclaim
+# it. Backends then accumulate for the lifetime of the daemon.
+#
+# The asymmetry that makes this possible: a half-open transport is INVISIBLE to
+# a reader and only observable on a WRITE. An idle session performs no writes,
+# so the death has no way to surface. ``_drain_inbox_to_stub`` already handles
+# the write error correctly — it simply never gets a frame to write.
+#
+# So the gateway writes one itself. Each sweep sends a reserved control frame
+# to every live stub; a dead transport fails that write, and the handler is
+# cancelled so its existing teardown runs. Reclamation then follows the normal
+# refcount path — detach -> refcount 0 -> idle eviction — rather than a
+# separate garbage-collection concept layered on top of it.
+#
+# This mirrors the gateway<->backend direction, which has carried a heartbeat
+# under a reserved id since pooling landed. The gateway<->stub direction was
+# the half without one.
+#
+# Reserved ``type`` field, matching the existing ``ping``/``pong`` control
+# frames. The stub consumes it in its gateway->stdout pump and never forwards
+# it to kiro-cli. An older stub that does not know the frame passes it through,
+# where it is inert: it carries no ``jsonrpc``/``id``/``method``, so an MCP
+# client has nothing to dispatch on — the same graceful-degradation property
+# the ``pong`` frame already relies on.
+STUB_KEEPALIVE_TYPE = "keepalive"
+
+#: Bound on a single keepalive write+drain. A stub that has stopped reading
+#: must not pin the sweeper: the drain pump uses the same bound for the same
+#: reason. Exceeding it is treated as a dead transport.
+_STUB_KEEPALIVE_TIMEOUT_SECS = 5.0
+
+
+class _StubProbe:
+    """A live stub connection's write handle plus its owning handler task.
+
+    Registered for the full lifetime of the connection handler and removed in
+    the same ``finally`` that detaches the stub, so the registry can never
+    outlive the attachment it describes.
+    """
+
+    __slots__ = ("stub_uuid", "writer", "task")
+
+    def __init__(
+        self,
+        stub_uuid: str,
+        writer: asyncio.StreamWriter,
+        task: "asyncio.Task[None]",
+    ) -> None:
+        self.stub_uuid = stub_uuid
+        self.writer = writer
+        self.task = task
+
+
+#: Every live stub connection, keyed by identity of the probe record. A set of
+#: records (not a dict keyed by stub_uuid) because a reconnecting stub may
+#: briefly overlap with its predecessor, and clobbering the old entry would
+#: leak the very handler the probe exists to tear down.
+_STUB_PROBES: set[_StubProbe] = set()
+
+
+def _stub_probe_add(probe: _StubProbe) -> None:
+    _STUB_PROBES.add(probe)
+
+
+def _stub_probe_discard(probe: _StubProbe) -> None:
+    _STUB_PROBES.discard(probe)
+
+
+async def _probe_stub_transports() -> int:
+    """Write a keepalive to every live stub; cancel the handler of any that
+    fails. Returns the number of dead transports found.
+
+    The write is the entire point: it converts a silently half-open transport
+    into an observable error. Cancelling the handler is what makes the existing
+    teardown run — this function deliberately does NOT touch refcounts or the
+    pool itself, so there is exactly one code path that detaches a stub.
+
+    Never raises: a probe failure must not take down the sweeper.
+    """
+    payload = json.dumps({"type": STUB_KEEPALIVE_TYPE}).encode() + b"\n"
+    dead = 0
+    for probe in list(_STUB_PROBES):
+        if probe.task.done():
+            # Handler already exiting; its finally owns the teardown.
+            continue
+        lock = getattr(probe.writer, "_mc_write_lock", None)
+        guard: Any = lock if lock is not None else contextlib.nullcontext()
+        try:
+            with _counted_stub_write():
+                async with guard:
+                    probe.writer.write(payload)
+                    await asyncio.wait_for(
+                        probe.writer.drain(),
+                        timeout=_STUB_KEEPALIVE_TIMEOUT_SECS,
+                    )
+        except (ConnectionError, BrokenPipeError, asyncio.TimeoutError) as exc:
+            dead += 1
+            logger.info(
+                "stub %s: transport dead on keepalive (%s) — cancelling handler "
+                "so the stub detaches and its backend can be reclaimed",
+                probe.stub_uuid or "unknown",
+                type(exc).__name__,
+            )
+            probe.task.cancel()
+        except Exception:  # pragma: no cover — defensive
+            logger.warning(
+                "stub %s: keepalive probe raised unexpectedly",
+                probe.stub_uuid or "unknown",
+                exc_info=True,
+            )
+    return dead
 
 
 def _register_pids(register: dict[str, Any]) -> list[int]:
@@ -1813,6 +1946,15 @@ async def _handle_connection(
     conn = _StubConn(stub_uuid, indexed_pids, pool_key.human_readable(), caller)
     _conn_index_add(conn)
 
+    # Register this connection for the keepalive probe. Scoped to the handler's
+    # own task so a dead transport can cancel exactly the coroutine that is
+    # parked on the read, letting its finally run the detach.
+    _probe: Optional[_StubProbe] = None
+    _self_task = asyncio.current_task()
+    if _self_task is not None:
+        _probe = _StubProbe(stub_uuid, writer, _self_task)
+        _stub_probe_add(_probe)
+
     # Provisional backend_id: the real pid isn't known until the backend
     # spawns. Using the pool digest gives operators a stable grep key that
     # ties together every stub sharing the same backend even before spawn.
@@ -2206,6 +2348,8 @@ async def _handle_connection(
                 return
     finally:
         _conn_index_discard(conn)
+        if _probe is not None:
+            _stub_probe_discard(_probe)
         if backend is not None:
             # Scope A: before detaching, cancel any in-flight tool calls this
             # stub owned — the backend would otherwise run them to completion

--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -60,6 +60,13 @@ _BRIDGE_PING_TYPE = "ping"
 # would reproduce the defect it exists to fix.
 _ERROR_EMIT_TIMEOUT_SECS = 5.0
 _BRIDGE_PONG_TYPE = "pong"
+# Reserved type for the gateway->stub keepalive control frame. The gateway
+# writes one to every live stub each heartbeat sweep so that a half-open
+# transport — which a parked reader cannot observe — fails an actual write and
+# becomes detectable. It carries no payload and expects no reply: the write
+# succeeding or failing IS the signal, and it is consumed here rather than
+# forwarded, exactly like the pong frame above.
+_BRIDGE_KEEPALIVE_TYPE = "keepalive"
 # Pre-flight ``ensure_backend`` reply timeout. Must comfortably
 # exceed cold backend fork latency. On timeout the stub falls back to a
 # direct per-session exec, so an over-generous value only costs a slower
@@ -730,24 +737,32 @@ async def run_bridge(
                     return
                 if not line:
                     return
-                # Intercept pong control frames (gateway liveness reply) and
-                # track response IDs to clear outstanding requests.
+                # Intercept control frames (gateway liveness reply, gateway
+                # keepalive) and track response IDs to clear outstanding
+                # requests.
                 # Best-effort: parse failures pass the line through verbatim.
-                _is_pong = False
+                _is_control = False
                 try:
                     msg = json.loads(line)
                     if isinstance(msg, dict):
-                        if msg.get("type") == _BRIDGE_PONG_TYPE:
+                        _mtype = msg.get("type")
+                        if _mtype == _BRIDGE_PONG_TYPE:
                             _pong_received.set()
-                            _is_pong = True
+                            _is_control = True
+                        elif _mtype == _BRIDGE_KEEPALIVE_TYPE:
+                            # Gateway-side transport probe. Nothing to do: the
+                            # gateway learns what it needs from whether the
+                            # write succeeded. Swallow it.
+                            _is_control = True
                         elif "id" in msg and "method" not in msg:
                             # A response (has id, no method) — clear from
                             # outstanding set.
                             _outstanding_ids.discard(msg["id"])
                 except (json.JSONDecodeError, ValueError, TypeError):
                     pass
-                # Pong is a control frame; never forward to kiro-cli stdout.
-                if _is_pong:
+                # Control frames are gateway<->stub only; never forward to
+                # kiro-cli stdout.
+                if _is_control:
                     continue
                 try:
                     await _emit(line)

--- a/test/test_mcp_gateway_stub_keepalive.py
+++ b/test/test_mcp_gateway_stub_keepalive.py
@@ -1,0 +1,288 @@
+"""Gateway->stub keepalive transport probe (issue #1574).
+
+A stub whose transport dies without a clean close leaves its connection handler
+parked in ``reader.readuntil()``, so the ``finally`` that owns ``detach_stub``
+never runs and the backend's refcount never reaches 0 -- putting the backend
+permanently out of reach of the idle sweep.
+
+A half-open transport is invisible to a reader and observable only on a write,
+and an idle session performs no writes. These tests cover the probe that
+supplies that write, and assert the two properties that matter:
+
+* a dead transport cancels exactly its own handler task (so the existing
+  teardown runs and the stub detaches), and
+* a live transport is left completely alone.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+from kiro_crew.mcp_gateway import gatewayd as gw
+
+
+def _run(coro):
+    """Run an async test body without pytest-asyncio."""
+    return asyncio.run(coro)
+
+
+class _FakeWriter:
+    """StreamWriter double that records writes and can fail on drain."""
+
+    def __init__(self, *, fail: Optional[BaseException] = None) -> None:
+        self.writes: list[bytes] = []
+        self._fail = fail
+        self.drains = 0
+
+    def write(self, payload: bytes) -> None:
+        self.writes.append(payload)
+
+    async def drain(self) -> None:
+        self.drains += 1
+        if self._fail is not None:
+            raise self._fail
+
+
+async def _park() -> None:
+    """Stand in for a handler parked on a read that will never return."""
+    await asyncio.Event().wait()
+
+
+def _clear_registry() -> None:
+    gw._STUB_PROBES.clear()
+
+
+# --- dead transport -> handler cancelled ------------------------------------
+
+
+def test_dead_transport_cancels_its_handler() -> None:
+    """A write failure means the peer is gone. The probe cancels that stub's
+    handler so the handler's finally can run detach_stub."""
+
+    async def _inner():
+        _clear_registry()
+        task = asyncio.create_task(_park())
+        await asyncio.sleep(0)
+        writer = _FakeWriter(fail=BrokenPipeError("client closed"))
+        gw._stub_probe_add(gw._StubProbe("stub-dead", writer, task))  # type: ignore[arg-type]
+
+        dead = await gw._probe_stub_transports()
+
+        assert dead == 1
+        # Let the cancellation land, then confirm the handler is finished --
+        # that is what runs the teardown in the real handler.
+        await asyncio.sleep(0)
+        assert task.done()
+        assert task.cancelled()
+        _clear_registry()
+
+    _run(_inner())
+
+
+def test_connection_error_also_counts_as_dead() -> None:
+    """ConnectionError (not just BrokenPipeError) is a dead transport."""
+
+    async def _inner():
+        _clear_registry()
+        task = asyncio.create_task(_park())
+        await asyncio.sleep(0)
+        writer = _FakeWriter(fail=ConnectionResetError("reset"))
+        gw._stub_probe_add(gw._StubProbe("stub-reset", writer, task))  # type: ignore[arg-type]
+
+        assert await gw._probe_stub_transports() == 1
+        await asyncio.sleep(0)
+        assert task.done()
+        _clear_registry()
+
+    _run(_inner())
+
+
+def test_drain_timeout_counts_as_dead() -> None:
+    """A stub that accepts the write but never drains is treated as dead: it
+    must not pin the sweeper, matching the drain pump's own bound."""
+
+    async def _inner():
+        _clear_registry()
+        task = asyncio.create_task(_park())
+        await asyncio.sleep(0)
+
+        class _HangingWriter(_FakeWriter):
+            async def drain(self) -> None:
+                await asyncio.sleep(3600)
+
+        writer = _HangingWriter()
+        gw._stub_probe_add(gw._StubProbe("stub-hang", writer, task))  # type: ignore[arg-type]
+
+        # Shrink the bound so the test does not wait the production timeout.
+        original = gw._STUB_KEEPALIVE_TIMEOUT_SECS
+        gw._STUB_KEEPALIVE_TIMEOUT_SECS = 0.01
+        try:
+            assert await gw._probe_stub_transports() == 1
+        finally:
+            gw._STUB_KEEPALIVE_TIMEOUT_SECS = original
+        await asyncio.sleep(0)
+        assert task.done()
+        _clear_registry()
+
+    _run(_inner())
+
+
+# --- live transport -> untouched --------------------------------------------
+
+
+def test_live_transport_is_left_alone() -> None:
+    """A healthy stub is not cancelled, and receives exactly one keepalive."""
+
+    async def _inner():
+        _clear_registry()
+        task = asyncio.create_task(_park())
+        await asyncio.sleep(0)
+        writer = _FakeWriter()
+        gw._stub_probe_add(gw._StubProbe("stub-live", writer, task))  # type: ignore[arg-type]
+
+        assert await gw._probe_stub_transports() == 0
+        assert not task.done()
+        assert len(writer.writes) == 1
+        assert writer.drains == 1
+
+        task.cancel()
+        _clear_registry()
+
+    _run(_inner())
+
+
+def test_keepalive_frame_is_the_reserved_control_type() -> None:
+    """The probe writes a single newline-terminated reserved control frame.
+
+    Shape matters: the stub consumes it by ``type``, and it deliberately
+    carries no ``jsonrpc``/``id``/``method`` so that an older stub which
+    forwards it hands an MCP client nothing to dispatch on.
+    """
+
+    async def _inner():
+        _clear_registry()
+        task = asyncio.create_task(_park())
+        await asyncio.sleep(0)
+        writer = _FakeWriter()
+        gw._stub_probe_add(gw._StubProbe("stub-shape", writer, task))  # type: ignore[arg-type]
+
+        await gw._probe_stub_transports()
+
+        raw = writer.writes[0]
+        assert raw.endswith(b"\n")
+        frame = json.loads(raw)
+        assert frame == {"type": gw.STUB_KEEPALIVE_TYPE}
+        assert "jsonrpc" not in frame and "id" not in frame and "method" not in frame
+
+        task.cancel()
+        _clear_registry()
+
+    _run(_inner())
+
+
+def test_already_finished_handler_is_skipped() -> None:
+    """A handler that is already exiting owns its own teardown; the probe must
+    not write to it or double-cancel."""
+
+    async def _inner():
+        _clear_registry()
+
+        async def _done() -> None:
+            return None
+
+        task = asyncio.create_task(_done())
+        await task
+        writer = _FakeWriter(fail=BrokenPipeError("would fail if written"))
+        gw._stub_probe_add(gw._StubProbe("stub-gone", writer, task))  # type: ignore[arg-type]
+
+        assert await gw._probe_stub_transports() == 0
+        assert writer.writes == []
+        _clear_registry()
+
+    _run(_inner())
+
+
+def test_one_dead_stub_does_not_stop_the_sweep() -> None:
+    """Probing is per-connection: a dead stub must not prevent the live ones
+    behind it in the iteration from being probed."""
+
+    async def _inner():
+        _clear_registry()
+        dead_task = asyncio.create_task(_park())
+        live_task = asyncio.create_task(_park())
+        await asyncio.sleep(0)
+        dead_writer = _FakeWriter(fail=BrokenPipeError("gone"))
+        live_writer = _FakeWriter()
+        gw._stub_probe_add(gw._StubProbe("stub-a", dead_writer, dead_task))  # type: ignore[arg-type]
+        gw._stub_probe_add(gw._StubProbe("stub-b", live_writer, live_task))  # type: ignore[arg-type]
+
+        assert await gw._probe_stub_transports() == 1
+        # The live stub was still probed.
+        assert len(live_writer.writes) == 1
+        assert not live_task.done()
+
+        live_task.cancel()
+        _clear_registry()
+
+    _run(_inner())
+
+
+def test_unexpected_exception_does_not_cancel_or_crash() -> None:
+    """An unexpected error is not evidence of a dead peer, so the handler is
+    left running rather than being torn down on a guess."""
+
+    async def _inner():
+        _clear_registry()
+        task = asyncio.create_task(_park())
+        await asyncio.sleep(0)
+
+        class _OddWriter(_FakeWriter):
+            def write(self, payload: bytes) -> None:
+                raise RuntimeError("unexpected")
+
+        gw._stub_probe_add(gw._StubProbe("stub-odd", _OddWriter(), task))  # type: ignore[arg-type]
+
+        assert await gw._probe_stub_transports() == 0
+        assert not task.done()
+
+        task.cancel()
+        _clear_registry()
+
+    _run(_inner())
+
+
+# --- registry lifetime ------------------------------------------------------
+
+
+def test_registry_add_and_discard() -> None:
+    """Discard is idempotent: the handler's finally may run after the probe has
+    already observed the connection."""
+    _clear_registry()
+    writer: Any = _FakeWriter()
+    task: Any = MagicMock()
+    probe = gw._StubProbe("stub-x", writer, task)
+
+    gw._stub_probe_add(probe)
+    assert probe in gw._STUB_PROBES
+    gw._stub_probe_discard(probe)
+    assert probe not in gw._STUB_PROBES
+    gw._stub_probe_discard(probe)  # idempotent
+    _clear_registry()
+
+
+def test_two_connections_for_one_stub_uuid_both_tracked() -> None:
+    """A reconnecting stub can briefly overlap with its predecessor. Both
+    records must be tracked, or the probe loses the stale handler it exists to
+    tear down."""
+    _clear_registry()
+    writer: Any = _FakeWriter()
+    old = gw._StubProbe("same-uuid", writer, MagicMock())
+    new = gw._StubProbe("same-uuid", writer, MagicMock())
+
+    gw._stub_probe_add(old)
+    gw._stub_probe_add(new)
+    assert len(gw._STUB_PROBES) == 2
+    _clear_registry()


### PR DESCRIPTION
## What is the problem?

MCP backend processes accumulate for the lifetime of the daemon. On one Windows host, **30 backends were live after 6.5 hours** (10 each of `core`/`cron`/`computer`, against an expected 3-4), holding **~3.5 GB and 394 threads**.

The consequence is not just waste. Once the daemon's thread/handle budget is exhausted, unrelated child processes fail to start — which surfaces to the user as `getaddrinfo() thread failed to start` from a plain `git fetch` during a Dev Fleet Pull + Build.

## Why this issue matters to the user

The only recovery today is a full gateway restart, and the symptom appears far from the cause: the user sees a git operation fail and has no way to connect that to MCP pooling. It also degrades progressively, so a long-running session gets slower and less reliable the longer it stays up.

## Fix: symptom → root cause → change

### Root cause — refcount never drops, so the backend becomes unreachable

`_handle_connection`'s `finally` block **already owns the correct teardown**: it cancels the stub's in-flight requests and calls `detach_stub`. It simply never runs. The handler is parked in `reader.readuntil()` on the stub transport, and when a stub dies without a clean close that read never returns:

```
read never returns → finally never runs → detach_stub never runs
  → refcount stays > 0 → the idle sweep (which keys on refcount == 0)
  can never reclaim the backend
```

Every layer downstream of the leak behaves correctly. The bug is that the death is never observed at all.

### Why it never surfaces on its own

A half-open transport is asymmetric: **invisible to a reader, observable only on a write.**

`_drain_inbox_to_stub` already handles the write error correctly — it catches `ConnectionError`/`BrokenPipeError` and exits. It just never gets a frame to write, because it is parked on `await inbox.get()` and an idle session produces no backend→stub traffic. The one code path that could detect the death is starved of the event that would trigger it.

This is also why the failure is far worse on Windows than POSIX. It is not a Windows-only bug — the same starvation exists everywhere — but on POSIX a dying peer usually delivers EOF/EPIPE to the parked reader, which *incidentally* runs the teardown. Windows named pipes make no such guarantee, so the leak is fully exposed there.

### The change — supply the missing write

We considered a **time-based backstop** (recycle a backend that has held a refcount without traffic past some ceiling) and rejected it:

- it treats the symptom (accumulated backends) rather than the cause (the leak);
- it must **infer** death from silence, which is not sound — silence is also exactly what a healthy idle session looks like;
- it adds a second reclamation concept that can disagree with the refcount the rest of the pool trusts.

Deciding liveness by inference is what makes such a rule either over-reap healthy sessions or never fire at all.

Instead, **the gateway writes a keepalive to every live stub on the sweep it already runs.** The write converts an unobservable half-open transport into an ordinary error, and its failure is *proof* of death rather than a guess. A failed write cancels that stub's handler task, which makes the existing `finally` run:

```
keepalive write fails → cancel handler → existing finally runs
  → detach_stub → refcount 0 → existing idle sweep reclaims the backend
```

There is still **exactly one code path that detaches a stub**, and no new notion of reclamation is introduced.

This also restores a symmetry the transport was missing:

| Direction | Liveness detection |
|---|---|
| gateway → backend | heartbeat under a reserved id (since pooling landed) |
| gateway ← stub | bridge liveness monitor (#1584) |
| **gateway → stub** | **none — added here** |

Detection improves from unbounded (never) to **one sweep interval**.

## Implementation

- **`_STUB_PROBES`** tracks each live stub connection's writer and owning handler task. Registered/discarded at the handler's own lifecycle points, so the registry cannot outlive the attachment it describes. A *set of records* rather than a dict keyed by `stub_uuid`: a reconnecting stub may briefly overlap with its predecessor, and clobbering the old entry would leak the very handler the probe exists to tear down.
- **`_probe_stub_transports`** writes one reserved `{"type": "keepalive"}` control frame per stub, under the same write lock and the same drain bound the existing drain pump uses. `ConnectionError`, `BrokenPipeError` and a drain timeout are treated as death; anything else is logged and left alone, because an unexpected error is not evidence the peer is gone. Handlers already finishing are skipped — they own their own teardown. Never raises, so one bad stub cannot stop the sweep.
- **Stub side** consumes the frame in its gateway→stdout pump exactly as it already consumes `pong`, so it never reaches kiro-cli. The frame carries no `jsonrpc`/`id`/`method`, so an older stub that forwards it hands an MCP client nothing to dispatch on — the same graceful-degradation property `pong` already relies on, which matters because stub and gateway can be different builds.
- Probing runs **before** the backend sweep in the same tick, so the backend and idle sweeps observe the corrected refcount immediately rather than one interval later.

## Tests

10 tests in `test/test_mcp_gateway_stub_keepalive.py`, covering **both** directions of the contract:

| Test | Locks in |
|---|---|
| `test_dead_transport_cancels_its_handler` | broken pipe → that handler is cancelled, so teardown runs |
| `test_connection_error_also_counts_as_dead` | reset is death too |
| `test_drain_timeout_counts_as_dead` | a stub that stops draining cannot pin the sweeper |
| `test_live_transport_is_left_alone` | healthy stub not cancelled; gets exactly one keepalive |
| `test_keepalive_frame_is_the_reserved_control_type` | frame shape, incl. no `jsonrpc`/`id`/`method` |
| `test_already_finished_handler_is_skipped` | no write, no double-cancel |
| `test_one_dead_stub_does_not_stop_the_sweep` | per-connection isolation |
| `test_unexpected_exception_does_not_cancel_or_crash` | never tears down on a guess |
| `test_registry_add_and_discard` | idempotent discard |
| `test_two_connections_for_one_stub_uuid_both_tracked` | overlapping reconnect keeps both |

Verified locally: **349 passed** across the gateway/stub suites (`-k "mcp_gateway or stub or gatewayd"`), including all 7 pre-existing async bridge-liveness tests. `isort`, `flake8` and `mypy` clean on the changed files at the CI-pinned versions.

One unrelated pre-existing failure (`test_gatewayd_peer_identity_refuses_symlinked_pid_file`) reproduces on `main` without this change — a Windows symlink-permission issue, not touched here.

## Manual verification

N/A — the behaviour under test is a transport error path on a background sweep with no user-visible surface, and the failure modes that matter (which handler gets cancelled, and whether a healthy stub is left alone) are asserted directly in the tests above.

## Screenshots

N/A — no user-visible UI change.

---

Fixes #1574
Complements #1584 (stub-side bridge liveness — already merged), which covers the opposite direction.
