### PR TITLE
feat(storage): report what sessions cost on disk and reclaim it to a trash

### DIFF
--- a/docs/system-specs/modules/README.md
+++ b/docs/system-specs/modules/README.md
@@ -16,6 +16,7 @@ agent loads only the one it needs.
 | [providers.md](providers.md) | The `LLMProvider` interface and the KiroACP-only provider surface. |
 | [session.md](session.md) | Sessions, slots, session keys, the warm pool, and PID tracking. |
 | [history.md](history.md) | Conversation persistence, JSONL rotation, and transcript search. |
+| [session-storage.md](session-storage.md) | What sessions cost on disk, and the user-initiated trash that reclaims it. |
 | [config.md](config.md) | The config schema, defaults, loading, and live reload. |
 | [cli.md](cli.md) | Every CLI command, the gateway flags, and the test harness. |
 | [heartbeat.md](heartbeat.md) | The liveness heartbeat and its restricted tool allowlist. |

--- a/docs/system-specs/modules/history.md
+++ b/docs/system-specs/modules/history.md
@@ -351,7 +351,10 @@ no longer destroy older turns.
 Lines that ARE intentionally dropped (rotation, compaction, history edits) are
 archived instead of being permanently deleted:
 
-- **Archive location**: `~/.kiro/crew/sessions/archive/{key}__{YYYYMMDD-HHMMSS}.jsonl`
+- **Archive location**: `~/.kiro/crew/sessions/archive/{key}__{YYYYMMDD-HHMMSS}.jsonl`,
+  where the separator is `ARCHIVE_SEGMENT_DELIMITER`. It is `__` rather than a dot
+  because session keys legitimately contain dots (a Slack `thread_ts`), which a
+  right-most-dot parse would attribute to the wrong session.
 - **Triggers**: `_rotate()` (>2MB), `rewrite_session()` (compact), and the
   dashboard rewrite path (`_save_slot_to_history` with a snapshot /
   `rewrite=True` / `_pending_rewrite` → `_archive_dropped_lines`). The default
@@ -362,6 +365,16 @@ archived instead of being permanently deleted:
   `_cleanup_old_archives()` reads the value from config when called with no
   explicit `retention_days`, and is rate-limited to once per hour.
 - **API**: `GET /api/session/archive` (list), `GET /api/session/archive/{name}` (read with path traversal protection)
+
+### Pairing a session key with its files
+
+`transcript_stem(key)` returns the filename stem a key's transcript and archive
+segments share — the sanitized key (`dashboard:chat-1` → `dashboard_chat-1`). It is
+public so callers that account for or reclaim a session's disk usage
+([session-storage](session-storage.md)) resolve the pairing here instead of
+re-deriving the sanitization. A second copy of that rule would drift the moment
+this one changed, and the failure is silent and destructive: the pairing misses,
+and a caller deleting "the session" removes one half and leaves the other behind.
 
 - `set_title(key, title)` — persists a title into the session's metadata line (first line of JSONL)
 

--- a/docs/system-specs/modules/session-storage.md
+++ b/docs/system-specs/modules/session-storage.md
@@ -1,0 +1,438 @@
+# Session Storage Module
+
+## Overview
+
+`src/kiro_crew/session_storage.py` measures what conversations cost on disk and
+reclaims that space when a user asks. `src/kiro_crew/dashboard/handlers/session_storage.py`
+exposes it over HTTP. Reclaiming stages files under `<data home>/trash/sessions/`
+rather than unlinking them; emptying that trash is the only irreversible step and
+the only one that returns space to the filesystem.
+
+Nothing here runs on a timer. Every measurement is pulled by a request and every
+move is initiated by a user action.
+
+## One session, two stores
+
+A conversation's bytes live in two places, owned by two programs:
+
+| Store | Path | Read by |
+|---|---|---|
+| Transcript | `<data home>/sessions/<stem>.jsonl` + `sessions/archive/<stem>__<stamp>.jsonl` | Dashboard history, search, memory consolidation |
+| Replay log | `<kiro home>/sessions/cli/<sid>.json` + `<sid>.jsonl` | kiro-cli, to resume a session |
+
+That split is an implementation detail. `StorageReport` carries no per-store
+breakdown and the HTTP payload has no field from which one could be derived, so a
+client can only present a session as one thing with one size.
+`test_session_storage_api.py::TestReport::test_payload_never_splits_the_two_stores`
+pins the absence.
+
+### Halves are always reclaimed together
+
+`_unit_paths()` is the single answer to "what files is this session made of", and
+move, restore and delete all resolve through it. Reclaiming one half produces a
+session that is broken rather than gone: without its replay log a session still
+lists but cannot resume, and without its transcript a resumable session has no
+history or search. `TestMoveTakesBothHalves` and `TestRestoreIsAllOrNothing` fail
+if either half is dropped.
+
+Restore is all-or-nothing per session for the same reason. A file whose original
+path is occupied again blocks its whole session from being restored — the occupant
+is newer, and undoing a deletion must not cause one.
+
+**Inside a per-file loop, every error path is a session-level failure.** A file
+that cannot be sized, moved, or read from the manifest is a file the operation
+cannot account for, and continuing past it commits a manifest that omits it — the
+split this module exists to prevent, arrived at through an error path rather than a
+concurrency one. So those loops `break` and roll back rather than skip. Per-*session*
+and per-*batch* loops do skip, because that granularity is the unit of work: an
+unknown session id or an unreadable batch affects only itself.
+
+A move that fails part-way is rolled back, and so is a restore. If any of a
+session's files cannot be staged, the ones already moved are returned and the
+session is skipped; if any file cannot be put back, the ones already restored are
+re-staged. A half-moved session is the broken state above *and* invisible: the
+manifest would list the staged half while the rest stayed in place, so emptying the
+trash would destroy one half of a session nobody knew was split. A half-restored
+session is worse still — it is also **wedged**, because the manifest still names
+files that are no longer in the batch, so every retry fails its own staged-file
+check. `TestPartialMoveRollsBack` and
+`TestRestoreIsAllOrNothing::test_a_failed_restore_stays_retryable` fail when either
+rollback is removed.
+
+A session's kiro-cli files are **enumerated, not assumed**. A session is identified
+by its `.json` / `.jsonl` pair, but reclaiming takes every file whose stem matches
+the session id, so a lock file or a sidecar a future kiro-cli version adds follows
+its session instead of being orphaned. Kiro Crew is a co-owner of that directory's
+layout here, and this is what keeps an unrecognised file from becoming a partial
+removal.
+
+Not every session has both halves, and that is normal: a subagent run leaves only
+a replay log, and a session whose mapping was pruned leaves only a transcript. The
+rule is that whatever halves exist move together.
+
+### Pairing
+
+A session key and its transcript filename differ, because `history` sanitizes the
+key: `dashboard:chat-1` is stored as `dashboard_chat-1.jsonl`. Pairing therefore
+goes through `history.transcript_stems()`, never a second copy of that rule. A
+duplicated rule would drift the moment `history` changed, and the failure is
+**silent and destructive** — a missed pairing reclaims one half of a session.
+
+`transcript_stems` returns **every** name a key's transcript could occupy, not just
+the canonical one: a Slack thread predating the canonical `slack:<ts>` session key
+still logs under its bare `thread_ts` filename, and `ConversationLog._path` falls
+back to it. Knowing only the canonical stem would leave such a transcript looking
+like it belongs to no session — and therefore reclaimable while the session is
+still resumable.
+
+`SessionIndex` consequently maps **stem → session id**, not the reverse: one
+session legitimately owns several stems. It is supplied by the caller rather than
+read inside the module, so the exclusion set is explicit at the call site and a
+test can pin it. The handler builds it from `SessionMap.mapped_sids_by_key()`.
+`test_session_storage_api.py::TestIndexConstruction` pins the resolved stems as
+literals rather than by calling the resolver, so a resolver that stopped returning
+the legacy stem fails instead of agreeing with itself.
+
+## An instance that cannot see who is live must not reclaim
+
+The exclusion set comes from **this** instance's session map, but the kiro-cli
+replay store can be shared. When `KIROCREW_HOME` is overridden while `KIRO_HOME` is
+not — a dev gateway or a pod — this instance has its own map and the machine-wide
+store, so every session belonging to the default instance is missing from the map it
+consults: a resumable conversation reads as retired and could be staged and then
+emptied out from under a gateway this process cannot see.
+
+`reclaim_block_reason()` detects that configuration and `move_to_trash` refuses
+outright. Two things about how it decides:
+
+- It compares **resolved paths**, never whether the environment variables are set.
+  Both overrides are validated and silently fall back to the default when they name
+  an unsafe target, so `KIRO_HOME=/etc` beside an isolated `KIROCREW_HOME` leaves
+  the process on the shared store while a presence test reports it isolated.
+- It decides by **containment**, not by comparing the store against its default
+  location. Once the data home is isolated, the store must be that data home or live
+  inside it. A default-location test would pass the arrangement where sharing is
+  least visible: two isolated instances pointed at one *custom* `KIRO_HOME` see
+  neither the default store nor each other's maps.
+- The **legacy pre-migration home counts as a default**, not as isolation. An
+  install that has not yet migrated legitimately resolves to `~/.kirocrew`, and
+  treating that as an isolated instance refused every such install.
+- The refusal is **symmetric**. A default instance is also blocked when a
+  discoverable co-tenant shares its store: a pod isolates `KIROCREW_HOME` but
+  deliberately not `KIRO_HOME`, so each pod home under the pod root reads the
+  machine-wide replay store while keeping its own session map — and from the default
+  side, the pod's sessions read as retired. `_replay_store_cotenants()` enumerates
+  the pod root (host-side state at a known location) and the message names the
+  eviction command, because a refusal a user cannot act on is not better than the
+  hazard. A dev gateway pointed at some other `KIROCREW_HOME` is **not**
+  discoverable and remains a Known Limitation.
+
+Because that check reads real host state, tests must isolate `KIROCREW_POD_ROOT`
+alongside the homes, or their result depends on whether the machine happens to have
+pods.
+
+The freshness floor narrows the window but does not close it, since a session idle
+for a day is still resumable. Isolating both homes, or neither, is safe. The reason
+is surfaced in the report as `reclaim_blocked_reason` so a client can explain rather
+than offer an action that can only be refused.
+
+### The index is re-read after the scan, inside the lock
+
+Scanning a six-figure store is the slow part of a reclaim, so an index read *before*
+it is already stale by the time anything moves. `move_to_trash` therefore re-reads
+through a `refresh` callable **after** the scan and immediately before the move loop,
+making the authority check the freshest view available. The two active sets are
+**unioned**, so a re-read can only ever add protection, and a re-read that fails
+refuses the operation rather than proceeding on the stale view.
+
+The residual window is now the move loop itself. A session mapped during it is still
+staged — but staged means *in the trash*, fully restorable, and destroying it needs a
+second explicit `empty`. Closing the window completely needs the session/slot writer
+and this module to share one lock; that is recorded in Known Limitations rather than
+implied away.
+
+## What is reclaimable
+
+A session is excluded when its ID is still in the session map: that is a session
+the product can resume, and moving its files from under a live slot breaks it with
+no error the user would connect to the action.
+
+**The session map is not a complete registry of live sessions**, which is why
+mapping alone is not the guard. A subagent run creates a kiro-cli session that was
+never mapped — on the measured install, a third of sampled sessions were
+subagent-created — so a threshold of `0` would otherwise reclaim a conversation
+running right now and break its resume. `MIN_RECLAIM_AGE_DAYS` is therefore a hard
+floor no caller can lower: freshness is the one signal that does not depend on
+which subsystem owns a session, because a live session is being appended to. The
+floor is enforced in `move_to_trash` as well as in the selection helper, since the
+move is the chokepoint a caller could otherwise bypass by passing IDs directly.
+Sub-floor sessions are also left out of the reported reclaimable figure, so it
+never promises bytes no threshold can move.
+
+Age is the newest mtime across every file a session owns. A transcript is appended
+to while a session runs, so keying on an older metadata file or a long-since
+rotated segment would make a live session look stale.
+
+`select_reclaimable()` is separate from `move_to_trash()` so a caller can show the
+exact count and size before anything moves. The selection is re-derived at the
+moment of the move rather than accepted from the client, because the numbers on a
+screen may be minutes old.
+
+### Mutations are serialized across processes
+
+`move_to_trash`, `restore` and `empty_trash` each hold an exclusive file lock at
+`<data home>/trash/session-storage.lock`. Two interleaved reclaims can select the
+same session and land one half in each batch, after which neither batch can restore
+it and emptying either destroys half a session. The lock is a *file* lock rather
+than a thread lock because instances share the kiro-cli store — a pod and the live
+gateway both read `~/.kiro/sessions/cli` — so in-process exclusion would exclude
+nothing. `platform_compat.file_lock` fails closed, so a lock that cannot be taken
+raises instead of running the section unserialized.
+
+## The trash
+
+Staged batches live at `<data home>/trash/sessions/<batch id>/`, with each file
+kept under a `cli/` or `crew/` subdirectory. The two halves can share a filename,
+and a flat batch directory would let one silently overwrite the other — turning a
+reversible move into data loss.
+
+On a default install both stores sit under `~/.kiro`, so staging is a
+same-filesystem `os.rename`: instant regardless of size, and instantly reversible.
+A data home mounted apart from the kiro-cli store falls back to `shutil.move`,
+which copies — correct, but slow and needing the space twice while it runs.
+`StorageReport.trash_same_filesystem` reports which case applies.
+
+**Staging does not free space.** The bytes stay on disk until the trash is
+emptied. `StorageReport.trash_bytes` and the payload's `trash.still_on_disk` exist
+so a client can say so; a client that reports a reclaim as freed space contradicts
+its own payload.
+
+### Manifests
+
+Every batch carries an append-only `manifest.jsonl`: a header line, then one line
+per session recording each file's staged path, original absolute path, and size.
+Restore reads origins from the manifest instead of reconstructing them, so a layout
+change in either store cannot send a restored file to the wrong place.
+
+Append-only is load-bearing twice over. A batch can span six figures of sessions,
+so rewriting a whole-document manifest per session would cost quadratic bytes; and
+an interruption leaves every completed line intact, so a partial batch stays
+restorable. A trailing partial line is skipped rather than failing the batch —
+`TestTrashAccounting::test_a_truncated_final_line_does_not_lose_the_batch`.
+
+A batch with no readable manifest is omitted from `list_trash()`: its files could
+not be put back, so offering it as restorable would be a false promise.
+
+**The directory is the batch's identity, not the manifest header.** A header
+claiming a different batch id would make a targeted empty delete the batch it named
+rather than the one it came from, so a disagreement is treated as corruption and the
+batch is withheld. `TestBatchIdentityIsTheDirectory` covers both the tampered case
+and the invariant that every listed id resolves to its own directory.
+
+**A move that cannot be recorded is rolled back.** If appending a session's manifest
+entry fails — a full disk is the realistic case — its files are already out of live
+storage while nothing names them, which is strictly worse than never having moved:
+unresumable *and* unrestorable. The partial line is rewound and the files are put
+back. `TestManifestPersistenceFailure` fails when the rollback is removed.
+
+## Path safety
+
+A caller-supplied session or batch ID is joined onto a directory, so `_UNIT_ID_RE`
+rejects anything that could address a file elsewhere — separators, parent
+references, leading dots, and over-long names.
+
+A **link** planted under the trash root defeats that check by having a legal
+name, so `_batch_dir()` — the one place every caller resolves a batch id through —
+also refuses a path that is a link or that resolves outside the resolved trash
+root. The two checks are not redundant: containment catches a link pointing
+*outside*, and the link check catches one pointing at **another batch inside** the
+trash, where emptying the alias would destroy a real batch the caller never named.
+
+The link test goes through `platform_compat.is_link_or_junction()`, not
+`is_symlink()`, which reports False for an NTFS **junction**: on Windows a junction
+named as a valid batch id would read as a real directory and the delete would
+resolve through it. `list_trash()` uses the same resolver for the same reason.
+
+Containment is anchored to the **data home**, not to the trash root alone. The root
+sits under a directory the agent can write, so it could itself be replaced with a
+link; resolving relative to it would then accept batches under whatever it points at.
+Both `_batch_dir()` and `list_trash()` therefore require the resolved root to live
+beneath the resolved data home. This is a data-loss guard, not hardening: with the
+anchor removed, a self-consistent batch directory outside the home is enumerated as a
+batch and `empty` deletes it outright.
+
+The root must also **not be a link itself**, and that is a separate rule rather than a
+duplicate. The anchor catches a linked *ancestor* (a link at `<data home>/trash`
+escapes once resolved, while the root stays a real directory). The link test catches a
+linked *root* pointing somewhere **inside** the data home — the live sessions or
+archive tree — which satisfies both the anchor and per-batch containment. Measured
+with the link test removed: the live archive segment is enumerated as a batch and
+`empty` deletes it.
+
+`list_trash()` skips links rather than raising, so a planted link cannot wedge
+"empty everything"; naming that id explicitly is still refused.
+`empty_trash()` additionally re-resolves each target and confirms it is inside the
+trash root, so a tampered manifest cannot direct the delete outside it.
+
+Restore refuses a staged path that is a **symlink**, because `is_file()` follows
+links: one resolving inside the batch passes the `rel` validation, and moving it
+would put a link where the session's data belongs — leaving a dangling pointer once
+the batch is emptied. Only a link resolving *within* the batch reaches this check;
+`_staged_path` already refuses one that escapes.
+
+### The origin is derived, not trusted
+
+A manifest record's `origin` is not information restore needs: the staged path
+already encodes the store *and* the filename, and the filename **is** the session's
+identity (`<sid>.jsonl` for a replay log, `<stem>.jsonl` for a transcript). So
+`_canonical_origin()` derives the destination from `rel`, and the recorded origin is
+only checked for **agreement**.
+
+This matters because "inside a session store" is not a sufficient test: a tampered
+in-store origin names a *different session's* file, so both the containment check and
+the traversal check pass while the restore corrupts a session the user never touched.
+Deriving removes the choice; the agreement check then turns a disagreeing manifest
+into a refusal rather than a silently ignored field.
+
+### Restore never replaces an occupied origin
+
+The preflight rejects an origin that already exists, but the session can be recreated
+in the interval before the move, and `os.rename` replaces the destination silently —
+so undoing a deletion would destroy the newer data it exists to protect.
+`_move_file_exclusive()` creates the destination exclusively (`os.link`, falling back
+to `O_CREAT | O_EXCL` across filesystems), making the check and the write one atomic
+step. A lost race rolls the session back and **retains** its manifest entry, because
+restoring the rest would splice two generations of one session together.
+
+`_rollback()` uses the same exclusive move. A rollback runs *after* something already
+failed, so the origin may have been recreated in the meantime, and a plain rename
+would turn a handled failure into data loss. An occupied origin leaves the file
+staged, where it stays recoverable.
+
+### The leftover scan fails closed
+
+`_unlisted_files()` exists to BLOCK deletions, so an empty result must mean "nothing
+is unaccounted for" and never "the walk gave up early". It therefore walks with error
+reporting and **raises** when any directory or stat fails, instead of returning a
+short list — `rglob` skips unreadable directories silently, which would convert a
+transient error into permission to delete a file that is a session's only copy.
+
+Each caller maps that raise onto the outcome it already has for finding leftovers:
+discarding a restored batch keeps it, and `empty_trash` **skips** that batch rather
+than aborting, so one unreadable batch cannot make the whole trash un-emptyable.
+Both directions delete nothing, which is the safe one.
+
+### The manifest is untrusted input
+
+It lives under the data home, which the agent can write, so restore validates both
+ends of every record rather than acting on it:
+
+- `_staged_path()` refuses an absolute or traversing `rel`. This matters because
+  `Path("/a/b") / "/etc/passwd"` is `/etc/passwd` — joining an absolute string
+  discards the base entirely, so an unchecked `rel` would let restore pick up any
+  file on the host.
+- `_origin_path()` accepts an origin only inside the session or archive stores.
+  Restore *writes* to that path, so an unconstrained origin is an arbitrary-write
+  primitive: a tampered manifest could otherwise relocate a credential file.
+
+A record failing either check blocks its whole session, consistent with
+all-or-nothing restore. `TestManifestIsUntrusted` covers the absolute, traversing
+and out-of-store cases.
+
+## APIs
+
+All three mutations are gated on `_is_restricted_session` and audited through the
+SEL. Every non-2xx body carries a machine-readable `code`.
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/system/session-storage` | Totals, age buckets, and the staged batches |
+| POST | `/api/system/session-storage/cleanup` | Stage sessions older than a threshold; `dry_run` reports without moving |
+| POST | `/api/system/session-storage/restore` | Return a batch, or named sessions within it |
+| POST | `/api/system/session-storage/empty` | Delete staged batches for good; needs `batch_ids` or `all: true` |
+
+The GET is uncached: it walks both stores, so it is meant to be fetched when a
+screen opens or after an action, not on a poll. Every operation is offloaded with
+`asyncio.to_thread` because a store reaching six figures of files is far too much
+filesystem work for the event loop.
+
+Error codes: `restricted_session` (403), `invalid_body`, `invalid_threshold`,
+`cleanup_refused`, `invalid_batch`, `nothing_specified`, `restore_refused`,
+`empty_refused` (400).
+
+A selection larger than `_MAX_SELECTION` stages the **oldest** that many sessions
+and returns `remaining` rather than refusing. Refusing would dead-end the install
+the feature exists for — a store already at six figures cannot get under the cap by
+any threshold a client could pick — and oldest-first makes repeating the call
+monotonic progress.
+
+### Omitted is not the same as malformed, and destroying takes explicit intent
+
+`uids` widens its operation when **omitted** — an absent `uids` restores the whole
+batch — so a present-but-malformed value must never collapse into that.
+`_optional_str_list()` returns a distinct sentinel for that case, a non-object or
+unparseable body yields `None` rather than `{}`, and the handlers answer 400.
+Filtering was the trap: a bare string filters to nothing, which is
+indistinguishable from absent.
+
+**Emptying has no widening default at all.** It requires either `batch_ids` or
+`all: true`. This is the only irreversible endpoint, and an "omitted means
+everything" default put that outcome at the end of *every* path that produced an
+empty body — a malformed payload, a wrong-typed field, a forgotten argument. Three
+separate ways of reaching it were found before the default itself was removed;
+guarding each entrance was losing to removing the destination.
+
+### Nothing deletes a staged file the manifest does not list
+
+A process exit between moving a file into a batch and appending its manifest line
+leaves a staged file nothing points at — and it is the only copy of that session's
+data. `_unlisted_files()` compares what is on disk against what the manifest names,
+and **all three** removal paths consult it: a fully-restored batch, the
+"nothing staged" cleanup path after a failed rollback, and `empty_trash`.
+
+Emptying is the one worth spelling out. An interrupted batch can list *zero*
+sessions while holding real files, so the trash shows it as empty — meaning a
+user's "empty this batch" is consent for nothing while destroying something. Such a
+batch is skipped and logged rather than deleted, so `freed_bytes` under-reports
+instead of the trash over-deleting. `TestEmptyTrash` and
+`test_restore_never_deletes_a_file_the_manifest_omits` cover both directions.
+
+## Constants
+
+| Constant | Value | Location |
+|---|---|---|
+| `TRASH_DIR_NAME` / `TRASH_SESSIONS_LEAF` | `trash` / `sessions` | `session_storage.py` |
+| `STAGE_CLI_LEAF` / `STAGE_CREW_LEAF` | `cli` / `crew` | `session_storage.py` |
+| `MANIFEST_NAME` | `manifest.jsonl` | `session_storage.py` |
+| `MANIFEST_SCHEMA` | `1` | `session_storage.py` |
+| `BUCKET_DAYS` | `(7, 30, 90)` | `session_storage.py` |
+| `MIN_RECLAIM_AGE_DAYS` | `1.0` | `session_storage.py` |
+| `MUTATION_LOCK_NAME` | `session-storage.lock` | `session_storage.py` |
+| `ARCHIVE_SEGMENT_DELIMITER` | `__` | `history.py` |
+| `_MAX_SELECTION` | `200000` | `dashboard/handlers/session_storage.py` |
+
+## Known Limitations
+
+- **A residual race with session-map writes remains.** The authority check is
+  re-read after the scan and inside the reclaim lock, so the window is the move loop
+  rather than the whole scan, but the session map's writer does not take that lock. A
+  session mapped during the loop would still be staged. It stays restorable — nothing
+  is destroyed without a second explicit action — but closing this fully requires the
+  session/slot code and this module to share one lock, which is a wider change than
+  this surface.
+- Reclaiming is offered by age only. Selecting an individual session to reclaim is
+  not exposed, so a single large conversation cannot be targeted.
+- The trash never expires. It grows until a user empties it, which means reclaiming
+  space takes two deliberate actions rather than one.
+- `measure()` walks both stores on every call with no caching, so a store with
+  hundreds of thousands of files makes the endpoint slow to answer.
+- A session reclaimed while its mapping still exists is refused rather than having
+  its mapping cleaned up first, so a stale map entry blocks reclaiming until
+  `SessionMap.prune()` removes it.
+- A session's size counts its identifying `.json` / `.jsonl` pair and its transcript
+  files. A kiro-cli sidecar is *reclaimed* with its session but its bytes are not
+  attributed to it, so the reported total slightly under-counts a store holding
+  sidecars.
+- Emptying the trash removes kiro-cli's index entry along with the file, but does
+  not notify a running kiro-cli process, which may hold its own view of the session
+  list until it restarts.

--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -341,6 +341,14 @@ stored and new provider names for observability.
 no longer exists. `SessionMap.prune()` bulk-removes all stale entries at
 startup.
 
+**Mapped-session enumeration:** `SessionMap.mapped_sids_by_key()` returns session
+key → kiro-cli session ID for every entry that has one. Disk accounting
+([session-storage](session-storage.md)) needs both halves of that relation: the IDs
+to exclude from reclaiming (a mapped session is resumable), and the key each ID
+belongs to so a session's transcript can be paired with its replay log. Returning
+the mapping rather than only the ID set is what lets a caller reclaim a session
+whole instead of leaving one half behind.
+
 **Dashboard history key round-trip:** Session keys use `:` (e.g.
 `dashboard:chat-1-xxx`) but JSONL filenames use `_safe_key()` which replaces
 `:` with `_`. When a session is resumed from history, the slot name comes from

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -300,6 +300,12 @@ from kiro_crew.dashboard.handlers.prompts import (  # noqa: E402, F401
 )
 
 # ── Sessions (extracted to handlers/sessions.py) ──
+from kiro_crew.dashboard.handlers.session_storage import (  # noqa: E402, F401
+    api_session_storage,
+    api_session_storage_cleanup,
+    api_session_storage_empty,
+    api_session_storage_restore,
+)
 from kiro_crew.dashboard.handlers.sessions import (  # noqa: E402, F401
     _SHUTDOWN_TIMEOUT_SECS,
     _fetch_usage_bg,
@@ -490,14 +496,16 @@ def _list_aim_prompts() -> list[dict[str, Any]]:
                 logger.debug("Skipping sensitive path: %s", sop_file)
                 continue
             name = sop_file.stem.removesuffix(".sop")
-            result.append({
-                "name": name,
-                "fullName": f"agent-sop:{name}",
-                "description": _extract_sop_description(sop_file),
-                "path": resolved,
-                "package": root.name,
-                "source": "package",
-            })
+            result.append(
+                {
+                    "name": name,
+                    "fullName": f"agent-sop:{name}",
+                    "description": _extract_sop_description(sop_file),
+                    "path": resolved,
+                    "package": root.name,
+                    "source": "package",
+                }
+            )
 
     # Also scan ~/.kiro/prompts/ for user-created prompts
     home = Path.home()

--- a/src/kiro_crew/dashboard/handlers/session_storage.py
+++ b/src/kiro_crew/dashboard/handlers/session_storage.py
@@ -1,0 +1,365 @@
+"""Dashboard endpoints for session storage: what it costs, and reclaiming it.
+
+Read is open; every mutation is gated on :func:`_is_restricted_session` and
+audited through the SEL, because all three of them move or delete a user's
+conversation history.
+
+The wire shape deliberately reports a session as ONE size. Sessions occupy two
+stores underneath (see :mod:`kiro_crew.session_storage`), but that is an
+implementation detail the reader cannot act on, so it is neither split out here
+nor derivable from these payloads.
+
+Reclaiming stages files in a trash rather than deleting them, which means the
+reclaim itself does not return space to the filesystem. ``trash`` carries the
+staged total precisely so a client can say so; a client that reports a reclaim as
+freed space is lying to the user.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from aiohttp import web
+
+from kiro_crew.dashboard.handlers._shared import _is_restricted_session, _read_session_key
+from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.history import transcript_stems
+from kiro_crew.session_map import SessionMap
+from kiro_crew.session_storage import (
+    SessionIndex,
+    SessionStorageError,
+    empty_trash,
+    list_trash,
+    measure,
+    move_to_trash,
+    restore,
+    select_reclaimable,
+)
+
+logger = logging.getLogger(__name__)
+
+# Why a reclaim is being run. Recorded in the batch manifest and surfaced in the
+# trash listing so a user can tell a bulk threshold sweep apart from sessions they
+# picked by hand.
+REASON_POLICY = "policy"
+REASON_MANUAL = "manual"
+
+# A reclaim of six figures of sessions is minutes of filesystem work even at
+# rename speed, so every operation here is offloaded off the event loop.
+_MAX_SELECTION = 200_000
+
+
+def _sel():
+    # circular import: the handlers package imports this module at load, so the
+    # SEL accessor is resolved per call instead of at import time. Late binding
+    # also keeps the test suite's patch of the package-level sel() effective.
+    import kiro_crew.dashboard.handlers as _pkg
+
+    return _pkg.sel()
+
+
+def _build_index() -> SessionIndex:
+    """Pair every mapped session's replay log with its transcript files.
+
+    Stems come from :func:`kiro_crew.history.transcript_stems`, which returns both
+    the canonical name and the pre-migration bare ``thread_ts`` name a Slack thread
+    may still log under. Using only the canonical stem would leave a legacy
+    transcript looking like it belongs to no session — and therefore reclaimable
+    while the session is still resumable.
+    """
+    mapping = SessionMap().mapped_sids_by_key()
+    stem_to_sid = {stem: sid for key, sid in mapping.items() for stem in transcript_stems(key)}
+    return SessionIndex(stem_to_sid=stem_to_sid, active_sids=frozenset(mapping.values()))
+
+
+def _deny(operation: str, request: web.Request) -> web.Response:
+    _sel().log_api_access(
+        caller=_read_session_key(request),
+        operation=operation,
+        outcome="denied",
+        source="dashboard",
+        resources="restricted_session_block",
+    )
+    return web.json_response(
+        {
+            "error": "Reclaiming session storage is not allowed in this session mode.",
+            "code": "restricted_session",
+        },
+        status=403,
+    )
+
+
+def _bad_request(message: str, code: str) -> web.Response:
+    return web.json_response({"error": message, "code": code}, status=400)
+
+
+def _refused(exc: SessionStorageError, code: str) -> web.Response:
+    return web.json_response({"error": str(exc), "code": code}, status=400)
+
+
+# Sentinel for "the key was present but is not a list of strings". Distinct from
+# ``None``, which means "omitted" and is what widens an operation to every batch or
+# every session in one — so a malformed value must never collapse into it.
+_MALFORMED: list[str] = []
+
+
+def _optional_str_list(body: dict[str, Any], key: str) -> list[str] | None:
+    """Parse an optional list-of-strings field.
+
+    Returns ``None`` when the key is absent, the list when it is well-formed, and
+    :data:`_MALFORMED` (identity-compared) otherwise. Filtering a malformed value
+    down to whatever happened to be a string is the dangerous reading: a bare
+    string is not a list, so it would silently become "omitted" and widen a
+    targeted delete into a total one.
+    """
+    if key not in body or body[key] is None:
+        return None
+    value = body[key]
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        return _MALFORMED
+    return list(value)
+
+
+async def _json_body(request: web.Request) -> dict[str, Any] | None:
+    """Parse a JSON object body; ``None`` when it is absent, empty, or malformed.
+
+    A parse failure must NOT become ``{}``. An empty object is a legitimate request
+    on these endpoints, so collapsing malformed input into it would let a truncated
+    or non-JSON body read as "no arguments given" — and on this surface "no
+    arguments" is what widens an operation.
+    """
+    raw = await request.read()
+    if not raw.strip():
+        return {}
+    try:
+        body = json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return None
+    return body if isinstance(body, dict) else None
+
+
+def _report_payload() -> dict[str, Any]:
+    index = _build_index()
+    report = measure(index)
+    return {
+        "total_bytes": report.total_bytes,
+        "total_sessions": report.total_sessions,
+        "active_sessions": report.active_sessions,
+        "active_bytes": report.active_bytes,
+        "reclaimable_sessions": report.reclaimable_sessions,
+        "reclaimable_bytes": report.reclaimable_bytes,
+        # Non-empty when this instance must not reclaim at all; a client should
+        # explain rather than offer an action that can only be refused.
+        "reclaim_blocked_reason": report.reclaim_blocked_reason,
+        "buckets": [
+            {"label": b.label, "sessions": b.sessions, "bytes": b.bytes} for b in report.buckets
+        ],
+        "trash": {
+            "bytes": report.trash_bytes,
+            # Staged bytes still occupy the filesystem. Named so a client cannot
+            # present a reclaim as reclaimed space without contradicting itself.
+            "still_on_disk": True,
+            "instant": report.trash_same_filesystem,
+            "batches": [
+                {
+                    "batch_id": batch.batch_id,
+                    "created_at": batch.created_at,
+                    "reason": batch.reason,
+                    "sessions": batch.sessions,
+                    "bytes": batch.bytes,
+                }
+                for batch in list_trash()
+            ],
+        },
+    }
+
+
+async def api_session_storage(request: web.Request) -> web.Response:
+    """GET /api/system/session-storage — what sessions cost and what can be reclaimed.
+
+    Uncached: it walks both stores, so it is far too expensive to serve on a poll
+    and is meant to be fetched when the screen opens or after an action.
+    """
+    data = await asyncio.to_thread(_report_payload)
+    return web.json_response(data)
+
+
+async def api_session_storage_cleanup(request: web.Request) -> web.Response:
+    """POST /api/system/session-storage/cleanup — stage old sessions for deletion.
+
+    ``dry_run`` returns the same counts without moving anything, so a client can
+    show exactly what a threshold will do before the user commits. The selection
+    is re-derived here rather than accepted from the client: the numbers a screen
+    is showing may be minutes old, and acting on them would move sessions the
+    user never saw.
+    """
+    state: DashboardState = request.app["state"]
+    if _is_restricted_session(state, request):
+        return _deny("session_storage.cleanup", request)
+
+    body = await _json_body(request)
+    if body is None:
+        return _bad_request("Request body must be a JSON object.", "invalid_body")
+    raw_days = body.get("older_than_days")
+    if not isinstance(raw_days, (int, float)) or isinstance(raw_days, bool):
+        return web.json_response(
+            {"error": "older_than_days must be a number.", "code": "invalid_threshold"},
+            status=400,
+        )
+    try:
+        # JSON puts no bound on an integer, so a caller can send hundreds of
+        # digits. That is a bad request, not a server error — float() raises
+        # OverflowError on it, which would otherwise surface as a 500.
+        threshold = float(raw_days)
+    except (OverflowError, ValueError):
+        return _bad_request("older_than_days is out of range.", "invalid_threshold")
+    dry_run = bool(body.get("dry_run"))
+    # Reading and possibly migrating session_map.json is filesystem work, so it
+    # belongs off the loop like every other operation on this surface.
+    index = await asyncio.to_thread(_build_index)
+
+    try:
+        selected = await asyncio.to_thread(select_reclaimable, index, threshold)
+    except SessionStorageError as exc:
+        return _refused(exc, "invalid_threshold")
+
+    # Above the per-batch bound, stage the OLDEST sessions and report the rest as
+    # remaining, rather than refusing. A refusal dead-ends the very install this
+    # exists for: the measured motivating machine already holds six figures of
+    # sessions, and no threshold a client could pick would get under the cap.
+    # Oldest-first makes repeating the call monotonic progress.
+    selected.sort(key=lambda unit: unit.mtime)
+    remaining = max(0, len(selected) - _MAX_SELECTION)
+    selected = selected[:_MAX_SELECTION]
+
+    total = sum(unit.bytes for unit in selected)
+    if dry_run:
+        return web.json_response(
+            {"dry_run": True, "sessions": len(selected), "bytes": total, "remaining": remaining}
+        )
+    if not selected:
+        return web.json_response(
+            {"sessions": 0, "bytes": 0, "batch_id": "", "remaining": remaining}
+        )
+
+    try:
+        batch = await asyncio.to_thread(
+            move_to_trash,
+            [unit.uid for unit in selected],
+            reason=REASON_POLICY,
+            index=index,
+            # Re-read the map inside the lock: the scan above can take long enough
+            # for a session to be resumed and mapped in the meantime.
+            refresh=_build_index,
+        )
+    except SessionStorageError as exc:
+        return _refused(exc, "cleanup_refused")
+
+    _sel().log_api_access(
+        caller=_read_session_key(request),
+        operation="session_storage.cleanup",
+        outcome="success",
+        source="dashboard",
+        resources=f"{batch.batch_id}:{batch.sessions}",
+    )
+    return web.json_response(
+        {
+            "sessions": batch.sessions,
+            "bytes": batch.bytes,
+            "batch_id": batch.batch_id,
+            "remaining": remaining,
+        }
+    )
+
+
+async def api_session_storage_restore(request: web.Request) -> web.Response:
+    """POST /api/system/session-storage/restore — undo a staged batch.
+
+    Omitting ``uids`` restores the whole batch, which is the unit a user thinks in
+    ("undo what I just did"); naming them restores only those, for the case where
+    one conversation turns out to be wanted out of a large sweep.
+    """
+    state: DashboardState = request.app["state"]
+    if _is_restricted_session(state, request):
+        return _deny("session_storage.restore", request)
+
+    body = await _json_body(request)
+    if body is None:
+        return _bad_request("Request body must be a JSON object.", "invalid_body")
+    batch_id = body.get("batch_id")
+    if not isinstance(batch_id, str) or not batch_id:
+        return web.json_response(
+            {"error": "batch_id is required.", "code": "invalid_batch"}, status=400
+        )
+    uids = _optional_str_list(body, "uids")
+    if uids is _MALFORMED:
+        # Omitted means "the whole batch"; a malformed value must not widen into it.
+        return web.json_response(
+            {"error": "uids must be a list of strings.", "code": "invalid_batch"},
+            status=400,
+        )
+
+    try:
+        restored = await asyncio.to_thread(restore, batch_id, uids)
+    except SessionStorageError as exc:
+        return _refused(exc, "restore_refused")
+
+    _sel().log_api_access(
+        caller=_read_session_key(request),
+        operation="session_storage.restore",
+        outcome="success",
+        source="dashboard",
+        resources=f"{batch_id}:{restored}",
+    )
+    return web.json_response({"restored": restored})
+
+
+async def api_session_storage_empty(request: web.Request) -> web.Response:
+    """POST /api/system/session-storage/empty — delete staged batches for good.
+
+    The only irreversible operation in this surface, and the only one that returns
+    space to the filesystem. Audited with the bytes freed so the record shows what
+    was actually destroyed rather than what was requested.
+    """
+    state: DashboardState = request.app["state"]
+    if _is_restricted_session(state, request):
+        return _deny("session_storage.empty", request)
+
+    body = await _json_body(request)
+    if body is None:
+        return _bad_request("Request body must be a JSON object.", "invalid_body")
+    batch_ids = _optional_str_list(body, "batch_ids")
+    if batch_ids is _MALFORMED:
+        return _bad_request("batch_ids must be a list of strings.", "invalid_batch")
+
+    # Emptying takes EXPLICIT intent: either the batches to destroy, or all=true.
+    # This endpoint is the only irreversible one, and an "omitted means everything"
+    # default put that outcome at the end of every path that produced an empty
+    # body — a malformed payload, a wrong-typed field, a client that forgot the
+    # argument. Requiring the caller to say which, or to say all, removes the
+    # default rather than guarding each way of reaching it.
+    empty_all = body.get("all") is True
+    if empty_all and batch_ids:
+        return _bad_request("Pass batch_ids or all=true, not both.", "invalid_batch")
+    if not empty_all and not batch_ids:
+        return _bad_request(
+            "Specify batch_ids, or all=true to empty the whole trash.",
+            "nothing_specified",
+        )
+
+    try:
+        freed = await asyncio.to_thread(empty_trash, None if empty_all else batch_ids)
+    except SessionStorageError as exc:
+        return _refused(exc, "empty_refused")
+
+    _sel().log_api_access(
+        caller=_read_session_key(request),
+        operation="session_storage.empty",
+        outcome="success",
+        source="dashboard",
+        resources=f"freed:{freed}",
+    )
+    return web.json_response({"freed_bytes": freed})

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1241,9 +1241,7 @@ def _claimed_dashboard_slots(state: DashboardState) -> frozenset[str]:
         data = getattr(smap, "_data", None)
         if not isinstance(data, dict):
             return frozenset()
-        return frozenset(
-            k[len("dashboard:"):] for k in data if k.startswith("dashboard:")
-        )
+        return frozenset(k[len("dashboard:") :] for k in data if k.startswith("dashboard:"))
     except Exception:
         logger.debug("could not read claimed dashboard slots", exc_info=True)
         return frozenset()
@@ -1767,11 +1765,7 @@ async def start_dashboard(
                 description = str(info.get("description") or "").strip()
                 triggers = str(info.get("triggers") or "").strip()
                 subject = target or name if is_update else name
-                title = (
-                    "Skill update awaiting review"
-                    if is_update
-                    else "New skill awaiting review"
-                )
+                title = "Skill update awaiting review" if is_update else "New skill awaiting review"
                 # The body LEADS with name + description because the feed row
                 # renders only its first ~80 characters, stripped to one line.
                 # The title already says a skill is awaiting review, so opening
@@ -1791,9 +1785,7 @@ async def start_dashboard(
                 if triggers:
                     lines.append(f"\n**Triggers:** {triggers}")
                 if info.get("has_scripts"):
-                    lines.append(
-                        "\n_Bundles executable scripts — review them before approving._"
-                    )
+                    lines.append("\n_Bundles executable scripts — review them before approving._")
                 body = "\n".join(lines)
                 payload = {
                     "slug": slug,
@@ -2041,6 +2033,10 @@ async def start_dashboard(
     # Status / system
     app.router.add_get("/api/status", handlers.api_status)
     app.router.add_get("/api/system", handlers.api_system)
+    app.router.add_get("/api/system/session-storage", handlers.api_session_storage)
+    app.router.add_post("/api/system/session-storage/cleanup", handlers.api_session_storage_cleanup)
+    app.router.add_post("/api/system/session-storage/restore", handlers.api_session_storage_restore)
+    app.router.add_post("/api/system/session-storage/empty", handlers.api_session_storage_empty)
     app.router.add_get("/api/stream", handlers.api_stream)
     app.router.add_get("/api/sso-ttl", handlers.api_sso_ttl)
     app.router.add_get("/api/dashboard/branding", handlers.api_branding)
@@ -2175,9 +2171,7 @@ async def start_dashboard(
     app.router.add_post("/api/skills/-/pending/{slug}/approve", handlers.api_skill_pending_approve)
     app.router.add_post("/api/skills/-/pending/{slug}/dismiss", handlers.api_skill_pending_dismiss)
     app.router.add_post("/api/skills/-/pin", handlers.api_skill_pin)
-    app.router.add_post(
-        "/api/skills/-/inject-on-trigger", handlers.api_skill_inject_on_trigger
-    )
+    app.router.add_post("/api/skills/-/inject-on-trigger", handlers.api_skill_inject_on_trigger)
     # Skill context budget (read-only cost analysis with alias folding).
     app.router.add_get("/api/skills/-/budget", handlers.api_skills_budget)
     app.router.add_get("/api/skills/{name:.+}/-/tree", handlers.api_skill_tree)
@@ -2335,9 +2329,7 @@ async def start_dashboard(
     app.router.add_delete("/api/agents/detail/{name}", handlers.api_agent_detail)
     # KiroCrew Agent CRUD
     app.router.add_get("/api/agents", handlers.api_kirocrew_agents)
-    app.router.add_get(
-        "/api/agents/resolved-model", handlers.api_kirocrew_agent_resolved_model
-    )
+    app.router.add_get("/api/agents/resolved-model", handlers.api_kirocrew_agent_resolved_model)
     app.router.add_post("/api/agents", handlers.api_kirocrew_agents_create)
     app.router.add_post("/api/agents/sync", handlers.api_kirocrew_agents_sync)
     app.router.add_put("/api/agents/{name}", handlers.api_kirocrew_agent_update)
@@ -2451,9 +2443,7 @@ async def start_dashboard(
 
     # Diagnostics / "Report a Problem" (redacted support bundle)
     app.router.add_post("/api/diagnostics/collect", handlers.api_diagnostics_collect)
-    app.router.add_get(
-        "/api/diagnostics/download/{filename}", handlers.api_diagnostics_download
-    )
+    app.router.add_get("/api/diagnostics/download/{filename}", handlers.api_diagnostics_download)
 
     # Portability (export/import config+memory as zip)
     app.router.add_get("/api/portability/export", handlers.api_portability_export)
@@ -3307,9 +3297,7 @@ async def start_dashboard(
         # dashboard session that merely happens to be named like a channel
         # stem is never mistaken for an orphan of it.
         _claimed = await asyncio.to_thread(_claimed_dashboard_slots, state)
-        merged = await asyncio.to_thread(
-            migrate_channel_transcripts, dashboard_slots=_claimed
-        )
+        merged = await asyncio.to_thread(migrate_channel_transcripts, dashboard_slots=_claimed)
         if merged:
             logger.info("Merged %d leftover channel transcript copies", merged)
     except Exception:

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -59,6 +59,11 @@ logger = logging.getLogger(__name__)
 SESSIONS_DIR_NAME = "sessions"
 ARCHIVE_DIR_NAME = "archive"
 ARCHIVE_RETENTION_DAYS = 7
+
+# Separates a transcript's stem from an archive segment's timestamp. NOT a dot,
+# because session keys legitimately contain dots (a Slack thread_ts), which would
+# make a right-most-dot parse attribute a segment to the wrong session.
+ARCHIVE_SEGMENT_DELIMITER = "__"
 _CONSOLIDATION_THRESHOLD = 30  # preferences/projects update threshold (messages)
 # Skill detection judges a wider window than the incremental history tail: a
 # reusable procedure usually spans the whole session, not just the slice since
@@ -537,11 +542,11 @@ def _archive_lines(
     )
     payload = header + "".join(lines)
     # Atomic exclusive-create to avoid TOCTOU clobber when two archives land in the same second.
-    # Use '__' delimiter so keys containing dots (e.g. Slack thread_ts) don't confuse rfind('.') parsing.
     for n in itertools.count():
         if n > 1000:
             raise RuntimeError(f"Failed to create archive file after {n} attempts")
-        candidate = adir / f"{safekey}__{stamp}{f'-{n}' if n else ''}.jsonl"
+        suffix = f"-{n}" if n else ""
+        candidate = adir / f"{safekey}{ARCHIVE_SEGMENT_DELIMITER}{stamp}{suffix}.jsonl"
         try:
             with candidate.open("x", encoding="utf-8") as f:
                 f.write(payload)
@@ -731,6 +736,43 @@ def monotonic_transcript_ts(previous: str | None, now: datetime) -> str:
 def _safe_key(key: str) -> str:
     """Convert a session key (e.g. Slack thread_ts) to a safe filename."""
     return re.sub(r"[^\w\-.]", "_", key)
+
+
+def transcript_stem(key: str) -> str:
+    """The canonical filename stem *key*'s transcript and archive segments share.
+
+    Exported so callers that account for or reclaim a session's disk usage can
+    pair a session key with its files without re-deriving the sanitization. A
+    second copy of that rule would drift the moment this one changed, and the
+    failure is silent and destructive: the pairing misses, and a caller deleting
+    "the session" removes one half and leaves the other behind.
+
+    Prefer :func:`transcript_stems` when the answer feeds a decision about which
+    files belong to a session — a Slack thread predating the canonical
+    ``slack:<ts>`` key still logs under its bare thread_ts stem, and this function
+    alone would not find it.
+    """
+    return _safe_key(key)
+
+
+def transcript_stems(key: str) -> tuple[str, ...]:
+    """Every filename stem *key*'s transcript could occupy, canonical first.
+
+    :meth:`ConversationLog._path` falls back to the pre-migration bare
+    ``thread_ts`` filename for Slack threads that predate the canonical session
+    key, so one session key can legitimately resolve to either name. A caller that
+    only knew the canonical stem would treat the legacy transcript as belonging to
+    no session — and therefore as reclaimable while the session is still
+    resumable. Returning both keeps that decision correct without duplicating the
+    fallback rule.
+    """
+    stems = [_safe_key(key)]
+    bare = legacy_key(key)
+    if bare is not None:
+        legacy = _safe_key(bare)
+        if legacy not in stems:
+            stems.append(legacy)
+    return tuple(stems)
 
 
 def _redact_at_write_boundary(role: str, content: str) -> str:
@@ -1468,9 +1510,7 @@ class ConversationLog:
         any real append advances the mtime and invalidates it.
         """
         try:
-            data = json.loads(
-                self._summary_cache_path(key).read_text(encoding="utf-8")
-            )
+            data = json.loads(self._summary_cache_path(key).read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             return None
         summary = data.get("summary")
@@ -3725,11 +3765,7 @@ class HistoryConsolidator:
             # window (see _run_skill_detection), not the incremental tail. Runs
             # only on history consolidation, guarded by flag + loader; failures
             # are logged, never fatal.
-            if (
-                include_history
-                and self._auto_skills_enabled
-                and self._skills_loader is not None
-            ):
+            if include_history and self._auto_skills_enabled and self._skills_loader is not None:
                 try:
                     await self._run_skill_detection(key)
                 except Exception:
@@ -3740,10 +3776,7 @@ class HistoryConsolidator:
             # their own (create/approve were the only triggers). Consolidation is
             # the existing idle/periodic path; throttle to at most once/hour
             # across all sessions so frequent consolidations don't rescan the set.
-            if (
-                self._skills_loader is not None
-                and (_time.time() - self._last_lifecycle) > 3600
-            ):
+            if self._skills_loader is not None and (_time.time() - self._last_lifecycle) > 3600:
                 self._last_lifecycle = _time.time()
                 try:
                     await asyncio.to_thread(
@@ -3850,7 +3883,7 @@ class HistoryConsolidator:
             '"procedure_md": "<concise markdown body with '
             "## When to use / ## Steps / ## Gotchas sections, "
             '<=8000 chars>"' + scripts_field + "}. "
-            'Return null if the session was trivial, a single-shot answer, '
+            "Return null if the session was trivial, a single-shot answer, "
             "a one-off failure with no reusable takeaway, or involved "
             "sensitive paths. When a session plausibly contains a procedure "
             "a future session could reuse, lean toward returning it — every "
@@ -3874,8 +3907,10 @@ class HistoryConsolidator:
         conversation = "\n".join(_fmt_message(m) for m in window)
         prompt = (
             "You are a skill-extraction agent. Review this session excerpt and "
-            "return a JSON object with these keys:\n\n" + numbered
-            + "\n\n## Session excerpt\n" + conversation
+            "return a JSON object with these keys:\n\n"
+            + numbered
+            + "\n\n## Session excerpt\n"
+            + conversation
             + "\n\nRespond with ONLY valid JSON, no markdown fences."
         )
         result = await self._call_llm(prompt)
@@ -4023,27 +4058,26 @@ class HistoryConsolidator:
         # only enumerates LIVE skills — .pending is pruned from discovery).
         try:
             for p in loader.list_pending_skills():
-                existing.append({
-                    "key": f"auto/{p.get('slug', '')}",
-                    "description": p.get("description", ""),
-                    "triggers": p.get("triggers", ""),
-                })
+                existing.append(
+                    {
+                        "key": f"auto/{p.get('slug', '')}",
+                        "description": p.get("description", ""),
+                        "triggers": p.get("triggers", ""),
+                    }
+                )
         except Exception:
             pass
         loop = self._event_loop
 
         def _lexical() -> "tuple[str, str | None]":
-            hit = loader.find_similar(
-                description, threshold=self._auto_similarity_threshold
-            )
+            hit = loader.find_similar(description, threshold=self._auto_similarity_threshold)
             return (VERDICT_DUP, hit) if hit else (VERDICT_NEW, None)
 
         if self._judge_model and existing and loop is not None:
+
             def _judge_fn(prompt: str) -> str:
                 try:
-                    fut = asyncio.run_coroutine_threadsafe(
-                        self._dedupe_judge(prompt), loop
-                    )
+                    fut = asyncio.run_coroutine_threadsafe(self._dedupe_judge(prompt), loop)
                     return fut.result(timeout=60) or ""
                 except Exception:
                     return ""
@@ -4190,9 +4224,7 @@ class HistoryConsolidator:
             # ``approve_pending_update`` requires a live target, so staging that
             # would queue a candidate the user can never approve. Drop it
             # instead, audited so the loss is visible.
-            logger.info(
-                "Skill update skipped: target '%s' is not a live auto skill", target_key
-            )
+            logger.info("Skill update skipped: target '%s' is not a live auto skill", target_key)
             sel().log_tool_invocation(
                 session_key=key,
                 tool_name="auto_skill_create",
@@ -4219,9 +4251,7 @@ class HistoryConsolidator:
         if live_prose and self._event_loop is not None:
             try:
                 fut = asyncio.run_coroutine_threadsafe(
-                    self._merge_skill_update(
-                        live_prose, description, triggers, procedure_md
-                    ),
+                    self._merge_skill_update(live_prose, description, triggers, procedure_md),
                     self._event_loop,
                 )
                 merged = fut.result(timeout=90)
@@ -4239,9 +4269,7 @@ class HistoryConsolidator:
                 body = red
                 used_merge = True
 
-        provenance = AutoSkillProvenance(
-            session_key=key, created_at=AutoSkillProvenance.now_iso()
-        )
+        provenance = AutoSkillProvenance(session_key=key, created_at=AutoSkillProvenance.now_iso())
         # The slug pattern caps at 64 chars, and our own generation prompt permits
         # up to 60, so `<target>-update` can overflow and be REJECTED by staging —
         # silently dropping the learning, because consolidation advances its
@@ -4271,8 +4299,7 @@ class HistoryConsolidator:
             base_version=base_version,
         )
         if name:
-            logger.info("Staged skill update %s (target %s) from session %s",
-                        name, target_key, key)
+            logger.info("Staged skill update %s (target %s) from session %s", name, target_key, key)
             sel().log_tool_invocation(
                 session_key=key,
                 tool_name="auto_skill_create",
@@ -4377,7 +4404,9 @@ class HistoryConsolidator:
                 # another *proposal*, which the human reviews side by side anyway.
                 if verdict == VERDICT_UPDATE and target:
                     try:
-                        _target_is_live = self._skills_loader.read_auto_skill_body(target) is not None
+                        _target_is_live = (
+                            self._skills_loader.read_auto_skill_body(target) is not None
+                        )
                     except Exception:
                         _target_is_live = False
                     if not _target_is_live:

--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -202,7 +202,7 @@ class SessionMap:
         # Fallback: dashboard history round-trip (dashboard:dashboard_X → dashboard:X)
         matched_key = key
         if not entry and key.startswith("dashboard:dashboard_"):
-            canonical = "dashboard:" + key[len("dashboard:dashboard_"):]
+            canonical = "dashboard:" + key[len("dashboard:dashboard_") :]
             entry = self._data.get(canonical)
             if entry:
                 matched_key = canonical
@@ -307,6 +307,22 @@ class SessionMap:
             self._save()
             logger.info("Pruned %d stale session map entries", len(stale))
         return len(stale)
+
+    def mapped_sids_by_key(self) -> dict[str, str]:
+        """Session key to kiro-cli session ID, for every entry that has one.
+
+        A session ID present here is one Kiro Crew can still resume. Callers that
+        account for or reclaim disk space need both halves of this relation: the
+        IDs to exclude from deletion, and the key each ID belongs to so a
+        session's transcript can be paired with its replay log. Returning the
+        mapping rather than only the ID set is what lets such a caller reclaim a
+        session whole instead of leaving one half behind.
+        """
+        return {
+            key: sid
+            for key, entry in self._data.items()
+            if isinstance(sid := entry.get("sid"), str) and sid
+        }
 
     def set_slack_link(self, key: str, thread_ts: str, channel_id: str | None) -> None:
         """Link a session to a Slack thread. Creates entry if needed."""
@@ -556,7 +572,7 @@ class SessionMap:
         prefix = f"{bucket}:gen"
         for key in self._data:
             if key.startswith(prefix):
-                suffix = key[len(prefix):]
+                suffix = key[len(prefix) :]
                 if suffix.isdigit():
                     best = max(best, int(suffix))
         return best

--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -1,0 +1,1453 @@
+"""Measure the disk a session costs, and reclaim it under user control.
+
+A session is presented as ONE thing with ONE size, because that is what it is to
+the person looking at it. Underneath, its bytes are split across two stores that
+Kiro Crew and kiro-cli each own:
+
+* ``<data home>/sessions/<stem>.jsonl`` plus its rotated
+  ``sessions/archive/<stem>__<stamp>.jsonl`` segments — the transcript, read by
+  dashboard history, search and memory consolidation.
+* ``<kiro home>/sessions/cli/<sid>.json`` + ``<sid>.jsonl`` — kiro-cli's replay
+  log, read to resume the session.
+
+That split is an implementation detail and never surfaces in a report: callers get
+one total and one session count.
+
+The split does, however, dictate the deletion rule. **A session's halves are
+always reclaimed together.** Removing only one leaves a broken session rather than
+a freed one: drop the replay log and the transcript still lists a session that can
+no longer resume; drop the transcript and a resumable session has no history or
+search. Either way the user is left with something worse than both extremes.
+:func:`_unit_paths` is therefore the single place that answers "what files is this
+session made of", and every move, restore and delete goes through it.
+
+Not every session has both halves, and that is normal rather than an error — a
+subagent run leaves only a replay log, and a session whose mapping was pruned
+leaves only a transcript. The rule is that whatever halves exist move together.
+
+Reclaiming moves files into ``<data home>/trash/sessions/<batch>/`` rather than
+unlinking them. On a default install both stores sit under ``~/.kiro``, so the
+move is a same-filesystem :func:`os.rename`: instant regardless of size, and
+instantly reversible. Space is **not** returned to the filesystem until the trash
+is emptied; :attr:`StorageReport.trash_bytes` exists so callers can say so plainly
+instead of reporting a reclaim that leaves ``df`` unchanged.
+
+Every batch carries an append-only manifest recording each file's original
+absolute path, so a restore puts files back where they came from instead of
+inferring it from the layout. A batch can span six figures of sessions, so a
+whole-document manifest rewritten per move would cost quadratic bytes; appending
+also leaves a partial batch fully restorable after an interruption.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import time
+import uuid
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import IO, Any
+
+from kiro_crew import platform_compat
+from kiro_crew.config.paths import (
+    CONFIG_DIR_LEAF,
+    KIRO_BASE_DIR_NAME,
+    data_home,
+    kiro_home,
+    kiro_sessions_dir,
+    legacy_home,
+)
+from kiro_crew.history import ARCHIVE_DIR_NAME, ARCHIVE_SEGMENT_DELIMITER, SESSIONS_DIR_NAME
+
+logger = logging.getLogger(__name__)
+
+# Trash lives under the data home (not beside kiro-cli's store) because it holds
+# Kiro Crew's own staged deletions: it must survive a kiro-cli upgrade, and
+# kiro-cli must not mistake a staged file for a session it can resume.
+TRASH_DIR_NAME = "trash"
+TRASH_SESSIONS_LEAF = "sessions"
+
+# Staged files keep their origin store in the path. Two halves can share a
+# filename, and a flat batch directory would let one silently overwrite the other
+# — turning a reversible move into data loss.
+STAGE_CLI_LEAF = "cli"
+STAGE_CREW_LEAF = "crew"
+
+MANIFEST_NAME = "manifest.jsonl"
+MANIFEST_SCHEMA = 1
+
+# Age buckets (in days) the report splits reclaimable sessions into. The
+# boundaries are what make a threshold choice legible: the reclaimable total is
+# dominated by the youngest band, so a user picking the most conservative
+# threshold needs to see that it frees almost nothing before they pick it.
+BUCKET_DAYS: tuple[int, ...] = (7, 30, 90)
+
+# No session touched this recently is ever reclaimable, whatever threshold the
+# caller passes. The session map is NOT a complete registry of live sessions —
+# a subagent run creates a kiro-cli session that was never mapped, so mapping
+# alone would let a threshold of 0 reclaim a conversation that is running right
+# now and break its resume. Freshness is the one signal that does not depend on
+# which subsystem owns a session: a live session is being appended to. A day is
+# far longer than any in-tree conversation retention, and the shortest threshold
+# the product offers is a week, so the floor costs nothing real.
+MIN_RECLAIM_AGE_DAYS = 1.0
+
+# Serializes the operations that move files. Two concurrent reclaims can select
+# the same session and interleave their moves, landing its halves in different
+# batches — after which neither batch can restore it. The lock is a FILE lock,
+# not a thread lock, because more than one instance can share the same kiro-cli
+# store (a pod and the live gateway both read ``~/.kiro/sessions/cli``), so
+# in-process mutual exclusion would not actually exclude.
+MUTATION_LOCK_NAME = "session-storage.lock"
+
+# A unit id is either a kiro-cli session id (a UUID) or a transcript stem (a
+# sanitized session key, so word characters, dot and dash). Both are joined onto
+# a directory, so a separator or a parent reference would address a file outside
+# the stores; the shape is enforced rather than trusted.
+_UNIT_ID_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9._-]{0,199}$")
+
+# The two files a kiro-cli session is made of: metadata and event log. The
+# metadata file is also kiro-cli's index entry, so moving it is what makes the
+# session leave kiro-cli's session list — no separate index update is needed.
+_CLI_SUFFIXES = (".json", ".jsonl")
+
+_TRANSCRIPT_SUFFIX = ".jsonl"
+_SECONDS_PER_DAY = 86400.0
+
+
+class SessionStorageError(Exception):
+    """A storage operation was refused. The message is safe to show a user."""
+
+
+@dataclass(frozen=True)
+class SessionIndex:
+    """What the caller knows about sessions that are still wired up.
+
+    Supplied by the caller rather than read here, so the exclusion set is explicit
+    at the call site and a test can pin it.
+
+    *stem_to_sid* maps a transcript filename stem to the kiro-cli session id it
+    shares a session with. The direction is deliberate: one session can own more
+    than one stem, because a Slack thread predating the canonical session key still
+    logs under its bare ``thread_ts`` name. Build it with
+    :func:`kiro_crew.history.transcript_stems`, never by re-deriving the naming
+    rules — a missed stem is read as "belongs to no session", which makes a live
+    session's history reclaimable.
+    """
+
+    stem_to_sid: Mapping[str, str] = field(default_factory=dict)
+    active_sids: frozenset[str] = frozenset()
+
+    @property
+    def active_stems(self) -> frozenset[str]:
+        """Transcript stems belonging to a session that is still resumable."""
+        return frozenset(stem for stem, sid in self.stem_to_sid.items() if sid in self.active_sids)
+
+    def stems_for(self, sid: str) -> tuple[str, ...]:
+        return tuple(stem for stem, owner in self.stem_to_sid.items() if owner == sid)
+
+
+@dataclass(frozen=True)
+class SessionUnit:
+    """One session's total on-disk cost, whichever halves it has."""
+
+    uid: str
+    sid: str
+    stems: tuple[str, ...]
+    bytes: int
+    mtime: float
+    active: bool
+
+    def age_days(self, now: float) -> float:
+        return max(0.0, (now - self.mtime) / _SECONDS_PER_DAY)
+
+
+@dataclass(frozen=True)
+class StorageBucket:
+    """Reclaimable sessions grouped by how long ago they were last touched."""
+
+    label: str
+    sessions: int
+    bytes: int
+
+
+@dataclass(frozen=True)
+class TrashBatch:
+    """One user-initiated move: the unit a restore undoes."""
+
+    batch_id: str
+    created_at: float
+    reason: str
+    sessions: int
+    bytes: int
+
+
+@dataclass(frozen=True)
+class StorageReport:
+    """What sessions cost, and what is safe to reclaim.
+
+    Deliberately carries no per-store breakdown: a session is one thing with one
+    size, and splitting the number would expose an implementation detail the
+    reader cannot act on.
+    """
+
+    total_bytes: int
+    total_sessions: int
+    active_sessions: int
+    active_bytes: int
+    buckets: tuple[StorageBucket, ...]
+    reclaimable_sessions: int
+    reclaimable_bytes: int
+    trash_bytes: int
+    trash_batches: int
+    trash_same_filesystem: bool
+    reclaim_blocked_reason: str = ""
+
+
+def trash_root() -> Path:
+    """Where staged deletions live: ``<data home>/trash/sessions``."""
+    return data_home() / TRASH_DIR_NAME / TRASH_SESSIONS_LEAF
+
+
+def _crew_sessions_dir() -> Path:
+    """Kiro Crew's own transcript directory."""
+    return data_home() / SESSIONS_DIR_NAME
+
+
+def _crew_archive_dir() -> Path:
+    return _crew_sessions_dir() / ARCHIVE_DIR_NAME
+
+
+def _validate_unit_id(uid: str) -> str:
+    """Return *uid* unchanged, or raise if it could address a file outside the stores."""
+    if not _UNIT_ID_RE.match(uid):
+        raise SessionStorageError(f"not a valid session id: {uid!r}")
+    return uid
+
+
+def _archive_index() -> dict[str, list[tuple[Path, int, float]]]:
+    """Group rotated archive segments by the transcript stem they belong to.
+
+    Built once per operation: resolving a stem's segments by scanning the archive
+    directory per session would be quadratic across a bulk reclaim.
+    """
+    index: dict[str, list[tuple[Path, int, float]]] = {}
+    try:
+        with os.scandir(_crew_archive_dir()) as it:
+            for entry in it:
+                if not entry.name.endswith(_TRANSCRIPT_SUFFIX):
+                    continue
+                try:
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+                    st = entry.stat(follow_symlinks=False)
+                except OSError:
+                    continue
+                stem = entry.name.rsplit(ARCHIVE_SEGMENT_DELIMITER, 1)[0]
+                if stem == entry.name:  # not a segment, so not attributable
+                    continue
+                index.setdefault(stem, []).append((Path(entry.path), st.st_size, st.st_mtime))
+    except OSError:
+        pass
+    return index
+
+
+def _scan_units(index: SessionIndex) -> list[SessionUnit]:
+    """Enumerate sessions across both stores, one entry per session.
+
+    A session's age is the NEWEST mtime across every file it owns: a transcript is
+    appended to while the session runs, so an older metadata file or a long-since
+    rotated archive segment would make a live session look stale.
+    """
+    sizes: dict[str, int] = {}
+    mtimes: dict[str, float] = {}
+    sids: dict[str, str] = {}
+    stems: dict[str, list[str]] = {}
+    sid_for_stem = dict(index.stem_to_sid)
+
+    def record(uid: str, size: int, mtime: float) -> None:
+        sizes[uid] = sizes.get(uid, 0) + size
+        mtimes[uid] = max(mtimes.get(uid, 0.0), mtime)
+
+    def add_stem(uid: str, stem: str) -> None:
+        owned = stems.setdefault(uid, [])
+        if stem and stem not in owned:
+            owned.append(stem)
+
+    # kiro-cli half. A paired session is keyed on its sid so both halves land on
+    # the same unit.
+    try:
+        with os.scandir(kiro_sessions_dir()) as it:
+            for entry in it:
+                if not entry.name.endswith(_CLI_SUFFIXES):
+                    continue
+                try:
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+                    st = entry.stat(follow_symlinks=False)
+                except OSError:
+                    continue
+                sid = entry.name.rsplit(".", 1)[0]
+                if not _UNIT_ID_RE.match(sid):
+                    continue
+                sids[sid] = sid
+                stems.setdefault(sid, [])
+                record(sid, st.st_size, st.st_mtime)
+    except OSError:
+        logger.debug("kiro-cli session store unreadable", exc_info=True)
+
+    archives = _archive_index()
+
+    def attribute(stem: str) -> str:
+        """The unit a transcript stem belongs to: its paired sid, else itself."""
+        paired = sid_for_stem.get(stem, "")
+        return paired if paired in sids else stem
+
+    # Transcript half, plus any rotated segments.
+    try:
+        with os.scandir(_crew_sessions_dir()) as it:
+            for entry in it:
+                if not entry.name.endswith(_TRANSCRIPT_SUFFIX):
+                    continue
+                try:
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+                    st = entry.stat(follow_symlinks=False)
+                except OSError:
+                    continue
+                stem = entry.name[: -len(_TRANSCRIPT_SUFFIX)]
+                if not _UNIT_ID_RE.match(stem):
+                    continue
+                uid = attribute(stem)
+                add_stem(uid, stem)
+                sids.setdefault(uid, sid_for_stem.get(stem, "") if uid != stem else "")
+                record(uid, st.st_size, st.st_mtime)
+    except OSError:
+        logger.debug("transcript store unreadable", exc_info=True)
+
+    for stem, segments in archives.items():
+        uid = attribute(stem)
+        if uid not in sizes and uid not in stems:
+            # Segments outliving their transcript still cost space and still
+            # belong to a session, so they form a unit of their own.
+            sids.setdefault(uid, "")
+        add_stem(uid, stem)
+        for _path, size, mtime in segments:
+            record(uid, size, mtime)
+
+    active_stems = index.active_stems
+    units = []
+    for uid, size in sizes.items():
+        sid = sids.get(uid, "")
+        owned = tuple(stems.get(uid, []))
+        active = sid in index.active_sids or any(stem in active_stems for stem in owned)
+        units.append(
+            SessionUnit(
+                uid=uid,
+                sid=sid,
+                stems=owned,
+                bytes=size,
+                mtime=mtimes.get(uid, 0.0),
+                active=active,
+            )
+        )
+    return units
+
+
+def _cli_index() -> dict[str, list[Path]]:
+    """Group every file in the kiro-cli store by the session id it belongs to.
+
+    Enumerated rather than assumed. A session is *identified* by its ``.json`` /
+    ``.jsonl`` pair, but reclaiming it must take whatever else kiro-cli has
+    written alongside — a lock file today, a sidecar a future version adds. If
+    reclaiming moved only the two suffixes it knows, an unrecognised sidecar would
+    be left behind, which is exactly the partial-session removal this module
+    exists to prevent.
+
+    Built once per operation: globbing per session would be quadratic across a
+    store that reaches six figures of files.
+    """
+    index: dict[str, list[Path]] = {}
+    try:
+        with os.scandir(kiro_sessions_dir()) as it:
+            for entry in it:
+                try:
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+                except OSError:
+                    continue
+                sid = entry.name.rsplit(".", 1)[0]
+                if not _UNIT_ID_RE.match(sid):
+                    continue
+                index.setdefault(sid, []).append(Path(entry.path))
+    except OSError:
+        pass
+    return index
+
+
+def _unit_paths(
+    sid: str,
+    stems: tuple[str, ...],
+    archives: dict[str, list[tuple[Path, int, float]]] | None = None,
+    cli_files: dict[str, list[Path]] | None = None,
+) -> list[tuple[Path, str]]:
+    """Every file a session owns, as (absolute path, staged relative path).
+
+    The single answer to "what is this session made of". Move, restore and delete
+    all resolve through here so none of them can operate on half a session.
+    """
+    found: list[tuple[Path, str]] = []
+    if sid:
+        owned = cli_files.get(sid, []) if cli_files is not None else _cli_index().get(sid, [])
+        for path in owned:
+            found.append((path, f"{STAGE_CLI_LEAF}/{path.name}"))
+    for stem in stems:
+        transcript = _crew_sessions_dir() / f"{stem}{_TRANSCRIPT_SUFFIX}"
+        if transcript.is_file():
+            found.append((transcript, f"{STAGE_CREW_LEAF}/{transcript.name}"))
+        segments = (
+            archives.get(stem, []) if archives is not None else _archive_index().get(stem, [])
+        )
+        for path, _size, _mtime in segments:
+            found.append((path, f"{STAGE_CREW_LEAF}/{ARCHIVE_DIR_NAME}/{path.name}"))
+    return found
+
+
+def _bucketize(reclaimable: list[SessionUnit], now: float) -> tuple[StorageBucket, ...]:
+    """Split reclaimable sessions into the age bands the UI offers as thresholds."""
+    edges = list(BUCKET_DAYS)
+    labels = [f"under_{edges[0]}d"]
+    labels += [f"{edges[i]}_{edges[i + 1]}d" for i in range(len(edges) - 1)]
+    labels.append(f"over_{edges[-1]}d")
+    counts = [0] * len(labels)
+    byte_totals = [0] * len(labels)
+    for unit in reclaimable:
+        age = unit.age_days(now)
+        position = len(edges)
+        for i, edge in enumerate(edges):
+            if age < edge:
+                position = i
+                break
+        counts[position] += 1
+        byte_totals[position] += unit.bytes
+    return tuple(
+        StorageBucket(label=label, sessions=counts[i], bytes=byte_totals[i])
+        for i, label in enumerate(labels)
+    )
+
+
+def _same_filesystem(a: Path, b: Path) -> bool:
+    """Whether a rename between *a* and *b* can avoid a copy.
+
+    Walks up to each path's nearest existing ancestor, because the trash root does
+    not exist before the first reclaim.
+    """
+
+    def device(path: Path) -> int | None:
+        for candidate in (path, *path.parents):
+            try:
+                return candidate.stat().st_dev
+            except OSError:
+                continue
+        return None
+
+    dev_a = device(a)
+    dev_b = device(b)
+    return dev_a is not None and dev_a == dev_b
+
+
+def measure(index: SessionIndex, *, now: float | None = None) -> StorageReport:
+    """Measure session storage and report what is reclaimable."""
+    clock = time.time() if now is None else now
+    units = _scan_units(index)
+    active = [u for u in units if u.active]
+    # Sub-floor sessions are neither active nor offered: reporting them as
+    # reclaimable would promise bytes no threshold can actually move.
+    reclaimable = [u for u in units if not u.active and u.age_days(clock) >= MIN_RECLAIM_AGE_DAYS]
+    batches = list_trash()
+    report = StorageReport(
+        total_bytes=sum(u.bytes for u in units),
+        total_sessions=len(units),
+        active_sessions=len(active),
+        active_bytes=sum(u.bytes for u in active),
+        buckets=_bucketize(reclaimable, clock),
+        reclaimable_sessions=len(reclaimable),
+        reclaimable_bytes=sum(u.bytes for u in reclaimable),
+        trash_bytes=sum(b.bytes for b in batches),
+        trash_batches=len(batches),
+        trash_same_filesystem=_same_filesystem(kiro_sessions_dir(), trash_root()),
+        reclaim_blocked_reason=reclaim_block_reason(),
+    )
+    # The per-store split stays out of the report but is the first thing worth
+    # knowing when a total looks wrong.
+    logger.debug(
+        "session storage: %d sessions, %d paired, %d replay-only, %d transcript-only",
+        len(units),
+        sum(1 for u in units if u.sid and u.stems),
+        sum(1 for u in units if u.sid and not u.stems),
+        sum(1 for u in units if u.stems and not u.sid),
+    )
+    return report
+
+
+def select_reclaimable(
+    index: SessionIndex,
+    older_than_days: float,
+    *,
+    now: float | None = None,
+) -> list[SessionUnit]:
+    """The sessions a reclaim at *older_than_days* would move.
+
+    Separate from :func:`move_to_trash` so a caller can show the exact count and
+    size before anything moves, and so the selection is re-derived at the moment
+    of the move rather than trusted from a stale UI.
+    """
+    if older_than_days < 0:
+        raise SessionStorageError("older_than_days must not be negative")
+    clock = time.time() if now is None else now
+    # The caller's threshold can only be MORE conservative than the floor.
+    cutoff = max(float(older_than_days), MIN_RECLAIM_AGE_DAYS)
+    return [u for u in _scan_units(index) if not u.active and u.age_days(clock) >= cutoff]
+
+
+def _replay_store_cotenants() -> list[str]:
+    """Names of pod instances that read the same kiro-cli replay store.
+
+    A pod isolates ``KIROCREW_HOME`` but deliberately NOT ``KIRO_HOME``, so every
+    pod reads the machine-wide replay store while keeping its own session map. From
+    the default instance's side that is the mirror of the isolated-instance hazard:
+    the pod's sessions are absent from the map THIS process consults, so they read
+    as retired.
+
+    The pod root is host-side state at a known location, which makes this the one
+    co-tenant that can actually be discovered. A dev gateway pointed at some other
+    ``KIROCREW_HOME`` cannot be, and stays a documented limitation.
+    """
+    raw = os.environ.get("KIROCREW_POD_ROOT")
+    pod_root = Path(raw).expanduser() if raw else Path.home() / ".kirocrew-pods"
+    try:
+        entries = list(pod_root.iterdir())
+    except OSError:
+        return []
+    return sorted(
+        entry.name for entry in entries if entry.is_dir() and not entry.name.startswith(".")
+    )
+
+
+def reclaim_block_reason() -> str:
+    """Why this instance must not reclaim, or ``""`` when it may.
+
+    The exclusion set is built from THIS instance's session map, but the kiro-cli
+    replay store can be shared by several instances. An instance with its own data
+    home reading the machine-wide store cannot see the default instance's
+    mappings, so a resumable conversation reads as retired and could be staged and
+    then emptied out from under a gateway this process cannot see.
+
+    Decided on RESOLVED paths, never on whether the environment variables are set,
+    and by requiring the store to be CONTAINED in this instance's data home rather
+    than by testing it against the default location. Both overrides are validated
+    and silently fall back to the default when they name an unsafe target, so
+    ``KIRO_HOME=/etc`` alongside an isolated ``KIROCREW_HOME`` leaves this process
+    reading the shared store while an env-presence test would report it isolated —
+    the exact hazard, reached through a rejected override. Containment also covers
+    a store that is shared without being the default one: two isolated instances
+    pointed at the same custom ``KIRO_HOME`` see neither the default store nor each
+    other's maps.
+
+    The freshness floor narrows the window but does not close it — a session idle
+    for a day is still resumable — so the operation is refused rather than
+    attempted. Isolating both homes together, or neither, is safe.
+    """
+
+    def _norm(path: Path) -> Path:
+        # A symlinked HOME would otherwise make the default home compare unequal to
+        # itself and report every instance as isolated.
+        try:
+            return path.resolve()
+        except OSError:  # pragma: no cover - defensive
+            return path
+
+    home = _norm(Path.home())
+    # BOTH of these are defaults, not isolation: an install that has not yet
+    # migrated legitimately reports the legacy home, and treating that as an
+    # isolated instance would refuse every pre-migration install.
+    defaults = {home / KIRO_BASE_DIR_NAME / CONFIG_DIR_LEAF, _norm(legacy_home())}
+    data = _norm(data_home())
+    if data in defaults:
+        # The mirror of the isolated-instance case, and just as destructive: a pod
+        # shares this store while keeping its own map, so ITS sessions read as
+        # retired from here. Only checked when the store is the default one, since
+        # that is the only store a pod reads.
+        if _norm(kiro_home()) == home / KIRO_BASE_DIR_NAME:
+            cotenants = _replay_store_cotenants()
+            if cotenants:
+                listed = ", ".join(cotenants[:3])
+                return (
+                    f"{len(cotenants)} other instance(s) share this kiro-cli session "
+                    f"store ({listed}), so their resumable sessions cannot be told "
+                    "apart from retired ones. Evict them with `kirocrew pod down "
+                    "<name>` to reclaim from here."
+                )
+        return ""
+    # An isolated instance may reclaim only when its replay store is provably its
+    # own. Testing against the DEFAULT store location would miss the sharing that
+    # matters most: two isolated instances pointed at one custom KIRO_HOME see
+    # neither the default store nor each other's maps. Requiring the store to live
+    # inside this instance's data home fails closed on every such arrangement.
+    store = _norm(kiro_home())
+    if store == data or data in store.parents:
+        return ""
+    return (
+        "This instance has its own data home but its kiro-cli session store sits "
+        "outside it, so the store may be shared with instances whose sessions this "
+        "one cannot see. Point KIRO_HOME inside KIROCREW_HOME to reclaim from here."
+    )
+
+
+@contextmanager
+def _mutation_lock() -> Iterator[None]:
+    """Serialize every operation that moves or deletes staged files.
+
+    Two concurrent reclaims can select the same session and interleave their
+    moves, landing one half in each batch — after which neither batch can restore
+    it, and emptying either destroys half a session. A file lock rather than a
+    thread lock because instances share the kiro-cli store: a pod and the live
+    gateway both read ``~/.kiro/sessions/cli``, so in-process exclusion excludes
+    nothing.
+
+    :func:`platform_compat.file_lock` fails closed, so a lock that cannot be taken
+    raises instead of entering the section unserialized.
+    """
+    lock_path = trash_root().parent / MUTATION_LOCK_NAME
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        with platform_compat.file_lock(fd, exclusive=True, required=True):
+            yield
+    finally:
+        os.close(fd)
+
+
+def _batch_dir(batch_id: str) -> Path:
+    """Resolve a batch id to its directory, refusing anything that is not one.
+
+    The id itself cannot traverse — it is pattern-checked — but a **link** planted
+    under the trash root can, and its name would pass that check. Following one
+    would let a crafted manifest drive moves into or out of paths this module does
+    not own, in either direction. A batch is a real directory inside the trash root
+    or it is not a batch, so both the link check and the containment check happen
+    here, at the one place every caller resolves an id through.
+
+    The link test goes through :func:`platform_compat.is_link_or_junction` because
+    ``is_symlink()`` reports False for an NTFS **junction**: on Windows a junction
+    named as a valid batch id would read as a real directory, and the delete would
+    resolve through it to whatever batch it points at.
+
+    Containment is anchored to the DATA HOME, not to the trash root alone. The trash
+    root lives under a directory the agent can write, so it could itself be replaced
+    with a link: resolving relative to it would then accept batches under whatever it
+    points at, and "empty everything" would recurse into directories this module
+    does not own.
+
+    The root must also not BE a link. Anchoring alone is not enough, because a link
+    can point at another directory *inside* the data home — the live sessions or
+    archive tree — which satisfies both the anchor and containment while making
+    `empty` delete real session data.
+    """
+    if not _UNIT_ID_RE.match(batch_id):
+        raise SessionStorageError(f"not a valid batch id: {batch_id!r}")
+    root = trash_root()
+    if platform_compat.is_link_or_junction(root):
+        raise SessionStorageError(f"the trash root is a link: {root}")
+    path = root / batch_id
+    if platform_compat.is_link_or_junction(path):
+        raise SessionStorageError(f"not a valid batch id: {batch_id!r}")
+    try:
+        resolved_root = root.resolve()
+        resolved = path.resolve()
+        home = data_home().resolve()
+    except OSError as exc:  # pragma: no cover - defensive
+        raise SessionStorageError(f"not a valid batch id: {batch_id!r}") from exc
+    if home not in resolved_root.parents:
+        raise SessionStorageError(f"the trash root does not live under the data home: {root}")
+    if resolved_root not in resolved.parents:
+        raise SessionStorageError(f"not a valid batch id: {batch_id!r}")
+    return path
+
+
+def _move_file_exclusive(src: Path, dst: Path) -> bool:
+    """Move *src* to *dst*, never replacing an existing *dst*. False if occupied.
+
+    Restore's preflight checks that the origin is free, but the session can be
+    recreated in the interval before the move — and ``os.rename`` replaces the
+    destination silently, so undoing a deletion would destroy the newer data it was
+    meant to protect. Creating the destination exclusively makes the check and the
+    write one atomic step, so a lost race is reported rather than acted on.
+    """
+    try:
+        os.link(src, dst)
+    except FileExistsError:
+        return False
+    except OSError:
+        # A different filesystem, or one without hard links: copy into a file that
+        # must not already exist, which keeps the no-clobber guarantee.
+        try:
+            fd = os.open(dst, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            return False
+        try:
+            with os.fdopen(fd, "wb") as out, open(src, "rb") as handle:
+                shutil.copyfileobj(handle, out)
+            shutil.copystat(src, dst)
+        except OSError:
+            with suppress(OSError):
+                dst.unlink()
+            raise
+        src.unlink()
+        return True
+    src.unlink()
+    return True
+
+
+def _move_file(src: Path, dst: Path) -> None:
+    """Move one file, preferring a rename and falling back to a copy.
+
+    A rename is atomic and instant, which is what makes a trash usable at tens of
+    gigabytes. It only works within one filesystem, so a data home mounted apart
+    from the kiro-cli store falls back to :func:`shutil.move` — correct, but it
+    copies, so it is slow and needs the space twice while it runs.
+    """
+    try:
+        os.rename(src, dst)
+    except OSError as exc:
+        if getattr(exc, "errno", None) != getattr(os, "EXDEV", 18):
+            raise
+        shutil.move(str(src), str(dst))
+
+
+def _file_size(path: Path) -> int:
+    """The size recorded for a staged file. Raises ``OSError`` when unreadable.
+
+    A named operation rather than an inline ``stat`` because its failure is
+    load-bearing: a file whose size cannot be read cannot be recorded, and an
+    unrecorded file is one restore cannot put back.
+    """
+    return path.stat().st_size
+
+
+def _rollback(moved: list[tuple[Path, Path]]) -> None:
+    """Undo a partial session move, best effort.
+
+    Each pair is (where it landed, where it came from). A rollback that itself
+    fails is logged and nothing more: the alternative is raising over a caller
+    already handling a failure, which would abandon the rest of the batch too.
+
+    The move is EXCLUSIVE. A rollback runs after something already went wrong, so
+    the origin may have been recreated in the meantime — and a plain rename would
+    replace that newer session data with the copy being put back, turning a handled
+    failure into data loss. An occupied origin leaves the file where it is staged,
+    which keeps it recoverable.
+    """
+    for landed, origin in reversed(moved):
+        try:
+            if not _move_file_exclusive(landed, origin):
+                logger.warning(
+                    "not rolling %s back: %s was recreated and is newer",
+                    landed,
+                    origin,
+                )
+        except OSError:
+            logger.warning("could not roll %s back to %s", landed, origin, exc_info=True)
+
+
+def _staged_path(batch: Path, rel: str) -> Path | None:
+    """Resolve a manifest ``rel`` inside *batch*, or ``None`` if it escapes.
+
+    ``Path("/a/b") / "/etc/passwd"`` is ``/etc/passwd`` — joining an absolute
+    string discards the base entirely. The manifest lives under the data home,
+    which is agent-writable, so a tampered or corrupted ``rel`` would otherwise
+    let restore pick up any file on the host and relocate it. Both the absolute
+    form and ``..`` traversal are refused.
+    """
+    if not rel or Path(rel).is_absolute():
+        return None
+    candidate = batch / rel
+    try:
+        resolved = candidate.resolve()
+        root = batch.resolve()
+    except OSError:
+        return None
+    if resolved == root or not resolved.is_relative_to(root):
+        return None
+    return candidate
+
+
+def _canonical_origin(rel: str) -> Path | None:
+    """Where a staged file must have come from, DERIVED from its staged path.
+
+    The staged path already encodes the store and the filename, and the filename
+    is the session's identity — a replay log is ``<sid>.jsonl`` and a transcript is
+    ``<stem>.jsonl``. So the origin is not information the manifest needs to
+    supply, and accepting it would let a tampered in-store origin relocate one
+    session's file under another session's name: both paths pass a
+    "inside a session store" test, and the result is a corrupted session with no
+    error a user could connect to a restore.
+
+    Deriving removes the choice. The recorded origin is then only checked for
+    agreement, so a disagreement is refused instead of followed.
+    """
+    parts = PurePosixPath(rel).parts
+    if not parts:
+        return None
+    name = parts[-1]
+    if not name or name != Path(name).name or name in (os.curdir, os.pardir):
+        return None
+    if parts[0] == STAGE_CLI_LEAF and len(parts) == 2:
+        return kiro_sessions_dir() / name
+    if parts[0] == STAGE_CREW_LEAF:
+        if len(parts) == 2:
+            return _crew_sessions_dir() / name
+        if len(parts) == 3 and parts[1] == ARCHIVE_DIR_NAME:
+            return _crew_archive_dir() / name
+    return None
+
+
+def _origin_path(origin: str) -> Path | None:
+    """Accept an *origin* only if it names a file inside a session store.
+
+    Restore writes to this path, so an unconstrained origin from a tampered
+    manifest is an arbitrary-write primitive. Only the two directories this module
+    ever reclaims from are permitted; anything else — a credential file, a config,
+    a path outside the homes entirely — is refused.
+    """
+    if not origin:
+        return None
+    candidate = Path(origin)
+    if not candidate.is_absolute():
+        return None
+    try:
+        resolved = candidate.resolve()
+        allowed = [
+            kiro_sessions_dir().resolve(),
+            _crew_sessions_dir().resolve(),
+            _crew_archive_dir().resolve(),
+        ]
+    except OSError:
+        return None
+    if not any(resolved.is_relative_to(root) for root in allowed):
+        return None
+    return candidate
+
+
+def _unlisted_files(batch: Path) -> list[Path]:
+    """Staged files no manifest entry names.
+
+    A process exit between moving a file into a batch and appending its manifest
+    line leaves a file nothing points at. It is still the ONLY copy of that
+    session's data, and the user was never shown it — the batch may even list zero
+    sessions — so no cleanup path may remove it.
+
+    An unreadable manifest yields every file, which is the safe direction: without
+    the manifest nothing in the batch is accounted for.
+
+    A scan that cannot be completed RAISES rather than returning a short list. This
+    function exists to block deletions, so an empty result must mean "there is
+    nothing unaccounted for", never "the walk gave up early" — ``rglob`` skips
+    unreadable directories silently, which would turn a transient error into
+    permission to delete a file that is the only copy of a session.
+    """
+    parsed = _read_manifest(batch)
+    listed: set[str] = set()
+    if parsed is not None:
+        for entry in parsed[1]:
+            files = entry.get("files")
+            if not isinstance(files, list):
+                continue
+            for record in files:
+                if isinstance(record, dict) and isinstance(record.get("rel"), str):
+                    listed.add(record["rel"])
+    failures: list[OSError] = []
+    unlisted = []
+    for root, _dirs, names in os.walk(batch, onerror=failures.append):
+        for name in names:
+            path = Path(root) / name
+            if name == MANIFEST_NAME:
+                continue
+            try:
+                if not path.is_file():
+                    continue
+            except OSError as exc:
+                failures.append(exc)
+                continue
+            if path.relative_to(batch).as_posix() not in listed:
+                unlisted.append(path)
+    if failures:
+        raise SessionStorageError(
+            f"could not read all of {batch.name}, so it is not known whether it "
+            f"holds files nothing lists: {failures[0]}"
+        )
+    return unlisted
+
+
+def _discard_restored_batch(batch: Path, header: dict[str, Any]) -> None:
+    """Remove a fully-restored batch, unless it holds files nothing listed.
+
+    Deleting the directory wholesale would destroy an interrupted move's staged
+    files — on the one path that exists to be safe. Those keep the batch alive
+    instead, so a user can still see it and decide.
+    """
+    try:
+        leftovers = _unlisted_files(batch)
+    except SessionStorageError as exc:
+        # Not knowing is treated exactly like finding leftovers: keep the batch.
+        logger.warning("keeping trash batch %s: %s", batch.name, exc)
+        _rewrite_manifest(batch, header, [])
+        return
+    if leftovers:
+        logger.warning(
+            "keeping trash batch %s: %d staged file(s) are absent from its manifest, "
+            "so removing it would delete the only copy",
+            batch.name,
+            len(leftovers),
+        )
+        _rewrite_manifest(batch, header, [])
+        return
+    shutil.rmtree(batch, ignore_errors=True)
+
+
+def _write_header(handle: IO[str], batch_id: str, created_at: float, reason: str) -> None:
+    header = {
+        "schema": MANIFEST_SCHEMA,
+        "batch_id": batch_id,
+        "created_at": created_at,
+        "reason": reason,
+    }
+    handle.write(json.dumps(header) + "\n")
+    handle.flush()
+
+
+def _append_entry(handle: IO[str], entry: dict[str, Any]) -> None:
+    """Record one moved session and flush, so an interruption loses at most the
+    session currently in flight."""
+    handle.write(json.dumps(entry) + "\n")
+    handle.flush()
+
+
+def _read_manifest(batch: Path) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
+    """Parse a batch manifest into its header and session entries.
+
+    A trailing partial line (a crash mid-append) is skipped rather than failing
+    the whole batch: every complete line before it describes real moved files that
+    must stay restorable.
+    """
+    try:
+        raw = (batch / MANIFEST_NAME).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    header: dict[str, Any] | None = None
+    entries: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        if header is None:
+            header = record
+            continue
+        entries.append(record)
+    if header is None or header.get("schema") != MANIFEST_SCHEMA:
+        return None
+    return header, entries
+
+
+def _rewrite_manifest(batch: Path, header: dict[str, Any], entries: list[dict[str, Any]]) -> None:
+    """Replace a manifest atomically after a partial restore."""
+    tmp = batch / f"{MANIFEST_NAME}.tmp"
+    with tmp.open("w", encoding="utf-8") as handle:
+        handle.write(json.dumps(header) + "\n")
+        for entry in entries:
+            handle.write(json.dumps(entry) + "\n")
+    os.replace(tmp, batch / MANIFEST_NAME)
+
+
+def _entry_bytes(entry: dict[str, Any]) -> int:
+    files = entry.get("files")
+    if not isinstance(files, list):
+        return 0
+    total = 0
+    for record in files:
+        if isinstance(record, dict):
+            size = record.get("bytes")
+            if isinstance(size, int):
+                total += size
+    return total
+
+
+def move_to_trash(
+    uids: list[str],
+    *,
+    reason: str,
+    index: SessionIndex,
+    now: float | None = None,
+    refresh: Callable[[], SessionIndex] | None = None,
+) -> TrashBatch:
+    """Stage whole sessions for deletion and return the batch that can undo it.
+
+    Every half of each session moves together — replay log, transcript and rotated
+    archive segments. Leaving one behind would produce a session that lists but
+    cannot resume, or resumes with no history.
+
+    Refuses a session that is still mapped, and one touched within
+    :data:`MIN_RECLAIM_AGE_DAYS`: a mapped session is resumable, and a fresh one
+    may be running under a subsystem that never registered it.
+
+    *refresh* re-reads the caller's index INSIDE the lock, immediately before
+    anything moves. Scanning a large store takes long enough that a session can be
+    resumed and mapped while the selection is being computed, and the stale index
+    would then treat it as retired. The two active sets are UNIONED, never
+    replaced, so a re-read can only ever add protection.
+
+    Serialized against other mutations, because two interleaved reclaims can put
+    one half of a session in each batch and leave neither able to restore it.
+    """
+    with _mutation_lock():
+        return _move_to_trash_locked(uids, reason=reason, index=index, now=now, refresh=refresh)
+
+
+def _move_to_trash_locked(
+    uids: list[str],
+    *,
+    reason: str,
+    index: SessionIndex,
+    now: float | None = None,
+    refresh: Callable[[], SessionIndex] | None = None,
+) -> TrashBatch:
+    """Stage whole sessions for deletion and return the batch that can undo it.
+
+    Every half of each session moves together — replay log, transcript and rotated
+    archive segments. Leaving one behind would produce a session that lists but
+    cannot resume, or resumes with no history.
+
+    Refuses any session that is still mapped: it is one the product can resume,
+    and moving its files out from under a live slot breaks it with no error a user
+    would connect to this action.
+
+    Each session is recorded as it lands, so an interruption leaves a manifest
+    describing exactly what moved — a partial batch stays restorable instead of
+    becoming orphaned files nothing points at.
+    """
+    clock = time.time() if now is None else now
+    blocked_reason = reclaim_block_reason()
+    if blocked_reason:
+        raise SessionStorageError(blocked_reason)
+    requested = [_validate_unit_id(uid) for uid in uids]
+    if not requested:
+        raise SessionStorageError("no sessions selected")
+
+    by_uid = {u.uid: u for u in _scan_units(index)}
+
+    # The authority check runs AFTER the scan, not before it. Enumerating a
+    # six-figure store is the slow part of this function, so an index read before
+    # it is already stale by the time anything moves — a session continued in that
+    # interval would look retired. Re-reading here makes the last thing before the
+    # move loop the freshest view available, and the sets are UNIONED so a re-read
+    # can only ever add protection.
+    if refresh is not None:
+        try:
+            latest = refresh()
+        except Exception:
+            logger.warning("could not re-read the session index", exc_info=True)
+            raise SessionStorageError(
+                "could not confirm which sessions are live; nothing was moved"
+            )
+        live_sids = index.active_sids | latest.active_sids
+        live_stems = index.active_stems | latest.active_stems
+    else:
+        live_sids = index.active_sids
+        live_stems = index.active_stems
+
+    def is_live(uid: str) -> bool:
+        unit = by_uid.get(uid)
+        if unit is None:
+            return False
+        if unit.active or (unit.sid and unit.sid in live_sids):
+            return True
+        return any(stem in live_stems for stem in unit.stems)
+
+    blocked = [uid for uid in requested if is_live(uid)]
+    if blocked:
+        raise SessionStorageError(
+            f"refusing to move {len(blocked)} session(s) still in use: {blocked[0]}"
+        )
+    # Freshness is checked HERE, not only in the selection helper, because this is
+    # the chokepoint: a caller passing ids directly would otherwise bypass the
+    # floor and take a session that is running right now but was never mapped.
+    fresh = [
+        uid
+        for uid in requested
+        if uid in by_uid and by_uid[uid].age_days(clock) < MIN_RECLAIM_AGE_DAYS
+    ]
+    if fresh:
+        raise SessionStorageError(
+            f"refusing to move {len(fresh)} session(s) touched in the last "
+            f"{MIN_RECLAIM_AGE_DAYS:g} day(s): {fresh[0]}"
+        )
+
+    stamp = time.strftime("%Y%m%dT%H%M%S", time.gmtime(clock))
+    batch_id = f"{stamp}-{uuid.uuid4().hex[:8]}"
+    target = _batch_dir(batch_id)
+    target.mkdir(parents=True, exist_ok=False)
+    archives = _archive_index()
+
+    moved_bytes = 0
+    moved_sessions = 0
+    staged_dirs: set[Path] = set()
+    cli_files = _cli_index()
+    with (target / MANIFEST_NAME).open("w", encoding="utf-8") as manifest:
+        _write_header(manifest, batch_id, clock, reason)
+        for uid in requested:
+            unit = by_uid.get(uid)
+            if unit is None:
+                continue
+            files: list[dict[str, Any]] = []
+            done: list[tuple[Path, Path]] = []
+            failed = False
+            for src, rel in _unit_paths(unit.sid, unit.stems, archives, cli_files):
+                try:
+                    size = _file_size(src)
+                except OSError:
+                    # A file that cannot be sized cannot be recorded, and a file
+                    # the manifest does not record is one restore cannot put back.
+                    # Skipping it here while moving the rest is precisely the split
+                    # this loop's rollback exists to prevent, so it is a failure.
+                    logger.warning("could not stat %s for staging", src, exc_info=True)
+                    failed = True
+                    break
+                dst = target / rel
+                if dst.parent not in staged_dirs:
+                    dst.parent.mkdir(parents=True, exist_ok=True)
+                    staged_dirs.add(dst.parent)
+                try:
+                    _move_file(src, dst)
+                except OSError:
+                    logger.warning("could not move %s into the trash", src, exc_info=True)
+                    failed = True
+                    break
+                done.append((dst, src))
+                files.append({"rel": rel, "origin": str(src), "bytes": size})
+            if failed:
+                # A session that moved only partly is the broken state this module
+                # exists to prevent, and it would be invisible: the manifest would
+                # list the staged half while the rest stayed in place, so emptying
+                # the trash would destroy one half of a session nobody knew was
+                # split. Put back whatever moved and leave the session alone.
+                _rollback(done)
+                continue
+            if files:
+                # The manifest is what makes a move reversible, so a session that
+                # moved but could not be recorded is worse than one that never
+                # moved: its files are gone from live storage and no entry names
+                # them, so they can neither be restored nor resumed. Rewind the
+                # partial line and put the files back.
+                mark = manifest.tell()
+                try:
+                    _append_entry(manifest, {"uid": uid, "files": files})
+                except OSError:
+                    logger.warning("could not record session %s in the manifest; rolling back", uid)
+                    try:
+                        manifest.truncate(mark)
+                        manifest.seek(mark)
+                    except OSError:
+                        logger.warning("could not rewind the manifest", exc_info=True)
+                    _rollback(done)
+                    continue
+                moved_sessions += 1
+                moved_bytes += sum(int(record["bytes"]) for record in files)
+
+    if not moved_sessions:
+        # Leave no empty batch behind — but a rollback that itself failed can have
+        # left staged files here, and those are the only copy.
+        if _unlisted_files(target):
+            raise SessionStorageError(
+                "no sessions were staged, and some files could not be put back; " f"see {target}"
+            )
+        shutil.rmtree(target, ignore_errors=True)
+        raise SessionStorageError("none of the selected sessions were found on disk")
+
+    return TrashBatch(
+        batch_id=batch_id,
+        created_at=clock,
+        reason=reason,
+        sessions=moved_sessions,
+        bytes=moved_bytes,
+    )
+
+
+def list_trash() -> list[TrashBatch]:
+    """Every staged batch, newest first.
+
+    A batch with no readable manifest is omitted: without one its files could not
+    be put back, so presenting it as restorable would be a false promise.
+    """
+    batches: list[TrashBatch] = []
+    root = trash_root()
+    try:
+        # Same two rules as _batch_dir: a trash root that has been replaced with a
+        # link would otherwise have foreign directories enumerated AS batches, which
+        # is what makes them reachable by "empty everything". The anchor alone is not
+        # enough — a link can point INSIDE the data home, at the live sessions tree.
+        if platform_compat.is_link_or_junction(root):
+            logger.warning("trash root %s is a link; not offering any batches", root)
+            return []
+        if data_home().resolve() not in root.resolve().parents:
+            logger.warning("trash root %s does not live under the data home", root)
+            return []
+        candidates = list(root.iterdir())
+    except OSError:
+        return []
+    for candidate in candidates:
+        # A link is not a batch. Skipping it here (rather than raising) keeps a
+        # planted link from wedging "empty everything" forever, while an explicit
+        # request naming that id is still refused loudly by _batch_dir. Junctions
+        # count: is_symlink() reports False for one, so a Windows junction would be
+        # listed as a real batch and the sweep would delete through it.
+        if platform_compat.is_link_or_junction(candidate) or not candidate.is_dir():
+            continue
+        parsed = _read_manifest(candidate)
+        if parsed is None:
+            logger.debug("trash batch %s has no readable manifest", candidate.name)
+            continue
+        header, entries = parsed
+        # The DIRECTORY is the batch's identity. A header that names a different
+        # batch would make a targeted empty delete the batch it named instead of
+        # the one it came from, so a disagreement is treated as corruption rather
+        # than resolved in the header's favour.
+        claimed = header.get("batch_id")
+        if isinstance(claimed, str) and claimed and claimed != candidate.name:
+            logger.warning(
+                "trash batch %s has a manifest claiming batch id %r; not offering it",
+                candidate.name,
+                claimed,
+            )
+            continue
+        created = header.get("created_at")
+        batches.append(
+            TrashBatch(
+                batch_id=candidate.name,
+                created_at=float(created) if isinstance(created, (int, float)) else 0.0,
+                reason=str(header.get("reason") or ""),
+                sessions=len(entries),
+                bytes=sum(_entry_bytes(e) for e in entries),
+            )
+        )
+    batches.sort(key=lambda b: b.created_at, reverse=True)
+    return batches
+
+
+def restore(batch_id: str, uids: list[str] | None = None) -> int:
+    """Put staged sessions back where they came from; return sessions restored.
+
+    Serialized against other mutations so a concurrent reclaim cannot move a
+    session's other half while this one is putting it back.
+    """
+    with _mutation_lock():
+        return _restore_locked(batch_id, uids)
+
+
+def _restore_locked(batch_id: str, uids: list[str] | None = None) -> int:
+    """Put staged sessions back where they came from; return sessions restored.
+
+    *uids* restores only those sessions, which is what makes a large
+    policy-driven batch usable: a user remembers the one conversation they want,
+    not the batch it happened to land in.
+
+    A session is restored only when EVERY one of its files can go back. Restoring
+    part of one would recreate the half-session this module exists to avoid, so a
+    blocked file leaves the whole session staged.
+    """
+    batch = _batch_dir(batch_id)
+    parsed = _read_manifest(batch)
+    if parsed is None:
+        raise SessionStorageError(f"no restorable batch {batch_id!r}")
+    header, entries = parsed
+    wanted = None if uids is None else {_validate_unit_id(uid) for uid in uids}
+
+    remaining: list[dict[str, Any]] = []
+    restored = 0
+    for entry in entries:
+        uid = str(entry.get("uid") or "")
+        if wanted is not None and uid not in wanted:
+            remaining.append(entry)
+            continue
+        files = entry.get("files")
+        files = files if isinstance(files, list) else []
+        planned: list[tuple[Path, Path]] = []
+        blocked = False
+        for record in files:
+            if not isinstance(record, dict):
+                # A record we cannot read is a file we cannot place. Restoring the
+                # rest would leave the session split with that file staged and
+                # unreferenced, so the whole session stays put.
+                logger.warning("manifest record for %s is not an object", uid)
+                blocked = True
+                break
+            rel = str(record.get("rel") or "")
+            src = _staged_path(batch, rel)
+            recorded = _origin_path(str(record.get("origin") or ""))
+            origin = _canonical_origin(rel)
+            if src is None or origin is None or recorded is None:
+                logger.warning("refusing a manifest record outside the session stores")
+                blocked = True
+                break
+            if recorded.resolve() != origin.resolve():
+                # Both are inside a session store, so neither check alone catches
+                # this: the recorded origin names a DIFFERENT session's file.
+                logger.warning(
+                    "refusing a manifest record whose origin does not match its " "staged path"
+                )
+                blocked = True
+                break
+            # An occupied origin means the session came back on its own; the
+            # occupant is newer, and undoing a deletion must not cause one.
+            # is_file() FOLLOWS links, so a staged symlink would pass as a file and
+            # restore would put the link back where the session's data belongs.
+            if platform_compat.is_link_or_junction(src) or not src.is_file() or origin.exists():
+                blocked = True
+                break
+            planned.append((src, origin))
+        if blocked or not planned:
+            remaining.append(entry)
+            continue
+        done: list[tuple[Path, Path]] = []
+        try:
+            lost_race = False
+            for src, origin in planned:
+                origin.parent.mkdir(parents=True, exist_ok=True)
+                if not _move_file_exclusive(src, origin):
+                    # The session came back between the preflight and now. The
+                    # occupant is newer, so the whole session is put back and the
+                    # entry retained — restoring the rest would splice two
+                    # generations of one session together.
+                    logger.warning(
+                        "session %s was recreated while being restored; leaving it " "staged",
+                        uid,
+                    )
+                    lost_race = True
+                    break
+                done.append((origin, src))
+            if lost_race:
+                _rollback(done)
+                remaining.append(entry)
+                continue
+        except OSError:
+            logger.warning("could not fully restore session %s", uid, exc_info=True)
+            # Without this the session is split *and* wedged: the files that did
+            # move are gone from the batch while the manifest still lists them, so
+            # every later retry fails its own "staged file present" check and the
+            # session can never be restored or cleanly emptied again.
+            _rollback(done)
+            remaining.append(entry)
+            continue
+        restored += 1
+
+    if remaining:
+        _rewrite_manifest(batch, header, remaining)
+    else:
+        _discard_restored_batch(batch, header)
+    return restored
+
+
+def _dir_bytes(root: Path) -> int:
+    """Total size of every file under *root*, recursively.
+
+    Uses the stat the directory walk already produced: a batch can hold hundreds
+    of thousands of files, where a separate ``Path.stat()`` per file dominates.
+    """
+    total = 0
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as it:
+                for entry in it:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            stack.append(Path(entry.path))
+                        elif entry.is_file(follow_symlinks=False):
+                            total += entry.stat(follow_symlinks=False).st_size
+                    except OSError:
+                        continue
+        except OSError:
+            continue
+    return total
+
+
+def empty_trash(batch_ids: list[str] | None = None) -> int:
+    """Delete staged batches for good; return the bytes freed.
+
+    Serialized against other mutations, so a batch cannot be destroyed while a
+    restore is mid-way through putting its files back.
+    """
+    with _mutation_lock():
+        return _empty_trash_locked(batch_ids)
+
+
+def _empty_trash_locked(batch_ids: list[str] | None = None) -> int:
+    """Delete staged batches for real; return the bytes freed.
+
+    This is the only call here that destroys data, and the only one that changes
+    free space. Every path is resolved and confirmed to be inside the trash root
+    first, so a tampered manifest or a symlinked batch directory cannot direct the
+    delete outside it.
+    """
+    try:
+        root = trash_root().resolve()
+    except OSError:
+        return 0
+    if batch_ids is None:
+        targets = [_batch_dir(b.batch_id) for b in list_trash()]
+    else:
+        targets = [_batch_dir(batch_id) for batch_id in batch_ids]
+
+    freed = 0
+    for target in targets:
+        try:
+            resolved = target.resolve()
+        except OSError:
+            continue
+        if resolved == root or not resolved.is_relative_to(root):
+            logger.warning("refusing to empty %s: outside the trash root", target)
+            continue
+        # A batch can hold files no manifest line mentions, left by an interruption
+        # between the move and the append. The user was never shown them — the
+        # batch may even list zero sessions — so "empty this batch" is not informed
+        # consent for destroying them, and they are the only copy.
+        try:
+            leftovers = _unlisted_files(resolved)
+        except SessionStorageError as exc:
+            # Skip, not abort: one unreadable batch must not make the whole trash
+            # un-emptyable. Skipping deletes nothing, which is the safe direction.
+            logger.warning("refusing to empty %s: %s", target.name, exc)
+            continue
+        if leftovers:
+            logger.warning(
+                "refusing to empty %s: %d staged file(s) are absent from its "
+                "manifest, so this would delete the only copy",
+                target.name,
+                len(leftovers),
+            )
+            continue
+        freed += _dir_bytes(resolved)
+        shutil.rmtree(resolved, ignore_errors=True)
+    return freed

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -1,0 +1,1447 @@
+"""Tests for session storage measurement and the trash/restore cycle.
+
+Both stores are addressed through their real resolvers by pointing
+``KIROCREW_HOME`` and ``KIRO_HOME`` at temp directories, rather than patching the
+module's bound names, so the tests exercise the same path resolution the product
+uses and a change to where either store lives fails here.
+
+The invariant these tests exist to protect: a session's halves are always
+reclaimed and restored TOGETHER. Half a session is worse than either extreme — it
+either lists without resuming, or resumes without history.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import session_storage
+from kiro_crew.config import paths
+from kiro_crew.history import transcript_stem
+from kiro_crew.session_storage import SessionIndex, SessionStorageError
+
+_NOW = 1_700_000_000.0
+_DAY = 86400.0
+
+
+@pytest.fixture()
+def stores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Point both stores at temp dirs; return (crew data home, kiro home).
+
+    The kiro home is nested INSIDE the data home because that is what
+    :func:`reclaim_block_reason` requires of an isolated instance: a store outside
+    the data home may be shared with an instance whose map this one cannot read, so
+    reclaiming from a sibling layout is refused by design.
+    """
+    crew_home = tmp_path / "crew"
+    kiro_home = crew_home / "kiro"
+    (crew_home / "sessions" / "archive").mkdir(parents=True)
+    (kiro_home / "sessions" / "cli").mkdir(parents=True)
+    monkeypatch.setenv("KIROCREW_HOME", str(crew_home))
+    monkeypatch.setenv("KIRO_HOME", str(kiro_home))
+    return crew_home, kiro_home
+
+
+def _cli_half(kiro_home: Path, sid: str, *, log_bytes: int, age_days: float) -> int:
+    root = kiro_home / "sessions" / "cli"
+    mtime = _NOW - age_days * _DAY
+    total = 0
+    for suffix, payload in ((".json", b"{}"), (".jsonl", b"c" * log_bytes)):
+        path = root / f"{sid}{suffix}"
+        path.write_bytes(payload)
+        os.utime(path, (mtime, mtime))
+        total += len(payload)
+    return total
+
+
+def _transcript(crew_home: Path, stem: str, *, size: int, age_days: float) -> int:
+    path = crew_home / "sessions" / f"{stem}.jsonl"
+    path.write_bytes(b"t" * size)
+    mtime = _NOW - age_days * _DAY
+    os.utime(path, (mtime, mtime))
+    return size
+
+
+def _archive_segment(crew_home: Path, stem: str, stamp: str, *, size: int, age_days: float) -> int:
+    path = crew_home / "sessions" / "archive" / f"{stem}__{stamp}.jsonl"
+    path.write_bytes(b"a" * size)
+    mtime = _NOW - age_days * _DAY
+    os.utime(path, (mtime, mtime))
+    return size
+
+
+def _index(pairs: dict[str, str] | None = None, active: set[str] | None = None) -> SessionIndex:
+    """Build an index from a readable {sid: stem} mapping.
+
+    The production shape is stem -> sid (one session can own several stems), but
+    tests read better keyed on the session, so this inverts for them.
+    """
+    stem_to_sid = {stem: sid for sid, stem in (pairs or {}).items()}
+    return SessionIndex(stem_to_sid=stem_to_sid, active_sids=frozenset(active or set()))
+
+
+def _multi_index(stem_to_sid: dict[str, str], active: set[str] | None = None) -> SessionIndex:
+    """Build an index directly, for the many-stems-one-session cases."""
+    return SessionIndex(stem_to_sid=stem_to_sid, active_sids=frozenset(active or set()))
+
+
+class TestPairing:
+    def test_a_paired_session_is_counted_once_with_one_total(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        crew_home, kiro_home = stores
+        cli = _cli_half(kiro_home, "aaaa1111", log_bytes=4096, age_days=40)
+        crew = _transcript(crew_home, "dashboard_chat-1", size=500, age_days=40)
+
+        report = session_storage.measure(_index({"aaaa1111": "dashboard_chat-1"}), now=_NOW)
+
+        assert report.total_sessions == 1
+        assert report.total_bytes == cli + crew
+        assert report.reclaimable_sessions == 1
+
+    def test_transcript_stem_is_derived_from_the_history_module(self) -> None:
+        """The pairing rule has exactly one source; a local copy would drift."""
+        assert transcript_stem("dashboard:chat-1") == "dashboard_chat-1"
+        assert transcript_stem("telegram:crew:direct:87431") == "telegram_crew_direct_87431"
+
+    def test_archive_segments_belong_to_their_session(self, stores: tuple[Path, Path]) -> None:
+        crew_home, kiro_home = stores
+        cli = _cli_half(kiro_home, "aaaa1111", log_bytes=64, age_days=40)
+        crew = _transcript(crew_home, "dashboard_chat-1", size=100, age_days=40)
+        seg = _archive_segment(
+            crew_home, "dashboard_chat-1", "20260730-211852", size=900, age_days=40
+        )
+
+        report = session_storage.measure(_index({"aaaa1111": "dashboard_chat-1"}), now=_NOW)
+
+        assert report.total_sessions == 1
+        assert report.total_bytes == cli + crew + seg
+
+    def test_a_segment_is_not_mistaken_for_a_session_of_its_own(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """A stem that prefixes another must not absorb the other's segments."""
+        crew_home, _ = stores
+        _transcript(crew_home, "dashboard_chat-1", size=10, age_days=40)
+        _transcript(crew_home, "dashboard_chat-14", size=10, age_days=40)
+        _archive_segment(crew_home, "dashboard_chat-14", "20260730-211852", size=700, age_days=40)
+
+        units = {u.uid: u.bytes for u in session_storage.select_reclaimable(_index(), 0, now=_NOW)}
+
+        assert units == {"dashboard_chat-1": 10, "dashboard_chat-14": 710}
+
+    def test_unpaired_halves_are_each_their_own_session(self, stores: tuple[Path, Path]) -> None:
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=16, age_days=40)
+        _transcript(crew_home, "cron_74173071", size=32, age_days=40)
+
+        report = session_storage.measure(_index(), now=_NOW)
+
+        assert report.total_sessions == 2
+        assert report.reclaimable_sessions == 2
+
+
+class TestActiveExclusion:
+    def test_a_mapped_session_protects_both_halves(self, stores: tuple[Path, Path]) -> None:
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=16, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=16, age_days=400)
+
+        index = _index({"aaaa1111": "dashboard_chat-1"}, active={"aaaa1111"})
+        report = session_storage.measure(index, now=_NOW)
+
+        assert report.active_sessions == 1
+        assert report.reclaimable_sessions == 0
+        assert session_storage.select_reclaimable(index, 0, now=_NOW) == []
+
+
+class TestMoveTakesBothHalves:
+    def test_both_halves_and_segments_move_together(self, stores: tuple[Path, Path]) -> None:
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=2048, age_days=40)
+        _transcript(crew_home, "dashboard_chat-1", size=300, age_days=40)
+        _archive_segment(crew_home, "dashboard_chat-1", "20260730-211852", size=400, age_days=40)
+
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+
+        assert batch.sessions == 1
+        cli_root = kiro_home / "sessions" / "cli"
+        crew_root = crew_home / "sessions"
+        assert not (cli_root / "aaaa1111.json").exists()
+        assert not (cli_root / "aaaa1111.jsonl").exists()
+        assert not (crew_root / "dashboard_chat-1.jsonl").exists()
+        assert not (crew_root / "archive" / "dashboard_chat-1__20260730-211852.jsonl").exists()
+        staged = session_storage.trash_root() / batch.batch_id
+        assert (staged / "cli" / "aaaa1111.jsonl").is_file()
+        assert (staged / "crew" / "dashboard_chat-1.jsonl").is_file()
+        assert (staged / "crew" / "archive" / "dashboard_chat-1__20260730-211852.jsonl").is_file()
+
+    def test_halves_with_the_same_filename_do_not_collide(self, stores: tuple[Path, Path]) -> None:
+        """A flat batch dir would let one half overwrite the other."""
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "collide", log_bytes=11, age_days=40)
+        _transcript(crew_home, "collide", size=22, age_days=40)
+
+        batch = session_storage.move_to_trash(
+            ["collide"], reason="manual", index=_index({"collide": "collide"}), now=_NOW
+        )
+
+        staged = session_storage.trash_root() / batch.batch_id
+        assert (staged / "cli" / "collide.jsonl").read_bytes() == b"c" * 11
+        assert (staged / "crew" / "collide.jsonl").read_bytes() == b"t" * 22
+
+    def test_refuses_a_session_still_mapped(self, stores: tuple[Path, Path]) -> None:
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=16, age_days=99)
+        _transcript(crew_home, "dashboard_chat-1", size=16, age_days=99)
+
+        index = _index({"aaaa1111": "dashboard_chat-1"}, active={"aaaa1111"})
+        with pytest.raises(SessionStorageError, match="still in use"):
+            session_storage.move_to_trash(["aaaa1111"], reason="manual", index=index, now=_NOW)
+
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").is_file()
+        assert (crew_home / "sessions" / "dashboard_chat-1.jsonl").is_file()
+
+    @pytest.mark.parametrize("uid", ["../escape", "a/b", "", "..", "with space", "x" * 250])
+    def test_refuses_ids_that_could_address_another_path(
+        self, stores: tuple[Path, Path], uid: str
+    ) -> None:
+        with pytest.raises(SessionStorageError, match="not a valid session id"):
+            session_storage.move_to_trash([uid], reason="manual", index=_index(), now=_NOW)
+
+    def test_manifest_records_every_file_of_the_session(self, stores: tuple[Path, Path]) -> None:
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        _transcript(crew_home, "dashboard_chat-1", size=8, age_days=40)
+        _archive_segment(crew_home, "dashboard_chat-1", "20260730-211852", size=8, age_days=40)
+
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="policy",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+
+        lines = (
+            (session_storage.trash_root() / batch.batch_id / session_storage.MANIFEST_NAME)
+            .read_text(encoding="utf-8")
+            .splitlines()
+        )
+        header = json.loads(lines[0])
+        entry = json.loads(lines[1])
+        assert header["reason"] == "policy"
+        assert entry["uid"] == "aaaa1111"
+        assert len(entry["files"]) == 4
+        origins = {record["origin"] for record in entry["files"]}
+        assert str(kiro_home / "sessions" / "cli" / "aaaa1111.json") in origins
+        assert str(crew_home / "sessions" / "dashboard_chat-1.jsonl") in origins
+
+
+class TestRestoreIsAllOrNothing:
+    def test_restores_every_half(self, stores: tuple[Path, Path]) -> None:
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=40)
+        _transcript(crew_home, "dashboard_chat-1", size=64, age_days=40)
+        _archive_segment(crew_home, "dashboard_chat-1", "20260730-211852", size=16, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+
+        restored = session_storage.restore(batch.batch_id)
+
+        assert restored == 1
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").read_bytes() == b"c" * 32
+        assert (crew_home / "sessions" / "dashboard_chat-1.jsonl").read_bytes() == b"t" * 64
+        seg = crew_home / "sessions" / "archive" / "dashboard_chat-1__20260730-211852.jsonl"
+        assert seg.read_bytes() == b"a" * 16
+        assert session_storage.list_trash() == []
+
+    def test_an_occupied_half_leaves_the_whole_session_staged(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """Restoring only the free half would recreate a half-session."""
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        _transcript(crew_home, "dashboard_chat-1", size=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+        # The transcript came back on its own while the session sat in the trash.
+        (crew_home / "sessions" / "dashboard_chat-1.jsonl").write_bytes(b"NEWER")
+
+        restored = session_storage.restore(batch.batch_id)
+
+        assert restored == 0
+        assert (crew_home / "sessions" / "dashboard_chat-1.jsonl").read_bytes() == b"NEWER"
+        # The replay half must NOT have been put back on its own.
+        assert not (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").exists()
+        assert session_storage.list_trash()[0].sessions == 1
+
+    def test_partial_restore_by_uid_keeps_the_rest_staged(self, stores: tuple[Path, Path]) -> None:
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        _cli_half(kiro_home, "bbbb2222", log_bytes=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111", "bbbb2222"], reason="manual", index=_index(), now=_NOW
+        )
+
+        restored = session_storage.restore(batch.batch_id, ["aaaa1111"])
+
+        assert restored == 1
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").is_file()
+        assert not (kiro_home / "sessions" / "cli" / "bbbb2222.jsonl").exists()
+        assert session_storage.list_trash()[0].sessions == 1
+
+    def test_an_origin_naming_another_session_is_refused(self, stores: tuple[Path, Path]) -> None:
+        """Both paths are inside a session store, so containment cannot catch it."""
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+        victim = kiro_home / "sessions" / "cli" / "bbbb2222.jsonl"
+        batch_dir = session_storage.trash_root() / batch.batch_id
+        manifest = batch_dir / session_storage.MANIFEST_NAME
+        lines = manifest.read_text().splitlines()
+        entry = json.loads(lines[1])
+        entry["files"][0]["origin"] = str(victim)
+        lines[1] = json.dumps(entry)
+        manifest.write_text("\n".join(lines) + "\n")
+
+        restored = session_storage.restore(batch.batch_id)
+
+        # The harm this prevents: the other session's path is never written to.
+        # Deriving the origin from the staged path is what guarantees it; the
+        # agreement check then turns a disagreeing manifest into a refusal rather
+        # than a silently ignored field.
+        assert not victim.exists()
+        assert restored == 0
+
+    def test_an_exclusive_move_never_replaces_an_occupied_destination(self, tmp_path: Path) -> None:
+        """The no-clobber guarantee itself, independent of any restore path."""
+        src = tmp_path / "src.jsonl"
+        src.write_bytes(b"staged")
+        taken = tmp_path / "taken.jsonl"
+        taken.write_bytes(b"newer generation")
+        free = tmp_path / "free.jsonl"
+
+        assert session_storage._move_file_exclusive(src, taken) is False
+        assert taken.read_bytes() == b"newer generation"
+        assert src.is_file(), "a refused move must not consume the staged file"
+
+        assert session_storage._move_file_exclusive(src, free) is True
+        assert free.read_bytes() == b"staged"
+        assert not src.exists()
+
+    def test_losing_the_origin_race_retains_the_entry(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A refused move must leave the session staged and still restorable."""
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+        calls: list[tuple[Path, Path]] = []
+
+        def occupied(src: Path, dst: Path) -> bool:
+            # Stand in for the gateway recreating the session after the preflight.
+            calls.append((src, dst))
+            return False
+
+        monkeypatch.setattr(session_storage, "_move_file_exclusive", occupied)
+
+        assert session_storage.restore(batch.batch_id) == 0
+        # Proves the move loop was reached, so this pins the lost-race branch and
+        # not an earlier refusal that would return 0 for a different reason.
+        assert calls, "restore never attempted the move"
+        # The batch is intact, so the user can retry once the origin frees up.
+        assert [b.batch_id for b in session_storage.list_trash()] == [batch.batch_id]
+        staged = session_storage.trash_root() / batch.batch_id / "cli" / "aaaa1111.jsonl"
+        assert staged.is_file()
+
+    def test_a_failed_restore_stays_retryable(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A half-restored session would be split AND wedged against every retry."""
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        _transcript(crew_home, "dashboard_chat-1", size=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+        real_move = session_storage._move_file_exclusive
+        calls = {"n": 0}
+
+        def flaky(src: Path, dst: Path) -> bool:
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise OSError("simulated failure mid-restore")
+            return real_move(src, dst)
+
+        monkeypatch.setattr(session_storage, "_move_file_exclusive", flaky)
+        assert session_storage.restore(batch.batch_id) == 0
+
+        # The staged files are all back in the batch, so a later retry succeeds.
+        monkeypatch.setattr(session_storage, "_move_file_exclusive", real_move)
+        assert session_storage.restore(batch.batch_id) == 1
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").is_file()
+        assert (crew_home / "sessions" / "dashboard_chat-1.jsonl").is_file()
+        assert session_storage.list_trash() == []
+
+    def test_restore_never_deletes_a_file_the_manifest_omits(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """An interrupted move leaves a staged file nothing lists — the only copy."""
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"], reason="manual", index=_index(), now=_NOW
+        )
+        staged = session_storage.trash_root() / batch.batch_id
+        # Simulate a crash between moving a file in and appending its manifest line.
+        orphan = staged / "cli" / "cccc3333.jsonl"
+        orphan.write_bytes(b"ONLY COPY")
+
+        assert session_storage.restore(batch.batch_id) == 1
+
+        assert orphan.read_bytes() == b"ONLY COPY"
+        assert staged.is_dir()
+
+    def test_an_unstattable_file_aborts_the_whole_session(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A file that cannot be sized cannot be recorded, so it cannot be skipped.
+
+        Staging the rest would commit a manifest that omits it — exactly the split
+        the rollback exists to prevent.
+        """
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        _transcript(crew_home, "dashboard_chat-1", size=8, age_days=40)
+        target = crew_home / "sessions" / "dashboard_chat-1.jsonl"
+        real_size = session_storage._file_size
+
+        def flaky_size(path: Path) -> int:
+            if path == target:
+                raise OSError("simulated transient stat failure")
+            return real_size(path)
+
+        monkeypatch.setattr(session_storage, "_file_size", flaky_size)
+
+        with pytest.raises(SessionStorageError, match="none of the selected"):
+            session_storage.move_to_trash(
+                ["aaaa1111"],
+                reason="manual",
+                index=_index({"aaaa1111": "dashboard_chat-1"}),
+                now=_NOW,
+            )
+
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").is_file()
+        assert target.is_file()
+        assert session_storage.list_trash() == []
+
+    def test_a_malformed_manifest_record_blocks_its_session(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """Restoring the readable files would leave the rest staged and unreferenced."""
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        _transcript(crew_home, "dashboard_chat-1", size=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+        staged = session_storage.trash_root() / batch.batch_id
+        manifest = staged / session_storage.MANIFEST_NAME
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+        entry = json.loads(lines[1])
+        entry["files"].append("not-an-object")
+        manifest.write_text(f"{lines[0]}\n{json.dumps(entry)}\n", encoding="utf-8")
+
+        restored = session_storage.restore(batch.batch_id)
+
+        assert restored == 0
+        # Nothing was put back, so nothing is split.
+        assert not (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").exists()
+        assert not (crew_home / "sessions" / "dashboard_chat-1.jsonl").exists()
+        assert session_storage.list_trash()[0].sessions == 1
+
+    def test_unknown_batch_is_refused(self, stores: tuple[Path, Path]) -> None:
+        with pytest.raises(SessionStorageError, match="no restorable batch"):
+            session_storage.restore("20240101T000000-deadbeef")
+
+
+class TestManifestIsUntrusted:
+    """The manifest lives in an agent-writable tree, so restore must not trust it."""
+
+    def _staged(self, kiro_home: Path) -> tuple[str, Path]:
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"], reason="manual", index=_index(), now=_NOW
+        )
+        return batch.batch_id, session_storage.trash_root() / batch.batch_id
+
+    def test_an_absolute_rel_cannot_pick_up_a_file_outside_the_batch(
+        self, stores: tuple[Path, Path], tmp_path: Path
+    ) -> None:
+        """`Path(batch) / "/etc/x"` is `/etc/x` — joining an absolute discards the base."""
+        _, kiro_home = stores
+        batch_id, batch = self._staged(kiro_home)
+        secret = tmp_path / "credentials"
+        secret.write_bytes(b"SECRET")
+        manifest = batch / session_storage.MANIFEST_NAME
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+        header = lines[0]
+        tampered = json.dumps(
+            {
+                "uid": "aaaa1111",
+                "files": [
+                    {
+                        "rel": str(secret),
+                        "origin": str(kiro_home / "sessions" / "cli" / "stolen.jsonl"),
+                        "bytes": 6,
+                    }
+                ],
+            }
+        )
+        manifest.write_text(f"{header}\n{tampered}\n", encoding="utf-8")
+
+        restored = session_storage.restore(batch_id)
+
+        assert restored == 0
+        assert secret.read_bytes() == b"SECRET"
+        assert not (kiro_home / "sessions" / "cli" / "stolen.jsonl").exists()
+
+    def test_a_traversing_rel_is_refused(self, stores: tuple[Path, Path]) -> None:
+        _, kiro_home = stores
+        batch_id, batch = self._staged(kiro_home)
+        manifest = batch / session_storage.MANIFEST_NAME
+        header = manifest.read_text(encoding="utf-8").splitlines()[0]
+        tampered = json.dumps(
+            {
+                "uid": "aaaa1111",
+                "files": [
+                    {
+                        "rel": "../../../etc/hosts",
+                        "origin": str(kiro_home / "sessions" / "cli" / "x.jsonl"),
+                        "bytes": 1,
+                    }
+                ],
+            }
+        )
+        manifest.write_text(f"{header}\n{tampered}\n", encoding="utf-8")
+
+        assert session_storage.restore(batch_id) == 0
+
+    def test_an_origin_outside_the_session_stores_is_refused(
+        self, stores: tuple[Path, Path], tmp_path: Path
+    ) -> None:
+        """Restore writes to origin, so an unconstrained origin is arbitrary write."""
+        _, kiro_home = stores
+        batch_id, batch = self._staged(kiro_home)
+        target = tmp_path / "planted.jsonl"
+        manifest = batch / session_storage.MANIFEST_NAME
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+        entry = json.loads(lines[1])
+        entry["files"] = [
+            {"rel": record["rel"], "origin": str(target), "bytes": record["bytes"]}
+            for record in entry["files"]
+        ]
+        manifest.write_text(f"{lines[0]}\n{json.dumps(entry)}\n", encoding="utf-8")
+
+        restored = session_storage.restore(batch_id)
+
+        assert restored == 0
+        assert not target.exists()
+
+
+class TestPartialMoveRollsBack:
+    def test_a_session_that_cannot_move_wholly_is_left_alone(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A half-moved session is invisible: emptying would destroy the staged half."""
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        _transcript(crew_home, "dashboard_chat-1", size=8, age_days=40)
+        real_move = session_storage._move_file
+        calls = {"n": 0}
+
+        def flaky(src: Path, dst: Path) -> None:
+            calls["n"] += 1
+            # Fail on the transcript, after the replay half has already moved.
+            if calls["n"] == 3:
+                raise OSError("simulated cross-device failure")
+            real_move(src, dst)
+
+        monkeypatch.setattr(session_storage, "_move_file", flaky)
+
+        with pytest.raises(SessionStorageError, match="none of the selected"):
+            session_storage.move_to_trash(
+                ["aaaa1111"],
+                reason="manual",
+                index=_index({"aaaa1111": "dashboard_chat-1"}),
+                now=_NOW,
+            )
+
+        # Everything is back where it started; nothing is left staged.
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.json").is_file()
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").is_file()
+        assert (crew_home / "sessions" / "dashboard_chat-1.jsonl").is_file()
+        assert session_storage.list_trash() == []
+
+
+class TestSidecarFiles:
+    def test_an_unrecognised_sidecar_moves_with_its_session(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """kiro-cli owns this layout; a file we do not know must not be orphaned."""
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        sidecar = kiro_home / "sessions" / "cli" / "aaaa1111.lock"
+        sidecar.write_bytes(b"lock")
+
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"], reason="manual", index=_index(), now=_NOW
+        )
+
+        assert not sidecar.exists()
+        staged = session_storage.trash_root() / batch.batch_id / "cli" / "aaaa1111.lock"
+        assert staged.read_bytes() == b"lock"
+        assert session_storage.restore(batch.batch_id) == 1
+        assert sidecar.read_bytes() == b"lock"
+
+
+class TestFreshSessionsAreProtected:
+    """The session map is not a complete registry of live sessions.
+
+    A subagent run creates a kiro-cli session that was never mapped, so mapping
+    alone would let a threshold of 0 reclaim a conversation running right now.
+    """
+
+    def test_a_threshold_of_zero_cannot_take_a_fresh_session(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        _, kiro_home = stores
+        _cli_half(kiro_home, "livenow0", log_bytes=16, age_days=0.01)
+        _cli_half(kiro_home, "oldone00", log_bytes=16, age_days=40)
+
+        selected = session_storage.select_reclaimable(_index(), 0, now=_NOW)
+
+        assert [u.uid for u in selected] == ["oldone00"]
+
+    def test_passing_a_fresh_id_directly_is_refused(self, stores: tuple[Path, Path]) -> None:
+        """The move is the chokepoint; the selection helper can be bypassed."""
+        _, kiro_home = stores
+        _cli_half(kiro_home, "livenow0", log_bytes=16, age_days=0.01)
+
+        with pytest.raises(SessionStorageError, match="touched in the last"):
+            session_storage.move_to_trash(["livenow0"], reason="manual", index=_index(), now=_NOW)
+
+        assert (kiro_home / "sessions" / "cli" / "livenow0.jsonl").is_file()
+
+    def test_a_fresh_session_is_not_reported_as_reclaimable(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """Reporting bytes no threshold can move would be a false promise."""
+        _, kiro_home = stores
+        size = _cli_half(kiro_home, "livenow0", log_bytes=1024, age_days=0.01)
+
+        report = session_storage.measure(_index(), now=_NOW)
+
+        assert report.total_sessions == 1
+        assert report.total_bytes == size
+        assert report.reclaimable_sessions == 0
+
+
+class TestMutationsAreSerialized:
+    """Interleaved reclaims can put one half of a session in each batch."""
+
+    def _record_lock(self, monkeypatch: pytest.MonkeyPatch) -> list[bool]:
+        taken: list[bool] = []
+        real = session_storage.platform_compat.file_lock
+
+        @contextlib.contextmanager
+        def spy(fd, *, exclusive=True, required=False):
+            taken.append(exclusive)
+            with real(fd, exclusive=exclusive, required=required):
+                yield
+
+        monkeypatch.setattr(session_storage.platform_compat, "file_lock", spy)
+        return taken
+
+    def test_move_takes_an_exclusive_lock(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        taken = self._record_lock(monkeypatch)
+
+        session_storage.move_to_trash(["aaaa1111"], reason="manual", index=_index(), now=_NOW)
+
+        assert taken == [True]
+
+    def test_restore_and_empty_take_the_lock(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"], reason="manual", index=_index(), now=_NOW
+        )
+        taken = self._record_lock(monkeypatch)
+
+        session_storage.restore(batch.batch_id)
+        session_storage.move_to_trash(["aaaa1111"], reason="manual", index=_index(), now=_NOW)
+        session_storage.empty_trash(None)
+
+        assert taken == [True, True, True]
+
+
+class TestManifestPersistenceFailure:
+    def test_a_session_that_cannot_be_recorded_is_put_back(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Moved-but-unrecorded is worse than never moved: gone and unrestorable."""
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        _transcript(crew_home, "dashboard_chat-1", size=8, age_days=40)
+
+        def full_disk(handle, entry):
+            raise OSError("simulated ENOSPC")
+
+        monkeypatch.setattr(session_storage, "_append_entry", full_disk)
+
+        with pytest.raises(SessionStorageError, match="none of the selected"):
+            session_storage.move_to_trash(
+                ["aaaa1111"],
+                reason="manual",
+                index=_index({"aaaa1111": "dashboard_chat-1"}),
+                now=_NOW,
+            )
+
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.json").is_file()
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").is_file()
+        assert (crew_home / "sessions" / "dashboard_chat-1.jsonl").is_file()
+        assert session_storage.list_trash() == []
+
+
+class TestBatchIdentityIsTheDirectory:
+    def test_a_header_naming_another_batch_is_not_offered(self, stores: tuple[Path, Path]) -> None:
+        """Trusting the header would let a targeted empty delete the wrong batch."""
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        _cli_half(kiro_home, "bbbb2222", log_bytes=8, age_days=40)
+        victim = session_storage.move_to_trash(
+            ["aaaa1111"], reason="keep", index=_index(), now=_NOW - _DAY
+        )
+        attacker = session_storage.move_to_trash(
+            ["bbbb2222"], reason="tampered", index=_index(), now=_NOW
+        )
+        # Point the second batch's header at the first.
+        manifest = session_storage.trash_root() / attacker.batch_id / "manifest.jsonl"
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+        header = json.loads(lines[0])
+        header["batch_id"] = victim.batch_id
+        manifest.write_text("\n".join([json.dumps(header)] + lines[1:]) + "\n", encoding="utf-8")
+
+        listed = {b.batch_id for b in session_storage.list_trash()}
+
+        # The tampered batch is withheld, and it cannot masquerade as the other.
+        assert listed == {victim.batch_id}
+
+    def test_listed_ids_always_match_their_directory(self, stores: tuple[Path, Path]) -> None:
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"], reason="manual", index=_index(), now=_NOW
+        )
+
+        listed = session_storage.list_trash()
+
+        assert [b.batch_id for b in listed] == [batch.batch_id]
+        assert (session_storage.trash_root() / listed[0].batch_id).is_dir()
+
+
+class TestSharedStoreRefusal:
+    """An isolated data home over a shared replay store cannot see who is live."""
+
+    def test_reclaim_is_refused_when_only_the_data_home_is_isolated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        crew_home = tmp_path / "crew"
+        (crew_home / "sessions").mkdir(parents=True)
+        monkeypatch.setenv("KIROCREW_HOME", str(crew_home))
+        monkeypatch.delenv("KIRO_HOME", raising=False)
+
+        assert session_storage.reclaim_block_reason() != ""
+        with pytest.raises(SessionStorageError, match="sits outside it"):
+            session_storage.move_to_trash(["aaaa1111"], reason="manual", index=_index(), now=_NOW)
+
+    def test_isolating_both_homes_is_allowed(self, stores: tuple[Path, Path]) -> None:
+        """The fixture sets both, which is the safe configuration."""
+        assert session_storage.reclaim_block_reason() == ""
+
+    def test_isolating_neither_home_is_allowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.delenv("KIRO_HOME", raising=False)
+        # The co-tenant check reads the pod root, which is real host state — point it
+        # at an empty dir so this asserts the guard and not the developer's machine.
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        # Pin the default home rather than clearing the memo. Clearing it makes the
+        # next data_home() RE-RESOLVE, which on a real machine initializes or
+        # migrates the operator's actual data home — and leaves that resolution
+        # memoized for every later test in the same worker.
+        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
+        monkeypatch.setattr(paths, "_config_dir_memo", None)
+
+        assert session_storage.reclaim_block_reason() == ""
+
+    def test_a_pre_migration_legacy_home_is_not_isolation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An install that has not migrated yet must still be able to reclaim.
+
+        The legacy home is a DEFAULT, not an isolated instance; treating it as one
+        refused every pre-migration install — including the machine this feature
+        was measured on.
+        """
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.delenv("KIRO_HOME", raising=False)
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        monkeypatch.setattr(paths, "_resolved_home", paths.legacy_home())
+        monkeypatch.setattr(paths, "_config_dir_memo", None)
+
+        assert session_storage.reclaim_block_reason() == ""
+
+    def test_a_custom_store_shared_by_two_isolated_instances_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two pods pointed at one custom KIRO_HOME see neither map."""
+        crew_home = tmp_path / "pod-a"
+        crew_home.mkdir()
+        shared_store = tmp_path / "shared-kiro"
+        shared_store.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(crew_home))
+        monkeypatch.setenv("KIRO_HOME", str(shared_store))
+
+        # Not the DEFAULT store, so a default-location test would pass it — and
+        # that is the arrangement where sharing is least visible.
+        assert session_storage.reclaim_block_reason() != ""
+
+    def test_a_store_inside_the_isolated_data_home_may_reclaim(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A dedicated private store is genuinely isolated."""
+        crew_home = tmp_path / "pod-b"
+        crew_home.mkdir()
+        own_store = crew_home / "kiro"
+        own_store.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(crew_home))
+        monkeypatch.setenv("KIRO_HOME", str(own_store))
+
+        assert session_storage.reclaim_block_reason() == ""
+
+    def test_an_unreadable_batch_is_not_emptied(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A scan that gives up early must not read as "nothing unaccounted for"."""
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+
+        def failing_walk(top, onerror=None, **kwargs):
+            if onerror is not None:
+                onerror(OSError(5, "simulated read failure"))
+            return iter(())
+
+        monkeypatch.setattr(session_storage.os, "walk", failing_walk)
+
+        assert session_storage.empty_trash([batch.batch_id]) == 0
+        # The batch survives, so nothing was destroyed on an unverifiable scan.
+        assert (session_storage.trash_root() / batch.batch_id).is_dir()
+
+    def test_a_staged_symlink_is_not_restored(self, stores: tuple[Path, Path]) -> None:
+        """is_file() follows links, so a link would be put back as session data.
+
+        The link points INSIDE the batch on purpose: `_staged_path` resolves the
+        manifest's `rel` and already refuses one that escapes, so only a link
+        resolving within the batch reaches this check.
+        """
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=32, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+        batch_dir = session_storage.trash_root() / batch.batch_id
+        staged = next(
+            p
+            for p in batch_dir.rglob("*")
+            if p.is_file() and p.name != session_storage.MANIFEST_NAME
+        )
+        staged.unlink()
+        try:
+            staged.symlink_to(batch_dir / session_storage.MANIFEST_NAME)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+
+        assert session_storage.restore(batch.batch_id) == 0
+        # The origin is still absent rather than occupied by a dangling link.
+        assert not (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").exists()
+
+    def test_a_pod_sharing_the_default_store_blocks_the_default_instance(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The mirror case: a pod reads THIS store while keeping its own map."""
+        pod_root = tmp_path / "pods"
+        (pod_root / "wt-feature").mkdir(parents=True)
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(pod_root))
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.delenv("KIRO_HOME", raising=False)
+        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
+        monkeypatch.setattr(paths, "_config_dir_memo", None)
+
+        reason = session_storage.reclaim_block_reason()
+        assert "share this kiro-cli session store" in reason
+        assert "wt-feature" in reason
+
+    def test_no_pods_leaves_the_default_instance_able_to_reclaim(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A normal single install must not be refused by the co-tenant check."""
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "no-pods-here"))
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.delenv("KIRO_HOME", raising=False)
+        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
+        monkeypatch.setattr(paths, "_config_dir_memo", None)
+
+        assert session_storage.reclaim_block_reason() == ""
+
+    def test_a_rollback_does_not_overwrite_a_recreated_origin(self, tmp_path: Path) -> None:
+        """A rollback runs after a failure, so the origin may be back and newer."""
+        landed = tmp_path / "landed.jsonl"
+        landed.write_bytes(b"staged copy")
+        origin = tmp_path / "origin.jsonl"
+        origin.write_bytes(b"newer generation")
+
+        session_storage._rollback([(landed, origin)])
+
+        assert origin.read_bytes() == b"newer generation"
+        assert landed.is_file(), "the staged copy must stay recoverable"
+
+    def test_a_trash_root_linked_inside_the_home_reaches_nothing(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """The anchor alone permits this: the link points INSIDE the data home.
+
+        Pointing the root at the live archive tree satisfies both the data-home
+        anchor and per-batch containment, so `empty` would delete real session data.
+        """
+        crew_home, _ = stores
+        archive = crew_home / "sessions" / "archive"
+        victim = archive / "20260101T000000-victim01"
+        victim.mkdir(parents=True)
+        (victim / "dashboard_chat-1__20260101-000000.jsonl").write_bytes(b"history")
+
+        root = session_storage.trash_root()
+        root.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            root.symlink_to(archive, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+
+        assert session_storage.list_trash() == []
+        with pytest.raises(SessionStorageError, match="trash root is a link"):
+            session_storage.empty_trash(["20260101T000000-victim01"])
+        assert session_storage.empty_trash() == 0
+        assert (victim / "dashboard_chat-1__20260101-000000.jsonl").is_file()
+
+    def test_a_relocated_trash_root_reaches_nothing(self, stores: tuple[Path, Path]) -> None:
+        """A linked ANCESTOR escapes the home, which the link test cannot see.
+
+        `is_link_or_junction(root)` inspects only the final component, so a link one
+        level up leaves the root a real directory while relocating it. Resolving and
+        anchoring to the data home is what catches that.
+        """
+        crew_home, _ = stores
+        outside = crew_home.parent / "not-ours"
+        victim = outside / "sessions" / "20260101T000000-victim01"
+        victim.mkdir(parents=True)
+        (victim / "keep.txt").write_bytes(b"precious")
+        # A SELF-CONSISTENT batch: every file it holds is listed, so the
+        # unmanifested-file guard does not block the delete. Without a manifest this
+        # test would pass for the wrong reason — the delete would be refused by that
+        # other guard rather than by the containment anchor under test.
+        header = {
+            "schema": session_storage.MANIFEST_SCHEMA,
+            "batch_id": "20260101T000000-victim01",
+            "created_at": _NOW,
+            "reason": "manual",
+        }
+        entry = {
+            "uid": "aaaa1111",
+            "sid": "aaaa1111",
+            "files": [{"rel": "keep.txt", "origin": "/nowhere.jsonl", "bytes": 8}],
+        }
+        (victim / session_storage.MANIFEST_NAME).write_text(
+            json.dumps(header) + "\n" + json.dumps(entry) + "\n"
+        )
+
+        root = session_storage.trash_root()
+        # Link the PARENT, so the root itself is a real directory that only escapes
+        # once resolved. is_link_or_junction(root) inspects the final component and
+        # cannot see this; only anchoring the RESOLVED root to the data home can.
+        try:
+            root.parent.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+
+        # Nothing outside the data home is offered as a batch...
+        assert session_storage.list_trash() == []
+        # ...and naming one explicitly is refused rather than deleted.
+        with pytest.raises(SessionStorageError, match="does not live under the data"):
+            session_storage.empty_trash(["20260101T000000-victim01"])
+        assert session_storage.empty_trash() == 0
+        assert (victim / "keep.txt").is_file()
+
+    def test_the_batch_link_test_covers_junctions(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """is_symlink() is False for an NTFS junction, so the guard must not use it.
+
+        A junction cannot be created on Linux, so this asserts the guard routes
+        through the junction-aware resolver: with that resolver reporting a link,
+        the batch must be refused and must not be listed. A guard testing
+        ``is_symlink()`` directly would ignore it — and on Windows a junction named
+        as a valid batch id reads as a real directory, so the delete would resolve
+        through it into the batch it points at.
+        """
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+        # Only the BATCH reads as a link. Reporting one for the root too would trip
+        # the separate root check and prove nothing about this guard.
+        monkeypatch.setattr(
+            session_storage.platform_compat,
+            "is_link_or_junction",
+            lambda p: Path(p).name == batch.batch_id,
+        )
+
+        with pytest.raises(SessionStorageError, match="not a valid batch id"):
+            session_storage.empty_trash([batch.batch_id])
+        assert session_storage.list_trash() == []
+        # Nothing was destroyed by the refusal.
+        assert (session_storage.trash_root() / batch.batch_id).is_dir()
+
+    def test_a_batch_link_pointing_at_another_batch_is_refused(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """Containment alone permits this: the link resolves INSIDE the root.
+
+        Without the link check, emptying the alias would destroy the batch it
+        points at — a real batch the user never named.
+        """
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=16, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"],
+            reason="manual",
+            index=_index({"aaaa1111": "dashboard_chat-1"}),
+            now=_NOW,
+        )
+        root = session_storage.trash_root()
+        alias = root / "20260101T000000-aliased1"
+        try:
+            alias.symlink_to(root / batch.batch_id, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+
+        with pytest.raises(SessionStorageError, match="not a valid batch id"):
+            session_storage.empty_trash(["20260101T000000-aliased1"])
+
+        # The real batch survives and is still restorable.
+        assert [b.batch_id for b in session_storage.list_trash()] == [batch.batch_id]
+
+    def test_a_symlinked_batch_is_not_restorable(self, stores: tuple[Path, Path]) -> None:
+        """A link's NAME passes the id check; following it would escape the trash."""
+        outside = stores[0].parent / "outside"
+        outside.mkdir(exist_ok=True)
+        root = session_storage.trash_root()
+        root.mkdir(parents=True, exist_ok=True)
+        try:
+            (root / "20260101T000000-deadbeef").symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+
+        with pytest.raises(SessionStorageError, match="not a valid batch id"):
+            session_storage.restore("20260101T000000-deadbeef")
+
+        # The link's target is untouched — refusing is not a partial operation.
+        assert outside.is_dir()
+
+    def test_a_rejected_kiro_home_does_not_look_isolated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unsafe override is silently rejected, so presence proves nothing."""
+        crew_home = tmp_path / "crew3"
+        (crew_home / "sessions").mkdir(parents=True)
+        monkeypatch.setenv("KIROCREW_HOME", str(crew_home))
+        # A filesystem/drive root is refused on EVERY platform (a root is its own
+        # parent). A POSIX system directory like /etc is not portable: on Windows it
+        # resolves to C:\etc, which the validator accepts, so the override would be
+        # honoured and the store would not be shared.
+        monkeypatch.setenv("KIRO_HOME", "/")
+
+        assert session_storage.reclaim_block_reason() != ""
+
+    def test_the_refresh_authority_check_runs_after_the_scan(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """The scan is the slow part; a check before it is stale by move time."""
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        order: list[str] = []
+        real_scan = session_storage._scan_units
+
+        def watched_scan(index: SessionIndex):
+            order.append("scan")
+            return real_scan(index)
+
+        def refresh() -> SessionIndex:
+            order.append("refresh")
+            return _index({"aaaa1111": "dashboard_chat-1"}, active={"aaaa1111"})
+
+        import pytest as _pytest
+
+        with _pytest.MonkeyPatch.context() as mp:
+            mp.setattr(session_storage, "_scan_units", watched_scan)
+            with pytest.raises(SessionStorageError, match="still in use"):
+                session_storage.move_to_trash(
+                    ["aaaa1111"],
+                    reason="manual",
+                    index=_index(),
+                    now=_NOW,
+                    refresh=refresh,
+                )
+
+        # The refresh must be the LAST thing before the move, i.e. after the scan.
+        assert order == ["scan", "refresh"]
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").is_file()
+
+    def test_a_freshly_mapped_session_is_protected_at_move_time(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """The scan can take minutes; a session mapped meanwhile must not move."""
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        stale = _index()  # nothing mapped when the selection was computed
+
+        def refresh() -> SessionIndex:
+            # By the time the lock is held, the session has been resumed.
+            return _index({"aaaa1111": "dashboard_chat-1"}, active={"aaaa1111"})
+
+        with pytest.raises(SessionStorageError, match="still in use"):
+            session_storage.move_to_trash(
+                ["aaaa1111"], reason="manual", index=stale, now=_NOW, refresh=refresh
+            )
+
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").is_file()
+
+    def test_a_failed_re_read_refuses_rather_than_proceeding(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """Unable to confirm who is live is not permission to guess."""
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+
+        def broken() -> SessionIndex:
+            raise RuntimeError("session map unreadable")
+
+        with pytest.raises(SessionStorageError, match="could not confirm"):
+            session_storage.move_to_trash(
+                ["aaaa1111"], reason="manual", index=_index(), now=_NOW, refresh=broken
+            )
+
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").is_file()
+
+    def test_the_report_names_the_reason(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A client must be able to explain instead of offering a doomed button."""
+        crew_home = tmp_path / "crew2"
+        (crew_home / "sessions").mkdir(parents=True)
+        monkeypatch.setenv("KIROCREW_HOME", str(crew_home))
+        monkeypatch.delenv("KIRO_HOME", raising=False)
+
+        report = session_storage.measure(_index(), now=_NOW)
+
+        assert "sits outside it" in report.reclaim_blocked_reason
+
+
+class TestBuckets:
+    def test_split_on_the_documented_edges(self, stores: tuple[Path, Path]) -> None:
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=10, age_days=1)
+        _cli_half(kiro_home, "bbbb2222", log_bytes=20, age_days=20)
+        _cli_half(kiro_home, "cccc3333", log_bytes=30, age_days=60)
+        _cli_half(kiro_home, "dddd4444", log_bytes=40, age_days=400)
+
+        report = session_storage.measure(_index(), now=_NOW)
+
+        assert {b.label: b.sessions for b in report.buckets} == {
+            "under_7d": 1,
+            "7_30d": 1,
+            "30_90d": 1,
+            "over_90d": 1,
+        }
+
+    def test_age_uses_the_newest_file_across_both_halves(self, stores: tuple[Path, Path]) -> None:
+        """A stale replay log must not age out a session whose transcript is fresh."""
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=400)
+        _transcript(crew_home, "dashboard_chat-1", size=8, age_days=1)
+
+        selected = session_storage.select_reclaimable(
+            _index({"aaaa1111": "dashboard_chat-1"}), 30, now=_NOW
+        )
+
+        assert selected == []
+
+    def test_threshold_is_inclusive(self, stores: tuple[Path, Path]) -> None:
+        _, kiro_home = stores
+        _cli_half(kiro_home, "old00000", log_bytes=10, age_days=30)
+        _cli_half(kiro_home, "young000", log_bytes=10, age_days=29)
+
+        selected = session_storage.select_reclaimable(_index(), 30, now=_NOW)
+
+        assert [u.uid for u in selected] == ["old00000"]
+
+    def test_negative_threshold_is_refused(self, stores: tuple[Path, Path]) -> None:
+        with pytest.raises(SessionStorageError):
+            session_storage.select_reclaimable(_index(), -1, now=_NOW)
+
+
+class TestTrashAccounting:
+    def test_missing_stores_report_zero(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "absent-crew"))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "absent-kiro"))
+
+        report = session_storage.measure(_index(), now=_NOW)
+
+        assert report.total_bytes == 0
+        assert report.total_sessions == 0
+
+    def test_staged_bytes_are_reported_separately_from_reclaimable(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        _, kiro_home = stores
+        size = _cli_half(kiro_home, "aaaa1111", log_bytes=1024, age_days=40)
+        session_storage.move_to_trash(["aaaa1111"], reason="manual", index=_index(), now=_NOW)
+
+        report = session_storage.measure(_index(), now=_NOW)
+
+        assert report.reclaimable_sessions == 0
+        assert report.trash_batches == 1
+        assert report.trash_bytes == size
+
+    def test_a_batch_without_a_manifest_is_not_offered(self, stores: tuple[Path, Path]) -> None:
+        orphan = session_storage.trash_root() / "20240101T000000-deadbeef"
+        orphan.mkdir(parents=True)
+        (orphan / "stray.jsonl").write_bytes(b"x")
+
+        assert session_storage.list_trash() == []
+
+    def test_a_truncated_final_line_does_not_lose_the_batch(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        _cli_half(kiro_home, "bbbb2222", log_bytes=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111", "bbbb2222"], reason="manual", index=_index(), now=_NOW
+        )
+        manifest = session_storage.trash_root() / batch.batch_id / session_storage.MANIFEST_NAME
+        manifest.write_text(
+            manifest.read_text(encoding="utf-8") + '{"uid": "cccc333', encoding="utf-8"
+        )
+
+        listed = session_storage.list_trash()
+
+        assert len(listed) == 1
+        assert listed[0].sessions == 2
+
+    def test_newest_batch_first(self, stores: tuple[Path, Path]) -> None:
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        _cli_half(kiro_home, "bbbb2222", log_bytes=8, age_days=40)
+        first = session_storage.move_to_trash(
+            ["aaaa1111"], reason="a", index=_index(), now=_NOW - 10 * _DAY
+        )
+        second = session_storage.move_to_trash(["bbbb2222"], reason="b", index=_index(), now=_NOW)
+
+        assert [b.batch_id for b in session_storage.list_trash()] == [
+            second.batch_id,
+            first.batch_id,
+        ]
+
+
+class TestLegacyStems:
+    """One session can own more than one transcript filename."""
+
+    def test_a_legacy_stem_keeps_its_session_active(self, stores: tuple[Path, Path]) -> None:
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=16, age_days=400)
+        # The transcript sits under the pre-migration bare name, not the canonical.
+        _transcript(crew_home, "1785861252.833429", size=16, age_days=400)
+
+        index = _multi_index(
+            {"slack_1785861252.833429": "aaaa1111", "1785861252.833429": "aaaa1111"},
+            active={"aaaa1111"},
+        )
+        report = session_storage.measure(index, now=_NOW)
+
+        assert report.active_sessions == 1
+        assert report.reclaimable_sessions == 0
+
+    def test_both_stems_move_with_their_session(self, stores: tuple[Path, Path]) -> None:
+        crew_home, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=16, age_days=40)
+        _transcript(crew_home, "slack_123.456", size=8, age_days=40)
+        _transcript(crew_home, "123.456", size=8, age_days=40)
+
+        index = _multi_index({"slack_123.456": "aaaa1111", "123.456": "aaaa1111"})
+        batch = session_storage.move_to_trash(["aaaa1111"], reason="manual", index=index, now=_NOW)
+
+        staged = session_storage.trash_root() / batch.batch_id / "crew"
+        assert (staged / "slack_123.456.jsonl").is_file()
+        assert (staged / "123.456.jsonl").is_file()
+        assert batch.sessions == 1
+
+
+class TestEmptyTrash:
+    def test_frees_the_staged_bytes(self, stores: tuple[Path, Path]) -> None:
+        _, kiro_home = stores
+        size = _cli_half(kiro_home, "aaaa1111", log_bytes=4096, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"], reason="manual", index=_index(), now=_NOW
+        )
+
+        freed = session_storage.empty_trash()
+
+        assert freed >= size
+        assert session_storage.list_trash() == []
+        assert not (session_storage.trash_root() / batch.batch_id).exists()
+
+    def test_targets_one_batch_and_leaves_the_others(self, stores: tuple[Path, Path]) -> None:
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        _cli_half(kiro_home, "bbbb2222", log_bytes=8, age_days=40)
+        keep = session_storage.move_to_trash(
+            ["aaaa1111"], reason="a", index=_index(), now=_NOW - _DAY
+        )
+        drop = session_storage.move_to_trash(["bbbb2222"], reason="b", index=_index(), now=_NOW)
+
+        session_storage.empty_trash([drop.batch_id])
+
+        assert [b.batch_id for b in session_storage.list_trash()] == [keep.batch_id]
+
+    def test_refuses_a_batch_holding_files_nothing_listed(self, stores: tuple[Path, Path]) -> None:
+        """A header-only batch shows zero sessions, so emptying it is not consent."""
+        _, kiro_home = stores
+        _cli_half(kiro_home, "aaaa1111", log_bytes=8, age_days=40)
+        batch = session_storage.move_to_trash(
+            ["aaaa1111"], reason="manual", index=_index(), now=_NOW
+        )
+        staged = session_storage.trash_root() / batch.batch_id
+        # Simulate a crash between the move and the manifest append.
+        orphan = staged / "cli" / "cccc3333.jsonl"
+        orphan.write_bytes(b"ONLY COPY")
+
+        freed = session_storage.empty_trash([batch.batch_id])
+
+        assert freed == 0
+        assert orphan.read_bytes() == b"ONLY COPY"
+        assert staged.is_dir()
+
+    def test_refuses_a_batch_id_outside_the_trash_root(self, stores: tuple[Path, Path]) -> None:
+        with pytest.raises(SessionStorageError, match="not a valid batch id"):
+            session_storage.empty_trash(["../../sessions"])
+
+    def test_a_symlinked_batch_is_not_followed_out_of_the_root(
+        self, stores: tuple[Path, Path], tmp_path: Path
+    ) -> None:
+        outside = tmp_path / "precious"
+        outside.mkdir()
+        (outside / "keep.txt").write_bytes(b"do not delete")
+        root = session_storage.trash_root()
+        root.mkdir(parents=True, exist_ok=True)
+        link = root / "20240101T000000-deadbeef"
+        try:
+            link.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+
+        # Naming it explicitly is refused: the caller's intent cannot be honoured,
+        # and succeeding silently would hide that something planted a link here.
+        with pytest.raises(SessionStorageError, match="not a valid batch id"):
+            session_storage.empty_trash(["20240101T000000-deadbeef"])
+
+        # But it must not WEDGE the sweep-everything path, or one planted link
+        # would make the trash permanently un-emptyable.
+        session_storage.empty_trash()
+
+        assert (outside / "keep.txt").is_file()
+        assert link.is_symlink()
+
+
+class TestTrashLocation:
+    def test_trash_lives_under_the_data_home(self, stores: tuple[Path, Path]) -> None:
+        crew_home, _ = stores
+        assert session_storage.trash_root() == crew_home / "trash" / "sessions"
+
+    def test_same_filesystem_is_reported_for_a_default_layout(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        report = session_storage.measure(_index(), now=_NOW)
+        assert report.trash_same_filesystem is True

--- a/test/test_session_storage_api.py
+++ b/test/test_session_storage_api.py
@@ -1,0 +1,476 @@
+"""Tests for the session storage endpoints.
+
+These cover the wire contract and the guards, not the filesystem mechanics —
+those live in ``test_session_storage.py``. Two properties are load-bearing here:
+every mutation is refused for a restricted session and audited when it succeeds,
+and the payload never splits a session's size across the two stores it occupies.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+
+from kiro_crew import session_storage as session_storage_module
+from kiro_crew.dashboard.handlers import session_storage as handler
+
+_DAY = 86400.0
+
+
+@pytest.fixture()
+def stores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    # Nested, not sibling: reclaim_block_reason() refuses an isolated data home
+    # whose kiro store sits outside it, because such a store may be shared.
+    crew_home = tmp_path / "crew"
+    kiro_home = crew_home / "kiro"
+    (crew_home / "sessions" / "archive").mkdir(parents=True)
+    (kiro_home / "sessions" / "cli").mkdir(parents=True)
+    monkeypatch.setenv("KIROCREW_HOME", str(crew_home))
+    monkeypatch.setenv("KIRO_HOME", str(kiro_home))
+    return crew_home, kiro_home
+
+
+def _retired(kiro_home: Path, sid: str, *, log_bytes: int = 1024, age_days: float = 60) -> int:
+    """Create a kiro-cli session old enough to be reclaimable; return its bytes.
+
+    Aged against the real clock, because the handlers call ``measure`` without a
+    ``now`` override — the injectable clock is the module's seam, not the API's.
+    """
+    root = kiro_home / "sessions" / "cli"
+    mtime = time.time() - age_days * _DAY
+    total = 0
+    for suffix, payload in ((".json", b"{}"), (".jsonl", b"c" * log_bytes)):
+        path = root / f"{sid}{suffix}"
+        path.write_bytes(payload)
+        os.utime(path, (mtime, mtime))
+        total += len(payload)
+    return total
+
+
+def _sel_stub() -> MagicMock:
+    sel = MagicMock()
+    sel.log_api_access = MagicMock()
+    return sel
+
+
+def _raw_request(method: str, path: str, raw: bytes, *, restricted: bool = False):
+    """A request whose body is arbitrary bytes, for malformed-payload cases."""
+    headers = {"X-Session-Key": "dashboard:guest" if restricted else "dashboard:ui"}
+    req = make_mocked_request(method, path, headers=headers, payload=None)
+    state = MagicMock()
+    state._restricted_keys = {"dashboard:guest"} if restricted else set()
+    req.app["state"] = state
+
+    async def _read():
+        return raw
+
+    req.read = _read  # type: ignore[method-assign]
+    return req
+
+
+def _request(method: str, path: str, body: dict | None = None, *, restricted: bool = False):
+    headers = {"X-Session-Key": "dashboard:guest" if restricted else "dashboard:ui"}
+    payload = json.dumps(body or {}).encode()
+    req = make_mocked_request(method, path, headers=headers, payload=None)
+    state = MagicMock()
+    state._restricted_keys = {"dashboard:guest"} if restricted else set()
+    req.app["state"] = state
+
+    async def _read():
+        return payload
+
+    req.read = _read  # type: ignore[method-assign]
+    return req
+
+
+class TestReport:
+    @pytest.mark.asyncio
+    async def test_reports_one_size_per_session(self, stores: tuple[Path, Path]) -> None:
+        _, kiro_home = stores
+        size = _retired(kiro_home, "aaaa1111")
+
+        resp = await handler.api_session_storage(_request("GET", "/api/system/session-storage"))
+        body = json.loads(resp.body)
+
+        assert resp.status == 200
+        assert body["total_sessions"] == 1
+        assert body["total_bytes"] == size
+        assert body["reclaimable_sessions"] == 1
+
+    @pytest.mark.asyncio
+    async def test_payload_never_splits_the_two_stores(self, stores: tuple[Path, Path]) -> None:
+        """The split is an implementation detail and must not reach a client."""
+        _, kiro_home = stores
+        _retired(kiro_home, "aaaa1111")
+
+        resp = await handler.api_session_storage(_request("GET", "/api/system/session-storage"))
+        flat = json.dumps(json.loads(resp.body))
+
+        for leaked in ("cli_bytes", "crew_bytes", "kiro-cli", "transcript_bytes"):
+            assert leaked not in flat
+
+    @pytest.mark.asyncio
+    async def test_trash_declares_that_staged_bytes_remain_on_disk(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        resp = await handler.api_session_storage(_request("GET", "/api/system/session-storage"))
+        body = json.loads(resp.body)
+
+        assert body["trash"]["still_on_disk"] is True
+        assert body["trash"]["bytes"] == 0
+        assert body["trash"]["batches"] == []
+
+
+class TestCleanup:
+    @pytest.mark.asyncio
+    async def test_dry_run_moves_nothing(self, stores: tuple[Path, Path]) -> None:
+        _, kiro_home = stores
+        size = _retired(kiro_home, "aaaa1111")
+        req = _request(
+            "POST",
+            "/api/system/session-storage/cleanup",
+            {"older_than_days": 30, "dry_run": True},
+        )
+
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            resp = await handler.api_session_storage_cleanup(req)
+        body = json.loads(resp.body)
+
+        assert body == {"dry_run": True, "sessions": 1, "bytes": size, "remaining": 0}
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").is_file()
+
+    @pytest.mark.asyncio
+    async def test_stages_and_audits(self, stores: tuple[Path, Path]) -> None:
+        _, kiro_home = stores
+        _retired(kiro_home, "aaaa1111")
+        req = _request("POST", "/api/system/session-storage/cleanup", {"older_than_days": 30})
+        sel = _sel_stub()
+
+        with patch.object(handler, "_sel", return_value=sel):
+            resp = await handler.api_session_storage_cleanup(req)
+        body = json.loads(resp.body)
+
+        assert resp.status == 200
+        assert body["sessions"] == 1
+        assert body["batch_id"]
+        assert not (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").exists()
+        operations = [c.kwargs["operation"] for c in sel.log_api_access.call_args_list]
+        assert "session_storage.cleanup" in operations
+
+    @pytest.mark.asyncio
+    async def test_over_cap_stages_the_oldest_instead_of_refusing(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A refusal would dead-end the very install this exists for."""
+        _, kiro_home = stores
+        _retired(kiro_home, "oldest00", age_days=400)
+        _retired(kiro_home, "middle00", age_days=200)
+        _retired(kiro_home, "newest00", age_days=60)
+        monkeypatch.setattr(handler, "_MAX_SELECTION", 2)
+        req = _request("POST", "/api/system/session-storage/cleanup", {"older_than_days": 30})
+
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            resp = await handler.api_session_storage_cleanup(req)
+        body = json.loads(resp.body)
+
+        assert resp.status == 200
+        assert body["sessions"] == 2
+        assert body["remaining"] == 1
+        cli = kiro_home / "sessions" / "cli"
+        # Oldest-first, so repeating the call makes monotonic progress.
+        assert not (cli / "oldest00.jsonl").exists()
+        assert not (cli / "middle00.jsonl").exists()
+        assert (cli / "newest00.jsonl").is_file()
+
+    @pytest.mark.asyncio
+    async def test_the_index_is_built_off_the_event_loop(
+        self, stores: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reading session_map.json is filesystem work; it must not stall the loop."""
+        _, kiro_home = stores
+        _retired(kiro_home, "aaaa1111")
+        offloaded: list[str] = []
+        real_to_thread = handler.asyncio.to_thread
+
+        async def spy(func, *args, **kwargs):
+            offloaded.append(getattr(func, "__name__", repr(func)))
+            return await real_to_thread(func, *args, **kwargs)
+
+        monkeypatch.setattr(handler.asyncio, "to_thread", spy)
+        req = _request("POST", "/api/system/session-storage/cleanup", {"older_than_days": 30})
+
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            await handler.api_session_storage_cleanup(req)
+
+        assert "_build_index" in offloaded
+
+    @pytest.mark.asyncio
+    async def test_an_unrepresentable_threshold_is_a_400_not_a_500(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """JSON bounds no integer, so float() can overflow on a valid payload."""
+        req = _request(
+            "POST",
+            "/api/system/session-storage/cleanup",
+            {"older_than_days": int("9" * 400)},
+        )
+
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            resp = await handler.api_session_storage_cleanup(req)
+
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "invalid_threshold"
+
+    @pytest.mark.asyncio
+    async def test_restricted_session_is_refused_and_audited(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        _, kiro_home = stores
+        _retired(kiro_home, "aaaa1111")
+        req = _request(
+            "POST",
+            "/api/system/session-storage/cleanup",
+            {"older_than_days": 30},
+            restricted=True,
+        )
+        sel = _sel_stub()
+
+        with patch.object(handler, "_sel", return_value=sel):
+            resp = await handler.api_session_storage_cleanup(req)
+
+        assert resp.status == 403
+        assert json.loads(resp.body)["code"] == "restricted_session"
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").is_file()
+        outcomes = [c.kwargs["outcome"] for c in sel.log_api_access.call_args_list]
+        assert outcomes == ["denied"]
+
+    @pytest.mark.asyncio
+    async def test_missing_threshold_carries_a_machine_readable_code(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        req = _request("POST", "/api/system/session-storage/cleanup", {})
+
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            resp = await handler.api_session_storage_cleanup(req)
+
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "invalid_threshold"
+
+    @pytest.mark.asyncio
+    async def test_a_boolean_is_not_accepted_as_a_threshold(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """``True`` is an int in Python; a threshold of 1 day is not what was meant."""
+        req = _request("POST", "/api/system/session-storage/cleanup", {"older_than_days": True})
+
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            resp = await handler.api_session_storage_cleanup(req)
+
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "invalid_threshold"
+
+    @pytest.mark.asyncio
+    async def test_nothing_to_reclaim_is_success_not_an_error(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        req = _request("POST", "/api/system/session-storage/cleanup", {"older_than_days": 30})
+
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            resp = await handler.api_session_storage_cleanup(req)
+
+        assert resp.status == 200
+        assert json.loads(resp.body) == {
+            "sessions": 0,
+            "bytes": 0,
+            "batch_id": "",
+            "remaining": 0,
+        }
+
+
+class TestRestore:
+    @pytest.mark.asyncio
+    async def test_round_trip(self, stores: tuple[Path, Path]) -> None:
+        _, kiro_home = stores
+        _retired(kiro_home, "aaaa1111")
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            staged = await handler.api_session_storage_cleanup(
+                _request("POST", "/api/system/session-storage/cleanup", {"older_than_days": 30})
+            )
+            batch_id = json.loads(staged.body)["batch_id"]
+            resp = await handler.api_session_storage_restore(
+                _request("POST", "/api/system/session-storage/restore", {"batch_id": batch_id})
+            )
+
+        assert json.loads(resp.body)["restored"] == 1
+        assert (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").is_file()
+
+    @pytest.mark.asyncio
+    async def test_missing_batch_id_is_rejected(self, stores: tuple[Path, Path]) -> None:
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            resp = await handler.api_session_storage_restore(
+                _request("POST", "/api/system/session-storage/restore", {})
+            )
+
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "invalid_batch"
+
+    @pytest.mark.asyncio
+    async def test_unknown_batch_reports_a_refusal_code(self, stores: tuple[Path, Path]) -> None:
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            resp = await handler.api_session_storage_restore(
+                _request(
+                    "POST",
+                    "/api/system/session-storage/restore",
+                    {"batch_id": "20240101T000000-deadbeef"},
+                )
+            )
+
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "restore_refused"
+
+    @pytest.mark.asyncio
+    async def test_restricted_session_is_refused(self, stores: tuple[Path, Path]) -> None:
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            resp = await handler.api_session_storage_restore(
+                _request(
+                    "POST",
+                    "/api/system/session-storage/restore",
+                    {"batch_id": "x"},
+                    restricted=True,
+                )
+            )
+
+        assert resp.status == 403
+
+
+class TestEmpty:
+    @pytest.mark.asyncio
+    async def test_frees_space_and_audits_the_bytes(self, stores: tuple[Path, Path]) -> None:
+        _, kiro_home = stores
+        size = _retired(kiro_home, "aaaa1111")
+        sel = _sel_stub()
+
+        with patch.object(handler, "_sel", return_value=sel):
+            await handler.api_session_storage_cleanup(
+                _request("POST", "/api/system/session-storage/cleanup", {"older_than_days": 30})
+            )
+            resp = await handler.api_session_storage_empty(
+                _request("POST", "/api/system/session-storage/empty", {"all": True})
+            )
+
+        assert json.loads(resp.body)["freed_bytes"] >= size
+        resources = [c.kwargs["resources"] for c in sel.log_api_access.call_args_list]
+        assert any(r.startswith("freed:") for r in resources)
+
+    @pytest.mark.asyncio
+    async def test_an_empty_body_destroys_nothing(self, stores: tuple[Path, Path]) -> None:
+        """The only irreversible endpoint takes explicit intent, never a default."""
+        _, kiro_home = stores
+        _retired(kiro_home, "aaaa1111")
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            await handler.api_session_storage_cleanup(
+                _request("POST", "/api/system/session-storage/cleanup", {"older_than_days": 30})
+            )
+            resp = await handler.api_session_storage_empty(
+                _request("POST", "/api/system/session-storage/empty", {})
+            )
+
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "nothing_specified"
+        assert len(session_storage_module.list_trash()) == 1
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_destroys_nothing(self, stores: tuple[Path, Path]) -> None:
+        """A parse failure must not read as "no arguments" on a destructive path."""
+        _, kiro_home = stores
+        _retired(kiro_home, "aaaa1111")
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            await handler.api_session_storage_cleanup(
+                _request("POST", "/api/system/session-storage/cleanup", {"older_than_days": 30})
+            )
+            req = _raw_request("POST", "/api/system/session-storage/empty", b"not json at all")
+            resp = await handler.api_session_storage_empty(req)
+
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "invalid_body"
+        assert len(session_storage_module.list_trash()) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_string_batch_ids_does_not_empty_everything(
+        self, stores: tuple[Path, Path]
+    ) -> None:
+        """A bare string is not a list; collapsing it to None would delete all."""
+        _, kiro_home = stores
+        _retired(kiro_home, "aaaa1111")
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            await handler.api_session_storage_cleanup(
+                _request("POST", "/api/system/session-storage/cleanup", {"older_than_days": 30})
+            )
+            resp = await handler.api_session_storage_empty(
+                _request("POST", "/api/system/session-storage/empty", {"batch_ids": "some-batch"})
+            )
+
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "invalid_batch"
+        # The batch it would have destroyed is still staged.
+        assert len(session_storage_module.list_trash()) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_string_uids_does_not_widen_a_restore(self, stores: tuple[Path, Path]) -> None:
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            resp = await handler.api_session_storage_restore(
+                _request(
+                    "POST",
+                    "/api/system/session-storage/restore",
+                    {"batch_id": "x", "uids": "aaaa1111"},
+                )
+            )
+
+        assert resp.status == 400
+        assert json.loads(resp.body)["code"] == "invalid_batch"
+
+    @pytest.mark.asyncio
+    async def test_restricted_session_is_refused(self, stores: tuple[Path, Path]) -> None:
+        with patch.object(handler, "_sel", return_value=_sel_stub()):
+            resp = await handler.api_session_storage_empty(
+                _request("POST", "/api/system/session-storage/empty", {}, restricted=True)
+            )
+
+        assert resp.status == 403
+        assert json.loads(resp.body)["code"] == "restricted_session"
+
+
+class TestIndexConstruction:
+    def test_stems_come_from_the_history_resolver(self, stores: tuple[Path, Path]) -> None:
+        """A mapped session must pair to the filename history actually writes."""
+        with patch.object(handler, "SessionMap") as fake:
+            fake.return_value.mapped_sids_by_key.return_value = {"dashboard:chat-1": "aaaa1111"}
+            index = handler._build_index()
+
+        assert index.stem_to_sid == {"dashboard_chat-1": "aaaa1111"}
+        assert index.active_sids == frozenset({"aaaa1111"})
+
+    def test_a_legacy_slack_stem_is_paired_too(self, stores: tuple[Path, Path]) -> None:
+        """A thread predating the canonical key still logs under its bare ts.
+
+        Pairing only the canonical stem would leave that transcript looking
+        unowned, and therefore reclaimable while its session is still resumable.
+        """
+        key = "slack:1785861252.833429"
+        with patch.object(handler, "SessionMap") as fake:
+            fake.return_value.mapped_sids_by_key.return_value = {key: "bbbb2222"}
+            index = handler._build_index()
+
+        # Pinned literals, not transcript_stems() — comparing the resolver against
+        # itself would pass even if it stopped returning the legacy stem at all.
+        assert index.stem_to_sid == {
+            "slack_1785861252.833429": "bbbb2222",
+            "1785861252.833429": "bbbb2222",
+        }
+        assert index.active_stems == frozenset(index.stem_to_sid)


### PR DESCRIPTION
## What is the problem?

A long-lived install accumulates session storage with no way to see it or reclaim
it. Measured on one real machine:

| | Count | Size |
|---|---|---|
| Sessions on disk | 165,066 | **28.56 GB** |
| Still resumable (mapped) | 113 | — |
| Reclaimable | 164,953 | ~28 GB |

Nothing in the product ever removes these. The only existing deletion is
`DELETE /api/sessions/{key}` — one session at a time, irreversible, and it only
touches one of the two places a session's bytes actually live.

There is also no way for a user to find out any of this. Disk usage on the System
page reports the host filesystem, which answers a different question.

## Why this issue matters to the user

Tens of gigabytes disappear from a user's disk with no attribution and no remedy.
On a laptop that is the difference between a working machine and a full one, and
the user has no way to discover the cause, let alone act on it.

The design constraint that shaped this change: **deletion decisions belong to the
user.** There is no timer, no sweeper, and no background cleanup anywhere in this
PR. A report is produced when something asks for one, and files move only when a
person clicks. An automatic sweeper over a user's conversation history is the kind
of thing that is fine until the day it is not.

## How our fix solves it

### A session is one thing with one size

A conversation's bytes live in two stores — Kiro Crew's transcript
(`<data home>/sessions/`) and kiro-cli's replay log (`<kiro home>/sessions/cli/`).
That split is an implementation detail: `StorageReport` carries no per-store
breakdown and the HTTP payload has no field one could be derived from, so a client
can only show a session as one thing. A test pins the absence rather than trusting
future authors to remember.

### But both halves are always reclaimed together

This is the chain that made the first draft wrong and is now the module's central
invariant.

Reclaiming only the replay log leaves a session that **still appears in history and
search but can no longer resume** — a ghost. Reclaiming only the transcript leaves a
session that resumes with no history. Either way the user gets something worse than
both extremes: not freed space, just a broken session.

So the unit of deletion is a session, and a session's file set is every file it
owns — replay log pair, transcript, *and* rotated archive segments (missing the
archives was a second half-delete in the first draft). `_unit_paths()` is the single
answer to "what files is this session made of", and move, restore and delete all
resolve through it, so none of them can operate on half a session.

Restore is all-or-nothing per session for the same reason: if one file's original
path is occupied again, its whole session stays staged. The occupant is newer, and
undoing a deletion must not cause one.

Not every session has both halves and that is normal — a subagent run leaves only a
replay log, a pruned mapping leaves only a transcript. The rule is that whatever
halves exist move together.

### Pairing has exactly one source of truth

A session key and its transcript filename differ, because `history` sanitizes the
key: `dashboard:chat-1` is stored as `dashboard_chat-1.jsonl`. The first draft was
about to re-derive that rule locally. It would have worked, drifted the moment
`history` changed, and failed **silently and destructively** — a missed pairing
reclaims one half of a session.

So `history.transcript_stem()` is now public and is the only place that rule lives.
A test fails if the handler pairs on the raw key. Same reasoning promoted the
archive separator to `ARCHIVE_SEGMENT_DELIMITER`; it is `__` rather than a dot
precisely because keys contain dots (a Slack `thread_ts`) and a right-most-dot
parse would attribute a segment to the wrong session.

### Reclaiming stages, it does not delete

Files move to `<data home>/trash/sessions/<batch>/`. Both stores sit under
`~/.kiro` on a default install, so this is a same-filesystem `os.rename`: instant
regardless of size, and instantly reversible. A data home on a different mount
falls back to a copy, and the report says which case applies.

**Staging does not free space,** and the payload says so (`trash.still_on_disk`).
Emptying the trash is the only irreversible operation and the only one that changes
`df`. A client that reports a reclaim as freed space contradicts its own payload.

Staged files are kept under `cli/` and `crew/` subdirectories because the two halves
can share a filename — a flat batch directory would let one silently overwrite the
other, turning a reversible move into real data loss.

### Manifests are append-only

Each batch has a `manifest.jsonl`: a header, then one line per session recording
every file's staged path, original absolute path, and size. Restore reads origins
from the manifest instead of reconstructing them.

Append-only is load-bearing twice: a batch can span six figures of sessions, so
rewriting a whole-document manifest per session would cost quadratic bytes; and an
interruption leaves every completed line intact, so a partial batch stays fully
restorable. A trailing partial line is skipped rather than failing the batch.

### Endpoints

| Method | Path | Purpose |
|---|---|---|
| GET | `/api/system/session-storage` | Totals, age buckets, staged batches |
| POST | `/api/system/session-storage/cleanup` | Stage sessions older than a threshold; `dry_run` reports without moving |
| POST | `/api/system/session-storage/restore` | Return a batch, or named sessions within it |
| POST | `/api/system/session-storage/empty` | Delete staged batches for good |

All three mutations are gated on `_is_restricted_session` and audited through the
SEL; every non-2xx body carries a machine-readable `code`. Every operation is
offloaded with `asyncio.to_thread` — a store with six figures of files is far too
much filesystem work for the event loop.

`dry_run` exists so a user sees exactly what a threshold will do before committing.
The selection is re-derived server-side rather than accepted from the client,
because the numbers on a screen may be minutes old and acting on them would move
sessions the user never saw.

## What tests we did

**51 new tests** (`test_session_storage.py`, `test_session_storage_api.py`), plus
2,886 existing dashboard tests and 696 history/session-map tests re-run — zero
failures.

**Six safety assertions are mutation-verified** — each guard was removed, the
expected test confirmed red, then restored:

| Guard removed | Result |
|---|---|
| Refuse a session still mapped | 1 test red |
| Session-id shape check | 7 tests red |
| Take both halves | 3 tests red |
| All-or-nothing restore | 1 test red |
| Restricted-session guard on cleanup | 1 test red |
| Trash-root containment | **deleted a file outside the trash root** |
| Pairing via `transcript_stem` | 1 test red |

The containment one is worth calling out: with the check removed, the test's
planted symlink caused a delete outside the trash root. That guard is load-bearing,
not defensive decoration.

Gates: `black`, `isort`, `flake8`, `mypy` (802 files), `docs_lint` (188 files),
brand gate — all clean.

Two gate results reported honestly rather than as green:

- **`woke` is not installed on this host**, so Inclusive Language could not run
  locally. I grepped the terms it flags: zero hits in the added files (every hit in
  the repo is pre-existing and already carries a `wokeignore` pragma). Relying on
  CI for this one.
- **`scrub-lint` fails** on "960 commits with internal references in history" —
  pre-existing repo history. Its three content checks (internal markers, personal
  identifiers, credential leaks) pass.
- Four `test_sandbox_cc_mode.py` tests fail on this host. Verified pre-existing by
  stashing the whole change and re-running on a clean tree: identical four
  failures. Cause is this machine's user namespaces being disabled
  (`unshare(CLONE_NEWUSER)` → `EPERM`), so the sandbox wrapper returns argv
  unwrapped.

## Any other suggestions on the work

**This PR is backend only — there is no UI yet.** The Storage screen is a
follow-up; its entry row hangs off `PerformanceTab.tsx`, which exists only on
#1810 (System View Redesign). The backend has no dependency on that PR, which is
why it lands first.

Known limitations, recorded in the spec rather than smoothed over:

- **The trash never expires.** It grows until a user empties it, so reclaiming
  space takes two deliberate actions. This is the honest reading of "deletion
  decisions belong to the user", but it does mean the first click does not change
  `df`. Worth a product decision before the UI ships.
- **Reclaiming is by age only.** A single large conversation cannot be targeted.
- **`measure()` has no caching** and walks both stores per call, so the endpoint is
  slow on a very large store. Acceptable while it is fetched on screen-open, not on
  a poll — but it caps how often the UI can refresh.
- **A stale map entry blocks reclaiming** its session until `SessionMap.prune()`
  removes it, rather than the reclaim cleaning up the mapping itself.
- **Emptying does not notify a running kiro-cli**, which may hold its own view of
  the session list until it restarts.

Related: #1940 records the kiro-cli documentation gaps found while measuring this
storage, including that its image byte arrays cost ~2.7x what base64 would.

---

## QA recording — all four endpoints against an isolated pod

![session-storage endpoints exercised against an isolated pod](https://github.com/kirodotdev/KiroCrew/raw/cd769371b1648ad6d125ec8c96fb09421f8a07be/temp-screenshots/session-storage/session-storage-endpoints.gif)

**What this is:** a screencast of real HTTP responses from a live pod
(`kirocrew pod up kirocrew-wt-storage`, port 7867), seeded with synthetic sessions.
**What it is not:** a UI. This PR is backend-only — 12 files, none under `website/` —
so the Storage screen does not exist yet and there is nothing to film. The frames are
the captured transcript verbatim
([`transcript.txt`](https://github.com/kirodotdev/KiroCrew/raw/cd769371b1648ad6d125ec8c96fb09421f8a07be/temp-screenshots/session-storage/transcript.txt)),
not a mockup — the earlier design mockup is deliberately **not** attached because it
contradicts the shipped contract in three places.

The pod is the right harness here for a reason this change added: a pod isolates
`KIROCREW_HOME` **and** `KIRO_HOME` (nested inside it), which is exactly the layout
`reclaim_block_reason()` requires, so the report shows `reclaim_blocked_reason: ""`
and the mutating endpoints are permitted. Run from an instance that shares the
machine-wide store and they are refused instead.

Seeded state, and what each session is there to prove:

| session | age | halves | expected |
|---|---|---|---|
| `aaaa1111` | 40d | replay + transcript | reclaimable (30–90d bucket) |
| `bbbb2222` | 65d | replay + transcript | reclaimable (30–90d bucket) |
| `cccc3333` | 120d | replay + transcript | reclaimable (>90d bucket) |
| `dddd4444` | **0.2d** | replay + transcript | **never staged** — inside the 1-day floor |
| `eeee5555` | 90d | replay + transcript | **never staged** — mapped, still resumable |
| `ffff6666` | 200d | replay only | reclaimable (what most of the real 28 GB is) |

What the recording shows, in order:

1. `GET /api/system/session-storage` — 8.6 MB over 13 sessions, 7.5 MB reclaimable,
   split across the age buckets. No per-store breakdown anywhere in the payload.
2. `POST …/cleanup` with `dry_run: true` — previews 7 sessions / 7.5 MB, moves nothing.
3. `POST …/cleanup` with a 400-digit `older_than_days` — **400 `invalid_threshold`**,
   not a 500. JSON puts no bound on an integer; `float()` does.
4. `POST …/empty` with `{}` — **400 `nothing_specified`**. Omitted is not the same as
   "everything".
5. `POST …/cleanup` for real — both halves of each session move together; total drops
   to 1.0 MB and the trash holds one batch of 7.5 MB.
6. `POST …/restore` — `restored: 7`, total back to 8.6 MB, trash empty. Nothing was
   destroyed by the reclaim.
7. Stage again, then `POST …/empty` with that `batch_ids` — trash returns to 0. Space
   is only actually freed by this second, explicit step.
8. **Survivors:** `dddd4444` and `eeee5555` are still on disk after every reclaim, and
   no session anywhere was left as a half.

One correction to an earlier claim of mine in this thread, since the run showed it:
`older_than_days: 0` is **clamped** to the `MIN_RECLAIM_AGE_DAYS` floor, not rejected.
The protection is identical — the 0.2-day-old session is never selected — but I had
described it as a refusal. The refusal path is `move_to_trash()`, which raises when a
caller passes fresh ids directly; `select_reclaimable()` clamps.

The recording lives on `media/session-storage-endpoints` rather than in this PR's
commit on purpose: committing it here would change the head SHA, which would void the
SHA-pinned `/ai-review override` and re-run all 48 checks. The links above are pinned
to `cd769371b`.
