### PR TITLE
fix(chat): stop pinning a new chat to a model the user did not pick

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -963,16 +963,29 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   const pendingProjectRef = useRef('')
   const setPendingProject = useCallback((v: string) => { pendingProjectRef.current = v }, [])
 
-  // Sync pendingModel with default agent's model on initial load. Keyed by the
-  // KiroCrew agent name: the backend resolver owns the precedence (the agent's
-  // own model, then its kiro template's pin, then the global default).
-  const _initAgent = pendingAgent || defaultAgent || 'default'
-  const { data: _initResolvedModel } = useQuery({
-    queryKey: ['resolved-model', _initAgent, provider.id],
-    queryFn: () => provider.resolveModel(_initAgent),
-    enabled: !!_initAgent && !pendingModel,
-  })
-  useEffect(() => { if (_initResolvedModel && !pendingModel) setPendingModel(_initResolvedModel) }, [_initResolvedModel]) // eslint-disable-line react-hooks/exhaustive-deps
+  // pendingModel is the model for the NEXT new slot, and it is deliberately
+  // left EMPTY unless the user explicitly picks one (switchModel below).
+  //
+  // It used to be seeded at mount from the backend resolver. That resolver
+  // answers "what would run", which is right for the composer chip but wrong as
+  // a session-create value: a session's model is a permanent pin (the runtime
+  // reads `slot.model or agent_model`, so a set slot.model wins for every later
+  // turn). Seeding it pinned every new chat to whatever the four-tier chain
+  // happened to resolve at page load, so an agent left on Auto never
+  // re-resolved and later changes to the agent or the global default never
+  // reached the session (#2035).
+  //
+  // Sending nothing is what preserves the chain. `SessionManager.get_or_create`
+  // documents that a `None` model "falls back to the global agent.model config
+  // -- but only when the named agent does not pin its own model ... and the
+  // global is not a sentinel value like 'auto', in which case it stays None to
+  // let the backend resolve from the agent's own JSON config". So omitting it
+  // honours the crew pin, the template pin, the global default and Auto, in that
+  // order, at session-create time.
+  //
+  // Sending the literal 'auto' would NOT be equivalent: it is truthy, so it
+  // short-circuits `slot.model or agent_model` and would override a template or
+  // global pin the user did configure.
   const [modelBtnRect, setModelBtnRect] = useState<DOMRect | null>(null)
   const planActionMutation = useMutation({
     mutationFn: ({ slot, action }: { slot: string; action: string }) => api.planAction(slot, action),
@@ -3407,8 +3420,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   const switchAgent = useCallback(async (agentName: string) => {
     if (!activeSlot) {
       setPendingAgent(agentName)
-      queryClient.fetchQuery({ queryKey: ['resolved-model', agentName, provider.id], queryFn: () => provider.resolveModel(agentName) })
-        .then(m => setPendingModel(m)).catch(() => setPendingModel(''))
+      // Clear any explicit pick made for the PREVIOUS agent rather than
+      // re-seeding a resolved model: an empty pendingModel makes createSlot omit
+      // `model`, which lets the backend resolve the new agent's own chain at
+      // create time. Seeding the resolved id here pinned it instead (#2035).
+      setPendingModel('')
       return
     }
     await api.chatSlotAgent(activeSlot, agentName)

--- a/website/src/test/ChatPage.newSessionModel.test.ts
+++ b/website/src/test/ChatPage.newSessionModel.test.ts
@@ -1,0 +1,71 @@
+// A new chat session must NOT be created carrying a model the user did not pick.
+//
+// A session's model is a permanent pin: the runtime reads `slot.model or
+// agent_model`, so once slot.model is set it wins for every later turn. ChatPage
+// used to seed `pendingModel` at mount from the backend resolver -- which answers
+// "what would run", correct for the composer chip and wrong as a create value --
+// so every new chat was pinned to whatever the four-tier chain resolved at page
+// load. An agent left on Auto never re-resolved, and later changes to the agent or
+// the global default never reached the session (#2035).
+//
+// Omitting `model` is what preserves the chain: `SessionManager.get_or_create`
+// documents that a `None` model falls back to the global `agent.model` config,
+// only when the named agent does not pin its own, and stays `None` for a sentinel
+// like "auto" so the backend resolves from the agent's own JSON config.
+//
+// WHY A SOURCE GUARD RATHER THAN A RENDER TEST: the observable contract is the
+// absence of a field in the `POST /api/chat/slots` body, and the paths that build
+// it (first send, and the empty-state "Start a new chat" button) sit behind a
+// ChatPage render harness that mocks ChatInput away -- so the send path is not
+// reachable and a render test could not actually observe the payload. This repo
+// already uses structural guards for invariants of exactly this shape (see the
+// `str()`-coercion guard in test/test_agent_default_model.py and the conftest
+// audit in test/test_mcp_gateway_pool_integ.py). The invariant here is "no
+// resolver result ever reaches setPendingModel", which is a property of the
+// source and is checked exactly.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const CHAT_PAGE = join(__dirname, '..', 'pages', 'ChatPage.tsx')
+const source = readFileSync(CHAT_PAGE, 'utf-8')
+
+/** Arguments that are legitimate for a create-time model: nothing, or an
+ *  explicit user pick. `v` is the setter's own parameter; `modelName` is the
+ *  argument of switchModel, i.e. the model the user clicked. */
+const ALLOWED_ARGS = new Set(["''", '', 'v', 'modelName'])
+
+describe('ChatPage — a new session carries no model the user did not pick', () => {
+  it('never passes a resolver result to setPendingModel', () => {
+    const calls = [...source.matchAll(/setPendingModel\(([^)]*)\)/g)].map(m => m[1].trim())
+    expect(calls.length).toBeGreaterThan(0)
+    const offenders = calls.filter(arg => !ALLOWED_ARGS.has(arg))
+    expect(offenders).toEqual([])
+  })
+
+  it('resolves a model for DISPLAY only -- one call site, not two', () => {
+    // Two call sites is the seeding coming back: one for the chip, one feeding
+    // pendingModel. One call site means display only.
+    const hits = [...source.matchAll(/provider\.resolveModel\(/g)]
+    expect(hits).toHaveLength(1)
+  })
+
+  it('has no mount-time query that seeds the next session\'s model', () => {
+    // The removed shapes, named explicitly so a revert is caught by name rather
+    // than only by the argument check above.
+    expect(source).not.toMatch(/new-session-model/)
+    expect(source).not.toMatch(/resolveNewSessionModel/)
+    expect(source).not.toMatch(/\.then\(m => setPendingModel\(/)
+  })
+
+  it('clears the previous pick when the agent changes on a slotless page', () => {
+    // Switching agent must not carry the old agent's explicit pick forward, and
+    // must not re-seed a resolved one either -- it clears, so createSlot omits
+    // `model` and the backend resolves the NEW agent's chain.
+    const switchAgent = source.slice(source.indexOf('const switchAgent = useCallback'))
+    const body = switchAgent.slice(0, switchAgent.indexOf('}, ['))
+    expect(body).toMatch(/setPendingModel\(''\)/)
+    expect(body).not.toMatch(/resolveModel/)
+  })
+})


### PR DESCRIPTION
Fixes #2035.

## Problem

An agent whose model is left on Auto does not get Auto on a new chat. The session
starts on a concrete model (the reporter saw `claude-opus-4.8`) and stays there.
Changing the agent's model, or the global default, never reaches a session that
already exists.

The agent config is stored correctly — `normalize_agent_model` collapses `"auto"` to
`""`, and `""` means "no pin". Nothing is lost on the save path. The break is at
session creation in the dashboard.

`ChatPage` seeded `pendingModel` at mount from the backend resolver, and `createSlot`
sends that value as the new session's `model`. That value then becomes permanent,
because `chat_runner.py` resolves each turn as:

```python
model=slot.model or agent_model or None
```

`slot.model` is checked first, so once set it wins for every later turn. Every new
chat was therefore pinned to whatever the four-tier chain (crew → bound template's pin
→ global `agent.model` → installed agent file) happened to resolve at page load.

Only two `createSlot` call sites pass a model and both read `pendingModel`: first send
(`ChatPage.tsx:3108`) and the empty-state "Start a new chat" button. Every other call
site already omits it and was never affected.

## Why it matters

Auto is what a user picks to avoid committing to one model, and this silently
converted it into a permanent pin. The divergence is invisible — the chip displays a
real model id, so nothing looks wrong. It also makes the global default model setting
unreliable: it applies only to sessions created after the change, never to the one in
front of you.

## Fix (symptom → root cause → change)

- **Symptom:** new chats run on a concrete model despite the agent being on Auto.
- **Root cause:** one function answering two different questions. `resolveModel` answers
  *"what will run"* — right for the composer chip, and deliberately delegated to the
  backend so the precedence is not duplicated client-side. It was also used to produce a
  *session-create* value, where the right answer is "nothing, unless the user picked one".
- **Change:** stop seeding `pendingModel` at all. It is now set only by an explicit user
  pick, and cleared when the agent changes so the previous agent's pick is not carried
  forward. With it empty, `createSlot` omits `model`.

Omitting it is what preserves the chain. `SessionManager.get_or_create` documents:

> `model`: Optional model override for the session. When `None`, falls back to the
> global `agent.model` config — but only when the named agent does not pin its own
> model (a per-agent pin outranks the global fallback) and the global is not a
> sentinel value like `"auto"`, in which case it stays `None` to let the backend
> resolve from the agent's own JSON config.

So `None` honours the crew pin, the template pin, the global default and Auto, in that
order, at create time.

### Rejected: sending the literal `'auto'`

An earlier revision of this PR did that, and GPT 5.6 Review correctly blocked it.
`'auto'` is **truthy**, so it short-circuits `slot.model or agent_model` and overrides a
template or global pin the user did configure. Nor can a flag fix it: the endpoint's
`pinned` is `bool(bindings.model)` — tier 1 only — so a crew inheriting from its
template or the global default reports `pinned: false` and would wrongly receive
`'auto'`. There is no flag exposed that separates those cases, so the approach was
dropped rather than patched.

## Tests

`website/src/test/ChatPage.newSessionModel.test.ts` — a structural guard. It checks that
no resolver result reaches `setPendingModel` (every argument is `''`, the setter's own
`v`, or switchModel's `modelName`), that `provider.resolveModel` has exactly **one** call
site so it stays display-only, that the removed seeding shapes are absent by name, and
that `switchAgent` clears rather than re-seeds.

Verified meaningful, not merely green: 4/4 pass on this revision and **2 of the 4 fail**
when `ChatPage.tsx` is reverted to main in the same tree.

The file header records why a structural guard rather than a render test: the observable
contract is the *absence* of a field in the `POST /api/chat/slots` body, and the paths
that build it sit behind a ChatPage harness that mocks `ChatInput` away, so a render test
cannot observe the payload. The repo already uses guards of this shape — the
`str()`-coercion guard in `test/test_agent_default_model.py`, the conftest audit in
`test/test_mcp_gateway_pool_integ.py`.

`tsc -b` clean, eslint 0 errors (8 warnings, identical count to the unmodified tree),
full frontend suite **10,475 passed**. Four local failures are pre-existing `Intl`
formatting noise (`src/i18n/format.test.ts`, `src/pages/settings/SecurityPanel.test.tsx`),
confirmed by reverting only this PR's files to `origin/main` and re-running.

## Manual verification

Traced end-to-end rather than assumed: confirmed only two `createSlot` sites send a
model, confirmed `_normalize_model` remaps deprecated names only, confirmed
`chat_runner.py` resolves `slot.model or agent_model` per turn, and read
`get_or_create`'s contract to establish that omission preserves the remaining tiers.

## Screenshots

**Not captured.** The visible delta is the absence of a pin, not a new surface: the
composer chip continues to render the resolved model through the existing
`resolveModel` display path, whose call site is unchanged. No new rendering is
introduced. Producing a real before/after would need the patched dashboard against a
live gateway with a configured agent, which I could not stand up here — flagging the gap
rather than shipping a screenshot that does not show the change.
