### PR TITLE
fix(apps): sign proxy HMAC over the wire-form request-target

### DIFF
--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -2329,6 +2329,14 @@ async def handle_app_api_proxy(request: web.Request) -> web.StreamResponse:
     target = f"{backend_url}/api/{path}"
     if request.query_string:
         target += f"?{request.query_string}"
+    # Parse once into a yarl.URL so the HMAC signs the exact wire form the
+    # backend will see as self.path. Without this, request.query_string is
+    # decoded (spaces stay as spaces) but yarl re-encodes when sending
+    # (space → '+'), causing an HMAC mismatch for any path containing
+    # percent-encodable characters (spaces, #, +, non-ASCII).
+    import yarl as _yarl
+
+    target_url = _yarl.URL(target)
 
     # Forward headers (strip hop-by-hop, inject proxy auth)
     headers: dict[str, str] = {}
@@ -2355,10 +2363,12 @@ async def handle_app_api_proxy(request: web.Request) -> web.StreamResponse:
             )
         ts = str(int(time.time()))
         body_hash = hashlib.sha256(body or b"").hexdigest()
-        msg = f"{ts}:{request.method}:/api/{path}"
-        if request.query_string:
-            msg += f"?{request.query_string}"
-        msg += f":{body_hash}"
+        # Sign the request-target in its wire form (raw_path_qs) so the
+        # signature matches what the backend receives as self.path. The
+        # decoded query_string would diverge after yarl re-encodes it
+        # (e.g. space → '+'), breaking HMAC verification for any path
+        # containing percent-encodable characters.
+        msg = f"{ts}:{request.method}:{target_url.raw_path_qs}:{body_hash}"
         sig = _hmac.new(secret.encode(), msg.encode(), hashlib.sha256).hexdigest()
         headers["X-KiroCrew-Proxy"] = f"{ts}:{sig}"
     except OSError as exc:
@@ -2377,7 +2387,7 @@ async def handle_app_api_proxy(request: web.Request) -> web.StreamResponse:
         try:
             async with session.request(
                 method=request.method,
-                url=target,
+                url=target_url,
                 headers=headers,
                 data=body,
                 timeout=timeout,

--- a/test/test_app_proxy_auth.py
+++ b/test/test_app_proxy_auth.py
@@ -65,3 +65,63 @@ def test_stale_timestamp_fails():
 def test_wrong_secret_fails():
     hdr = _sign("GET", "/api/read", b"")
     assert not verify_proxy_request(hdr, method="GET", target="/api/read", body=b"", secret="different")
+
+
+# ---------------------------------------------------------------------------
+# Regression: percent-encodable characters in query values (issue #2053)
+#
+# The gateway signs the request-target in its wire form (yarl raw_path_qs).
+# The backend verifies against self.path, which is also the wire form.
+# Both sides must agree on the encoded representation for paths containing
+# spaces, +, #, and non-ASCII characters.
+# ---------------------------------------------------------------------------
+
+
+def test_path_with_space_verifies():
+    """A query value with a space, signed and verified in wire form (space → +)."""
+    wire_target = "/api/read?path=/tmp/my+notes.md"
+    hdr = _sign("GET", wire_target, b"")
+    assert verify_proxy_request(
+        hdr, method="GET", target=wire_target, body=b"", secret=SECRET
+    )
+
+
+def test_path_with_percent_encoded_space_verifies():
+    """A space encoded as %20 (alternative to +) also round-trips."""
+    wire_target = "/api/read?path=/tmp/my%20notes.md"
+    hdr = _sign("GET", wire_target, b"")
+    assert verify_proxy_request(
+        hdr, method="GET", target=wire_target, body=b"", secret=SECRET
+    )
+
+
+def test_path_with_hash_verifies():
+    """A '#' in a query value is percent-encoded on the wire."""
+    wire_target = "/api/read?path=/tmp/issue%23123.md"
+    hdr = _sign("GET", wire_target, b"")
+    assert verify_proxy_request(
+        hdr, method="GET", target=wire_target, body=b"", secret=SECRET
+    )
+
+
+def test_path_with_non_ascii_verifies():
+    """Non-ASCII (accented) characters are percent-encoded on the wire."""
+    wire_target = "/api/read?path=/tmp/caf%C3%A9.md"
+    hdr = _sign("GET", wire_target, b"")
+    assert verify_proxy_request(
+        hdr, method="GET", target=wire_target, body=b"", secret=SECRET
+    )
+
+
+def test_decoded_vs_wire_form_mismatch_fails():
+    """Signing the decoded form while verifying the wire form must fail.
+
+    This is the exact bug: the gateway signed 'my notes.md' (decoded) but the
+    backend saw 'my+notes.md' (wire). The two must not verify against each other.
+    """
+    decoded_target = "/api/read?path=/tmp/my notes.md"
+    wire_target = "/api/read?path=/tmp/my+notes.md"
+    hdr = _sign("GET", decoded_target, b"")
+    assert not verify_proxy_request(
+        hdr, method="GET", target=wire_target, body=b"", secret=SECRET
+    )


### PR DESCRIPTION
## Summary

The app reverse proxy signs the HMAC over the decoded query string but sends the request through yarl, which re-encodes it. The backend verifies against the wire form. The two diverge for any path containing spaces, `#`, `+`, or non-ASCII — producing a blanket 401 for every affected filename.

Closes #2053

---

## Root cause

```
gateway signs:  /api/read?path=/tmp/my notes.md     (decoded)
yarl sends:     /api/read?path=/tmp/my+notes.md     (wire)
backend sees:   /api/read?path=/tmp/my+notes.md     (self.path)
                ↕ mismatch → HMAC fails → 401
```

`request.query_string` in aiohttp returns the decoded form. When the target URL string is passed to `session.request()`, yarl parses and re-encodes it. The backend's HTTP server delivers the encoded wire form as `self.path`.

## Fix

| File | Change |
|------|--------|
| `src/kiro_crew/apps/routes.py` | Parse target into `yarl.URL`, sign over `.raw_path_qs` (the wire form), pass the URL object to `session.request()` |
| `test/test_app_proxy_auth.py` | 5 regression tests for encodable characters |

**3 lines of logic changed. No new dependencies** — `yarl` is already a hard `aiohttp` dependency.

## Security property preserved

The signature still binds: timestamp, method, full request-target (path + query), and body hash. The only change is which canonical form both sides agree on — decoded → wire. The backend (`proxy_auth.py`) already verifies against the wire form and is unchanged.

## Testing

- `pytest test/test_app_proxy_auth.py` — **14 passed** (9 existing + 5 new)
- `pytest test/test_gateway_appkit_endpoints.py -k proxy` — **11 passed**
- New regression tests cover: space (`+`), space (`%20`), `#` (`%23`), non-ASCII (`%C3%A9`), and the exact decoded-vs-wire mismatch that was the bug

## Checklist

- [x] One focused change, one commit
- [x] Conventional Commits format
- [x] Tests pass locally
- [x] No new dependencies
- [x] Security property documented and preserved