### PR TITLE
fix(ci): self-heal a PR Readiness verdict frozen by a job-level re-run

### DIFF
--- a/.github/workflows/pr-readiness-sweep.yml
+++ b/.github/workflows/pr-readiness-sweep.yml
@@ -14,14 +14,34 @@ name: PR Readiness Self-Heal Sweep
 # is actually green. (Observed on PR #1461: all checks green at 20:00-20:11,
 # zero workflow_run readiness runs fired afterward, status stuck `pending`.)
 #
-# This sweep finds open PRs whose "PR Readiness" status has been `pending` for
-# longer than a live fan-out could plausibly still be running, and re-fires the
+# This sweep finds open PRs whose "PR Readiness" status is stale and re-fires the
 # EXISTING recompute via `pr-readiness.yml`'s `workflow_dispatch` path. It does
 # NOT re-run CI/Build/reviewers and never computes a verdict itself -- it only
 # nudges the authoritative readiness workflow to re-evaluate. The recompute is
 # idempotent and stale-SHA guarded, so a spurious nudge just republishes the
 # correct verdict (including `pending` again, harmlessly, if a long CI run is
 # genuinely still in flight) and stops.
+#
+# TWO freeze modes qualify as stale, and they need different tests:
+#
+#   1. `pending` past STALE_MINUTES -- the dropped-event case above. Age alone is
+#      the signal, because a live fan-out cannot plausibly still be running.
+#
+#   2. `failure` with check evidence that landed AFTER it was published -- the
+#      RE-RUN case. Re-running individual jobs inside an already-completed run
+#      (`gh run rerun --failed`) creates a new run ATTEMPT, and that attempt's
+#      completion does NOT emit a fresh `workflow_run: completed` event, so
+#      nothing re-triggers the aggregator. Proven on PR #2064: CI run 31208434535
+#      reached attempt 2 and completed SUCCESS at 19:16:13Z while "PR Readiness"
+#      stayed frozen on its 19:01:24Z failure -- every underlying check green, the
+#      required aggregate red, and no event left to correct it.
+#
+#      Age is the WRONG test here: a terminal failure is legitimately old on a PR
+#      that is genuinely failing. The test is instead "a check run finished after
+#      the verdict was published", which makes the verdict stale by construction.
+#      That is self-terminating -- republishing makes readiness the newest
+#      timestamp again -- so a genuinely failing PR is nudged at most once per new
+#      piece of check evidence, never once per sweep.
 on:
   schedule:
     # Every 15 minutes. A normal fan-out publishes terminal state via events
@@ -48,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Re-fire readiness for stale-pending pull requests
+      - name: Re-fire readiness for stale pull requests
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -58,7 +78,7 @@ jobs:
           STALE_MINUTES: "15"
           # Runaway backstop: never dispatch more than this many recomputes in
           # a single sweep. Anything beyond the cap is left for the next sweep
-          # (it stays stale-pending, so it is picked up again).
+          # (it stays stale, so it is picked up again).
           MAX_DISPATCH: "10"
         run: |
           set -euo pipefail
@@ -71,7 +91,7 @@ jobs:
             --json number,headRefOid)"
 
           total="$(jq 'length' <<<"$prs")"
-          echo "Scanning $total open pull request(s) for stale-pending PR Readiness."
+          echo "Scanning $total open pull request(s) for stale PR Readiness."
 
           dispatched=0
           skipped_cap=0
@@ -93,22 +113,70 @@ jobs:
             [ -n "$status_json" ] || continue
 
             state="$(jq -r '.state' <<<"$status_json")"
-            [ "$state" = "pending" ] || continue
-
             updated_at="$(jq -r '.updated_at' <<<"$status_json")"
             updated_epoch="$(date -u -d "$updated_at" +%s 2>/dev/null || echo 0)"
             age=$(( now_epoch - updated_epoch ))
-            if [ "$updated_epoch" -eq 0 ] || [ "$age" -lt "$stale_seconds" ]; then
-              # Either unparseable, or still within the plausible-running window.
-              continue
-            fi
+
+            case "$state" in
+              pending)
+                if [ "$updated_epoch" -eq 0 ] || [ "$age" -lt "$stale_seconds" ]; then
+                  # Either unparseable, or still within the plausible-running window.
+                  continue
+                fi
+                reason="pending for ${age}s (> ${stale_seconds}s)"
+                ;;
+              failure)
+                # A TERMINAL verdict can go stale too, and this is the case the
+                # pending-only sweep missed entirely. Re-running individual jobs
+                # inside an already-completed run (`gh run rerun --failed`)
+                # creates a new run ATTEMPT, and that attempt's completion does
+                # NOT emit a fresh `workflow_run: completed` event -- so nothing
+                # re-triggers the aggregator. Proven on PR #2064: CI run
+                # 31208434535 reached attempt 2 and completed SUCCESS at
+                # 19:16:13Z, while `PR Readiness` stayed frozen on its 19:01:24Z
+                # failure. Every underlying check was green and the aggregate was
+                # red, with no event left to fix it.
+                #
+                # The re-fire condition is deliberately NOT "state is failure":
+                # that would dispatch on every legitimately-failing PR every 15
+                # minutes, forever. It is "a check run for this SHA finished
+                # AFTER the verdict was published" -- i.e. the verdict is stale
+                # BY CONSTRUCTION, because evidence landed after it was computed.
+                #
+                # That condition is self-terminating, which is what makes it safe
+                # to run on a schedule: republishing the verdict makes the
+                # readiness status the newest timestamp again, so the next sweep
+                # sees nothing newer and does not re-fire. A PR that is genuinely
+                # failing is nudged at most once per new piece of check evidence,
+                # not once per sweep.
+                [ "$updated_epoch" -ne 0 ] || continue
+                newest_check="$(gh api "repos/$REPO/commits/$sha/check-runs" --paginate 2>/dev/null \
+                  | jq -r '[.check_runs[]? | select(.status == "completed") | .completed_at]
+                           | map(select(. != null)) | max // empty' \
+                  || echo "")"
+                [ -n "$newest_check" ] || continue
+                newest_epoch="$(date -u -d "$newest_check" +%s 2>/dev/null || echo 0)"
+                [ "$newest_epoch" -ne 0 ] || continue
+                # Strictly newer, with a small margin so a check completing in
+                # the same second as the publish does not look like new evidence.
+                if [ "$newest_epoch" -le $(( updated_epoch + 5 )) ]; then
+                  continue
+                fi
+                reason="failure published at $updated_at but a check completed later at $newest_check"
+                ;;
+              *)
+                # `success` needs no rescue, and `error` is a publisher fault the
+                # next real event will correct.
+                continue
+                ;;
+            esac
 
             if [ "$dispatched" -ge "$MAX_DISPATCH" ]; then
               skipped_cap=$(( skipped_cap + 1 ))
               continue
             fi
 
-            echo "PR #$number: PR Readiness pending for ${age}s (> ${stale_seconds}s) at $sha -> re-firing recompute."
+            echo "PR #$number: PR Readiness $reason at $sha -> re-firing recompute."
             if gh workflow run pr-readiness.yml --repo "$REPO" \
                 -f pr="$number" -f sha="$sha" >/dev/null 2>&1; then
               dispatched=$(( dispatched + 1 ))

--- a/test/test_pr_readiness_sweep.py
+++ b/test/test_pr_readiness_sweep.py
@@ -1,0 +1,314 @@
+"""Behavioural tests for .github/workflows/pr-readiness-sweep.yml.
+
+The sweep's entire decision logic lives in one `run:` block of shell + jq that no
+other test touches. These tests extract that script and execute it for real with
+`gh` replaced by a stub, so the re-fire CONDITIONS are verified rather than
+assumed -- and the condition is the whole point: too narrow and a frozen verdict
+stays frozen, too broad and every genuinely-failing PR gets dispatched every 15
+minutes forever.
+
+Skipped where the POSIX toolchain the script needs (bash, jq, GNU `date -d`) is
+unavailable, which is the case on the Windows leg of the matrix. Mirrors the
+explicit nt guard in test_issue_triage_workflow.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "pr-readiness-sweep.yml"
+)
+
+
+def _gnu_date() -> bool:
+    """GNU `date -d` is required; BSD date uses -j -f and would silently differ."""
+    return (
+        subprocess.run(
+            ["date", "-u", "-d", "2026-01-01T00:00:00Z", "+%s"],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    not WORKFLOW.exists()
+    or os.name == "nt"
+    or shutil.which("bash") is None
+    or shutil.which("jq") is None
+    or not _gnu_date(),
+    reason="requires the workflow plus a POSIX bash, jq and GNU date",
+)
+
+# `gh` stub. Three shapes are served, keyed on the subcommand:
+#   pr list                 -> the fixture PR list
+#   api .../statuses        -> the fixture readiness status history
+#   api .../check-runs      -> the fixture check runs
+#   workflow run            -> RECORD the dispatch instead of firing it
+GH_STUB = r"""#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1 ${2:-}" = "pr list" ]; then
+  cat "$FIXTURES/prs.json"
+  exit 0
+fi
+if [ "$1 ${2:-}" = "workflow run" ]; then
+  # Record every -f key=value so the test can assert pr/sha were passed through.
+  printf '%s\n' "$*" >> "$FIXTURES/dispatched.txt"
+  exit 0
+fi
+if [ "$1" = "api" ]; then
+  case "${2:-}" in
+    *"/check-runs") cat "$FIXTURES/check_runs.json"; exit 0 ;;
+    *"/statuses")   cat "$FIXTURES/statuses.json";   exit 0 ;;
+  esac
+fi
+echo "gh stub: unhandled: $*" >&2
+exit 90
+"""
+
+
+def _script() -> str:
+    spec = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = spec["jobs"]["sweep"]["steps"]
+    runs = [s["run"] for s in steps if "run" in s]
+    assert len(runs) == 1, f"sweep step count changed: {len(runs)}"
+    return runs[0]
+
+
+@pytest.fixture(scope="module")
+def script() -> str:
+    return _script()
+
+
+class Runner:
+    """Executes the sweep's one step against one fixture repository state."""
+
+    def __init__(self, root: Path, script: str) -> None:
+        self.script = script
+        self.fixtures = root / "fixtures"
+        self.work = root / "work"
+        bindir = root / "bin"
+        for d in (self.fixtures, self.work, bindir):
+            d.mkdir(parents=True)
+        stub = bindir / "gh"
+        stub.write_text(GH_STUB)
+        stub.chmod(0o755)
+        self.env = {
+            **os.environ,
+            "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+            "FIXTURES": str(self.fixtures),
+            "REPO": "kirodotdev/KiroCrew",
+            "STATUS_CONTEXT": "PR Readiness",
+            "STALE_MINUTES": "15",
+            "MAX_DISPATCH": "10",
+        }
+
+    def sweep(
+        self,
+        *,
+        state: str,
+        status_at: str,
+        check_completed_at: str | None = None,
+        pr: int = 2064,
+        sha: str = "4328fd0f941f09ff10f245fbdb4accf7c246febe",
+        context: str = "PR Readiness",
+        max_dispatch: str = "10",
+    ) -> list[str]:
+        """Run the sweep over ONE pull request; return the dispatches recorded."""
+        (self.fixtures / "prs.json").write_text(
+            json.dumps([{"number": pr, "headRefOid": sha}])
+        )
+        (self.fixtures / "statuses.json").write_text(
+            json.dumps(
+                [{"context": context, "state": state, "updated_at": status_at}]
+            )
+        )
+        runs = (
+            []
+            if check_completed_at is None
+            else [{"status": "completed", "completed_at": check_completed_at}]
+        )
+        (self.fixtures / "check_runs.json").write_text(json.dumps({"check_runs": runs}))
+        applied = self.fixtures / "dispatched.txt"
+        applied.unlink(missing_ok=True)
+
+        proc = subprocess.run(  # noqa: S603 - fixed argv, test-local stub
+            ["bash", "-c", self.script],
+            cwd=self.work,
+            env={**self.env, "MAX_DISPATCH": max_dispatch},
+            text=True,
+            capture_output=True,
+        )
+        # The sweep must never fail a run: a nudge it cannot make is not an error.
+        assert proc.returncode == 0, proc.stderr
+        self.last_stdout = proc.stdout
+        if not applied.exists():
+            return []
+        return applied.read_text().splitlines()
+
+
+@pytest.fixture
+def runner(tmp_path: Path, script: str) -> Runner:
+    return Runner(tmp_path, script)
+
+
+# ── The pending freeze (the sweep's original purpose) ────────────────────────
+
+
+def test_stale_pending_is_refired(runner: Runner) -> None:
+    dispatched = runner.sweep(state="pending", status_at="2020-01-01T00:00:00Z")
+    assert len(dispatched) == 1
+    assert "pr=2064" in dispatched[0]
+    assert "sha=4328fd0f941f09ff10f245fbdb4accf7c246febe" in dispatched[0]
+
+
+def test_fresh_pending_is_left_alone(runner: Runner) -> None:
+    """Inside STALE_MINUTES the fan-out may genuinely still be running."""
+    from datetime import datetime, timedelta, timezone
+
+    recent = (datetime.now(timezone.utc) - timedelta(minutes=2)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    assert runner.sweep(state="pending", status_at=recent) == []
+
+
+# ── The re-run freeze (the case this change adds) ────────────────────────────
+
+
+def test_failure_with_later_check_evidence_is_refired(runner: Runner) -> None:
+    """The PR #2064 incident, reduced.
+
+    `gh run rerun --failed` creates a new run ATTEMPT whose completion emits no
+    fresh `workflow_run: completed`, so the aggregator never re-evaluates. Here
+    the verdict was published at 19:01:24Z and a check finished at 19:16:13Z --
+    evidence that landed after the verdict, making it stale by construction.
+    """
+    dispatched = runner.sweep(
+        state="failure",
+        status_at="2026-08-07T19:01:24Z",
+        check_completed_at="2026-08-07T19:16:13Z",
+    )
+    assert len(dispatched) == 1
+    assert "pr=2064" in dispatched[0]
+
+
+def test_failure_with_no_later_evidence_is_left_alone(runner: Runner) -> None:
+    """The anti-storm property, and the reason age is NOT the test here.
+
+    A PR that is genuinely failing has an old terminal verdict and no newer check
+    evidence. Dispatching on `state == failure` alone would nudge it every 15
+    minutes forever; this asserts it is nudged zero times.
+    """
+    assert (
+        runner.sweep(
+            state="failure",
+            status_at="2026-08-07T19:16:13Z",
+            check_completed_at="2026-08-07T19:01:24Z",
+        )
+        == []
+    )
+
+
+def test_failure_refire_is_self_terminating(runner: Runner) -> None:
+    """Republishing must end the loop.
+
+    After a nudge, readiness becomes the NEWEST timestamp for that SHA. The next
+    sweep therefore sees no evidence newer than the verdict and stops -- which is
+    what makes a scheduled re-fire safe rather than a dispatch loop.
+    """
+    # Same evidence, but the verdict has since been republished after it.
+    assert (
+        runner.sweep(
+            state="failure",
+            status_at="2026-08-07T19:20:00Z",
+            check_completed_at="2026-08-07T19:16:13Z",
+        )
+        == []
+    )
+
+
+def test_failure_with_no_completed_checks_is_left_alone(runner: Runner) -> None:
+    """No check evidence at all means nothing proves the verdict stale."""
+    assert (
+        runner.sweep(state="failure", status_at="2026-08-07T19:01:24Z") == []
+    )
+
+
+def test_check_completing_in_the_same_second_is_not_new_evidence(runner: Runner) -> None:
+    """The publish and the completion that triggered it race within a second.
+
+    Without the margin, every ordinary terminal verdict would look stale on the
+    very next sweep.
+    """
+    assert (
+        runner.sweep(
+            state="failure",
+            status_at="2026-08-07T19:01:24Z",
+            check_completed_at="2026-08-07T19:01:26Z",
+        )
+        == []
+    )
+
+
+# ── States that must never be touched ───────────────────────────────────────
+
+
+@pytest.mark.parametrize("state", ["success", "error"])
+def test_other_states_are_never_refired(runner: Runner, state: str) -> None:
+    """`success` needs no rescue; `error` is a publisher fault a real event fixes."""
+    assert (
+        runner.sweep(
+            state=state,
+            status_at="2020-01-01T00:00:00Z",
+            check_completed_at="2026-08-07T19:16:13Z",
+        )
+        == []
+    )
+
+
+def test_a_different_status_context_is_ignored(runner: Runner) -> None:
+    """Only the aggregate this sweep owns may be nudged."""
+    assert (
+        runner.sweep(
+            state="failure",
+            status_at="2026-08-07T19:01:24Z",
+            check_completed_at="2026-08-07T19:16:13Z",
+            context="Coverage Gate",
+        )
+        == []
+    )
+
+
+def test_max_dispatch_caps_the_sweep(runner: Runner) -> None:
+    """The runaway backstop still applies to the new path."""
+    assert (
+        runner.sweep(
+            state="failure",
+            status_at="2026-08-07T19:01:24Z",
+            check_completed_at="2026-08-07T19:16:13Z",
+            max_dispatch="0",
+        )
+        == []
+    )
+
+
+def test_the_sweep_never_recomputes_a_verdict_itself(script: str) -> None:
+    """It may only nudge the authoritative workflow.
+
+    A sweep that published its own verdict would be a second source of truth for
+    a required status -- and could mark a PR ready without the reviewers.
+    """
+    assert "gh workflow run pr-readiness.yml" in script
+    for forbidden in ("/statuses -X POST", "--method POST", "-X POST"):
+        assert forbidden not in script, f"sweep must not write statuses: {forbidden}"


### PR DESCRIPTION
## Problem

`PR Readiness` can sit on `failure` while every underlying check is green, with
no event left to correct it and no automatic recovery.

Proven on PR #2064. A backend shard flaked, so readiness published
`failure` ("1 blocking readiness item(s)") at 19:01:24Z. The failed jobs were
re-run in place with `gh run rerun --failed`. That created a new run ATTEMPT:
CI run 31208434535 reached `run_attempt=2` and completed **success** at
19:16:13Z, and Backend Tests (3.10, 4) plus Coverage Gate both went green.

The verdict never moved. That SHA carries 11 `PR Readiness` statuses and the
newest is still the 19:01:24Z failure.

## Why it matters

`PR Readiness` is a required status. A PR in this state cannot merge, and nothing
gets it out:

- A job-level re-run creates a new attempt whose completion does **not** emit a
  fresh `workflow_run: completed`, so `pr-readiness.yml` never re-evaluates. Its
  `workflow_run` types already include `requested`/`in_progress`/`completed`, and
  none of them fire for an attempt.
- No `pull_request_target` type fires either -- the commit is unchanged, so
  there is no `synchronize`.
- `pr-readiness-sweep.yml` exists precisely to unstick frozen verdicts, but its
  filter is `[ "$state" = "pending" ] || continue`. A stale **failure** is
  skipped, so the one mechanism designed for this walks past it.

The only escape was a human noticing and hand-firing the `workflow_dispatch`
repair path -- which requires knowing it exists.

## Fix (symptom -> root cause -> change)

The symptom is a frozen terminal verdict; the root cause is that the sweep tests
only for `pending`; the change teaches it the second freeze mode.

`failure` now also qualifies -- but **age is the wrong test** for a terminal
verdict, because a genuinely failing PR legitimately has an old one. Filtering on
`state == failure` alone would dispatch on every failing PR every 15 minutes
forever.

The test is instead: **a check run for this SHA completed AFTER the verdict was
published.** That makes the verdict stale by construction -- evidence landed
after it was computed -- and it is *self-terminating*, which is what makes a
scheduled re-fire safe: republishing makes readiness the newest timestamp again,
so the next sweep sees nothing newer and stops. A genuinely failing PR is nudged
at most once per new piece of check evidence, never once per sweep. A 5-second
margin keeps the completion that *triggered* a publish from looking like new
evidence.

Blast radius is deliberately small: this touches only the sweep, not the gate.
`pr-readiness.yml` is unchanged -- no new trigger, no permission change, and its
deliberate concurrency separation between `pull_request_target` and the
`workflow_run` burst is untouched. The sweep still only ever nudges the existing
`workflow_dispatch` recompute; it never computes or writes a verdict, and
`MAX_DISPATCH` still caps every sweep.

That restraint is also why no trigger was added to the gate itself:
`pull_request_target` and `workflow_run` always run the DEFAULT-BRANCH copy of a
workflow, so a trigger change is untestable from a PR branch and would land
unverified on a status that gates every PR in the repo.

## Tests

`test/test_pr_readiness_sweep.py` (new, 12 cases) extracts the sweep's one `run:`
block and executes it for real against a `gh` stub, in the style of
`test_issue_triage_workflow.py`. The condition is the whole point of the change,
so both directions are pinned:

- the #2064 incident re-fires (failure at 19:01:24Z, check completed 19:16:13Z)
- a genuinely failing PR with no newer evidence is **not** re-fired (anti-storm)
- a republished verdict stops the loop (self-termination)
- a same-second completion is not new evidence
- `success` / `error`, a foreign status context, and `MAX_DISPATCH=0` are all
  never dispatched
- the original stale-`pending` path still re-fires, and a fresh `pending` does not
- the sweep never writes a status itself (it must not become a second source of
  truth for a required check)

Verified the suite is meaningful: against the PRE-change workflow exactly one
case fails -- `test_failure_with_later_check_evidence_is_refired` -- and the other
11 already pass, which shows the change is additive and does not alter existing
behaviour.

## Manual verification

Not run against live Actions: the sweep is `schedule`-triggered and only the
default-branch copy runs, so the real path cannot be exercised from a branch. The
behavioural harness above executes the actual shell instead, and the root cause
was confirmed from the live incident (`run_attempt=2`, `completed/success` at
19:16:13Z, newest readiness status 19:01:24Z).

## Verification

12/12 new tests pass; the YAML parses; `bash -n` clean on the extracted step;
isort and flake8 clean.
