### PR TITLE
feat(telegram): add /kirocrew dashboard command for mobile login

### DIFF
--- a/src/kiro_crew/telegram/commands.py
+++ b/src/kiro_crew/telegram/commands.py
@@ -9,6 +9,7 @@ Commands:
   /unlink      — stop mirroring dashboard replies here
   /stop        — stop the current reply and clear the queue (alias: /cancel)
   /help        — show available commands
+  /kirocrew dashboard [<N>h|<N>m] — send a presigned dashboard login link
 
 Mid-turn overrides (prefix a message sent WHILE a reply is running; they
 override the global ``messaging.queue_mode`` for that one message):
@@ -42,6 +43,9 @@ _STOP_ALIASES = frozenset(("/stop", "/cancel"))
 # "the feature isn't installed" rather than "you typed it wrong".
 _MODEL_ALIASES = frozenset(("/model", "/models"))
 _YOLO_ALIASES = frozenset(("/yolo",))
+# Two-token command: ``/kirocrew dashboard [<TTL>]``. The bare ``/kirocrew``
+# token is deliberately NOT a command on its own (see parse_command).
+_DASHBOARD_ALIASES = frozenset(("/kirocrew",))
 
 # Telegram bot usernames: 5-32 chars, alphanumeric + underscore, by convention
 # ending in "bot" -- but any alnum/underscore run after @ is accepted here
@@ -91,11 +95,10 @@ def parse_command(text: str, bot_username: str = "") -> str | None:
     """
     stripped = text.strip()
     # Telegram commands always start with /
-    cmd = (
-        _strip_bot_mention(stripped.split()[0].lower(), bot_username)
-        if stripped.startswith("/")
-        else ""
-    )
+    if not stripped.startswith("/"):
+        return None
+    parts = stripped.split()
+    cmd = _strip_bot_mention(parts[0].lower(), bot_username)
     if cmd in _NEW_ALIASES:
         return "new"
     if cmd in _COMPACT_ALIASES:
@@ -112,6 +115,11 @@ def parse_command(text: str, bot_username: str = "") -> str | None:
         return "help"
     if cmd in _STOP_ALIASES:
         return "stop"
+    # /kirocrew dashboard [<TTL>] -- requires the explicit "dashboard"
+    # subcommand, so a bare "/kirocrew" (typo or menu tap) falls through as
+    # ordinary chat text instead of minting a login link.
+    if cmd in _DASHBOARD_ALIASES and len(parts) >= 2 and parts[1].lower() == "dashboard":
+        return "dashboard"
     return None
 
 
@@ -119,6 +127,38 @@ def parse_command_argument(text: str) -> str:
     """Return the text following a command token (``""`` when there is none)."""
     parts = text.strip().split(None, 1)
     return parts[1].strip() if len(parts) == 2 else ""
+
+
+def parse_dashboard_ttl(text: str) -> int:
+    """Parse the optional TTL from a ``/kirocrew dashboard [<N>h|<N>m]`` command.
+
+    Returns the session TTL in seconds. Defaults to 3600 (1 hour) when no
+    duration is given or the duration is unparseable.
+    """
+    from kiro_crew.dashboard.token_auth import parse_duration
+
+    parts = text.strip().split()
+    # Expected: ["/kirocrew", "dashboard", "<ttl>"]
+    if len(parts) >= 3:
+        parsed = parse_duration(parts[2].lower())
+        if parsed is not None:
+            return parsed
+    return 3600
+
+
+def format_ttl(ttl_secs: int) -> str:
+    """Render a TTL in seconds as a human duration ("2h", "90m" -> "1h 30m").
+
+    Never truncates: a non-hour-multiple >= 1h renders both components so the
+    reply reports exactly how long the login link stays live.
+    """
+    hours, rem = divmod(ttl_secs, 3600)
+    mins = rem // 60
+    if hours and mins:
+        return f"{hours}h {mins}m"
+    if hours:
+        return f"{hours}h"
+    return f"{mins}m"
 
 
 _QUEUE_ALIASES = frozenset(("/queue",))
@@ -173,7 +213,9 @@ def is_bare_mid_turn_override(text: str, bot_username: str = "") -> bool:
 #: rejects one. ``/queue`` and ``/steer`` are deliberately absent: the Telegram
 #: client SENDS a menu entry on tap, and a bare ``/queue`` has no message body
 #: to act on, so listing them would put a dead entry in the menu — they stay
-#: documented in the help card's footer instead.
+#: documented in the help card's footer instead. ``/kirocrew`` is absent for
+#: the same reason: a menu tap sends the bare token, which is not a command
+#: without its ``dashboard`` subcommand — it is documented in the footer.
 COMMAND_SPEC: tuple[tuple[str, str], ...] = (
     ("new", "Start a fresh conversation"),
     ("compact", "Compress the context when it gets long"),
@@ -211,6 +253,8 @@ def bot_command_payload() -> list[dict[str, str]]:
 
 _HELP_HEADER = "🦞 Kiro Crew — Telegram"
 _HELP_FOOTER = (
+    "/kirocrew dashboard [<N>h|<N>m] — get a dashboard login link (DM only)\n"
+    "\n"
     "While a reply is running, prefix a message to control it:\n"
     "/queue <msg> — answer it after the current turn\n"
     "/steer <msg> — fold it into the running turn now\n"

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -58,9 +58,11 @@ from kiro_crew.telegram.attachments import process_telegram_attachments
 from kiro_crew.telegram.commands import (
     ConversationState,
     build_help_text,
+    format_ttl,
     is_bare_mid_turn_override,
     parse_command,
     parse_command_argument,
+    parse_dashboard_ttl,
     parse_mid_turn_override,
 )
 from kiro_crew.telegram.renderer import TelegramApprovalDecider, TelegramRenderer
@@ -317,6 +319,9 @@ class TelegramDispatcher:
             await self._handle_yolo(
                 chat_id, parse_command_argument(text), user_id, thread=reply_thread
             )
+            return
+        if cmd == "dashboard":
+            await self._handle_dashboard(route, chat_id, text, user_id)
             return
         # A lone "/queue" / "/steer" is a directive missing its message body.
         # Answering with the usage beats forwarding the token to the model, which
@@ -839,6 +844,81 @@ class TelegramDispatcher:
         await self._queue.finish_cancelled_locked(
             session_key, self._receipt_surface(chat_id, None)
         )
+
+    async def _handle_dashboard(
+        self, route: tuple[str, str], chat_id: int, text: str, user_id: int
+    ) -> None:
+        """Generate and send a presigned dashboard login link.
+
+        Mirrors the Slack ``/kirocrew dashboard`` implementation: calls
+        ``generate_token`` directly (never via shell) and builds the URL from
+        the ``dashboard.url`` config (``KIROCREW_PORT`` overrides the port,
+        matching every other link producer).
+
+        DM-only: a presigned link posted into a forum Topic would hand a
+        dashboard login to every member of the supergroup, so group requests
+        are refused with a pointer to DM — the same token-leak policy as
+        Slack's always-DM delivery.
+        """
+        assert self.client is not None
+        from kiro_crew.dashboard.token_auth import MAX_SESSION_TTL_SECS, generate_token
+        from kiro_crew.dashboard.urls import dashboard_origin, parse_dashboard_url
+
+        thread = self._route_thread(route)
+        if route[0] != CHAT_TYPE_DIRECT:
+            await self._reply(
+                chat_id,
+                "🔒 Dashboard links are only sent in a direct message — "
+                "DM me `/kirocrew dashboard`.",
+                thread=thread,
+            )
+            return
+        ttl_secs = min(parse_dashboard_ttl(text), MAX_SESSION_TTL_SECS)
+        try:
+            token = generate_token(str(user_id), ttl_seconds=ttl_secs)
+            origin = dashboard_origin(self.cfg.dashboard.url)
+            if not origin:
+                # No configured dashboard.url: fall back to the local port
+                # (parse_dashboard_url applies the KIROCREW_PORT override).
+                _, port = parse_dashboard_url(self.cfg.dashboard.url)
+                origin = f"http://localhost:{port}"
+            url = f"{origin}/?token={token}"
+            ttl_display = format_ttl(ttl_secs)
+            # Credential issuance MUST be audited (backend-security-controls):
+            # mirrors slack.dashboard_token and telegram.yolo_mode above.
+            sel().log_api_access(
+                caller=str(user_id),
+                operation="telegram.dashboard_token",
+                outcome="ok",
+                source="telegram",
+                resources=f"ttl={ttl_secs}",
+            )
+            await self._reply(
+                chat_id,
+                f"🔗 Dashboard link (valid {ttl_display}):\n{url}",
+                thread=thread,
+            )
+        except Exception as exc:
+            logger.warning(
+                "telegram /kirocrew dashboard: token generation failed", exc_info=True
+            )
+            try:
+                sel().log_api_access(
+                    caller=str(user_id),
+                    operation="telegram.dashboard_token",
+                    outcome="error",
+                    source="telegram",
+                    resources=f"ttl={ttl_secs}",
+                )
+            except Exception:
+                # The audit trail must never turn a user-facing failure reply
+                # into a crash; the warning above already captured the error.
+                pass
+            await self._reply(
+                chat_id,
+                f"⚠️ Could not generate dashboard link: {exc}",
+                thread=thread,
+            )
 
     async def _handle_stop(self, route: tuple[str, str], chat_id: int) -> None:
         """Hard cancel: abort the in-flight turn and clear everything.

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -48,9 +48,11 @@ from kiro_crew.telegram.commands import (
     ConversationState,
     bot_command_payload,
     build_help_text,
+    format_ttl,
     is_bare_mid_turn_override,
     parse_command,
     parse_command_argument,
+    parse_dashboard_ttl,
     parse_mid_turn_override,
 )
 from kiro_crew.telegram.renderer import (
@@ -519,6 +521,19 @@ class TestParseCommand:
         assert is_bare_mid_turn_override("/new") is False
         assert is_bare_mid_turn_override("hello") is False
 
+    def test_dashboard_command(self) -> None:
+        """Dashboard command requires both /kirocrew and the 'dashboard' subcommand."""
+        assert parse_command("/kirocrew dashboard") == "dashboard"
+        assert parse_command("/kirocrew dashboard 2h") == "dashboard"
+        assert parse_command("/KIROCREW DASHBOARD") == "dashboard"
+        assert parse_command("  /kirocrew   dashboard  ") == "dashboard"
+
+    def test_dashboard_command_requires_subcommand(self) -> None:
+        """Bare /kirocrew without 'dashboard' is not a command."""
+        assert parse_command("/kirocrew") is None
+        assert parse_command("/kirocrew help") is None
+        assert parse_command("/kirocrew other") is None
+
 
 class TestBotMentionSuffix:
     """Telegram's own clients append @BotUsername to a slash command in any
@@ -598,6 +613,50 @@ class TestBotMentionSuffix:
         none should be treated as ours (fail closed, not open)."""
         assert parse_command("/new@KiroCrewBot") is None
         assert parse_command("/yolo@KiroCrewBot") is None
+
+    def test_dashboard_command_strips_bot_mention(self) -> None:
+        assert parse_command("/kirocrew@KiroCrewBot dashboard", "KiroCrewBot") == "dashboard"
+        # A mention naming a different bot is not ours -- fail closed.
+        assert parse_command("/kirocrew@OtherBot dashboard", "KiroCrewBot") is None
+
+
+class TestParseDashboardTtl:
+    def test_default_ttl(self) -> None:
+        """Default is 1 hour when no TTL specified."""
+        assert parse_dashboard_ttl("/kirocrew dashboard") == 3600
+
+    def test_hours(self) -> None:
+        assert parse_dashboard_ttl("/kirocrew dashboard 2h") == 7200
+        assert parse_dashboard_ttl("/kirocrew dashboard 5H") == 18000
+
+    def test_minutes(self) -> None:
+        assert parse_dashboard_ttl("/kirocrew dashboard 30m") == 1800
+        assert parse_dashboard_ttl("/kirocrew dashboard 90M") == 5400
+
+    def test_invalid_ttl_uses_default(self) -> None:
+        """Invalid TTL format falls back to 1 hour."""
+        assert parse_dashboard_ttl("/kirocrew dashboard xyz") == 3600
+        assert parse_dashboard_ttl("/kirocrew dashboard") == 3600
+
+
+class TestFormatTtl:
+    def test_exact_hours(self) -> None:
+        assert format_ttl(3600) == "1h"
+        assert format_ttl(7200) == "2h"
+
+    def test_minutes_only(self) -> None:
+        assert format_ttl(1800) == "30m"
+        assert format_ttl(60) == "1m"
+
+    def test_mixed_never_truncates(self) -> None:
+        """90m must NOT display as '1h' -- the link lives 1.5h."""
+        assert format_ttl(5400) == "1h 30m"
+        assert format_ttl(3660) == "1h 1m"
+
+    def test_sub_minute_floors_to_zero_minutes(self) -> None:
+        # parse_duration never yields <60s, but the formatter stays total.
+        assert format_ttl(0) == "0m"
+        assert format_ttl(59) == "0m"
 
 
 class TestCommandCatalogue:


### PR DESCRIPTION
## Problem

When accessing KiroCrew from a mobile device (via Telegram), there's no way to get a dashboard login link. The Slack transport has `/kirocrew dashboard`, but Telegram users have to wait until they're back at a computer.

## Why it matters

Users on mobile (phone-only) can't access the dashboard to review sessions, manage crons, or perform other dashboard-only tasks.

## Fix

Add the `/kirocrew dashboard [<N>h|<N>m]` command to the Telegram transport, mirroring the existing Slack implementation:

- **commands.py**: Add `_DASHBOARD_ALIASES` and `parse_dashboard_ttl()` for parsing the command and optional TTL
- **transport_dispatch.py**: Add `_handle_dashboard()` method that calls `generate_token()` directly and sends the presigned URL

Key implementation details:
- Calls `generate_token()` directly from `kiro_crew.dashboard.token_auth` (not via shell) for security
- Supports optional TTL with default 1h, max 20h (same as Slack)
- Returns a localhost URL with the token that opens the dashboard

## Tests

Added tests in `test/test_telegram.py`:
- `test_dashboard_command`: Verifies `/kirocrew dashboard` parsing
- `test_dashboard_command_requires_subcommand`: Ensures bare `/kirocrew` doesn't match
- `TestParseDashboardTtl`: Tests TTL parsing (hours, minutes, defaults)

## Manual verification

Tested locally by restarting the gateway and running `/kirocrew dashboard 20h` from Telegram - received a working dashboard link.