### PR TITLE
ci(review): bring fork Opus lane to operational parity with same-repo Opus

### DIFF
--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -45,7 +45,12 @@ jobs:
   fork-opus-review:
     name: Fork Opus 5 Review
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Runaway/hang backstop only, NOT a per-review budget: the review
+    # self-terminates well before this. Set at 90 min (matches claude-review.yml)
+    # so it never cuts a completing --max-turns 120 review the way the old 30-min
+    # wall did, while still failing the gate closed on a true hang. Keep in sync
+    # with claude-review.yml.
+    timeout-minutes: 90
     # Only for a SUCCESSFUL Stage 1 run that was itself a fork pull_request.
     if: >-
       github.event.workflow_run.event == 'pull_request'
@@ -213,7 +218,7 @@ jobs:
             --model us.anthropic.claude-opus-5
             --fallback-model us.anthropic.claude-opus-4-8
             --max-turns 120
-            --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*)"
+            --allowedTools "Read,Grep,Glob"
           prompt: |
             You are reviewing pull request #${{ steps.pr.outputs.pr }}
             of ${{ github.repository }} (HEAD ${{ steps.pr.outputs.head_sha }}).


### PR DESCRIPTION
## Problem
`fork-opus-review.yml` drifted from its same-repo twin `claude-review.yml` on two operational points, neither justified by the fork trust model:
1. **Timeout too low.** Fork ran `timeout-minutes: 30` while invoking `--max-turns 120`. The same-repo lane runs `90` with an explicit comment that a completing 120-turn review must never hit the wall. A large fork PR review gets killed mid-run → the fail-closed gate turns the **required "Opus 5 Review" check RED on a healthy review**.
2. **Stray allowedTool.** `Bash(gh pr diff:*)` was copied from the same-repo lane, but the fork reviewer's input is the SHA-pinned `authentic.patch` (fetched via local `git diff` precisely because the compare/`gh` endpoint truncates large diffs). The tool is a redundant escape hatch to a *truncatable* diff.

## Why it matters
A required review check going red for a pure infra timeout (not a finding) blocks legitimate fork contributors and erodes trust in the gate. The stray tool lets the model read a silently-truncated diff instead of the vetted patch.

## Fix (symptom → root cause → change)
- `timeout-minutes: 30 → 90` (matches `claude-review.yml`, with the same sync comment).
- allowedTools `"Read,Grep,Glob,Bash(gh pr diff:*)" → "Read,Grep,Glob"`.

The review **contract** (threshold, ≤2-BLOCKING budget, AUTOSDE base-ref rule files, FIX BAR, markers, fail-closed gate) is already identical to `claude-review.yml` and is unchanged. `INPUT DISCIPLINE` (Opus deliberately does **not** read the PR description — GPT owns description-vs-code scope-match) is intentional and kept.

## Tests
N/A — workflow-only change. YAML validated with `yaml.safe_load`.

## Manual verification
Confirmed `claude-review.yml` uses `timeout-minutes: 90`; confirmed the fork lane's review input is `${{ runner.temp }}/authentic.patch`, not `gh pr diff`.

## Screenshots
N/A — no user-visible UI change.
