### PR TITLE
test(auto-improvement): stop GC interleaving flaking the pstats recursion test

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_profile_normalize.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_profile_normalize.py
@@ -11,6 +11,7 @@ degrades into "always highlight the entry point" if it regresses.
 from __future__ import annotations
 
 import cProfile
+import gc
 import json
 import pstats
 import unittest.mock as mock
@@ -209,9 +210,26 @@ class TestPstatsNormalization:
             fib(12)
 
         prof = cProfile.Profile()
-        prof.enable()
-        entry()
-        prof.disable()
+        # GC is held off for the profiled region, because a collection that fires
+        # while `fib` is on the stack attributes the collected objects' weakref
+        # /  __del__ callbacks to `fib` as CALLEES. Those frames are real -- the
+        # profiler saw them -- but they have nothing to do with recursion, and
+        # their appearance is timing- and memory-pressure-dependent: this test
+        # passed alone and failed inside a 4-way xdist shard, where the other
+        # workers' allocation churn made a mid-`fib` collection likely (a
+        # `weakref`-module frame showed up as a child of `fib` with calls=4).
+        #
+        # Disabling GC removes the nondeterminism at its source rather than
+        # teaching the assertion to tolerate it.
+        gc_was_enabled = gc.isenabled()
+        gc.disable()
+        try:
+            prof.enable()
+            entry()
+            prof.disable()
+        finally:
+            if gc_was_enabled:
+                gc.enable()
         path = tmp_path / "rec.pstats"
         prof.dump_stats(str(path))
 
@@ -223,7 +241,11 @@ class TestPstatsNormalization:
         assert tree is not None
         walked = _find(tree["root"], "fib")
         assert walked is not None
-        assert walked["children"] == []  # the self-edge is cut, not followed
+        # The property under test is that the SELF-EDGE is cut, not that `fib`
+        # happens to have no callees at all. Asserting `children == []` conflated
+        # the two, so any incidental frame the profiler attributed to `fib` failed
+        # a test about recursion.
+        assert "fib" not in [c["name"] for c in walked["children"]]
         assert _depth(tree["root"]) < 50  # bounded, not merely finite
 
     def test_corrupt_and_missing_files_return_none(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`test_profile_normalize.py::TestPstatsNormalization::test_recursion_terminates`
fails intermittently on the Backend Tests shards:

    AssertionError: assert [{'calls': 4,...ref.py', ...}] == []

Observed on CI run 31208434535 (Backend Tests (3.10, shard 4/4)). It passes in
isolation, main was green on the same test at baa524ed and 90b691e3, and the PR
that hit it was frontend-only and could not reach this code.

## Root cause

The test profiles a recursive `fib` and asserted `walked["children"] == []` --
that the normalizer cut the self-edge. But `cProfile` attributes to `fib` every
frame that runs while `fib` is on the stack, and that includes work `fib` never
called: when a garbage collection fires mid-recursion, the collected objects'
`weakref` / `__del__` callbacks are recorded as CALLEES of `fib`.

Those frames are real -- the profiler genuinely saw them -- but they have nothing
to do with recursion, and whether they appear depends on allocation timing. Under
a 4-way xdist shard the other workers' churn makes a mid-`fib` collection likely,
which is exactly the "passes alone, fails in a shard" signature. The CI frame was
from the `weakref` module (`…ref.py`, calls=4).

Reproduced deliberately, through the real normalizer: with cyclic garbage and a
tightened GC threshold inside the profiled region, `fib` gains a `<lambda>` child
(a weakref callback) and the old assertion fails. With GC held off it has no
children at all.

    GC ACTIVE (CI-like pressure)     children=['<lambda>']  OLD assert passes=False  NEW assert passes=True
    gc.disable() IN TEST             children=[]            OLD assert passes=True   NEW assert passes=True

This is a TEST bug, not a product bug. `normalize_pstats` did its job: the
self-edge was cut correctly every time. The assertion over-specified, conflating
"the recursive self-edge is cut" with "this frame has no callees whatsoever", so
unrelated profiler noise failed a test about recursion.

## Fix

Both layers, because each closes a different half:

1. **Remove the nondeterminism at its source.** GC is disabled for the profiled
   region (restored in a `finally`, and only re-enabled if it was on), so no
   collection can interleave and the dump contains only `fib`'s own edges.
2. **Assert the property actually under test.** `"fib" not in [c["name"] for c in
   walked["children"]]` -- the self-edge specifically is absent -- instead of an
   exact empty list. The depth bound is unchanged.

Step 2 is not a loosening to tolerate a real defect: the failure being guarded
against (an unbounded walk over the cyclic edge) is still fully asserted, by both
the self-edge check and `_depth(...) < 50`. It just no longer fails on frames
that are irrelevant to it.

## Scope

`test_recursion_terminates` was the ONLY test in this file asserting an exact
children list against a REAL `cProfile` dump, which is why it was the only one
that flaked. The other exact-equality assertions (line 284's children list, and
every `highlight == [...]`) run against fabricated `Stats` / cpuprofile objects
under `mock.patch`, so they are deterministic and need no change. Checked rather
than assumed.

## Verification

- the single test passes `-n0`
- the whole file passes `-n0` (45 passed, 1 skipped)
- the whole `auto_improvement` test dir passes under `-n 4 --dist loadgroup`,
  the sharding mode that produced the failure
- isort, `flake8 -j1` and mypy (823 files) clean

The 10 failures in that sharded dir run are pre-existing and environmental --
`test_pr_watchers.py::TestCloneIsolation::*` and
`test_dogfood_learnings.py::TestAFailedHeadCheckoutRefusesTheClone::*`, which need
`git clone --local` and fail in this sandbox on main too. `test_recursion_terminates`
is not among them.
