### PR TITLE
test: cover the source launcher contract

### DIFF
--- a/bin/kirocrew
+++ b/bin/kirocrew
@@ -20,11 +20,11 @@ if [ -x "$SCRIPT_DIR/.venv/bin/kirocrew" ]; then
     exec "$SCRIPT_DIR/.venv/bin/kirocrew" "$@"
 fi
 
-# No venv found. The OSS build runs entirely from a pip venv created by
-# install.sh / setup.sh / minimal_install.sh, so this is almost always a
-# missing or incomplete install rather than a Brazil workspace.
-echo "❌ KiroCrew venv not found at $SCRIPT_DIR/.venv" >&2
-echo "   The OSS build runs from a Python venv — set one up with:" >&2
-echo "       cd $SCRIPT_DIR && bash minimal_install.sh" >&2
-echo "   (brazil not found — Brazil workspaces are not used in the OSS build)" >&2
+# No venv found. Source checkouts run from a pip venv created by
+# install.sh / setup.sh / minimal_install.sh, so this is a missing or
+# incomplete install.
+echo "❌ Kiro Crew virtual environment not found at $SCRIPT_DIR/.venv" >&2
+echo "   Set up the source checkout with:" >&2
+printf '       cd "%s" && bash minimal_install.sh\n' "$SCRIPT_DIR" >&2
+echo "   Source checkouts run from their own Python virtual environment." >&2
 exit 1

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -120,6 +120,12 @@ Both targets bootstrap their toolchain first (`ensure-node.sh`,
 backend target refuses to build a venv from an interpreter older than 3.10
 rather than letting the install backtrack forever.
 
+After the backend target runs, `bin/kirocrew` resolves its real install root,
+sets `KIROCREW_PROJECT_DIR`, and delegates to `.venv/bin/kirocrew`. That console
+script comes from the editable package metadata (`kiro_crew._bootstrap:main`),
+so the virtual environment makes `src/kiro_crew` importable without the wrapper
+modifying `PYTHONPATH`; caller-provided entries pass through unchanged.
+
 Any CLI subcommand works the same way, for example
 `PYTHONPATH=src python -m kiro_crew setup` or `... doctor`.
 
@@ -156,7 +162,7 @@ Installed console script:
 
 | Command | Entry point |
 |---------|-------------|
-| `kirocrew` | `kiro_crew.cli:main` |
+| `kirocrew` | `kiro_crew._bootstrap:main` |
 
 `pyproject.toml`'s `[project.scripts]` declares `kirocrew` and nothing else.
 Because a `[project]` table exists, setuptools reads the entry points from

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -4,6 +4,18 @@
 
 The CLI module (`kiro_crew/cli.py`) provides the `kirocrew` command using stdlib `argparse`.
 
+## Source Checkout Launcher
+
+The POSIX wrapper at `bin/kirocrew` resolves symlinks to find the real checkout,
+sets `KIROCREW_PROJECT_DIR` to that checkout unless the caller already supplied
+one, and delegates every argument to `.venv/bin/kirocrew`. The virtualenv entry
+point comes from the editable install created by the setup scripts, so it makes
+`src/kiro_crew` importable without adding the source tree to `PYTHONPATH`. Any
+caller-provided `PYTHONPATH` is inherited unchanged.
+
+If `.venv/bin/kirocrew` is unavailable, the wrapper exits with source-install
+guidance instead of falling through to a different Python environment.
+
 ## Standalone Wheel Installer Trust Contract
 
 `cli.sh` installs channel or pinned-version wheels only from an authenticated
@@ -392,7 +404,7 @@ CLI compaction is blocking (single-user, acceptable).
 
 ## Entry Point
 
-`console_scripts` in `setup.cfg` maps `kirocrew` → `kiro_crew.cli:main`.
+`console_scripts` in `setup.cfg` maps `kirocrew` → `kiro_crew._bootstrap:main`.
 
 ### Gateway asyncio child watcher
 

--- a/test/test_source_launcher.py
+++ b/test/test_source_launcher.py
@@ -1,0 +1,90 @@
+"""Regression tests for the POSIX source-checkout launcher."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SOURCE_LAUNCHER = _REPO_ROOT / "bin" / "kirocrew"
+_POSIX_ONLY = pytest.mark.skipif(os.name != "posix", reason="POSIX shell launcher")
+
+
+def _copy_launcher(tmp_path: Path) -> tuple[Path, Path]:
+    """Copy the real wrapper into an install root whose path contains spaces."""
+    install_root = tmp_path / "Kiro Crew checkout"
+    launcher = install_root / "bin" / "kirocrew"
+    launcher.parent.mkdir(parents=True)
+    shutil.copy2(_SOURCE_LAUNCHER, launcher)
+    launcher.chmod(launcher.stat().st_mode | stat.S_IXUSR)
+    return install_root, launcher
+
+
+@_POSIX_ONLY
+def test_launcher_delegates_to_venv_without_rewriting_pythonpath(tmp_path: Path) -> None:
+    """The editable venv owns imports while the wrapper preserves caller state."""
+    install_root, launcher = _copy_launcher(tmp_path)
+    capture_path = tmp_path / "launcher-environment.txt"
+    venv_entry = install_root / ".venv" / "bin" / "kirocrew"
+    venv_entry.parent.mkdir(parents=True)
+    venv_entry.write_text(
+        "#!/bin/sh\n"
+        "{\n"
+        "  printf '%s\\n' \"$KIROCREW_PROJECT_DIR\"\n"
+        "  printf '%s\\n' \"${PYTHONPATH-}\"\n"
+        "  printf '%s\\n' \"$@\"\n"
+        '} > "$KIROCREW_LAUNCH_CAPTURE"\n',
+        encoding="utf-8",
+    )
+    venv_entry.chmod(venv_entry.stat().st_mode | stat.S_IXUSR)
+
+    existing_pythonpath = os.pathsep.join(("/existing/one", "/existing/two"))
+    env = os.environ.copy()
+    env.pop("KIROCREW_PROJECT_DIR", None)
+    env.update(
+        {
+            "KIROCREW_LAUNCH_CAPTURE": str(capture_path),
+            "PYTHONPATH": existing_pythonpath,
+        }
+    )
+
+    result = subprocess.run(
+        [str(launcher), "mcp-core", "--probe"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=env,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert capture_path.read_text(encoding="utf-8").splitlines() == [
+        str(install_root),
+        existing_pythonpath,
+        "mcp-core",
+        "--probe",
+    ]
+
+
+@_POSIX_ONLY
+def test_launcher_without_venv_explains_source_install(tmp_path: Path) -> None:
+    """An incomplete checkout fails with one actionable installation path."""
+    install_root, launcher = _copy_launcher(tmp_path)
+
+    result = subprocess.run(
+        [str(launcher), "doctor"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        timeout=10,
+    )
+
+    assert result.returncode == 1
+    assert f"Kiro Crew virtual environment not found at {install_root}/.venv" in result.stderr
+    assert f'cd "{install_root}" && bash minimal_install.sh' in result.stderr
+    assert "Source checkouts run from their own Python virtual environment." in result.stderr


### PR DESCRIPTION
## Problem

The source-checkout launcher had no direct regression coverage for virtual-environment delegation, argument forwarding, project-root discovery, or preservation of a caller's `PYTHONPATH`. The install guide also named the stale `kiro_crew.cli:main` console entry point, and the missing-environment guidance still used obsolete terminology.

## Why it matters

Contributors run `bin/kirocrew` directly from paths that may contain spaces and may already carry custom Python import paths. Without an explicit contract, launcher changes can silently select the wrong environment, lose arguments or environment values, or provide recovery instructions that do not work. Stale entry-point documentation also sends maintainers to the wrong bootstrap path.

## Fix (symptoms → root cause → change)

The public source checkout already uses `pip install -e .`, so editable package metadata—not launcher-level `PYTHONPATH` injection—makes `src/kiro_crew` importable. This change documents that ownership and the actual `kiro_crew._bootstrap:main` entry point, specifies the launcher contract, and adds tests proving that `bin/kirocrew`:

- resolves and exports the real checkout root as `KIROCREW_PROJECT_DIR`;
- delegates to `.venv/bin/kirocrew` with arguments unchanged;
- preserves a caller-provided `PYTHONPATH` unchanged;
- reports actionable, correctly quoted setup guidance when the checkout venv is missing.

The missing-environment text now uses public source-checkout terminology and the correct Kiro Crew product spelling.

## Tests

- `.venv/bin/python -m pytest test/test_source_launcher.py -n0 -q` — 2 passed, including a checkout path containing spaces.
- `sh -n bin/kirocrew`.
- Black, isort, and flake8 checks for the new launcher test.
- Full backend isort, flake8, and mypy gates — mypy passed across 825 source files.
- Documentation lint, brand-name gate, and public-tree scrub lint.
- Node 20 frontend build passed; the full Vitest run passed 10,578 tests with one unrelated load-sensitive dynamic-import timeout, whose file passed all 15 tests on an immediate targeted rerun.
- A CI-shaped local backend run passed 36,545 tests; the remaining 9 host subprocess/worktree failures are unrelated host/main-baseline failures, with representative failures reproduced against untouched `origin/main`.
- Local GPT and Opus contract reviews found no blocking issues; the sole stale-spec observation was fixed and independently re-verified.

## Manual verification

N/A — the launcher regression tests execute copied launchers end to end, including delegation and missing-venv behavior from a checkout path containing spaces.
<!-- prepare-pr-reviewed-sha: 5c85c8aac0af1a2d1c22c951dd72b4cce03febb9 -->