### PR TITLE
refactor(core): fold five named atomic-write duplicates into the shared helper

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -31,7 +31,6 @@ import re
 import shutil
 import stat
 import sys
-import tempfile
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -48,6 +47,7 @@ from kiro_crew.agent_files import (
     REQUIRED_KIRO_AGENT_FILES,
 )
 from kiro_crew.agent_files import RESEARCH_AGENT_FILENAME as _RESEARCH_AGENT_FILENAME
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.browser.setup import converge_playwright_servers
 from kiro_crew.config import config_dir
 from kiro_crew.config import config_path as _mc_config_path
@@ -85,26 +85,19 @@ def _atomic_json_write(path: Path, data: dict) -> None:
     ACP process with exit code 1.  rename() is atomic on Linux when source
     and destination are on the same filesystem.
 
-    Uses mkstemp for a unique temp file per call so concurrent writers
-    to the same path don't clobber each other's temp files.
+    Uses the shared ``atomic_write`` helper, which additionally retries the
+    ``os.replace`` on a Windows sharing violation (a concurrent reader holding
+    the target open) rather than surfacing it as a failed write.
     """
-    fd, tmp_name = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    # The mode is read off the EXISTING file and passed through, so a config an
+    # operator has deliberately tightened survives the rewrite (0o644 for a file
+    # that does not exist yet). atomic_write applies it to the temp before the
+    # payload lands, so the file is never briefly more permissive than intended.
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            try:
-                mode = stat.S_IMODE(path.stat().st_mode)
-            except FileNotFoundError:
-                mode = 0o644
-            platform_compat.fchmod_safe(f.fileno(), mode)
-            json.dump(data, f, indent=2)
-            f.write("\n")
-        os.replace(tmp_name, path)
-    except BaseException:
-        try:
-            os.unlink(tmp_name)
-        except OSError:
-            pass
-        raise
+        mode = stat.S_IMODE(path.stat().st_mode)
+    except FileNotFoundError:
+        mode = 0o644
+    atomic_write(path, json.dumps(data, indent=2) + "\n", mode=mode)
 
 
 # Resolved per call, never captured at import: an import-time binding freezes

--- a/src/kiro_crew/apps/builtins/dev_fleet/gateway_service.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/gateway_service.py
@@ -71,11 +71,11 @@ from __future__ import annotations
 import os
 import re
 import subprocess
-import uuid
 from pathlib import Path
 from typing import IO, Awaitable, Callable, Protocol
 
 from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 
 # service.* is import-safe on every platform (it only touches launchctl/systemctl
@@ -149,14 +149,13 @@ def atomic_write_text(path: Path, content: str) -> None:
     """Write *content* to *path* atomically (temp sibling + ``os.replace``).
 
     ``os.replace`` is an atomic same-filesystem rename, so a crash or partial
-    write never leaves a half-written service definition behind.
+    write never leaves a half-written service definition behind. Delegates to the
+    shared helper, which also retries the rename on a Windows sharing violation
+    (a concurrent reader holding the target open) rather than surfacing it as a
+    failed write, and writes UTF-8 explicitly rather than at whatever the
+    process locale happens to be.
     """
-    tmp = path.parent / f".{path.name}.tmp-{uuid.uuid4().hex}"
-    try:
-        tmp.write_text(content)
-        os.replace(tmp, path)
-    finally:
-        tmp.unlink(missing_ok=True)
+    atomic_write(path, content)
 
 
 class GatewayServiceBackend(Protocol):

--- a/src/kiro_crew/apps/builtins/mochi/queue_file.py
+++ b/src/kiro_crew/apps/builtins/mochi/queue_file.py
@@ -40,7 +40,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator, Literal, TypedDict
 
-from kiro_crew.platform_compat import chmod_safe, file_lock
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.platform_compat import file_lock
 
 logger = logging.getLogger(__name__)
 
@@ -193,15 +194,17 @@ def write_queue_atomic(queue_path: str | Path, data: MochiQueue) -> None:
 
     0600 like every other Mochi state file: the queue is the planner's task
     list — what the user asked for and what the pet intends to do — and it was
-    the one file landing at the umask default (0644) because it writes its own
-    temp file rather than going through ``atomic_write`` (whose mkstemp is
-    already owner-only). Same reasoning as the watchlist and stats files.
+    the one file landing at the umask default (0644) because it wrote its own
+    temp file rather than going through ``atomic_write``. It now goes through
+    ``atomic_write`` with an explicit 0600, which also cleans up the temp when
+    the write fails (the hand-rolled version left it behind) and retries the
+    rename on a Windows sharing violation.
     """
-    path = Path(queue_path)
-    tmp_path = path.with_name(f"{path.name}.tmp.{os.getpid()}")
-    tmp_path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
-    chmod_safe(tmp_path, 0o600)
-    os.replace(tmp_path, path)
+    atomic_write(
+        Path(queue_path),
+        json.dumps(data, indent=2, ensure_ascii=False),
+        mode=0o600,
+    )
 
 
 # ── Pure functions ─────────────────────────────────────────────────────────

--- a/src/kiro_crew/dashboard/handlers/themes.py
+++ b/src/kiro_crew/dashboard/handlers/themes.py
@@ -36,6 +36,7 @@ from typing import Any
 
 from aiohttp import web
 
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.dashboard.theme_validate import (
     _THEME_ASSET_CSP,
     _THEME_ASSET_CT,
@@ -350,20 +351,13 @@ def _atomic_write_theme_json(target: Path, text: str) -> None:
     reader ever sees either the old or the new complete file, never a partial
     one. Callers MUST hold ``_theme_install_lock(slug)`` so the exists-check and
     this write are one critical section (closes the create/update TOCTOU).
+
+    ``mode=0o600`` is not optional. ``mkstemp`` created the temp owner-only and
+    this function never widened it, so the theme JSON this publishes is 0o600
+    today. Omitting the mode would publish at the umask default (0o644)
+    instead, which is a permission change dressed up as a refactor.
     """
-    fd, tmp = tempfile.mkstemp(
-        dir=str(target.parent), prefix=f".{target.stem}-", suffix=".tmp"
-    )
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            fh.write(text)
-        os.replace(tmp, target)
-    except BaseException:
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        raise
+    atomic_write(target, text, mode=0o600)
 
 
 def _read_theme_bytes_nolink(slug: str, target: Path) -> bytes | None:

--- a/src/kiro_crew/service/macos.py
+++ b/src/kiro_crew/service/macos.py
@@ -16,6 +16,7 @@ import sys
 import tempfile
 from pathlib import Path
 
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.gateway_shutdown_budget import TOTAL_SHUTDOWN_BUDGET_SECS
 from kiro_crew.service.common import (
     LAUNCHD_LABEL,
@@ -161,25 +162,17 @@ class ServiceInstallError(RuntimeError):
 def _write_plist_atomic(contents: str) -> None:
     """Write the plist atomically.
 
-    Writes to a sibling temp file in the same directory, then
-    ``os.replace`` to swap into place. ``os.replace`` is atomic on POSIX
-    when source and destination are on the same filesystem, so a SIGINT
-    or crash mid-write leaves either the old plist or no plist at all —
-    never a partial XML document that ``launchctl load`` would reject.
+    ``os.replace`` is atomic on POSIX when source and destination are on the
+    same filesystem, so a SIGINT or crash mid-write leaves either the old plist
+    or no plist at all, never a partial XML document that ``launchctl load``
+    would reject. Delegates to the shared helper, which also retries the rename
+    on a sharing violation.
     """
-    fd, tmp_path = tempfile.mkstemp(
-        prefix=PLIST_PATH.name + ".", suffix=".tmp", dir=str(PLIST_DIR)
-    )
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            fh.write(contents)
-        os.replace(tmp_path, PLIST_PATH)
-    except Exception:
-        try:
-            os.unlink(tmp_path)
-        except FileNotFoundError:
-            pass
-        raise
+    # mode=0o600 is NOT optional here. mkstemp created the temp owner-only and
+    # this function never widened it, so the published plist is 0o600 today.
+    # Letting atomic_write fall back to _get_default_mode() (0o666 & ~umask,
+    # normally 0o644) would loosen a file that currently is not world-readable.
+    atomic_write(PLIST_PATH, contents, mode=0o600)
 
 
 def _launchctl(*args: str, check: bool = False) -> subprocess.CompletedProcess[str]:

--- a/test/test_theme_install.py
+++ b/test/test_theme_install.py
@@ -26,7 +26,9 @@ structure/security logic lives, so no aiohttp app is needed. Covers:
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import stat
 from pathlib import Path
 
 import pytest
@@ -380,8 +382,12 @@ class TestAtomicWriteThemeJson:
         target = tmp_path / "sunset.json"
         _atomic_write_theme_json(target, json.dumps({"slug": "sunset"}) + "\n")
         assert json.loads(target.read_text("utf-8")) == {"slug": "sunset"}
-        # No leftover ".sunset-*.tmp" scratch files in the directory.
-        assert list(tmp_path.glob(".sunset-*.tmp")) == []
+        # No leftover temp files. This must glob "*.tmp" and not the old
+        # ".sunset-*.tmp" name: the helper's mkstemp sets no prefix, so a
+        # prefixed glob can never match and would assert nothing at all.
+        # "*.tmp" is the stronger check anyway, since pathlib matches dotfiles
+        # and so it still catches a legacy-named leftover.
+        assert list(tmp_path.glob("*.tmp")) == []
 
     def test_overwrite_is_atomic_and_complete(self, tmp_path: Path) -> None:
         target = tmp_path / "sunset.json"
@@ -390,7 +396,7 @@ class TestAtomicWriteThemeJson:
         # os.replace overwrites in place — the new complete content wins, and
         # exactly one file exists (no torn half-write, no temp residue).
         assert json.loads(target.read_text("utf-8")) == {"v": 2}
-        assert list(tmp_path.glob(".sunset-*.tmp")) == []
+        assert list(tmp_path.glob("*.tmp")) == []
 
     def test_failed_write_leaves_no_partial_or_temp(self, tmp_path: Path) -> None:
         target = tmp_path / "sunset.json"
@@ -400,7 +406,21 @@ class TestAtomicWriteThemeJson:
         with pytest.raises(TypeError):
             _atomic_write_theme_json(target, 123)  # type: ignore[arg-type]
         assert not target.exists()
-        assert list(tmp_path.glob(".sunset-*.tmp")) == []
+        assert list(tmp_path.glob("*.tmp")) == []
+
+    @pytest.mark.skipif(os.name == "nt", reason="asserts POSIX permission bits")
+    def test_published_theme_stays_owner_only(self, tmp_path: Path) -> None:
+        """The helper publishes at the umask default unless told otherwise.
+
+        This function's temp came from ``mkstemp`` and was never widened, so the
+        theme JSON has always landed at 0600. Dropping the explicit ``mode``
+        would widen it to 0644 with no other symptom, so pin the mode here
+        rather than trusting the call site to keep the argument.
+        """
+        target = tmp_path / "sunset.json"
+        _atomic_write_theme_json(target, json.dumps({"slug": "sunset"}) + "\n")
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
 
 
 class TestThemeInstallGovernanceAudit:


### PR DESCRIPTION
Each of these is a *named* local helper that reimplements atomic_write:
agent._atomic_json_write, dev_fleet.atomic_write_text,
mochi.write_queue_atomic, service.macos._write_plist_atomic and
themes._atomic_write_theme_json. Every one therefore misses the Windows
os.replace sharing-violation retry the shared helper carries, where a concurrent
reader holding the target open makes os.replace raise PermissionError and the
write is reported as failed.

The public function names and signatures are unchanged, so no call site moves and
nothing outside these five bodies is touched. mochi's own docstring already named
the gap, saying the queue "was the one file landing at the umask default (0644)
because it writes its own temp file rather than going through atomic_write".

No file overlap with #2037, and none of these five needs the bytes,
restrict_to_owner or restrict_on_error capabilities it adds. Merge order does
matter in one respect though, covered below: #2037 is what widens the shared
helper's cleanup clause, and one site here depends on that.

Mode is passed explicitly wherever the hand-rolled version did not publish at the
umask default, because atomic_write falls back to _get_default_mode()
(0o666 & ~umask, normally 0o644):

- macos._write_plist_atomic created its temp via mkstemp and never widened it, so
  the published plist is 0o600 today. It passes mode=0o600. Without that the
  migration would have LOOSENED a file that is currently not world-readable.
- themes._atomic_write_theme_json is the same shape and the same fix: mkstemp,
  no widening, so the theme JSON lands at 0o600 today and it passes mode=0o600.
- agent._atomic_json_write reads the mode off the existing file (0o644 when
  absent) and now passes it through, so a config an operator has deliberately
  tightened still survives the rewrite.
- mochi.write_queue_atomic chmod'd its temp to 0o600 after writing; it now passes
  mode=0o600, which the helper applies BEFORE the payload lands rather than
  after, so the task list is never briefly world-readable.

Three assertions in test_theme_install.py were re-pointed, and this is the reason
themes.py was held out of the first revision of this PR

The three temp-residue assertions read glob(".sunset-*.tmp") == [], matching the
prefix=f".{target.stem}-" the hand-rolled version passed to mkstemp. The shared
helper sets NO prefix, so that pattern can never match anything it creates. The
assertions would therefore have kept passing while asserting nothing: VACUOUS
rather than failing, which is the failure mode that does not get noticed.

They now glob "*.tmp", which is the stronger check in both directions:
pathlib.Path.glob matches dotfiles, so it still catches a legacy-named leftover
as well as the helper's own. Verified by mutation rather than by reading: leaking
a stray temp on the success path fails two of the three, and removing the
helper's failure-path unlink fails the third. Before the re-point both mutations
passed.

One new test, test_published_theme_stays_owner_only, pins the 0o600 publish mode
POSIX-only. The mode argument is the whole defence against a silent widening and
nothing else would catch its removal, so it gets a guard rather than a comment.
Mutation-checked: dropping mode=0o600 fails it with 420 == 384.

Two incidental fixes, both from deleting hand-rolled bookkeeping:

- mochi.write_queue_atomic had NO temp cleanup, so a failing chmod or rename left
  the temp behind. The helper unlinks it.
- dev_fleet.atomic_write_text called tmp.write_text(content) with no encoding, so
  it wrote at whatever the process locale happened to be. The helper writes UTF-8
  explicitly, which makes the service definition byte-identical across hosts.

Interrupt-time temp cleanup, and why #2037 should land first

Of the five, only themes._atomic_write_theme_json cleaned up under
except BaseException. macos._write_plist_atomic already used except Exception,
so its migration narrows nothing.

#2037 widens the shared helper's clause to except BaseException for exactly
this reason, so once it lands there is no narrowing here at all. If this merges
first there is a window where a Ctrl-C mid-write leaves the theme temp behind.
It carries the target's 0o600 and keeps the .tmp suffix, so it is not mistaken
for a theme.

NOT included, deliberately:

- md_notebook._atomic_write_text_sync is a clean candidate (the helper takes the
  newline="" it needs), but #2037 already edits that file and adds the same
  import, so it waits for that to land rather than manufacturing a conflict.

Refs #1105

