### PR TITLE
fix(learn): stop dropping the negative field on MCP-written lessons

### DIFF
--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -800,6 +800,7 @@ async def api_lessons_create(request: web.Request) -> web.Response:
         return web.json_response({"error": "rule is required"}, status=400)
     category = cleaned.get("category", "knowledge")
     scope = cleaned.get("scope", "global")
+    negative = cleaned.get("negative") or None
     # Write to vector store if available, else JSONL
     vs = _get_memory(state).vector_store
     if vs:
@@ -821,15 +822,39 @@ async def api_lessons_create(request: web.Request) -> web.Response:
         # for a lesson that was actually saved (and re-saved on every retry).
         # Writing first, then sweeping in the background, keeps the slow LLM call
         # off the request path.
-        await asyncio.to_thread(
+        applied = await asyncio.to_thread(
             vs.write_lesson,
             rule,
             category,
-            None,
+            # Forward the caller's "what not to do" — a literal None here
+            # silently discarded the negative on every vector-store write even
+            # though write_lesson has carried the parameter all along.
+            negative,
             "user_explicit",
             rule_emb,
             rule_emb_generation,
         )
+        # write_lesson returning False means NO row was written: either a
+        # benign dedup (the guidance is already covered) or a store rejection
+        # (e.g. the combined value exceeds the size cap). Without a negative
+        # that is the long-standing silent-dedup behavior; WITH a negative the
+        # caller asked to persist information that may now be nowhere, and a
+        # 200 would be a false success (the exact bug class this PR fixes).
+        # The two False causes are not distinguishable from the boolean, so
+        # the response says so honestly instead of guessing.
+        if not applied and negative:
+            return web.json_response(
+                {
+                    "error": (
+                        "lesson not updated: the store applied no write — the "
+                        "guidance may already be covered by an existing lesson, "
+                        "or the combined value was rejected (e.g. size cap). "
+                        "Verify with learn_list."
+                    ),
+                    "code": "lesson_write_not_applied",
+                },
+                status=422,
+            )
         candidates = await asyncio.to_thread(
             vs.find_contradiction_candidates, rule, 0.4, 0.85, rule_emb
         )
@@ -845,12 +870,35 @@ async def api_lessons_create(request: web.Request) -> web.Response:
             state._background_tasks.add(task)
             task.add_done_callback(state._background_tasks.discard)
     else:
-        lesson = Lesson(rule=rule, category=category, ts=datetime.now(timezone.utc).isoformat())
+        lesson = Lesson(
+            rule=rule,
+            category=category,
+            ts=datetime.now(timezone.utc).isoformat(),
+            negative=negative,
+        )
         if scope == "workspace":
             ws = cleaned.get("workspace")
-            _get_lessons(state, ws).save(lesson)
+            outcome = _get_lessons(state, ws).save(lesson)
         else:
-            state.lessons.save(lesson)
+            outcome = state.lessons.save(lesson)
+        # Same false-success guard as the vector branch: "deduped" with a
+        # supplied negative means the caller's guidance was NOT applied (the
+        # stored record already carries a — possibly different — negative);
+        # a 200 would silently discard it (design review: this was the
+        # declared bug class, live on one of the two backends).
+        if outcome == "deduped" and negative:
+            return web.json_response(
+                {
+                    "error": (
+                        "lesson not updated: an existing lesson with this rule "
+                        "already carries a negative, and a stored negative is "
+                        "never overwritten. Remove the old lesson first "
+                        "(learn_remove) if the new guidance should replace it."
+                    ),
+                    "code": "lesson_write_not_applied",
+                },
+                status=422,
+            )
     state.push_refresh("lessons")
     return web.json_response({"ok": True})
 
@@ -1092,7 +1140,21 @@ async def api_lessons(request: web.Request) -> web.Response:
                 rule = json.loads(e["value_json"])
             except (json.JSONDecodeError, TypeError):
                 continue
-            data.append({"rule": rule, "category": "knowledge", "ts": e.get("updated_at", "")})
+            # BACKEND ASYMMETRY, on purpose: write_lesson stores ONE fused
+            # string ("<rule> — NOT: <negative>"), and a read-side split
+            # cannot be faithful — a rule legitimately containing the literal
+            # separator would be truncated with a fabricated negative. Until
+            # the lesson value model is structured (follow-up), the vector
+            # branch returns the fused value as `rule` and `negative: None`;
+            # only the JSONL branch carries a separate negative.
+            data.append(
+                {
+                    "rule": rule,
+                    "category": "knowledge",
+                    "ts": e.get("updated_at", ""),
+                    "negative": None,
+                }
+            )
     else:
         # Merge global + workspace-scoped lessons
         global_lessons = state.lessons.load_all()
@@ -1104,6 +1166,7 @@ async def api_lessons(request: web.Request) -> web.Response:
                 if le.rule.lower().strip() not in seen:
                     global_lessons.append(le)
         data = [
-            {"rule": le.rule, "category": le.category, "ts": le.ts} for le in global_lessons[-50:]
+            {"rule": le.rule, "category": le.category, "ts": le.ts, "negative": le.negative}
+            for le in global_lessons[-50:]
         ]
     return web.json_response({"lessons": data})

--- a/src/kiro_crew/learn.py
+++ b/src/kiro_crew/learn.py
@@ -101,16 +101,37 @@ class LessonStore:
         # mtime-based cache: (mtime, lessons)
         self._cache: tuple[float, list[Lesson]] | None = None
 
-    def save(self, lesson: Lesson) -> None:
-        """Append a lesson, skipping near-duplicates and pruning if over limit."""
+    def save(self, lesson: Lesson) -> str:
+        """Append a lesson, skipping near-duplicates and pruning if over limit.
+
+        Returns a small status the caller can act on — ``"written"`` (new
+        record), ``"upgraded"`` (exact-rule duplicate gained the incoming
+        ``negative``), ``"deduped"`` (nothing applied), — so a handler can
+        distinguish "your guidance is stored" from "your guidance was
+        discarded" instead of guessing from a void return (design review on
+        the negative-drop fix: a conflicting re-teach previously got HTTP 200
+        while the new negative was silently dropped).
+
+        Duplicate handling is an UPGRADE, not always a skip: an exact-rule
+        duplicate that arrives carrying a ``negative`` the stored record lacks
+        fills it in (write-through). A stored negative is never OVERWRITTEN by
+        a different one; conflicting guidance is a curation decision, not a
+        silent last-writer-wins.
+        """
         with self._lock:
             existing = self.load_all()
             new_lower = lesson.rule.lower().strip()
+            upgraded = False
             for ex in existing:
                 if ex.rule.lower().strip() == new_lower:
+                    if lesson.negative and not ex.negative:
+                        ex.negative = lesson.negative
+                        upgraded = True
+                        break
                     logger.debug("Skipping duplicate lesson: %s", lesson.rule)
-                    return
-            existing.append(lesson)
+                    return "deduped"
+            if not upgraded:
+                existing.append(lesson)
             if len(existing) > _MAX_LESSONS_TOTAL:
                 existing = existing[-_MAX_LESSONS_TOTAL:]
             self._dir.mkdir(parents=True, exist_ok=True)
@@ -119,7 +140,10 @@ class LessonStore:
                 encoding="utf-8",
             )
             self._cache = None  # invalidate
-        logger.info("Saved lesson: %s", lesson.rule)
+        logger.info(
+            "Saved lesson%s: %s", " (negative upgraded)" if upgraded else "", lesson.rule
+        )
+        return "upgraded" if upgraded else "written"
 
     def remove(self, rule_substring: str) -> bool:
         """Remove lessons whose rule contains *rule_substring*. Returns True if any removed."""

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -3986,6 +3986,16 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             return f"Error: {_gov_mem}"
         scope = args.get("scope", "global")
         payload: dict[str, str] = {"rule": rule, "category": category, "scope": scope}
+        # Pass through every OTHER schema-known field verbatim instead of
+        # enumerating them by hand: ``negative`` was silently dropped at this
+        # exact hop for some time (schema advertised it, model supplied it,
+        # payload never carried it), and a hand-maintained list would let the
+        # next LEARN_ADD_SCHEMA field recur the same bug. ``workspace`` stays
+        # explicit below — it carries required-when-scope semantics.
+        _handled = {"rule", "category", "scope", "workspace"}
+        for _field in LEARN_ADD_SCHEMA.fields:
+            if _field.name not in _handled and args.get(_field.name):
+                payload[_field.name] = args[_field.name]
         if scope == "workspace":
             ws = args.get("workspace", "")
             if not ws:

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -1827,9 +1827,27 @@ class VectorMemoryStore:
                         )
                     self.db.commit()
 
+        upgrade_key: str | None = None
         for existing in self.get_lessons():
             existing_val = str(json.loads(existing["value_json"]))
             existing_lower = existing_val.lower()
+
+            # Exact-rule UPGRADE: the same rule re-taught WITH a negative the
+            # stored value lacks falls through to the normal write instead of
+            # being skipped as "already covered" — otherwise a record written
+            # before its negative reached the store could never be repaired.
+            # DELIBERATELY no delete here: the write below upserts the
+            # EXISTING row's key — and set_semantic validates BEFORE writing,
+            # so an oversize combined value is rejected with the old row
+            # intact (deleting first turned that rejection into permanent
+            # loss while the API still returned 200). The comparison is
+            # case-insensitive, so the upgrade must reuse the STORED row's
+            # key: hashing the incoming casing ("always x" vs stored
+            # "Always X") would mint a second key and leave duplicate active
+            # records instead of upgrading.
+            if existing_lower == rule_lower and negative:
+                upgrade_key = str(existing["key"])
+                continue
 
             # Substring dedup
             if rule_lower in existing_lower:
@@ -1904,7 +1922,9 @@ class VectorMemoryStore:
         _flush_backfills()
 
         slug = hashlib.md5(rule.encode(), usedforsecurity=False).hexdigest()[:12]
-        key = f"lesson.{slug}"
+        # An exact-rule (case-insensitive) upgrade targets the STORED row's
+        # key — hashing the incoming casing would mint a duplicate record.
+        key = upgrade_key or f"lesson.{slug}"
         value = rule if not negative else f"{rule} — NOT: {negative}"
         confidence = 1.0 if source == "user_explicit" else 0.9
         err = self.set_semantic(key, value, confidence, source)

--- a/test/test_api_input_validation.py
+++ b/test/test_api_input_validation.py
@@ -10,6 +10,7 @@ assert 400-not-500 for the exact reproduction payloads plus enum/length bounds.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -132,6 +133,202 @@ class TestLessonsCreateTypeValidation:
         ):
             resp = await api_lessons_create(request)
         assert resp.status == 400
+
+
+class TestLessonsCreateNegativeForwarding:
+    """The 'what not to do' half must survive the write, not be silently
+    dropped: the vector path passed a literal ``None`` for negative, and the
+    JSONL path constructed the Lesson without it."""
+
+    @pytest.mark.asyncio
+    async def test_vector_path_forwards_negative(self):
+        request = _lessons_request(
+            {"rule": "always X", "category": "tool", "negative": "never Y"}
+        )
+        state = request.app["state"]
+        vs = state.memory.vector_store
+        vs.write_lesson = MagicMock(return_value=True)
+        vs.find_contradiction_candidates = MagicMock(return_value=[])
+        vs.embed_lesson = MagicMock(return_value=[0.0])
+        with (
+            patch("kiro_crew.dashboard.handlers.cron._sel"),
+            patch("kiro_crew.dashboard.handlers.cron._is_restricted_session", return_value=False),
+            patch("kiro_crew.dashboard.handlers.cron._get_memory", return_value=state.memory),
+        ):
+            resp = await api_lessons_create(request)
+        assert resp.status == 200
+        args = vs.write_lesson.call_args.args
+        assert args[0] == "always X"
+        assert args[2] == "never Y", "negative must reach write_lesson, not a literal None"
+
+    @pytest.mark.asyncio
+    async def test_unapplied_write_with_negative_is_422_not_silent_200(self):
+        """FALSE SUCCESS GUARD: write_lesson returning False with a supplied
+        negative means the caller's guidance may be nowhere — the handler must
+        say so instead of reporting 200 (the bug class this PR fixes)."""
+        request = _lessons_request(
+            {"rule": "always X", "category": "tool", "negative": "never Y"}
+        )
+        state = request.app["state"]
+        vs = state.memory.vector_store
+        vs.write_lesson = MagicMock(return_value=False)  # deduped or rejected
+        vs.embed_lesson = MagicMock(return_value=[0.0])
+        with (
+            patch("kiro_crew.dashboard.handlers.cron._sel"),
+            patch("kiro_crew.dashboard.handlers.cron._is_restricted_session", return_value=False),
+            patch("kiro_crew.dashboard.handlers.cron._get_memory", return_value=state.memory),
+        ):
+            resp = await api_lessons_create(request)
+        assert resp.status == 422
+        body = json.loads(resp.body)
+        assert body["code"] == "lesson_write_not_applied"
+
+    @pytest.mark.asyncio
+    async def test_unapplied_write_without_negative_stays_200(self):
+        """Plain dedup without a negative keeps the long-standing silent-200
+        semantics — only a potentially-lost negative escalates."""
+        request = _lessons_request({"rule": "always X", "category": "tool"})
+        state = request.app["state"]
+        vs = state.memory.vector_store
+        vs.write_lesson = MagicMock(return_value=False)
+        vs.find_contradiction_candidates = MagicMock(return_value=[])
+        vs.embed_lesson = MagicMock(return_value=[0.0])
+        with (
+            patch("kiro_crew.dashboard.handlers.cron._sel"),
+            patch("kiro_crew.dashboard.handlers.cron._is_restricted_session", return_value=False),
+            patch("kiro_crew.dashboard.handlers.cron._get_memory", return_value=state.memory),
+        ):
+            resp = await api_lessons_create(request)
+        assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_jsonl_path_persists_negative(self):
+        request = _lessons_request(
+            {"rule": "always X", "category": "tool", "negative": "never Y"}
+        )
+        state = request.app["state"]
+        saved = []
+        state.lessons.save = MagicMock(side_effect=lambda le: (saved.append(le), "written")[1])
+        memory = MagicMock()
+        memory.vector_store = None  # force the JSONL fallback path
+        with (
+            patch("kiro_crew.dashboard.handlers.cron._sel"),
+            patch("kiro_crew.dashboard.handlers.cron._is_restricted_session", return_value=False),
+            patch("kiro_crew.dashboard.handlers.cron._get_memory", return_value=memory),
+        ):
+            resp = await api_lessons_create(request)
+        assert resp.status == 200
+        assert len(saved) == 1
+        assert saved[0].negative == "never Y"
+
+    @pytest.mark.asyncio
+    async def test_jsonl_conflicting_negative_is_422_not_silent_200(self):
+        """JSONL parity with the vector-branch guard (design review): a
+        conflicting re-teach whose negative is discarded by the
+        never-overwrite rule must surface as 422, not silent 200."""
+        request = _lessons_request(
+            {"rule": "always X", "category": "tool", "negative": "never Z"}
+        )
+        state = request.app["state"]
+        state.lessons.save = MagicMock(return_value="deduped")
+        memory = MagicMock()
+        memory.vector_store = None
+        with (
+            patch("kiro_crew.dashboard.handlers.cron._sel"),
+            patch("kiro_crew.dashboard.handlers.cron._is_restricted_session", return_value=False),
+            patch("kiro_crew.dashboard.handlers.cron._get_memory", return_value=memory),
+        ):
+            resp = await api_lessons_create(request)
+        assert resp.status == 422
+        assert json.loads(resp.body)["code"] == "lesson_write_not_applied"
+
+
+class TestVectorLessonUpgradeAndListShape:
+    def test_write_lesson_exact_rule_with_new_negative_replaces_row(self, tmp_path):
+        """Re-teaching a rule WITH a negative repairs a pre-fix row instead of
+        being deduped away as 'already covered'."""
+        from kiro_crew.vector_memory import VectorMemoryStore
+
+        vs = VectorMemoryStore(db_path=tmp_path / "m.db", embedding_dim=4)
+        vs.init()
+        try:
+            assert vs.write_lesson("always X") is True  # pre-fix shape: no negative
+            assert vs.write_lesson("always X", negative="never Y") is True
+            values = [json.loads(e["value_json"]) for e in vs.get_lessons()]
+            assert values == ["always X — NOT: never Y"]
+        finally:
+            vs.close()
+
+    def test_case_insensitive_upgrade_reuses_the_stored_key(self, tmp_path):
+        """'Always X' re-taught as 'always x' + negative must UPGRADE the
+        stored row, not mint a second key from the different casing and leave
+        duplicate active records."""
+        from kiro_crew.vector_memory import VectorMemoryStore
+
+        vs = VectorMemoryStore(db_path=tmp_path / "m.db", embedding_dim=4)
+        vs.init()
+        try:
+            assert vs.write_lesson("Always X") is True
+            assert vs.write_lesson("always x", negative="never Y") is True
+            lessons = vs.get_lessons()
+            assert len(lessons) == 1, "upgrade must not duplicate the record"
+            assert json.loads(lessons[0]["value_json"]) == "always x — NOT: never Y"
+        finally:
+            vs.close()
+
+    def test_oversize_upgrade_rejection_preserves_the_old_row(self, tmp_path):
+        """VALIDATE-BEFORE-WRITE: an upgrade whose combined value exceeds the
+        store's size cap must be rejected with the ORIGINAL lesson intact —
+        an upgrade path must never convert a validation failure into
+        permanent loss."""
+        from kiro_crew.vector_memory import VectorMemoryStore
+
+        vs = VectorMemoryStore(db_path=tmp_path / "m.db", embedding_dim=4)
+        vs.init()
+        try:
+            rule = "always " + "x" * 400  # valid alone
+            assert vs.write_lesson(rule) is True
+            # Combined value blows past the store's value cap.
+            ok = vs.write_lesson(rule, negative="n" * 100_000)
+            values = [json.loads(e["value_json"]) for e in vs.get_lessons()]
+            assert values == [rule], "old row must survive a rejected upgrade"
+            assert ok is False
+        finally:
+            vs.close()
+
+    @pytest.mark.asyncio
+    async def test_vector_list_branch_returns_fused_value_without_fabricating(self):
+        """The vector store fuses 'rule — NOT: negative' at write time and a
+        read-side split cannot be faithful (a rule containing the literal
+        separator would be truncated with a fabricated negative). The vector
+        branch therefore returns the fused value as `rule` and negative=None
+        — the documented backend asymmetry."""
+        from kiro_crew.dashboard.handlers.cron import api_lessons
+
+        request = _lessons_request({})
+        request.query = {}
+        memory = MagicMock()
+        memory.vector_store.get_lessons.return_value = [
+            {"value_json": json.dumps("always X — NOT: never Y"), "updated_at": "t1"},
+            {
+                # A rule LEGITIMATELY containing the separator — must not be split.
+                "value_json": json.dumps("when parsing ' — NOT: ' treat it as literal"),
+                "updated_at": "t2",
+            },
+        ]
+        with (
+            patch("kiro_crew.dashboard.handlers.cron._sel"),
+            patch(
+                "kiro_crew.dashboard.handlers.cron._blocks_reads_session", return_value=False
+            ),
+            patch("kiro_crew.dashboard.handlers.cron._get_memory", return_value=memory),
+        ):
+            resp = await api_lessons(request)
+        body = json.loads(resp.body)
+        assert body["lessons"][0]["rule"] == "always X — NOT: never Y"
+        assert body["lessons"][0]["negative"] is None
+        assert body["lessons"][1]["rule"] == "when parsing ' — NOT: ' treat it as literal"
+        assert body["lessons"][1]["negative"] is None
 
     @pytest.mark.asyncio
     async def test_non_object_body_returns_400(self):

--- a/test/test_learn.py
+++ b/test/test_learn.py
@@ -50,6 +50,32 @@ class TestLessonStore:
         assert "tool-a" in ctx
         assert "Learned corrections" in ctx
 
+    def test_duplicate_with_new_negative_upgrades_the_stored_record(self, tmp_path: Path) -> None:
+        """Re-teaching a rule WITH a negative repairs a record saved without
+        one (e.g. written while the MCP path dropped the field) — instead of
+        being skipped as a duplicate while the caller sees success."""
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("always X"))  # no negative (pre-fix record)
+        store.save(_make_lesson("always X", negative="never Y"))
+        loaded = store.load_all()
+        assert len(loaded) == 1, "still one record — upgraded, not duplicated"
+        assert loaded[0].negative == "never Y"
+
+    def test_duplicate_never_overwrites_an_existing_negative(self, tmp_path: Path) -> None:
+        """Conflicting guidance is a curation decision, not last-writer-wins."""
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("always X", negative="never Y"))
+        store.save(_make_lesson("always X", negative="never Z"))
+        loaded = store.load_all()
+        assert len(loaded) == 1
+        assert loaded[0].negative == "never Y"
+
+    def test_plain_duplicate_still_skipped(self, tmp_path: Path) -> None:
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("always X"))
+        store.save(_make_lesson("always X"))
+        assert len(store.load_all()) == 1
+
     def test_load_corrupted_line(self, tmp_path: Path) -> None:
         path = tmp_path / "lessons.jsonl"
         path.write_text("not json\n")


### PR DESCRIPTION
## What

Fixes an end-to-end drop of the `negative` ('what NOT to do') field on lessons written through the `learn_add` MCP tool.

## The bug

- The `learn_add` MCP tool **advertises `negative` in its schema** and models supply it — but the handler never put it in the REST payload it posts to `/api/lessons`.
- Independently, the REST handler's vector-store path passed a **literal `None`** to `write_lesson`, which has carried a `negative` parameter all along.
- The JSONL fallback path constructed the `Lesson` without the field, and `GET /api/lessons` omitted it from the list payload.

Net effect: every MCP-written lesson silently lost its 'what not to do' half. Only the CLI path (`kirocrew learn add --negative`) preserved it, which masked the bug.

## The fix

Forward the field end-to-end: MCP payload → REST handler → both backends (vector store's existing `negative` parameter, JSONL `Lesson.negative`), and include it in the `GET /api/lessons` response.

## Tested

- New `TestLessonsCreateNegativeForwarding`: vector path receives the caller's `negative` (regression for the literal `None`); JSONL path persists it
- Full sweep: `test_api_input_validation`, `test_learn`, `test_validation`, all `test_mcp_core*` — 304 passed, flake8 clean

Replaces the fix half of #2136, which mixed this bug fix with an unrelated feature — split per review feedback.

## Duplicate-policy change (declared)

Fixing the drop alone is not enough to *repair* lessons corrupted while the bug was live, so this PR also changes both stores' exact-rule duplicate handling from "always skip" to **upgrade-if-filling-a-gap**: re-teaching an identical rule WITH a `negative` fills the missing half of the stored record. Bounds on the new behavior:

- A stored `negative` is never **overwritten** by a different one (conflicting guidance is a curation decision, not last-writer-wins); plain duplicates still skip.
- Vector store: the upgrade is a validate-first **upsert on the same key** — no tombstone-before-validate, so an oversize combined value is rejected with the original row intact (covered by a test).

## Known backend asymmetry (declared)

`GET /api/lessons` returns a separate `negative` field only from the JSONL store. The vector store fuses the halves into one string at write time (`"rule — NOT: negative"`), and a read-side split cannot be faithful — a rule legitimately containing the literal separator would be truncated with a fabricated negative. The vector branch therefore returns the fused value as `rule` with `negative: null`, documented in a code comment; a structured lesson value model is the follow-up that closes this (see #2149).
