### PR TITLE
feat(learn): evidence provenance on lessons; fix dropped negative field

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -138,6 +138,10 @@ would stall heartbeats, Slack, and the dashboard.
 
 The history consolidation prompt includes a `"lessons"` key that extracts only implicit correction patterns — corrections the user made without explicitly saying "remember" (those are already saved immediately via `learn_add`). All lesson writes go through `write_lesson()` which provides substring dedup and topic-overlap dedup (>50% keyword overlap → newer replaces older). When vector memory is not active, falls back to `lessons.jsonl` via `LessonStore.save()`.
 
+### Lesson provenance (`evidence`) and the `negative` pass-through
+
+A `Lesson` record carries two optional fields beyond the rule: `negative` (what NOT to do — injected into context alongside the rule) and `evidence` (WHY the lesson exists — what went wrong or what the user said when it was learned, with a concrete anchor). `evidence` is provenance for later review/refinement and is deliberately **never injected into session context** (`get_context` renders rule + negative only), so it costs nothing per session. It flows from the `learn_add` MCP tool / `kirocrew learn add --evidence` / `POST /api/lessons` into the JSONL store (`Lesson.evidence`) and back out through `GET /api/lessons` and `learn_list`. The vector-store path has no metadata column yet, so there `evidence` is traced via a SEL event instead of persisted on the row (follow-up: metadata column or structured lesson values). NOTE: the MCP `learn_add` payload previously dropped `negative` entirely (the tool advertised it, the handler never forwarded it, and the REST vector path passed a literal `None`); both halves now pass through end-to-end.
+
 ### Configuration
 
 `~/.kiro/crew/config.json` → `"memory"` section:

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1626,6 +1626,10 @@ Examples:
         help="Lesson category (default: knowledge)",
     )
     learn_add.add_argument("--negative", help="What NOT to do (optional)")
+    learn_add.add_argument(
+        "--evidence",
+        help="Why the lesson exists — what went wrong when it was learned (optional, one line)",
+    )
     learn_sub.add_parser("list", help="List all lessons")
     learn_rm = learn_sub.add_parser("remove", help="Remove lessons matching a substring")
     learn_rm.add_argument("query", help="Substring to match against lesson rules")

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -1304,6 +1304,7 @@ def _learn(args: argparse.Namespace) -> None:
             rule = args.rule
             category = args.category
             negative = getattr(args, "negative", None)
+            evidence = getattr(args, "evidence", None)
             if vs.write_lesson(rule, category, negative):
                 neg = f" ({negative})" if negative else ""
                 print(f"Saved: {rule}{neg} [{category}]")
@@ -1313,6 +1314,7 @@ def _learn(args: argparse.Namespace) -> None:
                     rule=rule,
                     category=category,
                     negative=negative,
+                    evidence=evidence,
                 )
                 jsonl_store.save(lesson)
                 neg = f" ({lesson.negative})" if lesson.negative else ""

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -800,6 +800,8 @@ async def api_lessons_create(request: web.Request) -> web.Response:
         return web.json_response({"error": "rule is required"}, status=400)
     category = cleaned.get("category", "knowledge")
     scope = cleaned.get("scope", "global")
+    negative = cleaned.get("negative") or None
+    evidence = cleaned.get("evidence") or None
     # Write to vector store if available, else JSONL
     vs = _get_memory(state).vector_store
     if vs:
@@ -825,11 +827,23 @@ async def api_lessons_create(request: web.Request) -> web.Response:
             vs.write_lesson,
             rule,
             category,
-            None,
+            # Forward the caller's "what not to do" — a literal None here
+            # silently discarded the negative on every vector-store write even
+            # though write_lesson has carried the parameter all along.
+            negative,
             "user_explicit",
             rule_emb,
             rule_emb_generation,
         )
+        # The semantic_memory schema has no metadata column, so ``evidence``
+        # has no durable home on this path yet (follow-up: metadata column /
+        # structured lesson values). Keep a trace in SEL so the provenance is
+        # at least recoverable from the audit log instead of vanishing.
+        if evidence:
+            _sel().log_api_access(
+                caller=sk, operation="learn_add", outcome="allowed",
+                source="dashboard", resources=f"evidence:{evidence[:200]}",
+            )
         candidates = await asyncio.to_thread(
             vs.find_contradiction_candidates, rule, 0.4, 0.85, rule_emb
         )
@@ -845,7 +859,13 @@ async def api_lessons_create(request: web.Request) -> web.Response:
             state._background_tasks.add(task)
             task.add_done_callback(state._background_tasks.discard)
     else:
-        lesson = Lesson(rule=rule, category=category, ts=datetime.now(timezone.utc).isoformat())
+        lesson = Lesson(
+            rule=rule,
+            category=category,
+            ts=datetime.now(timezone.utc).isoformat(),
+            negative=negative,
+            evidence=evidence,
+        )
         if scope == "workspace":
             ws = cleaned.get("workspace")
             _get_lessons(state, ws).save(lesson)
@@ -1104,6 +1124,13 @@ async def api_lessons(request: web.Request) -> web.Response:
                 if le.rule.lower().strip() not in seen:
                     global_lessons.append(le)
         data = [
-            {"rule": le.rule, "category": le.category, "ts": le.ts} for le in global_lessons[-50:]
+            {
+                "rule": le.rule,
+                "category": le.category,
+                "ts": le.ts,
+                "negative": le.negative,
+                "evidence": le.evidence,
+            }
+            for le in global_lessons[-50:]
         ]
     return web.json_response({"lessons": data})

--- a/src/kiro_crew/learn.py
+++ b/src/kiro_crew/learn.py
@@ -49,6 +49,12 @@ class Lesson:
     rule: str
     category: str  # "tool", "preference", "knowledge"
     negative: str | None = None
+    # WHY the lesson exists — what went wrong, or what the user said, when it
+    # was learned (one line, e.g. "user corrected PR #2126's description: it
+    # referenced private research"). Provenance for later review/refinement;
+    # deliberately NOT injected into session context (get_context) — the rule
+    # and negative are the actionable parts, the evidence is the audit trail.
+    evidence: str | None = None
 
 
 # ── Storage ──
@@ -159,6 +165,7 @@ class LessonStore:
                         rule=data.get("rule", ""),
                         category=data.get("category", "knowledge"),
                         negative=data.get("negative"),
+                        evidence=data.get("evidence"),
                     )
                 )
             except (json.JSONDecodeError, KeyError):

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -630,6 +630,18 @@ def _list_tools() -> list[dict[str, Any]]:
                             "characters — rejected if exceeded."
                         ),
                     },
+                    "evidence": {
+                        "type": "string",
+                        "maxLength": _neg_max,
+                        "description": (
+                            "WHY this lesson exists (optional, one line): what "
+                            "went wrong or what the user said that triggered it, "
+                            "with a concrete anchor (a PR, file, or error). "
+                            "Stored as provenance for later review — never "
+                            "injected into context, so it costs nothing per "
+                            f"session. HARD LIMIT {_neg_max} characters."
+                        ),
+                    },
                     "scope": {
                         "type": "string",
                         "enum": ["global", "workspace"],
@@ -3986,6 +3998,14 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             return f"Error: {_gov_mem}"
         scope = args.get("scope", "global")
         payload: dict[str, str] = {"rule": rule, "category": category, "scope": scope}
+        # Forward the optional record fields. ``negative`` was silently DROPPED
+        # here before — the tool schema advertised it, the model supplied it,
+        # and the payload never carried it, so every MCP-written lesson lost
+        # its "what not to do" half (the CLI path kept it, masking the bug).
+        if args.get("negative"):
+            payload["negative"] = args["negative"]
+        if args.get("evidence"):
+            payload["evidence"] = args["evidence"]
         if scope == "workspace":
             ws = args.get("workspace", "")
             if not ws:
@@ -4033,7 +4053,12 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             return "No lessons saved."
         lines = []
         for le in lessons:
-            lines.append(f"[{le.get('category', '?')}] {le['rule']}")
+            entry = f"[{le.get('category', '?')}] {le['rule']}"
+            if le.get("negative"):
+                entry += f" — NOT: {le['negative']}"
+            if le.get("evidence"):
+                entry += f" (learned: {le['evidence']})"
+            lines.append(entry)
         return "\n".join(lines)
 
     if name == "learn_remove":

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -969,6 +969,9 @@ LEARN_ADD_SCHEMA = ToolSchema(
         FieldSpec("rule", str, required=True, max_len=MAX_SHORT_STRING),
         FieldSpec("category", str, allowed=ALLOWED_LESSON_CATEGORIES, default="knowledge"),
         FieldSpec("negative", str, max_len=MAX_SHORT_STRING),
+        # Provenance: why/where the lesson was learned (one line). Stored on the
+        # lesson record for later review; never injected into session context.
+        FieldSpec("evidence", str, max_len=MAX_SHORT_STRING),
         # scope/workspace: the learn_add MCP tool (mcp_core.py) and the
         # /api/lessons handler support workspace-scoped lessons. The "workspace
         # required when scope='workspace'" rule is enforced in the handler.

--- a/test/test_api_input_validation.py
+++ b/test/test_api_input_validation.py
@@ -133,6 +133,62 @@ class TestLessonsCreateTypeValidation:
             resp = await api_lessons_create(request)
         assert resp.status == 400
 
+
+class TestLessonsCreateFieldForwarding:
+    """negative/evidence must survive the write, not be silently dropped.
+
+    Regression coverage: the vector path passed a literal ``None`` for
+    negative (discarding the caller's "what not to do"), and the JSONL path
+    constructed the Lesson without negative at all.
+    """
+
+    @pytest.mark.asyncio
+    async def test_vector_path_forwards_negative(self):
+        request = _lessons_request(
+            {"rule": "always X", "category": "tool", "negative": "never Y"}
+        )
+        state = request.app["state"]
+        vs = state.memory.vector_store  # MagicMock chain from _lessons_request
+        vs.write_lesson = MagicMock(return_value=True)
+        vs.find_contradiction_candidates = MagicMock(return_value=[])
+        vs.embed_lesson = MagicMock(return_value=[0.0])
+        with (
+            patch("kiro_crew.dashboard.handlers.cron._sel"),
+            patch("kiro_crew.dashboard.handlers.cron._is_restricted_session", return_value=False),
+            patch("kiro_crew.dashboard.handlers.cron._get_memory", return_value=state.memory),
+        ):
+            resp = await api_lessons_create(request)
+        assert resp.status == 200
+        args = vs.write_lesson.call_args.args
+        assert args[0] == "always X"
+        assert args[2] == "never Y", "negative must reach write_lesson, not a literal None"
+
+    @pytest.mark.asyncio
+    async def test_jsonl_path_persists_negative_and_evidence(self):
+        request = _lessons_request(
+            {
+                "rule": "always X",
+                "category": "tool",
+                "negative": "never Y",
+                "evidence": "user corrected this in review",
+            }
+        )
+        state = request.app["state"]
+        saved = []
+        state.lessons.save = MagicMock(side_effect=saved.append)
+        memory = MagicMock()
+        memory.vector_store = None  # force the JSONL fallback path
+        with (
+            patch("kiro_crew.dashboard.handlers.cron._sel"),
+            patch("kiro_crew.dashboard.handlers.cron._is_restricted_session", return_value=False),
+            patch("kiro_crew.dashboard.handlers.cron._get_memory", return_value=memory),
+        ):
+            resp = await api_lessons_create(request)
+        assert resp.status == 200
+        assert len(saved) == 1
+        assert saved[0].negative == "never Y"
+        assert saved[0].evidence == "user corrected this in review"
+
     @pytest.mark.asyncio
     async def test_non_object_body_returns_400(self):
         request = _lessons_request(["not", "an", "object"])

--- a/test/test_learn.py
+++ b/test/test_learn.py
@@ -50,6 +50,40 @@ class TestLessonStore:
         assert "tool-a" in ctx
         assert "Learned corrections" in ctx
 
+    def test_evidence_round_trips_but_stays_out_of_context(self, tmp_path: Path) -> None:
+        """Evidence is provenance: persisted and reloadable, but never injected
+        into session context — the rule/negative are the actionable parts."""
+        store = LessonStore(base_dir=tmp_path)
+        store.save(
+            Lesson(
+                ts="2026-01-01T00:00:00Z",
+                rule="PR descriptions must be self-contained",
+                category="preference",
+                negative="Do not cite private research",
+                evidence="user corrected PR #2126: 'the reader can't see the research'",
+            )
+        )
+        loaded = store.load_all()
+        assert loaded[0].evidence == (
+            "user corrected PR #2126: 'the reader can't see the research'"
+        )
+        ctx = store.get_context()
+        assert "self-contained" in ctx
+        assert "can't see the research" not in ctx, "evidence must not cost context tokens"
+
+    def test_lessons_without_evidence_field_still_load(self, tmp_path: Path) -> None:
+        """Pre-existing JSONL rows (no evidence key) load with evidence=None."""
+        path = tmp_path / "lessons.jsonl"
+        path.write_text(
+            '{"ts": "2026-01-01T00:00:00Z", "rule": "old rule", "category": "tool"}\n',
+            encoding="utf-8",
+        )
+        store = LessonStore(base_dir=tmp_path)
+        loaded = store.load_all()
+        assert len(loaded) == 1
+        assert loaded[0].rule == "old rule"
+        assert loaded[0].evidence is None
+
     def test_load_corrupted_line(self, tmp_path: Path) -> None:
         path = tmp_path / "lessons.jsonl"
         path.write_text("not json\n")


### PR DESCRIPTION
## What

Two changes to the lesson (learned-corrections) system:

1. **New optional `evidence` field** — one line recording *why* a lesson exists (what went wrong, or what the user said, with a concrete anchor like a PR or file). Plumbed through the `learn_add` MCP tool, `kirocrew learn add --evidence`, and `POST /api/lessons`, persisted in the JSONL store, and surfaced by `GET /api/lessons` and `learn_list`.
2. **Bug fix: the `negative` field was silently dropped end-to-end on the MCP path.** The `learn_add` tool schema advertised `negative` ('what NOT to do'), the model supplied it, and the handler never put it in the REST payload; independently, the REST handler's vector-store path passed a literal `None` to `write_lesson`. So every MCP-written lesson lost its 'what not to do' half — only the CLI path preserved it, masking the bug. Both fields now flow through on both backends, and the JSONL list path now returns them too (it also omitted `negative` before).

## Why evidence matters

A rule like "always run tests under Node 20" is obeyable but not *reviewable*: six months later nobody knows whether it's still relevant, or what failure it prevents. Recording the trigger ("vitest native bindings failed under Node 18 in <repo>") makes lessons auditable and gives any future refinement/curation pass the signal it needs to keep, merge, or retire them. This mirrors how self-improving agent harnesses (e.g. [PrimeIntellect-ai/prime-agent](https://github.com/PrimeIntellect-ai/prime-agent)'s Continual Harness) require refinements to be *evidence-backed* — trajectory-linked, not free-floating assertions.

## Design decisions

- **Evidence is never injected into session context**: `get_context` renders rule + negative only, so provenance costs zero tokens per session. It's for the lessons UI, `learn_list`, and future curation.
- **Vector-store path**: `semantic_memory` has no metadata column, so evidence there is traced via a SEL audit event rather than persisted on the row — noted in the spec doc as a follow-up (metadata column or structured lesson values). The JSONL store persists it fully.
- Backwards compatible: pre-existing JSONL rows load with `evidence=None` (covered by a test); the REST list payload gains optional keys only.

## Tested

- `test_learn.py`: evidence round-trip + stays-out-of-context, legacy rows without the field still load
- `test_api_input_validation.py`: new `TestLessonsCreateFieldForwarding` — vector path receives the caller's `negative` (regression for the literal `None`), JSONL path persists both fields
- Full sweep: learn/lessons suites, `test_validation`, all `test_mcp_core*` — **327 passed**, flake8 clean
- `memory-skills-hooks.md` updated in the same commit per AGENTS.md