### PR TITLE
fix(install): make the Linux install/start/configure/update path work on Ubuntu and CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,9 +330,15 @@ chat. Read the [security architecture](docs/architecture/security-deep-dive.md) 
 
 **Installer details.** The installer resolves the channel feed, verifies the wheel's SHA-256 against
 the published manifest, installs through `pipx` when available or a managed
-virtual environment at `~/.kiro/crew/venv`, and records the channel in
-`~/.kiro/crew/channel`. The channels are `stable`, `insider`, and `nightly`, and
-`KIROCREW_CHANNEL` sets the default.
+virtual environment at `~/.kiro/crew-venv` (beside the data home; override with
+`KIROCREW_VENV`), and records the channel in `~/.kiro/crew/channel`. The channels
+are `stable`, `insider`, and `nightly`, and `KIROCREW_CHANNEL` sets the default.
+On Linux it installs a Python 3.10+ interpreter from your distro when the system
+lacks one — via `apt` on Debian/Ubuntu, `dnf` on Amazon Linux / RHEL / CentOS
+Stream, `yum` on CentOS 7. Where no base-repo package supplies 3.10+ (CentOS 7,
+older Ubuntu) it uses an already-installed [mise](https://mise.jdx.dev/) if you
+have one, otherwise it prints how to install a newer Python and stops. The
+signed installer never pipes an unsigned third-party script into a shell.
 
 **Pin an exact wheel.** You can also install one exact wheel directly and pin it to its published
 SHA-256. Every version directory publishes a `SHA256SUMS` file next to the
@@ -381,6 +387,17 @@ kirocrew service install
 kirocrew service status
 kirocrew logs
 ```
+
+To bind a non-default port (for example a host where `5476` is already taken),
+set `KIROCREW_PORT` when you install the service — the value is baked into the
+unit:
+
+```bash
+KIROCREW_PORT=5477 kirocrew service install
+```
+
+To change it later without reinstalling, edit `/etc/kirocrew/kirocrew.env`
+(created by `service install`) and run `sudo systemctl restart kirocrew`.
 
 The desktop app can use this local Gateway or connect to a remote one. For an
 always-on VPS, home server, or cloud VM in your account, follow the

--- a/cli.sh
+++ b/cli.sh
@@ -128,24 +128,83 @@ command -v openssl >/dev/null 2>&1 || err "openssl is required to verify the sig
 # fine on 3.9 and then crash on first run. Prefer the newest interpreter the
 # project builds and tests on (3.12 is the CI target); 3.13 is untested and
 # only a last resort before bare python3, which itself only counts if >=3.10.
-PY=""
-for c in python3.12 python3.11 python3.10 python3.13 python3; do
-  command -v "$c" >/dev/null 2>&1 || continue
-  if "$c" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null; then
-    PY="$c"; break
+_py_usable() {
+  command -v "$1" >/dev/null 2>&1 || return 1
+  "$1" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null
+}
+
+# Resolve the newest supported interpreter into PY (left empty if none found).
+_resolve_python() {
+  for _c in python3.12 python3.11 python3.10 python3.13 python3; do
+    if _py_usable "$_c"; then PY="$_c"; return 0; fi
+  done
+  return 1
+}
+
+# Privilege prefix for a package-manager install: empty when already root or
+# when no sudo exists; otherwise `sudo`. Two sudo shapes by context:
+#   - A real terminal on stdin (`sh cli.sh` run interactively): use a normal
+#     `sudo`, which may prompt for a password the user can actually type. A
+#     non-interactive `sudo -n` here would fail on any password-protected sudo
+#     and drop the whole distro-install path (a fresh Ubuntu never installs
+#     python3-venv, then the venv step aborts).
+#   - No controlling TTY (the documented `curl ... | sh` pipe): only a
+#     passwordless `sudo -n` can work, so gate on it and otherwise leave SUDO
+#     empty and let the install attempt fail through to the guidance below.
+SUDO=""
+if [ "$(id -u)" != "0" ] && command -v sudo >/dev/null 2>&1; then
+  # A terminal on EITHER stdin or stderr means a password prompt can be shown
+  # and answered -- true for `sh cli.sh` and also for `curl ... | sh` in a normal
+  # shell, where stdin is the pipe but stderr is still the tty. Only when
+  # neither is a terminal (cron, CI, fully redirected) do we require a
+  # passwordless `sudo -n` and otherwise leave SUDO empty.
+  if [ -t 0 ] || [ -t 2 ]; then
+    SUDO="sudo"
+  elif sudo -n true 2>/dev/null; then
+    SUDO="sudo -n"
   fi
-done
-if [ -z "$PY" ] && command -v dnf >/dev/null 2>&1; then
-  # Amazon Linux 2023 ships python3 = 3.9; a 3.10+ interpreter is one dnf away.
-  echo "No Python >=3.10 found; attempting: dnf install python3.11 ..."
-  if [ "$(id -u)" = "0" ]; then
-    dnf install -y -q python3.11 >/dev/null 2>&1 || true
-  elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-    sudo dnf install -y -q python3.11 >/dev/null 2>&1 || true
-  fi
-  command -v python3.11 >/dev/null 2>&1 && PY="python3.11"
 fi
-[ -n "$PY" ] || err "Python >=3.10 is required (KiroCrew uses 3.10+ stdlib features). On Amazon Linux: sudo dnf install python3.11"
+
+PY=""
+_resolve_python || true
+if [ -z "$PY" ]; then
+  # No system Python >=3.10. Try the distro package manager first, then re-probe.
+  # Covers Debian/Ubuntu (apt), Amazon Linux 2023 / RHEL 8+ / CentOS Stream
+  # (dnf), and RHEL/CentOS 7 (yum). The apt branch also pulls python3-venv, which
+  # Debian splits out of the base interpreter (see the venv step below).
+  if command -v apt-get >/dev/null 2>&1; then
+    echo "No Python >=3.10 found; attempting: apt-get install python3 python3-venv python3-pip ..."
+    $SUDO apt-get update -qq >/dev/null 2>&1 || true
+    $SUDO apt-get install -y python3 python3-venv python3-pip >/dev/null 2>&1 || true
+  elif command -v dnf >/dev/null 2>&1; then
+    echo "No Python >=3.10 found; attempting: dnf install python3.11 ..."
+    $SUDO dnf install -y -q python3.11 python3.11-pip >/dev/null 2>&1 || true
+  elif command -v yum >/dev/null 2>&1; then
+    echo "No Python >=3.10 found; attempting: yum install python3 ..."
+    $SUDO yum install -y -q python3 python3-pip >/dev/null 2>&1 || true
+  fi
+  _resolve_python || true
+fi
+if [ -z "$PY" ]; then
+  # The distro packages could not supply >=3.10: RHEL/CentOS 7 ships 3.6 and
+  # older Ubuntu 3.8, and neither has a >=3.10 package in its base repos. If the
+  # operator has ALREADY installed mise (its python-build-standalone runs on old
+  # glibc and bundles venv/pip), use it. This installer never bootstraps mise
+  # itself: piping an unsigned third-party script into `sh` would break the
+  # whole point of a signed installer (pinned key + SHA-256-verified wheel, no
+  # unsigned fallback). A source build MAY provision mise -- see
+  # ensure-python.sh -- but that is an explicit, non-piped path, not this
+  # published one-liner.
+  MISE="$HOME/.local/bin/mise"
+  [ -x "$MISE" ] || MISE="$(command -v mise 2>/dev/null || true)"
+  if [ -n "$MISE" ] && [ -x "$MISE" ]; then
+    echo "No system Python >=3.10; using your installed mise to provision one ..."
+    "$MISE" use -g "python@3.12" >/dev/null 2>&1 || true
+    _cand="$("$MISE" which python 2>/dev/null || true)"
+    if _py_usable "$_cand"; then PY="$_cand"; fi
+  fi
+fi
+[ -n "$PY" ] || err "Python >=3.10 is required and could not be found. Install it (Debian/Ubuntu: 'sudo apt-get install python3 python3-venv python3-pip'; RHEL/CentOS 8+/Amazon Linux: 'sudo dnf install python3.11'; CentOS 7: install a newer Python via SCL or mise, e.g. 'curl https://mise.run | sh && mise use -g python@3.12'), then re-run."
 if command -v sha256sum >/dev/null 2>&1; then SHA_CMD="sha256sum"
 elif command -v shasum  >/dev/null 2>&1; then SHA_CMD="shasum -a 256"
 else err "need sha256sum or shasum to verify the download"; fi
@@ -328,6 +387,26 @@ else
   VENV="${KIROCREW_VENV:-${_DATA_HOME_FOR_VENV%/}-venv}"
   _OLD_VENV="${_DATA_HOME_FOR_VENV%/}/venv"
   echo "Installing into managed venv at $VENV ..."
+  # Debian/Ubuntu ship the base `python3` WITHOUT the venv/ensurepip module (it
+  # lives in the separate `python3-venv` / `python3.X-venv` package), so
+  # `python3 -m venv` there dies with "ensurepip is not available" and, under
+  # `set -eu`, aborts the whole install with a raw stack trace. Probe the
+  # capability first; if it is missing, try to apt-install the version-matched
+  # venv package, then re-probe. A minimal RHEL/CentOS python bundles venv, so
+  # this only bites apt systems.
+  if ! "$PY" -c 'import ensurepip, venv' >/dev/null 2>&1; then
+    if command -v apt-get >/dev/null 2>&1; then
+      # e.g. "3.12" -> python3.12-venv; also install the generic python3-venv so
+      # a bare `python3` interpreter is covered too.
+      _pyminor="$("$PY" -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null || true)"
+      echo "Installing the venv module (python3-venv) ..."
+      $SUDO apt-get update -qq >/dev/null 2>&1 || true
+      $SUDO apt-get install -y "python${_pyminor}-venv" python3-venv >/dev/null 2>&1 \
+        || $SUDO apt-get install -y python3-venv >/dev/null 2>&1 || true
+    fi
+    "$PY" -c 'import ensurepip, venv' >/dev/null 2>&1 \
+      || err "$PY cannot create a virtual environment (the venv/ensurepip module is missing). On Debian/Ubuntu install it with 'sudo apt-get install python3-venv' (or 'python${_pyminor:-3}-venv'), then re-run."
+  fi
   "$PY" -m venv "$VENV"
   "$VENV/bin/pip" install --quiet --upgrade pip >/dev/null 2>&1 || true
   "$VENV/bin/pip" install --quiet "$WHL"
@@ -379,6 +458,20 @@ printf '%s\n' "$CHANNEL" > "$_DATA_HOME/channel"
 echo ""
 echo "Installed kirocrew $VER (channel: $CHANNEL)."
 case ":$PATH:" in
-  *":$BIN:"*) echo "Run: kirocrew --help" ;;
-  *) echo "Add $BIN to your PATH, then run: kirocrew --help" ;;
+  *":$BIN:"*) : ;;
+  *) echo "Add $BIN to your PATH first (e.g. add it in your shell profile)." ;;
 esac
+# Point at the actual next step, not just --help: a user who ran the one-liner
+# wants a running gateway. The persistent-service path (systemd/launchd) is
+# otherwise buried in the docs, which is the #1 remote-crew onboarding
+# complaint. `service install` is the durable path; `gateway` is the foreground
+# one for a quick look.
+echo ""
+echo "Next steps:"
+echo "  kirocrew gateway            # start the dashboard now (http://localhost:5476)"
+echo "  kirocrew service install    # run it 24/7 as a service (survives logout, restarts on crash)"
+echo "  kirocrew --help             # everything else"
+echo ""
+echo "Need a non-default port (e.g. 5476 is already taken)? Set it at install time;"
+echo "it is baked into the service unit:"
+echo "  KIROCREW_PORT=5477 kirocrew service install"

--- a/cloud-install.sh
+++ b/cloud-install.sh
@@ -52,6 +52,13 @@ OS="$(uname -s)"
 ARCH="$(uname -m)"
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 
+# Privilege prefix for package installs: empty when already root (a minimal
+# CentOS / container image often has no `sudo` binary, and invoking it would
+# abort the installer under `set -e` with command-not-found), empty when sudo
+# is simply absent, else `sudo`.
+SUDO=""
+if [ "$(id -u)" != "0" ] && has sudo; then SUDO="sudo"; fi
+
 echo
 echo "  ${MAGENTA}${BOLD}KiroCrew — run on your own AWS${RESET}"
 echo "  ${DIM}Platform: $OS $ARCH${RESET}"
@@ -67,11 +74,17 @@ if [ -z "$PY" ]; then
         info "Installing the Xcode command-line tools (provides python3)…"
         xcode-select --install 2>/dev/null || true
         warn "Finish the Xcode CLT install if prompted, then re-run this script."
-    elif has apt-get; then sudo apt-get update -qq && sudo apt-get install -y python3 python3-venv python3-pip
-    elif has dnf; then sudo dnf install -y python3 python3-pip
+    elif has apt-get; then $SUDO apt-get update -qq && $SUDO apt-get install -y python3 python3-venv python3-pip
+    elif has dnf; then $SUDO dnf install -y python3.11 python3.11-pip 2>/dev/null || $SUDO dnf install -y python3 python3-pip
+    elif has yum; then $SUDO yum install -y python3 python3-pip
     elif has brew; then brew install python@3.12
     fi
-    for c in python3.12 python3.11 python3.10 python3; do has "$c" && PY="$c" && break; done
+    # Re-probe with the same >=3.10 gate as above -- a bare existence check would
+    # wrongly latch onto a distro's default python3 (RHEL/CentOS 7 = 3.6,
+    # Amazon Linux 2023 = 3.9), which then fails later at pip/venv.
+    for c in python3.12 python3.11 python3.10 python3; do
+        if has "$c" && "$c" -c 'import sys; assert sys.version_info>=(3,10)' 2>/dev/null; then PY="$c"; break; fi
+    done
 fi
 [ -n "$PY" ] || { warn "Python 3.10+ required. Install it and re-run."; exit 1; }
 ok "$($PY --version 2>&1)"

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -97,6 +97,18 @@ home (`~/.kiro/crew-venv`, override with `KIROCREW_VENV`) and symlinks
 data home, so no whole-home operation can ever delete the live interpreter. The
 selected channel is recorded to `~/.kiro/crew/channel`.
 
+If the host has no Python 3.10+, the installer installs one from your distro:
+`apt` on Debian/Ubuntu (including the split `python3-venv` package), `dnf` on
+Amazon Linux / RHEL / CentOS Stream, and `yum` on CentOS 7. Where no base-repo
+package supplies 3.10+ (CentOS 7 ships 3.6, older Ubuntu 3.8) it uses an
+**already-installed** [mise](https://mise.jdx.dev/) python-build-standalone
+interpreter if you have one (it runs on the older glibc those releases carry);
+otherwise it prints how to get a newer Python and stops. The signed installer
+never pipes an unsigned third-party script into a shell — to use the mise path,
+install mise yourself first (`curl https://mise.run | sh`). When it finishes it
+prints the next step: `kirocrew gateway` to start now, or `kirocrew service
+install` to run it as a service.
+
 ### b. From source (development)
 
 Build the dashboard, install the backend into a local virtualenv (`.venv`), and
@@ -280,6 +292,9 @@ so all user customizations survive.
 `KIROCREW_PORT` is an environment variable validated at CLI entry, not a config
 key. `--port` on the CLI overrides it (`--port auto` binds an OS-assigned
 ephemeral port). The `dashboard.url` config key only advertises a remote URL.
+For the installed service the port is baked into the unit at install time — see
+[Running as a service](#running-as-a-service) for how to set and later change
+it.
 
 ### The data home lives under `~/.kiro/`
 
@@ -337,7 +352,41 @@ kirocrew service uninstall
 
 On Linux this writes `/etc/systemd/system/kirocrew.service` (sudo is prompted
 for the unit file and the `systemctl` calls; the gateway itself runs as your own
-user, never under sudo). On macOS it writes a launchd plist and needs no sudo.
+user, never under sudo). When you are already root — a minimal container or
+`root` login — no `sudo` binary is required. On macOS it writes a launchd plist
+and needs no sudo.
+
+The gateway runs untrusted agent tools, so it must run as a **non-root** user:
+the installer sets `User=` to the account behind `sudo` (`$SUDO_USER`, else
+`$USER`), and **refuses to install a `User=root` service**. From a bare `root`
+login (or `sudo` with no `$SUDO_USER`), first create or pick a normal account and
+install as it, e.g. `sudo -u <user> KIROCREW_KIRO_BIN=... kirocrew service
+install` (the official Docker image already runs as the `kirocrew` user).
+
+### Setting the service port
+
+A system service inherits none of your shell environment, so `export
+KIROCREW_PORT=…` in your shell does **not** reach it. Set the port when you
+install so it is baked into the unit:
+
+```bash
+KIROCREW_PORT=5477 kirocrew service install
+```
+
+To change it later without reinstalling, edit the overrides file the installer
+creates and restart:
+
+```bash
+sudo sed -i 's/^#\?KIROCREW_PORT=.*/KIROCREW_PORT=5477/' /etc/kirocrew/kirocrew.env
+sudo systemctl restart kirocrew
+```
+
+`/etc/kirocrew/kirocrew.env` is read by the unit via `EnvironmentFile=`, so its
+values override the install-time snapshot and survive a reinstall. Use this to
+move the service off the default `5476` when that port is already taken (for
+example by a local crew you also run on this host — there is one
+`kirocrew.service` unit, so re-running `service install` updates it in place
+rather than creating a second service).
 
 For remote hosts, see [remote-and-mobile.md](remote-and-mobile.md).
 

--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -21,7 +21,8 @@ Four parts, in the order you will need them:
 ### Host requirements
 
 - **OS**: any modern Linux distribution (Ubuntu 22.04+, Debian 12+, Fedora,
-  Amazon Linux 2023). macOS works too, with launchd instead of systemd.
+  CentOS Stream / RHEL 8+, CentOS 7, Amazon Linux 2 / 2023). macOS works too,
+  with launchd instead of systemd.
 - **Python**: 3.10 or newer (`setup.cfg` sets `python_requires = >=3.10`).
 - **Node.js**: needed to build the dashboard bundle. `website/package.json`
   declares `"node": "20 || >=22"`; `kirocrew doctor` warns below Node 16.
@@ -39,14 +40,26 @@ Four parts, in the order you will need them:
 ### Install the basics
 
 ```bash
-# Debian / Ubuntu
+# Debian / Ubuntu (python3-venv is a separate package here)
 sudo apt-get update && sudo apt-get install -y git tmux python3 python3-pip python3-venv
 
-# Fedora / Amazon Linux 2023
-sudo dnf install -y git tmux python3 python3-pip
+# Fedora / CentOS Stream / RHEL 8+ / Amazon Linux 2023 (python3 may be 3.9;
+# python3.11 gives the 3.10+ the backend needs)
+sudo dnf install -y git tmux python3.11 python3.11-pip
+
+# CentOS 7 / RHEL 7 (yum; base repos ship only Python 3.6, which is too old —
+# install a newer interpreter yourself first, e.g. mise; see below)
+sudo yum install -y git tmux
+curl https://mise.run | sh && mise use -g python@3.12
 ```
 
-Install Node.js from your distro, [nodejs.org](https://nodejs.org/), or a
+The `curl … | sh` installer performs this distro Python bootstrap for you. On
+CentOS 7 and older Ubuntu, where no base-repo package supplies Python 3.10+, it
+uses an already-installed [mise](https://mise.jdx.dev/) if you have one and
+otherwise stops with instructions — the signed installer does not pipe an
+unsigned script into a shell, so install mise yourself first
+(`curl https://mise.run | sh`) if you want that path. Install Node.js from your
+distro, [nodejs.org](https://nodejs.org/), or a
 version manager such as [nvm](https://github.com/nvm-sh/nvm). `tmux` is handy
 for a first smoke test before you install the service.
 

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -681,11 +681,26 @@ on crash, and starts on boot. Implemented in `src/kiro_crew/service/`.
 
 - **Linux** (`current_platform() == SYSTEMD`):
   - Unit file: `/etc/systemd/system/kirocrew.service` (root-owned).
-  - Install: `sudo tee` writes the unit, then `sudo systemctl
+  - Install: `sudo install` writes the unit, then `sudo systemctl
     daemon-reload && sudo systemctl enable --now kirocrew.service`.
+    Privilege is resolved per call: already-root (euid 0) skips `sudo`
+    entirely — required on minimal container / `root`-login images that
+    ship no `sudo` binary — and a non-root caller with no `sudo` fails
+    with a clear `ServiceInstallError` rather than an uncaught
+    `FileNotFoundError`.
   - The gateway runs as `User=$USER Group=$(id -gn)` — kirocrew
-    code never runs under sudo. Only `tee` and `systemctl` invocations
+    code never runs under sudo. Only `install` and `systemctl` invocations
     are elevated.
+  - **Environment**: values are captured from the installer's environment
+    into the unit's `Environment=` lines at install time
+    (`service_environment()` in `service/common.py`) — this is how
+    `KIROCREW_PORT=5477 kirocrew service install` binds a non-default port.
+    The unit also reads `EnvironmentFile=-/etc/kirocrew/kirocrew.env`, an
+    operator-editable file the installer seeds create-if-absent (a reinstall
+    never clobbers edits). systemd applies the file AFTER — and overriding —
+    the baked `Environment=` lines, so editing it and running `sudo systemctl
+    restart kirocrew` changes a value (e.g. the port) without reinstalling.
+    Uninstall removes the file and its `/etc/kirocrew` directory.
   - Boot survival via `WantedBy=multi-user.target` (no linger needed —
     that's a user-service concept; this is system-level).
   - Crash-loop safety: `StartLimitBurst=3 StartLimitIntervalSec=300`.

--- a/src/kiro_crew/service/controller.py
+++ b/src/kiro_crew/service/controller.py
@@ -74,10 +74,18 @@ def uninstall_service() -> int:
     """Stop and remove the platform service. Idempotent."""
     plat = current_platform()
     if plat == Platform.SYSTEMD:
-        linux.uninstall()
-        # Whatever removes the service removes the grant, so a host is left as
-        # it was found rather than carrying an orphaned userns permission.
-        profile = linux.remove_apparmor_profile()
+        # uninstall() needs root to remove the root-owned unit, so it can raise
+        # ServiceInstallError on a non-root host without sudo. Catch it and exit
+        # non-zero with the reason rather than letting a traceback escape (and
+        # leaving the service installed).
+        try:
+            linux.uninstall()
+            # Whatever removes the service removes the grant, so a host is left
+            # as it was found rather than carrying an orphaned userns permission.
+            profile = linux.remove_apparmor_profile()
+        except linux.ServiceInstallError as exc:
+            print(f"❌ {exc}", file=sys.stderr)
+            return 1
         print("✅ kirocrew service stopped and removed.")
         if profile.message:
             print(f"   {'⚠️ ' if not profile.ok else ''}{profile.message}")

--- a/src/kiro_crew/service/linux.py
+++ b/src/kiro_crew/service/linux.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -36,6 +38,33 @@ from kiro_crew.service.common import (
 log = logging.getLogger(__name__)
 
 UNIT_PATH = Path(f"/etc/systemd/system/{SERVICE_NAME}.service")
+
+# Operator-editable environment overrides, read by the unit via
+# ``EnvironmentFile=``. Placed AFTER the baked ``Environment=`` lines in the
+# unit so an edit here overrides the install-time snapshot (systemd.exec(5):
+# later assignments win). This is what makes a port change a one-liner
+# (`edit + systemctl restart`) instead of a full re-install: the baked
+# ``Environment=KIROCREW_PORT`` was frozen at `service install` time, so before
+# this file there was no supported way to change it on a running unit.
+ENV_DIR = Path("/etc/kirocrew")
+ENV_FILE_PATH = ENV_DIR / "kirocrew.env"
+
+# Seed contents written only when the file is absent (a re-install never
+# clobbers operator edits). Everything is commented out so the file changes
+# nothing until an operator opts in.
+_ENV_FILE_TEMPLATE = """\
+# Kiro Crew service environment overrides.
+#
+# This file is read by the systemd unit (EnvironmentFile=) AFTER the values
+# baked in at `kirocrew service install` time, so anything set here WINS. Edit
+# it, then apply without reinstalling:
+#
+#     sudo systemctl restart kirocrew
+#
+# Bind a non-default dashboard port (e.g. to run a second crew beside the
+# default 5476, or when 5476 is already taken):
+#KIROCREW_PORT=5477
+"""
 
 
 def _sd_quote(value: str) -> str:
@@ -79,6 +108,18 @@ def _sd_quote(value: str) -> str:
 
 
 def _current_user() -> str:
+    """Resolve the user the gateway should run AS (the ``User=`` in the unit).
+
+    Prefer ``SUDO_USER`` when it names a non-root account: the module invariant
+    is that the gateway — which imports MCP / LLM / agent code — runs as the
+    invoking human, never root, so ``sudo kirocrew service install`` must target
+    that human, not the root that sudo elevated us to. Falls back to
+    ``USER`` / ``LOGNAME`` for a non-sudo invocation. May return ``"root"`` or
+    ``""``; :func:`install` refuses to render a root-run agent from either.
+    """
+    sudo_user = os.environ.get("SUDO_USER", "").strip()
+    if sudo_user and sudo_user != "root":
+        return sudo_user
     return os.environ.get("USER") or os.environ.get("LOGNAME") or ""
 
 
@@ -117,6 +158,25 @@ def _current_uid(user: str) -> int | None:
         return None
 
 
+def _home_for_user(user: str) -> str:
+    """Home directory of ``user`` from its passwd entry, else ``Path.home()``.
+
+    Must NOT use ``Path.home()`` for a sudo-selected user: under
+    ``sudo -H kirocrew service install`` the process's ``HOME`` is ``/root``
+    while ``User=`` is the human (``SUDO_USER``). Baking ``/root`` into the
+    unit's ``HOME`` / ``WorkingDirectory`` would then point the service at a
+    directory the non-root ``User=`` cannot enter, and it fails to start. Keep
+    the home tied to the SAME account the unit runs as. Falls back to
+    ``Path.home()`` when the lookup is unavailable (non-Unix, unknown user).
+    """
+    try:
+        import pwd  # Unix-only; lazy so this module still imports on Windows.
+
+        return pwd.getpwnam(user).pw_dir
+    except Exception:
+        return str(Path.home())
+
+
 def render_unit(apparmor_profile: str = "") -> str:
     """Render the systemd system-unit file contents.
 
@@ -132,7 +192,10 @@ def render_unit(apparmor_profile: str = "") -> str:
     bin_path = kirocrew_bin()
     user = _current_user()
     group = _current_group(user) if user else ""
-    home = str(Path.home())
+    # Tie HOME / WorkingDirectory to the SAME account as User= (see
+    # _home_for_user): under `sudo -H` the process HOME is /root while User= is
+    # the sudo-selected human, and baking /root in would break service start.
+    home = _home_for_user(user) if user else str(Path.home())
     # `--no-open` for the same reason as the launchd plist: a service starts on
     # boot and on every restart, and auto-opening a browser there is wrong. It is
     # simply less visible on a headless Linux box than on a desktop.
@@ -189,6 +252,13 @@ def render_unit(apparmor_profile: str = "") -> str:
         "Restart=on-failure\n"
         "RestartSec=10\n"
         f"TimeoutStopSec={TOTAL_SHUTDOWN_BUDGET_SECS}\n"
+        # Operator-editable overrides. systemd applies EnvironmentFile= AFTER —
+        # and overriding — the baked Environment= lines below (systemd.exec(5)),
+        # so editing this file and restarting changes a value (e.g.
+        # KIROCREW_PORT) without a re-install. The leading "-" makes a missing
+        # file non-fatal, so the unit still starts where install could not write
+        # /etc/kirocrew (the baked Environment= values then apply).
+        f"EnvironmentFile=-{ENV_FILE_PATH}\n"
         # Pin a high open-file limit rather than inheriting the host's
         # ambient DefaultLimitNOFILE. Stock systemd defaults to 1024 — and
         # the frontend production build (vite/rollup) opens ~1000
@@ -208,24 +278,85 @@ class ServiceInstallError(RuntimeError):
     """Raised when service install can't proceed without manual user action."""
 
 
+def _privilege_prefix() -> list[str]:
+    """Return the argv prefix that runs a command with root privilege.
+
+    Empty when the caller is already root (``euid == 0``) — a minimal
+    container or a ``root`` login often has no ``sudo`` binary at all, so
+    invoking ``sudo`` there would raise ``FileNotFoundError`` for a privilege
+    the process already holds. When not root, ``sudo`` is required to write the
+    root-owned unit and drive ``systemctl``; if it is missing we cannot proceed,
+    and the caller must surface a clear :class:`ServiceInstallError` rather than
+    let a raw ``FileNotFoundError`` escape ``controller.install_service`` (which
+    only catches ``ServiceInstallError``). ``_require_privilege`` enforces that.
+    """
+    # getattr: os.geteuid does not exist on Windows, where this module is
+    # imported (via controller) even though these functions never run there.
+    # Default 1000 (a non-root euid) keeps the "needs sudo" branch on any
+    # platform lacking geteuid, which is the safe assumption.
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is not None and geteuid() == 0:
+        return []
+    return ["sudo"]
+
+
+def _require_privilege() -> None:
+    """Raise a clean error if privilege escalation is needed but unavailable.
+
+    Called by every write/control action before it shells out, so a Linux host
+    without ``sudo`` (and not already root) fails on the friendly
+    ``ServiceInstallError`` path the CLI prints, instead of an uncaught
+    ``FileNotFoundError`` traceback.
+
+    Scoped to Linux: this is the systemd module, and in production the
+    controller only dispatches here on Linux (macOS uses launchd). The check
+    exists specifically for the Linux-host-without-sudo case, so on any other
+    platform it is a no-op — which also keeps these functions callable in
+    cross-platform unit tests that mock the subprocess layer on a host with no
+    ``sudo`` binary.
+    """
+    if not sys.platform.startswith("linux"):
+        return
+    geteuid = getattr(os, "geteuid", None)
+    is_root = geteuid is not None and geteuid() == 0
+    if not is_root and shutil.which("sudo") is None:
+        raise ServiceInstallError(
+            "This action needs root to manage the system service at "
+            f"{UNIT_PATH}, but 'sudo' was not found. Re-run as root, or install "
+            "sudo (e.g. 'yum install sudo' / 'apt-get install sudo')."
+        )
+
+
 def _sudo_run(
     *args: str,
     input_text: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    """Run a command under sudo, capturing output.
+    """Run a command with root privilege, capturing output.
 
-    Sudo prompts for a password on first use; subsequent calls within
-    the cached ticket window run silently. All three call sites
-    (``install``, ``uninstall``, ``stop``) are interactive user
-    commands invoked from a TTY, so we always allow the prompt.
+    Prepends ``sudo`` only when the caller is not already root (see
+    :func:`_privilege_prefix`). Sudo prompts for a password on first use;
+    subsequent calls within the cached ticket window run silently. All call
+    sites (``install``, ``uninstall``, ``stop``) are interactive user commands
+    invoked from a TTY, so we always allow the prompt.
+
+    A missing ``sudo`` is turned into a synthetic non-zero result rather than a
+    raised ``FileNotFoundError``, so best-effort callers (``restart``, ``stop``)
+    degrade to "did not run" instead of crashing. The raising entry points
+    (``install`` / ``uninstall``) call :func:`_require_privilege` first, so they
+    surface the precise reason before reaching here.
     """
-    return subprocess.run(
-        ["sudo", *args],
-        input=input_text,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        return subprocess.run(
+            [*_privilege_prefix(), *args],
+            input=input_text,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return subprocess.CompletedProcess(
+            args=list(args), returncode=127, stdout="", stderr="sudo: command not found"
+        )
 
 
 def _systemctl(*args: str, sudo: bool = True) -> subprocess.CompletedProcess[str]:
@@ -253,7 +384,7 @@ def _write_unit_via_sudo(contents: str) -> subprocess.CompletedProcess[str]:
             fh.write(contents)
         return subprocess.run(
             [
-                "sudo",
+                *_privilege_prefix(),
                 "install",
                 "-m",
                 "0644",
@@ -314,6 +445,48 @@ def _sudo_run_checked(*argv: str) -> None:
         raise ServiceInstallError((res.stderr or res.stdout).strip())
 
 
+def _seed_env_file() -> None:
+    """Create the operator-editable overrides file if it does not already exist.
+
+    Create-if-absent is the whole contract: a re-install must never clobber an
+    operator's edits (the value they set here is precisely what survives a
+    re-install, unlike the baked ``Environment=`` snapshot). Best-effort — the
+    unit references it with ``EnvironmentFile=-`` so a seeding failure is
+    non-fatal and simply leaves the baked defaults in force, and install() must
+    proceed to daemon-reload/restart regardless.
+
+    Existence is probed through a PRIVILEGED ``test -e``, never
+    ``Path.exists()``: a pre-existing root-owned ``/etc/kirocrew`` with a
+    restrictive mode makes ``Path.exists()`` raise ``PermissionError`` under the
+    invoking (non-root) user on Python 3.12, which would abort the install. The
+    whole body is wrapped so any unexpected error degrades to a warning.
+    """
+    try:
+        # rc 0 => the file already exists (privileged stat sees through a
+        # root-only directory); leave whatever is there untouched.
+        if _sudo_run("test", "-e", str(ENV_FILE_PATH)).returncode == 0:
+            return
+        _sudo_run("mkdir", "-p", str(ENV_DIR))
+        # 0644: readable so an operator can inspect it, root-owned so an
+        # unprivileged process cannot rewrite the service's environment.
+        _install_file_via_sudo(_ENV_FILE_TEMPLATE, ENV_FILE_PATH, mode="0644")
+    except (ServiceInstallError, OSError):
+        log.warning("Could not seed %s; the service uses baked defaults", ENV_FILE_PATH)
+
+
+def _env_file_is_untouched_seed() -> bool:
+    """True only when the overrides file still holds our exact seed template.
+
+    Uninstall uses this to decide whether the file is ours to delete. Any
+    difference — an operator edit, a file they pre-provisioned before install,
+    or an unreadable file — returns False so their configuration is left intact.
+    """
+    try:
+        return ENV_FILE_PATH.read_text(encoding="utf-8") == _ENV_FILE_TEMPLATE
+    except OSError:
+        return False
+
+
 def install() -> apparmor.ProfileOutcome:
     """Write the unit file and enable+start the service. Idempotent.
 
@@ -332,11 +505,29 @@ def install() -> apparmor.ProfileOutcome:
     service start, so loading it afterwards would leave the first gateway process
     unprofiled and every agent spawn failing closed until the next restart.
     """
+    # Fail early and cleanly if we cannot escalate: without this the first
+    # `sudo` call raises FileNotFoundError, which controller.install_service
+    # does not catch, so the CLI prints a traceback instead of the reason.
+    _require_privilege()
+
     user = _current_user()
     if not user:
         raise ServiceInstallError(
             "Could not determine current user (USER and LOGNAME both unset). "
             "Set $USER and re-run."
+        )
+    # Never render a root-run agent. The gateway imports MCP / LLM / agent code,
+    # and the module invariant is that it runs as the invoking human, never
+    # root. When invoked as bare root (a root login, or `sudo` with no
+    # SUDO_USER) `user` resolves to "root"; refuse rather than write a
+    # `User=root` unit that would run untrusted tools with host-wide root. The
+    # operator picks a real account via `sudo -u <user>` / `SUDO_USER` / `$USER`.
+    if user == "root":
+        raise ServiceInstallError(
+            "Refusing to install a service that runs the agent as root. The "
+            "gateway runs untrusted tools and must run as a normal user. Re-run "
+            "as that user (e.g. via their login, or `sudo -u <user> kirocrew "
+            "service install`), or set $USER to a non-root account."
         )
 
     # Decide before writing the unit: the directive has to be in the unit that
@@ -351,6 +542,10 @@ def install() -> apparmor.ProfileOutcome:
             f"{UNIT_PATH} is owned by root.\n"
             f"   sudo install said: {(write_res.stderr or write_res.stdout).strip()}"
         )
+
+    # Seed the operator-editable overrides file (create-if-absent), so a later
+    # `KIROCREW_PORT=...` edit + restart works without re-installing.
+    _seed_env_file()
 
     # Before daemon-reload/enable/restart: the AppArmorProfile= directive is
     # applied by systemd at unit START, so the profile must already be loaded or
@@ -438,9 +633,19 @@ def uninstall() -> None:
     # when the unit isn't even present.
     if not UNIT_PATH.exists():
         return
+    _require_privilege()
     _systemctl("stop", f"{SERVICE_NAME}.service")
     _systemctl("disable", f"{SERVICE_NAME}.service")
     _sudo_run("rm", "-f", str(UNIT_PATH))
+    # Remove the overrides file ONLY when it still holds our untouched seed —
+    # proving both that we wrote it and that the operator never edited it. An
+    # operator-authored or -edited /etc/kirocrew/kirocrew.env (including one
+    # pre-provisioned before install, which _seed_env_file preserves) is their
+    # config, not ours to delete. rmdir is best-effort and only clears an empty
+    # dir, so it never removes anything else parked under /etc/kirocrew.
+    if _env_file_is_untouched_seed():
+        _sudo_run("rm", "-f", str(ENV_FILE_PATH))
+        _sudo_run("rmdir", str(ENV_DIR))
     _systemctl("daemon-reload")
 
 

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -5403,13 +5403,51 @@ class GatewayOrchestrator:
             # layout. Teaching it the wheel path (which needs the installer, not a
             # git reset) is a separate change from making the CHECK honest.
             if update_required(_running_version):
+                # A mandatory floor is handled by layout, because "apply" means
+                # different things per install shape:
+                #   * git checkout (self_updatable) -> git fetch + reset applies.
+                #   * wheel/cli.sh (not self_updatable, but carries an installer
+                #     `update_command`) -> cannot self-apply unattended; warn and
+                #     light the dashboard badge so the operator runs `kirocrew
+                #     update`. Before this branch existed the path `return`ed
+                #     silently, leaving the host below the floor with no signal.
+                #   * externally managed (dmg/appimage/docker: not self_updatable
+                #     AND no `update_command`) -> its own updater owns this; the
+                #     backend must not drive a git reset on a non-git tree nor
+                #     show an inapplicable CLI-update badge. Log and return.
+                if _update_info.get("self_updatable"):
+                    logger.warning(
+                        "Version compliance: running %s is below the policy minimum %s — "
+                        "applying a mandatory update (overrides auto_update)",
+                        _running_version,
+                        min_version(),
+                    )
+                    await self._auto_apply_update()
+                    return
+                if _update_info.get("update_command"):
+                    logger.warning(
+                        "Version compliance: running %s is below the policy minimum %s, "
+                        "but this install (%s) updates by re-running the installer — "
+                        "run `kirocrew update`",
+                        _running_version,
+                        min_version(),
+                        _update_info.get("install_kind") or "unknown",
+                    )
+                    # Light the badge: the SSE snapshot reads
+                    # `_update_info["available"]`, which the check may have left
+                    # False (a pre-release remote reads as not-newer) even though
+                    # the floor makes this update mandatory.
+                    _update_info["available"] = True
+                    if self.dashboard_state:
+                        self.dashboard_state.push_refresh("update_available")
+                    return
                 logger.warning(
-                    "Version compliance: running %s is below the policy minimum %s — "
-                    "applying a mandatory update (overrides auto_update)",
+                    "Version compliance: running %s is below the policy minimum %s, but this "
+                    "install (%s) is updated by its own updater — not applying from the backend",
                     _running_version,
                     min_version(),
+                    _update_info.get("install_kind") or "unknown",
                 )
-                await self._auto_apply_update()
                 return
 
             if _update_info.get("available"):

--- a/test/test_installer_distro.py
+++ b/test/test_installer_distro.py
@@ -1,0 +1,211 @@
+"""Distro-bootstrap coverage for the shell installers.
+
+The published one-liner ``curl … cli.sh | sh`` must bring up a runnable gateway
+on Ubuntu (apt, and the split ``python3-venv`` package), RHEL/CentOS 7 (yum,
+Python 3.6 baseline), and RHEL/CentOS 8+/Amazon Linux (dnf). Before this
+coverage existed cli.sh had ONLY a dnf branch, so Ubuntu and CentOS 7 hard-
+failed at the "Python >=3.10 is required" gate, and no test ever entered the
+Python-resolution block (the signing harness leaks the host ``python3``).
+
+These tests run the real ``cli.sh`` under a fabricated ``PATH`` that contains NO
+usable ``python3`` plus fake package managers, so the script is forced through
+its distro-detection ladder. Each fake records that it ran; the assertion is
+which manager cli.sh reached for on which distro. POSIX-only scripts, so the
+suite skips on native Windows.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI_SH = REPO_ROOT / "cli.sh"
+INSTALL_SH = REPO_ROOT / "install.sh"
+CLOUD_INSTALL_SH = REPO_ROOT / "cloud-install.sh"
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="cli.sh / install.sh are POSIX shell (macOS + Linux)"
+)
+
+
+def test_shell_installers_parse() -> None:
+    """A syntax error in an installer reaches every new user's shell, and CI has
+    no shellcheck gate — so the cheap `-n` parse check lives here."""
+    subprocess.run(["sh", "-n", str(CLI_SH)], check=True)
+    # install.sh / cloud-install.sh are bash (`#!/usr/bin/env bash`).
+    subprocess.run(["bash", "-n", str(INSTALL_SH)], check=True)
+    subprocess.run(["bash", "-n", str(CLOUD_INSTALL_SH)], check=True)
+
+
+def _run_cli_with_fake_env(
+    tmp_path: Path,
+    *,
+    managers: list[str],
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    """Run cli.sh with a PATH that has NO python3 and only the named package
+    managers (each a stub that records its name and args). Returns the process
+    result plus the marker directory the stubs wrote to.
+
+    The stubs deliberately do NOT install a working python, so cli.sh proceeds
+    through every branch and then errs at the final "Python >=3.10 is required"
+    guard — by which point the marker proves which manager it tried.
+    """
+    tools = tmp_path / "tools"
+    tools.mkdir()
+    markers = tmp_path / "markers"
+    markers.mkdir()
+
+    # The PATH is ISOLATED to `tools` plus symlinks to the specific real
+    # coreutils cli.sh needs. It deliberately does NOT include /usr/bin etc.,
+    # because `command -v <mgr>` skips a non-executable shadow and finds the
+    # host's real binary beneath it (CI's Ubuntu runner HAS a real apt-get) —
+    # so a distro is "absent" here simply by NOT creating its stub, not by
+    # shadowing. Only managers this scenario declares present exist on PATH.
+    def _link_real(name: str) -> None:
+        real = shutil.which(name)
+        if real:
+            (tools / name).symlink_to(real)
+
+    for _util in ("sh", "env", "id", "awk", "sed", "mktemp", "rm", "rmdir",
+                  "mkdir", "cat", "printf", "chmod", "ln", "date", "grep",
+                  "tr", "head", "cut", "dirname", "basename", "uname", "sleep"):
+        _link_real(_util)
+
+    # A manager "under test" is an EXECUTABLE stub that records its args. The
+    # marker path is baked in absolutely: cli.sh does not EXPORT its variables,
+    # so a child stub would not inherit an env var.
+    for name in ("apt-get", "dnf", "yum"):
+        if name in managers:
+            marker = markers / name
+            stub = tools / name
+            stub.write_text(
+                "#!/bin/sh\n"
+                f'printf "%s\\n" "$*" >> "{marker}"\n'
+                "exit 0\n"
+            )
+            stub.chmod(0o755)
+    # mise, pipx are simply absent (never created) so the fallback finds none.
+
+    # Fake `sudo`: strip a leading `-n` / option flags and exec the rest through
+    # the SAME isolated PATH. Without this the test is not hermetic — a CI
+    # runner with passwordless sudo makes cli.sh pick `sudo -n`, and the real
+    # `sudo` resets PATH via secure_path so `sudo -n apt-get` would run the
+    # host's real apt-get instead of our recording stub. `exec env PATH=... "$@"`
+    # re-imposes the isolated PATH the way real sudo would impose secure_path.
+    sudo_stub = tools / "sudo"
+    sudo_stub.write_text(
+        "#!/bin/sh\n"
+        'while [ "$#" -gt 0 ]; do\n'
+        '  case "$1" in\n'
+        "    -n|-E|-H) shift ;;\n"
+        "    -*) shift ;;\n"
+        "    *) break ;;\n"
+        "  esac\n"
+        "done\n"
+        f'exec env "PATH={tools}" "$@"\n'
+    )
+    sudo_stub.chmod(0o755)
+
+    # Every interpreter cli.sh probes for is an executable stub reporting an
+    # OLD (<3.10) version, so the isolated PATH guarantees the "no usable
+    # python" branch. The stub answers cli.sh's version check (exit 1) and
+    # `--version`.
+    for name in ("python3.13", "python3.12", "python3.11", "python3.10", "python3", "python"):
+        stub = tools / name
+        stub.write_text(
+            "#!/bin/sh\n"
+            'case "$*" in\n'
+            "  *version_info*) exit 1 ;;\n"  # cli.sh's >=3.10 gate -> too old
+            "  *--version*) echo 'Python 3.6.8' ;;\n"
+            "  *) exit 1 ;;\n"
+            "esac\n"
+        )
+        stub.chmod(0o755)
+
+    # curl/openssl/sha256sum need to exist so cli.sh's tool preflight passes and
+    # it reaches the Python block; they are never actually called before the
+    # python gate fails, but `command -v` must find them.
+    for name in ("curl", "openssl", "sha256sum"):
+        stub = tools / name
+        stub.write_text("#!/bin/sh\nexit 0\n")
+        stub.chmod(0o755)
+
+    env = {
+        # Isolated: ONLY the fake tools dir. No system bin dirs, so no real
+        # package manager or interpreter can leak into cli.sh's ladder.
+        "PATH": str(tools),
+        "HOME": str(tmp_path / "home"),
+        "KIROCREW_HOME": str(tmp_path / "data-home"),
+    }
+    result = subprocess.run(
+        [str(tools / "sh"), str(CLI_SH)],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    return result, markers
+
+
+def test_cli_uses_apt_on_debian_ubuntu(tmp_path: Path) -> None:
+    result, markers = _run_cli_with_fake_env(tmp_path, managers=["apt-get"])
+    # No python was produced, so the run fails at the python gate — but it must
+    # have reached for apt-get first (the Ubuntu path that did not exist before).
+    assert (markers / "apt-get").exists(), result.stderr
+    assert "install" in (markers / "apt-get").read_text()
+    assert "python3-venv" in (markers / "apt-get").read_text()
+
+
+def test_cli_uses_yum_on_centos7(tmp_path: Path) -> None:
+    # CentOS 7 has yum but not dnf and no >=3.10 in base repos: the pre-fix
+    # script had no yum branch and died with dnf-only advice.
+    result, markers = _run_cli_with_fake_env(tmp_path, managers=["yum"])
+    assert (markers / "yum").exists(), result.stderr
+    assert "install" in (markers / "yum").read_text()
+
+
+def test_cli_uses_dnf_on_modern_rhel(tmp_path: Path) -> None:
+    result, markers = _run_cli_with_fake_env(tmp_path, managers=["dnf"])
+    assert (markers / "dnf").exists(), result.stderr
+    assert "python3.11" in (markers / "dnf").read_text()
+
+
+def test_cli_prefers_apt_over_a_present_yum(tmp_path: Path) -> None:
+    # Debian derivatives can carry a yum-alike; the apt branch must win so a
+    # Debian box never drives an rpm manager.
+    _result, markers = _run_cli_with_fake_env(tmp_path, managers=["apt-get", "yum"])
+    assert (markers / "apt-get").exists()
+    assert not (markers / "yum").exists()
+
+
+def test_cli_error_message_is_distro_neutral_when_no_manager(tmp_path: Path) -> None:
+    # With no package manager AND no mise reachable, the final error must not
+    # hardcode Amazon-Linux/dnf advice (the pre-fix message did): it names the
+    # Debian/Ubuntu and RHEL-family paths so a user on any target distro gets a
+    # command that applies to them.
+    result, _markers = _run_cli_with_fake_env(tmp_path, managers=[])
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "apt-get" in combined and "dnf" in combined and "CentOS 7" in combined
+
+
+def test_cli_does_not_pipe_an_unsigned_installer_into_a_shell() -> None:
+    # The signed installer must never fetch-and-execute a third-party script: a
+    # `curl … mise.run | sh` bootstrap was removed for exactly this reason. It
+    # may USE an already-installed mise, but never install one itself. Any
+    # remaining `mise.run` reference must live INSIDE the final `err "…"`
+    # guidance string — text the user chooses to run, not a line the installer
+    # executes.
+    for lineno, line in enumerate(CLI_SH.read_text().splitlines(), start=1):
+        if "mise.run" not in line:
+            continue
+        stripped = line.lstrip()
+        assert stripped.startswith("[ -n \"$PY\" ] || err ") or stripped.startswith("err "), (
+            f"cli.sh:{lineno} references mise.run outside the err() guidance string: {line!r}"
+        )

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -32,6 +32,19 @@ from kiro_crew.service.common import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_sudo_user(monkeypatch):
+    """Keep ``User=`` resolution deterministic across hosts.
+
+    ``_current_user()`` prefers ``SUDO_USER`` (so ``sudo … service install``
+    targets the human, not root). A CI runner that happened to set ``SUDO_USER``
+    would otherwise override the ``USER=tester`` these tests set. Clear it once
+    for every test in this module; tests that exercise the SUDO_USER path set it
+    explicitly themselves.
+    """
+    monkeypatch.delenv("SUDO_USER", raising=False)
+
+
 class TestPlatformDetection:
     def test_linux_with_systemctl_returns_systemd(self):
         with patch("kiro_crew.service.common.sys") as mock_sys, patch(
@@ -213,6 +226,9 @@ class TestLinuxUnitRendering:
         from kiro_crew.service import linux as svc_linux
 
         monkeypatch.setenv("USER", "tester")
+        # Pin a non-root euid so the privilege prefix is deterministically
+        # `sudo` regardless of the CI runner's uid (root CI would drop it).
+        monkeypatch.setattr(svc_linux.os, "geteuid", lambda: 1000, raising=False)
 
         # Capture every subprocess.run call. All return success.
         ok = MagicMock(returncode=0, stdout="", stderr="")
@@ -255,6 +271,7 @@ class TestLinuxUnitRendering:
         from kiro_crew.service import linux as svc_linux
 
         monkeypatch.setenv("USER", "tester")
+        monkeypatch.setattr(svc_linux.os, "geteuid", lambda: 1000, raising=False)
         install_failed = MagicMock(
             returncode=1, stdout="", stderr="sudo: a password is required"
         )
@@ -299,6 +316,279 @@ class TestLinuxUnitRendering:
         with patch("kiro_crew.service.linux.subprocess.run") as run:
             svc_linux.uninstall()
         run.assert_not_called()
+
+
+class TestLinuxPrivilegeResolution:
+    """Root fast-path and the missing-sudo error, so a minimal CentOS /
+    container image (root, no sudo) neither shells out to a nonexistent sudo
+    nor lets a raw FileNotFoundError escape controller.install_service."""
+
+    def test_privilege_prefix_is_empty_as_root(self, monkeypatch):
+        from kiro_crew.service import linux as svc_linux
+
+        monkeypatch.setattr(svc_linux.os, "geteuid", lambda: 0, raising=False)
+        assert svc_linux._privilege_prefix() == []
+
+    def test_privilege_prefix_is_sudo_when_not_root(self, monkeypatch):
+        from kiro_crew.service import linux as svc_linux
+
+        monkeypatch.setattr(svc_linux.os, "geteuid", lambda: 1000, raising=False)
+        assert svc_linux._privilege_prefix() == ["sudo"]
+
+    def test_require_privilege_ok_as_root_without_sudo(self, monkeypatch):
+        from kiro_crew.service import linux as svc_linux
+
+        monkeypatch.setattr(svc_linux.os, "geteuid", lambda: 0, raising=False)
+        monkeypatch.setattr(svc_linux.shutil, "which", lambda _n: None)
+        # Root needs no sudo — must not raise.
+        svc_linux._require_privilege()
+
+    def test_require_privilege_raises_when_not_root_and_no_sudo(self, monkeypatch):
+        from kiro_crew.service import linux as svc_linux
+
+        # The guard is Linux-scoped (systemd module); pin the platform so the
+        # test asserts the raising branch on any host it runs on.
+        monkeypatch.setattr(svc_linux.sys, "platform", "linux")
+        monkeypatch.setattr(svc_linux.os, "geteuid", lambda: 1000, raising=False)
+        monkeypatch.setattr(svc_linux.shutil, "which", lambda _n: None)
+        with pytest.raises(svc_linux.ServiceInstallError) as exc:
+            svc_linux._require_privilege()
+        assert "sudo" in str(exc.value).lower()
+
+    def test_require_privilege_is_noop_off_linux(self, monkeypatch):
+        from kiro_crew.service import linux as svc_linux
+
+        # On a non-Linux host (macOS/Windows) the systemd path is never the real
+        # dispatch target, and cross-platform unit tests call these functions
+        # with a mocked subprocess layer, so the guard must not raise there.
+        monkeypatch.setattr(svc_linux.sys, "platform", "darwin")
+        monkeypatch.setattr(svc_linux.os, "geteuid", lambda: 1000, raising=False)
+        monkeypatch.setattr(svc_linux.shutil, "which", lambda _n: None)
+        svc_linux._require_privilege()  # must not raise
+
+    def test_install_refuses_to_run_agent_as_root(self, monkeypatch):
+        """A bare-root install (root login, or sudo with no SUDO_USER) must NOT
+        produce a User=root unit — the gateway runs untrusted tools and the
+        module invariant is that it runs as a normal user."""
+        from kiro_crew.service import linux as svc_linux
+
+        monkeypatch.setenv("USER", "root")
+        monkeypatch.delenv("SUDO_USER", raising=False)
+        monkeypatch.delenv("LOGNAME", raising=False)
+        monkeypatch.setattr(svc_linux.os, "geteuid", lambda: 0, raising=False)
+        with pytest.raises(svc_linux.ServiceInstallError) as exc:
+            svc_linux.install()
+        assert "root" in str(exc.value).lower()
+
+    def test_current_user_prefers_sudo_user_over_root(self, monkeypatch):
+        """`sudo kirocrew service install` must target the human behind sudo,
+        not the root sudo elevated to — so the unit gets User=<human>."""
+        from kiro_crew.service import linux as svc_linux
+
+        monkeypatch.setenv("USER", "root")
+        monkeypatch.setenv("SUDO_USER", "alice")
+        assert svc_linux._current_user() == "alice"
+
+    def test_unit_home_matches_the_resolved_user_not_process_home(self, monkeypatch):
+        """Under `sudo -H` the process HOME is /root but User= is the sudo human.
+        HOME=/WorkingDirectory= in the unit must follow the resolved USER (from
+        that user's passwd home), never the process's /root — otherwise the
+        non-root service cannot enter its working dir and fails to start."""
+        from kiro_crew.service import linux as svc_linux
+
+        monkeypatch.setenv("USER", "root")
+        monkeypatch.setenv("SUDO_USER", "alice")
+        # Simulate `sudo -H`: process home is /root.
+        monkeypatch.setattr(svc_linux.Path, "home", classmethod(lambda cls: Path("/root")))
+        # alice's passwd home.
+        monkeypatch.setattr(svc_linux, "_home_for_user", lambda u: "/home/alice" if u == "alice" else "/root")
+        gid = MagicMock(returncode=0, stdout="alice\n", stderr="")
+        with patch(
+            "kiro_crew.service.common.shutil.which", return_value="/usr/local/bin/kirocrew"
+        ), patch("kiro_crew.service.linux.subprocess.run", return_value=gid):
+            unit = svc_linux.render_unit()
+        assert "User=alice" in unit
+        assert "WorkingDirectory=/home/alice" in unit
+        assert 'Environment="HOME=/home/alice"' in unit
+        assert "/root" not in unit
+
+    def test_install_raises_clean_error_when_sudo_missing(self, monkeypatch):
+        """The reported bug: on a root-only/minimal host without sudo, install
+        used to crash with an uncaught FileNotFoundError. It must raise the
+        friendly ServiceInstallError instead."""
+        from kiro_crew.service import linux as svc_linux
+
+        monkeypatch.setattr(svc_linux.sys, "platform", "linux")
+        monkeypatch.setenv("USER", "tester")
+        monkeypatch.delenv("SUDO_USER", raising=False)
+        monkeypatch.setattr(svc_linux.os, "geteuid", lambda: 1000, raising=False)
+        monkeypatch.setattr(svc_linux.shutil, "which", lambda _n: None)
+        with pytest.raises(svc_linux.ServiceInstallError):
+            svc_linux.install()
+
+    def test_sudo_run_survives_missing_sudo_binary(self, monkeypatch):
+        """restart()/stop() are best-effort and reachable from the update path;
+        a missing sudo must degrade to a failed result, never a raised
+        FileNotFoundError."""
+        from kiro_crew.service import linux as svc_linux
+
+        monkeypatch.setattr(svc_linux.os, "geteuid", lambda: 1000, raising=False)
+
+        def _boom(*_a, **_k):
+            raise FileNotFoundError("sudo")
+
+        monkeypatch.setattr(svc_linux.subprocess, "run", _boom)
+        res = svc_linux._sudo_run("systemctl", "restart", "kirocrew.service")
+        assert res.returncode == 127
+        # restart() surfaces the failure as False rather than crashing.
+        assert svc_linux.restart() is False
+
+
+class TestLinuxEnvironmentFile:
+    """The operator-editable overrides file — the honest fix to 'I set
+    KIROCREW_PORT on the service and it did not change the port'."""
+
+    def test_unit_references_the_env_file(self, monkeypatch):
+        from kiro_crew.service import linux as svc_linux
+
+        monkeypatch.setenv("USER", "tester")
+        with patch(
+            "kiro_crew.service.common.shutil.which",
+            return_value="/usr/local/bin/kirocrew",
+        ):
+            unit = svc_linux.render_unit()
+        assert f"EnvironmentFile=-{svc_linux.ENV_FILE_PATH}\n" in unit
+        # The overrides file is read after (and thus overrides) the baked
+        # Environment= snapshot; both must sit inside [Service].
+        service = unit.index("[Service]")
+        install = unit.index("[Install]")
+        assert service < unit.index("EnvironmentFile=") < install
+
+    def test_seed_env_file_creates_when_absent(self, tmp_path, monkeypatch):
+        from kiro_crew.service import linux as svc_linux
+
+        env_file = tmp_path / "kirocrew" / "kirocrew.env"
+        monkeypatch.setattr(svc_linux, "ENV_DIR", env_file.parent)
+        monkeypatch.setattr(svc_linux, "ENV_FILE_PATH", env_file)
+
+        written: dict[str, str] = {}
+
+        def _fake_install(contents, dest, mode="0644"):
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(contents)
+            written["contents"] = contents
+
+        # _seed_env_file probes existence via `_sudo_run("test", "-e", path)`;
+        # answer it from the real tmp file so the create-if-absent logic runs.
+        def _fake_sudo(*args, **_k):
+            if args and args[0] == "test":
+                rc = 0 if Path(args[-1]).exists() else 1
+                return MagicMock(returncode=rc, stdout="", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(svc_linux, "_install_file_via_sudo", _fake_install)
+        monkeypatch.setattr(svc_linux, "_sudo_run", _fake_sudo)
+
+        svc_linux._seed_env_file()
+        assert env_file.exists()
+        # Seed is inert until an operator opts in: the port line is commented.
+        assert "#KIROCREW_PORT=" in written["contents"]
+
+    def test_seed_env_file_never_clobbers_operator_edits(self, tmp_path, monkeypatch):
+        from kiro_crew.service import linux as svc_linux
+
+        env_file = tmp_path / "kirocrew" / "kirocrew.env"
+        env_file.parent.mkdir(parents=True)
+        env_file.write_text("KIROCREW_PORT=5477\n")
+        monkeypatch.setattr(svc_linux, "ENV_DIR", env_file.parent)
+        monkeypatch.setattr(svc_linux, "ENV_FILE_PATH", env_file)
+
+        def _fake_sudo(*args, **_k):
+            if args and args[0] == "test":
+                rc = 0 if Path(args[-1]).exists() else 1
+                return MagicMock(returncode=rc, stdout="", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        called = MagicMock()
+        monkeypatch.setattr(svc_linux, "_install_file_via_sudo", called)
+        monkeypatch.setattr(svc_linux, "_sudo_run", _fake_sudo)
+        svc_linux._seed_env_file()
+        # An existing file is left exactly as the operator wrote it.
+        called.assert_not_called()
+        assert env_file.read_text() == "KIROCREW_PORT=5477\n"
+
+    def test_seed_env_file_is_non_fatal_when_probe_denied(self, tmp_path, monkeypatch):
+        """A pre-existing root-only /etc/kirocrew must not abort install: the
+        existence probe goes through privileged `test -e`, and any error still
+        degrades to a warning instead of propagating."""
+        from kiro_crew.service import linux as svc_linux
+
+        env_file = tmp_path / "kirocrew" / "kirocrew.env"
+        monkeypatch.setattr(svc_linux, "ENV_DIR", env_file.parent)
+        monkeypatch.setattr(svc_linux, "ENV_FILE_PATH", env_file)
+
+        # Even if the privileged probe itself raised, _seed_env_file swallows it.
+        def _boom(*_a, **_k):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(svc_linux, "_sudo_run", _boom)
+        monkeypatch.setattr(svc_linux, "_install_file_via_sudo", MagicMock())
+        svc_linux._seed_env_file()  # must not raise
+
+    def test_uninstall_preserves_an_operator_edited_env_file(self, tmp_path, monkeypatch):
+        """Uninstall must delete ONLY our untouched seed — an operator-authored
+        or -edited overrides file (including one pre-provisioned before install)
+        is their config, not ours to remove."""
+        from kiro_crew.service import linux as svc_linux
+
+        unit = tmp_path / "kirocrew.service"
+        unit.write_text("[Unit]\n")
+        env_file = tmp_path / "kirocrew" / "kirocrew.env"
+        env_file.parent.mkdir(parents=True)
+        env_file.write_text("KIROCREW_PORT=5477\n")  # operator content, not our seed
+        monkeypatch.setattr(svc_linux, "UNIT_PATH", unit)
+        monkeypatch.setattr(svc_linux, "ENV_DIR", env_file.parent)
+        monkeypatch.setattr(svc_linux, "ENV_FILE_PATH", env_file)
+        monkeypatch.setattr(svc_linux.os, "geteuid", lambda: 1000, raising=False)
+
+        removed: list[str] = []
+
+        def _fake_sudo(*args, **_k):
+            if args and args[0] == "rm":
+                removed.append(args[-1])
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(svc_linux, "_sudo_run", _fake_sudo)
+        monkeypatch.setattr(svc_linux, "_systemctl", lambda *a, **k: MagicMock(returncode=0))
+        svc_linux.uninstall()
+        # The unit is removed; the operator's env file is NOT.
+        assert str(unit) in removed
+        assert str(env_file) not in removed
+
+    def test_uninstall_removes_our_untouched_seed(self, tmp_path, monkeypatch):
+        from kiro_crew.service import linux as svc_linux
+
+        unit = tmp_path / "kirocrew.service"
+        unit.write_text("[Unit]\n")
+        env_file = tmp_path / "kirocrew" / "kirocrew.env"
+        env_file.parent.mkdir(parents=True)
+        env_file.write_text(svc_linux._ENV_FILE_TEMPLATE)  # our exact untouched seed
+        monkeypatch.setattr(svc_linux, "UNIT_PATH", unit)
+        monkeypatch.setattr(svc_linux, "ENV_DIR", env_file.parent)
+        monkeypatch.setattr(svc_linux, "ENV_FILE_PATH", env_file)
+        monkeypatch.setattr(svc_linux.os, "geteuid", lambda: 1000, raising=False)
+
+        removed: list[str] = []
+
+        def _fake_sudo(*args, **_k):
+            if args and args[0] in ("rm", "rmdir"):
+                removed.append(args[-1])
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(svc_linux, "_sudo_run", _fake_sudo)
+        monkeypatch.setattr(svc_linux, "_systemctl", lambda *a, **k: MagicMock(returncode=0))
+        svc_linux.uninstall()
+        assert str(env_file) in removed
 
 
 class TestMacOSPlistRendering:
@@ -684,6 +974,23 @@ class TestControllerDispatch:
             rc = controller.uninstall_service()
         assert rc == 0
         mock_un.assert_called_once()
+
+    def test_uninstall_systemd_handles_service_install_error(self, capsys):
+        """uninstall() needs root to remove the root-owned unit, so it can raise
+        ServiceInstallError on a non-root host without sudo. The controller must
+        catch it and return non-zero, not let a traceback escape."""
+        from kiro_crew.service import controller
+        from kiro_crew.service import linux as svc_linux
+
+        with patch(
+            "kiro_crew.service.controller.current_platform",
+            return_value=Platform.SYSTEMD,
+        ), patch.object(
+            svc_linux, "uninstall", side_effect=svc_linux.ServiceInstallError("needs sudo")
+        ):
+            rc = controller.uninstall_service()
+        assert rc == 1
+        assert "needs sudo" in capsys.readouterr().err
 
     def test_uninstall_routes_to_macos(self):
         from kiro_crew.service import controller

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -868,7 +868,13 @@ class TestCheckForUpdates:
 
         orig = _h._update_info.copy()
         try:
-            _h._update_info.update({"available": False})
+            # A git checkout (self_updatable) below the floor: the git auto-apply
+            # is the correct mandatory action. `_do_update_check` sets this key
+            # per layout in the real flow; it is mocked here, so the fixture
+            # states the layout explicitly. The wheel layout (self_updatable
+            # False) takes the notify path instead — see
+            # TestMandatoryUpdateOnWheelInstall.
+            _h._update_info.update({"available": False, "self_updatable": True})
             with patch.object(_h, "_do_update_check", new_callable=AsyncMock):
                 with patch(
                     "kiro_crew.platform.update_governance.update_required", return_value=True
@@ -5118,3 +5124,114 @@ class TestChannelTransportStartGate:
         assert connected is True
         socket_client.connect.assert_awaited_once()
         assert orch._socket_client is socket_client
+
+
+class TestMandatoryUpdateOnWheelInstall:
+    """A policy min-version makes an update mandatory. On a wheel/cli.sh install
+    the git-based auto-apply cannot run, so the mandatory branch must NOTIFY
+    (warn + light the dashboard badge) instead of silently returning — which is
+    what it did before, leaving the host below the floor with no signal."""
+
+    @pytest.mark.asyncio
+    async def test_mandatory_update_on_wheel_notifies_not_silent(self, monkeypatch):
+        import kiro_crew.dashboard.handlers as handlers
+        import kiro_crew.platform.update_governance as gov
+
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+
+        async def _noop_check():
+            return None
+
+        # Wheel install below a policy floor: a feed-checkable layout reports
+        # self_updatable False, and the check can leave available False (a
+        # pre-release remote reads as not-newer) even though the floor mandates
+        # the update. Start from available False to prove the branch lights it.
+        handlers._update_info.clear()
+        handlers._update_info.update(
+            {
+                "available": False,
+                "self_updatable": False,
+                "install_kind": "wheel",
+                # A feed-checkable wheel carries an installer command; that is
+                # what distinguishes it from an externally-managed install.
+                "update_command": "curl -fsSL … | sh",
+            }
+        )
+        monkeypatch.setattr(handlers, "_do_update_check", _noop_check)
+        monkeypatch.setattr(gov, "update_required", lambda _v: True)
+        monkeypatch.setattr(gov, "min_version", lambda: "9.9.9")
+
+        apply_called = AsyncMock()
+        monkeypatch.setattr(orch, "_auto_apply_update", apply_called)
+
+        await orch._check_for_updates()
+
+        # Must NOT attempt the git apply on a non-git tree, and must surface it.
+        apply_called.assert_not_awaited()
+        ds.push_refresh.assert_called_once_with("update_available")
+        # The dashboard badge reads _update_info["available"]; a mandatory
+        # update must light it even though the check left it False.
+        assert handlers._update_info.get("available") is True
+
+    @pytest.mark.asyncio
+    async def test_mandatory_update_on_externally_managed_does_not_badge(self, monkeypatch):
+        """A dmg/appimage/docker install below the floor is not self_updatable
+        AND has no installer update_command — it updates via its own surface, so
+        the CLI 'run kirocrew update' badge must NOT light."""
+        import kiro_crew.dashboard.handlers as handlers
+        import kiro_crew.platform.update_governance as gov
+
+        orch = _make_orchestrator()
+        ds = _mock_dashboard_state()
+        orch.dashboard_state = ds
+
+        async def _noop_check():
+            return None
+
+        handlers._update_info.clear()
+        handlers._update_info.update(
+            {
+                "available": False,
+                "self_updatable": False,
+                "install_kind": "docker",
+                "update_command": "",  # externally managed: no CLI update path
+            }
+        )
+        monkeypatch.setattr(handlers, "_do_update_check", _noop_check)
+        monkeypatch.setattr(gov, "update_required", lambda _v: True)
+        monkeypatch.setattr(gov, "min_version", lambda: "9.9.9")
+        apply_called = AsyncMock()
+        monkeypatch.setattr(orch, "_auto_apply_update", apply_called)
+
+        await orch._check_for_updates()
+
+        apply_called.assert_not_awaited()
+        ds.push_refresh.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mandatory_update_on_git_still_auto_applies(self, monkeypatch):
+        import kiro_crew.dashboard.handlers as handlers
+        import kiro_crew.platform.update_governance as gov
+
+        orch = _make_orchestrator()
+        orch.dashboard_state = _mock_dashboard_state()
+
+        async def _noop_check():
+            return None
+
+        # Git checkout: self_updatable True, so the mandatory git apply runs.
+        handlers._update_info.clear()
+        handlers._update_info.update(
+            {"available": True, "self_updatable": True, "install_kind": "git"}
+        )
+        monkeypatch.setattr(handlers, "_do_update_check", _noop_check)
+        monkeypatch.setattr(gov, "update_required", lambda _v: True)
+        monkeypatch.setattr(gov, "min_version", lambda: "9.9.9")
+
+        apply_called = AsyncMock()
+        monkeypatch.setattr(orch, "_auto_apply_update", apply_called)
+
+        await orch._check_for_updates()
+        apply_called.assert_awaited_once()


### PR DESCRIPTION
## Problem

The advertised one-liner and the persistent-backend path assumed Amazon Linux
2023 (`dnf` + a repo `python3.11`). On **Ubuntu** and **CentOS**, using a desktop
as a "remote crew" broke at every step of download → start → configure → update:

- **download** — `cli.sh` had only a `dnf` branch, so Ubuntu (apt) and CentOS 7
  (yum, Python 3.6) hit the `Python >=3.10 is required` gate and stopped. Even
  with a new-enough interpreter, `python3 -m venv` failed on a fresh Ubuntu
  because `python3-venv`/`ensurepip` is a separate apt package.
- **start** — `kirocrew service install` crashed with an uncaught
  `FileNotFoundError` on a root-only/minimal host that has no `sudo`, and the
  installer never told the user how to start the gateway or run it as a service.
- **configure** — the systemd unit baked `KIROCREW_PORT` at install time with no
  operator-editable file, so setting the port on a running service and
  restarting changed nothing (the reported "I set the env and the port didn't
  change").
- **update** — a policy min-version (mandatory) update on a wheel install
  silently no-oped, leaving the host below the floor with no signal.

## Why it matters

This is the exact onboarding a user hits when pointing a Linux box at the
public installer. Each gap is a hard stop or a silent failure, so "desktop as a
remote crew" was effectively AL2023-only. The four target distros — Ubuntu,
CentOS 7 (yum), CentOS 8+/Stream (dnf), Amazon Linux — now all work.

## Fix (symptoms → root cause → change)

- **download** — root cause: no distro detection in `cli.sh`, and a venv step
  that assumed a bundled `venv` module. Change: a distro-aware Python bootstrap
  (`apt` / `dnf` / `yum`) with an inline **mise python-build-standalone**
  fallback for hosts whose base repos ship no 3.10+ (CentOS 7, older Ubuntu),
  plus a venv-capability guard that installs `python3-venv` on Debian/Ubuntu.
  `cloud-install.sh` gains the matching `yum` branch and a version-checked
  re-probe. `curl … | sh` runs no controlling TTY, so privilege escalation is
  non-interactive (`sudo -n`), falling through to the no-root mise path.
- **start** — root cause: `sudo` invoked unconditionally, and no next-step
  output. Change: privilege is resolved per call (skip `sudo` when already root;
  raise a clear `ServiceInstallError` when non-root without `sudo` instead of an
  uncaught `FileNotFoundError`), and `cli.sh` prints `kirocrew gateway` /
  `kirocrew service install` on success.
- **configure** — root cause: the port lived only in a baked `Environment=`
  snapshot. Change: the unit now reads an operator-editable
  `EnvironmentFile=-/etc/kirocrew/kirocrew.env`, seeded create-if-absent (a
  reinstall never clobbers edits, uninstall removes it). systemd applies it
  after — and overriding — the baked values, so a port change is `edit +
  systemctl restart`, not a reinstall. `KIROCREW_PORT=5477 kirocrew service
  install` still works and is now documented.
- **update** — root cause: the mandatory branch called the git-only apply, which
  returns immediately on a wheel tree, then `return`ed. Change: on a
  non-`self_updatable` (wheel) install it now warns and lights the dashboard
  update badge; git installs still auto-apply. It never drives a `git reset` on
  a non-git tree.

## Tests

- `test/test_installer_distro.py` (new) — syntax-checks all three installers,
  and drives `cli.sh` under a fabricated `PATH` (no usable python3 + fake
  package managers) to assert the apt / yum / dnf branch fires per distro,
  that apt wins over a present yum, and that the no-manager error is
  distro-neutral. Hermetic (non-executable placeholders shadow the host's real
  managers so CI's Ubuntu runner cannot leak in); skipped on Windows.
- `test/test_service.py` — new `TestLinuxPrivilegeResolution` (root fast-path,
  missing-sudo error, `_sudo_run` surviving a missing sudo binary) and
  `TestLinuxEnvironmentFile` (unit references the file; seed creates when
  absent; seed never clobbers operator edits). Two existing sudo-prefix tests
  now pin a non-root euid so they are deterministic on any runner.
- `test/test_slack_gateway.py` — new `TestMandatoryUpdateOnWheelInstall` (wheel
  notifies, git auto-applies); the existing mandate test's fixture now names its
  layout explicitly.

## Manual verification

Traced `cli.sh` end-to-end under a fake-distro `PATH` for the empty-`$SUDO` case
(safe under `set -eu`) and each package-manager branch; confirmed the signed-
manifest happy path is untouched (`test_cli_manifest_signature.py` green). Full
backend gate green locally: `isort` / `flake8` clean on changed files, `mypy`
clean on changed files (the 8 remaining `mypy` errors are pre-existing on
`main`, in files this PR does not touch), and the changed test files pass
(429 tests). `docs-lint`, `scrub-lint`, and the brand gate pass.

## Screenshots

N/A — no user-visible UI change (installer, systemd unit, CLI, and backend
update logic only).
