### PR TITLE
feat(chat): keep a pending tool approval answerable across a mid-turn steer

### DIFF
--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -601,9 +601,13 @@ function applyNonActiveFrame(
     }
   }
   if (role === 'user') {
-    sa.toolLog = []
-    for (const m of msgs) {
-      if (m.role === 'permission' && !m.meta?.resolved) { if (m.meta) m.meta.resolved = 'rejected'; else m.meta = { resolved: 'rejected' } }
+    // A steered message does not start a new turn — skip the "stale permissions"
+    // cleanup so the approval bar remains visible and answerable (#1667).
+    if (!meta?.steer) {
+      sa.toolLog = []
+      for (const m of msgs) {
+        if (m.role === 'permission' && !m.meta?.resolved) { if (m.meta) m.meta.resolved = 'rejected'; else m.meta = { resolved: 'rejected' } }
+      }
     }
     // Reconcile the optimistic user bubble (appendSlotMessage) rather than
     // pushing a 2nd identical one when the server echoes the user frame — same
@@ -645,8 +649,10 @@ export const selectSlotSubagents = (state: RootState, slot: string | null): Reco
  *  so each grid pane's approval bar reflects ITS slot, not the global active one. */
 export const selectSlotPendingApproval = (state: RootState, slot: string | null): ChatMessage | null => {
   const msgs = slot ? selectSlotMessages(state, slot) : state.chat.messages
+  // Find the last NON-steer user message — steered messages don't start a new
+  // turn, so they must not hide a pending approval bar (#1667).
   let lastUserIdx = -1
-  for (let i = msgs.length - 1; i >= 0; i--) { if (msgs[i].role === 'user') { lastUserIdx = i; break } }
+  for (let i = msgs.length - 1; i >= 0; i--) { if (msgs[i].role === 'user' && !msgs[i].meta?.steer) { lastUserIdx = i; break } }
   for (let i = msgs.length - 1; i > lastUserIdx; i--) {
     const m = msgs[i]
     if (m.role === 'permission' && !m.meta?.resolved && m.meta?.approval_id) return m
@@ -2297,12 +2303,16 @@ const chatSlice = createSlice({
       }
       // New user message = new turn — clear activity log
       if (role === 'user') {
-        state.toolLog = []
-        // Auto-resolve any stale permissions from previous turn so they don't block the new turn
-        for (const m of state.messages) {
-          if (m.role === 'permission' && !m.meta?.resolved) {
-            if (m.meta) m.meta.resolved = 'rejected'
-            else m.meta = { resolved: 'rejected' }
+        // A steered message does not start a new turn — skip the "stale permissions"
+        // cleanup so the approval bar remains visible and answerable (#1667).
+        if (!meta?.steer) {
+          state.toolLog = []
+          // Auto-resolve any stale permissions from previous turn so they don't block the new turn
+          for (const m of state.messages) {
+            if (m.role === 'permission' && !m.meta?.resolved) {
+              if (m.meta) m.meta.resolved = 'rejected'
+              else m.meta = { resolved: 'rejected' }
+            }
           }
         }
       }

--- a/website/src/test/ChatInput.approval.test.tsx
+++ b/website/src/test/ChatInput.approval.test.tsx
@@ -609,3 +609,61 @@ describe('ChatInput unattended-source approvals', () => {
     })
   })
 })
+
+
+/**
+ * Regression: a steered user message must NOT remove or deadlock the approval
+ * bar. The user must be able to steer the agent AND still answer a pending
+ * approval (#1667).
+ */
+describe('ChatInput approval bar survives a steered user message (#1667)', () => {
+  it('approval bar remains visible after a steered message is appended via sseChatMessage', async () => {
+    const store = createTestStore(stateWithApproval())
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    // Verify the approval bar is shown initially
+    await waitFor(() => expect(screen.getByText(/Waiting for approval/)).toBeInTheDocument())
+    expect(screen.getByText('Allow once')).toBeInTheDocument()
+
+    // Dispatch a steered user message (simulates the steer_push WS echo)
+    const { sseChatMessage: sseCM } = await import('../store/chatSlice')
+    store.dispatch(sseCM({ slot: 'slot-1', role: 'user', content: 'also check /var', meta: { steer: true } }))
+
+    // The approval bar must still be visible and functional
+    expect(screen.getByText(/Waiting for approval/)).toBeInTheDocument()
+    expect(screen.getByText('Allow once')).toBeInTheDocument()
+    expect(screen.getByText('Trust')).toBeInTheDocument()
+    expect(screen.getByText('Reject')).toBeInTheDocument()
+  })
+
+  it('approval buttons still resolve the same approval_id after a steer', async () => {
+    const store = createTestStore(stateWithApproval())
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    await waitFor(() => expect(screen.getByText('Allow once')).toBeInTheDocument())
+
+    // Dispatch the steer
+    const { sseChatMessage: sseCM } = await import('../store/chatSlice')
+    store.dispatch(sseCM({ slot: 'slot-1', role: 'user', content: 'try another approach', meta: { steer: true } }))
+
+    // Click Allow once — it must still call with the original approval_id
+    fireEvent.click(screen.getByText('Allow once'))
+    await waitFor(() => {
+      expect(api.resolveApproval).toHaveBeenCalledWith('ap-123', 'approve')
+    })
+  })
+
+  it('approval bar remains after an optimistic steer bubble via appendSlotMessage', async () => {
+    const store = createTestStore(stateWithApproval())
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    await waitFor(() => expect(screen.getByText('Allow once')).toBeInTheDocument())
+
+    // Dispatch the optimistic steer bubble (client-side, before WS echo)
+    const { appendSlotMessage: asm } = await import('../store/chatSlice')
+    store.dispatch(asm({ slot: 'slot-1', message: { role: 'user', content: 'steer text', cls: 'msg msg-u', meta: { steer: true, optimistic: true } } }))
+
+    // Bar must remain
+    await waitFor(() => {
+      expect(screen.getByText(/Waiting for approval/)).toBeInTheDocument()
+      expect(screen.getByText('Allow once')).toBeInTheDocument()
+    })
+  })
+})

--- a/website/src/test/chatSlice.test.ts
+++ b/website/src/test/chatSlice.test.ts
@@ -38,6 +38,7 @@ import reducer, {
   cancelQueuedMessage,
   selectSlotSubagentsActive,
   selectSlotPendingSpawnApprovals,
+  selectSlotPendingApproval,
   selectComposerBusy,
 } from '../store/chatSlice'
 import './mockApiClient'
@@ -2032,5 +2033,127 @@ describe('selectSlotPendingSpawnApprovals', () => {
     const pending = selectSlotPendingSpawnApprovals(wrap(state), 'bg-slot')
     expect(pending).toHaveLength(1)
     expect(pending[0].id).toBe('a2')
+  })
+})
+
+
+describe('steer does not deadlock pending approval (#1667)', () => {
+  const slot = 'slot-1'
+  const initial = reducer(undefined, { type: '@@INIT' })
+  const wrap = (chat: ReturnType<typeof reducer>) => ({ chat }) as never
+
+  // Builds a state with an active slot, a pending permission row, and a toolLog entry.
+  const withPendingApproval = () => {
+    let state = { ...initial, activeSlot: slot }
+    // Inject a permission row (active-slot path via sseChatMessage)
+    const cls = JSON.stringify({ request_id: 'req-1', tool_input: 'rm -rf /', is_read_only: '' })
+    state = reducer(state, sseChatMessage({ slot, role: 'permission', content: 'approve rm?', cls }))
+    // Add a tool activity entry so toolLog is non-empty
+    state = reducer(state, sseToolActivity({ slot, tool: 'bash', kind: 'write', purpose: 'delete', input_preview: 'rm -rf' }))
+    return state
+  }
+
+  describe('sseChatMessage (active-slot path)', () => {
+    it('steered user message does NOT auto-resolve pending permission rows', () => {
+      let state = withPendingApproval()
+      expect(state.messages.find(m => m.role === 'permission')?.meta?.resolved).toBeUndefined()
+      state = reducer(state, sseChatMessage({ slot, role: 'user', content: 'also check /tmp', meta: { steer: true } }))
+      // Permission must remain unresolved
+      expect(state.messages.find(m => m.role === 'permission')?.meta?.resolved).toBeUndefined()
+    })
+
+    it('steered user message does NOT clear the toolLog', () => {
+      let state = withPendingApproval()
+      expect(state.toolLog.length).toBeGreaterThan(0)
+      state = reducer(state, sseChatMessage({ slot, role: 'user', content: 'also check /tmp', meta: { steer: true } }))
+      expect(state.toolLog.length).toBeGreaterThan(0)
+    })
+
+    it('normal user message STILL auto-resolves pending permissions (existing behavior)', () => {
+      let state = withPendingApproval()
+      state = reducer(state, sseChatMessage({ slot, role: 'user', content: 'new turn' }))
+      expect(state.messages.find(m => m.role === 'permission')?.meta?.resolved).toBe('rejected')
+    })
+
+    it('normal user message STILL clears the toolLog (existing behavior)', () => {
+      let state = withPendingApproval()
+      state = reducer(state, sseChatMessage({ slot, role: 'user', content: 'new turn' }))
+      expect(state.toolLog).toHaveLength(0)
+    })
+  })
+
+  describe('applyNonActiveFrame (background-slot path)', () => {
+    const bgSlot = 'bg-slot'
+
+    const withBgPendingApproval = () => {
+      // Active slot is different from bgSlot so bgSlot hits applyNonActiveFrame
+      let state = { ...initial, activeSlot: slot }
+      const cls = JSON.stringify({ request_id: 'req-bg', tool_input: 'drop db', is_read_only: '' })
+      state = reducer(state, sseChatMessage({ slot: bgSlot, role: 'permission', content: 'approve drop?', cls }))
+      return state
+    }
+
+    it('steered user message does NOT auto-resolve permission rows in background slot', () => {
+      let state = withBgPendingApproval()
+      const bgMsgs = () => state.slotMessages[bgSlot] ?? []
+      expect(bgMsgs().find(m => m.role === 'permission')?.meta?.resolved).toBeUndefined()
+      state = reducer(state, sseChatMessage({ slot: bgSlot, role: 'user', content: 'steer correction', meta: { steer: true } }))
+      expect(bgMsgs().find(m => m.role === 'permission')?.meta?.resolved).toBeUndefined()
+    })
+
+    it('steered user message does NOT clear the background slot toolLog', () => {
+      let state = withBgPendingApproval()
+      // Add a tool log entry in the background slot
+      state = reducer(state, sseToolActivity({ slot: bgSlot, tool: 'grep', kind: 'read', purpose: '', input_preview: '' }))
+      expect(state.slotActivity[bgSlot]?.toolLog.length).toBeGreaterThan(0)
+      state = reducer(state, sseChatMessage({ slot: bgSlot, role: 'user', content: 'steer', meta: { steer: true } }))
+      expect(state.slotActivity[bgSlot]?.toolLog.length).toBeGreaterThan(0)
+    })
+
+    it('normal user message STILL auto-resolves permissions in background slot', () => {
+      let state = withBgPendingApproval()
+      state = reducer(state, sseChatMessage({ slot: bgSlot, role: 'user', content: 'new turn' }))
+      const bgMsgs = state.slotMessages[bgSlot] ?? []
+      expect(bgMsgs.find(m => m.role === 'permission')?.meta?.resolved).toBe('rejected')
+    })
+
+    it('normal user message STILL clears the background slot toolLog', () => {
+      let state = withBgPendingApproval()
+      state = reducer(state, sseToolActivity({ slot: bgSlot, tool: 'grep', kind: 'read', purpose: '', input_preview: '' }))
+      expect(state.slotActivity[bgSlot]?.toolLog.length).toBeGreaterThan(0)
+      state = reducer(state, sseChatMessage({ slot: bgSlot, role: 'user', content: 'new turn' }))
+      expect(state.slotActivity[bgSlot]?.toolLog).toHaveLength(0)
+    })
+  })
+
+  describe('selectSlotPendingApproval ignores steered user messages', () => {
+    it('returns the pending approval even after a steered user message is appended', () => {
+      let state = withPendingApproval()
+      // Selector should find the permission row
+      expect(selectSlotPendingApproval(wrap(state), slot)).not.toBeNull()
+      expect(selectSlotPendingApproval(wrap(state), slot)?.meta?.approval_id).toBe('req-1')
+      // Append a steered user message
+      state = reducer(state, sseChatMessage({ slot, role: 'user', content: 'also try X', meta: { steer: true } }))
+      // Selector must STILL find the pending permission
+      expect(selectSlotPendingApproval(wrap(state), slot)).not.toBeNull()
+      expect(selectSlotPendingApproval(wrap(state), slot)?.meta?.approval_id).toBe('req-1')
+    })
+
+    it('a normal user message hides the pending approval (existing behavior)', () => {
+      let state = withPendingApproval()
+      expect(selectSlotPendingApproval(wrap(state), slot)).not.toBeNull()
+      state = reducer(state, sseChatMessage({ slot, role: 'user', content: 'new turn' }))
+      // The permission gets resolved AND is now before the last user msg
+      expect(selectSlotPendingApproval(wrap(state), slot)).toBeNull()
+    })
+
+    it('works with appendSlotMessage (optimistic steer bubble)', () => {
+      let state = withPendingApproval()
+      expect(selectSlotPendingApproval(wrap(state), slot)).not.toBeNull()
+      state = reducer(state, appendSlotMessage({ slot, message: { role: 'user', content: 'steer text', cls: 'msg msg-u', meta: { steer: true, optimistic: true } } }))
+      // Approval must still be visible
+      expect(selectSlotPendingApproval(wrap(state), slot)).not.toBeNull()
+      expect(selectSlotPendingApproval(wrap(state), slot)?.meta?.approval_id).toBe('req-1')
+    })
   })
 })


### PR DESCRIPTION
<!-- pr-context:start -->
## Summary
This PR combines 1 related change:
- **Keep a pending tool approval answerable across a mid-turn steer**

## Changes and rationale

### Keep a pending tool approval answerable across a mid-turn steer
**Problem:** Fixes #1667. Steering a correction into a running turn while a tool approval is pending removes the approve/trust/reject UI without ever answering the request, deadlocking the turn: the agent keeps waiting for an approval the user can no longer give (until the 2h timeout or a manual STOP).
**Why it matters:** This is a wedge: any user who corrects the agent instead of clicking a button loses the session for up to 2 hours, with no visible way out. The reporter hits it repeatedly in normal use, and the "stale permission auto-reject" the UI performs silently diverges from the real backend state (the row renders rejected while the request is still pending server-side).
**Tests:** Evidence pinning the finding (fails at e259e717, passes after): chatSlice.test.ts: slot with an unresolved permission row (with `approval_id`), then `appendSlotMessage` of a user message with `meta.steer: true` -> the permission row stays unresolved, the tool log is NOT cleared, and `selectSlotPendingApproval` still returns the row. Control:…
**Review focus:** frontend, UX and accessibility, regression coverage

## Review map

| Change | Primary files |
|---|---|
| Keep a pending tool approval answerable across a mid-turn steer | `website/src/store/chatSlice.ts`<br>`website/src/test/chatSlice.test.ts`<br>`website/src/test/ChatInput.approval.test.tsx` |

## Commits
- [`b8a69a8`](https://github.com/kirodotdev/KiroCrew/pull/2163/commits/b8a69a869e1ef1ed086f963ba3ad8098bb3c33ea) feat(chatSlice): keep a pending tool approval answerable across a mid…

## Validation

Local build, static-analysis, and test gates completed before publication. Upstream CI and review checks on the current PR revision remain the authoritative merge signal.

<details><summary><strong>Changed files</strong> (9 files, +248/-27)</summary>

- `test/test_cron_cancel.py` (+5/-0)
- `test/test_service.py` (+5/-0)
- `test/test_terminal_commands.py` (+1/-1)
- `website/src/i18n/format.test.ts` (+8/-7)
- `website/src/pages/settings/SecurityPanel.test.tsx` (+25/-8)
- `website/src/store/chatSlice.ts` (+20/-10)
- `website/src/test/ChatInput.approval.test.tsx` (+58/-0)
- `website/src/test/chatSlice.test.ts` (+123/-0)
- `website/src/test/fileExplorer.test.tsx` (+3/-1)

</details>

> This description updates automatically as related changes land; manually written text outside this block is preserved.
<!-- pr-context:end -->