### PR TITLE
fix(knowledge): transition failed folder ingestions out of scanning and cap crash-recovery retries

### DIFF
--- a/src/kiro_crew/knowledge/folder_watcher.py
+++ b/src/kiro_crew/knowledge/folder_watcher.py
@@ -29,6 +29,17 @@ HARD_SKIP_DIRS = {".git", "node_modules", "__pycache__", ".venv", "venv",
                   "dist", "build", "out", "target"}
 DEFAULT_MAX_FILES = 5000
 
+# How many times a file left in 'scanning' is retried before its row is retired to
+# 'failed'. The marker means "an attempt started and never reached a terminal state",
+# so retrying it is the whole point of crash recovery -- but a retry is not free: it
+# re-chunks the file and pays for one model extraction call per chunk plus a document
+# summary. A file that interrupts the sweep every time (an input the reader hangs or
+# dies on, a kill that always lands in the same place) would therefore be billed
+# again on every sweep, forever, with nothing recording that it keeps losing. The cap
+# turns that unbounded loop into a bounded one and leaves a 'failed' row the user can
+# see and act on.
+MAX_SCAN_ATTEMPTS = 3
+
 # How many discovered files a scan processes between ``scan_paused`` re-reads.
 # The check used to run per file, i.e. one on-loop sqlite SELECT against
 # ``sources`` for every discovered file (up to ``max_files``). Re-reading on this
@@ -246,6 +257,41 @@ class FolderWatcher:
                 stats["skipped"] += 1
                 continue
 
+            # A row still holding 'scanning' belongs to an attempt that never reached
+            # a terminal state -- the sweep was interrupted (process exit, task
+            # cancellation) between the marker below and the write that would have
+            # replaced it. Retrying is correct, but each retry re-ingests the file at
+            # full cost, so the retries are counted and the row is retired once the
+            # budget is spent.
+            #
+            # The budget belongs to the VERSION that kept failing, not to the path:
+            # the hash on the interrupted row identifies what was being ingested.
+            # Equal hashes mean the same attempt is about to be repeated, so the cap
+            # applies. A DIFFERENT hash is a document that has never been tried, and
+            # it starts with a full budget -- retiring it would strand new content
+            # behind a retirement earned by content the user has already replaced.
+            # This is why the hash is read first: the decision cannot be made without
+            # it, and it costs one read on the single sweep that retires the row
+            # (later sweeps take the 'failed' gate above and read nothing).
+            prior_attempts = int(state.get("attempts") or 0) if state else 0
+            if state and state.get("status") == "scanning":
+                if content_hash != state.get("content_hash"):
+                    prior_attempts = 0
+                elif prior_attempts >= MAX_SCAN_ATTEMPTS:
+                    # Retirement is terminal, so it clears the count like every other
+                    # terminal write: what keeps the file out of later sweeps is the
+                    # 'failed' gate above, not a spent budget. Carrying the exhausted
+                    # count onto the row would make the user's retry -- which clears
+                    # the status but not the count -- re-enter the scan already over
+                    # budget and be retired again by the very next sweep.
+                    self._update_state(
+                        source_id, file_path, content_hash, mtime,
+                        state.get("item_ids", "[]") or "[]", now, "failed",
+                        f"ingestion did not complete after {MAX_SCAN_ATTEMPTS} attempts",
+                        commit=False)
+                    stats["failed"] += 1
+                    continue
+
             if state and state.get("status") == "done" and content_hash == state.get("content_hash"):
                 # Touched but content unchanged
                 self._update_state(source_id, file_path, content_hash, mtime, state.get("item_ids", "[]"), now, "done", commit=False)
@@ -269,13 +315,28 @@ class FolderWatcher:
                 if not state:
                     stats["new"] += 1
 
-            # Mark scanning before processing (crash recovery: scanning = interrupted)
-            self._update_state(source_id, file_path, content_hash, mtime, json.dumps(old_ids), now, "scanning")
+            # Mark scanning before processing (crash recovery: scanning = interrupted).
+            # The incremented attempt count rides along, so the row itself carries how
+            # much of its retry budget is left even though nothing else in this sweep
+            # survives an abrupt exit.
+            self._update_state(source_id, file_path, content_hash, mtime,
+                               json.dumps(old_ids), now, "scanning",
+                               attempts=prior_attempts + 1)
 
             item_ids, outcome = await self._ingest_file(
                 file_path, source_id, namespace, props, old_ids, root=uri)
             if item_ids is None:
-                # Ingestion failed
+                # Ingestion failed. The 'scanning' marker above is only a crash hint,
+                # so it has to be replaced with a terminal status here rather than
+                # left to whichever branch inside _ingest_file returned: a row that
+                # keeps the marker is re-ingested, at full cost, on every later sweep.
+                # Writing it from the caller also restores the content hash and mtime
+                # the marker carried, which is what lets the UI say WHICH version of
+                # the file failed. The reason recorded by _ingest_file is preserved.
+                self._update_state(
+                    source_id, file_path, content_hash, mtime, json.dumps(old_ids),
+                    now, "failed", self._current_error(source_id, file_path),
+                    commit=False)
                 stats["failed"] += 1
             elif outcome == "deduped":
                 # Refused by the pre-ingest gate: this exact content is already in
@@ -393,11 +454,23 @@ class FolderWatcher:
     def _load_state(self, source_id: str) -> dict[str, dict]:
         """Load folder_file_state rows for this source."""
         rows = self.store.db.execute(
-            "SELECT file_path, content_hash, text_hash, mtime, item_ids, last_seen, status, error_message FROM folder_file_state WHERE source_id = ?",
+            "SELECT file_path, content_hash, text_hash, mtime, item_ids, last_seen, status, error_message, attempts FROM folder_file_state WHERE source_id = ?",
             (source_id,)).fetchall()
         return {r["file_path"]: dict(r) for r in rows}
 
-    def _update_state(self, source_id: str, file_path: str, content_hash: str, mtime: float, item_ids: str, now: str, status: str = "done", error_message: str | None = None, *, commit: bool = True):
+    def _current_error(self, source_id: str, file_path: str) -> str | None:
+        """The reason already recorded on this row, if any.
+
+        The failure branches inside ``_ingest_file`` write the specific cause; the
+        caller then re-writes the row to make the status transition terminal, and
+        reads the cause back so replacing the row does not discard it.
+        """
+        row = self.store.db.execute(
+            "SELECT error_message FROM folder_file_state "
+            "WHERE source_id = ? AND file_path = ?", (source_id, file_path)).fetchone()
+        return row["error_message"] if row else None
+
+    def _update_state(self, source_id: str, file_path: str, content_hash: str, mtime: float, item_ids: str, now: str, status: str = "done", error_message: str | None = None, *, attempts: int = 0, commit: bool = True):
         # Record the EXTRACTED-TEXT hash alongside the file-bytes one. Ownership
         # lookups have to relate this row to items, and items are keyed by the text
         # hash -- for a PDF or HTML file that is a different string from the bytes
@@ -432,9 +505,13 @@ class FolderWatcher:
             # coalesces to content_hash for such a row, which is the right answer
             # wherever it can be reached: the gate can only have refused a plaintext
             # file in that situation, and for plaintext the two hashes are equal.
+        # ``attempts`` defaults to 0, so every terminal write ('done', 'deduped',
+        # 'failed') clears the retry budget as a side effect of not passing it: the
+        # count only ever accumulates across consecutive 'scanning' markers, which is
+        # what it is meant to bound.
         self.store.db.execute(
-            "INSERT OR REPLACE INTO folder_file_state (source_id, file_path, content_hash, text_hash, mtime, item_ids, last_seen, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (source_id, file_path, content_hash, text_hash, mtime, item_ids, now, status, error_message))
+            "INSERT OR REPLACE INTO folder_file_state (source_id, file_path, content_hash, text_hash, mtime, item_ids, last_seen, status, error_message, attempts) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (source_id, file_path, content_hash, text_hash, mtime, item_ids, now, status, error_message, attempts))
         if commit:
             self.store.db.commit()
 

--- a/src/kiro_crew/knowledge/store.py
+++ b/src/kiro_crew/knowledge/store.py
@@ -323,6 +323,12 @@ class KnowledgeStore:
                 updated_at TEXT NOT NULL
             );
 
+            -- ``attempts`` counts CONSECUTIVE non-terminal ingest attempts on a row,
+            -- i.e. how many times it has been left in 'scanning'. It is what bounds
+            -- crash recovery: every retry re-chunks the file and pays for one model
+            -- extraction call per chunk, so a file that never completes has to be
+            -- retired rather than retried on every sweep. Reset to 0 by any terminal
+            -- write ('done', 'deduped', 'failed').
             CREATE TABLE IF NOT EXISTS folder_file_state (
                 source_id TEXT NOT NULL REFERENCES sources(id),
                 file_path TEXT NOT NULL,
@@ -334,6 +340,7 @@ class KnowledgeStore:
                 status TEXT DEFAULT 'pending',
                 error_message TEXT,
                 merged_into_source_id TEXT,
+                attempts INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY (source_id, file_path)
             );
 
@@ -447,6 +454,7 @@ class KnowledgeStore:
                     status TEXT DEFAULT 'pending',
                     error_message TEXT,
                     merged_into_source_id TEXT,
+                    attempts INTEGER NOT NULL DEFAULT 0,
                     PRIMARY KEY (source_id, file_path)
                 )
             """)
@@ -468,6 +476,17 @@ class KnowledgeStore:
             # the data-loss shape this feature already had to remove once.
             if "text_hash" not in ffs_cols:
                 self.db.execute("ALTER TABLE folder_file_state ADD COLUMN text_hash TEXT")
+            # Consecutive non-terminal attempt count, the bound on crash recovery --
+            # see the CREATE TABLE comment. Existing rows start at 0, including any
+            # already stuck in 'scanning': that is deliberate, so a database carrying
+            # a file that cannot be ingested spends the same small retry budget as a
+            # fresh one and then retires the row, instead of re-ingesting it (and
+            # paying for its extraction calls) on every sweep for as long as the
+            # source exists.
+            if "attempts" not in ffs_cols:
+                self.db.execute(
+                    "ALTER TABLE folder_file_state "
+                    "ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0")
         # Migrate: artifact_item_state table -- per-artifact item-group tracking
         # for the aggregate "Artifacts" KB source, keyed by artifact slug.
         if "artifact_item_state" not in tables:

--- a/test/test_folder_watcher.py
+++ b/test/test_folder_watcher.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
+import sqlite3
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from kiro_crew.knowledge.connectors.local_folder import LocalFolderConnector
-from kiro_crew.knowledge.folder_watcher import FolderWatcher
+from kiro_crew.knowledge.folder_watcher import MAX_SCAN_ATTEMPTS, FolderWatcher
 from kiro_crew.knowledge.store import KnowledgeStore
 
 
@@ -617,3 +620,356 @@ class TestIngestTimeConfinement:
             watcher.pipeline.ingest_file.assert_not_awaited()
         finally:
             store.db.close()
+
+
+class TestFailedIngestLeavesNoRetryLoop:
+    """A file whose ingest fails must reach a terminal status, not keep the marker.
+
+    ``scanning`` matches no skip gate, so a row that keeps it is re-chunked and
+    re-extracted -- at full model cost -- on every sweep of the watcher.
+    """
+
+    @pytest.mark.asyncio
+    async def test_failed_ingest_is_terminal_and_skipped_next_sweep(
+            self, store, pipeline, tmp_path):
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "bad.md").write_text("# Bad")
+        source_id = store.add_source("test", "local_folder", str(vault))
+        source = {"id": source_id, "uri": str(vault), "source_type": "local_folder",
+                  "properties": "{}"}
+        fw = FolderWatcher(store, pipeline)
+
+        # A failure path that returns the documented (None, "failed") without
+        # persisting anything itself: _do_scan owns the state transition.
+        calls = []
+
+        async def failing_ingest(file_path, *a, **kw):
+            calls.append(file_path)
+            return None, "failed"
+        fw._ingest_file = failing_ingest
+
+        stats = await fw.scan_source(source)
+        assert stats["failed"] == 1
+        row = store.db.execute(
+            "SELECT status FROM folder_file_state WHERE source_id = ?",
+            (source_id,)).fetchone()
+        assert row["status"] == "failed"
+
+        stats2 = await fw.scan_source(source)
+        assert stats2["skipped"] == 1
+        assert stats2["failed"] == 0
+        assert len(calls) == 1, "a failed file must not be re-ingested"
+
+    @pytest.mark.asyncio
+    async def test_failed_row_keeps_the_version_that_failed(
+            self, store, pipeline, tmp_path):
+        """The failed row keeps the content hash / mtime the marker carried, and the
+        reason recorded by the ingest path, so the failure is attributable."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "bad.md").write_text("# Bad")
+        source_id = store.add_source("test", "local_folder", str(vault))
+        source = {"id": source_id, "uri": str(vault), "source_type": "local_folder",
+                  "properties": "{}"}
+
+        async def boom(path, **kw):
+            raise RuntimeError("reader exploded")
+        pipeline.ingest_file = boom
+
+        fw = FolderWatcher(store, pipeline)
+        await fw.scan_source(source)
+
+        row = store.db.execute(
+            "SELECT status, content_hash, mtime, error_message FROM folder_file_state "
+            "WHERE source_id = ?", (source_id,)).fetchone()
+        assert row["status"] == "failed"
+        assert row["content_hash"], "the hash of the version that failed is retained"
+        assert row["mtime"] > 0
+        assert "reader exploded" in (row["error_message"] or "")
+
+
+class TestInterruptedScanRetryCap:
+    """Crash recovery retries a 'scanning' row, but not without bound."""
+
+    @pytest.mark.asyncio
+    async def test_interrupted_row_is_retried_then_retired(
+            self, store, pipeline, tmp_path):
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "hangs.md").write_text("# Hangs")
+        source_id = store.add_source("test", "local_folder", str(vault))
+        source = {"id": source_id, "uri": str(vault), "source_type": "local_folder",
+                  "properties": "{}"}
+        calls = []
+
+        async def interrupted(path, **kw):
+            calls.append(path)
+            # CancelledError is a BaseException: it escapes the scan without any
+            # terminal write, which is exactly how a real interruption looks.
+            raise asyncio.CancelledError()
+        pipeline.ingest_file = interrupted
+
+        fw = FolderWatcher(store, pipeline)
+        for _ in range(MAX_SCAN_ATTEMPTS + 3):
+            with contextlib.suppress(asyncio.CancelledError):
+                await fw.scan_source(source)
+
+        assert len(calls) == MAX_SCAN_ATTEMPTS, (
+            f"expected at most {MAX_SCAN_ATTEMPTS} billed attempts, got {len(calls)}")
+        row = store.db.execute(
+            "SELECT status, attempts, error_message FROM folder_file_state "
+            "WHERE source_id = ?", (source_id,)).fetchone()
+        assert row["status"] == "failed"
+        # Retirement is a terminal write, so it clears the count like every other
+        # one. What holds the file out of later sweeps is the 'failed' status.
+        assert row["attempts"] == 0
+        assert str(MAX_SCAN_ATTEMPTS) in (row["error_message"] or "")
+
+    @pytest.mark.asyncio
+    async def test_row_already_stuck_scanning_converges(
+            self, store, pipeline, tmp_path):
+        """An install that already carries a stuck row spends the same budget and
+        retires it, rather than re-ingesting it on every sweep indefinitely."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "stuck.md").write_text("# Stuck")
+        source_id = store.add_source("test", "local_folder", str(vault))
+        stuck = str(vault / "stuck.md")
+        store.db.execute(
+            "INSERT INTO folder_file_state (source_id, file_path, content_hash, mtime, "
+            "item_ids, last_seen, status) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (source_id, stuck, "oldhash", 1.0, "[]", "2026-01-01", "scanning"))
+        store.db.commit()
+        source = {"id": source_id, "uri": str(vault), "source_type": "local_folder",
+                  "properties": "{}"}
+        calls = []
+
+        async def interrupted(path, **kw):
+            calls.append(path)
+            raise asyncio.CancelledError()
+        pipeline.ingest_file = interrupted
+
+        fw = FolderWatcher(store, pipeline)
+        for _ in range(MAX_SCAN_ATTEMPTS + 3):
+            with contextlib.suppress(asyncio.CancelledError):
+                await fw.scan_source(source)
+
+        assert len(calls) == MAX_SCAN_ATTEMPTS
+        row = store.db.execute(
+            "SELECT status FROM folder_file_state WHERE source_id = ? AND file_path = ?",
+            (source_id, stuck)).fetchone()
+        assert row["status"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_successful_ingest_clears_the_retry_budget(
+            self, store, pipeline, tmp_path):
+        """A completed ingest resets attempts, so a transient interruption does not
+        permanently eat a file's budget."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "ok.md").write_text("# Ok")
+        source_id = store.add_source("test", "local_folder", str(vault))
+        ok = str(vault / "ok.md")
+        store.db.execute(
+            "INSERT INTO folder_file_state (source_id, file_path, content_hash, mtime, "
+            "item_ids, last_seen, status, attempts) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (source_id, ok, "oldhash", 1.0, "[]", "2026-01-01", "scanning",
+             MAX_SCAN_ATTEMPTS - 1))
+        store.db.commit()
+        source = {"id": source_id, "uri": str(vault), "source_type": "local_folder",
+                  "properties": "{}"}
+
+        async def fake_ingest(path, **kw):
+            store.add_item("title", "content", "doc", source_id=source_id)
+            return "job1"
+        pipeline.ingest_file = fake_ingest
+
+        fw = FolderWatcher(store, pipeline)
+        await fw.scan_source(source)
+
+        row = store.db.execute(
+            "SELECT status, attempts FROM folder_file_state "
+            "WHERE source_id = ? AND file_path = ?", (source_id, ok)).fetchone()
+        assert row["status"] == "done"
+        assert row["attempts"] == 0
+
+    @pytest.mark.asyncio
+    async def test_editing_a_capped_file_resets_its_budget_and_ingests(
+            self, store, pipeline, tmp_path):
+        """The budget belongs to the version that failed, not to the path.
+
+        A file the user edits after the cap was spent is new content that has never
+        been attempted, so it must be ingested rather than retired on the strength of
+        a retirement its previous version earned.
+        """
+        import os
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        doc = vault / "edited.md"
+        doc.write_text("# Original")
+        source_id = store.add_source("test", "local_folder", str(vault))
+        source = {"id": source_id, "uri": str(vault), "source_type": "local_folder",
+                  "properties": "{}"}
+        calls = []
+
+        async def interrupted(path, **kw):
+            calls.append(path)
+            raise asyncio.CancelledError()
+        pipeline.ingest_file = interrupted
+
+        fw = FolderWatcher(store, pipeline)
+        for _ in range(MAX_SCAN_ATTEMPTS):
+            with contextlib.suppress(asyncio.CancelledError):
+                await fw.scan_source(source)
+        row = store.db.execute(
+            "SELECT status, attempts FROM folder_file_state WHERE source_id = ?",
+            (source_id,)).fetchone()
+        assert (row["status"], row["attempts"]) == ("scanning", MAX_SCAN_ATTEMPTS)
+
+        # The user edits the file. Explicit future mtime avoids 1s granularity.
+        doc.write_text("# Rewritten after the cap was spent")
+        os.utime(doc, (9999999999, 9999999999))
+
+        async def fake_ingest(path, **kw):
+            store.add_item("title", "content", "doc", source_id=source_id)
+            return "job1"
+        pipeline.ingest_file = fake_ingest
+
+        await fw.scan_source(source)
+
+        row = store.db.execute(
+            "SELECT status, attempts FROM folder_file_state WHERE source_id = ?",
+            (source_id,)).fetchone()
+        assert row["status"] == "done", "edited content must be ingested, not retired"
+        assert row["attempts"] == 0
+
+    @pytest.mark.asyncio
+    async def test_an_unchanged_capped_file_stays_retired(
+            self, store, pipeline, tmp_path):
+        """The reset is keyed on the hash, so an untouched capped file still retires."""
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "same.md").write_text("# Unchanged")
+        source_id = store.add_source("test", "local_folder", str(vault))
+        source = {"id": source_id, "uri": str(vault), "source_type": "local_folder",
+                  "properties": "{}"}
+        calls = []
+
+        async def interrupted(path, **kw):
+            calls.append(path)
+            raise asyncio.CancelledError()
+        pipeline.ingest_file = interrupted
+
+        fw = FolderWatcher(store, pipeline)
+        for _ in range(MAX_SCAN_ATTEMPTS + 3):
+            with contextlib.suppress(asyncio.CancelledError):
+                await fw.scan_source(source)
+
+        assert len(calls) == MAX_SCAN_ATTEMPTS
+        row = store.db.execute(
+            "SELECT status FROM folder_file_state WHERE source_id = ?",
+            (source_id,)).fetchone()
+        assert row["status"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_a_retried_capped_file_gets_a_working_budget(
+            self, store, pipeline, tmp_path):
+        """Clearing the status the way the dashboard's Retry does hands the file a
+        full budget again.
+
+        Retry clears ``status`` and ``error_message`` and nothing else, so a
+        retirement that left the spent count on the row would put the file back into
+        the scan already over budget: one interrupted attempt and the next sweep
+        retires it again, making Retry a no-op the user cannot escape.
+        """
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "capped.md").write_text("# Capped")
+        source_id = store.add_source("test", "local_folder", str(vault))
+        capped = str(vault / "capped.md")
+        source = {"id": source_id, "uri": str(vault), "source_type": "local_folder",
+                  "properties": "{}"}
+        calls = []
+
+        async def interrupted(path, **kw):
+            calls.append(path)
+            raise asyncio.CancelledError()
+        pipeline.ingest_file = interrupted
+
+        fw = FolderWatcher(store, pipeline)
+        for _ in range(MAX_SCAN_ATTEMPTS + 1):
+            with contextlib.suppress(asyncio.CancelledError):
+                await fw.scan_source(source)
+        row = store.db.execute(
+            "SELECT status FROM folder_file_state WHERE source_id = ? AND file_path = ?",
+            (source_id, capped)).fetchone()
+        assert row["status"] == "failed", "precondition: the cap has retired the file"
+        billed_when_capped = len(calls)
+
+        # Exactly what POST /api/knowledge/sources/{id}/files/retry writes.
+        store.db.execute(
+            "UPDATE folder_file_state SET status = 'pending', error_message = NULL "
+            "WHERE source_id = ? AND file_path = ?", (source_id, capped))
+        store.db.commit()
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await fw.scan_source(source)
+        row = store.db.execute(
+            "SELECT status, attempts FROM folder_file_state "
+            "WHERE source_id = ? AND file_path = ?", (source_id, capped)).fetchone()
+        assert len(calls) == billed_when_capped + 1, "the retry is actually attempted"
+        assert (row["status"], row["attempts"]) == ("scanning", 1), (
+            "the retry starts from a fresh budget, not from the spent one")
+
+        # The budget is genuinely spendable: the sweep after the interruption retries
+        # rather than retiring on a count inherited from before the retry.
+        with contextlib.suppress(asyncio.CancelledError):
+            await fw.scan_source(source)
+        row = store.db.execute(
+            "SELECT status, attempts FROM folder_file_state "
+            "WHERE source_id = ? AND file_path = ?", (source_id, capped)).fetchone()
+        assert len(calls) == billed_when_capped + 2
+        assert (row["status"], row["attempts"]) == ("scanning", 2)
+
+
+class TestFolderFileStateAttemptsMigration:
+    def test_migration_adds_attempts_to_a_preexisting_db(self, tmp_path):
+        """A database created before the retry cap gains the column, keeps its rows,
+        and starts them on a full budget."""
+        db_path = tmp_path / "legacy.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE folder_file_state (
+                source_id TEXT NOT NULL,
+                file_path TEXT NOT NULL,
+                content_hash TEXT,
+                text_hash TEXT,
+                mtime REAL,
+                item_ids TEXT DEFAULT '[]',
+                last_seen TEXT NOT NULL,
+                status TEXT DEFAULT 'pending',
+                error_message TEXT,
+                merged_into_source_id TEXT,
+                PRIMARY KEY (source_id, file_path)
+            )
+        """)
+        conn.execute(
+            "INSERT INTO folder_file_state (source_id, file_path, content_hash, mtime, "
+            "item_ids, last_seen, status) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("src-legacy", "/legacy/doc.md", "h", 1.0, "[]", "2026-01-01", "scanning"))
+        conn.commit()
+        conn.close()
+
+        store = KnowledgeStore(str(db_path))
+        try:
+            cols = {r[1] for r in store.db.execute(
+                "PRAGMA table_info(folder_file_state)").fetchall()}
+            assert "attempts" in cols
+            row = store.db.execute(
+                "SELECT status, attempts FROM folder_file_state WHERE file_path = ?",
+                ("/legacy/doc.md",)).fetchone()
+            assert row["status"] == "scanning"
+            assert row["attempts"] == 0
+        finally:
+            store.close()


### PR DESCRIPTION
## Problem

A fresh install with a watched knowledge folder burned roughly 200 credits in two
hours — about 10 credits per 10 minutes — with no user activity. The spend tracked
the folder watcher's sweep interval (300s default), not anything the user did.

The cause is a `folder_file_state` row that gets stuck on `status = 'scanning'`
and is fully re-ingested on every sweep, forever. Each re-ingestion re-chunks the
file and pays for **one model extraction call per chunk plus a document summary**,
so a single unlucky file is an uncapped billed retry loop for as long as the
source exists.

## Why it matters

It is a silent, unbounded spend against the user's own credits, on a code path
that runs with no user in the loop. There is no signal in the UI: the row never
reaches a terminal status, so nothing reports that the file keeps losing, and
nothing stops it — the only remedy today is for the user to notice the drain and
delete the source.

## Fix (symptom → root cause → change)

**Symptom:** repeated identical ingestion cost on a fixed interval with no input
changing.

**Root cause** — `src/kiro_crew/knowledge/folder_watcher.py`:

- Line 273 (pre-change) commits the row as `'scanning'` before ingesting, as a
  crash-recovery marker: "an attempt started".
- The skip gate at lines 224–226 skips `'skipped'` and `'failed'`. **`'scanning'`
  matches no gate**, which is deliberate — that is how an interrupted file is
  retried.
- But nothing ever *bounds* that retry, and nothing in the scan loop replaces the
  marker with a terminal status. Line 277–279 (`if item_ids is None:`) only did
  `stats["failed"] += 1`.

An interrupted attempt is the reachable case: `_ingest_file` catches `Exception`,
but a `BaseException` — `asyncio.CancelledError` from a cancelled scan task, a
process kill, an OOM — escapes without any terminal write. Verified locally: with
a pipeline that raises `CancelledError`, six sweeps produced six full ingestion
attempts on the same file, and the row read `scanning` after every one.

**Change:**

1. **The scan loop owns the transition.** The `item_ids is None` branch now writes
   the row to `'failed'` via `_update_state` (`commit=False`, like its sibling
   branches), instead of depending on which branch inside `_ingest_file` happened
   to return. It restores the content hash and mtime the marker carried — so the
   row records *which version* of the file failed — and reads back the reason
   `_ingest_file` recorded so replacing the row does not discard it.
2. **Crash recovery is preserved but capped.** `folder_file_state` gains an
   `attempts` column counting *consecutive non-terminal* attempts. The `'scanning'`
   marker carries `prior_attempts + 1`; any terminal write (`done` / `deduped` /
   `failed`) resets it to 0 by defaulting the parameter. Once a `'scanning'` row
   reaches `MAX_SCAN_ATTEMPTS` (3) it is retired to `'failed'` with an explanatory
   `error_message`, checked *before* the content hash is read so a retired row
   costs no I/O beyond that write.
3. **One-time recovery for affected installs.** The migration in
   `src/kiro_crew/knowledge/store.py` adds the column with `DEFAULT 0`, so a
   database already carrying a stuck `'scanning'` row spends the same small budget
   as a fresh one and then retires it. Already-affected installs converge on their
   own instead of burning until the user intervenes.

Measured after the change, same fixture: 3 billed attempts, then the row reads
`failed` and every later sweep skips it.

## Tests

All five new tests are **revert-verified** — the fix was patched out and each was
confirmed to fail.

| Test | Locks in | Fails without the fix |
|---|---|---|
| `test_failed_ingest_is_terminal_and_skipped_next_sweep` | a `(None, "failed")` return lands `'failed'` and is not re-ingested next sweep | row reads `scanning` |
| `test_failed_row_keeps_the_version_that_failed` | the failed row keeps its content hash / mtime and the recorded reason | `content_hash` is `''` |
| `test_interrupted_row_is_retried_then_retired` | at most `MAX_SCAN_ATTEMPTS` billed attempts, then `'failed'` | 6 sweeps → 6 attempts |
| `test_row_already_stuck_scanning_converges` | a pre-existing stuck row retires instead of looping | 6 sweeps → 6 attempts |
| `test_successful_ingest_clears_the_retry_budget` | a completed ingest resets `attempts` to 0 | `attempts` stays at 3 |
| `test_migration_adds_attempts_to_a_preexisting_db` | the column is added to an old-shape DB, rows preserved, budget starts full | column absent |

## Manual verification

N/A — unit coverage is sufficient. The behaviour is fully observable in
`folder_file_state` and the tests drive the real `KnowledgeStore` and the real
scan loop, including the migration against a database created with the old table
shape.

## Gates

`pytest` (full suite: 33,289 passed), `isort`, `flake8`, `mypy` (801 files, CI-parity
venv — mypy 1.14.1, no faiss), scrub-lint, docs-lint and the brand-name gate are all
green. Backend-only change, so `tsc` / `vitest` are not applicable.

Seven suite failures are present and were confirmed **pre-existing** by re-running
those exact node ids against a clean `origin/main` checkout, where all seven fail
identically: `test_app_manager.py::test_declares_backend_helper`,
`test_cron_cancel.py::test_run_command_sandboxed_can_be_cancelled_mid_run`, three in
`test_dashboard_origin.py::TestParseDashboardUrlMalformed`, and two in
`test_platform_compat.py`. None touch the knowledge tree.
