### PR TITLE
fix(ci): stop the brand gate's quadratic guard from skipping its own check

### DIFF
--- a/scripts/check_brand_name.py
+++ b/scripts/check_brand_name.py
@@ -61,6 +61,19 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _PERF_ATTEMPTS = 5
 _PERF_MIN_BASE_SECS = 0.020
 
+# Baseline workloads, tried in order until one produces a measurable baseline.
+# A single fixed size cannot serve both ends of the hardware range: 20k costs a
+# fast machine ~19-21ms, which straddles the floor above, so the ratio went
+# UNJUDGED on a large fraction of runs -- the check reported `ok` while testing
+# nothing. Growing the workload buys a measurable baseline instead of abandoning
+# the check.
+#
+# Escalating is close to free because a REGRESSED scan never reaches it: its
+# baseline is ~25x the linear one, so it clears the floor at the first size and
+# is judged there. Only linear scans -- the fast case -- ever pay for a larger
+# size, and a slow runner clears the floor at 20k and pays nothing at all.
+_PERF_BASE_SIZES = (20_000, 50_000, 120_000)
+
 # ---------------------------------------------------------------------------
 # What counts as a misspelling
 # ---------------------------------------------------------------------------
@@ -665,23 +678,37 @@ def self_test() -> int:
                 best, best_pair = candidate, (base_time, doubled_time)
         return (0.0 if best is math.inf else best), best_pair[0], found[0], found[1]
 
-    ratio, base_time, base_found, doubled_found = ratio_of(20_000)
-    if (base_found, doubled_found) != (20_000, 40_000):
-        print(f"  FAIL repeated-brands: found {base_found}/{doubled_found}, want 20000/40000")
+    # Grow the workload until the baseline is big enough to divide. `ratio_of`
+    # is only called again when the previous size came in under the floor, so
+    # the common cases cost exactly one call.
+    base_count = 0
+    ratio = base_time = 0.0
+    base_found = doubled_found = 0
+    for base_count in _PERF_BASE_SIZES:
+        ratio, base_time, base_found, doubled_found = ratio_of(base_count)
+        if base_time >= _PERF_MIN_BASE_SECS:
+            break
+
+    if (base_found, doubled_found) != (base_count, base_count * 2):
+        print(f"  FAIL repeated-brands: found {base_found}/{doubled_found}, "
+              f"want {base_count}/{base_count * 2}")
         failures += 1
     elif base_time < _PERF_MIN_BASE_SECS:
-        # Too small to divide. Quadratic growth at this size costs far more than
-        # the floor, so a baseline under it cannot be hiding a regression --
-        # report the fact rather than dividing noise by noise.
-        print(f"  ok   repeated-brands (baseline {base_time * 1000:.1f}ms below the "
-              f"{_PERF_MIN_BASE_SECS * 1000:.0f}ms measurement floor; ratio not judged)")
+        # Even the largest workload was too fast to measure. Quadratic growth at
+        # that size costs orders of magnitude more than the floor, so this cannot
+        # be hiding a regression -- report the fact rather than dividing noise by
+        # noise.
+        print(f"  ok   repeated-brands (baseline {base_time * 1000:.1f}ms at {base_count} "
+              f"brands still below the {_PERF_MIN_BASE_SECS * 1000:.0f}ms measurement "
+              f"floor; ratio not judged)")
     elif ratio > 3.0:
         print(f"  FAIL repeated-brands: doubling the input cost {ratio:.1f}x CPU time "
-              f"(best of {_PERF_ATTEMPTS}, baseline {base_time:.3f}s); linear is ~2x, "
-              f"so a per-match scan of the line has come back")
+              f"(best of {_PERF_ATTEMPTS}, baseline {base_time:.3f}s at {base_count} "
+              f"brands); linear is ~2x, so a per-match scan of the line has come back")
         failures += 1
     else:
-        print(f"  ok   repeated-brands (doubling cost {ratio:.1f}x, linear)")
+        print(f"  ok   repeated-brands (doubling cost {ratio:.1f}x at {base_count} "
+              f"brands, linear)")
 
     # A wider fence is not closed by a narrower run inside it, so a doc can quote
     # a fenced example without exposing its contents as prose.

--- a/test/test_brand_name_gate.py
+++ b/test/test_brand_name_gate.py
@@ -573,6 +573,32 @@ class TestDiffScopedRun:
         assert result.returncode == 0, result.stdout
         assert "self-test passed" in result.stdout
 
+    def test_self_test_actually_judges_the_growth_ratio(self, tmp_path) -> None:
+        """The repeated-brands check must reach a verdict, not skip itself.
+
+        Its baseline used to be a fixed 20k brands, which costs fast hardware
+        ~19-21ms against a 20ms measurement floor. Landing under the floor made
+        the check print `ok ... ratio not judged` and test nothing, so on a fast
+        machine the quadratic guard was a coin-flip no-op. The workload now grows
+        until the baseline is measurable, so a real ratio is always reported.
+        """
+        root = self._repo(tmp_path)
+        self._commit(root, "doc.md", "clean\n", "base")
+        result = subprocess.run(
+            [sys.executable, os.path.join(root, "scripts", "check_brand_name.py"), "--test"],
+            cwd=root,
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        assert result.returncode == 0, result.stdout
+        verdict = [ln for ln in result.stdout.splitlines() if "repeated-brands" in ln]
+        assert len(verdict) == 1, f"expected one repeated-brands line, got {verdict!r}"
+        assert "ratio not judged" not in verdict[0], (
+            f"the quadratic guard skipped its own measurement: {verdict[0]!r}"
+        )
+        assert "doubling cost" in verdict[0], verdict[0]
+
 
 class TestExplicitPathFailsClosed:
     """A path handed to the gate directly must be read, or the run must fail.


### PR DESCRIPTION
Fixes #1711. Also closes #1648 (same check, same assertion, same test).

## Problem

`scripts/check_brand_name.py --test` has a `repeated-brands` case that guards
against reintroducing a per-match scan of the line — the quadratic shape a line
carrying thousands of brand tokens exploits. It decides by dividing two
`process_time()` samples, and correctly refuses to judge a baseline too small to
divide (`_PERF_MIN_BASE_SECS = 0.020`).

The baseline workload is fixed at 20,000 brands. On current fast hardware that
costs **19–21 ms** — straddling the 20 ms floor. So the check frequently declines
to judge, prints `ok`, and asserts nothing.

Measured against `ade63df1`, 15 consecutive runs on an M-series Mac (Python 3.12.13):

```
judged = 4    ratio not judged = 11    of 15
  ok   repeated-brands (baseline 19.2ms below the 20ms measurement floor; ratio not judged)
```

Roughly **73% of runs on this machine exercise no linearity assertion at all.**

## Why it matters

A gate that silently stops gating is worse than no gate — `.github/workflows/ci.yml`
makes that argument itself. The quadratic regression this guards is a real
historical defect (the comment block at `check_brand_name.py:614-645` documents it),
it is invisible in normal use, and it only surfaces as multi-second CPU burn on
a line with many brand tokens. If it is reintroduced, the check that exists to
catch it currently has a ~1-in-4 chance of even looking, and the odds get worse
as developer and runner hardware gets faster.

Note this is **not** the flake #1711 and #1648 reported. That mechanism — wall-clock
sampling and a ~2x ratio — was fixed by #1733 (`2b5910b8`), which landed *after*
both issues were filed. #1733's move to paired best-of-5 CPU time is right and is
kept intact here. What it did not address is that the workload size it inherited
was chosen for the old wall-clock check, and now lands under the floor it added.

## Fix (symptom → root cause → change)

- **Symptom:** `ratio not judged` on most runs; no linearity assertion.
- **Root cause:** one fixed workload cannot serve both ends of the hardware range.
  20k is comfortably measurable on a 4-vCPU Windows runner (~60 ms) and
  unmeasurable on a fast Mac (~20 ms), and the code treated "too fast to measure"
  as a reason to give up rather than a reason to measure more.
- **Change:** try successively larger baselines (`20k → 50k → 120k`) until one
  clears the floor, then judge that one. The verdict lines now name the size used,
  so the log says what was actually measured.

Two properties make this close to free, both verified rather than assumed:

1. **A regressed scan never escalates.** Its baseline is ~25x the linear one
   (0.509 s vs 0.021 s at 20k), so it clears the floor at the *first* size and is
   judged there. The regressed-case cost is therefore unchanged from `main`.
2. **Escalation only happens for linear scans on fast hardware**, and larger
   workloads are *less* noisy, so this reduces flake risk rather than adding to it.

| baseline size | baseline CPU (min–max) | runs under floor | worst best-of-5 ratio |
|---|---|---|---|
| 20,000 (before) | 19.0–21.0 ms | **5/12** | 1.983 |
| 50,000 | 48.0–54.8 ms | 0/12 | 2.026 |
| 120,000 | 97.7–112.8 ms (@100k) | 0/12 | 2.023 |

## Tests

`test/test_brand_name_gate.py::TestDiffScopedRun::test_self_test_actually_judges_the_growth_ratio`
asserts the `repeated-brands` line reports an actual ratio and never
`ratio not judged`. Run against unpatched `main` it fails on ~11 of 15 attempts
(exactly the defect); with this change it passed 12/12.

Full file: **85 passed**. `flake8`, `isort --check-only`, `mypy` clean.

## Manual verification

Teeth confirmed intact by reintroducing the exact documented regression — a
per-match `line[:start]` prefix copy — into a scratch copy of the patched script:

```
run1 FAIL repeated-brands: doubling the input cost 3.8x CPU time (best of 5, baseline 0.509s at 20000 brands)
run2 FAIL repeated-brands: doubling the input cost 3.8x CPU time (best of 5, baseline 0.500s at 20000 brands)
run3 FAIL repeated-brands: doubling the input cost 3.8x CPU time (best of 5, baseline 0.510s at 20000 brands)
self-test FAILED (1)   # exit 1
```

Caught 3/3, at 20,000 brands, i.e. without escalating — confirming property (1).

Healthy runs after the change (12 consecutive): 10 judged at 20k, 2 escalated to
50k, 0 unjudged, all `ok`, exit 0.

## Screenshots

N/A — no user-visible surface; this changes a CI self-test only.
