### PR TITLE
test(system): cover autoResetPageIndex guard against pagination setState loop

### DIFF
--- a/website/src/test/SessionsTab.renderLoop.test.tsx
+++ b/website/src/test/SessionsTab.renderLoop.test.tsx
@@ -44,6 +44,24 @@ vi.mock('../pages/system/sessionRows', async importOriginal => {
   }
 })
 
+/**
+ * Captures every `options` object passed to `useReactTable` so tests can assert
+ * on resolved table configuration. The wrapper is transparent: the table still
+ * works normally, and existing tests are unaffected.
+ */
+const capturedTableOptions: Array<Record<string, unknown>> = []
+
+vi.mock('@tanstack/react-table', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tanstack/react-table')>()
+  return {
+    ...actual,
+    useReactTable: (options: Record<string, unknown>) => {
+      capturedTableOptions.push(options)
+      return actual.useReactTable(options as never)
+    },
+  }
+})
+
 /** A render that never settles is the bug; anything near this is a loop. */
 const RENDER_CEILING = 25
 
@@ -67,7 +85,7 @@ function mount() {
 }
 
 describe('SessionsTab render stability', () => {
-  beforeEach(() => { renders = 0; buildTreeCalls.n = 0 })
+  beforeEach(() => { renders = 0; buildTreeCalls.n = 0; capturedTableOptions.length = 0 })
   afterEach(() => { cleanup(); vi.restoreAllMocks() })
 
   it('settles while the first fetch is still in flight', async () => {
@@ -196,5 +214,35 @@ describe('SessionsTab render stability', () => {
 
     await waitFor(() => expect(screen.getByText('No active sessions')).toBeTruthy())
     expect(renders).toBeLessThan(RENDER_CEILING)
+  })
+
+  it('disables autoResetPageIndex to prevent the pagination setState loop', async () => {
+    // This table has no paginator (no `getPaginationRowModel`) and no
+    // `onPaginationChange`, so TanStack's default `autoResetPageIndex: true`
+    // routes every data-identity change through `makeStateUpdater('pagination')`
+    // into `table.setState` — triggering a re-render that, with unstable `data`,
+    // becomes an infinite loop. The ONLY thing breaking that cycle is the explicit
+    // `autoResetPageIndex: false` in the table options.
+    //
+    // This is a configuration-level lock: it asserts the option is passed rather
+    // than reproducing the loop (which requires real RAF scheduling that jsdom
+    // cannot provide — see file header). It is the direct complement of the
+    // `buildTree` churn tests above: those prove data identity is stable, this
+    // proves the table will not self-destruct even if a future refactor
+    // accidentally reintroduces an identity change.
+    vi.spyOn(api, 'sessionsMemory').mockResolvedValue({
+      sessions: [], tasks: [], totals: { rss_mb: 0, host_mb: 1000, procs: 0, sessions: 0, tasks: 0 },
+      unattributed: null, history: [],
+    } as never)
+
+    mount()
+    await waitFor(() => expect(capturedTableOptions.length).toBeGreaterThan(0))
+
+    // Every call to useReactTable from this component must carry the guard.
+    // (There is only one table, but renders call the hook repeatedly.)
+    const withoutGuard = capturedTableOptions.filter(
+      opts => opts.autoResetPageIndex !== false,
+    )
+    expect(withoutGuard).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## What is the problem

PR #2146 fixed the System page freeze (an infinite TanStack Table render loop) with two complementary guards:

1. **Stable fallback references** — `data?.sessions ?? EMPTY_SESSIONS` instead of `?? []`, preventing a new array identity on every render.
2. **`autoResetPageIndex: false`** — disabling the TanStack default that routes every data-identity change through `makeStateUpdater('pagination')` → `table.setState` → re-render.

Post-merge mutation testing revealed that removing `autoResetPageIndex: false` left all 8 existing tests green — zero coverage on the line that actually gates the freeze.

## Why it matters to the user

Without test coverage on this guard, a future refactor could delete or accidentally revert it with no test signal. The freeze locks the entire Electron renderer at ~80% CPU with no recovery path short of force-quit.

## How the fix solves it

A new 9th test in `SessionsTab.renderLoop.test.tsx` wraps `useReactTable` in a transparent capture mock, collects every `options` object passed to it, and asserts that every invocation carries `autoResetPageIndex: false`. This is a **configuration-level lock**, not a behavioural reproduction of the loop itself.

Honest limitation stated up front: the `setState` loop does not reproduce under jsdom because TanStack's internal `queued` guard prevents re-entry within a single flush — it needs each flush to schedule the next, which the test harness's batching settles. What this test verifies is the presence of the option that *prevents* the queue from being armed in the first place. That the option gates `resetPageIndex` at all is proven from table-core source and from the paired Electron A/B reproduction documented in #2146.

## What tests we did

| Scenario | Result |
|----------|--------|
| `npx tsc -b` | exit 0 |
| `npx vitest run src/test/SessionsTab.renderLoop.test.tsx` (fix intact) | **9 passed**, 0 failed |
| Mutation A: delete `autoResetPageIndex: false` from SessionsTab.tsx | New test fails (`expected [...] to have length 0 but got N`), 8 pass |
| Mutation B: revert `?? EMPTY_SESSIONS`/`?? EMPTY_TASKS` to `?? []` | Pre-existing `buildTree` test fails (`expected N to be 0`), 8 pass |

The full 10k+ frontend suite and backend suite are not run locally — this PR touches a single test file and CI covers the rest.

## Any other suggestions

None. This is a minimal, additive test-only change. The `useReactTable` mock is transparent (calls through to the real implementation) so existing tests are unaffected, and `capturedTableOptions` is reset in `beforeEach` to prevent cross-test bleed.
