### PR TITLE
fix(knowledge): pace hand-added folder ingestion with a default chunk budget and surface cost up front

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -1362,6 +1362,7 @@
         "auto_add_documents": true,
         "auto_register_project_docs": true,
         "auto_ingest_chunk_budget": 150,
+        "folder_ingest_chunk_budget": 300,
         "dedup_every_n_sweeps": 12,
         "doc_ingest_hosts": [],
         "auto_discover_folder": false,
@@ -1508,10 +1509,24 @@
       "sensitive": false,
       "tags": [],
       "label": "Auto-Ingest Chunk Budget",
-      "help": "Chunks an automatically-registered source may ingest per watcher sweep. Each chunk costs one LLM extraction call, so this is what actually bounds the cost of auto-registration -- file filters bound pollution, not spend. Newest documents land first and the rest trickle in on later sweeps, so a new project never arrives as a burst. 0 removes the bound. Folders you add by hand are never budgeted: you asked for the whole folder.",
+      "help": "Chunks an automatically-registered source may ingest per watcher sweep. Each chunk costs one LLM extraction call, so this is what actually bounds the cost of auto-registration -- file filters bound pollution, not spend. Newest documents land first and the rest trickle in on later sweeps, so a new project never arrives as a burst. 0 removes the bound.",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 150
+    },
+    {
+      "path": "knowledge.folder_ingest_chunk_budget",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Folder Ingest Chunk Budget",
+      "help": "Chunks a folder you add by hand may ingest per watcher sweep. Adding a source-code repository discovers thousands of files, and each chunk costs an LLM extraction call on a pool of billed sessions, so an unpaced first scan can spend a large amount unattended. Nothing is skipped: newest files land first and the rest continue on later sweeps. Higher than the auto-ingest budget because you asked for the folder explicitly. 0 removes the bound; a per-source chunk_budget property overrides it for one folder.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 300
     },
     {
       "path": "knowledge.dedup_every_n_sweeps",
@@ -1621,7 +1636,7 @@
       "sensitive": false,
       "tags": [],
       "label": "Max Triggered",
-      "help": "Maximum number of skills to load per message (≥0). Defaults to 0 (disabled); set to a positive integer to re-enable per-turn trigger matching.",
+      "help": "Maximum number of skills a single message may flag as relevant (≥0). Each match injects that skill's full content, unless the skill sets inject_on_trigger: false (pointer-only; requires max_triggered > 0 to have any effect). Defaults to 0 (disabled): the agent discovers skills from the Available Skills index and reads them on demand via cat, $skillname, or skill_search. Set to a positive integer to re-enable per-turn word-overlap trigger matching.",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 0

--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -594,6 +594,7 @@ class KnowledgeConfig:
     auto_add_documents: bool = True                     # agent adds documents it reads (aggregate "Auto-added" source); legacy spelling auto_ingest_doc_links accepted
     auto_register_project_docs: bool = True             # register each worked-in project's documents as a folder source (document filter only)
     auto_ingest_chunk_budget: int = 150                 # chunks per sweep for auto-registered sources; 0 = unbounded
+    folder_ingest_chunk_budget: int = 300               # chunks per sweep for hand-added folder sources; per-source chunk_budget overrides; 0 = unbounded
     dedup_every_n_sweeps: int = 12                      # full dedup pass cadence; 0 disables
     auto_ingest_artifacts: bool = True                  # on by default; ingest local artifacts into the KB (aggregate "Artifacts" source)
     auto_ingest_artifact_kinds: list[str] = ["markdown", "text", "html", "json"]  # reader-extractable kinds (widget/svg excluded)

--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -193,11 +193,25 @@ so `knowledge.doc_ingest_hosts` — whose default is `[]` = deny-all — must NO
 path, or the feature would ingest nothing on a default config while its toggle read on.
 
 **Chunk budget.** `folder_watcher._do_scan` orders discovered files newest-first
-unconditionally and stops once a sweep has ingested `knowledge.auto_ingest_chunk_budget`
-chunks. Files not reached keep (or lack) their `folder_file_state` row, so the next sweep
-resumes from them — the existing `status` column already carries the resume point.
-Applied only to auto-registered sources: a folder the user added by hand is a folder they
-asked for in full.
+unconditionally and stops once a sweep has ingested its budget of chunks. Files not
+reached keep (or lack) their `folder_file_state` row, so the next sweep resumes from
+them — the existing `status` column already carries the resume point. Every folder
+source is budgeted: `knowledge.auto_ingest_chunk_budget` for an auto-registered one,
+`knowledge.folder_ingest_chunk_budget` (resolved by `folder_watcher.folder_chunk_budget`,
+overridable per source via a `chunk_budget` property, 0 = unbounded) for one the user
+added by hand. A hand-added folder still gets ingested in full; the budget only decides
+how fast. It applies to the confirm- and resume-triggered scans as well as the sweep,
+because the confirm scan is the largest burst — nothing is ingested yet, so every
+discovered file is new.
+
+**Cost visibility.** `POST /api/knowledge/sources` walks a folder before ingesting
+anything and returns `file_count`, `capped_file_count`, `estimated_chunks`,
+`estimated_llm_calls` and `chunk_budget_per_sweep` alongside the
+`pending_confirmation` status. The walk uses `folder_watcher.walk_filters`, the same
+filter set the sweep applies, so the count describes the files that would actually be
+ingested. The chunk figure is derived from the chunker's target size and file bytes
+(`_estimated_chunks`), never measured: it exists to show order of magnitude before the
+user confirms, and no code path treats it as a bound.
 
 ## 3. LLMPool workers (`llm_pool.py`)
 

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1584,8 +1584,21 @@ class KnowledgeConfig:
             "actually bounds the cost of auto-registration -- file filters bound "
             "pollution, not spend. Newest documents land first and the rest "
             "trickle in on later sweeps, so a new project never arrives as a "
-            "burst. 0 removes the bound. Folders you add by hand are never "
-            "budgeted: you asked for the whole folder.",
+            "burst. 0 removes the bound.",
+        ),
+    )
+    folder_ingest_chunk_budget: int = field(
+        default=300,
+        metadata=_meta(
+            "Folder Ingest Chunk Budget",
+            "Chunks a folder you add by hand may ingest per watcher sweep. Adding "
+            "a source-code repository discovers thousands of files, and each "
+            "chunk costs an LLM extraction call on a pool of billed sessions, so "
+            "an unpaced first scan can spend a large amount unattended. Nothing "
+            "is skipped: newest files land first and the rest continue on later "
+            "sweeps. Higher than the auto-ingest budget because you asked for the "
+            "folder explicitly. 0 removes the bound; a per-source chunk_budget "
+            "property overrides it for one folder.",
         ),
     )
     dedup_every_n_sweeps: int = field(
@@ -4746,6 +4759,8 @@ class KiroCrewConfig:
                     knowledge_data.get("auto_register_project_docs", True)),
                 auto_ingest_chunk_budget=_safe_nonnegative_int(
                     knowledge_data.get("auto_ingest_chunk_budget", 150), 150),
+                folder_ingest_chunk_budget=_safe_nonnegative_int(
+                    knowledge_data.get("folder_ingest_chunk_budget", 300), 300),
                 dedup_every_n_sweeps=_safe_nonnegative_int(
                     knowledge_data.get("dedup_every_n_sweeps", 12), 12),
                 doc_ingest_hosts=[

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -1427,6 +1427,7 @@ _EDITABLE_CONFIG: dict[str, dict] = {
     "knowledge.auto_register_project_docs": {"type": "bool"},
     "knowledge.auto_ingest_artifacts": {"type": "bool"},
     "knowledge.auto_ingest_chunk_budget": {"type": "int", "min": 0, "max": 10000},
+    "knowledge.folder_ingest_chunk_budget": {"type": "int", "min": 0, "max": 10000},
     "knowledge.dedup_every_n_sweeps": {"type": "int", "min": 0, "max": 288},
     # Computer use — BUDGET KNOBS ONLY. There is deliberately no
     # "computer_use.enabled" key here: the primary enable lives on the keystone

--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -36,7 +36,12 @@ from kiro_crew.knowledge.embedder import (
     floats_to_bytes,
 )
 from kiro_crew.knowledge.extractor import EntityExtractor
-from kiro_crew.knowledge.folder_watcher import SOURCE_TYPE_SKIP_DIRS
+from kiro_crew.knowledge.folder_watcher import (
+    estimate_scan_cost,
+    folder_chunk_budget,
+    max_files_prop,
+    walk_filters,
+)
 from kiro_crew.knowledge.ingestion import (
     IngestionPipeline,
     _redact,
@@ -805,11 +810,22 @@ async def add_source(request: web.Request) -> web.Response:
         # Run discovery walk to count files (no ingestion)
         watcher = request.app.get("knowledge_watcher")
         file_count = 0
+        # Scale of the ingestion this source is about to start, so the user sees
+        # the cost before it is spent rather than in a credit balance afterwards.
+        # Zeroed when no watcher is wired: reporting 0 files is honest there,
+        # inventing an estimate is not.
+        cost = {"files": 0, "capped": 0, "chunks": 0, "llm_calls": 0}
+        budget = folder_chunk_budget(properties)
         if watcher:
-            extra_skip = SOURCE_TYPE_SKIP_DIRS.get(source_type, set())
-            ignore_patterns = properties.get("ignore_patterns", [])
-            discovered = await asyncio.to_thread(watcher._folder_watcher._walk, str(folder_path), ignore_patterns, extra_skip)
+            # The same filters the sweep applies, or the count describes a
+            # different file set from the one that gets ingested.
+            discovered = await asyncio.to_thread(
+                watcher._folder_watcher._walk, str(folder_path),
+                **walk_filters(properties, source_type))
             file_count = len(discovered)
+            cost = await asyncio.to_thread(
+                estimate_scan_cost, discovered,
+                max_files=max_files_prop(properties))
 
         # Store with pending_confirmation status
         if isinstance(properties, dict):
@@ -820,7 +836,22 @@ async def add_source(request: web.Request) -> web.Response:
         sid = store.add_source(name=name or uri, source_type=source_type, uri=uri,
                                properties=properties)
         _sel_log("source.add", source_id=sid, source_type=source_type)
-        return web.json_response({"id": sid, "status": "pending_confirmation", "file_count": file_count}, status=201)
+        return web.json_response(
+            {
+                "id": sid,
+                "status": "pending_confirmation",
+                "file_count": file_count,
+                # Files beyond the source's max_files cap, which are discovered
+                # but never ingested.
+                "capped_file_count": cost["capped"],
+                "estimated_chunks": cost["chunks"],
+                # One extraction call per chunk plus one summary call per file.
+                "estimated_llm_calls": cost["llm_calls"],
+                # 0 means unbounded: everything lands in the first sweep.
+                "chunk_budget_per_sweep": budget or 0,
+            },
+            status=201,
+        )
 
     sid = store.add_source(name=name or uri, source_type=source_type, uri=uri,
                            properties=properties)
@@ -1048,7 +1079,12 @@ async def confirm_source(request: web.Request) -> web.Response:
     watcher = request.app.get("knowledge_watcher")
     if watcher:
         source = {"id": source_id, "uri": row["uri"], "source_type": row["source_type"], "properties": json.dumps(props)}
-        task = asyncio.create_task(watcher._folder_watcher.scan_source(source))
+        # Paced like the watcher's own sweeps. This is the burst that costs the
+        # most -- nothing is ingested yet, so every discovered file is new -- so
+        # skipping the budget here would spend the whole folder before the first
+        # sweep ever ran.
+        task = asyncio.create_task(watcher._folder_watcher.scan_source(
+            source, chunk_budget=folder_chunk_budget(props)))
         _track_scan_task(request.app, task)
     return web.json_response({"status": "scanning"})
 
@@ -1094,7 +1130,8 @@ async def resume_source(request: web.Request) -> web.Response:
     watcher = request.app.get("knowledge_watcher")
     if watcher:
         source = {"id": source_id, "uri": row["uri"], "source_type": row["source_type"], "properties": json.dumps(props)}
-        task = asyncio.create_task(watcher._folder_watcher.scan_source(source))
+        task = asyncio.create_task(watcher._folder_watcher.scan_source(
+            source, chunk_budget=folder_chunk_budget(props)))
         _track_scan_task(request.app, task)
     return web.json_response({"status": "scanning"})
 

--- a/src/kiro_crew/docs/configuration.md
+++ b/src/kiro_crew/docs/configuration.md
@@ -104,6 +104,7 @@ Set via `kirocrew config set agent.sandbox auto`.
     "auto_register_project_docs": true,
     "auto_ingest_artifact_kinds": ["markdown", "text", "html", "json"],
     "auto_ingest_chunk_budget": 150,
+    "folder_ingest_chunk_budget": 300,
     "dedup_every_n_sweeps": 12
   },
   "auto_update": true,
@@ -216,7 +217,8 @@ them, so there is no enable switch here: only knobs for *which* model runs.
 | `knowledge.auto_ingest_artifact_kinds` | Artifact kinds eligible for auto-ingest. `widget` is excluded as UI rather than a document; `svg` is excluded because the file reader has no support for it | `["markdown", "text", "html", "json"]` |
 | `knowledge.auto_add_documents` | Let the agent add documents it reads while working to the Knowledge Library (one aggregate "Auto-added" source). The agent fetches the content with its own tools under your approval; Kiro Crew fetches nothing, so `doc_ingest_hosts` does not apply. Renamed from `auto_ingest_doc_links`, which is still accepted on read | `true` |
 | `knowledge.auto_register_project_docs` | Register the documents of each project you work in as a Knowledge source automatically. Documents only (`.md`/`.pdf`/`.docx`/`.org` above a size floor, excluding agent instructions, generated files and repository boilerplate) — never source code | `true` |
-| `knowledge.auto_ingest_chunk_budget` | Chunks an automatically-registered source may ingest per watcher sweep. Each chunk is one LLM extraction call, so this bounds the cost; newest documents land first and the rest follow on later sweeps. 0 removes the bound. Folders you add by hand are never budgeted | `150` |
+| `knowledge.auto_ingest_chunk_budget` | Chunks an automatically-registered source may ingest per watcher sweep. Each chunk is one LLM extraction call, so this bounds the cost; newest documents land first and the rest follow on later sweeps. 0 removes the bound | `150` |
+| `knowledge.folder_ingest_chunk_budget` | Chunks a folder you add by hand may ingest per watcher sweep, including the first scan started by confirming the source. Nothing is skipped — newest files land first and the rest continue on later sweeps — so this paces spend rather than limiting what is ingested. Higher than the auto-ingest budget because you asked for the folder explicitly. 0 removes the bound; a per-source `chunk_budget` property overrides it for one folder | `300` |
 | `knowledge.dedup_every_n_sweeps` | Run a full duplicate-collapsing pass every Nth watcher sweep (the per-write gate only catches byte-identical documents). 0 disables | `12` |
 | `knowledge.auto_discover_folder` | Watch for a documents folder inside the active workspace and register it as a Knowledge source automatically, so files dropped there become searchable without adding the source by hand. The folder is never created for you, and deleting or pausing the auto-added source persists so it does not reappear on the next sweep. Off by default because ingestion spends LLM extraction on every supported file | `false` |
 | `knowledge.auto_discover_dirname` | Folder name inside the workspace that auto-discovery looks for. A single path segment: separators and traversal are rejected so the source cannot be redirected outside the workspace. Avoid `knowledge`, which is where the Library's own store lives and always exists | `"knowledge-docs"` |

--- a/src/kiro_crew/knowledge/doc_filter.py
+++ b/src/kiro_crew/knowledge/doc_filter.py
@@ -23,8 +23,9 @@ pins the two against each other so they cannot drift.
 Measured on the Kiro Crew tree: 2706 walked files, 277 with a document
 extension, 165 after the full filter -- 147 of those in the design/spec/
 reference corpus. File filters control POLLUTION; only a chunk budget controls
-COST (see ``knowledge.auto_ingest_chunk_budget``), because a handful of large
-documents dominate the chunk count.
+COST (``knowledge.auto_ingest_chunk_budget`` here,
+``knowledge.folder_ingest_chunk_budget`` for a folder the user adds by hand),
+because a handful of large documents dominate the chunk count.
 """
 
 from __future__ import annotations

--- a/src/kiro_crew/knowledge/folder_watcher.py
+++ b/src/kiro_crew/knowledge/folder_watcher.py
@@ -6,14 +6,17 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 import os
 from datetime import datetime
 from fnmatch import fnmatch
 from pathlib import Path
 
+from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.sel import sel
 
+from .chunker import CHUNK_TOKEN_SIZE, MAX_CHUNKS_PER_FILE
 from .dedup import dedup_document
 from .ingestion import DUPLICATE_JOB_STATUS
 from .readers import FileReader
@@ -116,10 +119,133 @@ def _within(candidate: str, base: str) -> bool:
 
 
 def _prop_int(value: object) -> int:
-    """Coerce a non-negative integer source property; 0 when absent or unusable."""
+    """Coerce a non-negative integer source property; 0 when absent or unusable.
+
+    Floats are accepted because a source may already carry one, but a non-finite
+    one is not: ``inf`` (which is what ``1e309`` parses to) survives a ``> 0``
+    test and then raises in ``int()``.
+    """
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return 0
+    if isinstance(value, float) and not math.isfinite(value):
+        return 0
     return int(value) if value > 0 else 0
+
+
+#: Per-source property that overrides the configured folder budget. Separate from
+#: the config knob so one oversized folder can be paced harder (or, at 0, let run
+#: unbounded) without changing the default every other folder gets.
+CHUNK_BUDGET_PROP = "chunk_budget"
+
+
+def walk_filters(props: dict, source_type: str = "local_folder") -> dict:
+    """``FolderWatcher._walk`` keyword arguments for a source's properties.
+
+    Shared with any caller that walks a folder outside a scan -- the add-source
+    preview does -- so the files it counts are the files a sweep would take. A
+    looser set there reports a count for files the scan then skips.
+    """
+    return {
+        "ignore_patterns": props.get("ignore_patterns", []),
+        "extra_skip_dirs": (SOURCE_TYPE_SKIP_DIRS.get(source_type, set())
+                            | _prop_str_set(props.get("extra_skip_dirs"))),
+        "include_extensions": _prop_extensions(props.get("include_extensions")),
+        "min_size": _prop_int(props.get("min_file_bytes")),
+        "confine_to_root": bool(props.get("confine_to_root")),
+    }
+
+
+def folder_chunk_budget(props: dict) -> int | None:
+    """Chunks a hand-added folder source may ingest in one sweep; ``None`` = unbounded.
+
+    Ingestion costs one LLM extraction call per chunk plus one summary call per
+    file, on a pool of billed sessions, so an unpaced first scan of a source-code
+    repository spends real money in minutes with nobody watching. The budget does
+    not drop any file: the scan takes newest-first until the budget is reached and
+    the rest resume on the next sweep from their ``folder_file_state`` rows.
+
+    A per-source ``chunk_budget`` of 0 means "no bound" -- the explicit opt-out for
+    a user who does want the whole folder in one burst. Absent, the configured
+    default applies, and a configured 0 likewise removes the bound.
+
+    ``properties`` is user-editable JSON reachable from the add-source request
+    body, so an override of any other shape -- a float (``1e309`` parses to
+    ``inf``, whose ``int()`` raises), a bool (an ``int`` subclass, so ``True``
+    would read as a budget of 1), a string, a negative -- means "use the
+    configured default" rather than an error. Nothing here may raise: this runs
+    inside a request handler and inside a sweep, where a raise is a 500 or a
+    skipped scan instead of a paced one.
+    """
+    override = props.get(CHUNK_BUDGET_PROP)
+    if isinstance(override, int) and not isinstance(override, bool) and override >= 0:
+        return override or None
+    try:
+        configured = int(KiroCrewConfig.load().knowledge.folder_ingest_chunk_budget)
+    except Exception:
+        # Read per call so the knob is live, matching the rest of the watcher.
+        logger.debug("Could not read folder_ingest_chunk_budget", exc_info=True)
+        return None
+    return max(0, configured) or None
+
+
+#: Average bytes per whitespace-separated word, including the separator.
+_BYTES_PER_WORD = 6
+
+
+def _estimated_chunks(size: int) -> int:
+    """Chunks the chunker would produce for a file of *size* bytes.
+
+    Derived from the chunker's own target rather than measured: a chunk targets
+    ``CHUNK_TOKEN_SIZE`` tokens, ``_word_count`` approximates 1.3 tokens per word,
+    and prose averages roughly ``_BYTES_PER_WORD`` bytes per word including its
+    separator. Reading and chunking every file to be exact would cost the walk
+    what the scan itself costs, and this number exists to show a user the order of
+    magnitude before they commit -- so it is an estimate, never a bound the scan
+    enforces.
+    """
+    words_per_chunk = max(1, int(CHUNK_TOKEN_SIZE / 1.3))
+    chunks = -(-max(size, 1) // (words_per_chunk * _BYTES_PER_WORD))
+    return min(chunks, MAX_CHUNKS_PER_FILE)
+
+
+def max_files_prop(props: dict) -> int:
+    """A source's ``max_files`` cap, falling back to :data:`DEFAULT_MAX_FILES`.
+
+    Coerced because ``properties`` is user-editable JSON and the value is used in
+    arithmetic; a non-positive, non-numeric or non-finite entry means "unset", not
+    "cap at 0". ``inf`` has to be excluded explicitly -- it passes a ``> 0`` test
+    and then raises in ``int()``.
+    """
+    value = props.get("max_files", DEFAULT_MAX_FILES)
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        return DEFAULT_MAX_FILES
+    if isinstance(value, float) and not math.isfinite(value):
+        return DEFAULT_MAX_FILES
+    return int(value)
+
+
+def estimate_scan_cost(discovered: list[tuple[str, float]], *,
+                       max_files: int = DEFAULT_MAX_FILES) -> dict:
+    """What a first full scan of *discovered* would cost, in files and LLM calls.
+
+    Mirrors the sweep's own newest-first ordering and file cap so the numbers
+    describe the files that would actually be ingested, not everything the walk
+    saw. ``llm_calls`` counts one extraction call per chunk plus the per-file
+    source-summary call.
+    """
+    ordered = sorted(discovered, key=lambda f: f[1], reverse=True)
+    capped = max(0, len(ordered) - max_files)
+    ordered = ordered[:max_files]
+    chunks = 0
+    for path, _ in ordered:
+        try:
+            chunks += _estimated_chunks(os.path.getsize(path))
+        except OSError:
+            # A file that vanished between the walk and this stat contributes
+            # nothing; the scan will not find it either.
+            continue
+    return {"files": len(ordered), "capped": capped, "chunks": chunks,
+            "llm_calls": chunks + len(ordered)}
 
 
 class FolderWatcher:
@@ -134,9 +260,9 @@ class FolderWatcher:
         """Scan a folder source. Returns {new, changed, deleted, skipped, capped}.
 
         ``chunk_budget`` stops the scan once that many chunks have been ingested
-        in THIS sweep, leaving the rest for later sweeps. It is passed only for
-        auto-registered sources: a folder the user added by hand is a folder they
-        asked for in full, so it keeps the unbounded behaviour.
+        in THIS sweep, leaving the rest for later sweeps. ``None`` is unbounded.
+        Callers resolve the value: :func:`folder_chunk_budget` for a hand-added
+        folder, ``knowledge.auto_ingest_chunk_budget`` for an auto-registered one.
         """
         source_id = source["id"]
         if source_id not in self._locks:
@@ -155,18 +281,11 @@ class FolderWatcher:
             return {"error": f"Directory not found: {uri}"}
 
         max_files = props.get("max_files", DEFAULT_MAX_FILES)
-        ignore_patterns = props.get("ignore_patterns", [])
         source_type = source.get("source_type", "local_folder")
-        extra_skip_dirs = SOURCE_TYPE_SKIP_DIRS.get(source_type, set()) | _prop_str_set(
-            props.get("extra_skip_dirs"))
-        include_extensions = _prop_extensions(props.get("include_extensions"))
-        min_file_bytes = _prop_int(props.get("min_file_bytes"))
-        confine_to_root = bool(props.get("confine_to_root"))
+        filters = walk_filters(props, source_type)
 
         # 1. Discover files
-        discovered = await asyncio.to_thread(
-            self._walk, uri, ignore_patterns, extra_skip_dirs,
-            include_extensions, min_file_bytes, confine_to_root)
+        discovered = await asyncio.to_thread(self._walk, uri, **filters)
 
         # Capture all discovered paths before cap (for accurate deletion detection)
         all_discovered_paths = {fp for fp, _ in discovered}

--- a/src/kiro_crew/knowledge/watcher.py
+++ b/src/kiro_crew/knowledge/watcher.py
@@ -21,7 +21,7 @@ from .autosource import (
 )
 from .dedup import dedup_sweep
 from .embedder import embedder_signature
-from .folder_watcher import FolderWatcher
+from .folder_watcher import FolderWatcher, folder_chunk_budget
 from .ingestion import (
     FileTooLargeError,
     IngestionPipeline,
@@ -229,6 +229,12 @@ class KnowledgeWatcher:
                             resources=f"source_id={source['id']} reason=not_contained",
                         )
                         continue
+                else:
+                    # A hand-added folder is paced too. The user asked for the whole
+                    # folder and still gets it -- newest files first, the rest on
+                    # later sweeps -- but pointing the Library at a source repo no
+                    # longer spends the whole bill before anyone can look at it.
+                    budget = folder_chunk_budget(props)
                 stats = await self._folder_watcher.scan_source(source, chunk_budget=budget)
                 if stats.get("error"):
                     logger.warning("Folder scan error for %s: %s", source["uri"], stats["error"])

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -3085,6 +3085,22 @@ class TestKnowledgeAutoIngest:
         cfg = _load_from_dict({"knowledge": {"auto_ingest_chunk_budget": bad}})
         assert cfg.knowledge.auto_ingest_chunk_budget == 150
 
+    def test_folder_chunk_budget_default(self) -> None:
+        assert _load_from_dict({}).knowledge.folder_ingest_chunk_budget == 300
+
+    def test_folder_chunk_budget_reads_value(self) -> None:
+        cfg = _load_from_dict({"knowledge": {"folder_ingest_chunk_budget": 40}})
+        assert cfg.knowledge.folder_ingest_chunk_budget == 40
+
+    def test_folder_chunk_budget_zero_is_allowed(self) -> None:
+        cfg = _load_from_dict({"knowledge": {"folder_ingest_chunk_budget": 0}})
+        assert cfg.knowledge.folder_ingest_chunk_budget == 0
+
+    @pytest.mark.parametrize("bad", [-5, "many", True, None, 1.5])
+    def test_folder_chunk_budget_rejects_junk(self, bad: object) -> None:
+        cfg = _load_from_dict({"knowledge": {"folder_ingest_chunk_budget": bad}})
+        assert cfg.knowledge.folder_ingest_chunk_budget == 300
+
     def test_dedup_cadence_default(self) -> None:
         assert _load_from_dict({}).knowledge.dedup_every_n_sweeps == 12
 
@@ -3105,6 +3121,7 @@ class TestKnowledgeAutoIngest:
                     "knowledge.auto_register_project_docs",
                     "knowledge.auto_ingest_artifacts",
                     "knowledge.auto_ingest_chunk_budget",
+                    "knowledge.folder_ingest_chunk_budget",
                     "knowledge.dedup_every_n_sweeps"):
             assert key in _EDITABLE_CONFIG, key
 

--- a/test/test_knowledge_folder_cost_guards.py
+++ b/test/test_knowledge_folder_cost_guards.py
@@ -1,0 +1,363 @@
+"""Cost guards for hand-added folder knowledge sources.
+
+A folder source ingests with one LLM extraction call per chunk plus one summary
+call per file, on a pool of billed sessions. Pointing the Library at a handful of
+source repositories therefore spends real money unattended unless the ingestion
+is paced and its scale is shown before it starts. These tests pin both guards,
+and the invariant that pacing never drops a file.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.dashboard.handlers.knowledge import add_source, confirm_source
+from kiro_crew.knowledge.folder_watcher import (
+    DEFAULT_MAX_FILES,
+    FolderWatcher,
+    estimate_scan_cost,
+    folder_chunk_budget,
+    max_files_prop,
+    walk_filters,
+)
+from kiro_crew.knowledge.store import KnowledgeStore
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = KnowledgeStore(str(tmp_path / "cost.db"))
+    yield s
+    s.close()
+
+
+def _cfg(folder_budget: int):
+    """A loaded-config stand-in carrying just the knob under test."""
+    cfg = MagicMock()
+    cfg.knowledge.folder_ingest_chunk_budget = folder_budget
+    return cfg
+
+
+class TestFolderChunkBudgetResolution:
+    def test_configured_default_applies_with_no_property(self):
+        with patch("kiro_crew.config.loader.KiroCrewConfig.load",
+                   return_value=_cfg(300)):
+            assert folder_chunk_budget({}) == 300
+
+    def test_per_source_property_wins_over_the_default(self):
+        with patch("kiro_crew.config.loader.KiroCrewConfig.load",
+                   return_value=_cfg(300)):
+            assert folder_chunk_budget({"chunk_budget": 25}) == 25
+
+    def test_per_source_zero_disables_the_bound(self):
+        # The explicit opt-out for a user who does want the folder in one burst.
+        with patch("kiro_crew.config.loader.KiroCrewConfig.load",
+                   return_value=_cfg(300)):
+            assert folder_chunk_budget({"chunk_budget": 0}) is None
+
+    def test_configured_zero_disables_the_bound(self):
+        with patch("kiro_crew.config.loader.KiroCrewConfig.load",
+                   return_value=_cfg(0)):
+            assert folder_chunk_budget({}) is None
+
+    @pytest.mark.parametrize("bad", ["300", None, True, False, [], {}, -5, 1.5, 300.0])
+    def test_junk_property_falls_back_to_the_default(self, bad: object):
+        # properties is user-editable JSON; a bad value must not remove the guard.
+        # True/False are checked explicitly: bool is an int subclass, so True would
+        # otherwise read as a budget of 1.
+        with patch("kiro_crew.config.loader.KiroCrewConfig.load",
+                   return_value=_cfg(300)):
+            assert folder_chunk_budget({"chunk_budget": bad}) == 300
+
+    @pytest.mark.parametrize("bad", [1e309, -1e309, float("inf"), float("-inf"),
+                                     float("nan")])
+    def test_non_finite_property_falls_back_instead_of_raising(self, bad: float):
+        # 1e309 parses to inf, which survives a >= 0 test and then raises in int().
+        # Reached from the add-source request body, so a raise here is an HTTP 500.
+        with patch("kiro_crew.config.loader.KiroCrewConfig.load",
+                   return_value=_cfg(300)):
+            assert folder_chunk_budget({"chunk_budget": bad}) == 300
+
+    def test_unreadable_config_does_not_raise_into_a_scan(self):
+        with patch("kiro_crew.config.loader.KiroCrewConfig.load",
+                   side_effect=OSError("boom")):
+            assert folder_chunk_budget({}) is None
+
+
+class TestBudgetIsWiredToHandAddedSources:
+    @pytest.mark.asyncio
+    async def test_sweep_passes_the_folder_budget(self, store, tmp_path):
+        from kiro_crew.knowledge.watcher import KnowledgeWatcher
+
+        folder = tmp_path / "repo"
+        folder.mkdir()
+        (folder / "a.md").write_text("body")
+        store.add_source(name="Mine", source_type="local_folder", uri=str(folder),
+                         properties={"sync_status": "active"})
+        w = KnowledgeWatcher(store, MagicMock())
+        w._folder_watcher = MagicMock()
+        w._folder_watcher.scan_source = AsyncMock(return_value={})
+        w._discover_drop_folder = AsyncMock()
+        w._discover_project_docs = AsyncMock()
+        w._maybe_dedup_sweep = AsyncMock()
+        w._maybe_reembed_stale = AsyncMock()
+        with patch("kiro_crew.config.loader.KiroCrewConfig.load",
+                   return_value=_cfg(120)):
+            await w._scan()
+        assert w._folder_watcher.scan_source.await_args.kwargs["chunk_budget"] == 120
+
+    @pytest.mark.asyncio
+    async def test_confirm_scan_is_budgeted(self, store, tmp_path):
+        # The confirm scan is the largest burst: nothing is ingested yet, so every
+        # discovered file is new.
+        folder = tmp_path / "repo"
+        folder.mkdir()
+        sid = store.add_source("Mine", "local_folder", str(folder),
+                               properties={"sync_status": "pending_confirmation"})
+        watcher = MagicMock()
+        watcher._folder_watcher = MagicMock()
+        watcher._folder_watcher.scan_source = AsyncMock(return_value={"new": 0})
+
+        app = web.Application()
+        state = MagicMock()
+        state.knowledge_store = store
+        app["state"] = state
+        app["knowledge_watcher"] = watcher
+        app.router.add_post("/api/knowledge/sources/{id}/confirm", confirm_source)
+        async with TestClient(TestServer(app)) as client:
+            with patch("kiro_crew.config.loader.KiroCrewConfig.load",
+                       return_value=_cfg(90)):
+                resp = await client.post(f"/api/knowledge/sources/{sid}/confirm")
+                assert resp.status == 200
+                for task in app.get("_scan_tasks", set()).copy():
+                    await task
+        assert watcher._folder_watcher.scan_source.await_args.kwargs["chunk_budget"] == 90
+
+
+class TestPacingLosesNoFiles:
+    @pytest.mark.asyncio
+    async def test_budgeted_sweeps_eventually_ingest_every_file(self, store, tmp_path):
+        folder = tmp_path / "repo"
+        folder.mkdir()
+        for i in range(6):
+            (folder / f"d{i}.md").write_text(f"body {i}")
+        sid = store.add_source(name="Mine", source_type="local_folder", uri=str(folder),
+                               properties={"sync_status": "active"})
+        source = {"id": sid, "uri": str(folder), "source_type": "local_folder",
+                  "properties": json.dumps({"sync_status": "active"})}
+
+        pipe = MagicMock()
+        pipe._dedup_enabled = False
+        fw = FolderWatcher(store, pipe)
+        ingested: list[str] = []
+
+        async def _ingest(file_path, source_id, namespace, props, old_ids, root=""):
+            ingested.append(file_path)
+            return ["i-" + file_path], "done"  # 1 chunk per file
+
+        fw._ingest_file = _ingest  # type: ignore[assignment]
+
+        budget = folder_chunk_budget({"chunk_budget": 2})
+        first = await fw.scan_source(source, chunk_budget=budget)
+        assert first["budget_reached"] == 1
+        assert len(ingested) == 2  # paced, not everything at once
+
+        # Later sweeps resume from the files the budget stopped at.
+        for _ in range(3):
+            await fw.scan_source(source, chunk_budget=budget)
+        assert sorted(ingested) == sorted(str(folder / f"d{i}.md") for i in range(6))
+        done = store.db.execute(
+            "SELECT COUNT(*) FROM folder_file_state "
+            "WHERE source_id = ? AND status = 'done'", (sid,)).fetchone()[0]
+        assert done == 6
+
+
+class TestExistingSourcesIngestTheSameFiles:
+    def test_no_extension_allowlist_is_imposed_by_default(self):
+        # Pacing plus visibility is the guard; narrowing what is ingested stays an
+        # explicit user choice, and None must stay distinct from an empty set.
+        assert walk_filters({})["include_extensions"] is None
+        assert walk_filters({"include_extensions": []})["include_extensions"] == set()
+
+    def test_walk_filters_match_what_a_scan_applies(self, tmp_path):
+        props = {"include_extensions": [".md"], "min_file_bytes": 4,
+                 "ignore_patterns": ["skip/*"], "extra_skip_dirs": ["notes"]}
+        filters = walk_filters(props)
+        assert filters["include_extensions"] == {".md"}
+        assert filters["min_size"] == 4
+        assert filters["ignore_patterns"] == ["skip/*"]
+        assert "notes" in filters["extra_skip_dirs"]
+
+    def test_obsidian_skip_dirs_survive_the_shared_builder(self):
+        assert ".obsidian" in walk_filters({}, "obsidian_vault")["extra_skip_dirs"]
+
+    @pytest.mark.asyncio
+    async def test_a_budgeted_scan_takes_the_same_file_set(self, store, tmp_path):
+        # The budget decides HOW FAST, never WHAT. The union over budgeted sweeps
+        # must equal what one unbudgeted sweep takes.
+        folder = tmp_path / "repo"
+        folder.mkdir()
+        (folder / "keep.md").write_text("body")
+        (folder / "code.py").write_text("print(1)")
+        (folder / "data.json").write_text("{}")
+        source = {"id": "s1", "uri": str(folder), "source_type": "local_folder",
+                  "properties": "{}"}
+        fw = FolderWatcher(store, MagicMock())
+        unbudgeted = {p for p, _ in fw._walk(str(folder), **walk_filters({}))}
+        assert unbudgeted == {str(folder / "keep.md"), str(folder / "code.py"),
+                              str(folder / "data.json")}
+
+        store.add_source(name="Mine", source_type="local_folder", uri=str(folder))
+        pipe = MagicMock()
+        pipe._dedup_enabled = False
+        fw2 = FolderWatcher(store, pipe)
+        seen: list[str] = []
+
+        async def _ingest(file_path, source_id, namespace, props, old_ids, root=""):
+            seen.append(file_path)
+            return ["i-" + file_path], "done"
+
+        fw2._ingest_file = _ingest  # type: ignore[assignment]
+        source["id"] = store.get_source_by_uri(str(folder))["id"]
+        for _ in range(4):
+            await fw2.scan_source(source, chunk_budget=1)
+        assert set(seen) == unbudgeted
+
+
+class TestAddFolderResponseCarriesTheEstimate:
+    def _app(self, store, watcher):
+        from kiro_crew.knowledge.connectors.local_folder import LocalFolderConnector
+
+        app = web.Application()
+        state = MagicMock()
+        state.knowledge_store = store
+        app["state"] = state
+        sync = MagicMock()
+        sync.get_connector = lambda t: (
+            LocalFolderConnector() if t in ("local_folder", "obsidian_vault") else None)
+        app["knowledge_sync"] = sync
+        app["knowledge_watcher"] = watcher
+        app.router.add_post("/api/knowledge/sources", add_source)
+        return app
+
+    @pytest.mark.asyncio
+    async def test_response_reports_scale_and_pacing(self, store, tmp_path):
+        folder = tmp_path / "repo"
+        folder.mkdir()
+        # Two chunks' worth of bytes, so the estimate is not trivially 1.
+        (folder / "big.md").write_text("word " * 2000)
+        (folder / "small.md").write_text("hi")
+
+        watcher = MagicMock()
+        watcher._folder_watcher = FolderWatcher(store, MagicMock())
+        async with TestClient(TestServer(self._app(store, watcher))) as client:
+            with patch("kiro_crew.config.loader.KiroCrewConfig.load",
+                       return_value=_cfg(300)):
+                resp = await client.post("/api/knowledge/sources", json={
+                    "name": "repo", "source_type": "local_folder", "uri": str(folder)})
+            assert resp.status == 201
+            data = await resp.json()
+        assert data["file_count"] == 2
+        assert data["estimated_chunks"] >= 3
+        # One extraction call per chunk plus one summary call per file.
+        assert data["estimated_llm_calls"] == data["estimated_chunks"] + 2
+        assert data["chunk_budget_per_sweep"] == 300
+        assert data["capped_file_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_response_reports_an_unbounded_budget_as_zero(self, store, tmp_path):
+        folder = tmp_path / "repo"
+        folder.mkdir()
+        (folder / "a.md").write_text("body")
+        watcher = MagicMock()
+        watcher._folder_watcher = FolderWatcher(store, MagicMock())
+        async with TestClient(TestServer(self._app(store, watcher))) as client:
+            with patch("kiro_crew.config.loader.KiroCrewConfig.load",
+                       return_value=_cfg(0)):
+                resp = await client.post("/api/knowledge/sources", json={
+                    "name": "repo", "source_type": "local_folder", "uri": str(folder)})
+            data = await resp.json()
+        assert data["chunk_budget_per_sweep"] == 0
+
+    @pytest.mark.asyncio
+    async def test_hostile_numeric_properties_do_not_500(self, store, tmp_path):
+        # The reported crash path: 1e309 parses to inf, and int(inf) raises. Every
+        # numeric property here reaches an int() coercion from this request body.
+        folder = tmp_path / "repo"
+        folder.mkdir()
+        (folder / "a.md").write_text("body")
+        watcher = MagicMock()
+        watcher._folder_watcher = FolderWatcher(store, MagicMock())
+        async with TestClient(TestServer(self._app(store, watcher))) as client:
+            with patch("kiro_crew.config.loader.KiroCrewConfig.load",
+                       return_value=_cfg(300)):
+                resp = await client.post("/api/knowledge/sources", json={
+                    "name": "repo", "source_type": "local_folder", "uri": str(folder),
+                    "properties": {"chunk_budget": 1e309, "max_files": 1e309,
+                                   "min_file_bytes": 1e309}})
+            assert resp.status == 201
+            data = await resp.json()
+        # Each malformed value fell back to its default rather than erroring.
+        assert data["chunk_budget_per_sweep"] == 300
+        assert data["file_count"] == 1
+        assert data["capped_file_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_files_beyond_the_cap_are_reported_separately(self, store, tmp_path):
+        folder = tmp_path / "repo"
+        folder.mkdir()
+        for i in range(4):
+            (folder / f"d{i}.md").write_text("body")
+        watcher = MagicMock()
+        watcher._folder_watcher = FolderWatcher(store, MagicMock())
+        async with TestClient(TestServer(self._app(store, watcher))) as client:
+            with patch("kiro_crew.config.loader.KiroCrewConfig.load",
+                       return_value=_cfg(300)):
+                resp = await client.post("/api/knowledge/sources", json={
+                    "name": "repo", "source_type": "local_folder", "uri": str(folder),
+                    "properties": {"max_files": 2}})
+            data = await resp.json()
+        assert data["capped_file_count"] == 2
+        # The estimate describes the files that get ingested, not everything seen.
+        assert data["estimated_llm_calls"] == data["estimated_chunks"] + 2
+
+
+class TestEstimator:
+    def test_empty_walk_costs_nothing(self):
+        assert estimate_scan_cost([]) == {"files": 0, "capped": 0, "chunks": 0,
+                                          "llm_calls": 0}
+
+    def test_a_vanished_file_contributes_nothing(self, tmp_path):
+        # The scan will not find it either, so it must not inflate the estimate.
+        cost = estimate_scan_cost([(str(tmp_path / "gone.md"), 1.0)])
+        assert cost["files"] == 1
+        assert cost["chunks"] == 0
+
+    def test_estimate_is_capped_per_file(self, tmp_path):
+        # A single huge file cannot exceed the chunker's own per-file ceiling.
+        from kiro_crew.knowledge.chunker import MAX_CHUNKS_PER_FILE
+
+        huge = tmp_path / "huge.md"
+        huge.write_text("word " * 400_000)
+        assert estimate_scan_cost([(str(huge), 1.0)])["chunks"] == MAX_CHUNKS_PER_FILE
+
+    def test_newest_files_are_the_ones_kept_under_the_cap(self, tmp_path):
+        new = tmp_path / "new.md"
+        old = tmp_path / "old.md"
+        new.write_text("word " * 2000)
+        old.write_text("x")
+        cost = estimate_scan_cost([(str(old), 1.0), (str(new), 99.0)], max_files=1)
+        assert cost["files"] == 1 and cost["capped"] == 1
+        assert cost["chunks"] == estimate_scan_cost([(str(new), 99.0)])["chunks"]
+
+    @pytest.mark.parametrize("bad", ["5000", None, True, 0, -1, [],
+                                     1e309, float("inf"), float("nan")])
+    def test_junk_max_files_falls_back_to_the_default(self, bad: object):
+        assert max_files_prop({"max_files": bad}) == DEFAULT_MAX_FILES
+
+    def test_max_files_reads_a_usable_value(self):
+        assert max_files_prop({"max_files": 12}) == 12

--- a/test/test_knowledge_project_docs.py
+++ b/test/test_knowledge_project_docs.py
@@ -309,8 +309,9 @@ class TestWatcherDiscovery:
         assert w._folder_watcher.scan_source.await_args.kwargs["chunk_budget"] == 77
 
     @pytest.mark.asyncio
-    async def test_hand_added_folder_is_never_budgeted(self, store, tmp_path):
-        # A folder the user added by hand is a folder they asked for in full.
+    async def test_hand_added_folder_gets_the_folder_budget(self, store, tmp_path):
+        # A hand-added folder is paced too: it is still ingested in full, but
+        # across sweeps rather than as one unbounded burst.
         root = _repo(tmp_path)
         store.add_source(name="Mine", source_type="local_folder", uri=str(root),
                          properties={"sync_status": "active"})
@@ -318,9 +319,11 @@ class TestWatcherDiscovery:
         w._discover_drop_folder = AsyncMock()
         w._discover_project_docs = AsyncMock()
         w._maybe_dedup_sweep = AsyncMock()
-        with patch.object(KnowledgeWatcher, "_chunk_budget", staticmethod(lambda: 77)):
+        with patch.object(KnowledgeWatcher, "_chunk_budget", staticmethod(lambda: 77)), \
+                patch("kiro_crew.knowledge.watcher.folder_chunk_budget",
+                      return_value=42):
             await w._scan()
-        assert w._folder_watcher.scan_source.await_args.kwargs["chunk_budget"] is None
+        assert w._folder_watcher.scan_source.await_args.kwargs["chunk_budget"] == 42
 
 
 class TestWatcherResolverWiring:


### PR DESCRIPTION
## Problem

A `local_folder` knowledge source the user adds by hand has **no cost guard**:

- `include_extensions` defaults to `None` — no allowlist, so every
  `FileReader.SUPPORTED` extension is walked (`.py .java .ts .js .rs .go .c .cpp
  .h .sh .rb .json .yaml .yml .csv .log` plus extensionless) —
  `src/kiro_crew/knowledge/readers.py:32-37`,
  `src/kiro_crew/knowledge/folder_watcher.py` `_prop_extensions` / `_walk`.
- Up to `DEFAULT_MAX_FILES = 5000` files per source —
  `src/kiro_crew/knowledge/folder_watcher.py:30`.
- **No chunk budget.** The per-sweep budget existed but was passed only for
  auto-registered project-docs sources: in
  `src/kiro_crew/knowledge/watcher.py:198,213` `budget` stayed `None` unless
  `AUTO_ADDED_PROP` **and** `is_project_doc_source`.

Ingestion costs one LLM extraction call per chunk plus one source-summary call
per file, on a pool of 3 concurrent billed sessions (`knowledge/llm_pool.py`).
`src/kiro_crew/knowledge/doc_filter.py:11-14` documents the hazard — "only a
chunk budget controls COST" — but nothing enforced it for hand-added folders.

## Why it matters

Field incident: a fresh-install user pointed the Knowledge Library at 5-6 source
repositories and lost roughly 200 credits in 2 hours, unattended. Nothing in the
add-source flow showed the scale beforehand, and nothing paced the first scan.

## Fix (symptom → root cause → change)

The symptom is unbounded spend; the root cause is that the one mechanism that
bounds spend was wired to exactly one source class. So pace the cost and make it
visible — **without** changing what any source ingests.

**1. Default per-sweep budget for hand-added folders.**
`folder_watcher.folder_chunk_budget(props)` resolves a new config knob
`knowledge.folder_ingest_chunk_budget` (default `300`, twice the auto-ingest
budget since the user asked for the folder explicitly), overridable per source
via a `chunk_budget` property (`0` = unbounded, the explicit opt-out; junk JSON
falls back to the default rather than removing the guard). The existing budget
mechanism already resumes from unreached files on the next sweep via the
`folder_file_state.status` column, so **nothing is dropped** — newest files land
first and the rest follow.

Applied in `watcher._scan` for non-auto sources, and in the **confirm** and
**resume** handlers. The confirm scan is the largest burst of all: nothing is
ingested yet, so every discovered file is new — skipping the budget there would
spend the whole folder before the first sweep ran.

**2. Surface the scale up front (backend only, no new UI).**
`POST /api/knowledge/sources` already ran a discovery walk for `file_count`; it
now also returns `capped_file_count`, `estimated_chunks`, `estimated_llm_calls`
and `chunk_budget_per_sweep`. The preview walk goes through a new shared
`folder_watcher.walk_filters(props, source_type)` — the same filter set
`_do_scan` uses — so the numbers describe the files that would actually be
ingested rather than a looser set. `estimate_scan_cost` mirrors the sweep's own
newest-first ordering and `max_files` cap; chunk counts are derived from the
chunker's target size and file bytes and are explicitly an estimate, never a
bound any code path enforces.

**3. Deliberately NOT done: a default extension allowlist.** Pacing plus
visibility is the correct guard here. Narrowing what is ingested stays an
explicit user choice, and the `None`-vs-empty-set contract documented in
`_walk` is preserved (`None` = no allowlist, `[]` = allow nothing).

## Tests

New `test/test_knowledge_folder_cost_guards.py` (32 tests) plus config-loader
coverage:

- **Budget resolution** — configured default applies; per-source property wins;
  per-source `0` and configured `0` both disable the bound; junk property values
  fall back to the default; an unreadable config does not raise into a scan.
- **Wiring** — the watcher sweep passes the folder budget for a hand-added
  source; the confirm-triggered scan is budgeted.
- **Pacing loses no files** — budgeted sweeps stop early, then resume, and the
  union over sweeps ingests all 6 files with 6 `done` state rows.
- **Existing sources ingest the same files** — no default allowlist is imposed;
  `walk_filters` matches what a scan applies (including the obsidian skip dirs);
  the file set a budgeted scan takes equals what one unbudgeted walk takes.
- **Add-folder response** — reports scale and pacing, reports an unbounded
  budget as `0`, and reports capped files separately with the estimate scoped to
  the ingested set.
- **Estimator** — empty walk, vanished file, per-file chunk ceiling, newest-first
  under the cap, `max_files` coercion.
- `test/test_config_loader.py` — default/read/zero/junk for the new knob, and it
  is on the dashboard-editable allowlist.
- `test/test_knowledge_project_docs.py::test_hand_added_folder_is_never_budgeted`
  is replaced by `test_hand_added_folder_gets_the_folder_budget` — that test
  pinned the old contract and is the intended change.

**Revert-verified:** all 8 guards were patched out one at a time and the pinning
tests confirmed to fail, then the tree restored and re-confirmed green — budget
resolver default, per-source override, sweep wiring, confirm wiring, response
estimate fields, estimator file cap, no-default-allowlist, and config parsing.

## Manual verification

N/A — the change is backend logic and one API response shape, both covered by
unit tests against the real handlers via `aiohttp` `TestClient` and the real
`FolderWatcher`/`KnowledgeStore`.

## Screenshots

N/A — no user-visible UI change. The new response fields are backend-only and
deliberately do not add frontend UI.

## Gates

`pytest` full suite (33,320 passed; 9 failures all reproduced on a clean
`origin/main` checkout or shown to pass in isolation on both branches — pty /
`ps` / ipv6 host-environment cases unrelated to this diff), `isort`, `flake8`,
`mypy` (801 files, CI-parity venv without faiss), docs-lint, scrub-lint and the
brand-name gate all clean.

`config-baseline.json` is regenerated by
`scripts/generate_config_baseline.py`, not hand-edited. It also picks up a
one-line `skills.max_triggered` help refresh that was **already stale on main**
(regenerating on a clean `origin/main` checkout produces the same line).
