### PR TITLE
fix(test): stop the gateway-service check asserting real launchctl state

### DIFF
--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -3371,11 +3371,69 @@ async def test_fleet_includes_gateway_service_active(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_gateway_service_active_non_linux(monkeypatch):
-    """On non-linux, _gateway_service_active returns False without spawning."""
+async def test_gateway_service_active_no_manager(monkeypatch):
+    """A platform with neither systemd nor launchd -> False, and NO spawn.
+
+    Was previously asserted with ``platform="darwin"``; darwin is now a
+    SUPPORTED backend, so the "no manager at all" case has to be expressed with
+    a platform that really has none -- mirroring
+    ``test_live_user_unit_status_no_manager``. Asserting darwin here made the
+    verdict depend on whether the *host* happened to have the agent loaded,
+    because neither ``shutil`` nor ``_run_cmd`` was faked.
+    """
     monkeypatch.setattr(mod, "_GATEWAY_SERVICE_ACTIVE", None)
     monkeypatch.setattr(mod, "_GATEWAY_SERVICE_CHECK_AT", 0.0)
-    monkeypatch.setattr(mod.sys, "platform", "darwin")
+    monkeypatch.setattr(mod, "sys", MagicMock(platform="win32"))
+    run = AsyncMock(return_value=(0, "", ""))
+    monkeypatch.setattr(mod, "_run_cmd", run)
+    assert await mod._gateway_service_active() is False
+    # The "without spawning" half of the original intent, now actually verified:
+    # backend() returns None for win32, so nothing may be probed.
+    run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_gateway_service_active_darwin_live_agent(monkeypatch):
+    """macOS with a loaded agent reporting a live pid -> True.
+
+    The darwin-True path had no *direct* assertion: the only ``is True`` case in
+    this area runs under ``platform="linux"``. It was covered indirectly via
+    ``test_restart_gateway_darwin_requests_graceful_stop``.
+    """
+    monkeypatch.setattr(mod, "_GATEWAY_SERVICE_ACTIVE", None)
+    monkeypatch.setattr(mod, "_GATEWAY_SERVICE_CHECK_AT", 0.0)
+    monkeypatch.setattr(mod, "sys", MagicMock(platform="darwin"))
+    monkeypatch.setattr(
+        mod, "shutil", MagicMock(which=MagicMock(return_value="/bin/launchctl"))
+    )
+    calls: list = []
+
+    async def fake_run_cmd(cmd, **kw):
+        calls.append(cmd)
+        return 0, "  pid = 4242\n", ""
+
+    monkeypatch.setattr(mod, "_run_cmd", fake_run_cmd)
+    assert await mod._gateway_service_active() is True
+    assert calls and calls[0][:2] == ["launchctl", "print"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_service_active_darwin_loaded_without_pid(monkeypatch):
+    """macOS agent loaded but not running (no pid line) -> False.
+
+    ``LaunchdBackend.active`` treats only a live pid as active, mirroring
+    ``systemctl is-active``; a zero exit from ``launchctl print`` alone is not
+    enough.
+    """
+    monkeypatch.setattr(mod, "_GATEWAY_SERVICE_ACTIVE", None)
+    monkeypatch.setattr(mod, "_GATEWAY_SERVICE_CHECK_AT", 0.0)
+    monkeypatch.setattr(mod, "sys", MagicMock(platform="darwin"))
+    monkeypatch.setattr(
+        mod, "shutil", MagicMock(which=MagicMock(return_value="/bin/launchctl"))
+    )
+    monkeypatch.setattr(
+        mod, "_run_cmd", AsyncMock(return_value=(0, "  state = waiting\n", ""))
+    )
     assert await mod._gateway_service_active() is False
 
 


### PR DESCRIPTION
Fixes #1702

## Problem

`test_gateway_service_active_non_linux` asserts `_gateway_service_active() is False` under `platform="darwin"`, but patches **only** `sys.platform` — `shutil.which` and `_run_cmd` are left real. Since #1434 gave darwin a real service backend, the test now shells out to the host's actual `launchctl` and lets the host decide the verdict:

```python
monkeypatch.setattr(mod.sys, "platform", "darwin")
assert await mod._gateway_service_active() is False
```

It is green on CI's `macos-14` runner only because no gateway LaunchAgent is loaded there, so `launchctl print gui/501/dev.kirocrew.gateway` exits non-zero.

Two consequences:

- **On macOS it asserts host state, not code.** Any runner or dev machine that *does* have the agent loaded turns it red — on a PR that changed nothing related.
- **On Linux it asserts nothing at all.** `LaunchdBackend._available()` short-circuits on `which("launchctl")` before any darwin logic runs, so the test passes having made zero calls.

The docstring's "without spawning" claim is also false on its face: darwin spawns.

## Why it matters

A test that reads host state is worse than no test. It gives a false green on the primary Linux matrix while holding a loaded gun on macOS — a red check that no PR author can explain from their own diff, on a suite that gates every PR.

## Fix (symptom → root cause → change)

**Symptom:** the assertion's truth depends on the machine, not the code.

**Root cause:** #1434 (`2205475d`, "drive the gateway service on macOS, not just Linux") added `LaunchdBackend`, so `gateway_service.backend()` returns a live backend for darwin instead of `None`. `_gateway_backend()` deliberately resolves `platform` and `which` through this module's globals so tests can control them — but this test patches neither `shutil` nor `_run_cmd`, so both stay real.

**This is a miss, not a new decision.** #1434 already made exactly this correction for the sibling probe, and left the reasoning in the docstring:

> ```
> """A platform with neither systemd nor launchd -> no_systemd, no spawn.
>
> Was previously asserted with ``platform="darwin"``; darwin is now a
> SUPPORTED backend, so the "no manager at all" case has to be expressed with
> a platform that really has none.
> """
> ```
> — `test_live_user_unit_status_no_manager`

`_gateway_service_active`'s test was overlooked in the same pass. This change applies the established pattern from the five neighbouring darwin tests in the same file (`monkeypatch.setattr(mod, "sys", MagicMock(platform=...))` + faked `shutil` + `AsyncMock` `_run_cmd`) — no new mechanism, no new helper.

It also swaps the module-local `sys` reference instead of mutating the global `sys` module's `platform` attribute, matching those neighbours.

## Tests

One host-dependent test becomes three deterministic ones (263 → 265 test defs; 266 collected, all passing):

| Test | Asserts | Why it exists |
|---|---|---|
| `..._no_manager` | win32 → `False`, **and** `run.assert_not_awaited()` | Where the original "without spawning" intent actually belongs — now asserted, not implied. `backend()` returns `None` for win32 before any probe. |
| `..._darwin_live_agent` | darwin + loaded agent with live pid → `True`, and `calls[0][:2] == ["launchctl", "print"]` | This path had no *direct* assertion; the only `is True` case in this area runs under `platform="linux"`. |
| `..._darwin_loaded_without_pid` | darwin + `rc=0` but no pid line → `False` | Locks in `LaunchdBackend.active`'s documented rule that only a live pid counts, "mirroring `systemctl is-active`". |

## Manual verification

The decisive evidence is a mutation of the *host*, not of the code — a pytest plugin that replaces the `_run_cmd` chokepoint so an unfaked test inherits a host where `launchctl print` reports a loaded agent with a live pid. A test that fakes `_run_cmd` itself overrides the plugin, so it only changes the verdict of tests that were reading real host state.

**Old test, host with the agent loaded — fails:**

```
$ PYTHONPATH=/tmp/kc1702proof pytest -k gateway_service_active_non_linux -p liveagent -n 0 -q -s
[FAKE-HOST] ['launchctl', 'print', 'gui/501/dev.kirocrew.gateway'] -> rc=0 (agent loaded, pid 4242)
>       assert await mod._gateway_service_active() is False
E       assert True is False
FAILED test/test_dev_fleet_app.py::test_gateway_service_active_non_linux
1 failed
```

The `[FAKE-HOST]` line is the proof it really reached the chokepoint.

**New tests, identical host — pass, and never reach it:**

```
$ PYTHONPATH=/tmp/kc1702proof pytest -k gateway_service_active -p liveagent -n 0 -q -s
4 passed
```

No `[FAKE-HOST]` line: all three fake `_run_cmd` themselves, so host state cannot reach them.

**Gates** (macOS, Python 3.12):

```
pytest test/test_dev_fleet_app.py     266 passed
flake8 test/test_dev_fleet_app.py     clean
isort  --check-only                   clean
```

`mypy` reports 18 pre-existing errors in this file, identical before and after; CI scopes `mypy` to `src/kiro_crew/` so they are out of gate scope either way.

## Screenshots

N/A — test-only change, no user-visible surface.

## Notes for review

- **Test count changes 1 → 3.** #1434's PR body advertised "34 gateway tests pass unchanged", so the delta is intentional: it is coverage expansion, not a rename. No test names are shadowed.
- **Scope held to one concern.** #1702 also mentions `test/conftest.py` not clearing `KIROCREW_PORT`. That is a separate one-line defect listed as "Related" in the issue, and is deliberately left out to keep this a single-concern commit.
- **The residual class is closed.** The one other platform-faking candidate in this file, `test_gateway_start_id_none_on_non_linux` (`test/test_dev_fleet_app.py:5147`), sets `which` → `None`, so `_available()` short-circuits before any probe — already deterministic.
