### PR TITLE
feat(skills): credit skill bodies the model reads directly

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -613,6 +613,70 @@ Skills with auxiliary files (scripts, assets) include `dir` path so the LLM can 
 
 **`skill_search` MCP tool (`kirocrew-core`):** greps skill name/description then, only on a metadata miss, the skill body (bounded, tool-call only — never per message). Schema in `mcp_core.py`, validated against `SKILL_SEARCH_SCHEMA` (`validation.py`). Does NOT record usage — searching is not using. Scope is **locally installed skills only**.
 
+**Direct reads.** The model reaches most skills by reading `SKILL.md` itself — a
+file-read tool, or `cat` in a shell — which bypasses the loader and so recorded
+nothing. Unrecorded, the ledger described one access route only, pushing
+search-discovered skills permanently down the ranking and making them harder to
+find still: a self-reinforcing bias, not a flat undercount.
+
+Crediting is two-phase, because the ledger's hits mean *a body reached the
+model*. `SkillsLoader.resolve_tool_read_keys(tool_name, raw_params, command)`
+resolves which served skills a tool call would deliver, recording nothing;
+`credit_skill_reads(keys)` records once the read is known to have happened.
+
+**Only content-delivering reads qualify.** A tool call that merely *names* a
+skill path earns nothing — `rm`, `mv`, `cp`, `wc`, `chmod`, `stat`, and `grep`
+(which emits matching lines, not the body) are all excluded. Crediting a mention
+would re-create the very mention-as-use conflation that keeps the searches tally
+out of `score()`, and would let a skill-maintenance session push an unread skill
+up the ranking. The shell path attributes a verb **per command segment**
+(`_shell_segments_reading_content`), so `cat a.txt && rm x/SKILL.md` does not
+read as a `cat` of the skill; the structured path allowlists content-returning
+tools (`_CONTENT_READ_TOOLS`), so an edit or grep tool carrying a `path` is not
+mistaken for a delivery.
+
+Reads are attributed through `_served_key_by_realpath()`, which applies the same
+canonical rule as `resolve_ledger_aliases` (real file beats symlink, then
+alphabetical), so a read through a symlinked skill lands on the key the Context
+Budget screen displays instead of splitting one file's cost.
+
+Observation sits in the **ACP client**, registered process-wide via
+`set_global_skill_read_observer` — the same module-level-slot pattern as
+`get_global_hook_store`. That layer is the only one that sees every surface's
+tool calls (dashboard, Slack, subagents, task runner); wiring it per surface
+would have left subagent reads uncounted, which is a skewed ledger rather than a
+partial one. The per-surface permission gate (`HookManager.on_tool_call`) is NOT
+usable here: file reads are auto-approved and never reach it.
+
+Registration goes through one helper, `register_skill_read_observer` in
+`skill_usage.py` — a leaf module, so no runtime imports another surface just to
+register. Called from every runtime that owns a `ContextBuilder`:
+`start_dashboard`, `start_api_server`, and the CLI in `cli_server.py`. Crediting
+must not vary by entry point: route-dependent visibility is precisely the bias
+this exists to remove, so a runtime that recorded nothing would ship a smaller
+version of the same defect. The helper takes several candidates and installs the
+first exposing a loader, because the API-server path builds its state **without**
+a `context_builder` and reaches the loader through `task_runner._ctx`; it returns
+whether it installed one so that path can log a miss instead of silently
+recording nothing.
+
+The read-intent allowlists (`_CONTENT_READ_TOOLS`, `_SHELL_READ_VERBS`) encode
+the provider's current tool spellings, so a rename would silently restore the
+pre-existing undercount. A call whose arguments clearly name a `SKILL.md` yet
+yields no candidate is therefore logged at debug — the one signal that separates
+tool-name drift from a legitimately non-reading call.
+
+`_maybe_note_skill_read` resolves at the tool call and **offloads to a thread** —
+resolution walks the skills tree after cache expiry and resolves every served
+skill, which on the event loop would stall every session in the gateway. Both the
+initial `tool_call` and its `tool_call_update` refinement are observed, since
+which one carries `rawInput` is provider-specific, deduped by `tool_call_id`.
+`_maybe_credit_skill_read` then records only on a `status == "completed"` result
+(`tool_final`), so a read that was denied, errored, or never ran leaves no
+delivery; that call is in-memory and safe inline. A cheap `SKILL.md` substring
+gate runs before the offload, so a tool call touching no skill costs a substring
+scan; observer failures in either phase are logged and swallowed.
+
 **Registry discovery — `skill_discover` / `skill_fetch` MCP tools (`kirocrew-core`).**
 The agent-facing twins of the dashboard's Skills → Discover panel, covering the
 skills that are *not* on disk. Both are read-only and reach the existing

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -119,6 +119,7 @@ from kiro_crew.sandbox import (
 )
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
+from kiro_crew.skill_usage import get_global_skill_read_observer
 
 logger = logging.getLogger(__name__)
 
@@ -550,6 +551,40 @@ _MAX_CONSECUTIVE_EMPTY = 5
 # popped on the permission event and wholesale-cleared per prompt; this is just a
 # backstop for the pathological no-permission case).
 _MAX_CACHED_TOOL_PARAMS = 256
+
+#: Basename a skill body lives under. Duplicated from ``skills`` deliberately —
+#: the ACP layer must not import the skills machinery just to test a substring.
+_SKILL_FILE_BASENAME = "SKILL.md"
+
+#: Backstop on the per-session set of tool-call ids already credited as skill
+#: reads. Far above any real turn's distinct skill reads; bounds memory for a
+#: long-lived session at the cost of at most one duplicate credit after a reset.
+_MAX_NOTED_SKILL_READS = 512
+
+
+def _mentions_skill_file(raw_params: dict | None, command: str | None) -> bool:
+    """Whether a tool call's arguments name a skill body at all.
+
+    A cheap pre-filter so observing skill reads costs a substring scan on the
+    overwhelming majority of tool calls, which touch no skill. Scans only string
+    and string-sequence values, since a model-authored argument dict may hold
+    arbitrary shapes.
+    """
+    if isinstance(command, str) and _SKILL_FILE_BASENAME in command:
+        return True
+    if not isinstance(raw_params, dict):
+        return False
+    for value in raw_params.values():
+        if isinstance(value, str):
+            if _SKILL_FILE_BASENAME in value:
+                return True
+        elif isinstance(value, (list, tuple)):
+            if any(
+                isinstance(v, str) and _SKILL_FILE_BASENAME in v for v in value
+            ):
+                return True
+    return False
+
 
 # Emitted by kiro-cli as a plain agent_message_chunk when its built-in, non-overridable
 # security filter cancels every tool use in an assistant turn (e.g. shell commands
@@ -1734,6 +1769,14 @@ class AcpClient:
         # the later permission_request event (which carries no kind) can inherit
         # the canonical shell signal. Mirrors _tool_call_inputs lifecycle.
         self._tool_call_is_shell: dict[str, bool] = {}
+        # toolCallIds already credited to the skill-usage ledger as a body read.
+        # The arguments arrive on either the initial tool_call or its refinement
+        # depending on the provider, so both are observed and this prevents one
+        # read being counted twice. Mirrors _tool_call_is_shell's lifecycle.
+        self._skill_read_noted: set[str] = set()
+        # toolCallId -> skill keys resolved at call time, credited only when
+        # the tool reports completion so a denied read leaves no delivery.
+        self._pending_skill_reads: dict[str, list[str]] = {}
         # Map toolCallId → trusted MCP server name (_meta.kiro.mcpServerName),
         # cached from the tool_call notification so the later permission_request
         # event (which carries no _meta) can inherit it — the signal the
@@ -3590,6 +3633,8 @@ class AcpClient:
         self.last_prompt_stats = self.last_prompt_stats.carry_over()
         self._tool_call_inputs.clear()
         self._tool_call_is_shell.clear()
+        self._skill_read_noted.clear()
+        self._pending_skill_reads.clear()
         self._tool_call_mcp_server.clear()
         self._tool_call_tool_name.clear()
         self._tool_call_params.clear()
@@ -3710,6 +3755,7 @@ class AcpClient:
                     # with the main agent / SubagentManager. PostToolUse fires
                     # separately on the tool_result branch below (fire_tool_hooks
                     # is Pre-only). No-op unless audit_source is set.
+                    await self._maybe_note_skill_read(tool_event)
                     await self._maybe_fire_pre_tool_hooks(tool_event)
                     yield tool_event
                 # Real-time tool result from `tool_call_update` session updates.
@@ -3729,6 +3775,7 @@ class AcpClient:
                     # (and its output) exists — the Pre-vs-Post split is required
                     # because fire_tool_hooks above is PreToolUse-only. No-op
                     # unless audit_source is set.
+                    self._maybe_credit_skill_read(tool_result_event)
                     await self._maybe_fire_post_tool_hooks(tool_result_event)
                     yield tool_result_event
                 # claude-agent-acp emits a separate `tool_call_update` carrying
@@ -3739,6 +3786,7 @@ class AcpClient:
                 # patched in place — see `EVENT_TOOL_CALL_UPDATE` in chat_runner.
                 tool_refine_event = self._extract_tool_call_refinement(msg)
                 if tool_refine_event:
+                    await self._maybe_note_skill_read(tool_refine_event)
                     yield tool_refine_event
             elif action == "metadata":
                 self._track_metadata(msg)
@@ -4179,9 +4227,11 @@ class AcpClient:
                             tool_event.tool_kind or "",
                         )
                     await self._maybe_audit_tool_call(tool_event)
+                    await self._maybe_note_skill_read(tool_event)
                     await self._maybe_fire_pre_tool_hooks(tool_event)
                 tool_result_event = self._extract_tool_call_update(msg)
                 if tool_result_event:
+                    self._maybe_credit_skill_read(tool_result_event)
                     await self._maybe_fire_post_tool_hooks(tool_result_event)
             elif action == "metadata":
                 self._track_metadata(msg)
@@ -4328,6 +4378,85 @@ class AcpClient:
             )
         except Exception:
             logger.warning("ACP-layer SEL audit failed", exc_info=True)
+
+    async def _maybe_note_skill_read(self, tool_event: "AcpEvent") -> None:
+        """Resolve which skills a tool call is about to read, crediting later.
+
+        Lives here because the ACP layer is the one place that sees EVERY
+        surface's tool calls — dashboard, Slack, subagents, task runner. The
+        per-surface permission gate (``HookManager.on_tool_call``) is not usable
+        for this: file reads are auto-approved, so they never reach it.
+
+        Resolution is filesystem-bound (a skills-tree walk after cache expiry,
+        plus a ``resolve()`` per served skill), so it is offloaded to a thread —
+        on the event loop it would stall every session in the gateway. Nothing
+        is recorded here: the keys are held until ``_maybe_credit_skill_read``
+        sees the tool complete, so a denied or failed read leaves no delivery.
+
+        Fires for the initial ``tool_call`` and its ``tool_call_update``
+        refinement, whichever first carries the arguments (claude-agent-acp
+        leaves ``rawInput`` empty on the initial notification), deduped by
+        ``tool_call_id``.
+
+        Gated on the skill basename appearing in the arguments BEFORE any
+        offload, so a tool call unrelated to skills costs one substring scan.
+        Whether the call is a content-delivering READ (rather than a delete,
+        move, or grep that merely names the path) is decided by the observer.
+        Failures are swallowed: telemetry must not disturb the tool call.
+        """
+        observer = get_global_skill_read_observer()
+        if observer is None:
+            return
+        tool_id = tool_event.tool_call_id or ""
+        if tool_id and tool_id in self._skill_read_noted:
+            return
+        raw_params = tool_event.raw_tool_params
+        command = tool_event.shell_command
+        if not _mentions_skill_file(raw_params, command):
+            return
+        if tool_id:
+            if len(self._skill_read_noted) >= _MAX_NOTED_SKILL_READS:
+                # A single turn cannot legitimately hold this many distinct
+                # skill reads; drop the tracking wholesale rather than letting
+                # it grow for the life of the session. Worst case after a reset
+                # is one duplicate credit, not a leak.
+                self._skill_read_noted.clear()
+                self._pending_skill_reads.clear()
+            self._skill_read_noted.add(tool_id)
+        try:
+            keys = await asyncio.to_thread(
+                observer.resolve_tool_read_keys,
+                tool_event.tool_name or "",
+                raw_params,
+                command,
+            )
+        except Exception:
+            logger.warning("skill-read resolution failed", exc_info=True)
+            return
+        if keys and tool_id:
+            self._pending_skill_reads[tool_id] = keys
+
+    def _maybe_credit_skill_read(self, tool_result_event: "AcpEvent") -> None:
+        """Credit the reads resolved for a tool call that has now completed.
+
+        Only a ``status == "completed"`` result (``tool_final``) credits, so a
+        read that was denied, errored, or never ran contributes no delivery.
+        In-memory only — the ledger debounces its own disk write — so this is
+        safe to run inline on the event loop.
+        """
+        if not tool_result_event.tool_final:
+            return
+        tool_id = tool_result_event.tool_call_id or ""
+        keys = self._pending_skill_reads.pop(tool_id, None) if tool_id else None
+        if not keys:
+            return
+        observer = get_global_skill_read_observer()
+        if observer is None:
+            return
+        try:
+            observer.credit_skill_reads(keys)
+        except Exception:
+            logger.warning("skill-read credit failed", exc_info=True)
 
     async def _maybe_fire_pre_tool_hooks(self, tool_event: "AcpEvent") -> None:
         """Fire the PreToolUse HOOK ENGINE for a tool_call, for audit-source clients.

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -56,6 +56,7 @@ from kiro_crew.service import linux as svc_linux
 from kiro_crew.service import macos as svc_macos
 from kiro_crew.service.common import SERVICE_NAME, Platform, current_platform
 from kiro_crew.session import SessionManager
+from kiro_crew.skill_usage import register_skill_read_observer
 from kiro_crew.skills import SkillsLoader
 from kiro_crew.slack.gateway import run_gateway
 from kiro_crew.taskrunner import TaskRunner
@@ -1688,7 +1689,7 @@ async def _run_task(args: argparse.Namespace) -> None:
     ctx = ContextBuilder(
         memory=memory, skills=skills, hooks=hooks, lessons=lessons, bot_name=cfg.agent.bot_name
     )
-
+    register_skill_read_observer(ctx)
     runner = TaskRunner(
         sessions=sessions,
         context_builder=ctx,

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -183,6 +183,7 @@ from kiro_crew.safety_override import (
 )
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
+from kiro_crew.skill_usage import register_skill_read_observer
 from kiro_crew.skills import SkillsLoader, set_pending_staged_hook
 from kiro_crew.suggestions import api_suggestions
 from kiro_crew.tips import api_tips_feedback, api_tips_next, api_tips_status
@@ -1972,6 +1973,10 @@ async def start_dashboard(
     state._hook_store = ScriptHookStore()
     set_global_hook_store(state._hook_store)
 
+    # Credit the skill-usage ledger for skill bodies the model reads directly
+    # (a file-read tool or `cat`), which bypass the loader entirely.
+    register_skill_read_observer(state.context_builder)
+
     # Wire script hooks into subagent tool execution path
     if state.subagents is not None:
         state.subagents.hook_store = state._hook_store
@@ -3435,6 +3440,15 @@ async def start_api_server(
     )
     state._hook_store = ScriptHookStore()
     set_global_hook_store(state._hook_store)
+
+    # This path builds its state without a context_builder, so the loader is
+    # reached through the task runner. Logged on a miss rather than silently
+    # recording nothing, since a route that credits no reads is the bias this
+    # observer exists to remove.
+    if not register_skill_read_observer(
+        state.context_builder, getattr(task_runner, "_ctx", None)
+    ):
+        logger.info("skill-read observer not registered: no skills loader reachable")
 
     # Wire script hooks into subagent tool execution path
     if state.subagents is not None:

--- a/src/kiro_crew/skill_usage.py
+++ b/src/kiro_crew/skill_usage.py
@@ -31,8 +31,72 @@ import tempfile
 import threading
 import time
 from pathlib import Path
+from typing import Protocol
 
 logger = logging.getLogger(__name__)
+
+#: Observer notified when a tool call reads a skill body, so reads that bypass
+#: the loader (a file-read tool, or ``cat`` in a shell) still reach the ledger.
+#: A module-level slot rather than constructor plumbing, mirroring
+#: ``get_global_hook_store``: the ACP layer sees every surface's tool calls but
+#: has no route to a SkillsLoader. This holds a process-wide hook, never
+#: per-caller data, so it does not make any MCP tool stateful.
+#:
+#: Two phases on purpose. ``resolve_tool_read_keys`` is filesystem-bound, so the
+#: caller runs it off the event loop; ``credit_skill_reads`` is in-memory and
+#: runs only once the read is confirmed complete, so a denied or failed tool
+#: call leaves no delivery behind.
+
+
+class SkillReadObserver(Protocol):
+    def resolve_tool_read_keys(
+        self,
+        tool_name: str = "",
+        raw_params: dict | None = None,
+        command: str | None = None,
+    ) -> list[str]: ...
+
+    def credit_skill_reads(self, keys: list[str]) -> None: ...
+
+
+_global_skill_read_observer: SkillReadObserver | None = None
+
+
+def set_global_skill_read_observer(observer: SkillReadObserver | None) -> None:
+    """Install (or clear, with ``None``) the process-wide skill-read observer."""
+    global _global_skill_read_observer
+    _global_skill_read_observer = observer
+
+
+def get_global_skill_read_observer() -> SkillReadObserver | None:
+    """The installed skill-read observer, or ``None`` when nothing registered."""
+    return _global_skill_read_observer
+
+
+def register_skill_read_observer(*candidates: object) -> bool:
+    """Install the observer from the first candidate exposing a skills loader.
+
+    Credits the ledger for skill bodies the model reads directly — a file-read
+    tool or ``cat`` bypasses the loader, so those reads recorded nothing and the
+    ledger described one access route only.
+
+    Takes several candidates because the object holding the loader differs by
+    runtime: the dashboard has ``state.context_builder``, while the API-server
+    path builds its state without one and reaches it through the task runner.
+    Returns whether an observer was installed, so a caller can log a miss rather
+    than silently recording nothing.
+
+    Lives here rather than in the dashboard: every runtime that owns a
+    ContextBuilder calls it, so homing it in one surface's module made the others
+    import that surface just to reach it.
+    """
+    for candidate in candidates:
+        skills = getattr(candidate, "skills", None)
+        if skills is not None:
+            set_global_skill_read_observer(skills)
+            return True
+    return False
+
 
 #: Basename of the persisted ledger, under ``$KIROCREW_HOME``.
 SKILL_USAGE_FILENAME = "skill-usage.json"

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -342,6 +342,108 @@ def _within_any(candidate: str, roots: tuple[str, ...]) -> bool:
     return False
 
 
+#: Basename every skill's body lives under. Used as a cheap pre-filter before
+#: any filesystem work when deciding whether a tool call touched a skill.
+_SKILL_FILE = "SKILL.md"
+
+#: Argument names under which file-reading tools carry their target. Covers the
+#: builtin read tool's ``path`` plus the spellings other tools use; a name that
+#: is absent simply yields no candidate.
+_TOOL_READ_PATH_KEYS = ("path", "file_path", "filePath", "paths", "files")
+
+#: A whitespace/quote-delimited token ending in the skill basename — how a skill
+#: read appears inside a shell command (``cat /x/SKILL.md``). Anchored on the
+#: basename so it cannot match an arbitrary argument.
+_SHELL_SKILL_PATH_RE = re.compile(r"""[^\s"'|;&><]+SKILL\.md""")
+
+
+def _tool_read_path_candidates(
+    tool_name: str, raw_params: dict | None, command: str | None
+) -> list[str]:
+    """File targets of a tool call that DELIVERS file content to the model.
+
+    Returns nothing for a call that merely names a path — a delete, move, line
+    count, or grep. The ledger's hits mean "a body reached the model", so
+    crediting a mention would re-create the mention-as-use conflation that the
+    separate searches tally exists to avoid.
+
+    Never raises on a malformed params dict — a tool's arguments are
+    model-authored and may hold anything.
+    """
+    out: list[str] = []
+    if isinstance(raw_params, dict) and tool_name in _CONTENT_READ_TOOLS:
+        for key in _TOOL_READ_PATH_KEYS:
+            value = raw_params.get(key)
+            if isinstance(value, str):
+                out.append(value)
+            elif isinstance(value, (list, tuple)):
+                out.extend(v for v in value if isinstance(v, str))
+    if isinstance(command, str) and command:
+        for segment in _shell_segments_reading_content(command):
+            out.extend(_SHELL_SKILL_PATH_RE.findall(segment))
+    return out
+
+
+#: Shell commands that deliver a file's CONTENT to the model. Deliberately
+#: narrow: the ledger counts bodies that reached the model, so a command that
+#: merely names a path — ``rm``, ``mv``, ``wc``, ``chmod`` — earns nothing, and
+#: neither does ``grep``, which emits matching lines rather than the body.
+#: ``head``/``tail`` deliver a prefix, which is still a body the model read.
+_SHELL_READ_VERBS = frozenset(
+    {"cat", "bat", "head", "tail", "less", "more", "view", "type"}
+)
+
+#: Tools whose result hands the model a file's content. ``grep``/``glob`` are
+#: read-KIND but return matches and names, not bodies, so they are excluded for
+#: the same reason ``grep`` is above.
+_CONTENT_READ_TOOLS = frozenset({"fs_read", "read", "read_file", "readFile"})
+
+#: Splits a shell command into independently-invoked segments, so the verb that
+#: applies to a given path is the one that precedes it in ITS segment — without
+#: this, ``cat a.txt && rm x/SKILL.md`` would read as a ``cat`` of the skill.
+_SHELL_SEGMENT_RE = re.compile(r"(?:\|\||&&|[;|&\n]|\$\(|`)")
+
+
+def _shell_segments_reading_content(command: str) -> list[str]:
+    """Segments of *command* whose leading verb delivers file content.
+
+    A segment's verb is its first bare token; leading environment assignments
+    (``FOO=bar cat x``) and absolute paths (``/bin/cat``) are tolerated.
+    """
+    reading: list[str] = []
+    for segment in _SHELL_SEGMENT_RE.split(command):
+        for token in segment.split():
+            if "=" in token and not token.startswith("-"):
+                continue  # leading VAR=value assignment
+            verb = token.rsplit("/", 1)[-1]
+            if verb in _SHELL_READ_VERBS:
+                reading.append(segment)
+            break  # only the segment's first bare token is its verb
+    return reading
+
+
+def _mentions_skill_basename(raw_params: dict | None, command: str | None) -> bool:
+    """Whether a tool call's arguments name a skill body at all.
+
+    Independent of read intent: used only to tell "this call had nothing to do
+    with skills" apart from "this call named a skill but our read-intent
+    allowlists did not recognise it", which is what a provider tool rename looks
+    like from here.
+    """
+    if isinstance(command, str) and _SKILL_FILE in command:
+        return True
+    if not isinstance(raw_params, dict):
+        return False
+    for value in raw_params.values():
+        if isinstance(value, str):
+            if _SKILL_FILE in value:
+                return True
+        elif isinstance(value, (list, tuple)):
+            if any(isinstance(v, str) and _SKILL_FILE in v for v in value):
+                return True
+    return False
+
+
 def _iter_skill_files(base: Path) -> list[tuple[str, Path]]:
     """Recursively find all SKILL.md files under *base*.
 
@@ -708,6 +810,99 @@ class SkillsLoader:
             return skill_file.is_relative_to(self._dir)
         except (OSError, ValueError):
             return False
+
+    def _served_key_by_realpath(self) -> dict[str, str]:
+        """Map each served skill file's realpath to its canonical served key.
+
+        Applies the same canonical rule as ``resolve_ledger_aliases`` — the real
+        file's key beats a symlink's, then alphabetical — so a read through a
+        symlinked skill is credited to the key the budget screen displays rather
+        than splitting one file's cost across two rows. Uncached and
+        resolve()-bound for the same reason stated there, so callers must gate
+        it behind a cheap check rather than running it per tool call.
+        """
+        by_realpath: dict[str, list[tuple[str, Path]]] = {}
+        for key, skill_file in self._iter():
+            try:
+                rp = str(skill_file.resolve())
+            except (OSError, RuntimeError):
+                # A cyclic symlink raises RuntimeError, not OSError.
+                continue
+            by_realpath.setdefault(rp, []).append((key, skill_file))
+        return {
+            rp: min(pairs, key=lambda p: (p[1].is_symlink(), p[0]))[0]
+            for rp, pairs in by_realpath.items()
+        }
+
+    def resolve_tool_read_keys(
+        self,
+        tool_name: str = "",
+        raw_params: dict | None = None,
+        command: str | None = None,
+    ) -> list[str]:
+        """Served skill keys whose body a tool call is about to deliver.
+
+        Resolution only — nothing is recorded, so the caller can run this off
+        the event loop and credit later, once the read is confirmed to have
+        completed. Returns keys deduped, so one command naming a file twice
+        yields it once.
+
+        Only content-delivering reads qualify (see
+        ``_tool_read_path_candidates``): a tool call that merely names a skill
+        path earns nothing, because the ledger's hits mean a body reached the
+        model.
+
+        Filesystem-bound (``_iter`` plus a ``resolve()`` per served skill), so
+        candidates are filtered on the ``SKILL.md`` basename first and callers
+        must keep this off the event loop.
+        """
+        if self._usage is None:
+            return []
+        candidates = [
+            c
+            for c in _tool_read_path_candidates(tool_name, raw_params, command)
+            if _SKILL_FILE in c
+        ]
+        if not candidates:
+            # The read-intent allowlists (`_CONTENT_READ_TOOLS`,
+            # `_SHELL_READ_VERBS`) encode the provider's current tool spellings.
+            # A rename would silently restore the pre-existing undercount with
+            # nothing failing, so a call that clearly names a skill yet yields no
+            # candidate is logged — the one signal that distinguishes drift from
+            # a legitimately non-reading tool call.
+            if _mentions_skill_basename(raw_params, command):
+                logger.debug(
+                    "skill-read: %r names a skill but is not a content read "
+                    "(tool=%r); check the read-intent allowlists if the provider "
+                    "renamed its tools",
+                    command or raw_params,
+                    tool_name,
+                )
+            return []
+        try:
+            realpath_to_key = self._served_key_by_realpath()
+        except OSError:
+            return []
+        keys: list[str] = []
+        for cand in candidates:
+            try:
+                rp = str(Path(cand).expanduser().resolve())
+            except (OSError, RuntimeError, ValueError):
+                continue
+            key = realpath_to_key.get(rp)
+            if key is not None and key not in keys:
+                keys.append(key)
+        return keys
+
+    def credit_skill_reads(self, keys: list[str]) -> None:
+        """Record a delivery for each key in *keys*. Best-effort, never raises.
+
+        Separate from ``resolve_tool_read_keys`` so the credit lands only after
+        the read has actually completed — a tool call that was denied or failed
+        must not leave a delivery behind.
+        """
+        for key in keys:
+            self._record_use(key)
 
     def resolve_ledger_aliases(self) -> dict[str, list[str]]:
         """Map served skill keys to ledger keys that resolve to the same file.

--- a/test/test_skill_read_observer.py
+++ b/test/test_skill_read_observer.py
@@ -1,0 +1,301 @@
+"""Skill-read observation at the ACP layer.
+
+The ACP client is the only place that sees every surface's tool calls, so the
+observer lives there rather than in each surface's event handler. These tests
+pin the properties that make it safe: the cheap gate that keeps unrelated tool
+calls off the filesystem, the dedup that stops one read being credited twice
+when both the initial ``tool_call`` and its refinement carry arguments, and the
+two-phase split that withholds the credit until the tool reports completion.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from kiro_crew.acp.client import _mentions_skill_file
+from kiro_crew.skill_usage import (
+    get_global_skill_read_observer,
+    register_skill_read_observer,
+    set_global_skill_read_observer,
+)
+
+
+class TestMentionsSkillFile:
+    def test_shell_command_naming_a_skill(self):
+        assert _mentions_skill_file(None, "cat /x/skills/a/SKILL.md") is True
+
+    def test_read_tool_path(self):
+        assert _mentions_skill_file({"path": "/x/skills/a/SKILL.md"}, None) is True
+
+    def test_list_valued_paths(self):
+        assert _mentions_skill_file({"paths": ["/a/SKILL.md"]}, None) is True
+
+    def test_unrelated_call_is_gated_out(self):
+        assert _mentions_skill_file({"path": "/etc/hosts"}, None) is False
+        assert _mentions_skill_file(None, "ls -la") is False
+        assert _mentions_skill_file(None, None) is False
+
+    def test_non_dict_and_odd_values_are_tolerated(self):
+        # Tool arguments are model-authored and may hold any shape.
+        assert _mentions_skill_file("nope", None) is False  # type: ignore[arg-type]
+        assert _mentions_skill_file({"path": 42, "x": [None, 1]}, None) is False
+
+    def test_any_argument_name_counts(self):
+        # The gate is deliberately name-agnostic: it decides only whether the
+        # offloaded resolver is worth calling, and the resolver applies the
+        # read-intent rules. Narrowing it here would let a differently-named
+        # argument slip past observation entirely.
+        assert _mentions_skill_file({"whatever": "/a/SKILL.md"}, None) is True
+
+
+class _Observer:
+    """Records both phases so a test can tell resolution from crediting."""
+
+    def __init__(self, keys=("alpha",), fail_resolve=False, fail_credit=False):
+        self._keys = list(keys)
+        self._fail_resolve = fail_resolve
+        self._fail_credit = fail_credit
+        self.resolved: list[tuple[str, dict | None, str | None]] = []
+        self.credited: list[list[str]] = []
+
+    def resolve_tool_read_keys(self, tool_name="", raw_params=None, command=None):
+        if self._fail_resolve:
+            raise RuntimeError("resolve exploded")
+        self.resolved.append((tool_name, raw_params, command))
+        return list(self._keys)
+
+    def credit_skill_reads(self, keys):
+        if self._fail_credit:
+            raise RuntimeError("credit exploded")
+        self.credited.append(list(keys))
+
+
+class _FakeClient:
+    """Binds the real observation methods to only the state they touch.
+
+    Exercises production logic without booting a kiro-cli subprocess; if those
+    methods later reach for more client state the test fails loudly rather than
+    passing against a fiction.
+    """
+
+    def __init__(self):
+        from kiro_crew.acp.client import AcpClient
+
+        self._skill_read_noted: set[str] = set()
+        self._pending_skill_reads: dict[str, list[str]] = {}
+        self._note = AcpClient._maybe_note_skill_read.__get__(self)
+        self._credit = AcpClient._maybe_credit_skill_read.__get__(self)
+
+    async def call(self, event):
+        await self._note(event)
+
+    def result(self, event):
+        self._credit(event)
+
+
+def _call_event(tool_call_id="t1", raw=None, command=None, tool_name="fs_read"):
+    return SimpleNamespace(
+        tool_call_id=tool_call_id,
+        raw_tool_params=raw,
+        shell_command=command,
+        tool_name=tool_name,
+    )
+
+
+def _result_event(tool_call_id="t1", final=True):
+    return SimpleNamespace(tool_call_id=tool_call_id, tool_final=final)
+
+
+SKILL_ARGS = {"path": "/x/a/SKILL.md"}
+
+
+class TestRegistrationIsNotRouteDependent:
+    """Every runtime that owns a ContextBuilder must register the observer.
+
+    Route-dependent crediting is the bias this feature exists to remove, so a
+    runtime that records nothing would ship a smaller version of the same
+    defect. The entry-point assertions read each module's SOURCE, because
+    booting three runtimes in a unit test would prove less and cost more.
+    """
+
+    def setup_method(self):
+        self._prior = get_global_skill_read_observer()
+
+    def teardown_method(self):
+        set_global_skill_read_observer(self._prior)
+
+    def test_the_first_candidate_with_a_loader_wins(self):
+        class _Ctx:
+            skills = "loader-sentinel"
+
+        assert register_skill_read_observer(_Ctx()) is True
+        assert get_global_skill_read_observer() == "loader-sentinel"
+
+    def test_a_later_candidate_is_used_when_the_first_has_none(self):
+        # The API-server path builds its state without a context_builder and
+        # reaches the loader through the task runner; registering only the first
+        # candidate would leave that whole route crediting nothing.
+        class _Runner:
+            skills = "runner-loader"
+
+        set_global_skill_read_observer(None)
+        assert register_skill_read_observer(None, _Runner()) is True
+        assert get_global_skill_read_observer() == "runner-loader"
+
+    def test_no_candidate_reports_a_miss_rather_than_installing(self):
+        set_global_skill_read_observer(None)
+        assert register_skill_read_observer(None, object()) is False
+        assert get_global_skill_read_observer() is None
+
+    def test_both_server_entry_points_register(self):
+        from pathlib import Path
+
+        import kiro_crew.dashboard.server as mod
+
+        src = Path(mod.__file__).read_text(encoding="utf-8")
+        for entry in ("async def start_dashboard(", "async def start_api_server("):
+            assert entry in src
+        assert src.count("register_skill_read_observer(") == 2
+
+    def test_the_api_server_path_passes_the_task_runner_context(self):
+        from pathlib import Path
+
+        import kiro_crew.dashboard.server as mod
+
+        src = Path(mod.__file__).read_text(encoding="utf-8")
+        assert 'getattr(task_runner, "_ctx", None)' in src
+
+    def test_the_cli_entry_point_registers_without_importing_the_dashboard(self):
+        from pathlib import Path
+
+        import kiro_crew.cli_server as mod
+
+        src = Path(mod.__file__).read_text(encoding="utf-8")
+        assert "register_skill_read_observer(ctx)" in src
+        # The helper is homed in a leaf module, so no runtime needs to import
+        # another surface just to register.
+        assert "from kiro_crew.dashboard.server import register" not in src
+
+
+class TestObserveSkillRead:
+    def setup_method(self):
+        self._prior = get_global_skill_read_observer()
+
+    def teardown_method(self):
+        set_global_skill_read_observer(self._prior)
+
+    @pytest.mark.asyncio
+    async def test_credit_waits_for_the_tool_to_complete(self):
+        # A read that is resolved but never completes must leave no delivery --
+        # otherwise a denied or failed read persists a false hit.
+        obs = _Observer()
+        set_global_skill_read_observer(obs)
+        client = _FakeClient()
+        await client.call(_call_event(raw=SKILL_ARGS))
+        assert obs.resolved and obs.credited == []
+        client.result(_result_event())
+        assert obs.credited == [["alpha"]]
+
+    @pytest.mark.asyncio
+    async def test_unfinished_result_does_not_credit(self):
+        obs = _Observer()
+        set_global_skill_read_observer(obs)
+        client = _FakeClient()
+        await client.call(_call_event(raw=SKILL_ARGS))
+        client.result(_result_event(final=False))
+        assert obs.credited == []
+
+    @pytest.mark.asyncio
+    async def test_same_tool_call_resolves_once(self):
+        # The arguments arrive on the initial tool_call for some providers and
+        # only on the refinement for others; both are observed, so without dedup
+        # a single read would be resolved -- and credited -- twice.
+        obs = _Observer()
+        set_global_skill_read_observer(obs)
+        client = _FakeClient()
+        ev = _call_event(raw=SKILL_ARGS)
+        await client.call(ev)
+        await client.call(ev)
+        assert len(obs.resolved) == 1
+        client.result(_result_event())
+        assert obs.credited == [["alpha"]]
+
+    @pytest.mark.asyncio
+    async def test_a_second_result_for_the_same_call_does_not_double_credit(self):
+        obs = _Observer()
+        set_global_skill_read_observer(obs)
+        client = _FakeClient()
+        await client.call(_call_event(raw=SKILL_ARGS))
+        client.result(_result_event())
+        client.result(_result_event())
+        assert obs.credited == [["alpha"]]
+
+    @pytest.mark.asyncio
+    async def test_distinct_tool_calls_are_both_credited(self):
+        obs = _Observer()
+        set_global_skill_read_observer(obs)
+        client = _FakeClient()
+        await client.call(_call_event("t1", raw=SKILL_ARGS))
+        await client.call(_call_event("t2", raw={"path": "/x/b/SKILL.md"}))
+        client.result(_result_event("t1"))
+        client.result(_result_event("t2"))
+        assert len(obs.credited) == 2
+
+    @pytest.mark.asyncio
+    async def test_unrelated_tool_call_never_reaches_the_observer(self):
+        obs = _Observer()
+        set_global_skill_read_observer(obs)
+        await _FakeClient().call(_call_event(raw={"path": "/etc/hosts"}))
+        assert obs.resolved == []
+
+    @pytest.mark.asyncio
+    async def test_resolver_returning_nothing_credits_nothing(self):
+        # A non-read tool naming a skill resolves to no keys; the result must
+        # then credit nothing rather than crediting an empty read.
+        obs = _Observer(keys=())
+        set_global_skill_read_observer(obs)
+        client = _FakeClient()
+        await client.call(_call_event(raw=SKILL_ARGS, tool_name="fs_write"))
+        client.result(_result_event())
+        assert obs.credited == []
+
+    @pytest.mark.asyncio
+    async def test_no_observer_registered_is_a_noop(self):
+        set_global_skill_read_observer(None)
+        client = _FakeClient()
+        await client.call(_call_event(raw=SKILL_ARGS))
+        client.result(_result_event())
+
+    @pytest.mark.asyncio
+    async def test_resolver_failure_does_not_propagate(self):
+        set_global_skill_read_observer(_Observer(fail_resolve=True))
+        await _FakeClient().call(_call_event(raw=SKILL_ARGS))
+
+    @pytest.mark.asyncio
+    async def test_credit_failure_does_not_propagate(self):
+        # Telemetry must never disturb the tool call it observes.
+        obs = _Observer(fail_credit=True)
+        set_global_skill_read_observer(obs)
+        client = _FakeClient()
+        await client.call(_call_event(raw=SKILL_ARGS))
+        client.result(_result_event())
+
+    @pytest.mark.asyncio
+    async def test_resolution_runs_off_the_event_loop(self):
+        # A skills-tree walk on the loop stalls every session in the gateway,
+        # so the resolver must not execute on the loop's thread.
+        import threading
+
+        loop_thread = threading.get_ident()
+        seen: list[int] = []
+
+        class _ThreadProbe(_Observer):
+            def resolve_tool_read_keys(self, tool_name="", raw_params=None, command=None):
+                seen.append(threading.get_ident())
+                return ["alpha"]
+
+        set_global_skill_read_observer(_ThreadProbe())
+        await _FakeClient().call(_call_event(raw=SKILL_ARGS))
+        assert seen and seen[0] != loop_thread

--- a/test/test_skills.py
+++ b/test/test_skills.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from kiro_crew.config.loader import KiroCrewConfig, SkillsConfig
+from kiro_crew.skill_usage import SkillUsageLedger
 from kiro_crew.skills import _SHORT_DESC_CHARS, SkillsLoader
 
 
@@ -33,6 +34,142 @@ def _create_skill(skills_dir, name, content):
     skill_dir = skills_dir / name
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(content)
+
+
+class TestNoteToolRead:
+    """Only content-delivering reads credit the ledger."""
+
+    def _loader(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        _create_skill(
+            skills_dir, "alpha", "---\nname: alpha\ndescription: A\n---\n# Alpha\n"
+        )
+        _create_skill(
+            skills_dir, "beta", "---\nname: beta\ndescription: B\n---\n# Beta\n"
+        )
+        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False)
+        loader._usage = SkillUsageLedger(tmp_path / "skill-usage.json")
+        return loader, skills_dir
+
+    def _read(self, loader, **kw):
+        """Resolve then credit, the way the ACP layer does across two events."""
+        keys = loader.resolve_tool_read_keys(**kw)
+        loader.credit_skill_reads(keys)
+        return keys
+
+    def test_read_tool_path_credits_a_hit(self, tmp_path):
+        loader, skills_dir = self._loader(tmp_path)
+        path = str(skills_dir / "alpha" / "SKILL.md")
+        assert self._read(loader, tool_name="fs_read", raw_params={"path": path}) == [
+            "alpha"
+        ]
+        assert loader._usage.score("alpha")[0] == 1.0
+        assert loader._usage.score("beta")[0] == 0.0
+
+    def test_shell_cat_credits_a_hit(self, tmp_path):
+        loader, skills_dir = self._loader(tmp_path)
+        cmd = f"cat {skills_dir / 'beta' / 'SKILL.md'}"
+        assert self._read(loader, command=cmd) == ["beta"]
+        assert loader._usage.score("beta")[0] == 1.0
+
+    def test_resolution_alone_records_nothing(self, tmp_path):
+        # The ACP layer resolves at call time and credits only once the tool
+        # reports completion, so resolving must have no side effect.
+        loader, skills_dir = self._loader(tmp_path)
+        cmd = f"cat {skills_dir / 'alpha' / 'SKILL.md'}"
+        assert loader.resolve_tool_read_keys(command=cmd) == ["alpha"]
+        assert loader._usage.snapshot() == {}
+
+    def test_one_command_naming_a_file_twice_counts_once(self, tmp_path):
+        loader, skills_dir = self._loader(tmp_path)
+        p = skills_dir / "alpha" / "SKILL.md"
+        assert self._read(loader, command=f"cat {p} && cat {p}") == ["alpha"]
+        assert loader._usage.score("alpha")[0] == 1.0
+
+    def test_non_read_shell_verbs_are_not_credited(self, tmp_path):
+        # A tool call that merely NAMES a skill is not a delivery. Crediting it
+        # would be the same mention-as-use conflation the searches tally avoids:
+        # a maintenance session could push an unread skill up the ranking.
+        loader, skills_dir = self._loader(tmp_path)
+        p = skills_dir / "alpha" / "SKILL.md"
+        for cmd in (
+            f"rm {p}",
+            f"mv {p} /tmp/x",
+            f"wc -l {p}",
+            f"grep -l foo {p}",
+            f"chmod 600 {p}",
+            f"cp {p} /tmp/x",
+            f"stat {p}",
+        ):
+            assert loader.resolve_tool_read_keys(command=cmd) == [], cmd
+        assert loader._usage.snapshot() == {}
+
+    def test_a_read_verb_in_another_segment_does_not_launder_a_delete(self, tmp_path):
+        # `cat` applies to its OWN segment only; without per-segment verb
+        # attribution this would credit the deleted skill.
+        loader, skills_dir = self._loader(tmp_path)
+        p = skills_dir / "alpha" / "SKILL.md"
+        assert loader.resolve_tool_read_keys(command=f"cat /etc/hosts && rm {p}") == []
+
+    def test_read_verb_variants_are_credited(self, tmp_path):
+        loader, skills_dir = self._loader(tmp_path)
+        p = skills_dir / "beta" / "SKILL.md"
+        for cmd in (f"head -20 {p}", f"tail -5 {p}", f"/bin/cat {p}", f"LC_ALL=C cat {p}"):
+            assert loader.resolve_tool_read_keys(command=cmd) == ["beta"], cmd
+
+    def test_non_read_tool_name_is_not_credited(self, tmp_path):
+        # Structured tools are allowlisted: an edit/write tool carrying a path
+        # must not be mistaken for a delivery.
+        loader, skills_dir = self._loader(tmp_path)
+        path = str(skills_dir / "alpha" / "SKILL.md")
+        assert loader.resolve_tool_read_keys("fs_write", {"path": path}) == []
+        assert loader.resolve_tool_read_keys("grep", {"path": path}) == []
+        assert loader.resolve_tool_read_keys("fs_read", {"path": path}) == ["alpha"]
+
+    def test_unrelated_tool_call_records_nothing(self, tmp_path):
+        loader, _ = self._loader(tmp_path)
+        assert self._read(loader, tool_name="fs_read", raw_params={"path": "/etc/hosts"}) == []
+        assert self._read(loader, command="ls -la /tmp") == []
+        assert loader._usage.snapshot() == {}
+
+    def test_path_outside_the_skills_tree_is_not_credited(self, tmp_path):
+        # A file that merely shares the basename must not be attributed to a skill.
+        decoy = tmp_path / "elsewhere"
+        decoy.mkdir()
+        (decoy / "SKILL.md").write_text("---\nname: fake\n---\n")
+        loader, _ = self._loader(tmp_path)
+        assert loader.resolve_tool_read_keys("fs_read", {"path": str(decoy / "SKILL.md")}) == []
+
+    def test_malformed_params_do_not_raise(self, tmp_path):
+        loader, _ = self._loader(tmp_path)
+        assert loader.resolve_tool_read_keys("fs_read", {"path": 42}) == []
+        assert loader.resolve_tool_read_keys("fs_read", {"paths": [None, 7]}) == []
+        assert loader.resolve_tool_read_keys("fs_read", "not-a-dict") == []  # type: ignore[arg-type]
+
+    def test_read_without_a_ledger_is_a_noop(self, tmp_path):
+        loader, skills_dir = self._loader(tmp_path)
+        loader._usage = None
+        path = str(skills_dir / "alpha" / "SKILL.md")
+        assert loader.resolve_tool_read_keys("fs_read", {"path": path}) == []
+
+    def test_symlinked_skill_credits_the_canonical_key(self, tmp_path):
+        # Reading through a symlinked skill must credit the same key the budget
+        # screen shows, or one file's cost splits across two rows.
+        loader, skills_dir = self._loader(tmp_path)
+        link_dir = skills_dir / "alpha-alias"
+        link_dir.mkdir()
+        try:
+            (link_dir / "SKILL.md").symlink_to(skills_dir / "alpha" / "SKILL.md")
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+        loader._iter_cache = None  # re-walk so the alias is served
+        recorded = self._read(
+            loader, tool_name="fs_read", raw_params={"path": str(link_dir / "SKILL.md")}
+        )
+        canonical = loader._served_key_by_realpath()[
+            str((skills_dir / "alpha" / "SKILL.md").resolve())
+        ]
+        assert recorded == [canonical] == ["alpha"]
 
 
 class TestSkillsLoader:


### PR DESCRIPTION
# What is the problem?

The skill-usage ledger records a hit in only two places: the body-delivery loop in
`context.py` and `resolve_dollar_skills`. Since `skills.max_triggered` defaults to `0`
the delivery loop never runs, so **`$skillname` is the ledger's only source of hits** —
a fact the module spec already states.

That is not how the model usually reaches a skill. It reads `SKILL.md` directly:
the builtin file-read tool, or `cat` in a shell. Those reads bypass the loader
entirely and record nothing.

The gap compounds, because the ledger feeds two orderings. `search_skills` ranks
its own results by `self._usage.score(...)`, and `_rank_key` ranks the session
index the same way — so a skill the model can only find via search never earns
weight, sinks in both orderings, and becomes harder to find. That is a
self-reinforcing bias, not a flat undercount.

# Why this issue matters to the user

Lazy-load ranking decides which skills get a slot in the session index and which
are left to `skill_search`. Fed by one access route, the ranking describes how a
skill was reached rather than how much it is used, and it degrades toward
recency-only. The user sees good skills stay buried, and a Context Budget screen
whose `deliveries` column undercounts every skill the model reads with `cat`.

This matters more over time, not less: as skill descriptions leave the session
index, the model leans harder on search to discover anything, so the route that
earns no ranking weight becomes the dominant one.

# How our fix solves it

**Symptom → root cause → fix.**

*Direct reads are invisible.* Root cause: the loader is not on the path — the
model talks to kiro-cli's own tools. Fix: `SkillsLoader.resolve_tool_read_keys()`
resolves which served skills a tool call would deliver, and
`credit_skill_reads()` records them.

*Only content-delivering reads qualify.* The ledger's hits mean "a body reached
the model", so a call that merely *names* a skill earns nothing — `rm`, `mv`,
`cp`, `wc`, `chmod`, `stat`, and `grep` (which emits matching lines, not the
body) are all excluded. Crediting a mention would re-create the mention-as-use
conflation that delivery-only recording exists to avoid, and would let a
skill-maintenance session push an unread skill up the ranking. The shell path
attributes a verb **per command segment**, so `cat a.txt && rm x/SKILL.md` is not
read as a `cat` of the skill; the structured path allowlists content-returning
tools, so an edit or grep tool carrying a `path` is not mistaken for a delivery.

*Attribution must match the budget screen.* Reads resolve through
`_served_key_by_realpath()`, which applies the **same canonical rule** as
`resolve_ledger_aliases` (real file beats symlink, then alphabetical). Without it
a read through a symlinked skill would land on a different key than the one the
Context Budget screen displays, splitting one file's cost across two rows.

*Where to observe.* The per-surface permission gate (`HookManager.on_tool_call`)
cannot serve: file reads are auto-approved, so they never reach it. Wiring each
surface's event handler separately would have left subagent reads uncounted — a
skewed ledger is worse than a partial one. So observation sits in the **ACP
client**, the one layer that sees every surface's tool calls, reached through a
process-wide slot — the same pattern the ACP client already uses for
`get_global_hook_store`. Both the initial `tool_call` and its `tool_call_update`
refinement are observed, since which one carries `rawInput` is provider-specific,
deduped by `tool_call_id`.

*Crediting waits for the read to happen.* Resolution runs at the tool call and is
**offloaded to a thread** (it walks the skills tree and resolves every served
skill; on the event loop that would stall every session in the gateway). The
credit lands only on a `status == "completed"` result, so a read that was denied,
errored, or never ran leaves no delivery behind. A cheap `SKILL.md` substring gate
runs before the offload, so a tool call touching no skill costs a substring scan.

*Crediting must not vary by entry point.* Registration goes through one helper,
`register_skill_read_observer`, called from `start_dashboard`, `start_api_server`,
and the CLI in `cli_server.py`. Route-dependent visibility is the exact bias this
PR removes, so a runtime that recorded nothing would ship a smaller version of
the same defect.

**The ledger itself is untouched.** `src/kiro_crew/skill_usage.py`'s existing code
is byte-identical to `main`; this PR only appends the observer slot. That is
deliberate — see below.

# What tests we did

21 tests across two files, all gates green locally: `pytest`, `isort`, `flake8`,
`mypy` 1.14.1 (matching the `pyproject.toml` pin, no `faiss` in the venv).

- `test_skills.py::TestNoteToolRead` (13) — read-tool `path`, shell `cat`,
  resolution having no side effect, one command naming a file twice counted once,
  seven non-read verbs (`rm`/`mv`/`wc`/`grep -l`/`chmod`/`cp`/`stat`) credited
  nothing, a read verb in another segment not laundering a delete, read-verb
  variants (`head`/`tail`/`/bin/cat`/`LC_ALL=C cat`), non-read tool names,
  a same-basename file outside the skills tree not attributed, malformed
  model-authored params tolerated, no-ledger no-op, and symlink attribution
  landing on the canonical key.
- `test_skill_read_observer.py` (21) — the cheap gate including malformed shapes;
  the credit waiting for completion; an unfinished result crediting nothing;
  dedup across the two events; a second result not double-crediting; distinct
  calls both credited; unrelated calls never reaching the observer; a resolver
  returning nothing crediting nothing; resolver and credit failures not
  propagating; resolution running off the event-loop thread (asserted by thread
  identity, not timing); and all three entry points registering.

**Mutations verified** (each reverted after): dropping the per-segment read-verb
gate makes all seven non-read verbs count as deliveries; crediting at call time
instead of on completion breaks the completion tests; the canonical rule `min` →
`max` misattributes a symlinked read; short-circuiting the dedup double-credits
one read; removing the CLI registration is caught by the route-dependence test.

Full backend suite: **33,207 passed, 64 failed** — every failure environmental on
this host (`uid 65534` file-ownership, sandbox backends, `gh` resolution) in
`test_sandbox_*`, `test_service.py`, `test_source_providers.py`,
`test_issue_radar_gh_bin.py`, `test_gateway_lock_diagnosis.py` and
`ops_mission_control`. Zero failures in any skill or ACP area, and the same subset
still fails with this branch's changes stashed.

No frontend changes, so the i18n gates are not engaged.

# Any other suggestions on the work

**A `searches` tally was cut from this PR, on review feedback, and the reasoning
is worth recording.** An earlier revision also counted `skill_search`
appearances in a tally separate from `hits`. Design Review pointed out that
`AGENTS.md` lines 265-270 require the opposite:

> **MCP tools MUST be stateless.** […] **Durable state lives behind a gateway
> endpoint keyed by session.**

`mcp_core` builds a throwaway `SkillsLoader` per `skill_search` call, and every
loader constructs its own ledger with its own snapshot — so recording there made
an MCP tool a second writer to a whole-file store. Keeping it safe took ~150
lines of pending-delta ledgers, cross-process locking, RMW merge and per-tally
TTL, and **two of three blocking review rounds landed inside that machinery**.
The design was fighting the repo; the review rounds were the symptom.

Cutting it removes the rule violation and the concurrency surface together, and
leaves the ledger byte-identical to `main`. Nothing user-visible is lost: the
tally had no consumer. The right home for it is a gateway endpoint, landed
together with the Context Budget column that would read it — where
"found 40×, read 0×" tells a user a skill's metadata advertises something its
body does not deliver.

**The recency-only ranking is a pre-existing condition this improves but does not
resolve.** With `max_triggered=0`, ranking was effectively recency-only.
Direct-read crediting restores a real usage signal, but skills reached only
through `skill_fetch` (registry, uninstalled) still record nothing — correctly,
since they are not local skills.

**Unrelated debt this touched next to but did not fix:** `list_skills()` still
emits an unredacted LLM-authored `name` (3 sites), and `always: true` cost remains
unmeasurable (`chars: null`) on the budget endpoint.
