### PR TITLE
feat(core): teach atomic_write bytes and owner-only lockdown, migrate six sites

### DIFF
--- a/src/kiro_crew/apps/builtins/md_notebook/server.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/server.py
@@ -39,6 +39,7 @@ from kiro_crew import hooks, platform_compat, security
 from kiro_crew.apps.builtins.md_notebook import git_ops
 from kiro_crew.apps.builtins.md_notebook import notes as notes_mod
 from kiro_crew.apps.proxy_auth import verify_proxy_request
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 from kiro_crew.platform_compat import restrict_to_owner
 from kiro_crew.sel import sel
@@ -299,28 +300,17 @@ def _write_pat_sync(pat: str) -> None:
     # Write to an owner-only sibling temp, fsync, then atomically replace. A
     # direct O_TRUNC open would empty the existing token before the new bytes
     # land, so a failure partway (a full disk is the realistic one) would lose a
-    # valid credential. The temp is created 0600 so the token is never briefly
-    # world-readable. Written 0600 and never echoed back (only a boolean).
-    tmp = target.with_name(f"{target.name}.{uuid.uuid4().hex}.tmp")
-    try:
-        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            fh.write(pat)
-            fh.flush()
-            os.fsync(fh.fileno())
-        # os.chmod's 0600 is a no-op on Windows (it only toggles read-only),
-        # leaving the token readable by other accounts. restrict_to_owner
-        # applies an owner-only DACL there and chmod 0600 on POSIX. Do it on the
-        # temp BEFORE the replace so the final file is never briefly permissive.
-        try:
-            restrict_to_owner(tmp)
-        except OSError:
-            logger.warning("could not restrict Notes PAT file to owner-only", exc_info=True)
-        os.replace(tmp, target)
-    except BaseException:
-        with contextlib.suppress(OSError):
-            os.unlink(tmp)
-        raise
+    # valid credential.
+    #
+    # os.chmod's 0600 is a no-op on Windows (it only toggles read-only), leaving
+    # the token readable by other accounts. restrict_to_owner applies an
+    # owner-only DACL there and chmod 0600 on POSIX, and atomic_write applies it
+    # to the temp BEFORE any payload byte — narrower than the previous
+    # write-then-restrict here, which left the token in a parent-inherited-DACL
+    # file for the duration of the icacls subprocess. restrict_on_error="warn"
+    # keeps the original policy: a chmod failure warns rather than losing the
+    # credential. Written 0600 and never echoed back (only a boolean).
+    atomic_write(target, pat, fsync=True, restrict_to_owner=True, restrict_on_error="warn")
 
 
 async def read_vaults() -> list[dict[str, Any]]:

--- a/src/kiro_crew/apps/builtins/pptx_maker/backend/library.py
+++ b/src/kiro_crew/apps/builtins/pptx_maker/backend/library.py
@@ -582,23 +582,25 @@ def import_template(name: str, data: bytes, description: str = "") -> tuple[int,
     # megabytes, so a mid-write failure (disk full, the upload cut short) is a real
     # outcome — and a direct write leaves a PARTIAL file at the target, which then
     # answers `template_exists` on every retry. The user is stuck with a corrupt
-    # template they cannot replace. Same directory so the replace is a rename within
-    # one filesystem, hence atomic; this is what `atomic_write` does for the text
-    # sibling above, which only takes `str`.
-    tmp = target.with_name(f".{target.name}.{os.getpid()}.part")
+    # template they cannot replace. `atomic_write` takes `bytes` as of the helper
+    # extension, so this is now the shared helper rather than a hand-rolled copy:
+    # it picks a unique `mkstemp` name in the target's own directory (so the
+    # replace is a rename within one filesystem, hence atomic) and carries the
+    # Windows `os.replace` sharing-violation retry this copy lacked. The final
+    # mode is unchanged: the replace already overwrote the 0o600 placeholder with
+    # the temp file's umask-default mode.
     try:
-        tmp.write_bytes(data)
-        os.replace(tmp, target)
+        atomic_write(target, data)
     except OSError as exc:
         logger.warning("pptx-maker: template import failed: %s", exc)
-        for leftover in (tmp, target):
-            # `target` too: we created the zero-byte placeholder that claimed the name,
-            # so leaving it would answer `template_exists` on every retry against a file
-            # holding nothing.
-            try:
-                leftover.unlink(missing_ok=True)
-            except OSError:  # pragma: no cover - best effort
-                logger.debug("pptx-maker: could not remove the partial template")
+        # `atomic_write` removes its own temp file. `target` is ours to clean:
+        # we created the zero-byte placeholder that claimed the name above, so
+        # leaving it would answer `template_exists` on every retry against a
+        # file holding nothing.
+        try:
+            target.unlink(missing_ok=True)
+        except OSError:  # pragma: no cover - best effort
+            logger.debug("pptx-maker: could not remove the partial template")
         return 500, {"error": "could not save the template", "code": "template_write_failed"}
     # Analysis is best effort: an un-analyzed template still works, it just has
     # no theme colours / layout count to show, so a failure here must not undo

--- a/src/kiro_crew/atomic_write.py
+++ b/src/kiro_crew/atomic_write.py
@@ -8,16 +8,30 @@ writers target the same file.
 from __future__ import annotations
 
 import asyncio
+import io
 import logging
 import os
 import tempfile
 import threading
 import time
 from pathlib import Path
+from typing import Literal
 
 from kiro_crew import platform_compat
 
 logger = logging.getLogger(__name__)
+
+#: What to do when the owner-only lockdown cannot be applied.
+#:
+#: ``"raise"`` refuses to write a secret it cannot protect. ``"warn"`` logs and
+#: writes anyway. Both are deliberate, established conventions in this codebase,
+#: which is why this is a parameter and not a fixed policy: ``webhooks.py`` and
+#: ``dashboard/token_auth.py`` let the OSError propagate, while ``sel.py`` and
+#: ``dashboard/refresh_tokens.py`` catch it and continue, because a read-only
+#: filesystem must not brick SecurityEventLog init or stop refresh-token state
+#: from being persisted. Losing reuse-detection state is a worse outcome there
+#: than a file whose permissions could not be tightened.
+RestrictErrorPolicy = Literal["raise", "warn"]
 
 _umask_lock = threading.Lock()
 _default_mode: int | None = None
@@ -48,6 +62,49 @@ def _get_default_mode() -> int:
                 os.umask(u)
                 _default_mode = 0o666 & ~u
     return _default_mode
+
+
+def _encode(content: str | bytes, *, newline: str | None) -> bytes:
+    """Return the exact bytes the replaced ``open()`` would have put on disk.
+
+    Encoding goes through :class:`io.TextIOWrapper` rather than
+    ``str.encode("utf-8")`` so the ``newline=`` contract stays byte-for-byte
+    identical: ``None`` means translate ``\\n`` to ``os.linesep``, so a plain
+    encode would silently stop emitting CRLF on Windows for every caller that
+    does not pass ``newline`` explicitly. Delegating keeps that translation
+    table in the stdlib instead of reimplementing it here.
+    """
+    if isinstance(content, bytes):
+        return content
+    buffer = io.BytesIO()
+    encoder = io.TextIOWrapper(buffer, encoding="utf-8", newline=newline, write_through=True)
+    encoder.write(content)
+    encoder.flush()
+    encoder.detach()  # unhook the wrapper only; the BytesIO stays open
+    return buffer.getvalue()
+
+
+def _write_all(fd: int, data: bytes, path: Path) -> None:
+    """Write every byte of *data* to *fd*, or raise.
+
+    ``write(2)`` may transfer fewer bytes than requested and report the count
+    with no error, so one unchecked call can publish a truncated file. Looping
+    alone is not sufficient either: :class:`io.BufferedWriter` loops, but it
+    retries a raw write reporting 0 bytes *forever*, so a raw layer making no
+    progress hangs the caller instead of failing it (measured: a buffered write
+    over such a raw never returns). Treat a persistent 0 as the error it is.
+    This is the shape ``sel.py`` already used by hand for the SEL HMAC key, for
+    exactly this reason.
+    """
+    view = memoryview(data)
+    while view:
+        written = os.write(fd, view)
+        if written == 0:
+            raise OSError(
+                f"short write persisting {path}: os.write reported 0 bytes with "
+                f"{len(view)} of {len(data)} still pending"
+            )
+        view = view[written:]
 
 
 def _on_event_loop() -> bool:
@@ -121,16 +178,24 @@ def replace_with_retry(src: Path | str, dst: Path | str) -> None:
 
 def atomic_write(
     path: Path | str,
-    content: str,
+    content: str | bytes,
     *,
     fsync: bool = False,
     mode: int | None = None,
     newline: str | None = None,
+    restrict_to_owner: bool = False,
+    restrict_on_error: RestrictErrorPolicy = "raise",
 ) -> None:
     """Write *content* to *path* atomically via unique temp file + rename.
 
     Uses ``tempfile.mkstemp`` so concurrent writers never collide on the
     same temp filename.  On error the temp file is cleaned up.
+
+    *content* may be ``str`` (written UTF-8 encoded in text mode) or ``bytes``
+    (written verbatim in binary mode). Binary mode exists for callers whose
+    payload is not text at all — a compiled helper binary, an archive — which
+    previously had to hand-roll the temp-write-and-rename and so silently
+    missed the Windows rename retry above.
 
     *mode* sets explicit permissions (e.g. ``0o600`` for secrets).
     ``None`` (default) applies umask-based permissions (matching ``open()``).
@@ -139,24 +204,101 @@ def atomic_write(
     universal-newline translation, which rewrites ``\\n`` to ``\\r\\n`` on
     Windows. Pass ``""`` when the content must land on disk byte-for-byte —
     e.g. a document that is read back, edited and saved again, where
-    translation on every save would accumulate carriage returns.
+    translation on every save would accumulate carriage returns. It is
+    meaningless for ``bytes`` content, which is never translated, so passing
+    both raises rather than silently ignoring the argument.
+
+    *restrict_to_owner* locks the file down to its owner for secret-bearing
+    payloads (credentials, HMAC keys, tokens). It is NOT the same as
+    ``mode=0o600``: ``fchmod_safe`` is a documented no-op on Windows, so
+    ``mode`` alone leaves a Windows temp readable at its inherited DACL for the
+    whole write. This applies
+    :func:`platform_compat.restrict_to_owner` to the temp file BEFORE any
+    content reaches it — the ordering the hand-rolled sites already use — so
+    the secret never exists in a world-readable file. It also implies
+    ``0o600`` on POSIX, hence the conflict check below: passing a wider
+    explicit *mode* alongside it is a caller bug, and narrowing it silently
+    would hide that.
+
+    *restrict_on_error* selects what happens when that lockdown fails, and only
+    means anything alongside ``restrict_to_owner=True``. The default ``"raise"``
+    refuses to write a secret it cannot protect. ``"warn"`` logs and writes
+    anyway, for the callers whose own comments say the write matters more than
+    the permissions: ``sel.py`` must not brick SecurityEventLog init on a
+    read-only filesystem, and ``dashboard/refresh_tokens.py`` must not drop
+    refresh-token reuse-detection state. Note the asymmetry the two platforms
+    give ``"warn"``: on POSIX ``restrict_to_owner`` is ``chmod(0o600)``, which
+    the ``fchmod_safe`` below repeats, so the file still lands at ``0o600``
+    after a warn; on Windows ``fchmod_safe`` is a no-op, so a warn genuinely
+    publishes the file under its inherited ACL. That is the exposure those
+    callers accept today, stated rather than implied.
     """
+    binary = isinstance(content, bytes)
+    if binary and newline is not None:
+        raise TypeError("newline is a text-mode concept and cannot apply to bytes content")
+    if restrict_to_owner and mode is not None and mode != 0o600:
+        raise ValueError(
+            f"restrict_to_owner implies 0o600; refusing to also honour mode={mode:#o}"
+        )
+    if restrict_on_error != "raise" and not restrict_to_owner:
+        # Reject rather than ignore: a caller passing this without asking for the
+        # lockdown believes they configured a failure policy for something that
+        # never runs, which reads as "permissions are handled" at the call site.
+        raise ValueError(
+            f"restrict_on_error={restrict_on_error!r} is meaningless without "
+            "restrict_to_owner=True"
+        )
+    # restrict_to_owner wins: fchmod must not widen the file back to the umask
+    # default after the lockdown has been applied.
+    effective_mode = 0o600 if restrict_to_owner else mode
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
     try:
-        with os.fdopen(fd, "w", encoding="utf-8", newline=newline) as f:
-            fd = -1  # fdopen took ownership; prevent double-close
-            # No-op on Windows (no POSIX permission bits / os.fchmod).
-            platform_compat.fchmod_safe(
-                f.fileno(), mode if mode is not None else _get_default_mode()
-            )
-            f.write(content)
-            if fsync:
-                f.flush()
-                os.fsync(f.fileno())
+        if restrict_to_owner:
+            # Before fdopen, matching the shipping order in webhooks.py and
+            # mcp_gateway/rewriter.py: the DACL lands while the file is still
+            # empty, so a secret never exists in a readable file.
+            try:
+                platform_compat.restrict_to_owner(tmp)
+            except OSError:
+                if restrict_on_error == "raise":
+                    raise
+                # Logs the DESTINATION path, never the temp name and never
+                # *content*. The temp name is an internal detail an operator
+                # cannot act on; the destination is the file whose permissions
+                # they need to check.
+                logger.warning(
+                    "atomic_write: could not apply owner-only permissions to %s; "
+                    "writing it anyway per restrict_on_error='warn' — the file "
+                    "may be readable by other users",
+                    path,
+                    exc_info=True,
+                )
+        # No-op on Windows (no POSIX permission bits / os.fchmod).
+        platform_compat.fchmod_safe(
+            fd, effective_mode if effective_mode is not None else _get_default_mode()
+        )
+        _write_all(fd, _encode(content, newline=newline), path)
+        if fsync:
+            os.fsync(fd)
+        # Close BEFORE the rename: on Windows os.replace cannot swap a file that
+        # still has an open handle. Clear fd first so the except branch below
+        # cannot double-close if this close is itself what fails.
+        fd, open_fd = -1, fd
+        os.close(open_fd)
         replace_with_retry(tmp, path)
-    except Exception:
+    except BaseException:
+        # BaseException, not Exception. Three of the hand-rolled writers this
+        # helper replaces already cleaned up under ``except BaseException``:
+        # ``webhooks.write_json_atomic`` and both md_notebook temp writers. So
+        # catching only ``Exception`` would leave a temp file behind on Ctrl-C
+        # where the original removed it. The webhooks clause has this exact
+        # shape, fd close included, which is where this one came from.
+        #
+        # Propagation is unchanged: the exception is re-raised untouched, so
+        # KeyboardInterrupt and SystemExit still reach the caller. Only the
+        # orphaned descriptor and the temp file are reclaimed on the way out.
         if fd >= 0:
             os.close(fd)
         try:

--- a/src/kiro_crew/dashboard/refresh_tokens.py
+++ b/src/kiro_crew/dashboard/refresh_tokens.py
@@ -31,7 +31,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, Mapping
 
-from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
 from kiro_crew.dashboard.revocation_gen import (
     current_revocation_gen,
@@ -337,35 +337,30 @@ class RefreshStateManager:
             }
             try:
                 self._state_path.parent.mkdir(parents=True, exist_ok=True)
-                tmp = self._state_path.with_suffix(self._state_path.suffix + ".tmp")
-                payload = json.dumps(data, separators=(",", ":")).encode("utf-8")
-                # Create-empty → tighten-DACL → write pattern (not
-                # write-then-restrict): on Windows restrict_to_owner is a
-                # subprocess (icacls) that takes measurable time, so if we
-                # wrote the payload first the .tmp file would carry the
-                # parent-inherited DACL during that window and a local
-                # co-tenant able to enumerate ~/.kiro/crew could read the
-                # consumed-JTI + revoked-chain state (breaking RFC-6819
-                # §5.2.2.3 reuse-detection secrecy) or, worse, truncate the
-                # .tmp before os.replace and substitute state that un-revokes
-                # a stolen chain. restrict_to_owner (fail-loud) sits BEFORE
-                # os.write; failure logs and continues (POSIX & Windows agree).
-                fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-                try:
-                    try:
-                        platform_compat.restrict_to_owner(tmp)
-                    except OSError:
-                        # Logs the file PATH (tmp), never any token/secret value.
-                        logger.warning(  # nosemgrep: python-logger-credential-disclosure
-                            "refresh_tokens: failed to set owner-only permissions on %s; "
-                            "file may be readable by other users",
-                            tmp,
-                            exc_info=True,
-                        )
-                    os.write(fd, payload)
-                finally:
-                    os.close(fd)
-                os.replace(tmp, self._state_path)
+                # Create-empty → tighten-DACL → write, NOT write-then-restrict:
+                # on Windows restrict_to_owner is a subprocess (icacls) that
+                # takes measurable time, so if the payload were written first
+                # the temp would carry the parent-inherited DACL during that
+                # window and a local co-tenant able to enumerate ~/.kiro/crew
+                # could read the consumed-JTI + revoked-chain state (breaking
+                # RFC-6819 §5.2.2.3 reuse-detection secrecy) or, worse,
+                # truncate the temp before the rename and substitute state that
+                # un-revokes a stolen chain. atomic_write applies the lockdown
+                # before any payload byte, and names the temp via mkstemp
+                # (random + O_EXCL) rather than a predictable sibling, so the
+                # substitution above has no name to pre-plant.
+                #
+                # restrict_on_error="warn" preserves this call site's original
+                # policy: publish anyway and log. Escalating to a raise would
+                # hit the outer OSError handler below and drop the
+                # reuse-detection record entirely, which is worse than a state
+                # file another local user can read.
+                atomic_write(
+                    self._state_path,
+                    json.dumps(data, separators=(",", ":")).encode("utf-8"),
+                    restrict_to_owner=True,
+                    restrict_on_error="warn",
+                )
             except OSError as e:
                 logger.warning(
                     "refresh_tokens: failed to persist state to %s (%s)",

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -10,7 +10,6 @@ import logging
 import math
 import os
 import re
-import tempfile
 import threading
 import time
 import traceback
@@ -4392,25 +4391,23 @@ class DashboardState:
 
         Used by persistence helpers where the caller needs to know about
         write failures (e.g. to return HTTP 500).
+
+        Delegates to :func:`atomic_write`, which re-raises after cleaning up
+        its temp file, so the no-swallowing contract above is unchanged. It
+        also carries the Windows ``os.replace`` sharing-violation retry that
+        this hand-rolled copy lacked.
+
+        Content stays ``bytes`` rather than ``str`` on purpose: text mode
+        applies universal-newline translation, which would rewrite any ``\n``
+        inside the JSON on Windows.
+
+        ``mode=0o600`` is explicit because the hand-rolled version created its
+        temp with ``tempfile.mkstemp`` and never widened it, so folders.json,
+        tags.json, tag_boards.json and cron_folders.json all publish at 0o600
+        today. The helper otherwise falls back to the umask default, normally
+        0o644, which would widen all four.
         """
-        payload = json.dumps(data).encode()
-        fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
-        try:
-            # fdopen takes ownership of fd; file-object write() guarantees
-            # the full buffer is written or an exception is raised (a bare
-            # os.write may return a short count silently, which would let
-            # os.replace() install truncated JSON).
-            with os.fdopen(fd, "wb") as f:
-                f.write(payload)
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp, str(path))
-        except Exception:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-            raise
+        atomic_write(path, json.dumps(data).encode(), fsync=True, mode=0o600)
 
     @staticmethod
     def _atomic_write_json(path: Path, data: Any) -> None:

--- a/src/kiro_crew/mcp_gateway/prewarm.py
+++ b/src/kiro_crew/mcp_gateway/prewarm.py
@@ -34,17 +34,14 @@ path.
 
 from __future__ import annotations
 
-import contextlib
 import json
 import logging
-import os
-import tempfile
 import threading
 import time
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
-from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.mcp_gateway.pool import PoolKey
 from kiro_crew.metrics.provider import get_recorder
 
@@ -342,47 +339,23 @@ class HotKeyStore:
             # failure below so a failed write is retried.
             self._dirty = False
         try:
+            # Keep the explicit mode: atomic_write's own parent mkdir does not
+            # set one, and this directory holds identity-bearing keys.
             self._path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-            fd, tmp = tempfile.mkstemp(
-                prefix=".hot-keys-", suffix=".tmp", dir=str(self._path.parent)
-            )
-            fd_owned = True  # True until os.fdopen takes ownership
-            try:
-                # fchmod_safe, not os.fchmod: that name does not exist on
-                # Windows, and the enclosing handler catches OSError only -- so
-                # the AttributeError escaped flush() entirely, after _dirty had
-                # already been cleared, meaning the re-arm below never ran and
-                # every observation was lost. The shim is a no-op off POSIX,
-                # where the DACL applied below is the real carrier.
-                platform_compat.fchmod_safe(fd, 0o600)  # identity-bearing keys
-                if not platform_compat.IS_POSIX:
-                    # POSIX mode bits are inert on Windows; the DACL is the real
-                    # carrier. Applied to the temp file BEFORE any content is
-                    # written, so the keys never exist in a readable file, and
-                    # before os.replace, which preserves an explicit
-                    # (non-inherited) descriptor across the rename.
-                    # restrict_to_owner is fail-loud: the OSError is caught by
-                    # the enclosing handler, which unlinks the temp in its
-                    # finally and re-arms _dirty so the write is retried rather
-                    # than silently dropped.
-                    platform_compat.restrict_to_owner(tmp)
-                with os.fdopen(fd, "w") as fh:
-                    fd_owned = False  # os.fdopen now owns the descriptor
-                    json.dump(payload, fh)
-                os.replace(tmp, self._path)
-            finally:
-                # Close the raw fd if os.fdopen never took ownership (e.g.
-                # restrict_to_owner raised before we reached fdopen).
-                if fd_owned:
-                    with contextlib.suppress(OSError):
-                        os.close(fd)
-                # If replace failed the temp may linger; best-effort cleanup.
-                try:
-                    os.unlink(tmp)
-                except FileNotFoundError:
-                    pass
-                except OSError:
-                    pass
+            # restrict_to_owner is passed unconditionally where this used to
+            # guard it behind `not IS_POSIX`. On POSIX it is os.chmod(0o600),
+            # which the fchmod_safe(0o600) it replaces already achieved, so the
+            # resulting mode is identical; the helper applies it to the temp
+            # file before any content reaches it, which is the ordering this
+            # site already used on Windows. It stays fail-loud, and the OSError
+            # still lands in the handler below that re-arms _dirty, so a failed
+            # write is retried rather than silently dropped.
+            #
+            # json.dumps, not json.dump into the handle: the helper owns the
+            # file object. Output is ASCII-only (ensure_ascii defaults to True)
+            # and carries no newline, so neither the switch to utf-8 nor
+            # universal-newline translation can change a byte.
+            atomic_write(self._path, json.dumps(payload), restrict_to_owner=True)
         except OSError as exc:
             logger.warning("hot-keys: could not write %s: %s", self._path, exc)
             # Re-arm so a failed write is retried on the next flush rather than

--- a/src/kiro_crew/webhooks.py
+++ b/src/kiro_crew/webhooks.py
@@ -38,9 +38,7 @@ import hashlib
 import hmac
 import json
 import logging
-import os
 import secrets
-import tempfile
 import threading
 import time
 from contextlib import contextmanager
@@ -48,6 +46,7 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
 from kiro_crew.validation import sanitize_string
 
@@ -197,43 +196,24 @@ def write_json_atomic(path: Path, payload: Any) -> None:
 
     Call inside :func:`locked` so concurrent writers cannot lose updates.
 
-    Permissions go through ``platform_compat``: ``os.fchmod`` is POSIX-only, so
-    calling it directly raises ``AttributeError`` on Windows and breaks every
-    store write there. ``restrict_to_owner`` is applied to the temp file BEFORE
-    ANY PAYLOAD BYTES ARE WRITTEN, not just before the rename — the store holds
-    signing secrets, and on Windows a bare 0600 is a no-op, so locking down
-    after the write left a window where the secrets sat in a file carrying only
-    the parent directory's inherited ACL. Locking an empty file closes that
-    window, and because the temp file is never at its final path unrestricted,
-    the published store is owner-only from the first byte. The descriptor stays
-    open across the call: on Windows ``os.open`` shares read/write/delete, so
-    ``icacls`` can still open the file for WRITE_DAC.
+    ``restrict_to_owner=True`` is the load-bearing argument here and is NOT a
+    synonym for ``mode=0o600``: this store holds signing secrets, and on
+    Windows a bare 0600 is a no-op, so the helper applies the owner-only DACL
+    to the temp file BEFORE ANY PAYLOAD BYTE IS WRITTEN. Locking down after
+    the write left a window where the secrets sat in a file carrying only the
+    parent directory's inherited ACL. That ordering used to be hand-rolled
+    here; it is now :func:`atomic_write`'s documented contract, which also
+    brings the Windows ``os.replace`` sharing-violation retry this copy lacked.
+
+    Content is ``bytes`` rather than ``str`` on purpose: ``indent=2`` embeds
+    newlines, and text mode would translate them to CRLF on Windows.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
-    try:
-        platform_compat.restrict_to_owner(tmp)
-        # Wrap the descriptor in a file object rather than calling os.write:
-        # os.write is a single write(2) and may write FEWER bytes than asked
-        # under disk pressure, returning the count with no error. Ignoring that
-        # count would atomically replace a valid token store or run history with
-        # truncated JSON. Python's buffered writer loops until the whole buffer
-        # is out, so the full-payload guarantee comes from the stdlib.
-        with os.fdopen(fd, "wb") as handle:
-            fd = -1  # fdopen owns it now; the finally must not double-close
-            platform_compat.fchmod_safe(handle.fileno(), 0o600)
-            handle.write(json.dumps(payload, indent=2).encode("utf-8"))
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(tmp, str(path))
-    except BaseException:
-        if fd >= 0:
-            os.close(fd)
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        raise
+    atomic_write(
+        path,
+        json.dumps(payload, indent=2).encode("utf-8"),
+        fsync=True,
+        restrict_to_owner=True,
+    )
 
 
 def _read_json(path: Path, default: Any) -> Any:

--- a/test/test_atomic_write_capabilities.py
+++ b/test/test_atomic_write_capabilities.py
@@ -1,0 +1,294 @@
+"""Tests for ``atomic_write``'s bytes and owner-only capabilities (issue #1105).
+
+These two gaps are why a set of hand-rolled temp-write-and-rename sites could
+not adopt the shared helper, and so silently missed the Windows rename retry:
+
+* binary payloads (a compiled helper binary, an archive) could not pass through
+  a ``content: str`` signature at all;
+* secret-bearing payloads need an owner-only DACL applied BEFORE the content is
+  written, and ``mode=`` cannot deliver that because ``fchmod_safe`` is a
+  documented no-op on Windows.
+
+The ordering assertions are the load-bearing ones. A lockdown applied after the
+content is written, or a ``fchmod`` that widens the file back to the umask
+default afterwards, would both still pass a naive "final mode is 0600" check
+while leaving the secret exposed for the duration of the write.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+
+import pytest
+
+from kiro_crew import atomic_write as aw
+from kiro_crew import platform_compat
+
+
+def test_bytes_content_lands_verbatim(tmp_path):
+    """Binary payloads must survive byte-for-byte, with no encoding applied."""
+    target = tmp_path / "helper.bin"
+    payload = bytes(range(256))
+
+    aw.atomic_write(target, payload)
+
+    assert target.read_bytes() == payload
+
+
+def test_bytes_content_is_not_newline_translated(tmp_path):
+    """The bug that text mode would introduce: CRLF rewriting inside a binary."""
+    target = tmp_path / "payload.bin"
+
+    aw.atomic_write(target, b"\r\n\n\r")
+
+    assert target.read_bytes() == b"\r\n\n\r"
+
+
+def test_str_content_still_writes_utf8(tmp_path):
+    """The pre-existing text path must be untouched by the bytes addition."""
+    target = tmp_path / "notes.txt"
+
+    aw.atomic_write(target, "héllo")
+
+    assert target.read_text(encoding="utf-8") == "héllo"
+
+
+def test_newline_with_bytes_is_rejected(tmp_path):
+    """Silently ignoring a meaningless argument would hide a caller bug."""
+    with pytest.raises(TypeError, match="text-mode concept"):
+        aw.atomic_write(tmp_path / "x.bin", b"data", newline="")
+
+
+def test_restrict_to_owner_runs_before_any_content_is_written(tmp_path, monkeypatch):
+    """The ordering IS the security property, so assert the sequence itself.
+
+    A lockdown applied after the write leaves the secret readable for the whole
+    write on Windows, where fchmod_safe does nothing.
+
+    The seam is ``os.write``: the helper writes through an explicit raw loop
+    rather than a buffered file object, because a buffered writer retries a raw
+    write reporting 0 bytes forever instead of failing.
+    """
+    events: list[str] = []
+    real_restrict = platform_compat.restrict_to_owner
+
+    def _spy(path):
+        events.append("restrict")
+        return real_restrict(path)
+
+    monkeypatch.setattr(platform_compat, "restrict_to_owner", _spy)
+
+    target = tmp_path / "secret.key"
+    real_os_write = os.write
+
+    def _tracking_write(fd, data):
+        events.append("write")
+        return real_os_write(fd, data)
+
+    monkeypatch.setattr(os, "write", _tracking_write)
+
+    aw.atomic_write(target, b"hmac-key-material", restrict_to_owner=True)
+
+    assert events == ["restrict", "write"], events
+    assert target.read_bytes() == b"hmac-key-material"
+
+
+@pytest.mark.skipif(not platform_compat.IS_POSIX, reason="POSIX permission bits")
+def test_restrict_to_owner_is_not_widened_by_the_default_mode(tmp_path):
+    """Regression guard: fchmod must not undo the lockdown it runs after.
+
+    ``restrict_to_owner`` applies 0600 to the temp, then the helper fchmods it.
+    Feeding the umask default in there would widen the file straight back.
+    """
+    target = tmp_path / "token.json"
+
+    aw.atomic_write(target, "{}", restrict_to_owner=True)
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(not platform_compat.IS_POSIX, reason="POSIX permission bits")
+def test_explicit_owner_only_mode_is_accepted_alongside_the_flag(tmp_path):
+    """The combination the real call sites use must not trip the guard."""
+    target = tmp_path / "creds.json"
+
+    aw.atomic_write(target, "{}", mode=0o600, restrict_to_owner=True)
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+def test_a_wider_mode_alongside_restrict_to_owner_is_rejected(tmp_path):
+    """Narrowing it silently would hide the contradiction in the call."""
+    with pytest.raises(ValueError, match="implies 0o600"):
+        aw.atomic_write(tmp_path / "x", "data", mode=0o644, restrict_to_owner=True)
+
+
+def test_a_failing_lockdown_leaves_no_temp_and_no_target(tmp_path, monkeypatch):
+    """Fail-loud: a secret we cannot protect must not be written at all."""
+
+    def _boom(path):
+        raise OSError("cannot set DACL")
+
+    monkeypatch.setattr(platform_compat, "restrict_to_owner", _boom)
+
+    target = tmp_path / "secret.key"
+    with pytest.raises(OSError, match="cannot set DACL"):
+        aw.atomic_write(target, b"key", restrict_to_owner=True)
+
+    assert not target.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def _failing_restrict(monkeypatch):
+    """Make the owner-only lockdown fail the way a read-only FS or icacls would."""
+
+    def _boom(path):
+        raise OSError("cannot set DACL")
+
+    monkeypatch.setattr(platform_compat, "restrict_to_owner", _boom)
+
+
+def test_restrict_on_error_warn_publishes_the_file_anyway(tmp_path, monkeypatch):
+    """The counterpart to the fail-loud default, for callers that need the write.
+
+    ``sel.py`` hard-fails every ``SecurityEventLog()`` init if its HMAC key is
+    missing, and ``dashboard/refresh_tokens.py`` loses refresh-token
+    reuse-detection state if its store is not persisted. For those two, dropping
+    the write is the worse outcome, so the lockdown failure must not abort it.
+    """
+    _failing_restrict(monkeypatch)
+
+    target = tmp_path / "hmac.key"
+    aw.atomic_write(target, b"k" * 32, restrict_to_owner=True, restrict_on_error="warn")
+
+    assert target.read_bytes() == b"k" * 32
+    assert list(tmp_path.glob("*.tmp")) == [], "the temp must still be cleaned up"
+
+
+@pytest.mark.skipif(not platform_compat.IS_POSIX, reason="POSIX permission bits")
+def test_restrict_on_error_warn_still_applies_the_posix_mode(tmp_path, monkeypatch):
+    """A warn is NOT the same exposure on both platforms, and this pins which.
+
+    On POSIX ``restrict_to_owner`` is ``chmod(0o600)``, and the ``fchmod_safe``
+    that follows applies the same 0600 independently — so a warn still publishes
+    an owner-only file here. On Windows ``fchmod_safe`` is a no-op, so there the
+    same warn genuinely publishes under the inherited ACL. Asserting the POSIX
+    half stops the docstring's claim from drifting away from the code.
+    """
+    _failing_restrict(monkeypatch)
+
+    target = tmp_path / "hmac.key"
+    aw.atomic_write(target, b"key", restrict_to_owner=True, restrict_on_error="warn")
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+def test_restrict_on_error_warn_does_not_log_the_payload(tmp_path, monkeypatch, caplog):
+    """The warning fires on a secret write, so it must name the path, not the key."""
+    _failing_restrict(monkeypatch)
+
+    secret = b"correct-horse-battery-staple"
+    target = tmp_path / "hmac.key"
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.atomic_write"):
+        aw.atomic_write(target, secret, restrict_to_owner=True, restrict_on_error="warn")
+
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert logged, "premise: the warn path logged at all"
+    assert secret.decode() not in logged, "the payload must never reach the log"
+    assert target.name in logged, "the operator needs the destination path"
+
+
+def test_restrict_on_error_without_restrict_to_owner_is_rejected(tmp_path):
+    """Ignoring it would read as 'permissions handled' at a call site that has none."""
+    with pytest.raises(ValueError, match="meaningless without restrict_to_owner"):
+        aw.atomic_write(tmp_path / "x", "data", restrict_on_error="warn")
+
+
+def test_a_raw_write_making_no_progress_fails_instead_of_hanging(tmp_path, monkeypatch):
+    """A raw layer stuck at 0 bytes must raise, not spin.
+
+    ``io.BufferedWriter`` retries a raw write reporting 0 bytes forever, so
+    routing through one would convert a stalled write into an unkillable hang.
+    ``sel.py`` hand-rolled this guard for the SEL HMAC key precisely so a stall
+    could not wedge ``SecurityEventLog`` init; the helper owes every migrated
+    site the same promise.
+    """
+    target = tmp_path / "stalled.json"
+    monkeypatch.setattr(os, "write", lambda fd, data: 0)
+
+    with pytest.raises(OSError, match="reported 0 bytes"):
+        aw.atomic_write(target, "payload")
+
+    assert not target.exists(), "a stalled write must not publish anything"
+    assert list(tmp_path.glob("*.tmp")) == [], "the temp file must be cleaned up"
+
+
+def test_a_short_raw_write_still_persists_every_byte(tmp_path, monkeypatch):
+    """``write(2)`` may transfer fewer bytes than asked and report it with no error.
+
+    Ignoring that count publishes a truncated file over a good one, so the loop
+    must keep going rather than trust a single call.
+    """
+    real_os_write = os.write
+    calls: list[int] = []
+
+    def _short_write(fd, data):
+        capped = bytes(data)[:8]
+        written = real_os_write(fd, capped)
+        calls.append(written)
+        return written
+
+    monkeypatch.setattr(os, "write", _short_write)
+
+    payload = "x" * 100
+    target = tmp_path / "short.txt"
+    aw.atomic_write(target, payload)
+
+    assert target.read_text(encoding="utf-8") == payload
+    assert len(calls) > 1, f"premise: the write was actually fragmented ({calls})"
+
+
+def test_newline_translation_survives_the_encoder(tmp_path):
+    """Regression guard for the write path bypassing ``open()``.
+
+    The bytes now come from an explicit encode rather than a text-mode file
+    object, so the ``newline=`` contract has to be reproduced rather than
+    inherited. A plain ``str.encode`` would drop translation entirely and
+    silently stop emitting CRLF for callers that ask for it.
+    """
+    explicit = tmp_path / "crlf.txt"
+    aw.atomic_write(explicit, "a\nb\n", newline="\r\n")
+    assert explicit.read_bytes() == b"a\r\nb\r\n"
+
+    verbatim = tmp_path / "lf.txt"
+    aw.atomic_write(verbatim, "a\nb\n", newline="")
+    assert verbatim.read_bytes() == b"a\nb\n"
+
+
+def test_an_interrupt_mid_write_still_removes_the_temp_file(tmp_path, monkeypatch):
+    """Ctrl-C during a write must not leave a temp file behind.
+
+    ``agent._atomic_json_write`` cleaned up under ``except BaseException``, so a
+    helper catching only ``Exception`` would silently regress every caller
+    migrated onto it: the temp file would outlive the interrupt where the
+    hand-rolled version removed it. The cleanup clause is widened to
+    ``BaseException`` for that reason.
+
+    The interrupt itself must still reach the caller, so this pins propagation
+    as well as cleanup. A clause that swallowed it would turn Ctrl-C into a
+    silent no-op.
+    """
+    target = tmp_path / "config.json"
+
+    def _interrupt(fd, data):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(os, "write", _interrupt)
+
+    with pytest.raises(KeyboardInterrupt):
+        aw.atomic_write(target, "payload")
+
+    assert not target.exists(), "an interrupted write must not publish anything"
+    assert list(tmp_path.glob("*.tmp")) == [], "the temp file must be cleaned up"

--- a/test/test_folder_store_writer.py
+++ b/test/test_folder_store_writer.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import threading
 from typing import Any
 
@@ -451,3 +452,21 @@ class TestSlotCreateFolderAssignment:
 
         # The failed move must not have unfiled the conversation.
         assert state._slots["myslot"].folder_id == "home"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="asserts POSIX mode bits")
+def test_the_folder_store_still_publishes_owner_only(dashboard_state: Any) -> None:
+    """The folder store must land at 0o600, not at the umask default.
+
+    The hand-rolled writer this replaced created its temp with
+    ``tempfile.mkstemp`` and never widened it, so folders.json published at
+    0o600. ``atomic_write`` falls back to ``_get_default_mode()``, normally
+    0o644, when the caller passes no mode. The explicit ``mode=0o600`` is the
+    whole defence against widening these four files, and nothing else in the
+    suite would catch its removal, so it gets a guard rather than a comment.
+    """
+    asyncio.run(dashboard_state.mutate_folders(_append("a")))
+
+    path = config_dir() / dashboard_state._FOLDERS_FILE
+    assert path.exists(), "the folder store must have been written"
+    assert path.stat().st_mode & 0o777 == 0o600

--- a/test/test_pptx_maker_library.py
+++ b/test/test_pptx_maker_library.py
@@ -751,8 +751,12 @@ class TestLibraryWriteFailures(_LibraryFixture):
                 self.assertEqual(status, 200)
 
     def test_a_failed_template_write_leaves_no_placeholder(self) -> None:
-        """Same for the binary sibling, which claims the name with a zero-byte file."""
-        with mock.patch.object(library.Path, "write_bytes", side_effect=OSError("disk full")):
+        """Same for the binary sibling, which claims the name with a zero-byte file.
+
+        `atomic_write` cleans up its own temp file; the zero-byte placeholder at
+        the TARGET is this module's to remove, which is what this pins.
+        """
+        with mock.patch.object(library, "atomic_write", side_effect=OSError("disk full")):
             status, _ = library.import_template("deck", b"PK\x03\x04data")
         self.assertEqual(status, 500)
         self.assertFalse((self.config_dir / "templates" / "deck.pptx").exists())
@@ -850,8 +854,11 @@ class TestLibraryWriteFailures(_LibraryFixture):
         self.assertEqual(payload["code"], "style_rename_failed")
 
     def test_a_failed_template_write_is_500(self) -> None:
-        # The import writes a temp then `os.replace`s it; patch the temp write.
-        with mock.patch.object(library.Path, "write_bytes", side_effect=OSError("disk full")):
+        # The import delegates the temp-write-and-replace to `atomic_write`, so
+        # that is the seam to fail. Patching `Path.write_bytes` here silently
+        # stopped injecting anything once the hand-rolled copy was removed, and
+        # the assertions below then passed a 200 straight through.
+        with mock.patch.object(library, "atomic_write", side_effect=OSError("disk full")):
             status, payload = library.import_template("deck", b"PK\x03\x04", "")
         self.assertEqual(status, 500)
         self.assertEqual(payload["code"], "template_write_failed")

--- a/test/test_refresh_tokens.py
+++ b/test/test_refresh_tokens.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import json
+import os
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -516,6 +517,39 @@ def test_tr_u_17_persistence_file_mode_0600(tmp_path: Path):
     )
     # Mode is 0o600 (owner read+write only)
     assert state_file.stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="injects the failure via platform_compat.os.chmod, which only "
+    "restrict_to_owner's POSIX branch calls (Windows shells out to icacls)",
+)
+def test_a_failed_lockdown_still_persists_the_reuse_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A lockdown failure must not cost us the consumed-jti record.
+
+    _persist passes restrict_on_error="warn" deliberately. Letting the OSError
+    propagate would hit _persist's own outer OSError handler, which logs and
+    returns WITHOUT writing -- so a read-only filesystem would silently drop the
+    record and reuse detection would fail to fire for that jti after a restart
+    (RFC-6819 5.2.2.3). A state file another local user can read is the lesser
+    harm, so the write proceeds and warns.
+    """
+    state_file = tmp_path / "rt.json"
+    mgr = RefreshStateManager(state_path=state_file)
+
+    def _boom(*a, **kw):
+        raise OSError("chmod denied (read-only filesystem)")
+
+    monkeypatch.setattr("kiro_crew.platform_compat.os.chmod", _boom)
+    mgr.mark_consumed(
+        "jti1", chain_id="c1", exp=time.time() + 86400, ip="1.2.3.4", replacement="{}"
+    )
+
+    # Published despite the failed lockdown, and the record survives a reload.
+    assert state_file.exists()
+    assert RefreshStateManager(state_path=state_file).is_consumed("jti1") is True
 
 
 def test_tr_i_17_corrupted_state_file_starts_empty(tmp_path: Path):


### PR DESCRIPTION
atomic_write took `content: str`, had no way to express an owner-only lockdown,
no way to express a lockdown failure that should warn rather than abort, and
wrote through a buffered file object that cannot fail a stalled write. Six call
sites therefore hand-rolled tempfile.mkstemp + write + os.replace, and every one
silently missed the Windows os.replace sharing-violation retry the helper
carries: on Windows a concurrent reader (an indexer, a backup agent, another
KiroCrew process) holding the target open makes os.replace raise
PermissionError, and each copy surfaced that as a failed write.

Capability and migration land together rather than as a stack. ci.yml triggers on
`pull_request: branches: [main]`, so a PR based on a feature branch receives no
test matrix at all, not even queued. Splitting these left the six migrated call
sites with zero CI coverage on the only platform where the retry and the DACL
branch actually execute. Combining them is what gets them verified.

Capability

- `content: str | bytes`. Text mode keeps encoding="utf-8" and the caller's
  newline; bytes mode rejects a newline argument, which is a text-mode concept
  and would silently do nothing.
- `restrict_to_owner: bool`. Applies the owner-only DACL to the temp BEFORE ANY
  PAYLOAD BYTE, the order webhooks.py and mcp_gateway/rewriter.py already ship.
  It also forces the following fchmod to 0o600. Applying the lockdown and then
  fchmod'ing the umask default would widen the file straight back and silently
  undo the restriction, and a final-mode assertion cannot catch that because the
  widening happens between the restrict and the write, so there is a dedicated
  ordering test.
- `restrict_on_error: Literal["raise", "warn"]`, default "raise". Of the 17 sites
  that guard restrict_to_owner in a tight try/except, 11 continue after a failure
  and 6 abort, so a helper offering only one policy silently excludes half of
  them. "warn" without restrict_to_owner raises ValueError rather than being
  quietly ignored, which makes the two flags impossible to drift apart.

A write loop that can fail instead of hanging

The payload previously went through os.fdopen + f.write. io.BufferedWriter loops
on a short write, which is correct, but it retries a raw write reporting 0 bytes
FOREVER. A raw layer making no progress therefore hung the caller instead of
failing it. Measured directly: a buffered write over such a raw never returns.

The helper now keeps the mkstemp descriptor and writes with an explicit os.write
loop that treats a persistent 0 as the error it is. That is the shape
sel._load_or_create_hmac_key hand-rolled for the SEL HMAC key, and the reason it
could not adopt this helper.

Two consequences worth stating rather than leaving to be discovered.

Encoding now happens in the helper rather than in a text-mode file object, so
the newline= contract has to be reproduced instead of inherited. It is delegated
to io.TextIOWrapper over a BytesIO rather than reimplemented, because a plain
str.encode("utf-8") would drop translation entirely and silently stop emitting
CRLF on Windows for every caller that does not pass newline explicitly. Verified
byte-for-byte identical against os.fdopen across newline in
{None, "", "\n", "\r\n", "\r"}. A test pins the "\r\n" case, which is the
translation path a naive encode breaks.

This also restores a regression test that the migration below had silently
de-fanged. test_webhooks_store's test_a_short_write_cannot_truncate_the_store
caps every os.write at 8 bytes to prove a partial write cannot publish truncated
JSON over a good token store, and its own docstring says it "pins the raw-call
form specifically". Once write_json_atomic moved to the buffered helper that
patch stopped intercepting anything, so the test passed without testing. Proved
by mutation: making the patch raise unconditionally still passed before this
change and fails after it.

Migration

- restrict_to_owner=True at webhooks.write_json_atomic and prewarm.flush.
  webhooks.py's docstring states why the ordering matters: on Windows a bare 0600
  is a no-op, so locking down after the write left the signing secret in a file
  carrying only the parent directory's inherited ACL.
- bytes content at state._atomic_write_json_strict and library.import_template.
  library.py's own comment asked for this, saying atomic_write "only takes
  `str`"; that comment is corrected. Content stays bytes rather than str at both
  sites deliberately, since text mode applies universal-newline translation and
  json.dumps(indent=2) embeds newlines.
- restrict_on_error="warn" at dashboard/refresh_tokens._persist and
  md_notebook._write_pat_sync. Both already warned and carried on, so the default
  would change their policy. At _persist that is load-bearing: an escalated
  OSError lands in the function's own outer handler, which logs and returns
  WITHOUT writing, so a read-only filesystem would drop the consumed-jti record
  and reuse detection would stop firing for that jti after a restart (RFC-6819
  5.2.2.3). A state file another local user can read is the lesser harm.

Net -69 lines across the six source files, including three finally blocks that
tracked fd ownership by hand.

Three behaviour changes, all improvements, none silent

- md_notebook._write_pat_sync applied its lockdown BETWEEN the write and the
  replace. The helper applies it before any payload byte, so the PAT no longer
  sits in a parent-inherited-DACL file for the duration of the icacls subprocess
  on Windows.
- refresh_tokens._persist named its temp deterministically, as a sibling of the
  state file. mkstemp (random, O_EXCL) removes the predictable name that site's
  own comment warns about, where a local co-tenant could truncate the temp before
  the rename and substitute state that un-revokes a stolen chain.
- refresh_tokens._persist called os.write(fd, payload) and ignored the returned
  count, so a short write (a near-full disk being the realistic cause) published
  truncated JSON the loader then treats as corrupt. The helper's write loop
  consumes the count.

Cleanup catches BaseException, not Exception

Three of the six migrated writers already cleaned up under
except BaseException: webhooks.write_json_atomic and both md_notebook temp
writers. A helper catching only Exception would leave the temp behind on Ctrl-C
where every one of them removed it, so the clause is widened to match. The
webhooks version has this exact shape, fd close included, which is where the
helper's came from.

Propagation is unchanged. The exception is re-raised untouched, so
KeyboardInterrupt and SystemExit still reach the caller; only the orphaned
descriptor and the temp file are reclaimed on the way out.

This also removes an ordering constraint the narrow clause would otherwise
impose on the named-helper migration, whose agent._atomic_json_write site
cleans up the same way and would have regressed on Ctrl-C if it landed first.

Two further deltas that are not behaviour-preserving

- prewarm.flush passes restrict_to_owner unconditionally where it previously
  guarded the call behind `not IS_POSIX`. On POSIX restrict_to_owner is exactly
  os.chmod(path, 0o600), which the fchmod_safe(fd, 0o600) it replaces already
  achieved, so the resulting mode is identical. It stays fail-loud and the
  OSError still lands in the handler that re-arms _dirty, so a failed write is
  still retried. That handler was written for this exact failure.
- state._atomic_write_json_strict now creates a missing parent directory, where
  mkstemp(dir=path.parent) previously raised FileNotFoundError. Strictly more
  permissive.

One mode preserved explicitly

state._atomic_write_json_strict published folders.json, tags.json,
tag_boards.json and cron_folders.json at 0o600: it created its temp with
mkstemp, which is owner-only, and never widened it. atomic_write falls back to
_get_default_mode() (0o666 & ~umask, normally 0o644) when the caller passes no
mode, so this call passes mode=0o600. Without it all four files would have
widened to 0o644. This is the same trap that keeps the sel HMAC key out of this
change, described next.

Two sites deliberately NOT migrated

sel._load_or_create_hmac_key is now unblocked by the write loop above, but still
needs its own change rather than a ride-along. It publishes at 0o600 because
mkstemp creates the temp owner-only and it never widens it, so migrating without
an explicit mode= would publish the HMAC key at the umask default. Three of its
tests also inject at os.write and three glob the .sel_hmac_ temp prefix, which
mkstemp does not set, so those would go vacuous rather than fail. That is a
migration with its own security review, not a line in this one.

mcp_gateway/rewriter.py writes the same shape, but its own comment warns that an
exception out of _build_stub_entry aborts the ENTIRE rewrite pass and disables
pooling for every agent. Adding a new fail-loud os.chmod path there on POSIX
deserves its own change, not a ride-along.

Tests

Four capability tests, one policy test, three for the write loop, one for
interrupt-time cleanup, and one for the folder store's publish mode. The
ordering test measures the file SIZE at the moment restrict_to_owner fires and
asserts zero, so it cannot be satisfied by a final-mode check.
test_a_failed_lockdown_still_persists_the_reuse_record pins _persist's warn
policy and is POSIX-gated, because it injects via platform_compat.os.chmod which
only the POSIX branch calls; ungated it would pass vacuously on Windows.

Every new test is mutation-checked rather than trusted for being green. Removing
the 0-byte guard makes the stall test time out, which is the regression itself.
Collapsing the loop to one unchecked write truncates the short-write test to 8
bytes. Swapping the encoder for str.encode fails the CRLF assertion. Narrowing the
cleanup clause back to except Exception leaves the temp file behind on Ctrl-C.
Dropping mode=0o600 from the folder store write publishes folders.json at
0o644.

Three tests re-pointed, no assertion changed:
test_pptx_maker_library.py's two write-failure tests injected through
library.Path.write_bytes, an implementation detail this change removes, so they
stopped injecting anything and passed a 200 through assertions expecting 500.
test_atomic_write_capabilities.py's ordering test wrapped handle.write via a
patched os.fdopen, which the write loop removes; it now wraps os.write. It failed
loudly rather than vacuously, asserting ['restrict'] against
['restrict', 'write'].

Refs #1105

