### PR TITLE
fix(sidebar): board view column clips content when sidebar is narrow

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -5312,7 +5312,7 @@ function ChatSidebar({
         ) : (
           // Trello-style horizontal column strip
           <div className="flex-1 min-h-0 flex flex-col">
-          <div className="flex-1 overflow-x-auto overflow-y-hidden flex gap-2 p-2" data-testid="column-strip">
+          <div className={`flex-1 ${orderedColumns.length > 1 ? 'overflow-x-auto' : 'overflow-x-hidden'} overflow-y-hidden flex gap-2 p-2`} data-testid="column-strip">
             {orderedColumns.map((col, colIdx) => {
               const colSlots = filteredSlots.filter(s => columnMatches(col, s))
               const colTags = col.tag_ids.map(tid => tagById[tid]).filter(Boolean) as ChatTag[]
@@ -5324,7 +5324,7 @@ function ChatSidebar({
                 // Board column is a drag-and-drop drop zone (column reorder + session
                 // card drop); mouse-only drag handlers, so scope-disable the rule.
                 // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-                <div key={col.id} data-testid={`column-${col.id}`} className="flex flex-col flex-1 min-w-[220px] bg-card border border-border rounded-md overflow-hidden"
+                <div key={col.id} data-testid={`column-${col.id}`} className="flex flex-col flex-1 min-w-0 bg-card border border-border rounded-md overflow-hidden" style={{ minWidth: orderedColumns.length > 1 ? '220px' : undefined }}
                   onDragOver={e => {
                     const types = e.dataTransfer.types
                     // Accept column reorder on the entire column surface
@@ -5402,7 +5402,7 @@ function ChatSidebar({
                     <button
                       type="button"
                       data-testid={`column-add-after-${col.id}`}
-                      className="text-muted hover:text-accent bg-transparent border-none cursor-pointer shrink-0 p-[2px] disabled:cursor-wait disabled:opacity-50"
+                      className={`text-muted hover:text-accent bg-transparent border-none cursor-pointer shrink-0 p-[2px] disabled:cursor-wait disabled:opacity-50${orderedColumns.length <= 1 ? ' hidden' : ''}`}
                       title={i18nT('pages.chatSidebar.add_column_after_this_one')}
                       aria-label={i18nT('pages.chatSidebar.add_column_after_this_one')}
                       disabled={addColumnAfterMutation.isPending}
@@ -5411,7 +5411,7 @@ function ChatSidebar({
                     <button
                       type="button"
                       data-testid={`column-delete-${col.id}`}
-                      className="text-muted hover:text-danger bg-transparent border-none cursor-pointer shrink-0 p-[2px]"
+                      className={`text-muted hover:text-danger bg-transparent border-none cursor-pointer shrink-0 p-[2px]${orderedColumns.length <= 1 ? ' hidden' : ''}`}
                       title={i18nT('pages.chatSidebar.delete_column')}
                       aria-label={i18nT('pages.chatSidebar.delete_column')}
                       onClick={() => { if (confirm(i18nT('pages.chatSidebar.delete_this_column'))) deleteColumnMutation.mutate(col.id) }}


### PR DESCRIPTION
## Problem

When the sessions sidebar is narrowed (dragged to minimum width), the board view's single-column layout clips content — the column header's action buttons (`+` `×`) disappear, folder names get hard-cut, and session timestamps are truncated. List view does not have this issue at the same width.

## Why it matters

Board view becomes unusable at narrow sidebar widths. Users lose access to column management buttons and can't read session titles/timestamps, forcing them to widen the sidebar or switch to list view.

## Fix (symptoms → root cause → change)

**Root cause:** Two layout issues compound in single-column board view:
1. The column-strip container uses `overflow-x: auto`, creating a hidden scroll area. In single-column mode, the column's content width exceeds the strip's visible width, so the right side is scroll-clipped.
2. Each column enforces `min-w-[220px]` via Tailwind, preventing it from shrinking below 220px even when the sidebar is narrower.

**Changes (ChatSidebar.tsx):**
1. Column-strip: use `overflow-x-hidden` in single-column mode (no horizontal scroll needed), `overflow-x-auto` only for multi-column.
2. Column: replace fixed `min-w-[220px]` class with `min-w-0` + inline style — single column shrinks freely; multi-column retains the 220px floor.
3. Hide the add-column (+) and delete-column (×) buttons when only one column exists — unnecessary in single-column mode, saves header space.

## Tests

Manual verification via isolated pod with narrow sidebar (200px forced width). Multi-column layout confirmed to retain horizontal scroll behavior.

## Manual verification

Before/after screenshots taken in an isolated sandbox pod (no user data). 
Before: column header buttons cut off, content hard-clipped. 
<img width="900" height="720" alt="image" src="https://github.com/user-attachments/assets/2b7341f1-7a2b-4afa-955f-c17e6b13a987" />

After: all content truncates naturally (ellipsis), header icons visible.
<img width="900" height="720" alt="image" src="https://github.com/user-attachments/assets/0a869c32-1cd2-4a6e-b3b3-fa0fa2d3a962" />
