### PR TITLE
fix(test): skip POSIX-only ACP tests on Windows fork runners

### DIFF
--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import signal
+import sys
 import time
 import types
 from collections import deque
@@ -35,6 +36,10 @@ from kiro_crew.acp.liveness import (
     LivenessOracle,
 )
 from kiro_crew.acp.types import ACP_BACKEND_CLAUDE, AcpPromptStats
+
+# Windows lacks os.killpg and POSIX process-tree APIs (ps, /proc).
+# Tests that exercise these paths are skipped on Windows.
+_POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="POSIX process tree APIs only")
 
 
 class TestVendoredClaudeAcp:
@@ -1682,6 +1687,7 @@ class TestGetChildPids:
         assert _get_child_pids(1000) == [2000, 4000, 3000, 5000]
 
 
+@_POSIX_ONLY
 class TestIsOurChild:
     def test_nonexistent_pid(self):
         from kiro_crew.acp.client import _is_our_child
@@ -1781,6 +1787,7 @@ class TestIsOurChild:
         assert _is_our_child(999, expected_start=42, expected_basename=None) is False
 
 
+@_POSIX_ONLY
 class TestKillEscapedChildren:
     def test_empty_dict(self):
         from kiro_crew.acp.client import _kill_escaped_children
@@ -1826,6 +1833,7 @@ class TestChildPidsField:
         assert client._child_pids == {}
 
 
+@_POSIX_ONLY
 class TestReadBasename:
     def test_reads_basename_from_ps(self, monkeypatch):
         import sys
@@ -3210,6 +3218,7 @@ class TestSendPipeErrors:
 # ── Coverage push: process lifecycle ──
 
 
+@_POSIX_ONLY
 class TestKillProcess:
     """Tests for _kill_process covering SIGTERM, SIGKILL, and edge cases."""
 
@@ -5656,6 +5665,7 @@ class TestSendMessageStreamBranches:
         assert client._turn_done.is_set()
 
 
+@_POSIX_ONLY
 class TestKillProcessPipeClose:
     """Test pipe closing in _kill_process."""
 


### PR DESCRIPTION
## What

Adds `@pytest.mark.skipif(sys.platform == "win32", ...)` guards to test classes that exercise POSIX-only process tree APIs (`os.killpg`, `ps(1)`, `/proc`). These tests deterministically fail on Windows fork PR runners where the Actions tool cache is not shared with the upstream repo.

## Why

The production code already handles Windows gracefully (`platform_compat.IS_WINDOWS` early-returns, `kill_process_tree` uses `taskkill /T`), but the test paths exercise the raw POSIX code path which doesn't exist on win32.

On fork PRs, the Windows backend shards all fail on the merge commit — preventing CI conclusion from reaching `success` and blocking AI review workflows (GPT/Opus/Design/UX) from triggering.

## Changes

Single file: `test/test_acp_client.py`

- Added `sys` to top-level imports
- Defined `_POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", ...)`
- Applied `@_POSIX_ONLY` to 5 test classes:
  - `TestIsOurChild` — `_read_basename` returns `None` on Windows via `IS_WINDOWS`
  - `TestKillEscapedChildren` — `os.killpg` does not exist on win32
  - `TestReadBasename` — relies on `ps(1)` / `/proc`
  - `TestKillProcess` — `os.killpg` / `os.getpgid` POSIX-only
  - `TestKillProcessPipeClose` — same (`os.killpg` in fixture)

## Testing

- All 473 tests in `test_acp_client.py` still pass on Linux (the skipif is a no-op on POSIX)
- On Windows, the 5 guarded classes (~20 tests) will be skipped instead of crashing

Closes #2041