### PR TITLE
fix: grow the chat action footer to 40px touch targets on touch devices

### DIFF
--- a/website/src/pages/chat/AssistantMessage.tsx
+++ b/website/src/pages/chat/AssistantMessage.tsx
@@ -280,8 +280,11 @@ const AssistantMessage = memo(function AssistantMessage({ content, isStreaming, 
         })()}
       </div>
     )}
+    {/* Where the pointer cannot hover, the footer's descendant overrides grow
+        every action to a 40px touch target (20px icon + 10px padding); pointer
+        devices keep the compact 14px icons untouched. */}
     {!isStreaming && showFooter && (
-      <div className="flex items-center gap-1 mt-0.5 opacity-0 transition-opacity duration-300 delay-100 group-hover/msg:opacity-100 group-hover/msg:delay-300 group-focus-within/msg:opacity-100 group-focus-within/msg:delay-300 [@media(hover:none)]:opacity-100">
+      <div className="flex items-center gap-1 mt-0.5 opacity-0 transition-opacity duration-300 delay-100 group-hover/msg:opacity-100 group-hover/msg:delay-300 group-focus-within/msg:opacity-100 group-focus-within/msg:delay-300 [@media(hover:none)]:opacity-100 [@media(hover:none)]:flex-wrap [@media(hover:none)]:[&_button]:p-2.5 [@media(hover:none)]:[&_svg]:h-5 [@media(hover:none)]:[&_svg]:w-5">
         {/* No `font-mono`: a formatted date is prose, and Tailwind's `font-mono`
             pins `var(--mono)` — a token the Font Family setting never writes, so
             it overrode the user's choice and put JetBrains Mono (no CJK

--- a/website/src/test/AssistantMessage.test.tsx
+++ b/website/src/test/AssistantMessage.test.tsx
@@ -500,3 +500,23 @@ describe('turn stats footer (elapsed time + credits)', () => {
     expect(fmtCredits(12.53)).toBe('12.5')
   })
 })
+
+describe('action footer touch sizing', () => {
+  // happy-dom does not evaluate media queries, so the hover-none utility
+  // classes themselves are pinned, the same way the footer reveal is.
+  it('enlarges the actions to 40px touch targets where the pointer cannot hover', () => {
+    render(<AssistantMessage content="Hi" isStreaming={false} slotRunning={false} onRegenerate={() => {}} />)
+    const footer = screen.getByTitle('Regenerate').parentElement!
+    expect(footer.className).toContain('[@media(hover:none)]:[&_button]:p-2.5')
+    expect(footer.className).toContain('[@media(hover:none)]:[&_svg]:h-5')
+    expect(footer.className).toContain('[@media(hover:none)]:[&_svg]:w-5')
+    // The grown row exceeds a phone's width, so it must wrap rather than
+    // crush the timestamp and clip the trailing actions.
+    expect(footer.className).toContain('[@media(hover:none)]:flex-wrap')
+  })
+
+  it('keeps the compact sizing on the buttons for pointer devices', () => {
+    render(<AssistantMessage content="Hi" isStreaming={false} slotRunning={false} onRegenerate={() => {}} />)
+    expect(screen.getByTitle('Regenerate').className).toContain('p-0.5')
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

On phones and tablets the assistant message actions (copy, copy link, fork, plan, speak, raw view, regenerate, variant chevrons) are 18x18px — a 14px icon with 2px padding — far below the ~40px touch-target floor, so hitting the intended action without triggering its neighbor is nearly impossible.

## Why it matters

With #1895 making the footer visible on touch, the actions still cannot be used reliably: 12 buttons at 18px in one row on a 390px screen means mis-taps are the norm, and mis-tapping "regenerate" when aiming at "copy" is destructive to the conversation flow.

## What changed (motivation → approach → change)

The compact sizing assumes a pointer with pixel precision; a fingertip has none. Where the pointer cannot hover, descendant overrides on the footer container now grow every action to 40px (20px icon + 10px padding: `[@media(hover:none)]:[&_button]:p-2.5`, `[&_svg]:h-5/w-5`) and `flex-wrap` lets the grown row wrap instead of overflowing a phone's width — without it the row crushes the timestamp into a vertical column and clips the trailing buttons (caught in live verification, then pinned in the tests). Hover-capable devices resolve none of these rules and keep the compact sizing pixel-identical. Composes with #1895, which makes this same footer visible on touch — that change makes the actions visible, this one makes them hittable; the two are independent.

## Tests

`website/src/test/AssistantMessage.test.tsx` extended: pins the hover-none utility classes (the test DOM does not evaluate media queries), plus the retained compact `p-0.5` on the buttons themselves.

```
# main without the fix
 × enlarges the actions to 40px touch targets where the pointer cannot hover
 Tests  1 failed | 57 passed (58)

# with the fix
 Tests  58 passed (58)
```

`npx tsc -b` and `npx eslint` over the touched files pass.

## Manual verification

Live gateway, 390x844 DPR 3 touch emulation (`(hover: none)` matches there): before, all footer buttons measured 18x18 (`padding: 2px`); after, all 12 rendered footer buttons measure exactly 40x40 (`padding: 10px`, 20px svg) and the footer wraps into two comfortable rows. At 1440x900 (`hover: none` false) buttons measure 18x18 with `padding: 2px` — unchanged.

## Screenshots / video

The visual delta on a touch device: the action row grows from a cramped 18px strip to two rows of 40px targets; desktop is pixel-identical. Before/after screenshots (mobile action row, desktop unchanged) exist and I am happy to attach them if useful for review — kept out of the branch to preserve the single, focused commit.

## Related Issues

Fixes #2012

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — the template's CLA section is still a placeholder without agreement text.
