### PR TITLE
test(ci): stop measuring test files CI never executes, lock it with a contract

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -272,6 +272,27 @@ parallel = true
 omit =
     */pytest-of-*/*
     */kirocrew-wt-example/*
+# Test files that CI's BACKEND_DESELECTS deselects on EVERY backend pytest
+# invocation, because the GH Actions runners lack what they need (Linux-namespace
+# sandbox, a real git/gh, POSIX rmtree/path assumptions). They are never
+# executed, so measuring them as coverable code is a measurement bug: it charged
+# ~3.9k permanently-unreachable statements to the denominator and understated the
+# real line-rate by ~1.5pp. Coverage measures code the suite CAN run.
+#
+# This list MUST stay in sync with BACKEND_DESELECTS in .github/workflows/ci.yml
+# (and with [coverage:report] omit below). That is enforced, not trusted --
+# test/test_coverage_omit_contract.py fails if the two lists drift.
+    */test/test_script_hooks.py
+    */test/test_cron_script.py
+    */ops_mission_control/tests/test_ledger_sync_git.py
+    */ops_mission_control/tests/test_schedule_file.py
+    */auto_improvement/tests/test_dogfood_learnings.py
+    */auto_improvement/tests/test_pr_watchers.py
+    */auto_improvement/tests/test_lint_findings.py
+    */auto_improvement/tests/test_github_profile.py
+    */auto_improvement/tests/test_profile_capture.py
+    */auto_improvement/tests/test_runner.py
+    */auto_improvement/tests/test_perf_track_propose.py
 
 [coverage:paths]
 source =
@@ -290,6 +311,21 @@ show_missing = true
 omit =
     */pytest-of-*/*
     */kirocrew-wt-example/*
+# Same never-executed test files as [coverage:run] omit above -- repeated here
+# because Coverage Combine reads shard data and reports it in a separate
+# process, where only report-time omit applies. Kept in sync by
+# test/test_coverage_omit_contract.py.
+    */test/test_script_hooks.py
+    */test/test_cron_script.py
+    */ops_mission_control/tests/test_ledger_sync_git.py
+    */ops_mission_control/tests/test_schedule_file.py
+    */auto_improvement/tests/test_dogfood_learnings.py
+    */auto_improvement/tests/test_pr_watchers.py
+    */auto_improvement/tests/test_lint_findings.py
+    */auto_improvement/tests/test_github_profile.py
+    */auto_improvement/tests/test_profile_capture.py
+    */auto_improvement/tests/test_runner.py
+    */auto_improvement/tests/test_perf_track_propose.py
 
 [coverage:html]
 directory = build/coverage

--- a/test/test_coverage_omit_contract.py
+++ b/test/test_coverage_omit_contract.py
@@ -1,0 +1,112 @@
+"""Contract: every test file CI refuses to run is excluded from coverage.
+
+``BACKEND_DESELECTS`` in ``.github/workflows/ci.yml`` deselects a fixed set of
+test files on EVERY backend pytest invocation, because the GitHub Actions
+runners lack what those tests need (Linux-namespace sandbox, a real ``git``/
+``gh``, POSIX rmtree/path assumptions). Those files are therefore never
+executed in CI.
+
+Coverage must not charge their statements to the denominator: an unreachable
+file is not an uncovered file, and counting it silently understates the real
+line-rate (it hid ~3.9k permanently-unreachable statements, ~1.5pp). So
+``setup.cfg`` omits them from BOTH ``[coverage:run]`` (collection time, in the
+test job) and ``[coverage:report]`` (report time, in the Coverage Combine job,
+a separate process that re-reads shard data).
+
+Three lists therefore have to agree, and they live in two different files. The
+CI deselect list has already drifted once against another copy of itself, so
+this test enforces the invariant instead of trusting a comment to be read.
+"""
+
+from __future__ import annotations
+
+import configparser
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+SETUP_CFG = REPO_ROOT / "setup.cfg"
+
+
+def _ci_deselected_paths() -> list[str]:
+    """Repo-relative test paths from ci.yml's BACKEND_DESELECTS block.
+
+    Parsed with a regex rather than a YAML loader so the test does not depend on
+    PyYAML being installed, and so it reads the literal text a maintainer edits.
+    """
+    text = CI_WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(r"^  BACKEND_DESELECTS: >-\n((?:    .*\n)+)", text, re.MULTILINE)
+    assert match, "BACKEND_DESELECTS block not found in ci.yml -- did its shape change?"
+    paths = re.findall(r"--deselect=(\S+)", match.group(1))
+    assert paths, "BACKEND_DESELECTS matched but contained no --deselect= entries"
+    return paths
+
+
+def _cfg_omit(section: str) -> list[str]:
+    parser = configparser.ConfigParser()
+    parser.read(SETUP_CFG, encoding="utf-8")
+    raw = parser.get(section, "omit")
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def _matches(pattern: str, path: str) -> bool:
+    """True if a coverage omit glob would exclude ``path``.
+
+    coverage.py matches omit patterns against the measured filename, which is
+    absolute at runtime, so the committed patterns are written with a leading
+    ``*/``. Compare on suffix semantics: translate the glob and allow it to
+    match the tail of the repo-relative path.
+    """
+    body = pattern[2:] if pattern.startswith("*/") else pattern
+    regex = "".join(".*" if part == "*" else re.escape(part) for part in re.split(r"(\*)", body))
+    return re.search(rf"(^|/){regex}$", path) is not None
+
+
+def test_ci_deselect_block_is_parseable() -> None:
+    """Guard the regex itself: a reshaped ci.yml must fail loudly, not silently."""
+    paths = _ci_deselected_paths()
+    assert len(paths) >= 11, f"expected the full deselect list, parsed only {len(paths)}"
+    assert all(p.endswith(".py") for p in paths), paths
+
+
+@pytest.mark.parametrize("section", ["coverage:run", "coverage:report"])
+def test_every_deselected_test_is_omitted_from_coverage(section: str) -> None:
+    """A file CI never executes must not be measured as coverable code."""
+    omit = _cfg_omit(section)
+    missing = [p for p in _ci_deselected_paths() if not any(_matches(pat, p) for pat in omit)]
+    assert not missing, (
+        f"[{section}] omit does not cover these CI-deselected test files: {missing}. "
+        "They are never executed, so measuring them understates the real line-rate. "
+        "Add a matching */... pattern to setup.cfg."
+    )
+
+
+def test_run_and_report_omit_lists_agree() -> None:
+    """Collection-time and report-time omit must stay identical.
+
+    They govern different processes (the test job vs Coverage Combine); if only
+    one carries an entry, the gate silently measures a different denominator
+    than the shards were collected under.
+    """
+    assert sorted(_cfg_omit("coverage:run")) == sorted(_cfg_omit("coverage:report"))
+
+
+def test_omit_patterns_do_not_swallow_product_code() -> None:
+    """Fail-safe: no pattern may match a non-test source file.
+
+    A pattern like ``*/kiro_crew/*`` would omit all real source and turn the
+    coverage gate green by measuring almost nothing. Assert every committed
+    pattern is either a pytest-tmp fixture escape or targets a test file.
+    """
+    fixture_escapes = {"*/pytest-of-*/*", "*/kirocrew-wt-example/*"}
+    for pattern in _cfg_omit("coverage:run"):
+        if pattern in fixture_escapes:
+            continue
+        tail = pattern.rsplit("/", 1)[-1]
+        assert tail.startswith("test_") and tail.endswith(".py"), (
+            f"omit pattern {pattern!r} is neither a pytest-tmp escape nor a specific "
+            "test file -- a broad pattern here can silently stop measuring product code."
+        )


### PR DESCRIPTION
## Problem

`BACKEND_DESELECTS` in `.github/workflows/ci.yml` deselects **11 test files on every backend pytest invocation** — full and reduced, Linux and Windows — because the GH Actions runners lack what those tests need (Linux-namespace sandbox, a real `git`/`gh`, POSIX rmtree/path assumptions).

Those files are never executed. Coverage measured them anyway.

## Why it matters

They contributed **4,763 statements** to the denominator, of which only 869 (18.2%) were ever hit — so **~3,894 permanently-unreachable statements were counted as "uncovered"**. An unreachable file is not an uncovered file. The gate was partly measuring its own deselect list instead of the suite's real reach, which understates the true line-rate and makes every future ratchet decision off by ~1.5pp.

Measured against main's own coverage artifact (CI run `31214485444`):

| | line-rate |
|---|---|
| Today | 78.69% |
| Excluding never-executed test files | **80.15%** |

## Fix (symptom → root cause → change)

Symptom: backend coverage reads ~78.7% while 3.9k of the "uncovered" statements live in files CI refuses to collect. Root cause: the deselect list governs *execution* only; `[coverage:*] omit` never learned about it. Change: omit those 11 paths from coverage.

Entries go in **both** `[coverage:run]` (collection time, in the test job) **and** `[coverage:report]` (report time, in the separate Coverage Combine process). If only one applied, the gate would report against a different denominator than the shards were collected under — the same class of bug the existing pytest-tmp omit comment already warns about.

## Tests

The list now lives in three places across two files, and the CI deselect list has **already drifted once against another copy of itself** (documented in ci.yml's own comment). So this enforces the invariant instead of trusting a comment — new `test/test_coverage_omit_contract.py`, 5 tests:

- every CI-deselected path is omitted — asserted separately for `[coverage:run]` and `[coverage:report]`
- the two omit lists are identical to each other
- the `BACKEND_DESELECTS` block is still parseable, so a reshaped workflow fails loudly rather than silently matching zero paths
- **fail-safe**: no omit pattern may be broader than one specific `test_*.py` file. This is the important one — a pattern like `*/kiro_crew/*` would omit all real source and turn the coverage gate green by measuring almost nothing.

## Manual verification

- 5/5 pass; `isort`, `flake8`, `mypy` clean.
- **Mutation-tested**: deleting one omit entry fails 2 of the 5 tests, naming the exact missing path (`['test/test_cron_script.py']`). The guard is not vacuous.
- `setup.cfg` re-parsed with `configparser` after editing to confirm all five `[coverage:*]` sections and `[coverage:paths] source` survived.

N/A on screenshots — no user-visible surface.

## Deliberately NOT in this PR

This does **not** raise the floor. The 77% floor stands; the ~1.5pp of headroom this recovers should be banked in a separate ratchet once main has held the higher number, per the policy comment added next to the floors.
