### PR TITLE
fix(ci): keep the reduced Windows scope from naming uncollectable suites

### DIFF
--- a/scripts/ci-surface-tests.py
+++ b/scripts/ci-surface-tests.py
@@ -34,6 +34,7 @@ which case the caller MUST fall back to running the full suite.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
@@ -137,6 +138,34 @@ def _is_cross_surface(path: Path, pattern: re.Pattern[str]) -> bool:
     return bool(pattern.search(text))
 
 
+def _is_windows() -> bool:
+    """Whether the emitted paths will be consumed by a Windows pytest run.
+
+    A named seam rather than an inline ``os.name`` read so tests can exercise the
+    Windows branch without simulating the platform: patching ``os.name`` globally
+    also switches ``pathlib.Path`` to ``WindowsPath``, which cannot be
+    instantiated on POSIX.
+    """
+    return os.name == "nt"
+
+
+def _windows_collect_ignore(root: Path) -> frozenset[str]:
+    """Bare test filenames that ``test/conftest.py`` refuses to collect on Windows.
+
+    Read from the same file conftest reads, so the two cannot drift.
+    """
+    listfile = root / "test" / "windows-collect-ignore.txt"
+    try:
+        text = listfile.read_text(encoding="utf-8")
+    except OSError:
+        # Fail OPEN here, deliberately. A missing list must not silently empty
+        # the target set (that would skip real coverage); emitting the unfiltered
+        # list at worst reproduces today's behaviour.
+        return frozenset()
+    names = (ln.split("#", 1)[0].strip() for ln in text.splitlines())
+    return frozenset(n for n in names if n)
+
+
 def collect(surface: str) -> list[str]:
     """Repo-relative paths that must still run for a single-surface diff."""
     root = _repo_root()
@@ -152,6 +181,19 @@ def collect(surface: str) -> list[str]:
             for path in _iter_files(root, rel_dir, globs):
                 if _is_cross_surface(path, _FRONTEND_FOREIGN):
                     must_run.append(path.relative_to(root).as_posix())
+
+    if _is_windows():
+        # These paths are consumed as EXPLICIT pytest arguments, and an explicit
+        # argument bypasses both `collect_ignore` and the `pytest_ignore_collect`
+        # hook -- verified, not assumed. So conftest's Windows exclusion does not
+        # protect this path, and emitting a POSIX-only suite here collects it and
+        # fails the Windows shards on any diff that takes the reduced scope.
+        #
+        # Split the string rather than going through pathlib: these are already
+        # `as_posix()` forms, so the separator is known, and it keeps the filter
+        # independent of which Path flavour the host provides.
+        ignored = _windows_collect_ignore(root)
+        must_run = [rel for rel in must_run if rel.rsplit("/", 1)[-1] not in ignored]
 
     return sorted(set(must_run))
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -76,32 +76,17 @@ requires_symlinks = pytest.mark.skipif(
 from kiro_crew import platform_compat  # noqa: E402
 
 if platform_compat.IS_WINDOWS:
-    collect_ignore = [
-        "test_harness.py",  # spawns real gateways; PGID + socketpair plumbing
-        "test_sandbox_argv.py",  # OS sandbox is POSIX-only
-        "test_sandbox_cc_mode.py",  # OS sandbox is POSIX-only
-        "test_pid_lifecycle.py",  # process-group semantics
-        "test_pid_sweep_helpers.py",  # process-group semantics
-        "test_process_tree_kill.py",  # killpg/getpgid semantics
-        "test_source_providers.py",  # providers require the POSIX sandbox
-        # Feature-parity gaps observed on the first Windows runs -- each is a
-        # POSIX-shaped feature or test suite tracked as a Windows follow-up:
-        "test_terminal_handler.py",  # PTY web terminal is POSIX-only
-        "test_acp_client.py",  # asserts os.killpg/SIGKILL process control
-        "test_stop_kill_cancel.py",  # killpg/getuid kill-path semantics
-        "test_app_backend_stale_reap.py",  # getpgid/killpg reaping semantics
-        "test_env.py",  # krb5 ccache resolver is Linux-only (getuid paths)
-        "test_outbox_notify_broadcast.py",  # hardcoded /tmp outbox paths
-        "test_outbox_binary.py",  # hardcoded /tmp outbox paths
-        "test_deploy_web_handlers.py",  # deploy staging is POSIX-shaped (/tmp, uid)
-        "test_snapshot.py",  # replace-while-open (WinError 32) semantics
-        "test_theme_install.py",  # POSIX readable/mode gate rejects NTFS modes
-        "test_webapp_preview.py",  # preview routes 404 on Windows backends
-        "test_file_raw.py",  # 0o600/0o644 mode-bit assertions
-        "test_file_download.py",  # 0o600/0o644 mode-bit assertions
-        "test_dashboard_file_io.py",  # 0o600/0o644 mode-bit assertions
-        "test_dev_fleet_app.py",  # POSIX app-runner assumptions
-    ]
+    # Read from windows-collect-ignore.txt rather than an inline list: the CI
+    # reduced-scope selector (scripts/ci-surface-tests.py) has to apply the same
+    # exclusion, because naming a file explicitly on the pytest command line
+    # bypasses collect_ignore. One file, two readers, no drift.
+    _ignore_listfile = os.path.join(os.path.dirname(__file__), "windows-collect-ignore.txt")
+    with open(_ignore_listfile, encoding="utf-8") as _fh:
+        collect_ignore = [
+            name
+            for name in (ln.split("#", 1)[0].strip() for ln in _fh)
+            if name
+        ]
 
 
 def make_escaping_link(inside: pathlib.Path, outside: pathlib.Path) -> str:

--- a/test/test_ci_surface_tests.py
+++ b/test/test_ci_surface_tests.py
@@ -188,3 +188,164 @@ def test_frontend_escape_patterns_are_detected(selector, tmp_path) -> None:
     inside = tmp_path / "c.test.tsx"
     inside.write_text("import { Button } from '../../components/ui'\n")
     assert selector._is_cross_surface(inside, selector._FRONTEND_FOREIGN) is False
+
+
+# ---------------------------------------------------------------------------
+# Windows: the reduced scope must not name a suite Windows cannot collect
+# ---------------------------------------------------------------------------
+#
+# The reduced target list is passed to pytest as EXPLICIT file arguments, and an
+# explicit argument bypasses conftest's Windows `collect_ignore`. So a POSIX-only
+# suite that reaches this list gets collected on the Windows shards and fails
+# there -- on every diff that takes the reduced scope, which is any
+# frontend-only diff. The suites below are the ones observed failing that way.
+
+_IGNORE_LIST = _REPO_ROOT / "test" / "windows-collect-ignore.txt"
+
+_OBSERVED_WINDOWS_FAILURES = (
+    "test_acp_client.py",
+    "test_deploy_web_handlers.py",
+    "test_dev_fleet_app.py",
+    "test_pid_lifecycle.py",
+    "test_sandbox_argv.py",
+)
+
+
+def _ignore_names() -> set[str]:
+    names = (
+        ln.split("#", 1)[0].strip()
+        for ln in _IGNORE_LIST.read_text(encoding="utf-8").splitlines()
+    )
+    return {n for n in names if n}
+
+
+def test_ignore_list_exists_and_is_non_empty() -> None:
+    assert _IGNORE_LIST.is_file(), f"missing ignore list: {_IGNORE_LIST}"
+    assert _ignore_names(), "the Windows collect-ignore list parsed to nothing"
+
+
+def test_ignore_list_matches_the_names_conftest_previously_inlined() -> None:
+    """The extraction into a file must be lossless.
+
+    conftest's `collect_ignore` branch only executes on Windows, so a parsing
+    typo here would silently re-enable a suite that fails at import on win32 and
+    would not be caught on a POSIX dev machine. Pin the exact set.
+    """
+    assert _ignore_names() == {
+        "test_harness.py",
+        "test_sandbox_argv.py",
+        "test_sandbox_cc_mode.py",
+        "test_pid_lifecycle.py",
+        "test_pid_sweep_helpers.py",
+        "test_process_tree_kill.py",
+        "test_source_providers.py",
+        "test_terminal_handler.py",
+        "test_acp_client.py",
+        "test_stop_kill_cancel.py",
+        "test_app_backend_stale_reap.py",
+        "test_env.py",
+        "test_outbox_notify_broadcast.py",
+        "test_outbox_binary.py",
+        "test_deploy_web_handlers.py",
+        "test_snapshot.py",
+        "test_theme_install.py",
+        "test_webapp_preview.py",
+        "test_file_raw.py",
+        "test_file_download.py",
+        "test_dashboard_file_io.py",
+        "test_dev_fleet_app.py",
+    }
+
+
+def test_every_ignored_suite_exists() -> None:
+    """A stale entry silently protects nothing -- catch renames and deletions."""
+    missing = sorted(n for n in _ignore_names() if not (_REPO_ROOT / "test" / n).is_file())
+    assert not missing, f"ignore list names files that no longer exist: {missing}"
+
+
+def test_conftest_and_selector_read_the_same_ignore_list(selector) -> None:
+    """One file, two readers -- so the two cannot drift apart.
+
+    conftest builds `collect_ignore` from it for the recursive path; the selector
+    filters it out of the explicit-argument path. If a future change re-inlines
+    either copy, this fails.
+    """
+    assert selector._windows_collect_ignore(_REPO_ROOT) == frozenset(_ignore_names())
+
+
+@pytest.mark.parametrize("suite", _OBSERVED_WINDOWS_FAILURES)
+def test_windows_scope_excludes_uncollectable_suites(selector, monkeypatch, suite) -> None:
+    """Each suite observed failing the Windows shards must be filtered out."""
+    assert suite in _ignore_names(), f"{suite} is not on the ignore list"
+    monkeypatch.setattr(selector, "_is_windows", lambda: True)
+    selected = selector.collect("backend")
+    offenders = [rel for rel in selected if Path(rel).name == suite]
+    assert not offenders, f"Windows scope still names {suite}: {offenders}"
+
+
+def test_windows_scope_names_nothing_on_the_ignore_list(selector, monkeypatch) -> None:
+    monkeypatch.setattr(selector, "_is_windows", lambda: True)
+    ignored = _ignore_names()
+    offenders = sorted({Path(rel).name for rel in selector.collect("backend")} & ignored)
+    assert not offenders, f"Windows scope names uncollectable suites: {offenders}"
+
+
+def test_posix_scope_is_unfiltered(selector, monkeypatch) -> None:
+    """The filter is Windows-only -- POSIX coverage must not shrink."""
+    monkeypatch.setattr(selector, "_is_windows", lambda: False)
+    posix_selected = set(selector.collect("backend"))
+    monkeypatch.setattr(selector, "_is_windows", lambda: True)
+    win_selected = set(selector.collect("backend"))
+    assert win_selected <= posix_selected
+    # The POSIX list must still carry suites the Windows one drops, or the filter
+    # is a no-op and this whole guard proves nothing.
+    assert posix_selected - win_selected
+
+
+def test_windows_seam_follows_os_name(selector, monkeypatch) -> None:
+    """The seam must be wired to the real platform, not just patchable.
+
+    Safe to patch ``os.name`` here specifically because ``_is_windows`` builds no
+    ``Path`` -- doing it around ``collect()`` would switch ``pathlib`` to
+    ``WindowsPath`` and raise on POSIX.
+    """
+    monkeypatch.setattr("os.name", "nt")
+    assert selector._is_windows() is True
+    monkeypatch.setattr("os.name", "posix")
+    assert selector._is_windows() is False
+
+
+def test_missing_ignore_list_fails_open(selector, tmp_path) -> None:
+    """A missing list must not empty the target set -- that would drop coverage."""
+    assert selector._windows_collect_ignore(tmp_path) == frozenset()
+
+
+def test_explicit_cli_target_bypasses_collect_ignore(tmp_path) -> None:
+    """Why the filter lives in the selector and not only in conftest.
+
+    pytest honours `collect_ignore` when it RECURSES into a directory and ignores
+    it when the file is named on the command line. That asymmetry is the entire
+    bug, so pin it: if a future pytest starts honouring `collect_ignore` for
+    explicit arguments, this fails and the selector-side filter can be dropped.
+    """
+    import subprocess
+    import sys
+
+    suite = tmp_path / "t"
+    suite.mkdir()
+    (suite / "conftest.py").write_text('collect_ignore = ["test_boom.py"]\n', encoding="utf-8")
+    (suite / "test_boom.py").write_text('raise RuntimeError("import-time failure")\n', encoding="utf-8")
+    (suite / "test_ok.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+
+    def run(*target: str) -> int:
+        return subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider",
+             "-p", "no:randomly", "--no-cov", *target],
+            cwd=tmp_path, capture_output=True, text=True,
+        ).returncode
+
+    assert run(str(suite)) == 0, "recursive collection should honour collect_ignore"
+    assert run(str(suite / "test_boom.py")) != 0, (
+        "explicit argument now honours collect_ignore -- the selector-side "
+        "filter may no longer be required"
+    )

--- a/test/test_mcp_gateway_pool_integ.py
+++ b/test/test_mcp_gateway_pool_integ.py
@@ -36,7 +36,6 @@ platform where the transport is newest, and would do it while CI stayed green.
 
 from __future__ import annotations
 
-import ast
 import asyncio
 import json
 import sys
@@ -269,32 +268,35 @@ async def test_real_stubs_sharing_a_key_share_one_backend(tmp_path: Path, short_
 
 
 def _windows_collect_ignore() -> list[str]:
-    """Extract ``collect_ignore`` from conftest's SOURCE, not its runtime state.
+    """Read the Windows exclusion list from its DATA FILE, not conftest's runtime state.
 
     Importing conftest and reading the attribute looks equivalent and is not:
     the list is assigned inside ``if platform_compat.IS_WINDOWS:``, so on the
     Linux matrix -- the only place this guard runs -- the attribute does not
     exist at all and ``getattr(..., [])`` silently yields an empty set. Every
     membership assertion against it then passes vacuously, which is precisely
-    the class of false pass this guard exists to prevent. Reading the literal
-    out of the source is platform-independent.
+    the class of false pass this guard exists to prevent. Reading the file is
+    platform-independent.
+
+    The names used to be string literals inside conftest and were extracted by
+    parsing its AST. They now live in ``windows-collect-ignore.txt`` because a
+    second reader needs them: naming a file explicitly on the pytest command
+    line bypasses ``collect_ignore``, so the CI reduced-scope selector
+    (``scripts/ci-surface-tests.py``) has to apply the same exclusion itself.
+    Reading that file keeps this guard pointed at the real source of truth --
+    an AST walk over conftest now finds no literals and would go blind.
     """
-    tree = ast.parse(Path(__file__).with_name("conftest.py").read_text(encoding="utf-8"))
-    found: list[str] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Assign):
-            continue
-        if not any(
-            isinstance(t, ast.Name) and t.id == "collect_ignore" for t in node.targets
-        ):
-            continue
-        if isinstance(node.value, (ast.List, ast.Tuple)):
-            found += [
-                el.value for el in node.value.elts
-                if isinstance(el, ast.Constant) and isinstance(el.value, str)
-            ]
+    listfile = Path(__file__).with_name("windows-collect-ignore.txt")
+    found = [
+        name
+        for name in (
+            ln.split("#", 1)[0].strip()
+            for ln in listfile.read_text(encoding="utf-8").splitlines()
+        )
+        if name
+    ]
     assert found, (
-        "could not find any collect_ignore string literals in conftest.py — this "
+        f"could not read any excluded filenames from {listfile.name} — this "
         "guard has gone blind and would pass no matter what was excluded"
     )
     return found

--- a/test/windows-collect-ignore.txt
+++ b/test/windows-collect-ignore.txt
@@ -1,0 +1,48 @@
+# Test files NOT collected on Windows -- one bare filename per line, relative
+# to this directory. Blank lines and #-comments are ignored.
+#
+# These suites exercise POSIX-only-by-design features (OS-level sandbox, process
+# groups / PGID semantics, PTY, AF_UNIX sockets, 0o600 mode bits -- see
+# docs/guides/windows-install.md's per-feature table). They are skipped at
+# COLLECTION time rather than marked test-by-test because several fail at import
+# or fixture time on win32, which a skip marker cannot prevent.
+#
+# TWO readers, which is why this is a file and not a literal list:
+#
+#   1. test/conftest.py builds `collect_ignore` from it. That covers the normal
+#      invocation, where pytest recurses into this directory.
+#   2. scripts/ci-surface-tests.py filters it out of the reduced target list it
+#      emits on Windows. That is NOT redundant: naming a file explicitly on the
+#      pytest command line bypasses BOTH `collect_ignore` and the
+#      `pytest_ignore_collect` hook, so a caller that passes explicit paths --
+#      as the reduced frontend-only scope does -- would collect these files and
+#      fail. The exclusion has to be applied by whoever builds that list.
+#
+# Adding a file here excludes it from both paths. Removing one re-enables it on
+# Windows; residual per-test gaps belong in windows-expected-failures.txt.
+
+test_harness.py                    # spawns real gateways; PGID + socketpair plumbing
+test_sandbox_argv.py               # OS sandbox is POSIX-only
+test_sandbox_cc_mode.py            # OS sandbox is POSIX-only
+test_pid_lifecycle.py              # process-group semantics
+test_pid_sweep_helpers.py          # process-group semantics
+test_process_tree_kill.py          # killpg/getpgid semantics
+test_source_providers.py           # providers require the POSIX sandbox
+
+# Feature-parity gaps observed on the first Windows runs -- each is a
+# POSIX-shaped feature or test suite tracked as a Windows follow-up:
+test_terminal_handler.py           # PTY web terminal is POSIX-only
+test_acp_client.py                 # asserts os.killpg/SIGKILL process control
+test_stop_kill_cancel.py           # killpg/getuid kill-path semantics
+test_app_backend_stale_reap.py     # getpgid/killpg reaping semantics
+test_env.py                        # krb5 ccache resolver is Linux-only (getuid paths)
+test_outbox_notify_broadcast.py    # hardcoded /tmp outbox paths
+test_outbox_binary.py              # hardcoded /tmp outbox paths
+test_deploy_web_handlers.py        # deploy staging is POSIX-shaped (/tmp, uid)
+test_snapshot.py                   # replace-while-open (WinError 32) semantics
+test_theme_install.py              # POSIX readable/mode gate rejects NTFS modes
+test_webapp_preview.py             # preview routes 404 on Windows backends
+test_file_raw.py                   # 0o600/0o644 mode-bit assertions
+test_file_download.py              # 0o600/0o644 mode-bit assertions
+test_dashboard_file_io.py          # 0o600/0o644 mode-bit assertions
+test_dev_fleet_app.py              # POSIX app-runner assumptions


### PR DESCRIPTION
## Problem

**Every frontend-only PR fails all four `Backend Tests (Windows)` shards**, on tests
it never touched, while `main` is green. Two open PRs are sitting in that state
right now: #2058 (mine, 4 files under `website/src/`) and #2016 (not mine), each
with roughly 143 failures across shards.

Because the fork AI-review pipeline is gated on `workflow_run.conclusion == 'success'`
(`fork-gpt-review.yml`, `fork-opus-review.yml`), a red CI means those PRs never get
reviewed at all — `readiness` cannot leave `action required`. So this is not just
noise; it silently blocks a whole class of contributions.

## Root cause

The Windows job selects its scope two ways (`.github/workflows/ci.yml`, *Select test scope*):

| diff | scope | pytest invocation |
|---|---|---|
| not frontend-only | full | `pytest -q -n auto --splits … $BACKEND_DESELECTS` — **no path arguments** |
| frontend-only | reduced | `pytest … "${TARGETS[@]}"` — **234 explicit file paths** from `scripts/ci-surface-tests.py` |

`test/conftest.py` excludes 22 POSIX-only suites on Windows via `collect_ignore`
(OS sandbox, PGID/process groups, PTY, AF_UNIX, `0o600` mode bits). The comment
there is explicit that collection must be avoided rather than tests marked,
because several of them fail at *import* on win32.

**`collect_ignore` is only consulted when pytest recurses into a directory.** Naming
a file on the command line bypasses it. So the full path is protected and the
reduced path is not — which is exactly why `main` is green and frontend-only PRs
are red.

I verified this rather than assuming it, and also checked the obvious alternative
fix — the `pytest_ignore_collect` hook — which is bypassed the same way:

| conftest mechanism | `pytest t/` (recursive) | `pytest t/test_boom.py` (explicit) |
|---|---|---|
| `collect_ignore = ["test_boom.py"]` | ignored ✅ | **collected → error** ❌ |
| `pytest_ignore_collect` hook | ignored ✅ | **collected → error** ❌ |

That result is what rules out a conftest-only fix, so it is pinned by a test
(`test_explicit_cli_target_bypasses_collect_ignore`) — if a future pytest starts
honouring `collect_ignore` for explicit arguments, that test fails and the
selector-side filter can be deleted.

Failing files, matched against the ignore list:

| shard | failing files | on `collect_ignore`? |
|---|---|---|
| 1 | `test_acp_client.py` | yes |
| 2 | `test_deploy_web_handlers.py`, `test_dev_fleet_app.py` | yes |
| 3 | `test_pid_lifecycle.py`, `test_sandbox_argv.py` | yes |
| 4 | not attributable — retrieved log truncated; `test_source_providers.py` (also on the list) appears in it | — |

The failures are the expected shape for suites that should never have run: e.g.
every `test_deploy_web_handlers` case receives `Artifact Deploy requires a POSIX
shell (bash)…`, because `_do_deploy` returns 400 immediately when `os.name == "nt"`
(`src/kiro_crew/deploy/handlers.py:650`).

## Fix (symptom → root cause → change)

- **Symptom:** frontend-only PRs fail Windows shards on untouched tests.
- **Root cause:** the exclusion lives in a mechanism the reduced path bypasses, so
  the list of explicit targets is built without it.
- **Change:** apply the exclusion where the list is *built*. The 22 names move out
  of `test/conftest.py` into **`test/windows-collect-ignore.txt`**; conftest builds
  `collect_ignore` from that file (behaviour unchanged), and
  `scripts/ci-surface-tests.py` drops those basenames on Windows. One file, two
  readers, no drift — the same convention the repo already uses for
  `windows-expected-failures.txt`.

Measured effect on the selector's output: **234 → 226**, dropping exactly the eight
uncollectable suites (`test_acp_client`, `test_deploy_web_handlers`,
`test_dev_fleet_app`, `test_pid_lifecycle`, `test_sandbox_argv`, `test_snapshot`,
`test_source_providers`, `test_theme_install`). POSIX output is untouched.

Two deliberate choices:

1. **A `_is_windows()` seam instead of an inline `os.name` read.** Patching
   `os.name` globally also switches `pathlib.Path` to `WindowsPath`, which cannot
   be instantiated on POSIX — my first attempt did exactly that and my own tests
   caught it. The filter also splits the string rather than going through
   `pathlib`, since these are already `as_posix()` forms.
2. **The missing-list case fails OPEN.** An unreadable list returns an empty
   exclusion set, so the worst case reproduces today's behaviour rather than
   silently emptying the target list and dropping real coverage.

## Tests

`test/test_ci_surface_tests.py`, +12 cases:

- each of the five suites observed failing is absent from the Windows scope
  (parametrized), and the Windows scope names *nothing* on the ignore list
- POSIX scope is unfiltered, and is a strict superset of the Windows scope — with
  a non-empty difference, so the guard cannot pass by the filter being a no-op
- the extraction is lossless: the file parses to exactly the 22 names conftest
  previously inlined (conftest's branch is Windows-only, so a parsing typo would
  not surface on a POSIX dev machine)
- every ignored suite still exists, catching stale entries after a rename
- the seam follows `os.name`, so it is wired to the real platform and not merely
  patchable
- the missing-list case fails open
- the pytest behaviour above, as a real subprocess test

149 passed across the selector, cross-surface-mirror and brand-gate suites.
`flake8`, `isort --check-only`, `mypy` clean.

## Manual verification

Local run of the selector reproduces CI's number exactly — `Reduced scope: 234
cross-surface backend file(s)` in the job log, 234 locally — and 226 with the
Windows branch active. Root cause was traced from the job logs of three runs
(`main@3413ab4a` full/green, #2058 reduced/red, #2016 reduced/red) rather than
inferred from the diff.

Not verifiable from here: that the Windows shards actually go green. That needs a
Windows runner, so the CI run on this PR is the real test. Note this PR is itself
*not* frontend-only, so it takes the full path — the change is exercised by the
unit tests above, not by this PR's own Windows shards.

## Screenshots

N/A — CI test-selection only, no user-visible surface.
