### PR TITLE
fix(shell): Stop replaying the entrance on every Local tab return

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1047,6 +1047,27 @@ export default function App() {
   // (the native dashboard); a non-null id means a remote instance's embedded
   // dashboard is shown instead, so the Local pane is hidden (not unmounted).
   const activeInstanceId = useAppSelector(s => s.instances.activeId)
+  // Whether the shell's one-shot entrance animation has already played.
+  //
+  // The local pane is HIDDEN, not unmounted, while a remote instance tab is
+  // active (`display:none` below) so its state and websocket survive the
+  // switch. But a CSS *animation* restarts when an element goes from
+  // `display:none` back to displayed — unlike a transition, and unlike
+  // framer-motion's JS-driven animations. Left unguarded, `animate-rise`
+  // therefore replays its 350ms opacity-0 -> 1 + 8px lift over the WHOLE
+  // dashboard every time the user returns to the Local tab, which reads as the
+  // entire UI (side panel included) flashing in again.
+  const [shellEntered, setShellEntered] = useState(false)
+  // Backstop for the latch below. `animationend` does NOT fire when a running
+  // animation is INTERRUPTED — the browser fires `animationcancel`, which React
+  // 18 has no synthetic handler for. Hiding the pane inside the entrance's
+  // 350ms window would therefore leave the class applied and replay it once on
+  // the next return. A timer comfortably past the duration closes that without
+  // a ref + native listener, and cannot cut the entrance short.
+  useEffect(() => {
+    const t = window.setTimeout(() => setShellEntered(true), 600)
+    return () => window.clearTimeout(t)
+  }, [])
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
 
   // Dynamic app nav items — all apps (builtin + installed) with UI pages
@@ -1633,7 +1654,15 @@ export default function App() {
       <div className="absolute inset-0" style={{ display: activeInstanceId === null ? 'block' : 'none' }}>
     <div
       data-testid="dashboard-shell"
-      className={`relative z-[1] h-full grid animate-rise overflow-hidden bg-bg ${isMacElectron ? `mac-electron ${macFullscreen ? 'mac-fullscreen' : ''}` : ''} ${isWinElectron ? 'win-electron' : ''} ${isMobile ? 'grid-cols-[minmax(0,1fr)] grid-rows-[42px_minmax(0,1fr)]' : 'grid-rows-[42px_minmax(0,1fr)]'}`}
+      className={`relative z-[1] h-full grid ${shellEntered ? '' : 'animate-rise'} overflow-hidden bg-bg ${isMacElectron ? `mac-electron ${macFullscreen ? 'mac-fullscreen' : ''}` : ''} ${isWinElectron ? 'win-electron' : ''} ${isMobile ? 'grid-cols-[minmax(0,1fr)] grid-rows-[42px_minmax(0,1fr)]' : 'grid-rows-[42px_minmax(0,1fr)]'}`}
+      // Retire the entrance animation once it has played, so re-showing this
+      // pane cannot replay it. Guarded on BOTH the keyframe name and the event
+      // target: `animationend` bubbles, and descendants (banners, cards) use
+      // `animate-rise` too, so an unguarded handler would retire the shell's
+      // entrance from an unrelated child's animation.
+      onAnimationEnd={e => {
+        if (e.target === e.currentTarget && e.animationName === 'rise') setShellEntered(true)
+      }}
       style={{
         gridTemplateAreas: isMobile ? '"topbar" "content"' : '"topbar topbar topbar" "nav content actbar"',
         ...(!isMobile && {

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -700,6 +700,69 @@ describe('App routing', () => {
     localStorage.removeItem('mc-nav')
   })
 
+  // ── Shell entrance animation is one-shot ──────────────────────────────────
+  // The local pane is hidden (`display:none`), not unmounted, while a remote
+  // instance tab is active. A CSS ANIMATION restarts when an element goes from
+  // `display:none` back to displayed, so leaving `animate-rise` on the shell
+  // replayed the whole dashboard's 350ms fade+lift on every return to the
+  // Local tab. The class must retire itself after it has played once.
+  it('retires the shell entrance animation once it has played', () => {
+    renderWithProviders(<App />, { route: '/chat' })
+
+    const shell = screen.getByTestId('dashboard-shell')
+    expect(shell).toHaveClass('animate-rise')
+
+    fireEvent.animationEnd(shell, { animationName: 'rise' })
+
+    // Re-showing the pane cannot replay an animation that is no longer applied.
+    expect(shell).not.toHaveClass('animate-rise')
+  })
+
+  it('does not retire the shell entrance from a descendant animation', () => {
+    // `animationend` bubbles, and descendants (banners, cards) use the SAME
+    // `rise` keyframe — so an unguarded handler would cut the shell's own
+    // entrance short the first time any child animated.
+    renderWithProviders(<App />, { route: '/chat' })
+
+    const shell = screen.getByTestId('dashboard-shell')
+    expect(shell).toHaveClass('animate-rise')
+
+    const child = document.createElement('div')
+    shell.appendChild(child)
+    fireEvent.animationEnd(child, { animationName: 'rise' })
+
+    expect(shell).toHaveClass('animate-rise')
+  })
+
+  it('keeps the shell entrance applied for an unrelated keyframe on the shell', () => {
+    renderWithProviders(<App />, { route: '/chat' })
+
+    const shell = screen.getByTestId('dashboard-shell')
+    fireEvent.animationEnd(shell, { animationName: 'fade-in' })
+
+    expect(shell).toHaveClass('animate-rise')
+  })
+
+  it('retires the shell entrance even when the animation is interrupted', () => {
+    // An INTERRUPTED animation fires `animationcancel`, not `animationend`, and
+    // React 18 exposes no handler for it — so hiding the pane inside the 350ms
+    // entrance window would strand the class and replay it once. The timer
+    // backstop must latch regardless of any animation event arriving.
+    vi.useFakeTimers()
+    try {
+      renderWithProviders(<App />, { route: '/chat' })
+
+      const shell = screen.getByTestId('dashboard-shell')
+      expect(shell).toHaveClass('animate-rise')
+
+      act(() => { vi.advanceTimersByTime(600) })
+
+      expect(shell).not.toHaveClass('animate-rise')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('hosts the collapse control in the nav menu row and hides the Main group heading', () => {
     localStorage.removeItem('mc-nav')
     renderWithProviders(<App />, { route: '/chat' })


### PR DESCRIPTION
## Problem

Switching between instances — most visibly when switching **back to the Local tab** — makes the whole dashboard flash: it fades and lifts in again, which reads as the chat side panel snapping open from closed.

## Why it matters

It happens on *every* return to Local, so the more someone uses remote instances the more they see it. A 350ms full-window fade on a tab switch reads as the UI reloading — it undercuts the whole point of the hide-not-unmount design, which exists precisely so switching feels instant and stateful.

## Fix (symptom → root cause → change)

**Symptom:** the entire shell fades in from transparent and lifts 8px on each return to Local.

**Root cause:** `InstancesViewport` deliberately hides the local pane instead of unmounting it (`App.tsx`, `display: activeInstanceId === null ? 'block' : 'none'`) so local state and the websocket survive the switch. The shell inside it carried `animate-rise` unconditionally — and **a CSS animation restarts when an element goes from `display:none` back to displayed.** That is what separates it from a CSS transition (which does not run) and from framer-motion's JS-driven animations (already finished and committed). So the one-shot entrance was not one-shot at all; it re-fired on every un-hide.

Measured on a harness reproducing the shell (grid, `auto` actbar track, same `animate-rise`), sampling the shell after it had already settled at `opacity: 1` with zero running animations:

| sample | running animations | shell opacity |
|---|---|---|
| after initial settle | `[]` | `1` |
| 1 frame after re-show | `rise` (CSSAnimation, running, t=7ms) | `0.12` |
| 120ms after re-show | `rise` (running, t=124ms) | `0.92` |
| 620ms after re-show | `[]` | `1` |

The `grid-template-columns` transition on the same element does **not** replay and the actbar track width never changes — so the flash is the fade/lift, not a real panel resize.

**Change:** retire the class once its entrance has played, so a later un-hide has no animation left to restart. Two details are load-bearing:

- **The latch is guarded on both the keyframe name and the event target.** `animationend` bubbles, and 73 descendant sites reuse the same `rise` keyframe (`components/ui.tsx` `Card`/`StatCard`/`EmptyState`, `MigrationBanner`, …). Unguarded, the first child banner to animate would retire the shell's own entrance and cut it short.
- **A mount-time timer backstops the interrupted case.** An interrupted animation fires `animationcancel`, not `animationend`, and React 18 exposes no `onAnimationCancel`. Hiding the pane inside the 350ms entrance window would otherwise strand the class and replay it once. 600ms is comfortably past the 350ms duration, so it cannot cut the entrance short.

`animate-rise` uses `backwards` fill (not `forwards`/`both`), so dropping the class leaves the element at its natural computed state — no snap on retirement.

### Framer Motion was investigated and ruled out

A second suspect — framer-motion layout projection measuring zero-size rects while the subtree is hidden, then animating from that stale zero on re-show — does not apply. Version 12.40.0 explicitly discards a zero-size snapshot:

```js
this.snapshot = this.measure()
if (this.snapshot && !calcLength(this.snapshot.measuredBox.x) && !calcLength(this.snapshot.measuredBox.y)) {
    this.snapshot = undefined   // a display:none measurement is 0×0 → thrown away
}
```

So `ChatSidebar`'s `LayoutGroup` / `layoutId` animations and the side panel's `width: 0 → auto` have no stale zero box to animate from. `animate-rise` is the single cause.

## Tests

Four tests in `website/src/test/App.test.tsx`, each proven red against its own targeted mutation rather than merely passing:

| test | mutation that makes it fail |
|---|---|
| retires the entrance once it has played | remove the fix entirely |
| does not retire from a descendant animation | drop the `e.target === e.currentTarget` guard |
| keeps the entrance for an unrelated keyframe on the shell | drop the `e.animationName === 'rise'` guard |
| retires even when the animation is interrupted | remove the timer backstop |

## Manual verification

N/A — and worth stating why rather than omitting. This change has **no steady-state visual difference**: before and after render identically once the animation settles, and `backwards` fill means retirement itself is invisible. The only difference is that a 350ms replay no longer occurs, which a still screenshot cannot show. The behavioural evidence is the opacity/animation sampling table above plus the four mutation-proven tests.

## Screenshots

N/A — no surface changes appearance in any state. See "Manual verification" for why a still frame would be vacuous evidence here.

## Gates

`tsc -b` clean · `eslint src/ --max-warnings 1116` 0 errors · `jscpd` 0 clones · `i18n:check` ok · vitest 10,478 passed. Frontend only — no Python files touched.

The 4 local vitest failures (`i18n/format.test.ts`, `i18n/moduleLevel.test.ts`, 2 in `settings/SecurityPanel.test.tsx`) are the repo's known timezone dependency: all 105 pass under CI's `TZ=UTC`, and none touch changed code.
