### PR TITLE
docs(autosde): forbid side effects in tests

### DIFF
--- a/AUTOSDE.yaml
+++ b/AUTOSDE.yaml
@@ -98,6 +98,37 @@ custom-rules:
       When in doubt, offload — a leaked worker thread is survivable; a frozen
       loop is not.
 
+  - id: no-test-side-effects
+    blocking: true
+    file-patterns:
+      - "test/**/*.py"
+      - "tests/**/*.py"
+      - "src/kiro_crew/apps/builtins/**/tests/**/*.py"
+      - "transfer/**/*.py"
+    rule: |
+      A test must have no side effects outside its own tmp dir. Never register a
+      real cron job, write into the operator's real ~/.kiro/crew or HOME, start
+      or reconfigure a gateway/service, or create directories in the repo or
+      anywhere else that outlives the run. Both shapes have already bitten us: a
+      unit test registered a live cron job, and test runs accumulated stray
+      directories under the developer's home.
+
+      Know which floor you are standing on — it is NOT the same everywhere:
+      - Tests under `test/` inherit the autouse fixtures in `test/conftest.py`
+        (`_isolate_kirocrew_home` pins KIROCREW_HOME per test,
+        `_isolate_subagents_dir`, `_isolate_sel_default_dir`, and friends).
+      - Tests under `src/kiro_crew/apps/builtins/*/tests/` and `tests/` see only
+        the ROOT `conftest.py`, which isolates $XDG_CONFIG_HOME and blocks host
+        service mutation but does NOT pin KIROCREW_HOME. A test there that
+        reaches `config_dir()` / `apps_dir()` writes the developer's real data
+        dir. Isolate it yourself: `monkeypatch.setenv("KIROCREW_HOME",
+        str(tmp_path))`.
+
+      Assert against the tmp dir, not the real one, and clean up anything you
+      create. If a test genuinely needs a host-level effect, it must be opt-in
+      and named in the corresponding conftest allowlist with a comment saying
+      why.
+
   - id: top-level-imports
     blocking: false
     file-patterns:


### PR DESCRIPTION
## Problem

A unit test registered a **live cron job** into the real registry. Separately, test
runs have **accumulated stray directories** under the developer's home. Nothing in
the AutoSDE rule set could have caught either: every rule in `AUTOSDE.yaml` scopes
its `file-patterns` to `src/kiro_crew/**/*.py`, so no rule the Claude/Codex
reviewers evaluate has ever applied to a test file.

## Why it matters

These are not cosmetic. A test that registers a cron job leaves a job that keeps
firing after the run ends — on a developer box that means a real recurring agent
turn nobody asked for. A test that writes the operator's real `~/.kiro/crew`
mutates the state of the gateway the developer is using. `test/conftest.py`
already carries hard-won autouse guards for exactly this class (see its
`_isolate_kirocrew_home` docstring on Hypothesis generating one orphan dir per
example, and the root `conftest.py` `_isolate_xdg_config_home` docstring on
#1722 taking the gateway down), but the guards are a floor, not a review gate —
nothing tells a reviewer to look.

## Fix (symptom → root cause → change)

- **Symptom:** tests mutate host state that outlives the run.
- **Root cause:** no AutoSDE rule's `file-patterns` matches any test file, so the
  reviewers are never asked the question.
- **Change:** add one `blocking: true` rule, `no-test-side-effects`, scoped to the
  test trees that are actually collected (`setup.cfg` `testpaths = test transfer
  src/kiro_crew/apps/builtins`, plus the uncollected `tests/` dir).

The rule also states the part that is easy to get wrong, because the isolation
floor is **not uniform**:

| Test tree | Inherits | KIROCREW_HOME pinned? |
|---|---|---|
| `test/**` | `test/conftest.py` + root | **yes** (`_isolate_kirocrew_home`) |
| `src/kiro_crew/apps/builtins/*/tests/**` | root `conftest.py` only | **no** |
| `tests/**` | root `conftest.py` only | **no** |

The root `conftest.py` isolates `$XDG_CONFIG_HOME` and blocks host service
mutation, but does not pin `KIROCREW_HOME`. So a test in an app-builtin tree that
reaches `config_dir()` / `apps_dir()` writes the developer's real data dir, and
must isolate itself — the rule says so and gives the one-liner.

## Tests

None. This file is review-policy consumed by the AI reviewers, not executable
code — there is no code path to cover. Verified instead that the change is
well-formed and internally accurate:

- `AUTOSDE.yaml` parses under `yaml.safe_load`; the new entry carries
  `blocking: true` and the four `file-patterns`.
- Every fixture the rule text names exists: `_isolate_kirocrew_home`,
  `_isolate_subagents_dir`, `_isolate_sel_default_dir` in `test/conftest.py`;
  `_isolate_xdg_config_home`, `_block_host_service_mutation` in root
  `conftest.py`.
- The pattern scope was checked against `setup.cfg:245` `testpaths`, not guessed
  — a first draft used `tests/**/*.py` alone, which would have been near-dead
  config: `tests/` holds 11 files and is not in `testpaths`, while `test/` holds
  ~1000.

## Manual verification

N/A — the reviewers load `AUTOSDE.yaml` from the **base** ref
(`claude-review.yml:92`, `codex-review.yml:63`), and both prompts say a PR
touching the rule files is judged against the base snapshot. So this PR is
deliberately not evaluated by its own new rule; it takes effect for the next PR
that touches a test file.

## Screenshots

N/A — no user-visible UI change.
