### PR TITLE
fix(session): recycle knowledge-pool sessions between documents and repair the dead _bg blind-recycle fallback

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -3515,16 +3515,7 @@ class AcpClient:
         await self.ensure_ready()
 
         req_id = await self._send_prompt(message)
-        prev_pct = self.last_prompt_stats.context_pct
-        _prev_used = self.last_prompt_stats.context_used_tokens
-        _prev_window = self.last_prompt_stats.context_window_tokens
-        _prev_from_usage = self.last_prompt_stats.context_tokens_from_usage
-        self.last_prompt_stats = AcpPromptStats(
-            context_pct=prev_pct,
-            context_used_tokens=_prev_used,
-            context_window_tokens=_prev_window,
-            context_tokens_from_usage=_prev_from_usage,
-        )
+        self.last_prompt_stats = self.last_prompt_stats.carry_over()
 
         # aclosing(): _prompt_loop holds _turn_lock and releases it in its
         # finally. Consumers below `return` on "complete" without exhausting the
@@ -3596,16 +3587,7 @@ class AcpClient:
         extract_agent_from_result: bool = False,
     ) -> AsyncIterator[AcpEvent]:
         """Shared event dispatch loop for prompts and commands."""
-        prev_pct = self.last_prompt_stats.context_pct
-        _prev_used = self.last_prompt_stats.context_used_tokens
-        _prev_window = self.last_prompt_stats.context_window_tokens
-        _prev_from_usage = self.last_prompt_stats.context_tokens_from_usage
-        self.last_prompt_stats = AcpPromptStats(
-            context_pct=prev_pct,
-            context_used_tokens=_prev_used,
-            context_window_tokens=_prev_window,
-            context_tokens_from_usage=_prev_from_usage,
-        )
+        self.last_prompt_stats = self.last_prompt_stats.carry_over()
         self._tool_call_inputs.clear()
         self._tool_call_is_shell.clear()
         self._tool_call_mcp_server.clear()
@@ -4154,16 +4136,7 @@ class AcpClient:
 
     async def _read_prompt_response(self, req_id: int, timeout: float) -> str:
         output: list[str] = []
-        prev_pct = self.last_prompt_stats.context_pct
-        _prev_used = self.last_prompt_stats.context_used_tokens
-        _prev_window = self.last_prompt_stats.context_window_tokens
-        _prev_from_usage = self.last_prompt_stats.context_tokens_from_usage
-        self.last_prompt_stats = AcpPromptStats(
-            context_pct=prev_pct,
-            context_used_tokens=_prev_used,
-            context_window_tokens=_prev_window,
-            context_tokens_from_usage=_prev_from_usage,
-        )
+        self.last_prompt_stats = self.last_prompt_stats.carry_over()
 
         async for action, msg in self._prompt_loop(req_id, timeout):
             if action == "complete":
@@ -4296,6 +4269,7 @@ class AcpClient:
                 # Mark the counts authoritative so a later metadata
                 # contextUsagePercentage cannot clobber this token-derived pct.
                 self.last_prompt_stats.context_tokens_from_usage = True
+                self.last_prompt_stats.note_pct_reported()
             else:
                 logger.debug("usage_update missing used/size: %s", update)
         elif kind == UPDATE_CONFIG_OPTION:
@@ -5054,6 +5028,7 @@ class AcpClient:
                 # valid JSON). NaN is caught by its self-inequality.
                 pct_f = 0.0 if pct_f != pct_f else min(max(pct_f, 0.0), 100.0)
                 self.last_prompt_stats.context_pct = pct_f
+                self.last_prompt_stats.note_pct_reported()
                 self._backfill_context_window(pct_f)
             except (TypeError, ValueError):
                 pass

--- a/src/kiro_crew/acp/session_handle.py
+++ b/src/kiro_crew/acp/session_handle.py
@@ -410,12 +410,7 @@ class AcpSessionHandle:
             except asyncio.QueueEmpty:
                 break
 
-        self.last_prompt_stats = AcpPromptStats(
-            context_pct=self.last_prompt_stats.context_pct,
-            context_used_tokens=self.last_prompt_stats.context_used_tokens,
-            context_window_tokens=self.last_prompt_stats.context_window_tokens,
-            context_tokens_from_usage=self.last_prompt_stats.context_tokens_from_usage,
-        )
+        self.last_prompt_stats = self.last_prompt_stats.carry_over()
 
         # send_request must be inside the turn-state guard: _turn_done was just
         # cleared above, so if the request raises (e.g. AcpRuntimeDead on a
@@ -1523,6 +1518,7 @@ class AcpSessionHandle:
                 # valid JSON). NaN is caught by its self-inequality.
                 pct_f = 0.0 if pct_f != pct_f else min(max(pct_f, 0.0), 100.0)
                 self.last_prompt_stats.context_pct = pct_f
+                self.last_prompt_stats.note_pct_reported()
                 self._backfill_context_window(pct_f)
             except (TypeError, ValueError):
                 pass
@@ -1728,6 +1724,7 @@ class AcpSessionHandle:
                         self.last_prompt_stats.context_window_tokens = int(size)
                         # Mark authoritative so metadata pct cannot clobber it.
                         self.last_prompt_stats.context_tokens_from_usage = True
+                        self.last_prompt_stats.note_pct_reported()
                 except (TypeError, ValueError, ZeroDivisionError):
                     pass
             return []

--- a/src/kiro_crew/acp/session_provider.py
+++ b/src/kiro_crew/acp/session_provider.py
@@ -307,6 +307,11 @@ class AcpSessionProvider(LLMProvider):
         """Return last known context usage percentage."""
         return self._handle.last_prompt_stats.context_pct
 
+    def context_usage_unknown(self) -> bool:
+        """True when the 0% reading is a post-compaction unknown, not an empty
+        transcript."""
+        return self._handle.last_prompt_stats.context_pct_unknown
+
     def context_window_tokens(self) -> int:
         """Return the context window size in tokens."""
         return self._handle.last_prompt_stats.context_window_tokens

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -482,6 +482,37 @@ class AcpPromptStats:
     # Per-turn billing credits summed from kiro's _kiro.dev/metadata
     # meteringUsage (unit="credit"). 0 for providers that bill in tokens.
     credits: float = 0.0
+    # True while ``context_pct`` reads 0.0 only because a compaction dropped the
+    # counts and no fresh telemetry has re-derived them. Distinguishes "the
+    # transcript is empty" from "the transcript's size is unknown" — the two are
+    # indistinguishable by value, and a consumer that reads the second as the
+    # first sees a session that just hit its context ceiling as brand new.
+    # Cleared the moment a real percentage or usage_update lands.
+    context_pct_unknown: bool = False
+
+    def carry_over(self) -> "AcpPromptStats":
+        """Return fresh per-turn stats carrying this turn's context state.
+
+        Event/tool/credit counters are per-turn and start at zero; the context
+        state describes the SESSION and must survive the re-init, or every turn
+        boundary would re-report an empty context.
+        """
+        return AcpPromptStats(
+            context_pct=self.context_pct,
+            context_used_tokens=self.context_used_tokens,
+            context_window_tokens=self.context_window_tokens,
+            context_tokens_from_usage=self.context_tokens_from_usage,
+            context_pct_unknown=self.context_pct_unknown,
+        )
+
+    def note_pct_reported(self) -> None:
+        """Mark ``context_pct`` as backed by real telemetry.
+
+        Called wherever a percentage or usage_update is applied, so a zero that
+        follows a compaction stops reading as "unknown" once the backend says
+        what the compacted transcript actually costs.
+        """
+        self.context_pct_unknown = False
 
     def reset_after_compaction(self) -> None:
         """Drop the usage counts after a successful compaction.
@@ -493,10 +524,16 @@ class AcpPromptStats:
         ``_track_metadata`` / ``_backfill_context_window``, so even a fresh
         post-compaction metadata percentage could never correct it. The window
         is kept: the model did not change, so the served window still holds.
+
+        The zeroed ``context_pct`` is flagged unknown, not empty: a consumer
+        that recycles or compacts on a threshold would otherwise read a session
+        sitting at its ceiling as freshly started and leave it in place, paying
+        the backend's own auto-compaction over and over.
         """
         self.context_tokens_from_usage = False
         self.context_used_tokens = 0
         self.context_pct = 0.0
+        self.context_pct_unknown = True
 
     def rebase_to_window(self, window_tokens: int) -> None:
         """Re-anchor the token stats to a new model's context window.

--- a/src/kiro_crew/knowledge/llm_pool.py
+++ b/src/kiro_crew/knowledge/llm_pool.py
@@ -52,6 +52,22 @@ AGENT_NAME = "kirocrew-knowledge"
 # (the always-on behaviour).
 DEFAULT_IDLE_TTL_SECS = 300.0
 
+# Conversation-recycle thresholds for a checked-out worker.
+#
+# Pool workers are long-lived sessions, but every prompt they serve is
+# self-contained: ``extractor.EXTRACTION_PROMPT`` inlines the whole chunk between
+# per-call nonce markers, and ``agent_fetch`` inlines the whole URL, so no call
+# depends on anything an earlier call said. The accumulating transcript is
+# therefore pure cost — and once it reaches the backend's own ceiling the backend
+# auto-compacts, which is a BILLED summarization turn over the entire transcript,
+# repeated every few minutes for the rest of a large ingestion.
+#
+# Recycling the conversation first makes that never happen. The percentage is the
+# real signal; the call count is the fallback for backends that report no context
+# telemetry at all (a 0% reading is indistinguishable from an empty transcript).
+WORKER_RECYCLE_PCT = 50.0
+WORKER_RECYCLE_CALLS = 20
+
 
 # Sandbox modes accepted by ``kiro_crew.sandbox.wrap_argv`` (see its docstring).
 # An out-of-set value from config falls back to the safe default rather than
@@ -150,6 +166,13 @@ def _get_idle_ttl(config: Optional[dict] = None) -> float:
 class Worker(ABC):
     """Abstract base for a long-lived LLM worker."""
 
+    # Prompts served since this worker's conversation was last reset. The pool
+    # reads it to decide when the transcript has grown far enough to be worth
+    # dropping (see WORKER_RECYCLE_CALLS). Declared at class level, not set in an
+    # ``__init__``, so a subclass that does not chain up still has the counter
+    # (``+=`` rebinds it per instance).
+    calls_since_reset: int = 0
+
     @abstractmethod
     async def start(self) -> None:
         """Initialize/spawn the worker process."""
@@ -165,6 +188,22 @@ class Worker(ABC):
     @abstractmethod
     def is_alive(self) -> bool:
         """True if this worker can still process messages."""
+
+    def context_pct(self) -> float:
+        """Backend-reported context usage for this worker's conversation.
+
+        ``0.0`` when the backend reports nothing (the pool then falls back to the
+        call count), so a subclass with no telemetry needs no override.
+        """
+        return 0.0
+
+    @abstractmethod
+    async def reset_conversation(self) -> None:
+        """Drop the accumulated transcript, leaving the worker ready to serve.
+
+        Must leave ``is_alive()`` true on success so the pool's dead-worker
+        replacement path stays reserved for genuine deaths.
+        """
 
 
 class AcpWorker(Worker):
@@ -240,6 +279,26 @@ class AcpWorker(Worker):
 
     def is_alive(self) -> bool:
         return self._client is not None and self._client.is_process_alive()
+
+    def context_pct(self) -> float:
+        client = self._client
+        if client is None:
+            return 0.0
+        try:
+            return float(client.last_prompt_stats.context_pct)
+        except (AttributeError, TypeError, ValueError):
+            return 0.0
+
+    async def reset_conversation(self) -> None:
+        """Spawn a fresh ACP session, discarding the accumulated transcript.
+
+        ``start()`` already tears the previous client down (and moves the sweep
+        shield to the new PID), so re-running it is the whole reset. It costs one
+        cold start per WORKER_RECYCLE_CALLS prompts, far less than the billed
+        auto-compaction the growing transcript would otherwise trigger.
+        """
+        await self.start()
+        self.calls_since_reset = 0
 
 
 class CCWorker(Worker):
@@ -367,6 +426,23 @@ class CCWorker(Worker):
 
     def is_alive(self) -> bool:
         return self._proc is not None and self._proc.returncode is None
+
+    async def reset_conversation(self) -> None:
+        """Respawn the CLI subprocess, discarding the accumulated transcript.
+
+        The transcript lives only in the process's own stream-json conversation,
+        so replacing the process is the reset. ``_spawn()`` cancels the old
+        reader task and installs a fresh event queue, leaving the worker ready.
+        """
+        old = self._proc
+        await self._spawn()
+        if old is not None and old is not self._proc:
+            try:
+                old.kill()
+                await old.wait()
+            except Exception:
+                logger.debug("CCWorker: stale process reap failed", exc_info=True)
+        self.calls_since_reset = 0
 
 
 class LLMPool:
@@ -587,7 +663,40 @@ class LLMPool:
         try:
             return await worker.send_message(prompt, timeout=timeout)
         finally:
-            self.release(idx)
+            try:
+                await self._maybe_recycle(idx, worker)
+            finally:
+                self.release(idx)
+
+    async def _maybe_recycle(self, idx: int, worker: Worker) -> None:
+        """Reset *worker*'s conversation once its transcript has grown enough.
+
+        Runs while the worker is still checked out, so no other caller can send
+        into a half-reset session. Every knowledge prompt is self-contained, so a
+        reset loses nothing — and it must land BEFORE the backend's own
+        auto-compaction, which bills a summarization turn over the whole
+        transcript every time it fires.
+
+        A failed reset is not fatal: the worker is left reporting dead and
+        ``acquire()`` replaces it on the next checkout.
+        """
+        worker.calls_since_reset += 1
+        try:
+            pct = worker.context_pct()
+        except Exception:
+            pct = 0.0
+        by_pct = pct >= WORKER_RECYCLE_PCT
+        if not by_pct and worker.calls_since_reset < WORKER_RECYCLE_CALLS:
+            return
+        reason = f"context at {pct:.0f}%" if by_pct else f"{worker.calls_since_reset} calls"
+        logger.info("LLMPool: recycling worker %d conversation — %s", idx, reason)
+        try:
+            await worker.reset_conversation()
+        except Exception:
+            logger.warning(
+                "LLMPool: worker %d conversation reset failed; will be replaced on "
+                "next acquire", idx, exc_info=True,
+            )
 
     async def send_batch(self, prompts: list[str], timeout: float = DEFAULT_TIMEOUT) -> list[str]:
         """Send multiple prompts concurrently, bounded by pool size.

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -1057,6 +1057,9 @@ class AcpProvider(LLMProvider):
     def context_usage_pct(self) -> float:
         return self._client.last_prompt_stats.context_pct
 
+    def context_usage_unknown(self) -> bool:
+        return self._client.last_prompt_stats.context_pct_unknown
+
     def context_window_tokens(self) -> int:
         return self._client.last_prompt_stats.context_window_tokens
 

--- a/src/kiro_crew/providers/base.py
+++ b/src/kiro_crew/providers/base.py
@@ -67,6 +67,16 @@ class LLMProvider(ABC):
     def context_usage_pct(self) -> float:
         """Return last known context usage percentage."""
 
+    def context_usage_unknown(self) -> bool:
+        """True when a 0% reading means "unknown", not "empty".
+
+        A backend that compacts in place reports 0% for a transcript whose real
+        size it has not measured yet, which is byte-identical to a brand-new
+        session. Callers that act on a threshold need the two apart. Default
+        False for providers that never compact unobserved.
+        """
+        return False
+
     def context_window_tokens(self) -> int:
         """Return the real served context window in tokens (0 if unknown).
 

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -468,6 +468,34 @@ def _provider_has_active_turn(provider: LLMProvider) -> bool:
     return res is True
 
 
+def _context_pct_is_unknown(provider: LLMProvider) -> bool:
+    """True only if ``provider`` reports its 0% context reading as unknown.
+
+    Mirrors :func:`_provider_has_active_turn`'s defensive shape: the probe is
+    optional (stubs and warm-pool doubles need not implement it), and an
+    ``AsyncMock``-style double that returns a coroutine is closed rather than
+    left to raise a RuntimeWarning. Anything that is not exactly ``True`` reads
+    as "the percentage is trustworthy", keeping the caller's recycle decision
+    fail-quiet on a double.
+    """
+    fn = getattr(provider, "context_usage_unknown", None)
+    if not callable(fn):
+        return False
+    try:
+        res = fn()
+    except Exception:
+        return False
+    if inspect.isawaitable(res):
+        close = getattr(res, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass
+        return False
+    return res is True
+
+
 def _provider_has_unfinished_turn(provider: LLMProvider) -> bool:
     """True only if ``provider`` reports a native turn that has not reached its
     done boundary — INDEPENDENT of cancel state (unlike
@@ -539,6 +567,27 @@ class _Session:
     # Consumed one-shot by the next prompt builder to re-inject the skills
     # index so the model can still discover skills post-compaction.
     needs_context_reinjection: bool = False
+
+    def adopt_provider(self, provider: LLMProvider) -> None:
+        """Swap in a freshly-spawned *provider*, resetting conversation state.
+
+        Recycling in place — rather than registering a new ``_Session`` — is what
+        lets a caller already holding this session (or blocked on its semaphore)
+        pick up the replacement instead of a torn-down provider: both the
+        semaphore and the object identity the registry is keyed on survive.
+        Everything reset below describes the OLD transcript, so carrying it onto
+        a fresh provider would misreport its size or replay a preamble the new
+        conversation never lost. ``agent`` and ``approval_policy`` describe the
+        session's role, not its transcript, so they are kept.
+        """
+        self.provider = provider
+        self.provider_switch_replay = False
+        self.prompt_count = 0
+        self.consecutive_failures = 0
+        self.prev_turn_cancelled = False
+        self.needs_context_reinjection = False
+        self.created_at = time.time()
+        self.last_used = time.monotonic()
 
 
 class _ProviderBgSession:
@@ -2047,35 +2096,100 @@ class SessionManager:
         """Check background session context and recycle if too full.
 
         Background tasks are stateless (cron, heartbeat, lessons), so we
-        don't need compaction — just kill the old session and create a fresh
-        one.  Called after each background task completes.
+        don't need compaction — just swap in a fresh provider.  Called after
+        each background task completes.
 
         Thresholds are more aggressive than chat compaction:
         - At ≥ 70% context → recycle
+        - Once the backend reports a post-compaction unknown → recycle
         - After 40 prompts with no metadata → recycle (blind fallback)
+
+        Runs under the session's own turn semaphore, so it is mutually exclusive
+        with background turns: callers ``release`` it on the line before calling
+        here, and a waiter can take it in that gap, so deciding or tearing down
+        outside it would SIGKILL a turn that had already started.
         """
         session = self._sessions.get(BACKGROUND_KEY)
         if not session:
             return
 
-        pct = session.provider.context_usage_pct()
-        needs_recycle = pct >= _BG_RECYCLE_PCT
-        if not needs_recycle and pct == 0.0:
-            # Blind fallback: recycle after N prompts if metadata never reports %
-            needs_recycle = session.prompt_count >= _BG_BLIND_RECYCLE_PROMPTS
-
-        if not needs_recycle:
+        # Take the same semaphore a turn takes, then re-validate identity and
+        # liveness under _lock — the shared dance every multiplexing path uses.
+        # If a waiter got the turn first this blocks until that turn finishes;
+        # if the entry was replaced or removed while we waited, we own nothing
+        # and must not tear anything down. No caller holds the semaphore at this
+        # point (they release immediately before calling), so this cannot
+        # self-deadlock.
+        if not await self._reacquire_and_validate(BACKGROUND_KEY, session):
             return
+        try:
+            provider = session.provider
 
-        reason = f"context at {pct:.0f}%" if pct > 0 else f"blind ({session.prompt_count} prompts)"
-        logger.info("Recycling background session — %s", reason)
+            # Count the completed turn HERE. ``check_context_usage`` — the only
+            # other place that advances ``prompt_count`` — is a chat-turn hook
+            # and never runs for BACKGROUND_KEY, so without this the blind
+            # fallback below reads a permanently-zero counter and can never fire.
+            session.prompt_count += 1
 
-        async with self._lock:
-            old = self._sessions.pop(BACKGROUND_KEY, None)
-        if old:
-            await old.provider.shutdown()
+            pct = provider.context_usage_pct()
+            needs_recycle = pct >= _BG_RECYCLE_PCT
+            # A 0% that the backend flags unknown means it already compacted this
+            # session in place: the transcript reached its ceiling and its
+            # post-compact size is unmeasured. Recycling now is strictly cheaper
+            # than leaving it to compact again, because every compaction is a
+            # billed summarization turn over the whole transcript and a
+            # background session keeps nothing worth summarizing.
+            post_compaction = pct == 0.0 and _context_pct_is_unknown(provider)
+            if not needs_recycle and post_compaction:
+                needs_recycle = True
+            elif not needs_recycle and pct == 0.0:
+                # Blind fallback: recycle after N prompts if metadata never reports %
+                needs_recycle = session.prompt_count >= _BG_BLIND_RECYCLE_PROMPTS
 
-        await self._ensure_background()
+            if not needs_recycle:
+                return
+
+            if pct > 0:
+                reason = f"context at {pct:.0f}%"
+            elif post_compaction:
+                reason = "compacted in place (context size unknown)"
+            else:
+                reason = f"blind ({session.prompt_count} prompts)"
+            logger.info("Recycling background session — %s", reason)
+
+            if not self._provider_factory:
+                return
+            # Spawn the replacement BEFORE tearing the old one down: a failed
+            # spawn then leaves the working session in place instead of leaving
+            # _bg with nothing, and the registered entry is never absent.
+            try:
+                replacement = self._provider_factory(BACKGROUND_KEY, agent=BACKGROUND_AGENT)
+                async with self._start_sem:
+                    await replacement.start()
+            except Exception:
+                logger.warning(
+                    "Background session recycle kept the old provider — "
+                    "replacement failed to start",
+                    exc_info=True,
+                )
+                return
+
+            async with self._lock:
+                # reset()/remove()/close_all() do not take the turn semaphore, so
+                # the entry can still have moved out from under us while the
+                # replacement was starting. Whoever owns it now owns the
+                # lifecycle; discard ours rather than overwrite theirs.
+                adopted = self._sessions.get(BACKGROUND_KEY) is session
+                if adopted:
+                    session.adopt_provider(replacement)
+
+            doomed = provider if adopted else replacement
+            try:
+                await doomed.shutdown()
+            except Exception:
+                logger.debug("Background recycle provider shutdown failed", exc_info=True)
+        finally:
+            session.semaphore.release()
 
     async def recycle_heartbeat(self) -> None:
         """Tear down the heartbeat session at the end of a cycle.

--- a/test/test_acp_session_provider.py
+++ b/test/test_acp_session_provider.py
@@ -61,6 +61,22 @@ class TestAcpSessionProviderBasic:
         provider = AcpSessionProvider(handle, runtime)
         assert provider.context_usage_pct() == 55.5
 
+    def test_context_usage_unknown_is_false_while_pct_is_measured(self):
+        handle = _make_handle(context_pct=55.5)
+        runtime = _make_runtime()
+        provider = AcpSessionProvider(handle, runtime)
+        assert provider.context_usage_unknown() is False
+
+    def test_context_usage_unknown_after_in_place_compaction(self):
+        """A compaction zeroes the percentage; the adapter must pass "unknown"
+        through so a threshold consumer does not read the session as brand new."""
+        handle = _make_handle(context_pct=91.0)
+        handle.last_prompt_stats.reset_after_compaction()
+        runtime = _make_runtime()
+        provider = AcpSessionProvider(handle, runtime)
+        assert provider.context_usage_pct() == 0.0
+        assert provider.context_usage_unknown() is True
+
     def test_context_window_tokens(self):
         handle = _make_handle(context_window=128000)
         runtime = _make_runtime()

--- a/test/test_llm_pool.py
+++ b/test/test_llm_pool.py
@@ -11,6 +11,8 @@ import pytest
 
 from kiro_crew.knowledge.llm_pool import (
     DEFAULT_IDLE_TTL_SECS,
+    WORKER_RECYCLE_CALLS,
+    WORKER_RECYCLE_PCT,
     AcpWorker,
     CCWorker,
     LLMPool,
@@ -54,6 +56,7 @@ class FakeWorker(Worker):
         self._call_count = 0
         self._alive = True
         self._started = False
+        self.resets = 0
 
     async def start(self) -> None:
         self._started = True
@@ -70,6 +73,10 @@ class FakeWorker(Worker):
 
     def is_alive(self) -> bool:
         return self._alive
+
+    async def reset_conversation(self) -> None:
+        self.resets += 1
+        self.calls_since_reset = 0
 
 
 class DeadOnSecondCallWorker(Worker):
@@ -94,6 +101,9 @@ class DeadOnSecondCallWorker(Worker):
 
     def is_alive(self) -> bool:
         return self._alive
+
+    async def reset_conversation(self) -> None:
+        self.calls_since_reset = 0
 
 
 def _make_pool_with_fake_workers(
@@ -212,6 +222,9 @@ class TestLLMPoolConcurrency:
             def is_alive(self) -> bool:
                 return True
 
+            async def reset_conversation(self) -> None:
+                self.calls_since_reset = 0
+
         pool = LLMPool(pool_size=2)
         pool._started = True
         pool._provider_type = "test"
@@ -296,6 +309,9 @@ class TestLLMPoolBatchErrors:
 
             def is_alive(self) -> bool:
                 return True
+
+            async def reset_conversation(self) -> None:
+                self.calls_since_reset = 0
 
         pool = LLMPool(pool_size=1)
         pool._started = True
@@ -950,3 +966,184 @@ class TestIdleReaper:
         assert all(not w.is_alive() for w in live)  # live set drained too
         assert pool._reaping_workers is None
         assert pool._started is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: conversation recycling (billed auto-compaction avoidance)
+# ---------------------------------------------------------------------------
+
+
+class _PctWorker(Worker):
+    """Worker whose reported context percentage the test drives directly."""
+
+    def __init__(self, pct: float = 0.0) -> None:
+        self.pct = pct
+        self.resets = 0
+        self.sends = 0
+
+    async def start(self) -> None:
+        pass
+
+    async def send_message(self, prompt: str, timeout: float = 60.0) -> str:
+        self.sends += 1
+        return "ok"
+
+    async def shutdown(self) -> None:
+        pass
+
+    def is_alive(self) -> bool:
+        return True
+
+    def context_pct(self) -> float:
+        return self.pct
+
+    async def reset_conversation(self) -> None:
+        self.resets += 1
+        self.calls_since_reset = 0
+
+
+def _pool_with(worker: Worker) -> LLMPool:
+    pool = LLMPool(pool_size=1)
+    pool._started = True
+    pool._provider_type = "test"
+    pool._workers.append(worker)
+    pool._available.put_nowait(0)
+    return pool
+
+
+class TestWorkerConversationRecycle:
+    """The pool must drop a worker's transcript before the backend compacts it.
+
+    Every knowledge prompt is self-contained, so the accumulated transcript buys
+    nothing while the backend's own auto-compaction bills a summarization turn
+    over all of it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_recycles_when_context_crosses_threshold(self):
+        worker = _PctWorker(pct=WORKER_RECYCLE_PCT)
+        pool = _pool_with(worker)
+
+        await pool.send("prompt")
+
+        assert worker.resets == 1
+        assert worker.calls_since_reset == 0
+
+    @pytest.mark.asyncio
+    async def test_no_recycle_below_threshold(self):
+        worker = _PctWorker(pct=WORKER_RECYCLE_PCT - 1)
+        pool = _pool_with(worker)
+
+        await pool.send("prompt")
+
+        assert worker.resets == 0
+        assert worker.calls_since_reset == 1
+
+    @pytest.mark.asyncio
+    async def test_recycles_on_call_count_when_backend_reports_no_pct(self):
+        """A 0% reading is indistinguishable from an empty transcript, so the
+        call count is the fallback that keeps an untelemetered backend from
+        growing without bound."""
+        worker = _PctWorker(pct=0.0)
+        pool = _pool_with(worker)
+
+        for _ in range(WORKER_RECYCLE_CALLS - 1):
+            await pool.send("prompt")
+        assert worker.resets == 0
+
+        await pool.send("prompt")
+        assert worker.resets == 1
+        assert worker.calls_since_reset == 0
+
+    @pytest.mark.asyncio
+    async def test_recycle_happens_between_calls_not_mid_call(self):
+        """The reset lands while the worker is still checked out, so a second
+        caller can never send into a half-reset session."""
+        worker = _PctWorker(pct=WORKER_RECYCLE_PCT)
+        order: list[str] = []
+
+        original_send = worker.send_message
+        original_reset = worker.reset_conversation
+
+        async def _send(prompt: str, timeout: float = 60.0) -> str:
+            order.append("send")
+            return await original_send(prompt, timeout=timeout)
+
+        async def _reset() -> None:
+            order.append("reset")
+            await original_reset()
+
+        worker.send_message = _send  # type: ignore[method-assign]
+        worker.reset_conversation = _reset  # type: ignore[method-assign]
+
+        pool = _pool_with(worker)
+        await pool.send("a")
+        await pool.send("b")
+
+        assert order == ["send", "reset", "send", "reset"]
+
+    @pytest.mark.asyncio
+    async def test_send_batch_recycles_through_the_same_chokepoint(self):
+        worker = _PctWorker(pct=WORKER_RECYCLE_PCT)
+        pool = _pool_with(worker)
+
+        await pool.send_batch(["a", "b", "c"])
+
+        assert worker.sends == 3
+        assert worker.resets == 3
+
+    @pytest.mark.asyncio
+    async def test_failed_reset_still_releases_the_worker(self):
+        """A reset failure must not wedge the pool — the worker is released and
+        ``acquire()`` replaces it on the next checkout."""
+        worker = _PctWorker(pct=WORKER_RECYCLE_PCT)
+
+        async def _boom() -> None:
+            raise RuntimeError("respawn failed")
+
+        worker.reset_conversation = _boom  # type: ignore[method-assign]
+        pool = _pool_with(worker)
+
+        assert await pool.send("prompt") == "ok"
+        # Permit returned and the index is queued again.
+        assert pool._available.qsize() == 1
+        assert pool._in_use == 0
+        assert await pool.send("prompt") == "ok"
+
+    @pytest.mark.asyncio
+    async def test_acp_worker_reset_respawns_the_client(self):
+        """``AcpWorker.reset_conversation`` must produce a NEW ACP session, not
+        reuse the one carrying the transcript."""
+        worker = AcpWorker(sandbox_mode="off")
+        old_client = AsyncMock()
+        old_client.is_process_alive = lambda: True
+        worker._client = old_client
+        worker.calls_since_reset = 7
+
+        new_client = AsyncMock()
+        new_client._pid = 4242
+        new_client.is_process_alive = lambda: True
+
+        # Patch the sweep shield like the other AcpWorker tests: it is a
+        # process-global registry, and a real registration leaked from a test
+        # makes _collect_active_pids report a non-empty protected set to whatever
+        # else shares this worker.
+        with patch("kiro_crew.knowledge.llm_pool.AcpClient", return_value=new_client), \
+             patch("kiro_crew.knowledge.llm_pool.register_protected_pid"), \
+             patch("kiro_crew.knowledge.llm_pool.unregister_protected_pid"):
+            await worker.reset_conversation()
+
+        old_client.shutdown.assert_awaited_once()
+        assert worker._client is new_client
+        new_client.ensure_ready.assert_awaited_once()
+        assert worker.calls_since_reset == 0
+
+    @pytest.mark.asyncio
+    async def test_acp_worker_context_pct_reads_client_stats(self):
+        worker = AcpWorker()
+        assert worker.context_pct() == 0.0
+
+        client = AsyncMock()
+        client.last_prompt_stats.context_pct = 63.5
+        worker._client = client
+        assert worker.context_pct() == 63.5

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -10,8 +10,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from kiro_crew.acp.types import AcpPromptStats
 from kiro_crew.config import KiroCrewConfig
-from kiro_crew.session import BACKGROUND_KEY, SessionManager
+from kiro_crew.session import (
+    _BG_BLIND_RECYCLE_PROMPTS,
+    BACKGROUND_KEY,
+    SessionManager,
+)
 
 
 @pytest.fixture
@@ -28,6 +33,10 @@ def _mock_provider_factory():
         m = AsyncMock()
         m.start = AsyncMock()
         m.shutdown = AsyncMock()
+        # Explicit, not AsyncMock-generated: the post-semaphore re-validate calls
+        # this synchronously, and an auto-generated coroutine would read as
+        # "alive" only by truthiness while leaking an un-awaited coroutine.
+        m.is_process_alive = lambda: True
         m.context_usage_pct = lambda: 0.0
         m.has_active_turn = lambda: False
         return m
@@ -560,6 +569,198 @@ class TestRecycleBackground:
         mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
         # Don't start pool — no background session
         await mgr.recycle_background()  # should not raise
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_blind_fallback_counts_its_own_prompts(self, cfg):
+        """The blind fallback must fire on its own counting.
+
+        ``check_context_usage`` is a chat-turn hook and never runs for
+        BACKGROUND_KEY, so if ``recycle_background`` does not count the turn the
+        counter stays at 0 forever and the 40-prompt fallback is dead code.
+        """
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.start_pool()
+
+        provider = mgr._sessions[BACKGROUND_KEY].provider
+        provider.context_usage_pct = lambda: 0.0  # backend reports no metadata
+        provider.context_usage_unknown = lambda: False
+
+        for _ in range(_BG_BLIND_RECYCLE_PROMPTS - 1):
+            await mgr.recycle_background()
+
+        assert mgr._sessions[BACKGROUND_KEY].provider is provider
+        assert mgr._sessions[BACKGROUND_KEY].prompt_count == _BG_BLIND_RECYCLE_PROMPTS - 1
+
+        await mgr.recycle_background()
+
+        provider.shutdown.assert_awaited_once()
+        assert mgr._sessions[BACKGROUND_KEY].provider is not provider
+        # The replacement starts its own count.
+        assert mgr._sessions[BACKGROUND_KEY].prompt_count == 0
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_just_compacted_zero_pct_does_not_suppress_recycle(self, cfg):
+        """A post-compaction 0% is "unknown", not "empty".
+
+        The backend zeroes the percentage when it compacts in place, which is
+        byte-identical to a brand-new session. Reading it as empty leaves a
+        session that just hit its ceiling in place to be compacted again — and
+        each compaction is a billed summarization turn over the whole transcript.
+        """
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.start_pool()
+
+        provider = mgr._sessions[BACKGROUND_KEY].provider
+        provider.context_usage_pct = lambda: 0.0
+        provider.context_usage_unknown = lambda: True
+
+        # One turn — far below the blind threshold, so only the unknown signal
+        # can trigger the recycle.
+        await mgr.recycle_background()
+
+        provider.shutdown.assert_awaited_once()
+        assert mgr._sessions[BACKGROUND_KEY].provider is not provider
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_acp_prompt_stats_flag_post_compaction_zero_as_unknown(self):
+        """The provider-level signal the recycle decision rides on."""
+        stats = AcpPromptStats(context_pct=88.0, context_used_tokens=170_000)
+        assert stats.context_pct_unknown is False
+
+        stats.reset_after_compaction()
+        assert stats.context_pct == 0.0
+        assert stats.context_pct_unknown is True
+
+        # Survives the per-turn stats re-init...
+        carried = stats.carry_over()
+        assert carried.context_pct_unknown is True
+
+        # ...and clears as soon as the backend reports a real number.
+        carried.note_pct_reported()
+        assert carried.context_pct_unknown is False
+
+    @pytest.mark.asyncio
+    async def test_recycle_never_kills_a_turn_that_started_after_release(self, cfg):
+        """A turn taken in the release→recycle gap must not be torn down.
+
+        Every call site releases the turn semaphore on the line before calling
+        ``recycle_background``, so a waiter can start a turn in that gap. If the
+        recycle decides and shuts down outside the semaphore it SIGKILLs that
+        live turn.
+        """
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.start_pool()
+
+        sess = mgr._sessions[BACKGROUND_KEY]
+        old_provider = sess.provider
+        old_provider.context_usage_pct = lambda: 95.0
+        old_provider.context_usage_unknown = lambda: False
+
+        killed_mid_turn: list[str] = []
+        turn_providers: list[object] = []
+        recycle_done = asyncio.Event()
+
+        async def _waiter_turn() -> None:
+            # Mirrors _ProviderBgSession.prompt: take the turn semaphore, then
+            # stream on whatever provider the session holds at that moment.
+            await sess.semaphore.acquire()
+            try:
+                provider = sess.provider
+                turn_providers.append(provider)
+                # Stay in the turn until the recycle attempt finishes. Deadline
+                # is a yield budget, not wall-clock, so the interleaving is
+                # deterministic.
+                for _ in range(200):
+                    if provider.shutdown.await_count:
+                        killed_mid_turn.append("provider shut down mid-turn")
+                        break
+                    if recycle_done.is_set():
+                        break
+                    await asyncio.sleep(0)
+            finally:
+                sess.semaphore.release()
+
+        async def _recycle() -> None:
+            try:
+                await mgr.recycle_background()
+            finally:
+                recycle_done.set()
+
+        # Reproduce the real call-site interleaving: a turn completes and
+        # releases, a waiter wins the gap, THEN the recycle runs.
+        await mgr.get_or_create(BACKGROUND_KEY)
+        mgr.release(BACKGROUND_KEY)
+        waiter = asyncio.create_task(_waiter_turn())
+        await asyncio.sleep(0)  # let the waiter take the semaphore
+
+        recycle = asyncio.create_task(_recycle())
+        await recycle
+        await waiter
+
+        assert killed_mid_turn == []
+        # The turn ran to completion on the provider it picked up...
+        assert turn_providers == [old_provider]
+        # ...and the recycle still happened, once the turn was done.
+        assert sess.provider is not old_provider
+        old_provider.shutdown.assert_awaited_once()
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_a_turn_starting_after_the_recycle_gets_the_replacement(self, cfg):
+        """The session is recycled in place, so a holder is routed to the new
+        provider rather than to the torn-down one."""
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        await mgr.start_pool()
+
+        sess = mgr._sessions[BACKGROUND_KEY]
+        old_provider = sess.provider
+        old_provider.context_usage_pct = lambda: 95.0
+        old_provider.context_usage_unknown = lambda: False
+
+        await mgr.recycle_background()
+
+        # A caller that captured the session before the recycle still finds a
+        # live provider on it, and the registry entry did not go absent.
+        assert mgr._sessions[BACKGROUND_KEY] is sess
+        await sess.semaphore.acquire()
+        try:
+            assert sess.provider is not old_provider
+            assert sess.provider.shutdown.await_count == 0
+        finally:
+            sess.semaphore.release()
+        # Conversation state describing the old transcript does not carry over.
+        assert sess.prompt_count == 0
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_failed_replacement_spawn_keeps_the_working_provider(self, cfg):
+        """A spawn failure must not leave _bg with no provider at all."""
+        calls = {"n": 0}
+        base = _mock_provider_factory()
+
+        def factory(session_key=None, agent=None, channel_id=None, **kwargs):
+            calls["n"] += 1
+            if calls["n"] > 1:
+                raise RuntimeError("no capacity")
+            return base(session_key, agent, channel_id, **kwargs)
+
+        mgr = SessionManager(cfg, provider_factory=factory)
+        await mgr.start_pool()
+
+        sess = mgr._sessions[BACKGROUND_KEY]
+        old_provider = sess.provider
+        old_provider.context_usage_pct = lambda: 95.0
+        old_provider.context_usage_unknown = lambda: False
+
+        await mgr.recycle_background()
+
+        assert sess.provider is old_provider
+        old_provider.shutdown.assert_not_awaited()
+        # The semaphore is handed back even on the failure path.
+        assert not sess.semaphore.locked()
         await mgr.close_all()
 
 


### PR DESCRIPTION
## Symptom

During a large Knowledge Library ingestion the gateway log fills with
`Compaction status: started` / `completed` pairs from `kiro_crew.acp.client`,
one pair every 1-3 minutes, for the whole run. Each of those is the backend's
own auto-compaction: a **billed summarization turn over the entire transcript**.
None of it buys anything, because the transcript being summarized is a pile of
independent extraction calls that never reference each other.

Two separate lifecycle defects let a session sit at its context ceiling instead
of being replaced.

## Root cause A — knowledge pool workers are never reset

`src/kiro_crew/knowledge/llm_pool.py:207` (`AcpWorker.start`) — the pool runs
`DEFAULT_POOL_SIZE = 3` long-lived `AcpClient` sessions on the
`kirocrew-knowledge` agent. `send_message` re-runs `start()` **only when the
client is not ready**, so across an entire ingestion each worker keeps one
conversation and its transcript grows monotonically: every chunk's prompt and
every JSON response accumulate until the backend hits its own ceiling and starts
auto-compacting, then re-compacting.

The carried-over context has no value. Verified in
`src/kiro_crew/knowledge/extractor.py`: `EXTRACTION_PROMPT` inlines the **whole
chunk** between per-call `uuid4` nonce markers and asks for a self-contained JSON
object — nothing in it refers to a prior turn. `agent_fetch.fetch_url_content`
inlines the whole URL the same way. Both reach the backend through the single
`LLMPool.send` chokepoint (`send_batch` fans out through `send`), so the
assumption holds for every knowledge call, not just extraction.

## Root cause B — the `_bg` blind-recycle fallback is dead code

`src/kiro_crew/session.py:2046` (`recycle_background`) had two independent holes:

1. **The 40-prompt fallback can never fire.** It tested
   `session.prompt_count >= _BG_BLIND_RECYCLE_PROMPTS` (40), but `prompt_count`
   is incremented in exactly one place — `check_context_usage`
   (`src/kiro_crew/session.py:2776`), a chat-turn hook that is never called for
   `BACKGROUND_KEY`. `_bg.prompt_count` was therefore permanently `0`.

2. **A just-compacted session reads as a fresh one.**
   `AcpPromptStats.reset_after_compaction` (`src/kiro_crew/acp/types.py`, reached
   from `AcpClient._handle_compaction_status` at
   `src/kiro_crew/acp/client.py:5072`) sets `context_pct = 0.0` — byte-identical
   to a session that has never reported usage. So the one state that proves the
   session hit its ceiling was indistinguishable from the state that proves it is
   empty, and `pct >= 70` never tripped.

## Fixes

**A. Recycle the pool worker's conversation before the backend compacts it.**

- `Worker` gains two hooks: `context_pct()` (0.0 when the backend reports
  nothing) and an abstract `reset_conversation()` that must leave the worker
  ready — so the pool's dead-worker replacement path stays reserved for genuine
  deaths, and no Worker implementation can silently skip the reset.
- `AcpWorker.reset_conversation` re-runs `start()`, which already tears the old
  client down and moves the orphan-sweep PID shield to the new process.
  `CCWorker.reset_conversation` respawns its stream-json subprocess and reaps the
  old one.
- `LLMPool.send` calls `_maybe_recycle` in its `finally`, **while the worker is
  still checked out**, so no other caller can send into a half-reset session. It
  resets at `WORKER_RECYCLE_PCT = 50.0`, with `WORKER_RECYCLE_CALLS = 20` as the
  fallback for a backend that reports no percentage. A failed reset is logged and
  the worker released; `acquire()` replaces it on the next checkout.

A per-document boundary is not visible to the pool (`send` is per-chunk), so the
percentage-with-call-count threshold is the cheapest mechanism that is also
correct for a single huge document — and it amortizes the respawn over ~20 calls
instead of paying it per chunk.

**B. Count `_bg` prompts where they happen, and treat a post-compaction zero as
unknown.**

- `recycle_background` increments `session.prompt_count` itself. It is the shared
  post-task chokepoint every `_bg` caller funnels through
  (`history.py`, `context.py`, `taskrunner.py`, `dashboard/chat_title.py`), which
  makes the 40-prompt fallback live.
- `AcpPromptStats` gains `context_pct_unknown`, set by `reset_after_compaction`
  and cleared by `note_pct_reported()` at every site that applies a real
  percentage or `usage_update` (`AcpClient._track_metadata`, its
  `usage_update` branch, and the two `AcpSessionHandle` mirrors).
- The four per-turn stats re-inits that hand-copied four context fields forward
  now call one `carry_over()` helper, so the new flag cannot be dropped at a turn
  boundary by a site that forgot to thread it.
- The signal is surfaced as `LLMProvider.context_usage_unknown()` (default
  `False`), implemented by `AcpProvider` and `AcpSessionProvider`, and read in
  `recycle_background` through `_context_pct_is_unknown` — which mirrors
  `_provider_has_active_turn`'s defensive shape (optional probe, coroutine-returning
  doubles closed, only an exact `True` counts). A post-compaction unknown triggers
  the recycle, since a background session keeps nothing worth summarizing.

## Tests

All revert-verified — each fix was patched out and the paired test confirmed to
fail (9 reverts, all detected):

- `test/test_llm_pool.py::TestWorkerConversationRecycle` — resets at the pct
  threshold; does not reset below it; resets on the call-count fallback when the
  backend reports no pct; the reset lands **between** calls, not mid-call;
  `send_batch` recycles through the same chokepoint; a failed reset still
  releases the worker; `AcpWorker.reset_conversation` produces a **new** client;
  `AcpWorker.context_pct` reads the client's stats.
- `test/test_session.py::TestRecycleBackground::test_blind_fallback_counts_its_own_prompts`
  — the fallback fires at the threshold on its own counting, and the replacement
  starts a fresh count.
- `test/test_session.py::TestRecycleBackground::test_just_compacted_zero_pct_does_not_suppress_recycle`
  — a post-compaction 0% recycles after one turn, far below the blind threshold.
- `test/test_session.py::TestRecycleBackground::test_acp_prompt_stats_flag_post_compaction_zero_as_unknown`
  — the flag is set by the compaction reset, survives `carry_over()`, and clears
  on `note_pct_reported()`.
- `test/test_acp_session_provider.py` — the adapter passes the unknown signal
  through and reports `False` while the pct is measured.

## Gates

`pytest` (33,294 passed), `isort`, `flake8`, `mypy` (801 files, mypy 1.14.1
matching the `pyproject.toml` pin, no `faiss` installed), scrub-lint, Brand Name
Gate, Docs Lint — all green. Eight suite failures are pre-existing: they
reproduce identically on a clean `origin/main` worktree
(`test_app_manager`, `test_cron_cancel`, `test_dashboard_origin`,
`test_platform_compat`, `test_search_sessions_cost` — host-environment
dependent). No `website/` files are touched, so `tsc`/`vitest` are unaffected.

## Recycle lifecycle: in-place provider adoption (reviewer attention requested)

Making the blind-recycle fallback live (root cause B) turned the old
pop-shutdown-recreate recycle into a real hazard: once the fallback can
actually fire, a recycle racing an in-flight `_bg` turn would SIGKILL the
provider mid-turn. The fix therefore replaces the recycle lifecycle, and this
section exists so that change gets deliberate review rather than incidental
passage:

- `_reacquire_and_validate` acquires the `_bg` turn semaphore and revalidates
  the session's identity under `_lock` before any teardown decision, so no
  turn can start on a provider that is about to be replaced.
- The replacement provider is spawned **before** the old one is torn down
  (spawn-before-teardown), so a spawn failure leaves the old, working provider
  in place instead of leaving `_bg` dead.
- `adopt_provider` swaps the provider **inside** the live `_Session` object:
  both the semaphore and the object identity the session registry is keyed on
  survive the swap. Nothing else re-keys the registry, so waiters blocked on
  the semaphore resume against the fresh provider transparently.

Invariants a reviewer should check: the `_bg` turn semaphore is held across
the whole decision-and-replace region (including the cold provider spawn — a
deliberate latency trade to keep the swap atomic), and no registry key changes
identity at any point.

On the 20-call cap firing even with healthy reported pct: intentional. The
cap is a spend ceiling, not only a missing-telemetry fallback — extraction
context has zero carry-over value (see root cause A), so respawning every
~20 calls bounds worst-case transcript growth even when the backend
under-reports usage, at the cost of one cheap respawn per ~20 calls.
