### PR TITLE
fix(history): persistent backoff and attempt cap for consolidation retries

### DIFF
--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -27,8 +27,10 @@ from kiro_crew.dashboard.chat_utils import (
 from kiro_crew.dashboard.state import DashboardState, _ChatSlot, _normalize_slot_key
 from kiro_crew.effort import EFFORT_LEVELS, EFFORT_VALUES
 from kiro_crew.history import (
+    SLOT_OWNED_META_KEYS,
     _archive_lines,
     carry_provenance,
+    carry_unowned_metadata,
     latest_transcript_ts,
     transcript_sort_key,
     update_metadata_off_loop,
@@ -1447,15 +1449,16 @@ def _save_slot_to_history(
                 "last_consolidated": existing_meta.get("last_consolidated", 0),
             }
             # Preserve history-layer-owned metadata this dashboard save does NOT
-            # manage. ``rotation_generation`` (bumped by ``_maybe_rotate``, with
-            # its ``rotated_at`` stamp) lets a concurrent consolidation detect a
-            # rotation and skip applying a stale offset. Reconstructing the
-            # metadata subset here would drop it, resetting the generation to 0
-            # and re-opening the exact consolidation race the rotation-generation
-            # fix closed. Carry these forward verbatim (absent field == no-op).
-            for _meta_key in ("rotation_generation", "rotated_at", "compacted_at"):
-                if _meta_key in existing_meta:
-                    meta_line[_meta_key] = existing_meta[_meta_key]
+            # manage. The save is authoritative only for the slot fields it writes
+            # (SLOT_OWNED_META_KEYS), where an absent field means "cleared"; every
+            # other key is another layer's durable state, and reconstructing the
+            # subset deletes it. That is not hypothetical: it erased the rotation
+            # generation (re-opening the consolidation race the generation check
+            # closed) and then the consolidation retry accounting (resetting the
+            # backoff so billed retries resumed). Carrying unowned keys through by
+            # default closes the class instead of enumerating one more field to
+            # rescue. Applied after the slot fields below so an inherited value can
+            # never shadow the slot's own state.
             if closed:
                 meta_line["closed"] = True
                 # Epoch stamp of WHEN the tab was closed. The channel-slot
@@ -1523,6 +1526,38 @@ def _save_slot_to_history(
             tab_id = getattr(slot, "_tab_id", None) or existing_meta.get("tab_id")
             if tab_id:
                 meta_line["tab_id"] = tab_id
+            # ``rewrite`` is the structural signal for "this save EDITS the
+            # conversation": the regenerate / rewind / fork paths pass an explicit
+            # window snapshot (or leave ``_pending_rewrite`` set), while a steady
+            # flush re-serializes the same window it already persisted.
+            #
+            # An edit swaps the live window's tail for content no consolidation
+            # turn has read, so it advances the rotation generation — the
+            # session's content-identity counter. That single write covers both
+            # halves of the invariant that a consolidation marker and its retry
+            # budget are bound to the content they measured:
+            #
+            # * An attempt already IN FLIGHT snapshotted the pre-edit generation,
+            #   so its ``mark_consolidated`` write is rejected as stale
+            #   (``ConversationLog.mark_consolidated``) instead of marking the
+            #   REPLACEMENT tail consolidated without ever extracting it. A
+            #   regenerate lands at the same message count, the same generation
+            #   and the same marker, so nothing else about the save distinguishes
+            #   it and the completion write would otherwise apply.
+            # * A charged (or capped) budget stamped against the pre-edit
+            #   generation stops describing the current span, so the replacement
+            #   content earns a fresh budget rather than inheriting an exhausted
+            #   one (``ConversationLog._attempts_describe_current_span``).
+            #
+            # This is the same release a rotation gets, and deliberately the same
+            # in both directions: the armed backoff deadline survives, so a user
+            # repeatedly regenerating a reply cannot re-bill a failing
+            # consolidation turn on each gesture.
+            if rewrite:
+                meta_line["rotation_generation"] = (
+                    int(existing_meta.get("rotation_generation", 0) or 0) + 1
+                )
+            carry_unowned_metadata(meta_line, existing_meta, SLOT_OWNED_META_KEYS)
             meta_str = json.dumps(meta_line) + "\n"
 
             # ── Frozen prefix (never rewritten) + freshly serialized window ──

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -1159,14 +1159,59 @@ async def api_memory_consolidate(request: web.Request) -> web.Response:
     if not key:
         return web.json_response({"error": "session key required"}, status=400)
     include_history = body.get("include_history", True)
-    # Fire consolidation in background
+    # Claim the key before the eligibility probe below, which awaits. Testing
+    # membership and adding must happen with no yield between them: the probe
+    # offloads a transcript read, and a check-then-act spanning that await lets
+    # two concurrent POSTs both pass the guard and both dispatch, double-billing
+    # an LLM turn on the same span. The claim is released again on every path
+    # that does not hand the key to _consolidate, which discards it in its own
+    # finally once the task ends.
     if key in state.consolidator._running:
         return web.json_response({"error": "consolidation already running"}, status=409)
     state.consolidator._running.add(key)
-    task = asyncio.create_task(state.consolidator._consolidate(key, include_history))
-    state.consolidator._tasks.add(task)
-    task.add_done_callback(state.consolidator._tasks.discard)
-    return web.json_response({"ok": True, "key": key})
+    dispatched = False
+    try:
+        # The manual trigger honours the same durable retry accounting as the idle
+        # sweep and the expiry sweep. A span whose consolidation keeps failing is in
+        # exponential backoff (or abandoned at the attempt cap), and re-firing it by
+        # hand spends another billed LLM turn on the same failure — so a bypass here
+        # would reopen the unbounded-retry hole from the UI.
+        #
+        # The extent the cap is scoped to needs the transcript's message total, and
+        # reading it is blocking file IO — offload it rather than stalling the loop on
+        # a large transcript.
+        _total = None
+        if include_history:
+            try:
+                _total = (
+                    await asyncio.to_thread(
+                        state.consolidator._log.consolidation_counts, key
+                    )
+                )[0]
+            except Exception:
+                # No count means the extent test is skipped and the cap stands, which
+                # only ever refuses a turn — never spends one on an unverified premise.
+                logger.warning("Could not read message count for %s", key, exc_info=True)
+        if include_history and not state.consolidator.retry_eligible(
+            key, message_count=_total
+        ):
+            return web.json_response(
+                {
+                    "error": "consolidation is in retry backoff for this session",
+                    "code": "consolidation_retry_backoff",
+                },
+                status=429,
+            )
+        task = asyncio.create_task(
+            state.consolidator._consolidate(key, include_history)
+        )
+        dispatched = True
+        state.consolidator._tasks.add(task)
+        task.add_done_callback(state.consolidator._tasks.discard)
+        return web.json_response({"ok": True, "key": key})
+    finally:
+        if not dispatched:
+            state.consolidator._running.discard(key)
 
 
 async def api_memory_observability(request: web.Request) -> web.Response:

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -21,7 +21,7 @@ from collections import OrderedDict
 from collections.abc import Callable, Container, Iterator
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, NamedTuple, TypeVar
 
 from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
@@ -60,12 +60,155 @@ SESSIONS_DIR_NAME = "sessions"
 ARCHIVE_DIR_NAME = "archive"
 ARCHIVE_RETENTION_DAYS = 7
 _CONSOLIDATION_THRESHOLD = 30  # preferences/projects update threshold (messages)
+# Persistent retry accounting for history consolidation. A pass spends a billed
+# LLM turn BEFORE it can write the durable "consolidated" marker, so any failure
+# in between leaves the span unconsolidated — and every entry point (the 60s
+# idle sweep, session-expiry sweeps, the dashboard trigger) then re-spends that
+# turn, forever, because the only thing suppressing a repeat is an in-memory
+# throttle that a failure skips and a restart forgets. Attempts are therefore
+# counted in the transcript's metadata line (durable, per span) and gated behind
+# exponential backoff up to a hard cap. At the cap the span is abandoned with
+# the marker written anyway: losing one memory pass costs one summary, while
+# retrying forever costs an LLM turn per heartbeat tick indefinitely.
+_CONSOLIDATION_MAX_ATTEMPTS = 5
+_CONSOLIDATION_BACKOFF_BASE_SECS = 900.0  # 15 min, doubling per failed attempt
+_CONSOLIDATION_BACKOFF_MAX_SECS = 86400.0  # 24 h ceiling on a single wait
+# Every metadata field the accounting owns, so the marker's success path can drop
+# the whole set in one place and a rebuilding writer can name it as foreign.
+_CONSOLIDATION_META_KEYS: frozenset[str] = frozenset(
+    {
+        "consolidation_attempts",
+        "consolidation_retry_at",
+        "consolidation_env_failures",
+        "consolidation_attempts_generation",
+        "consolidation_attempts_offset",
+        "consolidation_attempts_count",
+    }
+)
+
+
+class AttemptedSpan(NamedTuple):
+    """The span identity a consolidation turn actually covered.
+
+    All three fields come from ONE atomic
+    :meth:`ConversationLog.snapshot_for_consolidation` taken BEFORE the turn:
+    where the span starts (*generation*, *offset*) and how far it reaches
+    (*total*). They travel together because the accounting's whole guarantee is
+    that a charged attempt is stamped with the span it measured — mixing a
+    snapshot value with one re-read after the turn stamps content that was never
+    attempted, and the cap then either outlives its span (stranding messages
+    forever) or releases early (re-billing indefinitely).
+
+    Re-reading the metadata line at failure time is the specific mistake this
+    type exists to prevent. A rotation or a marker-resetting rewrite DURING the
+    turn moves all three, so a post-turn read stamps the counter with the NEW
+    span's identity while the count it carries was charged against the old one.
+    At the cap that leaves the post-rotation messages capped without ever having
+    been attempted, and because their generation and offset already match the
+    stamp no later append can release them.
+    """
+
+    #: Transcript message total the turn covered — the snapshot's total, not the
+    #: file's size afterwards. Named ``total`` rather than ``count`` because a
+    #: ``NamedTuple`` field called ``count`` would shadow ``tuple.count``.
+    total: int
+    #: ``rotation_generation`` at the snapshot.
+    generation: int
+    #: ``last_consolidated`` at the snapshot — where the attempted span begins.
+    offset: int
+
+
 # Skill detection judges a wider window than the incremental history tail: a
 # reusable procedure usually spans the whole session, not just the slice since
 # the last consolidation, so a tail-only view systematically misses skills in
 # any session consolidated more than once. Bound the window so pathologically
 # long sessions stay cost-safe.
 _SKILL_DETECTION_WINDOW = 200
+
+# The keys :meth:`ConversationLog.compact` is authoritative for; every other field
+# on the metadata line is another layer's and is carried through.
+_COMPACT_OWNED_META_KEYS: frozenset[str] = frozenset(
+    {"_type", "created_at", "last_consolidated", "compacted_at"}
+)
+
+# The keys the dashboard's slot save is authoritative for. It reconstructs the
+# line from the slot's in-memory state, so for THESE absence is meaningful (a
+# cleared title, an un-pinned slot, a reopened tab) — hence they are named here
+# and not preserved, while everything else survives the save.
+SLOT_OWNED_META_KEYS: frozenset[str] = frozenset(
+    {
+        "_type",
+        "created_at",
+        "last_consolidated",
+        "closed",
+        "closed_at",
+        "memory_mode",
+        "title",
+        "agent",
+        "model",
+        "reasoning_effort",
+        "mode",
+        "workspace",
+        "project",
+        "folder_id",
+        "app",
+        "artifact",
+        "pinned",
+        "color_index",
+        "color_theme",
+        "tags",
+        "forked_from",
+        "linked_session_key",
+        "tab_id",
+    }
+)
+
+
+def carry_unowned_metadata(
+    rebuilt: dict,
+    existing: dict,
+    owned: Container[str],
+) -> dict:
+    """Carry every pre-existing metadata field the rebuilding writer does not own.
+
+    A writer that reconstructs a transcript's metadata line from its own state
+    (the dashboard slot save, :meth:`ConversationLog.compact`) is authoritative
+    ONLY for the keys it writes: for those, absence is meaningful and must erase
+    (clearing a title, un-pinning, reopening a closed tab). For every OTHER key
+    absence means "not mine to know about", so reconstructing the subset silently
+    deletes another layer's durable state.
+
+    Enumerating the foreign keys to preserve instead is the failure mode this
+    replaces: each new field has to be added to every rebuilder, and the one that
+    is missed loses data with no error — the rotation generation and the
+    consolidation retry accounting were both erased that way. So *owned* names the
+    writer's OWN keys and everything else is carried through verbatim, making
+    preservation the default and erasure the deliberate act.
+
+    Preservation is unconditional, INCLUDING the consolidation retry accounting
+    (:data:`_CONSOLIDATION_META_KEYS`), because a rebuild is not evidence about
+    content: a slot flush re-serializes the same window, and a compaction archives
+    turns the budget has already measured without introducing any the LLM has not
+    seen — erasing the accounting there resets a live backoff and resumes billed
+    retries.
+
+    A save that genuinely EDITS the conversation is distinguished by the content
+    identity it writes, not by what this helper drops: the dashboard rewrite path
+    advances ``rotation_generation``, which releases the budget through the span
+    identity the accounting is stamped with (see :class:`AttemptedSpan` and
+    :meth:`ConversationLog._attempts_describe_current_span`) and invalidates any
+    in-flight attempt's marker write. Keeping that in ONE counter is what makes an
+    edit and a rotation behave identically; a second, parallel drop-the-keys valve
+    here would additionally discard the armed backoff deadline, handing a session
+    whose consolidation keeps failing a free billed turn on every user edit.
+
+    Returns *rebuilt*, mutated in place.
+    """
+    for meta_key, value in existing.items():
+        if meta_key in owned or meta_key in rebuilt:
+            continue
+        rebuilt[meta_key] = value
+    return rebuilt
 
 
 def _fmt_message(m: dict) -> str:
@@ -102,6 +245,19 @@ _SESSION_KEEP_LINES = 200
 # don't.
 _FLOCK_ACQUIRE_TIMEOUT_S = 10.0
 _FLOCK_POLL_INTERVAL_S = 0.05
+
+
+class _ConsolidationNotDispatched(Exception):
+    """A consolidation prompt never reached the provider.
+
+    Distinguishes "we could not send the turn" (no session manager; kiro-cli
+    missing, not logged in, or failing to start) from "the turn ran and returned
+    nothing useful". Only the latter costs money, so only the latter may consume
+    the attempt budget that abandons a span — charging an unsent turn would let a
+    broken host mark messages consolidated that no LLM has ever read. Raised
+    rather than reported as a flag beside the result so a caller cannot silently
+    drop the distinction.
+    """
 
 
 class HistoryLockTimeout(TimeoutError):
@@ -1714,14 +1870,23 @@ class ConversationLog:
         return messages[offset:], len(messages)
 
     def rotation_generation(self, key: str) -> int:
-        """Return the session's rotation generation counter.
+        """Return the session's content-identity counter for *key*.
 
-        Incremented by :meth:`_maybe_rotate` on every rotation. A consolidator
-        snapshots this alongside the message offset before its (slow) LLM call
-        and passes it back to :meth:`mark_consolidated`, which resets the offset
-        whenever the generation changed — closing the rotation-during-await race
-        for ANY retained count, not just files that shrank below the offset.
-        Absent field (legacy metadata / never rotated) reads as ``0``.
+        Advanced by every write that makes the transcript's messages a DIFFERENT
+        body of content than a consolidation may have snapshotted: a rotation
+        (:meth:`_maybe_rotate`), a dashboard rewrite save (regenerate / rewind /
+        fork), and a channel transcript merge. A consolidator snapshots it
+        alongside the message offset before its (slow) LLM call and passes it back
+        to :meth:`mark_consolidated`, which refuses to apply the offset whenever
+        the generation changed — closing the change-during-await race for ANY
+        retained count, including an edit that leaves the count untouched. It is
+        also the span identity the retry accounting is stamped against
+        (:meth:`_attempts_describe_current_span`), so the same bump releases a
+        budget charged against the superseded content.
+
+        Named for the rotation that first needed it; the field is now the general
+        content-identity counter. Absent field (legacy metadata / never advanced)
+        reads as ``0``.
         """
         return int(self._read_metadata(key).get("rotation_generation", 0) or 0)
 
@@ -1759,22 +1924,31 @@ class ConversationLog:
         *offset* is an absolute message index captured by the caller BEFORE a
         (potentially slow) LLM consolidation call. *generation* is the rotation
         generation counter (:meth:`rotation_generation`) captured at the same
-        moment. If a rotation fired while the consolidator awaited the LLM, the
-        file was truncated to its newest messages, ``last_consolidated`` reset
-        to 0, and the generation bumped — so the caller's *offset* is in the
-        stale PRE-rotation numbering: every surviving index shifted by the
-        number of dropped lines, so applying it would silently mark
-        never-consolidated retained messages as already processed.
+        moment. It advances on anything that changes the content under a
+        consolidation in flight, and each case makes the caller's *offset*
+        meaningless in a different way:
+
+        * A **rotation** truncated the file to its newest messages and reset
+          ``last_consolidated`` to 0, so every surviving index shifted by the
+          number of dropped lines and applying the offset would mark
+          never-consolidated retained messages as processed.
+        * A **transcript edit** (the dashboard regenerate / rewind / fork save)
+          replaced the live window's tail with content this turn never read. The
+          message count, the marker and the extent can all be unchanged, so the
+          offset still *looks* applicable — and applying it would mark the
+          REPLACEMENT tail consolidated without ever extracting it.
+
+        Both are silent memory loss, and the generation is what distinguishes
+        them from a turn whose span is still intact.
 
         Detection uses two independent signals:
 
         1. **Generation change** (primary, when *generation* is supplied):
-           any rotation between snapshot and write bumps the counter, so a
-           mismatch resets ``last_consolidated`` to 0 regardless of how many
-           messages the rotation retained. This closes the case a pure
-           offset-vs-count heuristic misses — a rotation that keeps >= *offset*
-           messages leaves ``offset <= msg_count`` true yet has still shifted
-           every index.
+           anything that changes the content between snapshot and write bumps the
+           counter, so a mismatch resets ``last_consolidated`` to 0. This closes
+           both cases a pure offset-vs-count heuristic misses — a rotation that
+           keeps >= *offset* messages, and an edit that keeps the count identical,
+           each leave ``offset <= msg_count`` true.
         2. **Offset exceeds current count** (fallback, always): the file shrank
            below the captured offset (rotation truncated it). Retained if
            *generation* is unavailable (legacy callers) or as defense-in-depth.
@@ -1802,20 +1976,25 @@ class ConversationLog:
             msg_count = sum(1 for ln in lines[1:] if ln.strip())
             current_generation = int(meta.get("rotation_generation", 0) or 0)
             if generation is not None and current_generation != generation:
-                # PRIMARY signal: a rotation fired between the caller's snapshot
-                # and now (the generation counter advanced). The offset is in
-                # the stale PRE-rotation numbering — every surviving index has
-                # shifted by the number of dropped lines — so it cannot be
-                # applied regardless of how many messages the rotation retained.
-                # A rotation that kept >= *offset* messages leaves
-                # ``offset <= msg_count`` true and would sail past the count
-                # heuristic below, silently marking never-consolidated retained
-                # messages as done. Reset to 0 and reconsolidate the retained
-                # tail (harmless, idempotent) rather than risk that loss.
+                # PRIMARY signal: the content under this consolidation changed
+                # between the caller's snapshot and now (the generation counter
+                # advanced) — a rotation, or a dashboard rewrite that swapped the
+                # live window's tail. Either way the offset cannot be applied.
+                # After a rotation it is in the stale PRE-rotation numbering
+                # (every surviving index shifted by the number of dropped lines);
+                # after an edit the numbering still fits but the messages it would
+                # mark are the REPLACEMENT tail, which no turn has read. Neither
+                # is caught by the count heuristic below: a rotation that kept
+                # >= *offset* messages and an edit that kept the count identical
+                # both leave ``offset <= msg_count`` true, and marking either
+                # would drop never-consolidated content from memory/history
+                # extraction. Reset to 0 and reconsolidate the current tail
+                # (harmless, idempotent) rather than risk that loss.
                 logger.warning(
                     "mark_consolidated: rotation generation changed %s->%d for "
-                    "%s (rotation during consolidation); resetting "
-                    "last_consolidated to 0 to avoid skipping retained messages",
+                    "%s (rotation or transcript edit during consolidation); "
+                    "resetting last_consolidated to 0 to avoid marking content "
+                    "no consolidation turn read",
                     generation,
                     current_generation,
                     key,
@@ -1847,6 +2026,22 @@ class ConversationLog:
                 safe_offset = offset
             meta["last_consolidated"] = safe_offset
             meta["updated_at"] = metadata_now_iso()
+            # The marker is the success signal for the retry accounting written
+            # by record_consolidation_failure: once a span is marked, its failed
+            # attempts and backoff deadline describe a span that no longer
+            # exists, and leaving them behind would charge the NEXT span for this
+            # one's failures. Dropped in the same locked write so no window
+            # exists where the marker is applied but the budget is not released.
+            #
+            # Only when the offset was actually APPLIED, though. Both branches
+            # above reset to 0 without advancing anything, so the span is still
+            # unconsolidated — and the abandon-at-cap path calls this method
+            # precisely to stop spending on it. Clearing the accounting there
+            # would hand a capped span a fresh budget every time a rotation
+            # raced the marker write, so the cap would never actually hold.
+            if safe_offset == offset:
+                for _acct_key in _CONSOLIDATION_META_KEYS:
+                    meta.pop(_acct_key, None)
             lines[0] = json.dumps(meta) + "\n"
             # Reduce lock hold for this one-line metadata rewrite: skip the
             # fsync (fsync=False). ``last_consolidated`` is recoverable
@@ -1865,6 +2060,291 @@ class ConversationLog:
         messages = self._read_messages(key)
         offset = self._read_metadata(key).get("last_consolidated", 0)
         return max(0, len(messages) - offset)
+
+    def consolidation_counts(self, key: str) -> tuple[int, int]:
+        """Return ``(total_messages, unconsolidated)`` from a SINGLE read.
+
+        The consolidator's entry points need both: the unconsolidated count to
+        decide there is anything to do, and the total as the extent
+        :meth:`consolidation_retry_state` compares the charged span against. Both
+        come from one ``_read_messages`` call so the eligibility check costs no
+        additional transcript read on the event loop.
+        """
+        messages = self._read_messages(key)
+        offset = self._read_metadata(key).get("last_consolidated", 0)
+        try:
+            offset = int(offset or 0)
+        except (TypeError, ValueError, OverflowError):
+            offset = 0
+        return len(messages), max(0, len(messages) - offset)
+
+    def consolidation_retry_state(
+        self, key: str, message_count: int | None = None
+    ) -> tuple[int, float]:
+        """Return ``(failed_attempts, next_eligible_at)`` for *key*.
+
+        Both live on the metadata line beside ``last_consolidated``, so the
+        accounting shares the marker's lifetime: it survives a gateway restart
+        (the consolidator's own throttle is in-memory only) and is cleared by
+        :meth:`mark_consolidated` when the span finally lands. ``(0, 0.0)`` means
+        no failed attempt is on record — the common case — so callers can treat a
+        missing entry as "eligible now".
+
+        Read UNCACHED. The accounting is cross-process (a gateway sweep, the CLI,
+        a subagent all record failures for the same session), and every writer of
+        these fields restores the file's pre-write mtime so housekeeping does not
+        reorder ``list_sessions``. The metadata cache is keyed on mtime, so a warm
+        entry survives another process's write byte-for-byte and would serve a
+        stale attempt count — bypassing the backoff on the read path and, on the
+        read-increment-write path, overwriting the other process's durable count
+        with a lower one. Dropping the entry first costs one first-line read.
+
+        Metadata is caller-supplied JSON, so every conversion is defensive:
+        ``1e309`` parses to ``inf`` and ``int(inf)`` raises ``OverflowError``
+        (which would surface as a 500 from the manual trigger or break the idle
+        sweep), while a ``NaN`` deadline makes every ``now >= retry_at``
+        comparison false and disables consolidation for the session forever.
+        Non-finite and unconvertible values therefore reset to the eligible zero
+        state rather than propagating.
+        """
+        self._meta_cache.pop(key, None)
+        meta = self._read_metadata(key)
+        try:
+            attempts = int(meta.get("consolidation_attempts", 0) or 0)
+        except (TypeError, ValueError, OverflowError):
+            attempts = 0
+        try:
+            retry_at = float(meta.get("consolidation_retry_at", 0.0) or 0.0)
+        except (TypeError, ValueError, OverflowError):
+            retry_at = 0.0
+        if not math.isfinite(retry_at):
+            retry_at = 0.0
+        if attempts and not self._attempts_describe_current_span(meta, message_count):
+            # The counter belongs to a span that no longer exists: a rotation
+            # archived those messages (generation bumped), a rewrite reset the
+            # marker they started from, or the transcript has grown past the
+            # extent that was charged. The cap ABANDONS a span, so carrying a
+            # capped count onto different content would silence consolidation for
+            # this session permanently — every message written after that point
+            # would stay ineligible forever. The new span gets a fresh budget.
+            #
+            # The deadline is deliberately kept: a fresh budget is not a free
+            # immediate turn, so a session that keeps failing still waits out the
+            # backoff already armed (4 h at the cap) rather than re-billing the
+            # instant one more message lands.
+            attempts = 0
+        return max(0, attempts), retry_at
+
+    def _attempts_describe_current_span(
+        self, meta: dict, message_count: int | None
+    ) -> bool:
+        """True when the recorded attempts belong to the span in front of us now.
+
+        A span is identified by where it starts AND how far it reaches: the
+        ``(rotation_generation, last_consolidated)`` pair it was charged against
+        plus the message count that was actually attempted. While a span keeps
+        failing none of the three move — the marker is only advanced on success —
+        so the cap holds across attempts. Anything that changes the CONTENT under
+        the counter moves one of them: a rotation and a dashboard rewrite
+        (regenerate / rewind / fork) both advance the generation, a rewrite that
+        cannot apply a stale offset resets the marker, and new messages push the
+        transcript past the extent that was attempted.
+
+        The generation is what covers the edit that moves nothing else. A
+        regenerate replaces the assistant tail with a reply the failing turns
+        never saw and lands at the same message count, the same marker and the
+        same extent, so without the bump a capped budget would sit over brand-new
+        content and refuse it forever.
+
+        The extent matters because the cap is what ABANDONS a span, and it is only
+        reachable from :meth:`HistoryConsolidator.retry_eligible` when the
+        abandon-marker write itself failed. Without it, that one transient write
+        failure would refuse the session forever: appended messages leave the
+        generation and marker untouched, so every entry point would keep rejecting
+        a transcript that is no longer the one that failed, and the session's
+        history would never be consolidated again.
+
+        *message_count* is the transcript's CURRENT total, supplied by the caller.
+        It is never read from disk here: this predicate runs inside
+        ``retry_eligible`` on the gateway event loop, and a synchronous full-file
+        read there stalls every other gateway task on a large transcript. Callers
+        that already hold a count pass it (see :meth:`consolidation_counts`);
+        ``None`` means "no count available", which skips the extent test and keeps
+        the cap — the conservative direction, since the alternative is spending a
+        billed turn on an unverified premise.
+
+        Growth is compared with ``>`` rather than ``!=`` on purpose. A count that
+        SHRANK is a rotation or compaction, which already moves the generation or
+        the marker; treating a shrink as new content on its own would hand a
+        budget to a span with nothing added to it.
+
+        Unstamped accounting (written before a given field existed) is treated as
+        belonging to the current span, so an unknown provenance keeps the cap
+        rather than granting an unbounded supply of billed retries.
+
+        The stamp this compares against is the ATTEMPTED span, captured before the
+        turn (see :class:`AttemptedSpan`), which is what makes all three tests
+        meaningful: if the stamp were re-read after the turn it would describe the
+        transcript in front of us by construction, and every test here would
+        trivially match.
+        """
+        for meta_key, span_key in (
+            ("rotation_generation", "consolidation_attempts_generation"),
+            ("last_consolidated", "consolidation_attempts_offset"),
+        ):
+            if span_key not in meta:
+                continue
+            try:
+                if int(meta.get(span_key, 0) or 0) != int(meta.get(meta_key, 0) or 0):
+                    return False
+            except (TypeError, ValueError, OverflowError):
+                # Unreadable stamp — fall back to keeping the cap.
+                continue
+        if message_count is not None and "consolidation_attempts_count" in meta:
+            try:
+                attempted = int(meta.get("consolidation_attempts_count", 0) or 0)
+            except (TypeError, ValueError, OverflowError):
+                return True
+            if message_count > attempted:
+                return False
+        return True
+
+    def _current_span_fields(self, span: AttemptedSpan) -> dict:
+        """The span-identity stamp to store beside a freshly charged attempt.
+
+        Every field comes from *span* — the consolidation's own pre-turn snapshot
+        (see :class:`AttemptedSpan`) — and NOTHING is re-read from the metadata
+        line here. The stamp must describe the span the turn actually attempted,
+        and the metadata line at failure time describes the transcript as it is
+        *now*, which a rotation or a marker-resetting rewrite during the turn has
+        already changed.
+        The clamps are the only normalization: *span* is typed, and its values come
+        from a snapshot's own ``len()``/generation reads, so there is nothing to
+        coerce — but a negative offset or count would be nonsense to stamp.
+        """
+        return {
+            "consolidation_attempts_generation": span.generation,
+            "consolidation_attempts_offset": max(0, span.offset),
+            "consolidation_attempts_count": max(0, span.total),
+        }
+
+    def record_consolidation_failure(
+        self,
+        key: str,
+        base_secs: float,
+        max_secs: float,
+        span: AttemptedSpan,
+        now: float | None = None,
+    ) -> tuple[int, float]:
+        """Durably count one failed consolidation attempt for *key*.
+
+        *span* is the identity of what the failing turn actually attempted, taken
+        from the pre-turn snapshot (see :class:`AttemptedSpan`). It serves twice:
+        as the stamp written beside the counter, and as the span the existing
+        counter is compared against — so a turn that attempted a DIFFERENT span
+        starts a fresh budget while one attempting the same span increments toward
+        the cap. Nothing about the span is re-read from the file here, so a
+        rotation or rewrite that landed during the turn cannot relabel this charge
+        as belonging to content it never measured.
+
+        Returns the new ``(attempts, next_eligible_at)``. The wait doubles per
+        attempt from *base_secs*, capped at *max_secs*, so a persistently broken
+        span costs a geometrically shrinking number of billed LLM turns instead
+        of one per heartbeat tick.
+
+        The read-increment-write runs under a single :meth:`_locked` hold: two
+        processes consolidating the same session (gateway sweep and CLI) would
+        otherwise both read the same count and write the same value, letting the
+        span consume unbounded attempts while the counter sits still. The read
+        inside is uncached for the same reason (see
+        :meth:`consolidation_retry_state`) — an mtime-preserving write by the
+        other process is invisible to a warm cache.
+
+        Returns ``(0, 0.0)`` without writing when the session's transcript is gone
+        (deleted while the consolidation was in flight): ``_update_metadata_locked``
+        upserts, so writing would resurrect the session as an empty metadata-only
+        file. Blocking file IO — call it off the event loop.
+        """
+        stamp = _time.time() if now is None else now
+        with self._locked(key):
+            if not self._path(key).exists():
+                # The session was deleted while this consolidation was in flight.
+                # _update_metadata_locked upserts, so writing here would recreate
+                # the transcript as a metadata-only file — resurrecting a deleted
+                # session as empty history in list_sessions. Nothing to account
+                # for: the span it described is gone.
+                logger.info(
+                    "Skipping consolidation retry accounting for %s: session deleted",
+                    key,
+                )
+                return 0, 0.0
+            attempts = self.consolidation_retry_state(key, span.total)[0] + 1
+            # The exponent comes from caller-supplied metadata, so clamp it before
+            # shifting: an absurd stored count would otherwise make ``2 ** n``
+            # allocate a huge int (or raise) instead of returning a wait. The
+            # backoff saturates at *max_secs* far below the clamp, so no reachable
+            # attempt count is affected.
+            retry_at = stamp + min(max_secs, base_secs * (2 ** min(attempts - 1, 64)))
+            self._update_metadata_locked(
+                key,
+                {
+                    "consolidation_attempts": attempts,
+                    "consolidation_retry_at": retry_at,
+                    # Bind the count to the span it was charged against — where it
+                    # starts and how far it reaches — so a rotation, a rewrite, or
+                    # a grown transcript cannot leave a capped counter sitting over
+                    # content it never measured (see
+                    # _attempts_describe_current_span). Every field comes from the
+                    # pre-turn snapshot, never from the file as it stands now, and
+                    # is written in the SAME locked update as the counter, so no
+                    # window exists where the count is charged but its span is
+                    # unidentified or misidentified.
+                    **self._current_span_fields(span),
+                },
+            )
+        return attempts, retry_at
+
+    def record_consolidation_environment_failure(
+        self,
+        key: str,
+        base_secs: float,
+        max_secs: float,
+        now: float | None = None,
+    ) -> tuple[int, float]:
+        """Arm the backoff for a consolidation that never reached the provider.
+
+        Counted separately from :meth:`record_consolidation_failure` because the
+        two failures have different costs. A spent turn costs money, so its
+        counter feeds a hard abandon cap. A pre-dispatch failure — no session
+        manager, or kiro-cli failing to start — costs nothing, so it must never
+        abandon a span: doing so would write the durable marker over messages no
+        LLM has ever read. It still needs a deadline, or a permanently broken host
+        re-attempts on every 60s heartbeat tick forever, so the count drives the
+        same widening wait up to *max_secs* and then holds there.
+
+        Returns the new ``(environment_failures, next_eligible_at)``. Same single
+        locked read-increment-write and same deleted-session guard as the billed
+        path. Blocking file IO — call it off the event loop.
+        """
+        stamp = _time.time() if now is None else now
+        with self._locked(key):
+            if not self._path(key).exists():
+                return 0, 0.0
+            meta = self._read_metadata(key)
+            try:
+                failures = int(meta.get("consolidation_env_failures", 0) or 0)
+            except (TypeError, ValueError, OverflowError):
+                failures = 0
+            failures = max(0, failures) + 1
+            retry_at = stamp + min(max_secs, base_secs * (2 ** min(failures - 1, 64)))
+            self._update_metadata_locked(
+                key,
+                {
+                    "consolidation_env_failures": failures,
+                    "consolidation_retry_at": retry_at,
+                },
+            )
+        return failures, retry_at
 
     def load_transcript(self, key: str) -> str:
         """Load full session as formatted text for LLM summarization."""
@@ -3115,7 +3595,11 @@ class ConversationLog:
                 _archive_lines(key, dropped, reason="compact", base=self._dir)
             except Exception:
                 logger.warning("Failed to archive dropped lines for %s", key, exc_info=True)
-        # Preserve select fields from original metadata
+        # Rebuild only the fields compaction owns; everything else on the metadata
+        # line belongs to another layer (the rotation generation an in-flight
+        # consolidation checks, its retry accounting, the slot's title/agent/pin)
+        # and is carried through verbatim. Enumerating what to keep is how those
+        # fields got dropped in the first place.
         orig_meta = self.get_metadata(key) or {}
         meta = {
             "_type": "metadata",
@@ -3123,13 +3607,7 @@ class ConversationLog:
             "last_consolidated": orig_meta.get("last_consolidated", 0),
             "compacted_at": metadata_now_iso(),
         }
-        # Carry the rotation generation forward so a compaction (which is NOT a
-        # rotation) doesn't reset it to 0 and spuriously trip the generation
-        # mismatch in mark_consolidated for an in-flight consolidation.
-        if orig_meta.get("rotation_generation"):
-            meta["rotation_generation"] = orig_meta["rotation_generation"]
-        if orig_meta.get("memory_mode"):
-            meta["memory_mode"] = orig_meta["memory_mode"]
+        carry_unowned_metadata(meta, orig_meta, _COMPACT_OWNED_META_KEYS)
         lines = [json.dumps(meta) + "\n"]
         for m in messages:
             lines.append(json.dumps(m) + "\n")
@@ -3443,6 +3921,141 @@ class HistoryConsolidator:
         # swaps the window's content) still forces a fresh pass.
         self._last_skillgen_marker: dict[str, tuple[int, int]] = {}
 
+    def retry_eligible(
+        self, key: str, now: float | None = None, message_count: int | None = None
+    ) -> bool:
+        """True when *key* may spend a billed consolidation turn right now.
+
+        Every automatic entry point consults this so a span whose consolidation
+        keeps failing backs off instead of re-billing an LLM turn on each sweep.
+        A span at :data:`_CONSOLIDATION_MAX_ATTEMPTS` is refused: the abandon path
+        normally writes the marker (which also clears the accounting), so reaching
+        here at the cap means even that write failed, and refusing keeps a broken
+        span from spending forever.
+
+        That refusal covers the SPAN, not the session. The cap is scoped to the
+        content it measured, so a rotation or new messages release it with a fresh
+        bounded budget (see
+        :meth:`ConversationLog._attempts_describe_current_span`) — otherwise one
+        transient marker-write failure would stop this session from ever
+        consolidating again.
+
+        Costs one metadata-line read and NO transcript read: this runs on the
+        gateway event loop (heartbeat sweep, expiry, dashboard trigger), where a
+        synchronous full-file read would stall every other gateway task on a large
+        transcript. *message_count* is the transcript's current total, which every
+        automatic caller already holds from its own
+        :meth:`ConversationLog.consolidation_counts` call; omitting it skips the
+        extent test and keeps the cap.
+        """
+        attempts, retry_at = self._log.consolidation_retry_state(key, message_count)
+        if attempts >= _CONSOLIDATION_MAX_ATTEMPTS:
+            return False
+        return (_time.time() if now is None else now) >= retry_at
+
+    async def _note_failed_attempt(
+        self, key: str, span: AttemptedSpan, reason: str
+    ) -> None:
+        """Charge one attempt for a billed turn that never reached the marker.
+
+        Called only once the prompt has actually reached the provider, so a
+        pre-dispatch failure (no session manager, kiro-cli failing to start) and a
+        cheap pre-call failure (snapshot, metadata read) both keep their free
+        retry. At the attempt cap the durable marker is written anyway and the span
+        is abandoned with a warning: the alternative is re-billing this failure
+        indefinitely.
+
+        *span* is the pre-turn snapshot identity (see :class:`AttemptedSpan`), used
+        both to stamp the charge and to place the abandon marker — the same values
+        for both, so the marker cannot be written for a span other than the one the
+        cap was reached on.
+        """
+        try:
+            attempts, retry_at = await asyncio.to_thread(
+                self._log.record_consolidation_failure,
+                key,
+                _CONSOLIDATION_BACKOFF_BASE_SECS,
+                _CONSOLIDATION_BACKOFF_MAX_SECS,
+                span,
+            )
+        except Exception:
+            # Without a persisted count the sweep cannot back off, so say so
+            # loudly — but never let bookkeeping mask the original failure.
+            logger.warning(
+                "Could not persist consolidation retry state for %s", key, exc_info=True
+            )
+            return
+        if attempts < 1:
+            # The session was deleted mid-consolidation, so nothing was recorded
+            # and there is no span left to abandon.
+            return
+        if attempts < _CONSOLIDATION_MAX_ATTEMPTS:
+            logger.warning(
+                "Consolidation attempt %d/%d failed for %s (%s); "
+                "next attempt in %.0fs",
+                attempts,
+                _CONSOLIDATION_MAX_ATTEMPTS,
+                key,
+                reason,
+                max(0.0, retry_at - _time.time()),
+            )
+            return
+        logger.warning(
+            "Abandoning consolidation for %s after %d failed attempts (%s): "
+            "marking %d messages consolidated WITHOUT a memory pass, so this "
+            "span's history/preferences/lessons are not extracted",
+            key,
+            attempts,
+            reason,
+            span.total,
+        )
+        try:
+            await asyncio.to_thread(
+                self._log.mark_consolidated, key, span.total, span.generation
+            )
+        except Exception:
+            # The count stays at the cap, so retry_eligible() keeps refusing —
+            # the span stops spending even though the marker is missing.
+            logger.warning(
+                "Could not mark abandoned consolidation for %s", key, exc_info=True
+            )
+
+    async def _note_environment_failure(self, key: str, reason: str) -> None:
+        """Arm the backoff for a consolidation that never reached the provider.
+
+        Deliberately does NOT touch the attempt cap. A pre-dispatch failure spends
+        nothing, so abandoning the span over one would write the durable marker
+        over messages no LLM has ever read — losing a memory pass to a broken
+        kiro-cli install rather than to a genuinely unprocessable span. The
+        environment counter only widens the retry interval, so a permanently broken
+        host settles at the backoff ceiling instead of re-attempting every tick.
+        """
+        try:
+            failures, retry_at = await asyncio.to_thread(
+                self._log.record_consolidation_environment_failure,
+                key,
+                _CONSOLIDATION_BACKOFF_BASE_SECS,
+                _CONSOLIDATION_BACKOFF_MAX_SECS,
+            )
+        except Exception:
+            logger.warning(
+                "Could not persist consolidation environment backoff for %s",
+                key,
+                exc_info=True,
+            )
+            return
+        if failures < 1:
+            return
+        logger.warning(
+            "Consolidation for %s could not reach the LLM (%s; environment "
+            "failure #%d, nothing billed); retrying in %.0fs without consuming "
+            "the attempt budget",
+            key,
+            reason,
+            failures,
+            max(0.0, retry_at - _time.time()),
+        )
+
     def maybe_consolidate(self, key: str) -> None:
         """Fire preferences/projects consolidation if message threshold exceeded."""
         self._last_activity[key] = _time.time()
@@ -3467,11 +4080,20 @@ class HistoryConsolidator:
         """Check all tracked sessions for idle-based history consolidation."""
         now = _time.time()
         for key, last in list(self._last_activity.items()):
+            if now - last < self._history_idle_secs:
+                continue
+            total, unconsolidated = self._log.consolidation_counts(key)
             if (
-                now - last < self._history_idle_secs
-                or self._log.unconsolidated_count(key) < 1
+                unconsolidated < 1
                 or now - self._history_consolidated.get(key, 0) < self._history_idle_secs
                 or key in self._running
+                # Durable backoff, checked last so it only costs a metadata read
+                # once the cheap conditions pass. The in-memory throttle above is
+                # set only when the task ends without an exception and is lost on
+                # restart, so it alone cannot stop a repeatedly failing span from
+                # re-billing an LLM turn every tick. *total* comes from the read
+                # above, so the check adds no transcript read on the loop.
+                or not self.retry_eligible(key, now, message_count=total)
             ):
                 continue
             self._running.add(key)
@@ -3495,7 +4117,8 @@ class HistoryConsolidator:
 
         Used by session-end hooks (dashboard close, Slack end, idle expiry)
         and the ``kirocrew consolidate`` CLI command.  Skips if the session
-        is already being consolidated or has no unconsolidated messages.
+        is already being consolidated, has no unconsolidated messages, or is
+        inside the durable consolidation retry backoff.
 
         Safety: skill detection (_run_skill_detection) re-checks
         _session_touched_sensitive() over its window before proposing anything,
@@ -3503,7 +4126,17 @@ class HistoryConsolidator:
         """
         if key in self._running:
             return
-        if self._log.unconsolidated_count(key) < 1:
+        total, unconsolidated = self._log.consolidation_counts(key)
+        if unconsolidated < 1:
+            return
+        # This path consults no time-based throttle at all — every session expiry
+        # for the same key fires a fresh consolidation — so the durable backoff is
+        # the only thing standing between a repeatedly failing span and one billed
+        # LLM turn per expiry.
+        if not self.retry_eligible(key, message_count=total):
+            logger.info(
+                "consolidate_session skipped for %s: consolidation retry backoff", key
+            )
             return
         # Short-circuit sensitive sessions before scheduling a task
         messages = self._log._read_messages(key)
@@ -3551,6 +4184,16 @@ class HistoryConsolidator:
         # Capture the gateway loop so the thread-offloaded _process_auto_skills
         # can schedule the async dedupe judge back onto it.
         self._event_loop = asyncio.get_running_loop()
+        # Flipped once the prompt actually reaches the provider, which is what
+        # makes a failure expensive: everything before that point is free to
+        # retry, everything after costs a turn that produced nothing durable.
+        billed = False
+        total = 0
+        generation_at_snapshot = 0
+        # The span identity any failure charge is stamped with. Rebuilt from the
+        # snapshot below; the zero value only ever reaches a charge if the snapshot
+        # itself raised, and that path is not billed.
+        attempted = AttemptedSpan(0, 0, 0)
         try:
             # Atomically snapshot the unconsolidated tail, the total message
             # count (the absolute offset handed to mark_consolidated below), and
@@ -3569,6 +4212,17 @@ class HistoryConsolidator:
             ) = await asyncio.to_thread(self._log.snapshot_for_consolidation, key)
             if not unconsolidated:
                 return
+            # Freeze the whole span identity from that one snapshot. The offset is
+            # derived rather than returned because the snapshot slices at it
+            # (``messages[offset:]``), so the subtraction is exact and comes from
+            # the same lock hold — no second read that a concurrent rotation could
+            # land between. A failure charge stamped with these values describes
+            # what the turn attempted even if the file changed underneath it.
+            attempted = AttemptedSpan(
+                total=total,
+                generation=generation_at_snapshot,
+                offset=total - len(unconsolidated),
+            )
 
             # Resolve workspace-scoped memory from session metadata
             meta = self._log.get_metadata(key)
@@ -3682,8 +4336,30 @@ class HistoryConsolidator:
             prompt_parts.append("\n\nRespond with ONLY valid JSON, no markdown fences.")
             prompt = "".join(prompt_parts)
 
-            result = await self._call_llm(prompt)
+            try:
+                result = await self._call_llm(prompt)
+            except _ConsolidationNotDispatched as exc:
+                # Nothing was sent, so nothing was billed. Charging this to the
+                # attempt cap would let a handful of environment failures abandon
+                # the span — writing the durable marker over messages no LLM has
+                # ever read, which is the exact false-abandonment this accounting
+                # exists to prevent. Arm the backoff only, so a broken host retries
+                # on a widening interval instead of on every 60s tick.
+                if include_history:
+                    await self._note_environment_failure(key, str(exc))
+                return
+            billed = True
             if not result:
+                # The turn reached the provider and produced nothing usable, so it
+                # was spent while the marker below stays unwritten. Returning
+                # silently would look like success to the done-callbacks, setting
+                # the in-memory throttle while the durable count still says
+                # unconsolidated: the span re-bills a full turn every idle window,
+                # and immediately after every restart. Charge the attempt.
+                if include_history:
+                    await self._note_failed_attempt(
+                        key, attempted, "empty LLM result"
+                    )
                 return
 
             if entry := result.get("history_entry"):
@@ -3773,6 +4449,15 @@ class HistoryConsolidator:
 
         except Exception:
             logger.exception("Consolidation failed for %s", key)
+            # Anything raised between the LLM call and mark_consolidated (memory
+            # writes, lesson writes, the marker write itself) re-raises, so the
+            # idle sweep's done-callback never sets its throttle and all of its
+            # skip conditions are false again on the next 60s tick. Charging the
+            # attempt here is what converts that tight loop into backoff.
+            if billed and include_history:
+                await self._note_failed_attempt(
+                    key, attempted, "exception after the LLM call"
+                )
             raise
         finally:
             self._running.discard(key)
@@ -3878,7 +4563,13 @@ class HistoryConsolidator:
             + "\n\n## Session excerpt\n" + conversation
             + "\n\nRespond with ONLY valid JSON, no markdown fences."
         )
-        result = await self._call_llm(prompt)
+        try:
+            result = await self._call_llm(prompt)
+        except _ConsolidationNotDispatched:
+            # Skill detection is best-effort and owns no retry accounting, so an
+            # unreachable provider is simply no detection this pass. The marker
+            # below is still recorded, matching the existing failed-turn path.
+            result = None
         # Record the (generation, count) marker regardless of outcome so an
         # unchanged session isn't re-evaluated on every subsequent
         # consolidation, but a rotation still forces a fresh pass.
@@ -4590,11 +5281,26 @@ class HistoryConsolidator:
         """Call LLM for consolidation via the persistent background session.
 
         Uses the shared background kiro-cli process (no spawn/teardown cost).
-        Returns parsed JSON dict or None on failure.
+        Returns the parsed JSON dict, or ``None`` when the turn reached the
+        provider but produced nothing usable (a failed or unparsable answer).
+
+        Raises :class:`_ConsolidationNotDispatched` when the prompt never reached
+        the provider at all — no session manager, or the background session could
+        not be acquired because kiro-cli is missing, not logged in, or failing to
+        start. That case is signalled separately rather than folded into ``None``
+        because the two cost different things: a spent turn costs money and must
+        consume the caller's retry budget, while a prompt that was never sent costs
+        nothing and must not, or a broken host would abandon spans it never read.
+        An exception (rather than a flag beside the result) is used so a caller
+        cannot silently drop the distinction.
+
+        Once ``stream_and_collect_json`` is entered the prompt counts as sent: a
+        failure inside it may still have been billed, so it returns ``None`` and is
+        charged rather than risk an unbounded retry loop over real spend.
         """
         if not self._sessions:
             logger.warning("LLM consolidation skipped — no session manager")
-            return None
+            raise _ConsolidationNotDispatched("no session manager")
 
         session_key = BACKGROUND_KEY
         # Timing instrumentation (_bg stall investigation): measure both the
@@ -4605,9 +5311,20 @@ class HistoryConsolidator:
         # consolidation stall.
         t_start = _time.monotonic()
         try:
-            client, _is_new, _resumed = await self._sessions.get_or_create(
-                session_key, agent="kirocrew-lite"
-            )
+            try:
+                client, _is_new, _resumed = await self._sessions.get_or_create(
+                    session_key, agent="kirocrew-lite"
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Consolidation could not acquire the background session "
+                    "after %.1fs — nothing was sent",
+                    _time.monotonic() - t_start,
+                    exc_info=True,
+                )
+                raise _ConsolidationNotDispatched(
+                    "background session unavailable"
+                ) from exc
             t_acquired = _time.monotonic()
             wait_s = t_acquired - t_start
             # Reject all tools: this is a text/JSON-only generation turn. kiro
@@ -4616,9 +5333,17 @@ class HistoryConsolidator:
             # kirocrew-core/cron toolset — without REJECT_ALL a background
             # consolidation turn could fire side-effecting tools (send_message,
             # learn_add, spawn_run). REJECT_ALL keeps both providers tool-free.
-            result = await stream_and_collect_json(
-                client, prompt, approval_policy=ToolApprovalPolicy.REJECT_ALL
-            )
+            try:
+                result = await stream_and_collect_json(
+                    client, prompt, approval_policy=ToolApprovalPolicy.REJECT_ALL
+                )
+            except Exception:
+                logger.warning(
+                    "LLM consolidation turn failed after %.1fs",
+                    _time.monotonic() - t_start,
+                    exc_info=True,
+                )
+                return None
             turn_s = _time.monotonic() - t_acquired
             logger.debug(
                 "Consolidation LLM turn: wait=%.1fs turn=%.1fs total=%.1fs ok=%s",
@@ -4628,13 +5353,6 @@ class HistoryConsolidator:
                 result is not None,
             )
             return result
-        except Exception:
-            logger.warning(
-                "LLM consolidation call failed after %.1fs",
-                _time.monotonic() - t_start,
-                exc_info=True,
-            )
-            return None
         finally:
             self._sessions.release(session_key)
             await self._sessions.recycle_background()

--- a/test/test_history_consolidation_retry.py
+++ b/test/test_history_consolidation_retry.py
@@ -1,0 +1,1599 @@
+"""Persistent retry accounting for history consolidation.
+
+A consolidation pass spends a billed LLM turn before it can write the durable
+``last_consolidated`` marker, so a failure in between leaves the span
+unconsolidated. Without durable accounting every entry point then re-spends that
+turn indefinitely — the 60s idle sweep on every tick, session-expiry sweeps on
+every expiry, and every gateway restart (the in-memory throttle is memory-only).
+These tests pin the attempt counter, the exponential backoff, the abandon cap,
+and that no entry point bypasses them.
+"""
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew import history as history_mod
+from kiro_crew.dashboard.chat_persistence import (
+    _rehydrate_slot_from_history,
+    _save_slot_to_history,
+)
+from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.history import (
+    _CONSOLIDATION_BACKOFF_BASE_SECS,
+    _CONSOLIDATION_MAX_ATTEMPTS,
+    ConversationLog,
+    HistoryConsolidator,
+)
+
+KEY = "dashboard:chat-retry"
+
+
+def _seed_log(tmp_path, key: str = KEY, count: int = 3) -> ConversationLog:
+    """A real transcript with *count* unconsolidated messages."""
+    log = ConversationLog(base_dir=tmp_path / "sessions")
+    log.init()
+    # These tests run on the event loop; the mutations under test are the
+    # production ones (offloaded inside _consolidate), not this fixture setup.
+    with history_mod.allow_on_loop_persist():
+        for i in range(count):
+            log.append(key, "user", f"m{i}")
+    return log
+
+
+def _make_consolidator(log: ConversationLog, **kw: Any) -> HistoryConsolidator:
+    memory = MagicMock()
+    memory.read_preferences.return_value = ""
+    memory.read_projects.return_value = ""
+    kw.setdefault("history_idle_secs", 0)
+    kw.setdefault("sessions", None)
+    return HistoryConsolidator(log=log, memory=memory, migrated=True, **kw)
+
+
+def _total(log: ConversationLog, key: str = KEY) -> int:
+    """The transcript's current message total, as an entry point would supply it."""
+    return log.consolidation_counts(key)[0]
+
+
+def _span(
+    log: ConversationLog, total: int | None = None, key: str = KEY
+) -> history_mod.AttemptedSpan:
+    """The span identity a turn over the CURRENT transcript would attempt.
+
+    Mirrors what ``_consolidate`` freezes from its pre-turn snapshot, so a test
+    charging a failure by hand stamps the same identity production would.
+    """
+    meta = log.get_metadata(key)
+    return history_mod.AttemptedSpan(
+        total=_total(log, key) if total is None else total,
+        generation=int(meta.get("rotation_generation", 0) or 0),
+        offset=int(meta.get("last_consolidated", 0) or 0),
+    )
+
+
+def _eligible(c: HistoryConsolidator, log: ConversationLog, now=None) -> bool:
+    """retry_eligible with the count its callers already hold."""
+    return c.retry_eligible(KEY, now, message_count=_total(log))
+
+
+def _dashboard_state(log: ConversationLog) -> DashboardState:
+    """A DashboardState wired to *log* — enough for the slot rehydrate/save paths."""
+    sessions = MagicMock(count=0)
+    sessions.get_pid = MagicMock(return_value=None)
+    sessions.channel_key_for_stem = MagicMock(return_value=None)
+    return DashboardState(
+        sessions=sessions,
+        crons=MagicMock(
+            list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})
+        ),
+        lessons=MagicMock(load_all=MagicMock(return_value=[])),
+        start_time=0.0,
+        conversation_log=log,
+    )
+
+
+def _plant_raw_meta(log: ConversationLog, key: str, raw_fields: str) -> None:
+    """Splice RAW JSON text into the metadata line.
+
+    Goes around ``json.dumps`` on purpose: the hostile inputs are literals a
+    serializer will not emit (``1e309``, a bare ``NaN``, ``"NaN"`` as a string),
+    and they are exactly what a hand-edited or foreign-written transcript can
+    carry.
+    """
+    path = log._path(key)
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    meta_txt = lines[0].strip()
+    assert meta_txt.endswith("}")
+    lines[0] = f"{meta_txt[:-1]},{raw_fields}}}\n"
+    path.write_text("".join(lines), encoding="utf-8")
+    log._invalidate_cache(key)
+
+
+class _FakeRequest:
+    """Minimal aiohttp request stand-in for the manual consolidate handler."""
+
+    def __init__(self, state: Any, body: dict) -> None:
+        self.app = {"state": state}
+        self.headers: dict[str, str] = {}
+        self._body = body
+
+    async def json(self) -> dict:
+        return self._body
+
+
+class TestFailureAfterTheBilledCall:
+    @pytest.mark.asyncio
+    async def test_exception_after_llm_call_does_not_retry_on_the_next_tick(
+        self, tmp_path
+    ):
+        """A raise between the LLM call and the marker must arm backoff.
+
+        The idle sweep's done-callback only sets its in-memory throttle when the
+        task ends WITHOUT an exception, so on a raise all of check_idle_sessions'
+        skip conditions are false again 60s later — a fresh billed turn per tick,
+        forever. The durable counter is the only thing that stops it.
+        """
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        c._last_activity[KEY] = time.time() - 10
+
+        with patch.object(
+            c, "_call_llm", AsyncMock(return_value={"history_entry": "x"})
+        ), patch.object(log, "mark_consolidated", side_effect=RuntimeError("disk full")):
+            c.check_idle_sessions()
+            assert c._tasks, "idle sweep did not schedule a consolidation"
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+        attempts, retry_at = log.consolidation_retry_state(KEY)
+        assert attempts == 1
+        assert retry_at > time.time()
+        # The span is still unconsolidated, and the throttle was never set —
+        # backoff is the sole remaining gate.
+        assert log.unconsolidated_count(KEY) == 3
+        assert KEY not in c._history_consolidated
+
+        c._tasks.clear()
+        c.check_idle_sessions()
+        assert not c._tasks, "consolidation re-fired while inside the backoff window"
+
+    @pytest.mark.asyncio
+    async def test_a_failure_before_the_llm_call_does_not_consume_budget(
+        self, tmp_path
+    ):
+        """Nothing was billed yet, so the attempt is free."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(
+            log, "snapshot_for_consolidation", side_effect=RuntimeError("io error")
+        ):
+            with pytest.raises(RuntimeError):
+                await c._consolidate(KEY, include_history=True)
+
+        assert log.consolidation_retry_state(KEY) == (0, 0.0)
+
+    @pytest.mark.asyncio
+    async def test_none_result_consumes_an_attempt(self, tmp_path):
+        """_call_llm swallows every exception and returns None.
+
+        _consolidate's bare ``return`` on a falsy result happens BEFORE the
+        marker write, so the task looks successful (throttle set) while the
+        durable count still says unconsolidated. Treat it as a failed attempt.
+        """
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(c, "_call_llm", AsyncMock(return_value=None)):
+            await c._consolidate(KEY, include_history=True)
+
+        attempts, retry_at = log.consolidation_retry_state(KEY)
+        assert attempts == 1
+        assert retry_at > time.time()
+        assert log.unconsolidated_count(KEY) == 3
+
+    @pytest.mark.asyncio
+    async def test_backoff_doubles_per_attempt(self, tmp_path):
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(c, "_call_llm", AsyncMock(return_value=None)):
+            await c._consolidate(KEY, include_history=True)
+            first = log.consolidation_retry_state(KEY)[1] - time.time()
+            with history_mod.allow_on_loop_persist():
+                log.update_metadata(KEY, {"consolidation_retry_at": 0.0})
+            await c._consolidate(KEY, include_history=True)
+            second = log.consolidation_retry_state(KEY)[1] - time.time()
+
+        assert first == pytest.approx(_CONSOLIDATION_BACKOFF_BASE_SECS, abs=5)
+        assert second == pytest.approx(2 * _CONSOLIDATION_BACKOFF_BASE_SECS, abs=5)
+
+
+class TestAttemptCap:
+    @pytest.mark.asyncio
+    async def test_cap_abandons_the_span_with_the_durable_marker(self, tmp_path):
+        """At the cap the marker is written anyway, ending the spend."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": _CONSOLIDATION_MAX_ATTEMPTS - 1,
+                    "consolidation_retry_at": 0.0,
+                },
+            )
+
+        with patch.object(c, "_call_llm", AsyncMock(return_value=None)):
+            await c._consolidate(KEY, include_history=True)
+
+        assert log.unconsolidated_count(KEY) == 0, (
+            "abandoned span left unmarked — it will re-bill a turn on the next "
+            "tick and after every restart"
+        )
+        # The marker releases the budget in the same write, so the NEXT span is
+        # not charged for this one's failures.
+        assert log.consolidation_retry_state(KEY) == (0, 0.0)
+        c._last_activity[KEY] = time.time() - 10
+        c._tasks.clear()
+        c.check_idle_sessions()
+        assert not c._tasks
+
+    @pytest.mark.asyncio
+    async def test_cap_without_a_marker_write_stays_ineligible(self, tmp_path):
+        """If even the abandon write fails, the span must stop spending."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": _CONSOLIDATION_MAX_ATTEMPTS,
+                    "consolidation_retry_at": 0.0,
+                },
+            )
+
+        assert c.retry_eligible(KEY) is False
+
+
+class TestSuccessClearsTheAccounting:
+    @pytest.mark.asyncio
+    async def test_marking_a_span_releases_its_retry_budget(self, tmp_path):
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(c, "_call_llm", AsyncMock(return_value=None)):
+            await c._consolidate(KEY, include_history=True)
+        assert log.consolidation_retry_state(KEY)[0] == 1
+
+        with patch.object(
+            c, "_call_llm", AsyncMock(return_value={"history_entry": "ok"})
+        ):
+            with history_mod.allow_on_loop_persist():
+                log.update_metadata(KEY, {"consolidation_retry_at": 0.0})
+            await c._consolidate(KEY, include_history=True)
+
+        assert log.unconsolidated_count(KEY) == 0
+        assert log.consolidation_retry_state(KEY) == (0, 0.0)
+
+
+class TestAccountingSurvivesARestart:
+    @pytest.mark.asyncio
+    async def test_a_fresh_consolidator_reads_the_persisted_backoff(self, tmp_path):
+        """The in-memory throttle is lost on restart; the counter is not."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        c._last_activity[KEY] = time.time() - 10
+
+        with patch.object(c, "_call_llm", AsyncMock(return_value=None)):
+            await c._consolidate(KEY, include_history=True)
+        assert log.consolidation_retry_state(KEY)[0] == 1
+
+        # Simulate a gateway restart: brand-new log + consolidator over the same
+        # session directory, with every in-memory dict empty.
+        fresh_log = ConversationLog(base_dir=tmp_path / "sessions")
+        fresh = _make_consolidator(fresh_log)
+        fresh._last_activity[KEY] = time.time() - 10
+        assert not fresh._history_consolidated
+
+        assert fresh.retry_eligible(KEY) is False
+        fresh.check_idle_sessions()
+        assert not fresh._tasks, "restart re-billed a turn for a backed-off span"
+
+
+class TestTheAccountingIsReadUncached:
+    """The accounting is cross-process, and its writers preserve the file mtime.
+
+    A gateway sweep, the CLI and a subagent all record failures for the same
+    session. Every writer of these fields restores the pre-write mtime so
+    housekeeping does not reorder ``list_sessions`` — which means the mtime-keyed
+    metadata cache cannot notice another process's write.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_second_writers_count_is_not_hidden_by_a_warm_cache(
+        self, tmp_path
+    ):
+        log = _seed_log(tmp_path)
+        # A separate ConversationLog over the same directory stands in for the
+        # other process — its own caches, its own view of the file.
+        other = ConversationLog(base_dir=tmp_path / "sessions")
+
+        path = log._path(KEY)
+        # Warm this process's metadata cache the way the idle sweep does: it calls
+        # unconsolidated_count (which caches the metadata line) immediately before
+        # consulting the backoff.
+        log.unconsolidated_count(KEY)
+        assert log._meta_cache.get(KEY) is not None
+        mtime_before = path.stat().st_mtime
+
+        with history_mod.allow_on_loop_persist():
+            other.record_consolidation_failure(KEY, 900.0, 86400.0, _span(other))
+
+        assert path.stat().st_mtime == mtime_before, (
+            "premise broken: the write advanced the mtime, so the cache would "
+            "have self-invalidated and this test proves nothing"
+        )
+
+        attempts, retry_at = log.consolidation_retry_state(KEY)
+        assert attempts == 1, "a stale cached count hid the other process's failure"
+        assert retry_at > time.time()
+
+    @pytest.mark.asyncio
+    async def test_the_increment_builds_on_the_other_writers_count(self, tmp_path):
+        """A stale read would overwrite the durable count with a lower one."""
+        log = _seed_log(tmp_path)
+        other = ConversationLog(base_dir=tmp_path / "sessions")
+        # Frozen before the deliberate cache warm below, so reading the span does
+        # not itself touch this process's caches.
+        span = _span(log)
+
+        with history_mod.allow_on_loop_persist():
+            other.record_consolidation_failure(KEY, 900.0, 86400.0, span)
+            other.record_consolidation_failure(KEY, 900.0, 86400.0, span)
+            log.unconsolidated_count(KEY)  # warm this process's cache
+            attempts, _ = log.record_consolidation_failure(KEY, 900.0, 86400.0, span)
+
+        assert attempts == 3
+        assert other.consolidation_retry_state(KEY)[0] == 3
+
+    @pytest.mark.asyncio
+    async def test_a_backed_off_span_is_not_re_fired_from_a_warm_cache(
+        self, tmp_path
+    ):
+        """End to end: the idle sweep must see the other process's backoff."""
+        log = _seed_log(tmp_path)
+        other = ConversationLog(base_dir=tmp_path / "sessions")
+        c = _make_consolidator(log)
+        c._last_activity[KEY] = time.time() - 10
+
+        log.unconsolidated_count(KEY)
+        with history_mod.allow_on_loop_persist():
+            other.record_consolidation_failure(KEY, 900.0, 86400.0, _span(other))
+
+        c.check_idle_sessions()
+        assert not c._tasks, (
+            "the sweep billed an LLM turn for a span another process had just "
+            "put into backoff"
+        )
+
+
+class TestHostileMetadataDoesNotBreakTheGate:
+    """Metadata is caller-supplied JSON; the conversions must fail safe."""
+
+    @pytest.mark.asyncio
+    async def test_an_overflowing_attempt_count_reads_as_zero(self, tmp_path):
+        """``1e309`` parses to ``inf``, and ``int(inf)`` raises OverflowError."""
+        log = _seed_log(tmp_path)
+        _plant_raw_meta(log, KEY, '"consolidation_attempts": 1e309')
+
+        assert log.consolidation_retry_state(KEY) == (0, 0.0)
+        assert _make_consolidator(log).retry_eligible(KEY) is True
+
+    @pytest.mark.asyncio
+    async def test_a_huge_integer_deadline_reads_as_zero(self, tmp_path):
+        """An integer too large for a float raises OverflowError from float()."""
+        log = _seed_log(tmp_path)
+        _plant_raw_meta(log, KEY, '"consolidation_retry_at": ' + "9" * 400)
+
+        assert log.consolidation_retry_state(KEY) == (0, 0.0)
+        assert _make_consolidator(log).retry_eligible(KEY) is True
+
+    @pytest.mark.asyncio
+    async def test_an_infinite_deadline_reads_as_zero(self, tmp_path):
+        """``1e309`` parses straight to ``inf``: no raise, but never expires."""
+        log = _seed_log(tmp_path)
+        _plant_raw_meta(log, KEY, '"consolidation_retry_at": 1e309')
+
+        assert log.consolidation_retry_state(KEY) == (0, 0.0)
+        assert _make_consolidator(log).retry_eligible(KEY) is True
+
+    @pytest.mark.asyncio
+    async def test_a_nan_deadline_does_not_disable_consolidation_forever(
+        self, tmp_path
+    ):
+        """Every ``now >= nan`` is false, so a NaN deadline never expires."""
+        raws = ('"consolidation_retry_at": NaN', '"consolidation_retry_at": "NaN"')
+        for i, raw in enumerate(raws):
+            log = _seed_log(tmp_path / f"case{i}")
+            _plant_raw_meta(log, KEY, raw)
+
+            assert log.consolidation_retry_state(KEY)[1] == 0.0
+            assert _make_consolidator(log).retry_eligible(KEY) is True, (
+                f"{raw} permanently disabled consolidation for the session"
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_non_numeric_value_reads_as_zero(self, tmp_path):
+        log = _seed_log(tmp_path)
+        _plant_raw_meta(
+            log,
+            KEY,
+            '"consolidation_attempts": "lots", "consolidation_retry_at": {"a": 1}',
+        )
+
+        assert log.consolidation_retry_state(KEY) == (0, 0.0)
+
+    @pytest.mark.asyncio
+    async def test_the_manual_trigger_does_not_500_on_hostile_metadata(
+        self, tmp_path
+    ):
+        """The gate runs inside a request handler — a raise there is a 500."""
+        from kiro_crew.dashboard.handlers.memory import api_memory_consolidate
+
+        log = _seed_log(tmp_path)
+        _plant_raw_meta(log, KEY, '"consolidation_attempts": 1e309')
+        c = _make_consolidator(log)
+
+        state = MagicMock()
+        state.consolidator = c
+        state._restricted_keys = set()
+        state._slots = {}
+        request = _FakeRequest(state, {"key": KEY})
+
+        with patch.object(c, "_consolidate", new_callable=AsyncMock):
+            resp = await api_memory_consolidate(request)  # type: ignore[arg-type]
+            assert resp.status == 200
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_an_absurd_stored_count_does_not_explode_the_backoff_shift(
+        self, tmp_path
+    ):
+        """The exponent is attacker-influenced; ``2 ** n`` must stay bounded."""
+        log = _seed_log(tmp_path)
+        _plant_raw_meta(log, KEY, '"consolidation_attempts": 100000000')
+
+        with history_mod.allow_on_loop_persist():
+            attempts, retry_at = log.record_consolidation_failure(
+                KEY, _CONSOLIDATION_BACKOFF_BASE_SECS, 86400.0, _span(log)
+            )
+
+        assert attempts == 100000001
+        assert retry_at == pytest.approx(time.time() + 86400.0, abs=5)
+
+
+class TestOnlyASentTurnConsumesTheCap:
+    """The cap abandons a span, so only real spend may advance it.
+
+    A pre-dispatch failure (no session manager, kiro-cli missing / not logged in /
+    failing to start) costs nothing. Charging it would let a handful of environment
+    failures write the durable marker over messages no LLM has ever read — the
+    exact false abandonment this accounting exists to prevent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_pre_dispatch_failure_does_not_consume_an_attempt(self, tmp_path):
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(
+            c,
+            "_call_llm",
+            AsyncMock(side_effect=history_mod._ConsolidationNotDispatched("no cli")),
+        ):
+            await c._consolidate(KEY, include_history=True)
+
+        attempts, retry_at = log.consolidation_retry_state(KEY)
+        assert attempts == 0, "an unsent turn consumed the abandon budget"
+        # The backoff is still armed, so a broken host does not re-attempt on the
+        # next 60s tick.
+        assert retry_at > time.time()
+        assert log.unconsolidated_count(KEY) == 3
+
+    @pytest.mark.asyncio
+    async def test_repeated_pre_dispatch_failures_never_abandon_the_span(
+        self, tmp_path
+    ):
+        """Past the cap count, the span must still be unmarked and retryable."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(
+            c,
+            "_call_llm",
+            AsyncMock(side_effect=history_mod._ConsolidationNotDispatched("no cli")),
+        ):
+            for _ in range(_CONSOLIDATION_MAX_ATTEMPTS + 3):
+                with history_mod.allow_on_loop_persist():
+                    log.update_metadata(KEY, {"consolidation_retry_at": 0.0})
+                await c._consolidate(KEY, include_history=True)
+
+        assert log.consolidation_retry_state(KEY)[0] == 0
+        assert log.unconsolidated_count(KEY) == 3, (
+            "a broken environment abandoned a span without one billed turn"
+        )
+        # Still eligible once the deadline passes: the messages are not lost.
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(KEY, {"consolidation_retry_at": 0.0})
+        assert c.retry_eligible(KEY) is True
+
+    @pytest.mark.asyncio
+    async def test_the_environment_backoff_widens_per_failure(self, tmp_path):
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(
+            c,
+            "_call_llm",
+            AsyncMock(side_effect=history_mod._ConsolidationNotDispatched("no cli")),
+        ):
+            await c._consolidate(KEY, include_history=True)
+            first = log.consolidation_retry_state(KEY)[1] - time.time()
+            with history_mod.allow_on_loop_persist():
+                log.update_metadata(KEY, {"consolidation_retry_at": 0.0})
+            await c._consolidate(KEY, include_history=True)
+            second = log.consolidation_retry_state(KEY)[1] - time.time()
+
+        assert first == pytest.approx(_CONSOLIDATION_BACKOFF_BASE_SECS, abs=5)
+        assert second == pytest.approx(2 * _CONSOLIDATION_BACKOFF_BASE_SECS, abs=5)
+
+    @pytest.mark.asyncio
+    async def test_a_post_dispatch_empty_result_still_consumes_an_attempt(
+        self, tmp_path
+    ):
+        """The other half of the contract: a sent turn is still charged."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(c, "_call_llm", AsyncMock(return_value=None)):
+            await c._consolidate(KEY, include_history=True)
+
+        assert log.consolidation_retry_state(KEY)[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_no_session_manager_is_reported_as_not_dispatched(self, tmp_path):
+        """_call_llm's own contract, not the caller's handling of it."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        assert c._sessions is None
+
+        with pytest.raises(history_mod._ConsolidationNotDispatched):
+            await c._call_llm("prompt")
+
+    @pytest.mark.asyncio
+    async def test_a_failure_acquiring_the_session_is_not_dispatched(self, tmp_path):
+        """kiro-cli failing to start must not look like a spent turn."""
+        log = _seed_log(tmp_path)
+        sessions = MagicMock()
+        sessions.get_or_create = AsyncMock(side_effect=RuntimeError("cli not found"))
+        sessions.release = MagicMock()
+        sessions.recycle_background = AsyncMock()
+        c = _make_consolidator(log, sessions=sessions)
+
+        with pytest.raises(history_mod._ConsolidationNotDispatched):
+            await c._call_llm("prompt")
+
+    @pytest.mark.asyncio
+    async def test_a_failure_inside_the_turn_is_charged_as_dispatched(self, tmp_path):
+        """Once the prompt is sent it may have been billed, so it returns None."""
+        log = _seed_log(tmp_path)
+        sessions = MagicMock()
+        sessions.get_or_create = AsyncMock(return_value=(MagicMock(), False, False))
+        sessions.release = MagicMock()
+        sessions.recycle_background = AsyncMock()
+        c = _make_consolidator(log, sessions=sessions)
+
+        with patch.object(
+            history_mod,
+            "stream_and_collect_json",
+            AsyncMock(side_effect=RuntimeError("stream died")),
+        ):
+            assert await c._call_llm("prompt") is None
+
+
+class TestAccountingNeverResurrectsADeletedSession:
+    @pytest.mark.asyncio
+    async def test_recording_a_failure_for_a_deleted_session_is_a_no_op(
+        self, tmp_path
+    ):
+        """_update_metadata_locked upserts, so a blind write recreates the file."""
+        log = _seed_log(tmp_path)
+        path = log._path(KEY)
+        # The span a turn would have attempted, frozen while the file still
+        # exists — the pre-turn snapshot production would be holding here.
+        span = _span(log)
+        path.unlink()
+
+        with history_mod.allow_on_loop_persist():
+            attempts, retry_at = log.record_consolidation_failure(
+                KEY, 900.0, 86400.0, span
+            )
+
+        assert (attempts, retry_at) == (0, 0.0)
+        assert not path.exists(), "a deleted session was resurrected as empty history"
+
+    @pytest.mark.asyncio
+    async def test_recording_an_environment_failure_for_a_deleted_session_is_a_no_op(
+        self, tmp_path
+    ):
+        log = _seed_log(tmp_path)
+        path = log._path(KEY)
+        path.unlink()
+
+        with history_mod.allow_on_loop_persist():
+            log.record_consolidation_environment_failure(KEY, 900.0, 86400.0)
+
+        assert not path.exists()
+
+    @pytest.mark.asyncio
+    async def test_a_session_deleted_mid_consolidation_leaves_no_file(self, tmp_path):
+        """End to end: the delete lands while the LLM turn is in flight."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        path = log._path(KEY)
+
+        async def _delete_then_fail(_prompt):
+            path.unlink()
+            return None
+
+        with patch.object(c, "_call_llm", AsyncMock(side_effect=_delete_then_fail)):
+            await c._consolidate(KEY, include_history=True)
+
+        assert not path.exists()
+
+
+class TestRotationDoesNotClearACappedBudget:
+    """mark_consolidated is also the abandon path, and a rotation resets to 0.
+
+    When the offset is not applied the span stays unconsolidated, so the write
+    must not drop the accounting: clearing it there would hand the span a fresh
+    budget every time a rewrite raced the marker, and the cap would never hold.
+    Whether a LATER read still counts those attempts is a separate question,
+    answered by span identity (see TestRotationReleasesTheBudgetForNewContent) —
+    these tests pin the durable write.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_generation_change_retains_the_capped_state(self, tmp_path):
+        log = _seed_log(tmp_path)
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": _CONSOLIDATION_MAX_ATTEMPTS,
+                    "consolidation_retry_at": time.time() + 3600,
+                    "rotation_generation": 4,
+                },
+            )
+            # The caller's snapshot generation (2) no longer matches, so
+            # mark_consolidated resets the offset to 0 instead of applying it.
+            log.mark_consolidated(KEY, 3, 2)
+
+        meta = log.get_metadata(KEY)
+        assert meta["last_consolidated"] == 0
+        assert meta.get("consolidation_attempts") == _CONSOLIDATION_MAX_ATTEMPTS, (
+            "an unapplied offset cleared the cap on an unmarked span, buying "
+            "another billed attempt"
+        )
+        assert meta.get("consolidation_retry_at")
+
+    @pytest.mark.asyncio
+    async def test_an_offset_beyond_the_message_count_retains_the_capped_state(
+        self, tmp_path
+    ):
+        """The count fallback also resets to 0 without advancing the marker."""
+        log = _seed_log(tmp_path)
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": _CONSOLIDATION_MAX_ATTEMPTS,
+                    "consolidation_retry_at": time.time() + 3600,
+                },
+            )
+            log.mark_consolidated(KEY, 999, 0)
+
+        assert log.get_metadata(KEY)["last_consolidated"] == 0
+        assert (
+            log.consolidation_retry_state(KEY)[0] == _CONSOLIDATION_MAX_ATTEMPTS
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_applied_offset_still_releases_the_budget(self, tmp_path):
+        """The success path is unchanged: a marked span drops its accounting."""
+        log = _seed_log(tmp_path)
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": 2,
+                    "consolidation_retry_at": time.time() + 3600,
+                    "consolidation_env_failures": 4,
+                    "consolidation_attempts_generation": 0,
+                    "consolidation_attempts_offset": 0,
+                },
+            )
+            log.mark_consolidated(KEY, 3, 0)
+
+        meta = log.get_metadata(KEY)
+        assert meta["last_consolidated"] == 3
+        assert log.consolidation_retry_state(KEY) == (0, 0.0)
+        for stale in (
+            "consolidation_env_failures",
+            "consolidation_attempts_generation",
+            "consolidation_attempts_offset",
+        ):
+            assert stale not in meta, f"{stale} outlived the span it described"
+
+
+class TestRotationReleasesTheBudgetForNewContent:
+    """The cap abandons ONE span, so it must not outlive that span.
+
+    A rotation archives the messages the failures were charged against and resets
+    the marker to 0. Carrying a capped count onto the retained tail would silence
+    consolidation for the session permanently — every message written afterwards
+    stays ineligible forever. The counter is therefore bound to the
+    ``(rotation_generation, last_consolidated)`` pair it was charged against: the
+    same span keeps its cap, a genuinely new one gets a fresh bounded budget.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_charged_attempt_records_the_span_it_belongs_to(self, tmp_path):
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(c, "_call_llm", AsyncMock(return_value=None)):
+            await c._consolidate(KEY, include_history=True)
+
+        meta = log.get_metadata(KEY)
+        assert meta["consolidation_attempts"] == 1
+        assert meta["consolidation_attempts_generation"] == 0
+        assert meta["consolidation_attempts_offset"] == 0
+
+    @pytest.mark.asyncio
+    async def test_a_new_generation_gets_a_fresh_budget(self, tmp_path):
+        log = _seed_log(tmp_path)
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": _CONSOLIDATION_MAX_ATTEMPTS,
+                    "consolidation_retry_at": time.time() - 1,
+                    "consolidation_attempts_generation": 0,
+                    "consolidation_attempts_offset": 0,
+                    "rotation_generation": 1,
+                },
+            )
+
+        assert log.consolidation_retry_state(KEY)[0] == 0, (
+            "a capped count from an archived span disabled consolidation for "
+            "every message written after the rotation"
+        )
+        assert _make_consolidator(log).retry_eligible(KEY) is True
+
+    @pytest.mark.asyncio
+    async def test_the_same_span_stays_capped(self, tmp_path):
+        """Round 2's invariant: no free attempt while the span is unchanged."""
+        log = _seed_log(tmp_path)
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": _CONSOLIDATION_MAX_ATTEMPTS,
+                    "consolidation_retry_at": time.time() - 1,
+                    "consolidation_attempts_generation": 0,
+                    "consolidation_attempts_offset": 0,
+                },
+            )
+
+        assert log.consolidation_retry_state(KEY)[0] == _CONSOLIDATION_MAX_ATTEMPTS
+        assert _make_consolidator(log).retry_eligible(KEY) is False, (
+            "the same failing span bought another billed attempt"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_fresh_budget_still_waits_out_the_backoff(self, tmp_path):
+        """A new span is not a free immediate turn on a host that keeps failing."""
+        log = _seed_log(tmp_path)
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": _CONSOLIDATION_MAX_ATTEMPTS,
+                    "consolidation_retry_at": time.time() + 3600,
+                    "consolidation_attempts_generation": 0,
+                    "consolidation_attempts_offset": 0,
+                    "rotation_generation": 1,
+                },
+            )
+
+        assert log.consolidation_retry_state(KEY)[0] == 0
+        assert _make_consolidator(log).retry_eligible(KEY) is False
+
+    @pytest.mark.asyncio
+    async def test_unstamped_accounting_keeps_the_cap(self, tmp_path):
+        """Unknown provenance must fail closed, not grant unbounded retries."""
+        log = _seed_log(tmp_path)
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": _CONSOLIDATION_MAX_ATTEMPTS,
+                    "consolidation_retry_at": time.time() - 1,
+                    "rotation_generation": 7,
+                },
+            )
+
+        assert log.consolidation_retry_state(KEY)[0] == _CONSOLIDATION_MAX_ATTEMPTS
+
+    @pytest.mark.asyncio
+    async def test_content_written_after_a_real_rotation_consolidates(self, tmp_path):
+        """End to end through the real rotation path, not a planted generation.
+
+        The capped state is planted rather than accrued: when the abandon path's
+        marker write SUCCEEDS it clears the accounting itself, so the state that
+        survives a rotation is the one whose marker write was refused.
+        """
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": _CONSOLIDATION_MAX_ATTEMPTS,
+                    "consolidation_retry_at": time.time() + 3600,
+                    "consolidation_attempts_generation": 0,
+                    "consolidation_attempts_offset": 0,
+                },
+            )
+            assert c.retry_eligible(KEY) is False
+
+            # Blow the byte budget so _maybe_rotate archives the failing messages
+            # and bumps the generation itself.
+            for i in range(5):
+                log.append(KEY, "user", f"{i}" * (600 * 1024))
+        assert log.get_metadata(KEY)["rotation_generation"] >= 1, "no rotation fired"
+
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(KEY, {"consolidation_retry_at": 0.0})
+        assert c.retry_eligible(KEY) is True, (
+            "a rotation left the session permanently unable to consolidate"
+        )
+
+        with patch.object(
+            c, "_call_llm", AsyncMock(return_value={"history_entry": "after rotation"})
+        ):
+            await c._consolidate(KEY, include_history=True)
+
+        assert log.unconsolidated_count(KEY) == 0, (
+            "post-rotation content never consolidated"
+        )
+        assert "consolidation_attempts" not in log.get_metadata(KEY)
+
+
+class TestARotationDuringTheTurnStampsTheAttemptedSpan:
+    """The charge must describe what the turn attempted, not what it returns to.
+
+    The billed call is the whole point of the accounting, and the transcript is
+    live while it is in flight — a rotation can land between the pre-turn
+    snapshot and the failure charge. Re-reading the metadata line at charge time
+    stamps the counter with the NEW generation, so the counter claims to have
+    measured content no LLM has seen. At the cap that content is refused with its
+    own identity already on the stamp, and nothing later can release it.
+    """
+
+    @staticmethod
+    def _rotating_failure(log):
+        """An LLM turn that rotates the transcript, then fails."""
+
+        async def _turn(*_a, **_kw):
+            with history_mod.allow_on_loop_persist():
+                # Blow the byte budget so the real _maybe_rotate archives the
+                # attempted messages and bumps the generation mid-turn.
+                for i in range(5):
+                    log.append(KEY, "user", f"{i}" * (600 * 1024))
+            assert log.get_metadata(KEY)["rotation_generation"] >= 1, (
+                "premise broken: no rotation fired during the turn"
+            )
+            return None
+
+        return AsyncMock(side_effect=_turn)
+
+    @pytest.mark.asyncio
+    async def test_the_charge_carries_the_pre_turn_generation(self, tmp_path):
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(c, "_call_llm", self._rotating_failure(log)):
+            await c._consolidate(KEY, include_history=True)
+
+        meta = log.get_metadata(KEY)
+        assert meta["consolidation_attempts"] == 1, "the failed turn was not charged"
+        assert meta["rotation_generation"] >= 1, "premise broken: no rotation landed"
+        assert meta["consolidation_attempts_generation"] == 0, (
+            "the charge was stamped with the generation the rotation produced, "
+            "so it claims to have measured content the turn never sent"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_rotated_span_does_not_inherit_the_charge(self, tmp_path):
+        """The consequence: retained messages must start with their own budget.
+
+        A charge stamped with the post-rotation identity reads back as belonging
+        to the retained content, so that content is short a turn of budget before
+        it has been attempted even once — and the cap abandons it early.
+        """
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(c, "_call_llm", self._rotating_failure(log)):
+            await c._consolidate(KEY, include_history=True)
+
+        total = _total(log)
+        meta = log.get_metadata(KEY)
+        assert meta["consolidation_attempts"] == 1, "the failed turn was not charged"
+        assert log.unconsolidated_count(KEY) > 0, (
+            "premise broken: nothing is left pending after the rotation, so "
+            "there is no span to strand"
+        )
+        assert total <= meta["consolidation_attempts_count"], (
+            "premise broken: the transcript grew past the attempted extent, so "
+            "the growth test would release the charge on its own and this would "
+            "pass with the generation stamp wrong"
+        )
+        assert log.consolidation_retry_state(KEY, total)[0] == 0, (
+            "the post-rotation messages carry a charge that was never spent on "
+            "them, so their own budget is short and the cap abandons them early"
+        )
+
+
+class TestForeignWritersCannotEraseTheAccounting:
+    """The accounting shares the metadata line with other layers' writers.
+
+    A writer that REBUILDS that line from its own state deletes every field it
+    does not enumerate. Two already did, and each silently reset the backoff so
+    billed retries resumed. Preservation is now the default: a rebuilder names the
+    keys it owns and carries the rest through.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_compaction_preserves_the_retry_accounting(self, tmp_path):
+        log = _seed_log(tmp_path)
+        deadline = time.time() + 3600
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": 3,
+                    "consolidation_retry_at": deadline,
+                    "consolidation_attempts_generation": 0,
+                    "consolidation_attempts_offset": 0,
+                    "title": "kept",
+                },
+            )
+            log.rewrite_session(KEY, log._read_messages(KEY)[-1:])
+
+        attempts, retry_at = log.consolidation_retry_state(KEY)
+        assert attempts == 3, "a compaction reset the backoff and re-billed the span"
+        assert retry_at == pytest.approx(deadline, abs=1)
+        assert log.get_metadata(KEY)["title"] == "kept"
+
+    def test_a_dashboard_slot_save_preserves_the_retry_accounting(
+        self, tmp_path, monkeypatch
+    ):
+        """The save rebuilds the whole metadata line from the slot's own state."""
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.state.config_dir", lambda: tmp_path
+        )
+        log = ConversationLog(base_dir=tmp_path)
+        log.init()
+        for i in range(3):
+            log.append("dashboard:chat1", "user", f"m{i}")
+        deadline = time.time() + 3600
+        log.update_metadata(
+            "dashboard:chat1",
+            {
+                "consolidation_attempts": 4,
+                "consolidation_retry_at": deadline,
+                "consolidation_attempts_generation": 0,
+                "consolidation_attempts_offset": 0,
+                "rotation_generation": 2,
+            },
+        )
+
+        state = _dashboard_state(log)
+        slot = _rehydrate_slot_from_history(state, "chat1")
+        assert slot is not None
+        slot._dirty = True
+        _save_slot_to_history(state, slot)
+
+        meta = log.get_metadata("dashboard:chat1")
+        assert meta.get("consolidation_attempts") == 4, (
+            "a dashboard slot save erased the retry accounting, resuming billed "
+            "retries on a span that already spent its budget"
+        )
+        assert meta.get("consolidation_retry_at") == pytest.approx(deadline, abs=1)
+        assert meta.get("consolidation_attempts_generation") == 0
+        assert meta.get("rotation_generation") == 2
+
+    def test_a_slot_owned_field_is_still_cleared_by_omission(
+        self, tmp_path, monkeypatch
+    ):
+        """Preserving unowned keys must not make the slot's own state unclearable."""
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.state.config_dir", lambda: tmp_path
+        )
+        log = ConversationLog(base_dir=tmp_path)
+        log.init()
+        log.append("dashboard:chat1", "user", "m0")
+        log.update_metadata(
+            "dashboard:chat1", {"pinned": True, "consolidation_attempts": 1}
+        )
+
+        state = _dashboard_state(log)
+        slot = _rehydrate_slot_from_history(state, "chat1")
+        assert slot is not None
+        slot.pinned = False
+        slot._dirty = True
+        _save_slot_to_history(state, slot)
+
+        meta = log.get_metadata("dashboard:chat1")
+        assert "pinned" not in meta, "an un-pinned slot could not clear its pin"
+        assert meta.get("consolidation_attempts") == 1
+
+    def test_the_helper_never_shadows_an_owned_key(self):
+        rebuilt = {"title": "new"}
+        existing = {"title": "old", "consolidation_attempts": 2, "rotation_generation": 1}
+        out = history_mod.carry_unowned_metadata(
+            rebuilt, existing, frozenset({"title"})
+        )
+        assert out == {
+            "title": "new",
+            "consolidation_attempts": 2,
+            "rotation_generation": 1,
+        }
+
+
+class TestAnEditedTranscriptEarnsAFreshBudget:
+    """An edit swaps in content no consolidation turn read, so it advances the
+    session's content identity — and that ONE counter carries both guarantees.
+
+    Preserving the accounting across a REBUILD is right; letting it (or a marker
+    written by a turn already in flight) apply to EDITED content is not. A
+    regenerate replaces the assistant tail with a reply the failing turns never
+    saw, and it lands at the same message count, the same marker and the same
+    extent — so nothing but the rotation generation distinguishes it, and without
+    the bump a capped span would strand brand-new content forever while an
+    in-flight attempt would mark it consolidated unread.
+    """
+
+    def _plant_capped_slot(
+        self, tmp_path, monkeypatch, retry_in: float = 3600.0
+    ) -> ConversationLog:
+        """A two-message dashboard transcript whose span sits at the cap.
+
+        *retry_in* places the armed backoff deadline relative to now — negative
+        for a span whose wait has already elapsed (so eligibility turns purely on
+        the budget), positive for one still serving it.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        log = ConversationLog(base_dir=tmp_path)
+        log.init()
+        log.append("dashboard:chat1", "user", "ask")
+        log.append("dashboard:chat1", "assistant", "first answer")
+        log.update_metadata(
+            "dashboard:chat1",
+            {
+                "consolidation_attempts": _CONSOLIDATION_MAX_ATTEMPTS,
+                "consolidation_retry_at": time.time() + retry_in,
+                "consolidation_attempts_generation": 0,
+                "consolidation_attempts_offset": 0,
+                "consolidation_attempts_count": log.consolidation_counts(
+                    "dashboard:chat1"
+                )[0],
+            },
+        )
+        return log
+
+    def _regenerate(self, state, slot) -> None:
+        """What the regenerate path does: swap the assistant tail for a different
+        reply and persist that window as an explicit snapshot (a rewrite)."""
+        snapshot = list(slot.messages)
+        snapshot[-1] = {**snapshot[-1], "content": "regenerated answer"}
+        slot.messages[:] = snapshot
+        slot._dirty = True
+        _save_slot_to_history(state, slot, snapshot)
+
+    def test_a_regenerated_reply_is_not_held_by_the_old_spans_cap(
+        self, tmp_path, monkeypatch
+    ):
+        log = self._plant_capped_slot(tmp_path, monkeypatch, retry_in=-1.0)
+        before = log.consolidation_counts("dashboard:chat1")[0]
+        c = _make_consolidator(log)
+        assert not c.retry_eligible("dashboard:chat1", message_count=before), (
+            "premise broken: the span is not capped, so the edit has nothing to "
+            "release and this would pass without the fix"
+        )
+
+        state = _dashboard_state(log)
+        slot = _rehydrate_slot_from_history(state, "chat1")
+        assert slot is not None
+        self._regenerate(state, slot)
+
+        after = log.consolidation_counts("dashboard:chat1")[0]
+        meta = log.get_metadata("dashboard:chat1")
+        assert after == before, (
+            "premise broken: the rewrite changed the message total, so the growth "
+            "test would release the charge on its own"
+        )
+        assert int(meta.get("last_consolidated", 0) or 0) == 0, (
+            "premise broken: the rewrite moved the marker, which releases the "
+            "charge on its own"
+        )
+        assert meta.get("consolidation_attempts") == _CONSOLIDATION_MAX_ATTEMPTS, (
+            "premise broken: the accounting was dropped outright, so this passes "
+            "without the span identity having moved"
+        )
+        assert "regenerated answer" in log._path("dashboard:chat1").read_text(
+            encoding="utf-8"
+        ), "premise broken: the replacement reply never reached disk"
+
+        assert log.consolidation_retry_state("dashboard:chat1", after)[0] == 0, (
+            "the replacement reply inherited the exhausted budget of the span it "
+            "replaced"
+        )
+        assert c.retry_eligible("dashboard:chat1", message_count=after), (
+            "a reply no consolidation turn has ever read is permanently "
+            "ineligible for consolidation"
+        )
+
+    def test_the_edit_advances_the_sessions_content_identity(
+        self, tmp_path, monkeypatch
+    ):
+        """The release above is the span-identity semantics, not a special case."""
+        log = self._plant_capped_slot(tmp_path, monkeypatch)
+        state = _dashboard_state(log)
+        slot = _rehydrate_slot_from_history(state, "chat1")
+        assert slot is not None
+        before = log.rotation_generation("dashboard:chat1")
+        self._regenerate(state, slot)
+        assert log.rotation_generation("dashboard:chat1") == before + 1, (
+            "the edit left the content identity untouched, so a consolidation "
+            "holding the pre-edit generation cannot tell its span was replaced"
+        )
+
+    def test_an_edit_does_not_buy_a_free_billed_turn(self, tmp_path, monkeypatch):
+        """A fresh budget is not an immediate turn — same as a rotation.
+
+        Releasing the deadline too would let a user hammering regenerate re-bill a
+        failing consolidation on every gesture, which is exactly what the backoff
+        exists to stop.
+        """
+        log = self._plant_capped_slot(tmp_path, monkeypatch, retry_in=3600.0)
+        armed = log.get_metadata("dashboard:chat1")["consolidation_retry_at"]
+        state = _dashboard_state(log)
+        slot = _rehydrate_slot_from_history(state, "chat1")
+        assert slot is not None
+        self._regenerate(state, slot)
+
+        count = log.consolidation_counts("dashboard:chat1")[0]
+        attempts, retry_at = log.consolidation_retry_state("dashboard:chat1", count)
+        assert attempts == 0, "the edit did not release the exhausted budget"
+        assert retry_at == pytest.approx(armed, abs=1), (
+            "the edit discarded the armed backoff deadline"
+        )
+        assert not _make_consolidator(log).retry_eligible(
+            "dashboard:chat1", message_count=count
+        ), "an edit let the session skip a backoff it had not served"
+
+    def test_an_edit_invalidates_an_attempt_already_in_flight(
+        self, tmp_path, monkeypatch
+    ):
+        """The completion write of a turn that snapshotted the PRE-edit span must
+        not mark the replacement tail consolidated.
+
+        The turn read the original reply, the user regenerated it, and only then
+        did the turn finish. Its offset still fits the file — the count, the
+        marker and the extent are all unchanged — so nothing but the advanced
+        generation stops ``mark_consolidated`` from marking a reply no LLM has
+        ever seen as already extracted.
+        """
+        log = self._plant_capped_slot(tmp_path, monkeypatch)
+        key = "dashboard:chat1"
+        # The consolidation turn starts: one atomic pre-turn snapshot.
+        _msgs, total, generation = log.snapshot_for_consolidation(key)
+        assert total == 2 and generation == 0
+
+        state = _dashboard_state(log)
+        slot = _rehydrate_slot_from_history(state, "chat1")
+        assert slot is not None
+        self._regenerate(state, slot)
+        assert log.consolidation_counts(key)[0] == total, (
+            "premise broken: the edit changed the message count, so the offset "
+            "fallback in mark_consolidated would catch this without the fix"
+        )
+
+        # The turn now completes and writes the marker for the span it read.
+        log.mark_consolidated(key, total, generation)
+
+        meta = log.get_metadata(key)
+        assert int(meta.get("last_consolidated", 0) or 0) == 0, (
+            "the regenerated reply was marked consolidated without ever being "
+            "extracted — silent memory loss"
+        )
+        assert log.consolidation_counts(key)[1] == total, (
+            "the replacement content is not queued for consolidation"
+        )
+
+    def test_a_steady_flush_leaves_the_content_identity_alone(
+        self, tmp_path, monkeypatch
+    ):
+        """Only an EDIT advances it; a re-serialization of the same window is not
+        evidence about content, or every flush would release the cap."""
+        log = self._plant_capped_slot(tmp_path, monkeypatch, retry_in=-1.0)
+        state = _dashboard_state(log)
+        slot = _rehydrate_slot_from_history(state, "chat1")
+        assert slot is not None
+        slot._dirty = True
+        _save_slot_to_history(state, slot)
+
+        count = log.consolidation_counts("dashboard:chat1")[0]
+        assert log.rotation_generation("dashboard:chat1") == 0
+        assert (
+            log.consolidation_retry_state("dashboard:chat1", count)[0]
+            == _CONSOLIDATION_MAX_ATTEMPTS
+        ), "a steady flush released the cap, so a failing span retries forever"
+
+    def test_the_helper_preserves_a_foreign_field_unconditionally(self):
+        existing = {
+            "consolidation_attempts": 3,
+            "consolidation_retry_at": 123.0,
+            "rotation_generation": 1,
+            "title": "kept",
+        }
+        assert history_mod.carry_unowned_metadata({}, existing, frozenset()) == existing
+
+
+class TestTheCapDoesNotOutliveTheSpanItMeasured:
+    """The cap is reachable only when the abandon-marker write itself failed.
+
+    Refusing that span is correct; refusing the SESSION is not. Appended messages
+    leave the generation and the marker untouched, so without the span's extent
+    one transient write failure would reject the transcript forever and the
+    session's history would never be consolidated again.
+    """
+
+    def _plant_capped(self, log, count: int | None = None, retry_at: float = -1.0):
+        """A span charged to the cap whose abandon-marker write did not land."""
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": _CONSOLIDATION_MAX_ATTEMPTS,
+                    "consolidation_retry_at": (
+                        time.time() + retry_at if retry_at > 0 else time.time() - 1
+                    ),
+                    "consolidation_attempts_generation": 0,
+                    "consolidation_attempts_offset": 0,
+                    "consolidation_attempts_count": (
+                        _total(log) if count is None else count
+                    ),
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_charged_attempt_records_the_spans_extent(self, tmp_path):
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(c, "_call_llm", AsyncMock(return_value=None)):
+            await c._consolidate(KEY, include_history=True)
+
+        assert log.get_metadata(KEY)["consolidation_attempts_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_the_extent_is_the_attempted_count_not_the_current_size(
+        self, tmp_path
+    ):
+        """A message arriving DURING the failing turn must not be swallowed.
+
+        It was never sent to the provider, so recording the post-turn size would
+        bury it inside the charged extent and the growth test would never fire for
+        it — at the cap it would be excluded from consolidation permanently.
+        """
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        async def _append_then_fail(_prompt):
+            with history_mod.allow_on_loop_persist():
+                log.append(KEY, "user", "arrived mid-turn")
+            return None
+
+        with patch.object(c, "_call_llm", AsyncMock(side_effect=_append_then_fail)):
+            await c._consolidate(KEY, include_history=True)
+
+        assert log.get_metadata(KEY)["consolidation_attempts_count"] == 3, (
+            "the mid-turn message was recorded as attempted, so growth can never "
+            "release it"
+        )
+        # It reads as growth, so the counter no longer describes this span. (The
+        # armed deadline still applies — a fresh budget is not a free turn.)
+        assert log.consolidation_retry_state(KEY, _total(log))[0] == 0
+        assert _total(log) == 4
+
+    @pytest.mark.asyncio
+    async def test_a_capped_span_with_no_growth_stays_ineligible(self, tmp_path):
+        """Round 2's guarantee: an unchanged failing span cannot burn forever."""
+        log = _seed_log(tmp_path)
+        self._plant_capped(log)
+
+        assert log.consolidation_retry_state(KEY, _total(log))[0] == (
+            _CONSOLIDATION_MAX_ATTEMPTS
+        )
+        assert _eligible(_make_consolidator(log), log) is False
+
+    @pytest.mark.asyncio
+    async def test_transcript_growth_releases_the_cap(self, tmp_path):
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        self._plant_capped(log)
+        assert _eligible(c, log) is False
+
+        with history_mod.allow_on_loop_persist():
+            log.append(KEY, "user", "arrived after the cap")
+
+        assert log.consolidation_retry_state(KEY, _total(log))[0] == 0, (
+            "one failed abandon write refused every message the session will "
+            "ever write again"
+        )
+        assert _eligible(c, log) is True
+
+    @pytest.mark.asyncio
+    async def test_growth_still_waits_out_the_armed_backoff(self, tmp_path):
+        """A fresh budget is not a free immediate turn."""
+        log = _seed_log(tmp_path)
+        self._plant_capped(log, retry_at=3600.0)
+        with history_mod.allow_on_loop_persist():
+            log.append(KEY, "user", "arrived after the cap")
+
+        assert log.consolidation_retry_state(KEY, _total(log))[0] == 0
+        assert _eligible(_make_consolidator(log), log) is False
+
+    @pytest.mark.asyncio
+    async def test_the_grown_span_re_arms_the_cap(self, tmp_path):
+        """Growth buys ONE bounded budget, not an escape from the cap."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        self._plant_capped(log)
+        with history_mod.allow_on_loop_persist():
+            log.append(KEY, "user", "arrived after the cap")
+        assert _eligible(c, log) is True
+
+        with history_mod.allow_on_loop_persist():
+            for _ in range(_CONSOLIDATION_MAX_ATTEMPTS):
+                log.record_consolidation_failure(KEY, 900.0, 86400.0, _span(log))
+                log.update_metadata(KEY, {"consolidation_retry_at": time.time() - 1})
+
+        meta = log.get_metadata(KEY)
+        assert meta["consolidation_attempts"] == _CONSOLIDATION_MAX_ATTEMPTS
+        assert meta["consolidation_attempts_count"] == 4, (
+            "the cap re-armed against the OLD extent, so the same growth would "
+            "release it again"
+        )
+        assert log.consolidation_retry_state(KEY, _total(log))[0] == (
+            _CONSOLIDATION_MAX_ATTEMPTS
+        )
+        assert _eligible(c, log) is False, (
+            "the original failing prefix can re-bill indefinitely"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_shrink_alone_does_not_release_the_cap(self, tmp_path):
+        """Growth is `>`, not `!=` — a rewrite that only drops content adds none."""
+        log = _seed_log(tmp_path)
+        self._plant_capped(log, count=99)
+
+        assert log.consolidation_retry_state(KEY, _total(log))[0] == (
+            _CONSOLIDATION_MAX_ATTEMPTS
+        )
+        assert _eligible(_make_consolidator(log), log) is False
+
+    @pytest.mark.asyncio
+    async def test_eligibility_never_reads_the_transcript(self, tmp_path):
+        """It runs on the gateway loop; a full-file read there stalls everything."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        self._plant_capped(log)
+        total = _total(log)
+
+        reads: list[str] = []
+        real_read_text = Path.read_text
+
+        def _counting_read_text(self_path, *a, **kw):
+            if self_path == log._path(KEY):
+                reads.append(str(self_path))
+            return real_read_text(self_path, *a, **kw)
+
+        with patch.object(Path, "read_text", _counting_read_text):
+            c.retry_eligible(KEY, message_count=total)
+            log.consolidation_retry_state(KEY, total)
+
+        assert reads == [], (
+            "the eligibility check read the whole transcript on the event loop"
+        )
+
+    @pytest.mark.asyncio
+    async def test_content_written_after_a_failed_abandon_consolidates(self, tmp_path):
+        """End to end through a real entry point, which is what consults the gate.
+
+        Driving ``_consolidate`` directly would prove nothing here: the cap lives
+        in ``retry_eligible``, so only a caller that passes through it can show the
+        session recovering.
+        """
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        self._plant_capped(log)
+
+        c.consolidate_session(KEY)
+        assert not c._tasks, "a capped span with no growth still fired a turn"
+
+        with history_mod.allow_on_loop_persist():
+            log.append(KEY, "user", "arrived after the cap")
+
+        with patch.object(
+            c, "_call_llm", AsyncMock(return_value={"history_entry": "recovered"})
+        ):
+            c.consolidate_session(KEY)
+            assert c._tasks, (
+                "one failed abandon write left the session permanently unable to "
+                "consolidate anything it writes from now on"
+            )
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+        assert log.unconsolidated_count(KEY) == 0
+        assert "consolidation_attempts" not in log.get_metadata(KEY)
+
+
+class TestEveryEntryPointRespectsTheAccounting:
+    @pytest.mark.asyncio
+    async def test_consolidate_session_honors_the_backoff(self, tmp_path):
+        """The expiry path consults no time throttle of its own at all."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": 1,
+                    "consolidation_retry_at": time.time() + 3600,
+                },
+            )
+
+        c.consolidate_session(KEY)
+        assert not c._tasks, "session expiry re-fired a backed-off consolidation"
+
+        # Past the deadline the same call proceeds, so backoff delays rather than
+        # disables the path.
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(KEY, {"consolidation_retry_at": time.time() - 1})
+        with patch.object(c, "_consolidate", new_callable=AsyncMock):
+            c.consolidate_session(KEY)
+            assert c._tasks
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_manual_dashboard_trigger_refuses_inside_the_backoff(self, tmp_path):
+        from kiro_crew.dashboard.handlers.memory import api_memory_consolidate
+
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": 2,
+                    "consolidation_retry_at": time.time() + 3600,
+                },
+            )
+
+        state = MagicMock()
+        state.consolidator = c
+        state._restricted_keys = set()
+        state._slots = {}
+        request = _FakeRequest(state, {"key": KEY})
+
+        resp = await api_memory_consolidate(request)  # type: ignore[arg-type]
+        assert resp.status == 429
+        assert not c._tasks, "manual trigger bypassed the backoff"
+
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(KEY, {"consolidation_retry_at": time.time() - 1})
+        with patch.object(c, "_consolidate", new_callable=AsyncMock):
+            resp = await api_memory_consolidate(request)  # type: ignore[arg-type]
+            assert resp.status == 200
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+
+class TestTheManualTriggerClaimsAtomically:
+    """Two concurrent POSTs must not both dispatch a billed turn.
+
+    The eligibility probe awaits an off-loop transcript read, so a membership
+    test taken before that yield and acted on after it is a check-then-act race.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_triggers_dispatch_only_once(self, tmp_path):
+        from kiro_crew.dashboard.handlers.memory import api_memory_consolidate
+
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        state = MagicMock()
+        state.consolidator = c
+        state._restricted_keys = set()
+        state._slots = {}
+
+        with patch.object(c, "_consolidate", new_callable=AsyncMock) as spy:
+            # Both requests are in flight across the handler's await, which is
+            # exactly the window a check-then-act guard leaves open.
+            responses = await asyncio.gather(
+                api_memory_consolidate(_FakeRequest(state, {"key": KEY})),  # type: ignore[arg-type]
+                api_memory_consolidate(_FakeRequest(state, {"key": KEY})),  # type: ignore[arg-type]
+            )
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+        statuses = sorted(r.status for r in responses)
+        assert statuses == [200, 409], f"expected one winner and one refusal, got {statuses}"
+        assert spy.await_count == 1, (
+            f"consolidation dispatched {spy.await_count} times for one span — "
+            "the claim is not atomic across the handler's await"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_refused_trigger_releases_its_claim(self, tmp_path):
+        """A 429 must not leave the key claimed, or the span is wedged forever."""
+        from kiro_crew.dashboard.handlers.memory import api_memory_consolidate
+
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": 2,
+                    "consolidation_retry_at": time.time() + 3600,
+                },
+            )
+
+        state = MagicMock()
+        state.consolidator = c
+        state._restricted_keys = set()
+        state._slots = {}
+        request = _FakeRequest(state, {"key": KEY})
+
+        resp = await api_memory_consolidate(request)  # type: ignore[arg-type]
+        assert resp.status == 429
+        assert KEY not in c._running, "the backoff refusal leaked its claim"
+
+        # Once the backoff expires the same key is dispatchable again, which it
+        # would not be if the refusal above had left the claim in place.
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(KEY, {"consolidation_retry_at": time.time() - 1})
+        with patch.object(c, "_consolidate", new_callable=AsyncMock):
+            resp = await api_memory_consolidate(request)  # type: ignore[arg-type]
+            assert resp.status == 200
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)


### PR DESCRIPTION
## The problem

`HistoryConsolidator` spends a **billed LLM turn** before it can write the durable
`consolidated` marker, and it has no attempt counter, no backoff, and no dead letter
anywhere in the class. Two distinct paths turn a single failure into unbounded spend.

### Hole A — an exception between the LLM call and the marker retries every 60s, forever

`_consolidate` makes the billed call at `src/kiro_crew/history.py:3627`, but writes
`mark_consolidated` as the **last** statement of the `try` block
(`src/kiro_crew/history.py:3708-3714`). Anything raised in between re-raises at
`src/kiro_crew/history.py:3716-3718`:

- embed-pool writes (`history.py:3636`, `history.py:3646`)
- `write_preferences` / `write_projects` (`history.py:3652`, `history.py:3656`)
- `_save_lessons` (`history.py:3664`)
- `mark_consolidated` itself

On a raise, `_on_idle_done`'s guard (`fut.exception() is None`,
`src/kiro_crew/history.py:3424-3431`) never sets the in-memory throttle
`_history_consolidated`. All four skip conditions in `check_idle_sessions`
(`src/kiro_crew/history.py:3412-3417`) are therefore false again on the next 60s
heartbeat tick — a fresh billed turn every ~(turn duration + 60s), indefinitely.

### Hole B — a `None` LLM result looks like success but leaves the span unconsolidated

`_call_llm` swallows **every** exception and returns `None`
(`src/kiro_crew/history.py:4573-4579`), and `_consolidate` does `if not result: return`
at `src/kiro_crew/history.py:3627-3629` — a bare `return` *before* `mark_consolidated`.
The task completes "cleanly", so the in-memory throttle **is** set, but the durable count
still says unconsolidated: the session re-burns a full turn every `history_idle_hours`
forever, and immediately after every gateway restart (the throttle dict is memory-only).

Additionally, `consolidate_session()` (`src/kiro_crew/history.py:3435-3470`, wired to
session-expiry sweeps) consults **no throttle at all** — every expiry of a failing key
re-fires a full consolidation.

## The fix

Persistent per-key retry accounting stored durably beside `last_consolidated` on the
transcript's metadata line, so it survives a gateway restart:

- `ConversationLog.consolidation_retry_state(key)` → `(attempts, next_eligible_at)`.
  Corrupt values degrade to "eligible" rather than raising into the sweep.
- `ConversationLog.record_consolidation_failure(key, base, max)` — read-increment-write
  under a **single** `_locked` hold, so a gateway sweep and a CLI run on the same session
  cannot both read the same count and write the same value.
- `mark_consolidated` clears `consolidation_attempts` / `consolidation_retry_at` in the
  same locked write as the marker, so a landed span never charges the next span for its
  failures and no window exists where the marker applies but the budget is not released.
- `HistoryConsolidator.retry_eligible(key)` gates every automatic entry point.
- Exponential backoff: 15 min doubling per failed attempt, 24 h ceiling, cap of
  5 attempts. At the cap the span is **abandoned**: the durable marker is written anyway
  and a WARNING names the key and message count. Losing one memory pass costs one
  summary; retrying forever costs a turn per heartbeat tick.

Behavioural details:

- A `None` result is charged as a **failed attempt**, not a silent success (hole B).
- A `billed` flag is set immediately after `_call_llm` returns, so a *cheap* pre-call
  failure (snapshot, metadata read) keeps its free retry — only turns that were actually
  spent consume budget.
- All three entry points respect the same accounting, so none bypasses it:
  `check_idle_sessions` (checked last, so it only costs a metadata read once the cheap
  conditions pass), `consolidate_session`, and the manual dashboard trigger
  (`dashboard/handlers/memory.py:1163-1168` → `429` with code
  `consolidation_retry_backoff`).
- If the abandon write itself fails, the count stays at the cap and `retry_eligible`
  keeps refusing — the span stops spending even without a marker.
- `_run_skill_detection` semantics are unchanged, and the prefs-only path
  (`include_history=False`) is untouched: it advances a separate in-memory offset and
  never writes the marker, so folding it into the same durable counter would
  cross-contaminate two different spans.

## Tests

`test/test_history_consolidation_retry.py` — 10 tests over a real `ConversationLog`,
all revert-verified (each of the 9 pieces of the fix was patched out individually and
the corresponding test confirmed to fail):

- an exception after the LLM call does **not** retry on the next tick (backoff armed,
  span still unconsolidated, throttle never set)
- a failure *before* the LLM call does not consume budget
- a `None` result consumes an attempt
- backoff doubles per attempt
- the attempt cap abandons the span with the durable marker, releasing the budget
- a span at the cap whose marker write failed stays permanently ineligible
- a successful pass releases the retry budget
- accounting survives a simulated restart (a fresh `ConversationLog` +
  `HistoryConsolidator` over the same directory refuses to re-bill)
- `consolidate_session` honours the backoff, and proceeds once past the deadline
- the manual dashboard trigger returns `429` inside the window, `200` outside it

## Gates

`pytest` 33290 passed (9 failures, 8 of which reproduce on a clean `origin/main` checkout
on this host — `test_dashboard_origin`, `test_platform_compat`, `test_app_manager`,
`test_cron_cancel`, `test_search_sessions_cost`; the 9th was
`test_error_code_contract` flagging the new `429`, fixed by adding the `code` field).
`isort`, `flake8`, `mypy` (1.14.1, no faiss — CI parity) all clean. `npx tsc -b` clean;
`vitest` 9788 passed with the one known host-Node `Intl.DurationFormat` divergence in
`src/i18n/format.test.ts` (no frontend files are touched by this change).
