### PR TITLE
fix(watchdog): stop empty startup dumps from evicting real stall evidence

### DIFF
--- a/src/kiro_crew/dashboard/crash_dump_store.py
+++ b/src/kiro_crew/dashboard/crash_dump_store.py
@@ -33,14 +33,20 @@ while guaranteeing the underlying fd is never closed until the process exits.
 
 from __future__ import annotations
 
+import functools
 import logging
 import os
+import re
+import socket
+import stat
 import sys
 import time
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 
 from kiro_crew.config.paths import config_dir
+from kiro_crew.platform_compat import pid_exists
 
 logger = logging.getLogger(__name__)
 
@@ -137,26 +143,332 @@ def get_dumps_dir() -> Path:
 
 
 def _list_dumps(dumps_dir: Path | None = None) -> list[Path]:
-    """Return existing dump files sorted oldest-first."""
+    """Return existing dump files sorted oldest-first.
+
+    A concurrent gateway on the same data home (isolated pod, overlapping
+    restart) can unlink a dump between ``iterdir()`` and ``stat()``. Vanished
+    entries are skipped instead of letting ``FileNotFoundError`` propagate —
+    the startup sweep runs on every boot, so that raise would abort gateway
+    startup.
+    """
     d = dumps_dir or get_dumps_dir()
     if not d.is_dir():
         return []
-    dumps = sorted(
-        (f for f in d.iterdir() if f.name.startswith(DUMP_PREFIX) and f.suffix == DUMP_SUFFIX),
-        key=lambda p: p.stat().st_mtime,
-    )
-    return dumps
-
-
-def rotate_dumps(max_dumps: int = _DEFAULT_MAX_DUMPS, dumps_dir: Path | None = None) -> int:
-    """Remove oldest dumps if count exceeds max_dumps.  Returns number removed."""
-    dumps = _list_dumps(dumps_dir)
-    removed = 0
-    # Keep max_dumps - 1 so there's room for the new one we're about to create
-    while len(dumps) > max_dumps - 1:
-        oldest = dumps.pop(0)
+    entries: list[tuple[float, Path]] = []
+    for f in d.iterdir():
+        if not (f.name.startswith(DUMP_PREFIX) and f.suffix == DUMP_SUFFIX):
+            continue
         try:
-            oldest.unlink()
+            entries.append((f.stat().st_mtime, f))
+        except OSError:
+            continue  # vanished mid-listing — a concurrent sweep got it first
+    entries.sort(key=lambda t: t[0])
+    return [p for _, p in entries]
+
+
+# The header written by open_dump_file() is 3 comment lines + 1 blank line.
+# Anything beyond that is real faulthandler stack content.
+_HEADER_LINES = 4
+
+_PID_LINE_RE = re.compile(r"^# PID: (\d+)(?: @ (\S+))?(?: start=(\S+))?\s*$", re.MULTILINE)
+
+# Ceiling for a plausible PID. Linux pid_max tops out at 2**22; Windows and
+# macOS stay far below 2**31-1. Anything above this is a corrupt header, not a
+# process — and values past the C int range would overflow ``os.kill``.
+_PID_MAX = 2**31 - 1
+
+
+# A real header is 4 short lines (~200 bytes); anything the sweep needs to see
+# — header-only-ness, the ``# PID:`` line — sits comfortably inside this bound.
+_HEADER_SCAN_BYTES = 8192
+
+
+def _read_dump_head(dump_path: Path) -> tuple[str, bool]:
+    """Read at most ``_HEADER_SCAN_BYTES`` bytes of a REGULAR dump file.
+
+    Returns ``(text, truncated)`` — ``truncated`` is computed on BYTES before
+    decoding (multibyte characters shrink the decoded length, so a character
+    count cannot detect the cut). Opens with ``O_NOFOLLOW`` (symlink ->
+    ``ELOOP``) and verifies the fd is a regular file, so a ``loopstall-*.txt``
+    symlinked at ``/dev/zero`` (or a FIFO) cannot pull an unbounded read into
+    the startup sweep. Raises ``OSError`` on refusal or read failure — callers
+    already treat that as "leave the file alone".
+    """
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
+    fd = os.open(str(dump_path), flags)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise OSError(f"not a regular file: {dump_path}")
+        chunks: list[bytes] = []
+        remaining = _HEADER_SCAN_BYTES + 1
+        while remaining > 0:
+            chunk = os.read(fd, remaining)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+    finally:
+        os.close(fd)
+    data = b"".join(chunks)
+    truncated = len(data) > _HEADER_SCAN_BYTES
+    return data[:_HEADER_SCAN_BYTES].decode("utf-8", errors="replace"), truncated
+
+
+def _is_header_only(dump_path: Path) -> bool:
+    """True iff *dump_path* contains only the startup header (no thread stacks).
+
+    A header-only dump means that gateway session never wedged — the file was
+    pre-created at startup (faulthandler needs a stable fd for the process
+    lifetime) and faulthandler never fired into it.  Raises ``OSError`` through
+    to the caller on read failure so callers can choose their own conservative
+    fallback.
+    """
+    content, truncated = _read_dump_head(dump_path)
+    if truncated:
+        return False  # far larger than any header — has stack content
+    return len(content.splitlines()) <= _HEADER_LINES
+
+
+@functools.lru_cache(maxsize=1)
+def _pid_domain() -> str:
+    """Identify the PID domain this process's PID is meaningful in.
+
+    A PID only names a process within one kernel PID table. The data home can
+    be shared across tables — an NFS/network home mounted on several hosts, or
+    a container bind-mounting the host's data home into its own PID namespace
+    — and there a locally-unknown PID says nothing about the owning gateway's
+    liveness. The domain string (hostname, plus the PID-namespace id on Linux)
+    is recorded next to the PID at header-write time so later readers can tell
+    "this PID is checkable here" from "this PID belongs to a table I cannot
+    see".
+    """
+    host = socket.gethostname() or "unknown-host"
+    try:
+        # Two containers sharing a bind-mounted data home can report the same
+        # hostname while having disjoint PID tables; the namespace id
+        # disambiguates. Absent /proc (macOS, Windows), hostname suffices.
+        ns = os.readlink("/proc/self/ns/pid")
+        host = f"{host}/{ns}"
+    except OSError:
+        pass
+    # The header line is parsed with a whitespace-delimited token; keep the
+    # recorded domain one token even if the hostname contains whitespace.
+    return re.sub(r"\s+", "-", host)
+
+
+def _pid_start_id(pid: int) -> str | None:
+    """Best-effort start identity of *pid* — distinguishes PID reuse.
+
+    A PID probing alive is necessary but not sufficient for ownership: the
+    recorded gateway may have exited and the kernel may have handed its PID to
+    an unrelated process. The starttime field (22nd in ``/proc/<pid>/stat``,
+    clock ticks since boot) is fixed for a process's lifetime, so a recorded
+    start ID that no longer matches means the owner is GONE even though the
+    PID is live. Returns ``None`` where the probe is unavailable (no procfs:
+    macOS, Windows) or unreadable — callers must then fall back to plain PID
+    liveness (conservative: protects a possibly-reused PID's file rather than
+    risking deletion of a live owner's fd target).
+    """
+    try:
+        with open(f"/proc/{pid}/stat", "rb") as f:
+            stat = f.read(4096)
+        # Field 2 (comm) may contain spaces/parens; fields after the LAST ')'
+        # are unambiguous. starttime is field 22 overall -> index 19 after it.
+        tail = stat.rsplit(b")", 1)[1].split()
+        return tail[19].decode("ascii")
+    except (OSError, IndexError, UnicodeDecodeError):
+        return None
+
+
+def _dump_owner(dump_path: Path) -> tuple[int, str | None, str | None] | None:
+    """Extract ``(pid, pid_domain, start_id)`` from a dump file's header.
+
+    ``pid_domain`` and ``start_id`` are ``None`` for headers written before
+    each was recorded. Returns ``None`` outright for anything that cannot be a
+    real PID — including digit strings too long to convert or values beyond
+    the pid_t ceiling, which would otherwise raise out of ``int()`` or
+    overflow the liveness probe's ``os.kill`` — so a corrupt header degrades
+    to "leave the file alone" instead of aborting the startup sweep.
+    """
+    try:
+        m = _PID_LINE_RE.search(_read_dump_head(dump_path)[0])
+    except OSError:
+        return None
+    if m is None:
+        return None
+    try:
+        pid = int(m.group(1))
+    except ValueError:
+        return None
+    if not 0 < pid <= _PID_MAX:
+        return None
+    return pid, m.group(2), m.group(3)
+
+
+def _owner_alive(dump_path: Path, is_pid_alive: Callable[[int], bool]) -> bool | None:
+    """Best-effort liveness of the gateway that owns *dump_path*.
+
+    Returns ``True`` (owner confirmed alive), ``False`` (owner confirmed
+    dead), or ``None`` when ownership cannot be established: no parseable
+    ``# PID:`` line, or a PID from a different PID domain (another host
+    sharing the data home, another PID namespace) where a local liveness
+    probe is meaningless — probing such a PID locally would misread an
+    active remote gateway as dead.
+
+    PID reuse: a live PID alone does not prove the OWNER is alive — the
+    recorded gateway may have exited and the kernel may have recycled its PID.
+    When the header recorded a start ID and the live process's start ID
+    differs, the owner is confirmed dead (``False``) despite the live PID.
+    When either side lacks a start ID (legacy header, no procfs), plain PID
+    liveness stands — conservative, since ``True`` only ever protects a file.
+    """
+    owner = _dump_owner(dump_path)
+    if owner is None:
+        return None
+    pid, domain, recorded_start = owner
+    if domain is None or domain != _pid_domain():
+        return None
+    if pid == os.getpid():
+        return True
+    if not is_pid_alive(pid):
+        return False
+    if recorded_start is not None:
+        current_start = _pid_start_id(pid)
+        if current_start is not None and current_start != recorded_start:
+            return False  # PID recycled: live process is not the owner
+    return True
+
+
+def _owner_foreign(dump_path: Path) -> bool:
+    """True iff the dump's header names an owner in a FOREIGN PID domain.
+
+    Distinct from "ownership unknown" (no/corrupt PID line): a foreign-domain
+    owner may be a LIVE gateway on another host or namespace sharing the data
+    home, whose faulthandler still holds this file's fd — deleting the path
+    would send its future stall evidence to an unreachable inode. Files with
+    no attributable owner carry no such risk and stay reapable.
+    """
+    owner = _dump_owner(dump_path)
+    return owner is not None and owner[1] is not None and owner[1] != _pid_domain()
+
+
+def sweep_stale_dumps(
+    dumps_dir: Path | None = None,
+    *,
+    is_pid_alive: Callable[[int], bool] = pid_exists,
+) -> int:
+    """Remove header-only dumps left behind by dead gateway sessions.
+
+    Every gateway startup pre-creates a dump file so faulthandler has a stable
+    fd; a session that exits without ever wedging leaves that file behind as a
+    4-line header with zero diagnostic content.  Restart the gateway often
+    enough and those empty files pile up to the rotation cap — padding the
+    diagnostics bundle's per-bundle dump quota and, worse, aging REAL stall
+    dumps out of rotation (``rotate_dumps`` removes oldest-first by mtime, so
+    nine clean restarts after a wedge would delete the only evidence of it).
+
+    A dump is swept iff ALL of:
+    * it is header-only (a dump with stacks is evidence — never touched), and
+    * its header carries a parseable ``# PID:`` line from THIS PID domain
+      (same host and, on Linux, same PID namespace — a PID recorded by a
+      gateway on another host sharing the data home, or in another PID
+      namespace, cannot be liveness-checked locally and is left alone), and
+    * that PID is confirmed no longer alive (a live PID means a concurrently
+      running gateway on this data home still owns the file — e.g. an
+      isolated pod or an overlapping restart — so it is left alone).
+
+    Unreadable files, headers without a PID line, and headers whose PID
+    belongs to a foreign PID domain are all left alone (conservative:
+    rotation will reap them eventually).  Returns the number of files
+    removed.
+    """
+    removed = 0
+    for path in _list_dumps(dumps_dir):
+        if _owner_alive(path, is_pid_alive) is not False:
+            continue  # owner alive, or ownership unknowable — leave it alone
+        # Classify only AFTER the owner is confirmed dead: a dead process can
+        # no longer append stacks, so the header-only verdict cannot be
+        # invalidated between this check and the unlink. The reverse order
+        # would race a gateway that wedges (writes stacks) and exits right
+        # after classification — deleting fresh evidence.
+        try:
+            if not _is_header_only(path):
+                continue
+        except OSError:
+            continue
+        try:
+            path.unlink()
+            removed += 1
+        except OSError:
+            logger.debug("could not sweep stale dump %s", path, exc_info=True)
+    if removed:
+        logger.info("swept %d stale header-only crash dump(s) from prior sessions", removed)
+    return removed
+
+
+def rotate_dumps(
+    max_dumps: int = _DEFAULT_MAX_DUMPS,
+    dumps_dir: Path | None = None,
+    *,
+    is_pid_alive: Callable[[int], bool] = pid_exists,
+) -> int:
+    """Remove dumps if count exceeds max_dumps.  Returns number removed.
+
+    Header-only dumps (no stack content — the session never wedged) are
+    sacrificed first, oldest-first; dumps with real stacks are only removed
+    once no header-only candidates remain.  This keeps genuine stall evidence
+    alive as long as possible when empty startup files share the directory.
+
+    A dump whose ``# PID:`` owner is this process, or is confirmed alive in
+    this PID domain, is never a victim: faulthandler holds that file's fd for
+    the owning session's whole lifetime, so unlinking it would send any later
+    stall evidence to an unreachable inode. Every live gateway's active dump
+    is header-only until it wedges — exactly the class sacrificed first.
+    A dump whose header names a FOREIGN-domain owner (another host or PID
+    namespace sharing the data home) is also never a victim: its owner may be
+    alive with faulthandler holding the fd, and that cannot be checked from
+    here — its own domain's rotation reaps it. Dumps with NO attributable
+    owner (no/corrupt PID line, legacy domain-less headers) stay
+    rotation-eligible and are ranked purely by content — under cap pressure
+    they are removed just as the pre-sweep rotation removed them, so
+    unattributable files cannot pile up unboundedly.
+    """
+    dumps = _list_dumps(dumps_dir)
+
+    def _sacrifice_order(dumps: list[Path]) -> list[Path]:
+        header_only: list[Path] = []
+        unreadable: list[Path] = []
+        stacked: list[Path] = []
+        for p in dumps:
+            if _owner_alive(p, is_pid_alive) is True:
+                continue  # a live session still owns this fd — never a victim
+            if _owner_foreign(p):
+                # A foreign-domain owner (another host/namespace sharing the
+                # data home) cannot be liveness-checked here, and if it IS
+                # alive its faulthandler holds this file's fd — unlinking the
+                # path would send its future stall evidence to an unreachable
+                # inode. Its own gateway's rotation reaps it in its domain.
+                continue
+            try:
+                (header_only if _is_header_only(p) else stacked).append(p)
+            except OSError:
+                # Unreadable is ambiguous: junk (symlink, wrong type) or real
+                # evidence behind a transient read error. Sacrifice it after
+                # known header-only files but before confirmed stack evidence.
+                unreadable.append(p)
+        return header_only + unreadable + stacked
+
+    victims = _sacrifice_order(dumps)
+    # Compute the excess ONCE and attempt exactly that many victims (keep
+    # max_dumps - 1 so there's room for the new one we're about to create).
+    # Counting only successful unlinks would let two overlapping rotations
+    # each treat the other's deletions as "still excess" and remove twice
+    # the intended number of files.
+    excess = len(dumps) - (max_dumps - 1)
+    removed = 0
+    for victim in victims[: max(excess, 0)]:
+        try:
+            victim.unlink()
             removed += 1
         except OSError:
             pass
@@ -191,9 +503,16 @@ def open_dump_file(dumps_dir: Path | None = None) -> DumpFile:
     fd = os.open(str(path), flags, 0o644)
 
     f = DumpFile(fd, path)
-    # Write a header so the file is identifiable even before a dump fires
+    # Write a header so the file is identifiable even before a dump fires.
+    # The PID is qualified with its PID domain (host + PID namespace) so a
+    # later sweep only trusts a local liveness probe for PIDs it can see, and
+    # with the process start ID so a recycled PID cannot masquerade as the
+    # owner (omitted where procfs is unavailable — readers then fall back to
+    # plain PID liveness).
+    start_id = _pid_start_id(os.getpid())
+    start_tok = f" start={start_id}" if start_id is not None else ""
     f.write(f"# KiroCrew loop-stall crash dump — opened {ts}\n")
-    f.write(f"# PID: {os.getpid()}\n")
+    f.write(f"# PID: {os.getpid()} @ {_pid_domain()}{start_tok}\n")
     f.write("# If thread stacks appear below, the event loop wedged and faulthandler fired.\n")
     f.write("\n")
     _active_dump_file = f
@@ -215,12 +534,7 @@ def newest_dump_with_stacks(dumps_dir: Path | None = None) -> Path | None:
     dumps = _list_dumps(dumps_dir)
     for path in reversed(dumps):
         try:
-            # Header is 4 lines (3 comment lines + blank).  Real dump content
-            # starts after that.
-            content = path.read_text(encoding="utf-8", errors="replace")
-            lines = content.splitlines()
-            # If there are more than 4 lines, there's actual stack content
-            if len(lines) > 4:
+            if not _is_header_only(path):
                 return path
         except OSError:
             continue
@@ -270,8 +584,7 @@ def dump_first_stack_lines(dump_path: Path, max_lines: int = 5) -> list[str]:
     """Extract the first N lines of actual stack content from a dump file."""
     try:
         lines = dump_path.read_text(encoding="utf-8", errors="replace").splitlines()
-        # Skip the 4-line header
-        stack_lines = [ln for ln in lines[4:] if ln.strip()]
+        stack_lines = [ln for ln in lines[_HEADER_LINES:] if ln.strip()]
         return stack_lines[:max_lines]
     except OSError:
         return []
@@ -291,8 +604,7 @@ def dump_replay_lines(
     except OSError:
         return [], False
     all_lines = content.splitlines()
-    # Skip the 4-line header
-    stack_lines = [ln for ln in all_lines[4:] if ln.strip()]
+    stack_lines = [ln for ln in all_lines[_HEADER_LINES:] if ln.strip()]
     result: list[str] = []
     total = 0
     for ln in stack_lines:

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -52,6 +52,7 @@ from kiro_crew.dashboard.crash_dump_store import (
     newest_dump_with_stacks,
     open_dump_file,
     rotate_dumps,
+    sweep_stale_dumps,
 )
 from kiro_crew.dashboard.handlers.artifacts import (
     api_artifact_comments,
@@ -3169,6 +3170,11 @@ async def start_dashboard(
     # Crash-dump discoverability: route dumps to a dedicated file under
     # ~/.kiro/crew/logs/crash-dumps/ so they are findable via `kirocrew doctor`
     # and startup warnings, rather than buried in interleaved stderr/journal.
+    # Crash-dump hygiene: sweep header-only dumps left by prior sessions that
+    # exited without ever wedging (every startup pre-creates one for
+    # faulthandler's fd), THEN rotate. Sweeping first keeps empty startup files
+    # from aging real stall dumps out of the rotation window.
+    await asyncio.to_thread(sweep_stale_dumps)
     await asyncio.to_thread(rotate_dumps)
     _dump_file = await asyncio.to_thread(open_dump_file)
     # exit_after is configurable because the right budget is host-dependent: a

--- a/test/test_crash_dump_store.py
+++ b/test/test_crash_dump_store.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+from kiro_crew.dashboard import crash_dump_store
 from kiro_crew.dashboard.crash_dump_store import (
     DUMP_PREFIX,
     DUMP_SUFFIX,
@@ -21,6 +22,7 @@ from kiro_crew.dashboard.crash_dump_store import (
     newest_dump_with_stacks,
     open_dump_file,
     rotate_dumps,
+    sweep_stale_dumps,
 )
 
 
@@ -31,13 +33,23 @@ def dumps_dir(tmp_path: Path) -> Path:
     return d
 
 
-def _create_header_only_dump(dumps_dir: Path, name: str) -> Path:
-    """Create a dump file with only the header (no stacks = clean exit)."""
+def _create_header_only_dump(
+    dumps_dir: Path, name: str, *, pid_domain: str | None = None
+) -> Path:
+    """Create a dump file with only the header (no stacks = clean exit).
+
+    ``pid_domain`` defaults to THIS process's domain so ownership is
+    attributable and the injected liveness check is consulted; pass a foreign
+    domain (or empty string for a legacy domain-less header) to exercise the
+    unattributable paths.
+    """
+    domain = crash_dump_store._pid_domain() if pid_domain is None else pid_domain
+    pid_line = f"# PID: 12345 @ {domain}\n" if domain else "# PID: 12345\n"
     p = dumps_dir / name
     p.write_text(
         "# KiroCrew loop-stall crash dump — opened 20260717T010000Z\n"
-        "# PID: 12345\n"
-        "# If thread stacks appear below, the event loop wedged and faulthandler fired.\n"
+        + pid_line
+        + "# If thread stacks appear below, the event loop wedged and faulthandler fired.\n"
         "\n"
     )
     return p
@@ -48,7 +60,7 @@ def _create_stacked_dump(dumps_dir: Path, name: str) -> Path:
     p = dumps_dir / name
     p.write_text(
         "# KiroCrew loop-stall crash dump — opened 20260717T020000Z\n"
-        "# PID: 12345\n"
+        f"# PID: 12345 @ {crash_dump_store._pid_domain()}\n"
         "# If thread stacks appear below, the event loop wedged and faulthandler fired.\n"
         "\n"
         "Thread 0x00007f1234 (most recent call first):\n"
@@ -430,3 +442,308 @@ def test_startup_crash_dump_replay_logs_stacks(dumps_dir: Path, caplog: pytest.L
 
     assert "Thread" in caplog.text
     assert "socket.py" in caplog.text
+
+
+# ── Stale header-only dump sweep ──
+
+
+def _dead_pid(pid: int) -> bool:
+    return False
+
+
+def _live_pid(pid: int) -> bool:
+    return True
+
+
+def test_sweep_removes_header_only_dump_of_dead_pid(dumps_dir: Path) -> None:
+    p = _create_header_only_dump(dumps_dir, f"{DUMP_PREFIX}20260717T010000Z{DUMP_SUFFIX}")
+    removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_dead_pid)
+    assert removed == 1
+    assert not p.exists()
+
+
+def test_sweep_keeps_header_only_dump_of_live_pid(dumps_dir: Path) -> None:
+    # A live PID means another gateway on this data home still owns the file
+    # (concurrent pod / overlapping restart) — must not be touched.
+    p = _create_header_only_dump(dumps_dir, f"{DUMP_PREFIX}20260717T010000Z{DUMP_SUFFIX}")
+    removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_live_pid)
+    assert removed == 0
+    assert p.exists()
+
+
+def test_sweep_never_touches_dumps_with_stacks(dumps_dir: Path) -> None:
+    p = _create_stacked_dump(dumps_dir, f"{DUMP_PREFIX}20260717T020000Z{DUMP_SUFFIX}")
+    removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_dead_pid)
+    assert removed == 0
+    assert p.exists()
+
+
+def test_sweep_keeps_own_pid_file(dumps_dir: Path) -> None:
+    # The current process's own pre-created file must survive even if the
+    # injected liveness check lies about it.
+    p = dumps_dir / f"{DUMP_PREFIX}20260717T030000Z{DUMP_SUFFIX}"
+    p.write_text(
+        "# KiroCrew loop-stall crash dump — opened 20260717T030000Z\n"  # brand-ok: mirrors production dump header
+        f"# PID: {os.getpid()} @ {crash_dump_store._pid_domain()}\n"
+        "# If thread stacks appear below, the event loop wedged and faulthandler fired.\n"
+        "\n"
+    )
+    removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_dead_pid)
+    assert removed == 0
+    assert p.exists()
+
+
+def test_sweep_keeps_dump_from_foreign_pid_domain(dumps_dir: Path) -> None:
+    # A PID recorded by a gateway on another host sharing the data home (or in
+    # another PID namespace) is not checkable with a local liveness probe — a
+    # locally-dead verdict says nothing about the remote owner, whose
+    # faulthandler still holds this file's fd. Must be left alone.
+    p = _create_header_only_dump(
+        dumps_dir,
+        f"{DUMP_PREFIX}20260717T090000Z{DUMP_SUFFIX}",
+        pid_domain="other-host/pid:[4026531836]",
+    )
+    removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_dead_pid)
+    assert removed == 0
+    assert p.exists()
+
+
+def test_sweep_keeps_legacy_dump_without_pid_domain(dumps_dir: Path) -> None:
+    # Headers written before the PID domain was recorded carry a bare PID.
+    # Ownership cannot be scoped to a PID table, so the sweep leaves the file
+    # for rotation to reap under pressure.
+    p = _create_header_only_dump(
+        dumps_dir, f"{DUMP_PREFIX}20260717T100000Z{DUMP_SUFFIX}", pid_domain=""
+    )
+    removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_dead_pid)
+    assert removed == 0
+    assert p.exists()
+
+
+def test_open_dump_file_header_records_pid_domain(dumps_dir: Path) -> None:
+    # The header must qualify the PID with this process's PID domain so a
+    # later sweep on a different host/namespace treats it as unattributable,
+    # and (where procfs exists) with the start ID so a recycled PID cannot
+    # masquerade as the owner.
+    f = open_dump_file(dumps_dir)
+    content = f.path.read_text(encoding="utf-8")
+    start_id = crash_dump_store._pid_start_id(os.getpid())
+    start_tok = f" start={start_id}" if start_id is not None else ""
+    assert f"# PID: {os.getpid()} @ {crash_dump_store._pid_domain()}{start_tok}\n" in content
+    # And a same-process sweep must classify it as alive-owned, not sweep it.
+    removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_dead_pid)
+    assert removed == 0
+    assert f.path.exists()
+
+
+def test_sweep_keeps_header_only_dump_without_pid_line(dumps_dir: Path) -> None:
+    # No parseable PID — cannot attribute the file, so leave it alone.
+    p = dumps_dir / f"{DUMP_PREFIX}20260717T040000Z{DUMP_SUFFIX}"
+    p.write_text("# KiroCrew loop-stall crash dump — opened 20260717T040000Z\n\n")  # brand-ok: mirrors production dump header
+    removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_dead_pid)
+    assert removed == 0
+    assert p.exists()
+
+
+def test_sweep_treats_oversized_pid_as_unparseable(dumps_dir: Path) -> None:
+    # A corrupt header whose digit run exceeds any real pid_t must not raise
+    # out of the startup sweep (int() digit-limit ValueError, os.kill
+    # OverflowError) — the file is unattributable and left alone.
+    for name, digits in (("20260717T050000Z", "9" * 5000), ("20260717T060000Z", str(2**31))):
+        p = dumps_dir / f"{DUMP_PREFIX}{name}{DUMP_SUFFIX}"
+        p.write_text(
+            "# KiroCrew loop-stall crash dump — opened 20260717T050000Z\n"  # brand-ok: mirrors production dump header
+            f"# PID: {digits}\n"
+            "\n"
+        )
+    removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_dead_pid)
+    assert removed == 0
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation needs privilege on Windows")
+def test_sweep_refuses_symlinked_dump(dumps_dir: Path) -> None:
+    # A dump-named symlink (e.g. pointed at /dev/zero) must not be followed:
+    # the header inspection opens O_NOFOLLOW, so the sweep leaves the entry
+    # alone instead of pulling an unbounded read.
+    target = dumps_dir / "target.txt"
+    target.write_text("# not a dump\n")
+    link = dumps_dir / f"{DUMP_PREFIX}20260717T070000Z{DUMP_SUFFIX}"
+    link.symlink_to(target)
+    removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_dead_pid)
+    assert removed == 0
+    assert link.is_symlink()
+
+
+def test_list_dumps_skips_files_vanishing_mid_listing(
+    dumps_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A concurrent gateway's sweep can unlink a dump between ``iterdir()`` and
+    # ``stat()``; the listing must skip the vanished entry, not raise out of
+    # the startup sweep.
+    keep = _create_header_only_dump(dumps_dir, f"{DUMP_PREFIX}20260717T010000Z{DUMP_SUFFIX}")
+    ghost = _create_header_only_dump(dumps_dir, f"{DUMP_PREFIX}20260717T020000Z{DUMP_SUFFIX}")
+
+    real_stat = Path.stat
+
+    def racing_stat(self: Path, **kwargs: object) -> object:
+        if self.name == ghost.name:
+            raise FileNotFoundError(str(self))
+        return real_stat(self, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "stat", racing_stat)
+    assert crash_dump_store._list_dumps(dumps_dir) == [keep]
+
+
+def test_sweep_reads_only_a_bounded_prefix(dumps_dir: Path) -> None:
+    # A huge file is by definition not header-only; the sweep must classify it
+    # from its leading bytes alone and never load the whole thing.
+    p = dumps_dir / f"{DUMP_PREFIX}20260717T080000Z{DUMP_SUFFIX}"
+    with p.open("w") as f:
+        f.write("# KiroCrew loop-stall crash dump — opened 20260717T080000Z\n")  # brand-ok: mirrors production dump header
+        f.write("# PID: 1\n\n")
+        f.write("x" * (1024 * 1024))  # single long line, no newlines
+    removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_dead_pid)
+    assert removed == 0
+    assert p.exists()
+
+
+def test_sweep_empty_dir(dumps_dir: Path) -> None:
+    assert sweep_stale_dumps(dumps_dir, is_pid_alive=_dead_pid) == 0
+
+
+def test_sweep_mixed_directory(dumps_dir: Path) -> None:
+    stale1 = _create_header_only_dump(dumps_dir, f"{DUMP_PREFIX}20260717T010000Z{DUMP_SUFFIX}")
+    real = _create_stacked_dump(dumps_dir, f"{DUMP_PREFIX}20260717T020000Z{DUMP_SUFFIX}")
+    stale2 = _create_header_only_dump(dumps_dir, f"{DUMP_PREFIX}20260717T030000Z{DUMP_SUFFIX}")
+    removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_dead_pid)
+    assert removed == 2
+    assert not stale1.exists()
+    assert not stale2.exists()
+    assert real.exists()
+
+
+# ── Stack-aware rotation ──
+
+
+def test_rotate_sacrifices_header_only_before_stacked(dumps_dir: Path) -> None:
+    # Oldest file has REAL stacks; three newer header-only files follow.
+    # With max_dumps=3 the rotation must delete header-only files (oldest
+    # first) and keep the stall evidence, even though it is the oldest file.
+    real = _create_stacked_dump(dumps_dir, f"{DUMP_PREFIX}20260710T000000Z{DUMP_SUFFIX}")
+    os.utime(real, (1000, 1000))
+    empties = []
+    for i in range(1, 4):
+        p = _create_header_only_dump(
+            dumps_dir, f"{DUMP_PREFIX}2026071{i}T000000Z{DUMP_SUFFIX}"
+        )
+        os.utime(p, (1000 + i, 1000 + i))
+        empties.append(p)
+
+    removed = rotate_dumps(max_dumps=3, dumps_dir=dumps_dir, is_pid_alive=_dead_pid)
+    assert removed == 2
+    assert real.exists()
+    # The two OLDEST header-only files are gone; the newest survives.
+    assert not empties[0].exists()
+    assert not empties[1].exists()
+    assert empties[2].exists()
+
+
+def test_rotate_removes_stacked_when_no_header_only_left(dumps_dir: Path) -> None:
+    paths = []
+    for i in range(4):
+        p = _create_stacked_dump(dumps_dir, f"{DUMP_PREFIX}2026071{i}T000000Z{DUMP_SUFFIX}")
+        os.utime(p, (1000 + i, 1000 + i))
+        paths.append(p)
+
+    removed = rotate_dumps(max_dumps=3, dumps_dir=dumps_dir, is_pid_alive=_dead_pid)
+    assert removed == 2
+    # Oldest two stacked dumps removed, newest two kept.
+    assert not paths[0].exists()
+    assert not paths[1].exists()
+    assert paths[2].exists()
+    assert paths[3].exists()
+
+
+def test_rotate_never_victimizes_a_live_owners_dump(dumps_dir: Path) -> None:
+    # A concurrently running gateway's pre-created dump is header-only until
+    # it wedges — exactly the class sacrificed first. faulthandler holds its
+    # fd for the owner's lifetime, so unlinking it would send later stall
+    # evidence to an unreachable inode. Live-owner dumps are never victims,
+    # even when that means staying over the cap.
+    live = _create_header_only_dump(dumps_dir, f"{DUMP_PREFIX}20260710T000000Z{DUMP_SUFFIX}")
+    os.utime(live, (1000, 1000))  # oldest — would be first victim otherwise
+    dead = []
+    for i in range(1, 4):
+        p = _create_header_only_dump(
+            dumps_dir, f"{DUMP_PREFIX}2026071{i}T000000Z{DUMP_SUFFIX}"
+        )
+        os.utime(p, (1000 + i, 1000 + i))
+        dead.append(p)
+
+    removed = rotate_dumps(max_dumps=3, dumps_dir=dumps_dir, is_pid_alive=_live_pid)
+    # All four dumps carry PID 12345; with every owner "alive" nothing is
+    # sacrificed regardless of rotation pressure.
+    assert removed == 0
+    assert live.exists() and all(p.exists() for p in dead)
+
+
+def test_rotate_never_victimizes_foreign_domain_dumps(dumps_dir: Path) -> None:
+    # GPT round: a foreign-domain owner (another host/namespace sharing the
+    # data home) may be a LIVE gateway whose faulthandler holds this file's
+    # fd — and that cannot be checked from here. Rotation must never unlink
+    # its path (evidence would land on an unreachable inode); the owner's own
+    # domain rotates it. Legacy domain-less files carry no such live-fd claim
+    # and stay reapable, so unattributable litter is still bounded.
+    foreign = _create_header_only_dump(
+        dumps_dir,
+        f"{DUMP_PREFIX}20260711T000000Z{DUMP_SUFFIX}",
+        pid_domain="other-host/pid:[4026531836]",
+    )
+    os.utime(foreign, (1001, 1001))
+    legacy = _create_header_only_dump(
+        dumps_dir, f"{DUMP_PREFIX}20260712T000000Z{DUMP_SUFFIX}", pid_domain=""
+    )
+    os.utime(legacy, (1002, 1002))
+    real = _create_stacked_dump(dumps_dir, f"{DUMP_PREFIX}20260710T000000Z{DUMP_SUFFIX}")
+    os.utime(real, (1000, 1000))  # oldest — kept anyway: stacked evidence
+
+    removed = rotate_dumps(max_dumps=2, dumps_dir=dumps_dir, is_pid_alive=_live_pid)
+    # 3 files, cap 2 => excess computed as 2, but the foreign dump is excluded
+    # from the victim list: only the legacy header-only file is sacrificed.
+    assert removed == 1
+    assert foreign.exists()
+    assert not legacy.exists()
+    assert real.exists()
+
+
+def test_owner_alive_detects_pid_reuse_via_start_id(dumps_dir: Path) -> None:
+    # GPT round: a live PID is not proof of a live OWNER — the kernel can
+    # recycle the recorded PID for an unrelated process. A header that
+    # recorded a start ID differing from the live process's start ID means
+    # the owner is dead; its file must be protectable no longer.
+    if crash_dump_store._pid_start_id(os.getpid()) is None:
+        pytest.skip("no procfs start-id probe on this platform")
+    # Use a REAL live process (the parent) so the start-id probe returns a
+    # value; record a fabricated start id that cannot match it.
+    reused_pid = os.getppid()
+    p = dumps_dir / f"{DUMP_PREFIX}20260717T110000Z{DUMP_SUFFIX}"
+    p.write_text(
+        "# KiroCrew loop-stall crash dump — opened 20260717T110000Z\n"  # brand-ok: mirrors production dump header
+        f"# PID: {reused_pid} @ {crash_dump_store._pid_domain()} start=fabricated-mismatch\n"
+        "# If thread stacks appear below, the event loop wedged and faulthandler fired.\n"
+        "\n"
+    )
+    assert crash_dump_store._owner_alive(p, _live_pid) is False
+    removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_live_pid)
+    assert removed == 1
+    assert not p.exists()
+
+
+def test_owner_alive_without_recorded_start_id_trusts_liveness(dumps_dir: Path) -> None:
+    # Legacy headers (no start= token) fall back to plain PID liveness —
+    # conservative: a live PID protects the file.
+    p = _create_header_only_dump(dumps_dir, f"{DUMP_PREFIX}20260717T120000Z{DUMP_SUFFIX}")
+    assert crash_dump_store._owner_alive(p, _live_pid) is True
+    removed = sweep_stale_dumps(dumps_dir, is_pid_alive=_live_pid)
+    assert removed == 0
+    assert p.exists()


### PR DESCRIPTION
## Problem

Every gateway startup pre-creates a loop-stall crash dump file (`open_dump_file()`) so `faulthandler.dump_traceback_later` has a stable fd for the process lifetime. A session that exits without ever wedging leaves that file behind as a 4-line header with **zero diagnostic content** — and nothing ever cleans those up.

Observed on a real host (4 gateway restarts in one day):

```
crash-dumps/loopstall-20260807T174743Z.txt   156 bytes
crash-dumps/loopstall-20260807T175803Z.txt   156 bytes
crash-dumps/loopstall-20260807T183948Z.txt   156 bytes
crash-dumps/loopstall-20260807T214121Z.txt   156 bytes
```

Each contains only:

```
# KiroCrew loop-stall crash dump — opened <ts>
# PID: <pid>
# If thread stacks appear below, the event loop wedged and faulthandler fired.
```

Consequences:

1. **Real stall evidence gets deleted.** `rotate_dumps()` removes oldest-first by mtime with a cap of 10. Nine clean restarts after a genuine wedge and the only stack dump of that hard-exit is rotated out — while ten empty header files survive.
2. **Diagnostics bundles get padded.** `diagnostics.py` bundles the 5 newest dumps by mtime; empty startup files crowd out real ones.
3. **False crash signal.** The dir fills with files that look like crashes but aren't (`doctor` already knows to skip them via `newest_dump_with_stacks()`; humans and log-scanning tooling looking at the directory don't).

## Fix

- **`sweep_stale_dumps()`** — called at gateway startup before rotation. Removes header-only dumps whose recorded `# PID:` is dead. Conservative by design:
  - dumps with stacks are **never** touched;
  - a live PID means a concurrently running gateway/pod on the same data home still owns the file → left alone;
  - the current process's own file and headers without a parseable PID line → left alone.
- **`rotate_dumps()`** — now sacrifices header-only dumps first (oldest-first); dumps with real stacks are only removed once no empty candidates remain.
- Consolidated the header-size checks (`newest_dump_with_stacks`, `dump_first_stack_lines`, `dump_replay_lines`) onto one `_HEADER_LINES` source of truth.

PID liveness reuses the existing cross-platform `kiro_crew.platform_compat.pid_exists` (POSIX `kill(pid, 0)`, Windows `OpenProcess` + `GetExitCodeProcess`).

## Tests

9 new tests in `test/test_crash_dump_store.py` (sweep: dead-PID removal, live-PID kept, stacked never touched, own-PID kept, no-PID-line kept, empty dir, mixed dir; rotation: header-only sacrificed before stacked, stacked-only falls back to oldest-first).

```
test/test_crash_dump_store.py + test/test_loop_watchdog.py   44 passed
test/test_loop_stall_surfacing.py                            10 passed
test/test_diagnostics.py                                     42 passed
```

flake8 clean on touched files.
