### PR TITLE
refactor(messaging): channel registry + boot eviction + the §9 address parser

### DIFF
--- a/src/kiro_crew/channels.py
+++ b/src/kiro_crew/channels.py
@@ -1,0 +1,57 @@
+"""The builtin channel roster — the ONE place that knows every channel.
+
+Adding a builtin channel = add its descriptor to :func:`builtin_channel_descriptors`.
+That is the "one required edit" the channel-plugin RFC's seam collapse promises
+(plus, for now, an icon and i18n keys on the frontend — measured in PR ③'s
+seam audit as irreducible until the frontend registry endpoint lands).
+
+WHY THIS MODULE EXISTS (and why the list is not in ``messaging/registry.py``):
+``messaging/`` must never import a channel package — the dependency direction
+``<channel> -> messaging`` is pinned in ``messaging/dispatch.py`` and is what
+keeps the shared pipeline reusable. But SOMETHING has to import all the
+channels to enumerate them. This module is that something: it sits above both
+sides and is imported only by hosts (the gateway, dashboard handlers), never
+by ``messaging/`` or by any channel package.
+
+Imports are at MODULE scope on purpose: channel modules pull in their vendor
+clients, and this module is imported by hosts (``slack/gateway.py``) at
+process import time — BEFORE any event loop starts. That preserves the
+pre-registry import timing exactly (the gateway used to import the six
+``maybe_start_*`` at its own module scope). Lazy in-function imports here
+would instead run those six dependency graphs synchronously on the live
+gateway loop the first time ``_start_channel_transports()`` enumerates the
+roster, stalling the dashboard mid-boot. Executor-side callers such as
+``_channel_members()`` still import this module lazily on their side, which
+stays correct either way.
+
+Slack's descriptor carries ``start=None``: it is governed like every other
+member, but its socket-client lifecycle is host-managed in ``_connect_slack``
+(a governance deny must drop the client, not merely skip a start call), and it
+deliberately connects AFTER the other channels — same boot order as before.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from kiro_crew.discord.gateway import maybe_start_discord
+from kiro_crew.messaging.registry import ChannelDescriptor
+from kiro_crew.teams.gateway import maybe_start_teams
+from kiro_crew.telegram.gateway import maybe_start_telegram
+from kiro_crew.webex.gateway import maybe_start_webex
+from kiro_crew.wecom.gateway import maybe_start_wecom
+from kiro_crew.weixin.gateway import maybe_start_weixin
+
+
+@lru_cache(maxsize=1)
+def builtin_channel_descriptors() -> tuple[ChannelDescriptor, ...]:
+    """Every builtin channel, in governance-membership order."""
+    return (
+        ChannelDescriptor(channel_type="slack", start=None),
+        ChannelDescriptor(channel_type="wecom", start=maybe_start_wecom),
+        ChannelDescriptor(channel_type="telegram", start=maybe_start_telegram),
+        ChannelDescriptor(channel_type="discord", start=maybe_start_discord),
+        ChannelDescriptor(channel_type="webex", start=maybe_start_webex),
+        ChannelDescriptor(channel_type="teams", start=maybe_start_teams),
+        ChannelDescriptor(channel_type="weixin", start=maybe_start_weixin),
+    )

--- a/src/kiro_crew/dashboard/handlers_system.py
+++ b/src/kiro_crew/dashboard/handlers_system.py
@@ -682,31 +682,15 @@ async def api_compliance_yolo_status(request: web.Request) -> web.Response:
 
 def _channel_members() -> tuple[str, ...]:
     """Canonical ``channel_type`` ids for the messaging channels, derived from
-    each transport's ``channel_type`` class attribute — the single source of
-    truth — so this list can never drift from the transports themselves.
-    Imported here (off the event loop, inside the executor worker) so the
-    transport modules' own imports don't run on the aiohttp loop.
+    the builtin channel registry — the single source of truth — so this list
+    can never drift from the channels themselves. Imported here (off the event
+    loop, inside the executor worker) so the channel modules' own imports don't
+    run on the aiohttp loop; the roster is cached after the first call.
     """
-    from kiro_crew.discord.transport import DiscordTransport
-    from kiro_crew.slack.transport import SlackTransport
-    from kiro_crew.teams.transport import TeamsTransport
-    from kiro_crew.telegram.transport import TelegramTransport
-    from kiro_crew.webex.transport import WebexTransport
-    from kiro_crew.wecom.transport import WeComTransport
-    from kiro_crew.weixin.transport import WeixinTransport
+    from kiro_crew.channels import builtin_channel_descriptors
+    from kiro_crew.messaging.registry import governed_members
 
-    return tuple(
-        t.channel_type
-        for t in (
-            SlackTransport,
-            DiscordTransport,
-            TelegramTransport,
-            WebexTransport,
-            WeComTransport,
-            TeamsTransport,
-            WeixinTransport,
-        )
-    )
+    return governed_members(builtin_channel_descriptors())
 
 
 def _collect_channel_governance() -> dict[str, object]:

--- a/src/kiro_crew/messaging/link.py
+++ b/src/kiro_crew/messaging/link.py
@@ -187,6 +187,89 @@ def session_key(channel_type: str, conversation_id: str) -> str:
     return f"{channel_type}:{conversation_id}"
 
 
+# ── Canonical address parsing (RFC §9 rule 4: exactly ONE parser module) ──
+
+
+@dataclass(frozen=True)
+class ParsedSessionKey:
+    """A conversational session key decomposed per the RFC §9 grammar.
+
+    ``{surface}:{agent}:{chat_type}:{scope…}[:genN]`` — the first segment is
+    the surface and is the routing authority (``ChannelTurn.channel_type``
+    MUST equal it; the contract tests pin this). ``scope`` is one or more
+    segments carrying the transport's own topology; ``gen`` is the rotating
+    generation (0 = bare bucket, no suffix).
+    """
+
+    surface: str
+    agent: str
+    chat_type: str
+    scope: tuple[str, ...]
+    gen: int = 0
+
+    @property
+    def bucket(self) -> str:
+        """The durable bucket — the key with any generation suffix removed."""
+        parts = [self.surface, self.agent, self.chat_type, *self.scope]
+        return ":".join(parts)
+
+
+_GEN_SUFFIX_RE = re.compile(r"^gen(\d+)$")
+
+
+def parse_session_key(key: str) -> ParsedSessionKey | None:
+    """Parse a canonical conversational key; ``None`` for anything else.
+
+    Deliberately STRICT: only the §9 grammar parses. Legacy shapes — bare
+    Slack ``thread_ts``, two-segment ``slack:<ts>``, ``dashboard:`` keys, the
+    app-platform ``channel:{id}:{agent}`` prefix — return ``None`` rather than
+    a wrong decomposition; they predate the grammar and their migration is
+    explicitly out of scope (§9 accepted debts). Callers that must handle
+    legacy keys keep using the prefix classifiers above.
+
+    Consumers must treat a ``None`` as "not addressable by grammar", never as
+    an error: the dispatch pipeline itself stays address-agnostic and does not
+    call this (pinned in ``dispatch.py`` docstrings).
+    """
+    if not key:
+        return None
+    segments = key.split(":")
+    if len(segments) < 4:
+        return None
+    surface = segments[0]
+    if surface not in CHANNEL_SESSION_NAMESPACES:
+        return None
+    gen = 0
+    tail = segments[-1]
+    m = _GEN_SUFFIX_RE.match(tail)
+    if m is not None:
+        gen = int(m.group(1))
+        segments = segments[:-1]
+        if len(segments) < 4:
+            return None
+    if any(not s for s in segments):
+        return None  # an empty segment means a malformed key, not an address
+    return ParsedSessionKey(
+        surface=surface,
+        agent=segments[1],
+        chat_type=segments[2],
+        scope=tuple(segments[3:]),
+        gen=gen,
+    )
+
+
+def assert_colon_free(segment: str, *, what: str) -> str:
+    """Enforce §9 rule 4 at BUILD time: segments must not contain ``:``.
+
+    A colon inside a segment silently shifts every later segment during
+    parsing — the address becomes wrong, not invalid. Builders call this so
+    the corruption is impossible to construct rather than detected later.
+    """
+    if ":" in segment:
+        raise ValueError(f"session-key {what} must not contain ':': {segment!r}")
+    return segment
+
+
 def is_legacy_slack_key(key: str) -> bool:
     """True iff ``key`` is a bare Slack ``thread_ts`` (un-namespaced)."""
     return bool(_SLACK_TS_RE.fullmatch(key))
@@ -267,9 +350,22 @@ def build_dm_session_key(
     keep their compatibility shim (see ``canonical_key``) untouched.
     """
     if dm_scope == DM_SCOPE_UNIFIED and chat_type == CHAT_TYPE_DIRECT:
-        bucket = f"{DM_SCOPE_UNIFIED}:{agent}"
+        bucket = f"{DM_SCOPE_UNIFIED}:{assert_colon_free(agent, what='agent')}"
     else:
-        bucket = f"{channel}:{agent}:{chat_type}:{user}"
+        # ``user`` is a SCOPE PATH, not a single segment: telegram forum routes
+        # pass "{chat_id}:{thread}" here, which §9 rule 2 blesses as two scope
+        # segments (hierarchy depth lives in the scope). So the colon-free rule
+        # applies to its SUB-segments (none may be empty), not to the whole.
+        if ":" in user and any(not s for s in user.split(":")):
+            raise ValueError(f"session-key scope path has an empty segment: {user!r}")
+        bucket = ":".join(
+            (
+                assert_colon_free(channel, what="channel"),
+                assert_colon_free(agent, what="agent"),
+                assert_colon_free(chat_type, what="chat_type"),
+                user,
+            )
+        )
     return f"{bucket}:gen{gen}" if gen else bucket
 
 

--- a/src/kiro_crew/messaging/registry.py
+++ b/src/kiro_crew/messaging/registry.py
@@ -1,0 +1,123 @@
+"""Channel registry: descriptors + the boot/shutdown loops (PR ③ of the RFC).
+
+One registry entry per channel replaces the hand-edited seams that adding a
+channel used to require in the host. This module owns the TYPES and the LOOPS
+only — it must not import any channel package (``dispatch.py`` pins the
+dependency direction: ``<channel> -> messaging``, never the reverse). The one
+place that knows every builtin channel is :mod:`kiro_crew.channels`, which sits
+ABOVE both this package and the channel packages.
+
+Two views over the same descriptor list, because Slack is deliberately split:
+
+* :func:`governed_members` — ALL channels, including Slack. Governance
+  membership (the ``channels`` scope) covers every transport.
+* the boot loop (:func:`start_channels`) — only descriptors with a ``start``
+  factory. Slack's is ``None`` because it owns its own socket-client lifecycle
+  (a governance deny must DROP that client, not merely skip a start call — see
+  ``_connect_slack``), so the host starts it separately, after the others,
+  preserving today's boot order.
+
+Descriptor honesty rule (learned from the capability truth pass): a field
+exists here ONLY if something consumes it in this change. Config schemas,
+credential field names for the sandbox denylist, and capability attachment are
+REAL parts of the RFC's descriptor design but land with their consumers (the
+config-schema PR), not as decorative fields nothing reads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+#: A channel start factory: takes the gateway orchestrator, returns the live
+#: client handle (or ``None`` when the channel is disabled/uncredentialed —
+#: every factory is a guarded no-op). The loose ``Any`` for the orchestrator is
+#: deliberate for this PR: the factories predate the registry and read
+#: pre-hoisted ``orch._<channel>_*`` attributes. The config-schema PR replaces
+#: this back-reference with a narrow ``ChannelBootContext``; widening the type
+#: now would freeze the wrong contract.
+StartFactory = Callable[[Any], Awaitable[Any]]
+
+
+@dataclass(frozen=True)
+class ChannelDescriptor:
+    """Everything the host needs to know about one channel, in one place.
+
+    ``channel_type`` is the single identity used EVERYWHERE: the governance
+    member id, ``MessagingTransport.channel_type``, the session-key surface
+    segment, the config section name, and the dashboard badge prefix. The
+    contract tests pin that these never diverge.
+    """
+
+    channel_type: str
+    """Identity. Must equal the transport class's ``channel_type``."""
+
+    start: Optional[StartFactory] = None
+    """Boot factory, or ``None`` for a host-managed lifecycle (Slack)."""
+
+
+def governed_members(descriptors: tuple[ChannelDescriptor, ...]) -> tuple[str, ...]:
+    """Every channel's governance member id — INCLUDING host-managed ones."""
+    return tuple(d.channel_type for d in descriptors)
+
+
+def bootable(descriptors: tuple[ChannelDescriptor, ...]) -> tuple[ChannelDescriptor, ...]:
+    """The descriptors the registry boot loop starts (``start`` is not None)."""
+    return tuple(d for d in descriptors if d.start is not None)
+
+
+async def start_channels(
+    orch: Any,
+    descriptors: tuple[ChannelDescriptor, ...],
+    permitted: Mapping[str, bool],
+) -> dict[str, Any]:
+    """Start every bootable, governance-permitted channel; return live handles.
+
+    ``permitted`` is computed by the CALLER (off the event loop — the
+    governance check does blocking profile-file I/O) and a member absent from
+    it counts as not-permitted, preserving the enabled-only-eval semantics:
+    a disabled channel is never evaluated, never starts, and never emits a
+    spurious deny audit.
+
+    Failure isolation is per-channel BY the factories themselves (each
+    ``maybe_start_*`` catches, badges the error, and returns ``None``), so a
+    raise escaping one factory here is unexpected; it is logged and the
+    remaining channels still start rather than aborting the block.
+    """
+    handles: dict[str, Any] = {}
+    for desc in bootable(descriptors):
+        if not permitted.get(desc.channel_type, False):
+            continue
+        assert desc.start is not None  # bootable() guarantees this
+        try:
+            client = await desc.start(orch)
+        except Exception:
+            logger.exception("channel registry: %s failed to start", desc.channel_type)
+            client = None
+        # Legacy attribute kept in sync for existing readers/tests; the dict is
+        # the authority and the attributes retire with the config-schema PR.
+        setattr(orch, f"_{desc.channel_type}_client", client)
+        if client is not None:
+            handles[desc.channel_type] = client
+    return handles
+
+
+def shutdown_tasks(handles: Mapping[str, Any], *, timeout: float = 2.0) -> list[Awaitable[Any]]:
+    """Bounded ``close()`` awaitables for every live handle, in one place.
+
+    Mirrors the shape the gateway's cleanup gather expects. Handles without a
+    ``close`` attribute are skipped with a warning rather than raising — a
+    shutdown path must never be the thing that fails shutdown.
+    """
+    tasks: list[Awaitable[Any]] = []
+    for channel_type, client in handles.items():
+        close = getattr(client, "close", None)
+        if close is None:
+            logger.warning("channel registry: %s client has no close()", channel_type)
+            continue
+        tasks.append(asyncio.wait_for(close(), timeout=timeout))
+    return tasks

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -54,6 +54,7 @@ from kiro_crew.autonudge import (
     is_channel_key,
 )
 from kiro_crew.channel_history import ChannelHistory
+from kiro_crew.channels import builtin_channel_descriptors
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import (
     CRED_DISCORD_BOT_TOKEN,
@@ -107,7 +108,6 @@ from kiro_crew.dashboard.state import (
 )
 from kiro_crew.dashboard.token_auth import MAX_SESSION_TTL_SECS, generate_token
 from kiro_crew.dashboard.turn_dispatch import spawn_guarded_turn
-from kiro_crew.discord.gateway import maybe_start_discord
 from kiro_crew.embeddings import (
     embedding_model_is_custom,
     get_shared_embedder,
@@ -151,6 +151,7 @@ from kiro_crew.mcp_gateway.rewriter import (
     rewrite_agents,
 )
 from kiro_crew.memory import MemoryStore
+from kiro_crew.messaging import registry
 from kiro_crew.messaging.identity import publish_turn_identity
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.platform import boot_platform
@@ -194,15 +195,11 @@ from kiro_crew.subagent import (
     resolve_max_subagents,
 )
 from kiro_crew.taskrunner import TaskRunner
-from kiro_crew.teams.gateway import maybe_start_teams
-from kiro_crew.telegram.gateway import maybe_start_telegram
-from kiro_crew.webex.gateway import maybe_start_webex
-from kiro_crew.wecom.gateway import maybe_start_wecom
-from kiro_crew.weixin.gateway import maybe_start_weixin
 
 if TYPE_CHECKING:
     from kiro_crew.dashboard.state import _ChatSlot
     from kiro_crew.discord.client import DiscordClient
+    from kiro_crew.messaging.registry import ChannelDescriptor
     from kiro_crew.providers.base import LLMProvider
     from kiro_crew.subagent_scale import SubagentEventCoalescer
     from kiro_crew.task_models import Task
@@ -943,6 +940,11 @@ class GatewayOrchestrator:
         self._pending_queue: dict[str, list] = {}
         self._socket_client: WSSocketModeClient | None = None
         self._wecom_client: "WeComClient | None" = None  # set by maybe_start_wecom
+        # Registry-owned live channel handles ({channel_type: client}). The
+        # per-channel _<type>_client attributes are legacy mirrors kept in sync
+        # by messaging.registry.start_channels until the config-schema PR
+        # retires them; shutdown closes through THIS dict.
+        self._channel_handles: dict[str, object] = {}
         self._model_download_task: "asyncio.Task[bool] | None" = None
         self._auto_migrate_task: "asyncio.Task[None] | None" = None
         # Boot-time update check, started fire-and-forget after the signal
@@ -5348,18 +5350,7 @@ class GatewayOrchestrator:
             cleanup_tasks.append(self._dashboard_runner.cleanup())
         if self._socket_client:
             cleanup_tasks.append(asyncio.wait_for(self._socket_client.close(), timeout=1.0))
-        if self._wecom_client:
-            cleanup_tasks.append(asyncio.wait_for(self._wecom_client.close(), timeout=2.0))
-        if self._telegram_client:
-            cleanup_tasks.append(asyncio.wait_for(self._telegram_client.close(), timeout=2.0))
-        if self._weixin_client:
-            cleanup_tasks.append(asyncio.wait_for(self._weixin_client.close(), timeout=2.0))
-        if self._discord_client:
-            cleanup_tasks.append(asyncio.wait_for(self._discord_client.close(), timeout=2.0))
-        if self._webex_client:
-            cleanup_tasks.append(asyncio.wait_for(self._webex_client.close(), timeout=2.0))
-        if self._teams_client:
-            cleanup_tasks.append(asyncio.wait_for(self._teams_client.close(), timeout=2.0))
+        cleanup_tasks.extend(registry.shutdown_tasks(self._channel_handles, timeout=2.0))
         # Cancel background model download if still in flight
         if self._model_download_task is not None and not self._model_download_task.done():
             self._model_download_task.cancel()
@@ -6059,32 +6050,39 @@ class GatewayOrchestrator:
         cleanup_orphaned_sessions()
         os._exit(0)
 
-    async def _start_channel_transports(self) -> None:
+    async def _start_channel_transports(
+        self, descriptors: "tuple[ChannelDescriptor, ...] | None" = None
+    ) -> None:
         """Start each non-Slack transport, gated on the ``channels`` scope.
+
+        Registry-driven (PR ③ of the channel-plugin RFC): the roster comes from
+        :func:`kiro_crew.channels.builtin_channel_descriptors` and the loop
+        lives in :mod:`kiro_crew.messaging.registry` — adding a channel no
+        longer edits this method. ``descriptors`` is injectable for tests.
 
         Every transport is a guarded no-op unless enabled + credentialed (its
         own ``maybe_start_*``), and is ADDITIONALLY gated on the ``channels``
         governance scope: a policy that denies the transport member keeps it from
-        connecting at all, and its client stays ``None``. The scope + member ids
-        (``wecom``/``telegram``/``discord``/``webex``) are IDENTICAL to the
-        outbound chokepoints — outbound-send (``mcp_core``) and outbound
-        cross-surface mirroring (``chat_runner``) — so one ``channels`` allowlist
-        governs a transport at connect time and on every outbound path (this gate
-        is the connect-time member; inbound receive is gated per-message by
+        connecting at all, and its client stays ``None``. The member ids are
+        IDENTICAL to the outbound chokepoints — outbound-send (``mcp_core``) and
+        outbound cross-surface mirroring (``chat_runner``) — so one ``channels``
+        allowlist governs a transport at connect time and on every outbound path
+        (inbound receive is gated per-message by
         ``messaging.identity.channel_inbound_permitted``).
 
         Default-build invariant: with no policy governing ``channels`` (the
         standard OSS build) the gate permits, so every transport starts exactly
-        as before — byte-identical behavior. Slack is gated too, but in
-        ``_connect_slack`` rather than here, because it owns its own socket-client
-        lifecycle (a deny must drop that client, not just skip a start call).
+        as before — byte-identical behavior. Slack is a registry member too
+        (``start=None``) but is gated in ``_connect_slack`` rather than here,
+        because it owns its own socket-client lifecycle (a deny must drop that
+        client, not just skip a start call).
 
         Loop hygiene: ``_channel_transport_permitted`` reaches
         ``ProfileStore._ensure_fresh``, which stats/reads the profile files off
         disk — blocking I/O. This method runs on the gateway event loop (inside
         ``run()``), so the governance decisions are computed together in an
-        executor BEFORE any transport is started; only the actual
-        ``await maybe_start_*`` stays on the loop.
+        executor BEFORE any transport is started; only the actual factory
+        awaits stay on the loop.
 
         Enabled-only eval: the gate is queried ONLY for a transport whose
         ``_<member>_enabled`` is set (config-enabled + credentialed). A transport
@@ -6094,38 +6092,22 @@ class GatewayOrchestrator:
         the no-policy default is unchanged: every ENABLED transport still resolves
         to permit and starts exactly as before.
         """
-        # Evaluate each channel-start decision OFF the loop (each does blocking
-        # profile-file I/O), but ONLY for config-enabled transports — a disabled
-        # transport never starts, so skip it to avoid a deny-SEL for a channel
-        # that would no-op anyway. Members not evaluated stay not-permitted.
-        members = ("wecom", "telegram", "discord", "webex", "teams", "weixin")
-        enabled = {m: bool(getattr(self, f"_{m}_enabled", False)) for m in members}
+        if descriptors is None:
+            descriptors = builtin_channel_descriptors()
+        boot = registry.bootable(descriptors)
+        enabled = {
+            d.channel_type: bool(getattr(self, f"_{d.channel_type}_enabled", False))
+            for d in boot
+        }
         loop = asyncio.get_running_loop()
         permitted = await loop.run_in_executor(
             maintenance_executor(),
             lambda: {
-                m: (_channel_transport_permitted(m) if enabled[m] else False) for m in members
+                m: (_channel_transport_permitted(m) if enabled[m] else False)
+                for m in enabled
             },
         )
-        # WeChat (WeCom AI-bot) channel — guarded no-op unless enabled + credentialed.
-        if permitted["wecom"]:
-            self._wecom_client = await maybe_start_wecom(self)
-        # Telegram channel — guarded no-op unless enabled + token present.
-        if permitted["telegram"]:
-            self._telegram_client = await maybe_start_telegram(self)
-        # Discord channel — guarded no-op unless enabled + token present.
-        if permitted["discord"]:
-            self._discord_client = await maybe_start_discord(self)
-        # Webex channel — guarded no-op unless enabled + token present.
-        if permitted["webex"]:
-            self._webex_client = await maybe_start_webex(self)
-        # Teams channel — guarded no-op unless enabled + App ID/password present.
-        if permitted["teams"]:
-            self._teams_client = await maybe_start_teams(self)
-        # WeChat (personal Weixin over iLink) channel — guarded no-op unless
-        # enabled + credentialed. Distinct member from "wecom" (enterprise).
-        if permitted["weixin"]:
-            self._weixin_client = await maybe_start_weixin(self)
+        self._channel_handles = await registry.start_channels(self, descriptors, permitted)
 
 
 async def run_gateway(

--- a/test/test_channel_registry.py
+++ b/test/test_channel_registry.py
@@ -1,0 +1,234 @@
+"""Contract tests for the channel registry and the §9 address parser (PR ③).
+
+Two contracts pinned here, deliberately in one file because they meet at the
+same invariant: the registry's ``channel_type`` IS the session key's first
+segment IS the governance member id. If any of the three drifts, channels
+become unaddressable or ungoverned.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from kiro_crew.channels import builtin_channel_descriptors
+from kiro_crew.messaging import registry
+from kiro_crew.messaging.link import (
+    CHANNEL_SESSION_NAMESPACES,
+    assert_colon_free,
+    build_dm_session_key,
+    parse_session_key,
+)
+from kiro_crew.messaging.registry import ChannelDescriptor
+
+
+class TestRegistryRoster:
+    def test_the_seven_builtin_channels_are_registered(self) -> None:
+        members = registry.governed_members(builtin_channel_descriptors())
+        assert set(members) == {
+            "slack",
+            "discord",
+            "telegram",
+            "webex",
+            "wecom",
+            "teams",
+            "weixin",
+        }
+
+    def test_channel_type_matches_each_transport_class(self) -> None:
+        """The descriptor id and the transport's channel_type must be ONE fact."""
+        from kiro_crew.discord.transport import DiscordTransport
+        from kiro_crew.slack.transport import SlackTransport
+        from kiro_crew.teams.transport import TeamsTransport
+        from kiro_crew.telegram.transport import TelegramTransport
+        from kiro_crew.webex.transport import WebexTransport
+        from kiro_crew.wecom.transport import WeComTransport
+        from kiro_crew.weixin.transport import WeixinTransport
+
+        transports = {
+            t.channel_type: t
+            for t in (
+                SlackTransport,
+                DiscordTransport,
+                TelegramTransport,
+                WebexTransport,
+                WeComTransport,
+                TeamsTransport,
+                WeixinTransport,
+            )
+        }
+        for desc in builtin_channel_descriptors():
+            assert desc.channel_type in transports, desc.channel_type
+
+    def test_every_descriptor_surface_is_an_addressable_namespace(self) -> None:
+        """channel_type must be a session-key namespace, or the channel's
+        sessions are invisible to is_channel_session_key and the sidebar."""
+        for desc in builtin_channel_descriptors():
+            assert desc.channel_type in CHANNEL_SESSION_NAMESPACES, desc.channel_type
+
+    def test_slack_is_governed_but_not_boot_managed(self) -> None:
+        """Slack's lifecycle is host-managed (_connect_slack): a governance
+        deny must DROP its socket client, which a skipped start cannot do."""
+        descs = builtin_channel_descriptors()
+        by_type = {d.channel_type: d for d in descs}
+        assert by_type["slack"].start is None
+        assert "slack" not in {d.channel_type for d in registry.bootable(descs)}
+        assert len(registry.bootable(descs)) == 6
+
+
+class TestRegistryBootLoop:
+    def _orch(self) -> Any:
+        class _Orch:
+            pass
+
+        return _Orch()
+
+    def test_only_permitted_channels_start_and_handles_are_kept(self) -> None:
+        started: list[str] = []
+
+        async def make_start(name: str):
+            async def start(orch: Any) -> Any:
+                started.append(name)
+                return f"{name}-client"
+
+            return start
+
+        async def go() -> None:
+            descs = (
+                ChannelDescriptor("alpha", start=await make_start("alpha")),
+                ChannelDescriptor("beta", start=await make_start("beta")),
+                ChannelDescriptor("host", start=None),
+            )
+            orch = self._orch()
+            handles = await registry.start_channels(
+                orch, descs, {"alpha": True, "beta": False}
+            )
+            assert started == ["alpha"], "beta denied, host not bootable"
+            assert handles == {"alpha": "alpha-client"}
+            # legacy mirror attribute stays in sync for existing readers
+            assert orch._alpha_client == "alpha-client"
+            # a DENIED channel is never attempted, so its attribute is not
+            # touched — same as the old hand-written if-blocks (the real
+            # orchestrator declares these as None in __init__)
+            assert getattr(orch, "_beta_client", None) is None
+
+        asyncio.run(go())
+
+    def test_a_member_absent_from_permitted_is_not_started(self) -> None:
+        """Enabled-only eval: unevaluated members default to not-permitted."""
+
+        async def start(orch: Any) -> Any:  # pragma: no cover - must not run
+            raise AssertionError("must not start")
+
+        async def go() -> None:
+            handles = await registry.start_channels(
+                self._orch(), (ChannelDescriptor("gamma", start=start),), {}
+            )
+            assert handles == {}
+
+        asyncio.run(go())
+
+    def test_one_failing_factory_does_not_abort_the_others(self) -> None:
+        async def boom(orch: Any) -> Any:
+            raise RuntimeError("factory exploded")
+
+        async def ok(orch: Any) -> Any:
+            return "ok-client"
+
+        async def go() -> None:
+            descs = (
+                ChannelDescriptor("boom", start=boom),
+                ChannelDescriptor("ok", start=ok),
+            )
+            handles = await registry.start_channels(
+                self._orch(), descs, {"boom": True, "ok": True}
+            )
+            assert handles == {"ok": "ok-client"}
+
+        asyncio.run(go())
+
+    def test_shutdown_tasks_close_every_handle_and_skip_closeless(self) -> None:
+        closed: list[str] = []
+
+        class _Client:
+            def __init__(self, name: str) -> None:
+                self._name = name
+
+            async def close(self) -> None:
+                closed.append(self._name)
+
+        async def go() -> None:
+            tasks = registry.shutdown_tasks(
+                {"a": _Client("a"), "b": _Client("b"), "odd": object()}
+            )
+            assert len(tasks) == 2, "the close()-less handle is skipped, not fatal"
+            await asyncio.gather(*tasks)
+            assert sorted(closed) == ["a", "b"]
+
+        asyncio.run(go())
+
+
+class TestSessionKeyParser:
+    """§9 rule 2 grammar + the channel_type == first-segment invariant."""
+
+    def test_round_trip_for_every_builtin_channel(self) -> None:
+        for desc in builtin_channel_descriptors():
+            key = build_dm_session_key(desc.channel_type, "agentA", "user1")
+            parsed = parse_session_key(key)
+            assert parsed is not None, key
+            assert parsed.surface == desc.channel_type, (
+                "channel_type MUST equal the first key segment (RFC §9)"
+            )
+            assert parsed.agent == "agentA"
+            assert parsed.chat_type == "direct"
+            assert parsed.scope == ("user1",)
+            assert parsed.gen == 0
+            assert parsed.bucket == key
+
+    def test_generation_suffix_parses_and_bucket_strips_it(self) -> None:
+        key = build_dm_session_key("telegram", "a", "42", gen=3)
+        parsed = parse_session_key(key)
+        assert parsed is not None
+        assert parsed.gen == 3
+        assert parsed.bucket == "telegram:a:direct:42"
+
+    def test_forum_scope_path_keeps_hierarchy_depth(self) -> None:
+        """Telegram forum comp '{chat_id}:{thread}' = TWO scope segments."""
+        key = build_dm_session_key("telegram", "a", "-100123:77", chat_type="forum")
+        parsed = parse_session_key(key)
+        assert parsed is not None
+        assert parsed.scope == ("-100123", "77")
+        assert parsed.bucket == key
+
+    @pytest.mark.parametrize(
+        "legacy",
+        [
+            "1723456789.123456",  # bare Slack thread_ts
+            "slack:1723456789.123456",  # two-segment slack key
+            "dashboard:dashboard_5",  # dashboard slot key
+            "channel:room1:agentA",  # app-platform Channel feature prefix
+            "",
+        ],
+    )
+    def test_legacy_shapes_return_none_not_a_wrong_parse(self, legacy: str) -> None:
+        assert parse_session_key(legacy) is None
+
+    def test_an_unknown_surface_does_not_parse(self) -> None:
+        assert parse_session_key("smoke-signal:a:direct:u") is None
+
+    def test_empty_segments_are_malformed(self) -> None:
+        assert parse_session_key("telegram:a::u") is None
+
+    def test_builders_reject_colons_in_single_segments(self) -> None:
+        with pytest.raises(ValueError):
+            build_dm_session_key("tele:gram", "a", "u")
+        with pytest.raises(ValueError):
+            build_dm_session_key("telegram", "a:b", "u")
+        with pytest.raises(ValueError):
+            assert_colon_free("x:y", what="test")
+
+    def test_empty_scope_subsegment_is_rejected_at_build(self) -> None:
+        with pytest.raises(ValueError):
+            build_dm_session_key("telegram", "a", "123::77", chat_type="forum")

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -4919,24 +4919,22 @@ class TestChannelTransportStartGate:
         import contextlib as _cl  # local import; keeps module import block untouched
 
         assert isinstance(stack, _cl.ExitStack)  # documents the contract
-        # slack.gateway imports the four maybe_start_* at module top (hoisted; no
-        # cycle), so patch the names bound IN the gateway module, not their source
-        # modules — patching the source would not affect the already-bound refs.
-        mocks = {}
-        mocks["wecom"] = stack.enter_context(
-            patch("kiro_crew.slack.gateway.maybe_start_wecom", new=AsyncMock())
-        )
-        mocks["telegram"] = stack.enter_context(
-            patch("kiro_crew.slack.gateway.maybe_start_telegram", new=AsyncMock())
-        )
-        mocks["discord"] = stack.enter_context(
-            patch(
-                "kiro_crew.slack.gateway.maybe_start_discord",
-                new=AsyncMock(return_value=discord_ret),
-            )
-        )
-        mocks["webex"] = stack.enter_context(
-            patch("kiro_crew.slack.gateway.maybe_start_webex", new=AsyncMock())
+        # The registry rewrite (PR ③) removed the module-level maybe_start_*
+        # bindings from slack.gateway — the roster now comes from
+        # kiro_crew.channels. Tests inject a descriptor tuple through
+        # _start_channel_transports(descriptors=...) instead of patching names;
+        # the mocks and every assertion below are unchanged.
+        from kiro_crew.messaging.registry import ChannelDescriptor
+
+        mocks = {
+            "wecom": AsyncMock(),
+            "telegram": AsyncMock(),
+            "discord": AsyncMock(return_value=discord_ret),
+            "webex": AsyncMock(),
+        }
+        self._descriptors = tuple(
+            ChannelDescriptor(channel_type=name, start=mock)
+            for name, mock in mocks.items()
         )
         return mocks
 
@@ -4964,7 +4962,7 @@ class TestChannelTransportStartGate:
         discord_client = MagicMock(name="discord_client")
         with contextlib.ExitStack() as stack:
             mocks = self._patch_starts(stack, discord_ret=discord_client)
-            await orch._start_channel_transports()
+            await orch._start_channel_transports(descriptors=self._descriptors)
 
         # Denied members: maybe_start_* never invoked, clients stay None.
         mocks["wecom"].assert_not_awaited()
@@ -4988,7 +4986,7 @@ class TestChannelTransportStartGate:
         self._enable_all_transports(orch)
         with contextlib.ExitStack() as stack:
             mocks = self._patch_starts(stack)
-            await orch._start_channel_transports()
+            await orch._start_channel_transports(descriptors=self._descriptors)
 
         mocks["wecom"].assert_awaited_once()
         mocks["telegram"].assert_awaited_once()
@@ -5034,7 +5032,7 @@ class TestChannelTransportStartGate:
         discord_client = MagicMock(name="discord_client")
         with contextlib.ExitStack() as stack:
             mocks = self._patch_starts(stack, discord_ret=discord_client)
-            await orch._start_channel_transports()
+            await orch._start_channel_transports(descriptors=self._descriptors)
 
         # Host profile narrows telegram out even though the policy allowed it.
         mocks["telegram"].assert_not_awaited()
@@ -5070,7 +5068,7 @@ class TestChannelTransportStartGate:
         monkeypatch.setattr(gw, "_channel_transport_permitted", _spy)
         with contextlib.ExitStack() as stack:
             mocks = self._patch_starts(stack)
-            await orch._start_channel_transports()
+            await orch._start_channel_transports(descriptors=self._descriptors)
 
         # Only the enabled transport was evaluated + started.
         assert queried == ["telegram"]


### PR DESCRIPTION
## What

PR ③ of the merged channel-plugin RFC (`rfc-channel-plugin-architecture.md`), sliced to its behavior-preserving core: **channel registry + boot/shutdown eviction + the §9 address parser**.

Adding a builtin channel is now **one descriptor entry** in `kiro_crew/channels.py` (plus a frontend icon and i18n keys — measured as irreducible until the frontend registry endpoint lands), instead of hand-edits across the gateway boot method, the shutdown block, and the governance member list.

## Design decisions the RFC left open (each resolved consciously, not silently)

| question | resolution |
|---|---|
| **Dependency direction.** `messaging/` must never import a channel package (pinned in `dispatch.py`), but *something* must enumerate the channels | `messaging/registry.py` holds types + loops only; the roster lives in a new top-level `kiro_crew/channels.py` that sits above both sides, imported only by hosts |
| **Two membership views.** Governance covers 7 channels (incl. slack); boot covers 6 | `ChannelDescriptor.start=None` for slack — governed member, host-managed lifecycle (`_connect_slack` must be able to DROP the socket client on a deny, which a skipped start cannot do). Boot order preserved: slack still connects after the others |
| **Config-schema migration** (RFC §3.3 puts it in ③) | **Deferred to its own PR** — it triples the scope and requires the `ChannelBootContext` that replaces the `orch` back-reference. The six `maybe_start_*` factories are untouched byte-for-byte |
| **Generic `/api/channels/{name}/config` route** | Deferred — collides with the multi-agent Channel feature's shipped `/api/channels/{id}` family; needs a naming amendment first |
| **Frontend registry endpooint** | Deferred per RFC §7's own open question |

## What the measurement said, and how it shaped this

Three parallel audits before any code: the seam table (26 seams, not the RFC's 9; 62% registry-drivable), the gateway map (the `maybe_start_*` functions were **already extracted** to channel packages — the eviction target was one 68-line dispatch method + 12-line shutdown block, not 15 functions), and the RFC contract extraction (which flagged the five open questions above).

Two hazards the measurement predicted, both handled:

- **Test patch targets**: `TestChannelTransportStartGate` patched `kiro_crew.slack.gateway.maybe_start_*` — names this PR removes. Rewritten to inject AsyncMock-backed descriptors via the new `descriptors=` parameter; **every assertion unchanged**.
- **31 governance assertions** import `_channel_transport_permitted` from `slack.gateway` — it deliberately **stays put** until the config-schema PR reshapes its inputs.

And one hazard found during implementation, worth a reviewer's eye: my first cut of build-time segment enforcement asserted the `user` argument colon-free — which would have **raised on every live telegram forum message**, because forum routes pass `"{chat_id}:{thread}"` as a §9-legal two-segment scope path. The shipped rule: `channel`/`agent`/`chat_type` are single segments; `user` is a scope path with empty sub-segments rejected. Pinned by `test_forum_scope_path_keeps_hierarchy_depth`.

## Governance semantics, preserved verbatim

Enabled-only evaluation (no spurious deny audit for disabled channels), off-loop decision computation in the maintenance executor, absent-from-permit-map = not-permitted, no-policy default starts every enabled transport exactly as before. All re-verified by the existing gate tests plus new registry contract tests.

## The §9 parser

`parse_session_key` (strict: legacy shapes → `None`, never a wrong decomposition) + `assert_colon_free` at build time + contract tests pinning `channel_type == first key segment` for all seven channels, generation suffixes, forum scope paths, and every legacy shape.

## Numbers

- `slack/gateway.py`: −~150 lines (boot method + shutdown block + 6 imports); the 179-line governance predicate deliberately not moved
- New: `messaging/registry.py` (127), `kiro_crew/channels.py` (51), `test/test_channel_registry.py` (231)
- Tests: 192 (slack gateway) + 158 (registry/governance/link) + 497 (channel dispatch wide surface) all green locally with `-n 0`; flake8/isort clean; mypy's 3 errors are pre-existing `hooks.py` xattr issues on main (file not in this diff)

## What this unblocks

B-⑤: Feishu as the first true plugin (spec's requirements.md already written). The config-schema PR (ChannelBootContext + descriptor-declared config) is the remaining structural step between this and a channel shipping as a self-contained package.
