### PR TITLE
fix: size the app shell in dvh so mobile browser UI shows the composer

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1743,7 +1743,7 @@ export default function App() {
         <Route path="*" element={<Navigate to={initialPopoutPath} replace />} />
       </Routes>
     ) : isEmbed ? (
-      <div className="h-screen w-screen overflow-hidden bg-bg flex flex-col">
+      <div className="h-screen supports-[height:100dvh]:h-dvh w-screen overflow-hidden bg-bg flex flex-col">
         <KiroCrewNavBridge />
         <EmbedTabStrip />
         <div className="flex-1 min-h-0">
@@ -1756,7 +1756,10 @@ export default function App() {
         </div>
       </div>
     ) : (
-    <div className="h-screen w-screen flex flex-col overflow-hidden bg-bg">
+    /* h-dvh (100vh fallback) so the shell tracks the visible viewport on
+       mobile: a 100vh shell extends under the browser's collapsible UI,
+       which hides the bottom row (the chat composer) on phones. */
+    <div className="h-screen supports-[height:100dvh]:h-dvh w-screen flex flex-col overflow-hidden bg-bg">
       {/* Embedded remote panes receive their switcher model from the parent via
           this bridge (option B) — no-op in the top-level dashboard. */}
       <EmbeddedHostBridge />

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -337,6 +337,16 @@ describe('App routing', () => {
     expect(screen.getByTestId('chat-page')).toBeInTheDocument()
   })
 
+  it('sizes the app shell in dvh so mobile browser chrome cannot cover the bottom row', () => {
+    renderWithProviders(<App />, { route: '/chat' })
+    // happy-dom does no layout, so the utility pair itself is pinned: h-dvh
+    // tracks the visible viewport where dvh is supported, h-screen (100vh,
+    // which extends under collapsible mobile browser UI) is the fallback.
+    const shell = screen.getByTestId('dashboard-shell').closest('.h-screen')
+    expect(shell).not.toBeNull()
+    expect(shell!.className).toContain('supports-[height:100dvh]:h-dvh')
+  })
+
   it('redirects /agents to the Agent Capabilities panel', () => {
     renderWithProviders(<App />, { route: '/agents' })
     expect(screen.getByTestId('capabilities-page')).toBeInTheDocument()


### PR DESCRIPTION
## Problem / Motivation

On a phone the chat composer is out of reach: the app shell is locked to `h-screen` (100vh), which mobile browsers size to the largest viewport (URL bar collapsed), so while the browser UI is visible the bottom band of the app sits under it. Pages that scroll tolerate this, but the chat page pins its composer to the shell's bottom edge — exactly the covered band — so the operator cannot type a message at all.

## Why it matters

Typing a chat message is the dashboard's core interaction, and on a phone in a normal browser tab it is blocked outright (on-device evidence: the composer entirely absent below the fold).

## What changed (motivation → approach → change)

The chat page cannot fix this locally — its height comes from the shell's grid, so any page-level change still sits inside a 100vh-locked container. The shell (dashboard and embed variants in `website/src/App.tsx`) now uses `h-dvh`, which tracks the *visible* viewport, with `h-screen` retained as the fallback for browsers without `dvh` via a `supports` variant: `h-screen supports-[height:100dvh]:h-dvh`. Desktop is unchanged (`dvh` equals `vh` there); the popout frames are separate desktop windows and keep `h-screen`.

## Tests

`website/src/test/App.test.tsx` extended: pins the utility pair on the shell (the test DOM does no layout, same idiom as the other mobile fixes).

```
# main without the fix
 × sizes the app shell in dvh so mobile browser chrome cannot cover the bottom row
 Tests  1 failed | 72 passed (73)

# with the fix
 Tests  73 passed (73)
```

`npx tsc -b` passes; `npx eslint` over the touched files: 0 errors.

## Manual verification

DevTools device emulation gives the page a single viewport, so `100dvh == 100vh` there and the covered band cannot be reproduced off-device — the on-device symptom (composer absent below the fold on a phone) is the before-evidence. Verified instead: the generated CSS carries `@supports (height:100dvh){…{height:100dvh}}`, the live shell resolves the class pair, and at 390x844 the composer is visible and focusable. Regression pass at mobile size after the shell change: the notifications page still has exactly one page-level scroll region, and overview/settings render and scroll normally.

## Screenshots / video

The visual delta only exists on a real device (emulators equate `dvh` and `vh`): before, the composer sits under the browser chrome band or below the fold; after, it is visible and focusable with the browser UI showing. An on-device before screenshot and after screenshots (chat at 390x844, plus notifications/overview regression shots) exist and I am happy to attach them if useful for review — kept out of the branch to preserve the single, focused commit.

## Related Issues

Fixes #2010

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the template's CLA section is still a placeholder without agreement text.
