### PR TITLE
docs(skills): cap web-verify frames at 2000px before reading them

### DIFF
--- a/src/kiro_crew/builtin_skills/web-verify/SKILL.md
+++ b/src/kiro_crew/builtin_skills/web-verify/SKILL.md
@@ -31,6 +31,29 @@ MCP", "captured with agent-browser", "scripted Playwright via pod-e2e" — so th
 knows whether they could have watched it happen, and never imply a panel stream that
 didn't occur.
 
+> **Keep every frame you read under 2000px on both edges.** A single image past
+> that wedges the session permanently: the provider rejects the WHOLE request once
+> a conversation carries many images, kiro-cli replays the full history every
+> turn, and the offending block sits at a fixed history index that nothing can
+> evict — the same error re-fires on every later turn no matter what you do next.
+> So capture at `deviceScaleFactor: 1` (a 1400-1500px viewport reads fine), and
+> prefer an element screenshot over `fullPage` on a long page. If a file is
+> already oversized, downscale it BEFORE reading it:
+>
+> ```bash
+> python3 "${KIROCREW_HOME:-$HOME/.kiro/crew}/skills/web-verify/scripts/downscale_image.py" "/abs/path/shot.png"
+> ```
+>
+> On native Windows, run the same script with that machine's launcher
+> (`py` or `python`) — the script itself is OS-agnostic. It takes paths as
+> arguments (so a path with an apostrophe or a space is the shell's problem, not
+> the script's), rewrites only files actually over the cap, and re-execs itself
+> under Kiro Crew's own venv interpreter when the Python you invoked has no
+> Pillow.
+>
+> The error is asymmetric, which is why the cap is not a nicety: downscaling only
+> costs detail, while one oversized read costs the rest of the conversation.
+
 ## Precondition — a browser must actually be available (the guard)
 
 `browser_navigate` / `browser_take_screenshot` come from the external

--- a/src/kiro_crew/builtin_skills/web-verify/scripts/downscale_image.py
+++ b/src/kiro_crew/builtin_skills/web-verify/scripts/downscale_image.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Downscale an image so an agent can read it back without wedging the session.
+
+A provider rejects the ENTIRE request when a many-image conversation carries any
+image wider or taller than ``MAX_EDGE_PX``. kiro-cli replays the whole message
+history every turn, and the offending block sits at a fixed history index that
+nothing can evict — so one oversized read poisons every later turn, not just its
+own. Capping is therefore not cosmetic, and the error is asymmetric: downscaling
+costs some detail, skipping it costs the rest of the conversation.
+
+This exists as a FILE rather than a shell one-liner in the skill because the
+one-liner had a portability hole per platform — GNU-only ``readlink -f`` on
+macOS, no ``python3`` on native Windows, and a path containing an apostrophe
+breaking an inlined ``p='...'`` literal. Paths arrive as ``argv`` here, so
+quoting is the shell's problem and not the snippet's.
+
+Usage:
+
+    python3 downscale_image.py shot.png [more.png ...]
+
+Exit codes: 0 = every path is now within the cap (including ones already
+within it), 1 = at least one path could not be processed.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from PIL import Image
+else:
+    # Optional at import time, not inside the function: a missing Pillow is a
+    # RECOVERABLE state here (main re-execs under Kiro Crew's venv, which has
+    # it), so the module must still import under an interpreter without it.
+    try:
+        from PIL import Image
+    except ImportError:
+        Image = None
+
+#: Longest edge (px) any image may have. Mirrors ``MAX_IMAGE_EDGE_PX`` in
+#: ``kiro_crew/acp/prompt_blocks.py``, which enforces the same ceiling on images
+#: entering a prompt. Kept as a literal rather than an import: this script runs
+#: under whichever interpreter has Pillow, which is not necessarily one that can
+#: import ``kiro_crew``.
+MAX_EDGE_PX = 2000
+
+#: Set on the child when this script re-execs itself under a different
+#: interpreter, so a Pillow-less environment cannot loop forever.
+_REEXEC_ENV = "KIROCREW_DOWNSCALE_REEXEC"
+
+#: Pixel ceiling for a decode. Pillow's stock guard is ~89M pixels, which a
+#: legitimate `fullPage` capture of a long page clears easily -- 3000x60000 is
+#: 180M -- and this script exists precisely to fix those. Raising it is safe for
+#: this input class (the user's own screenshot, not untrusted upload), and the
+#: `DecompressionBombError` handler below still fails a single path gracefully
+#: rather than aborting the whole run when a file is beyond even this.
+MAX_DECODE_PIXELS = 512_000_000
+
+
+def bundled_python() -> str | None:
+    """Path to an interpreter that has Pillow, or ``None``.
+
+    Kiro Crew's own venv ships Pillow (``prompt_blocks`` depends on it), and the
+    ``kirocrew`` console script lives in that venv's script directory — so the
+    interpreter is its SIBLING. That holds on every platform without special
+    casing the directory name: POSIX puts both in ``bin/``, Windows puts both in
+    ``Scripts/``. Only the executable's suffix differs.
+
+    ``realpath`` matters: the launcher is frequently a symlink from
+    ``~/.local/bin`` into the venv, and the sibling lookup has to run in the
+    venv, not next to the symlink.
+    """
+    launcher = shutil.which("kirocrew")
+    if not launcher:
+        return None
+    script_dir = os.path.dirname(os.path.realpath(launcher))
+    candidate = os.path.join(script_dir, "python.exe" if os.name == "nt" else "python")
+    return candidate if os.path.isfile(candidate) else None
+
+
+def _reexec_with_pillow(argv: list[str]) -> int:
+    """Re-run this script under an interpreter that has Pillow."""
+    if os.environ.get(_REEXEC_ENV):
+        print(
+            "downscale: Pillow is unavailable in "
+            f"{sys.executable} and the re-exec already happened; install Pillow "
+            "or run this under Kiro Crew's venv interpreter.",
+            file=sys.stderr,
+        )
+        return 1
+    interpreter = bundled_python()
+    if not interpreter:
+        print(
+            "downscale: Pillow is unavailable and no Kiro Crew venv interpreter "
+            "was found next to the 'kirocrew' launcher. Install Pillow into "
+            f"{sys.executable}, or pass the image through another resizer.",
+            file=sys.stderr,
+        )
+        return 1
+    env = {**os.environ, _REEXEC_ENV: "1"}
+    return subprocess.call([interpreter, os.path.abspath(__file__), *argv], env=env)
+
+
+def shrink(path: str) -> tuple[bool, str]:
+    """Cap ``path`` at ``MAX_EDGE_PX``. Returns ``(ok, message)``.
+
+    Only rewrites a file actually over the cap, so running this over a directory
+    is idempotent and never re-encodes a frame that was already safe
+    (re-encoding a JPEG twice visibly degrades it).
+
+    The rewrite goes to a sibling temp file and then ``os.replace``, NOT straight
+    back over ``path``. Two reasons, and the first is a hard failure rather than a
+    nicety: Pillow reads lazily and keeps the source file open, and on Windows a
+    second handle opened for writing on the same path is refused
+    (``PermissionError``) — which is exactly how this failed the Windows CI shard
+    while passing on POSIX. The replace is also atomic, so an interrupted save
+    cannot leave a truncated image where a valid one used to be.
+    """
+    assert Image is not None  # main() re-execs before reaching here
+
+    # Raised only for the duration of this call and then put back: the ceiling
+    # is a MODULE-LEVEL global in Pillow, so leaving it changed would silently
+    # relax the guard for every later decode in the process.
+    previous_ceiling = Image.MAX_IMAGE_PIXELS
+    Image.MAX_IMAGE_PIXELS = MAX_DECODE_PIXELS
+
+    tmp: str | None = None
+    try:
+        with Image.open(path) as img:
+            before = img.size
+            if max(before) <= MAX_EDGE_PX:
+                return True, f"{path}: {before[0]}x{before[1]} already within {MAX_EDGE_PX}px"
+            fmt = img.format
+            img.thumbnail((MAX_EDGE_PX, MAX_EDGE_PX))
+            after = img.size
+            fd, tmp = tempfile.mkstemp(
+                dir=os.path.dirname(os.path.abspath(path)), suffix=".downscale-tmp"
+            )
+            os.close(fd)
+            img.save(tmp, format=fmt)
+        # OUTSIDE the with: the source handle must be closed before the replace,
+        # or Windows refuses to overwrite the file it still has open.
+        os.replace(tmp, path)
+        tmp = None
+    except FileNotFoundError:
+        return False, f"{path}: no such file"
+    except Image.DecompressionBombError as exc:
+        # NOT an OSError, so it would otherwise escape main() and abandon every
+        # remaining path -- the opposite of this script's job.
+        return False, f"{path}: refusing to decode ({exc})"
+    except OSError as exc:  # unreadable, or a format Pillow cannot decode
+        return False, f"{path}: {exc}"
+    finally:
+        Image.MAX_IMAGE_PIXELS = previous_ceiling
+        if tmp and os.path.exists(tmp):
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+    return True, f"{path}: {before[0]}x{before[1]} -> {after[0]}x{after[1]}"
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print(__doc__, file=sys.stderr)
+        return 1
+    if Image is None:
+        return _reexec_with_pillow(argv)
+
+    failed = False
+    for path in argv:
+        ok, message = shrink(path)
+        print(message, file=sys.stdout if ok else sys.stderr)
+        failed = failed or not ok
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/test/test_web_verify_downscale.py
+++ b/test/test_web_verify_downscale.py
@@ -1,0 +1,219 @@
+"""Tests for the web-verify downscale helper.
+
+The helper exists because a shell one-liner had a portability hole per platform,
+so the tests pin exactly those holes: a path an inline Python literal would choke
+on, the Windows interpreter suffix, and the idempotence that keeps a repeat run
+from re-encoding an already-safe frame.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from PIL import Image
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "kiro_crew"
+    / "builtin_skills"
+    / "web-verify"
+    / "scripts"
+    / "downscale_image.py"
+)
+
+
+def _load():
+    """Import the script by path — it ships inside a skill dir, not a package."""
+    spec = importlib.util.spec_from_file_location("downscale_image", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load()
+
+
+class DownscaleTest(unittest.TestCase):
+    def _png(self, tmp: Path, size: tuple[int, int], name: str = "shot.png") -> Path:
+        p = tmp / name
+        Image.new("RGB", size, "red").save(p)
+        return p
+
+    def test_oversized_image_is_capped_on_the_longest_edge(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            import tempfile
+
+            with tempfile.TemporaryDirectory() as td:
+                p = self._png(Path(td), (3000, 1800))
+                ok, msg = mod.shrink(str(p))
+                self.assertTrue(ok, msg)
+                with Image.open(p) as img:
+                    self.assertEqual(img.size, (2000, 1200))
+                self.assertIn("3000x1800 -> 2000x1200", msg)
+
+    def test_image_within_the_cap_is_left_untouched(self) -> None:
+        """Idempotence: a second pass must not re-encode an already-safe frame."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            p = self._png(Path(td), (1500, 900))
+            before = p.read_bytes()
+            ok, msg = mod.shrink(str(p))
+            self.assertTrue(ok, msg)
+            self.assertEqual(p.read_bytes(), before)
+            self.assertIn("already within", msg)
+
+    def test_path_containing_an_apostrophe_is_handled(self) -> None:
+        """The hole that killed the inline `p='...'` literal: argv, not source."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / "O'Brien dir"
+            d.mkdir()
+            p = self._png(d, (2400, 2400), name="it's a shot.png")
+            self.assertEqual(mod.main([str(p)]), 0)
+            with Image.open(p) as img:
+                self.assertEqual(img.size, (2000, 2000))
+
+    def test_failed_save_leaves_the_original_intact(self) -> None:
+        """The rewrite is a temp-file + os.replace, never a save onto the live
+        path: Pillow holds the source open (which Windows refuses to overwrite,
+        the failure that took out the Windows CI shard), and an interrupted save
+        must not truncate a valid image."""
+        import tempfile as _tf
+
+        with _tf.TemporaryDirectory() as td:
+            p = self._png(Path(td), (2400, 2400))
+            before = p.read_bytes()
+            with mock.patch("PIL.Image.Image.save", side_effect=OSError("disk full")):
+                ok, msg = mod.shrink(str(p))
+            self.assertFalse(ok, msg)
+            self.assertEqual(p.read_bytes(), before)
+            leftovers = [f for f in os.listdir(td) if f.endswith(".downscale-tmp")]
+            self.assertEqual(leftovers, [], f"temp file leaked: {leftovers}")
+
+    def test_no_temp_file_is_left_behind_on_success(self) -> None:
+        import tempfile as _tf
+
+        with _tf.TemporaryDirectory() as td:
+            p = self._png(Path(td), (2400, 1200))
+            self.assertEqual(mod.main([str(p)]), 0)
+            self.assertEqual(sorted(os.listdir(td)), [p.name])
+
+    def test_decompression_bomb_does_not_abort_the_remaining_paths(self) -> None:
+        """A tall `fullPage` capture can exceed Pillow's pixel guard, and
+        `DecompressionBombError` is NOT an OSError -- uncaught it escapes `main`
+        and abandons every path after it, which is the opposite of this script's
+        job. The ceiling is squeezed here rather than writing a 180M-pixel
+        fixture, so BOTH paths trip it; what is asserted is that the run reported
+        on both instead of dying on the first.
+        """
+        import contextlib
+        import io
+        import tempfile as _tf
+
+        with _tf.TemporaryDirectory() as td:
+            first = self._png(Path(td), (2400, 2400), name="bomb.png")
+            second = self._png(Path(td), (2400, 1200), name="later.png")
+            untouched = first.read_bytes()
+            err = io.StringIO()
+            with mock.patch.object(mod, "MAX_DECODE_PIXELS", 16), \
+                    contextlib.redirect_stderr(err):
+                rc = mod.main([str(first), str(second)])
+
+            self.assertEqual(rc, 1)
+            messages = err.getvalue()
+            self.assertIn("bomb.png", messages)
+            self.assertIn("later.png", messages, "the run stopped at the first path")
+            self.assertIn("refusing to decode", messages)
+            self.assertEqual(first.read_bytes(), untouched)
+            # The ceiling is restored, so this process can still decode normally.
+            self.assertGreater(Image.MAX_IMAGE_PIXELS or 0, 16)
+
+    def test_pillow_is_imported_at_module_level(self) -> None:
+        """The optional import is module-level (top-level-imports rule); a missing
+        Pillow must leave the module importable so main() can re-exec."""
+        self.assertIsNotNone(mod.Image)
+        src = _SCRIPT.read_text(encoding="utf-8")
+        body = src.split("def shrink(", 1)[1].split("\ndef ", 1)[0]
+        self.assertNotIn("import", body.split('"""', 2)[-1])
+
+    def test_missing_file_reports_failure_without_raising(self) -> None:
+        self.assertEqual(mod.main(["/nonexistent/shot.png"]), 1)
+
+    def test_no_arguments_is_an_error(self) -> None:
+        self.assertEqual(mod.main([]), 1)
+
+    def test_bundled_python_is_the_launcher_s_sibling(self) -> None:
+        """bin/kirocrew -> bin/python, resolved THROUGH the launcher's symlink.
+
+        `realpath` is patched rather than creating a real symlink: on Windows
+        `Path.symlink_to` needs a privilege the CI runner does not hold, which
+        failed shard 4 with the link never being created. What matters here is
+        that the lookup runs on the RESOLVED path, and patching the resolver
+        asserts exactly that on every platform.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            bindir = Path(td) / "venv" / "bin"
+            bindir.mkdir(parents=True)
+            (bindir / "kirocrew").write_text("#!/bin/sh\n")
+            (bindir / "python").write_text("#!/bin/sh\n")
+            shim = str(Path(td) / "shim" / "kirocrew")
+            with mock.patch.object(mod.shutil, "which", return_value=shim), \
+                    mock.patch.object(mod.os.path, "realpath", return_value=str(bindir / "kirocrew")), \
+                    mock.patch.object(mod.os, "name", "posix"):
+                self.assertEqual(mod.bundled_python(), str(bindir / "python"))
+
+    def test_bundled_python_uses_the_exe_suffix_on_windows(self) -> None:
+        """Windows: Scripts/kirocrew.exe -> Scripts/python.exe. Only the suffix
+        differs, which is why the directory name needs no special casing.
+
+        Compared as RESOLVED paths, not strings: on Windows
+        `TemporaryDirectory` hands back the 8.3 short form
+        (`C:\\Users\\RUNNER~1\\...`) while the code under test runs
+        `os.path.realpath`, which returns the long form
+        (`C:\\Users\\runneradmin\\...`). The two name the same file and a raw
+        string compare fails — which is exactly how this failed the Windows CI
+        shard while passing on POSIX.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            scripts = Path(td) / "venv" / "Scripts"
+            scripts.mkdir(parents=True)
+            (scripts / "kirocrew.exe").write_text("")
+            (scripts / "python.exe").write_text("")
+            with mock.patch.object(mod.shutil, "which", return_value=str(scripts / "kirocrew.exe")), \
+                    mock.patch.object(mod.os, "name", "nt"):
+                got = mod.bundled_python()
+            self.assertIsNotNone(got)
+            self.assertEqual(
+                os.path.realpath(str(got)), os.path.realpath(str(scripts / "python.exe"))
+            )
+
+    def test_bundled_python_is_none_without_a_launcher(self) -> None:
+        with mock.patch.object(mod.shutil, "which", return_value=None):
+            self.assertIsNone(mod.bundled_python())
+
+    def test_reexec_refuses_to_loop(self) -> None:
+        """The guard that stops a Pillow-less venv re-execing forever."""
+        with mock.patch.dict(os.environ, {mod._REEXEC_ENV: "1"}, clear=False):
+            self.assertEqual(mod._reexec_with_pillow(["x.png"]), 1)
+
+    def test_cap_matches_the_prompt_block_ceiling(self) -> None:
+        """One number, two enforcement points — drift here is silent."""
+        from kiro_crew.acp.prompt_blocks import MAX_IMAGE_EDGE_PX
+
+        self.assertEqual(mod.MAX_EDGE_PX, MAX_IMAGE_EDGE_PX)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

One block in the `web-verify` skill: keep any frame you read back under 2000px on
both edges, and downscale a file that is already oversized before reading it.

## Why

An image past 2000px on either edge does not fail the turn that read it — it
wedges the **session**. The provider rejects the entire request once a
conversation carries many images, kiro-cli replays the full history every turn,
and the offending block sits at a fixed history index that nothing can evict.
Reading a smaller copy just appends another image while the original stays put.

Observed twice in one working session, at two different indices, with two request
ids:

```
messages.12.content.1.image.source.base64.data: At least one of the image
dimensions exceed max allowed size for many-image requests: 2000 pixels
(request_id: 91b58be4-9156-4071-837a-894b42ecb423)

messages.26.content.1.image.source.base64.data: … 2000 pixels
(request_id: fc072362-566d-4e3b-b403-73559194cf80)
```

This is easy to hit while doing exactly what the skill asks for: a 1500x900
viewport at `deviceScaleFactor: 2` is 3000x1800, and that is the default in
several harnesses under `website/scripts/`.

## Scope

Mitigation only, on the one surface we own. Two things deliberately NOT in here:

- **The read-side fix.** `fs_read`'s Image mode should downscale before inlining,
  the way `acp/prompt_blocks.py` already does for every image entering a prompt
  (2000px longest edge, 5 MiB encoded cap, shrink loop, 256px floor). The bytes
  never cross our process, so it cannot be fixed here — filed upstream as
  kiro-team/kiro-cli#3936 with that file cited as a reference implementation.
- **The proxy's height hole.** `mcp_playwright_proxy._encode_frame` caps *width*
  at 1920 and leaves height unbounded, so `browser_take_screenshot` on a long page
  saves a frame taller than the cap. That one reaches real users rather than just
  agents and wants its own change.

## Verification

- The downscale command in the block was run against a real oversized capture:
  `(3000, 1800) -> (2000, 1200)`.
- It resolves the interpreter via `command -v kirocrew` on purpose: bare `python3`
  frequently has no Pillow (it does not on this dev desk), while KiroCrew's venv
  always does — `prompt_blocks.py` depends on it.
- `scripts/docs_lint.py`: 187 markdown files scanned, all checks passed.
