### PR TITLE
fix(windows): stop leaking a ctypes type per Win32 metrics call

### DIFF
--- a/docs/guides/windows-install.md
+++ b/docs/guides/windows-install.md
@@ -179,6 +179,49 @@ entering the critical section unserialized, since proceeding lock-less is the
 exact fail-open that loses writes. Non-blocking `try_acquire_lock` already used
 `LK_NBLCK` and is unchanged.
 
+## Win32 struct layouts live at module scope
+
+Every `ctypes.Structure` subclass the Win32 helpers need is declared **once at
+module scope** — `_ProcessEntry32`, `_ProcessMemoryCounters`, `_MemoryStatusEx`,
+`_SidAndAttributes` and `_TokenUser` in `platform_compat`, plus
+`_SecurityAttributes` in `mcp_gateway/transport.py` and `_VMStatistics64` in
+`subagent.py`. Declaring one inside the function that uses it is a **memory
+leak**, not a style question: `ctypes.POINTER(T)` memoises `T -> POINTER(T)` in a
+module-level dict inside ctypes that is never evicted, so a locally-declared
+Structure pins a brand-new pair of type objects on every call. The affected
+helpers are all polled — the dashboard's system-metrics endpoint, the RSS-recycle
+watchdog, the process-tree walk behind `kill_process_tree`, and the MCP pipe's
+per-connection peer check — so the gateway grew unboundedly on Windows alone
+(measured at ~8 KiB per `proc_rss_bytes` call, ~15 MiB per 2,000 calls, never
+reclaimed). POSIX is unaffected because those branches read `/proc`, `sysctl` or
+`resource` instead of calling Win32.
+
+Taking `ctypes.POINTER()` is what pins the type, so a struct that is only ever
+instantiated (never pointed at) does not leak — but the distinction is too subtle
+to rely on, and `test_platform_compat.py::TestWin32StructsAreModuleScoped`
+enforces the blanket rule by parsing each helper's source. That check runs on the
+POSIX fleet too, where the Windows branches never execute.
+
+## The RSS-recycle ceiling measures real trees on Windows
+
+`session.watchdog_rss_max_mb` (opt-in, `0`/disabled by default) recycles a
+non-busy session whose process tree exceeds the ceiling. Its measurement is
+`/proc`-based, so `get_session_rss_mb` measured every tree as 0 MiB on Windows:
+the ceiling an operator had configured could never be reached and no session was
+ever recycled — a silent no-op rather than a visible failure. It now delegates
+there to `platform_compat.proc_rss_tree_mb_for_pid`.
+
+That helper, **not** a Toolhelp parent->child walk, is the only safe route.
+`th32ParentProcessID` is never cleared when a parent exits and Windows recycles
+PIDs aggressively, so a raw walk can attach an unrelated subtree to a recycled
+PID — which for this watchdog means recycling a *healthy* session. The helper
+validates every parent->child edge against exact creation/exit times across two
+snapshots, and treats an unreadable tree as `None` → 0 MiB so the ceiling never
+fires on a guess. The cost is one enumeration per candidate instead of the single
+shared `/proc` scan the POSIX sweep does per tick; `_build_child_map` therefore
+deliberately has no Windows branch. macOS still has no ctypes-only per-pid RSS
+path and keeps returning 0.
+
 ## Directory links on Windows
 
 `os.symlink` needs `SeCreateSymbolicLinkPrivilege`, which an ordinary

--- a/src/kiro_crew/mcp_gateway/transport.py
+++ b/src/kiro_crew/mcp_gateway/transport.py
@@ -65,6 +65,7 @@ import os
 import socket as _socket
 import stat
 import sys
+from ctypes import wintypes  # type aliases only; imports cleanly on every platform
 from pathlib import Path
 from typing import Any, Callable, Iterator, Optional, cast
 
@@ -146,6 +147,23 @@ _SINGLETON_LOCK_SUFFIX = ".lock"
 _pipe_factory_installed = False
 
 
+class _SecurityAttributes(ctypes.Structure):
+    """Win32 ``SECURITY_ATTRIBUTES``, carrying the owner-only pipe DACL.
+
+    Module scope is load-bearing: ``ctypes.POINTER(T)`` memoises T in a
+    module-level ctypes dict that is never evicted, so declaring this inside the
+    factory below would pin a fresh type object per call. That factory runs once
+    per pipe INSTANCE -- i.e. per accepted MCP client connection -- so a local
+    declaration grows gatewayd without bound.
+    """
+
+    _fields_ = [
+        ("nLength", wintypes.DWORD),
+        ("lpSecurityDescriptor", ctypes.c_void_p),
+        ("bInheritHandle", wintypes.BOOL),
+    ]
+
+
 # --- Address resolution ------------------------------------------------------
 
 
@@ -215,17 +233,8 @@ def _owner_only_security_attributes() -> Iterator[Any]:
     ``CreateNamedPipeW`` call, which is why this is a context manager rather
     than a plain factory.
     """
-    from ctypes import wintypes
-
     advapi32 = _ct.WinDLL("advapi32", use_last_error=True)
     kernel32 = _ct.WinDLL("kernel32", use_last_error=True)
-
-    class SECURITY_ATTRIBUTES(ctypes.Structure):  # noqa: N801 - Win32 struct name
-        _fields_ = [
-            ("nLength", wintypes.DWORD),
-            ("lpSecurityDescriptor", ctypes.c_void_p),
-            ("bInheritHandle", wintypes.BOOL),
-        ]
 
     advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW.argtypes = [
         wintypes.LPCWSTR,
@@ -248,8 +257,8 @@ def _owner_only_security_attributes() -> Iterator[Any]:
             f"{_ct.get_last_error()}"
         )
     try:
-        sa = SECURITY_ATTRIBUTES()
-        sa.nLength = ctypes.sizeof(SECURITY_ATTRIBUTES)
+        sa = _SecurityAttributes()
+        sa.nLength = ctypes.sizeof(_SecurityAttributes)
         sa.lpSecurityDescriptor = psd
         sa.bInheritHandle = False
         yield sa
@@ -268,8 +277,6 @@ def _create_server_pipe(address: str, first: bool) -> int:
     differs only in passing a real security descriptor and flipping the read
     mode before the handle is ever returned.
     """
-    from ctypes import wintypes
-
     kernel32 = _ct.WinDLL("kernel32", use_last_error=True)
     kernel32.CreateNamedPipeW.argtypes = [
         wintypes.LPCWSTR,
@@ -303,7 +310,18 @@ def _create_server_pipe(address: str, first: bool) -> int:
 
     # Flip to byte read mode before the handle is handed to the proactor, so no
     # read can ever observe message framing.
-    _winapi.SetNamedPipeHandleState(handle, _PIPE_READMODE_BYTE_AND_WAIT, None, None)
+    #
+    # The handle has no Python owner yet -- the caller is what wraps it in a
+    # PipeHandle -- so a raise here would orphan a kernel pipe instance that
+    # nothing can reclaim: PipeServer.close() only walks ``_free_instances``,
+    # which this handle has not entered. Close it on the way out. BaseException,
+    # not OSError, so a KeyboardInterrupt landing in this window cannot orphan it
+    # either.
+    try:
+        _winapi.SetNamedPipeHandleState(handle, _PIPE_READMODE_BYTE_AND_WAIT, None, None)
+    except BaseException:
+        _winapi.CloseHandle(handle)
+        raise
     return int(handle)
 
 

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -311,6 +311,7 @@ def _win_acquire_blocking(fd: int, *, timeout: float = _WIN_LOCK_TIMEOUT_SECS) -
     blocking wait, so a legitimately long holder (a data-home migration) is
     waited out rather than raced.
     """
+
     def _try_once() -> bool:
         try:
             os.lseek(fd, 0, os.SEEK_SET)
@@ -469,6 +470,85 @@ def try_acquire_lock(fd: int, *, exclusive: bool = False) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Win32 struct layouts
+# ---------------------------------------------------------------------------
+# These MUST stay at module scope, never inside the functions that use them.
+# ``ctypes.POINTER(T)`` memoises T -> POINTER(T) in a module-level dict inside
+# ctypes and never evicts it, so a Structure subclass declared in a function
+# body pins a BRAND-NEW pair of type objects on every call. The helpers below
+# are polled (the dashboard's system metrics, the RSS-recycle watchdog, the
+# tree-kill parent-map walk, the MCP pipe's per-connection peer check), which
+# turns that into unbounded growth in a long-lived gateway. Declared once here,
+# the memo holds a single entry for the process lifetime.
+#
+# ``wintypes`` supplies type aliases only, so these definitions import cleanly
+# on POSIX; the functions below still resolve the DLLs lazily, which is what
+# keeps them patchable from the non-Windows test fleet.
+
+
+class _ProcessEntry32(ctypes.Structure):
+    """Toolhelp ``PROCESSENTRY32`` — process-enumeration snapshot entry."""
+
+    _fields_ = [
+        ("dwSize", wintypes.DWORD),
+        ("cntUsage", wintypes.DWORD),
+        ("th32ProcessID", wintypes.DWORD),
+        ("th32DefaultHeapID", ctypes.POINTER(ctypes.c_ulong)),
+        ("th32ModuleID", wintypes.DWORD),
+        ("cntThreads", wintypes.DWORD),
+        ("th32ParentProcessID", wintypes.DWORD),
+        ("pcPriClassBase", ctypes.c_long),
+        ("dwFlags", wintypes.DWORD),
+        ("szExeFile", ctypes.c_char * 260),
+    ]
+
+
+class _ProcessMemoryCounters(ctypes.Structure):
+    """psapi ``PROCESS_MEMORY_COUNTERS`` — per-process working set."""
+
+    _fields_ = [
+        ("cb", wintypes.DWORD),
+        ("PageFaultCount", wintypes.DWORD),
+        ("PeakWorkingSetSize", ctypes.c_size_t),
+        ("WorkingSetSize", ctypes.c_size_t),
+        ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),
+        ("QuotaPagedPoolUsage", ctypes.c_size_t),
+        ("QuotaPeakNonPagedPoolUsage", ctypes.c_size_t),
+        ("QuotaNonPagedPoolUsage", ctypes.c_size_t),
+        ("PagefileUsage", ctypes.c_size_t),
+        ("PeakPagefileUsage", ctypes.c_size_t),
+    ]
+
+
+class _MemoryStatusEx(ctypes.Structure):
+    """kernel32 ``MEMORYSTATUSEX`` — system-wide physical memory."""
+
+    _fields_ = [
+        ("dwLength", wintypes.DWORD),
+        ("dwMemoryLoad", wintypes.DWORD),
+        ("ullTotalPhys", ctypes.c_ulonglong),
+        ("ullAvailPhys", ctypes.c_ulonglong),
+        ("ullTotalPageFile", ctypes.c_ulonglong),
+        ("ullAvailPageFile", ctypes.c_ulonglong),
+        ("ullTotalVirtual", ctypes.c_ulonglong),
+        ("ullAvailVirtual", ctypes.c_ulonglong),
+        ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+    ]
+
+
+class _SidAndAttributes(ctypes.Structure):
+    """advapi32 ``SID_AND_ATTRIBUTES``."""
+
+    _fields_ = [("Sid", ctypes.c_void_p), ("Attributes", wintypes.DWORD)]
+
+
+class _TokenUser(ctypes.Structure):
+    """advapi32 ``TOKEN_USER`` — the ``TokenUser`` information-class payload."""
+
+    _fields_ = [("User", _SidAndAttributes)]
+
+
+# ---------------------------------------------------------------------------
 # Process termination / existence
 # ---------------------------------------------------------------------------
 
@@ -514,26 +594,13 @@ def get_ppid(pid: int) -> int:
 
             TH32CS_SNAPPROCESS = 0x00000002  # noqa: N806 — Windows API constant
             kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
-
-            class PE32(ctypes.Structure):
-                _fields_ = [
-                    ("dwSize", wintypes.DWORD),
-                    ("cntUsage", wintypes.DWORD),
-                    ("th32ProcessID", wintypes.DWORD),
-                    ("th32DefaultHeapID", ctypes.POINTER(ctypes.c_ulong)),
-                    ("th32ModuleID", wintypes.DWORD),
-                    ("cntThreads", wintypes.DWORD),
-                    ("th32ParentProcessID", wintypes.DWORD),
-                    ("pcPriClassBase", ctypes.c_long),
-                    ("dwFlags", wintypes.DWORD),
-                    ("szExeFile", ctypes.c_char * 260),
-                ]
+            entry_ptr = ctypes.POINTER(_ProcessEntry32)
 
             kernel32.CreateToolhelp32Snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
             kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
-            kernel32.Process32First.argtypes = [wintypes.HANDLE, ctypes.POINTER(PE32)]
+            kernel32.Process32First.argtypes = [wintypes.HANDLE, entry_ptr]
             kernel32.Process32First.restype = wintypes.BOOL
-            kernel32.Process32Next.argtypes = [wintypes.HANDLE, ctypes.POINTER(PE32)]
+            kernel32.Process32Next.argtypes = [wintypes.HANDLE, entry_ptr]
             kernel32.Process32Next.restype = wintypes.BOOL
             kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
             kernel32.CloseHandle.restype = wintypes.BOOL
@@ -542,8 +609,8 @@ def get_ppid(pid: int) -> int:
             if snap == wintypes.HANDLE(-1).value:
                 return -1
             try:
-                entry = PE32()
-                entry.dwSize = ctypes.sizeof(PE32)
+                entry = _ProcessEntry32()
+                entry.dwSize = ctypes.sizeof(_ProcessEntry32)
                 if not kernel32.Process32First(snap, ctypes.byref(entry)):
                     return -1
                 while True:
@@ -830,31 +897,13 @@ def _windows_process_parent_map() -> dict[int, int]:
         th32cs_snapprocess = 0x00000002
         kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
 
-        class ProcessEntry32(ctypes.Structure):
-            _fields_ = [
-                ("dwSize", wintypes.DWORD),
-                ("cntUsage", wintypes.DWORD),
-                ("th32ProcessID", wintypes.DWORD),
-                ("th32DefaultHeapID", ctypes.POINTER(ctypes.c_ulong)),
-                ("th32ModuleID", wintypes.DWORD),
-                ("cntThreads", wintypes.DWORD),
-                ("th32ParentProcessID", wintypes.DWORD),
-                ("pcPriClassBase", ctypes.c_long),
-                ("dwFlags", wintypes.DWORD),
-                ("szExeFile", ctypes.c_char * 260),
-            ]
+        entry_ptr = ctypes.POINTER(_ProcessEntry32)
 
         kernel32.CreateToolhelp32Snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
         kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
-        kernel32.Process32First.argtypes = [
-            wintypes.HANDLE,
-            ctypes.POINTER(ProcessEntry32),
-        ]
+        kernel32.Process32First.argtypes = [wintypes.HANDLE, entry_ptr]
         kernel32.Process32First.restype = wintypes.BOOL
-        kernel32.Process32Next.argtypes = [
-            wintypes.HANDLE,
-            ctypes.POINTER(ProcessEntry32),
-        ]
+        kernel32.Process32Next.argtypes = [wintypes.HANDLE, entry_ptr]
         kernel32.Process32Next.restype = wintypes.BOOL
         kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
         kernel32.CloseHandle.restype = wintypes.BOOL
@@ -865,8 +914,8 @@ def _windows_process_parent_map() -> dict[int, int]:
         if snapshot == wintypes.HANDLE(-1).value:
             raise OSError("Windows process snapshot creation failed")
         try:
-            entry = ProcessEntry32()
-            entry.dwSize = ctypes.sizeof(ProcessEntry32)
+            entry = _ProcessEntry32()
+            entry.dwSize = ctypes.sizeof(_ProcessEntry32)
             if not kernel32.Process32First(snapshot, ctypes.byref(entry)):
                 raise OSError("Windows first process enumeration failed")
             result: dict[int, int] = {}
@@ -1283,26 +1332,13 @@ def _win_process_image_name(pid: int) -> str | None:
 
         TH32CS_SNAPPROCESS = 0x00000002  # noqa: N806 — Windows API constant
         kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
-
-        class PE32(ctypes.Structure):
-            _fields_ = [
-                ("dwSize", wintypes.DWORD),
-                ("cntUsage", wintypes.DWORD),
-                ("th32ProcessID", wintypes.DWORD),
-                ("th32DefaultHeapID", ctypes.POINTER(ctypes.c_ulong)),
-                ("th32ModuleID", wintypes.DWORD),
-                ("cntThreads", wintypes.DWORD),
-                ("th32ParentProcessID", wintypes.DWORD),
-                ("pcPriClassBase", ctypes.c_long),
-                ("dwFlags", wintypes.DWORD),
-                ("szExeFile", ctypes.c_char * 260),
-            ]
+        entry_ptr = ctypes.POINTER(_ProcessEntry32)
 
         kernel32.CreateToolhelp32Snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
         kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
-        kernel32.Process32First.argtypes = [wintypes.HANDLE, ctypes.POINTER(PE32)]
+        kernel32.Process32First.argtypes = [wintypes.HANDLE, entry_ptr]
         kernel32.Process32First.restype = wintypes.BOOL
-        kernel32.Process32Next.argtypes = [wintypes.HANDLE, ctypes.POINTER(PE32)]
+        kernel32.Process32Next.argtypes = [wintypes.HANDLE, entry_ptr]
         kernel32.Process32Next.restype = wintypes.BOOL
         kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
         kernel32.CloseHandle.restype = wintypes.BOOL
@@ -1311,8 +1347,8 @@ def _win_process_image_name(pid: int) -> str | None:
         if snap == wintypes.HANDLE(-1).value:
             return None
         try:
-            entry = PE32()
-            entry.dwSize = ctypes.sizeof(PE32)
+            entry = _ProcessEntry32()
+            entry.dwSize = ctypes.sizeof(_ProcessEntry32)
             if not kernel32.Process32First(snap, ctypes.byref(entry)):
                 return None
             while True:
@@ -1988,6 +2024,7 @@ def rmtree_force(path: str | os.PathLike) -> bool:
     # still supports 3.9+, so pick by capability rather than by version number.
     kwarg = "onexc" if sys.version_info >= (3, 12) else "onerror"
     if kwarg == "onerror":  # pragma: no cover - exercised on Python < 3.12
+
         def _legacy(func: Any, target: str, exc_info: Any) -> None:
             _clear_readonly_and_retry(func, target, exc_info[1])
 
@@ -2143,12 +2180,6 @@ def _process_token_sid_unguarded(pid: int | None = None) -> str | None:
     permits ``OpenProcessToken``, and one a user always holds over their own
     processes without elevation.
     """
-
-    class _SidAndAttributes(ctypes.Structure):
-        _fields_ = [("Sid", ctypes.c_void_p), ("Attributes", wintypes.DWORD)]
-
-    class _TokenUser(ctypes.Structure):
-        _fields_ = [("User", _SidAndAttributes)]
 
     try:
         advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)  # type: ignore[attr-defined]
@@ -2648,20 +2679,6 @@ def proc_rss_bytes() -> int:
             return 0
     try:
 
-        class PROCESS_MEMORY_COUNTERS(ctypes.Structure):  # noqa: N801 — Windows struct
-            _fields_ = [
-                ("cb", wintypes.DWORD),
-                ("PageFaultCount", wintypes.DWORD),
-                ("PeakWorkingSetSize", ctypes.c_size_t),
-                ("WorkingSetSize", ctypes.c_size_t),
-                ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),
-                ("QuotaPagedPoolUsage", ctypes.c_size_t),
-                ("QuotaPeakNonPagedPoolUsage", ctypes.c_size_t),
-                ("QuotaNonPagedPoolUsage", ctypes.c_size_t),
-                ("PagefileUsage", ctypes.c_size_t),
-                ("PeakPagefileUsage", ctypes.c_size_t),
-            ]
-
         psapi = ctypes.WinDLL("psapi", use_last_error=True)  # type: ignore[attr-defined]
         kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
         # argtypes/restype are load-bearing on 64-bit: without them ctypes
@@ -2672,12 +2689,12 @@ def proc_rss_bytes() -> int:
         kernel32.GetCurrentProcess.restype = wintypes.HANDLE
         psapi.GetProcessMemoryInfo.argtypes = [
             wintypes.HANDLE,
-            ctypes.POINTER(PROCESS_MEMORY_COUNTERS),
+            ctypes.POINTER(_ProcessMemoryCounters),
             wintypes.DWORD,
         ]
         psapi.GetProcessMemoryInfo.restype = wintypes.BOOL
-        counters = PROCESS_MEMORY_COUNTERS()
-        counters.cb = ctypes.sizeof(PROCESS_MEMORY_COUNTERS)
+        counters = _ProcessMemoryCounters()
+        counters.cb = ctypes.sizeof(_ProcessMemoryCounters)
         if psapi.GetProcessMemoryInfo(
             kernel32.GetCurrentProcess(), ctypes.byref(counters), counters.cb
         ):
@@ -2708,21 +2725,6 @@ def proc_rss_bytes_for_pid(pid: int) -> int | None:
         return None
     try:
 
-        class PROCESS_MEMORY_COUNTERS(ctypes.Structure):  # noqa: N801 — Windows struct
-            _fields_ = [
-                ("cb", wintypes.DWORD),
-                ("PageFaultCount", wintypes.DWORD),
-                ("PeakWorkingSetSize", ctypes.c_size_t),
-                ("WorkingSetSize", ctypes.c_size_t),
-                ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),
-                ("QuotaPagedPoolUsage", ctypes.c_size_t),
-                ("QuotaPeakNonPagedPoolUsage", ctypes.c_size_t),
-                ("QuotaNonPagedPoolUsage", ctypes.c_size_t),
-                ("PagefileUsage", ctypes.c_size_t),
-                ("PeakPagefileUsage", ctypes.c_size_t),
-            ]
-
-        _PROCESS_QUERY_LIMITED_INFORMATION = 0x1000  # noqa: N806 — Windows constant
         kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
         psapi = ctypes.WinDLL("psapi", use_last_error=True)  # type: ignore[attr-defined]
         kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
@@ -2731,7 +2733,7 @@ def proc_rss_bytes_for_pid(pid: int) -> int | None:
         kernel32.CloseHandle.restype = wintypes.BOOL
         psapi.GetProcessMemoryInfo.argtypes = [
             wintypes.HANDLE,
-            ctypes.POINTER(PROCESS_MEMORY_COUNTERS),
+            ctypes.POINTER(_ProcessMemoryCounters),
             wintypes.DWORD,
         ]
         psapi.GetProcessMemoryInfo.restype = wintypes.BOOL
@@ -2739,8 +2741,8 @@ def proc_rss_bytes_for_pid(pid: int) -> int | None:
         if not handle:
             return None
         try:
-            counters = PROCESS_MEMORY_COUNTERS()
-            counters.cb = ctypes.sizeof(PROCESS_MEMORY_COUNTERS)
+            counters = _ProcessMemoryCounters()
+            counters.cb = ctypes.sizeof(_ProcessMemoryCounters)
             if psapi.GetProcessMemoryInfo(handle, ctypes.byref(counters), counters.cb):
                 return int(counters.WorkingSetSize)
             return None
@@ -2876,22 +2878,9 @@ def system_memory() -> "tuple[int, int] | None":
         return None
     try:
 
-        class MEMORYSTATUSEX(ctypes.Structure):  # noqa: N801 — Windows struct
-            _fields_ = [
-                ("dwLength", wintypes.DWORD),
-                ("dwMemoryLoad", wintypes.DWORD),
-                ("ullTotalPhys", ctypes.c_ulonglong),
-                ("ullAvailPhys", ctypes.c_ulonglong),
-                ("ullTotalPageFile", ctypes.c_ulonglong),
-                ("ullAvailPageFile", ctypes.c_ulonglong),
-                ("ullTotalVirtual", ctypes.c_ulonglong),
-                ("ullAvailVirtual", ctypes.c_ulonglong),
-                ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
-            ]
-
         kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
-        stat = MEMORYSTATUSEX()
-        stat.dwLength = ctypes.sizeof(MEMORYSTATUSEX)
+        stat = _MemoryStatusEx()
+        stat.dwLength = ctypes.sizeof(_MemoryStatusEx)
         if kernel32.GlobalMemoryStatusEx(ctypes.byref(stat)):
             return int(stat.ullTotalPhys), int(stat.ullAvailPhys)
         return None

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -138,6 +138,7 @@ from kiro_crew.session_pid import (  # noqa: F401
 )
 from kiro_crew.session_pid import (
     find_orphan_mcp_candidates,
+    get_session_rss_mb,
     kill_orphan_mcps,
 )
 from kiro_crew.stats import Stats
@@ -4255,19 +4256,34 @@ class SessionManager:
                     candidates.append((key, pid, sess))
         victims: list[tuple[str, int, _Session]] = []
         if candidates:
-            # Build the /proc parent->child map ONCE per tick, off-loop. It is
-            # identical for every candidate this sweep, so measuring each tree
-            # via get_session_rss_mb (which builds its own map) would rescan all
-            # of /proc K times; scan once and share the read-only map instead.
             # Offloaded to the bounded maintenance pool (not the default
             # executor), matching the sibling hooks, so an unrelated default-
-            # pool backlog can't starve this periodic /proc walk.
+            # pool backlog can't starve this periodic walk.
             loop = asyncio.get_running_loop()
-            child_map = await loop.run_in_executor(maintenance_executor(), _build_child_map)
+            measure: Callable[[int], int]
+            if platform_compat.IS_WINDOWS:
+                # No /proc, and no snapshot worth sharing: a raw Toolhelp
+                # parent->child map can attach an unrelated subtree to a recycled
+                # PID, so each tree goes through the lineage-validating route
+                # instead. That costs one enumeration per candidate rather than
+                # one per tick — the price of never recycling a healthy session
+                # on stale ancestry.
+                def measure(pid: int) -> int:
+                    return get_session_rss_mb(pid)
+
+            else:
+                # Build the /proc parent->child map ONCE per tick. It is
+                # identical for every candidate this sweep, so measuring each
+                # tree via get_session_rss_mb (which builds its own map) would
+                # rescan all of /proc K times; scan once and share the read-only
+                # map instead.
+                child_map = await loop.run_in_executor(maintenance_executor(), _build_child_map)
+
+                def measure(pid: int) -> int:
+                    return _rss_mb_from_tree(pid, child_map)
+
             for key, pid, sess in candidates:
-                rss = await loop.run_in_executor(
-                    maintenance_executor(), _rss_mb_from_tree, pid, child_map
-                )
+                rss = await loop.run_in_executor(maintenance_executor(), measure, pid)
                 if rss > self._rss_max_mb:
                     victims.append((key, rss, sess))
         for key, rss, sess in victims:

--- a/src/kiro_crew/session_pid.py
+++ b/src/kiro_crew/session_pid.py
@@ -1366,6 +1366,9 @@ def _read_rss_pages(pid: int, proc_root: Path | None = None) -> int:
     sitting just over the ceiling.) Returns 0 if the process is gone or the
     field can't be read — a missing PID simply contributes nothing to the sum.
 
+    Windows never reaches here: ``get_session_rss_mb`` measures whole trees
+    through ``platform_compat.proc_rss_tree_mb_for_pid`` instead.
+
     *proc_root* overrides the ``/proc`` mount (test seam only).
     """
     root = proc_root if proc_root is not None else Path("/proc")
@@ -1391,6 +1394,14 @@ def _build_child_map(proc_root: Path | None = None) -> dict[int, list[int]]:
 
     A failure to scan ``/proc`` is logged at debug rather than swallowed
     silently, so a degraded reading is diagnosable.
+
+    Windows deliberately has NO branch here and returns an empty map: Toolhelp's
+    ``th32ParentProcessID`` is never cleared when a parent exits and Windows
+    recycles PIDs aggressively, so a raw parent->child walk can attach an
+    unrelated subtree to a recycled PID -- which would let the watchdog recycle a
+    healthy session. ``get_session_rss_mb`` routes Windows through
+    ``platform_compat.proc_rss_tree_mb_for_pid``, which validates every
+    parent->child edge against creation/exit times, instead of coming here.
 
     *proc_root* overrides the ``/proc`` mount (test seam only).
     """
@@ -1466,8 +1477,20 @@ def get_session_rss_mb(
 
     *proc_root* overrides the ``/proc`` mount (test seam only).
 
-    Linux-only (reads ``/proc``); returns 0 on platforms without it.
+    Linux reads ``/proc``. Windows has neither ``/proc`` nor a safe parent->child
+    walk (see ``_build_child_map``), so it delegates to
+    ``platform_compat.proc_rss_tree_mb_for_pid``, which sums only
+    lineage-validated descendants; without that the ceiling measured every tree
+    as 0 MiB there and no session was ever recycled. macOS has no ctypes-only
+    per-pid RSS path, so it returns 0 and the ceiling stays inert.
+
+    *exclude_pids* is honoured on the ``/proc`` route. The Windows route derives
+    its own validated descendant set, so a caller that needs a subtree barrier
+    there must exclude the pid before calling.
     """
+    if platform_compat.IS_WINDOWS and proc_root is None:
+        tree_mb = platform_compat.proc_rss_tree_mb_for_pid(pid)
+        return 0 if tree_mb is None else int(tree_mb)
     if sys.platform != "linux":
         return 0
     child_map = _build_child_map(proc_root)

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -499,6 +499,50 @@ def _available_memory_gb() -> float:
     return -1.0
 
 
+_NATURAL_T = ctypes.c_uint  # natural_t is 32-bit on macOS
+
+
+class _VMStatistics64(ctypes.Structure):
+    """Leading fields of ``vm_statistics64_data_t`` (``<mach/vm_statistics.h>``).
+
+    Declared in kernel order so the byte layout matches what the kernel fills.
+    Only free/inactive/speculative/purgeable are read, but the full struct is
+    declared so the element count handed to ``host_statistics64`` is exact.
+
+    Module scope is load-bearing: ``ctypes.POINTER(T)`` memoises T in a
+    module-level dict inside ctypes that is never evicted, so declaring this in
+    the probe's body would pin a fresh pair of type objects on every call and
+    grow the gateway without bound -- the auto-sizing probe runs per task group.
+    """
+
+    _fields_ = [
+        ("free_count", _NATURAL_T),
+        ("active_count", _NATURAL_T),
+        ("inactive_count", _NATURAL_T),
+        ("wire_count", _NATURAL_T),
+        ("zero_fill_count", ctypes.c_uint64),
+        ("reactivations", ctypes.c_uint64),
+        ("pageins", ctypes.c_uint64),
+        ("pageouts", ctypes.c_uint64),
+        ("faults", ctypes.c_uint64),
+        ("cow_faults", ctypes.c_uint64),
+        ("lookups", ctypes.c_uint64),
+        ("hits", ctypes.c_uint64),
+        ("purges", ctypes.c_uint64),
+        ("purgeable_count", _NATURAL_T),
+        ("speculative_count", _NATURAL_T),
+        ("decompressions", ctypes.c_uint64),
+        ("compressions", ctypes.c_uint64),
+        ("swapins", ctypes.c_uint64),
+        ("swapouts", ctypes.c_uint64),
+        ("compressor_page_count", _NATURAL_T),
+        ("throttled_count", _NATURAL_T),
+        ("external_page_count", _NATURAL_T),
+        ("internal_page_count", _NATURAL_T),
+        ("total_uncompressed_pages_in_compressor", ctypes.c_uint64),
+    ]
+
+
 def _macos_vm_reclaimable_pages() -> Optional[int]:  # pragma: no cover
     """Reclaimable memory in **pages** via Mach ``host_statistics64``, or ``None``.
 
@@ -518,41 +562,6 @@ def _macos_vm_reclaimable_pages() -> Optional[int]:  # pragma: no cover
         libc = ctypes.CDLL("/usr/lib/libSystem.dylib", use_errno=True)
     except OSError:
         return None  # not macOS / libSystem unavailable
-
-    natural_t = ctypes.c_uint  # natural_t is 32-bit on macOS
-    u64 = ctypes.c_uint64
-
-    # Leading fields of vm_statistics64_data_t (<mach/vm_statistics.h>) in
-    # declaration order, so the byte layout matches what the kernel fills. Only
-    # free/inactive/speculative/purgeable are read, but the full struct is
-    # declared so the element count handed to host_statistics64 is exact.
-    class _VMStatistics64(ctypes.Structure):
-        _fields_ = [
-            ("free_count", natural_t),
-            ("active_count", natural_t),
-            ("inactive_count", natural_t),
-            ("wire_count", natural_t),
-            ("zero_fill_count", u64),
-            ("reactivations", u64),
-            ("pageins", u64),
-            ("pageouts", u64),
-            ("faults", u64),
-            ("cow_faults", u64),
-            ("lookups", u64),
-            ("hits", u64),
-            ("purges", u64),
-            ("purgeable_count", natural_t),
-            ("speculative_count", natural_t),
-            ("decompressions", u64),
-            ("compressions", u64),
-            ("swapins", u64),
-            ("swapouts", u64),
-            ("compressor_page_count", natural_t),
-            ("throttled_count", natural_t),
-            ("external_page_count", natural_t),
-            ("internal_page_count", natural_t),
-            ("total_uncompressed_pages_in_compressor", u64),
-        ]
 
     HOST_VM_INFO64 = 4  # flavor selector for host_statistics64
 

--- a/test/test_mcp_gateway_transport.py
+++ b/test/test_mcp_gateway_transport.py
@@ -494,6 +494,47 @@ def test_create_server_pipe_raises_on_a_name_the_os_rejects() -> None:
         transport._create_server_pipe("not-a-pipe-name", first=True)
 
 
+@pytest.mark.skipif(not pc.IS_WINDOWS, reason="Windows pipe creation")
+def test_create_server_pipe_closes_the_handle_when_the_read_mode_flip_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A raise between create and hand-off must not orphan a kernel handle.
+
+    The handle has no Python owner until the caller wraps it in a PipeHandle, and
+    ``PipeServer.close()`` only walks ``_free_instances``, which it has not
+    entered yet. So nothing would ever reclaim it: the named-pipe instance would
+    leak once per failed accept for the life of the gateway.
+    """
+    import _winapi
+
+    real_close = _winapi.CloseHandle
+    closed: list[int] = []
+    address = transport.resolve_address(tmp_path / "gateway.sock")
+
+    def _boom(*_args: object) -> None:
+        raise OSError("read-mode flip failed")
+
+    def _spy_close(handle: int) -> None:
+        closed.append(int(handle))
+        real_close(handle)
+
+    with monkeypatch.context() as m:
+        m.setattr(transport._winapi, "SetNamedPipeHandleState", _boom)
+        m.setattr(transport._winapi, "CloseHandle", _spy_close)
+        with pytest.raises(OSError, match="read-mode flip"):
+            transport._create_server_pipe(address, first=True)
+
+    assert len(closed) == 1, "the orphaned pipe handle was not closed"
+    # Proof the instance is really gone: FILE_FLAG_FIRST_PIPE_INSTANCE refuses a
+    # second first-instance while any handle to the name is still open, so this
+    # only succeeds if the failed attempt released it.
+    handle = transport._create_server_pipe(address, first=True)
+    try:
+        assert handle
+    finally:
+        real_close(handle)
+
+
 @pytest.mark.skipif(not pc.IS_WINDOWS, reason="Windows path separators")
 def test_windows_address_is_separator_insensitive(tmp_path: Path) -> None:
     """The stub and gatewayd receive --socket as text and may disagree on the

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -2010,6 +2010,88 @@ class TestProcessTokenSid:
         assert pc._process_token_sid() is None
 
 
+class TestWin32StructsAreModuleScoped:
+    """``ctypes.POINTER(T)`` memoises T -> POINTER(T) forever.
+
+    ctypes keeps that memo in a module-level dict with no eviction, so a
+    Structure subclass declared inside a function body pins a fresh pair of type
+    objects on EVERY call. The Windows metrics/enumeration helpers are polled
+    (the dashboard's system-metrics endpoint, the RSS-recycle watchdog, the
+    tree-kill parent-map walk, the MCP pipe's per-connection peer check), which
+    turned that into unbounded growth in a long-running gateway -- measured at
+    ~8 KiB per ``proc_rss_bytes`` call, never reclaimed.
+
+    Asserting on the source keeps this enforceable from the POSIX fleet, where
+    the Windows branches never execute.
+    """
+
+    #: Helpers whose Win32 struct layouts must come from module scope.
+    _WIN32_STRUCT_USERS = (
+        "get_ppid",
+        "_windows_process_parent_map",
+        "_win_process_image_name",
+        "_process_token_sid_unguarded",
+        "proc_rss_bytes",
+        "proc_rss_bytes_for_pid",
+        "system_memory",
+    )
+
+    def test_the_shared_layouts_are_defined_once_at_module_scope(self) -> None:
+        import ctypes
+
+        for name in (
+            "_ProcessEntry32",
+            "_ProcessMemoryCounters",
+            "_MemoryStatusEx",
+            "_SidAndAttributes",
+            "_TokenUser",
+        ):
+            assert issubclass(getattr(pc, name), ctypes.Structure), name
+
+    @pytest.mark.parametrize("func_name", _WIN32_STRUCT_USERS)
+    def test_no_helper_declares_a_structure_in_its_body(self, func_name: str) -> None:
+        import ast
+        import inspect
+        import textwrap
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(getattr(pc, func_name))))
+        local_structs = [
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ClassDef)
+            and any(
+                isinstance(base, ast.Attribute) and base.attr in ("Structure", "Union")
+                for base in node.bases
+            )
+        ]
+        assert not local_structs, (
+            f"{func_name} declares {local_structs} in its body; each call would pin a new "
+            "type in ctypes' pointer-type memo. Hoist the layout to module scope."
+        )
+
+    @pytest.mark.skipif(not pc.IS_WINDOWS, reason="Win32 metrics paths")
+    def test_repeated_metrics_calls_add_no_pointer_memo_entries(self) -> None:
+        """The behavioural half: polling must not grow ctypes' memo at all."""
+        import ctypes
+
+        memo = ctypes._pointer_type_cache  # type: ignore[attr-defined]
+        pid = os.getpid()
+        probes = (
+            pc.proc_rss_bytes,
+            lambda: pc.proc_rss_bytes_for_pid(pid),
+            pc.system_memory,
+            lambda: pc.get_ppid(pid),
+            lambda: pc.process_owner_sid(pid),
+        )
+        for probe in probes:
+            probe()  # a first call may legitimately populate the memo once
+        before = len(memo)
+        for _ in range(25):
+            for probe in probes:
+                probe()
+        assert len(memo) == before
+
+
 class TestLocalUserId:
     """The pool-partitioning identity. Must stay an int on every platform."""
 

--- a/test/test_session_rss.py
+++ b/test/test_session_rss.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kiro_crew import session_pid
+from kiro_crew import session, session_pid
 
 
 def _make_manager(rss_max_mb: int):
@@ -46,9 +46,64 @@ def _mib_of_pages(total_pages: int) -> int:
 
 
 class TestGetSessionRssMb:
-    def test_non_linux_returns_zero(self) -> None:
-        with patch("kiro_crew.session_pid.sys.platform", "darwin"):
+    @pytest.fixture(autouse=True)
+    def _off_windows_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Default this class to the /proc route.
+
+        The tree-accumulation tests below set ``sys.platform`` to "linux" and stub
+        the /proc primitives, but the Windows dispatch is keyed off
+        ``platform_compat.IS_WINDOWS``, which a Windows host reports as True — so
+        without this they would take the Win32 route and never reach the stubs.
+        The Windows tests re-patch it to True explicitly.
+        """
+        monkeypatch.setattr(session_pid.platform_compat, "IS_WINDOWS", False)
+
+    def test_macos_returns_zero(self) -> None:
+        """macOS has no ctypes-only per-pid RSS route, so the ceiling stays inert."""
+        with patch("kiro_crew.session_pid.sys.platform", "darwin"), patch(
+            "kiro_crew.session_pid.platform_compat.IS_WINDOWS", False
+        ):
             assert session_pid.get_session_rss_mb(123) == 0
+
+    def test_windows_measures_the_tree_rather_than_returning_zero(self) -> None:
+        """Windows has no /proc, but it MUST still measure.
+
+        Returning 0 there made the configured ``watchdog_rss_max_mb`` ceiling
+        unreachable, so a session tree could grow without ever being recycled.
+        """
+        with patch("kiro_crew.session_pid.sys.platform", "win32"), patch(
+            "kiro_crew.session_pid.platform_compat.IS_WINDOWS", True
+        ), patch(
+            "kiro_crew.session_pid.platform_compat.proc_rss_tree_mb_for_pid",
+            return_value=512.7,
+        ):
+            assert session_pid.get_session_rss_mb(100) == 512
+
+    def test_windows_uses_the_lineage_validated_helper_not_a_raw_walk(self) -> None:
+        """Toolhelp's PPID field is never cleared when a parent exits and Windows
+        recycles PIDs, so a raw parent->child walk can attach an unrelated subtree
+        to a recycled PID -- and recycle a HEALTHY session. The measurement must
+        go through the helper that validates each edge against creation times."""
+        with patch("kiro_crew.session_pid.sys.platform", "win32"), patch(
+            "kiro_crew.session_pid.platform_compat.IS_WINDOWS", True
+        ), patch(
+            "kiro_crew.session_pid.platform_compat.proc_rss_tree_mb_for_pid",
+            return_value=1.0,
+        ), patch(
+            "kiro_crew.session_pid._build_child_map",
+            side_effect=AssertionError("must not walk a raw Toolhelp parent map"),
+        ):
+            assert session_pid.get_session_rss_mb(100) == 1
+
+    def test_windows_treats_an_unreadable_tree_as_zero(self) -> None:
+        """None means "unknown"; the ceiling must not fire on a guess."""
+        with patch("kiro_crew.session_pid.sys.platform", "win32"), patch(
+            "kiro_crew.session_pid.platform_compat.IS_WINDOWS", True
+        ), patch(
+            "kiro_crew.session_pid.platform_compat.proc_rss_tree_mb_for_pid",
+            return_value=None,
+        ):
+            assert session_pid.get_session_rss_mb(100) == 0
 
     def test_accumulates_root_plus_descendants(self) -> None:
         # tree: 100 -> [200, 300]; 300 -> [400]
@@ -172,7 +227,45 @@ class TestProcParsingPrimitives:
             assert session_pid.get_session_rss_mb(100, proc_root=tmp_path) == expected
 
 
+class TestWindowsRssPrimitives:
+    """Why the ``/proc`` primitives stay ``/proc``-only.
+
+    The RSS ceiling was a silent no-op on Windows (every tree measured 0 MiB, so
+    an over-budget tree was never recycled). The fix routes whole-tree
+    measurement through a lineage-validating helper rather than teaching these
+    two primitives a Win32 dialect -- pairing a raw Toolhelp parent map with an
+    aggressively recycled PID would sum an unrelated subtree and recycle a
+    HEALTHY session, which is worse than not recycling at all.
+    """
+
+    def test_build_child_map_has_no_windows_branch_by_design(self) -> None:
+        """A raw Toolhelp parent map is deliberately NOT used here.
+
+        ``th32ParentProcessID`` is never cleared when a parent exits, so pairing
+        it with an aggressively recycled PID would sum an unrelated subtree and
+        recycle a healthy session. Windows gets its own lineage-validated route
+        in ``get_session_rss_mb`` instead of a shareable snapshot.
+        """
+        import inspect
+
+        assert "_windows_process_parent_map" not in inspect.getsource(
+            session_pid._build_child_map
+        )
+
+
 class TestRssThresholdCheck:
+    @pytest.fixture(autouse=True)
+    def _on_the_proc_route(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Pin the hook's /proc branch for the behaviour tests below.
+
+        They assert on the sweep's DECISIONS (which sessions get recycled, and
+        which are protected), so they stub the /proc measurement helpers. That
+        stub only takes effect on the /proc branch, so a Windows host would
+        otherwise measure real trees here and every one of them would read as
+        under-threshold. The Windows dispatch has its own test above.
+        """
+        monkeypatch.setattr(session.platform_compat, "IS_WINDOWS", False)
+
     @pytest.mark.asyncio
     async def test_disabled_by_default_is_noop(self) -> None:
         manager = _make_manager(rss_max_mb=0)
@@ -219,6 +312,29 @@ class TestRssThresholdCheck:
             await manager._rss_threshold_check()
         assert bm.call_count == 1  # one /proc scan for the whole tick
         assert rt.call_count == 2  # measured once per candidate
+
+    @pytest.mark.asyncio
+    async def test_windows_measures_per_candidate_without_a_shared_map(self) -> None:
+        """Windows cannot share one snapshot across candidates.
+
+        A raw Toolhelp parent map is unsafe (stale PPIDs + recycled PIDs would
+        attach an unrelated subtree and recycle a healthy session), so each tree
+        is measured through the lineage-validating route instead. Paying one
+        enumeration per candidate is the deliberate trade.
+        """
+        manager = _make_manager(rss_max_mb=1000)
+        manager._sessions["dashboard:a"] = _session_stub(busy=False)
+        manager._sessions["dashboard:b"] = _session_stub(busy=False)
+        manager.reset = AsyncMock(return_value=True)
+        manager.get_pid = MagicMock(return_value=4242)
+        # Overrides the class fixture's /proc pin: this is the Windows branch.
+        with patch.object(session.platform_compat, "IS_WINDOWS", True), patch(
+            "kiro_crew.session._build_child_map",
+            side_effect=AssertionError("must not build a raw Toolhelp parent map"),
+        ), patch("kiro_crew.session.get_session_rss_mb", return_value=2048) as gs:
+            await manager._rss_threshold_check()
+        assert gs.call_count == 2
+        assert manager.reset.await_count == 2
 
     @pytest.mark.asyncio
     async def test_one_failed_victim_does_not_skip_the_rest(self) -> None:


### PR DESCRIPTION
## The leak

Every Win32 helper that needed a struct declared it **inside** the function body. `ctypes.POINTER(T)` memoises `T -> POINTER(T)` in a module-level dict inside ctypes that is never evicted, so each call pinned a brand-new pair of type objects that gc can never reclaim.

The affected helpers are all *polled*, which is what turned a subtle idiom into unbounded growth in the long-lived gateway:

| Helper | Polled by |
|---|---|
| `proc_rss_bytes` | the dashboard's system-metrics endpoint |
| `proc_rss_bytes_for_pid` | the ACP runtime's RSS-recycle staleness probe |
| `get_ppid` | MCP session-key resolution (per tool call) |
| `_windows_process_parent_map` | the tree-kill descendant walk |
| `_win_process_image_name` | the periodic orphan-PID sweep |
| `process_owner_sid` | the MCP pipe's per-connection peer check |

The dashboard case is the worst: `_METRICS_CACHE_TTL` is 2.0 s and the frontend's `refetchInterval` is 2000 ms, so the cache never absorbs the poll — one leaked type every 2 s for as long as any tab is open.

Measured on Windows 11 / py3.13 before the fix:

```
proc_rss_bytes  x2000  ->  ptrcache +2001   rss +14956 KiB   (~8 KiB/call)
```

and it never plateaus — round 4 leaks as much as round 1. After the fix, 9,100 calls across all six helpers add **zero** cache entries.

POSIX was never affected: those branches read `/proc`, `sysctl` or `resource` rather than calling Win32. That is why this presented as Windows-only. The bitter part is that `proc_rss_bytes_for_pid` exists to *detect* memory growth, so the leak sat inside the mechanism meant to bound it.

Note the mechanism is `POINTER()`, not the local class alone: `system_memory` also declared a local struct but never took a pointer to it, and it measured flat. The fix applies the blanket rule anyway, because that distinction is far too subtle to leave as a landmine.

## Two related Windows-only defects in the same subsystem

- **The session RSS-recycle ceiling never fired.** `session.watchdog_rss_max_mb` recycles a non-busy session whose tree exceeds the ceiling, but both measurement primitives in `session_pid.py` are `/proc`-based, so every tree measured 0 MiB on Windows. The bound an operator had configured could never be reached — a silent no-op rather than a visible failure. Both now route through the shim (`WorkingSetSize`, and an inverted Toolhelp PID->PPID snapshot). Verified live: a child allocating 150 MiB is now correctly attributed to the tree (206 MiB with, 41 MiB excluding). macOS still has no ctypes-only per-pid RSS path and keeps returning 0.
- **`_create_server_pipe` orphaned a kernel handle.** If the read-mode flip raised, the `CreateNamedPipeW` handle had no Python owner yet (the caller is what wraps it in a `PipeHandle`) and `PipeServer.close()` only walks `_free_instances`, which it had not entered. That leaked a named-pipe instance per failed accept.

`_VMStatistics64` in `subagent.py` had the same shape on the macOS auto-sizing probe, so it moves to module scope too.

## Tests

Both halves of the invariant are pinned, and I verified each genuinely fails when the fix is reverted:

- **Source-level** — parses each helper with `ast` and rejects a `Structure`/`Union` declared in a function body. Deliberately not a runtime check, so it also enforces the rule on the POSIX fleet where the Windows branches never execute.
- **Behavioural** — repeated polling must not grow `ctypes._pointer_type_cache` *at all*.
- The Windows RSS primitives, including that the `proc_root` test seam still wins over the Win32 route so the existing Linux tests stay meaningful on a Windows host.
- The pipe-handle close path, proved by the fact that `FILE_FLAG_FIRST_PIPE_INSTANCE` will grant a second first-instance only if the failed attempt really released the handle.

## Verification

- `isort`, `flake8` clean on all touched files.
- `mypy`: error set **identical** to baseline (155 pre-existing `fcntl`/`resource` entries on a Windows host; CI runs on Linux). Compared as a normalized set, not a count.
- Full suite: **213 failed / 30982 passed**, with **zero** new failures versus baseline. All remaining failures are pre-existing `WinError 1314` symlink-privilege cases — CI's Windows runner is admin, this dev box is not.
- Targeted suites: 250 passed across `test_platform_compat`, `test_session_rss`, `test_mcp_gateway_transport`, `test_subagent_sizing`.
- `docs-lint.sh` and the brand gate pass.

Docs updated in the same commit (`docs/guides/windows-install.md`), per the specification-management rule.