### PR TITLE
fix(acp): drop an oversize stdout frame instead of tearing down the runtime

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -467,15 +467,60 @@ Three properties make the counter safe on the demux hot path: it never awaits
 (`_DROP_SUMMARY_MAX_KEYS` = 64 distinct keys forces an early flush instead of
 growth, and both backend-controlled key halves are truncated to
 `_DROP_SUMMARY_KEY_MAX_CHARS` = 80), and the residual count is flushed in the
-loop's `finally` on **every** exit (EOF, stdout overrun, cancel, crash) so a
-low-rate trickle is reported late rather than swallowed. No lock is needed:
-`_reader_loop` is the sole writer (`spawn()` creates exactly one reader task).
-The two response-shaped drop branches (non-numeric id, unmatched id) stay
+loop's `finally` on **every** exit (EOF, exhausted oversize-drain budget, cancel,
+crash) so a low-rate trickle is reported late rather than swallowed. No lock is
+needed: `_reader_loop` is the sole writer (`spawn()` creates exactly one reader
+task). The two response-shaped drop branches (non-numeric id, unmatched id) stay
 per-frame on purpose — the id is their whole diagnostic value and is distinct per
 frame, so aggregating by it would give the counter an unbounded key space while
 aggregating without it would discard the only identifying datum; both are also
 bounded by the requests this runtime issued, so neither has the after-teardown
 steady state.
+
+**An oversize stdout line is a dropped frame, not a dead runtime.** A single
+JSON-RPC line over the reader's `_STDOUT_BUFFER_LIMIT` (10 MB) used to
+`_mark_dead` the runtime, which fails every pending future and poisons every
+session queue — so one huge frame ended *every* session multiplexed on that
+process mid-turn, surfacing to users as "process exited / chat failure". Both ACP
+readers did this on the strength of a claim that asyncio leaves the stream
+corrupted after an overrun and every subsequent read also fails. That claim is
+false: `StreamReader.readline` repairs the buffer *before* raising `ValueError`
+(deleting the oversize line through its terminating newline when one is buffered,
+else clearing the buffer) and resumes the transport, as its own docstring states.
+
+So `_reader_loop` reads through `readuntil(b"\n")` and, on `LimitOverrunError`,
+hands the line to `_drain_oversize_line()`, which consumes it **entirely, through
+its terminating newline**, and discards it — the same consume-prefix-and-retry
+drain as `mcp_gateway/backend.py::run_stdout_pump`, where a plain `read(n)` would
+eat into the *next* frame. Draining the whole line rather than one prefix at a
+time is load-bearing, not tidiness: the unterminated branch's discard boundary is
+an arbitrary byte offset (`consumed = len(buffer)`), so surfacing the remainder as
+a line hands the parser a byte-slice that can start mid-character. `json.loads`
+then raises `UnicodeDecodeError`, which is **not** a `json.JSONDecodeError` — it
+escapes the loop's non-JSON guard into its crash handler and kills every
+multiplexed session, the very outcome this replaces. Any oversize frame carrying
+CJK or emoji reaches it whenever the final remainder falls under the reader limit.
+
+Because this reader is a standalone task with no deadline, an endlessly
+unterminated stream still needs a terminal state, so the drain carries a budget of
+`_OVERSIZE_DRAIN_MAX_BYTES` (160 MB) and raises `OversizeLineUnrecoverable` past
+it, which the loop turns into `_mark_dead`. The budget counts **bytes** and is
+scoped to a single drain call — deliberately *not* a count of oversize *frames*,
+and needing no cross-iteration state because every call that returns ends on a
+frame boundary. A replay of properly terminated but oversize frames therefore
+stays survivable frame after frame; a frame counter would reproduce the very
+defect this replaces. The liveness oracle cannot substitute for the budget: it
+judges by CPU/IO movement, and a garbage-spewing stream moves both, so it would
+report `WORKING`.
+
+A pending request whose response was in a dropped frame is not orphaned —
+`_send_and_await` wraps every future in `wait_for(timeout=…)`, so the caller gets
+a timeout; the warning names the request ids in flight at the drop so that timeout
+is attributable. `AcpClient._read_message` takes the same drop-and-continue stance
+by returning `None` (joining its blank-line and non-JSON paths) but keeps
+`readline` and carries **no** budget: every call there is bounded by the caller's
+`timeout` and the callers run their own deadlines, so the worst case is one turn
+ending on its deadline rather than unbounded state.
 
 Every kiro session runs on `AcpRuntime` + `AcpSessionHandle`:
 `AcpProvider.start()` (`providers/acp.py`) unconditionally calls

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -541,6 +541,62 @@ def _resolve_ssh_auth_sock(env: dict[str, str]) -> None:
 
 # Subprocess stdout buffer — kiro-cli can send large JSON-RPC lines (tool outputs)
 _STDOUT_BUFFER_LIMIT = 10 * 1024 * 1024  # 10MB
+# Ceiling on the bytes discarded while draining ONE oversize line. Per drain call
+# and expressed in BYTES: each call provably ends ON a frame boundary, so a replay
+# of many legitimately-oversize-but-terminated frames each gets its own budget and
+# stays survivable. A count of oversize FRAMES would kill the runtime on exactly
+# that replay. Only a single blob that never terminates can exhaust this.
+_OVERSIZE_DRAIN_MAX_BYTES = 16 * _STDOUT_BUFFER_LIMIT  # 160MB
+
+
+class OversizeLineUnrecoverable(Exception):
+    """An oversize stdout line exceeded the drain budget without terminating."""
+
+
+async def _drain_oversize_line(
+    reader: asyncio.StreamReader, exc: asyncio.LimitOverrunError
+) -> int:
+    """Discard one oversize line ENTIRELY, leaving the stream on a frame boundary.
+
+    Called after ``readuntil(b"\\n")`` raised ``LimitOverrunError``, which consumes
+    nothing. ``exc.consumed`` is the already-buffered prefix that provably holds no
+    separator, so consuming it cannot cross into the next frame; retrying
+    ``readuntil`` then either returns the remainder of the line or raises for
+    another step. Same consume-prefix-and-retry drain as
+    ``mcp_gateway/backend.py::run_stdout_pump``; a plain ``read(n)`` would instead
+    eat into the NEXT frame.
+
+    The recovered remainder is **discarded, never parsed**. It is a byte-slice of
+    the line cut at an arbitrary offset, so it can split a multibyte UTF-8
+    character — and ``json.loads`` on that raises ``UnicodeDecodeError``, which is
+    NOT a ``json.JSONDecodeError`` and would escape the caller's non-JSON guard
+    into its crash handler, killing every multiplexed session over one oversize
+    frame.
+
+    Returns the bytes discarded. Raises ``OversizeLineUnrecoverable`` past
+    ``_OVERSIZE_DRAIN_MAX_BYTES`` (the stream is garbage, not merely verbose) and
+    propagates ``IncompleteReadError`` on EOF mid-drain so the caller can use its
+    normal end-of-stream path.
+    """
+    discarded = 0
+    while True:
+        if exc.consumed <= 0:
+            # Unreachable via CPython, whose consumed always exceeds the reader's
+            # limit; guarded because a zero would make this loop spin without
+            # awaiting and starve the event loop.
+            raise OversizeLineUnrecoverable(
+                f"stream reported a {exc.consumed}-byte oversize prefix"
+            )
+        discarded += len(await reader.readexactly(exc.consumed))
+        if discarded > _OVERSIZE_DRAIN_MAX_BYTES:
+            raise OversizeLineUnrecoverable(
+                f"discarded {discarded} bytes with no frame boundary "
+                f"(limit {_OVERSIZE_DRAIN_MAX_BYTES})"
+            )
+        try:
+            return discarded + len(await reader.readuntil(b"\n"))
+        except asyncio.LimitOverrunError as again:
+            exc = again
 
 # Max consecutive empty reads before checking if process is alive
 _MAX_CONSECUTIVE_EMPTY = 5
@@ -2968,14 +3024,29 @@ class AcpClient:
             return None
         except (ValueError, asyncio.LimitOverrunError) as exc:
             # A single JSON-RPC line exceeded the stdout StreamReader buffer
-            # (_STDOUT_BUFFER_LIMIT). asyncio leaves the stream in a corrupted
-            # state after an overrun — every subsequent read also fails — so
-            # treat the process as dead and let session recovery respawn it
-            # instead of freezing the session on an unhandled exception.
-            raise AcpProcessDied(
-                f"ACP stdout line exceeded {_STDOUT_BUFFER_LIMIT}-byte buffer: {exc}"
-            ) from exc
-
+            # (_STDOUT_BUFFER_LIMIT). This does NOT corrupt the stream, contrary
+            # to what this call site used to assume: before raising ValueError,
+            # readline() deletes the oversize line through its terminating
+            # newline when one is already buffered, else clears the buffer, then
+            # resumes the transport (CPython asyncio.streams.StreamReader
+            # .readline — its docstring states this). So drop the frame and let
+            # the caller read the next one, exactly like the blank-line and
+            # non-JSON paths below; raising AcpProcessDied here ended a healthy
+            # live turn over one unreadably large frame.
+            #
+            # NOTE the deliberate asymmetry with AcpRuntime._reader_loop, which
+            # additionally enforces a drain budget: that reader is a standalone
+            # task with no deadline, so an endlessly unterminated stream needs an
+            # explicit terminal state there. HERE every call is bounded by the
+            # caller's `timeout` and the callers run their own deadlines, so the
+            # worst case is one turn ending on its deadline instead of a frame —
+            # no unbounded state, and still strictly better than killing the turn
+            # on the first oversize frame. Computing a byte budget would require
+            # readuntil (readline reports neither the branch taken nor the bytes
+            # dropped), i.e. hand-rolling readline's buffer repair on the path
+            # that is NOT the reported failure.
+            logger.warning("Dropped an oversize ACP stdout frame: %s", exc)
+            return None
         if not line:
             # EOF — process likely died or closing. Check and avoid busy-loop.
             if self._process and self._process.returncode is not None:

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -33,6 +33,8 @@ from kiro_crew.acp._dispatch import (
 )
 from kiro_crew.acp.client import (
     _NOT_LOGGED_IN_RE,
+    OversizeLineUnrecoverable,
+    _drain_oversize_line,
     _get_start_time,
     _KiroExecutableTrustError,
     _resolve_kiro_bin_for_spawn,
@@ -90,6 +92,11 @@ __all__ = [
 # ── AcpRuntime ──
 
 _STDOUT_BUFFER_LIMIT = 10 * 1024 * 1024  # 10MB
+# How many in-flight request ids to name in the oversize-frame warning. A dropped
+# frame can carry a response, and the caller then fails as an opaque
+# _send_and_await timeout — naming what was in flight at the drop makes that
+# timeout attributable instead of a mystery. Capped so the line stays bounded.
+_DROP_IDS_IN_LOG = 8
 _INIT_TIMEOUT = 30.0
 _REQUEST_TIMEOUT = 30.0
 _INIT_NOTIFICATION_BUFFER_LIMIT = 100
@@ -872,11 +879,50 @@ class AcpRuntime:
         try:
             while True:
                 try:
-                    line = await stdout.readline()
-                except (ValueError, asyncio.LimitOverrunError) as exc:
-                    logger.error("stdout buffer overrun: %s", exc)
-                    self._mark_dead(f"stdout overrun: {exc}")
-                    return
+                    line = await stdout.readuntil(b"\n")
+                except asyncio.IncompleteReadError as exc:
+                    # EOF, possibly holding a trailing unterminated line. Keep
+                    # readline()'s old shape: hand the partial to the parser, and
+                    # an empty partial falls through to the exit branch below.
+                    line = exc.partial
+                except asyncio.LimitOverrunError as exc:
+                    # ONE oversize frame must not kill the demux — same invariant
+                    # as the non-dict and non-numeric-id guards below. Tearing
+                    # the runtime down here ends EVERY multiplexed session
+                    # mid-turn, which is what users see as "process exited /
+                    # chat failure" after a single huge tool result.
+                    #
+                    # _drain_oversize_line consumes the whole line THROUGH its
+                    # terminating newline and discards it, so the stream is back
+                    # on a frame boundary and no byte-slice of the oversize line
+                    # ever reaches json.loads. Its budget is per call and needs no
+                    # cross-iteration state, because every call that returns ends
+                    # on a boundary — so a replay of oversize-but-terminated
+                    # frames is survivable frame after frame.
+                    #
+                    # An awaited request whose response was in a dropped frame is
+                    # not orphaned: _send_and_await wraps every future in
+                    # wait_for(timeout=...), so the caller gets a timeout instead
+                    # of hanging. The ids in flight at the drop are logged so that
+                    # timeout is attributable.
+                    try:
+                        dropped = await _drain_oversize_line(stdout, exc)
+                    except asyncio.IncompleteReadError:
+                        self._mark_dead("stdout closed mid-oversize-line")
+                        return
+                    except OversizeLineUnrecoverable as fatal:
+                        logger.error("stdout unrecoverable: %s", fatal)
+                        self._mark_dead(f"stdout overrun: {fatal}")
+                        return
+                    logger.warning(
+                        "dropped an oversize stdout frame (%d bytes); resynced at "
+                        "next frame (in-flight awaited=%s routed=%s): %s",
+                        dropped,
+                        sorted(self._pending_requests)[:_DROP_IDS_IN_LOG],
+                        sorted(self._routed_requests)[:_DROP_IDS_IN_LOG],
+                        exc,
+                    )
+                    continue
 
                 if not line:
                     rc = self._process.returncode if self._process else "?"

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -1375,27 +1375,59 @@ class TestAcpClientReadMessage:
         assert msg is None
 
     @pytest.mark.asyncio
-    async def test_read_buffer_overrun_raises_process_died(self, tmp_path):
-        """A line exceeding the stdout buffer must surface as AcpProcessDied.
+    async def test_read_buffer_overrun_drops_frame_and_keeps_reading(self, tmp_path):
+        """A line exceeding the stdout buffer costs that ONE frame, not the turn.
 
-        asyncio's StreamReader.readline() raises ValueError when a single
-        line exceeds its limit; the stream is corrupted afterward. The read
-        loop must convert that into AcpProcessDied so session recovery
-        respawns the process instead of the session freezing.
+        The stream is NOT corrupted afterwards, contrary to what this call site
+        used to assume: readline() removes the oversize line through its
+        terminating newline (or clears the buffer when the newline has not
+        arrived yet) and resumes the transport before raising ValueError. So the
+        overrun joins the blank-line and non-JSON paths in returning None, and
+        the caller's next read gets the following frame. Raising AcpProcessDied
+        here killed a healthy live turn over one unreadably large frame.
+
+        Driven through a REAL StreamReader so the recovery claim is asserted
+        against asyncio's actual behaviour rather than a mock's side_effect.
         """
         client = AcpClient(work_dir=tmp_path)
 
+        reader = asyncio.StreamReader(limit=256)
         mock_process = MagicMock()
-        mock_stdout = AsyncMock()
-        mock_stdout.readline = AsyncMock(
-            side_effect=ValueError("Separator is not found, and chunk exceed the limit")
-        )
-        mock_process.stdout = mock_stdout
+        mock_process.stdout = reader
         mock_process.returncode = None
         client._process = mock_process
 
-        with pytest.raises(AcpProcessDied):
-            await client._read_message(timeout=1.0)
+        reader.feed_data(b"X" * 1024 + b"\n")  # oversize frame
+        reader.feed_data(b'{"jsonrpc":"2.0","method":"session/update","params":{}}\n')
+
+        assert await client._read_message(timeout=1.0) is None  # frame dropped
+        msg = await client._read_message(timeout=1.0)
+        assert msg is not None and msg.method == "session/update"
+
+    @pytest.mark.asyncio
+    async def test_repeated_buffer_overruns_never_kill_the_process(self, tmp_path):
+        """Oversize frames must not accumulate into a kill here.
+
+        This reader carries no drain budget on purpose (see the asymmetry note in
+        `_read_message`): every call is bounded by the caller's timeout, so a run
+        of oversize frames costs only those frames. A frame-count cap would
+        reintroduce exactly the defect this PR removes — death from a replay of
+        properly-terminated but oversize frames."""
+        client = AcpClient(work_dir=tmp_path)
+
+        reader = asyncio.StreamReader(limit=256)
+        mock_process = MagicMock()
+        mock_process.stdout = reader
+        mock_process.returncode = None
+        client._process = mock_process
+
+        for _ in range(40):
+            reader.feed_data(b"X" * 1024 + b"\n")  # oversize, terminated
+            assert await client._read_message(timeout=1.0) is None
+
+        reader.feed_data(b'{"jsonrpc":"2.0","method":"session/update","params":{}}\n')
+        msg = await client._read_message(timeout=1.0)
+        assert msg is not None and msg.method == "session/update"
 
 
 class TestAcpClientExtractChunk:

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -29,6 +29,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from spawn_test_helpers import strip_spawn_shim
 
+from kiro_crew.acp.client import _OVERSIZE_DRAIN_MAX_BYTES
 from kiro_crew.acp.runtime import (
     _TERMINATE_TIMEOUT,
     AcpRuntime,
@@ -466,6 +467,169 @@ async def test_non_object_json_line_does_not_crash_reader():
         assert not rt._dead  # reader never marked the runtime dead
     finally:
         await _stop_reader(task)
+
+
+@pytest.mark.asyncio
+async def test_oversize_stdout_frame_is_dropped_not_fatal():
+    """A single JSON-RPC line over the stdout buffer must cost ONE frame, not
+    the whole runtime.
+
+    Regression: the reader used to _mark_dead on overrun, which poisons every
+    multiplexed session's queue and fails every pending future — users saw
+    "process exited / chat failure" mid-turn after one huge tool result.
+
+    Driven through a REAL StreamReader so this asserts asyncio's actual
+    behaviour, not a mock's.
+    """
+    rt, _, proc = _make_runtime()
+    reader = asyncio.StreamReader(limit=256)
+    proc.stdout = reader
+    q = _register(rt, "sA")
+    task = await _start_reader(rt)
+    try:
+        reader.feed_data(b"X" * 1024 + b"\n")  # oversize, newline present
+        _feed(reader, {"method": "session/update", "params": {"sessionId": "sA"}})
+        msg = await asyncio.wait_for(q["sA"].get(), timeout=5.0)
+        assert msg.params["sessionId"] == "sA"
+        assert not rt._dead
+    finally:
+        await _stop_reader(task)
+
+
+@pytest.mark.asyncio
+async def test_unterminated_oversize_stdout_recovers_at_next_frame():
+    """The shape actually observed in the field: an oversize line whose newline
+    has NOT arrived yet, so the reader drains prefix after prefix before the
+    stream is back in sync. It must ride through every step and route the next
+    real frame.
+
+    Asserts the outcome (recovery), not the step count: how many buffer-fulls
+    the reader sees depends on how the feeds interleave with its task.
+    """
+    rt, _, proc = _make_runtime()
+    reader = asyncio.StreamReader(limit=256)
+    proc.stdout = reader
+    q = _register(rt, "sA")
+    task = await _start_reader(rt)
+    try:
+        for _ in range(4):
+            reader.feed_data(b"Y" * 512)  # no newline anywhere
+            await asyncio.sleep(0)
+        reader.feed_data(b"TAIL-OF-OVERSIZE-LINE\n")  # line finally terminates
+        _feed(reader, {"method": "session/update", "params": {"sessionId": "sA"}})
+        msg = await asyncio.wait_for(q["sA"].get(), timeout=5.0)
+        assert msg.params["sessionId"] == "sA"
+        assert not rt._dead
+    finally:
+        await _stop_reader(task)
+
+
+@pytest.mark.asyncio
+async def test_oversize_frame_split_mid_multibyte_does_not_kill_demux():
+    """The drained remainder must never reach json.loads.
+
+    Regression for a defect in the second cut of this fix: the drain consumed only
+    the buffered prefix and let the recovered tail through as a line. That tail is
+    a byte-slice cut at an arbitrary offset, so an oversize frame carrying
+    multibyte UTF-8 (CJK, emoji — ordinary in tool output) splits a character;
+    `json.loads` then raises UnicodeDecodeError, which is NOT a
+    json.JSONDecodeError, so it escaped the non-JSON guard into the loop's crash
+    handler and killed EVERY multiplexed session.
+    """
+    rt, _, proc = _make_runtime()
+    reader = asyncio.StreamReader(limit=256)
+    proc.stdout = reader
+    q = _register(rt, "sA")
+    task = await _start_reader(rt)
+    try:
+        # Two conditions make the tail reach the parser, and both are ordinary:
+        #  - the discard boundary must fall mid-character, which the UNTERMINATED
+        #    branch does by construction (it reports `consumed = len(buffer)`, an
+        #    arbitrary byte offset; a newline-terminated overrun instead reports
+        #    the newline's offset, already a character boundary), and
+        #  - the remainder after the last discard must be UNDER the reader limit,
+        #    so readuntil returns it as a normal-looking line instead of
+        #    overrunning again.
+        # Dense CJK, fed in 500-byte slices that are not multiples of 3.
+        blob = ("苹" * 400).encode() + b"\n"  # 1201 bytes
+        assert len(blob) % 3 != 0
+        for off in range(0, 1000, 500):
+            reader.feed_data(blob[off : off + 500])
+            await asyncio.sleep(0)
+        reader.feed_data(blob[1000:])  # 201 bytes < limit → returned as a line
+        _feed(reader, {"method": "session/update", "params": {"sessionId": "sA"}})
+        msg = await asyncio.wait_for(q["sA"].get(), timeout=5.0)
+        assert msg.params["sessionId"] == "sA"
+        assert not rt._dead
+    finally:
+        await _stop_reader(task)
+
+
+@pytest.mark.asyncio
+async def test_many_terminated_oversize_frames_never_exhaust_the_budget():
+    """A run of oversize-but-properly-terminated frames must stay survivable.
+
+    Regression for a defect in the first cut of this fix: the guard counted
+    oversize *frames* rather than bytes-without-a-boundary, so a replay of N
+    newline-terminated >limit frames walked straight into runtime death even
+    though every one of them recovered a frame boundary. The budget is now scoped
+    to a single drain call, each of which provably ends on a boundary.
+    """
+    rt, _, proc = _make_runtime()
+    reader = asyncio.StreamReader(limit=256)
+    proc.stdout = reader
+    q = _register(rt, "sA")
+    task = await _start_reader(rt)
+    rounds = 40
+    try:
+        for i in range(rounds):
+            reader.feed_data(b"X" * 4096 + b"\n")
+            _feed(reader, {"method": "session/update", "params": {"sessionId": "sA", "n": i}})
+        for i in range(rounds):
+            msg = await asyncio.wait_for(q["sA"].get(), timeout=5.0)
+            assert msg.params["n"] == i
+        assert not rt._dead
+    finally:
+        await _stop_reader(task)
+
+
+@pytest.mark.asyncio
+async def test_unterminated_blob_past_the_byte_budget_marks_runtime_dead():
+    """The escape hatch: a stream that never yields a frame boundary would have
+    the reader draining forever, so exceeding the byte budget must still reach the
+    terminal state.
+
+    The liveness oracle cannot cover this case — it reads CPU/IO movement, and a
+    garbage-spewing stream moves both, so it would be judged WORKING.
+    """
+    rt, _, proc = _make_runtime()
+    reader = asyncio.StreamReader(limit=256)
+    proc.stdout = reader
+    _register(rt, "sA")
+    task = await _start_reader(rt)
+    try:
+        fed = 0
+        while fed <= _OVERSIZE_DRAIN_MAX_BYTES and not rt._dead:
+            reader.feed_data(b"Z" * 65536)  # never a newline
+            fed += 65536
+            await asyncio.sleep(0)
+        await asyncio.wait_for(task, timeout=5.0)
+    except Exception:
+        pass
+    finally:
+        await _stop_reader(task)
+    assert rt._dead
+
+
+def test_runtime_reuses_clients_oversize_drain_helper():
+    """The consume-prefix-and-retry drain must have ONE definition. A second copy
+    is how two read paths drift apart (they already disagreed once, when only one
+    of them killed the process)."""
+    import kiro_crew.acp.client as client_mod
+    import kiro_crew.acp.runtime as runtime_mod
+
+    assert runtime_mod._drain_oversize_line is client_mod._drain_oversize_line
+    assert runtime_mod.OversizeLineUnrecoverable is client_mod.OversizeLineUnrecoverable
 
 
 def test_runtime_uses_clients_augmented_kiro_bin_resolver():


### PR DESCRIPTION
## Problem

`AcpRuntime._reader_loop` is the **single owner** of one kiro-cli process's stdout and demultiplexes every session hosted on that runtime. When one JSON-RPC line exceeded the 10 MB `StreamReader` limit, it called `_mark_dead` — which fails every pending future and poisons every session queue on the runtime. **One oversize frame ended every co-hosted session mid-turn.**

Captured in the wild via a user diagnostics bundle:

```
14:37:46 ERROR kiro_crew.acp.runtime: stdout buffer overrun:
         Separator is not found, and chunk exceed the limit
14:37:46 WARNING AcpRuntime dead (PID 47340): stdout overrun
14:37:46 WARNING ACP process died in slot chat-138-1785959986:
         Runtime process died during prompt — resetting session
```

## Why it matters

A single large tool result takes out unrelated concurrent sessions on the same runtime. The user sees "process exited / chat failure" mid-turn, in a session that did nothing wrong.

## Root cause: a false premise in the code

Both ACP read paths did this on the strength of this comment in `client.py`:

> asyncio leaves the stream in a corrupted state after an overrun — every subsequent read also fails

That is **not true**. CPython's `StreamReader.readline` repairs the buffer *before* raising `ValueError`, as its own docstring states:

> If limit is reached, ValueError will be raised. In that case, if newline was found, complete line including newline will be removed from internal buffer. Else, internal buffer will be cleared. […] If stream was paused, this function will automatically resume it if needed.

Verified empirically against a real `StreamReader`, reproducing the exact variant seen in the field (`Separator is not found`, i.e. the newline had not arrived yet):

```
0..5: ValueError Separator is not found, and chunk exceed the limit
6:    ok len=5  b'TAIL\n'
7:    ok len=60 b'{"method": "session/update"…'   <- back in sync
```

The stream recovers unaided. So the fix is to drop the frame and resynchronise.

## Fix

**`runtime.py::_reader_loop`** reads through `readuntil(b"\n")` and, on `LimitOverrunError`, hands the line to `_drain_oversize_line()`, which consumes it **entirely through its terminating newline** and discards it — the same consume-prefix-and-retry drain as `mcp_gateway/backend.py::run_stdout_pump`, where a plain `read(n)` would instead eat into the *next* frame.

Draining the whole line rather than one prefix at a time is load-bearing, and is review round 2's finding. The unterminated branch's discard boundary is an arbitrary byte offset (`consumed = len(buffer)`), so surfacing the remainder as a line hands the parser a byte-slice that can start mid-character. `json.loads` then raises `UnicodeDecodeError` — a `ValueError` but **not** a `json.JSONDecodeError` — which escapes the loop's non-JSON guard into its `except Exception` → `_mark_dead`, reproducing the exact outcome this PR removes. Any oversize frame carrying CJK or emoji reaches it whenever the final remainder falls under the reader limit.

Because this reader is a standalone task with no deadline, an endlessly unterminated stream still needs a terminal state, so the drain carries a budget of `_OVERSIZE_DRAIN_MAX_BYTES` (160 MB) and raises `OversizeLineUnrecoverable` past it. The budget counts **bytes** and is scoped to a **single drain call** — deliberately *not* a count of oversize *frames*, which was review round 1's finding: a frame counter takes the runtime down on a replay of properly-terminated oversize frames, each of which *did* recover a boundary. Per-call scoping needs no cross-iteration state, because every call that returns provably ends on a frame boundary.

The liveness oracle cannot substitute for the budget — checked, not assumed: it judges by CPU/IO movement, and a garbage-spewing stream moves both, so it would report `WORKING`.

A pending request whose response was in a dropped frame is not orphaned — `_send_and_await` wraps every future in `wait_for(timeout=…)`, so the caller times out. The drop warning names the request ids in flight at that moment so the timeout is attributable rather than a mystery.

**`client.py::_read_message`** returns `None`, joining its existing blank-line and non-JSON drop paths that callers already handle by retrying (`if msg is None: continue`). It keeps `readline` and carries **no** budget, deliberately: every call is bounded by the caller's `timeout` and the callers run their own deadlines, so the worst case is one turn ending on its deadline rather than unbounded state — still strictly better than ending the turn on the first oversize frame. A budget there would mean hand-rolling readline's buffer repair on the path that is not the reported failure. The asymmetry is documented at both call sites.

## Tests

`test_read_buffer_overrun_raises_process_died` asserted the false premise through a mocked `side_effect`, so it is rewritten rather than kept.

- **Recovery** tests drive **real `StreamReader`s** — the whole defect was a wrong belief about asyncio's behaviour, so a mock cannot be the witness. Both overrun branches are covered.
- `test_oversize_frame_split_mid_multibyte_does_not_kill_demux` locks in round 2's finding. It reproduces the two conditions that let the tail reach the parser (mid-character discard boundary from the unterminated branch, and a final remainder under the reader limit) and fails on the prefix-only drain with `UnicodeDecodeError: … byte 0x8b` → `AcpRuntime dead: reader crash`.
- `test_many_terminated_oversize_frames_never_exhaust_the_budget` locks in round 1's finding: 40 terminated oversize frames all deliver, in order, runtime alive. Instrumenting the real reader showed **40 drain steps** — the original 16-*frame* cap would have died at step 17.
- `test_unterminated_blob_past_the_byte_budget_marks_runtime_dead` proves the terminal state is still reachable.
- `test_runtime_reuses_clients_oversize_drain_helper` keeps the drain single-sourced; a second copy is how these two paths drifted apart in the first place.

Every new test was confirmed **red** against the code it guards.

## Manual verification

N/A — unit coverage is sufficient: the behaviour under test is a stream-framing contract, and the tests exercise it through real `StreamReader`s rather than mocks. The originating failure itself came from a field diagnostics bundle, quoted above.

## Screenshots

N/A — backend only, no user-visible UI surface.

## Docs

`docs/system-specs/modules/acp-client.md` listed `stdout overrun` among the reader loop's *exit* causes, which this PR makes false. That clause is corrected and a section added covering the drop-and-resync class, the byte budget and why it is not a frame count, the full-drain requirement and the `UnicodeDecodeError` hazard behind it, the liveness-oracle gap, and the client/runtime asymmetry.

## Verification

- 1911 tests pass across the ACP, worker-pool, `test_dashboard_chat.py`, `test_gateway_pipe_death.py`, `test_slack_gateway.py` and `test_taskrunner.py` suites
- `isort`, `flake8`, `mypy` 1.14.1 (matching the `pyproject.toml` pin), and both docs-lint gates clean
- Rebased onto current `main`
