### PR TITLE
fix(terminal): stop the title poller forking lsof twice a second per session

### DIFF
--- a/src/kiro_crew/dashboard/handlers/terminal.py
+++ b/src/kiro_crew/dashboard/handlers/terminal.py
@@ -123,6 +123,15 @@ class _TerminalSession:
     # _session_cwd_cached). Cleared as soon as the client submits a line, since
     # that line may be the `cd` the memo would otherwise hide.
     cwd_probe: tuple[float, str | None] | None = None
+    # Whether the title/cwd poller still has anything to recompute. A shell
+    # cannot change directory, or start or finish a command, without writing to
+    # the PTY — so a session that has produced no output since the last probe
+    # cannot have gone stale, and probing it again would spend a process
+    # introspection call (a forked `lsof` where nothing cheaper answers) to
+    # re-derive a label it already has. Set on PTY output, on a submitted line,
+    # and on (re)connect, where the dedup markers are cleared and both frames
+    # must be pushed again.
+    frames_dirty: bool = True
     # Serializes concurrent WS writes (reader loop + title poller + pong);
     # aiohttp's WebSocket writer is not safe for concurrent sends.
     send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
@@ -193,14 +202,16 @@ _LSOF_PATHS = ("/usr/sbin/lsof", "/usr/bin/lsof")
 
 
 def _proc_cwd(pid: int) -> str | None:
-    """Current working directory of a process. Linux /proc first; on hosts
-    without /proc (macOS/BSD) falls back to `lsof -d cwd`, whose ``-Fn`` output
-    carries the path on an ``n``-prefixed line. Blocking (subprocess) — callers
-    must run this off the event loop (the title poller already does)."""
-    try:
-        return os.readlink(f"/proc/{pid}/cwd")
-    except OSError:
-        pass
+    """Current working directory of a process, or None if it cannot be read.
+
+    Prefers the subprocess-free sources (``/proc`` on Linux, ``libproc`` on
+    macOS) and only falls back to ``lsof -d cwd`` — whose ``-Fn`` output carries
+    the path on an ``n``-prefixed line — on a host where neither answers. That
+    fallback forks, so callers must still run this off the event loop.
+    """
+    cwd = platform_compat.process_cwd(pid)
+    if cwd is not None:
+        return cwd
     lsof = next((p for p in _LSOF_PATHS if os.path.isfile(p)), None)
     if not lsof:
         return None  # fail closed rather than resolve via PATH
@@ -217,22 +228,36 @@ def _proc_cwd(pid: int) -> str | None:
     return None
 
 
-def _session_cwd(sess: "_TerminalSession") -> str | None:
-    """Full current working directory of the session's shell, or None."""
-    if not platform_compat.IS_POSIX or sess.proc is None:
-        return None
-    return _proc_cwd(sess.proc.pid)
-
-
-# How long a completion request may reuse the previous cwd probe. Short enough
-# that `cd foo` followed immediately by a completion sees the new directory,
-# long enough that holding a key down does not spawn an lsof per keystroke
-# (_proc_cwd shells out on macOS, where there is no /proc).
+# How long a cwd probe may be reused. Short enough that `cd foo` followed
+# immediately by a completion sees the new directory, long enough that one poll
+# tick — which needs the cwd for both the title and the cwd frame — probes the
+# shell once rather than twice, and that holding a key down does not re-probe
+# per keystroke.
 _CWD_PROBE_TTL_S = 0.4
 
 
+def _session_cwd(sess: "_TerminalSession") -> str | None:
+    """Full current working directory of the session's shell, or None.
+
+    Memoized on the session for :data:`_CWD_PROBE_TTL_S`, because the answer has
+    two consumers a fraction of a millisecond apart (the title label and the cwd
+    frame) and on a host where ``_proc_cwd`` has to fork ``lsof`` the probe, not
+    the polling, is the cost that matters.
+    """
+    if not platform_compat.IS_POSIX or sess.proc is None:
+        return None
+    now = time.monotonic()
+    probe = sess.cwd_probe
+    if probe is not None and now - probe[0] < _CWD_PROBE_TTL_S:
+        return probe[1]
+    cwd = _proc_cwd(sess.proc.pid)
+    sess.cwd_probe = (now, cwd)
+    return cwd
+
+
 async def _session_cwd_cached(sess: "_TerminalSession") -> str | None:
-    """``_session_cwd`` with a short TTL memo, probed off the event loop.
+    """``_session_cwd`` probed off the event loop, skipping the executor hop
+    entirely on a memo hit.
 
     The title poller's ``sess.last_cwd`` is deliberately NOT reused here: it is
     refreshed on a 1 s cadence, so a completion issued right after a ``cd``
@@ -245,15 +270,21 @@ async def _session_cwd_cached(sess: "_TerminalSession") -> str | None:
         return probe[1]
     loop = asyncio.get_running_loop()
     cwd = await loop.run_in_executor(subprocess_executor(), _session_cwd, sess)
+    # _session_cwd memoizes its own probes; this covers the branches where it
+    # returns without probing (no shell, non-POSIX host) so those do not re-hop
+    # to the executor on every keystroke.
     sess.cwd_probe = (now, cwd)
     return cwd
 
 
 def _session_title(sess: "_TerminalSession") -> str | None:
     """Best-effort "what is this terminal doing" label: the foreground command
-    name while one runs, else the shell's cwd basename. Linux /proc based;
-    returns None when it can't tell (client keeps its current title, so on
-    non-Linux hosts the tab simply stays at its cwd default)."""
+    name while one runs, else the shell's cwd basename. Returns None when it
+    can't tell (client keeps its current title, so a host that can resolve
+    neither source simply stays at the tab's cwd default).
+
+    The cwd goes through :func:`_session_cwd` rather than :func:`_proc_cwd` so
+    that deriving this label shares one probe with the poller's cwd frame."""
     if not platform_compat.IS_POSIX or sess.master_fd < 0 or sess.proc is None:  # wokeignore:rule=master
         return None
     try:
@@ -266,7 +297,7 @@ def _session_title(sess: "_TerminalSession") -> str | None:
         name = _proc_comm(fg)
         if name:
             return name
-    cwd = _proc_cwd(sess.proc.pid)
+    cwd = _session_cwd(sess)
     if cwd:
         return os.path.basename(cwd.rstrip("/")) or cwd
     return None
@@ -492,6 +523,7 @@ async def api_terminal_ws(request: web.Request) -> web.WebSocketResponse | web.R
         # markers so the next poll re-pushes both frames even when unchanged.
         existing.last_title = None
         existing.last_cwd = None
+        existing.frames_dirty = True
         sess = existing
         _sel().log_api_access(
             caller=caller,
@@ -633,6 +665,7 @@ async def api_terminal_ws(request: web.Request) -> web.WebSocketResponse | web.R
                 if not data:
                     break
                 sess.scrollback.extend(data)
+                sess.frames_dirty = True
                 if len(sess.scrollback) > _SCROLLBACK_MAX:
                     sess.scrollback = sess.scrollback[-_SCROLLBACK_MAX:]
                 if sess.ws and not sess.ws.closed:
@@ -668,6 +701,7 @@ async def api_terminal_ws(request: web.Request) -> web.WebSocketResponse | web.R
                 # the memo's TTL alone leaves a window where it would.
                 if b"\r" in msg.data or b"\n" in msg.data:
                     sess.cwd_probe = None
+                    sess.frames_dirty = True
             elif msg.type == web.WSMsgType.TEXT:
                 try:
                     ctrl = json.loads(msg.data)
@@ -1431,9 +1465,13 @@ async def reap_orphaned_terminals(app: web.Application) -> None:
 
 async def poll_terminal_titles(app: web.Application) -> None:
     """Background task: push a per-session title (foreground command name while
-    one runs, else the shell's cwd basename) to each connected terminal ~1/s,
-    and only when it changes. Fast commands that finish within the poll interval
-    never flip the title, so there's no flicker at the prompt."""
+    one runs, else the shell's cwd basename) and the shell's full cwd to each
+    connected terminal, on change only. Fast commands that finish within the
+    poll interval never flip the title, so there's no flicker at the prompt.
+
+    The cadence is an upper bound, not a rate: a session is only probed when it
+    has written to the PTY since its last probe, so a terminal idling at a
+    prompt costs nothing at all."""
     try:
         while True:
             await asyncio.sleep(1.0)
@@ -1445,11 +1483,19 @@ async def poll_terminal_titles(app: web.Application) -> None:
             for sess in list(registry.values()):
                 if sess is None or sess.ws is None or sess.ws.closed:
                     continue
+                if not sess.frames_dirty:
+                    continue
+                # Cleared BEFORE probing, never after: output landing while a
+                # probe is in flight must re-dirty the session so the next tick
+                # picks up the change instead of the flag swallowing it.
+                sess.frames_dirty = False
                 # _session_title / _session_cwd do blocking syscalls (tcgetpgrp
-                # ioctl, /proc reads, lsof on macOS) that can wedge on a D-state
-                # process or a stuck fs; run them off the loop on the subprocess
-                # pool (same rationale as the os.close offload in _kill_session)
-                # so one stuck read can never freeze the gateway event loop.
+                # ioctl, /proc reads, lsof where nothing cheaper answers) that
+                # can wedge on a D-state process or a stuck fs; run them off the
+                # loop on the subprocess pool (same rationale as the os.close
+                # offload in _kill_session) so one stuck read can never freeze
+                # the gateway event loop. Both probes share one cwd lookup via
+                # the session's memo.
                 # The WS can detach (sess.ws = None) while an executor probe is
                 # in flight — capture + revalidate the socket after EACH hop so
                 # a disconnect can never AttributeError the singleton poller.

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -469,6 +469,101 @@ def try_acquire_lock(fd: int, *, exclusive: bool = False) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Process introspection
+# ---------------------------------------------------------------------------
+
+# Byte layout of the macOS ``proc_vnodepathinfo`` struct filled by
+# ``proc_pidinfo(PROC_PIDVNODEPATHINFO)``: two ``vnode_info_path`` records (the
+# process's cwd, then its root), each a fixed-size ``vnode_info`` header
+# followed by a NUL-terminated path of up to ``MAXPATHLEN``. Only the header
+# size matters to us, since it is the offset the cwd path starts at.
+_DARWIN_PROC_PIDVNODEPATHINFO = 9
+_DARWIN_VNODE_INFO_SIZE = 152
+_DARWIN_MAXPATHLEN = 1024
+_DARWIN_VNODE_INFO_PATH_SIZE = _DARWIN_VNODE_INFO_SIZE + _DARWIN_MAXPATHLEN
+_DARWIN_PROC_VNODEPATHINFO_SIZE = 2 * _DARWIN_VNODE_INFO_PATH_SIZE
+
+_darwin_libproc: Any = None
+_darwin_libproc_loaded = False
+
+
+def _darwin_libproc_handle() -> Any:
+    """Cached ``libproc`` handle, or None when it cannot be loaded.
+
+    Cached rather than opened per call because the cwd probe runs on a poll
+    cadence per open terminal, and a fresh ``CDLL`` would dlopen every time.
+    """
+    global _darwin_libproc, _darwin_libproc_loaded
+    if _darwin_libproc_loaded:
+        return _darwin_libproc
+    _darwin_libproc_loaded = True
+    try:
+        path = ctypes.util.find_library("proc")
+        if path is None:
+            return None
+        lib = ctypes.CDLL(path)
+        lib.proc_pidinfo.argtypes = [
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+            ctypes.c_int,
+        ]
+        lib.proc_pidinfo.restype = ctypes.c_int
+        _darwin_libproc = lib
+    except Exception:
+        _darwin_libproc = None
+    return _darwin_libproc
+
+
+def _darwin_process_cwd(pid: int) -> str | None:
+    """macOS cwd of *pid* via ``libproc``, or None when it cannot be read.
+
+    Requires no entitlement for a same-uid process. The kernel reports how many
+    bytes it filled; anything other than the exact struct size means the layout
+    assumed by the offsets above no longer matches, so the answer is refused
+    rather than sliced out of the wrong place.
+    """
+    lib = _darwin_libproc_handle()
+    if lib is None:
+        return None
+    try:
+        buf = ctypes.create_string_buffer(_DARWIN_PROC_VNODEPATHINFO_SIZE)
+        filled = lib.proc_pidinfo(
+            pid,
+            _DARWIN_PROC_PIDVNODEPATHINFO,
+            0,
+            buf,
+            _DARWIN_PROC_VNODEPATHINFO_SIZE,
+        )
+        if filled != _DARWIN_PROC_VNODEPATHINFO_SIZE:
+            return None
+        raw = buf.raw[_DARWIN_VNODE_INFO_SIZE:_DARWIN_VNODE_INFO_PATH_SIZE]
+        cwd = raw.split(b"\0", 1)[0].decode("utf-8", errors="replace")
+        return cwd or None
+    except Exception:
+        return None
+
+
+def process_cwd(pid: int) -> str | None:
+    """Current working directory of *pid*, or None when no source can answer.
+
+    Never spawns a subprocess. Callers poll this per open terminal, where a
+    fork+exec of the whole gateway costs orders of magnitude more than the
+    answer is worth. ``/proc`` serves Linux; macOS goes to ``libproc``. Windows
+    and any host with neither source get None, leaving the caller to decide
+    whether a costlier fallback is warranted.
+    """
+    try:
+        return os.readlink(f"/proc/{pid}/cwd")
+    except OSError:
+        pass
+    if sys.platform == "darwin":
+        return _darwin_process_cwd(pid)
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Process termination / existence
 # ---------------------------------------------------------------------------
 

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -150,6 +150,85 @@ class TestProcessHelpers:
         assert pc.process_matches(2_000_000_000, ("kiro-cli", "claude")) is False
 
 
+class TestProcessCwd:
+    """``process_cwd`` is polled per open terminal, so its contract is that it
+    answers from ``/proc`` or ``libproc`` and NEVER spawns a subprocess. The
+    macOS branch is exercised on every platform by faking the ``libproc``
+    handle, since the byte offsets it slices with are the risky part."""
+
+    def test_returns_own_cwd(self):
+        cwd = pc.process_cwd(os.getpid())
+        if cwd is None:
+            pytest.skip("no /proc and no libproc on this host")
+        assert os.path.samefile(cwd, os.getcwd())
+
+    def test_returns_none_for_unused_pid(self):
+        assert pc.process_cwd(2_000_000_000) is None
+
+    def test_never_spawns_a_subprocess(self, monkeypatch):
+        # The whole point of this helper: a fork+exec of the gateway per poll is
+        # what it exists to avoid, so a regression that reintroduces one here
+        # must fail loudly rather than just get slower.
+        def explode(*a, **k):
+            raise AssertionError("process_cwd must not spawn a subprocess")
+
+        monkeypatch.setattr(subprocess, "run", explode)
+        monkeypatch.setattr(subprocess, "Popen", explode)
+        pc.process_cwd(os.getpid())
+        pc.process_cwd(2_000_000_000)
+
+    @staticmethod
+    def _fake_libproc(path: bytes, *, filled: int | None = None):
+        """A libproc stand-in whose proc_pidinfo writes *path* at the cwd offset."""
+        size = pc._DARWIN_PROC_VNODEPATHINFO_SIZE
+
+        class _Lib:
+            def proc_pidinfo(self, pid, flavor, arg, buf, buffersize):
+                buf.raw = (
+                    b"\0" * pc._DARWIN_VNODE_INFO_SIZE
+                    + path
+                    + b"\0" * (size - pc._DARWIN_VNODE_INFO_SIZE - len(path))
+                )
+                return size if filled is None else filled
+
+        return _Lib()
+
+    def test_darwin_reads_the_path_at_the_cwd_offset(self, monkeypatch):
+        monkeypatch.setattr(
+            pc, "_darwin_libproc_handle", lambda: self._fake_libproc(b"/Users/u/proj"),
+        )
+        assert pc._darwin_process_cwd(4242) == "/Users/u/proj"
+
+    def test_darwin_refuses_a_short_write(self, monkeypatch):
+        # A byte count other than the exact struct size means the layout the
+        # offsets assume no longer matches the kernel's, so the path cannot be
+        # sliced out safely — the caller falls back instead of getting garbage.
+        monkeypatch.setattr(
+            pc,
+            "_darwin_libproc_handle",
+            lambda: self._fake_libproc(b"/Users/u/proj", filled=64),
+        )
+        assert pc._darwin_process_cwd(4242) is None
+
+    def test_darwin_refuses_an_error_return(self, monkeypatch):
+        monkeypatch.setattr(
+            pc, "_darwin_libproc_handle", lambda: self._fake_libproc(b"/x", filled=-1),
+        )
+        assert pc._darwin_process_cwd(4242) is None
+
+    def test_darwin_returns_none_without_libproc(self, monkeypatch):
+        monkeypatch.setattr(pc, "_darwin_libproc_handle", lambda: None)
+        assert pc._darwin_process_cwd(4242) is None
+
+    def test_darwin_swallows_a_throwing_libproc(self, monkeypatch):
+        class _Boom:
+            def proc_pidinfo(self, *a):
+                raise OSError("nope")
+
+        monkeypatch.setattr(pc, "_darwin_libproc_handle", lambda: _Boom())
+        assert pc._darwin_process_cwd(4242) is None
+
+
 class TestFindListeningPids:
     def test_returns_list_of_ints_for_unused_port(self):
         # A very-high port nothing is bound to → empty list, never raises, on any OS.

--- a/test/test_terminal_handler.py
+++ b/test/test_terminal_handler.py
@@ -2047,8 +2047,9 @@ class TestTerminalWsIntegration:
     @pytest.mark.asyncio
     async def test_submitted_line_invalidates_the_cwd_memo(self, monkeypatch, tmp_path):
         """A submitted line may be a `cd`, so it drops the completion route's cwd
-        memo; a keystroke that submits nothing leaves the memo intact (otherwise
-        every character typed would force a fresh cwd probe)."""
+        memo and re-arms the title poller; a keystroke that submits nothing
+        leaves the memo intact (otherwise every character typed would force a
+        fresh cwd probe)."""
         cfg_file = tmp_path / "config.json"
         cfg_file.write_text(json.dumps({"dashboard": {"terminal": {"enabled": True}}}))
         monkeypatch.setattr(terminal, "config_path", lambda: cfg_file)
@@ -2081,6 +2082,18 @@ class TestTerminalWsIntegration:
                 await ws.send_bytes(b"d /tmp\r")
                 await _drain_to_pong(ws)
                 assert sess.cwd_probe is None
+
+                # The submitted line is the one input that can change the cwd,
+                # so it re-arms the title poller directly rather than relying on
+                # the shell's echo to do it. Stop the PTY reader first, since
+                # that echo would otherwise re-arm the session either way and
+                # the assertion would prove nothing.
+                if sess.reader_task is not None:
+                    sess.reader_task.cancel()
+                sess.frames_dirty = False
+                await ws.send_bytes(b"cd /tmp\r")
+                await _drain_to_pong(ws)
+                assert sess.frames_dirty is True
 
                 await ws.close()
 
@@ -2550,6 +2563,50 @@ class TestSessionTitle:
             assert terminal._session_title(self._sess()) is None
 
 
+# ── one cwd probe per poll tick ──
+
+
+@pytest.mark.skipif(
+    terminal.platform_compat.IS_WINDOWS,
+    reason="the cwd/title probes are POSIX-only (os.tcgetpgrp, /proc, libproc); "
+    "both helpers return None on Windows",
+)
+class TestCwdProbeSharing:
+    """The title label and the cwd frame are two consumers of ONE answer: with no
+    foreground command the title is just the cwd's basename. On a host where
+    _proc_cwd has to fork lsof — no /proc and no libproc — asking twice per tick
+    is the entire cost of an otherwise idle terminal, so the session memo has to
+    collapse them into one probe."""
+
+    def test_memoizes_within_the_ttl(self):
+        sess = _make_session()
+        with patch.object(terminal.platform_compat, "IS_POSIX", True), \
+             patch.object(terminal, "_proc_cwd", return_value="/tmp/a") as probe:
+            assert terminal._session_cwd(sess) == "/tmp/a"
+            assert terminal._session_cwd(sess) == "/tmp/a"
+        assert probe.call_count == 1
+
+    def test_reprobes_once_the_ttl_expires(self):
+        # The memo must not outlive one tick, or a `cd` would take two polls to
+        # show up in the tab title.
+        sess = _make_session()
+        sess.cwd_probe = (time.monotonic() - terminal._CWD_PROBE_TTL_S - 1, "/tmp/old")
+        with patch.object(terminal.platform_compat, "IS_POSIX", True), \
+             patch.object(terminal, "_proc_cwd", return_value="/tmp/new") as probe:
+            assert terminal._session_cwd(sess) == "/tmp/new"
+        assert probe.call_count == 1
+
+    def test_title_and_cwd_frame_share_one_probe(self):
+        # Exactly the pair of calls one poll tick makes, in order.
+        sess = _make_session()
+        with patch.object(terminal.platform_compat, "IS_POSIX", True), \
+             patch("os.tcgetpgrp", return_value=12345), \
+             patch.object(terminal, "_proc_cwd", return_value="/home/u/proj") as probe:
+            assert terminal._session_title(sess) == "proj"
+            assert terminal._session_cwd(sess) == "/home/u/proj"
+        assert probe.call_count == 1
+
+
 # ── poll_terminal_titles ──
 
 
@@ -2606,6 +2663,55 @@ class TestPollTerminalTitles:
              patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError]):
             await terminal.poll_terminal_titles(self._app(sess))
         mock_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_probe_a_session_with_no_new_output(self):
+        # A shell cannot change directory or start a command without writing to
+        # the PTY, so a session that has produced nothing since its last probe
+        # cannot have gone stale. Probing it anyway is what made an idle
+        # terminal cost a forked lsof every second on hosts with no /proc.
+        ws = AsyncMock()
+        ws.closed = False
+        sess = _make_session(session_id="s1", ws=ws)
+        sess.frames_dirty = False
+        with patch.object(terminal, "_session_title") as title, \
+             patch.object(terminal, "_session_cwd") as cwd, \
+             patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError]):
+            await terminal.poll_terminal_titles(self._app(sess))
+        title.assert_not_called()
+        cwd.assert_not_called()
+        ws.send_str.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_disarms_itself_after_probing(self):
+        ws = AsyncMock()
+        ws.closed = False
+        sess = _make_session(session_id="s1", ws=ws)
+        with patch.object(terminal, "_session_title", return_value="vim"), \
+             patch.object(terminal, "_session_cwd", return_value="/tmp/x"), \
+             patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError]):
+            await terminal.poll_terminal_titles(self._app(sess))
+        assert sess.frames_dirty is False
+
+    @pytest.mark.asyncio
+    async def test_output_landing_mid_probe_re_arms_the_session(self):
+        # The flag is cleared BEFORE the probe, so a write that lands while the
+        # probe is in flight is picked up on the next tick. Clearing it after the
+        # probe would swallow that write and freeze the title until some later,
+        # unrelated output happened to re-arm it.
+        ws = AsyncMock()
+        ws.closed = False
+        sess = _make_session(session_id="s1", ws=ws)
+
+        def output_lands_mid_probe(s):
+            s.frames_dirty = True  # what read_pty does on every PTY read
+            return "vim"
+
+        with patch.object(terminal, "_session_title", side_effect=output_lands_mid_probe), \
+             patch.object(terminal, "_session_cwd", return_value=None), \
+             patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError]):
+            await terminal.poll_terminal_titles(self._app(sess))
+        assert sess.frames_dirty is True
 
     @pytest.mark.asyncio
     async def test_swallows_send_error(self):


### PR DESCRIPTION
## Problem

Reported from a macOS install (`v0.1.3-insider.2`): the machine progressively
slowed down, `lsof` was being spawned about twice a second, and killing the
gateway was the only thing that stopped it.

`poll_terminal_titles` runs a 1 s loop per **connected** terminal session and
makes two blocking probes per tick — `_session_title`, then `_session_cwd`.
Both end in `_proc_cwd`, which reads `/proc/<pid>/cwd` and, where that does not
exist, forks `lsof -a -p <pid> -d cwd -Fn`. On macOS that is **2 forks per
second per session**, from a multi-hundred-MB multithreaded process
(`close_fds=True` keeps CPython on `fork`+`exec` rather than `posix_spawn`), for
as long as the socket is open — and `terminalRegistry.ts` deliberately keeps the
socket open across tab switches, chat switches and route changes, so it does not
stop when the terminal leaves the screen.

Three separate problems, largest first:

1. **Nothing gated the probe on there being anything to recompute.** A terminal
   idling at a prompt was probed every second forever.
2. **The two probes computed the same value.** `_session_title` returns the
   foreground command name while one is running, else the cwd's basename — and
   its cheap source (`_proc_comm`) is `/proc`-only, so on macOS it *always* fell
   through to a cwd probe whose answer the very next call was about to fetch.
   (Side effect: on macOS the tab title can never show the running command, only
   the cwd basename — it pays full price for half the feature.)
3. **The cwd had no subprocess-free source outside Linux**, even though macOS
   exposes one.

Worth noting the same file already understood the cost — `_CWD_PROBE_TTL_S`
exists on the *completion* route precisely so "holding a key down does not spawn
an lsof per keystroke". The higher-volume, unattended caller got no equivalent
guard.

## Fix

**Share one probe per tick.** `_session_title` now takes the cwd from
`_session_cwd`, which memoizes it on the session for `_CWD_PROBE_TTL_S` (0.4 s —
shorter than the 1 s cadence, so nothing goes stale across ticks). The
completion route's memo is the same field, so completions now often find it
warm.

**Only probe a session that could have changed.** New `frames_dirty` flag, set
on PTY output, on a submitted line, and on (re)connect (where the dedup markers
are cleared and both frames must be re-pushed). The invariant: a shell cannot
change directory, or start or finish a command, without writing to the PTY. The
flag is cleared **before** the probe, not after, so output landing mid-probe
re-arms the session rather than being swallowed.

**Give macOS a fork-free cwd source.** `platform_compat.process_cwd()` answers
from `/proc` on Linux and from `libproc`
(`proc_pidinfo` / `PROC_PIDVNODEPATHINFO`) on macOS — following the existing
`get_ppid` precedent in that module — and never spawns anything. `lsof` remains
the last-resort fallback for a host where neither answers.

Net effect on macOS: a visible-but-idle terminal goes from 2 forks/sec to
**zero**. While a command is actually running it is one `libproc` syscall per
second and no fork at all.

## Safety of the macOS path

`_darwin_process_cwd` slices the cwd out of the struct at a fixed offset, so it
refuses any reply whose reported byte count is not *exactly* the struct size it
assumes. A future kernel layout change therefore degrades to the `lsof`
fallback instead of returning a path sliced from the wrong offset. That refusal
is covered by a test.

**Not verified on real macOS.** I have no macOS host; the `libproc` branch is
exercised by faking the handle. It is written so that a wrong assumption fails
into the existing fallback rather than misbehaving, but a reviewer on macOS
confirming `process_cwd(os.getpid())` matches `os.getcwd()` would close the
gap.

## Tests

9 new, all revert-verified (fix patched out → paired test fails):

| Revert | Test that catches it |
| --- | --- |
| title re-probes instead of sharing the memo | `test_title_and_cwd_frame_share_one_probe` |
| `_session_cwd` memo removed | `test_memoizes_within_the_ttl` |
| poller dirty gate removed | `test_does_not_probe_a_session_with_no_new_output` |
| flag cleared *after* the probes | `test_output_landing_mid_probe_re_arms_the_session` |
| submitted line no longer re-arms the poller | `test_submitted_line_invalidates_the_cwd_memo` |
| libproc struct-size self-check relaxed | `test_darwin_refuses_a_short_write` |

`test_never_spawns_a_subprocess` pins the contract directly by making
`subprocess.run`/`Popen` raise for the duration of a `process_cwd` call — a
regression that reintroduces a fork here fails loudly rather than merely getting
slower.

The submitted-line test cancels the PTY reader first: otherwise the shell's echo
re-arms the session either way and the assertion proves nothing.

## Verification

- `pytest` full suite: 34230 passed. 21 failures, all reproduced on the base
  revision with my files swapped out — host-environment issues (`ps` returning
  nothing in this sandbox, a local `ssh_config` `ssh -G` rejects) plus one
  pre-existing thread-timing flake in
  `test_mcp_gateway_wedge_ping_gate.py` (5/12 failures on base, unmodified).
- `isort`, `flake8` clean; `mypy` 1.14.1 (matching the `pyproject.toml` pin, no
  `faiss` in the venv) clean across 824 files.
- No frontend changes, so no dist rebuild.

## Deliberately not in this PR

A `visible`/`hidden` frame letting the poller skip terminals that are off
screen. It was on the table, but once the dirty gate and the fork-free macOS
source land it buys almost nothing — the residual case is an off-screen terminal
producing output, which now costs one syscall per second — and it would add a
protocol frame plus frontend lifecycle wiring. Happy to follow up if wanted.
