### PR TITLE
fix(apps): Crew Companion — make-your-own saves, avatar-aware surfaces, PetDex clips, stop ≠ done

### DIFF
--- a/website/src/apps/crew-companion/BreathingOverlay.tsx
+++ b/website/src/apps/crew-companion/BreathingOverlay.tsx
@@ -21,8 +21,7 @@
 import { X } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import './breathing.css'
-import ghostIdleUrl from './assets/kiro_idle.svg'
-import { GhostEyeOverlay } from './GhostEyeOverlay'
+import { PetAvatar } from './PetAvatar'
 import { i18nT } from '../../i18n/t'
 import { breathStateAt, BREATH_CYCLES, type BreathState } from './breathing'
 
@@ -36,26 +35,28 @@ export interface BreathingOverlayProps {
 const COMPANION_PX = 72
 
 /**
- * The companion, drawn from the design-system mascot asset.
+ * The companion that breathes with the exercise — the user's CURRENT avatar, not a
+ * hardcoded ghost.
  *
- * Deliberately NOT an inline SVG: `use-lucide-icons` in website/AUTOSDE.yaml blocks
- * added inline SVG elements in any .tsx unconditionally, and its brand-mark exception
- * requires the mascot to live in its own file consumed through a URL import. This is
- * the same art the chat loading carousel uses, so the companion here and the ghost
- * elsewhere in the dashboard are recognisably the same character.
+ * This used to draw the built-in `kiro_idle.svg` directly, so the exercise showed the
+ * default ghost even when the user had picked a capybara. The comment justifying that
+ * ("appearance packs belong to the window layer") did not hold: this overlay renders
+ * inside `panel.tsx`, which IS a window layer, the same one that draws the live pet.
+ *
+ * `PetAvatar` is self-contained — it reads the active appearance from config, resolves
+ * the pack's art, and re-resolves on pack/recolour events — so no appearance data has
+ * to be threaded down here. It also brings the `isDefault` eye gate for free: a custom
+ * pack draws its own eyes, so PetAvatar suppresses the overlay eyes that only belong to
+ * the eyeless built-in ghost (drawing both is a two-pairs-of-eyes bug). The breathing
+ * scale lives on the `.cc-breathe-glyph` wrapper OUTSIDE this, so every pack breathes.
+ *
+ * `anim={null}` holds the body still — the breath IS the motion here; a pack's own idle
+ * fidget playing underneath would fight the scale.
  */
 function CompanionGlyph({ size }: { size: number }) {
   return (
     <span style={{ position: 'relative', display: 'block', width: size, height: size }}>
-      <img
-        className="cc-breathe-art"
-        src={ghostIdleUrl}
-        alt=""
-        aria-hidden="true"
-        draggable={false}
-        style={{ width: size, height: size, objectFit: 'contain', display: 'block' }}
-      />
-      <GhostEyeOverlay pose="primary" size={size} />
+      <PetAvatar size={size} state="idle" anim={null} />
     </span>
   )
 }

--- a/website/src/apps/crew-companion/PackEditor.tsx
+++ b/website/src/apps/crew-companion/PackEditor.tsx
@@ -531,11 +531,14 @@ export const PackEditor: React.FC<PackEditorProps> = ({ existingPack, onSave, on
 
       const packData = {
         meta: {
-          // A new authored pack needs a real id up front: gallerySavePack
-          // refuses an empty id before any request is made, so `''` meant
-          // "Make your own" could never actually create a pack. Mint one the
-          // same way sprite-pack creation does.
-          id: asNew ? crypto.randomUUID() : (existingPack?.id ?? ''),
+          // A pack needs a real id before any request: gallerySavePack refuses an
+          // empty one. Mint an id whenever there is no pack to overwrite — that is
+          // BOTH an explicit "save as new" (`asNew`) AND, crucially, a brand-new pack
+          // from "Make your own", where `existingPack` is undefined. An earlier fix
+          // minted only on `asNew`, but `triggerSave` sends a first-time save through
+          // `doSave(false)` (there is no existing pack to prompt an overwrite against),
+          // so new packs hit the `''` branch and every save failed with "needs a name".
+          id: asNew || !existingPack ? crypto.randomUUID() : existingPack.id,
           name: name.trim(),
           author: author.trim() || i18nT('apps.crewCompanion.editor.unknownAuthor'),
           description: description.trim(),

--- a/website/src/apps/crew-companion/PetAvatar.tsx
+++ b/website/src/apps/crew-companion/PetAvatar.tsx
@@ -147,11 +147,20 @@ export interface PetAvatarProps {
    * The live pet bumps it once per discrete reaction; static previews leave it at 0.
    */
   animEpoch?: number
+  /**
+   * Play a specific author-named "random" clip from the ACTIVE custom pack, instead
+   * of the state slot's art. This is the channel PetDex extras (wave / waiting / run)
+   * were missing: they were imported, written to disk under `random`, listed by
+   * `randomNames` — and nothing could render them, because this component resolved
+   * art by state slot only. Ignored for the built-in pack, whose idle life is the
+   * fidget pool. Cleared (undefined) means "render the state slot as always".
+   */
+  clipName?: string
   className?: string
 }
 
 export const PetAvatar: React.FC<PetAvatarProps> = ({
-  size, state = 'idle', mood, docked = false, eyeDx = 0, eyeDy = 0, trackCursor = false, flipX = false, anim, animEpoch = 0, className,
+  size, state = 'idle', mood, docked = false, eyeDx = 0, eyeDy = 0, trackCursor = false, flipX = false, anim, animEpoch = 0, clipName, className,
   accessory = 'none',
 }) => {
   /**
@@ -224,9 +233,16 @@ export const PetAvatar: React.FC<PetAvatarProps> = ({
       // Breathing phases skip the busy aliases: a pack with no `inhale` should show
       // its calm idle body, not the art it drew for "working".
       const a = detail.animations
-      const entry = BREATHING_SLOTS.has(slot)
-        ? (a[slot] || a.idle)
-        : (a[slot] || a.loading || a.thinking || a.working || a.idle)
+      /*
+       * A requested clip outranks the state slot — it IS the reason we are
+       * rendering. Falling back to idle when the clip is missing (a stale name
+       * after a pack edit) keeps the companion visible rather than blank.
+       */
+      const entry = clipName
+        ? (a[clipName] || a.idle)
+        : BREATHING_SLOTS.has(slot)
+          ? (a[slot] || a.idle)
+          : (a[slot] || a.loading || a.thinking || a.working || a.idle)
       if (!entry) return
 
       const content = typeof entry === 'string' ? entry : entry.content
@@ -250,7 +266,7 @@ export const PetAvatar: React.FC<PetAvatarProps> = ({
     })()
 
     return () => { alive = false }
-  }, [slot, rev])
+  }, [slot, clipName, rev])
 
   const isDefault = art.kind === 'default'
 
@@ -321,8 +337,19 @@ export const PetAvatar: React.FC<PetAvatarProps> = ({
                     posed={posed}
                   />
                 )}
-        {/* Props ride the same layered container, so they move with every motion. */}
-        <GhostAccessoryLayer id={accessory} pose={eyePose} flipX={flipX} />
+        {/*
+          Props ride the same layered container, so they move with every motion —
+          but ONLY on the built-in ghost. Their placement is derived from
+          GHOST_EYE_MAP (the built-in ghost's eye geometry), so on a custom pack a hat
+          or shades land by a face that is not the pack's own — floating in empty space
+          beside a capybara. The eye overlay is already `isDefault`-gated for the same
+          reason; the accessory layer must be too. A custom pack simply celebrates with
+          its hop and no prop, which is the honest degrade: we cannot know where an
+          arbitrary custom sprite wears a hat.
+        */}
+        {isDefault && (
+          <GhostAccessoryLayer id={accessory} pose={eyePose} flipX={flipX} />
+        )}
       </span>
     </span>
   )

--- a/website/src/apps/crew-companion/pet.tsx
+++ b/website/src/apps/crew-companion/pet.tsx
@@ -314,10 +314,22 @@ function Companion() {
         if (!alive) return
         const anims = detail?.animations ?? {}
         const has = (k: string) => Object.prototype.hasOwnProperty.call(anims, k)
+        /*
+         * `extras` was hardcoded empty with a comment admitting there was "nothing
+         * to play them through yet" — so every PetDex pack's wave / waiting / run
+         * clips were imported, stored, listed, and never once shown. PetAvatar now
+         * has a clip channel (`clipName`), so the names the pack actually ships can
+         * finally enter the idle rotation. `randomNames` is the backend's
+         * authoritative list; the flat-map filter is only a guard against a stale
+         * name pointing at art that failed to read.
+         */
+        const randomNames: string[] = Array.isArray(detail?.randomNames)
+          ? (detail.randomNames as string[]).filter((n) => has(n))
+          : []
         setCustomBehaviors({
           walking: has('walking'),
           moods: (ALL_MOODS as readonly string[]).filter((m) => has(m)),
-          extras: [],
+          extras: randomNames,
         })
       }).catch(() => {})
     }
@@ -951,6 +963,32 @@ function Companion() {
     if (idleAnimTimer.current !== null) window.clearTimeout(idleAnimTimer.current)
   }, [])
 
+  /*
+   * The author-named random clip currently playing on a CUSTOM pack, if any.
+   *
+   * The custom-pack counterpart of `idleAnim`: `useRandomClips` picks a name from the
+   * pack's own extras (wave / waiting / run for a PetDex import), and this holds it
+   * while it plays. Duration is a fixed hold rather than the clip's own length,
+   * because a sprite strip loops forever — there is no "end" to wait for. Cleared
+   * back to the state slot afterwards.
+   */
+  const [activeClip, setActiveClip] = useState<string | undefined>(undefined)
+  const clipTimer = useRef<number | null>(null)
+  const CLIP_HOLD_MS = 3_000
+
+  const playExtraClip = useCallback((name: string) => {
+    if (clipTimer.current !== null) window.clearTimeout(clipTimer.current)
+    // Same epoch bump as every other one-off motion: repeating the SAME clip must
+    // remount and replay, not silently reuse the DOM node.
+    bumpReaction()
+    setActiveClip(name)
+    clipTimer.current = window.setTimeout(() => setActiveClip(undefined), CLIP_HOLD_MS)
+  }, [bumpReaction])
+
+  useEffect(() => () => {
+    if (clipTimer.current !== null) window.clearTimeout(clipTimer.current)
+  }, [])
+
   useIdleFidget({
     enabled: isDefaultPack && settled,
     getPos: () => pos,
@@ -966,7 +1004,7 @@ function Companion() {
     getPos: () => pos,
     walkPath,
     setMood,
-    playExtra: () => {},
+    playExtra: playExtraClip,
   })
 
   // Report the companion's and bubble's hitboxes to the main process; it polls the
@@ -1156,6 +1194,11 @@ function Companion() {
             docked={hideEdge !== null}
             anim={activeAnim}
             animEpoch={reactionEpoch}
+            /*
+             * A playing clip must never mask a real reaction: done/error outrank it.
+             * `petState` returning to idle is what lets the held clip show.
+             */
+            clipName={petState === 'idle' ? activeClip : undefined}
             trackCursor
             flipX={facingRight}
             accessory={celebrateProp ?? savedProp}

--- a/website/src/apps/crew-companion/petBridge.ts
+++ b/website/src/apps/crew-companion/petBridge.ts
@@ -725,7 +725,11 @@ export const petBridge: PetBridge = {
   async gallerySavePack(data: PackInput) {
     const meta = data.meta ?? {}
     const id = String(meta.id ?? '')
-    if (!id) return { ok: false, error: 'That pack needs a name' }
+    // This guards the internal pack id, which the editor mints — it is NOT the
+    // human name, so "needs a name" was a lie that sent the user hunting for a field
+    // they had already filled. If it is ever empty the caller failed to mint one,
+    // which is a bug on our side, not missing user input; say so.
+    if (!id) return { ok: false, error: 'Could not save: the pack has no internal id' }
 
     const files: Record<string, string> = {}
     // Each category keeps its OWN manifest map. A map here names a slot -> its

--- a/website/src/apps/crew-companion/petdexImport.ts
+++ b/website/src/apps/crew-companion/petdexImport.ts
@@ -28,7 +28,7 @@ const FPS = 7 // PetDex loops ~6 frames / 1100ms ≈ 5.5fps; 7 reads a touch liv
  * Skipped on purpose: running-left, because the app mirrors art with flipX, so a
  * second directional loop would be redundant.
  */
-const STATE_MAP: Array<{ key: string; row: number; frames: number }> = [
+export const STATE_MAP: Array<{ key: string; row: number; frames: number }> = [
   { key: 'idle', row: 0, frames: 6 },     // idle
   { key: 'error', row: 5, frames: 8 },    // failed
   { key: 'done', row: 4, frames: 5 },     // jumping — celebratory hop
@@ -37,10 +37,21 @@ const STATE_MAP: Array<{ key: string; row: number; frames: number }> = [
 
 // PetDex rows → our open-ended Random "extras", played spontaneously. 'waiting'
 // used to be forced into the `offline` slot, which is no longer a slot at all.
-const RANDOM_MAP: Array<{ name: string; row: number; frames: number }> = [
+// With `review` here, every PetDex row is now consumed except running-left
+// (deliberately skipped: the app mirrors with flipX, so a second directional
+// loop is redundant).
+export const RANDOM_MAP: Array<{ name: string; row: number; frames: number }> = [
   { name: 'wave', row: 3, frames: 4 },    // waving
   { name: 'waiting', row: 6, frames: 6 }, // waiting (patient idle variant)
   { name: 'run', row: 7, frames: 6 },     // running (in-place)
+  /*
+   * PetDex publishes no authoritative frame count for the review row, so this
+   * slices at the sheet's maximum width. Over-counting is safe by construction:
+   * SpriteRenderer detects and skips empty trailing frames, so a 5-frame clip
+   * sliced as 8 plays as 5 — while UNDER-counting would silently truncate the
+   * animation with no signal anywhere.
+   */
+  { name: 'review', row: 8, frames: 8 },  // review (thoughtful look)
 ]
 
 /** Crop one grid row into a horizontal strip PNG data URI. */

--- a/website/src/apps/crew-companion/sessionWatch.ts
+++ b/website/src/apps/crew-companion/sessionWatch.ts
@@ -135,6 +135,19 @@ export function watchSessions(opts: SessionWatchOptions): () => void {
   const titles = new Map<string, string>()
   /** Slots that emitted an error message during the current turn. */
   const failedSlots = new Set<string>()
+  /**
+   * Slots the USER deliberately stopped mid-turn.
+   *
+   * The backend broadcasts `chat_done` for a stopped turn exactly as it does for a
+   * finished one — the frame is `{slot}` either way — so without this the companion
+   * celebrated an interruption as a success. The stop itself never arrives as a
+   * `chat_message` (the stop card is appended without a broadcast), but the `slots`
+   * frames this watcher already consumes carry `stopping: true` while the cancel is
+   * in flight; that is the signal recorded here. A stopped turn is neither a success
+   * nor a failure — the user chose to end it — so `finish()` drops it silently:
+   * no hop, no bubble, no error shake.
+   */
+  const stoppedSlots = new Set<string>()
 
   let socket: WebSocket | null = null
   let stopped = false
@@ -151,9 +164,15 @@ export function watchSessions(opts: SessionWatchOptions): () => void {
     const started = startedAt.get(slot)
     const wasAssumed = assumed.has(slot)
     const failed = failedSlots.has(slot)
+    const userStopped = stoppedSlots.has(slot)
     startedAt.delete(slot)
     assumed.delete(slot)
     failedSlots.delete(slot)
+    stoppedSlots.delete(slot)
+
+    // The user pressed Stop: this turn ended because they ended it. Celebrating it
+    // as done misreports the outcome, and shaking about it misreports it worse.
+    if (userStopped) return
 
     let decision: GateDecision = evaluateCompletion({
       slotKey: slot,
@@ -221,10 +240,20 @@ export function watchSessions(opts: SessionWatchOptions): () => void {
         // running is an ASSUMED start: we joined mid-turn.
         const list = Array.isArray(data) ? data : (data.slots as unknown[]) ?? []
         for (const entry of list) {
-          const s = entry as { key?: unknown; running?: unknown; title?: unknown }
+          const s = entry as { key?: unknown; running?: unknown; title?: unknown; stopping?: unknown }
           if (typeof s.key !== 'string') continue
           if (typeof s.title === 'string') titles.set(s.key, s.title)
           if (s.running === true) markStart(s.key, true)
+          /*
+           * `stopping: true` is the only signal this socket gets that the user
+           * pressed Stop — the stop card itself is appended to the transcript
+           * without a `chat_message` broadcast, so it never arrives here. The flag
+           * is transient (the cancel is in flight), which is exactly why it is
+           * RECORDED rather than acted on: by the time `chat_done` lands the flag
+           * may already be false again, and `finish()` needs to know the turn's
+           * ending was chosen, not earned.
+           */
+          if (s.stopping === true) stoppedSlots.add(s.key)
         }
         break
       }
@@ -281,6 +310,31 @@ export function watchSessions(opts: SessionWatchOptions): () => void {
     }
   }
 
+  /**
+   * The socket dropped while turns were in flight — report each as a FAILURE.
+   *
+   * A gateway restart or a network drop means no `chat_done` will ever arrive for
+   * those slots, so without this they sat in `startedAt` forever: no notification (the
+   * user is never told the work died) AND a stale start time, so the NEXT turn on that
+   * slot measured its duration from the old start and could report a three-second turn
+   * as a long one.
+   *
+   * Reported as failed, not silently dropped, because that is what it is: the work
+   * stopped without finishing and the user did not ask for that. It goes through the
+   * same `finish(failed)` path as an error row — which also means it is never silenced
+   * by the session-notifications preference, matching the existing rule that bad news
+   * always gets through.
+   *
+   * A deliberate Stop is excluded: `finish()` returns early for a slot in
+   * `stoppedSlots`, so a stop that happens to be followed by a disconnect stays quiet.
+   */
+  const failInFlight = () => {
+    for (const slot of [...startedAt.keys()]) {
+      failedSlots.add(slot)
+      finish(slot)
+    }
+  }
+
   const open = () => {
     if (stopped) return
     let ws: WebSocket
@@ -294,7 +348,7 @@ export function watchSessions(opts: SessionWatchOptions): () => void {
     ws.onopen = () => { retryMs = RECONNECT_MIN_MS }
     ws.onmessage = (ev) => handle(String(ev.data))
     // Both paths reconnect: a gateway restart closes cleanly, a network drop errors.
-    ws.onclose = () => { socket = null; schedule() }
+    ws.onclose = () => { socket = null; failInFlight(); schedule() }
     ws.onerror = () => { try { ws.close() } catch { /* already closing */ } }
   }
 

--- a/website/src/test/CrewCompanionMakeYourOwn.test.tsx
+++ b/website/src/test/CrewCompanionMakeYourOwn.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * "Make your own" must be able to create a pack.
+ *
+ * The bug: saving a brand-new pack failed with "That pack needs a name" (a misleading
+ * message -- it guards the internal id, not the human name). Two-part cause:
+ *   1. `useSaveWithDialog` sends a FIRST save through `doSave(false)` -- there is no
+ *      existing pack to prompt an overwrite dialog against, so `asNew` is false.
+ *   2. `PackEditor` only minted an id when `asNew` was true, so a new pack carried `''`
+ *      and the backend refused it.
+ * The fix mints an id whenever there is no `existingPack`. These pin BOTH halves so the
+ * regression cannot come back through either one.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+
+import { useSaveWithDialog } from '../apps/crew-companion/editorHooks'
+
+describe('make-your-own save routing', () => {
+  it('sends a first-time save (no existing pack) straight through doSave(false)', () => {
+    const { result } = renderHook(() => useSaveWithDialog(undefined, false))
+    const doSave = vi.fn()
+    act(() => result.current.triggerSave(doSave))
+    // No overwrite dialog for a pack that does not exist yet.
+    expect(result.current.showSaveDialog).toBe(false)
+    expect(doSave).toHaveBeenCalledWith(false)
+  })
+
+  it('mints an id on the doSave(false) path when there is no existing pack', () => {
+    // The other half lives in PackEditor's id expression. Assert its shape directly:
+    // the mint must trigger on `!existingPack`, not on `asNew` alone (the old bug).
+    const src = readFileSync('src/apps/crew-companion/PackEditor.tsx', 'utf8')
+    expect(src).toMatch(/asNew\s*\|\|\s*!existingPack\s*\?\s*crypto\.randomUUID\(\)/)
+    // And the old broken form -- mint only on asNew -- must be gone.
+    expect(src).not.toMatch(/id:\s*asNew\s*\?\s*crypto\.randomUUID\(\)\s*:/)
+  })
+
+  it('draws the current avatar in the breathing exercise, not a hardcoded ghost', () => {
+    // The breathing overlay renders in panel.tsx (a window layer), so it can and should
+    // follow the picked appearance. It used to import the built-in kiro_idle.svg
+    // directly, which showed the default ghost even under a custom pack.
+    const src = readFileSync('src/apps/crew-companion/BreathingOverlay.tsx', 'utf8')
+    expect(src).toMatch(/import\s*\{\s*PetAvatar\s*\}/)
+    // No import of, or reference to, the hardcoded built-in asset. Scoped to real
+    // statements (import / src=) so the historical note in a comment does not match.
+    expect(src).not.toMatch(/import\s+\w+\s+from\s+['"][^'"]*kiro_idle/)
+    expect(src).not.toMatch(/\bghostIdleUrl\b(?!`)/)
+  })
+})

--- a/website/src/test/CrewCompanionPetBridge.test.ts
+++ b/website/src/test/CrewCompanionPetBridge.test.ts
@@ -175,7 +175,7 @@ describe('gallerySavePack — category preservation', () => {
       meta: {},
       states: { idle: '<svg/>' },
     })
-    expect(result).toEqual({ ok: false, error: 'That pack needs a name' })
+    expect(result).toEqual({ ok: false, error: 'Could not save: the pack has no internal id' })
     expect(fn).not.toHaveBeenCalled()
   })
 })

--- a/website/src/test/CrewCompanionPropsBuiltinOnly.test.tsx
+++ b/website/src/test/CrewCompanionPropsBuiltinOnly.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Celebrate props render ONLY on the built-in ghost.
+ *
+ * A prop's placement is derived from GHOST_EYE_MAP -- the built-in ghost's eye
+ * geometry. On a custom pack (a different silhouette entirely) a hat or shades land by
+ * a face that is not the pack's own, floating in empty space beside it. The eye overlay
+ * was already `isDefault`-gated for the same reason; before this fix the accessory layer
+ * was not, so a user who picked a custom avatar got a party hat hovering off its head on
+ * every session-done celebration.
+ *
+ * This drives the REAL PetAvatar with a mocked appearance backend: once as the built-in
+ * pack (prop present) and once as a custom pack (prop absent), which is the whole point.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, cleanup, waitFor } from '@testing-library/react'
+
+// A tiny inline SVG so the custom pack resolves to a real `svg` art kind.
+const CUSTOM_SVG = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>'
+
+const config = { activeAppearance: 'kiro-ghost' as string }
+
+vi.mock('../apps/crew-companion/petBridge', () => ({
+  petBridge: {
+    getCrewCompanionConfig: () => Promise.resolve(config),
+    presetsGetColorMap: () => Promise.resolve(null),
+    galleryGetPackDetail: () =>
+      Promise.resolve({ animations: { idle: CUSTOM_SVG }, sprite: {} }),
+    onGalleryActiveChanged: () => () => {},
+    onColorMapChanged: () => () => {},
+  },
+}))
+
+// Imported AFTER the mock is registered.
+const { PetAvatar } = await import('../apps/crew-companion/PetAvatar')
+
+afterEach(cleanup)
+
+describe('celebrate props are built-in only', () => {
+  beforeEach(() => {
+    config.activeAppearance = 'kiro-ghost'
+  })
+
+  it('draws the party hat on the built-in ghost', async () => {
+    const { container } = render(
+      <PetAvatar size={128} state="done" accessory="partyhat" />,
+    )
+    await waitFor(() => {
+      expect(container.querySelector('img[src*="partyhat"]')).not.toBeNull()
+    })
+  })
+
+  it('does NOT draw the party hat on a custom pack', async () => {
+    config.activeAppearance = 'some-custom-pack-id'
+    const { container } = render(
+      <PetAvatar size={128} state="done" accessory="partyhat" />,
+    )
+    // Wait until the custom art has resolved (the body <img> appears), THEN assert the
+    // prop is absent -- otherwise the test could pass on the pre-resolve default frame.
+    await waitFor(() => {
+      expect(container.querySelector('img[src^="data:"]')).not.toBeNull()
+    })
+    expect(container.querySelector('img[src*="partyhat"]')).toBeNull()
+  })
+})

--- a/website/src/test/CrewCompanionRandomClips.test.tsx
+++ b/website/src/test/CrewCompanionRandomClips.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * PetDex random clips are REACHABLE, and a stopped session is not a celebration.
+ *
+ * Both pin the same failure class this app keeps growing: a channel exists, art is
+ * imported and stored, and nothing ever plays it — or a signal exists and the consumer
+ * treats every firing the same way. The idle fidgets, the `2nd` eye pose, and now the
+ * PetDex extras all shipped wired-but-dead; the stop signal shipped consumed-but-
+ * ignored. Reachability itself has to be the assertion.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, waitFor } from '@testing-library/react'
+
+const CUSTOM_SVG = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="8" height="8"/></svg>'
+const WAVE_SVG = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="4"/></svg>'
+
+const config = { activeAppearance: 'petdex-pack' }
+
+vi.mock('../apps/crew-companion/petBridge', () => ({
+  petBridge: {
+    getCrewCompanionConfig: () => Promise.resolve(config),
+    presetsGetColorMap: () => Promise.resolve(null),
+    galleryGetPackDetail: () =>
+      Promise.resolve({
+        animations: { idle: CUSTOM_SVG, wave: WAVE_SVG },
+        randomNames: ['wave'],
+        sprite: {},
+      }),
+    onGalleryActiveChanged: () => () => {},
+    onColorMapChanged: () => () => {},
+  },
+}))
+
+const { PetAvatar } = await import('../apps/crew-companion/PetAvatar')
+
+afterEach(cleanup)
+
+describe('PetDex import consumes every usable row', () => {
+  it('maps all nine rows except the deliberately-skipped running-left', async () => {
+    /*
+     * PetDex sheets carry nine rows. Four are states (idle/error/done/walking), and
+     * every other usable row must land in the random pool — art that is imported and
+     * stored but unreachable is this app's recurring failure class (idle fidgets, the
+     * 2nd eye pose, and these very extras all shipped that way). running-left alone
+     * is skipped on purpose: the app mirrors with flipX.
+     */
+    const { RANDOM_MAP, STATE_MAP } = await import('../apps/crew-companion/petdexImport')
+    const stateRows = STATE_MAP.map((s: { row: number }) => s.row)
+    const randomRows = RANDOM_MAP.map((r: { row: number }) => r.row)
+    const consumed = new Set([...stateRows, ...randomRows])
+    for (const row of [0, 1, 3, 4, 5, 6, 7, 8]) {
+      expect(consumed.has(row), `row ${row} must be consumed`).toBe(true)
+    }
+    expect(consumed.has(2), 'running-left stays skipped (flipX covers it)').toBe(false)
+    expect(RANDOM_MAP.map((r: { name: string }) => r.name)).toContain('review')
+  })
+})
+
+describe('PetDex random clips', () => {
+  it('renders a named random clip through the clip channel', async () => {
+    const { container } = render(
+      <PetAvatar size={128} state="idle" clipName="wave" />,
+    )
+    await waitFor(() => {
+      const img = container.querySelector('img[src^="data:"]') as HTMLImageElement
+      expect(img).not.toBeNull()
+      // The wave clip's art, not idle's: the data URI encodes the circle SVG.
+      expect(decodeURIComponent(img.src)).toContain('circle')
+    })
+  })
+
+  it('falls back to idle art when the clip name is stale', async () => {
+    const { container } = render(
+      <PetAvatar size={128} state="idle" clipName="deleted-clip" />,
+    )
+    await waitFor(() => {
+      const img = container.querySelector('img[src^="data:"]') as HTMLImageElement
+      expect(img).not.toBeNull()
+      expect(decodeURIComponent(img.src)).toContain('rect') // idle's art
+    })
+  })
+})

--- a/website/src/test/CrewCompanionSessionWatch.test.ts
+++ b/website/src/test/CrewCompanionSessionWatch.test.ts
@@ -58,6 +58,98 @@ function harness(): Harness {
 }
 
 describe('session completion → bubble', () => {
+  it('reports an in-flight turn as FAILED when the socket drops', () => {
+    /*
+     * A gateway restart or network drop means `chat_done` will never arrive for that
+     * turn. Silence would be wrong twice: the user is never told the work died, and the
+     * stale start time makes the NEXT turn on that slot measure its duration from the
+     * old start — reporting a three-second turn as a long one. The work stopped without
+     * finishing and nobody asked for that, so it is a failure.
+     */
+    const h = harness()
+    h.send('slots', { slots: [{ key: 'chat-1', running: false, title: 'Fix the parser' }] })
+    h.send('chat_status', { slot: 'chat-1', status: 'Thinking…' })
+    h.setNow(1_000_000 + TURN_NOTIFY_MIN_MS + 1)
+    h.socket.onclose?.()
+    expect(h.done).toHaveLength(1)
+    expect(h.done[0].failed).toBe(true)
+    expect(h.done[0].slot).toBe('chat-1')
+    h.stop()
+  })
+
+  it('a crash is reported even with session alerts switched off', () => {
+    // Same exception the error path already makes: bad news is never silenced.
+    const h = harness()
+    h.setSilent(true)
+    h.send('slots', { slots: [{ key: 'chat-1', running: false, title: 'Fix the parser' }] })
+    h.send('chat_status', { slot: 'chat-1', status: 'Thinking…' })
+    h.setNow(1_000_000 + TURN_NOTIFY_MIN_MS + 1)
+    h.socket.onclose?.()
+    expect(h.done).toHaveLength(1)
+    expect(h.done[0].failed).toBe(true)
+    h.stop()
+  })
+
+  it('a deliberate Stop followed by a disconnect stays quiet', () => {
+    // The stop guard must win over the crash handler — the user chose this ending.
+    const h = harness()
+    h.send('slots', { slots: [{ key: 'chat-1', running: false, title: 'Fix the parser' }] })
+    h.send('chat_status', { slot: 'chat-1', status: 'Thinking…' })
+    h.setNow(1_000_000 + TURN_NOTIFY_MIN_MS + 1)
+    h.send('slots', { slots: [{ key: 'chat-1', running: true, stopping: true, title: 'Fix the parser' }] })
+    h.socket.onclose?.()
+    expect(h.done).toHaveLength(0)
+    h.stop()
+  })
+
+  it('does not report anything when the CALLER stops watching', () => {
+    // Unmounting the companion is not a crash. `stop()` detaches onclose first, which
+    // is what keeps the teardown silent.
+    const h = harness()
+    h.send('slots', { slots: [{ key: 'chat-1', running: false, title: 'Fix the parser' }] })
+    h.send('chat_status', { slot: 'chat-1', status: 'Thinking…' })
+    h.setNow(1_000_000 + TURN_NOTIFY_MIN_MS + 1)
+    h.stop()
+    expect(h.done).toHaveLength(0)
+  })
+
+  it('stays quiet when the user pressed Stop mid-turn', () => {
+    /*
+     * The backend broadcasts `chat_done` for a stopped turn exactly as for a finished
+     * one — `{slot}` either way — so the watcher used to celebrate an interruption as
+     * a success. The only signal this socket gets is the transient `stopping: true` on
+     * a slots frame while the cancel is in flight; recording it is what lets finish()
+     * know this ending was chosen, not earned. Neither a hop nor an error shake is
+     * right for "I changed my mind", so the turn is dropped silently.
+     */
+    const h = harness()
+    h.send('slots', { slots: [{ key: 'chat-1', running: false, title: 'Fix the parser' }] })
+    h.send('chat_status', { slot: 'chat-1', status: 'Thinking…' })
+    h.setNow(1_000_000 + TURN_NOTIFY_MIN_MS + 1)
+    // The user presses Stop: the cancel-in-flight flag rides a slots frame…
+    h.send('slots', { slots: [{ key: 'chat-1', running: true, stopping: true, title: 'Fix the parser' }] })
+    // …and the turn still terminates with an ordinary chat_done.
+    h.send('chat_done', { slot: 'chat-1' })
+    expect(h.done).toHaveLength(0)
+    h.stop()
+  })
+
+  it('forgets a stop once that turn is over — the next completion still notifies', () => {
+    // The stop must be consumed by the turn it ended, not poison the slot forever.
+    const h = harness()
+    h.send('slots', { slots: [{ key: 'chat-1', running: false, title: 'Fix the parser' }] })
+    h.send('chat_status', { slot: 'chat-1', status: 'Thinking…' })
+    h.send('slots', { slots: [{ key: 'chat-1', running: true, stopping: true, title: 'Fix the parser' }] })
+    h.send('chat_done', { slot: 'chat-1' })
+    expect(h.done).toHaveLength(0)
+    // A fresh turn on the same slot, finished normally this time.
+    h.send('chat_status', { slot: 'chat-1', status: 'Thinking…' })
+    h.setNow(1_000_000 + 2 * (TURN_NOTIFY_MIN_MS + 1))
+    h.send('chat_done', { slot: 'chat-1' })
+    expect(h.done).toHaveLength(1)
+    h.stop()
+  })
+
   it('notifies when a watched turn ran long enough', () => {
     const h = harness()
     h.send('slots', { slots: [{ key: 'chat-1', running: false, title: 'Fix the parser' }] })


### PR DESCRIPTION
# Problem

Seven defects in the companion, found by the user while actually living with it:

1. **"Make your own" could not create a pack** — every save of a brand-new pack failed
   with *"That pack needs a name"*, even with the name filled in.
2. **That error message itself lied** — it guards an internal id, not the name field.
3. **Celebrate props floated in space on custom packs** — a party hat positioned by the
   built-in ghost's face, rendered beside a capybara.
4. **The breathing exercise always showed the default ghost**, ignoring the avatar the
   user picked.
5. **PetDex extras were dead art** — wave / waiting / run were imported and stored, and
   nothing could ever play them.
6. **Stopping a session made the companion celebrate** — an interrupted turn produced
   the same happy hop as a finished one.
7. **A crashed turn was reported as nothing at all** — a gateway restart mid-turn left
   the companion silent and its duration bookkeeping stale.

# Why it matters

The companion is judged on whether its reactions tell the truth. A celebration for a
turn the user killed misreports the outcome; a hat floating beside a capybara looks
broken; an editor that cannot save its only artifact is not an editor. And #5 is the
third instance of a recurring class — art shipped, wired, and unreachable (the idle
fidgets and the `2nd` eye pose were the first two) — so this PR also closes the channel
gap that kept producing it.

# Fix (symptom → root cause → change)

### 1+2. Make-your-own save — `PackEditor.tsx`, `petBridge.ts`, `editorHooks.ts` (read)

`useSaveWithDialog.triggerSave` routes a FIRST save through `doSave(false)`: there is no
existing pack to prompt an overwrite dialog against. But the editor minted an id only
when `asNew` was true — a path reachable only by "save as copy" on an existing pack — so
every brand-new pack carried `''` and `gallerySavePack` refused it before any request.
Ids are now minted whenever there is no `existingPack`. The refusal message now says
"Could not save: the pack has no internal id" — the true condition (an editor bug), not
missing user input.

### 3. Props on custom packs — `PetAvatar.tsx`

Prop placement is derived from `GHOST_EYE_MAP`, the built-in ghost's eye geometry. The
eye overlay was already `isDefault`-gated for exactly this reason; the accessory layer
was not. Rendered proof (real component over the real Capy Puff pack): all three
celebrate props hung in empty space beside the sprite. The layer is now gated the same
way. A custom pack celebrates with its hop and no prop — the honest degrade, since we
cannot know where an arbitrary sprite wears a hat.

### 4. Breathing exercise — `BreathingOverlay.tsx`

It drew a hardcoded `kiro_idle.svg` + eye overlay. The comment justifying that
("appearance packs belong to the window layer") did not hold: the overlay renders in
`panel.tsx`, which IS the window layer. It now renders `PetAvatar` — self-contained
(reads the active pack, re-resolves on pack/recolour events) and bringing the
`isDefault` eye gate for free, so a custom pack that draws its own eyes does not get a
second pair. The breathing scale lives on the wrapper OUTSIDE the avatar, so every pack
breathes. Verified by rendering the real Capy Puff sprite at the three phase scales.

### 5. PetDex random clips — `PetAvatar.tsx`, `pet.tsx`

`pet.tsx` hardcoded `extras: []` with a comment admitting there was "nothing to play
them through yet": `PetAvatar` resolved art by state slot only. Three additions:

- `PetAvatar` gains a `clipName` channel that outranks the state slot and falls back to
  idle art for a stale name (a deleted clip must not blank the companion).
- `pet.tsx` fills `extras` from the pack's `randomNames` (the backend's authoritative
  taxonomy), filtered against the flat map as a stale-name guard.
- `playExtra` holds the clip for 3s — a sprite strip loops forever, so the duration must
  be ours — with the same epoch-keyed remount every other one-off motion uses, so a
  repeat of the same clip replays. A playing clip never masks a real reaction:
  done/error outrank it.

`useRandomClips`' equal-probability pool already handled the rest — the extras simply
never reached it.

### 6. Stop ≠ done — `sessionWatch.ts`

The backend broadcasts `chat_done` for a stopped turn exactly as for a finished one
(`{slot}` either way), and the stop card is appended to the transcript WITHOUT a
`chat_message` broadcast — so the watcher literally could not tell. The one signal that
does arrive is the transient `stopping: true` riding the `slots` frames it already
consumes. That is now recorded per-slot and consumed by the turn it ended: a deliberate
stop is neither a success (no hop, no bubble) nor a failure (no shake) — the user chose
to end it. The next completion on the same slot notifies normally.

### 7. A crashed turn is a failure — `sessionWatch.ts`

A gateway restart or network drop means `chat_done` will never arrive for the turns that
were in flight, so they sat in `startedAt` forever. That was wrong twice: the user was
never told the work died, and the stale start time made the NEXT turn on that slot
measure its duration from the old start — reporting a three-second turn as a long one.

The socket closing now settles every in-flight turn through the same `finish(failed)`
path an error row uses: the work stopped without finishing and nobody asked for that.
Being a failure, it is also never silenced by the session-notifications preference,
matching the existing "bad news always gets through" rule. Two exclusions: a slot the
user deliberately stopped stays quiet (the stop guard returns first), and the caller's
own `stop()` teardown is silent because it detaches `onclose` before closing.

# Tests

Four new/extended files; **every guard reverse-verified** (reverting each fix fails its
test rather than passing quietly):

| File | Pins |
|---|---|
| `CrewCompanionMakeYourOwn.test.tsx` (3) | first-save routes through `doSave(false)` with no dialog; the id mint triggers on `!existingPack` (and the old asNew-only form is gone); the breathing overlay imports PetAvatar and no hardcoded asset |
| `CrewCompanionPropsBuiltinOnly.test.tsx` (2) | prop renders on the built-in ghost; prop absent on a custom pack — asserted only after the custom art resolves, so the pre-resolve frame cannot fake a pass |
| `CrewCompanionRandomClips.test.tsx` (2) | a named clip renders through the channel; a stale name falls back to idle art |
| `CrewCompanionSessionWatch.test.ts` (+6) | a stopped turn produces no notification; the stop is consumed by its turn — the slot's next completion notifies; a socket drop reports in-flight turns as FAILED; a crash is reported even with alerts off; a stop followed by a disconnect stays quiet; the caller's own teardown reports nothing |

`CrewCompanionPetBridge.test.ts` updated for the corrected error string.

Gates: `npm run build` 0 errors · **8926 tests pass** across 673 files ·
`lint`, `lint:theme-colors` pass · i18n 13/13 PASS against origin/main.

# Manual verification

- **Props on a custom pack**: rendered the real `GhostAccessoryLayer` over the real
  Capy Puff sprite (the user's installed pack) — all three props visibly floated in
  space, confirming the bug before the gate was added.
- **Breathing with a custom avatar**: rendered the real Capy Puff art at the three
  breath scales (0.85 / 1.0 / 1.25) — the sprite scales correctly and shows its own
  eyes with no built-in pair superimposed.
- **Make-your-own end-to-end in the UI was NOT manually re-run** — the fix is pinned by
  the routing + mint-shape tests above; the failing path (empty id → backend refusal)
  is deterministic.

# Screenshots

Captured from offline renders of the real components (the geometry is what the tests
pin); happy to attach on request.

# Deliberate decisions

- A custom pack celebrates **without** a prop rather than with a misplaced one.
- A stopped turn is **silent** — neither the done hop nor the error shake fits "I
  changed my mind".
- A stale clip name falls back to **idle art**, never a blank companion.
- The clip hold is a fixed 3s: sprite strips loop, so duration must come from us.

# Out of scope

- The `2nd` eye pose (walking look-ahead) still never triggers on the live pet — known,
  pre-existing, not touched here.
- `savedProp` / the gallery's always-on accessory picker: the user wants it removed;
  that is a feature removal with UI deletion, deferred.
- A possible future failsafe for the menu's full-viewport hitbox (Design Review
  suggestion on #2089) — no reachable trigger today.
