### PR TITLE
fix(chat): reopen a chat on the side-panel tab it was left on

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -4121,16 +4121,22 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // Bridge explicit view requests (e.g. the /side slash command dispatches
   // openActivityToTab('side')) into the tab model.
   const activityTab = useAppSelector(s => s.chat.activityTab)
-  // Skip the mount invocation: this bridge only reacts to a GENUINE activityTab
-  // change (e.g. the /side slash command via openActivityToTab). Firing on mount
-  // would re-open the activityTab view (Files by default) on top of the
-  // now-persisted strip every time ChatPage remounts after a route change.
+  // Keyed on the REQUEST counter, never on the tab's value. `activityTab` also
+  // changes when a chat switch restores the incoming chat's cached tab (Files
+  // when it has none), and bridging that would force-focus Files — or whatever
+  // view was last requested in that chat — over the tab the tab strip has
+  // remembered and the user actually left the chat on. Only openActivityToTab
+  // bumps the counter, so only a deliberate request moves focus.
+  const activityTabRequest = useAppSelector(s => s.chat.activityTabRequest)
+  // Skip the mount invocation: the counter is already non-zero after any earlier
+  // request this page load, so firing on mount would re-open that view on top of
+  // the now-persisted strip every time ChatPage remounts after a route change.
   const activityTabBridged = useRef(false)
   useEffect(() => {
     if (!activityTabBridged.current) { activityTabBridged.current = true; return }
     if (activityOpen) tabsCtl.openView(activityTab === ('nav' as string) ? 'files' : activityTab)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activityTab])
+  }, [activityTabRequest])
   // Stable row callbacks. Inline lambdas in the row renderer would hand
   // AssistantMessage a fresh function identity every render, so its memo()
   // could never bail out — the boundary would break at the call site, not in the

--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -368,6 +368,15 @@ interface ChatState {
   workflowRuns: Record<string, WorkflowRunProgress>
   activityOpen: boolean
   activityTab: 'changes' | 'issues' | 'subagents' | 'workflows' | 'logs' | 'files' | 'side' | 'artifacts'
+  /** Monotonic counter bumped ONLY by `openActivityToTab` — i.e. only when
+   *  something deliberately asks for a view (a slash command, a sub-agent /
+   *  workflow card, a keyboard shortcut). The side panel's tab strip owns which
+   *  tab is focused and persists that per chat, so a consumer must distinguish a
+   *  genuine request from `activityTab` merely taking a new VALUE: switching
+   *  chats restores the incoming chat's cached tab (defaulting to Files), and
+   *  treating that as a request would force-focus Files or the last requested
+   *  view over the tab the user actually left the chat on. */
+  activityTabRequest: number
   /** Tool call to highlight & auto-expand inline. Set by openActivityToTool;
    *  consumed (cleared) once the matching ToolCallLine has expanded itself. */
   focusToolCallId: string | null
@@ -455,6 +464,7 @@ const initialState: ChatState = {
   workflowRuns: {},
   activityOpen: false,
   activityTab: 'files' as const,
+  activityTabRequest: 0,
   focusToolCallId: null,
   mcpApps: {},
   slotActivity: seedSlotActivity(),
@@ -1616,7 +1626,7 @@ const chatSlice = createSlice({
     setVoiceAudio(state, action: PayloadAction<string | null>) { state.voiceAudio = action.payload },
     toggleActivity(state) { state.activityOpen = !state.activityOpen; if (!state.activityOpen) state.focusToolCallId = null; persistActivityOpen(state.activeSlot, state.activityOpen) },
     openActivityPanel(state) { state.activityOpen = true; persistActivityOpen(state.activeSlot, true) },
-    openActivityToTab(state, action: PayloadAction<'changes' | 'issues' | 'subagents' | 'workflows' | 'logs' | 'files' | 'side' | 'artifacts'>) { state.activityOpen = true; state.activityTab = action.payload; state.focusToolCallId = null; persistActivityOpen(state.activeSlot, true) },
+    openActivityToTab(state, action: PayloadAction<'changes' | 'issues' | 'subagents' | 'workflows' | 'logs' | 'files' | 'side' | 'artifacts'>) { state.activityOpen = true; state.activityTab = action.payload; state.activityTabRequest += 1; state.focusToolCallId = null; persistActivityOpen(state.activeSlot, true) },
     /** Tool details expand inline in the chat. This action signals the matching
      *  ToolCallLine pill to auto-expand and scroll into view. */
     openActivityToTool(state, action: PayloadAction<string>) { state.focusToolCallId = action.payload },

--- a/website/src/test/ChatPage.panelTabFocus.test.tsx
+++ b/website/src/test/ChatPage.panelTabFocus.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Reopening a chat must land on the tab that chat was left on.
+ *
+ * Two stores decide what the side panel shows, and they are not the same thing:
+ *  - the tab strip (`usePanelTabs`) owns FOCUS and persists it per chat — this
+ *    is what the user actually manipulates by clicking a tab chip;
+ *  - `chat.activityTab` is a REQUEST channel written only by `openActivityToTab`
+ *    (a slash command, a sub-agent / workflow card, a keyboard shortcut).
+ *
+ * A chat switch restores the incoming chat's cached `activityTab` (Files when it
+ * has none), so bridging that value CHANGE into the strip force-focused Files —
+ * or whatever view was last requested in that chat — over the tab the strip had
+ * remembered. These tests pin the request counter that separates the two, and
+ * the two ways the bridge must still fire.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+import { __resetPanelTabs, usePanelTabs } from '../hooks/usePanelTabs'
+import { switchSlot, openActivityToTab, openActivityPanel } from '../store/chatSlice'
+
+vi.mock('react-virtuoso', () => ({ Virtuoso: () => null }))
+vi.mock('../components/ChatInput', () => ({ default: () => null }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: () => null }))
+vi.mock('../components/TypewriterText', () => ({ default: () => null }))
+vi.mock('../components/OverlayDrawer', () => ({ default: () => null }))
+vi.mock('../components/AgentDropdownList', () => ({ default: () => null }))
+vi.mock('../components/ModelDropdownList', () => ({ default: () => null }))
+vi.mock('../components/InfoTip', () => ({ default: () => null }))
+vi.mock('../components/SegmentedControl', () => ({ default: () => null }))
+vi.mock('../pages/chat/CollapsibleToolGroup', () => ({ default: () => null }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../pages/chat/SessionColorPicker', () => ({ default: () => null }))
+vi.mock('../pages/chat', () => ({ ChatFooter: () => null, AssistantMessage: () => null, McpInfoButton: () => null }))
+vi.mock('../pages/ChatSidebar', () => ({ default: () => null, SIDEBAR_MIN: 200, SIDEBAR_MAX: 500 }))
+vi.mock('../pages/chat/ChatSettings', () => ({ loadChatConfig: () => ({ contentWidth: 'compact' }), CONTENT_WIDTH: { compact: { messages: '800px', input: '816px' }, comfortable: { messages: '84%', input: '85%' }, full: { messages: '92%', input: '93%' } } }))
+// The strip's focus is the assertion target, so the panel itself is stubbed —
+// including `syncPinned`, which lives in the real component and would add the
+// pinned views this test does not need.
+vi.mock('../pages/chat/SidePanel', () => ({
+  default: () => <div data-testid="side-panel" />,
+  SIDE_PANEL_MIN_W: 320,
+  SIDE_PANEL_RESERVED_W: 560,
+  CHAT_PANE_MIN_W: 320,
+  measureSidePanelReservedW: () => 560,
+  sidePanelFillWidth: () => undefined,
+}))
+vi.mock('../hooks/usePanelState', () => ({ usePanelState: () => ({ isOpen: false, openPanel: vi.fn(), closePanel: vi.fn() }), useDiffPanel: () => ({ isOpen: false, filePath: '', original: '', modified: '', openDiff: vi.fn(), closeDiff: vi.fn() }) }))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: null }) }))
+vi.mock('../hooks/useFilteredDropdown', () => ({ useFilteredDropdown: () => ({ filtered: [], query: '', setQuery: vi.fn(), selectedIndex: 0, setSelectedIndex: vi.fn(), onKeyDown: vi.fn() }) }))
+vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
+vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => false }))
+vi.mock('../api/client', () => ({
+  api: Object.fromEntries(
+    ['sessions', 'chatSlotDetail', 'createChatSlot', 'deleteChatSlot', 'resumeChatSlot',
+     'deleteSession', 'agentDetail', 'approveChatSlot', 'chatSlotAgent', 'chatSlotModel',
+     'chatSlotWorkspace', 'models', 'planAction', 'planFromChat', 'renameSlot',
+     'resolveApproval', 'screenshot', 'slackChannels', 'slackLink', 'spawnList',
+     'stopChatSlot', 'uploadFiles', 'voiceSynthesize', 'workspaces', 'chatSlots',
+     'notifications', 'status', 'generateTitle', 'dashboardConfig'].map(k => [k, vi.fn().mockResolvedValue(
+      k === 'chatSlotDetail' ? { messages: [], has_more: false, total: 0 } : {}
+    )])
+  ),
+}))
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }) as unknown as typeof fetch
+globalThis.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} } as unknown as typeof ResizeObserver
+
+import ChatPage from '../pages/ChatPage'
+
+function renderChat(store: ReturnType<typeof createTestStore>) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={['/chat']}>
+            <Routes><Route path="/chat/:slug?" element={<ChatPage />} /></Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('ChatPage — side panel focus survives a chat switch', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1400 })
+    localStorage.clear()
+    __resetPanelTabs()
+  })
+
+  it('reopens a chat on the tab the user left it on, not the last requested view', () => {
+    const store = createTestStore()
+    renderChat(store)
+    const stripA = renderHook(() => usePanelTabs('slot-a'))
+    const stripB = renderHook(() => usePanelTabs('slot-b'))
+
+    // Chat A: a sub-agent card opens the panel straight to Subagents.
+    act(() => { store.dispatch(switchSlot.pending('r1', 'slot-a')) })
+    act(() => { store.dispatch(openActivityToTab('subagents')) })
+    expect(stripA.result.current.activeId).toBe('subagents')
+
+    // Chat B: panel open, and the user is looking at Changes.
+    act(() => { store.dispatch(switchSlot.pending('r2', 'slot-b')) })
+    act(() => { store.dispatch(openActivityPanel()) })
+    act(() => { stripB.result.current.openView('changes') })
+    expect(stripB.result.current.activeId).toBe('changes')
+
+    // Away and back. Leaving B caches its activityTab as the restore default
+    // (Files) and returning restores it, so a value-keyed bridge fired here and
+    // pulled focus off Changes onto Files.
+    act(() => { store.dispatch(switchSlot.pending('r3', 'slot-a')) })
+    act(() => { store.dispatch(switchSlot.pending('r4', 'slot-b')) })
+
+    expect(store.getState().chat.activityOpen).toBe(true)
+    expect(stripB.result.current.activeId).toBe('changes')
+  })
+
+  it('still honours a deliberate view request after the switch', () => {
+    const store = createTestStore()
+    renderChat(store)
+    const strip = renderHook(() => usePanelTabs('slot-b'))
+
+    act(() => { store.dispatch(switchSlot.pending('r1', 'slot-b')) })
+    act(() => { store.dispatch(openActivityToTab('changes')) })
+    expect(strip.result.current.activeId).toBe('changes')
+
+    act(() => { store.dispatch(openActivityToTab('workflows')) })
+    expect(strip.result.current.activeId).toBe('workflows')
+  })
+
+  it('re-focuses a view requested twice with a strip click in between', () => {
+    // The counter, not the tab value, is the trigger — so a card asking for the
+    // view it already asked for still pulls focus back after the user has
+    // clicked away in the strip.
+    const store = createTestStore()
+    renderChat(store)
+    const strip = renderHook(() => usePanelTabs('slot-b'))
+
+    act(() => { store.dispatch(switchSlot.pending('r1', 'slot-b')) })
+    act(() => { store.dispatch(openActivityToTab('subagents')) })
+    act(() => { strip.result.current.openView('changes') })
+    expect(strip.result.current.activeId).toBe('changes')
+
+    act(() => { store.dispatch(openActivityToTab('subagents')) })
+    expect(strip.result.current.activeId).toBe('subagents')
+  })
+})

--- a/website/src/test/chatSlice.test.ts
+++ b/website/src/test/chatSlice.test.ts
@@ -30,6 +30,9 @@ import reducer, {
   sseChatMessageUpdate,
   sseContextUsage,
   toggleActivity,
+  openActivityPanel,
+  openActivityToTab,
+  switchSlot,
   resolveByApprovalId,
   sseSideResult,
   sideClose,
@@ -938,6 +941,25 @@ describe('activity viewer reducers', () => {
     const state = reducer(initial, toggleActivity())
     expect(state.activityOpen).toBe(true)
     expect(reducer(state, toggleActivity()).activityOpen).toBe(false)
+  })
+
+  it('counts a view request only when one is actually made', () => {
+    // The counter is what tells the side panel's tab strip "focus this view".
+    // A chat switch restores the incoming chat's cached activityTab, and that
+    // restore must NOT read as a request — otherwise reopening a chat drags
+    // focus off the tab the user left it on.
+    expect(initial.activityTabRequest).toBe(0)
+    const requested = reducer(withSlot, openActivityToTab('subagents'))
+    expect(requested.activityTabRequest).toBe(1)
+    // Same view asked for twice is two requests: the user may have clicked away
+    // in the strip in between, and the second ask must still pull focus back.
+    expect(reducer(requested, openActivityToTab('subagents')).activityTabRequest).toBe(2)
+
+    const switched = reducer(requested, switchSlot.pending('req-1', 'slot-2'))
+    expect(switched.activityTab).toBe('files')
+    expect(switched.activityTabRequest).toBe(1)
+    // Opening the panel without naming a view is not a request either.
+    expect(reducer(switched, openActivityPanel()).activityTabRequest).toBe(1)
   })
 
   it('sseToolActivity adds to toolLog', () => {


### PR DESCRIPTION
## Problem

Reopening a chat does not land on the side-panel tab you left it on. You are looking at **Changes** in one chat, switch to another chat and come back, and the panel is showing **Files** — or whatever view was last requested in that chat (commonly **Subagents**, because a sub-agent card asks for it).

## Why it matters

The tab strip already persists its focused tab per chat, so this reads as the persistence being broken. Every return to a chat costs the user a re-click to get back to the view they were working in, and the tab they land on is not merely arbitrary — it is a *stale* request from earlier in that chat's life, so the panel actively misrepresents what it is showing them as a deliberate choice.

## Fix (symptom → root cause → change)

Two independent stores decide what the panel shows, and only one of them is the user's choice:

- **`usePanelTabs`** (the tab strip) owns FOCUS. Clicking a tab chip calls `setActive`, and the strip is persisted per chat slot under `mc-panel-tabs:<slot>`. This is the store that already worked correctly.
- **`chat.activityTab`** is a REQUEST channel, written only by `openActivityToTab` — the `/side` slash command, a sub-agent card, a workflow card, a keyboard shortcut. A tab-chip click deliberately does **not** write it.

The root cause is that `activityTab` is *also* rewritten by the chat-switch restore: `switchSlot.pending` (and `resumeFromHistory.fulfilled`, `createSlot.fulfilled`) sets it from the incoming chat's cached value, **defaulting to `'files'`**. The bridge in `ChatPage` that turns a request into strip focus was keyed on the `activityTab` **value**, so that restore was indistinguishable from a request: it fired on every chat switch where the value happened to change, and called `openView(...)` — which focuses the view — right over the tab the strip had remembered.

The fix separates "a request happened" from "the value changed": a monotonic `activityTabRequest` counter, bumped **only** by `openActivityToTab`, and the bridge now keys on the counter. None of the restore paths touch the counter, so a chat switch can neither advance it (phantom request) nor rewind it. This mirrors the pattern `usePanelTabs` already uses for the same class of problem — `revealLine.nonce`, where a repeat request carrying an identical value must still act.

The same change repairs a second defect in that bridge: because it was keyed on the value, a card asking for the view it had **already** asked for never re-focused it. Click a sub-agent card, click away to Changes in the strip, click the sub-agent card again — nothing happened. It now works.

## Tests

- **`website/src/test/ChatPage.panelTabFocus.test.tsx`** (new, 3 tests)
  - `reopens a chat on the tab the user left it on, not the last requested view` — drives the real reproduction through the real store and the real tab strip: chat A opens the panel to Subagents via `openActivityToTab`, chat B is left focused on Changes, then away-and-back. Asserts B is still on `changes`.
  - `still honours a deliberate view request after the switch` — the bridge must not go inert; `openActivityToTab` still moves focus.
  - `re-focuses a view requested twice with a strip click in between` — pins the second defect described above.
- **`website/src/test/chatSlice.test.ts`** — `counts a view request only when one is actually made`: the counter starts at 0, `openActivityToTab` bumps it (twice for the same view = two requests), `switchSlot.pending` restores `activityTab` to `'files'` **without** bumping, and `openActivityPanel` (open, no view named) does not bump either.

**Revert-verified.** With the bridge's dep array put back to `[activityTab]`, the first test fails with `expected 'files' to be 'changes'` — the exact reported symptom — and the third fails with `expected 'changes' to be 'subagents'`. The middle test passes either way, which is what makes it a useful guard against over-correcting.

## Manual verification

N/A — the defect is pure state-coordination between two stores, and the new ChatPage test exercises the real reducer, the real bridge effect and the real `usePanelTabs` store through actual chat switches, so it reproduces the user-visible sequence rather than a stub of it.

## Screenshots

N/A — no rendering, layout, copy or styling change. The diff adds one numeric field to Redux state and changes one `useEffect` dependency; which tab is focused is existing UI in an existing state.
