### PR TITLE
fix(dev-fleet): portal the Pull+Build confirm popover so the Card cannot clip it

### DIFF
--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -344,21 +344,90 @@ function MenuBtn({ items }: { items: (MenuItemDef | null)[] }) {
 }
 
 interface ConfirmBtnProps { title: string; desc: string; confirmLabel?: string; onConfirm: () => void; btn?: Record<string, unknown>; children: ReactNode }
+// Confirm popover width, and the height estimate that drives the flip
+// decision. The estimate only picks a side; `maxHeight` + `overflowY` below
+// keep the popover inside the viewport even when a locale's `desc` wraps to
+// more lines than assumed here.
+const CONFIRM_W = 264
+const CONFIRM_EST_H = 140
 function ConfirmBtn({ title, desc, confirmLabel, onConfirm, btn, children }: ConfirmBtnProps) {
   const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLSpanElement>(null)
+  // Trigger rect captured on open; drives the portaled popover's fixed
+  // position. Same approach as MenuBtn above: an absolutely positioned
+  // popover is clipped by the row's `.card-glow { overflow: hidden }`
+  // ancestor, so it must be portaled to <body> instead.
+  const [rect, setRect] = useState<DOMRect | null>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const popRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    // Portaled to <body>, so the popover is not a DOM descendant of the
+    // trigger — the outside-click guard must exclude BOTH, or every click
+    // inside the popover (including Cancel/Start) would close it first.
+    const onDown = (e: MouseEvent) => {
+      const t = e.target as Node
+      if (!triggerRef.current?.contains(t) && !popRef.current?.contains(t)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') { setOpen(false); triggerRef.current?.focus() } }
+    // position:fixed desyncs from any scrolling ancestor — close on scroll
+    // (capture phase catches nested scrollers) and on resize.
+    const onScrollOrResize = () => setOpen(false)
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    window.addEventListener('scroll', onScrollOrResize, true)
+    window.addEventListener('resize', onScrollOrResize)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+      window.removeEventListener('scroll', onScrollOrResize, true)
+      window.removeEventListener('resize', onScrollOrResize)
+    }
+  }, [open])
+
+  const toggle = () => {
+    if (!open && triggerRef.current) setRect(triggerRef.current.getBoundingClientRect())
+    setOpen((o) => !o)
+  }
+
+  // Right-align to the trigger (as before), clamped so the popover never sits
+  // flush against a viewport edge. Open downward by default; flip up when
+  // there is no room below and more room above. Either `top` or `bottom` is
+  // set, never both.
+  const spaceBelow = rect ? window.innerHeight - rect.bottom - MENU_GAP : 0
+  const spaceAbove = rect ? rect.top - MENU_GAP : 0
+  const openUp = !!rect && spaceBelow < CONFIRM_EST_H + MENU_MARGIN && spaceAbove > spaceBelow
+  const avail = Math.max(80, (openUp ? spaceAbove : spaceBelow) - MENU_MARGIN)
+  const posStyle: CSSProperties = rect
+    ? {
+        position: 'fixed',
+        right: Math.max(MENU_MARGIN, window.innerWidth - rect.right),
+        ...(openUp
+          ? { bottom: window.innerHeight - rect.top + MENU_GAP }
+          : { top: rect.bottom + MENU_GAP }),
+        maxHeight: avail,
+      }
+    : { position: 'fixed' }
+
   return (
-    <span ref={ref} style={{ position: 'relative', display: 'inline-flex' } as CSSProperties}>
-      <Btn {...(btn || {})} onClick={() => setOpen(!open)}>{children}</Btn>
-      {open && (
-        <div style={{ position: 'absolute', top: 'calc(100% + 6px)', right: 0, zIndex: 1200, background: 'var(--card, #16161a)', border: '1px solid var(--border)', borderRadius: 10, padding: '10px 12px', width: 264, boxShadow: '0 8px 24px rgba(0,0,0,0.45)', textAlign: 'left' as const } as CSSProperties}>
+    <span style={{ display: 'inline-flex' } as CSSProperties}>
+      <Btn ref={triggerRef} {...(btn || {})} onClick={toggle} aria-haspopup="dialog" aria-expanded={open}>{children}</Btn>
+      {open && rect && createPortal(
+        <div
+          ref={popRef}
+          role="dialog"
+          aria-label={title}
+          data-placement={openUp ? 'up' : 'down'}
+          style={{ ...posStyle, zIndex: 4000, overflowY: 'auto', background: 'var(--card, #16161a)', border: '1px solid var(--border)', borderRadius: 10, padding: '10px 12px', width: CONFIRM_W, boxShadow: '0 8px 24px rgba(0,0,0,0.45)', textAlign: 'left' as const } as CSSProperties}
+        >
           <div style={{ fontSize: 12.5, fontWeight: 600, marginBottom: 4 }}>{title}</div>
           <div style={{ fontSize: 11.5, color: 'var(--muted)', lineHeight: 1.5, marginBottom: 9 }}>{desc}</div>
           <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' } as CSSProperties}>
             <Btn onClick={() => setOpen(false)}>{i18nT('pages.devFleetPage.cancel')}</Btn>
             <Btn primary onClick={() => { setOpen(false); onConfirm() }}>{confirmLabel || i18nT('pages.devFleetPage.start')}</Btn>
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
     </span>
   )

--- a/website/src/test/DevFleetPage.test.tsx
+++ b/website/src/test/DevFleetPage.test.tsx
@@ -737,6 +737,84 @@ describe('DevFleetPage', () => {
     expect(menu.style.top).toBe('')
   })
 
+  /* ─── Pull+Build confirm popover: portal + flip ─── */
+  // The confirm popover used to be position:absolute inside the row, so the
+  // Worktrees Card's `.card-glow { overflow: hidden }` clipped it. It is now
+  // portaled to <body> with fixed positioning, like the row-actions menu.
+  async function openPullBuildConfirm() {
+    mockFleet(FLEET_MENU)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    const trigger = screen.getByText('Pull+Build').closest('button') as HTMLButtonElement
+    fireEvent.click(trigger)
+    return { trigger, pop: await screen.findByRole('dialog') }
+  }
+
+  it('renders the Pull+Build confirm popover in a portal on document.body (escapes Card overflow)', async () => {
+    const { pop } = await openPullBuildConfirm()
+    // Portaled: a direct child of <body>, not nested inside the row Card whose
+    // overflow:hidden previously cut the popover off mid-render.
+    expect(pop.parentElement).toBe(document.body)
+    expect(pop.getAttribute('aria-label')).toBe('Pull + Build main')
+    expect(within(pop).getByText('Pulls main and rebuilds (~6 min). Does NOT restart.')).toBeInTheDocument()
+  })
+
+  it('Start inside the portaled confirm popover still fires the sync request', async () => {
+    const { pop } = await openPullBuildConfirm()
+    // The outside-click guard must exclude the portaled popover itself, or the
+    // mousedown preceding this click would close it before the click lands.
+    fireEvent.click(within(pop).getByText('Start'))
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    await waitFor(() => {
+      const calls = (globalThis.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls
+      const urls = calls.map((c) => (typeof c[0] === 'string' ? c[0] : (c[0] as Request).url))
+      expect(urls.some((u) => u.includes('/sync'))).toBe(true)
+    })
+  })
+
+  it('outside-click and Escape close the portaled confirm popover', async () => {
+    const { trigger } = await openPullBuildConfirm()
+    fireEvent.mouseDown(document.body)
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    fireEvent.click(trigger)
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+  })
+
+  it('confirm popover opens downward when there is room below', async () => {
+    mockFleet(FLEET_MENU)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    const trigger = screen.getByText('Pull+Build').closest('button') as HTMLButtonElement
+    vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+      top: 100, bottom: 120, left: 400, right: 440, width: 40, height: 20, x: 400, y: 100, toJSON: () => ({}),
+    } as DOMRect)
+    fireEvent.click(trigger)
+    const pop = await screen.findByRole('dialog') as HTMLElement
+    expect(pop.getAttribute('data-placement')).toBe('down')
+    expect(pop.style.position).toBe('fixed')
+    expect(pop.style.top).not.toBe('')
+    expect(pop.style.bottom).toBe('')
+  })
+
+  it('confirm popover flips upward when near the viewport bottom', async () => {
+    mockFleet(FLEET_MENU)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    const trigger = screen.getByText('Pull+Build').closest('button') as HTMLButtonElement
+    // A row a few px above the bottom edge is exactly the case in the bug
+    // report: no room below, so the popover must flip up instead of being cut.
+    vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+      top: window.innerHeight - 8, bottom: window.innerHeight - 4, left: 400, right: 440, width: 40, height: 20, x: 400, y: window.innerHeight - 8, toJSON: () => ({}),
+    } as DOMRect)
+    fireEvent.click(trigger)
+    const pop = await screen.findByRole('dialog') as HTMLElement
+    expect(pop.getAttribute('data-placement')).toBe('up')
+    expect(pop.style.bottom).not.toBe('')
+    expect(pop.style.top).toBe('')
+  })
+
   /* ─── Provision progress: expandable log panel + failure persistence ─── */
   // 'unprov' is the only non-main has_dist:false row, so it renders the single
   // "Provision" button. Provision polling uses real 2s sleeps, hence the


### PR DESCRIPTION
## Problem

On the Dev Fleet page, the **Pull + Build** confirm popover renders clipped: the
title and description show, then the box is cut off at the Worktrees card's
bottom edge, hiding the **Cancel** / **Start** buttons entirely.

Root cause: `ConfirmBtn`'s popover is `position: absolute` inside the worktree
row, and the card wrapper carries `.card-glow { position: relative; overflow: hidden }`
(`website/src/index.css`). Anything the popover overflows past the card's box is
clipped. On the main row — the last row — that is most of the popover.

`MenuBtn` in the same file already hit and fixed this exact problem; its comment
says `<Card overflow> can't clip it`. `ConfirmBtn` never got the same treatment.

## Fix

Apply `MenuBtn`'s pattern to `ConfirmBtn`:

- portal the popover to `<body>` so no ancestor's `overflow` can clip it
- capture the trigger rect on open and position `fixed`, right-aligned to the
  trigger and clamped to `MENU_MARGIN` from the viewport edge
- flip up when there is no room below and more room above; `maxHeight` +
  `overflowY: auto` clamp it inside the viewport either way
- the popover is no longer a DOM descendant of the trigger, so the outside-click
  guard excludes **both** the trigger and the popover — otherwise the `mousedown`
  preceding a Cancel/Start click would close it before the click landed
- Escape closes and restores focus to the trigger; scroll (capture phase) and
  resize close, because `position: fixed` desyncs from a scrolling ancestor
- `role="dialog"` + `aria-label` on the popover, `aria-haspopup`/`aria-expanded`
  on the trigger

The height constant only picks a side; a locale whose description wraps to more
lines than estimated is still clamped by `maxHeight`, not cut off.

## Tests

5 new cases in `website/src/test/DevFleetPage.test.tsx`, mirroring the existing
row-actions portal suite:

- popover is a direct child of `<body>` (the regression guard)
- **Start** inside the portaled popover still fires the `/sync` request — proves
  the outside-click guard does not eat in-popover clicks
- outside-click and Escape both close it
- `data-placement="down"` anchors via `top`; flipped `data-placement="up"`
  anchors via `bottom`

`npx tsc -b` clean; `DevFleetPage.test.tsx` 67/67 pass. Frontend-only change —
no Python touched.
