### PR TITLE
chore(ci): ratchet the backend coverage floor 77% -> 80%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -665,12 +665,25 @@ jobs:
     # measures, so the gate blocks a real coverage regression without going red
     # on ordinary noise. Raise a floor only after main has held the higher
     # number for a while, and never above the LOWEST recent main measurement.
-    #   Backend  measured 78.41-78.70% on main (2026-08-07) -> floor 77%
+    #
+    #   Backend  measured ~81.9% on main (2026-08-07) -> floor 80%
     #   Frontend measured 60.46-61.74% on main (2026-08-07) -> floor 60%
     #     (frontend sits ~0.5pp above its floor: it cannot be ratcheted until
     #      website/src gains real test coverage)
+    #
+    # How backend got here, so the next person can judge the headroom:
+    #   78.69%  starting point
+    #   80.15%  #2090 stopped measuring test files CI never executes (the
+    #           BACKEND_DESELECTS set) -- an accounting fix, not new tests
+    #   81.50%  #2103 added unit coverage for 7 pure-logic-ish modules
+    #   81.94%  #2115 added 11 dashboard/Slack/app-platform modules
+    # 80% therefore leaves ~1.9pp of headroom, wider than the ~1.4pp the 77%
+    # floor had. Deliberately conservative: the last wave converted at a third
+    # the rate of the one before it (1,883 tests for +0.44pp vs 1,040 for
+    # +1.35pp), because the remaining uncovered lines sit behind I/O a unit test
+    # cannot reach. Do not assume the next raise is as cheap.
     env:
-      BACKEND_MIN: 77
+      BACKEND_MIN: 80
       FRONTEND_MIN: 60
     # Always run so the required check emits a real verdict. Without
     # `if: always()`, a failing OR skipped dependency would SKIP this job, and
@@ -743,7 +756,7 @@ jobs:
           F=backend-cov/coverage.xml
           test -f "$F" || { echo "::error::coverage.xml missing from coverage-backend artifact"; exit 1; }
           # Compare the raw line-rate against the threshold; round only for
-          # display (a round-then-compare would let 76.95%..76.99% pass 77%).
+          # display (a round-then-compare would let 79.95%..79.99% pass 80%).
           python3 - "$F" "$BACKEND_MIN" Backend <<'PY'
           import sys, xml.etree.ElementTree as ET
           path, floor, label = sys.argv[1], float(sys.argv[2]), sys.argv[3]

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -185,7 +185,7 @@ jobs:
             cfn-lint, Semgrep, CodeQL, Dependency Audit, 12 pytest shards
             (Linux 3.10/3.12 + Windows), an offline Playwright e2e suite with
             strict on-loop-persist assertions, and a FAIL-CLOSED Coverage Gate
-            (backend 77% / frontend 60%).
+            (backend 80% / frontend 60%).
 
             NEVER report anything those tools own: style, formatting, naming,
             import order, typing, lint warnings, dead code, duplication,

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -166,7 +166,7 @@ jobs:
           cfn-lint, Semgrep, CodeQL, Dependency Audit, 12 pytest shards
           (Linux 3.10/3.12 + Windows), an offline Playwright e2e suite with
           strict on-loop-persist assertions, and a FAIL-CLOSED Coverage Gate
-          (backend 77% / frontend 60%).
+          (backend 80% / frontend 60%).
 
           NEVER report anything those tools own: style, formatting, naming,
           import order, typing, lint warnings, dead code, duplication,

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -250,7 +250,7 @@ jobs:
             cfn-lint, Semgrep, CodeQL, Dependency Audit, 12 pytest shards
             (Linux 3.10/3.12 + Windows), an offline Playwright e2e suite with
             strict on-loop-persist assertions, and a FAIL-CLOSED Coverage Gate
-            (backend 77% / frontend 60%).
+            (backend 80% / frontend 60%).
 
             NEVER report anything those tools own: style, formatting, naming,
             import order, typing, lint warnings, dead code, duplication,

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -82,7 +82,7 @@ Every job here is blocking.
 | `backend-test-windows` | windows-latest, 4 shards, `--no-cov`, 180s per-test timeout. The backend supports Windows natively via `platform_compat`, and nothing else in CI holds that line |
 | `backend-test-macos` | macos-14, deliberately SCOPED (gateway, socketsec, platform-compat, pod and MCP-apps suites via a glob). A full macOS run needs its own exclusion burn-down first, and a job that is red on arrival trains people to ignore it |
 | `backend-test-sandbox` | The two suites the sharded matrix deselects because they need unprivileged user namespaces: `test_script_hooks.py` and `test_cron_script.py` |
-| `coverage-combine` then `coverage-gate` | Combines the 3.12 shard data, then enforces backend >= 77% and frontend >= 60% on the raw line-rate (floors live in the job's `env:` block) |
+| `coverage-combine` then `coverage-gate` | Combines the 3.12 shard data, then enforces backend >= 80% and frontend >= 60% on the raw line-rate (floors live in the job's `env:` block) |
 | `frontend-lint` | `tsc -b`, `eslint --max-warnings 1116`, `jscpd`, and `npm run i18n:check` |
 | `electron-test` | The Electron shell's own node:test suite (`website/electron`) |
 | `frontend-test` | `vitest run --coverage` |
@@ -105,7 +105,7 @@ Details worth knowing:
 - **`coverage-gate` is fail-closed.** It runs `if: always()` and its first step
   converts any non-success upstream result into an explicit failure, because GitHub
   treats a **skipped** required check as satisfied. It also compares the raw
-  line-rate and rounds only for display, so 76.95% cannot pass a 77% floor.
+  line-rate and rounds only for display, so 79.95% cannot pass an 80% floor.
 - **`eslint --max-warnings 1116` is a ratchet baseline.** Burn it down, never raise
   it.
 - **The i18n gates split into three tiers,** and only two can fail: diff-scoped


### PR DESCRIPTION
## Problem

The backend Coverage Gate floor is **77%** while `main` now measures **~81.9%**. That is ~5pp of dead slack: a change could delete four points of coverage and the gate would shrug, which is the exact condition #2079 was opened to fix in the first place.

## Fix

Ratchet the backend floor to **80%**. How main got here:

| | backend | what changed |
|---|---|---|
| | 78.69% | starting point |
| #2090 | 80.15% | stopped measuring test files CI never executes (the `BACKEND_DESELECTS` set) — an accounting fix, not new tests |
| #2103 | 81.50% | unit coverage for 7 pure-logic-ish modules |
| #2115 | **81.94%** | 11 dashboard / Slack / app-platform modules |

**80% leaves ~1.9pp of headroom**, deliberately wider than the ~1.4pp the 77% floor had. The reason is in the data: the last wave converted at **a third the rate** of the one before it — 1,883 tests for +0.44pp versus 1,040 tests for +1.35pp — because the remaining uncovered lines sit behind I/O a unit test cannot reach. Anyone raising this again should not assume the next point is as cheap as the last, so that history now lives in the comment beside the floors rather than needing to be re-derived.

**The floor also holds against the lowest *confirmed* main measurement, 80.16%**, taken before the two coverage PRs merged. So it is safe even if the post-merge number lands below expectation.

**Frontend stays at 60%.** It still measures 60.46–61.74%, roughly 0.5pp above its floor, and cannot be ratcheted until `website/src` gains real test coverage. Raising it would turn `main` red.

## Tests

No new tests — this changes a threshold. The invariants that matter are already enforced elsewhere:

- `test/test_coverage_omit_contract.py` (from #2090) keeps the omit lists from drifting.
- The floors live in one `env:` block, referenced by the check steps, their step names, and the summary table, so the enforced value and the displayed value cannot diverge.

## Manual verification

- `ci.yml` parses; `env` resolves in both step names (`env` is an allowed context for `steps[*].name`).
- Boundary check against the unchanged raw-rate comparator: **79.99% → FAIL**, **80.16% → PASS**, **81.94% → PASS**. The raw-rate compare still refuses to round 79.95–79.99% up into a pass.
- `scripts/docs-lint.sh` clean.
- Derived references updated so nothing quotes the stale number: the rounding comment, the three AI-review workflow prompts that state the thresholds to reviewers, and `docs/ci/ci-and-reviews.md`. A `grep` confirms the only surviving `77%` is the intentional historical note.

**This PR's own Coverage Gate is the real check** — it measures merged `main` and must report ≥ 80%.

N/A on screenshots — no user-visible surface.
