### PR TITLE
chore(ci): raise backend coverage floor to 77% and single-source the floors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,6 +658,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [coverage-combine, frontend-test, backend-test, changes]
+    # Single source of truth for the floors -- referenced by the check steps,
+    # their names, and the summary table so the three can never drift apart.
+    #
+    # RATCHET POLICY: keep each floor a little under what `main` actually
+    # measures, so the gate blocks a real coverage regression without going red
+    # on ordinary noise. Raise a floor only after main has held the higher
+    # number for a while, and never above the LOWEST recent main measurement.
+    #   Backend  measured 78.41-78.70% on main (2026-08-07) -> floor 77%
+    #   Frontend measured 60.46-61.74% on main (2026-08-07) -> floor 60%
+    #     (frontend sits ~0.5pp above its floor: it cannot be ratcheted until
+    #      website/src gains real test coverage)
+    env:
+      BACKEND_MIN: 77
+      FRONTEND_MIN: 60
     # Always run so the required check emits a real verdict. Without
     # `if: always()`, a failing OR skipped dependency would SKIP this job, and
     # GitHub treats a skipped required check as SATISFIED -- silently defeating
@@ -723,14 +737,14 @@ jobs:
           name: coverage-frontend
           path: frontend-cov
 
-      - name: Check backend coverage (min 70%)
+      - name: Check backend coverage (min ${{ env.BACKEND_MIN }}%)
         if: needs.coverage-combine.result == 'success'
         run: |
           F=backend-cov/coverage.xml
           test -f "$F" || { echo "::error::coverage.xml missing from coverage-backend artifact"; exit 1; }
           # Compare the raw line-rate against the threshold; round only for
-          # display (a round-then-compare would let 69.95%..69.99% pass 70%).
-          python3 - "$F" 70 Backend <<'PY'
+          # display (a round-then-compare would let 76.95%..76.99% pass 77%).
+          python3 - "$F" "$BACKEND_MIN" Backend <<'PY'
           import sys, xml.etree.ElementTree as ET
           path, floor, label = sys.argv[1], float(sys.argv[2]), sys.argv[3]
           rate = float(ET.parse(path).getroot().attrib["line-rate"]) * 100
@@ -740,12 +754,12 @@ jobs:
               sys.exit(1)
           PY
 
-      - name: Check frontend coverage (min 60%)
+      - name: Check frontend coverage (min ${{ env.FRONTEND_MIN }}%)
         if: needs.changes.outputs.only_backend != 'true'
         run: |
           F=$(find frontend-cov -name 'cobertura*.xml' 2>/dev/null | head -1)
           test -n "$F" || { echo "::error::cobertura report missing from coverage-frontend artifact"; exit 1; }
-          python3 - "$F" 60 Frontend <<'PY'
+          python3 - "$F" "$FRONTEND_MIN" Frontend <<'PY'
           import sys, xml.etree.ElementTree as ET
           path, floor, label = sys.argv[1], float(sys.argv[2]), sys.argv[3]
           rate = float(ET.parse(path).getroot().attrib["line-rate"]) * 100
@@ -764,12 +778,12 @@ jobs:
           BF=backend-cov/coverage.xml
           if [ -f "$BF" ]; then
             B=$(python3 -c "import xml.etree.ElementTree as ET; print(f\"{float(ET.parse('$BF').getroot().attrib['line-rate'])*100:.2f}\")")
-            echo "| Backend | ${B}% | 70% |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Backend | ${B}% | ${BACKEND_MIN}% |" >> "$GITHUB_STEP_SUMMARY"
           fi
           FF=$(find frontend-cov -name 'cobertura*.xml' 2>/dev/null | head -1)
           if [ -n "$FF" ]; then
             FR=$(python3 -c "import xml.etree.ElementTree as ET; print(f\"{float(ET.parse('$FF').getroot().attrib['line-rate'])*100:.2f}\")")
-            echo "| Frontend | ${FR}% | 60% |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Frontend | ${FR}% | ${FRONTEND_MIN}% |" >> "$GITHUB_STEP_SUMMARY"
           fi
 
   frontend-lint:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -185,7 +185,7 @@ jobs:
             cfn-lint, Semgrep, CodeQL, Dependency Audit, 12 pytest shards
             (Linux 3.10/3.12 + Windows), an offline Playwright e2e suite with
             strict on-loop-persist assertions, and a FAIL-CLOSED Coverage Gate
-            (backend 70% / frontend 60%).
+            (backend 77% / frontend 60%).
 
             NEVER report anything those tools own: style, formatting, naming,
             import order, typing, lint warnings, dead code, duplication,

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -166,7 +166,7 @@ jobs:
           cfn-lint, Semgrep, CodeQL, Dependency Audit, 12 pytest shards
           (Linux 3.10/3.12 + Windows), an offline Playwright e2e suite with
           strict on-loop-persist assertions, and a FAIL-CLOSED Coverage Gate
-          (backend 70% / frontend 60%).
+          (backend 77% / frontend 60%).
 
           NEVER report anything those tools own: style, formatting, naming,
           import order, typing, lint warnings, dead code, duplication,

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -250,7 +250,7 @@ jobs:
             cfn-lint, Semgrep, CodeQL, Dependency Audit, 12 pytest shards
             (Linux 3.10/3.12 + Windows), an offline Playwright e2e suite with
             strict on-loop-persist assertions, and a FAIL-CLOSED Coverage Gate
-            (backend 70% / frontend 60%).
+            (backend 77% / frontend 60%).
 
             NEVER report anything those tools own: style, formatting, naming,
             import order, typing, lint warnings, dead code, duplication,

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -82,7 +82,7 @@ Every job here is blocking.
 | `backend-test-windows` | windows-latest, 4 shards, `--no-cov`, 180s per-test timeout. The backend supports Windows natively via `platform_compat`, and nothing else in CI holds that line |
 | `backend-test-macos` | macos-14, deliberately SCOPED (gateway, socketsec, platform-compat, pod and MCP-apps suites via a glob). A full macOS run needs its own exclusion burn-down first, and a job that is red on arrival trains people to ignore it |
 | `backend-test-sandbox` | The two suites the sharded matrix deselects because they need unprivileged user namespaces: `test_script_hooks.py` and `test_cron_script.py` |
-| `coverage-combine` then `coverage-gate` | Combines the 3.12 shard data, then enforces backend >= 70% and frontend >= 60% on the raw line-rate |
+| `coverage-combine` then `coverage-gate` | Combines the 3.12 shard data, then enforces backend >= 77% and frontend >= 60% on the raw line-rate (floors live in the job's `env:` block) |
 | `frontend-lint` | `tsc -b`, `eslint --max-warnings 1116`, `jscpd`, and `npm run i18n:check` |
 | `electron-test` | The Electron shell's own node:test suite (`website/electron`) |
 | `frontend-test` | `vitest run --coverage` |
@@ -105,7 +105,7 @@ Details worth knowing:
 - **`coverage-gate` is fail-closed.** It runs `if: always()` and its first step
   converts any non-success upstream result into an explicit failure, because GitHub
   treats a **skipped** required check as satisfied. It also compares the raw
-  line-rate and rounds only for display, so 69.95% cannot pass a 70% floor.
+  line-rate and rounds only for display, so 76.95% cannot pass a 77% floor.
 - **`eslint --max-warnings 1116` is a ratchet baseline.** Burn it down, never raise
   it.
 - **The i18n gates split into three tiers,** and only two can fail: diff-scoped


### PR DESCRIPTION
## Problem / Motivation

The Coverage Gate floors had drifted far below what `main` actually measures, so a sizable coverage regression could land without the gate ever noticing.

Measured across 14 recent **successful `main` CI runs** (2026-08-07):

| Lane | Observed on `main` | Old floor | Slack |
|---|---|---|---|
| Backend | 78.41% – 78.70% | 70% | **8.4pp of dead slack** |
| Frontend | 60.46% – 61.74% | 60% | 0.46pp |

## What changed

**Backend floor 70% → 77%.** That keeps 1.4pp of room under the *lowest* observed `main` measurement — enough for ordinary shard/noise variance and for a normal feature branch, but not enough to absorb a real regression.

**Frontend stays at 60%, deliberately.** It already sits ~0.5pp above its floor, so it cannot be ratcheted until `website/src` gains real test coverage. Raising it now would just turn the gate red on `main`.

**Floors are now single-sourced.** They live in the `coverage-gate` job's `env:` block and are referenced from the check steps, the step names, and the summary table — the numbers were previously repeated in five literal spots in `ci.yml`, which is exactly how a threshold and its displayed value drift apart. The ratchet policy is documented next to them:

> Keep each floor a little under what `main` actually measures. Raise a floor only after main has held the higher number for a while, and never above the LOWEST recent main measurement.

The three AI-review workflows and `docs/ci/ci-and-reviews.md` quote the thresholds to reviewers and contributors, so they are updated to match.

## Testing

- `python3 -c "yaml.safe_load(...)"` on `ci.yml` — parses; `env` resolves in both step names (`env` is an allowed context for `steps[*].name`).
- Boundary check of the unchanged comparator against the new floor: a `line-rate` of `0.7695` (76.95%) exits 1 with `Backend coverage 76.95% below 77% minimum`, confirming the raw-rate compare still refuses to round up into a pass.
- Lowest observed `main` value (78.41%) re-checked against floor 77 → PASS.
- `scripts/docs-lint.sh` → 187 files scanned, all checks passed.

This PR's own Coverage Gate run is the real end-to-end proof of the new floor.

## Follow-up (not in this PR)

Frontend cannot be ratcheted until `website/src` coverage moves. The two options there are (a) write tests for the biggest uncovered frontend surfaces and then ratchet, or (b) switch the frontend lane from an absolute floor to a per-PR no-regression delta, which gates the direction of travel instead of an absolute number.
