### PR TITLE
fix(dashboard): retry transient transcript reads so restore keeps the tab

### DIFF
--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -2661,27 +2661,83 @@ class ConversationLog:
         if not path.exists():
             self._msg_cache.pop(key, None)
             return []
-        try:
-            mtime = path.stat().st_mtime
-        except OSError:
-            return []
-        cached = self._msg_cache.get(key)
-        if cached and cached[0] == mtime:
-            return cached[1]
-        messages: list[dict] = []
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
+        # Retry transient read failures rather than reporting an empty session.
+        # This method is on the open-tab restore path
+        # (``read_messages_chained`` -> ``_rehydrate_slot_from_history``); on
+        # Windows a just-written transcript can be briefly unopenable while an
+        # indexer or AV scanner holds it (``ERROR_SHARING_VIOLATION`` ->
+        # ``PermissionError``, an ``OSError`` subclass). An unhandled OSError
+        # here propagates out of rehydrate and DROPS the tab, which is the
+        # intermittent ``restored == N-1`` (``assert 7 == 8``) failure on the
+        # Windows CI line. Mirror the retry ``_read_metadata`` already uses so
+        # the tab keeps its full history instead of vanishing. The old bare
+        # ``except OSError: return []`` on the stat silently yielded a
+        # history-less tab on the same fault; retrying first recovers it.
+        for attempt in range(_METADATA_READ_ATTEMPTS):
             try:
-                data = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if data.get("_type") == "metadata":
-                continue
-            messages.append(data)
-        self._msg_cache[key] = (mtime, messages)
-        return messages
+                mtime = path.stat().st_mtime
+                cached = self._msg_cache.get(key)
+                if cached and cached[0] == mtime:
+                    return cached[1]
+                with open(path, encoding="utf-8") as fh:
+                    raw = fh.read()
+            except FileNotFoundError:
+                # The transcript was deleted AFTER the exists() check above -- a
+                # concurrent delete_session racing this read. That is NOT a
+                # transient lock (retrying cannot bring the file back), and the
+                # correct answer is an empty read: it matches the exists()-miss
+                # branch above and the pre-PR stat() OSError branch. Letting it
+                # fall through to the generic OSError arm below -- which now
+                # re-raises on exhaustion -- would turn a benign race into an
+                # HTTP 500 in a caller like api_session_detail that reaches
+                # read_messages after its own exists() check (GPT review, PR
+                # #2052). Return [] immediately, dropping any stale cache entry;
+                # do not spend the retry budget on a file that is gone.
+                self._msg_cache.pop(key, None)
+                return []
+            except OSError:
+                if attempt + 1 < _METADATA_READ_ATTEMPTS:
+                    self._pause_for_transient_retry()
+                    continue
+                # Out of retries. Do NOT swallow to [] here. A persistent read
+                # failure is indistinguishable from a genuinely empty session,
+                # and on the restore path _rehydrate_slot_from_history would then
+                # register an EMPTY slot -- which restore_recent_sessions dedupes
+                # by key and skips, stranding the tab history-less for the whole
+                # session (GPT review, PR #2052). Re-raise instead so rehydrate
+                # rolls back its partial slot and the tab is DROPPED rather than
+                # registered empty -- recoverable on a later restore pass, most
+                # reliably the next restart once the holder has released the file
+                # (the same-startup restore_recent_sessions fallback only recovers
+                # it if the file is readable by then). That matches the
+                # "drop, don't register empty" outcome _read_metadata reaches by
+                # returning {} on exhaustion. It is also the pre-retry behaviour:
+                # the old unwrapped read_text() propagated this OSError with no
+                # retry, so callers already tolerate it -- the loop above just
+                # absorbs the transient case first.
+                logger.warning(
+                    "history: could not read messages for %s after %d attempts; "
+                    "re-raising so restore can retry",
+                    key,
+                    _METADATA_READ_ATTEMPTS,
+                    exc_info=True,
+                )
+                raise
+            messages: list[dict] = []
+            for line in raw.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if data.get("_type") == "metadata":
+                    continue
+                messages.append(data)
+            self._msg_cache[key] = (mtime, messages)
+            return messages
+        return []
 
     #: Starting tail window (bytes) for :meth:`_read_tail_messages`. Sized to
     #: comfortably cover a few dozen JSONL message lines in one read; grown
@@ -2929,6 +2985,27 @@ class ConversationLog:
         """Return session metadata for *key*."""
         return self._read_metadata(key)
 
+    def _pause_for_transient_retry(self) -> None:
+        """Pause briefly before retrying a transient read, but ONLY off the loop.
+
+        Shared by :meth:`_read_metadata` and :meth:`_read_messages`. Both are
+        reached ON the event loop by ``restore_open_slots_async`` (which keeps
+        the whole restore on the loop deliberately: creating a slot broadcasts
+        through ``asyncio.Queue.put_nowait`` / ``Event.set``, neither
+        thread-safe). A kernel sleep there stops ``_loop_heartbeat`` from petting
+        the LoopStallWatchdog -- whose ``exit_after`` timer then kills the
+        gateway, the exact crash-loop the async restore exists to prevent. So
+        sleep only when NOT on a running loop; on the loop the retry is
+        immediate (a stat plus an open -- cheap enough to be worth taking).
+        """
+        on_loop = True
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            on_loop = False
+        if not on_loop:
+            _time.sleep(_METADATA_READ_RETRY_SECS)
+
     def _read_metadata(self, key: str) -> dict:
         """Read the metadata line (first line) from a session JSONL file.
 
@@ -2966,27 +3043,8 @@ class ConversationLog:
                     first = fh.readline().strip()
             except OSError:
                 if attempt + 1 < _METADATA_READ_ATTEMPTS:
-                    # Pause before retrying ONLY off the event loop. This path is
-                    # reached ON it: ``restore_open_slots_async`` keeps the whole
-                    # restore on the loop deliberately (creating a slot broadcasts
-                    # through ``asyncio.Queue.put_nowait`` / ``Event.set``, neither
-                    # thread-safe), and a kernel sleep there stops
-                    # ``_loop_heartbeat`` from petting the LoopStallWatchdog --
-                    # whose ``exit_after`` timer then kills the gateway. That
-                    # crash-loop is the exact thing the async restore exists to
-                    # prevent, so it must not be reintroduced here. Same probe as
-                    # the cross-process lock acquire above.
-                    on_loop = True
-                    try:
-                        asyncio.get_running_loop()
-                    except RuntimeError:
-                        on_loop = False
-                    if not on_loop:
-                        _time.sleep(_METADATA_READ_RETRY_SECS)
-                    # On the loop the retry is immediate instead. It costs a stat
-                    # plus an open, so it is cheap enough to be worth taking, and
-                    # losing it only yields the same ``{}`` this returned before
-                    # any retry existed -- never worse than the old behaviour.
+                    # Pause before retrying (off-loop only -- see the helper).
+                    self._pause_for_transient_retry()
                     continue
                 # Out of retries. Distinguish this from "no metadata" in the log
                 # so a dropped tab is traceable to its cause instead of looking

--- a/test/test_open_slots_persistence.py
+++ b/test/test_open_slots_persistence.py
@@ -1061,3 +1061,146 @@ def test_a_transient_metadata_read_failure_does_not_drop_a_tab(tmp_path, monkeyp
         f"restored slots: {sorted(state2._slots)}"
     )
     assert keys[2] in state2._slots
+
+
+def test_read_messages_retries_transient_sharing_violation(tmp_path, monkeypatch):
+    """A transient sharing violation on the transcript BODY is retried, not lost.
+
+    Companion to ``test_a_transient_metadata_read_failure_does_not_drop_a_tab``,
+    which covers the metadata (first-line) read. ``_read_messages`` is on the
+    same restore path (``read_messages_chained`` ->
+    ``_rehydrate_slot_from_history``), and before the fix its body read
+    propagated a Windows ``PermissionError`` (``ERROR_SHARING_VIOLATION``, an
+    ``OSError`` subclass) straight out of rehydrate. ``_restore_open_slots_steps``
+    then dropped the tab -- the same intermittent ``assert 7 == 8`` shape on the
+    Windows CI line, but from the body read rather than the metadata read, so the
+    metadata-only retry did not cover it.
+
+    Primes the metadata cache first so the ONLY open under the violation is the
+    body read we want to exercise, faults it once, and requires the messages
+    back intact.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-body")
+    log = state.conversation_log
+    assert log is not None
+    key = _history_key_for("chat-1-body")
+    victim = log._path(key).name
+    # Prime the metadata cache and drop any warmed message cache so the sole
+    # open under the violation is the body read this test targets.
+    log.get_metadata(key)
+    log._msg_cache.clear()
+
+    with builtin_open_sharing_violation(match=victim, times=1) as seen:
+        msgs = log._read_messages(key)
+
+    assert seen["n"] >= 1, "the simulator never intercepted the body open"
+    assert [m.get("content") for m in msgs] == ["hello"], (
+        f"a transient sharing violation lost the message body (got {msgs!r}); "
+        "the tab would restore empty or be dropped on the Windows CI line"
+    )
+
+
+def test_read_messages_reraises_after_exhausting_retries(tmp_path, monkeypatch):
+    """A PERSISTENT body-read failure must re-raise, not swallow to ``[]``.
+
+    GPT review (PR #2052): swallowing an exhausted read to ``[]`` is
+    indistinguishable from a genuinely empty session, so
+    ``_rehydrate_slot_from_history`` would register an EMPTY slot -- which
+    ``restore_recent_sessions`` then dedupes by key and skips, stranding the tab
+    history-less for the whole session. ``_read_messages`` must instead re-raise
+    on exhaustion so rehydrate rolls back and the fallback restore can retry.
+    Transient failures are still absorbed (see the companion test above).
+    """
+    from kiro_crew.history import _METADATA_READ_ATTEMPTS
+
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-persist")
+    log = state.conversation_log
+    assert log is not None
+    key = _history_key_for("chat-1-persist")
+    victim = log._path(key).name
+    # Prime the metadata cache and drop the message cache so the ONLY opens
+    # under the violation are the body reads -- and fault EVERY attempt.
+    log.get_metadata(key)
+    log._msg_cache.clear()
+
+    with builtin_open_sharing_violation(match=victim, times=_METADATA_READ_ATTEMPTS):
+        with pytest.raises(OSError):
+            log._read_messages(key)
+
+
+def test_read_messages_missing_file_mid_read_returns_empty(tmp_path, monkeypatch):
+    """A transcript deleted AFTER exists() (concurrent delete race) yields ``[]``.
+
+    GPT review (PR #2052): ``_read_messages`` re-raises a persistent OSError so
+    restore can drop+retry the tab -- but ``FileNotFoundError`` is NOT a
+    transient lock. Re-raising it would turn a benign concurrent
+    ``delete_session`` into an HTTP 500 in a caller like ``api_session_detail``,
+    which reaches ``read_messages`` after its own ``exists()`` check. It must be
+    caught separately and return ``[]`` (matching the ``exists()``-miss branch),
+    without spending the retry budget on a file that is gone.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-race")
+    log = state.conversation_log
+    assert log is not None
+    key = _history_key_for("chat-1-race")
+    # Prime metadata cache + drop the message cache so the body read happens.
+    log.get_metadata(key)
+    log._msg_cache.clear()
+
+    # Simulate the file vanishing between the (passing) exists()/stat() and the
+    # body open() -- the concurrent-delete race the guard is for.
+    victim = log._path(key).name
+    real_open = open
+
+    def _fnf_open(file, *args, **kwargs):
+        if victim in str(file):
+            raise FileNotFoundError(2, "No such file or directory", str(file))
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", _fnf_open)
+
+    # Must return [] (not raise) so read_messages callers don't 500 on the race.
+    assert log._read_messages(key) == []
+
+
+def test_persistent_body_read_failure_drops_tab_not_registers_empty(tmp_path, monkeypatch):
+    """End-to-end: a persistent body-read failure DROPS the tab, never registers
+    it empty.
+
+    Pins the GPT #2052 fix at the restore layer: the other tabs restore, and the
+    unreadable one is ABSENT from ``_slots`` (so the mtime-based
+    ``restore_recent_sessions`` fallback -- and the next restart -- can still
+    recover it) rather than being registered as a history-less slot that the
+    dedup guard would then skip.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-persist" for i in range(3)]
+    for k in keys:
+        _seed_session(state, k)
+    (tmp_path / "open_slots.json").write_text(json.dumps({"keys": keys, "ts": 0.0}))
+
+    state2 = _make_state(tmp_path / "sessions")
+    victim_key = _history_key_for(keys[1])
+    victim = state2.conversation_log._path(victim_key).name
+    # Warm the metadata cache so the victim's metadata reads are served cached;
+    # then fault EVERY victim open so the message-body read exhausts its retries
+    # (a large count also covers any incidental victim opens -- e.g. a tab_id
+    # index rebuild -- without letting the body read slip through unfaulted).
+    state2.conversation_log.get_metadata(victim_key)
+
+    with builtin_open_sharing_violation(match=victim, times=10_000):
+        restored = restore_open_slots(state2)
+
+    assert restored == 2, f"expected the two readable tabs; got {restored}"
+    assert keys[1] not in state2._slots, (
+        "an unreadable tab was registered EMPTY instead of dropped -- "
+        "restore_recent_sessions would dedupe it and the history would be lost"
+    )
+    assert keys[0] in state2._slots and keys[2] in state2._slots


### PR DESCRIPTION
## Problem

The open-tab restore intermittently came back **one tab short** on the `Backend Tests (Windows)` CI line — surfacing as `test_open_slots_persistence.py::test_flush_during_async_restore_does_not_truncate_snapshot` failing with `assert 7 == 8` (and the same `assert N == N+1` shape elsewhere on that line). A tab the user had open silently vanished from the sidebar after a gateway restart.

## Why it matters

Restore is the promise that your open tabs survive a gateway restart. A read that loses one tab breaks that promise non-deterministically — it passes locally on macOS/Linux and only bites on Windows, so it reads as "flaky CI" rather than the real data-visibility bug it is. On a real Windows host the same fault drops a tab from the sidebar for good.

## Fix (symptom → root cause → change)

- **Symptom:** restore returns one fewer tab than were seeded; `assert 7 == 8`.
- **Root cause:** `_read_metadata` was already hardened to **retry** a transient `OSError` — on Windows a just-written transcript is briefly unopenable while an AV/indexer holds it (`ERROR_SHARING_VIOLATION` → `PermissionError`, an `OSError` subclass). But `_read_messages` was **not**: its transcript-body read let that `PermissionError` propagate out of `read_messages_chained` → `_rehydrate_slot_from_history`, and `_restore_open_slots_steps` catches the exception and **drops the tab** (`continue`). So the metadata retry covered the first-line read but not the body read on the same path.
- **Change (`src/kiro_crew/history.py`):**
  - Extract the on-loop-safe pause into a shared `_pause_for_transient_retry()` — it sleeps **only when not on a running event loop**, so it cannot starve the `LoopStallWatchdog` heartbeat during the async restore (the exact crash-loop the async restore exists to prevent). `_read_metadata` now calls it instead of its own inline probe (behaviour-identical extraction).
  - `_read_messages` now runs the same bounded retry loop (`_METADATA_READ_ATTEMPTS`), reading the body via `open(path)` + `fh.read()`, and arms two `except` clauses in order:
    - **`FileNotFoundError` → return `[]` immediately** (pop the cache, no retry). A transcript deleted after the `exists()` check is a `delete_session` race, not a transient lock — retrying can't bring it back, and `[]` matches the `exists()`-miss branch and the pre-PR `stat()` `OSError` branch. This keeps a `read_messages` caller like `api_session_detail` from turning a benign race into an HTTP 500.
    - **other `OSError` → retry, then RE-RAISE on exhaustion.** A transient lock is retried; on a **transient** failure the tab keeps its full history. On a **persistent** one, re-raising (rather than returning `[]`) is deliberate: swallowing to `[]` is indistinguishable from a genuinely empty session, so `_rehydrate_slot_from_history` would register an **empty** slot that `restore_recent_sessions` then dedupes by key and skips, stranding the tab history-less. Re-raising lets rehydrate's `except BaseException` roll back its partial slot, so `_restore_open_slots_steps` **drops** the tab — recoverable on a later restore pass, most reliably the next restart.

The re-raise restores the pre-PR contract: the old unwrapped `read_text()` already propagated this `OSError` with no retry, so callers already tolerate it — the loop just absorbs the transient case first. The read-style change to `open().read()` (from `path.read_text()`) routes through `builtins.open`, matching `_read_metadata` and making the body read interceptable by the `builtin_open_sharing_violation` simulator so the fix is testable on POSIX.

## Tests

- **`test_read_messages_retries_transient_sharing_violation`** — a single transient fault on the body read is absorbed; the messages come back intact.
- **`test_read_messages_reraises_after_exhausting_retries`** — a persistent fault (every attempt) must **re-raise**, not return `[]`.
- **`test_read_messages_missing_file_mid_read_returns_empty`** — a transcript that vanishes between `exists()` and the body `open()` (concurrent-delete race) returns `[]`, not a raise (no 500 for `read_messages` callers).
- **`test_persistent_body_read_failure_drops_tab_not_registers_empty`** — end-to-end: a persistently-unreadable transcript is **dropped** by restore (absent from `_slots`, so the fallback/next restart can recover it), never registered empty; the other tabs still restore.
- **Existing regressions kept green:** `test_flush_during_async_restore_does_not_truncate_snapshot` (the `assert 7 == 8` test) and `test_a_transient_metadata_read_failure_does_not_drop_a_tab` (the metadata-side companion).

## Manual verification

N/A — unit coverage is sufficient. The Windows-only faults are reproduced deterministically on POSIX by the `windows_sim.builtin_open_sharing_violation` simulator (and a `FileNotFoundError` inject for the delete race), so the code paths a Windows host takes are exercised directly. Verified locally: `test_open_slots_persistence.py` + `test_history.py` (+ `test_file_change_snapshots.py`) all pass; `isort`/`flake8`/`mypy` clean.

## Screenshots

N/A — no user-visible UI change (backend history read path + tests only).
