### PR TITLE
fix: keep Restart & Update disabled after install is dispatched

### DIFF
--- a/website/src/components/UpdateModal.tsx
+++ b/website/src/components/UpdateModal.tsx
@@ -50,7 +50,12 @@ export default function UpdateModal() {
   }
 
   const installMutation = useMutation({ mutationFn: () => getUpdateApi()!.install() })
-  const installing = installMutation.isPending
+  // install() resolves as soon as the install is DISPATCHED — on macOS the
+  // platform installer then works for several seconds before the app quits.
+  // Keying `disabled` on `isPending` alone lets the button re-arm during that
+  // window, so the user sees a clickable "Restart & Update" followed by an
+  // unexplained quit — which reads as a crash.
+  const installing = installMutation.isPending || installMutation.isSuccess
 
   const open = !!update && update.state === 'downloaded' && !dismissed
 


### PR DESCRIPTION
## Problem

After clicking "Restart & Update" in the update modal, the button briefly re-enables before the app actually quits and relaunches. The user sees a clickable button again and thinks the click did nothing.

## Why it matters

On macOS, the platform installer works for several seconds after the IPC call resolves. During that window the user sees an active button, clicks it again, and interprets the subsequent quit as a crash rather than a successful update.

## Fix

`update:install` resolves as soon as the install is **dispatched** — not when the app actually quits. Keying `disabled` on `isPending` alone lets the button re-arm during that window.

Fix: key on `isPending || isSuccess` so the button stays disabled once the install is dispatched.

This is the exact pattern already used in `AboutPanel.tsx` (lines 259–265), which has an explicit comment documenting this same problem. `UpdateModal` was written later and missed it.

```tsx
// before
const installing = installMutation.isPending

// after
const installing = installMutation.isPending || installMutation.isSuccess
```

## Tests

No automated tests added — this is a one-line fix mirroring an established pattern in the same codebase. `AboutPanel.tsx` has the same logic and no test for it either.

## Manual verification

Reproduced locally using a mock `window.updateAPI` that resolves after 2 seconds (simulating the dispatch-to-quit window). With the fix, the button remains disabled through `isSuccess` until the app would quit.