### PR TITLE
test(backend): add unit coverage for 9 under-tested backend modules

### DIFF
--- a/test/test_apps_backend_coverage.py
+++ b/test/test_apps_backend_coverage.py
@@ -1,0 +1,1852 @@
+"""Additional unit coverage for :mod:`kiro_crew.apps.backend`.
+
+Complements ``test_app_backend.py`` (port allocation, spawn survival, dispatch)
+and ``test_app_backend_stale_reap.py`` (pidfile reap safety) by exercising the
+branches those files leave untouched:
+
+* the adopt-an-already-healthy-instance path and its refusals,
+* the per-app venv / pip and npm dependency-install branches,
+* the Node and ASGI dispatch branches,
+* ``stop_app_backend``'s adopted-PID revalidation and SIGKILL escalation,
+* the pidfile helpers' error paths and ``_proc_start_time``'s two platforms,
+* the boot-time MCP + executable-resource reconcile in
+  ``start_enabled_app_backends``.
+
+Everything here is hermetic and order-independent: no real process is spawned,
+no socket is bound, no network request is made, and no wall-clock duration is
+asserted. ``subprocess.Popen`` / ``subprocess.run``, the ``socket`` module,
+and ``urllib.request.urlopen`` are stubbed, and the spawn body is frozen at the
+``Popen`` seam with a sentinel exception.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+import urllib.error
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import kiro_crew.apps.backend as bmod
+from kiro_crew.apps.backend import AppProcess
+
+# ---------------------------------------------------------------------------
+# Shared doubles
+# ---------------------------------------------------------------------------
+
+
+class _StopSpawn(Exception):
+    """Stands in for ``subprocess.Popen`` so the spawn body freezes there.
+
+    Not an ``OSError``, so it is NOT swallowed by the body's Popen guard — it
+    propagates out and the test inspects whatever the dispatch had built.
+    """
+
+
+class _FakeProc:
+    """Minimal ``Popen`` stand-in: a pid plus a controllable exit status."""
+
+    def __init__(self, pid: int = 4242, returncode: int | None = None) -> None:
+        self.pid = pid
+        self.returncode = returncode
+        self.wait_raises = False
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self.wait_raises:
+            raise subprocess.TimeoutExpired(cmd="app", timeout=timeout or 0)
+        return self.returncode or 0
+
+
+def _fake_proc(pid: int = 4242, returncode: int | None = None) -> Any:
+    """A ``Popen`` stand-in typed as ``Any`` so ``AppProcess.proc`` accepts it."""
+
+    return _FakeProc(pid=pid, returncode=returncode)
+
+
+class _FakeSock:
+    """Socket stand-in supporting the two uses in this module: bind and connect."""
+
+    def __init__(self, connect_exc: BaseException | None) -> None:
+        self._connect_exc = connect_exc
+
+    def __enter__(self) -> _FakeSock:
+        return self
+
+    def __exit__(self, *_a: Any) -> None:
+        return None
+
+    def settimeout(self, _timeout: float) -> None:
+        return None
+
+    def bind(self, _addr: Any) -> None:
+        return None
+
+    def connect(self, _addr: Any) -> None:
+        if self._connect_exc is not None:
+            raise self._connect_exc
+
+
+class _FakeResp:
+    """``urlopen`` stand-in: a status code usable as a context manager."""
+
+    def __init__(self, status: int = 200) -> None:
+        self.status = status
+
+    def __enter__(self) -> _FakeResp:
+        return self
+
+    def __exit__(self, *_a: Any) -> None:
+        return None
+
+
+def _install_fake_socket(
+    monkeypatch: pytest.MonkeyPatch, *, connect_exc: BaseException | None
+) -> None:
+    """Replace the module's ``socket`` reference with an inert stand-in.
+
+    ``connect_exc=OSError(...)`` models "nothing is on this port" (the normal
+    spawn path); ``connect_exc=None`` models an occupied port (the adopt path).
+    ``bind`` always succeeds so auto-port selection never touches a real port.
+    """
+
+    monkeypatch.setattr(
+        bmod,
+        "socket",
+        SimpleNamespace(
+            AF_INET=2,
+            SOCK_STREAM=1,
+            socket=lambda *_a, **_k: _FakeSock(connect_exc),
+        ),
+    )
+
+
+def _manifest(
+    entry_point: str,
+    *,
+    port: str = "auto",
+    health: str = "/health",
+    backend_type: str = "",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        backend=SimpleNamespace(
+            entryPoint=entry_point,
+            port=port,
+            healthCheck=health,
+            type=backend_type,
+        )
+    )
+
+
+def _capture_popen(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Freeze the spawn at Popen and capture the argv + kwargs it built."""
+
+    seen: dict[str, Any] = {}
+
+    def _popen(argv: Any, **kwargs: Any) -> Any:
+        seen["argv"] = list(argv)
+        seen["kwargs"] = kwargs
+        raise _StopSpawn()
+
+    monkeypatch.setattr(bmod.subprocess, "Popen", _popen)
+    return seen
+
+
+def _record_runs(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    result: Any = None,
+    exc: BaseException | None = None,
+) -> list[list[str]]:
+    """Record every ``subprocess.run`` argv, optionally failing the call."""
+
+    calls: list[list[str]] = []
+
+    def _run(argv: Any, **_kwargs: Any) -> Any:
+        calls.append(list(argv))
+        if exc is not None:
+            raise exc
+        if result is not None:
+            return result
+        return SimpleNamespace(returncode=0, stdout="")
+
+    monkeypatch.setattr(bmod.subprocess, "run", _run)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_module_state(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Give every test a clean process table, pidfile, and audit sink."""
+
+    home = tmp_path / "kirocrew-home"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("KIROCREW_HOME", str(home))
+    monkeypatch.setattr(bmod, "_pidfile_path", lambda: tmp_path / "app_backends.pids.json")
+    monkeypatch.setattr(bmod, "sel", lambda: MagicMock())
+    with bmod._lock:
+        bmod._processes.clear()
+        bmod._allocated_ports.clear()
+    yield
+    with bmod._lock:
+        bmod._processes.clear()
+        bmod._allocated_ports.clear()
+
+
+@pytest.fixture()
+def spawn_root(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> Any:
+    """An app root wired so ``_start_app_backend_body`` runs without side effects."""
+
+    root = tmp_path / "app-root"
+    root.mkdir()
+    monkeypatch.setattr(bmod, "app_dir", lambda _name: root)
+    monkeypatch.setattr(bmod, "app_execution_denied", lambda _name, **_kw: None)
+    monkeypatch.setattr(bmod, "wrap_argv", lambda argv, **_kw: (list(argv), None))
+    monkeypatch.setattr(bmod, "cgroup_scope_argv", lambda argv: list(argv))
+    monkeypatch.setattr(bmod, "resource_limit_preexec", lambda: None)
+    monkeypatch.setattr(bmod, "build_resource_limit_preexec", lambda: None)
+    monkeypatch.setattr(bmod, "_health_check_loop", lambda *_a, **_k: None)
+    _install_fake_socket(monkeypatch, connect_exc=OSError("connection refused"))
+    return root
+
+
+@pytest.fixture()
+def boot_env(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
+    """Stub every collaborator ``start_enabled_app_backends`` reaches out to."""
+
+    calls: dict[str, list[Any]] = {
+        "started": [],
+        "dereg_mcp": [],
+        "dereg_agents": [],
+        "dereg_skills": [],
+        "register": [],
+        "reconcile_skills": [],
+    }
+
+    def _start(name: str) -> AppProcess | None:
+        calls["started"].append(name)
+        return None
+
+    monkeypatch.setattr(bmod, "_reap_stale_app_backends", lambda: 0)
+    monkeypatch.setattr(bmod, "get_app_manifest", lambda _name: None)
+    monkeypatch.setattr(bmod, "shipped_builtin_app_root", lambda _name: None)
+    monkeypatch.setattr(bmod, "app_admission_denied", lambda _name, **_kw: None)
+    monkeypatch.setattr(bmod, "app_execution_denied", lambda _name, **_kw: None)
+    monkeypatch.setattr(bmod, "start_app_backend", _start)
+    monkeypatch.setattr("kiro_crew.apps.manager._app_activation_denied", lambda _name: None)
+
+    def _dereg_mcp(name: str) -> int:
+        calls["dereg_mcp"].append(name)
+        return 1
+
+    def _dereg_agents(name: str) -> int:
+        calls["dereg_agents"].append(name)
+        return 1
+
+    def _dereg_skills(name: str) -> int:
+        calls["dereg_skills"].append(name)
+        return 1
+
+    def _register(name: str) -> Any:
+        calls["register"].append(name)
+        return SimpleNamespace(errors=[])
+
+    def _reconcile(name: str) -> None:
+        calls["reconcile_skills"].append(name)
+
+    monkeypatch.setattr("kiro_crew.apps.bridges._deregister_mcp_servers", _dereg_mcp)
+    monkeypatch.setattr("kiro_crew.apps.bridges._deregister_agents", _dereg_agents)
+    monkeypatch.setattr("kiro_crew.apps.bridges._deregister_skills", _dereg_skills)
+    monkeypatch.setattr("kiro_crew.apps.bridges.register_app", _register)
+    monkeypatch.setattr("kiro_crew.apps.bridges.reconcile_app_skills", _reconcile)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Port + listener probes
+# ---------------------------------------------------------------------------
+
+
+class TestPortProbes:
+    def test_exhausted_range_raises_rather_than_returning_a_taken_port(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Handing back an already-reserved port would crash-loop the loser."""
+
+        monkeypatch.setattr(bmod, "_MIN_PORT", 9100)
+        monkeypatch.setattr(bmod, "_MAX_PORT", 9103)
+        with bmod._lock:
+            bmod._allocated_ports.update({"a": 9100, "b": 9101, "c": 9102})
+        with pytest.raises(RuntimeError, match="No free ports"):
+            bmod._find_free_port()
+
+    def test_port_is_listening_true_when_connect_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The True branch, without a real host socket.
+
+        An earlier revision bound a real ephemeral loopback listener here. Even
+        on port 0 that is a host-level side effect outside ``tmp_path``, and it
+        can fail outright on a locked-down runner -- so the success path is
+        faked the same way the refusal path below already is. ``_port_is_listening``
+        only uses the connection as a context manager and discards it, so a
+        minimal stub is a faithful double.
+        """
+
+        class _FakeConn:
+            def __enter__(self) -> _FakeConn:
+                return self
+
+            def __exit__(self, *_exc: object) -> None:
+                return None
+
+        seen: dict[str, object] = {}
+
+        def _connect(address: tuple[str, int], **kwargs: object) -> _FakeConn:
+            seen["address"] = address
+            seen["timeout"] = kwargs.get("timeout")
+            return _FakeConn()
+
+        monkeypatch.setattr(bmod.socket, "create_connection", _connect)
+        assert bmod._port_is_listening(9100) is True
+        # Probing anything but loopback would reach off-box.
+        assert seen["address"] == ("127.0.0.1", 9100)
+        assert seen["timeout"] == bmod._PORT_PROBE_TIMEOUT
+
+    def test_port_is_listening_false_when_connect_refused(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            bmod.socket,
+            "create_connection",
+            lambda *_a, **_k: (_ for _ in ()).throw(OSError("refused")),
+        )
+        assert bmod._port_is_listening(9100) is False
+
+    def test_listening_pids_passes_through_the_platform_probe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(bmod.platform_compat, "find_listening_pids", lambda _p: [7, 9])
+        assert bmod._listening_pids(9100) == [7, 9]
+
+    def test_listening_pids_never_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A probe failure must degrade to 'unknown', not fail the spawn."""
+
+        def _boom(_port: int) -> list[int]:
+            raise RuntimeError("lsof exploded")
+
+        monkeypatch.setattr(bmod.platform_compat, "find_listening_pids", _boom)
+        assert bmod._listening_pids(9100) == []
+
+
+class TestPidAncestry:
+    def test_same_pid_is_its_own_ancestor(self) -> None:
+        assert bmod._pid_is_self_or_descendant_of(11, 11) is True
+
+    def test_direct_child_is_a_descendant(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(bmod.platform_compat, "get_ppid", lambda _p: 11)
+        assert bmod._pid_is_self_or_descendant_of(22, 11) is True
+
+    def test_ppid_probe_failure_denies_ownership(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boom(_pid: int) -> int:
+            raise OSError("no /proc")
+
+        monkeypatch.setattr(bmod.platform_compat, "get_ppid", _boom)
+        assert bmod._pid_is_self_or_descendant_of(22, 11) is False
+
+    def test_reaching_pid_0_denies_ownership(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(bmod.platform_compat, "get_ppid", lambda _p: 0)
+        assert bmod._pid_is_self_or_descendant_of(22, 11) is False
+
+    def test_walk_is_depth_bounded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unbounded walk on a pathological parent map must not hang."""
+
+        seen: list[int] = []
+
+        def _ppid(pid: int) -> int:
+            seen.append(pid)
+            return pid + 1  # never reaches the ancestor
+
+        monkeypatch.setattr(bmod.platform_compat, "get_ppid", _ppid)
+        assert bmod._pid_is_self_or_descendant_of(100, 11) is False
+        assert len(seen) == bmod._PID_ANCESTRY_MAX_DEPTH
+
+    def test_spawn_owns_listener_combines_probe_and_ancestry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(bmod, "_listening_pids", lambda _p: [55])
+        monkeypatch.setattr(
+            bmod, "_pid_is_self_or_descendant_of", lambda pid, anc: pid == 55 and anc == 42
+        )
+        assert bmod._spawn_owns_listener(9100, 42) is True
+        assert bmod._spawn_owns_listener(9100, 43) is False
+
+
+# ---------------------------------------------------------------------------
+# Node / npm binary resolution
+# ---------------------------------------------------------------------------
+
+
+class TestNvmResolution:
+    def test_no_nvm_script_returns_none(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NVM_DIR", str(tmp_path / "absent"))
+        assert bmod._resolve_nvm_path("node") is None
+
+    def _nvm_dir(self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> Any:
+        nvm = tmp_path / "nvm"
+        nvm.mkdir()
+        (nvm / "nvm.sh").write_text("# nvm\n")
+        monkeypatch.setenv("NVM_DIR", str(nvm))
+        return nvm
+
+    def test_resolves_sibling_binary_of_the_nvm_node(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._nvm_dir(tmp_path, monkeypatch)
+        bin_dir = tmp_path / "versions" / "bin"
+        bin_dir.mkdir(parents=True)
+        (bin_dir / "node").write_text("")
+        (bin_dir / "npm").write_text("")
+        _record_runs(
+            monkeypatch,
+            result=SimpleNamespace(returncode=0, stdout=f"{bin_dir / 'node'}\n"),
+        )
+        assert bmod._resolve_nvm_path("npm") == str(bin_dir / "npm")
+
+    def test_missing_sibling_binary_returns_none(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._nvm_dir(tmp_path, monkeypatch)
+        bin_dir = tmp_path / "versions" / "bin"
+        bin_dir.mkdir(parents=True)
+        (bin_dir / "node").write_text("")
+        _record_runs(
+            monkeypatch,
+            result=SimpleNamespace(returncode=0, stdout=f"{bin_dir / 'node'}\n"),
+        )
+        assert bmod._resolve_nvm_path("npm") is None
+
+    def test_nonzero_nvm_exit_returns_none(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._nvm_dir(tmp_path, monkeypatch)
+        _record_runs(monkeypatch, result=SimpleNamespace(returncode=1, stdout=""))
+        assert bmod._resolve_nvm_path("node") is None
+
+    def test_nvm_probe_failure_returns_none(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._nvm_dir(tmp_path, monkeypatch)
+        _record_runs(monkeypatch, exc=OSError("no bash"))
+        assert bmod._resolve_nvm_path("node") is None
+
+    def test_node_and_npm_prefer_nvm_over_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(bmod, "_resolve_nvm_path", lambda name: f"/nvm/{name}")
+        monkeypatch.setattr(
+            bmod.shutil, "which", lambda _n: pytest.fail("PATH consulted despite nvm hit")
+        )
+        assert bmod._find_node_binary() == "/nvm/node"
+        assert bmod._find_npm_binary() == "/nvm/npm"
+
+    def test_node_and_npm_fall_back_to_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(bmod, "_resolve_nvm_path", lambda _name: None)
+        monkeypatch.setattr(bmod.shutil, "which", lambda name: f"/usr/bin/{name}")
+        assert bmod._find_node_binary() == "/usr/bin/node"
+        assert bmod._find_npm_binary() == "/usr/bin/npm"
+
+
+# ---------------------------------------------------------------------------
+# Entry-point heuristics
+# ---------------------------------------------------------------------------
+
+
+class TestEntryHeuristics:
+    def test_asgi_entry_needs_both_markers(self, tmp_path: Any) -> None:
+        both = tmp_path / "asgi.py"
+        both.write_text("app = FastAPI()\nimport uvicorn\n")
+        assert bmod._is_asgi_entry(both) is True
+
+        only_one = tmp_path / "plain.py"
+        only_one.write_text("app = FastAPI()\n")
+        assert bmod._is_asgi_entry(only_one) is False
+
+    def test_asgi_entry_unreadable_is_not_asgi(self, tmp_path: Any) -> None:
+        assert bmod._is_asgi_entry(tmp_path) is False  # a directory: OSError
+
+    def test_shebang_argv_unreadable_falls_back_to_bin_sh(self, tmp_path: Any) -> None:
+        assert bmod._shebang_argv(tmp_path) == ["/bin/sh"]
+
+    def test_shebang_argv_non_utf8_falls_back_to_bin_sh(self, tmp_path: Any) -> None:
+        entry = tmp_path / "weird"
+        entry.write_bytes(b"#!\xff\xfe\n")
+        assert bmod._shebang_argv(entry) == ["/bin/sh"]
+
+    def test_shebang_argv_empty_interpreter_falls_back_to_bin_sh(self, tmp_path: Any) -> None:
+        entry = tmp_path / "bare"
+        entry.write_bytes(b"#!\n")
+        assert bmod._shebang_argv(entry) == ["/bin/sh"]
+
+    def test_shebang_argv_keeps_the_single_kernel_argument(self, tmp_path: Any) -> None:
+        entry = tmp_path / "run"
+        entry.write_text("#!/usr/bin/env bash\n")
+        assert bmod._shebang_argv(entry) == ["/usr/bin/env", "bash"]
+
+
+# ---------------------------------------------------------------------------
+# start_app_backend coordination
+# ---------------------------------------------------------------------------
+
+
+class TestStartCoordination:
+    def test_no_manifest_is_a_no_op(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(bmod, "get_app_manifest", lambda _n: None)
+        assert bmod.start_app_backend("ghost") is None
+
+    def test_a_live_spawned_process_is_reused_not_respawned(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(bmod, "get_app_manifest", lambda _n: _manifest("server.py"))
+        monkeypatch.setattr(
+            bmod,
+            "_start_app_backend_body",
+            lambda *_a: pytest.fail("respawned an already-running backend"),
+        )
+        existing = AppProcess(app_name="live", port=9100, pid=1, proc=_fake_proc())
+        with bmod._lock:
+            bmod._processes["live"] = existing
+        assert bmod.start_app_backend("live") is existing
+
+    def test_an_adopted_instance_is_reused_not_respawned(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(bmod, "get_app_manifest", lambda _n: _manifest("server.py"))
+        monkeypatch.setattr(
+            bmod,
+            "_start_app_backend_body",
+            lambda *_a: pytest.fail("respawned over an adopted instance"),
+        )
+        existing = AppProcess(
+            app_name="adopted", port=9100, pid=0, proc=None, adopted_pids=[123], healthy=True
+        )
+        with bmod._lock:
+            bmod._processes["adopted"] = existing
+        assert bmod.start_app_backend("adopted") is existing
+
+    def test_a_raising_spawn_body_clears_the_starting_placeholder(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Otherwise the app is wedged in 'starting' until a gateway restart."""
+
+        monkeypatch.setattr(bmod, "get_app_manifest", lambda _n: _manifest("server.py"))
+
+        def _boom(_name: str, _manifest: Any) -> None:
+            raise RuntimeError("sandbox unavailable")
+
+        monkeypatch.setattr(bmod, "_start_app_backend_body", _boom)
+        with pytest.raises(RuntimeError, match="sandbox unavailable"):
+            bmod.start_app_backend("boomer")
+        assert "boomer" not in bmod._processes
+        assert "boomer" not in bmod._allocated_ports
+
+
+class TestAwaitInflightSpawn:
+    def test_a_cleared_placeholder_resolves_to_none(self) -> None:
+        assert bmod._await_inflight_spawn("nobody", timeout=0.2) is None
+
+    def test_a_resolved_process_is_returned(self) -> None:
+        ap = AppProcess(app_name="done", port=9100, pid=7)
+        with bmod._lock:
+            bmod._processes["done"] = ap
+        assert bmod._await_inflight_spawn("done", timeout=0.2) is ap
+
+    def test_a_process_that_resolved_at_the_deadline_is_still_returned(self) -> None:
+        """The post-deadline recheck must not throw away a real started process."""
+
+        ap = AppProcess(app_name="late", port=9100, pid=7)
+        with bmod._lock:
+            bmod._processes["late"] = ap
+        # timeout=0 skips the poll loop entirely and goes straight to the recheck.
+        assert bmod._await_inflight_spawn("late", timeout=0.0) is ap
+
+    def test_an_absent_entry_at_the_deadline_resolves_to_none(self) -> None:
+        assert bmod._await_inflight_spawn("absent", timeout=0.0) is None
+
+
+# ---------------------------------------------------------------------------
+# Spawn body: port resolution
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnPortResolution:
+    def test_fixed_port_outside_the_allowed_range_is_refused(
+        self, spawn_root: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        (spawn_root / "server.py").write_text("x = 1\n")
+        with caplog.at_level(logging.ERROR):
+            assert (
+                bmod._start_app_backend_body("ranged", _manifest("server.py", port="1")) is None
+            )
+        assert any("outside allowed range" in r.message for r in caplog.records)
+
+    def test_fixed_port_held_by_another_app_is_refused(
+        self, spawn_root: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Double-booking a port is the EADDRINUSE crash this refusal prevents."""
+
+        taken = bmod._MIN_PORT + 4
+        bmod._claim_port("incumbent", taken)
+        (spawn_root / "server.py").write_text("x = 1\n")
+        with caplog.at_level(logging.ERROR):
+            result = bmod._start_app_backend_body(
+                "latecomer", _manifest("server.py", port=str(taken))
+            )
+        assert result is None
+        assert any("cannot start" in r.message for r in caplog.records)
+        assert "latecomer" not in bmod._allocated_ports
+
+    def test_a_non_numeric_port_falls_back_to_auto_allocation(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (spawn_root / "server.py").write_text("x = 1\n")
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("fuzzy", _manifest("server.py", port="not-a-number"))
+        assert bmod._MIN_PORT <= bmod._allocated_ports["fuzzy"] <= bmod._MAX_PORT
+
+
+# ---------------------------------------------------------------------------
+# Spawn body: adopting an existing instance on a fixed port
+# ---------------------------------------------------------------------------
+
+
+class TestAdoptExistingInstance:
+    @pytest.fixture()
+    def occupied(self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch) -> Any:
+        (spawn_root / "server.py").write_text("x = 1\n")
+        _install_fake_socket(monkeypatch, connect_exc=None)  # port answers => occupied
+        monkeypatch.setattr(
+            bmod.subprocess, "Popen", lambda *_a, **_k: pytest.fail("spawned onto a taken port")
+        )
+        return spawn_root
+
+    def _run(self, port: int) -> AppProcess | None:
+        return bmod._start_app_backend_body("adoptee", _manifest("server.py", port=str(port)))
+
+    def test_a_healthy_instance_is_adopted_with_its_listening_pids(
+        self, occupied: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        port = bmod._MIN_PORT + 6
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        _record_runs(
+            monkeypatch,
+            # A non-numeric line must be skipped, not abort the adoption.
+            result=SimpleNamespace(returncode=0, stdout="111\nbogus\n222\n"),
+        )
+        ap = self._run(port)
+        assert ap is not None
+        assert ap.proc is None
+        assert ap.healthy is True
+        assert ap.adopted_pids == [111, 222]
+        assert bmod._processes["adoptee"] is ap
+        assert bmod._allocated_ports["adoptee"] == port
+
+    def test_adoption_survives_an_audit_sink_failure(
+        self, occupied: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A broken audit sink must not cost us a healthy running backend."""
+
+        def _boom() -> Any:
+            raise RuntimeError("sel unavailable")
+
+        monkeypatch.setattr(bmod, "sel", _boom)
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        _record_runs(monkeypatch, result=SimpleNamespace(returncode=0, stdout="333\n"))
+        ap = self._run(bmod._MIN_PORT + 7)
+        assert ap is not None
+        assert ap.adopted_pids == [333]
+
+    def test_adoption_is_refused_when_no_owning_pid_can_be_recorded(
+        self, occupied: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Adopting without PIDs would leave a backend we can never stop."""
+
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        _record_runs(monkeypatch, result=SimpleNamespace(returncode=1, stdout=""))
+        with caplog.at_level(logging.WARNING):
+            assert self._run(bmod._MIN_PORT + 8) is None
+        assert any("cannot record PIDs" in r.message for r in caplog.records)
+        assert "adoptee" not in bmod._processes
+
+    def test_adoption_is_refused_when_the_pid_probe_is_unavailable(
+        self, occupied: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(200))
+        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        assert self._run(bmod._MIN_PORT + 9) is None
+
+    def test_an_unhealthy_occupant_blocks_the_spawn_instead_of_colliding(
+        self, occupied: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        def _refused(*_a: Any, **_k: Any) -> Any:
+            raise urllib.error.URLError("connection refused")
+
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", _refused)
+        with caplog.at_level(logging.WARNING):
+            assert self._run(bmod._MIN_PORT + 10) is None
+        assert any("occupied by unhealthy process" in r.message for r in caplog.records)
+
+    def test_an_error_status_counts_as_unhealthy(
+        self, occupied: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(503))
+        assert self._run(bmod._MIN_PORT + 11) is None
+
+
+# ---------------------------------------------------------------------------
+# Spawn body: dependency installation
+# ---------------------------------------------------------------------------
+
+
+class TestDependencyInstall:
+    def test_requirements_txt_provisions_a_per_app_venv_then_pip_installs(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / "requirements.txt").write_text("requests\n")
+        runs = _record_runs(monkeypatch)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("deps", _manifest("server.py"))
+        assert any("venv" in argv for argv in runs), runs
+        assert any("install" in argv for argv in runs), runs
+
+    def test_a_failed_dependency_install_does_not_block_the_spawn(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Deps are best-effort: an offline host must still get its backend tried."""
+
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / "requirements.txt").write_text("requests\n")
+        _record_runs(monkeypatch, exc=RuntimeError("no network"))
+        _capture_popen(monkeypatch)
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(_StopSpawn):
+                bmod._start_app_backend_body("deps-fail", _manifest("server.py"))
+        assert any("Failed to install deps" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Spawn body: dispatch branches
+# ---------------------------------------------------------------------------
+
+
+class TestNodeDispatch:
+    def test_a_node_backend_without_a_node_binary_is_refused(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        (spawn_root / "server.js").write_text("// noop\n")
+        monkeypatch.setattr(bmod, "_find_node_binary", lambda: None)
+        monkeypatch.setattr(
+            bmod.subprocess, "Popen", lambda *_a, **_k: pytest.fail("spawned without node")
+        )
+        with caplog.at_level(logging.ERROR):
+            assert bmod._start_app_backend_body("nodeless", _manifest("server.js")) is None
+        assert any("no node binary found" in r.message for r in caplog.records)
+
+    def test_a_js_entry_runs_under_node_and_installs_npm_deps(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (spawn_root / "server.js").write_text("// noop\n")
+        (spawn_root / "package.json").write_text(json.dumps({"name": "x"}))
+        monkeypatch.setattr(bmod, "_find_node_binary", lambda: "/usr/bin/node")
+        monkeypatch.setattr(bmod, "_find_npm_binary", lambda: "/usr/bin/npm")
+        runs = _record_runs(monkeypatch)
+        seen = _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("nodeapp", _manifest("server.js"))
+        assert seen["argv"][0] == "/usr/bin/node"
+        assert seen["kwargs"]["env"]["NODE_ENV"] == "production"
+        assert runs == [["/usr/bin/npm", "install", "--production", "--no-audit", "--no-fund"]]
+
+    def test_npm_install_is_skipped_when_node_modules_is_present(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (spawn_root / "server.js").write_text("// noop\n")
+        (spawn_root / "package.json").write_text(json.dumps({"name": "x"}))
+        (spawn_root / "node_modules").mkdir()
+        monkeypatch.setattr(bmod, "_find_node_binary", lambda: "/usr/bin/node")
+        monkeypatch.setattr(
+            bmod, "_find_npm_binary", lambda: pytest.fail("npm resolved despite node_modules")
+        )
+        runs = _record_runs(monkeypatch)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("nodeapp2", _manifest("server.js"))
+        assert runs == []
+
+    def test_a_failed_npm_install_does_not_block_the_spawn(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        (spawn_root / "server.js").write_text("// noop\n")
+        (spawn_root / "package.json").write_text(json.dumps({"name": "x"}))
+        monkeypatch.setattr(bmod, "_find_node_binary", lambda: "/usr/bin/node")
+        monkeypatch.setattr(bmod, "_find_npm_binary", lambda: "/usr/bin/npm")
+        _record_runs(monkeypatch, exc=RuntimeError("registry down"))
+        _capture_popen(monkeypatch)
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(_StopSpawn):
+                bmod._start_app_backend_body("nodeapp3", _manifest("server.js"))
+        assert any("Failed to install npm deps" in r.message for r in caplog.records)
+
+    def test_an_explicit_node_type_wins_over_the_filename_heuristic(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``type: node`` must route a non-.js entry to node, not the Python branch."""
+
+        (spawn_root / "launch.bundle").write_text("// noop\n")
+        monkeypatch.setattr(bmod, "_find_node_binary", lambda: "/usr/bin/node")
+        seen = _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body(
+                "nodeapp4", _manifest("launch.bundle", backend_type="node")
+            )
+        assert seen["argv"][0] == "/usr/bin/node"
+
+
+class TestAsgiDispatch:
+    _ASGI_SRC = "from fastapi import FastAPI\napp = FastAPI()\nimport uvicorn\n"
+
+    def test_a_sniffed_asgi_entry_is_served_by_uvicorn(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (spawn_root / "backend").mkdir()
+        (spawn_root / "backend" / "app.py").write_text(self._ASGI_SRC)
+        seen = _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("asgi", _manifest("backend/app.py"))
+        assert seen["argv"][1:3] == ["-m", "uvicorn"]
+        assert seen["argv"][3] == "backend.app:app"
+        assert seen["kwargs"]["cwd"] == str(spawn_root)
+
+    def test_a_src_layout_asgi_entry_runs_from_the_src_root(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without the src/ rewrite uvicorn cannot import the declared module."""
+
+        pkg = spawn_root / "src" / "pkg"
+        pkg.mkdir(parents=True)
+        (pkg / "app.py").write_text(self._ASGI_SRC)
+        seen = _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body(
+                "asgi-src", _manifest("src/pkg/app.py", backend_type="asgi")
+            )
+        assert seen["argv"][3] == "pkg.app:app"
+        assert seen["kwargs"]["cwd"] == str(spawn_root / "src")
+
+    def test_the_app_venv_interpreter_is_preferred_when_present(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        venv_bin = spawn_root / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "python3").write_text("")
+        (spawn_root / "app.py").write_text(self._ASGI_SRC)
+        seen = _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("asgi-venv", _manifest("app.py"))
+        assert seen["argv"][0] == str(venv_bin / "python3")
+
+
+# ---------------------------------------------------------------------------
+# Spawn body: environment construction and the Popen tail
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnEnvironment:
+    def test_platform_overrides_and_the_proxy_secret_reach_the_backend(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """minimal_env() strips these, so the explicit forwards are the contract."""
+
+        (spawn_root / "server.py").write_text("x = 1\n")
+        (spawn_root / ".app_secret").write_text("  s3cr3t  \n")
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", "/checkout")
+        monkeypatch.setenv("KIROCREW_EDITION_DIR", "/edition")
+        monkeypatch.setenv("KIROCREW_DEVFLEET_REPO", "/opt/kirocrew")
+        monkeypatch.setenv("KIROCREW_DEVFLEET_BIN_GH", "/opt/bin/gh")
+        seen = _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("envapp", _manifest("server.py"))
+        env = seen["kwargs"]["env"]
+        assert env["KIROCREW_PROJECT_DIR"] == "/checkout"
+        assert env["KIROCREW_EDITION_DIR"] == "/edition"
+        assert env["KIROCREW_DEVFLEET_REPO"] == "/opt/kirocrew"
+        assert env["KIROCREW_DEVFLEET_BIN_GH"] == "/opt/bin/gh"
+        assert env["KIROCREW_PROXY_SECRET"] == "s3cr3t"
+        assert env["KIROCREW_APP_NAME"] == "envapp"
+
+    def test_a_missing_proxy_secret_is_tolerated(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (spawn_root / "server.py").write_text("x = 1\n")
+        seen = _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("nosecret", _manifest("server.py"))
+        assert "KIROCREW_PROXY_SECRET" not in seen["kwargs"]["env"]
+
+    def test_an_audit_sink_failure_does_not_block_the_spawn(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (spawn_root / "server.py").write_text("x = 1\n")
+
+        def _boom() -> Any:
+            raise RuntimeError("sel unavailable")
+
+        monkeypatch.setattr(bmod, "sel", _boom)
+        seen = _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("audit-down", _manifest("server.py"))
+        assert seen["argv"]
+
+
+class TestSpawnOutcome:
+    def test_a_surviving_child_is_recorded_and_persisted(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (spawn_root / "server.py").write_text("x = 1\n")
+        monkeypatch.setattr(bmod, "_survived_spawn", lambda _proc, _port=None: True)
+        recorded: list[tuple[str, int, int]] = []
+        monkeypatch.setattr(
+            bmod,
+            "_record_app_pid",
+            lambda name, pid, port: recorded.append((name, pid, port)),
+        )
+        monkeypatch.setattr(bmod.subprocess, "Popen", lambda *_a, **_k: _FakeProc(pid=777))
+        ap = bmod._start_app_backend_body("okapp", _manifest("server.py"))
+        assert ap is not None
+        assert ap.pid == 777
+        # Surviving the bind is NOT health: the health loop owns that transition.
+        assert ap.healthy is False
+        assert bmod._processes["okapp"] is ap
+        assert recorded == [("okapp", 777, ap.port)]
+
+    def test_a_child_that_dies_on_its_bind_is_not_reported_as_started(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A 'started' record for a dead pid makes the proxy 502 and respawn forever."""
+
+        (spawn_root / "server.py").write_text("x = 1\n")
+        monkeypatch.setattr(bmod, "_survived_spawn", lambda _proc, _port=None: False)
+
+        def _popen(_argv: Any, **kwargs: Any) -> Any:
+            # Write the crash reason the real child would have logged.
+            kwargs["stdout"].write("OSError: [Errno 98] Address already in use\n")
+            kwargs["stdout"].flush()
+            return _FakeProc(returncode=1)
+
+        monkeypatch.setattr(bmod.subprocess, "Popen", _popen)
+        with caplog.at_level(logging.ERROR):
+            assert bmod._start_app_backend_body("dyingapp", _manifest("server.py")) is None
+        assert any("PORT COLLISION" in r.getMessage() for r in caplog.records)
+        assert "dyingapp" not in bmod._processes
+
+
+# ---------------------------------------------------------------------------
+# Stop
+# ---------------------------------------------------------------------------
+
+
+class TestStopSpawnedBackend:
+    @pytest.fixture()
+    def kills(self, monkeypatch: pytest.MonkeyPatch) -> list[tuple[int, int]]:
+        recorded: list[tuple[int, int]] = []
+        monkeypatch.setattr(
+            bmod.platform_compat,
+            "kill_process_tree",
+            lambda pid, sig: recorded.append((pid, sig)),
+        )
+        return recorded
+
+    def test_a_live_child_gets_sigterm(self, kills: list[tuple[int, int]]) -> None:
+        proc = _fake_proc(pid=555)
+        with bmod._lock:
+            bmod._processes["spawned"] = AppProcess(
+                app_name="spawned", port=9100, pid=555, proc=proc
+            )
+        assert bmod.stop_app_backend("spawned") is True
+        assert kills == [(555, bmod.platform_compat.SIGTERM)]
+        assert "spawned" not in bmod._processes
+
+    def test_a_child_that_ignores_sigterm_is_escalated_to_sigkill(
+        self, kills: list[tuple[int, int]]
+    ) -> None:
+        proc = _fake_proc(pid=556)
+        proc.wait_raises = True
+        with bmod._lock:
+            bmod._processes["stubborn"] = AppProcess(
+                app_name="stubborn", port=9100, pid=556, proc=proc
+            )
+        assert bmod.stop_app_backend("stubborn") is True
+        assert kills == [
+            (556, bmod.platform_compat.SIGTERM),
+            (556, bmod.platform_compat.SIGKILL),
+        ]
+
+    def test_a_vanished_child_is_not_an_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _gone(_pid: int, _sig: int) -> None:
+            raise ProcessLookupError
+
+        monkeypatch.setattr(bmod.platform_compat, "kill_process_tree", _gone)
+        with bmod._lock:
+            bmod._processes["gone"] = AppProcess(
+                app_name="gone", port=9100, pid=557, proc=_fake_proc(pid=557)
+            )
+        assert bmod.stop_app_backend("gone") is True
+
+    def test_a_failing_log_handle_close_is_swallowed(
+        self, kills: list[tuple[int, int]]
+    ) -> None:
+        handle = MagicMock()
+        handle.close.side_effect = OSError("already closed")
+        with bmod._lock:
+            bmod._processes["loggy"] = AppProcess(
+                app_name="loggy", port=9100, pid=558, proc=_fake_proc(pid=558), log_fh=handle
+            )
+        assert bmod.stop_app_backend("loggy") is True
+        handle.close.assert_called_once()
+
+
+class TestStopAdoptedBackend:
+    @pytest.fixture(autouse=True)
+    def _fast_wait(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(bmod, "_wait_for_pids", lambda _pids, timeout=2.0: None)
+
+    @pytest.fixture()
+    def kills(self, monkeypatch: pytest.MonkeyPatch) -> list[tuple[int, int]]:
+        recorded: list[tuple[int, int]] = []
+        monkeypatch.setattr(
+            bmod.platform_compat, "kill_pid", lambda pid, sig: recorded.append((pid, sig))
+        )
+        monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: False)
+        return recorded
+
+    def _track(self, **kwargs: Any) -> AppProcess:
+        ap = AppProcess(app_name="ext", port=bmod._MIN_PORT + 12, pid=0, proc=None, **kwargs)
+        with bmod._lock:
+            bmod._processes["ext"] = ap
+            bmod._allocated_ports["ext"] = ap.port
+        return ap
+
+    def test_an_adopted_backend_with_no_recorded_pids_is_left_alone(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Killing unknown PIDs on a port could take out an unrelated service."""
+
+        ap = self._track(healthy=True)
+        with caplog.at_level(logging.WARNING):
+            assert bmod.stop_app_backend("ext") is False
+        assert any("refusing to kill unknown processes" in r.message for r in caplog.records)
+        # Tracking is restored so a retry after re-adoption is possible.
+        assert bmod._processes["ext"] is ap
+        assert bmod._allocated_ports["ext"] == ap.port
+
+    def test_only_pids_still_listening_on_the_port_are_signalled(
+        self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Revalidation guards against a PID recycled since adoption."""
+
+        self._track(adopted_pids=[111, 222], healthy=True)
+        _record_runs(monkeypatch, result=SimpleNamespace(returncode=0, stdout="111\n999\n"))
+        assert bmod.stop_app_backend("ext") is True
+        assert kills == [(111, bmod.platform_compat.SIGTERM)]
+
+    def test_an_unavailable_pid_probe_falls_back_to_the_adopted_set(
+        self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._track(adopted_pids=[111], healthy=True)
+        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        assert bmod.stop_app_backend("ext") is True
+        assert kills == [(111, bmod.platform_compat.SIGTERM)]
+
+    def test_nonpositive_recorded_pids_are_never_signalled(
+        self, kills: list[tuple[int, int]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._track(adopted_pids=[0, -1], healthy=True)
+        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        assert bmod.stop_app_backend("ext") is True
+        assert kills == []
+
+    def test_a_survivor_is_escalated_to_sigkill(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recorded: list[tuple[int, int]] = []
+        monkeypatch.setattr(
+            bmod.platform_compat, "kill_pid", lambda pid, sig: recorded.append((pid, sig))
+        )
+        monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: True)
+        self._track(adopted_pids=[111], healthy=True)
+        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        assert bmod.stop_app_backend("ext") is True
+        assert recorded == [
+            (111, bmod.platform_compat.SIGTERM),
+            (111, bmod.platform_compat.SIGKILL),
+        ]
+
+    def test_an_unsignalable_pid_is_skipped_not_fatal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _denied(_pid: int, _sig: int) -> None:
+            raise ProcessLookupError
+
+        monkeypatch.setattr(bmod.platform_compat, "kill_pid", _denied)
+        monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: False)
+        self._track(adopted_pids=[111], healthy=True)
+        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        assert bmod.stop_app_backend("ext") is True
+
+    def test_an_unexpected_stop_failure_restores_tracking(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Losing the record would orphan the backend with no way to retry."""
+
+        def _bad(_pid: int, _sig: int) -> None:
+            raise ValueError("bad signal")
+
+        monkeypatch.setattr(bmod.platform_compat, "kill_pid", _bad)
+        ap = self._track(adopted_pids=[111], healthy=True)
+        _record_runs(monkeypatch, exc=OSError("no lsof"))
+        with caplog.at_level(logging.WARNING):
+            assert bmod.stop_app_backend("ext") is False
+        assert any("Failed to stop adopted backend" in r.message for r in caplog.records)
+        assert bmod._processes["ext"] is ap
+        assert bmod._allocated_ports["ext"] == ap.port
+
+
+class TestWaitForPids:
+    def test_polling_stops_as_soon_as_every_pid_is_gone(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        states = [bmod.platform_compat.PID_ALIVE, bmod.platform_compat.PID_DEAD]
+
+        def _liveness(_pid: int) -> str:
+            return states.pop(0) if states else bmod.platform_compat.PID_DEAD
+
+        monkeypatch.setattr(bmod.platform_compat, "pid_liveness", _liveness)
+        monkeypatch.setattr(bmod.time, "sleep", lambda _s: None)
+        bmod._wait_for_pids([111], timeout=5.0)
+        assert states == []
+
+    def test_an_unsignalable_pid_counts_as_done(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """EPERM means 'not ours' — waiting the full deadline on it is pure latency."""
+
+        monkeypatch.setattr(
+            bmod.platform_compat,
+            "pid_liveness",
+            lambda _pid: bmod.platform_compat.PID_UNSIGNALABLE,
+        )
+        monkeypatch.setattr(
+            bmod.time, "sleep", lambda _s: pytest.fail("slept on an unsignalable pid")
+        )
+        bmod._wait_for_pids([111], timeout=5.0)
+
+    def test_an_already_elapsed_deadline_polls_nothing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            bmod.platform_compat, "pid_liveness", lambda _pid: pytest.fail("polled")
+        )
+        bmod._wait_for_pids([111], timeout=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Accessors
+# ---------------------------------------------------------------------------
+
+
+def test_the_proxy_port_is_only_published_once_the_backend_is_healthy() -> None:
+    """Publishing a pre-health port routes user traffic at a dead socket."""
+
+    with bmod._lock:
+        bmod._processes["p"] = AppProcess(app_name="p", port=9111, pid=1, healthy=False)
+    assert bmod.get_app_backend_port("p") is None
+    with bmod._lock:
+        bmod._processes["p"].healthy = True
+    assert bmod.get_app_backend_port("p") == 9111
+    assert bmod.get_app_backend_port("absent") is None
+
+
+# ---------------------------------------------------------------------------
+# Pidfile helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPidfileHelpers:
+    def test_a_corrupt_pidfile_reads_as_empty_and_is_reported(
+        self, tmp_path: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Silently swallowing it would disable the very reap it exists for."""
+
+        bmod._pidfile_path().write_text("{not json")
+        with caplog.at_level(logging.WARNING):
+            assert bmod._read_pidfile() == {}
+        assert any("pidfile unreadable" in r.message for r in caplog.records)
+
+    def test_a_non_mapping_pidfile_reads_as_empty(self, tmp_path: Any) -> None:
+        bmod._pidfile_path().write_text("[1, 2, 3]")
+        assert bmod._read_pidfile() == {}
+
+    def test_an_unwritable_pidfile_never_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(*_a: Any, **_k: Any) -> None:
+            raise OSError("read-only filesystem")
+
+        monkeypatch.setattr(bmod, "atomic_write", _boom)
+        bmod._write_pidfile({"app": {"pid": 1}})  # must not raise
+
+    def test_recording_a_pid_never_breaks_a_spawn(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(_pid: int) -> str:
+            raise RuntimeError("ps exploded")
+
+        monkeypatch.setattr(bmod, "_proc_start_time", _boom)
+        bmod._record_app_pid("app", 4321, 9100)  # must not raise
+        assert bmod._read_pidfile() == {}
+
+    def test_forgetting_a_pid_never_breaks_a_stop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom() -> dict[str, dict[str, Any]]:
+            raise RuntimeError("disk gone")
+
+        monkeypatch.setattr(bmod, "_read_pidfile", _boom)
+        bmod._forget_app_pid("app")  # must not raise
+
+
+class TestProcStartTime:
+    def test_linux_reads_the_starttime_field_past_a_parenthesised_comm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Splitting on the FIRST ')' would mis-index any comm containing one."""
+
+        tail = " ".join(str(i) for i in range(4, 24))
+        stat = f"4242 (my (odd) proc) S 1 {tail}"
+
+        class _FakeStatPath:
+            def __init__(self, _p: str) -> None:
+                pass
+
+            def read_text(self) -> str:
+                return stat
+
+        monkeypatch.setattr(bmod.sys, "platform", "linux")
+        monkeypatch.setattr(bmod, "Path", _FakeStatPath)
+        assert bmod._proc_start_time(4242) == "21"
+
+    def test_a_malformed_stat_line_yields_no_identity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class _FakeStatPath:
+            def __init__(self, _p: str) -> None:
+                pass
+
+            def read_text(self) -> str:
+                return "no closing paren here"
+
+        monkeypatch.setattr(bmod.sys, "platform", "linux")
+        monkeypatch.setattr(bmod, "Path", _FakeStatPath)
+        assert bmod._proc_start_time(4242) is None
+
+    def test_non_linux_shells_out_to_ps(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(bmod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            bmod.subprocess, "check_output", lambda *_a, **_k: b" Mon Jan  1 00:00:00 2024\n"
+        )
+        assert bmod._proc_start_time(4242) == "Mon Jan  1 00:00:00 2024"
+
+    def test_empty_ps_output_yields_no_identity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(bmod.sys, "platform", "darwin")
+        monkeypatch.setattr(bmod.subprocess, "check_output", lambda *_a, **_k: b"\n")
+        assert bmod._proc_start_time(4242) is None
+
+    def test_a_failed_ps_probe_yields_no_identity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(*_a: Any, **_k: Any) -> bytes:
+            raise OSError("no ps")
+
+        monkeypatch.setattr(bmod.sys, "platform", "darwin")
+        monkeypatch.setattr(bmod.subprocess, "check_output", _boom)
+        assert bmod._proc_start_time(4242) is None
+
+    def test_pid_alive_delegates_to_the_platform_shim(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: True)
+        assert bmod._pid_alive(4242) is True
+
+
+# ---------------------------------------------------------------------------
+# Health-gated MCP registration
+# ---------------------------------------------------------------------------
+
+
+class TestGateMcpRegistration:
+    def test_a_healthy_backend_is_registered_with_its_live_port(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[tuple[str, int]] = []
+        monkeypatch.setattr(
+            "kiro_crew.apps.bridges.reregister_app_mcp_servers",
+            lambda name, live_port: seen.append((name, live_port)),
+        )
+        bmod._gate_mcp_registration("app", 9133, healthy=True)
+        assert seen == [("app", 9133)]
+
+    def test_an_unhealthy_backend_has_its_entries_scrubbed(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A dead MCP url breaks every kiro-cli session, not just this app."""
+
+        monkeypatch.setattr("kiro_crew.apps.bridges._deregister_mcp_servers", lambda _n: 2)
+        with caplog.at_level(logging.WARNING):
+            bmod._gate_mcp_registration("app", 9133, healthy=False)
+        assert any("Scrubbed 2 MCP server(s)" in r.getMessage() for r in caplog.records)
+
+    def test_a_reconcile_failure_never_crashes_the_health_loop(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        def _boom(*_a: Any, **_k: Any) -> None:
+            raise RuntimeError("mcp.json locked")
+
+        monkeypatch.setattr("kiro_crew.apps.bridges.reregister_app_mcp_servers", _boom)
+        with caplog.at_level(logging.WARNING):
+            bmod._gate_mcp_registration("app", 9133, healthy=True)
+        assert any("Health-gated MCP registration failed" in r.message for r in caplog.records)
+
+
+class TestHealthCheckLoop:
+    @pytest.fixture(autouse=True)
+    def _instant(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(bmod, "_HEALTH_CHECK_INTERVAL", 0)
+        monkeypatch.setattr(bmod, "_HEALTH_CHECK_RETRIES", 2)
+
+    def test_an_error_status_is_retried_and_then_scrubbed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        gate: list[tuple[str, int, bool]] = []
+        monkeypatch.setattr(
+            bmod,
+            "_gate_mcp_registration",
+            lambda name, port, *, healthy: gate.append((name, port, healthy)),
+        )
+        attempts = {"n": 0}
+
+        def _urlopen(*_a: Any, **_k: Any) -> Any:
+            attempts["n"] += 1
+            return _FakeResp(500)
+
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", _urlopen)
+        with bmod._lock:
+            bmod._processes["sick"] = AppProcess(app_name="sick", port=9134)
+        bmod._health_check_loop("sick", 9134, "/health")
+        assert attempts["n"] == 2
+        assert gate == [("sick", 9134, False)]
+
+    def test_an_app_stopped_between_the_probe_and_the_commit_is_not_registered(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Registering here would write the dead-url entry the gate exists to avoid."""
+
+        gate: list[Any] = []
+        monkeypatch.setattr(
+            bmod,
+            "_gate_mcp_registration",
+            lambda name, port, *, healthy: gate.append((name, port, healthy)),
+        )
+
+        def _urlopen(*_a: Any, **_k: Any) -> Any:
+            # The disable lands after the top-of-loop guard, before the commit.
+            with bmod._lock:
+                bmod._processes.pop("racy", None)
+            return _FakeResp(200)
+
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", _urlopen)
+        with bmod._lock:
+            bmod._processes["racy"] = AppProcess(app_name="racy", port=9135)
+        bmod._health_check_loop("racy", 9135, "/health")
+        assert gate == []
+
+
+# ---------------------------------------------------------------------------
+# Boot reconcile
+# ---------------------------------------------------------------------------
+
+
+def _app(
+    name: str, *, enabled: bool = True, origin: str = "builtin", manifest: Any = None
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "enabled": enabled,
+        "origin": origin,
+        "manifest": {"backend": {"entryPoint": "server.py"}} if manifest is None else manifest,
+    }
+
+
+class TestBootMcpReconcile:
+    def test_a_disabled_app_with_mcp_servers_is_scrubbed(
+        self, boot_env: dict[str, list[Any]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Its backend is not running, so its HTTP MCP url points at a dead port."""
+
+        monkeypatch.setattr(
+            bmod,
+            "list_apps",
+            lambda: [_app("off", enabled=False, manifest={"mcpServers": {"x": {}}})],
+        )
+        assert bmod.start_enabled_app_backends() == []
+        assert boot_env["dereg_mcp"] == ["off"]
+
+    def test_a_disabled_app_without_mcp_servers_is_left_alone(
+        self, boot_env: dict[str, list[Any]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            bmod, "list_apps", lambda: [_app("off", enabled=False, manifest={})]
+        )
+        bmod.start_enabled_app_backends()
+        assert boot_env["dereg_mcp"] == []
+
+    def test_a_failing_scrub_does_not_crash_boot(
+        self,
+        boot_env: dict[str, list[Any]],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        def _boom(_name: str) -> int:
+            raise RuntimeError("mcp.json locked")
+
+        monkeypatch.setattr("kiro_crew.apps.bridges._deregister_mcp_servers", _boom)
+        monkeypatch.setattr(
+            bmod,
+            "list_apps",
+            lambda: [_app("off", enabled=False, manifest={"mcpServers": {"x": {}}})],
+        )
+        with caplog.at_level(logging.WARNING):
+            bmod.start_enabled_app_backends()
+        assert any("Boot MCP reconcile failed" in r.message for r in caplog.records)
+
+
+class TestBootResourceReconcile:
+    def test_an_admitted_app_is_re_registered_and_its_skills_reconciled(
+        self, boot_env: dict[str, list[Any]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(bmod, "list_apps", lambda: [_app("good")])
+        bmod.start_enabled_app_backends()
+        assert boot_env["register"] == ["good"]
+        assert boot_env["reconcile_skills"] == ["good"]
+        assert boot_env["started"] == ["good"]
+
+    def test_registration_errors_are_surfaced_not_swallowed(
+        self,
+        boot_env: dict[str, list[Any]],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setattr(
+            "kiro_crew.apps.bridges.register_app",
+            lambda _n: SimpleNamespace(errors=["skill clash"]),
+        )
+        monkeypatch.setattr(bmod, "list_apps", lambda: [_app("noisy")])
+        with caplog.at_level(logging.WARNING):
+            bmod.start_enabled_app_backends()
+        assert any("completed with errors" in r.message for r in caplog.records)
+
+    def test_a_failing_reconcile_does_not_crash_boot(
+        self,
+        boot_env: dict[str, list[Any]],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        def _boom(_name: str) -> Any:
+            raise RuntimeError("registry corrupt")
+
+        monkeypatch.setattr("kiro_crew.apps.bridges.register_app", _boom)
+        monkeypatch.setattr(bmod, "list_apps", lambda: [_app("broken")])
+        with caplog.at_level(logging.WARNING):
+            bmod.start_enabled_app_backends()
+        assert any("Boot resource reconcile failed" in r.message for r in caplog.records)
+        # The backend spawn loop is independent of the reconcile outcome.
+        assert boot_env["started"] == ["broken"]
+
+    def test_a_denied_app_has_its_derivative_resources_revoked(
+        self, boot_env: dict[str, list[Any]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A policy tightened after enable must revoke, not merely decline to start."""
+
+        monkeypatch.setattr(
+            "kiro_crew.apps.manager._app_activation_denied", lambda _n: "not in allowlist"
+        )
+        monkeypatch.setattr(bmod, "list_apps", lambda: [_app("banned")])
+        assert bmod.start_enabled_app_backends() == []
+        assert boot_env["dereg_agents"] == ["banned"]
+        assert boot_env["dereg_skills"] == ["banned"]
+        assert boot_env["dereg_mcp"] == ["banned"]
+        assert boot_env["register"] == []
+        assert boot_env["started"] == []
+
+    def test_a_failed_revocation_is_logged_as_an_error(
+        self,
+        boot_env: dict[str, list[Any]],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        def _boom(_name: str) -> int:
+            raise RuntimeError("agents dir read-only")
+
+        monkeypatch.setattr("kiro_crew.apps.bridges._deregister_agents", _boom)
+        monkeypatch.setattr(
+            "kiro_crew.apps.manager._app_activation_denied", lambda _n: "banned"
+        )
+        monkeypatch.setattr(bmod, "list_apps", lambda: [_app("banned")])
+        with caplog.at_level(logging.ERROR):
+            bmod.start_enabled_app_backends()
+        assert any("FAILED to revoke resources" in r.message for r in caplog.records)
+
+    def test_a_vetting_error_is_treated_as_a_denial(
+        self, boot_env: dict[str, list[Any]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fail-closed: an unverifiable app must not keep its resources."""
+
+        def _boom(_name: str, **_kw: Any) -> str:
+            raise RuntimeError("provenance store unreadable")
+
+        monkeypatch.setattr(bmod, "app_execution_denied", _boom)
+        monkeypatch.setattr(bmod, "list_apps", lambda: [_app("unknowable")])
+        bmod.start_enabled_app_backends()
+        assert boot_env["dereg_agents"] == ["unknowable"]
+        assert boot_env["register"] == []
+
+    def test_an_unavailable_bridges_module_aborts_only_the_reconcile(
+        self,
+        boot_env: dict[str, list[Any]],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Boot must still start admitted backends when the reconcile cannot load."""
+
+        monkeypatch.setitem(sys.modules, "kiro_crew.apps.bridges", SimpleNamespace())
+        monkeypatch.setattr(bmod, "list_apps", lambda: [_app("a"), _app("b")])
+        with caplog.at_level(logging.WARNING):
+            bmod.start_enabled_app_backends()
+        assert any("Boot resource reconcile unavailable" in r.message for r in caplog.records)
+        assert sorted(boot_env["started"]) == ["a", "b"]
+
+
+class TestBootSpawnGating:
+    def test_a_governance_denied_app_is_not_spawned(
+        self, boot_env: dict[str, list[Any]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "kiro_crew.apps.manager._app_activation_denied", lambda _n: "not allowed"
+        )
+        monkeypatch.setattr(bmod, "list_apps", lambda: [_app("blocked")])
+        assert bmod.start_enabled_app_backends() == []
+        assert boot_env["started"] == []
+
+    def test_an_enabled_app_without_a_backend_is_skipped(
+        self, boot_env: dict[str, list[Any]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(bmod, "list_apps", lambda: [_app("uionly", manifest={})])
+        assert bmod.start_enabled_app_backends() == []
+        assert boot_env["started"] == []
+
+    def test_an_admission_revet_error_fails_closed(
+        self,
+        boot_env: dict[str, list[Any]],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """An app whose admission cannot be confirmed must not boot unchecked."""
+
+        def _boom(_name: str, **_kw: Any) -> str:
+            raise RuntimeError("signature store unreadable")
+
+        monkeypatch.setattr(bmod, "app_admission_denied", _boom)
+        monkeypatch.setattr(bmod, "list_apps", lambda: [_app("shady", origin="registry")])
+        with caplog.at_level(logging.ERROR):
+            assert bmod.start_enabled_app_backends() == []
+        assert any("treating as denied" in r.message for r in caplog.records)
+        assert boot_env["started"] == []
+
+    def test_a_boot_spawn_error_is_isolated_even_if_the_audit_sink_is_down(
+        self, boot_env: dict[str, list[Any]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _start(name: str) -> AppProcess | None:
+            if name == "bad":
+                raise RuntimeError("sandbox unavailable")
+            boot_env["started"].append(name)
+            return None
+
+        def _no_sel() -> Any:
+            raise RuntimeError("sel unavailable")
+
+        monkeypatch.setattr(bmod, "start_app_backend", _start)
+        monkeypatch.setattr(bmod, "sel", _no_sel)
+        monkeypatch.setattr(bmod, "list_apps", lambda: [_app("bad"), _app("ok")])
+        assert bmod.start_enabled_app_backends() == []
+        assert boot_env["started"] == ["ok"]
+
+
+class TestPreclaimFixedPorts:
+    def test_two_apps_declaring_the_same_fixed_port_is_reported_once(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        port = bmod._MIN_PORT + 13
+        manifests = {
+            "first": _manifest("s.py", port=str(port)),
+            "second": _manifest("s.py", port=str(port)),
+        }
+        monkeypatch.setattr(bmod, "get_app_manifest", lambda n: manifests.get(n))
+        with caplog.at_level(logging.WARNING):
+            bmod._preclaim_fixed_ports(["first", "second"])
+        assert bmod._allocated_ports == {"first": port}
+        assert any("fixed-port pre-claim" in r.message for r in caplog.records)
+
+    def test_an_empty_boot_set_short_circuits(self) -> None:
+        assert bmod._start_backends_concurrently([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Remaining defensive branches
+# ---------------------------------------------------------------------------
+
+
+class TestDefensiveBranches:
+    def test_an_unreadable_extensionless_entry_is_not_a_shell_launcher(
+        self, tmp_path: Any
+    ) -> None:
+        """A directory passes the executable check but cannot be sniffed."""
+
+        candidate = tmp_path / "launcher"
+        candidate.mkdir()
+        assert bmod._is_shell_entry(candidate) is False
+
+    def test_refusing_an_unhealthy_occupant_survives_an_audit_sink_failure(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (spawn_root / "server.py").write_text("x = 1\n")
+        _install_fake_socket(monkeypatch, connect_exc=None)
+
+        def _no_sel() -> Any:
+            raise RuntimeError("sel unavailable")
+
+        monkeypatch.setattr(bmod, "sel", _no_sel)
+        monkeypatch.setattr(bmod.urllib.request, "urlopen", lambda *_a, **_k: _FakeResp(500))
+        monkeypatch.setattr(
+            bmod.subprocess, "Popen", lambda *_a, **_k: pytest.fail("spawned onto a taken port")
+        )
+        result = bmod._start_app_backend_body(
+            "occupied", _manifest("server.py", port=str(bmod._MIN_PORT + 14))
+        )
+        assert result is None
+
+    def test_npm_install_proceeds_when_the_audit_sink_is_down(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (spawn_root / "server.js").write_text("// noop\n")
+        (spawn_root / "package.json").write_text(json.dumps({"name": "x"}))
+
+        def _no_sel() -> Any:
+            raise RuntimeError("sel unavailable")
+
+        monkeypatch.setattr(bmod, "sel", _no_sel)
+        monkeypatch.setattr(bmod, "_find_node_binary", lambda: "/usr/bin/node")
+        monkeypatch.setattr(bmod, "_find_npm_binary", lambda: "/usr/bin/npm")
+        runs = _record_runs(monkeypatch)
+        _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("nodeaudit", _manifest("server.js"))
+        assert runs and runs[0][0] == "/usr/bin/npm"
+
+    def test_a_missing_npm_binary_does_not_block_the_node_spawn(
+        self, spawn_root: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dependencies may already be vendored; a missing npm is not fatal."""
+
+        (spawn_root / "server.js").write_text("// noop\n")
+        (spawn_root / "package.json").write_text(json.dumps({"name": "x"}))
+        monkeypatch.setattr(bmod, "_find_node_binary", lambda: "/usr/bin/node")
+        monkeypatch.setattr(bmod, "_find_npm_binary", lambda: None)
+        runs = _record_runs(monkeypatch)
+        seen = _capture_popen(monkeypatch)
+        with pytest.raises(_StopSpawn):
+            bmod._start_app_backend_body("nonpm", _manifest("server.js"))
+        assert runs == []
+        assert seen["argv"][0] == "/usr/bin/node"
+
+    def test_stopping_a_spawned_backend_survives_audit_and_signal_failures(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Neither a broken audit sink nor a pid that vanished may fail the stop."""
+
+        def _no_sel() -> Any:
+            raise RuntimeError("sel unavailable")
+
+        signals: list[int] = []
+
+        def _kill(_pid: int, sig: int) -> None:
+            signals.append(sig)
+            if sig == bmod.platform_compat.SIGKILL:
+                raise ProcessLookupError
+
+        monkeypatch.setattr(bmod, "sel", _no_sel)
+        monkeypatch.setattr(bmod.platform_compat, "kill_process_tree", _kill)
+        proc = _fake_proc(pid=600)
+        proc.wait_raises = True
+        with bmod._lock:
+            bmod._processes["audit"] = AppProcess(
+                app_name="audit", port=9100, pid=600, proc=proc
+            )
+        assert bmod.stop_app_backend("audit") is True
+        assert signals == [
+            bmod.platform_compat.SIGTERM,
+            bmod.platform_compat.SIGKILL,
+        ]
+
+    def test_refusing_an_adopted_stop_survives_an_audit_sink_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _no_sel() -> Any:
+            raise RuntimeError("sel unavailable")
+
+        monkeypatch.setattr(bmod, "sel", _no_sel)
+        with bmod._lock:
+            bmod._processes["ext"] = AppProcess(
+                app_name="ext", port=9100, pid=0, proc=None, healthy=True
+            )
+        assert bmod.stop_app_backend("ext") is False
+        assert "ext" in bmod._processes
+
+    def test_a_garbled_pid_probe_line_is_skipped_during_an_adopted_stop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _no_sel() -> Any:
+            raise RuntimeError("sel unavailable")
+
+        killed: list[tuple[int, int]] = []
+        monkeypatch.setattr(bmod, "sel", _no_sel)
+        monkeypatch.setattr(bmod, "_wait_for_pids", lambda _pids, timeout=2.0: None)
+        monkeypatch.setattr(
+            bmod.platform_compat, "kill_pid", lambda pid, sig: killed.append((pid, sig))
+        )
+        monkeypatch.setattr(bmod.platform_compat, "pid_exists", lambda _pid: True)
+        _record_runs(monkeypatch, result=SimpleNamespace(returncode=0, stdout="111\nnope\n"))
+        with bmod._lock:
+            bmod._processes["ext"] = AppProcess(
+                app_name="ext", port=9100, pid=0, proc=None, adopted_pids=[111], healthy=True
+            )
+        assert bmod.stop_app_backend("ext") is True
+        assert killed == [
+            (111, bmod.platform_compat.SIGTERM),
+            (111, bmod.platform_compat.SIGKILL),
+        ]
+
+    def test_a_boot_admission_denial_survives_an_audit_sink_failure(
+        self, boot_env: dict[str, list[Any]], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _no_sel() -> Any:
+            raise RuntimeError("sel unavailable")
+
+        monkeypatch.setattr(bmod, "sel", _no_sel)
+        monkeypatch.setattr(bmod, "app_admission_denied", lambda _n, **_kw: "unsigned")
+        monkeypatch.setattr(bmod, "list_apps", lambda: [_app("shady", origin="registry")])
+        assert bmod.start_enabled_app_backends() == []
+        assert boot_env["started"] == []
+
+
+class TestReapDefensiveBranches:
+    @pytest.fixture()
+    def matched_orphan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A recorded pid that is alive and positively identified."""
+
+        bmod._write_pidfile({"app": {"pid": 4321, "start_time": "ST-1", "port": 9100}})
+        monkeypatch.setattr(bmod, "_proc_start_time", lambda _pid: "ST-1")
+        monkeypatch.setattr(
+            bmod.platform_compat, "pid_liveness", lambda _pid: bmod.platform_compat.PID_ALIVE
+        )
+        monkeypatch.setattr(bmod, "_pid_alive", lambda _pid: True)
+        monkeypatch.setattr(bmod, "_REAP_SIGTERM_GRACE", 0.0)
+        monkeypatch.setattr(bmod, "_REAP_POLL_INTERVAL", 0.0)
+
+    def test_malformed_and_nonpositive_entries_are_dropped_without_signalling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bmod._write_pidfile(
+            {
+                "bad-type": {"pid": "not-an-int", "start_time": "ST", "port": 9100},
+                "zero": {"pid": 0, "start_time": "ST", "port": 9101},
+            }
+        )
+        monkeypatch.setattr(
+            bmod.platform_compat,
+            "kill_process_tree",
+            lambda *_a: pytest.fail("signalled an unusable pidfile entry"),
+        )
+        assert bmod._reap_stale_app_backends() == 0
+        assert bmod._read_pidfile() == {}
+
+    def test_a_pid_that_exits_before_the_signal_is_dropped(
+        self, matched_orphan: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _gone(_pid: int, _sig: int) -> None:
+            raise ProcessLookupError
+
+        monkeypatch.setattr(bmod.platform_compat, "kill_process_tree", _gone)
+        assert bmod._reap_stale_app_backends() == 0
+        assert bmod._read_pidfile() == {}
+
+    def test_the_reap_survives_an_audit_sink_failure_on_both_signals(
+        self, matched_orphan: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _no_sel() -> Any:
+            raise RuntimeError("sel unavailable")
+
+        signals: list[int] = []
+        monkeypatch.setattr(bmod, "sel", _no_sel)
+        monkeypatch.setattr(
+            bmod.platform_compat, "kill_process_tree", lambda _pid, sig: signals.append(sig)
+        )
+        assert bmod._reap_stale_app_backends() == 1
+        assert signals == [
+            bmod.platform_compat.SIGTERM,
+            bmod.platform_compat.SIGKILL,
+        ]
+
+    def test_a_pid_that_exits_before_the_escalation_is_not_an_error(
+        self, matched_orphan: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _kill(_pid: int, sig: int) -> None:
+            if sig == bmod.platform_compat.SIGKILL:
+                raise ProcessLookupError
+
+        monkeypatch.setattr(bmod.platform_compat, "kill_process_tree", _kill)
+        assert bmod._reap_stale_app_backends() == 1
+        assert bmod._read_pidfile() == {}

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -1,0 +1,2068 @@
+"""Coverage tests for :mod:`kiro_crew.cli_commands` subcommand dispatch.
+
+Each handler in ``cli_commands`` is a plain ``argparse.Namespace`` consumer, so
+these tests call the handlers DIRECTLY (never through a subprocess) and assert
+on the routed side effects: which collaborator was called, what was printed, and
+which exit code was raised. Everything that would touch the network, the real
+data home, or a live gateway is mocked -- the module's HTTP paths are exercised
+by patching ``urllib.request.urlopen``, and every filesystem write lands in
+``tmp_path``.
+
+Follows the style already established by ``test_cli.py`` (``argparse.Namespace``
++ ``patch("kiro_crew.cli_commands.<name>")``) and ``test_workspace_crud_cli.py``
+(config fixtures written into ``tmp_path``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import urllib.error
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew import cli_commands as cc
+from kiro_crew.config.loader import KiroCrewAgentConfig, KiroCrewConfig, WorkspaceConfig
+from kiro_crew.cron import CronSchedule
+from kiro_crew.eval.scenario import AssertionType
+
+# ── helpers ──
+
+
+def _ns(**kw: Any) -> argparse.Namespace:
+    return argparse.Namespace(**kw)
+
+
+def _http_error(code: int, body: bytes | None = None, reason: str = "Boom") -> urllib.error.HTTPError:
+    """Build an ``HTTPError`` whose ``.read()`` yields *body*."""
+    fp = io.BytesIO(body if body is not None else b"")
+    return urllib.error.HTTPError("http://localhost/x", code, reason, {}, fp)  # type: ignore[arg-type]
+
+
+class _FakeResponse:
+    """Minimal context-manager stand-in for ``urlopen``'s return value."""
+
+    def __init__(self, payload: Any) -> None:
+        self._raw = payload if isinstance(payload, bytes) else json.dumps(payload).encode()
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._raw
+
+
+def _result(ok: bool, *, message: str = "done", error: str = "nope", name: str = "demo") -> Any:
+    return SimpleNamespace(ok=ok, message=message, error=error, name=name)
+
+
+def _registration(**kw: Any) -> Any:
+    base: dict[str, list[str]] = {"agents": [], "skills": [], "crons": [], "errors": []}
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _cfg_with(
+    *,
+    agents: dict[str, KiroCrewAgentConfig] | None = None,
+    workspaces: dict[str, WorkspaceConfig] | None = None,
+    default_agent: str = "default",
+    default_workspace: str = "default",
+) -> KiroCrewConfig:
+    """An in-memory config whose ``save()`` is a no-op recorder."""
+    cfg = KiroCrewConfig()
+    cfg.agents = agents if agents is not None else {}
+    cfg.workspaces = workspaces if workspaces is not None else {}
+    cfg.default_agent = default_agent
+    cfg.default_workspace = default_workspace
+    cfg.save = MagicMock()  # type: ignore[method-assign]
+    return cfg
+
+
+# ── _internal_secret / _format_schedule ──
+
+
+class TestSmallHelpers:
+    def test_internal_secret_reads_file(self, tmp_path: Path) -> None:
+        (tmp_path / ".local_secret").write_text("  s3cr3t\n", encoding="utf-8")
+        with patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path):
+            assert cc._internal_secret() == "s3cr3t"
+
+    def test_internal_secret_missing_file_is_empty(self, tmp_path: Path) -> None:
+        """A missing secret must yield "" so the server answers 403, not a crash."""
+        with patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path):
+            assert cc._internal_secret() == ""
+
+    def test_format_schedule_non_schedule_falls_back_to_str(self) -> None:
+        assert cc._format_schedule("weekly-ish") == "weekly-ish"
+
+    def test_format_schedule_at_job_shows_full_date(self) -> None:
+        sched = CronSchedule(kind="at", at_ts=1700000000.0)
+        out = cc._format_schedule(sched)
+        assert out.startswith("at ") and len(out) == len("at 2023-11-14 14:13")
+
+    def test_format_schedule_delegates_for_every(self) -> None:
+        sched = CronSchedule(kind="every", every_secs=300)
+        with patch("kiro_crew.cli_commands.format_schedule", return_value="every 5m") as fmt:
+            assert cc._format_schedule(sched) == "every 5m"
+        fmt.assert_called_once_with(sched)
+
+
+class TestWorkspaceDirGuard:
+    """``_ws_dir_resolves_inside_home`` must fail CLOSED, never raise."""
+
+    def test_relative_name_inside_home_is_accepted(self, tmp_path: Path) -> None:
+        with patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path):
+            assert cc._ws_dir_resolves_inside_home("workspace-demo") is True
+
+    def test_home_root_itself_is_refused(self, tmp_path: Path) -> None:
+        with patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path):
+            assert cc._ws_dir_resolves_inside_home(".") is False
+
+    def test_escaping_path_is_refused(self, tmp_path: Path) -> None:
+        with patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path):
+            assert cc._ws_dir_resolves_inside_home("../elsewhere") is False
+
+    def test_unknown_user_tilde_fails_closed(self, tmp_path: Path) -> None:
+        """``expanduser`` raises RuntimeError here -- it must not escape."""
+        with patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path):
+            assert cc._ws_dir_resolves_inside_home("~nosuchuser1234/x") is False
+
+    def test_sensitive_target_is_refused(self, tmp_path: Path) -> None:
+        with (
+            patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
+            patch("kiro_crew.cli_commands.is_sensitive_path", return_value=True),
+        ):
+            assert cc._ws_dir_resolves_inside_home("profiles") is False
+
+    def test_error_message_names_boundary_and_value(self, tmp_path: Path) -> None:
+        with patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path):
+            msg = cc._ws_dir_error("/etc")
+            assert "data home" in msg and "/etc" in msg and "relative directory name" in msg
+
+
+# ── _spawn / _spawn_run ──
+
+
+class TestSpawnCli:
+    def test_list_prints_agents_with_status_glyphs(self, capsys: pytest.CaptureFixture[str]) -> None:
+        payload = {"agents": [{"id": "a1", "task": "do x", "done": True}, {"id": "a2", "task": "y"}]}
+        with (
+            patch("kiro_crew.cli_commands._internal_secret", return_value="s"),
+            patch("urllib.request.urlopen", return_value=_FakeResponse(payload)),
+        ):
+            cc._spawn(_ns(spawn_action="list", port=1234))
+        out = capsys.readouterr().out
+        assert "a1" in out and "a2" in out and "✅" in out and "⏳" in out
+
+    def test_list_empty_says_so(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("kiro_crew.cli_commands._internal_secret", return_value=""),
+            patch("urllib.request.urlopen", return_value=_FakeResponse({"agents": []})),
+        ):
+            cc._spawn(_ns(spawn_action="list", port=1234))
+        assert "No subagents." in capsys.readouterr().out
+
+    def test_list_http_error_with_json_body_prints_server_error(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        err = _http_error(400, json.dumps({"error": "bad spawn"}).encode())
+        with (
+            patch("kiro_crew.cli_commands._internal_secret", return_value=""),
+            patch("urllib.request.urlopen", side_effect=err),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._spawn(_ns(spawn_action="list", port=1234))
+        assert exc.value.code == 1
+        assert "bad spawn" in capsys.readouterr().out
+
+    def test_list_http_error_with_opaque_body_prints_status(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("kiro_crew.cli_commands._internal_secret", return_value=""),
+            patch("urllib.request.urlopen", side_effect=_http_error(503, b"<html>")),
+            pytest.raises(SystemExit),
+        ):
+            cc._spawn(_ns(spawn_action="list", port=1234))
+        assert "503" in capsys.readouterr().out
+
+    def test_list_unreachable_gateway_reports_port(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("kiro_crew.cli_commands._internal_secret", return_value=""),
+            patch("urllib.request.urlopen", side_effect=urllib.error.URLError("refused")),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._spawn(_ns(spawn_action="list", port=4321))
+        assert exc.value.code == 1
+        assert "4321" in capsys.readouterr().out
+
+    def test_unknown_action_prints_usage(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cc._spawn(_ns(spawn_action="bogus", port=1))
+        assert "Usage: kirocrew spawn" in capsys.readouterr().out
+
+    def test_run_fire_and_forget_prints_id_and_returns(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("kiro_crew.cli_commands._internal_secret", return_value=""),
+            patch(
+                "urllib.request.urlopen",
+                return_value=_FakeResponse({"id": "ag1", "task": "t"}),
+            ) as uo,
+        ):
+            cc._spawn(_ns(spawn_action="run", port=1, task="t", fire_and_forget=True))
+        assert "Spawned subagent ag1" in capsys.readouterr().out
+        assert uo.call_count == 1
+
+    def test_run_blocking_polls_until_done_then_prints_result(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        responses = [
+            _FakeResponse({"id": "ag2", "task": "t"}),
+            _FakeResponse({"done": False}),
+            _FakeResponse({"done": True, "result": "final answer"}),
+        ]
+        with (
+            patch("kiro_crew.cli_commands._internal_secret", return_value=""),
+            patch.object(cc._time, "sleep") as slept,
+            patch("urllib.request.urlopen", side_effect=responses),
+        ):
+            cc._spawn(_ns(spawn_action="run", port=1, task="t", fire_and_forget=False))
+        assert "final answer" in capsys.readouterr().out
+        assert slept.call_count == 2
+
+    def test_run_blocking_surfaces_agent_error_as_exit_1(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        responses = [
+            _FakeResponse({"id": "ag3", "task": "t"}),
+            _FakeResponse({"done": True, "error": "agent blew up"}),
+        ]
+        with (
+            patch("kiro_crew.cli_commands._internal_secret", return_value=""),
+            patch.object(cc._time, "sleep"),
+            patch("urllib.request.urlopen", side_effect=responses),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._spawn(_ns(spawn_action="run", port=1, task="t", fire_and_forget=False))
+        assert exc.value.code == 1
+        assert "agent blew up" in capsys.readouterr().err
+
+    def test_run_lost_connection_during_poll_exits_1(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("kiro_crew.cli_commands._internal_secret", return_value=""),
+            patch.object(cc._time, "sleep"),
+            patch(
+                "urllib.request.urlopen",
+                side_effect=[_FakeResponse({"id": "ag4", "task": "t"}), OSError("gone")],
+            ),
+            pytest.raises(SystemExit),
+        ):
+            cc._spawn(_ns(spawn_action="run", port=1, task="t", fire_and_forget=False))
+        assert "lost connection" in capsys.readouterr().err
+
+    def test_run_create_http_error_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        err = _http_error(422, json.dumps({"error": "task too long"}).encode())
+        with (
+            patch("kiro_crew.cli_commands._internal_secret", return_value=""),
+            patch("urllib.request.urlopen", side_effect=err),
+            pytest.raises(SystemExit),
+        ):
+            cc._spawn(_ns(spawn_action="run", port=1, task="t", fire_and_forget=True))
+        assert "task too long" in capsys.readouterr().out
+
+    def test_run_unreachable_gateway_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("kiro_crew.cli_commands._internal_secret", return_value=""),
+            patch("urllib.request.urlopen", side_effect=OSError("no route")),
+            pytest.raises(SystemExit),
+        ):
+            cc._spawn(_ns(spawn_action="run", port=9, task="t", fire_and_forget=True))
+        assert "gateway not running" in capsys.readouterr().out
+
+
+# ── app subcommands ──
+
+
+class TestAppCli:
+    def test_install_success_reports_registrations(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("kiro_crew.cli_commands.install_app", return_value=_result(True, name="demo")),
+            patch(
+                "kiro_crew.cli_commands.register_app",
+                return_value=_registration(
+                    agents=["a"], skills=["s"], crons=["c"], errors=["partial"]
+                ),
+            ),
+        ):
+            cc._handle_app(_ns(app_action="install", source="/pkg"))
+        out = capsys.readouterr().out
+        assert "Agents: a" in out and "Skills: s" in out and "Crons:  c" in out
+        assert "partial" in out and "kirocrew app enable demo" in out
+
+    def test_install_failure_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch(
+                "kiro_crew.cli_commands.install_app",
+                return_value=_result(False, error="not an app"),
+            ),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._handle_app(_ns(app_action="install", source="/pkg"))
+        assert exc.value.code == 1
+        assert "not an app" in capsys.readouterr().err
+
+    def test_list_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("kiro_crew.cli_commands.list_apps", return_value=[]):
+            cc._handle_app(_ns(app_action="list"))
+        assert "No apps installed." in capsys.readouterr().out
+
+    def test_list_renders_enabled_and_disabled_rows(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        apps = [
+            {"name": "one", "version": "1.0", "enabled": True, "displayName": "One"},
+            {"name": "two", "enabled": False},
+        ]
+        with patch("kiro_crew.cli_commands.list_apps", return_value=apps):
+            cc._handle_app(_ns(app_action="list"))
+        out = capsys.readouterr().out
+        assert "one" in out and "enabled" in out and "two" in out and "disabled" in out
+
+    def test_enable_success_counts_registrations(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("kiro_crew.cli_commands.enable_app", return_value=_result(True, message="on")),
+            patch(
+                "kiro_crew.cli_commands.register_app",
+                return_value=_registration(agents=["a", "b"], skills=["s"]),
+            ),
+        ):
+            cc._handle_app(_ns(app_action="enable", name="demo"))
+        out = capsys.readouterr().out
+        assert "Agents registered: 2" in out and "Skills registered: 1" in out
+
+    def test_enable_failure_exits_1(self) -> None:
+        with (
+            patch("kiro_crew.cli_commands.enable_app", return_value=_result(False)),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._handle_app(_ns(app_action="enable", name="demo"))
+        assert exc.value.code == 1
+
+    def test_disable_cleans_crons_then_deregisters(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("kiro_crew.cli_commands._cleanup_app_crons_from_scheduler") as cleanup,
+            patch("kiro_crew.cli_commands.deregister_app") as dereg,
+            patch("kiro_crew.cli_commands.disable_app", return_value=_result(True, message="off")),
+        ):
+            cc._handle_app(_ns(app_action="disable", name="demo"))
+        cleanup.assert_called_once_with("demo")
+        dereg.assert_called_once_with("demo")
+        assert "off" in capsys.readouterr().out
+
+    def test_disable_failure_exits_1(self) -> None:
+        with (
+            patch("kiro_crew.cli_commands._cleanup_app_crons_from_scheduler"),
+            patch("kiro_crew.cli_commands.deregister_app"),
+            patch("kiro_crew.cli_commands.disable_app", return_value=_result(False)),
+            pytest.raises(SystemExit),
+        ):
+            cc._handle_app(_ns(app_action="disable", name="demo"))
+
+    @pytest.mark.parametrize(
+        ("purge", "expect_keep_data"),
+        [(False, True), (True, False)],
+    )
+    def test_uninstall_maps_purge_flag_to_keep_data(
+        self, purge: bool, expect_keep_data: bool
+    ) -> None:
+        with (
+            patch("kiro_crew.cli_commands._cleanup_app_crons_from_scheduler"),
+            patch("kiro_crew.cli_commands.deregister_app"),
+            patch(
+                "kiro_crew.cli_commands.uninstall_app", return_value=_result(True)
+            ) as uninstall,
+        ):
+            cc._handle_app(_ns(app_action="uninstall", name="demo", purge_data=purge))
+        uninstall.assert_called_once_with("demo", keep_data=expect_keep_data)
+
+    def test_uninstall_failure_exits_1(self) -> None:
+        with (
+            patch("kiro_crew.cli_commands._cleanup_app_crons_from_scheduler"),
+            patch("kiro_crew.cli_commands.deregister_app"),
+            patch("kiro_crew.cli_commands.uninstall_app", return_value=_result(False)),
+            pytest.raises(SystemExit),
+        ):
+            cc._handle_app(_ns(app_action="uninstall", name="demo", purge_data=False))
+
+    def test_dev_on_prints_live_reload_hint(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("kiro_crew.apps.dev_mode.set_dev_mode", return_value={"ok": True}):
+            cc._handle_app(_ns(app_action="dev", name="demo", off=False))
+        out = capsys.readouterr().out
+        assert "dev mode" in out and "--off" in out
+
+    def test_dev_off_restores_caching(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("kiro_crew.apps.dev_mode.set_dev_mode", return_value={"ok": True}) as setter:
+            cc._handle_app(_ns(app_action="dev", name="demo", off=True))
+        setter.assert_called_once_with("demo", False)
+        assert "dev mode off" in capsys.readouterr().out
+
+    def test_dev_error_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("kiro_crew.apps.dev_mode.set_dev_mode", return_value={"error": "no such app"}),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._handle_app(_ns(app_action="dev", name="demo", off=False))
+        assert exc.value.code == 1
+        assert "no such app" in capsys.readouterr().err
+
+    def test_info_prints_json(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("kiro_crew.cli_commands.get_app", return_value={"name": "demo", "v": 1}):
+            cc._handle_app(_ns(app_action="info", name="demo"))
+        assert json.loads(capsys.readouterr().out) == {"name": "demo", "v": 1}
+
+    def test_info_missing_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("kiro_crew.cli_commands.get_app", return_value=None),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._handle_app(_ns(app_action="info", name="ghost"))
+        assert exc.value.code == 1
+        assert "not installed" in capsys.readouterr().err
+
+    def test_init_scaffolds_and_prints_next_steps(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        target = tmp_path / "my-app"
+        with patch("kiro_crew.cli_commands.scaffold_app", return_value=target) as scaffold:
+            cc._handle_app(
+                _ns(
+                    app_action="init",
+                    name="my-app",
+                    dir=str(tmp_path),
+                    backend=True,
+                    ui=True,
+                    cron=True,
+                )
+            )
+        scaffold.assert_called_once_with(
+            tmp_path.resolve(),
+            "my-app",
+            include_backend=True,
+            include_ui=True,
+            include_cron=True,
+        )
+        out = capsys.readouterr().out
+        assert "Scaffolded app" in out and "npm install" in out and "app install" in out
+
+    def test_init_without_ui_skips_npm_hint(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with patch("kiro_crew.cli_commands.scaffold_app", return_value=tmp_path / "a"):
+            cc._handle_app(
+                _ns(app_action="init", name="a", dir=str(tmp_path), backend=False, ui=False)
+            )
+        assert "npm install" not in capsys.readouterr().out
+
+    def test_mcp_action_delegates_to_server_runner(self) -> None:
+        with patch("kiro_crew.cli_commands._run_app_mcp_server") as runner:
+            cc._handle_app(_ns(app_action="mcp", name="demo"))
+        runner.assert_called_once_with("demo")
+
+    def test_unknown_action_prints_usage(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cc._handle_app(_ns(app_action=None))
+        assert "Usage: kirocrew app" in capsys.readouterr().out
+
+
+class TestRunAppMcpServer:
+    def test_missing_module_exits_1_on_stderr(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """stdout is the JSON-RPC channel -- diagnostics must go to stderr."""
+        with (
+            patch("importlib.import_module", side_effect=ImportError("nope")),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._run_app_mcp_server("my-app")
+        captured = capsys.readouterr()
+        assert exc.value.code == 1
+        assert captured.out == ""
+        assert "my-app" in captured.err
+
+    def test_module_without_runner_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch("importlib.import_module", return_value=SimpleNamespace()),
+            pytest.raises(SystemExit),
+        ):
+            cc._run_app_mcp_server("my-app")
+        assert "run_mcp_server" in capsys.readouterr().err
+
+    def test_runner_is_invoked(self) -> None:
+        runner = MagicMock()
+        with patch(
+            "importlib.import_module", return_value=SimpleNamespace(run_mcp_server=runner)
+        ) as imp:
+            cc._run_app_mcp_server("my-app")
+        runner.assert_called_once_with()
+        # Hyphens in app names map to underscores in the module path.
+        assert imp.call_args[0][0].endswith("my_app.mcp_server")
+
+
+class TestCleanupAppCrons:
+    async def _zero(self, *_a: object, **_kw: object) -> int:
+        return 0
+
+    def test_reports_removed_count_and_audits(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        async def _two(*_a: object, **_kw: object) -> int:
+            return 2
+
+        with (
+            patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
+            patch("kiro_crew.cli_commands.CronService"),
+            patch("kiro_crew.cli_commands.deregister_app_crons_from_service", new=_two),
+            patch("kiro_crew.cli_commands.sel") as sel,
+        ):
+            assert cc._cleanup_app_crons_from_scheduler("demo") == 2
+        assert "removed 2 cron job(s)" in capsys.readouterr().out
+        assert sel.return_value.log_api_access.call_args.kwargs["outcome"] == "completed"
+
+    def test_zero_removed_prints_nothing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
+            patch("kiro_crew.cli_commands.CronService"),
+            patch("kiro_crew.cli_commands.deregister_app_crons_from_service", new=self._zero),
+            patch("kiro_crew.cli_commands.sel"),
+        ):
+            assert cc._cleanup_app_crons_from_scheduler("demo") == 0
+        assert capsys.readouterr().out == ""
+
+    def test_failure_is_audited_then_reraised(self, tmp_path: Path) -> None:
+        async def _boom(*_a: object, **_kw: object) -> int:
+            raise RuntimeError("scheduler down")
+
+        with (
+            patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
+            patch("kiro_crew.cli_commands.CronService"),
+            patch("kiro_crew.cli_commands.deregister_app_crons_from_service", new=_boom),
+            patch("kiro_crew.cli_commands.sel") as sel,
+            pytest.raises(RuntimeError, match="scheduler down"),
+        ):
+            cc._cleanup_app_crons_from_scheduler("demo")
+        assert sel.return_value.log_api_access.call_args.kwargs["outcome"] == "failed"
+
+
+# ── agent subcommands ──
+
+
+class TestAgentCli:
+    def test_list_marks_default(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cfg = _cfg_with(
+            agents={
+                "default": KiroCrewAgentConfig(kiro_agent="kirocrew"),
+                "other": KiroCrewAgentConfig(kiro_agent="alt"),
+            }
+        )
+        with patch.object(KiroCrewConfig, "load", return_value=cfg):
+            cc._handle_agent(_ns(agent_action="list"))
+        out = capsys.readouterr().out
+        assert "default *" in out and "other" in out and "alt" in out
+
+    def test_create_persists_new_agent(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cfg = _cfg_with(agents={})
+        with patch.object(KiroCrewConfig, "load", return_value=cfg):
+            cc._handle_agent(
+                _ns(
+                    agent_action="create",
+                    name="new",
+                    kiro_agent="ka",
+                    workspace="ws",
+                    memory_store="ms",
+                )
+            )
+        assert cfg.agents["new"].kiro_agent == "ka"
+        assert cfg.agents["new"].workspace == "ws"
+        cfg.save.assert_called_once()  # type: ignore[attr-defined]
+        assert "Created agent: new" in capsys.readouterr().out
+
+    def test_create_duplicate_exits_1_without_saving(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        cfg = _cfg_with(agents={"dup": KiroCrewAgentConfig()})
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=cfg),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._handle_agent(
+                _ns(
+                    agent_action="create",
+                    name="dup",
+                    kiro_agent="",
+                    workspace="",
+                    memory_store="",
+                )
+            )
+        assert exc.value.code == 1
+        cfg.save.assert_not_called()  # type: ignore[attr-defined]
+        assert "already exists" in capsys.readouterr().err
+
+    def test_update_applies_only_provided_fields(self) -> None:
+        cfg = _cfg_with(
+            agents={"a": KiroCrewAgentConfig(kiro_agent="old", workspace="ws0", memory_store="m0")}
+        )
+        with patch.object(KiroCrewConfig, "load", return_value=cfg):
+            cc._handle_agent(
+                _ns(
+                    agent_action="update",
+                    name="a",
+                    kiro_agent="new",
+                    workspace=None,
+                    memory_store=None,
+                )
+            )
+        assert cfg.agents["a"].kiro_agent == "new"
+        assert cfg.agents["a"].workspace == "ws0"
+        assert cfg.agents["a"].memory_store == "m0"
+
+    def test_update_all_fields(self) -> None:
+        cfg = _cfg_with(agents={"a": KiroCrewAgentConfig()})
+        with patch.object(KiroCrewConfig, "load", return_value=cfg):
+            cc._handle_agent(
+                _ns(
+                    agent_action="update",
+                    name="a",
+                    kiro_agent="k",
+                    workspace="w",
+                    memory_store="m",
+                )
+            )
+        agent = cfg.agents["a"]
+        assert (agent.kiro_agent, agent.workspace, agent.memory_store) == ("k", "w", "m")
+
+    def test_update_missing_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cfg = _cfg_with(agents={})
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=cfg),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._handle_agent(
+                _ns(
+                    agent_action="update",
+                    name="ghost",
+                    kiro_agent=None,
+                    workspace=None,
+                    memory_store=None,
+                )
+            )
+        assert exc.value.code == 1
+        assert "not found" in capsys.readouterr().err
+
+    def test_delete_removes_non_default(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cfg = _cfg_with(
+            agents={"default": KiroCrewAgentConfig(), "spare": KiroCrewAgentConfig()},
+        )
+        with patch.object(KiroCrewConfig, "load", return_value=cfg):
+            cc._handle_agent(_ns(agent_action="delete", name="spare"))
+        assert "spare" not in cfg.agents
+        assert "Deleted agent: spare" in capsys.readouterr().out
+
+    def test_delete_default_is_refused(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cfg = _cfg_with(agents={"default": KiroCrewAgentConfig()})
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=cfg),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._handle_agent(_ns(agent_action="delete", name="default"))
+        assert exc.value.code == 1
+        assert "default" in cfg.agents
+        assert "cannot delete default agent" in capsys.readouterr().err
+
+    def test_delete_missing_exits_1(self) -> None:
+        cfg = _cfg_with(agents={})
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=cfg),
+            pytest.raises(SystemExit),
+        ):
+            cc._handle_agent(_ns(agent_action="delete", name="ghost"))
+
+    def test_unknown_action_prints_usage(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch.object(KiroCrewConfig, "load", return_value=_cfg_with()):
+            cc._handle_agent(_ns(agent_action=None))
+        assert "Usage: kirocrew agent" in capsys.readouterr().out
+
+
+# ── workspace create --copy-from ──
+
+
+class TestWorkspaceCopyFrom:
+    def _base(self) -> KiroCrewConfig:
+        return _cfg_with(
+            workspaces={
+                "default": WorkspaceConfig(dir="workspace"),
+                "src": WorkspaceConfig(dir="workspace-src"),
+            }
+        )
+
+    def test_copy_from_unknown_source_exits_1(self, tmp_path: Path) -> None:
+        with (
+            patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
+            patch.object(KiroCrewConfig, "load", return_value=self._base()),
+            patch("kiro_crew.cli_commands.sel"),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._handle_workspace(
+                _ns(workspace_action="create", name="new", dir=None, copy_from="ghost")
+            )
+        assert exc.value.code == 1
+
+    def test_copy_from_copies_tree_and_registers(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        src = tmp_path / "workspace-src"
+        (src / "memory").mkdir(parents=True)
+        (src / "memory" / "notes.md").write_text("hi", encoding="utf-8")
+        cfg = self._base()
+        with (
+            patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
+            patch.object(KiroCrewConfig, "load", return_value=cfg),
+            patch("kiro_crew.cli_commands.sel"),
+        ):
+            cc._handle_workspace(
+                _ns(workspace_action="create", name="copy1", dir=None, copy_from="src")
+            )
+        assert (tmp_path / "workspace-copy1" / "memory" / "notes.md").read_text() == "hi"
+        assert cfg.workspaces["copy1"].dir == "workspace-copy1"
+        assert "Created workspace: copy1" in capsys.readouterr().out
+
+    def test_copy_from_skips_sensitive_entries(self, tmp_path: Path) -> None:
+        src = tmp_path / "workspace-src"
+        src.mkdir()
+        (src / "ok.txt").write_text("keep", encoding="utf-8")
+        (src / "secret.env").write_text("nope", encoding="utf-8")
+
+        def _sensitive(p: str) -> bool:
+            return p.endswith("secret.env")
+
+        with (
+            patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
+            patch.object(KiroCrewConfig, "load", return_value=self._base()),
+            patch("kiro_crew.cli_commands.is_sensitive_path", side_effect=_sensitive),
+            patch("kiro_crew.cli_commands.sel"),
+        ):
+            cc._handle_workspace(
+                _ns(workspace_action="create", name="copy2", dir=None, copy_from="src")
+            )
+        dst = tmp_path / "workspace-copy2"
+        assert (dst / "ok.txt").exists()
+        assert not (dst / "secret.env").exists()
+
+    def test_copy_from_escaping_dir_is_refused(self, tmp_path: Path) -> None:
+        with (
+            patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
+            patch.object(KiroCrewConfig, "load", return_value=self._base()),
+            patch("kiro_crew.cli_commands.sel") as sel,
+            pytest.raises(SystemExit),
+        ):
+            cc._handle_workspace(
+                _ns(workspace_action="create", name="bad", dir="/etc", copy_from="src")
+            )
+        assert sel.return_value.log_api_access.call_args.kwargs["outcome"] == "denied"
+
+    def test_copy_from_dir_collision_is_refused(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
+            patch.object(KiroCrewConfig, "load", return_value=self._base()),
+            patch("kiro_crew.cli_commands.sel"),
+            pytest.raises(SystemExit),
+        ):
+            cc._handle_workspace(
+                _ns(
+                    workspace_action="create",
+                    name="clash",
+                    dir="workspace-src",
+                    copy_from="src",
+                )
+            )
+        assert "already used by another workspace" in capsys.readouterr().err
+
+    def test_copy_from_missing_source_dir_still_registers(self, tmp_path: Path) -> None:
+        """A source workspace with no directory on disk is a config-only copy."""
+        cfg = self._base()
+        with (
+            patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
+            patch.object(KiroCrewConfig, "load", return_value=cfg),
+            patch("kiro_crew.cli_commands.sel"),
+        ):
+            cc._handle_workspace(
+                _ns(workspace_action="create", name="copy3", dir=None, copy_from="src")
+            )
+        assert "copy3" in cfg.workspaces
+        assert not (tmp_path / "workspace-copy3").exists()
+
+
+# ── security subcommands ──
+
+
+class TestSecurityCli:
+    def test_deny_list_prints_builtins_and_user_patterns(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        (tmp_path / "config.json").write_text(
+            json.dumps({"hooks": {"auto_deny_tools": ["my-custom-pattern"]}}), encoding="utf-8"
+        )
+        with patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path):
+            cc._security(_ns(sec_action="deny-list"))
+        out = capsys.readouterr().out
+        assert "Built-in deny patterns" in out
+        assert "my-custom-pattern" in out
+
+    def test_deny_list_without_config_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path):
+            cc._security(_ns(sec_action="deny-list"))
+        out = capsys.readouterr().out
+        assert "Built-in deny patterns" in out
+        assert "User-configured" not in out
+
+    def test_audit_clean_reports_history_only(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Both stores clean: the history line is printed and the memory verdict is
+        deliberately suppressed (the ``elif not findings: pass`` branch), so a fully
+        clean audit says nothing about vector memory."""
+        with (
+            patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
+            patch("kiro_crew.cli_commands.scan_history", return_value=[]),
+            patch("kiro_crew.cli_commands.scan_memory", return_value=[]),
+        ):
+            cc._security(_ns(sec_action="audit"))
+        out = capsys.readouterr().out
+        assert "No suspicious tool usage" in out
+        assert "vector memory" not in out
+
+    def test_audit_reports_history_and_memory_findings(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        history = [{"file": "s.jsonl", "warning": "exfil", "snippet": "curl evil"}]
+        memory = [{"type": "semantic", "key": "k", "warning": "odd", "value": "v"}]
+        with (
+            patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
+            patch("kiro_crew.cli_commands.scan_history", return_value=history),
+            patch("kiro_crew.cli_commands.scan_memory", return_value=memory),
+        ):
+            cc._security(_ns(sec_action="audit"))
+        out = capsys.readouterr().out
+        assert "1 suspicious entries found" in out and "s.jsonl" in out
+        assert "1 suspicious memory entries" in out and "[semantic] k" in out
+
+    def test_audit_history_findings_with_clean_memory(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        history = [{"file": "s.jsonl", "warning": "w", "snippet": "x"}]
+        with (
+            patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
+            patch("kiro_crew.cli_commands.scan_history", return_value=history),
+            patch("kiro_crew.cli_commands.scan_memory", return_value=[]),
+        ):
+            cc._security(_ns(sec_action="audit"))
+        assert "No suspicious content in vector memory." in capsys.readouterr().out
+
+    def test_events_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("kiro_crew.cli_commands.sel") as sel:
+            sel.return_value.recent.return_value = []
+            cc._security(_ns(sec_action="events", limit=5))
+        assert "No security events recorded." in capsys.readouterr().out
+
+    def test_events_renders_error_and_downstream(self, capsys: pytest.CaptureFixture[str]) -> None:
+        events = [
+            {
+                "timestamp": "2026-01-01T00:00:00Z",
+                "event_type": "api_access",
+                "operation": "cron.add",
+                "outcome": "allowed",
+                "source": "cli",
+                "caller_identity": "me",
+                "error": "boom",
+                "downstream_service": "slack",
+            }
+        ]
+        with patch("kiro_crew.cli_commands.sel") as sel:
+            sel.return_value.recent.return_value = events
+            cc._security(_ns(sec_action="events", limit=20))
+        out = capsys.readouterr().out
+        assert "cron.add → allowed" in out and "error: boom" in out and "slack" in out
+
+    @pytest.mark.parametrize(
+        ("total", "valid", "expected"),
+        [
+            (0, 0, "No security events to verify."),
+            (3, 3, "HMAC chain intact"),
+            (3, 1, "HMAC chain COMPROMISED"),
+        ],
+    )
+    def test_verify_reports_chain_state(
+        self, total: int, valid: int, expected: str, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with patch("kiro_crew.cli_commands.sel") as sel:
+            sel.return_value.verify_integrity.return_value = (total, valid)
+            cc._security(_ns(sec_action="verify"))
+        assert expected in capsys.readouterr().out
+
+    def test_unknown_action_prints_usage(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cc._security(_ns(sec_action="nope"))
+        assert "Usage: kirocrew security" in capsys.readouterr().out
+
+
+# ── policy subcommands ──
+
+
+def _fake_ceiling() -> Any:
+    return SimpleNamespace(
+        version=2,
+        signature_summary=lambda: "unsigned",
+        boot=SimpleNamespace(require_sandbox=True, allow_terminal=False, fail_closed=True),
+        controls={"capabilities.telemetry": "off"},
+    )
+
+
+class TestPolicyCli:
+    def test_show_without_policy(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch(
+            "kiro_crew.platform.context.current_context",
+            return_value=SimpleNamespace(governance=None),
+        ):
+            cc._policy(_ns(policy_action="show"))
+        assert "No enterprise security policy is active" in capsys.readouterr().out
+
+    def test_show_prints_provenance_boot_and_scopes(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with patch(
+            "kiro_crew.platform.context.current_context",
+            return_value=SimpleNamespace(governance=_fake_ceiling()),
+        ):
+            cc._policy(_ns(policy_action="show"))
+        out = capsys.readouterr().out
+        assert "Security policy v2" in out
+        assert "provenance: unsigned" in out
+        assert "require_sandbox=True" in out
+        assert "capabilities.telemetry: off" in out
+
+    def test_show_with_no_governed_scopes(self, capsys: pytest.CaptureFixture[str]) -> None:
+        ceiling = _fake_ceiling()
+        ceiling.controls = {}
+        with patch(
+            "kiro_crew.platform.context.current_context",
+            return_value=SimpleNamespace(governance=ceiling),
+        ):
+            cc._policy(_ns(policy_action="show"))
+        assert "(no governed scopes)" in capsys.readouterr().out
+
+    def test_validate_without_policy_or_profiles_dir(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch(
+                "kiro_crew.platform.context.current_context",
+                return_value=SimpleNamespace(governance=None),
+            ),
+            patch(
+                "kiro_crew.platform.governance_profiles._profiles_dir",
+                return_value=tmp_path / "absent",
+            ),
+        ):
+            cc._policy(_ns(policy_action="validate"))
+        out = capsys.readouterr().out
+        assert "nothing to validate" in out and "(no profiles directory)" in out and "valid" in out
+
+    def test_validate_flags_invalid_profile(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pdir = tmp_path / "profiles"
+        pdir.mkdir()
+        (pdir / "good.json").write_text("{}", encoding="utf-8")
+        (pdir / "bad.json").write_text("{}", encoding="utf-8")
+
+        def _get(stem: str) -> Any:
+            return SimpleNamespace(name="_deny_all" if stem == "bad" else stem)
+
+        with (
+            patch(
+                "kiro_crew.platform.context.current_context",
+                return_value=SimpleNamespace(governance=_fake_ceiling()),
+            ),
+            patch("kiro_crew.platform.governance_profiles._profiles_dir", return_value=pdir),
+            patch("kiro_crew.platform.governance_profiles.get_store_profile", side_effect=_get),
+        ):
+            cc._policy(_ns(policy_action="validate"))
+        out = capsys.readouterr().out
+        assert "Policy: v2 OK" in out
+        assert "bad.json: INVALID→deny-all" in out
+        assert "some profiles failed validation" in out
+
+    def test_explain_unknown_scope_lists_catalog(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch(
+                "kiro_crew.platform.context.current_context",
+                return_value=SimpleNamespace(governance=None),
+            ),
+            patch(
+                "kiro_crew.platform.governance.SCOPE_CATALOG",
+                {"capabilities.telemetry": object()},
+            ),
+        ):
+            cc._policy(
+                _ns(
+                    policy_action="explain",
+                    scope="nope.scope",
+                    item="x",
+                    session_key="s",
+                    agent=None,
+                    app=None,
+                )
+            )
+        out = capsys.readouterr().out
+        assert "Unknown scope" in out and "capabilities.telemetry" in out
+
+    def test_explain_known_scope_prints_verdicts(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        decision = SimpleNamespace(
+            permitted=False, rule="deny", layer="policy", reason="pinned off"
+        )
+        gate = SimpleNamespace(permitted=True, reason="title allowed")
+        with (
+            patch(
+                "kiro_crew.platform.context.current_context",
+                return_value=SimpleNamespace(governance=_fake_ceiling()),
+            ),
+            patch(
+                "kiro_crew.platform.governance.SCOPE_CATALOG",
+                {"capabilities.telemetry": object()},
+            ),
+            patch(
+                "kiro_crew.platform.governance_profiles.resolve_active_scope",
+                return_value=SimpleNamespace(name="prof"),
+            ),
+            patch("kiro_crew.platform.governance.resolve", return_value=decision),
+            patch("kiro_crew.platform.governance.gate_decision", return_value=gate),
+        ):
+            cc._policy(
+                _ns(
+                    policy_action="explain",
+                    scope="capabilities.telemetry",
+                    item="send",
+                    session_key="sess-1",
+                    agent="a",
+                    app=None,
+                )
+            )
+        out = capsys.readouterr().out
+        assert "DENIED: capabilities.telemetry" in out
+        assert "active profile : prof" in out
+        assert "deny / policy" in out
+        assert "gate verdict   : ALLOWED" in out
+
+    def test_explain_without_active_profile(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch(
+                "kiro_crew.platform.context.current_context",
+                return_value=SimpleNamespace(governance=None),
+            ),
+            patch("kiro_crew.platform.governance.SCOPE_CATALOG", {"s": object()}),
+            patch(
+                "kiro_crew.platform.governance_profiles.resolve_active_scope",
+                return_value=None,
+            ),
+            patch(
+                "kiro_crew.platform.governance.resolve",
+                return_value=SimpleNamespace(
+                    permitted=True, rule="allow", layer=None, reason="default"
+                ),
+            ),
+            patch(
+                "kiro_crew.platform.governance.gate_decision",
+                return_value=SimpleNamespace(permitted=True, reason="ok"),
+            ),
+        ):
+            cc._policy(
+                _ns(
+                    policy_action="explain",
+                    scope="s",
+                    item="i",
+                    session_key="k",
+                    agent=None,
+                    app=None,
+                )
+            )
+        out = capsys.readouterr().out
+        assert "ALLOWED: s" in out and "(none — policy only)" in out and "allow / —" in out
+
+    def test_profile_missing(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch(
+                "kiro_crew.platform.context.current_context",
+                return_value=SimpleNamespace(governance=None),
+            ),
+            patch(
+                "kiro_crew.platform.governance_profiles.get_store_profile", return_value=None
+            ),
+        ):
+            cc._policy(_ns(policy_action="profile", name="ghost"))
+        assert "No profile named 'ghost'" in capsys.readouterr().out
+
+    def test_profile_prints_bind_and_scopes(self, capsys: pytest.CaptureFixture[str]) -> None:
+        prof = SimpleNamespace(
+            name="team",
+            bind=SimpleNamespace(type="agent", id="kirocrew"),
+            extends="base",
+            controls={"capabilities.telemetry": "off"},
+        )
+        with (
+            patch(
+                "kiro_crew.platform.context.current_context",
+                return_value=SimpleNamespace(governance=None),
+            ),
+            patch(
+                "kiro_crew.platform.governance_profiles.get_store_profile", return_value=prof
+            ),
+        ):
+            cc._policy(_ns(policy_action="profile", name="team"))
+        out = capsys.readouterr().out
+        assert "bind=agent:kirocrew" in out and "extends=base" in out
+        assert "capabilities.telemetry: off" in out
+
+    def test_profile_unbound_with_no_controls(self, capsys: pytest.CaptureFixture[str]) -> None:
+        prof = SimpleNamespace(name="empty", bind=None, extends=None, controls={})
+        with (
+            patch(
+                "kiro_crew.platform.context.current_context",
+                return_value=SimpleNamespace(governance=None),
+            ),
+            patch(
+                "kiro_crew.platform.governance_profiles.get_store_profile", return_value=prof
+            ),
+        ):
+            cc._policy(_ns(policy_action="profile", name="empty"))
+        out = capsys.readouterr().out
+        assert "(unbound)" in out and "no governed scopes" in out
+
+    def test_unknown_action_prints_usage(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch(
+            "kiro_crew.platform.context.current_context",
+            return_value=SimpleNamespace(governance=None),
+        ):
+            cc._policy(_ns(policy_action=None))
+        assert "Usage: kirocrew policy" in capsys.readouterr().out
+
+
+# ── learn subcommands ──
+
+
+class _LearnHarness:
+    """Patches ``_learn``'s two stores and exposes the mocks."""
+
+    def __init__(self) -> None:
+        self.vs = MagicMock()
+        self.jsonl = MagicMock()
+        self._patches = [
+            patch("kiro_crew.cli_commands.VectorMemoryStore", return_value=self.vs),
+            patch("kiro_crew.cli_commands.LessonStore", return_value=self.jsonl),
+            patch.object(KiroCrewConfig, "load", return_value=KiroCrewConfig()),
+        ]
+
+    def __enter__(self) -> _LearnHarness:
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        for p in reversed(self._patches):
+            p.stop()
+
+
+class TestLearnCli:
+    def test_add_prefers_vector_store(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _LearnHarness() as h:
+            h.vs.write_lesson.return_value = True
+            cc._learn(_ns(learn_action="add", rule="do x", category="tool", negative="not y"))
+        h.vs.write_lesson.assert_called_once_with("do x", "tool", "not y")
+        h.jsonl.save.assert_not_called()
+        h.vs.close.assert_called_once()
+        assert "Saved: do x (not y) [tool]" in capsys.readouterr().out
+
+    def test_add_falls_back_to_jsonl_store(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _LearnHarness() as h:
+            h.vs.write_lesson.return_value = False
+            cc._learn(_ns(learn_action="add", rule="do x", category="knowledge", negative=None))
+        h.jsonl.save.assert_called_once()
+        saved = h.jsonl.save.call_args[0][0]
+        assert saved.rule == "do x" and saved.category == "knowledge"
+        assert "Saved: do x [knowledge]" in capsys.readouterr().out
+
+    def test_list_from_vector_store(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _LearnHarness() as h:
+            h.vs.get_lessons.return_value = [{"value_json": json.dumps({"rule": "r1"})}]
+            cc._learn(_ns(learn_action="list"))
+        assert "[knowledge]" in capsys.readouterr().out
+
+    def test_list_falls_back_to_jsonl(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _LearnHarness() as h:
+            h.vs.get_lessons.return_value = []
+            h.jsonl.load_all.return_value = [
+                SimpleNamespace(category="tool", rule="r", negative="n")
+            ]
+            cc._learn(_ns(learn_action="list"))
+        assert "[tool] r — n" in capsys.readouterr().out
+
+    def test_list_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _LearnHarness() as h:
+            h.vs.get_lessons.return_value = []
+            h.jsonl.load_all.return_value = []
+            cc._learn(_ns(learn_action="list"))
+        assert "No lessons." in capsys.readouterr().out
+
+    def test_remove_via_vector_store(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _LearnHarness() as h:
+            h.vs.get_lessons.return_value = [{"value_json": "{}"}]
+            h.vs.delete_lesson.return_value = True
+            cc._learn(_ns(learn_action="remove", query="q"))
+        assert "Removed lessons matching: q" in capsys.readouterr().out
+
+    def test_remove_via_jsonl_store(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _LearnHarness() as h:
+            h.vs.get_lessons.return_value = []
+            h.jsonl.remove.return_value = True
+            cc._learn(_ns(learn_action="remove", query="q"))
+        assert "Removed lessons matching: q" in capsys.readouterr().out
+
+    def test_remove_no_match(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _LearnHarness() as h:
+            h.vs.get_lessons.return_value = []
+            h.jsonl.remove.return_value = False
+            cc._learn(_ns(learn_action="remove", query="q"))
+        assert "No lessons match: q" in capsys.readouterr().out
+
+    def test_unknown_action_prints_usage_and_closes_store(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with _LearnHarness() as h:
+            cc._learn(_ns(learn_action=None))
+        h.vs.close.assert_called_once()
+        assert "Usage: kirocrew learn" in capsys.readouterr().out
+
+
+# ── memory subcommands ──
+
+
+class _MemHarness:
+    def __init__(self) -> None:
+        self.store = MagicMock()
+        self._patches = [
+            patch("kiro_crew.cli_commands.VectorMemoryStore", return_value=self.store),
+            patch.object(KiroCrewConfig, "load", return_value=KiroCrewConfig()),
+        ]
+
+    def __enter__(self) -> _MemHarness:
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        for p in reversed(self._patches):
+            p.stop()
+
+
+class TestMemoryCli:
+    def test_list_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _MemHarness() as h:
+            h.store.get_all_semantic.return_value = []
+            cc._memory_cmd(_ns(mem_action="list"))
+        assert "No semantic memory entries." in capsys.readouterr().out
+
+    def test_list_renders_json_and_raw_values(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _MemHarness() as h:
+            h.store.get_all_semantic.return_value = [
+                {"key": "a", "value_json": '{"x": 1}', "confidence": 0.9, "source": "cli"},
+                {"key": "b", "value_json": "not-json", "confidence": 0.1, "source": "cli"},
+            ]
+            cc._memory_cmd(_ns(mem_action="list"))
+        out = capsys.readouterr().out
+        assert "a: {'x': 1}" in out and "b: not-json" in out
+
+    def test_search_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _MemHarness() as h:
+            h.store.search_episodic.return_value = []
+            cc._memory_cmd(_ns(mem_action="search", query="q"))
+        assert "No episodic memories found." in capsys.readouterr().out
+
+    def test_search_handles_str_and_list_tags(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _MemHarness() as h:
+            h.store.search_episodic.return_value = [
+                {"text": "first", "importance": 0.5, "tags": '["t1"]'},
+                {"text": "second", "importance": 0.2, "tags": ["t2"]},
+                {"text": "third"},
+            ]
+            cc._memory_cmd(_ns(mem_action="search", query="q"))
+        out = capsys.readouterr().out
+        assert "tags: t1" in out and "tags: t2" in out and "third" in out
+
+    def test_stats(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _MemHarness() as h:
+            h.store.memory_stats.return_value = {
+                "semantic_active": 3,
+                "semantic_deleted": 1,
+                "episodic_active": 7,
+                "episodic_deleted": 2,
+                "faiss_index_size": 10,
+                "events_count": 4,
+            }
+            cc._memory_cmd(_ns(mem_action="stats"))
+        out = capsys.readouterr().out
+        assert "Semantic: 3 active, 1 deleted" in out and "FAISS index: 10 vectors" in out
+
+    def test_audit_with_and_without_findings(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _MemHarness(), patch("kiro_crew.cli_commands.scan_memory", return_value=[]):
+            cc._memory_cmd(_ns(mem_action="audit"))
+        assert "No suspicious content in memory." in capsys.readouterr().out
+
+        findings = [{"type": "semantic", "key": "k", "warning": "w", "value": "v"}]
+        with _MemHarness(), patch("kiro_crew.cli_commands.scan_memory", return_value=findings):
+            cc._memory_cmd(_ns(mem_action="audit"))
+        assert "1 suspicious entries" in capsys.readouterr().out
+
+    def test_export_to_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _MemHarness() as h:
+            h.store.get_all_semantic.return_value = [{"key": "a"}]
+            h.store.get_episodic_list.return_value = []
+            h.store.get_events.return_value = []
+            cc._memory_cmd(_ns(mem_action="export", output=None))
+        assert json.loads(capsys.readouterr().out)["semantic"] == [{"key": "a"}]
+
+    def test_export_to_file(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        out_file = tmp_path / "dump.json"
+        with _MemHarness() as h:
+            h.store.get_all_semantic.return_value = []
+            h.store.get_episodic_list.return_value = []
+            h.store.get_events.return_value = []
+            cc._memory_cmd(_ns(mem_action="export", output=str(out_file)))
+        assert json.loads(out_file.read_text())["episodic"] == []
+        assert "Exported to" in capsys.readouterr().out
+
+    def test_migrate_prints_counts(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _MemHarness() as h:
+            h.store.migrate_from_markdown.return_value = {
+                "semantic": 1,
+                "episodic": 2,
+                "skipped": 3,
+            }
+            cc._memory_cmd(_ns(mem_action="migrate"))
+        out = capsys.readouterr().out
+        assert "Migration complete" in out and "Skipped:  3" in out
+
+    def test_import_requires_a_file_argument(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _MemHarness():
+            cc._memory_cmd(_ns(mem_action="import", file=None))
+        assert "Usage: kirocrew memory import" in capsys.readouterr().out
+
+    def test_import_missing_file(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        with _MemHarness():
+            cc._memory_cmd(_ns(mem_action="import", file=str(tmp_path / "absent.json")))
+        assert "File not found" in capsys.readouterr().out
+
+    def test_import_reads_through_safe_read_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        src = tmp_path / "in.json"
+        src.write_text(json.dumps({"semantic": []}), encoding="utf-8")
+        with _MemHarness() as h:
+            h.store.import_memory.return_value = {"semantic": 5, "episodic": 0, "skipped": 1}
+            cc._memory_cmd(_ns(mem_action="import", file=str(src)))
+        h.store.import_memory.assert_called_once_with({"semantic": []})
+        assert "Import complete" in capsys.readouterr().out
+
+    def test_unknown_action_prints_usage_and_closes(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with _MemHarness() as h:
+            cc._memory_cmd(_ns(mem_action="bogus"))
+        h.store.close.assert_called_once()
+        assert "Usage: kirocrew memory" in capsys.readouterr().out
+
+
+# ── artifact subcommands ──
+
+
+class _ArtifactHarness:
+    """Patches config/dashboard resolution so ``_artifact`` talks to a fake HTTP layer."""
+
+    def __init__(self, responses: list[Any]) -> None:
+        self._responses = responses
+        self._patches: list[Any] = []
+        self.urlopen: MagicMock = MagicMock()
+
+    def __enter__(self) -> _ArtifactHarness:
+        self._patches = [
+            patch.object(KiroCrewConfig, "load", return_value=KiroCrewConfig()),
+            patch("kiro_crew.cli_commands.parse_dashboard_url", return_value=("localhost", 5476)),
+            patch("kiro_crew.cli_commands._internal_secret", return_value="s"),
+            patch("urllib.request.urlopen", side_effect=self._responses),
+        ]
+        started = [p.start() for p in self._patches]
+        self.urlopen = started[-1]
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        for p in reversed(self._patches):
+            p.stop()
+
+
+class TestArtifactCli:
+    def test_list_renders_rows(self, capsys: pytest.CaptureFixture[str]) -> None:
+        payload = {
+            "artifacts": [
+                {"slug": "s1", "version": 3, "kind": "widget", "tags": ["a"], "name": "One"},
+                {"slug": "s2", "version": 1, "kind": "markdown", "name": "Two"},
+            ]
+        }
+        with _ArtifactHarness([_FakeResponse(payload)]):
+            cc._artifact(_ns(artifact_action="list", tag="ops", kind=None, q="One"))
+        out = capsys.readouterr().out
+        assert "s1" in out and "[a]" in out and "s2" in out
+
+    def test_list_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _ArtifactHarness([_FakeResponse({"artifacts": []})]):
+            cc._artifact(_ns(artifact_action="list", tag=None, kind=None, q=None))
+        assert "No artifacts." in capsys.readouterr().out
+
+    def test_list_server_error_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        err = _http_error(500, json.dumps({"error": "db down"}).encode())
+        with _ArtifactHarness([err]), pytest.raises(SystemExit) as exc:
+            cc._artifact(_ns(artifact_action="list", tag=None, kind=None, q=None))
+        assert exc.value.code == 1
+        assert "db down" in capsys.readouterr().err
+
+    def test_list_transport_error_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            _ArtifactHarness([urllib.error.URLError("refused")]),
+            pytest.raises(SystemExit),
+        ):
+            cc._artifact(_ns(artifact_action="list", tag=None, kind=None, q=None))
+        assert "Error:" in capsys.readouterr().err
+
+    def test_show_prints_content(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _ArtifactHarness([_FakeResponse({"content": "<p>hi</p>"})]):
+            cc._artifact(_ns(artifact_action="show", slug="s1", version=None, meta=False))
+        assert "<p>hi</p>" in capsys.readouterr().out
+
+    def test_show_meta_strips_content(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _ArtifactHarness([_FakeResponse({"content": "x", "slug": "s1", "version": 2})]):
+            cc._artifact(_ns(artifact_action="show", slug="s1", version=2, meta=True))
+        data = json.loads(capsys.readouterr().out)
+        assert "content" not in data and data["slug"] == "s1"
+
+    def test_show_error_exits_1(self) -> None:
+        err = _http_error(404, json.dumps({"error": "no such artifact"}).encode())
+        with _ArtifactHarness([err]), pytest.raises(SystemExit):
+            cc._artifact(_ns(artifact_action="show", slug="ghost", version=None, meta=False))
+
+    def test_save_with_inline_content_and_tags(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _ArtifactHarness([_FakeResponse({"slug": "new", "version": 1})]):
+            cc._artifact(
+                _ns(
+                    artifact_action="save",
+                    name="New",
+                    content="body",
+                    content_file=None,
+                    tags="a, b ,",
+                    kind="widget",
+                    description="d",
+                )
+            )
+        assert "Saved: slug=new version=1" in capsys.readouterr().out
+
+    def test_save_reads_content_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        f = tmp_path / "body.html"
+        f.write_text("from-file", encoding="utf-8")
+        with _ArtifactHarness([_FakeResponse({"slug": "s", "version": 1})]):
+            cc._artifact(
+                _ns(
+                    artifact_action="save",
+                    name="N",
+                    content=None,
+                    content_file=str(f),
+                    tags=None,
+                    kind=None,
+                    description=None,
+                )
+            )
+        assert "Saved:" in capsys.readouterr().out
+
+    def test_save_refuses_sensitive_content_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        f = tmp_path / "creds"
+        f.write_text("secret", encoding="utf-8")
+        with (
+            _ArtifactHarness([]),
+            patch("kiro_crew.cli_commands.is_sensitive_path", return_value=True),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._artifact(
+                _ns(
+                    artifact_action="save",
+                    name="N",
+                    content=None,
+                    content_file=str(f),
+                    tags=None,
+                    kind=None,
+                    description=None,
+                )
+            )
+        assert exc.value.code == 1
+        assert "sensitive path" in capsys.readouterr().err
+
+    def test_save_error_exits_1(self) -> None:
+        err = _http_error(400, json.dumps({"error": "bad name"}).encode())
+        with _ArtifactHarness([err]), pytest.raises(SystemExit):
+            cc._artifact(
+                _ns(
+                    artifact_action="save",
+                    name="N",
+                    content="c",
+                    content_file=None,
+                    tags=None,
+                    kind=None,
+                    description=None,
+                )
+            )
+
+    def test_update_metadata_only_does_not_touch_content(self) -> None:
+        with (
+            _ArtifactHarness([_FakeResponse({"slug": "s", "version": 4})]) as h,
+            patch("sys.stdin.isatty", return_value=True),
+        ):
+            cc._artifact(
+                _ns(
+                    artifact_action="update",
+                    slug="s",
+                    content=None,
+                    content_file=None,
+                    name="Renamed",
+                    description="d",
+                    tags="x",
+                )
+            )
+        req = h.urlopen.call_args[0][0]
+        body = json.loads(req.data.decode())
+        assert "content" not in body
+        assert body == {"name": "Renamed", "description": "d", "tags": ["x"]}
+
+    def test_update_with_content_sends_it(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _ArtifactHarness([_FakeResponse({"slug": "s", "version": 5})]):
+            cc._artifact(
+                _ns(
+                    artifact_action="update",
+                    slug="s",
+                    content="new body",
+                    content_file=None,
+                    name=None,
+                    description=None,
+                    tags=None,
+                )
+            )
+        assert "Updated: slug=s version=5" in capsys.readouterr().out
+
+    def test_update_with_nothing_to_change_exits_1(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            _ArtifactHarness([]),
+            patch("sys.stdin.isatty", return_value=True),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._artifact(
+                _ns(
+                    artifact_action="update",
+                    slug="s",
+                    content=None,
+                    content_file=None,
+                    name=None,
+                    description=None,
+                    tags=None,
+                )
+            )
+        assert exc.value.code == 1
+        assert "provide content/--name" in capsys.readouterr().err
+
+    def test_update_error_exits_1(self) -> None:
+        err = _http_error(409, json.dumps({"error": "conflict"}).encode())
+        with _ArtifactHarness([err]), pytest.raises(SystemExit):
+            cc._artifact(
+                _ns(
+                    artifact_action="update",
+                    slug="s",
+                    content="c",
+                    content_file=None,
+                    name=None,
+                    description=None,
+                    tags=None,
+                )
+            )
+
+    def test_delete_reports_slug(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _ArtifactHarness([_FakeResponse(b"")]):
+            cc._artifact(_ns(artifact_action="delete", slug="gone"))
+        assert "Deleted: gone" in capsys.readouterr().out
+
+    def test_delete_error_exits_1(self) -> None:
+        err = _http_error(404, b"not json")
+        with _ArtifactHarness([err]), pytest.raises(SystemExit):
+            cc._artifact(_ns(artifact_action="delete", slug="gone"))
+
+    def test_versions_lists_numbers(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _ArtifactHarness([_FakeResponse({"versions": [1, 2, 3]})]):
+            cc._artifact(_ns(artifact_action="versions", slug="s"))
+        assert "v1, v2, v3" in capsys.readouterr().out
+
+    def test_versions_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _ArtifactHarness([_FakeResponse({"versions": []})]):
+            cc._artifact(_ns(artifact_action="versions", slug="s"))
+        assert "No versions for s." in capsys.readouterr().out
+
+    def test_versions_error_exits_1(self) -> None:
+        with _ArtifactHarness([_http_error(500, b"")]), pytest.raises(SystemExit):
+            cc._artifact(_ns(artifact_action="versions", slug="s"))
+
+    def test_unknown_action_exits_2(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with _ArtifactHarness([]), pytest.raises(SystemExit) as exc:
+            cc._artifact(_ns(artifact_action="bogus"))
+        assert exc.value.code == 2
+        assert "Usage: kirocrew artifact" in capsys.readouterr().err
+
+
+class TestPodDispatch:
+    def test_pod_delegates_to_verb_layer(self) -> None:
+        args = _ns(pod_action="ls")
+        with patch("kiro_crew.pod.cli.dispatch") as dispatch:
+            cc._pod(args)
+        dispatch.assert_called_once_with(args)
+
+
+# ── telemetry subcommand ──
+
+
+class TestTelemetryCli:
+    def test_status_is_read_only(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=KiroCrewConfig()),
+            patch("kiro_crew.cli_commands.beacon") as beacon,
+        ):
+            beacon.format_status.return_value = "beacon: OFF"
+            cc._telemetry(_ns(telemetry_action="status"))
+        assert "beacon: OFF" in capsys.readouterr().out
+
+    def test_missing_action_defaults_to_status(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=KiroCrewConfig()),
+            patch("kiro_crew.cli_commands.beacon") as beacon,
+        ):
+            beacon.format_status.return_value = "default-status"
+            cc._telemetry(_ns(telemetry_action=None))
+        assert "default-status" in capsys.readouterr().out
+
+    def test_unknown_action_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=KiroCrewConfig()),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._telemetry(_ns(telemetry_action="frobnicate"))
+        assert exc.value.code == 1
+        assert "Unknown telemetry action" in capsys.readouterr().err
+
+    def test_disable_writes_config_and_acks_privacy(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps({"agent": {"model": "auto"}}), encoding="utf-8")
+        effective = KiroCrewConfig()
+        effective.telemetry.beacon_enabled = False
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=effective),
+            patch("kiro_crew.cli_commands.config_path", return_value=path),
+            patch("kiro_crew.cli_commands.beacon") as beacon,
+        ):
+            beacon.DISABLE_ENV = "KIROCREW_NO_BEACON"
+            beacon.INSTALL_ID_FILE = "install_id"
+            cc._telemetry(_ns(telemetry_action="disable"))
+        data = json.loads(path.read_text())
+        assert data["telemetry"]["beacon_enabled"] is False
+        assert data["dashboard"]["privacy_acked"] is True
+        # Unrelated sections survive the rewrite.
+        assert data["agent"] == {"model": "auto"}
+        assert "DISABLED" in capsys.readouterr().out
+
+    def test_enable_creates_config_when_absent(self, tmp_path: Path) -> None:
+        path = tmp_path / "nested" / "config.json"
+        effective = KiroCrewConfig()
+        effective.telemetry.beacon_enabled = True
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=effective),
+            patch("kiro_crew.cli_commands.config_path", return_value=path),
+            patch("kiro_crew.cli_commands.beacon") as beacon,
+        ):
+            beacon.is_governance_pinned_off.return_value = False
+            cc._telemetry(_ns(telemetry_action="enable"))
+        assert json.loads(path.read_text())["telemetry"]["beacon_enabled"] is True
+
+    def test_enable_refused_when_governance_pins_off(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "config.json"
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=KiroCrewConfig()),
+            patch("kiro_crew.cli_commands.config_path", return_value=path),
+            patch("kiro_crew.cli_commands.beacon") as beacon,
+            pytest.raises(SystemExit) as exc,
+        ):
+            beacon.is_governance_pinned_off.return_value = True
+            cc._telemetry(_ns(telemetry_action="enable"))
+        assert exc.value.code == 1
+        assert not path.exists(), "must not write a setting that would have no effect"
+        assert "pinned OFF" in capsys.readouterr().err
+
+    def test_unreadable_config_exits_1(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "config.json"
+        path.write_text("{not json", encoding="utf-8")
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=KiroCrewConfig()),
+            patch("kiro_crew.cli_commands.config_path", return_value=path),
+            patch("kiro_crew.cli_commands.beacon"),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._telemetry(_ns(telemetry_action="disable"))
+        assert exc.value.code == 1
+        assert "Could not read" in capsys.readouterr().err
+
+    def test_non_object_config_is_refused_not_overwritten(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "config.json"
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=KiroCrewConfig()),
+            patch("kiro_crew.cli_commands.config_path", return_value=path),
+            patch("kiro_crew.cli_commands.beacon"),
+            pytest.raises(SystemExit),
+        ):
+            cc._telemetry(_ns(telemetry_action="disable"))
+        assert path.read_text() == "[1, 2, 3]", "a toggle must never be a data-loss path"
+        assert "refusing to overwrite" in capsys.readouterr().err
+
+    def test_non_object_section_is_refused(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "config.json"
+        original = json.dumps({"telemetry": "yes-please"})
+        path.write_text(original, encoding="utf-8")
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=KiroCrewConfig()),
+            patch("kiro_crew.cli_commands.config_path", return_value=path),
+            patch("kiro_crew.cli_commands.beacon"),
+            pytest.raises(SystemExit),
+        ):
+            cc._telemetry(_ns(telemetry_action="disable"))
+        assert path.read_text() == original
+        assert 'non-object "telemetry" value' in capsys.readouterr().err
+
+    def test_overlay_shadowing_the_write_is_reported_as_failure(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A false promise on a privacy control is worse than an error."""
+        path = tmp_path / "config.json"
+        path.write_text("{}", encoding="utf-8")
+        still_on = KiroCrewConfig()
+        still_on.telemetry.beacon_enabled = True
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=still_on),
+            patch("kiro_crew.cli_commands.config_path", return_value=path),
+            patch("kiro_crew.cli_commands.beacon") as beacon,
+            pytest.raises(SystemExit) as exc,
+        ):
+            beacon.DISABLE_ENV = "KIROCREW_NO_BEACON"
+            cc._telemetry(_ns(telemetry_action="disable"))
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "still ENABLED" in err and "config.local.json" in err
+
+    def test_write_failure_exits_1(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "config.json"
+        path.write_text("{}", encoding="utf-8")
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=KiroCrewConfig()),
+            patch("kiro_crew.cli_commands.config_path", return_value=path),
+            patch("kiro_crew.cli_commands.beacon"),
+            patch("kiro_crew.cli_commands.atomic_write", side_effect=OSError("disk full")),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cc._telemetry(_ns(telemetry_action="disable"))
+        assert exc.value.code == 1
+        assert "Could not write" in capsys.readouterr().err
+
+    def test_effective_check_failure_does_not_mask_the_write(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A broken diagnostic read must not turn a successful write into an error."""
+        path = tmp_path / "config.json"
+        path.write_text("{}", encoding="utf-8")
+        with (
+            patch.object(
+                KiroCrewConfig,
+                "load",
+                side_effect=[KiroCrewConfig(), RuntimeError("bad config")],
+            ),
+            patch("kiro_crew.cli_commands.config_path", return_value=path),
+            patch("kiro_crew.cli_commands.beacon") as beacon,
+        ):
+            beacon.INSTALL_ID_FILE = "install_id"
+            cc._telemetry(_ns(telemetry_action="disable"))
+        assert "DISABLED" in capsys.readouterr().out
+
+
+# ── eval runner (`kirocrew eval`) ──
+
+
+def _scenario(name: str = "smoke", *, turns: int = 2, judge_criteria: str = "") -> Any:
+    sessions = [SimpleNamespace(turns=[object()] * turns)]
+    return SimpleNamespace(
+        name=name,
+        description=f"{name} description",
+        judge_criteria=judge_criteria,
+        sessions=sessions,
+    )
+
+
+def _scenario_result(passed: bool = True, *, turn: Any | None = None) -> Any:
+    turns = [turn] if turn is not None else []
+    return SimpleNamespace(
+        passed=passed,
+        sessions=[SimpleNamespace(turns=turns)],
+        summary=lambda: {"passed": passed},
+    )
+
+
+class _EvalHarness:
+    """Stubs every collaborator ``_run_eval`` touches, so no provider is built,
+    no model is called, and results land under the (chdir'd) tmp dir."""
+
+    def __init__(self, results: list[Any]) -> None:
+        self.results = results
+        self.runner = MagicMock()
+        self.runner.run_scenarios = AsyncMock(return_value=results)
+        self.judge = MagicMock()
+        self.judge.pass_threshold = 3
+        self.judge.start = AsyncMock()
+        self.judge.shutdown = AsyncMock()
+        self.judge.judge_turn = AsyncMock(
+            return_value=SimpleNamespace(score=5, reason="looks right")
+        )
+        self._patches: list[Any] = []
+
+    def __enter__(self) -> _EvalHarness:
+        self._patches = [
+            patch.object(KiroCrewConfig, "load", return_value=KiroCrewConfig()),
+            patch("kiro_crew.cli_commands.build_provider_factory", return_value=MagicMock()),
+            patch("kiro_crew.cli_commands.EvalRunner", return_value=self.runner),
+            patch("kiro_crew.cli_commands.LLMJudge", return_value=self.judge),
+            patch("kiro_crew.cli_commands.format_results", return_value="## Report"),
+            patch("kiro_crew.cli_commands.score_by_dimension", return_value={}),
+        ]
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        for p in reversed(self._patches):
+            p.stop()
+
+
+class TestRunEval:
+    """``_run_eval`` writes its report into ``Path.cwd()``, so every test chdirs
+    into ``tmp_path`` first -- nothing is written outside the temp dir."""
+
+    @pytest.mark.asyncio
+    async def test_default_runs_smoke_test_and_writes_both_reports(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        with (
+            _EvalHarness([_scenario_result(True)]),
+            patch("kiro_crew.cli_commands.load_scenario", return_value=_scenario()) as loader,
+        ):
+            await cc._run_eval(_ns(all_scenarios=False, scenarios=None, judge=False))
+        assert loader.call_args[0][0].name == "smoke_test.json"
+        results_dir = tmp_path / "eval_results"
+        assert len(list(results_dir.iterdir())) == 2
+        report = next(p for p in results_dir.iterdir() if p.suffix == ".md")
+        assert report.read_text() == "## Report\n"
+        dump = next(p for p in results_dir.iterdir() if p.suffix == ".json")
+        payload = json.loads(dump.read_text())
+        assert payload["overall_passed"] == 1 and payload["overall_total"] == 1
+        out = capsys.readouterr().out
+        assert "Running: smoke (2 turns)" in out and "Overall: 1/1 scenarios passed" in out
+
+    @pytest.mark.asyncio
+    async def test_all_scenarios_loads_the_whole_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        scenarios = [_scenario("a"), _scenario("b")]
+        with (
+            _EvalHarness([_scenario_result(True), _scenario_result(False)]) as h,
+            patch("kiro_crew.cli_commands.load_scenarios", return_value=scenarios) as loader,
+        ):
+            await cc._run_eval(_ns(all_scenarios=True, scenarios=None, judge=False))
+        assert loader.call_args[0][0].name == "scenarios"
+        h.runner.run_scenarios.assert_awaited_once_with(scenarios)
+
+    @pytest.mark.asyncio
+    async def test_named_scenario_is_resolved_by_extension(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        with (
+            _EvalHarness([_scenario_result(True)]),
+            patch("kiro_crew.cli_commands.load_scenario", return_value=_scenario("named")) as ld,
+        ):
+            await cc._run_eval(
+                _ns(all_scenarios=False, scenarios=["memory_recall_basic"], judge=False)
+            )
+        assert ld.call_args[0][0].name == "memory_recall_basic.json"
+
+    @pytest.mark.asyncio
+    async def test_unknown_scenario_lists_available_and_returns(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        with _EvalHarness([]) as h:
+            await cc._run_eval(_ns(all_scenarios=False, scenarios=["does-not-exist"], judge=False))
+        out = capsys.readouterr().out
+        assert "scenario 'does-not-exist' not found" in out
+        assert "smoke_test" in out
+        h.runner.run_scenarios.assert_not_awaited()
+        assert not (tmp_path / "eval_results").exists()
+
+    @pytest.mark.asyncio
+    async def test_dimension_summary_marks_pass_and_fail_rates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        dims = {
+            "memory": {"rate": 0.8, "passed": 4, "total": 5},
+            "tools": {"rate": 0.5, "passed": 1, "total": 2},
+        }
+        with (
+            _EvalHarness([_scenario_result(True)]),
+            patch("kiro_crew.cli_commands.load_scenario", return_value=_scenario()),
+            patch("kiro_crew.cli_commands.score_by_dimension", return_value=dims),
+        ):
+            await cc._run_eval(_ns(all_scenarios=False, scenarios=None, judge=False))
+        out = capsys.readouterr().out
+        assert "✅ memory: 4/5 (80%)" in out
+        assert "❌ tools: 1/2 (50%)" in out
+
+    @pytest.mark.asyncio
+    async def test_judge_scores_judge_assertions(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        assertion = SimpleNamespace(type=AssertionType.JUDGE, value="was it helpful")
+        turn = SimpleNamespace(
+            assertion_results=[(assertion, False)],
+            user_message="hi",
+            agent_response="hello",
+        )
+        with (
+            _EvalHarness([_scenario_result(True, turn=turn)]) as h,
+            patch("kiro_crew.cli_commands.load_scenario", return_value=_scenario()),
+        ):
+            await cc._run_eval(_ns(all_scenarios=False, scenarios=None, judge=True))
+        h.judge.start.assert_awaited_once()
+        h.judge.shutdown.assert_awaited_once()
+        # score 5 >= pass_threshold 3, so the assertion flips to passing.
+        assert turn.assertion_results[0][1] is True
+        assert "Judge: 5/5" in capsys.readouterr().out
+
+    @pytest.mark.asyncio
+    async def test_judge_failure_marks_assertion_failed_without_aborting(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        assertion = SimpleNamespace(type=AssertionType.JUDGE, value=None)
+        turn = SimpleNamespace(
+            assertion_results=[(assertion, True)],
+            user_message="hi",
+            agent_response="hello",
+        )
+        with (
+            _EvalHarness([_scenario_result(True, turn=turn)]) as h,
+            patch(
+                "kiro_crew.cli_commands.load_scenario",
+                return_value=_scenario(judge_criteria="be terse"),
+            ),
+        ):
+            h.judge.judge_turn.side_effect = RuntimeError("judge offline")
+            await cc._run_eval(_ns(all_scenarios=False, scenarios=None, judge=True))
+        assert turn.assertion_results[0][1] is False
+        assert "Judge failed for turn: judge offline" in capsys.readouterr().out
+        h.judge.shutdown.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_judge_assertions_are_left_alone(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        assertion = SimpleNamespace(type=AssertionType.CONTAINS, value="x")
+        turn = SimpleNamespace(
+            assertion_results=[(assertion, False)],
+            user_message="hi",
+            agent_response="hello",
+        )
+        with (
+            _EvalHarness([_scenario_result(True, turn=turn)]) as h,
+            patch("kiro_crew.cli_commands.load_scenario", return_value=_scenario()),
+        ):
+            await cc._run_eval(_ns(all_scenarios=False, scenarios=None, judge=True))
+        h.judge.judge_turn.assert_not_awaited()
+        assert turn.assertion_results[0][1] is False

--- a/test/test_handlers_memory_coverage.py
+++ b/test/test_handlers_memory_coverage.py
@@ -1,0 +1,1514 @@
+"""Coverage tests for ``kiro_crew.dashboard.handlers.memory``.
+
+Focused on the request/response contract of the memory HTTP handlers: method
+dispatch, body and query validation, the restricted-session 403 gate, the
+not-found 404s, the single-flight 409s, and the fail-closed 500s. Handlers are
+invoked directly with a faked ``web.Request`` (the style ``test_memory_graph.py``
+uses) so no socket is bound; the vector store, memory store, embedder and
+download manager are all mocks, so nothing here touches the network, a real
+GGUF, or a sandbox.
+
+``_apply_embedding_model`` is deliberately NOT exercised here — it is owned by
+``test_embedding_model_apply.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+
+import kiro_crew.dashboard.handlers.memory as mem_mod
+
+_MOD = "kiro_crew.dashboard.handlers.memory"
+
+_CRED = "AKIAIOSFODNN7EXAMPLE"
+
+
+class _BadJSON:
+    """Sentinel: make ``request.json()`` raise, as aiohttp does on bad bytes."""
+
+
+def _body(resp: web.Response) -> Any:
+    """Decode a ``web.json_response`` body."""
+    return json.loads(resp.text or "")
+
+
+def _make_state(
+    *,
+    vector_store: Any = None,
+    memory: Any = None,
+    consolidator: Any = None,
+    restricted_keys: set[str] | None = None,
+) -> Any:
+    """A DashboardState stand-in wired for the memory handlers.
+
+    ``_slots`` / ``_restricted_keys`` are real containers (not auto-MagicMocks)
+    so ``_is_restricted_session`` runs its real logic instead of tripping over a
+    truthy mock slot.
+    """
+    mem = memory if memory is not None else MagicMock()
+    if vector_store is not None:
+        mem.vector_store = vector_store
+    state = MagicMock()
+    state.context_builder = MagicMock(memory=mem)
+    state.consolidator = consolidator
+    state._slots = {}
+    state._restricted_keys = set(restricted_keys or ())
+    return state
+
+
+def _make_request(
+    state: Any,
+    *,
+    method: str = "GET",
+    json_body: Any = None,
+    query: dict[str, str] | None = None,
+    match_info: dict[str, str] | None = None,
+    session_key: str = "",
+) -> Any:
+    req = MagicMock()
+    req.app = {"state": state}
+    req.method = method
+    req.query = query or {}
+    req.match_info = match_info or {}
+    req.headers = {"X-Session-Key": session_key} if session_key else {}
+    if isinstance(json_body, _BadJSON):
+        req.json = AsyncMock(side_effect=ValueError("not json"))
+    else:
+        req.json = AsyncMock(return_value=json_body)
+    return req
+
+
+def _store(**attrs: Any) -> Any:
+    """A vector-store mock with JSON-serializable defaults."""
+    store = MagicMock()
+    store.embed_fn = None
+    store.get_all_semantic.return_value = []
+    store.get_events.return_value = []
+    store.get_episodic_list.return_value = []
+    store.search_episodic.return_value = []
+    store.set_semantic.return_value = None
+    store.delete_semantic.return_value = True
+    store.delete_episodic.return_value = True
+    store.memory_stats.return_value = {"semantic_count": 0}
+    store.get_rejection_stats.return_value = {}
+    store.get_context_preview.return_value = {"semantic": ""}
+    store.get_semantic_context.return_value = ""
+    store.get_episodic_context.return_value = ""
+    store.import_memory.return_value = {"semantic": 0, "episodic": 0}
+    store.migrate_from_markdown.return_value = {"semantic": 0, "episodic": 0}
+    store.promote_episodic_patterns.return_value = 0
+    for k, v in attrs.items():
+        setattr(store, k, v)
+    return store
+
+
+@pytest.fixture(autouse=True)
+def _fake_sel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Never write to the real security event log from a unit test."""
+    monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: MagicMock())
+
+
+@pytest.fixture(autouse=True)
+def _reset_setup_status() -> Any:
+    saved = dict(mem_mod._embedding_setup_status)
+    mem_mod._embedding_setup_status = {"step": "idle", "error": ""}
+    yield
+    mem_mod._embedding_setup_status = saved
+
+
+# ---------------------------------------------------------------------------
+# preferences / projects / history — GET + PUT + malformed body
+# ---------------------------------------------------------------------------
+
+
+class TestPreferencesProjectsHistory:
+    @pytest.mark.asyncio
+    async def test_preferences_get_returns_stored_content(self) -> None:
+        mem = MagicMock()
+        mem.read_preferences.return_value = "- dark mode"
+        state = _make_state(memory=mem)
+        resp = await mem_mod.api_memory_preferences(_make_request(state))
+        assert resp.status == 200
+        assert _body(resp) == {"content": "- dark mode"}
+
+    @pytest.mark.asyncio
+    async def test_preferences_put_writes_content(self) -> None:
+        mem = MagicMock()
+        state = _make_state(memory=mem)
+        req = _make_request(state, method="PUT", json_body={"content": "- new"})
+        resp = await mem_mod.api_memory_preferences(req)
+        assert _body(resp) == {"ok": True}
+        mem.write_preferences.assert_called_once_with("- new")
+
+    @pytest.mark.asyncio
+    async def test_preferences_put_defaults_missing_content_to_empty(self) -> None:
+        mem = MagicMock()
+        state = _make_state(memory=mem)
+        req = _make_request(state, method="PUT", json_body={})
+        assert (await mem_mod.api_memory_preferences(req)).status == 200
+        mem.write_preferences.assert_called_once_with("")
+
+    @pytest.mark.asyncio
+    async def test_preferences_put_rejects_invalid_json(self) -> None:
+        mem = MagicMock()
+        state = _make_state(memory=mem)
+        req = _make_request(state, method="PUT", json_body=_BadJSON())
+        resp = await mem_mod.api_memory_preferences(req)
+        assert resp.status == 400
+        assert _body(resp) == {"error": "invalid JSON"}
+        mem.write_preferences.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_projects_get_returns_stored_content(self) -> None:
+        mem = MagicMock()
+        mem.read_projects.return_value = "## Proj"
+        state = _make_state(memory=mem)
+        resp = await mem_mod.api_memory_projects(_make_request(state))
+        assert _body(resp) == {"content": "## Proj"}
+
+    @pytest.mark.asyncio
+    async def test_projects_put_writes_content(self) -> None:
+        mem = MagicMock()
+        state = _make_state(memory=mem)
+        req = _make_request(state, method="PUT", json_body={"content": "## New"})
+        assert (await mem_mod.api_memory_projects(req)).status == 200
+        mem.write_projects.assert_called_once_with("## New")
+
+    @pytest.mark.asyncio
+    async def test_projects_put_rejects_invalid_json(self) -> None:
+        mem = MagicMock()
+        state = _make_state(memory=mem)
+        req = _make_request(state, method="PUT", json_body=_BadJSON())
+        resp = await mem_mod.api_memory_projects(req)
+        assert resp.status == 400
+        mem.write_projects.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_history_get_returns_recent(self) -> None:
+        mem = MagicMock()
+        mem.read_recent_history.return_value = "# 2026-01-01"
+        state = _make_state(memory=mem)
+        resp = await mem_mod.api_memory_history(_make_request(state))
+        assert _body(resp) == {"content": "# 2026-01-01"}
+
+    @pytest.mark.asyncio
+    async def test_history_put_writes_today_file_creating_parents(self, tmp_path: Path) -> None:
+        target = tmp_path / "history" / "2026-01-01.md"
+        mem = MagicMock()
+        mem._today_history_file.return_value = target
+        state = _make_state(memory=mem)
+        req = _make_request(state, method="PUT", json_body={"content": "entry"})
+        assert (await mem_mod.api_memory_history(req)).status == 200
+        assert target.read_text(encoding="utf-8") == "entry"
+
+    @pytest.mark.asyncio
+    async def test_history_put_rejects_invalid_json(self, tmp_path: Path) -> None:
+        mem = MagicMock()
+        mem._today_history_file.return_value = tmp_path / "h.md"
+        state = _make_state(memory=mem)
+        req = _make_request(state, method="PUT", json_body=_BadJSON())
+        resp = await mem_mod.api_memory_history(req)
+        assert resp.status == 400
+        assert not (tmp_path / "h.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# settings
+# ---------------------------------------------------------------------------
+
+
+def _cfg(idle: float = 6.0, days: int = 30, migrated: bool = False) -> Any:
+    cfg = MagicMock()
+    cfg.memory.history_idle_hours = idle
+    cfg.memory.history_max_days = days
+    cfg.memory.migrated = migrated
+    return cfg
+
+
+class TestMemorySettings:
+    @pytest.mark.asyncio
+    async def test_get_reports_config_values(self) -> None:
+        state = _make_state()
+        with patch(f"{_MOD}.KiroCrewConfig.load", return_value=_cfg(2.5, 14, True)):
+            resp = await mem_mod.api_memory_settings(_make_request(state))
+        assert _body(resp) == {
+            "history_idle_hours": 2.5,
+            "history_max_days": 14,
+            "migrated": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_invalid_json(self, tmp_path: Path) -> None:
+        state = _make_state()
+        req = _make_request(state, method="PUT", json_body=_BadJSON())
+        with (
+            patch(f"{_MOD}.KiroCrewConfig.load", return_value=_cfg()),
+            patch(f"{_MOD}.config_path", return_value=tmp_path / "config.json"),
+        ):
+            resp = await mem_mod.api_memory_settings(req)
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_put_clamps_and_persists(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({"agent": {"provider": "acp"}}), encoding="utf-8")
+        state = _make_state()
+        state.consolidator = None
+        req = _make_request(
+            state,
+            method="PUT",
+            json_body={"history_idle_hours": 0.1, "history_max_days": 1, "migrated": 1},
+        )
+        with (
+            patch(f"{_MOD}.KiroCrewConfig.load", return_value=_cfg()),
+            patch(f"{_MOD}.config_path", return_value=cfg_path),
+        ):
+            resp = await mem_mod.api_memory_settings(req)
+        assert _body(resp) == {"ok": True}
+        data = json.loads(cfg_path.read_text(encoding="utf-8"))
+        # Floors applied: 0.5 hours minimum, 7 days minimum.
+        assert data["memory"]["history_idle_hours"] == 0.5
+        assert data["memory"]["history_max_days"] == 7
+        assert data["memory"]["migrated"] is True
+        # Unrelated sections survive the read-modify-write.
+        assert data["agent"]["provider"] == "acp"
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_non_numeric_idle_hours(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.json"
+        state = _make_state()
+        req = _make_request(state, method="PUT", json_body={"history_idle_hours": "soon"})
+        with (
+            patch(f"{_MOD}.KiroCrewConfig.load", return_value=_cfg()),
+            patch(f"{_MOD}.config_path", return_value=cfg_path),
+        ):
+            resp = await mem_mod.api_memory_settings(req)
+        assert resp.status == 400
+        assert "history_idle_hours" in _body(resp)["error"]
+        assert not cfg_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_non_integer_max_days(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.json"
+        state = _make_state()
+        req = _make_request(state, method="PUT", json_body={"history_max_days": "many"})
+        with (
+            patch(f"{_MOD}.KiroCrewConfig.load", return_value=_cfg()),
+            patch(f"{_MOD}.config_path", return_value=cfg_path),
+        ):
+            resp = await mem_mod.api_memory_settings(req)
+        assert resp.status == 400
+        assert "history_max_days" in _body(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_put_fails_closed_on_unreadable_config(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text("{ not json", encoding="utf-8")
+        state = _make_state()
+        req = _make_request(state, method="PUT", json_body={"migrated": True})
+        with (
+            patch(f"{_MOD}.KiroCrewConfig.load", return_value=_cfg()),
+            patch(f"{_MOD}.config_path", return_value=cfg_path),
+        ):
+            resp = await mem_mod.api_memory_settings(req)
+        assert resp.status == 500
+        assert _body(resp)["code"] == "config_unreadable"
+        # The user's file is left byte-for-byte intact.
+        assert cfg_path.read_text(encoding="utf-8") == "{ not json"
+
+    @pytest.mark.asyncio
+    async def test_put_applies_to_running_consolidator(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.json"
+        consolidator = MagicMock()
+        state = _make_state(consolidator=consolidator)
+        req = _make_request(state, method="PUT", json_body={"history_idle_hours": 3})
+        with (
+            patch(f"{_MOD}.KiroCrewConfig.load", return_value=_cfg(idle=3.0, migrated=True)),
+            patch(f"{_MOD}.config_path", return_value=cfg_path),
+        ):
+            assert (await mem_mod.api_memory_settings(req)).status == 200
+        assert consolidator._history_idle_secs == 3.0 * 3600
+        assert consolidator._migrated is True
+
+
+# ---------------------------------------------------------------------------
+# _redact_memory_field / _get_vector_store
+# ---------------------------------------------------------------------------
+
+
+class TestRedactAndStoreResolution:
+    def test_bytes_are_dropped_not_serialized(self) -> None:
+        assert mem_mod._redact_memory_field(b"\x00\x01") is None
+        assert mem_mod._redact_memory_field(memoryview(b"ab")) is None
+
+    def test_nested_containers_are_redacted(self) -> None:
+        out = mem_mod._redact_memory_field({"a": [{"b": _CRED}], "n": 3})
+        assert isinstance(out, dict)
+        assert _CRED not in json.dumps(out)
+        assert out["n"] == 3
+
+    def test_non_string_scalars_pass_through(self) -> None:
+        assert mem_mod._redact_memory_field(None) is None
+        assert mem_mod._redact_memory_field(True) is True
+        assert mem_mod._redact_memory_field(1.5) == 1.5
+
+    def test_existing_vector_store_is_reused(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        assert mem_mod._get_vector_store(state) is store
+
+    def test_standalone_store_created_and_cached_when_absent(self) -> None:
+        mem = SimpleNamespace(vector_store=None)
+        state: Any = SimpleNamespace(context_builder=SimpleNamespace(memory=mem))
+        created = MagicMock()
+        with (
+            patch("kiro_crew.vector_memory.VectorMemoryStore", return_value=created) as ctor,
+            patch(f"{_MOD}.KiroCrewConfig.load", return_value=_cfg()),
+        ):
+            first = mem_mod._get_vector_store(state)
+            second = mem_mod._get_vector_store(state)
+        assert first is created
+        # Cached on state AND wired back onto the memory store, so only one build.
+        assert second is created
+        ctor.assert_called_once()
+        created.init.assert_called_once()
+        assert mem.vector_store is created
+
+
+# ---------------------------------------------------------------------------
+# semantic list / write / delete, events
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticEndpoints:
+    @pytest.mark.asyncio
+    async def test_list_caps_limit_at_1000(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        req = _make_request(state, query={"limit": "99999", "offset": "7"})
+        assert (await mem_mod.api_memory_semantic(req)).status == 200
+        store.get_all_semantic.assert_called_once_with(limit=1000, offset=7)
+
+    @pytest.mark.asyncio
+    async def test_list_rejects_non_integer_paging(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        req = _make_request(state, query={"limit": "abc"})
+        resp = await mem_mod.api_memory_semantic(req)
+        assert resp.status == 400
+        assert "integers" in _body(resp)["error"]
+        store.get_all_semantic.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_drops_binary_columns(self) -> None:
+        store = _store()
+        store.get_all_semantic.return_value = [
+            {"key": "k", "value_json": "v", "embedding": b"\x00\x01"}
+        ]
+        state = _make_state(vector_store=store)
+        entry = _body(await mem_mod.api_memory_semantic(_make_request(state)))["entries"][0]
+        assert "embedding" not in entry
+
+    @pytest.mark.asyncio
+    async def test_write_denied_for_restricted_session(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store, restricted_keys={"dashboard:ghost"})
+        req = _make_request(
+            state,
+            method="PUT",
+            json_body={"key": "k", "value": "v"},
+            session_key="dashboard:ghost",
+        )
+        resp = await mem_mod.api_memory_semantic_write(req)
+        assert resp.status == 403
+        store.set_semantic.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_rejects_invalid_json(self) -> None:
+        state = _make_state(vector_store=_store())
+        req = _make_request(state, method="PUT", json_body=_BadJSON())
+        assert (await mem_mod.api_memory_semantic_write(req)).status == 400
+
+    @pytest.mark.asyncio
+    async def test_write_requires_key_and_value(self) -> None:
+        state = _make_state(vector_store=_store())
+        for body in ({"value": "v"}, {"key": "k"}, {}):
+            req = _make_request(state, method="PUT", json_body=body)
+            resp = await mem_mod.api_memory_semantic_write(req)
+            assert resp.status == 400
+            assert _body(resp)["error"] == "key and value required"
+
+    @pytest.mark.asyncio
+    async def test_write_success_forwards_confidence_and_source(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        req = _make_request(
+            state,
+            method="PUT",
+            json_body={"key": "k", "value": "v", "confidence": 0.5, "source": "agent"},
+        )
+        assert _body(await mem_mod.api_memory_semantic_write(req)) == {"ok": True}
+        store.set_semantic.assert_called_once_with("k", "v", 0.5, "agent")
+
+    @pytest.mark.asyncio
+    async def test_write_non_numeric_confidence_falls_back_to_one(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        req = _make_request(
+            state, method="PUT", json_body={"key": "k", "value": "v", "confidence": "high"}
+        )
+        assert (await mem_mod.api_memory_semantic_write(req)).status == 200
+        assert store.set_semantic.call_args[0][2] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_write_conflict_reject_is_409(self) -> None:
+        from kiro_crew.vector_memory import SemanticRejectCode
+
+        store = _store()
+        store.set_semantic.return_value = (SemanticRejectCode.CONFLICT, "already set")
+        state = _make_state(vector_store=store)
+        req = _make_request(state, method="PUT", json_body={"key": "k", "value": "v"})
+        resp = await mem_mod.api_memory_semantic_write(req)
+        assert resp.status == 409
+        assert _body(resp)["error"] == "already set"
+
+    @pytest.mark.asyncio
+    async def test_write_other_reject_is_422_and_redacted(self) -> None:
+        from kiro_crew.vector_memory import SemanticRejectCode
+
+        store = _store()
+        store.set_semantic.return_value = (
+            SemanticRejectCode.VALUE_SIZE,
+            f"value too large for {_CRED}",
+        )
+        state = _make_state(vector_store=store)
+        req = _make_request(state, method="PUT", json_body={"key": "k", "value": "v"})
+        resp = await mem_mod.api_memory_semantic_write(req)
+        assert resp.status == 422
+        assert _CRED not in _body(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_delete_denied_for_restricted_session(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store, restricted_keys={"dashboard:ghost"})
+        req = _make_request(
+            state, method="DELETE", match_info={"key": "k"}, session_key="dashboard:ghost"
+        )
+        assert (await mem_mod.api_memory_semantic_delete(req)).status == 403
+        store.delete_semantic.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_key_is_404(self) -> None:
+        store = _store(delete_semantic=MagicMock(return_value=False))
+        state = _make_state(vector_store=store)
+        req = _make_request(state, method="DELETE", match_info={"key": "nope"})
+        resp = await mem_mod.api_memory_semantic_delete(req)
+        assert resp.status == 404
+        assert _body(resp) == {"error": "not found"}
+
+    @pytest.mark.asyncio
+    async def test_delete_success(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        req = _make_request(state, method="DELETE", match_info={"key": "k"})
+        assert _body(await mem_mod.api_memory_semantic_delete(req)) == {"ok": True}
+        store.delete_semantic.assert_called_once_with("k", source="user_explicit")
+
+    @pytest.mark.asyncio
+    async def test_events_caps_limit_at_200(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        req = _make_request(state, query={"limit": "10000", "offset": "3"})
+        assert (await mem_mod.api_memory_events(req)).status == 200
+        store.get_events.assert_called_once_with(limit=200, offset=3)
+
+    @pytest.mark.asyncio
+    async def test_events_rejects_non_integer_paging(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        req = _make_request(state, query={"offset": "x"})
+        assert (await mem_mod.api_memory_events(req)).status == 400
+        store.get_events.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# episodic endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestEpisodicEndpoints:
+    @pytest.mark.asyncio
+    async def test_search_without_embed_fn_skips_embedding(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        req = _make_request(state, query={"q": "hello", "tags": "a, b ,"})
+        assert (await mem_mod.api_memory_episodic_search(req)).status == 200
+        store._try_embed.assert_not_called()
+        kwargs = store.search_episodic.call_args.kwargs
+        assert kwargs["query_embedding"] is None
+        assert kwargs["tag_filter"] == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_search_embeds_query_when_embed_fn_present(self) -> None:
+        store = _store(embed_fn=lambda t: [0.1])
+        store._try_embed.return_value = [0.1]
+        state = _make_state(vector_store=store)
+        req = _make_request(state, query={"q": "hello"})
+        assert (await mem_mod.api_memory_episodic_search(req)).status == 200
+        store._try_embed.assert_called_once_with("hello")
+        assert store.search_episodic.call_args.kwargs["query_embedding"] == [0.1]
+
+    @pytest.mark.asyncio
+    async def test_search_bad_limit_falls_back_to_default(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        req = _make_request(state, query={"q": "x", "limit": "lots"})
+        assert (await mem_mod.api_memory_episodic_search(req)).status == 200
+        assert store.search_episodic.call_args.kwargs["limit"] == 20
+
+    @pytest.mark.asyncio
+    async def test_search_caps_limit_at_50_and_truncates_query(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        req = _make_request(state, query={"q": "z" * 900, "limit": "500"})
+        assert (await mem_mod.api_memory_episodic_search(req)).status == 200
+        kwargs = store.search_episodic.call_args.kwargs
+        assert kwargs["limit"] == 50
+        assert len(kwargs["query_text"]) == 500
+
+    @pytest.mark.asyncio
+    async def test_search_results_drop_binary_and_redact_strings(self) -> None:
+        store = _store()
+        store.search_episodic.return_value = [
+            {"id": "1", "text": f"saw {_CRED}", "embedding": b"\x00", "score": 0.5}
+        ]
+        state = _make_state(vector_store=store)
+        req = _make_request(state, query={"q": "saw"})
+        result = _body(await mem_mod.api_memory_episodic_search(req))["results"][0]
+        assert "embedding" not in result
+        assert _CRED not in result["text"]
+        assert result["score"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_list_entries_are_redacted(self) -> None:
+        store = _store()
+        store.get_episodic_list.return_value = [{"id": "1", "text": f"key {_CRED}"}]
+        state = _make_state(vector_store=store)
+        entry = _body(await mem_mod.api_memory_episodic_list(_make_request(state)))["entries"][0]
+        assert _CRED not in entry["text"]
+
+    @pytest.mark.asyncio
+    async def test_list_caps_limit_at_100(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        req = _make_request(state, query={"limit": "900", "offset": "2", "tags": "t1"})
+        assert (await mem_mod.api_memory_episodic_list(req)).status == 200
+        store.get_episodic_list.assert_called_once_with(limit=100, offset=2, tag_filter=["t1"])
+
+    @pytest.mark.asyncio
+    async def test_list_rejects_non_integer_paging(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        req = _make_request(state, query={"limit": "nope"})
+        assert (await mem_mod.api_memory_episodic_list(req)).status == 400
+        store.get_episodic_list.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_id_is_404(self) -> None:
+        store = _store(delete_episodic=MagicMock(return_value=False))
+        state = _make_state(vector_store=store)
+        req = _make_request(state, method="DELETE", match_info={"id": "42"})
+        resp = await mem_mod.api_memory_episodic_delete(req)
+        assert resp.status == 404
+        assert _body(resp) == {"error": "not found"}
+
+    @pytest.mark.asyncio
+    async def test_delete_success(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        req = _make_request(state, method="DELETE", match_info={"id": "42"})
+        assert _body(await mem_mod.api_memory_episodic_delete(req)) == {"ok": True}
+        store.delete_episodic.assert_called_once_with("42")
+
+
+# ---------------------------------------------------------------------------
+# stats / migrate / import / context-preview / observability / promote
+# ---------------------------------------------------------------------------
+
+
+class TestStatsMigrateImport:
+    @pytest.mark.asyncio
+    async def test_stats_merges_config_and_legacy_flags(self) -> None:
+        store = _store()
+        store.memory_stats.return_value = {"semantic_count": 4}
+        state = _make_state(vector_store=store)
+        cfg = _cfg(migrated=True)
+        cfg.memory.embedding_provider = "llama_cpp"
+        with (
+            patch(f"{_MOD}.KiroCrewConfig.load", return_value=cfg),
+            patch("kiro_crew.memory.legacy_memory_present", return_value=True),
+        ):
+            body = _body(await mem_mod.api_memory_stats(_make_request(state)))
+        assert body == {
+            "semantic_count": 4,
+            "embedding_provider": "llama_cpp",
+            "migrated": True,
+            "has_legacy_memory": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_migrate_restores_previous_embed_fn(self, tmp_path: Path) -> None:
+        def _prev(text: str) -> list[float]:
+            return [0.0]
+
+        store = _store(embed_fn=_prev)
+        state = _make_state(vector_store=store, consolidator=None)
+        with (
+            patch(f"{_MOD}.make_sync_embed_fn", return_value=lambda t: [1.0]),
+            patch(f"{_MOD}.config_path", return_value=tmp_path / "config.json"),
+        ):
+            body = _body(await mem_mod.api_memory_migrate(_make_request(state)))
+        assert body == {"semantic": 0, "episodic": 0}
+        # Nothing migrated -> migrated flag untouched, embed_fn restored.
+        assert store.embed_fn is _prev
+        assert not (tmp_path / "config.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_migrate_sets_migrated_when_entries_produced(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.json"
+        store = _store()
+        store.migrate_from_markdown.return_value = {"semantic": 3, "episodic": 0}
+        consolidator = MagicMock()
+        state = _make_state(vector_store=store, consolidator=consolidator)
+        with (
+            patch(f"{_MOD}.make_sync_embed_fn", return_value=lambda t: [1.0]),
+            patch(f"{_MOD}.config_path", return_value=cfg_path),
+        ):
+            body = _body(await mem_mod.api_memory_migrate(_make_request(state)))
+        assert body["semantic"] == 3
+        assert json.loads(cfg_path.read_text(encoding="utf-8"))["memory"]["migrated"] is True
+        assert consolidator._migrated is True
+
+    @pytest.mark.asyncio
+    async def test_import_denied_for_restricted_session(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store, restricted_keys={"dashboard:ghost"})
+        req = _make_request(
+            state, method="POST", json_body={"semantic": []}, session_key="dashboard:ghost"
+        )
+        assert (await mem_mod.api_memory_import(req)).status == 403
+        store.import_memory.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_import_rejects_invalid_json(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        req = _make_request(state, method="POST", json_body=_BadJSON())
+        assert (await mem_mod.api_memory_import(req)).status == 400
+        store.import_memory.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_import_returns_counts(self) -> None:
+        store = _store()
+        store.import_memory.return_value = {"semantic": 2, "episodic": 1}
+        state = _make_state(vector_store=store)
+        req = _make_request(state, method="POST", json_body={"semantic": [{"key": "k"}]})
+        assert _body(await mem_mod.api_memory_import(req)) == {"semantic": 2, "episodic": 1}
+
+
+class TestContextPreviewAndObservability:
+    @pytest.mark.asyncio
+    async def test_preview_without_query_skips_episodic(self) -> None:
+        store = _store()
+        store.get_semantic_context.return_value = "line one"
+        state = _make_state(vector_store=store)
+        body = _body(await mem_mod.api_memory_context_preview(_make_request(state)))
+        assert body == {"semantic_context": "line one", "episodic_context": ""}
+        store.get_episodic_context.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_preview_filters_semantic_lines_by_query(self) -> None:
+        store = _store()
+        store.get_semantic_context.return_value = "[Semantic]\nprefers dark mode\nlikes tea"
+        store.get_episodic_context.return_value = "episode"
+        state = _make_state(vector_store=store)
+        req = _make_request(state, query={"q": "dark"})
+        body = _body(await mem_mod.api_memory_context_preview(req))
+        assert "prefers dark mode" in body["semantic_context"]
+        assert "likes tea" not in body["semantic_context"]
+        assert body["episodic_context"] == "episode"
+
+    @pytest.mark.asyncio
+    async def test_preview_blanks_semantic_when_only_headers_match(self) -> None:
+        store = _store()
+        store.get_semantic_context.return_value = "[Semantic]\nlikes tea"
+        state = _make_state(vector_store=store)
+        req = _make_request(state, query={"q": "zzz-no-match"})
+        body = _body(await mem_mod.api_memory_context_preview(req))
+        assert body["semantic_context"] == ""
+
+    @pytest.mark.asyncio
+    async def test_observability_returns_stats_rejections_and_preview(self) -> None:
+        store = _store()
+        store.memory_stats.return_value = {"semantic_count": 1}
+        store.get_rejection_stats.return_value = {"allowlist_reject": 2}
+        store.get_context_preview.return_value = {"semantic": "s"}
+        state = _make_state(vector_store=store)
+        req = _make_request(state, query={"q": "q" * 900})
+        body = _body(await mem_mod.api_memory_observability(req))
+        assert body["stats"] == {"semantic_count": 1}
+        assert body["rejections"] == {"allowlist_reject": 2}
+        assert body["context_preview"] == {"semantic": "s"}
+        assert len(store.get_context_preview.call_args.kwargs["query_text"]) == 500
+
+
+class TestPromote:
+    @pytest.mark.asyncio
+    async def test_invalid_json_body_uses_defaults(self) -> None:
+        store = _store(promote_episodic_patterns=MagicMock(return_value=2))
+        state = _make_state(vector_store=store)
+        req = _make_request(state, method="POST", json_body=_BadJSON())
+        assert _body(await mem_mod.api_memory_promote(req)) == {"ok": True, "promoted": 2}
+        store.promote_episodic_patterns.assert_called_once_with(5, 0.75)
+
+    @pytest.mark.asyncio
+    async def test_explicit_thresholds_are_forwarded(self) -> None:
+        store = _store(promote_episodic_patterns=MagicMock(return_value=0))
+        state = _make_state(vector_store=store)
+        req = _make_request(state, method="POST", json_body={"min_count": 3, "min_sim": 0.9})
+        assert (await mem_mod.api_memory_promote(req)).status == 200
+        store.promote_episodic_patterns.assert_called_once_with(3, 0.9)
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_thresholds_are_400(self) -> None:
+        store = _store()
+        state = _make_state(vector_store=store)
+        req = _make_request(state, method="POST", json_body={"min_count": "five"})
+        resp = await mem_mod.api_memory_promote(req)
+        assert resp.status == 400
+        assert "min_count/min_sim" in _body(resp)["error"]
+        store.promote_episodic_patterns.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# consolidate
+# ---------------------------------------------------------------------------
+
+
+def _consolidator() -> Any:
+    c = MagicMock()
+    c._running = set()
+    c._tasks = set()
+    c._consolidate = AsyncMock(return_value=None)
+    return c
+
+
+class TestConsolidate:
+    @pytest.mark.asyncio
+    async def test_denied_for_restricted_session(self) -> None:
+        state = _make_state(consolidator=_consolidator(), restricted_keys={"dashboard:ghost"})
+        req = _make_request(
+            state, method="POST", json_body={"key": "s1"}, session_key="dashboard:ghost"
+        )
+        assert (await mem_mod.api_memory_consolidate(req)).status == 403
+
+    @pytest.mark.asyncio
+    async def test_503_without_consolidator(self) -> None:
+        state = _make_state(consolidator=None)
+        req = _make_request(state, method="POST", json_body={"key": "s1"})
+        resp = await mem_mod.api_memory_consolidate(req)
+        assert resp.status == 503
+        assert _body(resp) == {"error": "consolidator not available"}
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_json(self) -> None:
+        state = _make_state(consolidator=_consolidator())
+        req = _make_request(state, method="POST", json_body=_BadJSON())
+        assert (await mem_mod.api_memory_consolidate(req)).status == 400
+
+    @pytest.mark.asyncio
+    async def test_requires_non_blank_session_key(self) -> None:
+        state = _make_state(consolidator=_consolidator())
+        req = _make_request(state, method="POST", json_body={"key": "   "})
+        resp = await mem_mod.api_memory_consolidate(req)
+        assert resp.status == 400
+        assert _body(resp) == {"error": "session key required"}
+
+    @pytest.mark.asyncio
+    async def test_already_running_is_409(self) -> None:
+        cons = _consolidator()
+        cons._running.add("s1")
+        state = _make_state(consolidator=cons)
+        req = _make_request(state, method="POST", json_body={"key": "s1"})
+        resp = await mem_mod.api_memory_consolidate(req)
+        assert resp.status == 409
+        cons._consolidate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_schedules_background_consolidation(self) -> None:
+        cons = _consolidator()
+        state = _make_state(consolidator=cons)
+        req = _make_request(state, method="POST", json_body={"key": "s1", "include_history": False})
+        assert _body(await mem_mod.api_memory_consolidate(req)) == {"ok": True, "key": "s1"}
+        assert "s1" in cons._running
+        # Drain the spawned task so nothing is left pending at loop teardown.
+        for task in list(cons._tasks):
+            await task
+        cons._consolidate.assert_awaited_once_with("s1", False)
+
+
+# ---------------------------------------------------------------------------
+# embedding-model apply endpoint (request boundary only)
+# ---------------------------------------------------------------------------
+
+
+def _prog(active: bool = False) -> Any:
+    prog = MagicMock()
+    prog.is_active.return_value = active
+    prog.snapshot.return_value = {"state": "idle"}
+    return prog
+
+
+class TestEmbeddingModelEndpoint:
+    @pytest.fixture(autouse=True)
+    def _no_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("KIROCREW_EMBED_MODEL_PATH", raising=False)
+
+    @pytest.mark.asyncio
+    async def test_denied_for_restricted_session(self) -> None:
+        state = _make_state(restricted_keys={"dashboard:ghost"})
+        req = _make_request(
+            state, method="POST", json_body={"path": ""}, session_key="dashboard:ghost"
+        )
+        resp = await mem_mod.api_memory_embedding_model(req)
+        assert resp.status == 403
+        assert _body(resp)["code"] == "restricted_session"
+
+    @pytest.mark.asyncio
+    async def test_rejects_unparseable_body(self) -> None:
+        state = _make_state()
+        req = _make_request(state, method="POST", json_body=_BadJSON())
+        resp = await mem_mod.api_memory_embedding_model(req)
+        assert resp.status == 400
+        assert _body(resp)["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_rejects_valid_json_that_is_not_an_object(self) -> None:
+        state = _make_state()
+        payloads: list[Any] = [[], "str", 5]
+        for payload in payloads:
+            req = _make_request(state, method="POST", json_body=payload)
+            resp = await mem_mod.api_memory_embedding_model(req)
+            assert resp.status == 400
+            assert _body(resp)["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_validation_error_is_400_with_code(self) -> None:
+        state = _make_state()
+        req = _make_request(state, method="POST", json_body={"path": "/nope.gguf"})
+        with patch(
+            f"{_MOD}.validate_custom_model_path",
+            return_value=(Path("/nope.gguf"), "not a file", "not_found"),
+        ):
+            resp = await mem_mod.api_memory_embedding_model(req)
+        assert resp.status == 400
+        assert _body(resp) == {"ok": False, "error": "not a file", "code": "not_found"}
+
+    @pytest.mark.asyncio
+    async def test_validate_only_reports_size_without_applying(self, tmp_path: Path) -> None:
+        model = tmp_path / "m.gguf"
+        model.write_bytes(b"abcd")
+        state = _make_state()
+        req = _make_request(
+            state, method="POST", json_body={"path": str(model), "validate_only": True}
+        )
+        with (
+            patch(f"{_MOD}.validate_custom_model_path", return_value=(model, "", "")),
+            patch(f"{_MOD}._apply_embedding_model") as apply_mock,
+        ):
+            resp = await mem_mod.api_memory_embedding_model(req)
+        assert _body(resp) == {"ok": True, "size_bytes": 4}
+        apply_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_validate_only_tolerates_unstatable_path(self, tmp_path: Path) -> None:
+        missing = tmp_path / "gone.gguf"
+        state = _make_state()
+        req = _make_request(
+            state, method="POST", json_body={"path": str(missing), "validate_only": True}
+        )
+        with patch(f"{_MOD}.validate_custom_model_path", return_value=(missing, "", "")):
+            resp = await mem_mod.api_memory_embedding_model(req)
+        assert _body(resp) == {"ok": True, "size_bytes": 0}
+
+    @pytest.mark.asyncio
+    async def test_env_override_blocks_config_write_with_409(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KIROCREW_EMBED_MODEL_PATH", "/env/model.gguf")
+        state = _make_state()
+        req = _make_request(state, method="POST", json_body={"path": ""})
+        resp = await mem_mod.api_memory_embedding_model(req)
+        assert resp.status == 409
+        assert _body(resp)["code"] == "env_override_active"
+
+    @pytest.mark.asyncio
+    async def test_apply_in_progress_is_409(self) -> None:
+        state = _make_state()
+        req = _make_request(state, method="POST", json_body={"path": ""})
+        with patch(f"{_MOD}.reembed_progress", return_value=_prog(active=True)):
+            resp = await mem_mod.api_memory_embedding_model(req)
+        assert resp.status == 409
+        assert _body(resp)["code"] == "model_change_in_progress"
+
+    @pytest.mark.asyncio
+    async def test_unavailable_vector_store_is_503_and_arms_nothing(self) -> None:
+        state = _make_state()
+        prog = _prog()
+        req = _make_request(state, method="POST", json_body={"path": ""})
+        with (
+            patch(f"{_MOD}.reembed_progress", return_value=prog),
+            patch(f"{_MOD}._get_vector_store", side_effect=RuntimeError("db gone")),
+        ):
+            resp = await mem_mod.api_memory_embedding_model(req)
+        assert resp.status == 503
+        assert _body(resp)["code"] == "vector_store_unavailable"
+        prog.begin_apply.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_revert_to_bundled_dispatches_worker(self) -> None:
+        state = _make_state(vector_store=_store())
+        prog = _prog()
+        req = _make_request(state, method="POST", json_body={"path": ""})
+        with (
+            patch(f"{_MOD}.reembed_progress", return_value=prog),
+            patch(f"{_MOD}._apply_embedding_model") as apply_mock,
+        ):
+            resp = await mem_mod.api_memory_embedding_model(req)
+            assert _body(resp) == {"ok": True, "size_bytes": 0, "status": "applying"}
+            prog.begin_apply.assert_called_once()
+            await asyncio.wrap_future(state._embed_model_apply_task)
+        apply_mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# embedding-status custom-model branch
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingStatusCustomModel:
+    def _patches(self, custom: Any, model_present: bool) -> Any:
+        embedder = MagicMock(model_id="custom.gguf", dim=768)
+        embedder.is_ready.return_value = True
+        mgr = MagicMock()
+        mgr.status = {"step": "idle", "error": "", "attempt": 0}
+        return (
+            patch(f"{_MOD}.get_shared_embedder", return_value=embedder),
+            patch(f"{_MOD}.model_download_manager", return_value=mgr),
+            patch(f"{_MOD}.model_file_present", return_value=model_present),
+            patch(f"{_MOD}.resolve_custom_model", return_value=custom),
+        )
+
+    @pytest.mark.asyncio
+    async def test_healthy_custom_model_reports_done_and_no_retry(self) -> None:
+        model_path = Path("/models/custom.gguf")
+        custom = SimpleNamespace(error="", path=model_path)
+        a, b, c, d = self._patches(custom, model_present=True)
+        with a, b, c, d:
+            body = _body(await mem_mod.api_memory_embedding_status(_make_request(_make_state())))
+        assert body["model_source"] == "custom"
+        # Compare against str(Path) rather than the POSIX literal: the property
+        # is "the handler surfaces the resolved path", not which separator the
+        # host uses. Windows renders this as \models\custom.gguf.
+        assert body["model_path"] == str(model_path)
+        assert body["setup_step"] == "done"
+        assert body["setup_error"] == ""
+        assert body["can_retry"] is False
+        assert body["model_dim"] == 768
+
+    @pytest.mark.asyncio
+    async def test_broken_custom_model_reports_error_without_retry(self) -> None:
+        custom = SimpleNamespace(error="unreadable", path=Path("/models/custom.gguf"))
+        a, b, c, d = self._patches(custom, model_present=False)
+        with a, b, c, d:
+            body = _body(await mem_mod.api_memory_embedding_status(_make_request(_make_state())))
+        assert body["setup_step"] == "error"
+        assert body["setup_error"] == "unreadable"
+        assert body["can_retry"] is False
+
+    @pytest.mark.asyncio
+    async def test_missing_custom_file_reports_error_naming_the_path(self) -> None:
+        model_path = Path("/models/custom.gguf")
+        custom = SimpleNamespace(error="", path=model_path)
+        a, b, c, d = self._patches(custom, model_present=False)
+        with a, b, c, d:
+            body = _body(await mem_mod.api_memory_embedding_status(_make_request(_make_state())))
+        assert body["setup_step"] == "error"
+        # str(Path), not the POSIX literal -- see the note above.
+        assert str(model_path) in body["setup_error"]
+
+
+# ---------------------------------------------------------------------------
+# _write_embed_model_config
+# ---------------------------------------------------------------------------
+
+
+class TestWriteEmbedModelConfig:
+    @pytest.mark.asyncio
+    async def test_writes_path_and_dim_preserving_other_sections(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(
+            json.dumps({"agent": {"provider": "acp"}, "memory": {"embed_model_id": "old"}}),
+            encoding="utf-8",
+        )
+        with patch(f"{_MOD}.config_path", return_value=cfg_path):
+            await mem_mod._write_embed_model_config("/m/new.gguf", 1024)
+        data = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert data["memory"]["embed_model_path"] == "/m/new.gguf"
+        assert data["memory"]["embedding_dim"] == 1024
+        # The pinned id must be dropped so it is re-derived from the new file.
+        assert "embed_model_id" not in data["memory"]
+        assert data["agent"]["provider"] == "acp"
+
+    @pytest.mark.asyncio
+    async def test_empty_path_reverts_by_removing_the_key(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(
+            json.dumps({"memory": {"embed_model_path": "/m/old.gguf"}}), encoding="utf-8"
+        )
+        with patch(f"{_MOD}.config_path", return_value=cfg_path):
+            await mem_mod._write_embed_model_config("", 0)
+        memory = json.loads(cfg_path.read_text(encoding="utf-8"))["memory"]
+        assert "embed_model_path" not in memory
+        # dim <= 0 means "unknown width" and must not be persisted.
+        assert "embedding_dim" not in memory
+
+    @pytest.mark.asyncio
+    async def test_missing_config_is_created(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.json"
+        with patch(f"{_MOD}.config_path", return_value=cfg_path):
+            await mem_mod._write_embed_model_config("/m/new.gguf", 512)
+        data = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert data["memory"]["embedding_dim"] == 512
+
+    @pytest.mark.asyncio
+    async def test_unparseable_config_raises_and_is_left_intact(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text("{ broken", encoding="utf-8")
+        with patch(f"{_MOD}.config_path", return_value=cfg_path):
+            with pytest.raises(ValueError, match="could not be parsed"):
+                await mem_mod._write_embed_model_config("/m/new.gguf", 512)
+        assert cfg_path.read_text(encoding="utf-8") == "{ broken"
+
+
+# ---------------------------------------------------------------------------
+# _ensure_pip_available — sandbox refusal + timeout
+# ---------------------------------------------------------------------------
+
+
+class TestEnsurePipEdgeCases:
+    @pytest.mark.asyncio
+    async def test_sandbox_unavailable_is_a_normal_not_ok_result(self) -> None:
+        from kiro_crew.sandbox import SandboxUnavailableError
+
+        def _refuse(argv: Any, **kw: Any) -> Any:
+            raise SandboxUnavailableError("no backend", kind="no_backend", detail="not Linux")
+
+        with (
+            patch.dict("sys.modules", {"pip": None}),
+            patch(f"{_MOD}.wrap_argv", side_effect=_refuse),
+            patch(f"{_MOD}.create_subprocess_limited") as spawn,
+        ):
+            ok, err = await mem_mod._ensure_pip_available()
+        assert ok is False
+        assert "sandbox" in err
+        spawn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_timeout_reaps_the_child_and_reports_not_ok(self) -> None:
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.kill = MagicMock()
+        proc.wait = AsyncMock()
+
+        async def _timeout(coro: Any, *, timeout: Any = None) -> Any:
+            coro.close()
+            raise asyncio.TimeoutError
+
+        with (
+            patch.dict("sys.modules", {"pip": None}),
+            patch(f"{_MOD}.wrap_argv", side_effect=lambda argv, **kw: (argv, None)),
+            patch(f"{_MOD}.create_subprocess_limited", AsyncMock(return_value=proc)),
+            patch("asyncio.wait_for", side_effect=_timeout),
+        ):
+            ok, err = await mem_mod._ensure_pip_available()
+        assert ok is False
+        assert "timed out" in err
+        proc.kill.assert_called_once()
+        proc.wait.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_temp_wrapper_is_unlinked_even_when_already_gone(self, tmp_path: Path) -> None:
+        """The cleanup path tolerates an OSError from a vanished wrapper file."""
+        ghost = tmp_path / "wrapper.sh"  # never created
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+
+        with (
+            patch.dict("sys.modules", {"pip": None}),
+            patch(f"{_MOD}.wrap_argv", side_effect=lambda argv, **kw: (argv, str(ghost))),
+            patch(f"{_MOD}.create_subprocess_limited", AsyncMock(return_value=proc)),
+        ):
+            ok, err = await mem_mod._ensure_pip_available()
+        assert (ok, err) == (True, "")
+
+
+# ---------------------------------------------------------------------------
+# enable / disable embeddings — guards and the download done-callback
+# ---------------------------------------------------------------------------
+
+
+def _dl_mgr(step: str = "idle", ensure: Any = None) -> Any:
+    mgr = MagicMock()
+    mgr.status = {"step": step, "error": "download failed", "attempt": 0}
+    mgr.ensure_model = ensure if ensure is not None else AsyncMock(return_value=True)
+    return mgr
+
+
+async def _drain(state: Any) -> None:
+    """Let the retained background download task finish its callbacks."""
+    tasks = list(state.__dict__.get("_bg_embed_tasks", set()))
+    for task in tasks:
+        try:
+            await task
+        except BaseException:
+            pass
+    await asyncio.sleep(0)
+
+
+class TestEnableDisableEmbeddings:
+    @pytest.mark.asyncio
+    async def test_disable_is_a_deliberate_410(self) -> None:
+        resp = await mem_mod.api_memory_disable_embeddings(_make_request(_make_state()))
+        assert resp.status == 410
+        assert "always-on" in _body(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_setup_is_409(self) -> None:
+        mem_mod._embedding_setup_status = {"step": "installing_faiss", "error": ""}
+        with patch(f"{_MOD}.model_download_manager", return_value=_dl_mgr()):
+            resp = await mem_mod.api_memory_enable_embeddings(
+                _make_request(_make_state(), method="POST")
+            )
+        assert resp.status == 409
+        assert "installing_faiss" in _body(resp)["error"]
+
+    @pytest.mark.asyncio
+    async def test_previous_error_is_cleared_before_retry(self) -> None:
+        mem_mod._embedding_setup_status = {"step": "error", "error": "boom"}
+        state = _make_state()
+        with (
+            patch(f"{_MOD}.model_download_manager", return_value=_dl_mgr()),
+            patch(f"{_MOD}.model_file_present", return_value=False),
+        ):
+            resp = await mem_mod.api_memory_enable_embeddings(_make_request(state, method="POST"))
+            assert resp.status == 200
+            await _drain(state)
+        assert mem_mod._embedding_setup_status == {"step": "idle", "error": ""}
+
+    @pytest.mark.asyncio
+    async def test_download_failure_surfaces_as_failed_status(self) -> None:
+        state = _make_state()
+        mgr = _dl_mgr(ensure=AsyncMock(return_value=False))
+        with (
+            patch(f"{_MOD}.model_download_manager", return_value=mgr),
+            patch(f"{_MOD}.model_file_present", return_value=False),
+        ):
+            resp = await mem_mod.api_memory_enable_embeddings(_make_request(state, method="POST"))
+            assert _body(resp) == {"ok": True, "status": "downloading"}
+            await _drain(state)
+        assert mem_mod._embedding_setup_status["step"] == "failed"
+        assert mem_mod._embedding_setup_status["error"] == "download failed"
+
+    @pytest.mark.asyncio
+    async def test_download_exception_surfaces_as_failed_status(self) -> None:
+        state = _make_state()
+        mgr = _dl_mgr(ensure=AsyncMock(side_effect=RuntimeError("no disk space")))
+        with (
+            patch(f"{_MOD}.model_download_manager", return_value=mgr),
+            patch(f"{_MOD}.model_file_present", return_value=False),
+        ):
+            assert (
+                await mem_mod.api_memory_enable_embeddings(_make_request(state, method="POST"))
+            ).status == 200
+            await _drain(state)
+        assert mem_mod._embedding_setup_status["step"] == "failed"
+        assert "no disk space" in str(mem_mod._embedding_setup_status["error"])
+
+    @pytest.mark.asyncio
+    async def test_download_cancellation_surfaces_as_failed_status(self) -> None:
+        state = _make_state()
+        started = asyncio.Event()
+
+        async def _never_finishes(**_kw: Any) -> bool:
+            started.set()
+            await asyncio.Event().wait()
+            return True
+
+        mgr = _dl_mgr(ensure=_never_finishes)
+        with (
+            patch(f"{_MOD}.model_download_manager", return_value=mgr),
+            patch(f"{_MOD}.model_file_present", return_value=False),
+        ):
+            assert (
+                await mem_mod.api_memory_enable_embeddings(_make_request(state, method="POST"))
+            ).status == 200
+            await started.wait()
+            for task in list(state.__dict__.get("_bg_embed_tasks", set())):
+                task.cancel()
+            await _drain(state)
+        assert mem_mod._embedding_setup_status == {"step": "failed", "error": "cancelled"}
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_in_download_kick_is_500(self) -> None:
+        state = _make_state()
+        with (
+            patch(f"{_MOD}.model_download_manager", return_value=_dl_mgr()),
+            patch(f"{_MOD}.model_file_present", side_effect=RuntimeError("stat exploded")),
+        ):
+            resp = await mem_mod.api_memory_enable_embeddings(_make_request(state, method="POST"))
+        assert resp.status == 500
+        assert "Click Enable to retry" in _body(resp)["error"]
+        assert mem_mod._embedding_setup_status["step"] == "idle"
+
+    @pytest.mark.asyncio
+    async def test_config_unreadable_after_setup_is_500(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text("{ broken", encoding="utf-8")
+        store = _store()
+        state = _make_state(vector_store=store)
+        with (
+            patch(f"{_MOD}.model_download_manager", return_value=_dl_mgr("ready")),
+            patch(f"{_MOD}.model_file_present", return_value=True),
+            patch(f"{_MOD}.config_path", return_value=cfg_path),
+            patch(f"{_MOD}.make_sync_embed_fn", return_value=lambda t: [0.0]),
+            patch.dict("sys.modules", {"faiss": MagicMock(), "pip": MagicMock()}),
+            patch(f"{_MOD}._get_vector_store", return_value=store),
+        ):
+            resp = await mem_mod.api_memory_enable_embeddings(_make_request(state, method="POST"))
+        assert resp.status == 500
+        assert _body(resp)["code"] == "config_unreadable"
+        assert mem_mod._embedding_setup_status["step"] == "error"
+        assert cfg_path.read_text(encoding="utf-8") == "{ broken"
+
+
+# ---------------------------------------------------------------------------
+# _apply_embedding_model — the worker's rollback protocol, executed
+# ---------------------------------------------------------------------------
+
+
+def _apply_store(previous_dim: int = 512, retargeted: bool = True) -> Any:
+    store = MagicMock()
+    store._embedding_dim = previous_dim
+    store.set_embedding_dim.return_value = retargeted
+    store.recorded_embedding_space.return_value = "sig"
+    store.backfill_missing_embeddings.return_value = 7
+    return store
+
+
+class _ApplyHarness:
+    """Patched module surface for one ``_apply_embedding_model`` run."""
+
+    def __init__(
+        self,
+        *,
+        ready: bool = True,
+        has_wait_ready: bool = True,
+        recorded: str = "sig",
+        validate: tuple[Path, str, str] = (Path("/m/new.gguf"), "", ""),
+        write_error: Exception | None = None,
+        reconcile_error: Exception | None = None,
+        serving: bool = False,
+    ) -> None:
+        self.prog = MagicMock()
+        self.embedder = MagicMock(model_id="m", dim=1024)
+        self.embedder.is_ready.return_value = ready
+        if has_wait_ready:
+            self.embedder.wait_ready = MagicMock(return_value=ready)
+        else:
+            del self.embedder.wait_ready
+        self.reset = MagicMock()
+        self.activate = MagicMock()
+        self.install = MagicMock()
+        self.candidate = MagicMock()
+        self.bundled = MagicMock()
+        self.write = AsyncMock(side_effect=write_error)
+        self._recorded = recorded
+        self._validate = validate
+        self._reconcile_error = reconcile_error
+        self._serving = serving
+        self._stack: Any = None
+
+    def __enter__(self) -> "_ApplyHarness":
+        from contextlib import ExitStack
+
+        self._stack = ExitStack()
+        enter = self._stack.enter_context
+        enter(patch(f"{_MOD}.reembed_progress", return_value=self.prog))
+        enter(patch(f"{_MOD}.validate_custom_model_path", return_value=self._validate))
+        enter(patch(f"{_MOD}.install_shared_embedder", self.install))
+        enter(patch(f"{_MOD}.build_gated_candidate", return_value=self.candidate))
+        enter(patch(f"{_MOD}.build_gated_bundled", return_value=self.bundled))
+        enter(patch(f"{_MOD}.get_shared_embedder", return_value=self.embedder))
+        enter(patch(f"{_MOD}.reset_shared_embedder", self.reset))
+        enter(patch(f"{_MOD}.activate_shared_embedder", self.activate))
+        enter(patch(f"{_MOD}.make_sync_embed_fn", return_value=lambda t: [0.0]))
+        enter(
+            patch(
+                f"{_MOD}.reconcile_store_embedding_space",
+                side_effect=self._reconcile_error,
+            )
+        )
+        enter(patch(f"{_MOD}.active_embedding_space_signature", return_value="sig"))
+        enter(patch(f"{_MOD}.embedding_backend_serving", return_value=self._serving))
+        enter(patch(f"{_MOD}._write_embed_model_config", self.write))
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self._stack.close()
+
+
+async def _run_apply(store: Any, raw: str) -> None:
+    loop = asyncio.get_running_loop()
+    await asyncio.to_thread(mem_mod._apply_embedding_model, store, raw, loop)
+
+
+class TestApplyEmbeddingModelWorker:
+    @pytest.mark.asyncio
+    async def test_revalidation_failure_installs_nothing(self) -> None:
+        store = _apply_store()
+        with _ApplyHarness(validate=(Path("/x"), "sensitive path", "denied")) as h:
+            await _run_apply(store, "/x")
+        h.prog.fail.assert_called_once_with("sensitive path")
+        h.install.assert_not_called()
+        store.begin_space_change.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_custom_path_installs_a_gated_candidate(self) -> None:
+        store = _apply_store()
+        with _ApplyHarness() as h:
+            await _run_apply(store, "/m/new.gguf")
+        h.install.assert_called_once_with(h.candidate)
+        store.begin_space_change.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_path_reverts_through_the_bundled_candidate(self) -> None:
+        store = _apply_store()
+        with _ApplyHarness() as h:
+            await _run_apply(store, "")
+        h.install.assert_called_once_with(h.bundled)
+        h.activate.assert_called_once()
+        h.prog.finish.assert_called_once_with(7)
+        store.backfill_missing_embeddings.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_load_failure_drops_the_candidate_and_fails(self) -> None:
+        store = _apply_store()
+        with _ApplyHarness(ready=False) as h:
+            await _run_apply(store, "")
+        h.reset.assert_called_once()
+        assert "did not load" in h.prog.fail.call_args[0][0]
+        h.activate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_embedder_without_wait_ready_falls_back_to_is_ready(self) -> None:
+        store = _apply_store()
+        with _ApplyHarness(has_wait_ready=False) as h:
+            await _run_apply(store, "")
+        h.embedder.is_ready.assert_called_once()
+        h.activate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unreconciled_space_rolls_back_and_restores_the_width(self) -> None:
+        store = _apply_store(previous_dim=512)
+        store.recorded_embedding_space.return_value = "stale-sig"
+        with _ApplyHarness() as h:
+            await _run_apply(store, "")
+        h.reset.assert_called_once()
+        # Width restored to the model being restored, not left on the new one.
+        assert store.set_embedding_dim.call_args_list[-1][0][0] == 512
+        assert "could not be removed" in h.prog.fail.call_args[0][0]
+        h.write.assert_not_called()
+        h.activate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unwritable_config_rolls_back_before_activation(self) -> None:
+        store = _apply_store(previous_dim=512)
+        with _ApplyHarness(write_error=ValueError("config.json could not be parsed")) as h:
+            await _run_apply(store, "")
+        h.reset.assert_called_once()
+        assert store.set_embedding_dim.call_args_list[-1][0][0] == 512
+        h.prog.fail.assert_called_once_with("config.json could not be parsed")
+        h.activate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unexpected_failure_before_activation_rolls_back(self) -> None:
+        store = _apply_store(previous_dim=512)
+        with _ApplyHarness(reconcile_error=RuntimeError("disk full")) as h:
+            await _run_apply(store, "")
+        h.reset.assert_called_once()
+        assert store.set_embedding_dim.call_args_list[-1][0][0] == 512
+        h.prog.fail.assert_called_once_with("disk full")
+
+    @pytest.mark.asyncio
+    async def test_blank_exception_message_falls_back_to_the_class_name(self) -> None:
+        store = _apply_store()
+        with _ApplyHarness(reconcile_error=RuntimeError()) as h:
+            await _run_apply(store, "")
+        h.prog.fail.assert_called_once_with("RuntimeError")
+
+    @pytest.mark.asyncio
+    async def test_failure_after_activation_keeps_the_serving_model(self) -> None:
+        """Once the backend is serving, a later failure must not drop it."""
+        store = _apply_store()
+        store.backfill_missing_embeddings.side_effect = RuntimeError("backfill died")
+        with _ApplyHarness(serving=True) as h:
+            await _run_apply(store, "")
+        h.activate.assert_called_once()
+        h.reset.assert_not_called()
+        h.prog.fail.assert_called_once_with("backfill died")
+
+    @pytest.mark.asyncio
+    async def test_no_retarget_means_no_width_restore(self) -> None:
+        store = _apply_store(previous_dim=1024, retargeted=False)
+        with _ApplyHarness(reconcile_error=RuntimeError("boom")) as h:
+            await _run_apply(store, "")
+        h.reset.assert_called_once()
+        # set_embedding_dim was called once (the retarget attempt), never again.
+        store.set_embedding_dim.assert_called_once_with(1024)
+        assert h.prog.fail.call_args[0][0] == "boom"
+
+
+# ---------------------------------------------------------------------------
+# graph error path
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryGraphFailure:
+    @pytest.mark.asyncio
+    async def test_builder_failure_is_reported_as_500(self) -> None:
+        state = _make_state()
+        state.lessons.load_all.side_effect = RuntimeError("lesson store gone")
+        resp = await mem_mod.api_memory_graph(_make_request(state))
+        assert resp.status == 500
+        assert _body(resp) == {"error": "failed to build memory graph"}

--- a/test/test_handlers_taskrunner_coverage.py
+++ b/test/test_handlers_taskrunner_coverage.py
@@ -1,0 +1,1336 @@
+"""Coverage tests for the task-runner dashboard handlers.
+
+Focus: request validation, run-lifecycle state transitions, error responses and
+status codes for every endpoint in
+``kiro_crew.dashboard.handlers.taskrunner`` — plus the redaction applied to
+LLM-authored text on the status / plan / export surfaces.
+
+Everything is driven through ``make_mocked_request`` against a fake
+``DashboardState`` (matching the existing style in ``test_auto_approve.py`` and
+``test_project_alias.py``): no network, no git, no subprocess, no real agent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+from kiro_crew.acp.types import EVENT_COMPLETE, EVENT_PERMISSION_REQUEST, EVENT_TEXT_CHUNK, AcpEvent
+from kiro_crew.dashboard.handlers.taskrunner import (
+    _run_refine,
+    api_taskrunner_cancel,
+    api_taskrunner_delete,
+    api_taskrunner_execute_plan,
+    api_taskrunner_export_yaml,
+    api_taskrunner_from_chat,
+    api_taskrunner_pause,
+    api_taskrunner_plan,
+    api_taskrunner_plan_cancel,
+    api_taskrunner_plan_context,
+    api_taskrunner_refine,
+    api_taskrunner_refine_answer,
+    api_taskrunner_refine_cancel,
+    api_taskrunner_refine_status,
+    api_taskrunner_rename,
+    api_taskrunner_retry,
+    api_taskrunner_start,
+    api_taskrunner_status,
+    api_taskrunner_to_chat,
+    api_taskrunner_update_plan,
+    api_taskrunner_update_task,
+)
+from kiro_crew.taskrunner import Step, StepStatus, TaskRun
+
+# A URL whose oversized query payload trips the (domain-agnostic) exfiltration
+# scanner — see test_security.py::test_long_query_redacted_domain_agnostic.
+_EXFIL_URL = "https://collector.example.com/ingest?data=" + "A" * 250
+
+# ── Fixtures / helpers ──
+
+
+@pytest.fixture(autouse=True)
+def _stub_sel():
+    """No real security-event-log writes from any handler under test."""
+    with patch("kiro_crew.dashboard.handlers.taskrunner._sel") as sel:
+        sel.return_value = MagicMock()
+        yield sel
+
+
+def _runner(tmp_path: Path) -> MagicMock:
+    """A task runner mock with the attributes the handlers reach for."""
+    runner = MagicMock()
+    runner._runs = {}
+    runner._stall_cancelled_ids = set()
+    runner._work_dir = tmp_path / "work"
+    runner._workspace_dir = None
+    runner._agent = ""
+    runner._plan_task = None
+    runner._apersist_runs = AsyncMock()
+    runner._group_parallel_tasks = MagicMock(return_value=[])
+    runner.start_background = AsyncMock(return_value="tid-1")
+    runner.update_task = AsyncMock(return_value={"index": 0})
+    runner.update_plan = AsyncMock()
+    runner.execute_plan = AsyncMock()
+    runner.retry_from_task = AsyncMock()
+    runner.plan = AsyncMock()
+    runner.status = MagicMock(return_value={"runs": []})
+    return runner
+
+
+def _state(runner: MagicMock | None) -> SimpleNamespace:
+    return SimpleNamespace(task_runner=runner)
+
+
+def _request(
+    state: Any,
+    method: str = "POST",
+    path: str = "/api/taskrunner",
+    *,
+    match_info: dict[str, str] | None = None,
+    json_body: Any = None,
+    raw_json_error: bool = False,
+    request_app: str = "",
+    with_content_length: bool = True,
+) -> web.Request:
+    app = web.Application()
+    app["state"] = state
+    headers = {"Content-Length": "32"} if (json_body is not None and with_content_length) else {}
+    req = make_mocked_request(
+        method, path, app=app, match_info=match_info or {}, headers=headers
+    )
+    req["app"] = request_app
+    if raw_json_error:
+        req.json = AsyncMock(side_effect=ValueError("bad json"))  # type: ignore[method-assign]
+    elif json_body is not None:
+        req.json = AsyncMock(return_value=json_body)  # type: ignore[method-assign]
+    return req
+
+
+def _body(resp: web.Response) -> Any:
+    assert resp.body is not None
+    return json.loads(bytes(resp.body))  # type: ignore[arg-type]
+
+
+# ── GET /api/taskrunner ──
+
+
+class TestStatus:
+    @pytest.mark.asyncio
+    async def test_unavailable_when_no_runner(self) -> None:
+        resp = await api_taskrunner_status(_request(_state(None), "GET"))
+        assert resp.status == 200
+        assert _body(resp) == {"running": False, "available": False}
+
+    @pytest.mark.asyncio
+    async def test_hidden_sources_filtered_out(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner.status.return_value = {
+            "runs": [{"source": "dashboard"}, {"source": "cron"}, {"source": None}]
+        }
+        resp = await api_taskrunner_status(_request(_state(runner), "GET"))
+        data = _body(resp)
+        assert [r["source"] for r in data["runs"]] == ["dashboard"]
+        assert data["available"] is True
+
+    @pytest.mark.asyncio
+    async def test_run_and_step_text_is_redacted(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner.status.return_value = {
+            "runs": [
+                {
+                    "source": "chat",
+                    "error": "failed: aws_secret_access_key=AKIAIOSFODNN7EXAMPLEKEY0",
+                    "task_details": [
+                        {
+                            "title": f"post to {_EXFIL_URL}",
+                            "description": "",
+                            "result": "token=ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+                            "error": None,
+                        }
+                    ],
+                    "lessons_learned": [f"leak {_EXFIL_URL}"],
+                }
+            ]
+        }
+        resp = await api_taskrunner_status(_request(_state(runner), "GET"))
+        payload = resp.body or b""
+        run = _body(resp)["runs"][0]
+        assert "AKIAIOSFODNN7EXAMPLEKEY0" not in payload.decode()
+        assert "ghp_abcdefghijklmnopqrstuvwxyz0123456789" not in payload.decode()
+        assert _EXFIL_URL not in payload.decode()
+        assert "[REDACTED" in run["task_details"][0]["title"]
+        assert "[REDACTED" in run["lessons_learned"][0]
+        # Non-empty fields survive as (redacted) strings; falsy ones are untouched.
+        assert run["task_details"][0]["error"] is None
+        assert len(run["lessons_learned"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_default_workspace_dir_prefers_configured_value(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._workspace_dir = tmp_path / "ws"
+        resp = await api_taskrunner_status(_request(_state(runner), "GET"))
+        assert _body(resp)["default_workspace_dir"] == str(tmp_path / "ws")
+
+    @pytest.mark.asyncio
+    async def test_default_workspace_dir_falls_back_to_work_dir(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        resp = await api_taskrunner_status(_request(_state(runner), "GET"))
+        assert _body(resp)["default_workspace_dir"] == str(tmp_path / "work")
+
+
+# ── POST /api/taskrunner (start) ──
+
+
+class TestStart:
+    @pytest.mark.asyncio
+    async def test_no_runner_is_400(self) -> None:
+        resp = await api_taskrunner_start(_request(_state(None), json_body={"spec": "x"}))
+        assert resp.status == 400
+        assert _body(resp)["error"] == "task runner not available"
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_start(_request(_state(_runner(tmp_path)), raw_json_error=True))
+        assert resp.status == 400
+        assert _body(resp)["error"] == "invalid JSON"
+
+    @pytest.mark.asyncio
+    async def test_missing_spec_is_400(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_start(_request(_state(_runner(tmp_path)), json_body={}))
+        assert resp.status == 400
+        assert _body(resp)["error"] == "spec path required"
+
+    @pytest.mark.asyncio
+    async def test_traversal_path_rejected(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_start(
+            _request(_state(_runner(tmp_path)), json_body={"spec": "../etc/passwd"})
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "invalid spec path"
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_path_rejected(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_start(
+            _request(_state(_runner(tmp_path)), json_body={"spec": str(tmp_path / "nope.md")})
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "invalid spec path"
+
+    @pytest.mark.asyncio
+    async def test_sensitive_path_is_403(self, tmp_path: Path) -> None:
+        spec = tmp_path / "creds.md"
+        spec.write_text("# t", encoding="utf-8")
+        runner = _runner(tmp_path)
+        with patch(
+            "kiro_crew.dashboard.handlers.taskrunner.is_sensitive_path", return_value=True
+        ):
+            resp = await api_taskrunner_start(
+                _request(_state(runner), json_body={"spec": str(spec)})
+            )
+        assert resp.status == 403
+        assert _body(resp)["error"] == "access denied"
+
+    @pytest.mark.asyncio
+    async def test_real_file_spec_forwards_resolved_path(self, tmp_path: Path) -> None:
+        spec = tmp_path / "TASK.md"
+        spec.write_text("# t", encoding="utf-8")
+        runner = _runner(tmp_path)
+        resp = await api_taskrunner_start(
+            _request(
+                _state(runner),
+                json_body={"spec": str(spec), "agent": "a1", "name": "n1", "source": "file"},
+            )
+        )
+        assert resp.status == 200
+        assert _body(resp) == {"ok": True, "spec": str(spec.resolve()), "task_id": "tid-1"}
+        kwargs = runner.start_background.call_args.kwargs
+        assert kwargs["agent"] == "a1"
+        assert kwargs["name"] == "n1"
+        assert kwargs["source"] == "file"
+
+    @pytest.mark.asyncio
+    async def test_empty_inline_spec_is_400(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_start(
+            _request(_state(_runner(tmp_path)), json_body={"spec": "__inline__:   \n"})
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "empty spec content"
+
+    @pytest.mark.asyncio
+    async def test_inline_spec_written_to_work_dir(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        resp = await api_taskrunner_start(
+            _request(_state(runner), json_body={"spec": "__inline__:# hello"})
+        )
+        assert resp.status == 200
+        written = Path(_body(resp)["spec"])
+        assert written.parent == runner._work_dir
+        assert written.read_text(encoding="utf-8") == "# hello"
+
+    @pytest.mark.asyncio
+    async def test_unknown_source_coerced_to_dashboard(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        await api_taskrunner_start(
+            _request(
+                _state(runner), json_body={"spec": "__inline__:# t", "source": "bogus"}
+            )
+        )
+        assert runner.start_background.call_args.kwargs["source"] == "dashboard"
+
+    @pytest.mark.asyncio
+    async def test_runner_exception_is_400(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner.start_background = AsyncMock(side_effect=RuntimeError("cannot start"))
+        resp = await api_taskrunner_start(
+            _request(_state(runner), json_body={"spec": "__inline__:# t"})
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "cannot start"
+
+
+# ── cancel / pause / delete / rename ──
+
+
+class TestCancel:
+    @pytest.mark.asyncio
+    async def test_no_runner_is_400(self) -> None:
+        resp = await api_taskrunner_cancel(_request(_state(None), path="/api/taskrunner/cancel"))
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_cancel(
+            _request(_state(_runner(tmp_path)), json_body={}, raw_json_error=True)
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "invalid JSON"
+
+    @pytest.mark.asyncio
+    async def test_empty_body_cancels_all(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        resp = await api_taskrunner_cancel(_request(_state(runner)))
+        assert resp.status == 200
+        runner.cancel.assert_called_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_task_id_cancels_one(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        await api_taskrunner_cancel(_request(_state(runner), json_body={"task_id": "t9"}))
+        runner.cancel.assert_called_once_with("t9")
+
+
+class TestPause:
+    @pytest.mark.asyncio
+    async def test_no_runner_is_400(self) -> None:
+        resp = await api_taskrunner_pause(_request(_state(None), match_info={"task_id": "t1"}))
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_unknown_task_is_404(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_pause(
+            _request(_state(_runner(tmp_path)), match_info={"task_id": "nope"})
+        )
+        assert resp.status == 404
+        assert _body(resp)["error"] == "not found"
+
+    @pytest.mark.asyncio
+    async def test_non_running_task_is_409(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(
+            spec_path="s.md", spec_content="s", status="planned", task_id="t1"
+        )
+        resp = await api_taskrunner_pause(_request(_state(runner), match_info={"task_id": "t1"}))
+        assert resp.status == 409
+        assert _body(resp)["error"] == "cannot pause (status=planned)"
+
+    @pytest.mark.asyncio
+    async def test_lookup_by_name_then_pause(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(
+            spec_path="s.md", spec_content="s", status="running", task_id="t1", name="pretty"
+        )
+        resp = await api_taskrunner_pause(
+            _request(_state(runner), match_info={"task_id": "pretty"})
+        )
+        assert resp.status == 200
+        assert _body(resp)["ok"] is True
+        runner.pause.assert_called_once_with("t1")
+
+
+class TestDelete:
+    @pytest.mark.asyncio
+    async def test_no_runner_is_400(self) -> None:
+        resp = await api_taskrunner_delete(_request(_state(None), match_info={"task_id": "t1"}))
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_unknown_task_is_404(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_delete(
+            _request(_state(_runner(tmp_path)), match_info={"task_id": "t1"})
+        )
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", ["running", "cancelling"])
+    async def test_active_run_must_be_cancelled_first(self, tmp_path: Path, status: str) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(
+            spec_path="s.md", spec_content="s", status=status, task_id="t1"
+        )
+        resp = await api_taskrunner_delete(_request(_state(runner), match_info={"task_id": "t1"}))
+        assert resp.status == 409
+        assert _body(resp)["error"] == "cancel first"
+        assert "t1" in runner._runs
+
+    @pytest.mark.asyncio
+    async def test_finished_run_removed_and_persisted(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(
+            spec_path="s.md", spec_content="s", status="completed", task_id="t1"
+        )
+        runner._stall_cancelled_ids.add("t1")
+        resp = await api_taskrunner_delete(_request(_state(runner), match_info={"task_id": "t1"}))
+        assert resp.status == 200
+        assert runner._runs == {}
+        assert runner._stall_cancelled_ids == set()
+        runner._apersist_runs.assert_awaited_once()
+
+
+class TestRename:
+    @pytest.mark.asyncio
+    async def test_no_runner_is_400(self) -> None:
+        resp = await api_taskrunner_rename(_request(_state(None), match_info={"task_id": "t1"}))
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_unknown_task_is_404(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_rename(
+            _request(_state(_runner(tmp_path)), match_info={"task_id": "t1"})
+        )
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(spec_path="s.md", spec_content="s", task_id="t1")
+        resp = await api_taskrunner_rename(
+            _request(_state(runner), match_info={"task_id": "t1"}, raw_json_error=True)
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "invalid JSON"
+
+    @pytest.mark.asyncio
+    async def test_blank_name_is_400(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(spec_path="s.md", spec_content="s", task_id="t1")
+        resp = await api_taskrunner_rename(
+            _request(_state(runner), match_info={"task_id": "t1"}, json_body={"name": "   "})
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "name required"
+
+    @pytest.mark.asyncio
+    async def test_rename_persists(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = TaskRun(spec_path="s.md", spec_content="s", task_id="t1")
+        runner._runs["t1"] = run
+        resp = await api_taskrunner_rename(
+            _request(_state(runner), match_info={"task_id": "t1"}, json_body={"name": "  new  "})
+        )
+        assert _body(resp) == {"ok": True, "name": "new"}
+        assert run.name == "new"
+        runner._apersist_runs.assert_awaited_once()
+
+
+class TestUpdateTask:
+    @pytest.mark.asyncio
+    async def test_no_runner_is_400(self) -> None:
+        resp = await api_taskrunner_update_task(
+            _request(_state(None), match_info={"task_id": "t1", "index": "0"})
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_index_is_400(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_update_task(
+            _request(
+                _state(_runner(tmp_path)), match_info={"task_id": "t1", "index": "abc"}
+            )
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "invalid index"
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_update_task(
+            _request(
+                _state(_runner(tmp_path)),
+                match_info={"task_id": "t1", "index": "0"},
+                raw_json_error=True,
+            )
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "invalid JSON"
+
+    @pytest.mark.asyncio
+    async def test_success_merges_runner_result(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner.update_task = AsyncMock(return_value={"index": 2, "title": "t"})
+        resp = await api_taskrunner_update_task(
+            _request(
+                _state(runner),
+                match_info={"task_id": "t1", "index": "2"},
+                json_body={"title": "t"},
+            )
+        )
+        assert _body(resp) == {"ok": True, "index": 2, "title": "t"}
+
+    @pytest.mark.asyncio
+    async def test_runner_value_error_is_409(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner.update_task = AsyncMock(side_effect=ValueError("task already running"))
+        resp = await api_taskrunner_update_task(
+            _request(
+                _state(runner),
+                match_info={"task_id": "t1", "index": "0"},
+                json_body={"title": "t"},
+            )
+        )
+        assert resp.status == 409
+        assert _body(resp)["error"] == "task already running"
+
+
+class TestRetry:
+    @pytest.mark.asyncio
+    async def test_no_runner_is_400(self) -> None:
+        resp = await api_taskrunner_retry(_request(_state(None), match_info={"task_id": "t1"}))
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_retry(
+            _request(
+                _state(_runner(tmp_path)),
+                match_info={"task_id": "t1"},
+                json_body={},
+                raw_json_error=True,
+            )
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_default_from_step_is_one(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        resp = await api_taskrunner_retry(
+            _request(_state(runner), match_info={"task_id": "t1"})
+        )
+        assert _body(resp) == {"ok": True, "task_id": "t1"}
+        assert runner.retry_from_task.await_args.args == ("t1", 1)
+
+    @pytest.mark.asyncio
+    async def test_value_error_is_400(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner.retry_from_task = AsyncMock(side_effect=ValueError("no such step"))
+        resp = await api_taskrunner_retry(
+            _request(_state(runner), match_info={"task_id": "t1"}, json_body={"from_step": 3})
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "no such step"
+
+
+# ── plan-context / export ──
+
+
+class TestPlanContext:
+    @pytest.mark.asyncio
+    async def test_no_runner_is_400(self) -> None:
+        resp = await api_taskrunner_plan_context(
+            _request(_state(None), "GET", match_info={"task_id": "t1"})
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_unplanned_run_is_404(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(
+            spec_path="s.md", spec_content="s", status="running", task_id="t1"
+        )
+        resp = await api_taskrunner_plan_context(
+            _request(_state(runner), "GET", match_info={"task_id": "t1"})
+        )
+        assert resp.status == 404
+        assert _body(resp)["error"] == "not found or not planned"
+
+    @pytest.mark.asyncio
+    async def test_planned_run_returns_context(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(
+            spec_path="s.md", spec_content="s", status="planned", task_id="t1"
+        )
+        runner.plan_to_chat_context = MagicMock(return_value="ctx")
+        resp = await api_taskrunner_plan_context(
+            _request(_state(runner), "GET", match_info={"task_id": "t1"})
+        )
+        assert _body(resp) == {"ok": True, "context": "ctx", "task_id": "t1"}
+
+
+class TestExportYaml:
+    @pytest.mark.asyncio
+    async def test_no_runner_is_400(self) -> None:
+        resp = await api_taskrunner_export_yaml(
+            _request(_state(None), "GET", match_info={"task_id": "t1"})
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_unknown_run_is_generic_404(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_export_yaml(
+            _request(_state(_runner(tmp_path)), "GET", match_info={"task_id": "secret-id"})
+        )
+        assert resp.status == 404
+        assert "secret-id" not in (resp.body or b"").decode()
+
+    @pytest.mark.asyncio
+    async def test_planless_run_is_409(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(spec_path="s.md", spec_content="s", task_id="t1")
+        resp = await api_taskrunner_export_yaml(
+            _request(_state(runner), "GET", match_info={"task_id": "t1"})
+        )
+        assert resp.status == 409
+        assert _body(resp)["error"] == "no plan to export"
+
+    @pytest.mark.asyncio
+    async def test_serializer_failure_is_generic_500(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(
+            spec_path="s.md",
+            spec_content="s",
+            task_id="t1",
+            tasks=[Step(index=1, title="a", description="b")],
+        )
+        with patch(
+            "kiro_crew.dashboard.handlers.taskrunner.plan_to_yaml",
+            side_effect=RuntimeError("boom SECRET"),
+        ):
+            resp = await api_taskrunner_export_yaml(
+                _request(_state(runner), "GET", match_info={"task_id": "t1"})
+            )
+        assert resp.status == 500
+        assert "SECRET" not in (resp.body or b"").decode()
+
+    @pytest.mark.asyncio
+    async def test_filename_sanitized_from_run_name(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(
+            spec_path="s.md",
+            spec_content="s",
+            task_id="t1",
+            name="../../etc/passwd plan",
+            tasks=[Step(index=1, title="a", description="b")],
+        )
+        resp = await api_taskrunner_export_yaml(
+            _request(_state(runner), "GET", match_info={"task_id": "t1"})
+        )
+        assert resp.status == 200
+        disposition = resp.headers["Content-Disposition"]
+        assert ".." not in disposition
+        assert "/" not in disposition.split("filename=")[1]
+        assert resp.content_type == "application/x-yaml"
+
+    @pytest.mark.asyncio
+    async def test_blank_name_falls_back_to_plan(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(
+            spec_path="s.md",
+            spec_content="s",
+            task_id="...",
+            name="",
+            tasks=[Step(index=1, title="a", description="b")],
+        )
+        resp = await api_taskrunner_export_yaml(
+            _request(_state(runner), "GET", match_info={"task_id": "t1"})
+        )
+        assert resp.headers["Content-Disposition"] == 'attachment; filename="plan.yaml"'
+
+
+# ── to-chat ──
+
+
+def _chat_state(runner: MagicMock | None) -> SimpleNamespace:
+    slot = SimpleNamespace(key="slot-1", title="", task=None, append=MagicMock())
+    state = SimpleNamespace(
+        task_runner=runner,
+        _background_tasks=set(),
+        get_or_create_slot=MagicMock(return_value=slot),
+        push_slots_update=MagicMock(),
+    )
+    return state
+
+
+class TestToChat:
+    @pytest.fixture(autouse=True)
+    def _stub_run_chat(self):
+        async def _noop(*_a: Any, **_kw: Any) -> None:
+            return None
+
+        with patch("kiro_crew.dashboard.chat._run_chat", new=_noop):
+            yield
+
+    @staticmethod
+    async def _drain(state: SimpleNamespace) -> None:
+        for task in list(state._background_tasks):
+            await task
+
+    @pytest.mark.asyncio
+    async def test_no_runner_is_400(self) -> None:
+        resp = await api_taskrunner_to_chat(
+            _request(_chat_state(None), match_info={"task_id": "t1"})
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_unknown_run_is_404(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_to_chat(
+            _request(_chat_state(_runner(tmp_path)), match_info={"task_id": "t1"})
+        )
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_planned_run_opens_plan_slot(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(
+            spec_path="s.md", spec_content="s", status="planned", task_id="t1"
+        )
+        runner.plan_to_chat_context = MagicMock(return_value="plan ctx")
+        state = _chat_state(runner)
+        resp = await api_taskrunner_to_chat(_request(state, match_info={"task_id": "t1"}))
+        await self._drain(state)
+        assert _body(resp) == {"ok": True, "slot": "slot-1", "task_id": "t1"}
+        assert state.get_or_create_slot.return_value.title == "Plan: t1"
+        state.push_slots_update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_completed_run_summary_mentions_success(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(
+            spec_path="/specs/build.md",
+            spec_content="do the thing",
+            status="completed",
+            task_id="t1",
+            work_dir="/w",
+            branch_name="feat/x",
+            tasks=[Step(index=1, title="a", description="", status=StepStatus.PASSED)],
+            lessons_learned=["be careful"],
+        )
+        state = _chat_state(runner)
+        resp = await api_taskrunner_to_chat(_request(state, match_info={"task_id": "t1"}))
+        await self._drain(state)
+        assert _body(resp) == {"ok": True, "slot": "slot-1"}
+        summary = state.get_or_create_slot.return_value.append.call_args.args[1]
+        assert "# Task Review: build" in summary
+        assert "completed successfully" in summary
+        assert "Lessons Learned" in summary
+        assert "**Branch**: `feat/x`" in summary
+
+    @pytest.mark.asyncio
+    async def test_failed_run_summary_lists_failed_steps(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(
+            spec_path="__inline__:# t",
+            spec_content="",
+            status="failed",
+            task_id="t1",
+            error="exploded",
+            tasks=[
+                Step(index=1, title="ok", description="", status=StepStatus.PASSED),
+                Step(
+                    index=2,
+                    title="bad",
+                    description="",
+                    status=StepStatus.FAILED,
+                    error="stack trace",
+                ),
+                Step(index=3, title="wip", description="", status=StepStatus.IN_PROGRESS),
+                Step(index=4, title="skip", description="", status=StepStatus.SKIPPED),
+            ],
+        )
+        state = _chat_state(runner)
+        await api_taskrunner_to_chat(_request(state, match_info={"task_id": "t1"}))
+        await self._drain(state)
+        summary = state.get_or_create_slot.return_value.append.call_args.args[1]
+        # Inline specs fall back to the task id for the display name.
+        assert "# Task Review: t1" in summary
+        assert "failed at Step 2" in summary
+        assert "Error: stack trace" in summary
+        assert "## Task Error\nexploded" in summary
+        assert "(no spec)" in summary
+
+    @pytest.mark.asyncio
+    async def test_neutral_status_gets_generic_prompt(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner._runs["t1"] = TaskRun(
+            spec_path="/s/x.md", spec_content="c", status="cancelled", task_id="t1"
+        )
+        state = _chat_state(runner)
+        await api_taskrunner_to_chat(_request(state, match_info={"task_id": "t1"}))
+        await self._drain(state)
+        summary = state.get_or_create_slot.return_value.append.call_args.args[1]
+        assert "Review this task run." in summary
+
+
+# ── plan / update-plan / execute / from-chat ──
+
+
+def _planned_run(task_id: str = "p1") -> TaskRun:
+    return TaskRun(
+        spec_path="",
+        spec_content="",
+        status="planned",
+        task_id=task_id,
+        tasks=[
+            Step(index=1, title="first", description="do it", depends_on=[]),
+            Step(index=2, title="second", description="then", depends_on=[1]),
+        ],
+    )
+
+
+class TestPlan:
+    @pytest.mark.asyncio
+    async def test_no_runner_is_400(self) -> None:
+        resp = await api_taskrunner_plan(_request(_state(None), json_body={"input": "x"}))
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_plan(_request(_state(_runner(tmp_path)), raw_json_error=True))
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_success_returns_redacted_steps_and_groups(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _planned_run()
+        run.tasks[0].title = f"call {_EXFIL_URL}"
+        runner.plan = AsyncMock(return_value=run)
+        runner._group_parallel_tasks = MagicMock(return_value=[[run.tasks[0]], [run.tasks[1]]])
+        resp = await api_taskrunner_plan(
+            _request(_state(runner), json_body={"input": "build it", "source": "text"})
+        )
+        data = _body(resp)
+        assert data["task_id"] == "p1"
+        assert data["groups"] == [[1], [2]]
+        assert "[REDACTED" in data["steps"][0]["title"]
+        assert _EXFIL_URL not in json.dumps(data)
+        # The in-flight plan task handle is always cleared in the finally block.
+        assert runner._plan_task is None
+
+    @pytest.mark.asyncio
+    async def test_cancelled_plan_is_400(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner.plan = AsyncMock(side_effect=asyncio.CancelledError())
+        resp = await api_taskrunner_plan(_request(_state(runner), json_body={"input": "x"}))
+        assert resp.status == 400
+        assert _body(resp)["error"] == "Planning was cancelled."
+        assert runner._plan_task is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "exc", [FileNotFoundError("missing spec"), ValueError("empty input")]
+    )
+    async def test_expected_errors_are_400(self, tmp_path: Path, exc: Exception) -> None:
+        runner = _runner(tmp_path)
+        runner.plan = AsyncMock(side_effect=exc)
+        resp = await api_taskrunner_plan(_request(_state(runner), json_body={"input": "x"}))
+        assert resp.status == 400
+        assert _body(resp)["error"] == str(exc)
+
+
+class TestPlanCancel:
+    @pytest.mark.asyncio
+    async def test_no_runner_is_still_ok(self) -> None:
+        resp = await api_taskrunner_plan_cancel(_request(_state(None)))
+        assert _body(resp) == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_runner(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        await api_taskrunner_plan_cancel(_request(_state(runner)))
+        runner.cancel_plan.assert_called_once_with()
+
+
+class TestUpdatePlan:
+    @pytest.mark.asyncio
+    async def test_no_runner_is_400(self) -> None:
+        resp = await api_taskrunner_update_plan(
+            _request(_state(None), "PUT", match_info={"task_id": "p1"}, json_body={})
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_update_plan(
+            _request(
+                _state(_runner(tmp_path)), "PUT", match_info={"task_id": "p1"},
+                raw_json_error=True,
+            )
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_value_error_is_400(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner.update_plan = AsyncMock(side_effect=ValueError("run is not planned"))
+        resp = await api_taskrunner_update_plan(
+            _request(
+                _state(runner), "PUT", match_info={"task_id": "p1"}, json_body={"steps": []}
+            )
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "run is not planned"
+
+    @pytest.mark.asyncio
+    async def test_success_returns_steps(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _planned_run()
+        runner.update_plan = AsyncMock(return_value=run)
+        runner._group_parallel_tasks = MagicMock(return_value=[[run.tasks[0], run.tasks[1]]])
+        resp = await api_taskrunner_update_plan(
+            _request(
+                _state(runner),
+                "PUT",
+                match_info={"task_id": "p1"},
+                json_body={"steps": [{"title": "first"}]},
+            )
+        )
+        data = _body(resp)
+        assert [s["index"] for s in data["steps"]] == [1, 2]
+        assert data["steps"][1]["depends_on"] == [1]
+        assert data["groups"] == [[1, 2]]
+
+
+class TestExecutePlan:
+    @pytest.mark.asyncio
+    async def test_no_runner_is_400(self) -> None:
+        resp = await api_taskrunner_execute_plan(
+            _request(_state(None), match_info={"task_id": "p1"})
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_execute_plan(
+            _request(
+                _state(_runner(tmp_path)),
+                match_info={"task_id": "p1"},
+                json_body={},
+                raw_json_error=True,
+            )
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_value_error_is_400(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner.execute_plan = AsyncMock(side_effect=ValueError("nothing to execute"))
+        resp = await api_taskrunner_execute_plan(
+            _request(_state(runner), match_info={"task_id": "p1"})
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "nothing to execute"
+
+    @pytest.mark.asyncio
+    async def test_success_forwards_options(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        resp = await api_taskrunner_execute_plan(
+            _request(
+                _state(runner),
+                match_info={"task_id": "p1"},
+                json_body={"agent": "a", "fresh": True, "workspace_dir": "/ws"},
+            )
+        )
+        assert _body(resp) == {"ok": True, "task_id": "p1"}
+        kwargs = runner.execute_plan.await_args.kwargs
+        assert kwargs["agent"] == "a"
+        assert kwargs["fresh"] is True
+        assert kwargs["workspace_dir"] == "/ws"
+        assert kwargs["auto_approve"] is False
+
+
+class TestFromChat:
+    @pytest.mark.asyncio
+    async def test_no_runner_is_400(self) -> None:
+        resp = await api_taskrunner_from_chat(_request(_state(None), json_body={"steps": [{}]}))
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self, tmp_path: Path) -> None:
+        resp = await api_taskrunner_from_chat(
+            _request(_state(_runner(tmp_path)), raw_json_error=True)
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("steps", [[], "not-a-list", None])
+    async def test_steps_must_be_a_non_empty_list(self, tmp_path: Path, steps: Any) -> None:
+        resp = await api_taskrunner_from_chat(
+            _request(_state(_runner(tmp_path)), json_body={"steps": steps})
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "steps array required"
+
+    @pytest.mark.asyncio
+    async def test_existing_task_id_updates_in_place(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        run = _planned_run("existing")
+        runner.update_plan = AsyncMock(return_value=run)
+        resp = await api_taskrunner_from_chat(
+            _request(
+                _state(runner),
+                json_body={"steps": [{"title": "first"}], "task_id": "existing"},
+            )
+        )
+        assert _body(resp)["task_id"] == "existing"
+        assert runner.update_plan.await_args is not None
+        assert runner.update_plan.await_args.args[0] == "existing"
+        assert runner._runs == {}
+
+    @pytest.mark.asyncio
+    async def test_new_plan_is_registered_with_work_dir(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+
+        async def _update(new_id: str, _steps: list[Any]) -> TaskRun:
+            return runner._runs[new_id]
+
+        runner.update_plan = AsyncMock(side_effect=_update)
+        resp = await api_taskrunner_from_chat(
+            _request(
+                _state(runner),
+                json_body={"steps": [{"title": "first"}], "original_input": "make it"},
+            )
+        )
+        data = _body(resp)
+        assert data["task_id"].startswith("plan_")
+        created = runner._runs[data["task_id"]]
+        assert created.source == "chat"
+        assert created.status == "planned"
+        assert created.original_input == "make it"
+        assert Path(created.work_dir).is_dir()
+
+    @pytest.mark.asyncio
+    async def test_failed_new_plan_is_rolled_back(self, tmp_path: Path) -> None:
+        runner = _runner(tmp_path)
+        runner.update_plan = AsyncMock(side_effect=ValueError("bad step"))
+        resp = await api_taskrunner_from_chat(
+            _request(_state(runner), json_body={"steps": [{"title": ""}]})
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "bad step"
+        # The placeholder run must not survive a rejected plan.
+        assert runner._runs == {}
+
+
+# ── refine ──
+
+
+def _refine_state() -> Any:
+    """A DashboardState stand-in carrying only the refine-related attributes."""
+    return SimpleNamespace(
+        task_runner=None,
+        sessions=MagicMock(),
+        _refine_task=None,
+        _refine_text="",
+        _refine_error="",
+        _refine_status="idle",
+        _refine_input="",
+        _refine_session_key="",
+        _refine_answer_future=None,
+        _background_tasks=set(),
+        broadcast_ws=MagicMock(),
+        push_refresh=MagicMock(),
+        push_slots_update=MagicMock(),
+    )
+
+
+class TestRefineStart:
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self) -> None:
+        resp = await api_taskrunner_refine(_request(_refine_state(), raw_json_error=True))
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_blank_input_is_400(self) -> None:
+        resp = await api_taskrunner_refine(
+            _request(_refine_state(), json_body={"input": "  "})
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "input is required"
+
+    @pytest.mark.asyncio
+    async def test_starts_background_task_and_cancels_previous(self) -> None:
+        state = _refine_state()
+        started = asyncio.Event()
+
+        async def _never() -> None:
+            started.set()
+            await asyncio.Event().wait()
+
+        previous = asyncio.create_task(_never())
+        await started.wait()
+        state._refine_task = previous
+
+        async def _noop(*_a: Any, **_kw: Any) -> None:
+            return None
+
+        with patch("kiro_crew.dashboard.handlers.taskrunner._run_refine", new=_noop):
+            resp = await api_taskrunner_refine(
+                _request(state, json_body={"input": " build a thing "})
+            )
+        assert _body(resp) == {"ok": True}
+        assert state._refine_status == "running"
+        assert state._refine_input == "build a thing"
+        await asyncio.gather(previous, return_exceptions=True)
+        assert previous.cancelled()
+        await asyncio.gather(*list(state._background_tasks), return_exceptions=True)
+        assert state._background_tasks == set()
+
+
+class TestRefineStatusAndCancel:
+    @pytest.mark.asyncio
+    async def test_status_echoes_state(self) -> None:
+        state = _refine_state()
+        state._refine_status = "done"
+        state._refine_text = "spec"
+        state._refine_input = "in"
+        resp = await api_taskrunner_refine_status(_request(state, "GET"))
+        assert _body(resp) == {
+            "status": "done",
+            "text": "spec",
+            "error": "",
+            "input": "in",
+            "waiting": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_cancel_without_task_is_ok(self) -> None:
+        resp = await api_taskrunner_refine_cancel(_request(_refine_state()))
+        assert _body(resp) == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_cancel_cancels_running_task(self) -> None:
+        state = _refine_state()
+        started = asyncio.Event()
+
+        async def _never() -> None:
+            started.set()
+            await asyncio.Event().wait()
+
+        task = asyncio.create_task(_never())
+        await started.wait()
+        state._refine_task = task
+        resp = await api_taskrunner_refine_cancel(_request(state))
+        assert _body(resp) == {"ok": True}
+        await asyncio.gather(task, return_exceptions=True)
+        assert task.cancelled()
+
+
+class TestRefineAnswer:
+    @pytest.mark.asyncio
+    async def test_invalid_json_is_400(self) -> None:
+        resp = await api_taskrunner_refine_answer(
+            _request(_refine_state(), raw_json_error=True)
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_blank_answer_is_400(self) -> None:
+        resp = await api_taskrunner_refine_answer(
+            _request(_refine_state(), json_body={"answer": " "})
+        )
+        assert resp.status == 400
+        assert _body(resp)["error"] == "answer required"
+
+    @pytest.mark.asyncio
+    async def test_no_pending_question_is_409(self) -> None:
+        resp = await api_taskrunner_refine_answer(
+            _request(_refine_state(), json_body={"answer": "yes"})
+        )
+        assert resp.status == 409
+        assert _body(resp)["error"] == "no pending question"
+
+    @pytest.mark.asyncio
+    async def test_already_resolved_future_is_409(self) -> None:
+        state = _refine_state()
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        future.set_result("earlier")
+        state._refine_answer_future = future
+        resp = await api_taskrunner_refine_answer(
+            _request(state, json_body={"answer": "yes"})
+        )
+        assert resp.status == 409
+        assert _body(resp)["error"] == "no pending question"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_set_result_is_409(self) -> None:
+        """A racing answer that lands between the ``done()`` check and
+        ``set_result`` surfaces as 409, not a 500."""
+
+        class _RacingFuture:
+            def done(self) -> bool:
+                return False
+
+            def set_result(self, _value: str) -> None:
+                raise asyncio.InvalidStateError("already resolved")
+
+        state = _refine_state()
+        state._refine_answer_future = _RacingFuture()
+        resp = await api_taskrunner_refine_answer(
+            _request(state, json_body={"answer": "yes"})
+        )
+        assert resp.status == 409
+        assert _body(resp)["error"] == "question already resolved"
+
+    @pytest.mark.asyncio
+    async def test_answer_resolves_future(self) -> None:
+        state = _refine_state()
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        state._refine_answer_future = future
+        resp = await api_taskrunner_refine_answer(
+            _request(state, json_body={"answer": "  yes  "})
+        )
+        assert _body(resp) == {"ok": True}
+        assert future.result() == "yes"
+        # `waiting` flips to False once the question is answered.
+        status = await api_taskrunner_refine_status(_request(state, "GET"))
+        assert _body(status)["waiting"] is True  # future object still attached
+
+
+class TestRunRefine:
+    """The background refine coroutine itself (no real LLM, no real session)."""
+
+    @staticmethod
+    def _sessions(events: list[AcpEvent]) -> MagicMock:
+        client = MagicMock()
+
+        async def _stream(_msg: str) -> Any:
+            for ev in events:
+                yield ev
+
+        client.stream = _stream
+        client.reject_tool = AsyncMock()
+        sessions = MagicMock()
+        sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+        sessions.release = MagicMock()
+        sessions.reset = AsyncMock()
+        return sessions
+
+    @pytest.mark.asyncio
+    async def test_happy_path_redacts_and_broadcasts_done(self) -> None:
+        state = _refine_state()
+        state.sessions = self._sessions(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="# Task: leak "),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text=_EXFIL_URL),
+                AcpEvent(kind=EVENT_COMPLETE),
+            ]
+        )
+        await _run_refine(state, "build a thing")
+        assert state._refine_status == "done"
+        assert state._refine_task is None
+        assert state._refine_session_key == ""
+        final = state.broadcast_ws.call_args.args[1]
+        assert final["status"] == "done"
+        assert "[REDACTED" in final["text"]
+        assert _EXFIL_URL not in final["text"]
+        state.sessions.release.assert_called_once()
+        state.sessions.reset.assert_awaited_once()
+        state.push_refresh.assert_called_once_with("taskrunner")
+
+    @pytest.mark.asyncio
+    async def test_streaming_chunks_are_throttle_pushed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Interim progress is broadcast once the throttle window has elapsed.
+
+        The clock is stubbed (monotonic returns a fixed, increasing sequence) so
+        the test never sleeps and never depends on wall-clock timing.
+        """
+        import time as real_time
+
+        clock = {"t": 0.0}
+
+        def _monotonic() -> float:
+            clock["t"] += 1.0
+            return clock["t"]
+
+        monkeypatch.setattr(real_time, "monotonic", _monotonic)
+        state = _refine_state()
+        state.sessions = self._sessions(
+            [
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="a"),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="b"),
+                AcpEvent(kind=EVENT_TEXT_CHUNK, text="c"),
+                AcpEvent(kind=EVENT_COMPLETE),
+            ]
+        )
+        await _run_refine(state, "x")
+        assert state._refine_text == "abc"
+        # opening push + one push per chunk (clock always past the throttle
+        # window) + the post-loop push, then the final "done" broadcast.
+        statuses = [c.args[1]["status"] for c in state.broadcast_ws.call_args_list]
+        assert statuses.count("running") == 5
+        assert statuses[-1] == "done"
+
+    @pytest.mark.asyncio
+    async def test_permission_requests_are_rejected(self) -> None:
+        state = _refine_state()
+        sessions = self._sessions(
+            [
+                AcpEvent(kind=EVENT_PERMISSION_REQUEST, title="write_file", request_id="r1"),
+                AcpEvent(kind=EVENT_COMPLETE),
+            ]
+        )
+        state.sessions = sessions
+        await _run_refine(state, "x")
+        client = sessions.get_or_create.return_value[0]
+        client.reject_tool.assert_awaited_once_with("r1")
+        assert state._refine_status == "done"
+
+    @pytest.mark.asyncio
+    async def test_stream_error_is_captured_not_raised(self) -> None:
+        state = _refine_state()
+        sessions = self._sessions([])
+        sessions.get_or_create = AsyncMock(side_effect=RuntimeError("provider down"))
+        state.sessions = sessions
+        await _run_refine(state, "x")
+        assert state._refine_status == "error"
+        assert state._refine_error == "provider down"
+        assert state.broadcast_ws.call_args.args[1]["error"] == "provider down"
+
+    @pytest.mark.asyncio
+    async def test_teardown_failures_are_swallowed(self) -> None:
+        state = _refine_state()
+        sessions = self._sessions([AcpEvent(kind=EVENT_COMPLETE)])
+        sessions.release = MagicMock(side_effect=RuntimeError("release boom"))
+        sessions.reset = AsyncMock(side_effect=RuntimeError("reset boom"))
+        state.sessions = sessions
+        await _run_refine(state, "x")
+        # A failing teardown must not mask the completed refine.
+        assert state._refine_status == "done"
+        assert state.broadcast_ws.call_args.args[1]["status"] == "done"
+
+    @pytest.mark.asyncio
+    async def test_cancellation_marks_cancelled(self) -> None:
+        state = _refine_state()
+        sessions = self._sessions([])
+        sessions.get_or_create = AsyncMock(side_effect=asyncio.CancelledError())
+        state.sessions = sessions
+        await _run_refine(state, "x")
+        assert state._refine_status == "cancelled"

--- a/test/test_mcp_gateway_backend_coverage.py
+++ b/test/test_mcp_gateway_backend_coverage.py
@@ -1,0 +1,1856 @@
+"""Behavioural coverage for :mod:`kiro_crew.mcp_gateway.backend`.
+
+Complements the existing focused suites (``test_mcp_gateway_wedge_ping_gate``
+for heartbeat classification, ``test_mcp_gateway_apps_spool`` for the MCP Apps
+interception seam, ``test_mcp_gateway_oversize`` for the spill helpers) by
+driving the parts of :class:`~kiro_crew.mcp_gateway.backend.Backend` that had no
+direct test:
+
+* ``forward_from_stub`` — id rewriting, caller-identity strip/inject, the
+  ``notifications/initialized`` suppression, ``notifications/cancelled``
+  requestId remapping, and the dead-backend / broken-pipe error paths.
+* The initialize state machine — first stub upstream, later stubs queued,
+  cached replay, terminal failure, and ``prime_initialize`` on respawn.
+* The stdout pump end to end against a real :class:`asyncio.StreamReader`
+  (EOF, mid-line truncation, oversize-line drain, spill hook).
+* ``_route_backend_line`` routing/attribution: heartbeat pongs, unknown ids,
+  notification ownership, global broadcast, deny-by-default drop, and the
+  server->client request recycle.
+* Terminal/teardown paths: ``_broadcast_backend_gone``, ``_enqueue_to_stub``
+  overflow, ``cancel_in_flight_for_stub``, ``recycle_if_idle``, ``shutdown``.
+* ``spawn_backend`` / ``send_initialize`` with the subprocess seam stubbed, and
+  the ``_write_json_line`` / ``_pump_stderr`` / metrics helpers.
+
+Everything runs against in-memory pipes: no real subprocess, no network, no
+sandbox, no fixed ports, no wall-clock waits (bounded waits use ``timeout=0``,
+which asyncio resolves synchronously).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+from typing import Any, Optional, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.mcp_caller import CALLER_META_KEY, CallerContext
+from kiro_crew.mcp_gateway import backend as backend_mod
+from kiro_crew.mcp_gateway.backend import (
+    HEARTBEAT_PING_ID,
+    MCP_APPS_ENV_FLAG,
+    MCP_APPS_EXTENSION_KEY,
+    MCP_APPS_MIME_TYPE,
+    Backend,
+    BackendGone,
+    _inject_caller_meta,
+    _inject_client_extensions,
+    _is_heartbeat_id,
+    _mcp_apps_enabled,
+    _PendingRequest,
+    _pump_stderr,
+    _strip_caller_meta,
+    _write_json_line,
+    send_initialize,
+    spawn_backend,
+)
+from kiro_crew.mcp_gateway.pool import PoolKey
+
+
+@pytest.fixture(autouse=True)
+def _no_real_metrics_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Never append to the operator's real call-metrics file.
+
+    ``backend._METRICS_PATH`` is resolved from ``MCP_GATEWAY_CALL_METRICS_PATH``
+    at IMPORT time. On a machine where that variable is set, response routing
+    schedules ``_emit_call_metric`` and these tests would append to that real
+    path -- a host-level side effect outside ``tmp_path``, and one that only
+    appears on the machines that have the variable set. Force it off for the
+    whole module rather than per-test, so a newly added test cannot reintroduce
+    the leak by forgetting the guard.
+    """
+
+    monkeypatch.setattr(backend_mod, "_METRICS_PATH", None)
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+def _pool_key(server: str = "example-mcp") -> PoolKey:
+    return PoolKey(
+        server_name=server,
+        agent_name="kirocrew",
+        command_args_hash="cah",
+        effective_env_hash="eeh",
+        work_dir="/nonexistent-work-dir",
+        binary_version="1.0",
+        os_uid=1000,
+        sandbox_mode="none",
+        autoapprove_set_hash="aah",
+        approval_mode="reads",
+        trust_all_tools=False,
+        user_identity="testuser",
+        config_snapshot_hash="csh",
+    )
+
+
+def _make_backend(
+    *,
+    stdout: Optional[Any] = None,
+    returncode: Optional[int] = None,
+) -> Backend:
+    """A real :class:`Backend` over a mock process + mock stdin writer."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.pid = 4242
+    proc.wait = AsyncMock(return_value=returncode if returncode is not None else 0)
+    proc.kill = MagicMock()
+    stdin = MagicMock()
+    stdin.write = MagicMock()
+    stdin.close = MagicMock()
+    stdin.drain = AsyncMock()
+    now = time.monotonic()
+    return Backend(
+        pool_key=_pool_key(),
+        process=cast(Any, proc),
+        stdin=cast(Any, stdin),
+        stdout=cast(Any, stdout if stdout is not None else MagicMock()),
+        created_at=now,
+        last_used_at=now,
+    )
+
+
+def _frames(backend: Backend) -> list[dict]:
+    """Decode every JSON-RPC frame written to the backend's mock stdin."""
+    out: list[dict] = []
+    for call in cast(Any, backend.stdin).write.call_args_list:
+        for line in call.args[0].decode("utf-8").splitlines():
+            if line.strip():
+                out.append(json.loads(line))
+    return out
+
+
+def _reader(*chunks: bytes, eof: bool = True, limit: int = 65536) -> asyncio.StreamReader:
+    """A pre-filled StreamReader. Must be built inside a running loop."""
+    reader = asyncio.StreamReader(limit=limit)
+    for chunk in chunks:
+        reader.feed_data(chunk)
+    if eof:
+        reader.feed_eof()
+    return reader
+
+
+def _line(obj: Any) -> bytes:
+    return (json.dumps(obj, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+async def _drain(inbox: "asyncio.Queue[bytes]") -> dict:
+    return json.loads(inbox.get_nowait().decode("utf-8"))
+
+
+async def _settle(backend: Backend) -> None:
+    """Await any background metric/apps tasks so nothing is GC'd mid-flight."""
+    tasks = list(backend._metric_tasks) + list(backend._apps_tasks)
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+# --- Pure request-shaping helpers -------------------------------------------
+
+
+class TestFrameHelpers:
+    def test_strip_caller_meta_removes_forged_block(self) -> None:
+        msg: dict[str, Any] = {
+            "method": "tools/call",
+            "params": {"_meta": {CALLER_META_KEY: {"sessionKey": "forged"},
+                                 "progressToken": "pt"}},
+        }
+        out = _strip_caller_meta(msg)
+        assert CALLER_META_KEY not in out["params"]["_meta"]
+        assert out["params"]["_meta"]["progressToken"] == "pt"
+        # Original frame is not aliased/mutated.
+        assert CALLER_META_KEY in msg["params"]["_meta"]
+
+    def test_strip_caller_meta_drops_empty_meta_entirely(self) -> None:
+        msg = {"method": "tools/call", "params": {"_meta": {CALLER_META_KEY: {}}}}
+        out = _strip_caller_meta(msg)
+        assert "_meta" not in out["params"]
+
+    def test_strip_caller_meta_passthrough_shapes(self) -> None:
+        # No params at all, non-dict params, no _meta, non-dict _meta.
+        assert _strip_caller_meta({"method": "ping"}) == {"method": "ping"}
+        assert _strip_caller_meta({"params": 5})["params"] == 5
+        assert _strip_caller_meta({"params": {}})["params"] == {}
+        assert _strip_caller_meta({"params": {"_meta": "bad"}})["params"]["_meta"] == "bad"
+
+    def test_inject_caller_meta_synthesizes_params(self) -> None:
+        out = _inject_caller_meta({"method": "tools/call"},
+                                  CallerContext(session_key="dashboard:1"))
+        block = out["params"]["_meta"][CALLER_META_KEY]
+        assert block["sessionKey"] == "dashboard:1"
+
+    def test_inject_caller_meta_preserves_other_meta(self) -> None:
+        msg: dict[str, Any] = {
+            "method": "tools/call",
+            "params": {"_meta": {"progressToken": 7}, "name": "t"},
+        }
+        out = _inject_caller_meta(msg, CallerContext(session_key="s"))
+        assert out["params"]["_meta"]["progressToken"] == 7
+        assert out["params"]["name"] == "t"
+        assert "_meta" in msg["params"] and CALLER_META_KEY not in msg["params"]["_meta"]
+
+    def test_is_heartbeat_id_accepts_int_and_string(self) -> None:
+        assert _is_heartbeat_id(HEARTBEAT_PING_ID)
+        assert _is_heartbeat_id(str(HEARTBEAT_PING_ID))
+        assert not _is_heartbeat_id("gw-1-2")
+        assert not _is_heartbeat_id(None)
+
+
+class TestClientExtensionInjection:
+    def test_noop_when_flag_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(MCP_APPS_ENV_FLAG, "0")
+        msg = {"method": "initialize", "params": {"capabilities": {}}}
+        assert _inject_client_extensions(msg) is msg
+
+    def test_injects_ui_extension(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(MCP_APPS_ENV_FLAG, "1")
+        msg: dict[str, Any] = {
+            "method": "initialize", "params": {"capabilities": {"roots": {}}},
+        }
+        out = _inject_client_extensions(msg)
+        ext = out["params"]["capabilities"]["extensions"][MCP_APPS_EXTENSION_KEY]
+        assert ext == {"mimeTypes": [MCP_APPS_MIME_TYPE]}
+        # Pre-existing capabilities preserved; caller's frame untouched.
+        assert out["params"]["capabilities"]["roots"] == {}
+        assert "extensions" not in msg["params"]["capabilities"]
+
+    def test_preserves_caller_declared_extension(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(MCP_APPS_ENV_FLAG, "1")
+        msg = {
+            "method": "initialize",
+            "params": {"capabilities": {"extensions": {MCP_APPS_EXTENSION_KEY: {"mine": 1}}}},
+        }
+        out = _inject_client_extensions(msg)
+        assert out["params"]["capabilities"]["extensions"][MCP_APPS_EXTENSION_KEY] == {"mine": 1}
+
+    def test_non_dict_params_untouched(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(MCP_APPS_ENV_FLAG, "1")
+        msg = {"method": "initialize", "params": None}
+        assert _inject_client_extensions(msg) is msg
+
+    def test_env_kill_switch_beats_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(MCP_APPS_ENV_FLAG, "off")
+        assert _mcp_apps_enabled() is False
+        monkeypatch.setenv(MCP_APPS_ENV_FLAG, "yes")
+        assert _mcp_apps_enabled() is True
+
+
+# --- Bookkeeping ------------------------------------------------------------
+
+
+class TestAttachDetachAndAccounting:
+    @pytest.mark.asyncio
+    async def test_attach_twice_rejected(self) -> None:
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        with pytest.raises(RuntimeError, match="already attached"):
+            await backend.attach_stub("s1")
+        assert backend.refcount == 1
+
+    @pytest.mark.asyncio
+    async def test_detach_clears_pending_and_init_queue(self) -> None:
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.attach_stub("s2")
+        backend._pending_requests["gw-1"] = _PendingRequest("s1", 1, "tools/call")
+        backend._pending_requests["gw-2"] = _PendingRequest("s2", 2, "tools/call")
+        backend._init_pending = [("s1", 10), ("s2", 20)]
+
+        assert await backend.detach_stub("s1") == 1
+        assert list(backend._pending_requests) == ["gw-2"]
+        assert backend._init_pending == [("s2", 20)]
+        # Last detach restarts the idle clock.
+        before = backend.last_used_at
+        assert await backend.detach_stub("s2") == 0
+        assert backend.last_used_at >= before
+
+    @pytest.mark.asyncio
+    async def test_detach_unknown_stub_is_noop(self) -> None:
+        backend = _make_backend()
+        assert await backend.detach_stub("ghost") == 0
+
+    @pytest.mark.asyncio
+    async def test_outstanding_work_sums_all_three_sources(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        assert backend.outstanding_work == 0
+        backend._pending_requests["gw-1"] = _PendingRequest("s1", 1, "tools/call")
+        inbox.put_nowait(b"queued\n")
+        task = asyncio.create_task(asyncio.sleep(3600))
+        backend._apps_tasks.add(task)
+        try:
+            assert backend.outstanding_work == 3
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    def test_properties_and_touch(self) -> None:
+        backend = _make_backend()
+        assert backend.pid == 4242
+        assert backend.is_alive is True
+        assert backend.dead_reason is None
+        assert Backend._now() > 0
+        backend.touch(now=123.0)
+        assert backend.last_used_at == 123.0
+        backend._dead_reason = "boom"
+        assert backend.is_alive is False
+        assert backend.dead_reason == "boom"
+
+    def test_forward_ids_are_monotonic_and_pid_scoped(self) -> None:
+        backend = _make_backend()
+        assert backend._next_forward_id() == "gw-4242-1"
+        assert backend._next_forward_id() == "gw-4242-2"
+
+
+# --- forward_from_stub ------------------------------------------------------
+
+
+class TestForwardFromStub:
+    @pytest.mark.asyncio
+    async def test_dead_backend_raises_backend_gone(self) -> None:
+        backend = _make_backend()
+        backend._dead_reason = "exit rc=1"
+        with pytest.raises(BackendGone, match="exit rc=1"):
+            await backend.forward_from_stub("s1", {"method": "tools/list", "id": 1})
+
+    @pytest.mark.asyncio
+    async def test_stub_initialized_notification_never_reaches_backend(self) -> None:
+        backend = _make_backend()
+        await backend.forward_from_stub("s1", {"method": "notifications/initialized"})
+        assert _frames(backend) == []
+
+    @pytest.mark.asyncio
+    async def test_request_id_rewritten_and_pending_captured(self) -> None:
+        backend = _make_backend()
+        await backend.forward_from_stub("s1", {
+            "method": "tools/call",
+            "id": 77,
+            "params": {
+                "name": "draw",
+                "arguments": {"x": 1},
+                "_meta": {"progressToken": "pt-9"},
+            },
+        })
+        (frame,) = _frames(backend)
+        assert frame["id"] == "gw-4242-1"
+        pending = backend._pending_requests["gw-4242-1"]
+        assert (pending.stub_uuid, pending.original_id, pending.method) == (
+            "s1", 77, "tools/call")
+        assert pending.tool_name == "draw"
+        assert pending.tool_arguments == {"x": 1}
+        assert pending.progress_token == "pt-9"
+        assert pending.t_start_ms > 0
+
+    @pytest.mark.asyncio
+    async def test_non_string_tool_name_and_non_dict_args_ignored(self) -> None:
+        backend = _make_backend()
+        await backend.forward_from_stub("s1", {
+            "method": "tools/call", "id": 1,
+            "params": {"name": 42, "arguments": "not-a-dict"},
+        })
+        pending = backend._pending_requests["gw-4242-1"]
+        assert pending.tool_name == ""
+        assert pending.tool_arguments is None
+
+    @pytest.mark.asyncio
+    async def test_caller_identity_injected_only_when_advertised(self) -> None:
+        caller = CallerContext(session_key="dashboard:abc", session_type="dashboard")
+        off = _make_backend()
+        await off.forward_from_stub("s1", {"method": "tools/call", "id": 1}, caller=caller)
+        assert "_meta" not in _frames(off)[0].get("params", {})
+
+        on = _make_backend()
+        on.supports_caller_identity = True
+        await on.forward_from_stub("s1", {"method": "tools/call", "id": 1}, caller=caller)
+        meta = _frames(on)[0]["params"]["_meta"][CALLER_META_KEY]
+        assert meta["sessionKey"] == "dashboard:abc"
+        assert on._pending_requests["gw-4242-1"].session_key == "dashboard:abc"
+
+    @pytest.mark.asyncio
+    async def test_forged_caller_stripped_even_without_injection(self) -> None:
+        """The strip is unconditional: a stub that registered without a session
+        key must not be able to forge an identity on a non-tools/call method."""
+        backend = _make_backend()
+        await backend.forward_from_stub("s1", {
+            "method": "resources/list", "id": 3,
+            "params": {"_meta": {CALLER_META_KEY: {"sessionKey": "victim"}}},
+        })
+        assert "_meta" not in _frames(backend)[0]["params"]
+
+    @pytest.mark.asyncio
+    async def test_pure_notification_and_pure_response_pass_through(self) -> None:
+        backend = _make_backend()
+        await backend.forward_from_stub("s1", {"method": "notifications/roots/list_changed"})
+        await backend.forward_from_stub("s1", {"id": "server-req-1", "result": {"ok": True}})
+        notif, response = _frames(backend)
+        assert notif["method"] == "notifications/roots/list_changed"
+        # A pure response keeps the backend-owned id untouched.
+        assert response["id"] == "server-req-1"
+        assert backend._pending_requests == {}
+
+    @pytest.mark.asyncio
+    async def test_cancelled_request_id_remapped_to_gateway_id(self) -> None:
+        backend = _make_backend()
+        await backend.forward_from_stub("s1", {"method": "tools/call", "id": 5})
+        await backend.forward_from_stub("s1", {
+            "method": "notifications/cancelled",
+            "params": {"requestId": 5, "reason": "user stopped"},
+        })
+        assert _frames(backend)[1]["params"]["requestId"] == "gw-4242-1"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_for_other_stubs_request_not_remapped(self) -> None:
+        backend = _make_backend()
+        await backend.forward_from_stub("s1", {"method": "tools/call", "id": 5})
+        await backend.forward_from_stub("s2", {
+            "method": "notifications/cancelled", "params": {"requestId": 5},
+        })
+        assert _frames(backend)[1]["params"]["requestId"] == 5
+
+    @pytest.mark.asyncio
+    async def test_cancelled_without_request_id_passes_through(self) -> None:
+        backend = _make_backend()
+        await backend.forward_from_stub("s1", {"method": "notifications/cancelled",
+                                               "params": {}})
+        assert _frames(backend)[0]["params"] == {}
+
+    @pytest.mark.asyncio
+    async def test_broken_pipe_marks_backend_gone(self) -> None:
+        backend = _make_backend()
+        cast(Any, backend.stdin).write.side_effect = BrokenPipeError("epipe")
+        with pytest.raises(BackendGone, match="stdin closed"):
+            await backend.forward_from_stub("s1", {"method": "tools/list", "id": 1})
+        assert backend.is_alive is False
+
+    @pytest.mark.asyncio
+    async def test_non_dict_message_is_forwarded_verbatim(self) -> None:
+        backend = _make_backend()
+        await backend.forward_from_stub("s1", cast(Any, ["not", "a", "dict"]))
+        assert _frames(backend) == [["not", "a", "dict"]]
+
+
+# --- Initialize state machine ----------------------------------------------
+
+
+class TestInitializeStateMachine:
+    @staticmethod
+    def _init(id_: Any = 1) -> dict[str, Any]:
+        return {"jsonrpc": "2.0", "id": id_, "method": "initialize",
+                "params": {"capabilities": {}}}
+
+    @pytest.mark.asyncio
+    async def test_first_stub_drives_upstream_handshake(self) -> None:
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.forward_from_stub("s1", self._init(1))
+        (frame,) = _frames(backend)
+        assert frame["id"] == "gw-4242-1"
+        assert backend._init_state == "in_flight"
+        assert backend._init_first_stub == "s1"
+        assert backend._init_first_id == 1
+        assert backend._pending_requests["gw-4242-1"].stub_uuid == "__init__"
+        assert backend._init_pending == [("s1", 1)]
+
+    @pytest.mark.asyncio
+    async def test_second_stub_queues_while_in_flight(self) -> None:
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.attach_stub("s2")
+        await backend.forward_from_stub("s1", self._init(1))
+        await backend.forward_from_stub("s2", self._init(2))
+        # Only ONE upstream initialize.
+        assert len(_frames(backend)) == 1
+        assert backend._init_pending == [("s1", 1), ("s2", 2)]
+
+    @pytest.mark.asyncio
+    async def test_initialize_forged_caller_stripped_and_extensions_injected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(MCP_APPS_ENV_FLAG, "1")
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        msg = self._init(1)
+        msg["params"]["_meta"] = {CALLER_META_KEY: {"sessionKey": "forged"}}
+        await backend.forward_from_stub("s1", msg)
+        params = _frames(backend)[0]["params"]
+        assert "_meta" not in params
+        assert MCP_APPS_EXTENSION_KEY in params["capabilities"]["extensions"]
+
+    @pytest.mark.asyncio
+    async def test_initialize_without_id_rejected(self) -> None:
+        backend = _make_backend()
+        with pytest.raises(ValueError, match="initialize without id"):
+            await backend.forward_from_stub("s1", {"method": "initialize"})
+
+    @pytest.mark.asyncio
+    async def test_ready_state_replays_cached_result(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s2")
+        backend._init_state = "ready"
+        backend._init_result = {"protocolVersion": "2024-11-05", "capabilities": {}}
+        await backend.forward_from_stub("s2", self._init(99))
+        # Nothing hit the backend; the stub got a synthesized reply.
+        assert _frames(backend) == []
+        assert await _drain(inbox) == {
+            "jsonrpc": "2.0", "id": 99, "result": backend._init_result,
+        }
+
+    @pytest.mark.asyncio
+    async def test_cached_replay_to_detached_stub_is_dropped(self) -> None:
+        backend = _make_backend()
+        backend._init_state = "ready"
+        backend._init_result = {"capabilities": {}}
+        await backend.forward_from_stub("ghost", self._init(1))  # no inbox
+        assert _frames(backend) == []
+
+    @pytest.mark.asyncio
+    async def test_failed_state_raises_backend_gone(self) -> None:
+        # No ``_dead_reason``: the backend is still "alive", so the rejection
+        # must come from the initialize state machine itself.
+        backend = _make_backend()
+        backend._init_state = "failed"
+        with pytest.raises(BackendGone, match="backend initialize failed"):
+            await backend.forward_from_stub("s1", self._init(1))
+
+    @pytest.mark.asyncio
+    async def test_initialize_write_failure_marks_gone(self) -> None:
+        backend = _make_backend()
+        cast(Any, backend.stdin).write.side_effect = ConnectionResetError("reset")
+        with pytest.raises(BackendGone, match="stdin closed"):
+            await backend.forward_from_stub("s1", self._init(1))
+
+
+class TestUpstreamInitializeResolution:
+    @pytest.mark.asyncio
+    async def test_success_caches_flushes_and_sends_initialized(self) -> None:
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        backend._init_pending = [("s1", 1), ("s2", 2)]
+        result: dict[str, Any] = {
+            "capabilities": {"experimental": {"kirocrew.caller-identity": {}}}}
+        await backend._on_upstream_initialize({"jsonrpc": "2.0", "id": "gw-1",
+                                               "result": result})
+        assert backend._init_state == "ready"
+        assert backend._init_result == result
+        assert backend.supports_caller_identity is True
+        assert backend._init_done_event.is_set()
+        # Exactly one synthetic notifications/initialized upstream.
+        assert [f["method"] for f in _frames(backend)] == ["notifications/initialized"]
+        assert (await _drain(inbox1))["id"] == 1
+        assert (await _drain(inbox2))["id"] == 2
+
+    @pytest.mark.asyncio
+    async def test_capability_absent_leaves_flag_false(self) -> None:
+        backend = _make_backend()
+        await backend._on_upstream_initialize({"result": {"capabilities": {}}})
+        assert backend.supports_caller_identity is False
+
+    @pytest.mark.asyncio
+    async def test_initialized_write_failure_recorded_not_raised(self) -> None:
+        backend = _make_backend()
+        cast(Any, backend.stdin).write.side_effect = BrokenPipeError("epipe")
+        await backend._on_upstream_initialize({"result": {"capabilities": {}}})
+        assert backend._init_state == "ready"
+        assert "stdin closed during initialized" in (backend.dead_reason or "")
+
+    @pytest.mark.asyncio
+    async def test_error_response_fails_every_queued_stub(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        backend._init_pending = [("s1", 7), ("ghost", 8)]
+        await backend._on_upstream_initialize(
+            {"jsonrpc": "2.0", "id": "gw-1", "error": {"code": -1, "message": "nope"}}
+        )
+        assert backend._init_state == "failed"
+        assert backend._init_done_event.is_set()
+        assert backend._init_pending == []
+        err = await _drain(inbox)
+        assert err["id"] == 7
+        assert err["error"]["code"] == -32000
+        assert "initialize error" in err["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_malformed_result_fails_init(self) -> None:
+        backend = _make_backend()
+        await backend._on_upstream_initialize({"result": "not-a-dict"})
+        assert backend._init_state == "failed"
+        assert "missing/malformed result" in (backend.dead_reason or "")
+
+
+class TestPrimeInitialize:
+    @pytest.mark.asyncio
+    async def test_ready_backend_is_a_noop(self) -> None:
+        backend = _make_backend()
+        backend._init_state = "ready"
+        await backend.prime_initialize({"method": "initialize", "id": 1})
+        assert _frames(backend) == []
+
+    @pytest.mark.asyncio
+    async def test_dead_backend_rejected(self) -> None:
+        backend = _make_backend()
+        backend._dead_reason = "gone"
+        with pytest.raises(BackendGone, match="gone"):
+            await backend.prime_initialize({"method": "initialize", "id": 1})
+
+    @pytest.mark.asyncio
+    async def test_failed_backend_rejected(self) -> None:
+        backend = _make_backend()
+        backend._init_state = "failed"
+        with pytest.raises(BackendGone):
+            await backend.prime_initialize({"method": "initialize", "id": 1})
+
+    @pytest.mark.asyncio
+    async def test_replays_captured_initialize_without_stub_delivery(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+
+        async def _resolve() -> None:
+            await asyncio.sleep(0)
+            await backend._on_upstream_initialize({"result": {"capabilities": {}}})
+
+        waiter = asyncio.create_task(_resolve())
+        await backend.prime_initialize(
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize",
+             "params": {"_meta": {CALLER_META_KEY: {"sessionKey": "forged"}}}},
+            timeout=5,
+        )
+        await waiter
+        assert backend._init_state == "ready"
+        # The captured frame's forged identity was stripped before the replay.
+        replay = _frames(backend)[0]
+        assert "_meta" not in replay["params"]
+        # No stub ever saw a synthetic initialize reply.
+        assert inbox.empty()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_primer_waits_on_shared_event(self) -> None:
+        backend = _make_backend()
+        backend._init_state = "in_flight"
+        backend._init_done_event.set()
+        backend._init_state = "ready"
+        await backend.prime_initialize({"method": "initialize", "id": 1}, timeout=5)
+        # Second primer never wrote upstream.
+        assert _frames(backend) == []
+
+    @pytest.mark.asyncio
+    async def test_handshake_that_never_resolves_reaps_the_backend(self) -> None:
+        """timeout=0 makes asyncio.wait_for fail synchronously — no wall clock."""
+        backend = _make_backend()
+        with pytest.raises(BackendGone, match="initialize timed out on respawn"):
+            await backend.prime_initialize({"method": "initialize", "id": 1}, timeout=0)
+        assert backend._init_state == "failed"
+        assert backend._init_done_event.is_set()
+        cast(Any, backend.stdin).close.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_resolved_but_not_ready_raises(self) -> None:
+        backend = _make_backend()
+        backend._init_state = "in_flight"
+        backend._init_done_event.set()
+        with pytest.raises(BackendGone, match="initialize failed on respawn"):
+            await backend.prime_initialize({"method": "initialize", "id": 1}, timeout=5)
+
+    @pytest.mark.asyncio
+    async def test_write_failure_during_prime(self) -> None:
+        backend = _make_backend()
+        cast(Any, backend.stdin).write.side_effect = BrokenPipeError("epipe")
+        with pytest.raises(BackendGone, match="stdin closed"):
+            await backend.prime_initialize({"method": "initialize", "id": 1})
+
+
+# --- Terminal broadcast -----------------------------------------------------
+
+
+class TestBroadcastBackendGone:
+    @pytest.mark.asyncio
+    async def test_each_pending_request_gets_its_own_error(self) -> None:
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        backend._pending_requests.update({
+            "gw-1": _PendingRequest("s1", 11, "tools/call"),
+            "gw-2": _PendingRequest("s2", 22, "tools/list"),
+            "gw-3": _PendingRequest("ghost", 33, "tools/list"),
+        })
+        await backend._broadcast_backend_gone("stdout EOF")
+        assert (await _drain(inbox1))["id"] == 11
+        assert (await _drain(inbox2))["id"] == 22
+        assert backend._pending_requests == {}
+
+    @pytest.mark.asyncio
+    async def test_init_waiters_each_get_their_own_id(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        backend._pending_requests["gw-1"] = _PendingRequest("__init__", None, "initialize")
+        backend._init_pending = [("s1", 5), ("ghost", 6)]
+        await backend._broadcast_backend_gone("crash")
+        err = await _drain(inbox)
+        assert err["id"] == 5 and "backend gone: crash" in err["error"]["message"]
+        assert backend._init_pending == []
+
+    @pytest.mark.asyncio
+    async def test_in_flight_init_is_failed_and_waiters_woken(self) -> None:
+        backend = _make_backend()
+        backend._init_state = "in_flight"
+        await backend._broadcast_backend_gone("crash")
+        assert backend._init_state == "failed"
+        assert backend._init_done_event.is_set()
+        assert backend.dead_reason == "crash"
+
+    @pytest.mark.asyncio
+    async def test_parked_apps_future_is_failed_fast(self) -> None:
+        backend = _make_backend()
+        fut: "asyncio.Future[dict[str, Any]]" = asyncio.get_running_loop().create_future()
+        backend._pending_requests["gw-1"] = _PendingRequest(
+            backend_mod._APPS_STUB_SENTINEL, None, "resources/read", apps_future=fut,
+        )
+        await backend._broadcast_backend_gone("crash")
+        with pytest.raises(BackendGone):
+            await fut
+
+    @pytest.mark.asyncio
+    async def test_already_resolved_apps_future_is_left_alone(self) -> None:
+        backend = _make_backend()
+        fut: "asyncio.Future[dict[str, Any]]" = asyncio.get_running_loop().create_future()
+        fut.set_result({"already": "done"})
+        backend._pending_requests["gw-1"] = _PendingRequest(
+            backend_mod._APPS_STUB_SENTINEL, None, "resources/read", apps_future=fut,
+        )
+        await backend._broadcast_backend_gone("crash")
+        assert await fut == {"already": "done"}
+
+    @pytest.mark.asyncio
+    async def test_second_broadcast_is_a_noop(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        backend._pending_requests["gw-1"] = _PendingRequest("s1", 1, "tools/call")
+        await backend._broadcast_backend_gone("first")
+        backend._pending_requests["gw-2"] = _PendingRequest("s1", 2, "tools/call")
+        await backend._broadcast_backend_gone("second")
+        assert inbox.qsize() == 1
+        # The second call left the re-added pending entry alone.
+        assert list(backend._pending_requests) == ["gw-2"]
+
+
+# --- Inbox delivery ---------------------------------------------------------
+
+
+class TestStubDelivery:
+    @pytest.mark.asyncio
+    async def test_full_inbox_drops_the_slow_stub(self) -> None:
+        backend = _make_backend()
+        inbox: "asyncio.Queue[bytes]" = asyncio.Queue(maxsize=1)
+        async with backend._inbox_lock:
+            backend._stub_inboxes["slow"] = inbox
+            backend.refcount = 1
+        assert await backend._enqueue_to_stub("slow", inbox, b"a\n") is True
+        assert await backend._enqueue_to_stub("slow", inbox, b"b\n") is False
+        assert backend.refcount == 0
+        assert "slow" not in backend._stub_inboxes
+
+    @pytest.mark.asyncio
+    async def test_deliver_to_detached_stub_is_dropped(self) -> None:
+        backend = _make_backend()
+        await backend._deliver_to_stub("ghost", {"id": 1})  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_broadcast_reaches_every_stub(self) -> None:
+        backend = _make_backend()
+        inboxes = [await backend.attach_stub(f"s{i}") for i in range(3)]
+        await backend._broadcast({"method": "notifications/tools/list_changed"})
+        for inbox in inboxes:
+            assert (await _drain(inbox))["method"] == "notifications/tools/list_changed"
+
+
+class TestNotificationOwner:
+    def test_non_dict_params(self) -> None:
+        backend = _make_backend()
+        assert backend._notification_owner({"method": "x"}) is None
+        assert backend._notification_owner({"params": "bad"}) is None
+
+    def test_unique_progress_token_routes(self) -> None:
+        backend = _make_backend()
+        backend._pending_requests["gw-1"] = _PendingRequest(
+            "s1", 1, "tools/call", progress_token="pt")
+        assert backend._notification_owner(
+            {"params": {"progressToken": "pt"}}) == "s1"
+
+    def test_colliding_progress_token_is_unattributable(self) -> None:
+        backend = _make_backend()
+        backend._pending_requests.update({
+            "gw-1": _PendingRequest("s1", 1, "tools/call", progress_token="pt"),
+            "gw-2": _PendingRequest("s2", 2, "tools/call", progress_token="pt"),
+        })
+        assert backend._notification_owner({"params": {"progressToken": "pt"}}) is None
+
+    def test_related_request_id_routes(self) -> None:
+        backend = _make_backend()
+        backend._pending_requests["gw-9"] = _PendingRequest("s3", 1, "tools/call")
+        assert backend._notification_owner(
+            {"params": {"_meta": {"relatedRequestId": "gw-9"}}}) == "s3"
+
+    def test_init_sentinel_is_never_an_owner(self) -> None:
+        backend = _make_backend()
+        backend._pending_requests["gw-9"] = _PendingRequest("__init__", None, "initialize")
+        assert backend._notification_owner(
+            {"params": {"_meta": {"relatedRequestId": "gw-9"}}}) is None
+
+    def test_unknown_related_request_id(self) -> None:
+        backend = _make_backend()
+        assert backend._notification_owner(
+            {"params": {"_meta": {"relatedRequestId": "nope"}}}) is None
+        assert backend._notification_owner({"params": {"_meta": "bad"}}) is None
+        # A well-formed _meta that simply carries no routing token.
+        assert backend._notification_owner({"params": {"_meta": {"other": 1}}}) is None
+
+
+# --- _route_backend_line ----------------------------------------------------
+
+
+class TestRouteBackendLine:
+    @pytest.mark.asyncio
+    async def test_non_json_and_non_object_lines_dropped(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        await backend._route_backend_line(b"not json at all\n")
+        await backend._route_backend_line(b"\xff\xfe binary\n")
+        await backend._route_backend_line(b"[1,2,3]\n")
+        assert inbox.empty()
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_pong_is_swallowed(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        backend._last_ping_response_mono = 0.0
+        await backend._route_backend_line(_line({"id": HEARTBEAT_PING_ID, "result": {}}))
+        assert inbox.empty()
+        assert backend._last_ping_response_mono > 0.0
+        # Stringified form too.
+        backend._last_ping_response_mono = 0.0
+        await backend._route_backend_line(
+            _line({"id": str(HEARTBEAT_PING_ID), "error": {"code": -1}}))
+        assert backend._last_ping_response_mono > 0.0
+
+    @pytest.mark.asyncio
+    async def test_unknown_response_id_dropped(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        await backend._route_backend_line(_line({"id": "gw-nope", "result": {}}))
+        assert inbox.empty()
+
+    @pytest.mark.asyncio
+    async def test_response_restores_original_id(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        backend._pending_requests["gw-4242-1"] = _PendingRequest("s1", 42, "tools/list")
+        await backend._route_backend_line(
+            _line({"jsonrpc": "2.0", "id": "gw-4242-1", "result": {"tools": []}}))
+        assert await _drain(inbox) == {
+            "jsonrpc": "2.0", "id": 42, "result": {"tools": []}}
+        assert backend._pending_requests == {}
+
+    @pytest.mark.asyncio
+    async def test_completed_request_emits_latency_metric(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = tmp_path / "metrics.jsonl"
+        monkeypatch.setattr(backend_mod, "_METRICS_PATH", str(path))
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        backend._pending_requests["gw-1"] = _PendingRequest(
+            "s1", 1, "tools/call", t_start_ms=time.monotonic() * 1000.0)
+        await backend._route_backend_line(_line({"id": "gw-1", "result": {}}))
+        await _settle(backend)
+        record = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+        assert record["method"] == "tools/call"
+        assert record["ok"] is True
+        assert record["stub"] == "s1"
+        assert record["pid"] == 4242
+
+    @pytest.mark.asyncio
+    async def test_init_sentinel_response_goes_to_handshake(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        backend._pending_requests["gw-1"] = _PendingRequest("__init__", None, "initialize")
+        backend._init_pending = [("s1", 1)]
+        await backend._route_backend_line(
+            _line({"id": "gw-1", "result": {"capabilities": {}}}))
+        assert backend._init_state == "ready"
+        assert (await _drain(inbox))["id"] == 1
+
+    @pytest.mark.asyncio
+    async def test_apps_sentinel_response_resolves_parked_future(self) -> None:
+        backend = _make_backend()
+        fut: "asyncio.Future[dict[str, Any]]" = asyncio.get_running_loop().create_future()
+        backend._pending_requests["gw-1"] = _PendingRequest(
+            backend_mod._APPS_STUB_SENTINEL, None, "resources/read", apps_future=fut)
+        await backend._route_backend_line(_line({"id": "gw-1", "result": {"contents": []}}))
+        assert (await fut)["result"] == {"contents": []}
+
+    @pytest.mark.asyncio
+    async def test_resolved_apps_future_is_not_re_set(self) -> None:
+        backend = _make_backend()
+        fut: "asyncio.Future[dict[str, Any]]" = asyncio.get_running_loop().create_future()
+        fut.set_result({"first": True})
+        backend._pending_requests["gw-1"] = _PendingRequest(
+            backend_mod._APPS_STUB_SENTINEL, None, "resources/read", apps_future=fut)
+        await backend._route_backend_line(_line({"id": "gw-1", "result": {"second": True}}))
+        assert await fut == {"first": True}
+
+    @pytest.mark.asyncio
+    async def test_attributable_notification_goes_to_one_stub(self) -> None:
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        backend._pending_requests["gw-1"] = _PendingRequest(
+            "s1", 1, "tools/call", progress_token="pt")
+        await backend._route_backend_line(_line({
+            "method": "notifications/progress",
+            "params": {"progressToken": "pt", "progress": 1},
+        }))
+        assert (await _drain(inbox1))["method"] == "notifications/progress"
+        assert inbox2.empty()
+
+    @pytest.mark.asyncio
+    async def test_global_notification_is_broadcast(self) -> None:
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend._route_backend_line(
+            _line({"method": "notifications/tools/list_changed"}))
+        assert not inbox1.empty() and not inbox2.empty()
+
+    @pytest.mark.asyncio
+    async def test_unattributable_request_scoped_notification_dropped(self) -> None:
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        await backend._route_backend_line(_line({
+            "method": "notifications/message",
+            "params": {"level": "info", "data": "tenant secret"},
+        }))
+        assert inbox1.empty() and inbox2.empty()
+
+    @pytest.mark.asyncio
+    async def test_server_request_routed_via_related_request_id(self) -> None:
+        backend = _make_backend()
+        inbox1 = await backend.attach_stub("s1")
+        inbox2 = await backend.attach_stub("s2")
+        backend._pending_requests["gw-7"] = _PendingRequest("s2", 1, "tools/call")
+        await backend._route_backend_line(_line({
+            "id": "srv-1", "method": "sampling/createMessage",
+            "params": {"_meta": {"relatedRequestId": "gw-7"}},
+        }))
+        assert (await _drain(inbox2))["id"] == "srv-1"
+        assert inbox1.empty()
+
+    @pytest.mark.asyncio
+    async def test_server_request_routed_to_single_stub(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        await backend._route_backend_line(
+            _line({"id": "srv-1", "method": "roots/list"}))
+        assert (await _drain(inbox))["method"] == "roots/list"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("params", [
+        "not-a-dict",
+        {"_meta": "not-a-dict"},
+        {"_meta": {}},
+        {"_meta": {"relatedRequestId": "gw-unknown"}},
+    ])
+    async def test_malformed_related_request_id_falls_back_to_single_stub(
+        self, params: Any
+    ) -> None:
+        """Every rung of the relatedRequestId lookup that cannot resolve must
+        fall through to the single-stub rule rather than mis-attribute."""
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        await backend._route_backend_line(
+            _line({"id": "srv-1", "method": "roots/list", "params": params}))
+        assert (await _drain(inbox))["id"] == "srv-1"
+
+    @pytest.mark.asyncio
+    async def test_unattributable_server_request_recycles_backend(self) -> None:
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend.attach_stub("s2")
+        await backend._route_backend_line(
+            _line({"id": "srv-1", "method": "elicitation/create"}))
+        assert "cannot route without a cross-tenant leak" in (backend.dead_reason or "")
+        assert backend._gone_broadcast is True
+
+    @pytest.mark.asyncio
+    async def test_frame_with_neither_id_nor_method_dropped(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        await backend._route_backend_line(_line({"jsonrpc": "2.0"}))
+        assert inbox.empty()
+
+
+# --- run_stdout_pump --------------------------------------------------------
+
+
+class TestRunStdoutPump:
+    @pytest.mark.asyncio
+    async def test_routes_frames_then_broadcasts_on_eof(self) -> None:
+        backend = _make_backend(stdout=None)
+        backend.stdout = cast(Any, _reader(
+            _line({"id": "gw-1", "result": {"ok": 1}}),
+            _line({"method": "notifications/tools/list_changed"}),
+        ))
+        inbox = await backend.attach_stub("s1")
+        backend._pending_requests["gw-1"] = _PendingRequest("s1", 5, "tools/call")
+        await backend.run_stdout_pump()
+        assert (await _drain(inbox))["id"] == 5
+        assert (await _drain(inbox))["method"] == "notifications/tools/list_changed"
+        assert backend.dead_reason == "stdout EOF"
+
+    @pytest.mark.asyncio
+    async def test_exit_code_wins_over_generic_eof_reason(self) -> None:
+        backend = _make_backend(returncode=3)
+        backend.stdout = cast(Any, _reader())
+        await backend.run_stdout_pump()
+        assert backend.dead_reason == "exit rc=3"
+
+    @pytest.mark.asyncio
+    async def test_partial_final_line_is_reported(self) -> None:
+        backend = _make_backend()
+        backend.stdout = cast(Any, _reader(b'{"id":"gw-1","result"'))
+        inbox = await backend.attach_stub("s1")
+        backend._pending_requests["gw-1"] = _PendingRequest("s1", 1, "tools/call")
+        await backend.run_stdout_pump()
+        # The truncated frame is dropped, and the stub gets a backend-gone error.
+        assert (await _drain(inbox))["error"]["code"] == -32000
+
+    @pytest.mark.asyncio
+    async def test_oversize_line_dropped_without_eating_the_next_frame(self) -> None:
+        backend = _make_backend()
+        oversize = b'{"id":"gw-1","result":"' + b"x" * 400 + b'"}\n'
+        backend.stdout = cast(Any, _reader(
+            oversize, _line({"id": "gw-2", "result": {"ok": True}}), limit=64,
+        ))
+        inbox = await backend.attach_stub("s1")
+        backend._pending_requests.update({
+            "gw-1": _PendingRequest("s1", 1, "tools/call"),
+            "gw-2": _PendingRequest("s1", 2, "tools/call"),
+        })
+        await backend.run_stdout_pump()
+        first = await _drain(inbox)
+        assert first["id"] == 1
+        assert "exceeded size limit" in first["error"]["message"]
+        # The frame AFTER the oversize line still arrives intact.
+        assert (await _drain(inbox))["result"] == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_unterminated_oversize_line_at_eof_recycles(self) -> None:
+        """An oversize line that never terminates: the drain loop hits EOF, the
+        id cannot be recovered, so the shared backend is recycled rather than
+        failing an innocent stub."""
+        backend = _make_backend()
+        backend.stdout = cast(Any, _reader(b"x" * 400, limit=64))
+        inbox = await backend.attach_stub("s1")
+        backend._pending_requests["gw-1"] = _PendingRequest("s1", 1, "tools/call")
+        await backend.run_stdout_pump()
+        assert "unrecoverable request id" in (backend.dead_reason or "")
+        err = await _drain(inbox)
+        assert err["id"] == 1
+        assert "unrecoverable request id" in err["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_over_threshold_line_is_spilled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(backend_mod, "RESPONSE_SPILL_THRESHOLD_BYTES", 8)
+        monkeypatch.setattr(
+            backend_mod, "maybe_spill_response",
+            lambda line, server, threshold: _line({"id": "gw-1", "result": "spilled"}),
+        )
+        backend = _make_backend()
+        backend.stdout = cast(Any, _reader(_line({"id": "gw-1", "result": "x" * 64})))
+        inbox = await backend.attach_stub("s1")
+        backend._pending_requests["gw-1"] = _PendingRequest("s1", 1, "tools/call")
+        await backend.run_stdout_pump()
+        assert (await _drain(inbox))["result"] == "spilled"
+
+    @pytest.mark.asyncio
+    async def test_spill_failure_routes_the_raw_line(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(backend_mod, "RESPONSE_SPILL_THRESHOLD_BYTES", 8)
+
+        def _boom(line: bytes, server: str, threshold: int) -> bytes:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(backend_mod, "maybe_spill_response", _boom)
+        backend = _make_backend()
+        backend.stdout = cast(Any, _reader(_line({"id": "gw-1", "result": "raw"})))
+        inbox = await backend.attach_stub("s1")
+        backend._pending_requests["gw-1"] = _PendingRequest("s1", 1, "tools/call")
+        await backend.run_stdout_pump()
+        assert (await _drain(inbox))["result"] == "raw"
+
+    @pytest.mark.asyncio
+    async def test_cancellation_propagates(self) -> None:
+        backend = _make_backend()
+        backend.stdout = cast(Any, _reader(eof=False))
+        task = asyncio.create_task(backend.run_stdout_pump())
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+# --- _fail_oversize_request -------------------------------------------------
+
+
+class TestFailOversizeRequest:
+    @pytest.mark.asyncio
+    async def test_complete_prefix_json_identifies_the_request(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        backend._pending_requests["gw-9"] = _PendingRequest("s1", 90, "tools/call")
+        await backend._fail_oversize_request(b'{"jsonrpc":"2.0","id":"gw-9","result":{}}')
+        err = await _drain(inbox)
+        assert err["id"] == 90 and "exceeded size limit" in err["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_regex_fallback_recovers_truncated_head(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        backend._pending_requests["gw-8"] = _PendingRequest("s1", 80, "tools/call")
+        await backend._fail_oversize_request(
+            b'{"jsonrpc":"2.0","id":"gw-8","result":{"content":"' + b"y" * 600)
+        assert (await _drain(inbox))["id"] == 80
+
+    @pytest.mark.asyncio
+    async def test_brace_terminated_but_invalid_json_falls_back_to_regex(self) -> None:
+        """The head looks complete (ends in ``}``) but is not valid JSON, so the
+        prefix parse raises and the regex recovers the id."""
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        backend._pending_requests["gw-5"] = _PendingRequest("s1", 50, "tools/call")
+        await backend._fail_oversize_request(b'{"id":"gw-5", not-valid-json}')
+        assert (await _drain(inbox))["id"] == 50
+
+    @pytest.mark.asyncio
+    async def test_regex_match_that_is_not_decodable_recycles(self) -> None:
+        """The regex matches a quoted id containing an invalid escape, so the
+        second decode also fails and the backend is recycled."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        await backend._fail_oversize_request(b'{"id":"\\x"}')
+        assert "unrecoverable request id" in (backend.dead_reason or "")
+
+    @pytest.mark.asyncio
+    async def test_known_id_with_no_pending_entry_is_a_noop(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        await backend._fail_oversize_request(b'{"id":"gw-unknown","result":{}}')
+        assert inbox.empty()
+        assert backend._gone_broadcast is False
+
+    @pytest.mark.asyncio
+    async def test_oversize_initialize_recycles_the_backend(self) -> None:
+        """Failing just the one request cannot work for ``initialize``: the
+        handshake could never complete. The whole backend is recycled so init
+        waiters get a clean BackendGone and the done-event is woken."""
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        backend._init_state = "in_flight"
+        backend._pending_requests["gw-7"] = _PendingRequest("__init__", None, "initialize")
+        backend._init_pending = [("s1", 1)]
+        await backend._fail_oversize_request(b'{"id":"gw-7","result":{}}')
+        assert "oversize initialize response" in (backend.dead_reason or "")
+        assert backend._init_state == "failed"
+        assert backend._init_done_event.is_set()
+        assert backend._init_pending == []
+        assert backend._gone_broadcast is True
+
+    @pytest.mark.asyncio
+    async def test_unrecoverable_id_recycles_rather_than_guessing(self) -> None:
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        backend._pending_requests["gw-6"] = _PendingRequest("s1", 60, "tools/call")
+        await backend._fail_oversize_request(b"z" * 300)
+        assert "unrecoverable request id" in (backend.dead_reason or "")
+        assert backend._pending_requests == {}
+
+
+# --- MCP Apps helpers -------------------------------------------------------
+
+
+class TestParseUiContents:
+    def test_inline_text_with_csp_and_permissions(self) -> None:
+        backend = _make_backend()
+        html, csp, perms = backend._parse_ui_contents([{
+            "mimeType": MCP_APPS_MIME_TYPE,
+            "text": "<h1>hi</h1>",
+            "_meta": {"ui": {"csp": "default-src 'none'", "permissions": ["clipboard"]}},
+        }])
+        assert html == "<h1>hi</h1>"
+        assert csp == "default-src 'none'"
+        assert perms == ["clipboard"]
+
+    def test_base64_blob_decoded(self) -> None:
+        backend = _make_backend()
+        blob = base64.b64encode(b"<p>b</p>").decode("ascii")
+        html, csp, perms = backend._parse_ui_contents(
+            [{"mimeType": MCP_APPS_MIME_TYPE, "blob": blob}])
+        assert (html, csp, perms) == ("<p>b</p>", None, None)
+
+    def test_invalid_base64_rejected(self) -> None:
+        backend = _make_backend()
+        with pytest.raises(RuntimeError, match="invalid base64 blob"):
+            backend._parse_ui_contents(
+                [{"mimeType": MCP_APPS_MIME_TYPE, "blob": "!!!not-base64!!!"}])
+
+    def test_non_object_entry_rejected(self) -> None:
+        backend = _make_backend()
+        with pytest.raises(RuntimeError, match="is not an object"):
+            backend._parse_ui_contents(["nope"])
+
+    def test_wrong_mime_type_rejected(self) -> None:
+        backend = _make_backend()
+        with pytest.raises(RuntimeError, match="unexpected mimeType"):
+            backend._parse_ui_contents([{"mimeType": "text/plain", "text": "x"}])
+
+    def test_neither_text_nor_blob_rejected(self) -> None:
+        backend = _make_backend()
+        with pytest.raises(RuntimeError, match="neither text nor blob"):
+            backend._parse_ui_contents([{"mimeType": MCP_APPS_MIME_TYPE}])
+
+    def test_non_dict_meta_yields_no_csp(self) -> None:
+        backend = _make_backend()
+        _, csp, perms = backend._parse_ui_contents(
+            [{"mimeType": MCP_APPS_MIME_TYPE, "text": "x", "_meta": {"ui": "bad"}}])
+        assert csp is None and perms is None
+
+
+class TestInterceptionGating:
+    @pytest.mark.asyncio
+    async def test_flag_off_is_a_no_op(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(MCP_APPS_ENV_FLAG, "0")
+        backend = _make_backend()
+        backend._apps_declared_uris = {"draw": "ui://x/y.html"}
+        pending = _PendingRequest("s1", 1, "tools/call", tool_name="draw")
+        assert await backend._maybe_intercept_ui_result(pending, {"result": {}}) is False
+
+    @pytest.mark.asyncio
+    async def test_other_methods_and_shapes_never_intercept(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(MCP_APPS_ENV_FLAG, "1")
+        backend = _make_backend()
+        # Not a tools/call.
+        assert await backend._maybe_intercept_ui_result(
+            _PendingRequest("s1", 1, "resources/list"), {"result": {}}) is False
+        # tools/call whose result is not an object.
+        assert await backend._maybe_intercept_ui_result(
+            _PendingRequest("s1", 1, "tools/call"), {"result": "text"}) is False
+        # tools/call with no ui association anywhere.
+        assert await backend._maybe_intercept_ui_result(
+            _PendingRequest("s1", 1, "tools/call", tool_name="draw"),
+            {"result": {"content": []}}) is False
+
+    @pytest.mark.asyncio
+    async def test_tools_list_harvest_records_declarations(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(MCP_APPS_ENV_FLAG, "1")
+        backend = _make_backend()
+        msg = {"result": {"tools": [{
+            "name": "draw",
+            "inputSchema": {"type": "object", "properties": {}},
+            "_meta": {"ui": {"resourceUri": "ui://draw/app.html"}},
+        }]}}
+        assert await backend._maybe_intercept_ui_result(
+            _PendingRequest("s1", 1, "tools/list"), msg) is False
+        assert backend._apps_declared_uris == {"draw": "ui://draw/app.html"}
+
+    @pytest.mark.asyncio
+    async def test_tools_list_with_non_dict_result_leaves_map_alone(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(MCP_APPS_ENV_FLAG, "1")
+        backend = _make_backend()
+        backend._apps_declared_uris = {"draw": "ui://keep"}
+        assert await backend._maybe_intercept_ui_result(
+            _PendingRequest("s1", 1, "tools/list"), {"result": None}) is False
+        assert backend._apps_declared_uris == {"draw": "ui://keep"}
+
+
+class TestReadUiResource:
+    @pytest.mark.asyncio
+    async def test_error_reply_raises_and_clears_pending(self) -> None:
+        backend = _make_backend()
+
+        async def _answer(payload: dict[str, Any]) -> None:
+            await asyncio.sleep(0)
+            await backend._route_backend_line(_line(payload))
+
+        task = asyncio.create_task(_answer(
+            {"id": "gw-4242-1", "error": {"code": -1, "message": "nope"}}))
+        with pytest.raises(RuntimeError, match="resources/read error"):
+            await backend._read_ui_resource("ui://x/y.html")
+        await task
+        assert backend._pending_requests == {}
+        assert _frames(backend)[0]["method"] == "resources/read"
+
+    @pytest.mark.asyncio
+    async def test_malformed_result_raises(self) -> None:
+        backend = _make_backend()
+        task = asyncio.create_task(_deferred_route(
+            backend, {"id": "gw-4242-1", "result": "text"}))
+        with pytest.raises(RuntimeError, match="malformed result"):
+            await backend._read_ui_resource("ui://x/y.html")
+        await task
+
+    @pytest.mark.asyncio
+    async def test_empty_contents_raises(self) -> None:
+        backend = _make_backend()
+        task = asyncio.create_task(_deferred_route(
+            backend, {"id": "gw-4242-1", "result": {"contents": []}}))
+        with pytest.raises(RuntimeError, match="no contents"):
+            await backend._read_ui_resource("ui://x/y.html")
+        await task
+
+    @pytest.mark.asyncio
+    async def test_contents_returned_on_success(self) -> None:
+        backend = _make_backend()
+        entry = {"mimeType": MCP_APPS_MIME_TYPE, "text": "<b>ok</b>"}
+        task = asyncio.create_task(_deferred_route(
+            backend, {"id": "gw-4242-1", "result": {"contents": [entry]}}))
+        assert await backend._read_ui_resource("ui://x/y.html") == [entry]
+        await task
+
+
+async def _deferred_route(backend: Backend, payload: dict[str, Any]) -> None:
+    await asyncio.sleep(0)
+    await backend._route_backend_line(_line(payload))
+
+
+# --- Cancellation / recycle / shutdown -------------------------------------
+
+
+class TestCancelInFlight:
+    @pytest.mark.asyncio
+    async def test_sends_one_cancel_per_in_flight_request(self) -> None:
+        backend = _make_backend()
+        backend._pending_requests.update({
+            "gw-1": _PendingRequest("s1", 1, "tools/call"),
+            "gw-2": _PendingRequest("s1", 2, "tools/call"),
+            "gw-3": _PendingRequest("s2", 3, "tools/call"),
+        })
+        assert await backend.cancel_in_flight_for_stub("s1") == ["gw-1", "gw-2"]
+        frames = _frames(backend)
+        assert [f["params"]["requestId"] for f in frames] == ["gw-1", "gw-2"]
+        assert all(f["method"] == "notifications/cancelled" for f in frames)
+
+    @pytest.mark.asyncio
+    async def test_no_in_flight_work_writes_nothing(self) -> None:
+        backend = _make_backend()
+        assert await backend.cancel_in_flight_for_stub("s1") == []
+        assert _frames(backend) == []
+
+    @pytest.mark.asyncio
+    async def test_dead_backend_short_circuits(self) -> None:
+        backend = _make_backend()
+        backend._dead_reason = "gone"
+        backend._pending_requests["gw-1"] = _PendingRequest("s1", 1, "tools/call")
+        assert await backend.cancel_in_flight_for_stub("s1") == []
+
+    @pytest.mark.asyncio
+    async def test_broken_pipe_stops_sending(self) -> None:
+        backend = _make_backend()
+        cast(Any, backend.stdin).write.side_effect = BrokenPipeError("epipe")
+        backend._pending_requests["gw-1"] = _PendingRequest("s1", 1, "tools/call")
+        assert await backend.cancel_in_flight_for_stub("s1") == []
+
+    @pytest.mark.asyncio
+    async def test_many_cancels_are_summarised_in_the_log(self) -> None:
+        backend = _make_backend()
+        for i in range(7):
+            backend._pending_requests[f"gw-{i}"] = _PendingRequest("s1", i, "tools/call")
+        assert len(await backend.cancel_in_flight_for_stub("s1")) == 7
+
+
+class TestRecycleIfIdle:
+    @pytest.fixture(autouse=True)
+    def _no_real_signals(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(backend_mod, "SecurityEventLog", MagicMock())
+        monkeypatch.setattr(
+            backend_mod.platform_compat, "kill_process_tree_async",
+            AsyncMock(return_value=True))
+        monkeypatch.setattr(
+            backend_mod.platform_compat, "kill_pid_async", AsyncMock(return_value=True))
+
+    @pytest.mark.asyncio
+    async def test_co_tenants_present_quarantines_instead(self) -> None:
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        assert await backend.recycle_if_idle() is False
+        assert backend.quarantined is True
+        assert backend.is_alive is True
+
+    @pytest.mark.asyncio
+    async def test_idle_backend_is_killed_and_audited(self) -> None:
+        backend = _make_backend()
+        assert await backend.recycle_if_idle() is True
+        assert "recycled after last stub detached" in (backend.dead_reason or "")
+        cast(Any, backend_mod.platform_compat.kill_process_tree_async).assert_awaited_once()
+        cast(Any, backend_mod.SecurityEventLog).return_value.log_api_access.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_audit_failure_never_breaks_recycle(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sel = MagicMock()
+        sel.return_value.log_api_access.side_effect = RuntimeError("sel down")
+        monkeypatch.setattr(backend_mod, "SecurityEventLog", sel)
+        backend = _make_backend()
+        assert await backend.recycle_if_idle() is True
+
+    @pytest.mark.asyncio
+    async def test_refused_pid_reports_not_recycled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            backend_mod.platform_compat, "kill_process_tree_async",
+            AsyncMock(side_effect=ValueError("refused pid")))
+        backend = _make_backend()
+        assert await backend.recycle_if_idle() is False
+        assert backend.dead_reason is None
+
+    @pytest.mark.asyncio
+    async def test_tree_kill_failure_falls_back_to_pid_kill(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            backend_mod.platform_compat, "kill_process_tree_async",
+            AsyncMock(side_effect=ProcessLookupError()))
+        pid_kill = AsyncMock(return_value=True)
+        monkeypatch.setattr(backend_mod.platform_compat, "kill_pid_async", pid_kill)
+        backend = _make_backend()
+        assert await backend.recycle_if_idle() is True
+        pid_kill.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_already_dead_backend_is_not_re_killed(self) -> None:
+        backend = _make_backend(returncode=0)
+        assert await backend.recycle_if_idle() is False
+        cast(Any, backend_mod.platform_compat.kill_process_tree_async).assert_not_awaited()
+
+
+class TestBackgroundTasksAndShutdown:
+    @pytest.mark.asyncio
+    async def test_cancel_background_tasks_clears_both_pumps(self) -> None:
+        backend = _make_backend()
+        backend._stdout_task = asyncio.create_task(asyncio.sleep(3600))
+        backend._stderr_task = asyncio.create_task(asyncio.sleep(3600))
+        await backend._cancel_background_tasks()
+        assert backend._stdout_task is None and backend._stderr_task is None
+
+    @pytest.mark.asyncio
+    async def test_shutdown_of_exited_process_is_a_fast_noop(self) -> None:
+        backend = _make_backend(returncode=0)
+        await backend.shutdown()
+        cast(Any, backend.stdin).close.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_graceful_shutdown_closes_stdin_and_records_reason(self) -> None:
+        backend = _make_backend()
+        cast(Any, backend.process).wait = AsyncMock(return_value=0)
+        await backend.shutdown(timeout=5)
+        cast(Any, backend.stdin).close.assert_called_once()
+        assert backend.dead_reason is not None
+        assert backend.dead_reason.startswith("shutdown rc=")
+
+    @pytest.mark.asyncio
+    async def test_shutdown_preserves_an_existing_dead_reason(self) -> None:
+        backend = _make_backend()
+        backend._dead_reason = "wedged: recycled earlier"
+        await backend.shutdown(timeout=5)
+        assert backend.dead_reason == "wedged: recycled earlier"
+
+    @pytest.mark.asyncio
+    async def test_stdin_close_error_is_swallowed(self) -> None:
+        backend = _make_backend()
+        cast(Any, backend.stdin).close.side_effect = RuntimeError("already closed")
+        await backend.shutdown(timeout=5)
+        assert backend.dead_reason is not None
+
+    @pytest.mark.asyncio
+    async def test_timeout_escalates_to_tree_kill(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tree_kill = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            backend_mod.platform_compat, "kill_process_tree_async", tree_kill)
+        backend = _make_backend()
+        # timeout=0 makes the first wait_for fail synchronously.
+        await backend.shutdown(timeout=0)
+        tree_kill.assert_awaited_once()
+        cast(Any, backend.process).kill.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_tree_kill_failure_falls_back_to_process_kill(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            backend_mod.platform_compat, "kill_process_tree_async",
+            AsyncMock(side_effect=OSError("no perm")))
+        backend = _make_backend()
+        await backend.shutdown(timeout=0)
+        cast(Any, backend.process).kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_process_kill_of_vanished_pid_is_tolerated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            backend_mod.platform_compat, "kill_process_tree_async",
+            AsyncMock(side_effect=OSError("no perm")))
+        backend = _make_backend()
+        cast(Any, backend.process).kill.side_effect = ProcessLookupError()
+        await backend.shutdown(timeout=0)
+        assert backend.dead_reason is not None
+
+
+# --- Heartbeat edges not covered by the wedge suite ------------------------
+
+
+class TestHeartbeatEdges:
+    @pytest.mark.asyncio
+    async def test_reaped_process_is_gone_with_a_synthesized_reason(self) -> None:
+        backend = _make_backend(returncode=7)
+        inbox = await backend.attach_stub("s1")
+        backend._pending_requests["gw-1"] = _PendingRequest("s1", 1, "tools/call")
+        assert await backend._heartbeat_once(time.monotonic()) == "gone"
+        assert backend.dead_reason == "process exited rc=7"
+        assert (await _drain(inbox))["id"] == 1
+
+    @pytest.mark.asyncio
+    async def test_oldest_pending_scan_keeps_the_first_seen_maximum(self) -> None:
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        now = time.monotonic()
+        backend._pending_requests.update({
+            "gw-old": _PendingRequest("s1", 1, "tools/call",
+                                      t_start_ms=(now - 30.0) * 1000.0),
+            "gw-new": _PendingRequest("s1", 2, "tools/call", t_start_ms=now * 1000.0),
+        })
+        # Neither is old enough to be wedged, so this stays "alive" — the point
+        # is that the younger entry does not displace the older one.
+        assert await backend._heartbeat_once(now) == "alive"
+        assert backend._warned_slow_ids == set()
+
+    @pytest.mark.asyncio
+    async def test_idle_backend_is_left_to_the_idle_sweep(self) -> None:
+        backend = _make_backend()
+        assert await backend._heartbeat_once(time.monotonic()) == "idle"
+        assert _frames(backend) == []
+
+    @pytest.mark.asyncio
+    async def test_alive_backend_is_pinged_under_the_reserved_id(self) -> None:
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        assert await backend._heartbeat_once(time.monotonic()) == "alive"
+        (frame,) = _frames(backend)
+        assert frame == {"jsonrpc": "2.0", "id": HEARTBEAT_PING_ID, "method": "ping"}
+
+    @pytest.mark.asyncio
+    async def test_ping_write_failure_is_a_liveness_failure(self) -> None:
+        backend = _make_backend()
+        inbox = await backend.attach_stub("s1")
+        backend._pending_requests["gw-1"] = _PendingRequest(
+            "s1", 1, "tools/call", t_start_ms=time.monotonic() * 1000.0)
+        cast(Any, backend.stdin).write.side_effect = ConnectionResetError("reset")
+        assert await backend._heartbeat_once(time.monotonic()) == "gone"
+        assert "heartbeat ping write failed" in (backend.dead_reason or "")
+        assert (await _drain(inbox))["error"]["code"] == -32000
+
+    @pytest.mark.asyncio
+    async def test_warned_slow_ids_pruned_when_requests_complete(self) -> None:
+        backend = _make_backend()
+        await backend.attach_stub("s1")
+        backend._warned_slow_ids = {"gw-stale"}
+        assert await backend._heartbeat_once(time.monotonic()) == "alive"
+        assert backend._warned_slow_ids == set()
+
+
+# --- spawn_backend / send_initialize ---------------------------------------
+
+
+class _FakeProcess:
+    """Stand-in for asyncio.subprocess.Process with in-memory pipes."""
+
+    def __init__(
+        self,
+        *,
+        with_pipes: bool = True,
+        with_stderr: bool = True,
+        stderr_lines: bytes = b"",
+    ) -> None:
+        self.pid = 5150
+        self.returncode: Optional[int] = None
+        self.stdin = MagicMock() if with_pipes else None
+        if self.stdin is not None:
+            self.stdin.drain = AsyncMock()
+        self.stdout = asyncio.StreamReader() if with_pipes else None
+        self.stderr: Optional[asyncio.StreamReader] = None
+        if with_stderr:
+            self.stderr = asyncio.StreamReader()
+            self.stderr.feed_data(stderr_lines)
+            self.stderr.feed_eof()
+        self.killed = False
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+@pytest.fixture
+def fake_spawn(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Replace the real subprocess spawn with an in-memory fake."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_exec(program: str, *args: str, **kwargs: Any) -> _FakeProcess:
+        captured["program"] = program
+        captured["args"] = list(args)
+        captured["kwargs"] = kwargs
+        proc = _FakeProcess(
+            with_pipes=captured.get("with_pipes", True),
+            with_stderr=captured.get("with_stderr", True),
+            stderr_lines=captured.get("stderr_lines", b""),
+        )
+        captured["process"] = proc
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+    return captured
+
+
+class TestSpawnBackend:
+    @pytest.mark.asyncio
+    async def test_spawn_marks_env_and_wires_pipes(self, fake_spawn: dict[str, Any]) -> None:
+        fake_spawn["stderr_lines"] = b"boot line\n"
+        backend = await spawn_backend(
+            _pool_key(), "/usr/bin/example-mcp", ["--stdio"],
+            {"PATH": "/usr/bin"}, "/nonexistent-work-dir",
+        )
+        assert fake_spawn["program"] == "/usr/bin/example-mcp"
+        assert fake_spawn["args"] == ["--stdio"]
+        env = fake_spawn["kwargs"]["env"]
+        assert env["PATH"] == "/usr/bin"
+        assert env[backend_mod.KIROCREW_SPAWNED_ENV] == backend_mod.KIROCREW_SPAWNED_VALUE
+        assert fake_spawn["kwargs"]["start_new_session"] is True
+        assert backend.pid == 5150
+        assert backend._last_ping_response_mono > 0
+        assert backend._stderr_task is not None
+        await backend._stderr_task
+
+    @pytest.mark.asyncio
+    async def test_no_stderr_pipe_means_no_drain_task(
+        self, fake_spawn: dict[str, Any]
+    ) -> None:
+        fake_spawn["with_stderr"] = False
+        backend = await spawn_backend(
+            _pool_key(), "cmd", [], {}, "/nonexistent-work-dir")
+        assert backend._stderr_task is None
+
+    @pytest.mark.asyncio
+    async def test_missing_pipes_kills_the_child_and_raises(
+        self, fake_spawn: dict[str, Any]
+    ) -> None:
+        fake_spawn["with_pipes"] = False
+        with pytest.raises(RuntimeError, match="subprocess pipes not attached"):
+            await spawn_backend(_pool_key(), "cmd", [], {}, "/nonexistent-work-dir")
+        assert fake_spawn["process"].killed is True
+
+
+class TestSendInitialize:
+    @pytest.mark.asyncio
+    async def test_success_seeds_cache_and_detects_capability(self) -> None:
+        backend = _make_backend()
+        result: dict[str, Any] = {
+            "capabilities": {"experimental": {"kirocrew.caller-identity": {}}}}
+        backend.stdout = cast(Any, _reader(
+            b"backend boot noise, not json\n",
+            _line([1, 2, 3]),
+            _line({"id": "some-other-id", "result": {}}),
+            _line({"jsonrpc": "2.0", "id": backend_mod._GATEWAY_INIT_ID,
+                   "result": result}),
+        ))
+        assert await send_initialize(backend, timeout=5) == result
+        assert backend.supports_caller_identity is True
+        assert backend._init_state == "ready"
+        assert backend._init_result == result
+        request = _frames(backend)[0]
+        assert request["method"] == "initialize"
+        assert request["params"]["clientInfo"]["name"] == "kirocrew-gateway"
+
+    @pytest.mark.asyncio
+    async def test_custom_client_info_is_forwarded(self) -> None:
+        backend = _make_backend()
+        backend.stdout = cast(Any, _reader(_line(
+            {"id": backend_mod._GATEWAY_INIT_ID, "result": {"capabilities": {}}})))
+        await send_initialize(backend, client_info={"name": "probe", "version": "9"},
+                              timeout=5)
+        assert _frames(backend)[0]["params"]["clientInfo"] == {"name": "probe",
+                                                               "version": "9"}
+        assert backend.supports_caller_identity is False
+
+    @pytest.mark.asyncio
+    async def test_refuses_to_race_a_running_stdout_pump(self) -> None:
+        backend = _make_backend()
+        task = asyncio.create_task(asyncio.sleep(3600))
+        backend._stdout_task = task
+        try:
+            with pytest.raises(RuntimeError, match="must run before the stdout pump"):
+                await send_initialize(backend)
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_error_response_raises_value_error(self) -> None:
+        backend = _make_backend()
+        backend.stdout = cast(Any, _reader(_line(
+            {"id": backend_mod._GATEWAY_INIT_ID, "error": {"code": -1}})))
+        with pytest.raises(ValueError, match="returned initialize error"):
+            await send_initialize(backend, timeout=5)
+
+    @pytest.mark.asyncio
+    async def test_non_dict_result_raises_value_error(self) -> None:
+        backend = _make_backend()
+        backend.stdout = cast(Any, _reader(_line(
+            {"id": backend_mod._GATEWAY_INIT_ID, "result": "nope"})))
+        with pytest.raises(ValueError, match="missing/non-dict result"):
+            await send_initialize(backend, timeout=5)
+
+    @pytest.mark.asyncio
+    async def test_eof_before_response_raises_value_error(self) -> None:
+        backend = _make_backend()
+        backend.stdout = cast(Any, _reader(b'{"partial"'))
+        with pytest.raises(ValueError, match="closed stdout before initialize response"):
+            await send_initialize(backend, timeout=5)
+
+
+# --- Low-level helpers ------------------------------------------------------
+
+
+class TestWriteJsonLine:
+    @pytest.mark.asyncio
+    async def test_serialises_one_newline_terminated_frame(self) -> None:
+        writer = MagicMock()
+        writer.drain = AsyncMock()
+        await _write_json_line(cast(Any, writer), {"a": 1})
+        assert writer.write.call_args.args[0] == b'{"a":1}\n'
+        writer.drain.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_per_backend_lock_is_used_when_present(self) -> None:
+        backend = _make_backend()
+        lock = getattr(backend.stdin, "_mc_write_lock")
+        assert isinstance(lock, asyncio.Lock)
+        await _write_json_line(backend.stdin, {"a": 1})
+        assert not lock.locked()
+
+    @pytest.mark.asyncio
+    async def test_drain_timeout_surfaces_as_broken_pipe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(backend_mod, "_WRITE_DRAIN_TIMEOUT_SECS", 0)
+        writer = MagicMock()
+
+        async def _slow_drain() -> None:
+            await asyncio.sleep(3600)
+
+        writer.drain = _slow_drain
+        with pytest.raises(BrokenPipeError, match="drain timed out"):
+            await _write_json_line(cast(Any, writer), {"a": 1})
+
+
+class TestPumpStderr:
+    @pytest.mark.asyncio
+    async def test_drains_until_eof(self) -> None:
+        reader = _reader(b"line one\nline two\n")
+        await _pump_stderr(reader, "kirocrew:example-mcp")
+        assert reader.at_eof()
+
+    @pytest.mark.asyncio
+    async def test_oversize_line_skipped_without_wedging(self) -> None:
+        reader = _reader(b"x" * 400 + b"\n" + b"short\n", limit=32)
+        await _pump_stderr(reader, "kirocrew:example-mcp")
+        assert reader.at_eof()
+
+    @pytest.mark.asyncio
+    async def test_reader_error_ends_the_pump(self) -> None:
+        reader = MagicMock()
+        reader.readline = AsyncMock(side_effect=RuntimeError("closed"))
+        await _pump_stderr(cast(Any, reader), "label")
+
+
+class TestCallMetrics:
+    @pytest.mark.asyncio
+    async def test_disabled_metrics_write_nothing(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(backend_mod, "_METRICS_PATH", None)
+        await backend_mod._emit_call_metric({"method": "tools/call"})
+        assert list(tmp_path.iterdir()) == []
+        backend = _make_backend()
+        backend._spawn_metric_task({"method": "tools/call"})
+        assert backend._metric_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_enabled_metrics_append_one_json_line_per_call(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = tmp_path / "calls.jsonl"
+        monkeypatch.setattr(backend_mod, "_METRICS_PATH", str(path))
+        await backend_mod._emit_call_metric({"method": "tools/call", "dur_ms": 1.5})
+        await backend_mod._emit_call_metric({"method": "tools/list", "dur_ms": 2.5})
+        lines = path.read_text(encoding="utf-8").strip().splitlines()
+        assert [json.loads(line)["method"] for line in lines] == [
+            "tools/call", "tools/list"]
+
+    def test_unwritable_path_is_silently_dropped(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A directory can never be opened for append -> OSError -> swallowed.
+        monkeypatch.setattr(backend_mod, "_METRICS_PATH", str(tmp_path))
+        backend_mod._write_metric_line({"method": "tools/call"})
+
+    def test_write_metric_line_returns_early_when_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(backend_mod, "_METRICS_PATH", None)
+        backend_mod._write_metric_line({"method": "tools/call"})
+
+    @pytest.mark.asyncio
+    async def test_spawn_metric_task_is_tracked_then_discarded(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = tmp_path / "calls.jsonl"
+        monkeypatch.setattr(backend_mod, "_METRICS_PATH", str(path))
+        backend = _make_backend()
+        backend._spawn_metric_task({"method": "ping"})
+        assert len(backend._metric_tasks) == 1
+        await _settle(backend)
+        assert backend._metric_tasks == set()
+        assert json.loads(path.read_text(encoding="utf-8").strip())["method"] == "ping"

--- a/test/test_platform_compat_coverage.py
+++ b/test/test_platform_compat_coverage.py
@@ -1,0 +1,2892 @@
+"""Coverage-raising unit tests for :mod:`kiro_crew.platform_compat`.
+
+Companion to ``test_platform_compat.py``, which covers the POSIX-native surface
+and the process-session contracts that need a real process. This file targets
+the branches that the host platform alone never reaches on the Linux CI fleet:
+
+* the Windows ``ctypes``/``msvcrt`` paths, exercised by flipping ``IS_WINDOWS``
+  and standing in for the DLL entry points (the same technique the sibling file
+  already uses for the Toolhelp snapshot),
+* the macOS ``libproc`` paths, exercised by faking ``ctypes.CDLL``,
+* the macOS TCC walk-pruning rules,
+* the failure/degradation paths of the ``/proc`` readers.
+
+No test here spawns a process, touches the network, or writes outside
+``tmp_path``; every clock the product consults is replaced with a fake, so
+nothing depends on wall time or on execution order.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ctypes
+import datetime
+import errno
+import io
+import logging
+import os
+import subprocess
+import sys
+import types
+from typing import Any, Callable
+
+import pytest
+
+from kiro_crew import platform_compat as pc
+
+# Some tests below simulate the POSIX branch (forcing ``IS_POSIX = True``) or the
+# Windows branch from a POSIX host, by monkeypatching attributes that only exist
+# on one platform -- ``os.getpgid`` / ``os.killpg`` are absent on Windows, so
+# ``monkeypatch.setattr`` itself raises there before the assertion runs.
+#
+# Skipping them on Windows costs ZERO coverage: ci.yml measures coverage on the
+# ubuntu 3.12 shards only (the Windows lane runs --no-cov), so these lines are
+# already counted on the lane that reports the number. Simulating the other
+# platform's branch is only meaningful from the host that isn't that platform.
+_POSIX_ONLY = pytest.mark.skipif(
+    os.name == "nt",
+    reason="simulates a platform branch via attributes absent on Windows; "
+    "coverage is measured on the ubuntu 3.12 shards, so this loses none",
+)
+
+# Applied to the WHOLE module, deliberately.
+#
+# This file's method is to simulate BOTH platform branches from one host: it
+# flips ``IS_POSIX`` / ``IS_WINDOWS`` and monkeypatches ``os.getuid``,
+# ``os.getpgid``, ``os.killpg``, ``os.fchmod``, ``/proc/locks`` reads and the
+# Windows ``icacls`` subprocess. On real Windows those attributes do not exist
+# (so ``monkeypatch.setattr`` raises before any assertion) and the faked
+# branches diverge from what the OS actually does -- which produced 13 failures
+# across two CI rounds in TestFlockOwnerPid, TestRestrictToOwner,
+# TestChmodHelpers and TestCurrentUserSid. Fixing them one at a time was
+# whack-a-mole; the property under test is platform-independent logic, so the
+# honest fix is to run the simulation only from the host it is written for.
+#
+# This costs ZERO coverage: ci.yml measures coverage on the ubuntu 3.12 shards
+# only (the Windows lane runs --no-cov), so every line here is still counted on
+# the lane that reports the number.
+pytestmark = _POSIX_ONLY
+
+# ---------------------------------------------------------------------------
+# Windows / macOS fakes
+# ---------------------------------------------------------------------------
+
+
+class _Fn:
+    """Stand-in for a ctypes function pointer.
+
+    The product assigns ``argtypes``/``restype`` on every entry point before
+    calling it, so a plain lambda will not do — the attributes must be
+    assignable. Declaring them on the class lets the assignment shadow them per
+    instance exactly as ctypes would.
+    """
+
+    argtypes: list = []
+    restype: Any = None
+
+    def __init__(self, impl: Callable[..., Any]) -> None:
+        self._impl = impl
+
+    def __call__(self, *args: Any) -> Any:
+        return self._impl(*args)
+
+
+def _const(value: Any) -> _Fn:
+    """A fake entry point that ignores its arguments and returns *value*."""
+
+    return _Fn(lambda *_args: value)
+
+
+def _fake_windows(monkeypatch: pytest.MonkeyPatch, **dlls: Any) -> None:
+    """Pretend to be Windows, resolving *dlls* by name for both load styles.
+
+    ``platform_compat`` reaches Win32 two ways — ``ctypes.windll.<name>`` and
+    ``ctypes.WinDLL("<name>", use_last_error=True)`` — and neither attribute
+    exists on POSIX, hence ``raising=False``.
+    """
+
+    monkeypatch.setattr(pc, "IS_WINDOWS", True)
+    monkeypatch.setattr(pc, "IS_POSIX", False)
+    namespace = types.SimpleNamespace(**dlls)
+    monkeypatch.setattr(pc.ctypes, "windll", namespace, raising=False)
+    monkeypatch.setattr(
+        pc.ctypes,
+        "WinDLL",
+        lambda name, **_kwargs: getattr(namespace, str(name)),
+        raising=False,
+    )
+
+
+def _fake_clock(monkeypatch: pytest.MonkeyPatch, ticks: list[float]) -> list[float]:
+    """Replace ``platform_compat``'s ``time`` module with a scripted clock.
+
+    Only the module-level reference in ``platform_compat`` is swapped, so the
+    real :mod:`time` is untouched for everything else in the process. Returns
+    the list that records each faked sleep, so a test can assert the product
+    slept rather than busy-spun without ever sleeping for real.
+    """
+
+    slept: list[float] = []
+    reads = iter(ticks)
+    last: list[float] = [ticks[-1] if ticks else 0.0]
+
+    def _monotonic() -> float:
+        last[0] = next(reads, last[0])
+        return last[0]
+
+    monkeypatch.setattr(
+        pc,
+        "time",
+        types.SimpleNamespace(monotonic=_monotonic, sleep=slept.append),
+    )
+    return slept
+
+
+class _FakeMsvcrt:
+    """Minimal ``msvcrt`` stand-in: ``locking`` replays scripted outcomes."""
+
+    LK_NBLCK = 1
+    LK_UNLCK = 0
+
+    def __init__(self, outcomes: list[bool]) -> None:
+        self._outcomes = list(outcomes)
+        self.calls: list[int] = []
+
+    def locking(self, _fd: int, mode: int, _nbytes: int) -> None:
+        self.calls.append(mode)
+        if mode == self.LK_UNLCK:
+            return
+        allowed = self._outcomes.pop(0) if self._outcomes else True
+        if not allowed:
+            raise OSError(13, "locked")
+
+
+# ---------------------------------------------------------------------------
+# macOS TCC walk pruning
+# ---------------------------------------------------------------------------
+
+
+class TestTccWalkPruning:
+    """The home-rooted walk must prune TCC-gated folders, and only those."""
+
+    @staticmethod
+    def _as_macos(monkeypatch: pytest.MonkeyPatch, home: str) -> None:
+        monkeypatch.setattr(pc, "IS_MACOS", True)
+        monkeypatch.setattr(pc.os.path, "expanduser", lambda _p: home)
+
+    def test_no_pruning_off_macos(self, monkeypatch, tmp_path):
+        # Linux/Windows have no TCC, so the set is empty and a walk is untouched.
+        monkeypatch.setattr(pc, "IS_MACOS", False)
+        assert pc.tcc_protected_dirs_for_walk(str(tmp_path)) == frozenset()
+        names = ["Downloads", "src"]
+        assert pc.tcc_prune_walk_dirs(str(tmp_path), str(tmp_path), names) == names
+
+    def test_home_root_reports_the_gated_names(self, monkeypatch, tmp_path):
+        self._as_macos(monkeypatch, str(tmp_path))
+        assert pc.tcc_protected_dirs_for_walk(str(tmp_path)) == pc.TCC_PROTECTED_HOME_DIRS
+
+    def test_explicitly_scoped_root_is_never_pruned(self, monkeypatch, tmp_path):
+        # A walk the user rooted at ~/Downloads must still see its contents.
+        home = tmp_path / "home"
+        scoped = home / "Downloads"
+        scoped.mkdir(parents=True)
+        self._as_macos(monkeypatch, str(home))
+        assert pc.tcc_protected_dirs_for_walk(str(scoped)) == frozenset()
+
+    def test_unresolvable_root_prunes_nothing(self, monkeypatch):
+        # realpath raises ValueError on a NUL byte (not an OSError subclass) —
+        # it must be swallowed, not escape and 500 the file-search request.
+        self._as_macos(monkeypatch, "/home/u")
+
+        def _boom(_path: Any) -> str:
+            raise ValueError("embedded null byte")
+
+        monkeypatch.setattr(pc.os.path, "realpath", _boom)
+        assert pc.tcc_protected_dirs_for_walk("/home/u") == frozenset()
+
+    def test_root_position_drops_gated_folders_but_keeps_library(self, monkeypatch, tmp_path):
+        self._as_macos(monkeypatch, str(tmp_path))
+        root = str(tmp_path)
+        kept = pc.tcc_prune_walk_dirs(root, root, ["Downloads", "Desktop", "Library", "code"])
+        # Library survives so the walk can descend to the cloud mounts below it.
+        assert kept == ["Library", "code"]
+
+    def test_library_position_keeps_only_the_cloud_mounts(self, monkeypatch, tmp_path):
+        self._as_macos(monkeypatch, str(tmp_path))
+        root = str(tmp_path)
+        library = os.path.join(root, "Library")
+        kept = pc.tcc_prune_walk_dirs(
+            root, library, ["Mail", "Safari", "CloudStorage", "Mobile Documents"]
+        )
+        assert sorted(kept) == ["CloudStorage", "Mobile Documents"]
+
+    def test_deeper_positions_are_untouched(self, monkeypatch, tmp_path):
+        # A project's own Documents/ deeper in the tree is not TCC-gated.
+        self._as_macos(monkeypatch, str(tmp_path))
+        root = str(tmp_path)
+        deep = os.path.join(root, "code", "proj")
+        names = ["Documents", "Downloads"]
+        assert pc.tcc_prune_walk_dirs(root, deep, names) == names
+
+    def test_non_home_root_at_root_position_prunes_nothing(self, monkeypatch, tmp_path):
+        self._as_macos(monkeypatch, str(tmp_path / "elsewhere"))
+        root = str(tmp_path)
+        names = ["Downloads", "code"]
+        assert pc.tcc_prune_walk_dirs(root, root, names) == names
+
+
+# ---------------------------------------------------------------------------
+# Windows console encoding
+# ---------------------------------------------------------------------------
+
+
+class _ReconfigurableStream:
+    def __init__(self, encoding: str, *, reconfigure_to: str | None = None) -> None:
+        self.encoding = encoding
+        self._to = reconfigure_to
+        self.buffer = io.BytesIO()
+        self.reconfigured: list[tuple[str, str]] = []
+
+    def reconfigure(self, *, encoding: str, errors: str) -> None:
+        self.reconfigured.append((encoding, errors))
+        if self._to is not None:
+            self.encoding = self._to
+
+
+class _StubbornStream:
+    """A stream whose ``reconfigure`` is refused, as seen in the 3-layer spawn."""
+
+    encoding = "cp1252"
+
+    def __init__(self, *, with_buffer: bool = True) -> None:
+        self.buffer: Any = io.BytesIO() if with_buffer else None
+
+    def reconfigure(self, **_kwargs: Any) -> None:
+        raise ValueError("cannot reconfigure a detached stream")
+
+
+class TestEnsureUtf8Console:
+    def test_noop_off_windows(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        before = sys.stdout
+        pc.ensure_utf8_console()
+        assert sys.stdout is before
+
+    def test_reconfigure_in_place_is_preferred(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        out = _ReconfigurableStream("cp1252", reconfigure_to="utf-8")
+        err = _ReconfigurableStream("cp1252", reconfigure_to="UTF-8")
+        monkeypatch.setattr(pc.sys, "stdout", out)
+        monkeypatch.setattr(pc.sys, "stderr", err)
+
+        pc.ensure_utf8_console()
+
+        assert out.reconfigured == [("utf-8", "backslashreplace")]
+        # Reconfigure reported UTF-8, so the stream object is kept as-is.
+        assert sys.stdout is out
+        assert sys.stderr is err
+
+    def test_falls_back_to_wrapping_the_binary_buffer(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        out = _StubbornStream()
+        monkeypatch.setattr(pc.sys, "stdout", out)
+        monkeypatch.setattr(pc.sys, "stderr", _StubbornStream(with_buffer=False))
+
+        pc.ensure_utf8_console()
+
+        assert isinstance(sys.stdout, io.TextIOWrapper)
+        assert (sys.stdout.encoding or "").lower() == "utf-8"
+        # No buffer to wrap on stderr, so it is left untouched rather than lost.
+        assert sys.stderr is not None
+
+    def test_reconfigure_that_does_not_take_still_wraps(self, monkeypatch):
+        # reconfigure() succeeds but the encoding stays cp1252 — the wrap must
+        # still run, otherwise the first emoji print kills the gateway.
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        out = _ReconfigurableStream("cp1252")
+        monkeypatch.setattr(pc.sys, "stdout", out)
+        monkeypatch.setattr(pc.sys, "stderr", out)
+
+        pc.ensure_utf8_console()
+
+        assert isinstance(sys.stdout, io.TextIOWrapper)
+
+    def test_absent_stream_is_skipped(self, monkeypatch):
+        # pythonw / fully detached: sys.stdout is None and must not AttributeError.
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc.sys, "stdout", None)
+        monkeypatch.setattr(pc.sys, "stderr", None)
+        pc.ensure_utf8_console()  # no exception = pass
+
+
+# ---------------------------------------------------------------------------
+# Windows locking
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsLocking:
+    def test_acquire_takes_a_free_lock_on_the_first_try(self, monkeypatch, tmp_path):
+        fake = _FakeMsvcrt([True])
+        _fake_windows(monkeypatch)
+        monkeypatch.setattr(pc, "msvcrt", fake, raising=False)
+        _fake_clock(monkeypatch, [0.0])
+        lock = tmp_path / "a.lock"
+        lock.write_text("")
+        with open(lock, "r+") as handle:
+            assert pc._win_acquire_blocking(handle.fileno()) is True
+        assert fake.calls == [_FakeMsvcrt.LK_NBLCK]
+
+    def test_acquire_polls_until_the_holder_releases(self, monkeypatch, tmp_path):
+        # A contended fd must be waited out, not raced — and the wait must be a
+        # sleep, not a spin. The clock is fake, so nothing sleeps for real.
+        fake = _FakeMsvcrt([False, False, True])
+        _fake_windows(monkeypatch)
+        monkeypatch.setattr(pc, "msvcrt", fake, raising=False)
+        slept = _fake_clock(monkeypatch, [0.0, 0.1, 0.2, 0.3])
+        lock = tmp_path / "b.lock"
+        lock.write_text("")
+        with open(lock, "r+") as handle:
+            assert pc._win_acquire_blocking(handle.fileno(), timeout=100.0) is True
+        assert slept == [pc._WIN_LOCK_POLL_SECS, pc._WIN_LOCK_POLL_SECS]
+
+    def test_acquire_gives_up_at_the_ceiling(self, monkeypatch, tmp_path):
+        fake = _FakeMsvcrt([False] * 5)
+        _fake_windows(monkeypatch)
+        monkeypatch.setattr(pc, "msvcrt", fake, raising=False)
+        _fake_clock(monkeypatch, [0.0, 999.0])
+        lock = tmp_path / "c.lock"
+        lock.write_text("")
+        with open(lock, "r+") as handle:
+            assert pc._win_acquire_blocking(handle.fileno(), timeout=1.0) is False
+
+    @pytest.mark.asyncio
+    async def test_acquire_is_single_shot_on_the_event_loop(self, monkeypatch, tmp_path):
+        # A spin-sleep on the loop thread would freeze chat/heartbeat, so the
+        # on-loop acquire must try exactly once and fail closed.
+        fake = _FakeMsvcrt([False])
+        _fake_windows(monkeypatch)
+        monkeypatch.setattr(pc, "msvcrt", fake, raising=False)
+        slept = _fake_clock(monkeypatch, [0.0])
+        lock = tmp_path / "d.lock"
+        lock.write_text("")
+        with open(lock, "r+") as handle:
+            assert pc._win_acquire_blocking(handle.fileno()) is False
+        assert slept == []
+        assert fake.calls == [_FakeMsvcrt.LK_NBLCK]
+
+    def test_file_lock_round_trips_and_unlocks(self, monkeypatch, tmp_path):
+        fake = _FakeMsvcrt([True])
+        _fake_windows(monkeypatch)
+        monkeypatch.setattr(pc, "msvcrt", fake, raising=False)
+        _fake_clock(monkeypatch, [0.0])
+        lock = tmp_path / "e.lock"
+        lock.write_text("")
+        ran = False
+        with open(lock, "r+") as handle:
+            with pc.file_lock(handle.fileno()):
+                ran = True
+        assert ran
+        assert fake.calls == [_FakeMsvcrt.LK_NBLCK, _FakeMsvcrt.LK_UNLCK]
+
+    def test_file_lock_fails_closed_when_the_lock_is_unreachable(self, monkeypatch, tmp_path):
+        # Entering the critical section unserialized is the fail-open that loses
+        # writes, so an unacquirable lock must raise instead.
+        _fake_windows(monkeypatch)
+        monkeypatch.setattr(pc, "_win_acquire_blocking", lambda *_a, **_k: False)
+        lock = tmp_path / "f.lock"
+        lock.write_text("")
+        with open(lock, "r+") as handle:
+            with pytest.raises(OSError, match="refusing to proceed unserialized"):
+                with pc.file_lock(handle.fileno()):
+                    pytest.fail("body must not run without the lock")
+
+    def test_acquire_lock_fails_closed(self, monkeypatch, tmp_path):
+        _fake_windows(monkeypatch)
+        monkeypatch.setattr(pc, "_win_acquire_blocking", lambda *_a, **_k: False)
+        monkeypatch.setattr(pc, "msvcrt", _FakeMsvcrt([]), raising=False)
+        lock = tmp_path / "g.lock"
+        lock.write_text("")
+        with open(lock, "r+") as handle:
+            with pytest.raises(OSError, match="refusing to proceed unserialized"):
+                pc.acquire_lock(handle.fileno())
+
+    def test_acquire_lock_succeeds_then_releases(self, monkeypatch, tmp_path):
+        fake = _FakeMsvcrt([True])
+        _fake_windows(monkeypatch)
+        monkeypatch.setattr(pc, "msvcrt", fake, raising=False)
+        _fake_clock(monkeypatch, [0.0])
+        lock = tmp_path / "h.lock"
+        lock.write_text("")
+        with open(lock, "r+") as handle:
+            pc.acquire_lock(handle.fileno())
+            pc.release_lock(handle.fileno())
+        assert fake.calls == [_FakeMsvcrt.LK_NBLCK, _FakeMsvcrt.LK_UNLCK]
+
+    def test_release_lock_swallows_an_unlock_error(self, monkeypatch, tmp_path):
+        class _Failing(_FakeMsvcrt):
+            def locking(self, _fd: int, mode: int, _nbytes: int) -> None:
+                raise OSError(13, "not locked")
+
+        _fake_windows(monkeypatch)
+        monkeypatch.setattr(pc, "msvcrt", _Failing([]), raising=False)
+        lock = tmp_path / "i.lock"
+        lock.write_text("")
+        with open(lock, "r+") as handle:
+            pc.release_lock(handle.fileno())  # must not raise
+
+    def test_try_acquire_lock_reports_both_outcomes(self, monkeypatch, tmp_path):
+        fake = _FakeMsvcrt([True, False])
+        _fake_windows(monkeypatch)
+        monkeypatch.setattr(pc, "msvcrt", fake, raising=False)
+        lock = tmp_path / "j.lock"
+        lock.write_text("")
+        with open(lock, "r+") as handle:
+            assert pc.try_acquire_lock(handle.fileno()) is True
+            assert pc.try_acquire_lock(handle.fileno()) is False
+
+
+# ---------------------------------------------------------------------------
+# get_ppid / get_process_start_id — macOS libproc and Windows Toolhelp
+# ---------------------------------------------------------------------------
+
+
+def _bsdinfo(ppid: int = 0, sec: int = 0, usec: int = 0) -> bytes:
+    """A synthetic ``struct proc_bsdinfo`` with the three fields we read."""
+
+    buf = bytearray(pc._DARWIN_BSDINFO_SIZE)
+    buf[16:20] = ppid.to_bytes(4, "little")
+    buf[pc._DARWIN_OFF_START_TVSEC : pc._DARWIN_OFF_START_TVSEC + 8] = sec.to_bytes(8, "little")
+    buf[pc._DARWIN_OFF_START_TVUSEC : pc._DARWIN_OFF_START_TVUSEC + 8] = usec.to_bytes(
+        8, "little"
+    )
+    return bytes(buf)
+
+
+def _fake_libproc(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    payload: bytes | None,
+    ret: int,
+    library: str | None = "libproc.dylib",
+) -> None:
+    """Pretend to be macOS with a ``libproc`` that answers ``proc_pidinfo``."""
+
+    monkeypatch.setattr(pc.sys, "platform", "darwin")
+    monkeypatch.setattr(pc.ctypes.util, "find_library", lambda _n: library)
+
+    def _proc_pidinfo(_pid: Any, _flavor: Any, _arg: Any, buf: Any, _size: Any) -> int:
+        if payload is not None:
+            ctypes.memmove(buf, payload, len(payload))
+        return ret
+
+    lib = types.SimpleNamespace(proc_pidinfo=_Fn(_proc_pidinfo))
+    monkeypatch.setattr(pc.ctypes, "CDLL", lambda _p: lib)
+
+
+def _toolhelp_kernel32(entries: list[tuple[int, int, bytes]], *, snapshot: Any = 123) -> Any:
+    """A kernel32 whose process snapshot replays *entries* (pid, ppid, image)."""
+
+    remaining = list(entries)
+
+    def _fill(entry: Any) -> bool:
+        if not remaining:
+            return False
+        pid, ppid, image = remaining.pop(0)
+        entry._obj.th32ProcessID = pid
+        entry._obj.th32ParentProcessID = ppid
+        entry._obj.szExeFile = image
+        return True
+
+    return types.SimpleNamespace(
+        CreateToolhelp32Snapshot=_const(snapshot),
+        Process32First=_Fn(lambda _snap, entry: _fill(entry)),
+        Process32Next=_Fn(lambda _snap, entry: _fill(entry)),
+        CloseHandle=_const(True),
+    )
+
+
+class TestGetPpid:
+    def test_macos_returns_the_ppid_from_libproc(self, monkeypatch):
+        _fake_libproc(monkeypatch, payload=_bsdinfo(ppid=4321), ret=136)
+        assert pc.get_ppid(99) == 4321
+
+    def test_macos_without_libproc_reports_failure(self, monkeypatch):
+        _fake_libproc(monkeypatch, payload=None, ret=136, library=None)
+        assert pc.get_ppid(99) == -1
+
+    def test_macos_reports_failure_when_the_call_returns_nothing(self, monkeypatch):
+        _fake_libproc(monkeypatch, payload=None, ret=0)
+        assert pc.get_ppid(99) == -1
+
+    def test_macos_swallows_a_loader_error(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc.ctypes.util, "find_library", lambda _n: "libproc.dylib")
+
+        def _boom(_path: Any) -> Any:
+            raise OSError("cannot load")
+
+        monkeypatch.setattr(pc.ctypes, "CDLL", _boom)
+        assert pc.get_ppid(99) == -1
+
+    def test_unknown_platform_reports_failure(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "aix")
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc.get_ppid(99) == -1
+
+    def test_windows_walks_the_snapshot_to_the_matching_pid(self, monkeypatch):
+        kernel32 = _toolhelp_kernel32([(1, 0, b"a.exe"), (77, 42, b"b.exe")])
+        _fake_windows(monkeypatch, kernel32=kernel32)
+        monkeypatch.setattr(pc.sys, "platform", "win32")
+        assert pc.get_ppid(77) == 42
+
+    def test_windows_reports_failure_when_the_pid_is_absent(self, monkeypatch):
+        kernel32 = _toolhelp_kernel32([(1, 0, b"a.exe")])
+        _fake_windows(monkeypatch, kernel32=kernel32)
+        monkeypatch.setattr(pc.sys, "platform", "win32")
+        assert pc.get_ppid(999) == -1
+
+    def test_windows_reports_failure_on_an_invalid_snapshot(self, monkeypatch):
+        invalid = pc.wintypes.HANDLE(-1).value
+        kernel32 = _toolhelp_kernel32([], snapshot=invalid)
+        _fake_windows(monkeypatch, kernel32=kernel32)
+        monkeypatch.setattr(pc.sys, "platform", "win32")
+        assert pc.get_ppid(1) == -1
+
+    def test_windows_reports_failure_when_enumeration_cannot_start(self, monkeypatch):
+        kernel32 = _toolhelp_kernel32([])
+        _fake_windows(monkeypatch, kernel32=kernel32)
+        monkeypatch.setattr(pc.sys, "platform", "win32")
+        assert pc.get_ppid(1) == -1
+
+
+class TestGetProcessStartId:
+    def test_macos_formats_seconds_and_microseconds(self, monkeypatch):
+        _fake_libproc(monkeypatch, payload=_bsdinfo(sec=1700000000, usec=42), ret=136)
+        # Microsecond resolution is the point: two processes started in the same
+        # second must not alias onto one identity.
+        assert pc.get_process_start_id(5) == "1700000000.000042"
+
+    def test_macos_treats_a_zero_start_time_as_unknown(self, monkeypatch):
+        _fake_libproc(monkeypatch, payload=_bsdinfo(sec=0, usec=7), ret=136)
+        assert pc.get_process_start_id(5) is None
+
+    def test_macos_without_libproc_is_unknown(self, monkeypatch):
+        _fake_libproc(monkeypatch, payload=None, ret=136, library=None)
+        assert pc.get_process_start_id(5) is None
+
+    def test_macos_failed_call_is_unknown(self, monkeypatch):
+        _fake_libproc(monkeypatch, payload=None, ret=-1)
+        assert pc.get_process_start_id(5) is None
+
+    def test_windows_is_unknown_rather_than_a_mismatch(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "win32")
+        assert pc.get_process_start_id(5) is None
+
+    def test_identity_never_contains_a_colon(self, monkeypatch):
+        # Callers embed the value in colon-delimited records.
+        _fake_libproc(monkeypatch, payload=_bsdinfo(sec=17, usec=1), ret=136)
+        value = pc.get_process_start_id(5)
+        assert value is not None and ":" not in value
+
+
+# ---------------------------------------------------------------------------
+# Trusted system-binary resolution
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsSystemDirs:
+    def test_api_directory_leads_and_powershell_is_appended_per_root(self, monkeypatch):
+        def _get_system_directory(buf: Any, _size: Any) -> int:
+            buf.value = r"C:\Windows\system32"
+            return len(buf.value)
+
+        kernel32 = types.SimpleNamespace(GetSystemDirectoryW=_get_system_directory)
+        _fake_windows(monkeypatch, kernel32=kernel32)
+        monkeypatch.setitem(os.environ, "SystemRoot", r"C:\Windows")
+
+        dirs = pc._windows_system_dirs()
+
+        assert dirs[0] == r"C:\Windows\system32"
+        # The conventionally-cased hardcoded fallback names the same directory as
+        # the API answer and must be deduped case-insensitively, not probed twice.
+        assert r"C:\Windows\System32" not in dirs
+        assert any(d.endswith(os.path.join("WindowsPowerShell", "v1.0")) for d in dirs)
+
+    def test_falls_back_when_the_api_call_fails(self, monkeypatch):
+        def _boom(_buf: Any, _size: Any) -> int:
+            raise OSError("no such entry point")
+
+        kernel32 = types.SimpleNamespace(GetSystemDirectoryW=_boom)
+        _fake_windows(monkeypatch, kernel32=kernel32)
+        monkeypatch.setitem(os.environ, "SystemRoot", r"D:\Win")
+
+        dirs = pc._windows_system_dirs()
+
+        assert dirs[0] == os.path.join(r"D:\Win", "System32")
+        assert r"C:\Windows\System32" in dirs
+
+    def test_api_overflow_is_ignored(self, monkeypatch):
+        # A written length at or past the buffer size means truncation; the
+        # value must not be trusted.
+        kernel32 = types.SimpleNamespace(GetSystemDirectoryW=_const(10_000))
+        _fake_windows(monkeypatch, kernel32=kernel32)
+        dirs = pc._windows_system_dirs()
+        assert all("system32" not in d for d in dirs)
+
+
+class TestUnpinnedToolDiagnostic:
+    def test_silent_when_the_tool_is_not_installed_anywhere(self, monkeypatch, caplog):
+        monkeypatch.setattr(pc, "_UNPINNED_TOOL_PROBED", set())
+        monkeypatch.setattr(pc.shutil, "which", lambda _n: None)
+        with caplog.at_level(logging.WARNING, logger=pc.logger.name):
+            pc._log_tool_outside_trusted_dirs("lsof", ("/usr/bin",))
+        assert caplog.records == []
+
+    def test_warns_once_when_the_pin_is_what_hid_a_present_tool(self, monkeypatch, caplog):
+        monkeypatch.setattr(pc, "_UNPINNED_TOOL_PROBED", set())
+        monkeypatch.setattr(pc.shutil, "which", lambda _n: "/run/current-system/sw/bin/lsof")
+        with caplog.at_level(logging.WARNING, logger=pc.logger.name):
+            pc._log_tool_outside_trusted_dirs("lsof", ("/usr/bin",))
+            pc._log_tool_outside_trusted_dirs("lsof", ("/usr/bin",))
+        assert len(caplog.records) == 1
+        assert "/run/current-system/sw/bin/lsof" in caplog.records[0].getMessage()
+
+    def test_an_unresolvable_tool_is_none_and_diagnosed(self, monkeypatch):
+        # The pin decides; the miss is reported so the answer can be explained.
+        monkeypatch.setattr(pc, "_UNPINNED_TOOL_PROBED", set())
+        monkeypatch.setattr(pc.shutil, "which", lambda _n: None)
+        assert pc.trusted_system_bin("kirocrew-no-such-tool") is None
+
+    def test_tool_outside_trusted_dirs_is_none_when_the_pin_resolved(self, monkeypatch):
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: "/usr/bin/lsof")
+        assert pc.tool_outside_trusted_dirs("lsof") is None
+
+    def test_tool_outside_trusted_dirs_reports_the_path_lookup(self, monkeypatch):
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: None)
+        monkeypatch.setattr(pc.shutil, "which", lambda _n: "/opt/brew/bin/lsof")
+        assert pc.tool_outside_trusted_dirs("lsof") == "/opt/brew/bin/lsof"
+
+
+# ---------------------------------------------------------------------------
+# Windows process handles
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsHandleAcquisition:
+    """Opening, duplicating and closing identity-stable process handles."""
+
+    def test_open_handle_is_none_off_windows(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc._open_process_termination_handle(500) is None
+
+    def test_open_handle_returns_the_opened_handle(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=types.SimpleNamespace(OpenProcess=_const(4321)))
+        assert pc._open_process_termination_handle(500) == 4321
+
+    def test_open_handle_is_none_when_the_open_fails(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=types.SimpleNamespace(OpenProcess=_const(0)))
+        assert pc._open_process_termination_handle(500) is None
+
+    def test_open_handle_is_none_on_a_loader_failure(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.delattr(pc.ctypes, "WinDLL", raising=False)
+        assert pc._open_process_termination_handle(500) is None
+
+    def test_last_error_is_zero_without_the_windows_only_getter(self, monkeypatch):
+        # ctypes.get_last_error does not exist on POSIX; the helper must not
+        # assume it does.
+        monkeypatch.delattr(pc.ctypes, "get_last_error", raising=False)
+        assert pc._windows_last_error() == 0
+
+    def test_last_error_reads_the_thread_local_code(self, monkeypatch):
+        monkeypatch.setattr(pc.ctypes, "get_last_error", lambda: 5, raising=False)
+        assert pc._windows_last_error() == 5
+
+    @staticmethod
+    def _asyncio_process(handle: Any) -> Any:
+        popen = types.SimpleNamespace(_handle=handle)
+        transport = types.SimpleNamespace(get_extra_info=lambda _key: popen)
+        return types.SimpleNamespace(_transport=transport)
+
+    @staticmethod
+    def _duplicating_kernel32(*, ok: bool = True, out: int = 8899) -> Any:
+        def _duplicate(
+            _owner: Any,
+            _source: Any,
+            _target: Any,
+            duplicate: Any,
+            _options: Any,
+            _inherit: Any,
+            _access: Any,
+        ) -> int:
+            duplicate._obj.value = out
+            return 1 if ok else 0
+
+        return types.SimpleNamespace(
+            GetCurrentProcess=_const(1),
+            DuplicateHandle=_Fn(_duplicate),
+        )
+
+    def test_duplicate_is_none_off_windows(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc.duplicate_asyncio_process_handle(self._asyncio_process(1234)) is None
+
+    def test_duplicate_returns_the_new_handle(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=self._duplicating_kernel32())
+        assert pc.duplicate_asyncio_process_handle(self._asyncio_process(1234)) == 8899
+
+    def test_duplicate_is_none_without_an_underlying_popen_handle(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=self._duplicating_kernel32())
+        # A transport that exposes no subprocess yields no source handle.
+        bare = types.SimpleNamespace(_transport=None)
+        assert pc.duplicate_asyncio_process_handle(bare) is None
+        assert pc.duplicate_asyncio_process_handle(self._asyncio_process(0)) is None
+
+    def test_duplicate_is_none_when_the_call_fails(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=self._duplicating_kernel32(ok=False))
+        assert pc.duplicate_asyncio_process_handle(self._asyncio_process(1234)) is None
+
+    def test_duplicate_is_none_when_the_result_is_empty(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=self._duplicating_kernel32(out=0))
+        assert pc.duplicate_asyncio_process_handle(self._asyncio_process(1234)) is None
+
+
+def _identity_kernel32(
+    *,
+    pid: int = 4242,
+    creation: int = 100,
+    exit_times: list[int] | None = None,
+    exit_code: int = 259,
+    times_ok: list[bool] | None = None,
+    exit_code_ok: bool = True,
+) -> Any:
+    """kernel32 fake for ``_windows_process_handle_identity``.
+
+    ``exit_times`` is replayed one entry per ``GetProcessTimes`` call, so a test
+    can script the exited-but-exit-FILETIME-unpublished window; ``times_ok``
+    scripts per-call success of the same function.
+    """
+
+    times = list(exit_times or [0])
+    oks = list(times_ok or [])
+
+    def _get_times(_handle: Any, creation_out: Any, exit_out: Any, _k: Any, _u: Any) -> int:
+        if oks and not oks.pop(0):
+            return 0
+        value = times.pop(0) if times else (exit_times or [0])[-1]
+        creation_out._obj.dwHighDateTime = creation >> 32
+        creation_out._obj.dwLowDateTime = creation & 0xFFFFFFFF
+        exit_out._obj.dwHighDateTime = value >> 32
+        exit_out._obj.dwLowDateTime = value & 0xFFFFFFFF
+        return 1
+
+    def _get_exit_code(_handle: Any, out: Any) -> int:
+        out._obj.value = exit_code
+        return 1 if exit_code_ok else 0
+
+    return types.SimpleNamespace(
+        GetProcessId=_const(pid),
+        GetProcessTimes=_Fn(_get_times),
+        GetExitCodeProcess=_Fn(_get_exit_code),
+    )
+
+
+class TestWindowsHandleIdentity:
+    """The PID-recycling guard: (pid, creation_time, exit_time) or nothing."""
+
+    def test_none_off_windows_or_for_an_invalid_handle(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc._windows_process_handle_identity(5) is None
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        assert pc._windows_process_handle_identity(0) is None
+        assert pc._windows_process_handle_identity(-1) is None
+
+    def test_a_live_process_has_no_exit_bound(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=_identity_kernel32())
+        assert pc._windows_process_handle_identity(5) == (4242, 100, None)
+
+    def test_an_exited_process_reports_its_exit_filetime(self, monkeypatch):
+        _fake_windows(
+            monkeypatch,
+            kernel32=_identity_kernel32(exit_code=0, exit_times=[777, 777]),
+        )
+        assert pc._windows_process_handle_identity(5) == (4242, 100, 777)
+
+    def test_an_implausible_pid_is_refused(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=_identity_kernel32(pid=1))
+        assert pc._windows_process_handle_identity(5) is None
+
+    def test_unreadable_times_are_refused(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=_identity_kernel32(times_ok=[False]))
+        assert pc._windows_process_handle_identity(5) is None
+
+    def test_an_unreadable_exit_code_is_refused(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=_identity_kernel32(exit_code_ok=False))
+        assert pc._windows_process_handle_identity(5) is None
+
+    def test_a_zero_creation_time_is_refused(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=_identity_kernel32(creation=0))
+        assert pc._windows_process_handle_identity(5) is None
+
+    def test_a_failed_reread_after_exit_is_refused(self, monkeypatch):
+        # The second read exists so the exit bound belongs to the terminated
+        # object; losing it must refuse rather than report a stale bound.
+        _fake_windows(
+            monkeypatch,
+            kernel32=_identity_kernel32(exit_code=0, times_ok=[True, False]),
+        )
+        assert pc._windows_process_handle_identity(5) is None
+
+    def test_it_waits_out_the_unpublished_exit_filetime_window(self, monkeypatch):
+        # GetExitCodeProcess reports the exit before the kernel publishes the
+        # exit FILETIME; refusing inside that window rejected healthy handles.
+        _fake_windows(
+            monkeypatch,
+            kernel32=_identity_kernel32(exit_code=0, exit_times=[0, 0, 555]),
+        )
+        slept = _fake_clock(monkeypatch, [0.0, 0.0, 0.0])
+        assert pc._windows_process_handle_identity(5) == (4242, 100, 555)
+        assert slept == [pc._WINDOWS_EXIT_FILETIME_POLL_SECS]
+
+    def test_it_gives_up_when_the_exit_filetime_never_publishes(self, monkeypatch):
+        # The recycling guard must not weaken into "assume it is fine".
+        _fake_windows(monkeypatch, kernel32=_identity_kernel32(exit_code=0, exit_times=[0]))
+        _fake_clock(monkeypatch, [0.0, 0.0, 99.0])
+        assert pc._windows_process_handle_identity(5) is None
+
+    def test_a_failed_read_inside_the_window_is_refused(self, monkeypatch):
+        _fake_windows(
+            monkeypatch,
+            kernel32=_identity_kernel32(
+                exit_code=0, exit_times=[0, 0], times_ok=[True, True, False]
+            ),
+        )
+        _fake_clock(monkeypatch, [0.0, 0.0, 0.0])
+        assert pc._windows_process_handle_identity(5) is None
+
+    def test_a_loader_failure_is_refused(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.delattr(pc.ctypes, "WinDLL", raising=False)
+        assert pc._windows_process_handle_identity(5) is None
+
+
+def _exit_code_kernel32(code: int, *, ok: bool = True, terminated: bool = True) -> Any:
+    def _get_exit_code(_handle: Any, out: Any) -> int:
+        out._obj.value = code
+        return 1 if ok else 0
+
+    return types.SimpleNamespace(
+        GetExitCodeProcess=_Fn(_get_exit_code),
+        TerminateProcess=_const(terminated),
+        CloseHandle=_const(True),
+    )
+
+
+class TestProcessHandles:
+    def test_terminate_rejects_an_invalid_handle(self):
+        with pytest.raises(ValueError):
+            pc.terminate_process_handle(0)
+        with pytest.raises(ValueError):
+            pc.process_handle_active(-1)
+
+    def test_handle_helpers_are_inert_off_windows(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc.terminate_process_handle(5) is False
+        assert pc.process_handle_active(5) is False
+        pc.close_process_handle(5)  # no-op, must not raise
+
+    def test_terminate_kills_a_still_active_process(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=_exit_code_kernel32(259))
+        assert pc.terminate_process_handle(9) is True
+
+    def test_terminate_reports_false_for_an_already_exited_process(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=_exit_code_kernel32(0))
+        assert pc.terminate_process_handle(9) is False
+
+    def test_terminate_raises_when_the_exit_code_cannot_be_read(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=_exit_code_kernel32(259, ok=False))
+        with pytest.raises(OSError, match="GetExitCodeProcess"):
+            pc.terminate_process_handle(9)
+
+    def test_terminate_raises_when_the_kill_itself_fails(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=_exit_code_kernel32(259, terminated=False))
+        with pytest.raises(OSError, match="TerminateProcess"):
+            pc.terminate_process_handle(9)
+
+    def test_active_is_true_only_for_still_active(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=_exit_code_kernel32(259))
+        assert pc.process_handle_active(9) is True
+        _fake_windows(monkeypatch, kernel32=_exit_code_kernel32(1))
+        assert pc.process_handle_active(9) is False
+
+    def test_active_degrades_to_false_on_a_loader_failure(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.delattr(pc.ctypes, "WinDLL", raising=False)
+        assert pc.process_handle_active(9) is False
+
+    def test_close_handle_swallows_a_failure(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.delattr(pc.ctypes, "WinDLL", raising=False)
+        pc.close_process_handle(9)  # suppressed, must not raise
+
+
+class TestWindowsImageNameMatching:
+    def test_image_name_is_read_from_the_snapshot(self, monkeypatch):
+        kernel32 = _toolhelp_kernel32([(1, 0, b"init.exe"), (55, 1, b"kiro-cli.exe")])
+        _fake_windows(monkeypatch, kernel32=kernel32)
+        assert pc._win_process_image_name(55) == "kiro-cli.exe"
+
+    def test_image_name_is_none_when_the_pid_is_absent(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=_toolhelp_kernel32([(1, 0, b"init.exe")]))
+        assert pc._win_process_image_name(999) is None
+
+    def test_image_name_is_none_on_an_invalid_snapshot(self, monkeypatch):
+        invalid = pc.wintypes.HANDLE(-1).value
+        _fake_windows(monkeypatch, kernel32=_toolhelp_kernel32([], snapshot=invalid))
+        assert pc._win_process_image_name(1) is None
+
+    def test_image_name_is_none_when_enumeration_cannot_start(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=_toolhelp_kernel32([]))
+        assert pc._win_process_image_name(1) is None
+
+    def test_image_name_is_none_on_a_loader_failure(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc.ctypes, "windll", None, raising=False)
+        assert pc._win_process_image_name(1) is None
+
+    def test_process_matches_is_case_insensitive_on_windows(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc.sys, "platform", "win32")
+        monkeypatch.setattr(pc, "_win_process_image_name", lambda _pid: "Kiro-CLI.exe")
+        assert pc.process_matches(5, ("kiro-cli",)) is True
+        assert pc.process_matches(5, ("claude",)) is False
+
+    def test_process_matches_is_false_when_the_image_is_unknown(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc.sys, "platform", "win32")
+        monkeypatch.setattr(pc, "_win_process_image_name", lambda _pid: None)
+        assert pc.process_matches(5, ("kiro-cli",)) is False
+
+    def test_process_matches_uses_ps_on_macos(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: "/bin/ps")
+        monkeypatch.setattr(
+            pc.subprocess, "check_output", lambda *_a, **_k: b"/opt/kiro-cli --serve"
+        )
+        assert pc.process_matches(5, ("kiro-cli",)) is True
+
+    def test_process_matches_is_false_without_a_trusted_ps(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: None)
+        assert pc.process_matches(5, ("kiro-cli",)) is False
+
+    def test_process_matches_is_false_on_an_unknown_platform(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "aix")
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc.process_matches(5, ("kiro-cli",)) is False
+
+
+# ---------------------------------------------------------------------------
+# Command line / owner / liveness
+# ---------------------------------------------------------------------------
+
+
+class TestProcessCommandLine:
+    def test_macos_uses_ps(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: "/bin/ps")
+        monkeypatch.setattr(pc.subprocess, "check_output", lambda *_a, **_k: " kirocrew \n")
+        assert pc.process_command_line(5) == "kirocrew"
+
+    def test_macos_without_ps_is_empty(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: None)
+        assert pc.process_command_line(5) == ""
+
+    def test_windows_queries_wmi_through_powershell(self, monkeypatch):
+        seen: dict[str, Any] = {}
+
+        def _check_output(argv: Any, **kwargs: Any) -> str:
+            seen["argv"] = argv
+            seen["kwargs"] = kwargs
+            return "python.exe -m kiro_crew gateway\n"
+
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc.sys, "platform", "win32")
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: r"C:\ps.exe")
+        monkeypatch.setattr(pc.subprocess, "check_output", _check_output)
+
+        assert pc.process_command_line(7) == "python.exe -m kiro_crew gateway"
+        assert "-NoProfile" in seen["argv"]
+        assert "ProcessId=7" in " ".join(seen["argv"])
+        # A console-less parent must not flash a window per poll.
+        assert seen["kwargs"]["creationflags"] == pc._SUBPROCESS_NO_WINDOW
+
+    def test_windows_without_powershell_is_empty(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc.sys, "platform", "win32")
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: None)
+        assert pc.process_command_line(7) == ""
+
+    def test_a_spawn_failure_degrades_to_empty(self, monkeypatch):
+        def _boom(*_a: Any, **_k: Any) -> Any:
+            raise subprocess.SubprocessError("timeout")
+
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: "/bin/ps")
+        monkeypatch.setattr(pc.subprocess, "check_output", _boom)
+        assert pc.process_command_line(5) == ""
+
+    def test_unknown_platform_is_empty(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "aix")
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc.process_command_line(5) == ""
+
+
+class TestProcessOwnerUid:
+    def test_macos_parses_the_uid_from_ps(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: "/bin/ps")
+        monkeypatch.setattr(pc.subprocess, "check_output", lambda *_a, **_k: " 501 \n")
+        assert pc.process_owner_uid(5) == 501
+
+    def test_macos_non_numeric_output_is_unproven(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: "/bin/ps")
+        monkeypatch.setattr(pc.subprocess, "check_output", lambda *_a, **_k: "\n")
+        assert pc.process_owner_uid(5) is None
+
+    def test_macos_without_ps_is_unproven(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _n: None)
+        assert pc.process_owner_uid(5) is None
+
+    def test_windows_has_no_uid_concept(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "win32")
+        assert pc.process_owner_uid(5) is None
+
+
+class TestPidExistsWindows:
+    @staticmethod
+    def _kernel32(handle: int, code: int, *, got: bool = True) -> Any:
+        def _get_exit_code(_handle: Any, out: Any) -> int:
+            out._obj.value = code
+            return 1 if got else 0
+
+        return types.SimpleNamespace(
+            OpenProcess=_const(handle),
+            GetExitCodeProcess=_Fn(_get_exit_code),
+            CloseHandle=_const(True),
+        )
+
+    def test_still_active_exists(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=self._kernel32(42, 259))
+        assert pc.pid_exists(7) is True
+
+    def test_a_defunct_handle_to_a_dead_pid_does_not_exist(self, monkeypatch):
+        # OpenProcess succeeds while asyncio's Proactor transport still holds a
+        # duplicated handle; without the exit-code confirmation every recycle
+        # logged a false "PID survived kill".
+        _fake_windows(monkeypatch, kernel32=self._kernel32(42, 0))
+        assert pc.pid_exists(7) is False
+
+    def test_an_unreadable_exit_code_is_treated_as_alive(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=self._kernel32(42, 0, got=False))
+        assert pc.pid_exists(7) is True
+
+    def test_a_failed_open_reports_absent_on_linux_ctypes(self, monkeypatch):
+        # ctypes.get_last_error is Windows-only, so the ERROR_ACCESS_DENIED
+        # probe degrades to "absent" rather than raising.
+        _fake_windows(monkeypatch, kernel32=self._kernel32(0, 0))
+        monkeypatch.delattr(pc.ctypes, "get_last_error", raising=False)
+        assert pc.pid_exists(7) is False
+
+    def test_a_loader_failure_reports_absent(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.delattr(pc.ctypes, "WinDLL", raising=False)
+        assert pc.pid_exists(7) is False
+
+    def test_liveness_maps_windows_onto_two_states(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "pid_exists", lambda _pid: True)
+        assert pc.pid_liveness(7) == pc.PID_ALIVE
+        monkeypatch.setattr(pc, "pid_exists", lambda _pid: False)
+        assert pc.pid_liveness(7) == pc.PID_DEAD
+
+    def test_liveness_treats_an_unknown_errno_as_unsignalable(self, monkeypatch):
+        # Conservative by design: never prune or kill a PID we merely failed to
+        # probe for an unrecognised reason.
+        def _boom(_pid: int, _sig: int) -> None:
+            raise OSError(9999, "who knows")
+
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        monkeypatch.setattr(pc.os, "kill", _boom)
+        assert pc.pid_liveness(7) == pc.PID_UNSIGNALABLE
+
+
+# ---------------------------------------------------------------------------
+# /proc readers
+# ---------------------------------------------------------------------------
+
+
+_LINUX_ONLY = pytest.mark.skipif(
+    sys.platform != "linux", reason="reads Linux /proc; the shim returns None elsewhere"
+)
+
+
+class TestProcReaders:
+    def test_thread_count_is_unknown_off_linux(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        assert pc.process_thread_count(os.getpid()) is None
+
+    @_LINUX_ONLY
+    def test_thread_count_of_this_process_is_positive(self):
+        count = pc.process_thread_count(os.getpid())
+        assert count is not None and count >= 1
+
+    @_LINUX_ONLY
+    def test_thread_count_of_a_vanished_pid_is_unknown(self):
+        # A pid far above the default pid_max has no /proc entry.
+        assert pc.process_thread_count(2**30) is None
+
+    def test_parent_pid_is_unknown_off_linux(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "win32")
+        assert pc.parent_pid(os.getpid()) is None
+
+    @_LINUX_ONLY
+    def test_parent_pid_matches_the_real_ppid(self):
+        assert pc.parent_pid(os.getpid()) == os.getppid()
+
+    @_LINUX_ONLY
+    def test_parent_pid_of_a_vanished_pid_is_unknown(self):
+        assert pc.parent_pid(2**30) is None
+
+    def test_parent_pid_is_unknown_for_unparseable_stat(self, monkeypatch, tmp_path):
+        # No ')' at all means the comm field cannot be located.
+        stat_file = tmp_path / "stat"
+        stat_file.write_text("garbage without a paren")
+        monkeypatch.setattr(pc.sys, "platform", "linux")
+        monkeypatch.setattr(pc, "Path", lambda _p: stat_file)
+        assert pc.parent_pid(1) is None
+        assert pc.get_process_start_id(1) is None
+
+    def test_pids_holding_file_is_none_off_linux(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        assert pc.pids_holding_file(tmp_path) is None
+
+    @_LINUX_ONLY
+    def test_pids_holding_file_is_none_for_a_missing_path(self, tmp_path):
+        assert pc.pids_holding_file(tmp_path / "nope") is None
+
+    @_LINUX_ONLY
+    def test_pids_holding_file_finds_this_process(self, tmp_path):
+        target = tmp_path / "held"
+        target.write_text("x")
+        with open(target, "r"):
+            holders = pc.pids_holding_file(target)
+        assert holders is not None and os.getpid() in holders
+
+    @_LINUX_ONLY
+    def test_pids_holding_file_is_none_when_proc_is_unreadable(self, monkeypatch, tmp_path):
+        target = tmp_path / "held"
+        target.write_text("x")
+
+        def _boom(_path: Any) -> Any:
+            raise OSError("no /proc")
+
+        monkeypatch.setattr(pc.os, "listdir", _boom)
+        assert pc.pids_holding_file(target) is None
+
+
+def _locks_row(path: Any, pid: int) -> str:
+    """A ``/proc/locks`` FLOCK row whose device/inode triple matches *path*."""
+
+    info = os.stat(path)
+    return (
+        f"1: FLOCK ADVISORY WRITE {pid} "
+        f"{os.major(info.st_dev):02x}:{os.minor(info.st_dev):02x}:{info.st_ino} 0 EOF\n"
+    )
+
+
+def _fake_proc_locks(monkeypatch: pytest.MonkeyPatch, body: str) -> None:
+    """Serve *body* for ``/proc/locks`` and defer to the real ``open`` otherwise."""
+
+    real_open = open
+
+    def _open(path: Any, *args: Any, **kwargs: Any) -> Any:
+        if str(path) == "/proc/locks":
+            return io.StringIO(body)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(pc.sys, "platform", "linux")
+    monkeypatch.setattr(pc, "open", _open, raising=False)
+
+
+class TestFlockOwnerPid:
+    def test_none_off_linux(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        assert pc.flock_owner_pid(tmp_path) is None
+
+    def test_none_for_an_unstattable_path(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(pc.sys, "platform", "linux")
+        assert pc.flock_owner_pid(tmp_path / "missing") is None
+
+    def test_matching_triple_names_the_acquirer(self, monkeypatch, tmp_path):
+        lock = tmp_path / "gateway.lock"
+        lock.write_text("")
+        _fake_proc_locks(monkeypatch, _locks_row(lock, 39542))
+        assert pc.flock_owner_pid(lock) == 39542
+
+    def test_blocked_waiters_and_other_lock_types_are_skipped(self, monkeypatch, tmp_path):
+        lock = tmp_path / "gateway.lock"
+        lock.write_text("")
+        info = os.stat(lock)
+        triple = f"{os.major(info.st_dev):02x}:{os.minor(info.st_dev):02x}:{info.st_ino}"
+        body = (
+            f"1: -> FLOCK ADVISORY WRITE 111 {triple} 0 EOF\n"
+            f"2: POSIX ADVISORY WRITE 222 {triple} 0 EOF\n"
+            "3: short row\n"
+            f"4: FLOCK ADVISORY WRITE notanint {triple} 0 EOF\n" + _locks_row(lock, 333)
+        )
+        _fake_proc_locks(monkeypatch, body)
+        assert pc.flock_owner_pid(lock) == 333
+
+    def test_a_same_inode_lock_on_another_device_is_not_accepted(self, monkeypatch, tmp_path):
+        # Inode numbers are only unique within a filesystem; accepting a bare
+        # inode match would name a completely unrelated process.
+        lock = tmp_path / "gateway.lock"
+        lock.write_text("")
+        info = os.stat(lock)
+        body = f"1: FLOCK ADVISORY WRITE 777 fe:ff:{info.st_ino} 0 EOF\n"
+        _fake_proc_locks(monkeypatch, body)
+        assert pc.flock_owner_pid(lock) is None
+
+    def test_unreadable_proc_locks_is_none(self, monkeypatch, tmp_path):
+        lock = tmp_path / "gateway.lock"
+        lock.write_text("")
+
+        def _open(_path: Any, *_a: Any, **_k: Any) -> Any:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(pc.sys, "platform", "linux")
+        monkeypatch.setattr(pc, "open", _open, raising=False)
+        assert pc.flock_owner_pid(lock) is None
+
+
+# ---------------------------------------------------------------------------
+# Filesystem helpers
+# ---------------------------------------------------------------------------
+
+
+class TestRmtreeForce:
+    def test_removes_a_tree_containing_read_only_files(self, tmp_path):
+        # A git checkout is full of mode-444 loose objects, which Windows
+        # refuses to unlink; the helper must clear the bit and still succeed.
+        root = tmp_path / "tree"
+        (root / "objects").mkdir(parents=True)
+        obj = root / "objects" / "abc"
+        obj.write_text("blob")
+        obj.chmod(0o444)
+        assert pc.rmtree_force(root) is True
+        assert not root.exists()
+
+    def test_reports_false_when_the_tree_survives(self, monkeypatch, tmp_path):
+        # ignore_errors-style success reporting over a surviving tree is the bug
+        # this return value exists to catch.
+        root = tmp_path / "tree"
+        root.mkdir()
+        monkeypatch.setattr(pc.shutil, "rmtree", lambda *_a, **_k: None)
+        assert pc.rmtree_force(root) is False
+
+    def test_readonly_hook_retries_the_operation(self, tmp_path):
+        victim = tmp_path / "ro.txt"
+        victim.write_text("x")
+        victim.chmod(0o444)
+        removed: list[str] = []
+        pc._clear_readonly_and_retry(removed.append, str(victim), OSError("denied"))
+        assert removed == [str(victim)]
+
+    def test_readonly_hook_warns_when_the_retry_also_fails(self, tmp_path, caplog):
+        def _boom(_path: str) -> None:
+            raise OSError("still denied")
+
+        victim = tmp_path / "ro.txt"
+        victim.write_text("x")
+        with caplog.at_level(logging.WARNING, logger=pc.logger.name):
+            pc._clear_readonly_and_retry(_boom, str(victim), OSError("denied"))
+        assert any("Cannot remove" in r.getMessage() for r in caplog.records)
+
+
+class TestLinkHelpers:
+    def test_posix_symlink_round_trips(self, tmp_path):
+        target = tmp_path / "target"
+        target.mkdir()
+        link = tmp_path / "link"
+        pc.symlink_or_junction(target, link)
+        assert pc.is_link_or_junction(link) is True
+        pc.unlink_link_or_junction(link)
+        assert not link.exists()
+        # The target must survive removal of the link.
+        assert target.is_dir()
+
+    def test_windows_symlink_requests_a_directory_link(self, monkeypatch, tmp_path):
+        # Without target_is_directory=True the link is a FILE-type symlink to a
+        # directory, which is not traversable on Windows.
+        seen: dict[str, Any] = {}
+
+        def _symlink(src: str, dst: str, **kwargs: Any) -> None:
+            seen.update({"src": src, "dst": dst, **kwargs})
+
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc.os, "symlink", _symlink)
+        pc.symlink_or_junction(tmp_path / "t", tmp_path / "l")
+        assert seen["target_is_directory"] is True
+
+    def test_junction_fallback_is_false_for_a_plain_directory(self, tmp_path):
+        assert pc._is_junction_fallback(tmp_path) is False
+
+    def test_junction_fallback_is_false_for_a_missing_path(self, tmp_path):
+        assert pc._is_junction_fallback(tmp_path / "gone") is False
+
+    def test_junction_fallback_recognises_a_mount_point_reparse_tag(self, monkeypatch, tmp_path):
+        fake = types.SimpleNamespace(
+            st_file_attributes=pc._FILE_ATTRIBUTE_REPARSE_POINT,
+            st_reparse_tag=pc._IO_REPARSE_TAG_MOUNT_POINT,
+        )
+        monkeypatch.setattr(pc.os, "stat", lambda *_a, **_k: fake)
+        assert pc._is_junction_fallback(tmp_path) is True
+
+    def test_junction_fallback_rejects_another_reparse_tag(self, monkeypatch, tmp_path):
+        fake = types.SimpleNamespace(
+            st_file_attributes=pc._FILE_ATTRIBUTE_REPARSE_POINT,
+            st_reparse_tag=0xA000000C,
+        )
+        monkeypatch.setattr(pc.os, "stat", lambda *_a, **_k: fake)
+        assert pc._is_junction_fallback(tmp_path) is False
+
+    def test_is_link_or_junction_uses_the_stdlib_probe_when_present(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(pc, "_ISJUNCTION", lambda _p: True)
+        assert pc.is_link_or_junction(tmp_path) is True
+
+    def test_is_link_or_junction_degrades_to_false_when_the_probe_raises(
+        self, monkeypatch, tmp_path
+    ):
+        def _boom(_path: Any) -> bool:
+            raise OSError("bad path")
+
+        monkeypatch.setattr(pc, "_ISJUNCTION", _boom)
+        assert pc.is_link_or_junction(tmp_path) is False
+
+    def test_is_link_or_junction_uses_the_fallback_without_the_stdlib_probe(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(pc, "_ISJUNCTION", None)
+        assert pc.is_link_or_junction(tmp_path) is False
+
+    def test_unlink_removes_a_junction_with_rmdir(self, monkeypatch, tmp_path):
+        # A junction is a directory reparse point: rmdir unlinks the junction
+        # itself and never the target it points at.
+        victim = tmp_path / "junction"
+        victim.mkdir()
+        calls: list[str] = []
+        monkeypatch.setattr(pc, "_ISJUNCTION", lambda _p: True)
+        monkeypatch.setattr(pc.os, "rmdir", lambda p: calls.append(str(p)))
+        pc.unlink_link_or_junction(victim)
+        assert calls == [str(victim)]
+
+    def test_unlink_falls_through_to_unlink_for_a_real_file(self, tmp_path):
+        plain = tmp_path / "plain.txt"
+        plain.write_text("x")
+        pc.unlink_link_or_junction(plain)
+        assert not plain.exists()
+
+
+class TestChmodHelpers:
+    def test_chmod_safe_warns_instead_of_raising(self, monkeypatch, caplog, tmp_path):
+        def _boom(*_a: Any, **_k: Any) -> None:
+            raise OSError("read-only fs")
+
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        monkeypatch.setattr(pc.os, "chmod", _boom)
+        with caplog.at_level(logging.WARNING, logger=pc.logger.name):
+            pc.chmod_safe(tmp_path / "f", 0o600)
+        assert any("Cannot set permissions" in r.getMessage() for r in caplog.records)
+
+    def test_fchmod_safe_warns_instead_of_raising(self, monkeypatch, caplog):
+        def _boom(*_a: Any, **_k: Any) -> None:
+            raise OSError("bad fd")
+
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        monkeypatch.setattr(pc.os, "fchmod", _boom)
+        with caplog.at_level(logging.WARNING, logger=pc.logger.name):
+            pc.fchmod_safe(3, 0o600)
+        assert any("Cannot set permissions" in r.getMessage() for r in caplog.records)
+
+    def test_both_are_noops_on_windows(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+
+        def _never(*_a: Any, **_k: Any) -> None:
+            pytest.fail("POSIX mode bits must not be touched on Windows")
+
+        monkeypatch.setattr(pc.os, "chmod", _never)
+        monkeypatch.setattr(pc.os, "fchmod", _never)
+        pc.chmod_safe(tmp_path, 0o600)
+        pc.fchmod_safe(3, 0o600)
+
+
+# ---------------------------------------------------------------------------
+# Windows SIDs
+# ---------------------------------------------------------------------------
+
+
+def _token_dlls(
+    *,
+    sid: str = "S-1-5-21-1-2-3-1000",
+    open_process: int = 55,
+    open_token: bool = True,
+    size: int = 64,
+    read_info: bool = True,
+    convert: bool = True,
+) -> tuple[Any, Any, list[str]]:
+    """Fake advapi32/kernel32 for the access-token SID read.
+
+    Returns ``(kernel32, advapi32, closed)`` where ``closed`` records which
+    handles the product closed — the pseudo-handle from ``GetCurrentProcess``
+    must never be one of them.
+    """
+
+    closed: list[str] = []
+    info_calls: list[int] = []
+
+    def _open_process_token(_process: Any, _access: Any, token: Any) -> int:
+        if not open_token:
+            return 0
+        token._obj.value = 4242
+        return 1
+
+    def _get_token_information(_token: Any, _cls: Any, buf: Any, _len: Any, out_size: Any) -> int:
+        info_calls.append(1)
+        if len(info_calls) == 1:
+            # First call sizes the buffer and is expected to "fail".
+            out_size._obj.value = size
+            return 0
+        return 1 if read_info else 0
+
+    def _convert(_sid: Any, out: Any) -> int:
+        if not convert:
+            return 0
+        out._obj.value = sid
+        return 1
+
+    kernel32 = types.SimpleNamespace(
+        GetCurrentProcess=_const(1),
+        OpenProcess=_const(open_process),
+        CloseHandle=_Fn(lambda handle: closed.append(str(getattr(handle, "value", handle)))),
+        LocalFree=_const(0),
+    )
+    advapi32 = types.SimpleNamespace(
+        OpenProcessToken=_Fn(_open_process_token),
+        GetTokenInformation=_Fn(_get_token_information),
+        ConvertSidToStringSidW=_Fn(_convert),
+    )
+    return kernel32, advapi32, closed
+
+
+class TestProcessTokenSid:
+    def test_none_on_posix(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        assert pc._process_token_sid() is None
+
+    def test_reads_the_sid_from_this_process_token(self, monkeypatch):
+        kernel32, advapi32, closed = _token_dlls()
+        _fake_windows(monkeypatch, kernel32=kernel32, advapi32=advapi32)
+        assert pc._process_token_sid_unguarded() == "S-1-5-21-1-2-3-1000"
+        # The GetCurrentProcess pseudo-handle must NOT be closed; only the token.
+        assert closed == ["4242"]
+
+    def test_reads_the_sid_of_another_pid_and_closes_its_handle(self, monkeypatch):
+        kernel32, advapi32, closed = _token_dlls()
+        _fake_windows(monkeypatch, kernel32=kernel32, advapi32=advapi32)
+        assert pc._process_token_sid_unguarded(1234) == "S-1-5-21-1-2-3-1000"
+        assert closed == ["4242", "55"]
+
+    def test_unopenable_process_is_none(self, monkeypatch):
+        kernel32, advapi32, _ = _token_dlls(open_process=0)
+        _fake_windows(monkeypatch, kernel32=kernel32, advapi32=advapi32)
+        assert pc._process_token_sid_unguarded(1234) is None
+
+    def test_unopenable_token_is_none(self, monkeypatch):
+        kernel32, advapi32, _ = _token_dlls(open_token=False)
+        _fake_windows(monkeypatch, kernel32=kernel32, advapi32=advapi32)
+        assert pc._process_token_sid_unguarded() is None
+
+    def test_zero_sized_token_information_is_none(self, monkeypatch):
+        kernel32, advapi32, _ = _token_dlls(size=0)
+        _fake_windows(monkeypatch, kernel32=kernel32, advapi32=advapi32)
+        assert pc._process_token_sid_unguarded() is None
+
+    def test_failed_token_information_read_is_none(self, monkeypatch):
+        kernel32, advapi32, _ = _token_dlls(read_info=False)
+        _fake_windows(monkeypatch, kernel32=kernel32, advapi32=advapi32)
+        assert pc._process_token_sid_unguarded() is None
+
+    def test_failed_sid_conversion_is_none(self, monkeypatch):
+        kernel32, advapi32, _ = _token_dlls(convert=False)
+        _fake_windows(monkeypatch, kernel32=kernel32, advapi32=advapi32)
+        assert pc._process_token_sid_unguarded() is None
+
+    def test_a_non_sid_string_is_rejected(self, monkeypatch):
+        kernel32, advapi32, _ = _token_dlls(sid="not-a-sid")
+        _fake_windows(monkeypatch, kernel32=kernel32, advapi32=advapi32)
+        assert pc._process_token_sid_unguarded() is None
+
+    def test_missing_windll_is_none(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.delattr(pc.ctypes, "WinDLL", raising=False)
+        assert pc._process_token_sid_unguarded() is None
+
+    def test_guarded_wrapper_swallows_an_unexpected_error(self, monkeypatch):
+        def _boom(*_a: Any, **_k: Any) -> Any:
+            raise RuntimeError("unexpected")
+
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "_process_token_sid_unguarded", _boom)
+        assert pc._process_token_sid() is None
+
+    def test_process_owner_sid_is_none_on_posix(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        assert pc.process_owner_sid(7) is None
+
+    def test_process_owner_sid_reads_the_peer_token(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "_process_token_sid_unguarded", lambda pid: f"S-1-5-{pid}")
+        assert pc.process_owner_sid(7) == "S-1-5-7"
+
+    def test_process_owner_sid_is_unverifiable_on_failure(self, monkeypatch):
+        def _boom(_pid: Any) -> Any:
+            raise OSError("denied")
+
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "_process_token_sid_unguarded", _boom)
+        assert pc.process_owner_sid(7) is None
+
+
+class TestCurrentUserSid:
+    @staticmethod
+    def _fresh_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+        # Both memos are module-scoped; give each test its own so no test
+        # depends on another having run (or not run) first.
+        monkeypatch.setattr(pc, "_USER_SID_CACHE", [])
+        monkeypatch.setattr(pc, "_TOKEN_SID_CACHE", [])
+
+    def test_none_on_posix(self, monkeypatch):
+        self._fresh_caches(monkeypatch)
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        assert pc._current_user_sid() is None
+
+    def test_prefers_the_access_token_and_memoises_it(self, monkeypatch):
+        self._fresh_caches(monkeypatch)
+        calls: list[int] = []
+
+        def _token() -> str:
+            calls.append(1)
+            return "S-1-5-21-9"
+
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "_process_token_sid", _token)
+
+        assert pc._current_user_sid() == "*S-1-5-21-9"
+        assert pc._current_user_sid() == "*S-1-5-21-9"
+        assert len(calls) == 1
+
+    def test_falls_back_to_whoami_when_the_token_is_unavailable(self, monkeypatch):
+        self._fresh_caches(monkeypatch)
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "_process_token_sid", lambda: None)
+        monkeypatch.setattr(pc.shutil, "which", lambda _n: r"C:\whoami.exe")
+        result = types.SimpleNamespace(
+            returncode=0, stdout=b'"CORP\\zezhen","S-1-5-21-7-7-7-500"\n'
+        )
+        monkeypatch.setattr(pc.subprocess, "run", lambda *_a, **_k: result)
+        assert pc._current_user_sid() == "*S-1-5-21-7-7-7-500"
+
+    def test_a_failing_whoami_is_not_cached(self, monkeypatch):
+        # A transient failure must stay retryable — memoising None would poison
+        # every later restrict_to_owner for the process lifetime.
+        self._fresh_caches(monkeypatch)
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "_process_token_sid", lambda: None)
+        monkeypatch.setattr(pc.shutil, "which", lambda _n: r"C:\whoami.exe")
+        monkeypatch.setattr(
+            pc.subprocess,
+            "run",
+            lambda *_a, **_k: types.SimpleNamespace(returncode=1, stdout=b""),
+        )
+        assert pc._current_user_sid() is None
+        assert pc._USER_SID_CACHE == []
+
+    def test_a_whoami_spawn_error_is_none(self, monkeypatch):
+        self._fresh_caches(monkeypatch)
+
+        def _boom(*_a: Any, **_k: Any) -> Any:
+            raise OSError("not found")
+
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "_process_token_sid", lambda: None)
+        monkeypatch.setattr(pc.shutil, "which", lambda _n: None)
+        monkeypatch.setattr(pc.subprocess, "run", _boom)
+        assert pc._current_user_sid() is None
+
+    @pytest.mark.parametrize("stdout", [b'"only-one-field"\n', b'"CORP\\u","NOT-A-SID"\n'])
+    def test_unparseable_whoami_output_is_none(self, monkeypatch, stdout):
+        self._fresh_caches(monkeypatch)
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "_process_token_sid", lambda: None)
+        monkeypatch.setattr(pc.shutil, "which", lambda _n: r"C:\whoami.exe")
+        monkeypatch.setattr(
+            pc.subprocess,
+            "run",
+            lambda *_a, **_k: types.SimpleNamespace(returncode=0, stdout=stdout),
+        )
+        assert pc._current_user_sid() is None
+
+    def test_bare_sid_strips_the_icacls_prefix_and_memoises(self, monkeypatch):
+        self._fresh_caches(monkeypatch)
+        calls: list[int] = []
+
+        def _token() -> str:
+            calls.append(1)
+            return "*S-1-5-21-4"
+
+        monkeypatch.setattr(pc, "_process_token_sid", _token)
+        assert pc.current_user_sid() == "S-1-5-21-4"
+        assert pc.current_user_sid() == "S-1-5-21-4"
+        assert len(calls) == 1
+
+    def test_bare_sid_is_none_when_the_token_read_fails(self, monkeypatch):
+        self._fresh_caches(monkeypatch)
+        monkeypatch.setattr(pc, "_process_token_sid", lambda: None)
+        assert pc.current_user_sid() is None
+
+    def test_local_user_id_is_the_uid_on_posix(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        assert pc.local_user_id() == os.getuid()
+
+    def test_local_user_id_is_a_stable_crc_of_the_sid_on_windows(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "current_user_sid", lambda: "S-1-5-21-4")
+        first = pc.local_user_id()
+        assert isinstance(first, int) and first != 0
+        assert pc.local_user_id() == first
+
+    def test_local_user_id_collapses_to_zero_without_a_sid(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "current_user_sid", lambda: None)
+        assert pc.local_user_id() == 0
+
+
+class TestRestrictToOwner:
+    def test_posix_applies_owner_only_mode(self, tmp_path):
+        secret = tmp_path / "token.key"
+        secret.write_text("x")
+        secret.chmod(0o644)
+        pc.restrict_to_owner(secret)
+        assert oct(secret.stat().st_mode)[-3:] == "600"
+
+    def test_windows_refuses_a_half_configured_dacl(self, monkeypatch, tmp_path):
+        # An Owner-Rights-only DACL would lock the caller out of a file created
+        # by a different principal, so an unresolvable SID must fail loud.
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "_current_user_sid", lambda: None)
+
+        def _never(*_a: Any, **_k: Any) -> Any:
+            pytest.fail("icacls must not run without a resolved SID")
+
+        monkeypatch.setattr(pc.subprocess, "run", _never)
+        with pytest.raises(OSError, match="cannot resolve current user SID"):
+            pc.restrict_to_owner(tmp_path / "token.key")
+
+    def test_windows_grants_both_owner_rights_and_the_caller(self, monkeypatch, tmp_path):
+        seen: dict[str, Any] = {}
+
+        def _run(argv: Any, **kwargs: Any) -> Any:
+            seen["argv"] = argv
+            seen["kwargs"] = kwargs
+            return types.SimpleNamespace(returncode=0, stderr=b"", stdout=b"")
+
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-3")
+        monkeypatch.setattr(pc.shutil, "which", lambda _n: r"C:\icacls.exe")
+        monkeypatch.setattr(pc.subprocess, "run", _run)
+
+        pc.restrict_to_owner(tmp_path / "token.key")
+
+        argv = seen["argv"]
+        assert "/inheritance:r" in argv
+        assert f"{pc._OWNER_RIGHTS_SID}:F" in argv
+        assert "*S-1-5-21-3:F" in argv
+        assert seen["kwargs"]["creationflags"] == pc._SUBPROCESS_NO_WINDOW
+
+    def test_windows_does_not_duplicate_the_owner_rights_grant(self, monkeypatch, tmp_path):
+        seen: dict[str, Any] = {}
+
+        def _run(argv: Any, **_kwargs: Any) -> Any:
+            seen["argv"] = argv
+            return types.SimpleNamespace(returncode=0, stderr=b"", stdout=b"")
+
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "_current_user_sid", lambda: pc._OWNER_RIGHTS_SID)
+        monkeypatch.setattr(pc.shutil, "which", lambda _n: r"C:\icacls.exe")
+        monkeypatch.setattr(pc.subprocess, "run", _run)
+        pc.restrict_to_owner(tmp_path / "token.key")
+        assert seen["argv"].count(f"{pc._OWNER_RIGHTS_SID}:F") == 1
+
+    @_POSIX_ONLY
+    def test_windows_raises_on_a_non_zero_icacls(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-3")
+        monkeypatch.setattr(pc.shutil, "which", lambda _n: r"C:\icacls.exe")
+        monkeypatch.setattr(
+            pc.subprocess,
+            "run",
+            lambda *_a, **_k: types.SimpleNamespace(
+                returncode=5, stderr=b"Access is denied.", stdout=b""
+            ),
+        )
+        with pytest.raises(OSError, match="Access is denied"):
+            pc.restrict_to_owner(tmp_path / "token.key")
+
+    @_POSIX_ONLY
+    def test_windows_raises_when_icacls_cannot_be_spawned(self, monkeypatch, tmp_path):
+        def _boom(*_a: Any, **_k: Any) -> Any:
+            raise subprocess.SubprocessError("timeout")
+
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "_current_user_sid", lambda: "*S-1-5-21-3")
+        monkeypatch.setattr(pc.shutil, "which", lambda _n: r"C:\icacls.exe")
+        monkeypatch.setattr(pc.subprocess, "run", _boom)
+        with pytest.raises(OSError, match="icacls invocation failed"):
+            pc.restrict_to_owner(tmp_path / "token.key")
+
+    def test_make_owner_only_dir_warns_instead_of_raising(self, monkeypatch, caplog, tmp_path):
+        target = tmp_path / "secrets"
+
+        def _boom(*_a: Any, **_k: Any) -> None:
+            raise OSError("no perms")
+
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        monkeypatch.setattr(pc.Path, "chmod", _boom)
+        with caplog.at_level(logging.WARNING, logger=pc.logger.name):
+            pc.make_owner_only_dir(target)
+        assert target.is_dir()
+        assert any("owner-only" in r.getMessage() for r in caplog.records)
+
+    def test_make_owner_only_dir_uses_the_dacl_on_windows(self, monkeypatch, tmp_path):
+        called: list[Any] = []
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "restrict_to_owner", called.append)
+        target = tmp_path / "secrets"
+        pc.make_owner_only_dir(target)
+        assert called and str(called[0]) == str(target)
+
+
+# ---------------------------------------------------------------------------
+# Executable / interpreter discovery
+# ---------------------------------------------------------------------------
+
+
+class TestExecutableDiscovery:
+    def test_windows_target_accepts_known_script_suffixes(self, tmp_path):
+        hook = tmp_path / "pre.ps1"
+        hook.write_text("")
+        # No execute bit is set: on Windows there is none, so an X_OK check
+        # would silently disable every hook.
+        assert pc.is_executable_file(hook, platform_name="win32") is True
+
+    def test_windows_target_rejects_an_unknown_suffix(self, tmp_path):
+        hook = tmp_path / "notes.md"
+        hook.write_text("")
+        assert pc.is_executable_file(hook, platform_name="win32") is False
+
+    def test_posix_target_accepts_any_regular_file_from_a_windows_host(
+        self, monkeypatch, tmp_path
+    ):
+        hook = tmp_path / "pre.sh"
+        hook.write_text("")
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        assert pc.is_executable_file(hook, platform_name="linux") is True
+
+    def test_a_directory_is_not_executable(self, tmp_path):
+        assert pc.is_executable_file(tmp_path) is False
+
+    def test_an_os_error_degrades_to_false(self, monkeypatch, tmp_path):
+        def _boom(*_a: Any, **_k: Any) -> Any:
+            raise OSError("stat failed")
+
+        monkeypatch.setattr(pc.os.path, "isfile", _boom)
+        assert pc.is_executable_file(tmp_path / "x") is False
+
+    def test_store_stub_detection_is_windows_only(self, monkeypatch):
+        stub = r"C:\Users\u\AppData\Local\Microsoft\WindowsApps\python.exe"
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc._is_windows_store_python_stub(stub) is False
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        assert pc._is_windows_store_python_stub(stub) is True
+        assert pc._is_windows_store_python_stub(r"C:\Python312\python.exe") is False
+
+
+class TestFindPythonInterpreter:
+    @staticmethod
+    def _resolve(monkeypatch: pytest.MonkeyPatch, table: dict[str, str | None]) -> None:
+        monkeypatch.setattr(pc.shutil, "which", lambda name: table.get(name))
+
+    def test_skips_build_and_brazil_interpreters(self, monkeypatch):
+        self._resolve(
+            monkeypatch,
+            {
+                "python3.12": "/brazil-path/python3.12",
+                "python3.11": "/x/build/private/python3.11",
+                "python3.10": "/usr/bin/python3.10",
+            },
+        )
+        monkeypatch.setattr(pc.subprocess, "check_output", lambda *_a, **_k: "3.10\n")
+        assert pc.find_python_interpreter() == "/usr/bin/python3.10"
+
+    def test_skips_the_microsoft_store_stub(self, monkeypatch):
+        stub = r"C:\Users\u\AppData\Local\Microsoft\WindowsApps\python.exe"
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        self._resolve(monkeypatch, {"python": stub, "python3": r"C:\Python312\python.exe"})
+        monkeypatch.setattr(pc.subprocess, "check_output", lambda *_a, **_k: "3.12\n")
+        assert pc.find_python_interpreter() == r"C:\Python312\python.exe"
+
+    def test_rejects_an_interpreter_below_the_floor(self, monkeypatch):
+        self._resolve(monkeypatch, {"python3": "/usr/bin/python3"})
+        monkeypatch.setattr(pc.subprocess, "check_output", lambda *_a, **_k: "3.9\n")
+        assert pc.find_python_interpreter() is None
+
+    def test_a_probe_failure_falls_through(self, monkeypatch):
+        def _boom(*_a: Any, **_k: Any) -> Any:
+            raise subprocess.SubprocessError("timeout")
+
+        self._resolve(monkeypatch, {"python3": "/usr/bin/python3"})
+        monkeypatch.setattr(pc.subprocess, "check_output", _boom)
+        assert pc.find_python_interpreter() is None
+
+    def test_the_reject_predicate_falls_through_rather_than_aborting(self, monkeypatch):
+        # A single unusable interpreter must not short-circuit the whole search.
+        # POSIX order is 3.12, 3.11, 3.10, python3, 3.13 — vetoing 3.12 must
+        # land on 3.11, not give up.
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        self._resolve(
+            monkeypatch,
+            {"python3.12": "/usr/bin/python3.12", "python3.11": "/usr/bin/python3.11"},
+        )
+        monkeypatch.setattr(pc.subprocess, "check_output", lambda *_a, **_k: "3.12\n")
+        picked = pc.find_python_interpreter(reject=lambda p: p.endswith("3.12"))
+        assert picked == "/usr/bin/python3.11"
+
+    def test_nothing_resolvable_is_none(self, monkeypatch):
+        self._resolve(monkeypatch, {})
+        assert pc.find_python_interpreter() is None
+
+
+# ---------------------------------------------------------------------------
+# Resource / system metrics
+# ---------------------------------------------------------------------------
+
+
+def _fake_resource(monkeypatch: pytest.MonkeyPatch, **members: Any) -> None:
+    defaults: dict[str, Any] = {
+        "RUSAGE_SELF": 0,
+        "RLIMIT_NOFILE": 7,
+        "getrusage": lambda _who: types.SimpleNamespace(ru_maxrss=0, ru_utime=0.0, ru_stime=0.0),
+        "getrlimit": lambda _res: (1024, 4096),
+        "setrlimit": lambda _res, _limits: None,
+    }
+    defaults.update(members)
+    monkeypatch.setattr(pc, "resource", types.SimpleNamespace(**defaults), raising=False)
+
+
+def _memory_info_dll(working_set: int, *, ok: bool = True) -> Any:
+    def _get_memory_info(_handle: Any, counters: Any, _cb: Any) -> int:
+        counters._obj.WorkingSetSize = working_set
+        return 1 if ok else 0
+
+    return types.SimpleNamespace(GetProcessMemoryInfo=_Fn(_get_memory_info))
+
+
+class TestProcRss:
+    def test_linux_scales_kib_to_bytes(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        monkeypatch.setattr(pc.sys, "platform", "linux")
+        _fake_resource(
+            monkeypatch,
+            getrusage=lambda _who: types.SimpleNamespace(ru_maxrss=2048),
+        )
+        assert pc.proc_rss_bytes() == 2048 * 1024
+
+    def test_macos_reports_bytes_directly(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        _fake_resource(
+            monkeypatch,
+            getrusage=lambda _who: types.SimpleNamespace(ru_maxrss=999),
+        )
+        assert pc.proc_rss_bytes() == 999
+
+    def test_a_getrusage_failure_is_zero(self, monkeypatch):
+        def _boom(_who: Any) -> Any:
+            raise OSError("no rusage")
+
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        _fake_resource(monkeypatch, getrusage=_boom)
+        assert pc.proc_rss_bytes() == 0
+
+    def test_windows_reads_the_working_set(self, monkeypatch):
+        _fake_windows(
+            monkeypatch,
+            psapi=_memory_info_dll(8192),
+            kernel32=types.SimpleNamespace(GetCurrentProcess=_const(1)),
+        )
+        assert pc.proc_rss_bytes() == 8192
+
+    def test_windows_failure_is_zero(self, monkeypatch):
+        _fake_windows(
+            monkeypatch,
+            psapi=_memory_info_dll(8192, ok=False),
+            kernel32=types.SimpleNamespace(GetCurrentProcess=_const(1)),
+        )
+        assert pc.proc_rss_bytes() == 0
+
+    def test_windows_loader_failure_is_zero(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.delattr(pc.ctypes, "WinDLL", raising=False)
+        assert pc.proc_rss_bytes() == 0
+
+
+class TestProcRssForPid:
+    @_LINUX_ONLY
+    def test_linux_reads_statm_for_this_process(self):
+        rss = pc.proc_rss_bytes_for_pid(os.getpid())
+        assert rss is not None and rss > 0
+
+    @_LINUX_ONLY
+    def test_linux_vanished_pid_is_unknown(self):
+        assert pc.proc_rss_bytes_for_pid(2**30) is None
+
+    def test_macos_has_no_ctypes_only_path(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc.proc_rss_bytes_for_pid(1) is None
+
+    @staticmethod
+    def _win(monkeypatch: pytest.MonkeyPatch, handle: int, *, ok: bool = True) -> None:
+        kernel32 = types.SimpleNamespace(
+            OpenProcess=_const(handle),
+            CloseHandle=_const(True),
+        )
+        _fake_windows(monkeypatch, kernel32=kernel32, psapi=_memory_info_dll(4096, ok=ok))
+        monkeypatch.setattr(pc.sys, "platform", "win32")
+
+    def test_windows_reads_the_working_set_of_another_pid(self, monkeypatch):
+        self._win(monkeypatch, 77)
+        assert pc.proc_rss_bytes_for_pid(9) == 4096
+
+    def test_windows_unopenable_pid_is_unknown(self, monkeypatch):
+        self._win(monkeypatch, 0)
+        assert pc.proc_rss_bytes_for_pid(9) is None
+
+    def test_windows_failed_query_is_unknown(self, monkeypatch):
+        self._win(monkeypatch, 77, ok=False)
+        assert pc.proc_rss_bytes_for_pid(9) is None
+
+
+class TestProcRssTree:
+    def test_none_off_windows(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc.proc_rss_tree_mb_for_pid(os.getpid()) is None
+
+    @pytest.mark.parametrize("bad", [0, 1, -5, True])
+    def test_implausible_roots_are_refused(self, monkeypatch, bad):
+        # `True` is an int subclass; the strict type check keeps a bool out.
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        assert pc.proc_rss_tree_mb_for_pid(bad) is None
+
+    def test_unanchorable_root_falls_back_to_the_single_process_read(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_open_process_termination_handle", lambda _pid: None)
+        monkeypatch.setattr(pc, "proc_rss_bytes_for_pid", lambda _pid: 2 * 1024 * 1024)
+        assert pc.proc_rss_tree_mb_for_pid(500) == pytest.approx(2.0)
+
+    def test_unanchorable_and_unreadable_root_is_unknown(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_open_process_termination_handle", lambda _pid: None)
+        monkeypatch.setattr(pc, "proc_rss_bytes_for_pid", lambda _pid: None)
+        assert pc.proc_rss_tree_mb_for_pid(500) is None
+
+    def test_a_recycled_root_is_not_measured_as_a_tree(self, monkeypatch):
+        # Identity mismatch means the PID was recycled: fall back to the single
+        # read rather than summing an unrelated subtree.
+        closed: list[int] = []
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_open_process_termination_handle", lambda _pid: 900)
+        monkeypatch.setattr(pc, "_windows_process_handle_identity", lambda _h: (999, 1, None))
+        monkeypatch.setattr(pc, "proc_rss_bytes_for_pid", lambda _pid: 1024 * 1024)
+        monkeypatch.setattr(pc, "close_process_handle", closed.append)
+        assert pc.proc_rss_tree_mb_for_pid(500) == pytest.approx(1.0)
+
+    def test_sums_the_root_and_its_validated_descendants(self, monkeypatch):
+        closed: list[int] = []
+        rss = {500: 1024 * 1024, 501: 3 * 1024 * 1024}
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_open_process_termination_handle", lambda _pid: 900)
+        monkeypatch.setattr(pc, "_windows_process_handle_identity", lambda _h: (500, 1, None))
+        monkeypatch.setattr(pc, "descendant_termination_handles", lambda _pid, **_k: {501: 901})
+        monkeypatch.setattr(pc, "proc_rss_bytes_for_pid", rss.get)
+        monkeypatch.setattr(pc, "close_process_handle", closed.append)
+
+        assert pc.proc_rss_tree_mb_for_pid(500) == pytest.approx(4.0)
+        # Every handle the scan opened must be released.
+        assert sorted(closed) == [900, 901]
+
+    def test_a_failed_enumeration_measures_the_root_alone(self, monkeypatch):
+        def _boom(_pid: Any, **_k: Any) -> Any:
+            raise OSError("snapshot race")
+
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_open_process_termination_handle", lambda _pid: 900)
+        monkeypatch.setattr(pc, "_windows_process_handle_identity", lambda _h: (500, 1, None))
+        monkeypatch.setattr(pc, "descendant_termination_handles", _boom)
+        monkeypatch.setattr(pc, "proc_rss_bytes_for_pid", lambda _pid: 5 * 1024 * 1024)
+        monkeypatch.setattr(pc, "close_process_handle", lambda _h: None)
+        assert pc.proc_rss_tree_mb_for_pid(500) == pytest.approx(5.0)
+
+    def test_an_entirely_unreadable_tree_is_unknown(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_open_process_termination_handle", lambda _pid: 900)
+        monkeypatch.setattr(pc, "_windows_process_handle_identity", lambda _h: (500, 1, None))
+        monkeypatch.setattr(pc, "descendant_termination_handles", lambda _pid, **_k: {})
+        monkeypatch.setattr(pc, "proc_rss_bytes_for_pid", lambda _pid: None)
+        monkeypatch.setattr(pc, "close_process_handle", lambda _h: None)
+        assert pc.proc_rss_tree_mb_for_pid(500) is None
+
+
+class TestProcCpuSeconds:
+    def test_posix_sums_user_and_system_time(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        _fake_resource(
+            monkeypatch,
+            getrusage=lambda _who: types.SimpleNamespace(ru_utime=1.5, ru_stime=0.25),
+        )
+        assert pc.proc_cpu_seconds() == pytest.approx(1.75)
+
+    def test_posix_failure_is_zero(self, monkeypatch):
+        def _boom(_who: Any) -> Any:
+            raise ValueError("bad who")
+
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        _fake_resource(monkeypatch, getrusage=_boom)
+        assert pc.proc_cpu_seconds() == 0.0
+
+    @staticmethod
+    def _times_kernel32(kernel_ticks: int, user_ticks: int, *, ok: bool = True) -> Any:
+        def _get_times(_handle: Any, _creation: Any, _exit: Any, kernel: Any, user: Any) -> int:
+            kernel._obj.dwHighDateTime = kernel_ticks >> 32
+            kernel._obj.dwLowDateTime = kernel_ticks & 0xFFFFFFFF
+            user._obj.dwHighDateTime = user_ticks >> 32
+            user._obj.dwLowDateTime = user_ticks & 0xFFFFFFFF
+            return 1 if ok else 0
+
+        return types.SimpleNamespace(
+            GetCurrentProcess=_const(1),
+            GetProcessTimes=_Fn(_get_times),
+        )
+
+    def test_windows_converts_100ns_filetimes_to_seconds(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=self._times_kernel32(10_000_000, 25_000_000))
+        assert pc.proc_cpu_seconds() == pytest.approx(3.5)
+
+    def test_windows_failure_is_zero(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=self._times_kernel32(1, 1, ok=False))
+        assert pc.proc_cpu_seconds() == 0.0
+
+    def test_windows_loader_failure_is_zero(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc.ctypes, "windll", None, raising=False)
+        assert pc.proc_cpu_seconds() == 0.0
+
+
+class TestSystemMetrics:
+    def test_memory_is_none_off_windows(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc.system_memory() is None
+
+    @staticmethod
+    def _memory_status(total: int, avail: int, *, ok: bool = True) -> Any:
+        def _status(status: Any) -> int:
+            status._obj.ullTotalPhys = total
+            status._obj.ullAvailPhys = avail
+            return 1 if ok else 0
+
+        return types.SimpleNamespace(GlobalMemoryStatusEx=_Fn(_status))
+
+    def test_memory_reports_total_and_available(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=self._memory_status(16 << 30, 4 << 30))
+        assert pc.system_memory() == (16 << 30, 4 << 30)
+
+    def test_memory_failure_is_none(self, monkeypatch):
+        _fake_windows(monkeypatch, kernel32=self._memory_status(1, 1, ok=False))
+        assert pc.system_memory() is None
+
+    def test_memory_loader_failure_is_none(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc.ctypes, "windll", None, raising=False)
+        assert pc.system_memory() is None
+
+    def test_cpu_percent_is_none_off_windows(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc.system_cpu_percent() is None
+
+    @staticmethod
+    def _system_times(samples: list[tuple[int, int, int]], *, ok: bool = True) -> Any:
+        reads = iter(samples)
+
+        def _get(idle: Any, kernel: Any, user: Any) -> int:
+            if not ok:
+                return 0
+            idle_t, kernel_t, user_t = next(reads)
+            for holder, value in ((idle, idle_t), (kernel, kernel_t), (user, user_t)):
+                holder._obj.dwHighDateTime = value >> 32
+                holder._obj.dwLowDateTime = value & 0xFFFFFFFF
+            return 1
+
+        return types.SimpleNamespace(GetSystemTimes=_Fn(_get))
+
+    def test_cpu_percent_needs_two_samples(self, monkeypatch):
+        # The first call only primes the delta; a percentage from one sample
+        # would be meaningless. Between the samples 100 ticks elapsed of which
+        # 15 were idle, so 85% was busy.
+        monkeypatch.setattr(pc, "_prev_win_sys_cpu", {"idle": 0.0, "total": 0.0})
+        _fake_windows(
+            monkeypatch,
+            kernel32=self._system_times([(10, 40, 0), (25, 140, 0)]),
+        )
+        assert pc.system_cpu_percent() is None
+        assert pc.system_cpu_percent() == pytest.approx(85.0)
+
+    def test_cpu_percent_is_none_without_forward_progress(self, monkeypatch):
+        monkeypatch.setattr(pc, "_prev_win_sys_cpu", {"idle": 0.0, "total": 0.0})
+        _fake_windows(
+            monkeypatch,
+            kernel32=self._system_times([(0, 100, 0), (0, 100, 0)]),
+        )
+        assert pc.system_cpu_percent() is None  # primes
+        assert pc.system_cpu_percent() is None  # zero delta
+
+    def test_cpu_percent_failure_is_none(self, monkeypatch):
+        monkeypatch.setattr(pc, "_prev_win_sys_cpu", {"idle": 0.0, "total": 0.0})
+        _fake_windows(monkeypatch, kernel32=self._system_times([], ok=False))
+        assert pc.system_cpu_percent() is None
+
+    def test_cpu_percent_loader_failure_is_none(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc.ctypes, "windll", None, raising=False)
+        assert pc.system_cpu_percent() is None
+
+
+class _FormatRecorder:
+    """Captures the format string the shim finally hands to ``strftime``."""
+
+    def __init__(self) -> None:
+        self.seen: list[str] = []
+
+    def strftime(self, fmt: str) -> str:
+        self.seen.append(fmt)
+        return fmt
+
+
+class TestStrftime:
+    def test_posix_passes_the_format_through_unchanged(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        recorder = _FormatRecorder()
+        pc.strftime(recorder, "%-I:%M %p")
+        assert recorder.seen == ["%-I:%M %p"]
+
+    @pytest.mark.parametrize(
+        ("posix_fmt", "windows_fmt"),
+        [
+            ("%-I:%M %p", "%#I:%M %p"),
+            ("%-d/%-m", "%#d/%#m"),
+            ("%Y-%m-%d", "%Y-%m-%d"),
+            ("100%% done at %-I", "100%% done at %#I"),
+            ("trailing %", "trailing %"),
+            ("dangling %-", "dangling %-"),
+        ],
+    )
+    def test_windows_translates_the_no_pad_directives(self, monkeypatch, posix_fmt, windows_fmt):
+        # %-I is a glibc/BSD extension that MSVCRT rejects; %#I is its spelling.
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        recorder = _FormatRecorder()
+        pc.strftime(recorder, posix_fmt)
+        assert recorder.seen == [windows_fmt]
+
+    def test_a_real_datetime_still_formats_on_this_host(self):
+        moment = datetime.datetime(2026, 8, 7, 9, 5)
+        assert pc.strftime(moment, "%Y-%m-%d") == "2026-08-07"
+
+
+class TestRaiseNofileSoftLimit:
+    def test_noop_on_windows(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+
+        def _never(*_a: Any, **_k: Any) -> Any:
+            pytest.fail("there is no descriptor rlimit on Windows")
+
+        _fake_resource(monkeypatch, getrlimit=_never)
+        pc.raise_nofile_soft_limit(4096)
+
+    def test_raises_the_soft_limit_towards_the_target(self, monkeypatch):
+        applied: list[tuple[int, tuple[int, int]]] = []
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        _fake_resource(
+            monkeypatch,
+            getrlimit=lambda _res: (256, 4096),
+            setrlimit=lambda res, limits: applied.append((res, limits)),
+        )
+        pc.raise_nofile_soft_limit(1024)
+        assert applied == [(7, (1024, 4096))]
+
+    def test_the_hard_limit_is_the_ceiling(self, monkeypatch):
+        applied: list[tuple[int, tuple[int, int]]] = []
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        _fake_resource(
+            monkeypatch,
+            getrlimit=lambda _res: (256, 512),
+            setrlimit=lambda res, limits: applied.append((res, limits)),
+        )
+        pc.raise_nofile_soft_limit(99999)
+        assert applied == [(7, (512, 512))]
+
+    def test_an_already_generous_limit_is_left_alone(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+
+        def _never(*_a: Any, **_k: Any) -> Any:
+            pytest.fail("must not lower an already-sufficient limit")
+
+        _fake_resource(monkeypatch, getrlimit=lambda _res: (8192, 8192), setrlimit=_never)
+        pc.raise_nofile_soft_limit(1024)
+
+    def test_a_refused_setrlimit_is_logged_not_raised(self, monkeypatch, caplog):
+        def _boom(*_a: Any, **_k: Any) -> None:
+            raise ValueError("not permitted")
+
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        _fake_resource(monkeypatch, getrlimit=lambda _res: (256, 4096), setrlimit=_boom)
+        with caplog.at_level(logging.DEBUG, logger=pc.logger.name):
+            pc.raise_nofile_soft_limit(1024)
+        assert any("RLIMIT_NOFILE" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Lock release failures
+#
+# Every release path swallows its error on purpose: it runs from a ``finally``,
+# where raising would replace the real exception with a bookkeeping one. Forcing
+# the failure is the only way to execute those handlers, since a real fd never
+# refuses to unlock.
+# ---------------------------------------------------------------------------
+
+
+_POSIX_ONLY = pytest.mark.skipif(
+    pc.IS_WINDOWS, reason="drives the fcntl branch, which does not exist on Windows"
+)
+
+
+def _lock_fd(tmp_path: Any, name: str = "release.lock") -> int:
+    """A real fd, because the lock helpers ``lseek`` before locking."""
+
+    return os.open(str(tmp_path / name), os.O_RDWR | os.O_CREAT, 0o600)
+
+
+class _UnlockRefusingMsvcrt(_FakeMsvcrt):
+    """``msvcrt`` stand-in whose byte-range UNLOCK fails."""
+
+    def locking(self, _fd: int, mode: int, _nbytes: int) -> None:
+        self.calls.append(mode)
+        if mode == self.LK_UNLCK:
+            raise OSError(13, "unlock refused")
+
+
+class TestLockReleaseFailures:
+    @_POSIX_ONLY
+    def test_file_lock_body_result_survives_a_failed_posix_release(self, monkeypatch, tmp_path):
+        real_flock = pc.fcntl.flock
+
+        def _flock(fd: int, operation: int) -> None:
+            if operation == pc.fcntl.LOCK_UN:
+                raise OSError(errno.EBADF, "bad file descriptor")
+            real_flock(fd, operation)
+
+        monkeypatch.setattr(pc.fcntl, "flock", _flock)
+        fd = _lock_fd(tmp_path)
+        ran = False
+        try:
+            with pc.file_lock(fd, exclusive=True):
+                ran = True
+        finally:
+            os.close(fd)
+        assert ran, "a failed release must not mask the body's completion"
+
+    @_POSIX_ONLY
+    def test_release_lock_swallows_a_posix_failure(self, monkeypatch, tmp_path):
+        def _boom(_fd: int, _operation: int) -> None:
+            raise OSError(errno.EBADF, "bad file descriptor")
+
+        monkeypatch.setattr(pc.fcntl, "flock", _boom)
+        fd = _lock_fd(tmp_path, "release2.lock")
+        try:
+            pc.release_lock(fd)  # must not raise
+        finally:
+            os.close(fd)
+
+    def test_file_lock_swallows_a_failed_windows_release(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        fake = _UnlockRefusingMsvcrt([True])
+        monkeypatch.setattr(pc, "msvcrt", fake, raising=False)
+        monkeypatch.setattr(pc, "_win_acquire_blocking", lambda _fd: True)
+        fd = _lock_fd(tmp_path, "release3.lock")
+        try:
+            with pc.file_lock(fd):
+                pass
+        finally:
+            os.close(fd)
+        assert _FakeMsvcrt.LK_UNLCK in fake.calls
+
+    def test_release_lock_swallows_a_failed_windows_unlock(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "msvcrt", _UnlockRefusingMsvcrt([True]), raising=False)
+        fd = _lock_fd(tmp_path, "release4.lock")
+        try:
+            pc.release_lock(fd)  # must not raise
+        finally:
+            os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# Start-time identity and ppid -- the remaining failure returns
+# ---------------------------------------------------------------------------
+
+
+class TestProcessStartIdRemainingPaths:
+    @_LINUX_ONLY
+    def test_reads_a_stable_identity_for_a_live_process(self):
+        # Field 22 of /proc/<pid>/stat, parsed after the LAST ')' because comm
+        # may itself contain spaces and parens.
+        first = pc.get_process_start_id(os.getpid())
+        assert first is not None and first.isdigit()
+        # Stable for the process lifetime -- the property every recycle guard
+        # persists and re-compares from a different process.
+        assert pc.get_process_start_id(os.getpid()) == first
+
+    @_LINUX_ONLY
+    def test_reports_unknown_for_a_pid_with_no_proc_entry(self):
+        # "Unknown" must not be read as a mismatch by callers.
+        assert pc.get_process_start_id(2_000_000_000) is None
+
+    def test_macos_swallows_a_loader_error(self, monkeypatch):
+        monkeypatch.setattr(pc.sys, "platform", "darwin")
+        monkeypatch.setattr(pc.ctypes.util, "find_library", lambda _n: "libproc.dylib")
+
+        def _boom(_path: Any) -> Any:
+            raise OSError("cannot load libproc")
+
+        monkeypatch.setattr(pc.ctypes, "CDLL", _boom)
+        assert pc.get_process_start_id(99) is None
+
+
+class TestGetPpidWindowsLoaderFailure:
+    def test_reports_failure_when_kernel32_cannot_be_reached(self, monkeypatch):
+        # Introspection must never raise into a caller's kill path, however the
+        # Win32 boundary fails.
+        _fake_windows(monkeypatch)  # no kernel32 -> the attribute lookup raises
+        monkeypatch.setattr(pc.sys, "platform", "win32")
+        assert pc.get_ppid(77) == -1
+
+
+# ---------------------------------------------------------------------------
+# Trusted binary resolution and the process-table snapshots
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureUtf8ConsoleRewrapFailure:
+    def test_a_refused_rewrap_is_tolerated(self, monkeypatch):
+        # Best-effort by design: a stream that can neither be reconfigured nor
+        # re-wrapped is left as it is, because raising here would kill the
+        # gateway before it binds -- the very failure this function prevents.
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(sys, "stdout", _StubbornStream())
+        monkeypatch.setattr(sys, "stderr", _StubbornStream())
+
+        def _boom(*_args: Any, **_kwargs: Any) -> Any:
+            raise ValueError("cannot wrap this buffer")
+
+        monkeypatch.setattr(pc.io, "TextIOWrapper", _boom)
+        pc.ensure_utf8_console()  # must not raise
+
+
+class TestTrustedSystemBinWindowsSuffixes:
+    def test_a_bare_argv_name_resolves_with_the_loader_suffix(self, monkeypatch, tmp_path):
+        # Windows argv carries a bare name (``taskkill``) while the file on disk
+        # carries an extension, so the pinned lookup has to try the suffixes the
+        # loader would rather than requiring callers to spell them.
+        _fake_windows(monkeypatch)
+        monkeypatch.setattr(pc, "_windows_system_dirs", lambda: (str(tmp_path),))
+        planted = tmp_path / "taskkill.exe"
+        planted.write_text("")
+        planted.chmod(0o755)
+        resolved = pc.trusted_system_bin("taskkill")
+        assert resolved is not None and resolved.endswith("taskkill.exe")
+
+
+class TestPosixParentMapParsing:
+    def test_returns_empty_on_windows(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        assert pc._posix_process_parent_map() == {}
+
+    def test_skips_malformed_rows_instead_of_aborting(self, monkeypatch):
+        # ``ps`` output is not a schema: a truncated or non-numeric row must cost
+        # only that row, or one oddity erases the whole tree a kill depends on.
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _name: "/usr/bin/ps")
+        blob = b"  100    1\nshort\nnot a number\n  101  100\n\n"
+        monkeypatch.setattr(pc.subprocess, "check_output", lambda *_a, **_k: blob)
+        assert pc._posix_process_parent_map() == {100: 1, 101: 100}
+
+    def test_degrades_to_empty_when_ps_cannot_run(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _name: "/usr/bin/ps")
+
+        def _boom(*_a: Any, **_k: Any) -> Any:
+            raise subprocess.TimeoutExpired("ps", 5)
+
+        monkeypatch.setattr(pc.subprocess, "check_output", _boom)
+        assert pc._posix_process_parent_map() == {}
+
+
+class TestWindowsParentMapWalk:
+    def test_returns_empty_off_windows(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc._windows_process_parent_map() == {}
+
+    def test_walks_the_whole_snapshot_without_the_optional_error_hooks(self, monkeypatch):
+        # The kernel32 handle this code holds may not expose SetLastError /
+        # GetLastError (stub loaders, Wine); the walk must still end cleanly
+        # rather than mistake a missing entry point for an enumeration failure
+        # and raise into a kill path.
+        _fake_windows(
+            monkeypatch,
+            kernel32=_toolhelp_kernel32(
+                [(4, 0, b"System"), (100, 4, b"gateway.exe"), (101, 100, b"kiro-cli.exe")]
+            ),
+        )
+        assert pc._windows_process_parent_map() == {4: 0, 100: 4, 101: 100}
+
+    def test_reads_no_more_files_through_the_real_error_hooks(self, monkeypatch):
+        # The path a real Windows host takes: the error code is cleared before
+        # each step and read back after, so end-of-enumeration (ERROR_NO_MORE_FILES
+        # = 18) is told apart from a genuine failure mid-walk.
+        kernel32 = _toolhelp_kernel32([(100, 4, b"gateway.exe")])
+        kernel32.SetLastError = _const(True)
+        kernel32.GetLastError = _const(18)
+        _fake_windows(monkeypatch, kernel32=kernel32)
+        monkeypatch.setattr(pc.ctypes, "set_last_error", lambda _code: 0, raising=False)
+        assert pc._windows_process_parent_map() == {100: 4}
+
+
+# ---------------------------------------------------------------------------
+# PID-recycling lifetime validation
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsLineageLifetimes:
+    """Pure lifetime arithmetic over a Toolhelp snapshot -- the part that decides
+    whether a numeric parent link describes the tree we actually spawned.
+
+    Toolhelp never clears ``th32ParentProcessID`` when a parent dies and Windows
+    recycles PIDs aggressively, so without this every kill could widen onto an
+    unrelated subtree that merely inherited the number.
+    """
+
+    ROOT = 100
+
+    def test_accepts_a_direct_child_created_during_the_root(self):
+        identities = {self.ROOT: (self.ROOT, 10, None), 101: (101, 15, None)}
+        assert (
+            pc._windows_lineage_matches_lifetimes(101, self.ROOT, {101: self.ROOT}, identities)
+            is True
+        )
+
+    def test_accepts_a_grandchild_through_a_validated_chain(self):
+        parent_map = {101: self.ROOT, 102: 101}
+        identities = {
+            self.ROOT: (self.ROOT, 10, None),
+            101: (101, 15, 40),  # an immediate launcher that has already exited
+            102: (102, 20, None),
+        }
+        assert (
+            pc._windows_lineage_matches_lifetimes(102, self.ROOT, parent_map, identities) is True
+        )
+
+    def test_the_root_is_trivially_its_own_lineage(self):
+        assert pc._windows_lineage_matches_lifetimes(self.ROOT, self.ROOT, {}, {}) is True
+
+    def test_rejects_a_broken_parent_link(self):
+        identities = {self.ROOT: (self.ROOT, 10, None), 101: (101, 15, None)}
+        assert pc._windows_lineage_matches_lifetimes(101, self.ROOT, {}, identities) is False
+
+    def test_rejects_a_child_with_no_exact_handle(self):
+        identities = {self.ROOT: (self.ROOT, 10, None)}
+        assert (
+            pc._windows_lineage_matches_lifetimes(101, self.ROOT, {101: self.ROOT}, identities)
+            is False
+        )
+
+    def test_rejects_a_root_whose_handle_names_another_process(self):
+        identities = {self.ROOT: (999, 10, None), 101: (101, 15, None)}
+        assert (
+            pc._windows_lineage_matches_lifetimes(101, self.ROOT, {101: self.ROOT}, identities)
+            is False
+        )
+
+    def test_rejects_a_handle_that_names_a_different_pid(self):
+        # A handle whose GetProcessId disagrees with the Toolhelp row IS the
+        # recycled-PID case this check exists for.
+        identities = {self.ROOT: (self.ROOT, 10, None), 101: (999, 15, None)}
+        assert (
+            pc._windows_lineage_matches_lifetimes(101, self.ROOT, {101: self.ROOT}, identities)
+            is False
+        )
+
+    def test_rejects_a_child_older_than_its_parent(self):
+        identities = {self.ROOT: (self.ROOT, 30, None), 101: (101, 10, None)}
+        assert (
+            pc._windows_lineage_matches_lifetimes(101, self.ROOT, {101: self.ROOT}, identities)
+            is False
+        )
+
+    def test_rejects_a_child_created_after_the_parent_exited(self):
+        # Same numeric parent, but the child cannot belong to a process that had
+        # already exited -- the PID was reused.
+        identities = {self.ROOT: (self.ROOT, 10, 20), 101: (101, 25, None)}
+        assert (
+            pc._windows_lineage_matches_lifetimes(101, self.ROOT, {101: self.ROOT}, identities)
+            is False
+        )
+
+    def test_a_lifetime_consistent_cycle_still_terminates(self):
+        # Equal creation times make every edge pass the lifetime checks, so only
+        # the visited-set guard can stop the walk. Without it this hangs a kill
+        # path on a snapshot that PID reuse made cyclic.
+        parent_map = {101: 102, 102: 101}
+        identities = {
+            self.ROOT: (self.ROOT, 15, None),
+            101: (101, 15, None),
+            102: (102, 15, None),
+        }
+        assert (
+            pc._windows_lineage_matches_lifetimes(101, self.ROOT, parent_map, identities) is False
+        )
+
+
+class TestDescendantHandleScanCleanup:
+    def test_refuses_a_reserved_or_non_int_root_pid(self):
+        # Nothing about this call is safe if the root is not a real PID we own:
+        # pid 1 would anchor the walk at init and sweep in the whole session.
+        for candidate in (1, 0, True):
+            with pytest.raises(ValueError, match="reserved pid"):
+                pc.descendant_termination_handles(candidate, {}, 8001)
+
+    def test_returns_empty_off_windows(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", False)
+        assert pc.descendant_termination_handles(100, {}, 8001) == {}
+
+    def test_requires_an_exact_root_handle(self, monkeypatch):
+        # A numeric PID alone cannot anchor the walk -- it is the recycle-prone
+        # identifier this whole function exists to stop trusting.
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        for candidate in (None, 0, -1):
+            with pytest.raises(ValueError, match="exact root handle required"):
+                pc.descendant_termination_handles(100, {}, candidate)
+
+    def test_refuses_a_root_handle_that_names_another_process(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            pc, "_windows_process_handle_identity", lambda _h: (999, 1, None)
+        )
+        with pytest.raises(ValueError, match="root handle identity mismatch"):
+            pc.descendant_termination_handles(100, {}, 8001)
+
+    def test_closes_every_opened_handle_when_the_scan_fails(self, monkeypatch):
+        # The caller never sees these handles, so a leak here is unreachable and
+        # permanent -- and it pins the exited PID's kernel object alive, which is
+        # what makes a recycled PID look live.
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        maps: list[Any] = [{101: 100}, OSError("snapshot vanished")]
+
+        def _parent_map() -> Any:
+            head = maps.pop(0)
+            if isinstance(head, Exception):
+                raise head
+            return head
+
+        closed: list[int] = []
+        monkeypatch.setattr(pc, "_windows_process_parent_map", _parent_map)
+        monkeypatch.setattr(pc, "_open_process_termination_handle", lambda _pid: 9001)
+        monkeypatch.setattr(
+            pc,
+            "_windows_process_handle_identity",
+            {8001: (100, 10, None), 9001: (101, 15, None)}.get,
+        )
+        monkeypatch.setattr(pc, "close_process_handle", closed.append)
+        with pytest.raises(OSError, match="snapshot vanished"):
+            pc.descendant_termination_handles(100, {}, 8001)
+        assert closed == [9001]
+
+    def test_skips_children_whose_handle_cannot_be_opened(self, monkeypatch):
+        # A child that exits between the snapshot and the open is not an error;
+        # it just is not ours to terminate.
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_windows_process_parent_map", lambda: {101: 100})
+        monkeypatch.setattr(pc, "_open_process_termination_handle", lambda _pid: None)
+        monkeypatch.setattr(
+            pc, "_windows_process_handle_identity", lambda _h: (100, 10, None)
+        )
+        assert pc.descendant_termination_handles(100, {}, 8001) == {}
+
+
+class TestCloseProcessHandleWindows:
+    def test_closes_the_handle(self, monkeypatch):
+        closed: list[int] = []
+
+        def _close(handle: Any) -> bool:
+            closed.append(int(handle.value))
+            return True
+
+        _fake_windows(
+            monkeypatch,
+            kernel32=types.SimpleNamespace(CloseHandle=_Fn(_close)),
+        )
+        pc.close_process_handle(4321)
+        assert closed == [4321]
+
+    def test_suppresses_a_failed_close(self, monkeypatch):
+        # Called from ``finally`` blocks and from the scan's cleanup path, so it
+        # must never displace the exception that got us there.
+        _fake_windows(monkeypatch)  # no kernel32 -> the load raises
+        pc.close_process_handle(4321)
+
+
+class TestDuplicateAsyncioHandleFailure:
+    def test_reports_none_when_the_duplication_call_raises(self, monkeypatch):
+        popen = types.SimpleNamespace(_handle=909)
+        transport = types.SimpleNamespace(get_extra_info=lambda _key: popen)
+        process = types.SimpleNamespace(_transport=transport)
+
+        def _boom(*_args: Any) -> Any:
+            raise OSError("DuplicateHandle blew up")
+
+        _fake_windows(
+            monkeypatch,
+            kernel32=types.SimpleNamespace(
+                GetCurrentProcess=_const(1), DuplicateHandle=_Fn(_boom)
+            ),
+        )
+        assert pc.duplicate_asyncio_process_handle(process) is None
+
+
+class TestDescendantHandlesAsyncWindows:
+    def test_offloads_the_snapshot_walk_off_the_event_loop(self, monkeypatch):
+        # Two Toolhelp snapshots plus a handle open per child is a blocking
+        # burst; running it on the loop stalls chat and the heartbeat.
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        sentinel = object()
+        seen_executors: list[Any] = []
+        forwarded: list[Any] = []
+
+        monkeypatch.setattr(pc, "subprocess_executor", lambda: sentinel)
+
+        def _walk(*args: Any) -> Any:
+            forwarded.append(args)
+            return {101: 9001}
+
+        monkeypatch.setattr(pc, "descendant_termination_handles", _walk)
+
+        async def _driver() -> Any:
+            loop = asyncio.get_running_loop()
+
+            def _spy(executor: Any, func: Any, *args: Any) -> Any:
+                seen_executors.append(executor)
+                future: asyncio.Future = loop.create_future()
+                future.set_result(func(*args))
+                return future
+
+            # setattr rather than assignment: the stdlib signature is generic
+            # over the callable's parameters, which a spy cannot restate.
+            setattr(loop, "run_in_executor", _spy)
+            return await pc.descendant_termination_handles_async(100, {55: 7}, 8001)
+
+        assert asyncio.run(_driver()) == {101: 9001}
+        assert seen_executors == [sentinel]
+        # The retained map is copied before crossing the thread boundary, so a
+        # caller mutating its own dict cannot race the worker.
+        assert forwarded == [(100, {55: 7}, 8001)]
+
+
+# ---------------------------------------------------------------------------
+# Kill paths
+# ---------------------------------------------------------------------------
+
+
+class TestKillProcessTreeBroadcastGuard:
+    """``killpg(1, sig)`` is ``kill(-1, sig)`` in libc -- a signal to EVERY
+    process this uid owns, including the ``systemd --user`` manager, the user's
+    SSH session and the gateway itself. This guard is all that stands between a
+    mis-derived pgid and that.
+    """
+
+    def test_refuses_a_reserved_or_non_int_pid(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        # A mocked Popen's MagicMock pid coerces to 1 via __index__, which is
+        # exactly how a test double turns into a broadcast in production code.
+        for candidate in (1, 0, True):
+            with pytest.raises(ValueError, match="reserved pid"):
+                pc.kill_process_tree(candidate, pc.SIGTERM)
+
+    @_POSIX_ONLY
+    def test_degrades_to_a_pid_scoped_kill_for_a_broadcast_pgid(self, monkeypatch, caplog):
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        monkeypatch.setattr(pc.os, "getpgid", lambda _pid: 1)
+        killed: list[tuple[int, int]] = []
+        monkeypatch.setattr(pc.os, "kill", lambda pid, sig: killed.append((pid, sig)))
+
+        def _forbidden(*_args: Any) -> Any:
+            raise AssertionError("must never signal the whole process group")
+
+        monkeypatch.setattr(pc.os, "killpg", _forbidden)
+        with caplog.at_level(logging.ERROR, logger=pc.logger.name):
+            assert pc.kill_process_tree(4242, pc.SIGKILL) is True
+        assert killed == [(4242, pc.SIGKILL)]
+        assert any("refusing broadcast/self pgid" in r.getMessage() for r in caplog.records)
+
+    @_POSIX_ONLY
+    def test_degrades_to_a_pid_scoped_kill_for_our_own_group(self, monkeypatch):
+        # Our own pgid contains the gateway, so a group signal there is suicide.
+        # ``_OWN_PGID`` is captured at import precisely so the check cannot be
+        # defeated by test-time ``os.getpgid`` patching -- hence the fake returns
+        # that value rather than relying on the patch.
+        monkeypatch.setattr(pc, "IS_POSIX", True)
+        monkeypatch.setattr(pc.os, "getpgid", lambda _pid: pc._OWN_PGID)
+        killed: list[tuple[int, int]] = []
+        monkeypatch.setattr(pc.os, "kill", lambda pid, sig: killed.append((pid, sig)))
+
+        def _forbidden(*_args: Any) -> Any:
+            raise AssertionError("must never signal our own process group")
+
+        monkeypatch.setattr(pc.os, "killpg", _forbidden)
+        assert pc.kill_process_tree(4242, pc.SIGTERM) is True
+        assert killed == [(4242, pc.SIGTERM)]
+
+
+class TestWindowsKillWithoutTaskkill:
+    """A quiet ``True`` would strand a live process while reporting it
+    terminated, so an unresolvable ``taskkill`` must raise -- callers branch on
+    the exception to escalate."""
+
+    def test_kill_pid_raises_when_taskkill_is_unresolvable(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _name: None)
+
+        def _forbidden(*_a: Any, **_k: Any) -> Any:
+            raise AssertionError("must not spawn a PATH-resolved taskkill")
+
+        monkeypatch.setattr(pc.subprocess, "run", _forbidden)
+        with pytest.raises(OSError, match="trusted system directories"):
+            pc.kill_pid(999_999, pc.SIGKILL)
+
+    def test_kill_process_tree_raises_when_taskkill_is_unresolvable(self, monkeypatch):
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "trusted_system_bin", lambda _name: None)
+        with pytest.raises(OSError, match="trusted system directories"):
+            pc.kill_process_tree(999_999, pc.SIGKILL)
+
+    def test_the_tree_kill_argv_carries_the_recursive_flag(self, monkeypatch):
+        # /T is what makes it a TREE kill; losing it silently orphans every
+        # descendant while the call still reports success.
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(
+            pc, "trusted_system_bin", lambda _name: r"C:\Windows\System32\taskkill.exe"
+        )
+        captured: dict[str, list] = {}
+
+        def _run(argv: Any, **_kwargs: Any) -> Any:
+            captured["argv"] = list(argv)
+            return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+        monkeypatch.setattr(pc.subprocess, "run", _run)
+        assert pc.kill_process_tree(4242, pc.SIGKILL) is True
+        assert captured["argv"][1:] == ["/T", "/F", "/PID", "4242"]
+
+
+# ---------------------------------------------------------------------------
+# Directory links -- the junction fallback
+# ---------------------------------------------------------------------------
+
+
+class TestSymlinkJunctionFallback:
+    def test_falls_back_to_a_junction_when_the_symlink_is_refused(self, monkeypatch, tmp_path):
+        # An ordinary Windows account holds no SeCreateSymbolicLinkPrivilege, so
+        # os.symlink raises WinError 1314 and every feature that links a
+        # directory into place breaks unless this fallback fires.
+        monkeypatch.setattr(pc, "IS_POSIX", False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        target = tmp_path / "target"
+        target.mkdir()
+        link = tmp_path / "link"
+
+        def _refused(*_args: Any, **_kwargs: Any) -> Any:
+            raise OSError(1314, "A required privilege is not held by the client")
+
+        monkeypatch.setattr(pc.os, "symlink", _refused)
+        created: list[tuple[str, str]] = []
+        monkeypatch.setitem(
+            sys.modules,
+            "_winapi",
+            types.SimpleNamespace(
+                CreateJunction=lambda t, ln: created.append((t, ln)),
+            ),
+        )
+        pc.symlink_or_junction(target, link)
+        assert created == [(str(target), str(link))]
+
+
+# ---------------------------------------------------------------------------
+# Per-pid RSS -- the Win32 failure return
+# ---------------------------------------------------------------------------
+
+
+class TestProcRssForPidWindowsLoaderFailure:
+    def test_reports_unknown_when_the_win32_boundary_fails(self, monkeypatch):
+        # "Unknown" (None) is the contract the RSS staleness probe relies on: a
+        # zero would read as a healthy, tiny process.
+        monkeypatch.setattr(pc.sys, "platform", "win32")
+        _fake_windows(monkeypatch)  # neither kernel32 nor psapi resolves
+        assert pc.proc_rss_bytes_for_pid(777) is None

--- a/test/test_vector_memory_coverage.py
+++ b/test/test_vector_memory_coverage.py
@@ -1,0 +1,1461 @@
+"""Coverage-focused tests for the less-travelled paths of ``vector_memory``.
+
+The store's happy paths are already covered by ``test_vector_memory.py``. This
+module targets the branches that only fire on legacy/degraded input: the legacy
+markdown migration, the export/import round trip, episodic promotion, the
+keyword fallback, the embedding backfill sweeps, and the many "value on disk is
+not what the writer promised" recovery paths.
+
+Everything runs against a fresh SQLite file under ``tmp_path`` with a
+deterministic in-process embedder — no network, no model download, no FAISS
+requirement.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import time
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from kiro_crew import vector_memory as vm
+from kiro_crew.vector_memory import VectorMemoryStore
+
+_DIM = 8
+
+
+def _store(tmp_path: Path, *, episodic_max: int = 10_000) -> VectorMemoryStore:
+    store = VectorMemoryStore(
+        db_path=tmp_path / "mem.db", embedding_dim=_DIM, episodic_max=episodic_max
+    )
+    store.init()
+    return store
+
+
+def _fixed_embed(value: float = 0.5, dim: int = _DIM) -> Callable[[str], list[float] | None]:
+    """A deterministic embedder: every text maps to the same unit-able vector."""
+    return lambda _text: [value] * dim
+
+
+def _recorder(sink: list[tuple[int, int]]) -> Callable[[int, int], None]:
+    """A ``progress(done, total)`` callback that records every report."""
+
+    def _record(done: int, total: int) -> None:
+        sink.append((done, total))
+
+    return _record
+
+
+def _raw_semantic_embedding(store: VectorMemoryStore, key: str) -> bytes | None:
+    row = store.db.execute(
+        "SELECT embedding FROM semantic_memory WHERE key = ?", (key,)
+    ).fetchone()
+    return None if row is None else row["embedding"]
+
+
+def _episodic_texts(store: VectorMemoryStore, *, deleted: bool = False) -> list[str]:
+    rows = store.db.execute(
+        "SELECT text FROM episodic_memories WHERE is_deleted = ? ORDER BY created_at",
+        (1 if deleted else 0,),
+    ).fetchall()
+    return [r["text"] for r in rows]
+
+
+class TestMigrateV2:
+    """The embedding-column migration must be idempotent but not swallow real errors."""
+
+    def test_duplicate_column_is_tolerated(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        # init() already applied the migration; a second application must be a no-op.
+        vm._migrate_v2(store.db)
+        cols = {r[1] for r in store.db.execute("PRAGMA table_info(semantic_memory)")}
+        assert "embedding" in cols
+
+    def test_other_operational_errors_propagate(self) -> None:
+        db = vm.sqlite3.connect(":memory:")
+        try:
+            with pytest.raises(vm.sqlite3.OperationalError):
+                vm._migrate_v2(db)
+        finally:
+            db.close()
+
+
+class TestInitDegradesWithoutFaiss:
+    def test_index_load_failure_does_not_break_init(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(self: VectorMemoryStore) -> bool:
+            raise RuntimeError("faiss-cpu not installed")
+
+        monkeypatch.setattr(VectorMemoryStore, "load_faiss_index", _boom)
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db", embedding_dim=_DIM)
+        store.init()
+        # The store is still fully usable for semantic + keyword work.
+        assert store.set_semantic("pref.os", "linux", 0.9, "user_explicit") is None
+        store.close()
+
+
+class TestSetSemanticIfAbsent:
+    def test_imports_when_absent(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.set_semantic_if_absent("pref.editor", "vim", 0.9, "import") == "imported"
+        entry = store.get_semantic("pref.editor")
+        assert entry is not None and entry["value_json"] == '"vim"'
+
+    def test_does_not_replace_an_existing_value(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.set_semantic("pref.editor", "emacs", 0.9, "user_explicit")
+        assert store.set_semantic_if_absent("pref.editor", "vim", 0.9, "import") == "existing"
+        entry = store.get_semantic("pref.editor")
+        assert entry is not None and entry["value_json"] == '"emacs"'
+
+    def test_invalid_key_is_rejected(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.set_semantic_if_absent("Not A Key", "x", 0.9, "import") == "rejected"
+
+    def test_tombstoned_row_reports_existing_instead_of_crashing(self, tmp_path: Path) -> None:
+        """A tombstone keeps the primary key, so the INSERT hits an IntegrityError.
+
+        The active-row probe cannot see the tombstone (it filters is_deleted=0),
+        so this is the one path that reaches the IntegrityError handler. It must
+        report "existing" rather than propagating a DB error to the importer.
+        """
+        store = _store(tmp_path)
+        store.set_semantic("pref.editor", "emacs", 0.9, "user_explicit")
+        assert store.delete_semantic("pref.editor", "user_explicit")
+        assert store.set_semantic_if_absent("pref.editor", "vim", 0.9, "import") == "existing"
+
+
+class TestSemanticPaginationAndFormatting:
+    def test_get_all_semantic_paginates(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        for i in range(5):
+            store.set_semantic(f"pref.k{i}", i, 0.9, "user_explicit")
+        page = store.get_all_semantic(limit=2, offset=1)
+        assert [e["key"] for e in page] == ["pref.k1", "pref.k2"]
+
+    def test_unparseable_value_json_falls_back_to_the_raw_text(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.set_semantic("pref.editor", "vim", 0.9, "user_explicit")
+        store.db.execute(
+            "UPDATE semantic_memory SET value_json = ? WHERE key = ?",
+            ("this is not json", "pref.editor"),
+        )
+        store.db.commit()
+        assert "this is not json" in store.get_semantic_context()
+
+    def test_complex_values_render_as_json(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.set_semantic("pref.langs", ["python", "rust"], 0.9, "user_explicit")
+        assert '["python", "rust"]' in store.get_semantic_context()
+
+    def test_cap_smaller_than_the_first_line_yields_nothing(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.set_semantic("pref.editor", "vim", 0.9, "user_explicit")
+        assert store.get_semantic_context(cap=1) == ""
+
+
+class TestEventLog:
+    def test_events_paginate(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        for i in range(4):
+            store.set_semantic(f"pref.k{i}", i, 0.9, "user_explicit")
+        first = store.get_events(limit=2, offset=0)
+        second = store.get_events(limit=2, offset=2)
+        assert len(first) == len(second) == 2
+        assert {e["id"] for e in first}.isdisjoint({e["id"] for e in second})
+
+    def test_rotate_is_a_noop_under_the_cap(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.set_semantic("pref.editor", "vim", 0.9, "user_explicit")
+        assert store.rotate_events(max_rows=100) == 0
+
+    def test_rotate_trims_the_oldest_events(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        for i in range(5):
+            store.set_semantic(f"pref.k{i}", i, 0.9, "user_explicit")
+        before = store.db.execute("SELECT COUNT(*) FROM memory_events").fetchone()[0]
+        assert before >= 5
+        assert store.rotate_events(max_rows=2) == before - 2
+        assert store.db.execute("SELECT COUNT(*) FROM memory_events").fetchone()[0] == 2
+
+    def test_a_broken_audit_table_does_not_fail_the_write(self, tmp_path: Path) -> None:
+        """A broken audit write must never take the caller down with it."""
+        store = _store(tmp_path)
+        store.db.execute("DROP TABLE memory_events")
+        store.db.commit()
+
+        assert store.set_semantic("pref.editor", "vim", 0.9, "user_explicit") is None
+        entry = store.get_semantic("pref.editor")
+        assert entry is not None and entry["value_json"] == '"vim"'
+
+
+class TestRetireStaleEpisodicTextFallback:
+    def test_exact_phrase_references_are_tombstoned_without_embeddings(
+        self, tmp_path: Path
+    ) -> None:
+        """With no embedder the retirement falls back to exact phrase matching."""
+        store = _store(tmp_path)
+        store.set_semantic("pref.editor", "vim", 0.9, "user_explicit")
+        assert store.write_episodic("Remember that the editor: vim setting is global")
+        assert store.write_episodic("Unrelated note about the deployment pipeline schedule")
+
+        store.set_semantic("pref.editor", "emacs", 0.9, "user_explicit")
+
+        remaining = _episodic_texts(store)
+        assert remaining == ["Unrelated note about the deployment pipeline schedule"]
+        retired = _episodic_texts(store, deleted=True)
+        assert retired == ["Remember that the editor: vim setting is global"]
+
+    def test_retirement_failure_keeps_the_semantic_write(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = _store(tmp_path)
+        store.set_semantic("pref.editor", "vim", 0.9, "user_explicit")
+
+        def _boom(key: str, old_value: str) -> None:
+            raise RuntimeError("retirement exploded")
+
+        monkeypatch.setattr(store, "_retire_stale_episodic", _boom)
+        assert store.set_semantic("pref.editor", "emacs", 0.9, "user_explicit") is None
+        entry = store.get_semantic("pref.editor")
+        assert entry is not None and entry["value_json"] == '"emacs"'
+
+    def test_rephrased_references_are_retired_via_vector_similarity(
+        self, tmp_path: Path
+    ) -> None:
+        """With an embedder the retirement also runs the vector-similarity sweep."""
+        store = _store(tmp_path)
+        store.embed_fn = _fixed_embed()
+        store.set_semantic("pref.editor", "vim", 0.9, "user_explicit")
+        assert store.write_episodic("The user has always reached for vim on this box")
+
+        store.set_semantic("pref.editor", "emacs", 0.9, "user_explicit")
+
+        assert _episodic_texts(store) == []
+        assert _episodic_texts(store, deleted=True) == [
+            "The user has always reached for vim on this box"
+        ]
+
+    def test_an_unparseable_old_value_is_stringified(self, tmp_path: Path) -> None:
+        """A legacy row whose value_json is not JSON must still drive retirement."""
+        store = _store(tmp_path)
+        store.set_semantic("pref.editor", "vim", 0.9, "user_explicit")
+        store.db.execute(
+            "UPDATE semantic_memory SET value_json = ? WHERE key = ?",
+            ("bare-vim", "pref.editor"),
+        )
+        store.db.commit()
+        assert store.write_episodic("Remember that the editor bare-vim is the default")
+
+        assert store.set_semantic("pref.editor", "emacs", 0.9, "user_explicit") is None
+        assert _episodic_texts(store) == []
+
+
+class TestSqliteVectorSearchEdges:
+    def test_rows_with_a_different_width_are_skipped(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _fixed_embed()
+        assert store.write_episodic("A memory embedded at the store's native width")
+        # Corrupt one row's vector to a narrower width; it must be ignored, not crash.
+        store.db.execute(
+            "UPDATE episodic_memories SET embedding = ?",
+            (struct.pack("3f", 1.0, 0.0, 0.0),),
+        )
+        store.db.commit()
+        assert store.search_episodic(query_embedding=[0.5] * _DIM, limit=5) == []
+
+    def test_tag_filter_excludes_non_matching_rows(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _fixed_embed()
+        assert store.write_episodic("A note that belongs to the ops rotation", tags=["ops"])
+        assert store.write_episodic("A note that belongs to the docs backlog", tags=["docs"])
+
+        hits = store.search_episodic(query_embedding=[0.5] * _DIM, limit=5, tag_filter=["ops"])
+        assert [h["text"] for h in hits] == ["A note that belongs to the ops rotation"]
+
+
+class TestEpisodicListAndDelete:
+    def test_list_filters_by_tag(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_episodic("An entry filed under the ops rotation", tags=["ops"])
+        assert store.write_episodic("An entry filed under the docs backlog", tags=["docs"])
+        rows = store.get_episodic_list(tag_filter=["ops"])
+        assert [r["text"] for r in rows] == ["An entry filed under the ops rotation"]
+
+    def test_deleting_an_unknown_id_reports_false(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.delete_episodic("no-such-id") is False
+
+
+class TestEpisodicContext:
+    def test_query_text_is_embedded_when_no_vector_is_supplied(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _fixed_embed()
+        assert store.write_episodic("The release train ships every Thursday afternoon")
+        context = store.get_episodic_context(query_text="release train schedule")
+        assert "release train ships every Thursday" in context
+        assert context.startswith("[Episodic Memory")
+
+    def test_cap_truncates_the_result_list(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _fixed_embed()
+        for i in range(3):
+            assert store.write_episodic(f"Fragment number {i} of the capped context body")
+        context = store.get_episodic_context(query_embedding=[0.5] * _DIM, cap=50)
+        # Only the first line fits under a 50-char cap.
+        assert context.count("\n1. ") == 1
+        assert "\n2. " not in context
+
+    def test_cap_below_the_first_line_yields_nothing(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _fixed_embed()
+        assert store.write_episodic("A fragment long enough to blow a one-character cap")
+        assert store.get_episodic_context(query_embedding=[0.5] * _DIM, cap=1) == ""
+
+
+class TestEpisodicHelpers:
+    def test_matches_tags_accepts_an_already_decoded_list(self) -> None:
+        assert VectorMemoryStore._matches_tags({"tags": ["Ops"]}, ["ops"]) is True
+        assert VectorMemoryStore._matches_tags({"tags": ["docs"]}, ["ops"]) is False
+        assert VectorMemoryStore._matches_tags({"tags": None}, ["ops"]) is False
+
+    def test_batch_fetch_skips_missing_and_tombstoned_ids(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_episodic("The first batch-fetched episodic fragment")
+        assert store.write_episodic("The second batch-fetched episodic fragment")
+        ids = [r["id"] for r in store.get_episodic_list()]
+        assert store.delete_episodic(ids[0])
+
+        assert store._get_episodic_batch([]) == {}
+        fetched = store._get_episodic_batch([*ids, "ghost-id"])
+        assert set(fetched) == {ids[1]}
+        assert "embedding" not in fetched[ids[1]]
+
+    def test_touch_cache_is_swept_when_it_grows_past_the_cap(self, tmp_path: Path) -> None:
+        """The debounce map is process-local state, so it must stay bounded."""
+        store = _store(tmp_path)
+        store.embed_fn = _fixed_embed()
+        assert store.write_episodic("A memory whose access timestamp gets debounced")
+        # Seed the map past its cap with entries far older than the debounce window.
+        stale = time.monotonic() - 10_000.0
+        store._last_accessed_touch = {
+            f"stale-{i}": stale for i in range(store._LAST_ACCESSED_CACHE_MAX + 4)
+        }
+        hits = store.search_episodic(query_embedding=[0.5] * _DIM, limit=5)
+        assert hits
+        assert len(store._last_accessed_touch) <= store._LAST_ACCESSED_CACHE_MAX
+        assert not any(k.startswith("stale-") for k in store._last_accessed_touch)
+
+
+class TestParsePreference:
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("editor: vim", ("pref.editor", "vim")),
+            ("My favorite language is python", ("pref.favorite_language", "python")),
+            ("I prefer dark mode", ("pref.general", "dark mode")),
+            ("something entirely freeform", None),
+        ],
+    )
+    def test_heuristics(self, text: str, expected: tuple[str, str] | None) -> None:
+        assert VectorMemoryStore._parse_preference(text) == expected
+
+
+class TestDeleteLesson:
+    def test_deletes_every_lesson_matching_the_substring(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson("Always pin the release tag before publishing a wheel")
+        assert store.write_lesson("Never bind a diagnostic server to a public interface")
+        assert store.delete_lesson("RELEASE TAG") is True
+        remaining = [json.loads(e["value_json"]) for e in store.get_lessons()]
+        assert remaining == ["Never bind a diagnostic server to a public interface"]
+
+    def test_no_match_reports_false(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson("Always pin the release tag before publishing a wheel")
+        assert store.delete_lesson("something that is simply not there") is False
+
+
+class TestContradictionCandidateBlobRecovery:
+    def test_malformed_stored_vectors_are_skipped(self, tmp_path: Path) -> None:
+        """Truncated / unpackable blobs must be skipped, not raise."""
+        store = _store(tmp_path)
+        assert store.write_lesson("Prefer allowlists over denylists for network egress")
+        assert store.write_lesson("Rotate the signing key whenever a maintainer leaves")
+        keys = [e["key"] for e in store.get_lessons()]
+
+        # One blob too short to hold a single float, one that unpacks unevenly.
+        store.db.execute(
+            "UPDATE semantic_memory SET embedding = ? WHERE key = ?", (b"ab", keys[0])
+        )
+        store.db.execute(
+            "UPDATE semantic_memory SET embedding = ? WHERE key = ?", (b"abcde", keys[1])
+        )
+        store.db.commit()
+
+        store.embed_fn = _fixed_embed()
+        assert store.find_contradiction_candidates("Some brand new rule about egress") == []
+
+
+class TestTryEmbedFailureModes:
+    def test_an_exploding_embedder_yields_none(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+
+        def _boom(_text: str) -> list[float] | None:
+            raise RuntimeError("model crashed")
+
+        store.embed_fn = _boom
+        assert store._try_embed("anything at all") is None
+
+    def test_an_exploding_factory_yields_none(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store._embed_fn_rebind_cooldown_secs = 0.0
+
+        def _boom() -> Callable[[str], list[float] | None] | None:
+            raise RuntimeError("factory crashed")
+
+        store.embed_fn_factory = _boom
+        assert store._try_embed("anything at all") is None
+        assert store.embed_fn is None
+
+    def test_a_candidate_that_fails_its_probe_is_not_bound(self, tmp_path: Path) -> None:
+        """The factory succeeded but the model it produced cannot embed."""
+        store = _store(tmp_path)
+        store._embed_fn_rebind_cooldown_secs = 0.0
+
+        def _explodes_on_call(_text: str) -> list[float] | None:
+            raise RuntimeError("model load failed lazily")
+
+        store.embed_fn_factory = lambda: _explodes_on_call
+        assert store._try_embed("anything at all") is None
+        assert store.embed_fn is None
+
+
+class TestBackfillSweeps:
+    def test_no_embedder_is_a_noop(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_episodic("A fragment stored while embeddings were off")
+        assert store.backfill_missing_embeddings() == 0
+
+    def test_progress_is_reported_for_rows_that_fail_to_embed(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_episodic("A fragment that the embedder will refuse to embed")
+        seen: list[tuple[int, int]] = []
+        store.embed_fn = lambda _text: None
+        assert store.backfill_missing_embeddings(progress=_recorder(seen)) == 0
+        # Denominator up front, then one report for the skipped row.
+        assert seen == [(0, 1), (0, 1)]
+
+    def test_wrong_width_vectors_are_left_null_for_a_later_sweep(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_episodic("A fragment the embedder answers at the wrong width")
+        seen: list[tuple[int, int]] = []
+        store.embed_fn = _fixed_embed(dim=_DIM + 3)
+        assert store.backfill_missing_embeddings(progress=_recorder(seen)) == 0
+        assert seen == [(0, 1), (0, 1)]
+        row = store.db.execute("SELECT embedding FROM episodic_memories").fetchone()
+        assert row["embedding"] is None
+
+    def test_lesson_vectors_are_repaired_with_progress(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson("Always squash a review branch down to one commit")
+        key = store.get_lessons()[0]["key"]
+        assert _raw_semantic_embedding(store, key) is None
+
+        seen: list[tuple[int, int]] = []
+        store.embed_fn = _fixed_embed()
+        assert store._backfill_lesson_embeddings(progress=_recorder(seen)) == 1
+        assert seen == [(0, 1), (1, 1)]
+        blob = _raw_semantic_embedding(store, key)
+        assert blob is not None and len(blob) == _DIM * 4
+
+    def test_lessons_with_unparseable_values_are_skipped(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson("Always squash a review branch down to one commit")
+        key = store.get_lessons()[0]["key"]
+        store.db.execute(
+            "UPDATE semantic_memory SET value_json = ? WHERE key = ?", ("<not json>", key)
+        )
+        store.db.commit()
+
+        store.embed_fn = _fixed_embed()
+        assert store._backfill_lesson_embeddings() == 0
+        assert _raw_semantic_embedding(store, key) is None
+
+    def test_lessons_the_embedder_refuses_stay_null(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson("Always squash a review branch down to one commit")
+        key = store.get_lessons()[0]["key"]
+        store.embed_fn = lambda _text: None
+        assert store._backfill_lesson_embeddings() == 0
+        assert _raw_semantic_embedding(store, key) is None
+
+    def test_no_lesson_rows_is_a_noop(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _fixed_embed()
+        assert store._backfill_lesson_embeddings() == 0
+
+    def test_lesson_sweep_without_an_embedder_is_a_noop(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson("Always squash a review branch down to one commit")
+        assert store._backfill_lesson_embeddings() == 0
+
+
+class TestLessonDedup:
+    def test_a_rule_already_covered_by_a_longer_lesson_is_dropped(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson(
+            "Always pin the release tag before publishing a wheel to the CDN"
+        )
+        assert store.write_lesson("pin the release tag") is False
+        assert len(store.get_lessons()) == 1
+
+    def test_a_longer_rule_replaces_the_lesson_it_contains(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson("pin the release tag")
+        assert store.write_lesson(
+            "Always pin the release tag before publishing a wheel to the CDN"
+        )
+        remaining = [json.loads(e["value_json"]) for e in store.get_lessons()]
+        assert remaining == ["Always pin the release tag before publishing a wheel to the CDN"]
+
+    def test_an_unpackable_stored_vector_does_not_break_the_dedup_scan(
+        self, tmp_path: Path
+    ) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson("Prefer allowlists over denylists for network egress")
+        key = store.get_lessons()[0]["key"]
+        store.db.execute(
+            "UPDATE semantic_memory SET embedding = ? WHERE key = ?", (b"abcde", key)
+        )
+        store.db.commit()
+
+        store.embed_fn = _fixed_embed()
+        assert store.write_lesson("Rotate the signing key whenever a maintainer departs")
+        assert len(store.get_lessons()) == 2
+
+    def test_a_space_change_mid_scan_drops_the_lazy_backfills(self, tmp_path: Path) -> None:
+        """Lazy backfills embedded before a model swap must not be committed.
+
+        The dedup scan embeds legacy lessons inline, so a swap can land between
+        two entries. The blob from before the swap belongs to the old vector
+        space and has to be left NULL for the post-activation sweep instead of
+        being written behind reconcile's back.
+        """
+        store = _store(tmp_path)
+        assert store.write_lesson("Prefer allowlists over denylists for network egress")
+        assert store.write_lesson("Rotate the signing key whenever a maintainer departs")
+        keys = [e["key"] for e in store.get_lessons()]
+        assert all(_raw_semantic_embedding(store, k) is None for k in keys)
+
+        calls: list[str] = []
+
+        def _swap_on_the_last_backfill(text: str) -> list[float] | None:
+            calls.append(text)
+            # 1 = the new rule, 2 = first lazy backfill, 3 = second lazy backfill.
+            if len(calls) == 3:
+                store.begin_space_change()
+            # Distinct one-hot vectors so nothing trips the >0.85 semantic dedup.
+            vec = [0.0] * _DIM
+            vec[len(calls) % _DIM] = 1.0
+            return vec
+
+        store.embed_fn = _swap_on_the_last_backfill
+        assert store.write_lesson("Verify the changelog headings render on mobile widths")
+
+        assert len(calls) == 3
+        # Neither legacy lesson kept a vector from the superseded space.
+        assert all(_raw_semantic_embedding(store, k) is None for k in keys)
+
+
+class TestFaissAbsent:
+    @pytest.mark.skipif(vm._HAS_FAISS, reason="asserts the no-faiss degradation")
+    def test_index_build_is_a_noop_without_faiss(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _fixed_embed()
+        assert store.write_episodic("A fragment stored while faiss is unavailable")
+        assert store.build_faiss_index() == 0
+        # Vector search still works via the stdlib cosine fallback.
+        assert store.search_episodic(query_embedding=[0.5] * _DIM, limit=5)
+
+
+class TestKeywordFallback:
+    def test_a_query_with_no_usable_words_returns_nothing(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_episodic("A fragment about the nightly deployment pipeline")
+        assert store.search_episodic(query_text="a of to") == []
+
+    def test_keyword_search_matches_text(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_episodic("A fragment about the nightly deployment pipeline")
+        assert store.write_episodic("A fragment about the quarterly planning review")
+        hits = store.search_episodic(query_text="deployment", limit=5)
+        assert [h["text"] for h in hits] == ["A fragment about the nightly deployment pipeline"]
+
+    def test_keyword_search_honours_the_tag_filter(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_episodic(
+            "A fragment about the nightly deployment pipeline", tags=["ops"]
+        )
+        assert store.write_episodic(
+            "Another fragment about the deployment checklist", tags=["docs"]
+        )
+        hits = store.search_episodic(query_text="deployment", limit=5, tag_filter=["ops"])
+        assert [h["text"] for h in hits] == ["A fragment about the nightly deployment pipeline"]
+
+
+class TestEpisodicPromotion:
+    def test_promotion_without_an_embedder_is_skipped(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.promote_episodic_patterns() == 0
+
+    @pytest.mark.skipif(not vm._HAS_NUMPY, reason="clustering needs numpy")
+    def test_a_repeated_pattern_becomes_a_semantic_fact(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _fixed_embed()
+        for i in range(5):
+            assert store.write_episodic(
+                f"Note {i}: user prefers dark mode across every dashboard surface"
+            )
+
+        assert store.promote_episodic_patterns(min_count=5) == 1
+        entry = store.get_semantic("pref.general")
+        assert entry is not None
+        assert "dark mode" in json.loads(entry["value_json"])
+        # Every clustered member is retired so it cannot be promoted twice.
+        assert _episodic_texts(store) == []
+
+    @pytest.mark.skipif(not vm._HAS_NUMPY, reason="clustering needs numpy")
+    def test_a_cluster_with_no_inferrable_key_is_left_alone(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _fixed_embed()
+        for i in range(5):
+            assert store.write_episodic(
+                f"Shard {i} of the nightly sweep finished without any warnings"
+            )
+
+        assert store.promote_episodic_patterns(min_count=5) == 0
+        assert len(_episodic_texts(store)) == 5
+
+    @pytest.mark.skipif(not vm._HAS_NUMPY, reason="clustering needs numpy")
+    def test_a_cluster_below_the_threshold_is_left_alone(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _fixed_embed()
+        for i in range(2):
+            assert store.write_episodic(
+                f"Note {i}: user prefers dark mode across every dashboard surface"
+            )
+        assert store.promote_episodic_patterns(min_count=5) == 0
+        assert store.get_semantic("pref.general") is None
+
+
+class TestSemanticKeyInference:
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("User prefers tabs over spaces", "pref.general"),
+            ("i like short commit subjects", "pref.general"),
+            ("project Redwood uses terraform for provisioning", "project.redwood.tool"),
+            ("nothing here resembles a preference", None),
+        ],
+    )
+    def test_key_inference(self, text: str, expected: str | None) -> None:
+        assert VectorMemoryStore._infer_semantic_key(text) == expected
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("User prefers tabs over spaces", "tabs over spaces"),
+            ("project Redwood uses terraform", "terraform"),
+            ("already a bare value", "already a bare value"),
+        ],
+    )
+    def test_value_extraction(self, text: str, expected: str) -> None:
+        assert VectorMemoryStore._extract_value_from_text(text) == expected
+
+
+class TestImportMemory:
+    def test_round_trip_of_both_shapes(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        counts = store.import_memory(
+            {
+                "semantic": [
+                    {"key": "pref.editor", "value_json": '"vim"', "confidence": 0.9},
+                    {"key": "pref.shell", "value": "zsh"},
+                ],
+                "episodic": [
+                    {"text": "An imported fragment carrying JSON-encoded tags", "tags": '["ops"]'},
+                    {"text": "An imported fragment carrying already-decoded tags", "tags": ["qa"]},
+                ],
+            }
+        )
+        assert counts == {"semantic": 2, "episodic": 2, "skipped": 0}
+        editor = store.get_semantic("pref.editor")
+        shell = store.get_semantic("pref.shell")
+        assert editor is not None and json.loads(editor["value_json"]) == "vim"
+        assert shell is not None and json.loads(shell["value_json"]) == "zsh"
+        assert len(store.get_episodic_list(tag_filter=["ops"])) == 1
+        assert len(store.get_episodic_list(tag_filter=["qa"])) == 1
+
+    def test_missing_and_rejected_entries_are_counted_as_skipped(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        counts = store.import_memory(
+            {
+                "semantic": [
+                    {"value_json": '"orphan"'},  # no key at all
+                    {"key": "Not A Key", "value": "x"},  # fails validation
+                ],
+                "episodic": [
+                    {"tags": []},  # no text at all
+                    {"text": "tiny"},  # below the minimum length
+                ],
+            }
+        )
+        assert counts == {"semantic": 0, "episodic": 0, "skipped": 4}
+
+    def test_an_empty_payload_is_a_noop(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.import_memory({}) == {"semantic": 0, "episodic": 0, "skipped": 0}
+
+
+class TestMigrateFromMarkdown:
+    """The legacy markdown/JSONL importer, driven entirely off a tmp_path home."""
+
+    def _home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        home = tmp_path / "crew-home"
+        (home / "workspace" / "memory").mkdir(parents=True)
+        monkeypatch.setattr(vm, "config_dir", lambda: home)
+        return home
+
+    def test_nothing_on_disk_is_a_clean_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._home(tmp_path, monkeypatch)
+        store = _store(tmp_path)
+        assert store.migrate_from_markdown() == {"semantic": 0, "episodic": 0, "skipped": 0}
+
+    def test_lessons_jsonl(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        home = self._home(tmp_path, monkeypatch)
+        (home / "lessons.jsonl").write_text(
+            "\n".join(
+                [
+                    json.dumps({"rule": "Always pin the release tag before publishing"}),
+                    "",
+                    json.dumps({"rule": "Never bind a debug server to a public address"}),
+                    "{ not json at all",
+                    json.dumps({"category": "knowledge"}),  # no rule
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        store = _store(tmp_path)
+        counts = store.migrate_from_markdown()
+        assert counts["semantic"] == 2
+        assert counts["skipped"] == 2
+        assert len(store.get_lessons()) == 2
+
+    def test_preferences_md(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        home = self._home(tmp_path, monkeypatch)
+        oversized = "y" * 5000
+        (home / "workspace" / "memory" / "preferences.md").write_text(
+            "\n".join(
+                [
+                    "# Preferences",  # not a bullet
+                    "- editor: vim",  # parses into a key/value
+                    "- I prefer dark mode",  # parses via the "I prefer" heuristic
+                    "- ",  # empty bullet
+                    "- a freeform note that has no key and no favourite phrasing",
+                    f"- notes: {oversized}",  # parses, but the value is rejected as oversized
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        store = _store(tmp_path)
+        counts = store.migrate_from_markdown()
+
+        editor = store.get_semantic("pref.editor")
+        general = store.get_semantic("pref.general")
+        assert editor is not None and json.loads(editor["value_json"]) == "vim"
+        assert general is not None and json.loads(general["value_json"]) == "dark mode"
+        assert counts["semantic"] == 2
+        # The freeform line lands as episodic; the oversized one is dropped entirely.
+        assert counts["episodic"] == 1
+        assert counts["skipped"] == 1
+        assert store.get_episodic_list(tag_filter=["preference"])
+
+    def test_projects_md(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        home = self._home(tmp_path, monkeypatch)
+        oversized_name = "N" * 5000
+        (home / "workspace" / "memory" / "projects.md").write_text(
+            "\n".join(
+                [
+                    "Prose that is not a bullet at all",
+                    "- Redwood: the ingestion rewrite",
+                    "- The consolidation pass writes semantic keys nightly",
+                    "- The consolidation pass writes semantic keys nightly",  # duplicate
+                    "- s",  # too short for an episodic write
+                    f"- {oversized_name}: rejected as an oversized value",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        store = _store(tmp_path)
+        counts = store.migrate_from_markdown()
+
+        name = store.get_semantic("project.name")
+        assert name is not None and json.loads(name["value_json"]) == "Redwood"
+        assert counts["semantic"] == 1
+        assert counts["episodic"] == 1
+        # duplicate + too-short child + oversized project name
+        assert counts["skipped"] == 3
+        rows = store.get_episodic_list(tag_filter=["redwood"])
+        assert [r["text"] for r in rows] == [
+            "The consolidation pass writes semantic keys nightly"
+        ]
+
+    def test_history_directory(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        home = self._home(tmp_path, monkeypatch)
+        history = home / "workspace" / "memory" / "history"
+        history.mkdir()
+        (history / "a.md").write_text(
+            "# Daily log\n"
+            "[2026-01-01] The gateway restarted cleanly after the config change.\n"
+            "[9] x\n",
+            encoding="utf-8",
+        )
+        (history / "b.md").write_text(
+            "<!-- autogenerated, do not edit -->\n"
+            "[2026-02-01] The nightly consolidation swept forty two fragments.\n",
+            encoding="utf-8",
+        )
+        (history / "c.md").write_text(
+            "[2026-01-01] The gateway restarted cleanly after the config change.\n",
+            encoding="utf-8",
+        )
+        store = _store(tmp_path)
+        counts = store.migrate_from_markdown()
+
+        # Two distinct fragments imported; the duplicate in c.md is deduped away
+        # and the "#", "<!--" and too-short paragraphs are filtered before that.
+        assert counts["episodic"] == 2
+        assert counts["skipped"] == 1
+        assert len(store.get_episodic_list(tag_filter=["history"])) == 2
+
+    def test_long_history_paragraphs_are_truncated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = self._home(tmp_path, monkeypatch)
+        history = home / "workspace" / "memory" / "history"
+        history.mkdir()
+        (history / "a.md").write_text(
+            "[2026-01-01] " + ("w " * 2000) + "\n", encoding="utf-8"
+        )
+        store = _store(tmp_path)
+        assert store.migrate_from_markdown()["episodic"] == 1
+        stored = store.get_episodic_list()[0]["text"]
+        assert len(stored) <= vm._EPISODIC_TEXT_MAX
+
+    def test_embeddings_are_attached_when_an_embedder_is_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = self._home(tmp_path, monkeypatch)
+        (home / "workspace" / "memory" / "preferences.md").write_text(
+            "- a freeform note that has no key and no favourite phrasing\n", encoding="utf-8"
+        )
+        store = _store(tmp_path)
+        store.embed_fn = _fixed_embed()
+        assert store.migrate_from_markdown()["episodic"] == 1
+        embedded = store.db.execute(
+            "SELECT COUNT(*) FROM episodic_memories WHERE embedding IS NOT NULL"
+        ).fetchone()[0]
+        assert embedded == 1
+
+
+class TestObservability:
+    def test_rejection_stats_group_by_reason(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        # Not on the allow-list.
+        assert store.set_semantic("random.key", "x", 0.9, "user_explicit") is not None
+        # Below the confidence gate.
+        assert store.set_semantic("pref.editor", "vim", 0.1, "inferred") is not None
+        stats = store.get_rejection_stats()
+        assert stats.get("allowlist_reject") == 1
+        assert stats.get("low_confidence") == 1
+
+    def test_context_preview_reports_sizes(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _fixed_embed()
+        store.set_semantic("pref.editor", "vim", 0.9, "user_explicit")
+        assert store.write_lesson("Always squash a review branch down to one commit")
+        assert store.write_episodic("A fragment worth surfacing in the preview")
+
+        preview = store.get_context_preview(query_text="editor preferences")
+        assert preview["semantic_chars"] > 0
+        assert preview["episodic_chars"] > 0
+        assert preview["lessons_chars"] > 0
+        assert preview["total_chars"] == (
+            preview["semantic_chars"] + preview["episodic_chars"] + preview["lessons_chars"]
+        )
+        assert preview["lessons_count"] == 1
+        assert "vim" in preview["semantic_preview"]
+
+
+# ── Additional coverage: vector-space lifecycle, lesson dedup, ranking ──
+
+
+def _unit(index: int) -> list[float]:
+    """A basis vector of width ``_DIM``, orthogonal to every other basis vector."""
+    vec = [0.0] * _DIM
+    vec[index % _DIM] = 1.0
+    return vec
+
+
+class _TableEmbedder:
+    """Exact-text lookup embedder, so a test can pin two texts at a chosen cosine.
+
+    Falls back to a deterministic, process-independent vector for any text not in
+    the table (``hash()`` is salted per process and would make tests order- and
+    run-dependent).
+    """
+
+    def __init__(self, table: dict[str, list[float]] | None = None) -> None:
+        self.table = dict(table or {})
+        self.calls: list[str] = []
+
+    def __call__(self, text: str) -> list[float] | None:
+        self.calls.append(text)
+        if text in self.table:
+            return list(self.table[text])
+        vec = [0.0] * _DIM
+        for word in text.lower().split():
+            vec[sum(ord(ch) for ch in word) % _DIM] += 1.0
+        if not any(vec):
+            vec[0] = 1.0
+        return vec
+
+
+def _raw_episodic_embedding(store: VectorMemoryStore, mem_id: str) -> bytes | None:
+    row = store.db.execute(
+        "SELECT embedding FROM episodic_memories WHERE id = ?", (mem_id,)
+    ).fetchone()
+    return None if row is None else row["embedding"]
+
+
+def _lesson_key(rule: str) -> str:
+    import hashlib
+
+    return f"lesson.{hashlib.md5(rule.encode(), usedforsecurity=False).hexdigest()[:12]}"
+
+
+class TestFaissAbsentDegradation:
+    """FAISS is an optional accelerator, so every entry point must no-op without it."""
+
+    def test_build_save_and_load_are_noops(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(vm, "_HAS_FAISS", False)
+        store = _store(tmp_path)
+        assert store.build_faiss_index() == 0
+        store.save_faiss_index()
+        assert not (tmp_path / "memory.faiss").exists()
+        assert store.load_faiss_index() is False
+
+    def test_stats_report_an_empty_index(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_episodic("A fragment stored without any vector at all")
+        stats = store.memory_stats()
+        assert stats["episodic_active"] == 1
+        assert stats["faiss_index_size"] == 0
+        assert stats["embedded_count"] == 0
+
+
+class TestSqliteVectorSearchRanking:
+    """The stdlib cosine scan is the ranking path on a stock (FAISS-less) install."""
+
+    _EXACT = "Notes on the deployment pipeline rollout"
+    _HALF = "Notes on the kitchen renovation schedule"
+    _ORTHOGONAL = "Musings on the tidal patterns offshore"
+
+    def _seed(self, store: VectorMemoryStore) -> None:
+        vectors = {
+            self._EXACT: _unit(0),
+            self._HALF: [1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+            self._ORTHOGONAL: _unit(1),
+        }
+        for text, vec in vectors.items():
+            assert store.write_episodic(text, embedding=vec)
+
+    def test_results_are_ordered_by_similarity(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        self._seed(store)
+        hits = store.search_episodic(query_embedding=_unit(0), limit=5, mmr=False)
+        assert [h["text"] for h in hits] == [self._EXACT, self._HALF, self._ORTHOGONAL]
+        # Ordering rather than exact floats: strictly decreasing raw cosine.
+        assert hits[0]["cosine_sim"] > hits[1]["cosine_sim"] > hits[2]["cosine_sim"]
+
+    def test_limit_truncates_the_ranked_set(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        self._seed(store)
+        assert len(store.search_episodic(query_embedding=_unit(0), limit=1, mmr=False)) == 1
+
+    def test_mmr_rerank_preserves_membership(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        self._seed(store)
+        hits = store.search_episodic(query_embedding=_unit(0), limit=5, mmr=True)
+        assert {h["text"] for h in hits} == {self._EXACT, self._HALF, self._ORTHOGONAL}
+
+    def test_relevance_gate_drops_weak_short_matches(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        self._seed(store)
+        kept = [
+            h["text"]
+            for h in store.search_episodic(
+                query_embedding=_unit(0), limit=5, mmr=False, relevance_filter=True
+            )
+        ]
+        assert kept == [self._EXACT]
+
+    def test_relevance_gate_relaxes_for_long_text(self, tmp_path: Path) -> None:
+        """The same cosine that fails the short-text gate passes the long-text one."""
+        store = _store(tmp_path)
+        long_text = "Long form retrospective paragraph about the rollout. " * 8
+        assert len(long_text) > vm._EPISODIC_LONG_TEXT_CHARS
+        assert store.write_episodic(
+            long_text, embedding=[1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0]
+        )
+        hits = store.search_episodic(
+            query_embedding=_unit(0), limit=5, mmr=False, relevance_filter=True
+        )
+        assert [h["text"].strip() for h in hits] == [long_text.strip()]
+
+    def test_a_zero_norm_query_does_not_divide(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        self._seed(store)
+        hits = store.search_episodic(query_embedding=[0.0] * _DIM, limit=5, mmr=False)
+        assert len(hits) == 3
+        assert all(h["cosine_sim"] == 0.0 for h in hits)
+
+    def test_a_hit_records_its_access_timestamp(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        self._seed(store)
+        hit = store.search_episodic(query_embedding=_unit(0), limit=1, mmr=False)[0]
+        row = store.db.execute(
+            "SELECT last_accessed_at FROM episodic_memories WHERE id = ?", (hit["id"],)
+        ).fetchone()
+        assert row["last_accessed_at"] is not None
+
+    def test_a_second_search_is_debounced_not_rewritten(self, tmp_path: Path) -> None:
+        """Proven by DB state, with no wall-clock dependency: the row is untouched."""
+        store = _store(tmp_path)
+        self._seed(store)
+        hit = store.search_episodic(query_embedding=_unit(0), limit=1, mmr=False)[0]
+        store.db.execute(
+            "UPDATE episodic_memories SET last_accessed_at = 'SENTINEL' WHERE id = ?",
+            (hit["id"],),
+        )
+        store.db.commit()
+        store.search_episodic(query_embedding=_unit(0), limit=1, mmr=False)
+        row = store.db.execute(
+            "SELECT last_accessed_at FROM episodic_memories WHERE id = ?", (hit["id"],)
+        ).fetchone()
+        assert row["last_accessed_at"] == "SENTINEL"
+
+
+class TestEpisodicCapEnforcement:
+    def test_the_cap_tombstones_the_least_important_entry(self, tmp_path: Path) -> None:
+        store = _store(tmp_path, episodic_max=2)
+        assert store.write_episodic("The least important fragment of the three", importance=0.1)
+        assert store.write_episodic("The middling fragment of the three here", importance=0.5)
+        assert store.write_episodic("The most important fragment of the three", importance=0.9)
+        active = _episodic_texts(store)
+        assert "The least important fragment of the three" not in active
+        assert len(active) == 2
+
+    def test_preserve_existing_refuses_rather_than_evicting(self, tmp_path: Path) -> None:
+        store = _store(tmp_path, episodic_max=1)
+        assert store.write_episodic("The only fragment that fits under the cap")
+        assert not store.write_episodic(
+            "A second fragment the cap must refuse", preserve_existing=True
+        )
+        assert _episodic_texts(store) == ["The only fragment that fits under the cap"]
+
+
+class TestLessonDedupPaths:
+    def test_a_substring_of_an_existing_lesson_is_dropped(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson("Always pin dependency versions in the manifest")
+        assert not store.write_lesson("pin dependency versions")
+        assert len(store.get_lessons()) == 1
+
+    def test_a_superstring_replaces_the_existing_lesson(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson("pin dependency versions")
+        assert store.write_lesson("Always pin dependency versions in the manifest")
+        lessons = store.get_lessons()
+        assert len(lessons) == 1
+        assert "manifest" in json.loads(lessons[0]["value_json"])
+
+    def test_topic_overlap_replaces_the_older_lesson(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson("Rebase feature branches before pushing them")
+        assert store.write_lesson("Rebase branches before pushing, never merge upward")
+        lessons = store.get_lessons()
+        assert len(lessons) == 1
+        assert "never merge upward" in json.loads(lessons[0]["value_json"])
+
+    def test_a_negative_example_is_appended_to_the_value(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson("Quote shell arguments", negative="bare interpolation")
+        assert "NOT: bare interpolation" in json.loads(store.get_lessons()[0]["value_json"])
+
+    def test_a_non_user_source_lowers_the_confidence(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson("Quote every shell argument you interpolate", source="migration")
+        assert store.get_lessons()[0]["confidence"] == 0.9
+
+    def test_semantic_dedup_keeps_the_longer_rule(self, tmp_path: Path) -> None:
+        """Distinct wording, identical vectors: only the cosine path can dedup these."""
+        short_rule = "Zebra crossings need beacons"
+        long_rule = "Submarine hatches demand orange lanterns for visibility"
+        store = _store(tmp_path)
+        store.embed_fn = _TableEmbedder({short_rule: _unit(0), long_rule: _unit(0)})
+        assert store.write_lesson(short_rule)
+        assert store.write_lesson(long_rule)
+        assert [json.loads(e["value_json"]) for e in store.get_lessons()] == [long_rule]
+
+    def test_semantic_dedup_rejects_the_shorter_rule(self, tmp_path: Path) -> None:
+        long_rule = "Submarine hatches demand orange lanterns for visibility"
+        short_rule = "Zebra crossings need beacons"
+        store = _store(tmp_path)
+        store.embed_fn = _TableEmbedder({short_rule: _unit(0), long_rule: _unit(0)})
+        assert store.write_lesson(long_rule)
+        assert not store.write_lesson(short_rule)
+        assert [json.loads(e["value_json"]) for e in store.get_lessons()] == [long_rule]
+
+    def test_the_rule_vector_is_persisted(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _TableEmbedder()
+        assert store.write_lesson("Quote every shell argument you interpolate")
+        blob = _raw_semantic_embedding(store, store.get_lessons()[0]["key"])
+        assert blob is not None and len(blob) == _DIM * 4
+
+    def test_an_unpackable_stored_vector_does_not_stop_the_write(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson("Quote every shell argument you interpolate")
+        store.db.execute(
+            "UPDATE semantic_memory SET embedding = ? WHERE key = ?",
+            (b"\x00\x01\x02\x03\x04", store.get_lessons()[0]["key"]),
+        )
+        store.db.commit()
+        store.embed_fn = _TableEmbedder()
+        assert store.write_lesson("Rotate the signing credentials every ninety days")
+        assert len(store.get_lessons()) == 2
+
+    def test_lazy_vector_backfill_is_capped_per_call(self, tmp_path: Path) -> None:
+        """Legacy NULL-vector lessons are repaired inline, but only a few per write."""
+        legacy = [
+            "Alpha zeppelins hover",
+            "Beta walruses migrate",
+            "Gamma turbines whistle",
+            "Delta glaciers retreat",
+            "Epsilon orchids bloom",
+            "Zeta harbours silt",
+            "Eta volcanoes rumble",
+        ]
+        new_rule = "Theta lighthouses blink"
+        store = _store(tmp_path)
+        for rule in legacy:
+            assert store.write_lesson(rule)
+        assert all(e["embedding"] is None for e in store.get_lessons())
+
+        table = {rule: _unit(i) for i, rule in enumerate(legacy)}
+        table[new_rule] = _unit(7)
+        store.embed_fn = _TableEmbedder(table)
+        assert store.write_lesson(new_rule)
+
+        new_key = _lesson_key(new_rule)
+        backfilled = [
+            e
+            for e in store.get_lessons()
+            if e["key"] != new_key and e["embedding"] is not None
+        ]
+        assert len(backfilled) == vm._MAX_BACKFILLS_PER_CALL
+
+    def test_a_vector_from_a_previous_space_is_left_null(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _TableEmbedder()
+        generation = store.space_generation
+        pre_embedded = store.embed_lesson("Quote every shell argument you interpolate")
+        assert pre_embedded is not None
+        store.begin_space_change()
+        assert store.write_lesson(
+            "Quote every shell argument you interpolate",
+            rule_emb=pre_embedded,
+            rule_emb_generation=generation,
+        )
+        assert _raw_semantic_embedding(store, store.get_lessons()[0]["key"]) is None
+
+    def test_embed_lesson_without_an_embedder_returns_none(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.embed_lesson("Quote every shell argument you interpolate") is None
+
+    def test_lessons_context_is_empty_without_lessons(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.get_lessons_context() == ""
+
+
+class TestContradictionCandidateBanding:
+    def test_no_embedder_yields_no_candidates(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_lesson("Quote every shell argument you interpolate")
+        assert store.find_contradiction_candidates("Never quote a shell argument") == []
+
+    def test_only_mid_band_similarities_are_returned(self, tmp_path: Path) -> None:
+        near = "Alpha zeppelins hover above harbours"
+        mid = "Beta walruses migrate through channels"
+        far = "Gamma turbines whistle in the valley"
+        probe = "Theta lighthouses blink at dusk"
+        store = _store(tmp_path)
+        store.embed_fn = _TableEmbedder(
+            {
+                near: _unit(0),
+                mid: [1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                far: _unit(1),
+                probe: _unit(0),
+            }
+        )
+        for rule in (near, mid, far):
+            assert store.write_lesson(rule)
+        candidates = store.find_contradiction_candidates(probe)
+        # `near` is above the high threshold, `far` below the low one.
+        assert [c["rule"] for c in candidates] == [mid]
+        assert 0.4 <= candidates[0]["similarity"] < 0.85
+
+    def test_a_caller_supplied_vector_avoids_a_second_embed(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        embedder = _TableEmbedder()
+        store.embed_fn = embedder
+        assert store.write_lesson("Quote every shell argument you interpolate")
+        embedder.calls.clear()
+        store.find_contradiction_candidates("Theta lighthouses blink", rule_emb=_unit(3))
+        assert embedder.calls == []
+
+
+@pytest.mark.skipif(not vm._HAS_NUMPY, reason="the episodic backfill sweep needs numpy")
+class TestEpisodicBackfillSweep:
+    def test_deferred_rows_are_filled_and_progress_is_reported(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _TableEmbedder()
+        for i in range(3):
+            assert store.write_episodic(
+                f"Deferred fragment number {i} awaiting its vector", defer_embedding=True
+            )
+        seen: list[tuple[int, int]] = []
+        assert store.backfill_missing_embeddings(progress=_recorder(seen)) == 3
+        assert seen[0] == (0, 3)
+        assert seen[-1] == (3, 3)
+        assert all(
+            _raw_episodic_embedding(store, r["id"]) is not None
+            for r in store.get_episodic_list()
+        )
+
+    def test_the_sweep_is_idempotent(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _TableEmbedder()
+        assert store.write_episodic("A deferred fragment awaiting its vector", defer_embedding=True)
+        assert store.backfill_missing_embeddings() == 1
+        assert store.backfill_missing_embeddings() == 0
+
+    def test_backfilled_vectors_become_searchable(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _TableEmbedder({"Deferred fragment awaiting its vector": _unit(0)})
+        assert store.write_episodic("Deferred fragment awaiting its vector", defer_embedding=True)
+        assert store.search_episodic(query_embedding=_unit(0), limit=5) == []
+        assert store.backfill_missing_embeddings() == 1
+        assert len(store.search_episodic(query_embedding=_unit(0), limit=5)) == 1
+
+
+class TestEmbeddingSpaceReconciliation:
+    def test_the_first_call_stamps_without_clearing(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_episodic("A fragment that already carries a vector", embedding=_unit(0))
+        assert store.recorded_embedding_space() is None
+        assert store.reconcile_embedding_space("sig-a") == 0
+        assert store.recorded_embedding_space() == "sig-a"
+        mem_id = store.get_episodic_list()[0]["id"]
+        assert _raw_episodic_embedding(store, mem_id) is not None
+
+    def test_a_matching_signature_is_a_noop(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.reconcile_embedding_space("sig-a")
+        assert store.write_episodic("A fragment that already carries a vector", embedding=_unit(0))
+        assert store.reconcile_embedding_space("sig-a") == 0
+        mem_id = store.get_episodic_list()[0]["id"]
+        assert _raw_episodic_embedding(store, mem_id) is not None
+
+    def test_a_changed_signature_clears_episodic_and_lesson_vectors(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn = _TableEmbedder()
+        store.reconcile_embedding_space("sig-a")
+        assert store.write_episodic("A fragment that already carries a vector", embedding=_unit(0))
+        assert store.write_lesson("Quote every shell argument you interpolate")
+        assert store.reconcile_embedding_space("sig-b") == 2
+        mem_id = store.get_episodic_list()[0]["id"]
+        assert _raw_episodic_embedding(store, mem_id) is None
+        assert _raw_semantic_embedding(store, store.get_lessons()[0]["key"]) is None
+        assert store.recorded_embedding_space() == "sig-b"
+
+    def test_an_unknown_space_can_be_cleared_explicitly(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.write_episodic("A fragment that already carries a vector", embedding=_unit(0))
+        assert store.reconcile_embedding_space("sig-a", clear_when_unknown=True) == 1
+        mem_id = store.get_episodic_list()[0]["id"]
+        assert _raw_episodic_embedding(store, mem_id) is None
+
+    def test_a_surviving_stale_index_leaves_the_signature_unstamped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Stamping while a stale index survives would make the corruption permanent."""
+        store = _store(tmp_path)
+        store.reconcile_embedding_space("sig-a")
+        assert store.write_episodic("A fragment that already carries a vector", embedding=_unit(0))
+
+        def _refuse(self: Path, missing_ok: bool = False) -> None:
+            raise OSError("read-only directory")
+
+        monkeypatch.setattr(Path, "unlink", _refuse)
+        assert store.reconcile_embedding_space("sig-b") == 1
+        assert store.recorded_embedding_space() == "sig-a"
+
+    def test_a_store_with_no_vectors_still_records_the_change(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.reconcile_embedding_space("sig-a")
+        assert store.reconcile_embedding_space("sig-b") == 0
+        assert store.recorded_embedding_space() == "sig-b"
+
+
+class TestEmbeddingWidthAndGeneration:
+    def test_non_positive_and_unchanged_widths_are_rejected(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.set_embedding_dim(0) is False
+        assert store.set_embedding_dim(-1) is False
+        assert store.set_embedding_dim(_DIM) is False
+
+    def test_a_width_change_drops_the_in_memory_index(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert store.set_embedding_dim(_DIM * 2) is True
+        assert store.memory_stats()["faiss_index_size"] == 0
+
+    def test_the_generation_advances_on_a_space_change(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        before = store.space_generation
+        store.begin_space_change()
+        assert store.space_generation == before + 1
+
+    def test_a_vector_produced_across_a_swap_is_discarded(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+
+        def _swap_mid_embed(_text: str) -> list[float] | None:
+            store.begin_space_change()
+            return _unit(0)
+
+        store.embed_fn = _swap_mid_embed
+        assert store.write_episodic("A fragment embedded across a live model swap")
+        mem_id = store.get_episodic_list()[0]["id"]
+        assert _raw_episodic_embedding(store, mem_id) is None
+
+
+class TestEmbedFnLazyRebind:
+    """``embed_fn_factory`` recovers from a model that was absent at gateway boot.
+
+    Driven through ``import_memory``, which calls ``_try_embed`` unconditionally.
+    """
+
+    def _import_one(self, store: VectorMemoryStore, text: str) -> None:
+        store.import_memory({"episodic": [{"text": text}]})
+
+    def test_a_working_candidate_is_bound(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        embedder = _TableEmbedder()
+        store.embed_fn_factory = lambda: embedder
+        self._import_one(store, "A fragment imported after a lazy rebind")
+        assert store.embed_fn is embedder
+        mem_id = store.get_episodic_list()[0]["id"]
+        assert _raw_episodic_embedding(store, mem_id) is not None
+
+    def test_a_factory_returning_none_leaves_it_unbound(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn_factory = lambda: None
+        self._import_one(store, "A fragment imported while the factory yields nothing")
+        assert store.embed_fn is None
+
+    def test_a_candidate_whose_probe_returns_none_is_not_bound(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.embed_fn_factory = lambda: (lambda _text: None)
+        self._import_one(store, "A fragment imported while the probe returns nothing")
+        assert store.embed_fn is None
+
+    def test_a_candidate_whose_probe_returns_empty_is_not_bound(self, tmp_path: Path) -> None:
+        """A zero-width probe response is a misconfiguration, not a success."""
+        store = _store(tmp_path)
+        store.embed_fn_factory = lambda: (lambda _text: [])
+        self._import_one(store, "A fragment imported while the probe returns empty")
+        assert store.embed_fn is None
+
+    def test_a_candidate_whose_probe_raises_is_not_bound(self, tmp_path: Path) -> None:
+        def _explode(_text: str) -> list[float] | None:
+            raise RuntimeError("inference crashed")
+
+        store = _store(tmp_path)
+        store.embed_fn_factory = lambda: _explode
+        self._import_one(store, "A fragment imported while the probe explodes")
+        assert store.embed_fn is None
+
+    def test_the_cooldown_suppresses_a_second_factory_call(self, tmp_path: Path) -> None:
+        """At most one factory call per cooldown window, so a missing model is cheap."""
+        calls: list[int] = []
+
+        def _factory() -> Callable[[str], list[float] | None] | None:
+            calls.append(1)
+            return None
+
+        store = _store(tmp_path)
+        store.embed_fn_factory = _factory
+        store.import_memory(
+            {
+                "episodic": [
+                    {"text": "The first imported fragment triggering an attempt"},
+                    {"text": "The second imported fragment inside the cooldown"},
+                ]
+            }
+        )
+        assert len(calls) == 1
+
+
+class TestStoreLifecycle:
+    def test_using_a_closed_store_raises(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.close()
+        with pytest.raises(RuntimeError, match="not initialized"):
+            store.db.execute("SELECT 1")
+
+    def test_close_is_idempotent(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.close()
+        store.close()
+
+    def test_reopening_sees_the_prior_writes(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        store.set_semantic("pref.editor", "neovim", 0.95, "user_explicit")
+        store.close()
+        reopened = _store(tmp_path)
+        entry = reopened.get_semantic("pref.editor")
+        assert entry is not None and json.loads(entry["value_json"]) == "neovim"
+        reopened.close()


### PR DESCRIPTION
## Problem

Backend line coverage is **80.15%** on main against a **77%** floor. Reaching 85% needs roughly **+9,545 covered statements** — about 28% of all uncovered product code. This is wave 1, not the finish.

## Why it matters

The gap is concentrated: a handful of modules carry most of it, several far below the repo average (`dashboard/handlers/taskrunner.py` at 25.6%, `cli_commands.py` at 46.6%). Those are the cheapest real coverage available, and the floor cannot be ratcheted until they move.

## Fix

~1,150 new tests across 7 new files, one per target module. **No production code changed, no existing test touched.**

Coverage reached by these files **alone** — they overlap the existing suite, so this is *not* the union — against each module's full-suite baseline on main:

| module | baseline | new tests alone |
|---|---|---|
| `dashboard/handlers/taskrunner.py` | 25.6% | **97%** |
| `platform_compat.py` | 52.4% | **90%** |
| `mcp_gateway/backend.py` | 62.6% | **94%** |
| `apps/backend.py` | 58.8% | **86%** |
| `vector_memory.py` | 74.0% | **84%** |
| `cli_commands.py` | 46.6% | **76%** |
| `dashboard/handlers/memory.py` | 48.9% | **73%** |

Rough estimate of the union gain is **~1,900 statements (~+1pp)**. The authoritative number is **this PR's own Coverage Gate**, which measures the full suite — read the estimate as an estimate.

## Three files were dropped rather than shipped

All three were caught by verification rather than trusted from their authors:

| dropped target | why |
|---|---|
| `mcp_gateway/gatewayd.py` | failed 22/110 — 60× `TypeError: PoolKey.__init__() got an unexpected keyword argument` (a fabricated constructor signature) plus 3 hard timeouts |
| `apps/registry.py` | 44% alone vs 75.5% already covered → ~no union gain, **and** its symlink test failed on Windows (`NotImplementedError: utime: follow_symlinks unavailable`) |
| `dashboard/handlers/knowledge.py` | 53% alone vs 53.6% already covered → ~no union gain, **and** used `asyncio.Task.cancelling` (3.11+) while CI runs 3.10 |

Those three modules remain uncovered and are later targets. Padding this PR with files that add no coverage — or that CI has to deselect — would re-create the exact measurement bug #2090 just fixed.

## Fixes from the first CI round

- **Four `platform_compat` tests** simulate the *other* platform's branch by patching attributes absent on Windows (`os.getpgid`, `os.killpg`) or faking the Windows `icacls` path from a POSIX host. They now carry a `_POSIX_ONLY` skip. This costs **zero coverage**: `ci.yml` measures coverage on the ubuntu 3.12 shards only (Windows runs `--no-cov`), so those lines are still counted on the lane that reports the number.
- **GPT review, legitimate and blocking**: a port probe bound a **real loopback listener**. Even on an ephemeral port that is a host-level side effect outside `tmp_path` and can fail on a locked-down runner. Replaced with a stub `create_connection` mirroring the sibling refusal-path test — and the stub now additionally asserts the probe targets loopback using the product's own timeout constant, so it verifies more than the socket version did.

## Tests

Each file targets the largest uncovered branches of one module: request validation, error/status-code paths, empty and not-found results, platform branches, lifecycle transitions.

All tests are **CI-runnable by construction** — no real network, `git`/`gh`, Linux-namespace sandbox, docker, or fixed ports.

## Manual verification

Every file re-verified locally rather than trusted from its author: each individually under `-n 0`, all together under `-n 4` (never `-n auto` on this 32-core host), plus `isort`, `flake8`, `mypy` clean. A `grep` confirms no `.bind((` remains in any new test.

Local verification runs Linux + Python 3.11 only, which structurally **cannot** catch the Windows and 3.10 breakage above — that came from CI, which is why the first round was red.

N/A on screenshots — no user-visible surface.

## Deliberately NOT in this PR

This does **not** raise the floor. It stays at 77%; banking headroom is a separate, deliberate ratchet.
