### PR TITLE
fix(dashboard): read transcript before backfilling tab_id so restore keeps the tab

### DIFF
--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -498,13 +498,9 @@ def _rehydrate_slot_from_history(
         tab_id = meta.get("tab_id")
         if not tab_id:
             tab_id = uuid.uuid4().hex[:12]
-            # _rehydrate_slot_from_history runs on the event-loop thread (cold-slot
-            # resolution in api_send_message). update_metadata enters _locked
-            # (flock + os.close), a blocking-on-loop-prohibited op, so backfill the
-            # tab_id off the loop rather than on it.
-            update_metadata_off_loop(
-                state.conversation_log, history_key, {"tab_id": tab_id}
-            )
+            needs_tab_id_backfill = True
+        else:
+            needs_tab_id_backfill = False
         slot._tab_id = tab_id
         # Use read_messages_chained (not read_messages) so the loaded window walks
         # the tab_id ancestry across forks, matching restore_recent_sessions.
@@ -516,6 +512,28 @@ def _rehydrate_slot_from_history(
             if _prefetched_messages is not None
             else state.conversation_log.read_messages_chained(history_key)
         )
+        if needs_tab_id_backfill:
+            # Persist the freshly-minted tab_id AFTER reading the transcript above,
+            # never before. update_metadata_off_loop dispatches an os.replace() of
+            # THIS session file to a worker thread; scheduling it before the read
+            # let that replace race the loop-thread transcript read of the very
+            # same file. On Windows a concurrent replace makes the reader's open()
+            # fail with a sharing violation (PermissionError, an OSError subclass),
+            # and the on-loop read retry cannot pause (a loop sleep would starve the
+            # LoopStallWatchdog heartbeat), so the immediate retries expire while the
+            # replace is still in flight, _read_messages re-raises, and the
+            # except-BaseException arm below rolls the whole tab back — the
+            # intermittent `restored == N-1` open-tabs drop on restart
+            # (test_restore_open_slots_async_yields_between_tabs, Windows shard).
+            # Reading first removes the self-inflicted race: the file is quiescent
+            # for the read, and the backfill lands once nothing is reading it. The
+            # id is freshly minted with no on-disk siblings, so read_messages_chained
+            # returns the identical window whether it is written before or after.
+            # Kept off the loop because update_metadata enters _locked (flock +
+            # os.close), a blocking-on-loop-prohibited op.
+            update_metadata_off_loop(
+                state.conversation_log, history_key, {"tab_id": tab_id}
+            )
         # Only the recent window is loaded into memory; older on-disk lines become
         # the FROZEN PREFIX that saves never rewrite. _disk_older_count must
         # therefore count those older lines so the save model preserves them.

--- a/test/test_open_slots_persistence.py
+++ b/test/test_open_slots_persistence.py
@@ -767,6 +767,72 @@ def test_restore_open_slots_async_yields_between_tabs(tmp_path, monkeypatch):
     assert ticks >= 6, f"restore starved the loop (ticks={ticks})"
 
 
+def test_restore_reads_transcript_before_backfilling_tab_id(tmp_path, monkeypatch):
+    """A tab needing a tab_id backfill must be READ before the backfill fires.
+
+    ``_rehydrate_slot_from_history`` mints a tab_id for a legacy session that
+    lacks one and persists it via ``update_metadata_off_loop`` — which dispatches
+    an ``os.replace()`` of THIS session file to a worker thread. If that write is
+    dispatched BEFORE the loop-thread transcript read of the same file, the
+    replace races the read: on Windows the in-flight replace makes the reader's
+    ``open()`` raise a sharing violation, and the on-loop read retry cannot pause
+    (a loop sleep would starve the LoopStallWatchdog), so it drops the tab —
+    the intermittent ``restored == N-1`` open-tabs loss on restart.
+
+    Reproduced deterministically without threads: dispatching the backfill for a
+    key arms its transcript read to raise the sharing violation, standing in for
+    the in-flight replace holding the file. Under the correct order (read first)
+    the read completes while the file is quiescent, so nothing is ever armed and
+    every tab restores. Under the buggy order the armed read faults and the tab
+    is dropped. The read-retry mechanics themselves are out of scope here (they
+    are exercised by test_history's sharing-violation tests); this pins the
+    ordering that keeps the file quiescent for the read in the first place.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    n = 4
+    for i in range(n):
+        # _seed_session writes no tab_id, so every tab triggers the backfill.
+        _seed_session(state, f"chat-{i}-race")
+    (tmp_path / "open_slots.json").write_text(
+        json.dumps({"keys": [f"chat-{i}-race" for i in range(n)], "ts": 0.0})
+    )
+
+    import kiro_crew.dashboard.chat_persistence as chat_persistence
+
+    state2 = _make_state(tmp_path / "sessions")
+    log = state2.conversation_log
+    armed_unreadable: set[str] = set()
+
+    real_read_messages = log._read_messages
+
+    def guarded_read_messages(key):
+        if key in armed_unreadable:
+            raise PermissionError(
+                f"[WinError 32] simulated in-flight os.replace holding {key}"
+            )
+        return real_read_messages(key)
+
+    monkeypatch.setattr(log, "_read_messages", guarded_read_messages)
+
+    real_backfill = chat_persistence.update_metadata_off_loop
+
+    def arming_backfill(conv_log, key, fields):
+        # Dispatching the tab_id os.replace makes the file briefly unreadable.
+        armed_unreadable.add(key)
+        return real_backfill(conv_log, key, fields)
+
+    monkeypatch.setattr(chat_persistence, "update_metadata_off_loop", arming_backfill)
+
+    restored = asyncio.run(restore_open_slots_async(state2))
+
+    assert restored == n, (
+        "a tab was dropped: its transcript was read while its tab_id backfill "
+        "replace was in flight (read must precede the backfill dispatch)"
+    )
+    assert set(state2._slots) == {f"chat-{i}-race" for i in range(n)}
+
+
 def test_restore_open_slots_async_matches_sync_result(tmp_path, monkeypatch):
     """The async and sync drivers must restore the same slots.
 


### PR DESCRIPTION
## Problem
`test/test_open_slots_persistence.py::test_restore_open_slots_async_yields_between_tabs` fails intermittently with `assert 5 == 6` (generally `restored == N-1`) on the Windows backend shard. In production terms: on gateway restart the async open-tabs restore can silently **drop one open tab** — the user loses a tab that was open.

## Why it matters
Open-tab restore is the promise that your tabs survive a restart. A dropped tab is a real, if rare, data-visibility loss, and the flake also reddens the Windows shard for unrelated PRs.

## Fix (symptom → root cause → change)
- **Symptom:** one tab out of N fails to restore, only under real filesystem contention (never reproduces in isolation; only the loaded full-suite Windows shard bites).
- **Root cause:** for a session with no persisted `tab_id`, `_rehydrate_slot_from_history` dispatched `update_metadata_off_loop` — which performs an `os.replace()` of that session file on a **worker thread** — **before** reading the same file's transcript on the **loop thread**. On Windows the in-flight replace makes the reader's `open()` raise a sharing violation (`PermissionError`). The on-loop read retry cannot pause (a loop sleep would starve the `LoopStallWatchdog` heartbeat), so its immediate retries expire while the replace is still in flight, `_read_messages` re-raises, and rehydrate's `except BaseException` rolls the whole tab back → `restored == N-1`.
- **Change:** reorder — **read the transcript first, then dispatch the `tab_id` backfill.** The freshly-minted id has no on-disk siblings, so `read_messages_chained` returns the identical window whether the id is written before or after. The read now runs while the file is quiescent, and the replace lands once nothing is reading it. Behaviour no-op on POSIX (atomic replace never faults a concurrent read); removes the self-inflicted race on Windows.

## Tests
- New regression test `test_restore_reads_transcript_before_backfilling_tab_id` reproduces the drop deterministically **without threads**: dispatching the backfill for a key arms its transcript read to raise the sharing violation (standing in for the in-flight `os.replace`). Under the correct read-first order nothing is ever armed and every tab restores; under the old order the armed read faults and the tab is dropped. It FAILS on the pre-fix order and PASSES with the fix (verified both ways locally).
- Existing `test_open_slots_persistence.py` (42) + `test_history.py` (184) = 226 pass.

## Manual verification
N/A — the deterministic regression test covers the ordering invariant; the underlying sharing-violation retry mechanics are exercised by `test_history`'s existing sharing-violation tests. flake8 / isort clean; mypy clean on the changed file (the only mypy errors in the tree are pre-existing `os.getxattr/setxattr` macOS-platform noise in `hooks.py`, untouched here).
