### PR TITLE
fix(dashboard): stop a failed restore erasing the tab's reopen seed

### DIFF
--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -200,6 +200,11 @@ def _restore_open_slots_steps(state: DashboardState) -> "Iterator[int]":
     if not isinstance(keys, list):
         return
     restored = 0
+    # Rebound each pass so it reflects only THIS restore: a key that becomes
+    # readable later must stop being carried, and a fresh set() keeps mutation
+    # off the class-level frozenset baseline.
+    unrestored: set[str] = set()
+    state.unrestored_slot_keys = unrestored
     # Built once and shared across every tab — it is identical per slot.
     kiro_model_map = _build_kiro_model_map()
     for raw in keys:
@@ -226,17 +231,46 @@ def _restore_open_slots_steps(state: DashboardState) -> "Iterator[int]":
         if raw in state._slots:
             continue
         try:
-            slot = _rehydrate_slot_from_history(state, raw, kiro_model_map=kiro_model_map)
+            # Ask whether the metadata READ succeeded, not just whether it came
+            # back empty. get_metadata() reports {} for both "never persisted"
+            # and "could not be read after retries", and treating the second as
+            # the first is what silently discards a live tab. Key it exactly as
+            # _rehydrate_slot_from_history does, so the prefetch below is a hit.
+            #
+            # This read MUST stay inside the per-tab guard. restore_open_slots_async
+            # has no except at its call site, so anything escaping here aborts
+            # dashboard startup and costs every LATER tab too, not just this one.
+            meta, readable = state.conversation_log.get_metadata_status(
+                slot_transcript_key(raw)
+            )
+            if readable:
+                slot = _rehydrate_slot_from_history(
+                    state, raw, kiro_model_map=kiro_model_map, _prefetched_meta=meta
+                )
+                if slot is not None:
+                    restored += 1
+            else:
+                unrestored.add(raw)
+                logger.warning(
+                    "restore_open_slots: metadata unreadable for %s; keeping it "
+                    "in the reopen seed for the next restore instead of "
+                    "dropping it",
+                    raw,
+                )
         except Exception:
             logger.debug("restore_open_slots: rehydrate failed for %s", raw, exc_info=True)
+            # Same epistemic position as an unreadable read: the session was not
+            # shown to be gone, so keep its key rather than erasing the seed.
+            unrestored.add(raw)
             # No rollback here: _rehydrate_slot_from_history undoes its own
             # partial slot and restricted key, so every caller gets it rather
             # than only the ones that remembered to compensate.
-            continue
-        if slot is not None:
-            restored += 1
-        # One yield point per tab. The async driver turns this into a real event-loop
-        # yield; the sync driver just spins through it.
+        # One yield point per tab, reached on EVERY outcome. A failing tab still
+        # costs real I/O (the metadata read retries, and _pause_for_transient_retry
+        # deliberately does not sleep while on the loop), so a run of failing tabs
+        # that skipped the yield would monopolise the loop and feed the stall
+        # watchdog. The async driver turns this into a real event-loop yield; the
+        # sync driver just spins through it.
         yield restored
     if restored:
         logger.info("Restored %d open tab(s) from open_slots.json", restored)

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -1816,6 +1816,13 @@ class DashboardState:
     _slots_push_suspend: int = 0
     _slots_push_pending: bool = False
     restoring_open_slots: bool = False
+    # Keys the last open-tab restore could not read (not keys it proved absent).
+    # _persist_open_slots folds these back into the snapshot so a transient read
+    # failure cannot erase the reopen seed. The class-level baseline is an
+    # IMMUTABLE frozenset on purpose: a bare set() here would be one object
+    # shared by every __new__-built instance. __init__ and the restore each
+    # assign a fresh set(), so mutation only ever touches an instance attribute.
+    unrestored_slot_keys: "frozenset[str] | set[str]" = frozenset()
 
     def __init__(
         self,
@@ -1943,6 +1950,8 @@ class DashboardState:
         # being restored from with a half-populated slot set — see
         # _persist_open_slots.
         self.restoring_open_slots = False
+        # Per-instance (see the class-level frozenset baseline for why).
+        self.unrestored_slot_keys: set[str] = set()
         self._notification_log: list[dict[str, Any]] = _load_notifications()
         self._unread_count: int = 0
         # Notification bus (schema v2) — notify() adapts legacy calls onto it;
@@ -2664,6 +2673,25 @@ class DashboardState:
                 for name, slot in list(self._slots.items())
                 if getattr(slot, "memory_mode", "persistent") == "persistent"
             ]
+            # Re-add keys the last restore could not READ. Without this, a tab
+            # dropped by a transient metadata failure is erased from the seed by
+            # the very next flush (this snapshot is taken from live _slots), so
+            # "recoverable on a later restore pass" stops being true and the tab
+            # is gone for good. Only keys that came out of open_slots.json land
+            # here, so the persistent-only filter above still holds for them.
+            #
+            # Iterating this set is safe ONLY because the restoring_open_slots
+            # early-return above covers the one writer: the restore mutates it
+            # between tabs, and this method runs from two threads (the 5s
+            # executor flush and the shutdown thread). That guard is therefore
+            # load-bearing for thread safety here, not just for partial
+            # snapshots — do not narrow it without giving this set its own lock.
+            seen = set(keys)
+            keys.extend(
+                k
+                for k in getattr(self, "unrestored_slot_keys", frozenset())
+                if k not in seen
+            )
             payload = json.dumps({"keys": keys, "ts": time.time()})
             # Use the canonical atomic_write helper, not a deterministic
             # ".json.tmp" name — _persist_open_slots can run concurrently from

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -2985,6 +2985,23 @@ class ConversationLog:
         """Return session metadata for *key*."""
         return self._read_metadata(key)
 
+    def get_metadata_status(self, key: str) -> tuple[dict, bool]:
+        """Return ``(metadata, readable)`` for *key*.
+
+        ``readable`` is ``False`` only when the transcript exists but its
+        metadata line could not be read after
+        :data:`_METADATA_READ_ATTEMPTS` attempts. Every other empty result --
+        no transcript at all, an empty first line, an undecodable one -- is a
+        genuine answer and reports ``True``.
+
+        :meth:`get_metadata` cannot express that difference: it returns ``{}``
+        for both, and a caller that reads ``{}`` as "this session was never
+        persisted" will discard live state. Use this instead of
+        :meth:`get_metadata` wherever an empty result triggers something
+        destructive.
+        """
+        return self._read_metadata_status(key)
+
     def _pause_for_transient_retry(self) -> None:
         """Pause briefly before retrying a transient read, but ONLY off the loop.
 
@@ -3009,29 +3026,38 @@ class ConversationLog:
     def _read_metadata(self, key: str) -> dict:
         """Read the metadata line (first line) from a session JSONL file.
 
+        Thin wrapper over :meth:`_read_metadata_status` that drops the
+        readability flag, so the many callers for whom "empty" and "unreadable"
+        are equivalent keep a plain ``dict`` return.
+        """
+        return self._read_metadata_status(key)[0]
+
+    def _read_metadata_status(self, key: str) -> tuple[dict, bool]:
+        """Read the metadata line, reporting whether the read itself succeeded.
+
         Uses mtime-based caching to avoid re-reading unchanged files.
 
-        Returns ``{}`` for a session that genuinely has no metadata. A caller
-        cannot distinguish that from a transient read failure, and at least one
-        does something destructive with the answer: the open-tab restore treats
-        ``{}`` as "never persisted" and silently drops the tab. So absorb the
-        transient case HERE rather than reporting it as absence -- retry a few
-        times, and if it still fails, say so at warning level instead of
-        returning a confident empty dict. Windows makes this more than
-        theoretical: a freshly written file can be briefly unopenable while an
-        indexer or AV scanner holds it (``ERROR_SHARING_VIOLATION``), which
-        surfaces as ``PermissionError`` -- an ``OSError`` subclass.
+        Returns ``({}, True)`` for a session that genuinely has no metadata and
+        ``({}, False)`` when the file exists but could not be read after
+        retries. The retry absorbs the common transient case; the flag exists
+        because absorbing it is not always possible, and at least one caller
+        does something destructive with a confident empty answer: the open-tab
+        restore treats ``{}`` as "never persisted" and drops the tab. Windows
+        makes this more than theoretical: a freshly written file can be briefly
+        unopenable while an indexer or AV scanner holds it
+        (``ERROR_SHARING_VIOLATION``), which surfaces as ``PermissionError`` --
+        an ``OSError`` subclass.
         """
         path = self._path(key)
         if not path.exists():
             self._meta_cache.pop(key, None)
-            return {}
+            return {}, True
         for attempt in range(_METADATA_READ_ATTEMPTS):
             try:
                 mtime = path.stat().st_mtime
                 cached = self._meta_cache.get(key)
                 if cached and cached[0] == mtime:
-                    return cached[1]
+                    return cached[1], True
                 # Read ONLY the first line. The previous form slurped the entire
                 # file via read_text() and then threw all but the first line away
                 # — on a 26 MB transcript that is ~10ms and ~26 MB of transient
@@ -3056,17 +3082,28 @@ class ConversationLog:
                     _METADATA_READ_ATTEMPTS,
                     exc_info=True,
                 )
-                return {}
+                return {}, False
             if not first:
-                return {}
+                return {}, True
             try:
                 data = json.loads(first)
-                meta = data if data.get("_type") == "metadata" else {}
+                # ``isinstance`` guard, not just the _type check: a first line
+                # that is valid JSON but not an OBJECT (``null``, a list, a bare
+                # string, a number) would make ``.get`` raise AttributeError
+                # rather than JSONDecodeError. That is a corrupt metadata line
+                # exactly like an undecodable one, so report it the same way --
+                # an empty dict that IS a genuine answer -- instead of throwing a
+                # non-OSError out of a read that callers treat as total.
+                meta = (
+                    data
+                    if isinstance(data, dict) and data.get("_type") == "metadata"
+                    else {}
+                )
             except json.JSONDecodeError:
                 meta = {}
             self._meta_cache[key] = (mtime, meta)
-            return meta
-        return {}
+            return meta, True
+        return {}, True
 
     def sliding_window(self, key: str, keep_recent: int = 5) -> tuple[list[dict], list[dict]]:
         """Split messages into (older, recent) for compaction.

--- a/test/test_open_slots_persistence.py
+++ b/test/test_open_slots_persistence.py
@@ -1204,3 +1204,173 @@ def test_persistent_body_read_failure_drops_tab_not_registers_empty(tmp_path, mo
         "restore_recent_sessions would dedupe it and the history would be lost"
     )
     assert keys[0] in state2._slots and keys[2] in state2._slots
+
+
+def test_persistent_metadata_failure_keeps_key_in_reopen_seed(tmp_path, monkeypatch):
+    """A tab dropped by an unreadable read must survive in open_slots.json.
+
+    #1733 added a retry, so a ONE-shot sharing violation no longer costs a tab
+    (see ``test_a_transient_metadata_read_failure_does_not_drop_a_tab``). But
+    when the retry budget is exhausted the tab is still dropped, and the drop
+    was previously PERMANENT rather than deferred: this snapshot is taken from
+    live ``_slots``, the ``restoring_open_slots`` guard is released as soon as
+    the restore finishes, and the next 5s flush therefore rewrites the file
+    WITHOUT the dropped key. That erases the only seed a later restore could
+    have recovered from -- and ``dashboard.restore_sessions`` defaults to
+    ``False``, so the ``restore_recent_sessions`` fallback is not a safety net
+    for an unfoldered tab.
+
+    Asserts the seed, not the slot: dropping the tab for this boot is the
+    intended behaviour, losing the ability to ever restore it is not.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = [f"chat-{i}-seed" for i in range(4)]
+    for k in keys:
+        _seed_session(state, k)
+    (tmp_path / "open_slots.json").write_text(json.dumps({"keys": keys, "ts": 0.0}))
+
+    state2 = _make_state(tmp_path / "sessions")
+    victim = state2.conversation_log._path(_history_key_for(keys[2])).name
+
+    # times=3 exhausts _METADATA_READ_ATTEMPTS, so the retry cannot absorb it.
+    with builtin_open_sharing_violation(match=victim, times=3) as seen:
+        restored = restore_open_slots(state2)
+
+    assert seen["n"] >= 1, "the simulator never intercepted the transcript open"
+    assert restored == 3, f"expected the three readable tabs; got {restored}"
+    assert keys[2] not in state2._slots, "the unreadable tab should not be registered"
+    assert keys[2] in state2.unrestored_slot_keys
+
+    # The flush that previously erased it. Guard is already released by now.
+    assert state2.restoring_open_slots is False
+    state2._persist_open_slots()
+    persisted = set(json.loads((tmp_path / "open_slots.json").read_text())["keys"])
+    assert persisted == set(keys), (
+        "the post-restore flush erased the unreadable tab's key from the reopen "
+        f"seed, so it can never be restored; seed is now {sorted(persisted)}"
+    )
+
+
+def test_absent_session_is_dropped_from_reopen_seed(tmp_path, monkeypatch):
+    """Negative control: a key with no transcript is still pruned.
+
+    Preservation must be scoped to reads that FAILED. A session that genuinely
+    has no transcript is a real answer, and keeping its key would resurrect a
+    dead tab on every restart forever.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-real")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": ["chat-1-real", "chat-2-neverexisted"], "ts": 0.0})
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    restored = restore_open_slots(state2)
+
+    assert restored == 1
+    assert "chat-2-neverexisted" not in state2.unrestored_slot_keys
+    state2._persist_open_slots()
+    persisted = set(json.loads((tmp_path / "open_slots.json").read_text())["keys"])
+    assert persisted == {"chat-1-real"}
+
+
+def test_metadata_failure_is_reported_above_debug(tmp_path, monkeypatch, caplog):
+    """The restore layer must name the dropped tab, not just the history layer.
+
+    ``_read_metadata`` warns that it could not read the file, but nothing said a
+    TAB was affected -- ``restored`` was simply one lower, which is unactionable
+    when the user reports "a tab disappeared".
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _seed_session(state, "chat-1-logged")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": ["chat-1-logged"], "ts": 0.0})
+    )
+
+    state2 = _make_state(tmp_path / "sessions")
+    victim = state2.conversation_log._path(_history_key_for("chat-1-logged")).name
+    with caplog.at_level("WARNING", logger="kiro_crew.dashboard.chat_persistence"):
+        with builtin_open_sharing_violation(match=victim, times=3):
+            restore_open_slots(state2)
+
+    assert any(
+        "chat-1-logged" in r.message and "reopen seed" in r.message
+        for r in caplog.records
+    ), f"no WARNING named the affected tab; got {[r.message for r in caplog.records]}"
+
+
+def test_get_metadata_status_separates_unreadable_from_absent(tmp_path, monkeypatch):
+    """The new signal must not report absence as a read failure, or vice versa."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    log = state.conversation_log
+    assert log is not None
+    _seed_session(state, "chat-1-status")
+    history_key = _history_key_for("chat-1-status")
+
+    meta, readable = log.get_metadata_status(history_key)
+    assert readable is True and meta, "a healthy transcript must read back"
+
+    # No transcript at all -> empty, but a genuine answer.
+    meta, readable = log.get_metadata_status(_history_key_for("chat-2-missing"))
+    assert meta == {} and readable is True
+
+    # Exists but unopenable after every retry -> empty AND flagged unreadable.
+    log._meta_cache.clear()
+    victim = log._path(history_key).name
+    with builtin_open_sharing_violation(match=victim, times=3):
+        meta, readable = log.get_metadata_status(history_key)
+    assert meta == {} and readable is False
+
+    # get_metadata keeps its plain-dict contract for the same input.
+    log._meta_cache.clear()
+    with builtin_open_sharing_violation(match=victim, times=3):
+        assert log.get_metadata(history_key) == {}
+
+
+def test_non_object_metadata_line_does_not_abort_the_whole_restore(
+    tmp_path, monkeypatch
+):
+    """A transcript whose first line is valid JSON but not an OBJECT is skipped.
+
+    ``json.loads`` happily returns ``None`` / a list / a str / an int, and a bare
+    ``data.get("_type")`` on any of those raises ``AttributeError`` -- NOT
+    ``JSONDecodeError``. Two things must hold:
+
+    1. It stays isolated to the one tab. ``restore_open_slots_async`` has no
+       ``except`` at its call site in ``server.py``, so an escaping exception
+       aborts dashboard startup and no LATER tab restores either.
+    2. It is treated as a corrupt line, exactly like an undecodable one: a
+       genuine empty answer, so the key is PRUNED from the reopen seed. Carrying
+       it would retry a permanently-broken transcript on every boot forever,
+       and would disagree with the ``{not json`` case for no reason.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    keys = ["chat-0-ok", "chat-1-corrupt", "chat-2-ok"]
+    for k in keys:
+        _seed_session(state, k)
+    # Overwrite the corrupt tab's transcript so line 1 is valid JSON, not an object.
+    victim_path = state.conversation_log._path(_history_key_for("chat-1-corrupt"))
+    victim_path.write_text('null\n{"role": "user", "content": "hi"}\n')
+    (tmp_path / "open_slots.json").write_text(json.dumps({"keys": keys, "ts": 0.0}))
+
+    state2 = _make_state(tmp_path / "sessions")
+    restored = restore_open_slots(state2)
+
+    assert restored == 2, (
+        f"a corrupt metadata line cost more than its own tab; restored={restored}, "
+        f"slots={sorted(state2._slots)}"
+    )
+    assert "chat-2-ok" in state2._slots, (
+        "the tab AFTER the corrupt one did not restore -- the exception escaped "
+        "the per-tab guard and aborted the whole restore"
+    )
+    # Corrupt, not unreadable: a genuine answer, so do not carry it forever.
+    assert "chat-1-corrupt" not in state2.unrestored_slot_keys
+    state2._persist_open_slots()
+    persisted = set(json.loads((tmp_path / "open_slots.json").read_text())["keys"])
+    assert persisted == {"chat-0-ok", "chat-2-ok"}


### PR DESCRIPTION
Fixes #1836

## Problem

When the startup restore cannot read a tab's transcript metadata, it drops the tab. #1733 added a retry so a one-shot Windows sharing violation no longer costs anything, and #2052 applied the same treatment to the transcript body and picked the right outcome for a read that stays broken — drop the tab, don't register an empty one, because it is *"recoverable on a later restore pass, most reliably the next restart"*.

**That last part was not true.** The drop was permanent, not deferred.

`open_slots.json` is snapshotted from live `_slots`, and the `restoring_open_slots` guard is released the moment the restore finishes. A dropped tab is therefore absent from `_slots` when the next 5-second flush lands — and that flush rewrites the file *without its key*, destroying the only seed a later restore could have used.

Measured on `origin/main` (4 tabs, one transcript held for the full retry budget):

```
seed BEFORE restore : ['chat-0', 'chat-1', 'chat-2', 'chat-3']
restored tabs       : 3 of 4
victim in _slots    : False
guard released      : True
seed AFTER flush    : ['chat-0', 'chat-1', 'chat-3']     <- chat-2 erased
VERDICT: SEED ERASED - tab can never be restored
```

`restore_recent_sessions` is not a safety net either: `dashboard.restore_sessions` defaults to `False` (`config/loader.py:4919`), which runs that pass with `folders_only=True, window_minutes=0`, so an unfoldered tab is not recovered.

## Why it matters

The user loses a chat tab, permanently, because of a transient file lock — the exact scenario #1733 and #2052 were written to protect against. `_persist_open_slots`'s own docstring already treats this as unacceptable, and guards the *mid-restore* instance of it:

> NO-OP while `restoring_open_slots` is set. […] without this guard a flush lands mid-restore and snapshots a PARTIAL slot set over the very file being restored from — measured 77 tabs collapsing to 70. A kill in that window would drop the un-restored tabs from the sidebar **permanently**.

That guard covers the flush that lands *during* restore. This is the same harm arriving through the *post*-restore door, where the guard has already been released.

## Fix (symptom → root cause → change)

**Symptom:** a tab that fails to restore once never comes back.

**Root cause:** two separate things, and only the second is the erasure.
1. `_read_metadata` returns `{}` for three different outcomes — no transcript, an empty first line, and *a read that failed after every retry*. Its own docstring already flags this ("A caller cannot distinguish that from a transient read failure, and at least one does something destructive with the answer").
2. `_persist_open_slots` snapshots live `_slots`, so anything the restore skipped is erased on the next flush.

**Deliberately unchanged:** the tab is still dropped for the current boot and still not registered empty. Both probe runs report `restored: 3 of 4` and `victim in _slots: False`. #2052's chosen behaviour stands — this only makes its stated recovery real.

- **`ConversationLog.get_metadata_status()`** returns `(metadata, readable)`. `readable` is `False` only when the transcript exists but its metadata line could not be read after `_METADATA_READ_ATTEMPTS`. Genuine absence, an empty first line, an undecodable one, and a non-object one all report `True` — they are real answers. `_read_metadata` becomes a one-line delegate, so its ~20 call sites and the five internal `.get(...)` chains keep their plain `dict` return. This is why the fix is additive rather than changing `get_metadata`'s contract across 10 modules.
- **The restore records keys it could not read** (and keys whose rehydrate raised — the same epistemic position) in `state.unrestored_slot_keys`, and threads the metadata it just read into the existing `_prefetched_meta` parameter, so the check costs no extra I/O.
- **`_persist_open_slots` folds those keys back in.** Only keys that came out of `open_slots.json` reach it, so the persistent-only filter still covers them.
- **The restore now warns, naming the tab.** Previously only the history layer spoke, about a *file*, and `restored` was silently one lower — unactionable when a user reports "a tab disappeared".

### Preservation is scoped, so the seed cannot accumulate dead keys

Only a *failed read* is carried. Everything else is pruned as before:

| Transcript state | `get_metadata_status` | Seed |
|---|---|---|
| healthy | `(meta, True)` | restored |
| deleted (no file) | `({}, True)` | pruned |
| empty first line | `({}, True)` | pruned |
| undecodable (`{not json`) | `({}, True)` | pruned |
| non-object (`null`, `[]`, `"s"`, `42`) | `({}, True)` | pruned |
| **exists, unreadable after retries** | **`({}, False)`** | **kept** |

So the file converges to `live _slots ∪ (failed ⊆ file)`. Nothing new can enter, and a genuinely dead key leaves on the next boot.

### Two things worth flagging to reviewers

**The readability probe sits inside the per-tab `try`, and must.** `json.loads` returns `None` / a list / a str / an int happily, and a bare `.get()` on those raises `AttributeError`, not `JSONDecodeError`. `restore_open_slots_async` has **no** `except` at its call site (`server.py:3321` — only `with state.suspend_slots_push():`), so probing outside the guard turns a one-tab skip into an aborted startup that costs every later tab. An earlier revision of this PR had exactly that defect; it is now covered by a test, and `_read_metadata_status` additionally guards the `.get()` with `isinstance(data, dict)` so the exception cannot arise in the first place.

**Every tab now reaches the per-tab `yield`, including a failing one.** Previously the failure branch `continue`d past it. A failing tab still performs real I/O — the metadata read retries, and `_pause_for_transient_retry` deliberately skips its sleep while on the loop — so a run of failing tabs that skipped the yield would monopolise the event loop and feed the stall watchdog.

## Tests

Five added to `test/test_open_slots_persistence.py` (41 → 46). All five fail against unpatched `origin/main` src, verified by swapping `src/` and keeping the tests:

| Test | Locks in |
|---|---|
| `..._keeps_key_in_reopen_seed` | The headline: after the post-restore flush, the unreadable key is still in `open_slots.json`. Asserts the **seed**, not the slot — dropping for this boot is intended. |
| `..._absent_session_is_dropped_from_reopen_seed` | Negative control: a key with no transcript is still pruned. |
| `..._is_reported_above_debug` | The restore names the affected tab at WARNING. |
| `..._get_metadata_status_separates_unreadable_from_absent` | The new signal both ways, plus `get_metadata`'s unchanged dict contract. |
| `..._non_object_metadata_line_does_not_abort_the_whole_restore` | A corrupt non-object line costs only its own tab, and is pruned rather than carried forever. |

`builtin_open_sharing_violation(times=3)` exhausts the retry budget, so these exercise the *persistent* failure the retry cannot absorb — the gap left by #1733/#2052, which only cover `times=1`.

## Manual verification

macOS, Python 3.12. Reproduced with a version-agnostic probe (touches no API this PR adds, so it runs identically on both revisions):

```
########## origin/main ##########
restored tabs       : 3 of 4
seed AFTER flush    : ['chat-0-seed', 'chat-1-seed', 'chat-3-seed']
VERDICT: SEED ERASED - tab can never be restored

########## this branch ##########
restore_open_slots: metadata unreadable for chat-2-seed; keeping it in the
  reopen seed for the next restore instead of dropping it
restored tabs       : 3 of 4
seed AFTER flush    : ['chat-0-seed', 'chat-1-seed', 'chat-2-seed', 'chat-3-seed']
VERDICT: seed intact - tab recoverable on a later restore
```

Gates:

```
pytest test/test_open_slots_persistence.py              46 passed
pytest <19 suites: history|persist|slot|state|session|chat>   3172 passed, 1 failed
flake8 src/kiro_crew test                              clean
isort --check-only src/kiro_crew test                  clean
mypy src/kiro_crew/                                    3 errors (all pre-existing, hooks.py)
```

The one failure is `test_channel_history.py::TestChannelHistoryContext::test_context_builder_no_injection_without_history`, which fails identically on unpatched `origin/main` — pre-existing and unrelated.

## Screenshots

N/A — backend restore path, no user-visible surface changed.

## Notes for review

- **`unrestored_slot_keys` has an immutable `frozenset()` class-level default** on purpose. The surrounding block requires class-level defaults because several endpoint suites build a state via `DashboardState.__new__`, which never runs `__init__`; a bare `set()` there would be a single object shared by every instance. `__init__` and the restore each assign a fresh `set()`, so mutation only ever touches an instance attribute.
- **`restoring_open_slots` is now load-bearing for thread safety**, not only for partial snapshots. `_persist_open_slots` runs from two threads (the 5s executor flush and the shutdown thread) and iterates this set; the sole writer is the restore, which holds that flag for its whole generator, and the flush early-returns on it. The comment at the extend site records this so a future narrowing of the guard doesn't silently introduce a `Set changed size during iteration` race. (The synchronous `restore_open_slots`, which does not set the flag, has no production call sites — tests only.)
- **Adjacent open PRs.** #1816 rewrites `test_restore_open_slots_async_yields_between_tabs` in this same test file; that test still passes here, but a textual conflict is possible. #1841/#1971/#2032/#2038 touch `history.py`; #714/#1096/#1102/#1880/#1956/#2038 touch `chat_persistence.py`.
- **Not in scope:** issue #895 (restore materializing full slots for sidebar rows) would rewrite `_rehydrate_slot_from_history` itself. It has no open PR, and this change does not depend on how that lands.
