### PR TITLE
perf(system): share one process-table snapshot per sampling pass

### DIFF
--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -20,6 +20,7 @@ import os
 import re
 import subprocess
 import sys
+import threading
 import time
 from collections import deque
 from pathlib import Path
@@ -294,6 +295,90 @@ def _iter_descendant_pids(pid: int) -> list[int]:
     return order
 
 
+#: A whole-machine process table: ``(children_by_ppid, rss_kib_by_pid)``.
+_ProcessTable = tuple[dict[int, list[int]], dict[int, int]]
+
+#: How long one ``ps -A`` snapshot may be reused.
+#:
+#: This exists because the snapshot is WHOLE-MACHINE while its consumer asks
+#: per-pid. ``session_memory._blocking_sample`` samples every live runtime pid in
+#: one pass, so an uncached snapshot enumerated every process on the host once
+#: PER SESSION — 8 sessions on a host with ~150 MCP processes meant 8 full
+#: process-table walks every 5s, serialized in one worker. Measured cost on a
+#: typical Mac (875 procs): ~33ms per ``ps -Ao``, so 8 walks ≈ 272ms duty cycle
+#: per 5s poll — linear amplification that wastes a thread worker and grows with
+#: session count (macOS only: the Linux branch above uses ``/proc`` directly and
+#: never spawns anything).
+#:
+#: One second is chosen against the two consumers, not arbitrarily: the Sessions
+#: panel polls at 5s and the watchdog's RSS ceiling is a multi-GB threshold
+#: checked on a timer, so neither can tell a 1s-old measurement from a fresh
+#: one — while a sampling pass over N pids completes well inside the window and
+#: therefore pays for exactly one snapshot.
+_PS_TABLE_TTL_S = 1.0
+
+_ps_table_lock = threading.Lock()
+#: ``(monotonic_taken_at, table)``, or None before the first snapshot. A cached
+#: FAILURE is not stored — a transient ``ps`` error must not pin every caller to
+#: the single-pid fallback for a whole second.
+_ps_table_cache: tuple[float, _ProcessTable] | None = None
+
+
+def _reset_ps_table_cache() -> None:
+    """Drop the memoized process table. Test seam: the cache is keyed on wall
+    time only, so a test that fakes ``ps`` output would otherwise inherit the
+    previous test's snapshot."""
+    global _ps_table_cache
+    with _ps_table_lock:
+        _ps_table_cache = None
+
+
+def _ps_process_table() -> _ProcessTable | None:
+    """One ``ps -Ao pid=,ppid=,rss=`` snapshot as a parent map + RSS map.
+
+    Memoized for :data:`_PS_TABLE_TTL_S` so a caller that needs the tree for many
+    pids pays for ONE process-table walk rather than one per pid. Returns None
+    when ``ps`` is unavailable or fails, so callers fall back to a single-pid
+    read instead of reporting a phantom-empty tree.
+
+    The snapshot is taken under the lock rather than merely published under it:
+    concurrent first-callers would otherwise each spawn ``ps`` before any of them
+    stored a result, which is the exact amplification this cache exists to
+    remove.
+    """
+    global _ps_table_cache
+    with _ps_table_lock:
+        cached = _ps_table_cache
+        if cached is not None and (time.monotonic() - cached[0]) < _PS_TABLE_TTL_S:
+            return cached[1]
+        ps_bin = platform_compat.trusted_system_bin("ps")
+        if ps_bin is None:
+            return None
+        try:
+            out = (
+                subprocess.check_output([ps_bin, "-Ao", "pid=,ppid=,rss="], timeout=2)
+                .decode()
+                .strip()
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        children: dict[int, list[int]] = {}
+        rss_kib: dict[int, int] = {}
+        for line in out.splitlines():
+            parts = line.split()
+            if len(parts) < 3:
+                continue
+            try:
+                cpid, ppid, rss = int(parts[0]), int(parts[1]), int(parts[2])
+            except ValueError:
+                continue
+            children.setdefault(ppid, []).append(cpid)
+            rss_kib[cpid] = rss
+        table: _ProcessTable = (children, rss_kib)
+        _ps_table_cache = (time.monotonic(), table)
+        return table
+
+
 def _get_rss_tree_mb(pid: int) -> float | None:
     """Sum RSS (MiB) of *pid* and all its descendants, or None if unavailable.
 
@@ -302,8 +387,15 @@ def _get_rss_tree_mb(pid: int) -> float | None:
     launcher parent (small, stable, blocked in ``waitpid``) while the real
     kiro-cli that accumulates multi-GB RSS is a child. Measuring only
     ``self._pid`` therefore misses the growth entirely, so we sum the whole
-    descendant tree. On macOS (sandbox-exec / no launcher fork) the tree is
-    just the process itself, so the sum equals the single-process RSS.
+    descendant tree.
+
+    On macOS the tree is walked too, and it is NOT redundant: kiro-cli spawns
+    MCP-server / tool children there exactly as it does on Windows (see that
+    branch's note), so measuring only ``pid`` under-reports a session's real
+    footprint and blinds the watchdog's leak ceiling. An earlier version of this
+    docstring claimed the macOS tree "is just the process itself"; it is kept
+    corrected here because that claim is what made the per-pid whole-machine
+    snapshot look free.
     """
     if sys.platform == "linux":
         total = 0.0
@@ -329,29 +421,13 @@ def _get_rss_tree_mb(pid: int) -> float | None:
         # producing a phantom-low tree attached to a recycled root.
         return platform_compat.proc_rss_tree_mb_for_pid(pid)
 
-    # macOS / other: build a ppid map from a single ps snapshot, then sum the
-    # descendant subtree rooted at pid (ps reports RSS in KiB).
-    ps_bin = platform_compat.trusted_system_bin("ps")
-    if ps_bin is None:
+    # macOS / other: sum the descendant subtree rooted at pid off a SHARED
+    # whole-machine snapshot (ps reports RSS in KiB). The snapshot is memoized in
+    # _ps_process_table, so sampling N pids costs one process-table walk, not N.
+    table = _ps_process_table()
+    if table is None:
         return _get_rss_mb(pid)
-    try:
-        out = (
-            subprocess.check_output([ps_bin, "-Ao", "pid=,ppid=,rss="], timeout=2).decode().strip()
-        )
-    except (OSError, subprocess.SubprocessError):
-        return _get_rss_mb(pid)
-    children: dict[int, list[int]] = {}
-    rss_kib: dict[int, int] = {}
-    for line in out.splitlines():
-        parts = line.split()
-        if len(parts) < 3:
-            continue
-        try:
-            cpid, ppid, rss = int(parts[0]), int(parts[1]), int(parts[2])
-        except ValueError:
-            continue
-        children.setdefault(ppid, []).append(cpid)
-        rss_kib[cpid] = rss
+    children, rss_kib = table
     if pid not in rss_kib:
         return None
     total_kib = 0

--- a/src/kiro_crew/dashboard/handlers_system.py
+++ b/src/kiro_crew/dashboard/handlers_system.py
@@ -29,6 +29,7 @@ from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.config.paths import config_dir
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.embeddings import get_shared_embedder, model_file_present
+from kiro_crew.executors import subprocess_executor
 from kiro_crew.platform import current_context
 from kiro_crew.safety_override import safety_override, until_shutdown_permitted
 from kiro_crew.stats import Stats
@@ -365,6 +366,109 @@ def _macos_memory_gb(total_bytes: int, vm_stat_output: str) -> tuple[float, floa
     return used_gb, free_gb
 
 
+#: Process-scan results, cached independently of the rest of the payload.
+_proc_scan_cache: dict[str, object] = {}
+_proc_scan_cache_ts: float = 0.0
+
+#: How long a process COUNT may be reused.
+#:
+#: Deliberately much longer than :data:`_METRICS_CACHE_TTL`, because the two
+#: answer different questions. CPU / memory / network are a live graph and are
+#: meaningless stale; "how many MCP processes exist" is a slow-moving fact that
+#: nobody reads at 2s resolution — and on any host without ``/proc`` it costs a
+#: whole-machine ``ps`` walk to obtain, which grows with the process count the
+#: shared MCP gateway multiplies. Tying it to the graph's refresh rate is what
+#: made every poll pay for it.
+_PROC_SCAN_CACHE_TTL = 15.0
+
+
+def _scan_mcp_processes() -> dict[str, object]:
+    """Count MCP-ecosystem processes by command-line signature.
+
+    A single process may match multiple signatures (e.g. a sandboxed kiro-cli
+    matches both "kirocrew_sandbox" and "kiro-cli"); per-category counts can
+    overlap, while ``mcp_total`` dedups by PID. kiro-cli is an optional backend;
+    the signature is harmless when it is not installed.
+
+    Sandbox counting platform differences:
+      Linux:  The namespace launcher (python3 ~/.kiro/crew/run/kirocrew_sandbox_*.py ...)
+              forks — the parent stays alive with "kirocrew_sandbox" in its
+              /proc/cmdline, so sandbox count is accurate.
+      macOS:  sandbox-exec execs the target command, replacing the process
+              image. The final cmdline becomes "kiro-cli ..." and the
+              "kirocrew_sandbox" string (only in the -f path arg) is lost.
+              Sandbox count will be 0 even when sandboxes are running.
+    """
+    try:
+        _my = os.getpid()
+        _counts: dict[str, int] = {"sandbox": 0, "kiro_cli": 0}
+        _seen: set[str] = set()
+        if sys.platform == "linux":
+            for d in os.listdir("/proc"):
+                if not d.isdigit() or int(d) == _my:
+                    continue
+                try:
+                    cmd = Path(f"/proc/{d}/cmdline").read_bytes()
+                    matched = False
+                    if b"kirocrew_sandbox" in cmd:
+                        _counts["sandbox"] += 1
+                        matched = True
+                    if b"kiro-cli" in cmd:
+                        _counts["kiro_cli"] += 1
+                        matched = True
+                    if matched:
+                        _seen.add(d)
+                except OSError:
+                    pass
+        else:
+            _sigs = {
+                "kirocrew_sandbox": "sandbox",
+                "kiro-cli": "kiro_cli",
+            }
+            try:
+                out = subprocess.check_output(
+                    ["ps", "-eo", "pid,command"],
+                    timeout=5,
+                    text=True,
+                )
+                for line in out.splitlines():
+                    parts = line.split(None, 1)
+                    if len(parts) < 2:
+                        continue
+                    pid_s, cmd = parts
+                    if pid_s.strip() == str(_my):
+                        continue
+                    matched = False
+                    for sig, key in _sigs.items():
+                        if sig in cmd:
+                            _counts[key] += 1
+                            matched = True
+                    if matched:
+                        _seen.add(pid_s.strip())
+            except Exception:
+                pass
+        return {"mcp_processes": _counts, "mcp_total": len(_seen)}
+    except Exception:
+        return {"mcp_processes": {"sandbox": 0, "kiro_cli": 0}, "mcp_total": 0}
+
+
+def _apply_mcp_process_counts(data: dict[str, object]) -> None:
+    """Merge the (separately cached) process counts into a metrics payload.
+
+    Cached rather than recomputed so the expensive scan runs on its own slow
+    cadence while the live numbers around it stay at the graph's refresh rate.
+    Called from the sampling thread, and the write is a single rebind of two
+    module globals, so no lock is needed: a racing pair of samplers publishes
+    one consistent snapshot or the other, never a mixture.
+    """
+    global _proc_scan_cache, _proc_scan_cache_ts
+    now = time.monotonic()
+    if not _proc_scan_cache or now - _proc_scan_cache_ts >= _PROC_SCAN_CACHE_TTL:
+        _proc_scan_cache = _scan_mcp_processes()
+        _proc_scan_cache_ts = now
+    data.update(_proc_scan_cache)
+
+
 def _collect_system_metrics() -> dict[str, object]:
     """Collect system metrics synchronously (runs in thread pool).
 
@@ -553,73 +657,7 @@ def _collect_system_metrics() -> dict[str, object]:
     except Exception:
         data["child_processes"] = 0
 
-    # MCP ecosystem process count — scan for known command-line signatures.
-    # A single process may match multiple signatures (e.g. a sandboxed kiro-cli
-    # matches both "kirocrew_sandbox" and "kiro-cli"); per-category _counts can
-    # overlap, while mcp_total uses _seen for unique PID dedup. kiro-cli is an
-    # optional backend; the signature is harmless when it is not installed.
-    #
-    # Sandbox counting platform differences:
-    #   Linux:  The namespace launcher (python3 ~/.kiro/crew/run/kirocrew_sandbox_*.py ...)
-    #           forks — the parent stays alive with "kirocrew_sandbox" in its
-    #           /proc/cmdline, so sandbox count is accurate.
-    #   macOS:  sandbox-exec execs the target command, replacing the process
-    #           image. The final cmdline becomes "kiro-cli ..." and the
-    #           "kirocrew_sandbox" string (only in the -f path arg) is lost.
-    #           Sandbox count will be 0 even when sandboxes are running.
-    try:
-        _my = os.getpid()
-        _counts: dict[str, int] = {"sandbox": 0, "kiro_cli": 0}
-        _seen: set[str] = set()
-        if sys.platform == "linux":
-            for d in os.listdir("/proc"):
-                if not d.isdigit() or int(d) == _my:
-                    continue
-                try:
-                    cmd = Path(f"/proc/{d}/cmdline").read_bytes()
-                    matched = False
-                    if b"kirocrew_sandbox" in cmd:
-                        _counts["sandbox"] += 1
-                        matched = True
-                    if b"kiro-cli" in cmd:
-                        _counts["kiro_cli"] += 1
-                        matched = True
-                    if matched:
-                        _seen.add(d)
-                except OSError:
-                    pass
-        else:
-            _sigs = {
-                "kirocrew_sandbox": "sandbox",
-                "kiro-cli": "kiro_cli",
-            }
-            try:
-                out = subprocess.check_output(
-                    ["ps", "-eo", "pid,command"],
-                    timeout=5,
-                    text=True,
-                )
-                for line in out.splitlines():
-                    parts = line.split(None, 1)
-                    if len(parts) < 2:
-                        continue
-                    pid_s, cmd = parts
-                    if pid_s.strip() == str(_my):
-                        continue
-                    matched = False
-                    for sig, key in _sigs.items():
-                        if sig in cmd:
-                            _counts[key] += 1
-                            matched = True
-                    if matched:
-                        _seen.add(pid_s.strip())
-            except Exception:
-                pass
-        data["mcp_processes"] = _counts
-        data["mcp_total"] = len(_seen)
-    except Exception:
-        data["mcp_processes"] = {"sandbox": 0, "kiro_cli": 0}
-        data["mcp_total"] = 0
+    _apply_mcp_process_counts(data)
 
     # In-process embedder monitoring — the model runs inside the gateway process
     # now (no external server), so report functional availability instead of a
@@ -637,26 +675,48 @@ def _collect_system_metrics() -> dict[str, object]:
     return data
 
 
-# Cached system metrics (avoid subprocess spawning on every 1s poll)
+# Cached system metrics (avoid subprocess spawning on every poll)
 _metrics_cache: dict[str, object] = {}
 _metrics_cache_ts: float = 0.0
 _METRICS_CACHE_TTL = 2.0  # seconds
+
+#: Guards a single in-flight collection. The TTL alone does NOT bound the work:
+#: it is only stamped AFTER a collection returns, so while one is still running
+#: every further poll saw a stale cache and launched its own. On a host where a
+#: collection is cheap (Linux: pure ``/proc`` reads) that never showed; on a host
+#: where it spawns several subprocesses the duplicate collections stack up,
+#: because the dashboard polls this endpoint at exactly the TTL. Coalescing makes
+#: concurrent pollers await the SAME collection, so N tabs and a slow host cost
+#: one collection, not N.
+_metrics_lock: asyncio.Lock | None = None
 
 
 async def api_system(request: web.Request) -> web.Response:
     """System information endpoint with live CPU, memory, network metrics.
 
-    Caches results for 2 seconds to avoid spawning subprocesses on every
-    poll when multiple dashboard tabs are open.
+    Caches results briefly and coalesces concurrent collections, so several
+    dashboard tabs polling at once cost one collection rather than one each.
     """
-    global _metrics_cache, _metrics_cache_ts
+    global _metrics_cache, _metrics_cache_ts, _metrics_lock
     now = time.monotonic()
     if now - _metrics_cache_ts < _METRICS_CACHE_TTL and _metrics_cache:
         return web.json_response(_metrics_cache)
-    loop = asyncio.get_running_loop()
-    data = await loop.run_in_executor(None, _collect_system_metrics)
-    _metrics_cache = data
-    _metrics_cache_ts = now
+    if _metrics_lock is None:
+        _metrics_lock = asyncio.Lock()
+    async with _metrics_lock:
+        # Re-check under the lock: whoever held it may have just refreshed, and
+        # this waiter wants that result rather than a second collection of its own.
+        now = time.monotonic()
+        if now - _metrics_cache_ts < _METRICS_CACHE_TTL and _metrics_cache:
+            return web.json_response(_metrics_cache)
+        loop = asyncio.get_running_loop()
+        # subprocess_executor (mc-subproc), NOT the default pool: this is
+        # browser-triggered on a 2s poll and spawns up to six subprocesses on a
+        # host without /proc, so leaving it in the default pool let it contend
+        # with the getaddrinfo calls the event loop files there.
+        data = await loop.run_in_executor(subprocess_executor(), _collect_system_metrics)
+        _metrics_cache = data
+        _metrics_cache_ts = time.monotonic()
     return web.json_response(data)
 
 

--- a/src/kiro_crew/dashboard/session_memory.py
+++ b/src/kiro_crew/dashboard/session_memory.py
@@ -36,6 +36,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 from kiro_crew.acp.runtime import _get_rss_tree_mb, _iter_descendant_pids
 from kiro_crew.dashboard.handlers_system import _get_static_system_info
 from kiro_crew.dashboard.state import NEW_SESSION_TITLE
+from kiro_crew.executors import subprocess_executor
 from kiro_crew.messaging.link import telemetry_channel_of
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.session import BACKGROUND_KEY
@@ -348,8 +349,14 @@ class SessionMemorySampler:
     ) -> dict[str, object]:
         """Build the full payload: session rows, task rows, totals, history.
 
-        Session sampling is offloaded with ``asyncio.to_thread``; task rows are
-        read from samples the reaper already took, so they need no offload.
+        Session sampling runs on the dedicated ``subprocess_executor`` (``mc-subproc``)
+        rather than ``asyncio.to_thread``, which would use the DEFAULT executor —
+        the pool the event loop also hands ``getaddrinfo`` and every other
+        ``run_in_executor(None, ...)`` call. This sampling is browser-triggered on
+        a 5s poll and spawns ``ps`` on platforms without ``/proc``, so parking it
+        in the shared pool is what let a slow sample stall unrelated requests;
+        task rows are read from samples the reaper already took, so they need no
+        offload.
         ``get_slot`` resolves display titles (see :func:`session_title`); without
         it rows fall back to their raw keys.
 
@@ -361,7 +368,9 @@ class SessionMemorySampler:
         though the spend exists. Omitting it degrades to the direct join.
         """
         rows = sessions.runtime_pids()
-        samples = await asyncio.to_thread(self._blocking_sample, rows)
+        samples = await asyncio.get_running_loop().run_in_executor(
+            subprocess_executor(), self._blocking_sample, rows
+        )
         per_pid = samples["per_pid"]
         assert isinstance(per_pid, dict)
         spend = samples["spend"]

--- a/test/test_handlers_system_mcp_count.py
+++ b/test/test_handlers_system_mcp_count.py
@@ -17,9 +17,12 @@ def _run_collect() -> dict:
     from kiro_crew.dashboard import handlers_system
 
     with patch.object(handlers_system, "_get_static_system_info", return_value={}):
-        # Reset cache so each test gets a fresh call
+        # Reset both caches so each test gets a fresh call — the process scan
+        # cache has a 15s TTL that survives across xdist workers.
         handlers_system._metrics_cache.clear()
         handlers_system._metrics_cache_ts = 0.0
+        handlers_system._proc_scan_cache = {}
+        handlers_system._proc_scan_cache_ts = 0.0
         return handlers_system._collect_system_metrics()
 
 

--- a/test/test_macos_process_table.py
+++ b/test/test_macos_process_table.py
@@ -1,0 +1,167 @@
+"""Regression tests for the macOS process-table amplification.
+
+The bug: ``_get_rss_tree_mb``'s non-Linux branch took a WHOLE-MACHINE
+``ps -Ao pid=,ppid=,rss=`` snapshot, and ``session_memory._blocking_sample``
+calls it once per live runtime pid. So sampling N sessions walked the host's
+entire process table N times, every 5s, serialized in one worker — which
+saturated the pool the event loop shares and made the dashboard stop answering.
+
+These tests are written against the SHARED-snapshot contract rather than against
+timings, so they fail if the per-pid snapshot is ever reintroduced.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from kiro_crew.acp import runtime as rt
+
+# The Linux branch reads /proc directly and never spawns, so the behaviour under
+# test only exists on the non-Linux path. Force that path rather than skipping,
+# so the contract is verified on the CI runners too (which are mostly Linux).
+pytestmark = pytest.mark.usefixtures("_force_posix_ps_branch")
+
+
+@pytest.fixture
+def _force_posix_ps_branch(monkeypatch):
+    """Route _get_rss_tree_mb down the ``ps`` branch regardless of host OS."""
+    monkeypatch.setattr(rt.sys, "platform", "darwin")
+    monkeypatch.setattr(rt.platform_compat, "IS_WINDOWS", False)
+    monkeypatch.setattr(rt.platform_compat, "trusted_system_bin", lambda name: f"/bin/{name}")
+    rt._reset_ps_table_cache()
+    yield
+    rt._reset_ps_table_cache()
+
+
+#: pid ppid rss(KiB) — 100 is a runtime with one child, 200 an unrelated runtime.
+_PS_OUTPUT = b"\n".join(
+    [
+        b"  1     0   1024",
+        b"100     1   2048",
+        b"101   100   1024",
+        b"200     1   4096",
+    ]
+)
+
+
+def _counting_ps(monkeypatch, output: bytes = _PS_OUTPUT) -> list[list[str]]:
+    """Replace subprocess.check_output and record every argv it is handed."""
+    calls: list[list[str]] = []
+
+    def fake(argv, *a, **kw):
+        calls.append(list(argv))
+        return output
+
+    monkeypatch.setattr(rt.subprocess, "check_output", fake)
+    return calls
+
+
+def test_many_pids_share_one_process_table_snapshot(monkeypatch):
+    """N pids must cost ONE ps walk, not N.
+
+    This is the actual regression. With the per-pid snapshot restored this
+    asserts 1 and gets 3.
+    """
+    calls = _counting_ps(monkeypatch)
+
+    for pid in (100, 101, 200):
+        assert rt._get_rss_tree_mb(pid) is not None
+
+    assert len(calls) == 1, f"expected one ps snapshot for three pids, got {len(calls)}"
+    assert calls[0][1:] == ["-Ao", "pid=,ppid=,rss="]
+
+
+def test_tree_sum_still_includes_descendants(monkeypatch):
+    """Sharing the snapshot must not change the ANSWER.
+
+    pid 100 owns child 101, so its tree is 2048+1024 KiB. Measuring only the
+    root would report 2.0 — which is what the stale docstring's "on macOS the
+    tree is just the process itself" claim would have licensed, and what would
+    blind the watchdog to an MCP-child leak.
+    """
+    _counting_ps(monkeypatch)
+
+    assert rt._get_rss_tree_mb(100) == pytest.approx(3072 / 1024.0)
+    # A leaf is just itself, and an unrelated root does not absorb the tree above.
+    assert rt._get_rss_tree_mb(101) == pytest.approx(1024 / 1024.0)
+    assert rt._get_rss_tree_mb(200) == pytest.approx(4096 / 1024.0)
+
+
+def test_cache_expiry_takes_a_fresh_snapshot(monkeypatch):
+    """The cache is a short TTL, not a permanent freeze — RSS must still move."""
+    calls = _counting_ps(monkeypatch)
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(rt.time, "monotonic", lambda: clock["t"])
+
+    rt._get_rss_tree_mb(100)
+    assert len(calls) == 1
+
+    clock["t"] += rt._PS_TABLE_TTL_S / 2
+    rt._get_rss_tree_mb(100)
+    assert len(calls) == 1, "within the TTL the snapshot must be reused"
+
+    clock["t"] += rt._PS_TABLE_TTL_S
+    rt._get_rss_tree_mb(100)
+    assert len(calls) == 2, "past the TTL a fresh snapshot must be taken"
+
+
+def test_ps_failure_is_not_cached(monkeypatch):
+    """A transient ps failure must not pin callers to the fallback for a whole
+    TTL — otherwise one blip degrades every reading in the window."""
+    outcomes = {"fail": True}
+
+    def flaky(argv, *a, **kw):
+        if outcomes["fail"]:
+            raise subprocess.SubprocessError("boom")
+        return _PS_OUTPUT
+
+    monkeypatch.setattr(rt.subprocess, "check_output", flaky)
+    assert rt._ps_process_table() is None
+
+    outcomes["fail"] = False
+    assert rt._ps_process_table() is not None
+
+
+def test_missing_ps_binary_falls_back_to_single_pid(monkeypatch):
+    """No usable ps → single-pid read, never a phantom-empty tree."""
+    monkeypatch.setattr(rt.platform_compat, "trusted_system_bin", lambda name: None)
+    monkeypatch.setattr(rt, "_get_rss_mb", lambda pid: 7.5)
+
+    assert rt._get_rss_tree_mb(100) == 7.5
+
+
+def test_linux_branch_spawns_nothing(monkeypatch):
+    """The Linux path must stay pure /proc — it is why Linux never showed this
+    bug, and routing it through ps would import the problem."""
+    monkeypatch.setattr(rt.sys, "platform", "linux")
+    calls = _counting_ps(monkeypatch)
+    monkeypatch.setattr(rt, "_iter_descendant_pids", lambda pid: [pid])
+    monkeypatch.setattr(rt, "_get_rss_mb", lambda pid: 5.0)
+
+    assert rt._get_rss_tree_mb(100) == 5.0
+    assert calls == []
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX ps branch")
+def test_sampler_pass_over_many_pids_takes_one_snapshot(monkeypatch):
+    """End-to-end at the layer that regressed: the dashboard sampler.
+
+    ``_blocking_sample`` is what fans out over every live runtime pid, so the
+    guarantee has to hold there and not merely in isolation.
+    """
+    from kiro_crew.dashboard import session_memory as sm
+
+    calls = _counting_ps(monkeypatch)
+    monkeypatch.setattr(sm, "_iter_descendant_pids", lambda pid: [pid])
+    monkeypatch.setattr(sm, "_unattributed", lambda owned, self_pid: None)
+    monkeypatch.setattr("kiro_crew.dashboard.handlers.usage.slot_spend", lambda: {})
+
+    sampler = sm.SessionMemorySampler()
+    rows = [{"pid": 100}, {"pid": 101}, {"pid": 200}]
+    out = sampler._blocking_sample(rows)
+
+    assert len(out["per_pid"]) == 3
+    assert len(calls) == 1, f"one ps snapshot per sampling pass, got {len(calls)}"

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -137,7 +137,17 @@ PREEXEC_EXEMPT: frozenset[str] = frozenset(
 BENIGN_SPAWNS: frozenset[str] = frozenset(
     {
         "acp/runtime.py::_get_rss_mb",
-        "acp/runtime.py::_get_rss_tree_mb",
+        # _get_rss_tree_mb is deliberately NOT listed: its own spawn moved into
+        # _ps_process_table below, so an entry for it would be stale and would
+        # mask a future regression that put a spawn back inline.
+        #
+        # Whole-machine process-table snapshot behind _get_rss_tree_mb's macOS
+        # branch, extracted so N pids share ONE walk. Same trust profile as
+        # _get_rss_mb above: one fixed argv (`ps -Ao pid=,ppid=,rss=`) with a 2s
+        # timeout, no shell, no cwd, and no arguments at all — nothing here is
+        # agent-influenced, and the binary is resolved through
+        # platform_compat.trusted_system_bin (a vetted absolute path), not PATH.
+        "acp/runtime.py::_ps_process_table",
         # Console-entry self-heal for stale editable installs: ONE fixed
         # `python -m pip install -e <repo>` argv, no shell. The repo path is
         # derived from the module's own __file__ (never user/agent input) and
@@ -604,6 +614,12 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "dashboard/handlers/updates.py::_venv_pip_install",
         "dashboard/handlers/updates.py::api_update_apply",
         "dashboard/handlers_system.py::_collect_system_metrics",
+        # Split out of _collect_system_metrics above so the whole-machine process
+        # walk can be cached on its own (much longer) TTL instead of the live
+        # graph's. Identical trust profile to its former enclosing function,
+        # which is still listed: one fixed argv (`ps -eo pid,command`) with a 5s
+        # timeout, no shell, no cwd, no agent-influenced arguments.
+        "dashboard/handlers_system.py::_scan_mcp_processes",
         "dashboard/handlers_system.py::_get_static_system_info",
         "dashboard/port_reclaim.py::_listeners_on_port",
         "env.py::_run",

--- a/test/test_system_metrics_coalescing.py
+++ b/test/test_system_metrics_coalescing.py
@@ -1,0 +1,108 @@
+"""``/api/system`` must bound its own cost.
+
+Two independent leaks are pinned here:
+
+1. The TTL is stamped only AFTER a collection returns, so while one is running
+   every further poll saw a stale cache and started its own. The dashboard polls
+   this endpoint at exactly the TTL, so on a host where a collection is slow
+   (macOS spawns six subprocesses; Linux reads /proc and spawns none) the
+   collections stacked up.
+2. The whole-machine process scan was recomputed on the live graph's cadence,
+   even though a process COUNT does not need 2s freshness and costs a full ``ps``
+   walk off /proc — a walk the shared MCP gateway makes bigger.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from kiro_crew.dashboard import handlers_system as hs
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    hs._metrics_cache = {}
+    hs._metrics_cache_ts = 0.0
+    hs._metrics_lock = None
+    hs._proc_scan_cache = {}
+    hs._proc_scan_cache_ts = 0.0
+    yield
+    hs._metrics_cache = {}
+    hs._metrics_cache_ts = 0.0
+    hs._metrics_lock = None
+    hs._proc_scan_cache = {}
+    hs._proc_scan_cache_ts = 0.0
+
+
+class _Req(dict):
+    """Minimal stand-in for web.Request — api_system reads nothing off it."""
+
+
+@pytest.mark.asyncio
+async def test_concurrent_pollers_share_one_collection(monkeypatch):
+    """Several tabs polling at once must cost ONE collection, not one each.
+
+    The collection is made genuinely slow (a real blocking sleep on the real
+    executor) because that is the condition under which the un-coalesced version
+    launched a new one per poll: the TTL is stamped only after a collection
+    returns, so every poll arriving DURING one saw a stale cache. The count is
+    not scheduling-dependent — the lock either serializes these or it does not.
+    """
+    calls = {"n": 0}
+
+    def slow_collect():
+        calls["n"] += 1
+        time.sleep(0.25)
+        return {"cpu_pct": 1.0, "call": calls["n"]}
+
+    monkeypatch.setattr(hs, "_collect_system_metrics", slow_collect)
+
+    results = await asyncio.gather(*(hs.api_system(_Req()) for _ in range(5)))
+
+    assert calls["n"] == 1, f"expected one collection for five concurrent polls, got {calls['n']}"
+    assert all(r.status == 200 for r in results)
+
+
+def test_process_scan_is_cached_past_the_metrics_ttl(monkeypatch):
+    """The expensive scan must NOT refresh on the live graph's cadence."""
+    calls = {"n": 0}
+    monkeypatch.setattr(
+        hs, "_scan_mcp_processes", lambda: (calls.__setitem__("n", calls["n"] + 1) or {"mcp_total": calls["n"]})
+    )
+    clock = {"t": 500.0}
+    monkeypatch.setattr(hs.time, "monotonic", lambda: clock["t"])
+
+    data: dict[str, object] = {}
+    hs._apply_mcp_process_counts(data)
+    assert calls["n"] == 1
+
+    # Well past the metrics TTL, but inside the scan's own TTL.
+    clock["t"] += hs._METRICS_CACHE_TTL * 3
+    assert hs._METRICS_CACHE_TTL * 3 < hs._PROC_SCAN_CACHE_TTL
+    hs._apply_mcp_process_counts(data)
+    assert calls["n"] == 1, "process scan must not follow the metrics TTL"
+
+    clock["t"] += hs._PROC_SCAN_CACHE_TTL
+    hs._apply_mcp_process_counts(data)
+    assert calls["n"] == 2, "past its own TTL the scan must refresh"
+
+
+def test_process_scan_ttl_is_longer_than_the_metrics_ttl():
+    """The whole point of splitting the caches — if these converge the split is
+    decorative and the scan is back on the graph's cadence."""
+    assert hs._PROC_SCAN_CACHE_TTL > hs._METRICS_CACHE_TTL
+
+
+def test_scan_reports_both_fields_even_when_it_fails(monkeypatch):
+    """A failed scan must still populate both keys, so the UI renders 0 rather
+    than dropping the field and showing undefined."""
+    monkeypatch.setattr(hs.os, "listdir", lambda p: (_ for _ in ()).throw(OSError("boom")))
+    monkeypatch.setattr(hs.sys, "platform", "linux")
+
+    out = hs._scan_mcp_processes()
+
+    assert out["mcp_total"] == 0
+    assert out["mcp_processes"] == {"sandbox": 0, "kiro_cli": 0}

--- a/website/src/pages/settings/SharedMcpGatewayToggle.tsx
+++ b/website/src/pages/settings/SharedMcpGatewayToggle.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useNavigate } from 'react-router-dom'
 import { Loader2, Check, AlertTriangle } from 'lucide-react'
 import Modal from '../../components/Modal'
 import { SettingsSection, SettingsCard, SettingsToggle } from '../../components/settings'
@@ -13,7 +12,6 @@ type Phase = 'idle' | 'confirm' | 'applying' | 'done' | 'failed'
 
 export function SharedMcpGatewayToggle() {
   const qc = useQueryClient()
-  const navigate = useNavigate()
   const statusQ = useQuery<GatewayStatus>({ queryKey: ['mcpGatewayStatus'], queryFn: () => api.mcpGatewayStatus() })
   const enabled = statusQ.data?.enabled ?? false
   const pingOk = statusQ.data?.ping_ok ?? false
@@ -28,6 +26,13 @@ export function SharedMcpGatewayToggle() {
   // In-process apply: the POST starts/stops the broker, drops + relinks all
   // agent sessions, and verifies connectivity — no gateway restart, so this
   // dashboard session stays logged in.  The response is the verified state.
+  //
+  // Stays on this page on success. It used to navigate to Developer > System,
+  // which was wrong twice over: enabling the pool is the FIRST half of the job
+  // (the user then picks which servers to pool, on this very page), and the
+  // destination did not even carry the `plane` the metrics card lives on, so it
+  // landed on the Sessions table instead. Reporting the verified state here and
+  // letting the user choose where to go next is the honest shape.
   const run = async (next: boolean) => {
     setTarget(next)
     setPhase('applying')
@@ -35,9 +40,6 @@ export function SharedMcpGatewayToggle() {
       const r = await api.mcpGatewayEnable(next)
       const ok = next ? r.ping_ok : !r.running
       if (ok) qc.invalidateQueries({ queryKey: ['mcpGatewayStatus'] })
-      // Land on the live gateway metrics — the McpGatewayCard renders on
-      // Developer > System, not Settings Overview.
-      if (ok && next) { setPhase('idle'); navigate('/developer?tab=system'); return }
       setPhase(ok ? 'done' : 'failed')
     } catch {
       setPhase('failed')

--- a/website/src/test/SharedMcpGatewayToggle.noRedirect.test.tsx
+++ b/website/src/test/SharedMcpGatewayToggle.noRedirect.test.tsx
@@ -1,0 +1,73 @@
+// Enabling the shared MCP gateway must NOT navigate away.
+//
+// It used to `navigate('/developer?tab=system')` on success, which was wrong
+// twice over: enabling the pool is the first half of the job (the user then
+// picks which servers to pool, on this very page), and the destination carried
+// no `plane`, so it landed on the Sessions table rather than the metrics card
+// the redirect was written for. That table polls a whole-machine process scan,
+// so the redirect delivered users straight onto the surface that froze.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup, within } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import { SharedMcpGatewayToggle } from '../pages/settings/SharedMcpGatewayToggle'
+import { api } from '../api/client'
+
+function LocationProbe() {
+  const loc = useLocation()
+  return <div data-testid="loc">{`${loc.pathname}${loc.search}`}</div>
+}
+
+function mount() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <MemoryRouter initialEntries={['/developer?tab=mcp-pool']}>
+      <QueryClientProvider client={qc}>
+        <SharedMcpGatewayToggle />
+        <LocationProbe />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('SharedMcpGatewayToggle', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'mcpGatewayStatus').mockResolvedValue({
+      enabled: false, running: false, ping_ok: false, supported: true,
+    } as never)
+  })
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('stays on the current page after a successful enable', async () => {
+    const enable = vi.spyOn(api, 'mcpGatewayEnable').mockResolvedValue({
+      ok: true, enabled: true, running: true, ping_ok: true,
+    } as never)
+
+    mount()
+
+    // The toggle renders immediately but is `disabled` until the status query
+    // resolves, and its onClick short-circuits while disabled — so clicking on
+    // first paint is a silent no-op. `toBeDisabled()` cannot detect this: the
+    // switch is a <div role="switch">, and jest-dom only considers real form
+    // elements disable-able, so it passes vacuously. Wait on `aria-disabled`,
+    // which is the attribute Toggle actually sets.
+    const toggle = await waitFor(() => {
+      const el = screen.getByRole('switch')
+      expect(el.getAttribute('aria-disabled')).toBeNull()
+      return el
+    })
+    fireEvent.click(toggle)
+
+    // Confirm dialog → Continue
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByText('Continue'))
+
+    await waitFor(() => expect(enable).toHaveBeenCalledWith(true))
+    // The verified-state modal is the feedback, and the route is untouched.
+    await waitFor(() => expect(screen.getByText(/is active/i)).toBeTruthy())
+    expect(screen.getByTestId('loc').textContent).toBe('/developer?tab=mcp-pool')
+  })
+})


### PR DESCRIPTION
> **Retraction, recorded up front.** This PR was opened claiming it fixed a macOS System-page freeze. **It does not, and I was wrong.** A measurement on the reporting maintainer's own Mac (below) shows the cost I found is ~5% duty cycle, far too small to freeze anything. What remains is a real efficiency and architecture fix, and the freeze cause is still **unconfirmed**. The original title and body are corrected rather than quietly edited, because two people are waiting on a fix and the wrong diagnosis being on record would send the next person down the same path.

## 1. What is the problem?

`acp/runtime.py::_get_rss_tree_mb` reads a runtime's RSS. Its non-Linux branch takes a **whole-machine** `ps -Ao pid=,ppid=,rss=` snapshot to build a parent map, and `session_memory._blocking_sample` calls it **once per distinct runtime pid**. So sampling N sessions walks the host's entire process table N times, every 5s while the System page's Sessions plane is open.

Linux never pays it: that branch reads `/proc` directly and spawns nothing.

Measured on the reporting maintainer's Mac, 875 processes:

| | |
|---|---|
| one `ps -Ao pid=,ppid=,rss=` | 33 ms |
| eight (N=8, their session count) | 272 ms |

Linear, exactly 8×. Real amplification — and also only 272ms per 5s poll, a ~5% duty cycle. **That cannot freeze a UI**, which is why the freeze that prompted this PR is a separate, still-unidentified problem.

Three smaller things in the same path, all real but all similarly modest:

- On darwin one `/api/system` collection spawns **six** subprocesses (`sysctl`, `vm_stat`, `ps -A -o %cpu`, `netstat -ib`, `pgrep -P`, `ps -eo pid,command`) versus **zero** on Linux.
- `_METRICS_CACHE_TTL` (2.0s) exactly equals the dashboard's `refetchInterval` (2000ms), and the TTL is stamped only *after* a collection returns — so every poll arriving during one started another. No in-flight coalescing.
- All of it ran on the **default** executor, the pool the event loop also hands `getaddrinfo`.

## 2. Why this issue matters to the user

Straightforwardly now that the freeze claim is withdrawn: a page that only shows a handful of rows should not walk the host's entire process table once per row, and browser-triggered subprocess work should not share a thread pool with the event loop's DNS. The cost is currently **proportional to session count**, so it degrades exactly for the users with the most sessions, and the shared MCP gateway multiplies the constant by growing the process table from dozens of entries to hundreds.

The redirect fix stands on its own merits: enabling the pool silently threw the user onto a different page, and not even the page it intended.

## 3. How our fix solves it

- **`_ps_process_table()`** memoizes ONE snapshot for 1s, so a pass over N pids costs one walk instead of N — cost becomes independent of session count. The cache sits at the snapshot rather than being threaded through callers on purpose: a future caller cannot reintroduce the fan-out by forgetting to pass a table. 1s is chosen against both consumers (a 5s panel poll, a multi-GB watchdog ceiling), neither of which can distinguish a 1s-old reading. A failed `ps` is deliberately **not** cached, so one blip does not pin every reader to the single-pid fallback for a whole window.
- **Off the shared pool.** `session_memory.sample()` and `api_system` move to `subprocess_executor()` (`mc-subproc`), the same reasoning `api_governance_channels` already documents.
- **`/api/system` coalescing.** Concurrent pollers await one collection under a lock, with a re-check inside so a waiter takes the fresh result instead of starting its own.
- **Split caches.** The process scan moves to `_scan_mcp_processes()` behind its own 15s TTL; CPU/memory/network keep the 2s cadence they actually need.
- **No redirect** after enabling the shared MCP gateway.

One docstring correction, and it matters: `_get_rss_tree_mb` claimed the macOS tree "is just the process itself, so the sum equals the single-process RSS". False — kiro-cli spawns MCP-server/tool children on macOS exactly as the Windows branch notes it does. That stale claim is what made a per-pid whole-machine snapshot look free, and it also rules out the tempting "just read one pid on macOS" shortcut, which would under-report every session and blind the watchdog's leak ceiling.

## 4. What tests we did

12 tests across 3 new files.

`test/test_macos_process_table.py` forces the non-Linux branch so the contract is checked on Linux CI too: N pids share one snapshot; the tree sum still includes descendants (so sharing did not change the answer); TTL expiry does refresh; a `ps` failure is not cached; a missing `ps` falls back to a single-pid read rather than a phantom-empty tree; the Linux branch still spawns nothing; and the same guarantee end-to-end through `_blocking_sample`, the layer that actually fans out.

`test/test_system_metrics_coalescing.py`: concurrent pollers share one collection; the process scan survives past the metrics TTL and refreshes past its own; the two TTLs cannot converge; a failed scan still populates both fields.

`website/src/test/SharedMcpGatewayToggle.noRedirect.test.tsx`: a successful enable leaves the route untouched.

**Mutation-verified** — each fix disabled, and the test made to report the original numbers:

| Mutation | Test output |
|---|---|
| snapshot cache off | `expected one ps snapshot for three pids, got 3` |
| coalescing lock off | `expected one collection for five concurrent polls, got 5` |
| redirect restored | route assertion fails |

Gates: 285 Python tests pass across the affected suites; `isort`, `tsc --noEmit`, diff-scoped `i18n:check` and targeted vitest all clean. `flake8` and `mypy` report failures **only** in files this PR does not touch (`source_providers.py`, `cloudwatch.py`, `transcribe.py`); the same commands run against an unmodified `main` checkout reproduce them identically, so they are inherited.

**Explicitly NOT verified:**

- **That this fixes any freeze.** It almost certainly does not — see the retraction. Do not merge this expecting the freeze to go away.
- I have no macOS host, so the platform branch is exercised by forcing `sys.platform` in tests, not by running on darwin.
- An attempt to reproduce the freeze on Linux (vite dev server + headless Chromium against the #1810 System page) was **inconclusive**: the page closed 7s after navigation with no renderer `crash` event and `/api/ws` 403s, which is a dev-proxy auth artifact rather than a product signal. A clean Linux reproduction needs a pod with a real built `dist`.

## 5. Any other suggestions on the work

- **The freeze is still open and this PR does not close it.** Ruled out so far: this `ps` amplification (by the measurement above), payload size (3.5 KB for 8 sessions, and there is already a 500-session cap), and `Intl` formatter construction (`i18n/format.ts` memoizes on kind+locale+options). Not yet examined: the renderer main thread — `framer-motion` `AnimatePresence`/`layoutId` in `UnderlineTabs`, the `clip-path: polygon()` traces in `PerformanceTab`, and the TanStack grouped/expanded table. That is where I would look next.
- **"macOS-only" may be sampling bias, not a platform fact.** The maintainer's live gateway `dist` predates #1810, so only Mac users have actually run the new System page. Worth confirming on Linux before treating platform as a variable.
- **A macOS session sees almost nothing on this page.** `_all_runtime_pids`, `_iter_descendant_pids`, `procs` and `mcp` stubs are all Linux-only, so the Sessions table renders `—` for most columns on a Mac and the "Unattributed" row never appears. Pre-existing and out of scope, but the page currently costs a Mac user a lot to show them very little. Deserves its own issue.
- **`SessionsTab` says "No active sessions" while it is still loading.** It destructures only `data` from `useQuery`, never `isLoading`, so the empty-state renders during the first fetch — asserting something false rather than merely omitting a spinner. `PerformanceTab` gets this right with "collecting samples". Left out of this PR pending the maintainer's call on scope.
- **The spawn audit earned its keep**: it flagged the two new `ps` spawn sites AND flagged `_get_rss_tree_mb`'s now-stale allowlist entry. Both updated with justifications rather than blanket-listed.
- A companion revert of #1810 is open as #2128 at the maintainer's request. On the evidence here I do not believe it addresses the freeze either, and the pre-#1810 page polled `/api/system` (2s) **and** `SessionMemoryCard` (5s) on one screen — so on polling cost it is arguably a regression. Recorded so the two PRs are not read as alternatives.
