### PR TITLE
fix(ci): make PR Readiness base-aware so stacked PRs aren't stuck pending

### DIFF
--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -196,9 +196,15 @@ jobs:
           esac
 
           pr_json="$(gh pr view "$PR" --repo "$REPO" \
-            --json number,state,isDraft,isCrossRepository,headRefName,headRefOid,headRepository,headRepositoryOwner,url)"
+            --json number,state,isDraft,isCrossRepository,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,url)"
           SHA="$(jq -r '.headRefOid' <<<"$pr_json")"
           STATE="$(jq -r '.state' <<<"$pr_json")"
+          # The default branch is where CI / Build / CodeQL are gated to run
+          # (`pull_request: branches: [<default>]` and CodeQL default-setup).
+          # A PR whose base is any other branch -- a stacked PR sitting on
+          # another feature branch -- can never start those lanes, so the
+          # verdict step marks them ineligible instead of pending-forever.
+          DEFAULT_BRANCH="$(gh api "repos/$REPO" --jq '.default_branch')"
 
           {
             echo "pr=$PR"
@@ -207,6 +213,8 @@ jobs:
             echo "fork=$(jq -r '.isCrossRepository' <<<"$pr_json")"
             echo "draft=$(jq -r '.isDraft' <<<"$pr_json")"
             echo "url=$(jq -r '.url' <<<"$pr_json")"
+            echo "base=$(jq -r '.baseRefName' <<<"$pr_json")"
+            echo "default_branch=$DEFAULT_BRANCH"
             # (head repository, head branch) is how a monitored workflow run is
             # bound back to this PR below. Both fields are populated on a fork
             # run, unlike `pull_requests`.
@@ -255,17 +263,48 @@ jobs:
           HEAD_REF: ${{ steps.context.outputs.head_ref }}
           DRAFT: ${{ steps.context.outputs.draft }}
           FORK: ${{ steps.context.outputs.fork }}
+          BASE_REF: ${{ steps.context.outputs.base }}
+          DEFAULT_BRANCH: ${{ steps.context.outputs.default_branch }}
           TRIGGER_EVENT: ${{ github.event_name }}
           TRIGGER_ACTION: ${{ github.event.action }}
         run: |
           set -euo pipefail
 
-          workflow_specs=(
-            "ci.yml|CI"
-            "build.yml|Build"
-            "code-review.yml|Code Review"
-          )
+          # CI, Build and CodeQL only ever run for a PR whose base is the
+          # default branch: ci.yml / build.yml declare `pull_request:
+          # branches: [<default>]`, and CodeQL default-setup only scans PRs
+          # into the default branch. A stacked PR (base is another feature
+          # branch) therefore never starts those workflows, so the head SHA
+          # carries no run for them. Counting a run that structurally cannot
+          # exist as "(not started)" froze such a PR at pending forever, with
+          # no future event able to recompute it. Mark them ineligible on a
+          # non-default base instead -- the same "Not eligible" treatment the
+          # fork lane gives CodeQL. This is not a coverage hole: when the
+          # bottom PR of the stack merges, GitHub auto-retargets this PR to the
+          # default branch and CI/Build/CodeQL then run over the combined diff
+          # before anything can reach the default branch.
+          stacked=false
+          if [ -n "$DEFAULT_BRANCH" ] && [ "$BASE_REF" != "$DEFAULT_BRANCH" ]; then
+            stacked=true
+          fi
+
+          workflow_specs=()
           skipped=()
+
+          if [ "$stacked" = "true" ]; then
+            skipped+=("CI (only runs on PRs to $DEFAULT_BRANCH)")
+            skipped+=("Build (only runs on PRs to $DEFAULT_BRANCH)")
+          else
+            workflow_specs+=(
+              "ci.yml|CI"
+              "build.yml|Build"
+            )
+          fi
+
+          # Code Review and the AI reviewers trigger on `pull_request` with no
+          # base-branch filter, so they run on every PR regardless of base.
+          workflow_specs+=("code-review.yml|Code Review")
+
           if [ "$FORK" = "true" ]; then
             # A fork head cannot run the repository's managed default-setup
             # CodeQL, so that lane stays ineligible. The AI code reviews DO run
@@ -283,8 +322,12 @@ jobs:
               "checkrun:UX Review|UX Review"
             )
           else
+            if [ "$stacked" = "true" ]; then
+              skipped+=("CodeQL (only runs on PRs to $DEFAULT_BRANCH)")
+            else
+              workflow_specs+=("dynamic/github-code-scanning/codeql|CodeQL")
+            fi
             workflow_specs+=(
-              "dynamic/github-code-scanning/codeql|CodeQL"
               "claude-review.yml|Opus 5 Review"
               "codex-review.yml|GPT 5.6 Review"
               "design-review.yml|Design Review"

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -222,7 +222,8 @@ class TestPrReadiness:
         workflow = _workflow("pr-readiness.yml")
 
         assert (
-            "--json number,state,isDraft,isCrossRepository,headRefName,"
+            "--json number,state,isDraft,isCrossRepository,baseRefName,"
+            "headRefName,"
             "headRefOid,headRepository,headRepositoryOwner,url)"
         ) in workflow
         assert "mergeStateStatus" not in workflow


### PR DESCRIPTION
## Problem

PR Readiness freezes at `readiness: checking` / "N readiness check(s) still pending" for any PR whose base is **not** the default branch (a stacked PR sitting on another feature branch). Live example: #2060 → base `feat/cloud-provisioning-api`, stuck at "3 readiness check(s) still pending" with nothing able to clear it.

## Why it matters

The pending verdict never resolves on its own. Readiness only recomputes on a new event (a push, or a monitored workflow completing), but the three lanes it is waiting on will *never* run on this base, so no event can ever fire — the PR is stuck yellow indefinitely even though every check that can run has passed.

## Fix

- **Symptom:** three lanes report "(not started)" forever — CI, Build, CodeQL.
- **Root cause:** `ci.yml` and `build.yml` declare `pull_request: branches: [main]`, and CodeQL default-setup only scans PRs into the default branch. On a non-default base those workflows never trigger, so the head SHA carries no run for them. The evaluator's non-fork lane list unconditionally assumes every monitored workflow *can* run, so a structurally-impossible run is bucketed as pending.
- **Change:** make eligibility base-aware. The context step now resolves the repo default branch and the PR base; when they differ, the verdict step moves CI/Build/CodeQL into the existing `skipped` ("Not eligible") set instead of `workflow_specs` — the exact treatment already used for fork CodeQL. Code Review and the four AI reviewers trigger on any base, so they stay monitored and the PR resolves to its real verdict.

Not a coverage hole: when the bottom PR of the stack merges, GitHub auto-retargets this PR to the default branch, and CI/Build/CodeQL then run over the combined diff before anything can reach the default branch.

## Tests

Standalone verification of the eligibility branching for all three shapes:

| Case | Monitored | Not eligible |
|---|---|---|
| non-fork, base = feature branch | Code Review + Opus/GPT/Design/UX | CI, Build, CodeQL |
| non-fork, base = `main` | CI, Build, Code Review, CodeQL + 4 reviewers | — |
| fork, base = `main` | CI, Build, Code Review + 4 reviewers | CodeQL (fork) |

Same-repo-to-main and fork behavior are byte-for-byte unchanged; only the non-default-base path is new. YAML validated.

## Manual verification

After merge, re-run readiness on #2060 (`workflow_dispatch` with its head SHA) and confirm it flips from "3 pending" to `readiness: passed` with CI/Build/CodeQL listed under **Not eligible**.
