### PR TITLE
fix(auth): scope the inbound-webhook bypass to POST

### DIFF
--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -3237,9 +3237,9 @@ async def api_teams_activity(request: web.Request) -> web.Response:
     ``TeamsClient.on_activity`` built by ``maybe_start_teams`` once credentials
     are present. Until then (channel disabled/uncredentialed) we return 503.
 
-    This route is exempt from the dashboard cookie gate (see token_auth
-    ``_BYPASS_EXACT``); the delegated handler performs Bot Framework JWT
-    validation itself before doing anything with the payload.
+    This route is exempt from the dashboard cookie gate for POST only (see
+    token_auth ``_BYPASS_EXACT_METHODS``); the delegated handler performs Bot
+    Framework JWT validation itself before doing anything with the payload.
     """
     state: DashboardState = request.app["state"]
     handler = getattr(state, "teams_on_activity", None)

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -302,11 +302,13 @@ _STRICT_INTERNAL_API_PATHS = frozenset(
         # NOTE: "/api/hooks/agent" is deliberately NOT here. It is an inbound
         # webhook for EXTERNAL callers (CI runners, review bots) that hold no
         # dashboard cookie and no gateway IPC secret, so a strict-internal entry
-        # denied every real caller with 403 before the handler's own bearer check
-        # ever ran — the webhook token layer was unreachable. It now lives in
-        # token_auth._BYPASS_EXACT alongside /api/messaging/teams: a
-        # self-authenticating external webhook whose handler
-        # (api_hooks_agent -> _verify_hook_token) is the sole auth gate.
+        # denies every real caller with 403 before the handler's own bearer check
+        # can run, leaving the webhook token layer unreachable. It lives in
+        # token_auth._BYPASS_EXACT_METHODS, scoped to POST, alongside the
+        # /api/messaging/teams precedent: a self-authenticating external webhook
+        # whose handler (api_hooks_agent -> _verify_hook_token) is the sole auth
+        # gate. The POST scope matters — PUT/DELETE on that same literal path
+        # match the {hook_id} wildcard of the dashboard-authed CRUD routes.
         "/api/outbox/notify",
         "/api/notifications/agent",  # MCP-only (send_notification tool); no browser caller
         "/api/slack/upload-file",

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -416,27 +416,44 @@ _BYPASS_EXACT = {
     "/api/health",
     "/api/live",
     "/api/ready",
-    # Microsoft Teams inbound webhook: Bot Framework (Microsoft's servers, no
-    # dashboard cookie) POSTs activities here. The handler does its OWN auth --
-    # it validates the Bot Framework JWT (issuer + App-ID audience + signature)
-    # before processing -- so it must bypass the dashboard cookie gate. Same
-    # self-authenticating-external-caller class as a chat provider webhook.
-    "/api/messaging/teams",
-    # Inbound agent webhook: external systems (CI runners, code-review bots,
-    # deploy pipelines) POST here holding a webhook token and nothing else — no
-    # dashboard cookie, no gateway IPC secret. The handler does its OWN auth:
-    # api_hooks_agent calls _verify_hook_token, which compares the bearer
-    # against the sha256 of every stored token entry with hmac.compare_digest
-    # and refuses with 401 when none match (and when no token exists at all, so
-    # the endpoint is closed by default on a fresh install). Same
-    # self-authenticating-external-caller class as /api/messaging/teams above.
-    #
-    # This is a deliberate exposure decision: a valid token authorizes a real
-    # agent turn with full tool access, so the handler also rate-limits repeated
-    # failures per source (webhooks.auth_throttle) and records every 401 in the
-    # run history the dashboard shows. It was previously in
-    # server._STRICT_INTERNAL_API_PATHS, which made the token layer dead code.
-    "/api/hooks/agent",
+}
+
+# Exact-path bypasses that apply to SOME methods only, path -> allowed methods.
+#
+# A path-only bypass is unsound whenever another route pattern also matches the
+# same literal path under a different method: the entry opens every one of those
+# methods, not just the self-authenticating one it was written for. Scoping the
+# entry to the method whose handler does its own auth leaves the rest on the
+# ordinary token gate. Every self-authenticating webhook belongs here rather than
+# in the path-only set above, whether or not another route currently collides —
+# the collision is a property of the route table, which moves.
+#
+# ``POST /api/hooks/agent`` is the inbound agent webhook: external systems (CI
+# runners, code-review bots, deploy pipelines) post here holding a webhook token
+# and nothing else — no dashboard cookie, no gateway IPC secret. The handler does
+# its OWN auth (api_hooks_agent -> _verify_hook_token compares the bearer against
+# the sha256 of every stored token entry with hmac.compare_digest and refuses
+# with 401 when none match, including when no token exists at all, so the
+# endpoint is closed by default on a fresh install). It is a deliberate exposure
+# decision: a valid token authorizes a real agent turn with full tool access, so
+# the handler also rate-limits repeated failures per source
+# (webhooks.auth_throttle) and records every 401 in the run history.
+#
+# For that entry the method scope is load-bearing, not tidiness. The literal
+# string ``agent`` also matches the ``{hook_id}`` wildcard of the dashboard's own
+# hook CRUD routes — PUT and DELETE ``/api/hooks/{hook_id}`` — whose handler
+# (api_hook_detail) authenticates via the dashboard token alone. Unscoped, both
+# reach it with no credential of any kind.
+#
+# ``POST /api/messaging/teams`` is the Microsoft Teams inbound webhook: Bot
+# Framework (Microsoft's servers, no dashboard cookie) posts activities there and
+# the handler does its OWN auth, validating the Bot Framework JWT (issuer +
+# App-ID audience + signature) before processing. Only POST is routed today, so
+# the scope closes nothing yet — it is here so the shape a future entry gets
+# copied from is the safe one.
+_BYPASS_EXACT_METHODS: dict[str, frozenset[str]] = {
+    "/api/hooks/agent": frozenset({"POST"}),
+    "/api/messaging/teams": frozenset({"POST"}),
 }
 
 # Anchored bypass for installed-app static UI bundles only (federated-app
@@ -1499,6 +1516,11 @@ def token_auth_middleware(
         if any(path.startswith(p) for p in _BYPASS_PREFIXES):
             return await handler(request)  # type: ignore[operator]
         if path in _BYPASS_EXACT:
+            return await handler(request)  # type: ignore[operator]
+        # Method-scoped exact bypasses. A non-listed method on the same path
+        # falls through to the ordinary token gate rather than bypassing it.
+        _bypass_methods = _BYPASS_EXACT_METHODS.get(path)
+        if _bypass_methods is not None and request.method in _bypass_methods:
             return await handler(request)  # type: ignore[operator]
         # Icon files: anchored regex with bounded digit count to prevent
         # ReDoS and ensure only legitimate PWA icon paths bypass auth.

--- a/src/kiro_crew/docs/inbound-webhooks.md
+++ b/src/kiro_crew/docs/inbound-webhooks.md
@@ -121,10 +121,15 @@ breaking the others.
 - A token can additionally **require a signed request**, which is the default for
   newly minted tokens. See [Request signing](#request-signing).
 
-`/api/hooks/agent` is on the auth middleware's bypass list, in the same
+`POST /api/hooks/agent` is on the auth middleware's bypass list, in the same
 self-authenticating-external-webhook class as `/api/messaging/teams`. It is not
 a strict internal path: an external caller needs the bearer token and nothing
 else — no dashboard cookie, no gateway IPC secret.
+
+The bypass is scoped to **POST**, and only that method. The literal path also
+matches the `{hook_id}` wildcard of the dashboard's own hook CRUD routes
+(`PUT`/`DELETE /api/hooks/{hook_id}`), which authenticate on the dashboard token
+alone — so every method other than POST stays behind the ordinary gate.
 
 ### What actually limits reach
 

--- a/test/test_webhooks_auth_surface.py
+++ b/test/test_webhooks_auth_surface.py
@@ -1,21 +1,28 @@
 """``/api/hooks/agent`` must be reachable by external callers, token-gated only.
 
-The endpoint used to sit in ``server._STRICT_INTERNAL_API_PATHS``, which made the
-auth middleware refuse every non-loopback caller with 403 *before* the handler's
-bearer check ran — the webhook token layer was unreachable, so the documented use
-case (a CI runner calling back) could not work at all. It is now on
-``token_auth._BYPASS_EXACT`` like ``/api/messaging/teams``: a self-authenticating
-external webhook. These tests pin that contract in both directions, plus the
-failed-auth throttle that exposure requires.
+A strict-internal entry would deny every non-loopback caller with 403 *before* the
+handler's bearer check ran, making the webhook token layer unreachable and the
+documented use case (a CI runner calling back) impossible. The endpoint instead
+sits on ``token_auth._BYPASS_EXACT_METHODS`` — the METHOD-SCOPED bypass map —
+alongside ``/api/messaging/teams``: both are self-authenticating external
+webhooks, both POST-only. These tests pin that contract in both directions, plus
+the failed-auth throttle that exposure requires.
+
+The method scope is itself load-bearing. ``agent`` also matches the ``{hook_id}``
+wildcard of the dashboard's hook CRUD routes (PUT/DELETE
+``/api/hooks/{hook_id}``), whose handler authenticates on the dashboard token
+alone, so a path-only bypass would hand those two methods to an anonymous caller.
 """
 
 from __future__ import annotations
 
 import pytest
+from aiohttp import web
 
 from kiro_crew import webhooks
 from kiro_crew.dashboard import token_auth
 from kiro_crew.dashboard.server import _STRICT_INTERNAL_API_PATHS
+from kiro_crew.dashboard.token_auth import token_auth_middleware
 
 HOOK_PATH = "/api/hooks/agent"
 
@@ -26,21 +33,81 @@ class TestAuthSurface:
         assert HOOK_PATH not in _STRICT_INTERNAL_API_PATHS
 
     def test_on_middleware_bypass(self):
-        assert HOOK_PATH in token_auth._BYPASS_EXACT
+        assert token_auth._BYPASS_EXACT_METHODS.get(HOOK_PATH) == frozenset({"POST"})
+
+    def test_not_on_the_path_only_bypass(self):
+        """A path-only entry would also open PUT/DELETE on the same path."""
+        assert HOOK_PATH not in token_auth._BYPASS_EXACT
 
     def test_teams_precedent_still_holds(self):
-        """The bypass entry is justified by matching an existing self-auth webhook."""
-        assert "/api/messaging/teams" in token_auth._BYPASS_EXACT
+        """The bypass entry is justified by matching an existing self-auth webhook.
+
+        Which is method-scoped for the same reason, so the shape a future
+        self-authenticating webhook gets copied from is the safe one.
+        """
+        assert token_auth._BYPASS_EXACT_METHODS.get("/api/messaging/teams") == frozenset({"POST"})
+        assert "/api/messaging/teams" not in token_auth._BYPASS_EXACT
 
     def test_other_mcp_paths_stay_strict(self):
         """Widening one path must not widen the rest of the internal surface."""
         for path in ("/api/send-message", "/api/outbox/notify", "/api/spawn-approve"):
             assert path not in token_auth._BYPASS_EXACT
+            assert path not in token_auth._BYPASS_EXACT_METHODS
 
     def test_bypass_does_not_cover_the_dashboard_api(self):
         """The management endpoints stay dashboard-authed."""
         for path in ("/api/webhooks", "/api/webhooks/tokens", "/api/webhooks/test"):
             assert path not in token_auth._BYPASS_EXACT
+            assert path not in token_auth._BYPASS_EXACT_METHODS
+
+
+class TestBypassIsMethodScoped:
+    """End-to-end through the middleware: only POST may skip the token gate.
+
+    Asserting the constant alone would pass even if the middleware ignored the
+    method scope, so these drive the real middleware with no credential at all.
+    """
+
+    @staticmethod
+    async def _handler(request: web.Request) -> web.Response:
+        return web.Response(text="reached")
+
+    def _request(self, method: str, path: str = HOOK_PATH):
+        from unittest.mock import MagicMock
+
+        req = MagicMock(spec=web.Request)
+        req.path = path
+        req.query = {}
+        req.cookies = {}
+        req.remote = "203.0.113.9"  # non-loopback: an external webhook caller
+        req.headers = {}
+        req.method = method
+        return req
+
+    @pytest.mark.asyncio
+    async def test_post_reaches_the_handler(self):
+        """The webhook's own token check must be allowed to run."""
+        resp = await token_auth_middleware()(self._request("POST"), self._handler)
+        assert resp.status == 200
+        assert resp.text == "reached"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method", ["PUT", "DELETE", "GET", "PATCH"])
+    async def test_other_methods_are_denied(self, method: str):
+        """PUT/DELETE match api_hook_detail via {hook_id}; they need a token."""
+        resp = await token_auth_middleware()(self._request(method), self._handler)
+        assert resp.status != 200
+        assert resp.text != "reached"
+
+    @pytest.mark.asyncio
+    async def test_teams_webhook_is_scoped_the_same_way(self):
+        """The sibling self-auth webhook carries the same scope, POST only."""
+        path = "/api/messaging/teams"
+        resp = await token_auth_middleware()(self._request("POST", path), self._handler)
+        assert resp.status == 200
+        for method in ("PUT", "DELETE", "GET"):
+            resp = await token_auth_middleware()(self._request(method, path), self._handler)
+            assert resp.status != 200, f"{method} {path} bypassed the gate"
 
 
 class TestAuthThrottle:


### PR DESCRIPTION
## Problem

`/api/hooks/agent` is on the auth middleware's **path-only** bypass set. That entry exists for the inbound agent webhook, which is POST and authenticates itself (`api_hooks_agent` → `_verify_hook_token`).

But the literal string `agent` also matches the `{hook_id}` wildcard of the dashboard's own hook CRUD routes:

```python
app.router.add_put("/api/hooks/{hook_id}", handlers.api_hook_detail)
app.router.add_delete("/api/hooks/{hook_id}", handlers.api_hook_detail)
```

Because the bypass ignores the method, `PUT` and `DELETE /api/hooks/agent` also skip the token gate and reach `api_hook_detail` — a handler whose only credential is the dashboard token — carrying no credential of any kind.

Observed against a running gateway, with no cookie, no query token and no internal secret. The control on any other id is what makes this a gate failure rather than a routing quirk:

```
PUT    /api/hooks/agent           → 400 {"code":"invalid_json"}      ← reached the handler
DELETE /api/hooks/agent           → 404 {"code":"hook_not_found"}    ← reached the handler
PUT    /api/hooks/zzz-nonexistent → 403 {"error":"Token required"}   ← control, gated
DELETE /api/hooks/zzz-nonexistent → 403 {"error":"Token required"}   ← control, gated
```

## Blast radius

Narrow, and **not exploitable as it stands.** The bypass matches the exact path only, so the sibling routes stay gated:

```
POST /api/hooks/agent/toggle → 403     POST /api/hooks/agent/test → 403     POST /api/hooks/agentX → 403
```

Hook ids are `uuid.uuid4().hex[:12]` (`hooks.py:181`) and no path accepts a caller-supplied id, so an id literally `agent` cannot exist and the handler 404s. What an anonymous caller reaches today is the store-mutation path, the schema validator and the SEL audit path — one id collision short of unauthenticated update/delete on a real hook. This closes the gate instead of relying on the id space.

## Fix

Move the entry to a method-scoped map and check the method:

```python
_BYPASS_EXACT_METHODS: dict[str, frozenset[str]] = {
    "/api/hooks/agent": frozenset({"POST"}),
}
```

Any other method on that path falls through to the ordinary token gate. This shape already existed inline in the same middleware for the app-UI bundles (`GET`/`HEAD`) and the app token exchange (`POST`); making it declarative means the next self-authenticating entry can state its methods rather than opening all of them.

No behaviour change for the webhook itself — the documented external-caller flow is POST, which still bypasses the cookie gate and is still authenticated solely by its bearer.

## Tests

The existing coverage asserted `HOOK_PATH in _BYPASS_EXACT`, which would pass even if the middleware ignored the method scope entirely. Replaced with tests that drive the real middleware from a non-loopback remote holding no credential:

- `POST` reaches the handler (the webhook's own token check must still run)
- `PUT`, `DELETE`, `GET`, `PATCH` are all denied
- the path is no longer on the path-only set, and neither set covers the dashboard's management endpoints

Revert-verified: re-widening the middleware check to ignore the method fails 4 of them, each because the method reached the handler.

## Verification

`pytest` 336 passed across the four affected files (full suite 34,117 passed; 21 failures reproduce identically with this change reverted — this host defaults to Node 16 and lacks `jq`). `mypy` clean on 823 files with a CI-parity venv (no `faiss`, which would make it stricter than CI). `isort`, `flake8` and the Brand Name Gate clean. Rebased onto current main, 0 behind.

Docs and the cross-reference comment in `server.py` updated, both of which described the bypass as path-only.
