### PR TITLE
fix(knowledge): skip CDK output and dependency lock files by default

### DIFF
--- a/docs/system-specs/modules/knowledge.md
+++ b/docs/system-specs/modules/knowledge.md
@@ -45,7 +45,7 @@ files / uploads / artifacts / URLs
 | `FETCH_TIMEOUT` | `120.0` | `llm_pool.py`, `agent_fetch.py` | URL-fetch worker timeout |
 | `AGENT_NAME` | `"kirocrew-knowledge"` | `llm_pool.py` | kiro-cli agent the ACP worker drives |
 | `_VALID_SANDBOX_MODES` | `{auto, standard, strict, cc, off}` | `llm_pool.py` | Accepted `agent.sandbox` values |
-| `HARD_SKIP_DIRS` | `{.git, node_modules, __pycache__, .venv, venv}` | `folder_watcher.py` | Directories never walked |
+| `HARD_SKIP_DIRS` | `{.git, node_modules, __pycache__, .venv, venv, dist, build, out, target, cdk.out}` | `folder_watcher.py` | Directories never walked |
 | `_LARGE_REBUILD_WARN_THRESHOLD` | `1000` | `watcher.py` | Stale-item count at which the self-heal rebuild logs a prominent WARNING (usually an embedder-sig change invalidating the whole corpus) |
 | `DEFAULT_MAX_FILES` | `5000` | `folder_watcher.py` | Per-source file cap (newest-first) |
 | `CHUNK_TOKEN_SIZE` | `800` | `chunker.py` | Target chunk size (words) |
@@ -86,8 +86,10 @@ Base metadata always carries `format`, `title` (file stem), `file_size`, `extens
 `FolderWatcher.scan_source(source)` scans a folder-type source under a per-`source_id` `asyncio.Lock` (one scan per source at a time) and returns `{new, changed, deleted, skipped, capped, failed}`.
 
 **`_walk(root, ignore_patterns, extra_skip_dirs)`** (run via `asyncio.to_thread`) is the discovery step:
-- Prunes `HARD_SKIP_DIRS`, any per-source-type extra skip dirs (`SOURCE_TYPE_SKIP_DIRS["obsidian_vault"] = {.obsidian, .trash}`), and **all** dotfiles/dot-dirs in place during `os.walk`.
-- Skips OS junk/lock files by case-insensitive basename match against `DEFAULT_IGNORE_GLOBS` (macOS AppleDouble `._*`, `.ds_store`, Office `~$*`, LibreOffice `.~lock.*`, `thumbs.db`, `desktop.ini`, `*.tmp`, editor swap/backup, partial downloads). This exists because a discovered-but-unreadable file that carries a supported extension fails ingestion, is never auto-retried, and would otherwise leave a source permanently stalled below 100%.
+- Prunes `HARD_SKIP_DIRS`, any per-source-type extra skip dirs (`SOURCE_TYPE_SKIP_DIRS["obsidian_vault"] = {.obsidian, .trash}`), and **all** dotfiles/dot-dirs in place during `os.walk`. Build-output trees are in `HARD_SKIP_DIRS` because a rebuild presents hundreds of regenerated files as changed content; `cdk.out` (AWS CDK synth output) needs its own entry because its name only *contains* a dot, so the dot-prefix rule never prunes it.
+- Skips files that are never documents by case-insensitive basename match against `DEFAULT_IGNORE_GLOBS`. Two classes:
+  - OS junk / editor and Office lock files (macOS AppleDouble `._*`, `.ds_store`, Office `~$*`, LibreOffice `.~lock.*`, `thumbs.db`, `desktop.ini`, `*.tmp`, editor swap/backup, partial downloads). A discovered-but-unreadable file carrying a supported extension fails ingestion, is never auto-retried, and would leave a source permanently stalled below 100%.
+  - Dependency lock files (`package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`, `bun.lock`, `poetry.lock`, `uv.lock`, `pipfile.lock`, `cargo.lock`, `gemfile.lock`, `composer.lock`, `packages.lock.json`, `gradle.lockfile`, `flake.lock`). These ingest successfully, which is the problem: they are large machine-generated resolution output, each chunk costs one extraction call, and regenerating one bills it again on the next sweep.
 - Applies the source's `ignore_patterns` (fnmatch against the relative path).
 - **Extension filter**: keeps a file only if its lower-cased suffix is in `FileReader.SUPPORTED` **or** equals `.canvas` (Obsidian canvas files).
 - **Sensitive-path guard**: resolves each candidate (`Path.resolve()`) and skips it if `is_sensitive_path()` matches.

--- a/src/kiro_crew/knowledge/folder_watcher.py
+++ b/src/kiro_crew/knowledge/folder_watcher.py
@@ -28,8 +28,13 @@ logger = logging.getLogger(__name__)
 # per-file graph reload runs on the event loop and can stall it past the loop
 # watchdog (dist/assets/*.js was the motivating case). Dot-dirs (.cache, .next,
 # .venv) are already pruned separately by the startswith(".") rule in _walk.
+# ``cdk.out`` is the same churn with a cost attached rather than a stall: AWS CDK
+# rewrites hashed asset bundles and template JSON on every synth, so each build
+# presents megabytes of generated JSON as changed content and the scan pays a
+# fresh extraction call per chunk. Its name only CONTAINS a dot, so the
+# dot-prefix rule never prunes it, and the bare ``out`` entry does not match it.
 HARD_SKIP_DIRS = {".git", "node_modules", "__pycache__", ".venv", "venv",
-                  "dist", "build", "out", "target"}
+                  "dist", "build", "out", "target", "cdk.out"}
 DEFAULT_MAX_FILES = 5000
 
 # How many times a file left in 'scanning' is retried before its row is retired to
@@ -55,12 +60,23 @@ SOURCE_TYPE_SKIP_DIRS: dict[str, set[str]] = {
     "obsidian_vault": {".obsidian", ".trash"},
 }
 
-# OS-generated temp / lock / junk files that are never real documents. Matched
-# case-insensitively against the file basename for every folder source type, in
-# addition to any per-source ignore_patterns. Without this, files that carry an
-# otherwise-supported extension are discovered, fail ingestion, and (since failed
-# files are never auto-retried) leave a source permanently stalled below 100%.
-# The motivating case: macOS AppleDouble sidecars (``._<name>.docx``).
+# Files that are never real documents, matched case-insensitively against the
+# file basename for every folder source type in addition to any per-source
+# ignore_patterns. Entries must therefore be lowercase.
+#
+# Two classes, for two different reasons:
+#
+# OS-generated temp / lock / junk files carry an otherwise-supported extension,
+# so they are discovered, fail ingestion, and -- since failed files are never
+# auto-retried -- leave a source permanently stalled below 100%. macOS
+# AppleDouble sidecars (``._<name>.docx``) are the common case.
+#
+# Dependency lock files ingest successfully, which is worse: they are large,
+# fully machine-generated, and answer no question a human would ask, yet every
+# chunk costs one extraction call and a regenerated lock file is billed again on
+# the next sweep. Several of them carry an extension no reader supports today,
+# so the glob is what keeps them out regardless of what ``FileReader.SUPPORTED``
+# accepts.
 DEFAULT_IGNORE_GLOBS: tuple[str, ...] = (
     "._*",            # macOS AppleDouble resource forks
     ".ds_store",      # macOS Finder metadata
@@ -77,6 +93,22 @@ DEFAULT_IGNORE_GLOBS: tuple[str, ...] = (
     "*.crdownload",   # incomplete browser downloads
     "*.part",
     "*.partial",
+    # Dependency lock files: generated resolution output, not documentation.
+    "package-lock.json",     # npm
+    "npm-shrinkwrap.json",
+    "yarn.lock",             # Yarn
+    "pnpm-lock.yaml",        # pnpm
+    "bun.lockb",             # Bun (binary and text forms)
+    "bun.lock",
+    "poetry.lock",           # Python
+    "uv.lock",
+    "pipfile.lock",
+    "cargo.lock",            # Rust
+    "gemfile.lock",          # Ruby
+    "composer.lock",         # PHP
+    "packages.lock.json",    # NuGet
+    "gradle.lockfile",       # Gradle
+    "flake.lock",            # Nix
 )
 
 

--- a/test/test_folder_watcher.py
+++ b/test/test_folder_watcher.py
@@ -11,8 +11,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from kiro_crew.knowledge import folder_watcher
 from kiro_crew.knowledge.connectors.local_folder import LocalFolderConnector
 from kiro_crew.knowledge.folder_watcher import MAX_SCAN_ATTEMPTS, FolderWatcher
+from kiro_crew.knowledge.readers import FileReader
 from kiro_crew.knowledge.store import KnowledgeStore
 
 
@@ -161,6 +163,92 @@ class TestFolderWatcherWalk:
         text, meta = reader.read(str(org_file))
         assert "Body text" in text
         assert meta["extension"] == ".org"
+
+
+#: Real-world capitalisation, so the case-insensitive basename match is exercised.
+LOCK_FILES = (
+    "package-lock.json", "npm-shrinkwrap.json", "yarn.lock", "pnpm-lock.yaml",
+    "bun.lockb", "bun.lock", "poetry.lock", "uv.lock", "Pipfile.lock",
+    "Cargo.lock", "Gemfile.lock", "composer.lock", "packages.lock.json",
+    "gradle.lockfile", "flake.lock",
+)
+
+
+class TestGeneratedArtifactDefaults:
+    """Generated build output and dependency locks must not reach the embedder.
+
+    They ingest fine, which is what makes them expensive: each is regenerated on
+    every build, so a sweep re-chunks them and pays an extraction call per chunk
+    for content that answers no question.
+    """
+
+    def _names(self, store, pipeline, root):
+        fw = FolderWatcher(store, pipeline)
+        return {Path(p).name for p, _ in fw._walk(str(root), [], set())}
+
+    def _cdk_tree(self, tmp_path):
+        root = tmp_path / "repo"
+        (root / "cdk.out" / "asset.9f3c").mkdir(parents=True)
+        (root / "cdk.out" / "tree.json").write_text('{"tree": {}}')
+        (root / "cdk.out" / "asset.9f3c" / "manifest.json").write_text("{}")
+        (root / "notes.md").write_text("# real doc")
+        return root
+
+    def _lock_tree(self, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        (root / "notes.md").write_text("# real doc")
+        for name in LOCK_FILES:
+            (root / name).write_text("generated resolution output")
+        return root
+
+    def test_cdk_out_is_pruned(self, store, pipeline, tmp_path):
+        root = self._cdk_tree(tmp_path)
+        names = self._names(store, pipeline, root)
+        assert "notes.md" in names
+        assert "tree.json" not in names
+        assert "manifest.json" not in names
+
+    def test_cdk_out_entry_is_load_bearing(self, store, pipeline, tmp_path, monkeypatch):
+        # Nothing else keeps synth output out: the name only CONTAINS a dot so the
+        # dot-prefix rule skips it, the bare "out" entry does not match it, and
+        # .json is reader-supported.
+        monkeypatch.setattr(folder_watcher, "HARD_SKIP_DIRS",
+                            folder_watcher.HARD_SKIP_DIRS - {"cdk.out"})
+        names = self._names(store, pipeline, self._cdk_tree(tmp_path))
+        assert "tree.json" in names
+        assert "manifest.json" in names
+
+    def test_dependency_lock_files_are_never_discovered(self, store, pipeline, tmp_path):
+        names = self._names(store, pipeline, self._lock_tree(tmp_path))
+        assert "notes.md" in names
+        assert names.isdisjoint(LOCK_FILES)
+
+    def test_lock_files_stay_out_when_their_extension_is_readable(
+            self, store, pipeline, tmp_path, monkeypatch):
+        # ``.lock``/``.lockb``/``.lockfile`` are not reader-supported today, so the
+        # extension filter would mask a missing glob. Widening SUPPORTED isolates
+        # the globs as the thing under test.
+        monkeypatch.setattr(FileReader, "SUPPORTED",
+                            FileReader.SUPPORTED | {".lock", ".lockb", ".lockfile"})
+        names = self._names(store, pipeline, self._lock_tree(tmp_path))
+        assert "notes.md" in names
+        assert names.isdisjoint(LOCK_FILES)
+
+    def test_lock_globs_are_load_bearing(self, store, pipeline, tmp_path, monkeypatch):
+        lock_globs = {n.lower() for n in LOCK_FILES}
+        monkeypatch.setattr(FileReader, "SUPPORTED",
+                            FileReader.SUPPORTED | {".lock", ".lockb", ".lockfile"})
+        monkeypatch.setattr(folder_watcher, "DEFAULT_IGNORE_GLOBS", tuple(
+            g for g in folder_watcher.DEFAULT_IGNORE_GLOBS if g not in lock_globs))
+        names = self._names(store, pipeline, self._lock_tree(tmp_path))
+        assert set(LOCK_FILES) <= names
+
+    def test_every_lock_glob_is_registered_lowercase(self):
+        # The match runs against a lowercased basename, so an entry carrying any
+        # uppercase character can never fire.
+        for name in LOCK_FILES:
+            assert name.lower() in folder_watcher.DEFAULT_IGNORE_GLOBS, name
 
 
 class TestFolderWatcherScan:

--- a/test/test_knowledge_doc_filter.py
+++ b/test/test_knowledge_doc_filter.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from test_folder_watcher import LOCK_FILES
+
 from kiro_crew.knowledge.doc_filter import (
     DOC_EXTENSIONS,
     MIN_DOC_BYTES,
@@ -77,6 +79,20 @@ class TestSkips:
 
     def test_hard_skip_dirs_pruned(self):
         assert not should_ingest_doc("node_modules/pkg/readme.md", BIG)
+
+    def test_cdk_out_pruned(self):
+        # Inherited from HARD_SKIP_DIRS. The prose case is the one that matters:
+        # synth output is JSON, which the extension allowlist already drops.
+        assert not should_ingest_doc("cdk.out/tree.json", BIG)
+        assert not should_ingest_doc("infra/cdk.out/docs/readme.md", BIG)
+
+    def test_dependency_locks_need_no_project_doc_patterns(self):
+        # The extension allowlist alone excludes every lock file, at any depth,
+        # so this filter carries no lock-file entries of its own.
+        for name in LOCK_FILES:
+            assert Path(name).suffix.lower() not in DOC_EXTENSIONS, name
+            assert not should_ingest_doc(name, BIG), name
+            assert not should_ingest_doc(f"tools/{name}", BIG), name
 
     def test_os_junk_dropped(self):
         assert not should_ingest_doc("docs/._notes.md", BIG)


### PR DESCRIPTION
## Problem

A hand-added knowledge folder source walks a project tree with a **denylist only** — there is no include allowlist — so machine-generated files that happen to carry a reader-supported extension are discovered, chunked, and embedded. Every chunk costs one LLM extraction call, and a regenerated file is re-chunked and re-billed on the next sweep, at idle, with nobody watching.

Two gaps in `src/kiro_crew/knowledge/folder_watcher.py`:

1. **`HARD_SKIP_DIRS` lacks `cdk.out`.** AWS CDK rewrites hashed asset bundles and template JSON on every `cdk synth`, so each build presents megabytes of generated JSON as changed content. Nothing else keeps it out: the name only *contains* a dot, so `_walk`'s `startswith(".")` pruning never sees it, and the existing bare `out` entry does not match `cdk.out`.
2. **`DEFAULT_IGNORE_GLOBS` has no dependency lock files.** `.json` and `.yaml` are in `FileReader.SUPPORTED`, so `package-lock.json`, `npm-shrinkwrap.json`, `packages.lock.json` and `pnpm-lock.yaml` ingest *successfully* — which is worse than failing — and are re-billed whenever a dependency changes.

## Why this matters

Lock files and synth output are large, fully machine-generated, and answer no question a human would ask. Measured by walking this repository's own tree with and without the change: **3 lock files, 905,346 bytes** (≈190 chunks, i.e. ≈190 extraction calls per sweep) from lock files alone. A synthetic 4-file CDK project drops from 240,008 walked bytes to 8.

## Fix

- Add `cdk.out` to `HARD_SKIP_DIRS`.
- Add fifteen lock-file basenames to `DEFAULT_IGNORE_GLOBS`: `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`, `bun.lock`, `poetry.lock`, `uv.lock`, `pipfile.lock`, `cargo.lock`, `gemfile.lock`, `composer.lock`, `packages.lock.json`, `gradle.lockfile`, `flake.lock`.

`DEFAULT_IGNORE_GLOBS` (rather than a per-source-type list) is the right home: it applies to **every** folder source type, and a lock file is never a document under any of them. Entries are lowercase because the match runs against a lowercased basename — an entry carrying uppercase can never fire.

Honest scope note: the `.lock` / `.lockb` / `.lockfile` suffixes are **not** in `FileReader.SUPPORTED` today, so those ten entries are currently belt-and-braces — the extension filter already drops them. They are included so the guarantee survives any future widening of `SUPPORTED`, and a test proves they do real work by widening `SUPPORTED` and re-walking. The four that are ingested today (`.json`/`.yaml`) are the live bug.

`doc_filter.py` (project-doc auto-sources) needs **no additions**: it restricts to `DOC_EXTENSIONS = {.md, .pdf, .docx, .org}` and imports `HARD_SKIP_DIRS`, so it already excluded every lock file and now inherits the `cdk.out` prune for free. Tests pin both so this cannot regress silently.

The `knowledge` module spec's constants table was stale (missing `dist`/`build`/`out`/`target`); it is corrected and the two ignore classes are documented.

## Tests

New `TestGeneratedArtifactDefaults` in `test/test_folder_watcher.py` (6 tests) plus 2 in `test/test_knowledge_doc_filter.py`. Lock-file fixtures use real-world capitalisation (`Cargo.lock`, `Pipfile.lock`, `Gemfile.lock`) so the case-insensitive match is exercised.

Each new skip/glob class is **revert-verified** — the fix was patched out of source and the tests confirmed to fail:

| Reverted | Failing tests |
|---|---|
| `cdk.out` removed from `HARD_SKIP_DIRS` | `test_cdk_out_is_pruned`, `TestSkips::test_cdk_out_pruned` |
| 15 lock globs removed | `test_dependency_lock_files_are_never_discovered`, `test_lock_files_stay_out_when_their_extension_is_readable`, `test_every_lock_glob_is_registered_lowercase` |
| both | all 5 |

`test_every_lock_glob_is_registered_lowercase` fails if **any single** entry is removed or mis-cased, so the per-entry guarantee is pinned, not just the class.

## Manual verification

Walked two real trees through `FolderWatcher._walk` with the constants patched on and off:

```
== real repo tree (this worktree)
   with defaults          files= 3324 bytes=  68142732 locks=0 cdk_out=0
   without new defaults   files= 3327 bytes=  69048078 locks=3 cdk_out=0
        lock: site/package-lock.json (267134 bytes)
        lock: website/package-lock.json (500584 bytes)
        lock: website/electron/package-lock.json (137628 bytes)
== synthetic CDK project
   with defaults          files=    1 bytes=         8 locks=0 cdk_out=0
   without new defaults   files=    4 bytes=    240008 locks=0 cdk_out=3
        cdk : cdk.out/tree.json (80000 bytes)
        cdk : cdk.out/MyStack.template.json (120000 bytes)
        cdk : cdk.out/asset.7b21ce/index.json (40000 bytes)
```

## Gates

- `pytest test/test_folder_watcher.py test/test_knowledge_doc_filter.py` — 82 passed
- Full knowledge surface (9 modules incl. cost guards, project docs, autosource, ingest guard) — 348 passed
- `isort --check-only src/kiro_crew test` — clean
- `flake8 src/kiro_crew test` — clean
- CI-parity `mypy src/kiro_crew/` — Success, no issues in 824 source files

No frontend change, so no `tsc`/`vitest`/dist rebuild.
