### PR TITLE
fix(apps): sign wire_target HMAC in gateway reverse proxy for percent-encoded query strings

### DIFF
--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any
 
 import aiohttp
+import yarl
 from aiohttp import web
 
 from kiro_crew.apps.backend import (
@@ -2291,13 +2292,15 @@ async def handle_app_api_proxy(request: web.Request) -> web.StreamResponse:
             status=502,
         )
 
-    # Build target URL — preserve the `/api/` prefix from the route so the
-    # backend sees its own `/api/...` routes without needing any path-
-    # rewriting middleware.  The route captures `path` after `/api/`, so we
-    # explicitly re-add `/api/` here.
-    target = f"{backend_url}/api/{path}"
-    if request.query_string:
-        target += f"?{request.query_string}"
+    # Build target URL — preserve the exact wire encoding of path and query
+    # params so the gateway's HMAC signature matches what the backend sees on
+    # self.path. `request.query_string` is DECODED by aiohttp, so signing it causes
+    # HMAC verification to fail closed (401) whenever query parameters contain
+    # percent-encodable characters like spaces, non-ASCII, or '+'.
+    raw_qs = request.rel_url.raw_query_string
+    target_path = f"/api/{path}" + (f"?{raw_qs}" if raw_qs else "")
+    target_url = yarl.URL(f"{backend_url}{target_path}", encoded=True)
+    wire_target = target_url.raw_path_qs
 
     # Forward headers (strip hop-by-hop, inject proxy auth)
     headers: dict[str, str] = {}
@@ -2324,10 +2327,7 @@ async def handle_app_api_proxy(request: web.Request) -> web.StreamResponse:
             )
         ts = str(int(time.time()))
         body_hash = hashlib.sha256(body or b"").hexdigest()
-        msg = f"{ts}:{request.method}:/api/{path}"
-        if request.query_string:
-            msg += f"?{request.query_string}"
-        msg += f":{body_hash}"
+        msg = f"{ts}:{request.method}:{wire_target}:{body_hash}"
         sig = _hmac.new(secret.encode(), msg.encode(), hashlib.sha256).hexdigest()
         headers["X-KiroCrew-Proxy"] = f"{ts}:{sig}"
     except OSError as exc:
@@ -2346,7 +2346,7 @@ async def handle_app_api_proxy(request: web.Request) -> web.StreamResponse:
         try:
             async with session.request(
                 method=request.method,
-                url=target,
+                url=target_url,
                 headers=headers,
                 data=body,
                 timeout=timeout,

--- a/test/test_app_proxy_auth.py
+++ b/test/test_app_proxy_auth.py
@@ -4,6 +4,8 @@ import hashlib
 import hmac
 import time
 
+import pytest
+
 from kiro_crew.apps.proxy_auth import verify_proxy_request
 
 SECRET = "s3cret-app-key"
@@ -21,6 +23,22 @@ def _sign(method: str, target: str, body: bytes, *, ts: int | None = None) -> st
 def test_valid_signature_passes():
     hdr = _sign("GET", "/api/read?path=x", b"")
     assert verify_proxy_request(hdr, method="GET", target="/api/read?path=x", body=b"", secret=SECRET)
+
+
+@pytest.mark.parametrize(
+    "wire_target",
+    [
+        "/api/read?path=/tmp/my%20notes.md",
+        "/api/read?path=/tmp/my+notes.md",
+        "/api/read?path=/tmp/issue%23123.md",
+        "/api/read?path=/tmp/caf%C3%A9.md",
+        "/api/search?q=hello%20world&dir=/tmp/my%20folder",
+    ],
+)
+def test_wire_form_targets_verify_successfully(wire_target: str):
+    """Verify that wire-form targets (containing %20, +, %23, non-ASCII) pass HMAC verification."""
+    hdr = _sign("GET", wire_target, b"")
+    assert verify_proxy_request(hdr, method="GET", target=wire_target, body=b"", secret=SECRET)
 
 
 def test_valid_post_binds_body():

--- a/test/test_gateway_appkit_endpoints.py
+++ b/test/test_gateway_appkit_endpoints.py
@@ -879,6 +879,50 @@ class TestReverseProxy:
             await runner.cleanup()
 
     @pytest.mark.asyncio
+    async def test_hmac_includes_percent_encoded_query_string_with_spaces(self, monkeypatch):
+        """HMAC signature correctly signs percent-encoded query parameters (spaces, #, non-ASCII)."""
+        from kiro_crew.apps.proxy_auth import verify_proxy_request
+
+        received_headers: dict[str, str] = {}
+
+        async def echo_handler(request: web.Request) -> web.Response:
+            for k, v in request.headers.items():
+                received_headers[k.lower()] = v
+            auth_hdr = request.headers.get("x-kirocrew-proxy", "")
+            verified = verify_proxy_request(
+                auth_hdr,
+                method=request.method,
+                target=request.rel_url.raw_path_qs,
+                body=b"",
+                secret=self._secret,
+            )
+            if not verified:
+                return web.json_response({"error": "unauthorized"}, status=401)
+            return web.json_response({"ok": True, "raw_path_qs": request.rel_url.raw_path_qs})
+
+        backend_app = web.Application()
+        backend_app.router.add_route("*", "/{path:.*}", echo_handler)
+        runner = web.AppRunner(backend_app)
+        await runner.setup()
+        site = web.TCPSite(runner, "127.0.0.1", 0)
+        await site.start()
+        port = runner.addresses[0][1]
+
+        import kiro_crew.apps.routes as rmod
+        monkeypatch.setattr(rmod, "_resolve_app_backend_url", lambda name: f"http://127.0.0.1:{port}")
+
+        try:
+            async with self._make_client() as client:
+                # Test path containing space (%20) (#2053)
+                resp = await client.get("/apps/proxy-app/api/read?path=/tmp/my%20notes.md")
+                assert resp.status == 200, f"Expected 200, got {resp.status}"
+                data = await resp.json()
+                assert data["ok"] is True
+                assert data["raw_path_qs"] == "/api/read?path=/tmp/my%20notes.md"
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
     async def test_hmac_covers_body(self, monkeypatch):
         """HMAC binds sha256 of the request body (integrity)."""
         import hashlib


### PR DESCRIPTION
**What changed**
Files containing spaces or other percent-encodable characters in their path/query string (e.g. `/api/read?path=/tmp/my notes.md`) failed with `401 {"error": "unauthorized"}` when accessed in the Files app or any app using the gateway reverse proxy (`handle_app_api_proxy`).

**Root cause**
`handle_app_api_proxy` signed HMAC over `request.query_string` which `aiohttp` returns decoded (e.g. `path=/tmp/my notes.md`). When forwarded to the backend app, `yarl` re-encoded query parameters on the wire (converting spaces to `+` and percent-encoding reserved characters), resulting in `/api/read?path=/tmp/my+notes.md`. The backend verified the signature against `self.path` (the wire form). The two strings differed, so HMAC verification failed closed.

**Fix**
- Updated `handle_app_api_proxy` in `src/kiro_crew/apps/routes.py` to construct `target_url` using `request.rel_url.raw_query_string` and `yarl.URL(..., encoded=True)`.
- Signed `wire_target` (`target_url.raw_path_qs`) in the HMAC signature calculation so gateway and backend compute HMAC over the exact same request-target string.
- Passed `target_url` directly to `session.request` to avoid any ambiguity on the wire.
- Added regression test `test_hmac_includes_percent_encoded_query_string_with_spaces` in `test_gateway_appkit_endpoints.py` verifying end-to-end proxy HMAC verification for paths with spaces and encodable query parameters.

Closes #2053
