### PR TITLE
ci(release): require a CHANGELOG section and a shipped candidate before stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,142 @@ jobs:
           echo "wheel_version=$WHEEL_VERSION" >> "$GITHUB_OUTPUT"
           echo "Releasing $VERSION on channel $CHANNEL (wheel: $WHEEL_VERSION)"
 
+  # ── Stable publication gate ───────────────────────────────────────────
+  # A tag name is the ONLY thing that decides the channel, and the whole run
+  # is unattended: on v0.1.3 the stable CLI wheel was public 3m41s after the
+  # tag push, CDN keys are immutable (a republish is refused), and
+  # `cancel-in-progress: false` means a corrected tag queues behind rather
+  # than superseding. So `v0.2.0-rc.2` mistyped as `v0.2.0` is an
+  # unrecoverable stable release, and there is no window in which anyone
+  # would notice. This job is the missing precondition check.
+  #
+  # DETERMINISTIC, NOT A PROMPT. An approval button is the other obvious
+  # design; it is deliberately not this one, because the failure mode here is
+  # a typo by someone who believes they are shipping a prerelease — exactly
+  # the state of mind that clicks through a confirmation. These two checks
+  # instead ask for evidence the release was intended, and a mistyped bare
+  # tag cannot produce that evidence.
+  #
+  # WHY IT NEVER USES `if:`. The publish jobs `needs` this one, and a SKIPPED
+  # dependency skips its dependents — an `if: channel == 'stable'` here would
+  # silently stop insider and nightly from publishing at all. The channel test
+  # therefore lives INSIDE the step, which always runs and exits 0 for every
+  # non-stable channel.
+  #
+  # Validated against history: both prior stable releases promote the exact
+  # commit their last insider tag shipped (v0.1.2 == v0.1.2-insider.4,
+  # v0.1.3 == v0.1.3-insider.2), so check 2 encodes practice that already
+  # holds rather than imposing a new one. Check 1 would have blocked v0.1.3,
+  # which shipped with no CHANGELOG section — that is the check working, and
+  # it means a stable release now requires its section to be written first.
+  stable-gate:
+    name: Stable publication gate
+    needs: [version]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Replaces the workflow default: `actions: read` is what lets the promotion
+    # check ask whether a prerelease tag's release run actually SUCCEEDED.
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history so the stable tag resolves unambiguously, and so the
+          # CHANGELOG read is of the tagged commit rather than a partial tree.
+          fetch-depth: 0
+      - name: Verify stable publication preconditions
+        env:
+          CHANNEL: ${{ needs.version.outputs.channel }}
+          VERSION: ${{ needs.version.outputs.version }}
+          # Scoped to ONE version on purpose: it must equal the version being
+          # released, so it cannot be left switched on for every future tag.
+          OVERRIDE: ${{ vars.STABLE_GATE_OVERRIDE }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [ "$CHANNEL" != "stable" ]; then
+            echo "channel=$CHANNEL -- the stable gate does not apply."
+            exit 0
+          fi
+
+          failures=0
+
+          # ── 1. The release is documented ────────────────────────────────
+          # Heading form is `## [0.1.2] — 2026-07-30`. Matched as a LITERAL
+          # prefix through awk's index(), never as a regex: an unescaped
+          # `0.1.3` pattern would also be satisfied by a `## [0.1.31]` or
+          # `## [0y1z3]` heading, and a version string is exactly the kind of
+          # value whose dots must stay literal.
+          if awk -v want="## [$VERSION]" \
+               'index($0, want) == 1 { found = 1 } END { exit !found }' \
+               CHANGELOG.md; then
+            echo "changelog: CHANGELOG.md documents $VERSION"
+          else
+            echo "::error::CHANGELOG.md has no '## [$VERSION]' section. A stable release must be documented before it ships."
+            failures=$((failures + 1))
+          fi
+
+          # ── 2. Stable only promotes bytes insiders actually received ─────
+          # A TAG IS NOT EVIDENCE OF A RELEASE. A cancelled or failed
+          # prerelease run leaves its tag behind, so matching on tag names
+          # alone would let stable promote a candidate that never shipped
+          # (GPT 5.6 review on 2ce9bcef). The evidence is a SUCCESSFUL
+          # release-workflow run for a v<version>-* tag at this exact commit.
+          #
+          # Queried from GitHub's own API rather than the distribution CDN: an
+          # API outage already means this run is not happening, whereas a CDN
+          # blip is an unrelated failure that must not block a legitimate
+          # release (the objection #1031 raises elsewhere in this pipeline).
+          # A failed query FAILS CLOSED and says so -- a check that could not
+          # run is not a check that passed.
+          #
+          # The tag lookup is GUARDED rather than left to `set -e`: an absent
+          # tag would otherwise abort the script mid-way with git's own
+          # "ambiguous argument" fatal, skipping both the failure summary and
+          # the override path.
+          STABLE_COMMIT=""
+          if ! STABLE_COMMIT="$(git rev-list -n 1 "refs/tags/v$VERSION" 2>/dev/null)"; then
+            echo "::error::tag v$VERSION is not present in this checkout, so the promotion check cannot run. A deleted or unfetched tag fails closed."
+            failures=$((failures + 1))
+          else
+            # Exported so the jq program reads it through `env` instead of
+            # having a value spliced into the filter text.
+            export STABLE_COMMIT
+            # gh exits NON-ZERO on an API failure and zero-with-no-output when
+            # nothing matched. That distinction is the whole point: it
+            # separates "checked, and no such release exists" from "could not
+            # check", and only the first is a verdict.
+            if ! promoted="$(gh api --paginate \
+                 "repos/$GITHUB_REPOSITORY/actions/workflows/release.yml/runs?event=push&status=success&per_page=100" \
+                 --jq '.workflow_runs[]
+                       | select(.head_sha == env.STABLE_COMMIT)
+                       | select(.head_branch | startswith("v" + env.VERSION + "-"))
+                       | .head_branch' 2>&1)"; then
+              echo "::error::could not list successful release runs, so the promotion check could not run: $promoted"
+              failures=$((failures + 1))
+            elif [ -n "$promoted" ]; then
+              echo "promotion: $(printf '%s' "$promoted" | head -n 1) published $STABLE_COMMIT in a successful release run"
+            else
+              echo "::error::no SUCCESSFUL release run for a v$VERSION-* tag at $STABLE_COMMIT. Stable must promote a commit that already shipped to insider -- a prerelease tag whose run was cancelled or failed does not count."
+              failures=$((failures + 1))
+            fi
+          fi
+
+          if [ "$failures" -eq 0 ]; then
+            echo "stable gate: both preconditions satisfied for $VERSION"
+            exit 0
+          fi
+
+          if [ "${OVERRIDE:-}" = "$VERSION" ]; then
+            echo "::warning::stable gate overridden for $VERSION by vars.STABLE_GATE_OVERRIDE ($failures unmet precondition(s))."
+            exit 0
+          fi
+
+          echo "::error::stable publication of $VERSION blocked by $failures unmet precondition(s). Fix them, or set the repository variable STABLE_GATE_OVERRIDE to exactly '$VERSION' to release anyway."
+          exit 1
+
   dependency-vulnerability-gate:
     name: Production Dependency Vulnerability Gate
     uses: ./.github/workflows/dependency-vulnerability.yml
@@ -114,7 +250,7 @@ jobs:
   # failure never blocks the CLI release.
   publish-cli:
     name: Publish CLI (${{ needs.version.outputs.channel }} channel)
-    needs: [version, build-wheel]
+    needs: [version, stable-gate, build-wheel]
     permissions:
       contents: read
       id-token: write
@@ -134,7 +270,7 @@ jobs:
   # macOS signing failure can block it (per-platform releases).
   publish-linux:
     name: Publish Linux Desktop (${{ needs.version.outputs.channel }} channel)
-    needs: [version, build-desktop]
+    needs: [version, stable-gate, build-desktop]
     permissions:
       contents: read
       id-token: write
@@ -155,7 +291,7 @@ jobs:
   # also moves :latest.
   publish-docker:
     name: Publish Docker Image (${{ needs.version.outputs.channel }} channel)
-    needs: [version, build-wheel]
+    needs: [version, stable-gate, build-wheel]
     permissions:
       contents: read
       packages: write
@@ -183,7 +319,7 @@ jobs:
   # test_workflow_permissions.py).
   sign-and-notarize:
     name: Sign + Notarize macOS
-    needs: [version, build-wheel, build-desktop]
+    needs: [version, stable-gate, build-wheel, build-desktop]
     permissions:
       id-token: write
       contents: read
@@ -197,7 +333,7 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    needs: [version, sign-and-notarize]
+    needs: [version, stable-gate, sign-and-notarize]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/test/test_stable_release_gate.py
+++ b/test/test_stable_release_gate.py
@@ -1,0 +1,376 @@
+"""Contract tests for release.yml's stable publication gate.
+
+The gate exists because a tag name is the only thing that selects the release
+channel and nothing about the run is attended: on v0.1.3 the stable CLI wheel
+was public 3m41s after the tag push, the CDN key is immutable, and
+``cancel-in-progress: false`` means a corrected tag queues rather than
+superseding. ``v0.2.0-rc.2`` mistyped as ``v0.2.0`` is therefore an
+unrecoverable stable release.
+
+These tests EXECUTE the workflow's actual shell step against throwaway git
+repositories, with a ``gh`` shim on PATH standing in for the API, so a rewritten
+check, a regex that stops treating the version literally, a query failure that
+starts passing silently, or a publish lane that quietly stops depending on the
+gate cannot slip through.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt",
+    reason="the gate step runs under bash on ubuntu-latest",
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+GATE_JOB = "stable-gate"
+STEP_NAME = "Verify stable publication preconditions"
+
+#: Every job that makes bytes public, or publishes the GitHub Release that
+#: points at them. Each one MUST depend on the gate; this list is the ratchet.
+PUBLISH_JOBS = (
+    "publish-cli",
+    "publish-linux",
+    "publish-docker",
+    "sign-and-notarize",
+    "github-release",
+)
+
+#: What the gh shim prints when it is standing in for a matching release run.
+#: The real `gh api --jq` emits one head_branch per matching run.
+MATCHING_RUN = "v1.2.3-rc.1"
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _gate_step() -> dict:
+    steps = _workflow()["jobs"][GATE_JOB]["steps"]
+    step = next((item for item in steps if item.get("name") == STEP_NAME), None)
+    assert step is not None, f"release workflow step {STEP_NAME!r} not found"
+    return step
+
+
+def _gate_script() -> str:
+    script = _gate_step()["run"]
+    # The step reads its inputs through env, never through `${{ }}` spliced
+    # into the shell. Keep it that way: a version string interpolated into a
+    # shell body is a command-injection shape, and it also breaks this harness.
+    assert "${{" not in script, "gate script must take inputs via env, not inline expressions"
+    return script
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "gate test",
+            "GIT_AUTHOR_EMAIL": "gate@example.invalid",
+            "GIT_COMMITTER_NAME": "gate test",
+            "GIT_COMMITTER_EMAIL": "gate@example.invalid",
+        },
+    )
+
+
+def _make_repo(
+    tmp_path: Path,
+    *,
+    changelog_headings: Iterable[str] = (),
+    stable_tag: str | None = None,
+) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+
+    body = "# Changelog\n\n" + "".join(
+        f"{heading}\n\nnotes for {heading}\n\n" for heading in changelog_headings
+    )
+    (repo / "CHANGELOG.md").write_text(body, encoding="utf-8")
+    _git(repo, "add", "CHANGELOG.md")
+    _git(repo, "commit", "-q", "-m", "first")
+    if stable_tag:
+        _git(repo, "tag", stable_tag)
+    return repo
+
+
+def _run(
+    repo: Path,
+    *,
+    channel: str,
+    version: str,
+    override: str = "",
+    gh: str = "match",
+) -> subprocess.CompletedProcess[str]:
+    """Execute the real gate step with a ``gh`` shim on PATH.
+
+    ``gh`` selects the stand-in behaviour: ``match`` (a successful release run
+    exists), ``none`` (queried fine, nothing matched) or ``fail`` (the API call
+    itself failed). The shim mimics the real contract that matters here --
+    non-zero exit for an API failure, zero-with-no-output for no match.
+    """
+    bin_dir = repo / "shim-bin"
+    bin_dir.mkdir(exist_ok=True)
+    shim = bin_dir / "gh"
+    shim.write_text(
+        "#!/bin/sh\n"
+        'if [ "$GH_SHIM_MODE" = "fail" ]; then\n'
+        '  echo "HTTP 503: upstream connect error" >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        'if [ -n "$GH_SHIM_OUT" ]; then printf \'%s\\n\' "$GH_SHIM_OUT"; fi\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+
+    return subprocess.run(
+        ["bash", "-c", _gate_script()],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "HOME": str(repo),
+            "CHANNEL": channel,
+            "VERSION": version,
+            "OVERRIDE": override,
+            "GITHUB_REPOSITORY": "kirodotdev/KiroCrew",
+            "GH_TOKEN": "shim",
+            "GH_SHIM_MODE": "fail" if gh == "fail" else "ok",
+            "GH_SHIM_OUT": MATCHING_RUN if gh == "match" else "",
+        },
+    )
+
+
+# ── wiring: the gate cannot be bypassed by adding a publish lane ──────────
+
+
+@pytest.mark.parametrize("job", PUBLISH_JOBS)
+def test_every_publish_job_depends_on_the_gate(job: str) -> None:
+    needs = _workflow()["jobs"][job]["needs"]
+    assert GATE_JOB in needs, f"{job} publishes without waiting for {GATE_JOB}"
+
+
+def test_gate_job_has_no_job_level_condition() -> None:
+    """A skipped dependency skips its dependents.
+
+    An ``if:`` on the gate would make insider and nightly publish jobs skip
+    entirely instead of passing through, so the channel test must stay inside
+    the step body.
+    """
+    assert "if" not in _workflow()["jobs"][GATE_JOB]
+
+
+def test_gate_checks_out_full_history() -> None:
+    steps = _workflow()["jobs"][GATE_JOB]["steps"]
+    checkout = next(s for s in steps if str(s.get("uses", "")).startswith("actions/checkout@"))
+    assert checkout["with"]["fetch-depth"] == 0
+
+
+def test_gate_job_can_read_workflow_runs() -> None:
+    """The promotion check is an `actions: read` API call; least privilege only."""
+    permissions = _workflow()["jobs"][GATE_JOB]["permissions"]
+    assert permissions["actions"] == "read"
+    assert permissions["contents"] == "read"
+    assert "write" not in str(permissions.values())
+
+
+# ── the promotion query's shape (the shim cannot exercise jq itself) ──────
+
+
+def test_promotion_query_requires_a_successful_push_run() -> None:
+    script = _gate_script()
+    assert "status=success" in script, "a cancelled or failed prerelease run must not count"
+    assert "event=push" in script
+
+
+def test_promotion_query_filters_on_both_the_commit_and_the_tag() -> None:
+    """Dropping either selector would accept the wrong run."""
+    script = _gate_script()
+    assert "select(.head_sha == env.STABLE_COMMIT)" in script
+    assert 'startswith("v" + env.VERSION + "-")' in script
+
+
+def test_promotion_query_reads_its_inputs_from_env() -> None:
+    """No shell value is spliced into the jq filter text."""
+    script = _gate_script()
+    start = script.index("--jq '")
+    program = script[start + len("--jq '"):]
+    program = program[: program.index("'")]
+    assert "$" not in program, f"jq program splices a shell value: {program!r}"
+    assert "env.VERSION" in program
+
+
+# ── behaviour: non-stable channels pass straight through ──────────────────
+
+
+@pytest.mark.parametrize("channel", ["insider", "nightly"])
+def test_non_stable_channels_pass_with_no_evidence_at_all(tmp_path: Path, channel: str) -> None:
+    repo = _make_repo(tmp_path)  # no changelog section, no tag
+    result = _run(repo, channel=channel, version="1.2.3", gh="none")
+    assert result.returncode == 0, result.stderr
+    assert "does not apply" in result.stdout
+
+
+# ── behaviour: a well-formed stable promotion ─────────────────────────────
+
+
+def test_documented_and_promoted_release_passes(tmp_path: Path) -> None:
+    repo = _make_repo(
+        tmp_path,
+        changelog_headings=["## [1.2.3] — 2026-08-07"],
+        stable_tag="v1.2.3",
+    )
+    result = _run(repo, channel="stable", version="1.2.3")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert MATCHING_RUN in result.stdout
+    assert "both preconditions satisfied" in result.stdout
+
+
+# ── behaviour: each precondition fails on its own ─────────────────────────
+
+
+def test_missing_changelog_section_blocks(tmp_path: Path) -> None:
+    repo = _make_repo(
+        tmp_path,
+        changelog_headings=["## [1.2.2] — 2026-08-01"],
+        stable_tag="v1.2.3",
+    )
+    result = _run(repo, channel="stable", version="1.2.3")
+    assert result.returncode == 1
+    assert "no '## [1.2.3]' section" in result.stdout
+
+
+def test_no_successful_release_run_blocks(tmp_path: Path) -> None:
+    """The defect GPT 5.6 found: a leftover tag from a cancelled run."""
+    repo = _make_repo(
+        tmp_path,
+        changelog_headings=["## [1.2.3] — 2026-08-07"],
+        stable_tag="v1.2.3",
+    )
+    result = _run(repo, channel="stable", version="1.2.3", gh="none")
+    assert result.returncode == 1
+    assert "no SUCCESSFUL release run" in result.stdout
+    assert "cancelled or failed does not count" in result.stdout
+
+
+def test_a_failed_query_fails_closed_and_says_so(tmp_path: Path) -> None:
+    """A check that could not run is not a check that passed."""
+    repo = _make_repo(
+        tmp_path,
+        changelog_headings=["## [1.2.3] — 2026-08-07"],
+        stable_tag="v1.2.3",
+    )
+    result = _run(repo, channel="stable", version="1.2.3", gh="fail")
+    assert result.returncode == 1
+    assert "could not list successful release runs" in result.stdout
+    assert "503" in result.stdout, "the underlying error must be surfaced, not swallowed"
+    # Distinguishable from the "checked, nothing matched" verdict.
+    assert "no SUCCESSFUL release run" not in result.stdout
+
+
+def test_absent_stable_tag_fails_closed_with_a_readable_error(tmp_path: Path) -> None:
+    """The tag is the trigger in CI, but it can be deleted before a re-run.
+
+    Found by replaying the gate over real repository history: an unguarded
+    ``git rev-list`` aborted the script under ``set -e`` with git's own
+    "ambiguous argument" fatal and exit 128, which skipped both the failure
+    summary and the override path.
+    """
+    repo = _make_repo(tmp_path, changelog_headings=["## [1.2.3] — 2026-08-07"])
+    result = _run(repo, channel="stable", version="1.2.3")
+    assert result.returncode == 1, f"expected a clean failure, got {result.returncode}"
+    assert "tag v1.2.3 is not present" in result.stdout
+    assert "ambiguous argument" not in result.stderr
+    assert "blocked by 1 unmet precondition" in result.stdout
+
+
+def test_both_failures_are_reported_together(tmp_path: Path) -> None:
+    """One run should name everything wrong, not fail on the first check."""
+    repo = _make_repo(tmp_path, stable_tag="v1.2.3")
+    result = _run(repo, channel="stable", version="1.2.3", gh="none")
+    assert result.returncode == 1
+    assert "no '## [1.2.3]' section" in result.stdout
+    assert "no SUCCESSFUL release run" in result.stdout
+    assert "blocked by 2 unmet precondition" in result.stdout
+
+
+# ── behaviour: the version string is matched literally ────────────────────
+
+
+def test_a_longer_version_heading_does_not_satisfy_a_shorter_release(tmp_path: Path) -> None:
+    """`## [1.2.31]` must not pass for 1.2.3 -- the anchor is a literal prefix."""
+    repo = _make_repo(
+        tmp_path,
+        changelog_headings=["## [1.2.31] — 2026-08-07"],
+        stable_tag="v1.2.3",
+    )
+    assert _run(repo, channel="stable", version="1.2.3").returncode == 1
+
+
+def test_dots_in_the_version_are_not_regex_wildcards(tmp_path: Path) -> None:
+    repo = _make_repo(
+        tmp_path,
+        changelog_headings=["## [1x2x3] — 2026-08-07"],
+        stable_tag="v1.2.3",
+    )
+    assert _run(repo, channel="stable", version="1.2.3").returncode == 1
+
+
+def test_a_heading_that_is_not_at_the_line_start_does_not_count(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path, stable_tag="v1.2.3")
+    (repo / "CHANGELOG.md").write_text(
+        "# Changelog\n\nsee also ## [1.2.3] elsewhere\n", encoding="utf-8"
+    )
+    assert _run(repo, channel="stable", version="1.2.3").returncode == 1
+
+
+# ── behaviour: the override is deliberate and version-scoped ──────────────
+
+
+def test_override_matching_the_version_releases_anyway(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path, stable_tag="v1.2.3")
+    result = _run(repo, channel="stable", version="1.2.3", override="1.2.3", gh="none")
+    assert result.returncode == 0, result.stdout
+    assert "::warning::" in result.stdout
+    assert "overridden for 1.2.3" in result.stdout
+
+
+def test_override_rescues_an_api_outage_too(tmp_path: Path) -> None:
+    repo = _make_repo(
+        tmp_path,
+        changelog_headings=["## [1.2.3] — 2026-08-07"],
+        stable_tag="v1.2.3",
+    )
+    assert _run(repo, channel="stable", version="1.2.3", override="1.2.3", gh="fail").returncode == 0
+
+
+def test_override_for_a_different_version_does_not_apply(tmp_path: Path) -> None:
+    """A stale override left in repo settings must not clear a later release."""
+    repo = _make_repo(tmp_path, stable_tag="v1.2.3")
+    assert _run(repo, channel="stable", version="1.2.3", override="1.2.2", gh="none").returncode == 1
+
+
+def test_override_does_not_fire_when_nothing_is_wrong(tmp_path: Path) -> None:
+    repo = _make_repo(
+        tmp_path,
+        changelog_headings=["## [1.2.3] — 2026-08-07"],
+        stable_tag="v1.2.3",
+    )
+    result = _run(repo, channel="stable", version="1.2.3", override="1.2.3")
+    assert result.returncode == 0
+    assert "::warning::" not in result.stdout


### PR DESCRIPTION
ci(release): require a CHANGELOG section and a shipped candidate before stable

A tag name is the only thing that selects the release channel, and the run is
unattended. On v0.1.3 the stable CLI wheel was public 3m41s after the tag push
(run 31030575673: tag 17:33:30, `Publish CLI wheel (stable)` 17:37:11-17:37:44),
CDN keys are immutable so a republish is refused, and `cancel-in-progress:
false` means a corrected tag queues behind rather than superseding. So
`v0.2.0-rc.2` mistyped as `v0.2.0` is an unrecoverable stable release inside a
window nobody is watching.

Adds a `stable-gate` job that every publishing job now depends on. On a stable
tag it requires two pieces of evidence that a typo cannot produce:

1. `CHANGELOG.md` has a `## [<version>]` section.
2. A SUCCESSFUL `release.yml` run exists for a `v<version>-*` tag at the same
   commit as the stable tag -- i.e. stable only promotes bytes insiders
   actually received.

Deterministic rather than an approval button, on purpose: the failure mode is a
typo by someone who believes they are shipping a prerelease, which is exactly
the state of mind that clicks through a confirmation prompt.

Validated by replaying the gate over real history:

    v0.1.2  pass   CHANGELOG present; v0.1.2-insider.4 succeeded at 405a013c
    v0.1.3  BLOCK  promotion clean (v0.1.3-insider.2 at 8e988362), no CHANGELOG

So check 2 encodes practice that already holds (2/2), and check 1 would have
blocked v0.1.3 -- which did ship with no CHANGELOG section. Consequence worth
stating: the next stable release now requires its section to be written first,
and 0.2.0 does not have one yet. The promotion half of 0.2.0 is already
satisfied -- the live API query returns `v0.2.0-rc.1` for commit e8be7a14.

Three design details that are load-bearing:

- The job carries no `if:`. A skipped dependency skips its dependents, so an
  `if: channel == 'stable'` here would silently stop insider and nightly from
  publishing at all. The channel test lives inside the step, which always runs
  and exits 0 for every non-stable channel.
- The CHANGELOG heading is matched as a literal prefix through awk's `index()`,
  never as a regex, so the dots in a version stay literal.
- A failed API query FAILS CLOSED with the underlying error, distinguishable in
  both the log and the tests from "checked, and no such release exists". A check
  that could not run is not a check that passed.

Escape hatch: the repository variable `STABLE_GATE_OVERRIDE` must equal the
exact version being released, so it cannot be left switched on for future tags.

Tests execute the workflow's real shell step against throwaway git repos (the
idiom `test_release_macos_fail_closed.py` established), with a `gh` shim
standing in for the API, and ratchet the wiring so a new publish lane cannot
quietly skip the gate. Mutation-checked: dropping `stable-gate` from
`publish-cli` fails the wiring test, and swapping awk for `grep -E` fails the
literal-match test.

Addresses the GPT 5.6 blocking finding on 2ce9bcef: matching on tag NAMES alone
accepted a prerelease tag whose run was cancelled or failed, so stable could
promote a candidate that never shipped. The check now requires a successful run,
queried from GitHub's own API (`actions: read`) rather than the distribution CDN
-- an API outage already means this run is not happening, whereas a CDN blip is
an unrelated failure that must not block a legitimate release. The jq filter is
validated against the live API in both directions: it returns `v0.2.0-rc.1` for
version 0.2.0 at e8be7a14 and nothing for version 0.1.3 at the same commit.

Replaying over history also found a defect in the first draft: an unguarded
`git rev-list` aborted under `set -e` with git's own "ambiguous argument" fatal
and exit 128 when the stable tag was absent, skipping both the failure summary
and the override path. Now guarded, with a test.
