### PR TITLE
fix(security): stop loopback secret leaking to HTTP_PROXY

### DIFF
--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
@@ -58,6 +58,31 @@ try:
 except ImportError:  # pragma: no cover - standalone fallback
     redact_credentials = redact_exfiltration_urls = None  # type: ignore
 
+# Every loopback call below carries X-Internal-Secret, and urlopen honours
+# HTTP_PROXY for loopback addresses, so a proxied environment would send the
+# secret to the proxy in cleartext. The fallback must therefore stay
+# proxy-disabled too -- degrading to a bare urlopen would leave the standalone
+# path (`python3 sage_lib/review_driver.py`) carrying the leak this closes.
+#
+# It must ALSO refuse redirects, for the same reason the real helper does. An
+# earlier version of this fallback omitted that on the grounds that "these
+# endpoints never return a redirect" -- wrong for `_probe`, whose entire job is
+# to dial candidate ports that may have something other than our gateway
+# listening. A 302 from one of those would replay the secret to whatever host
+# Location names.
+try:
+    from kiro_crew.loopback_http import loopback_urlopen  # type: ignore
+except ImportError:  # pragma: no cover - standalone fallback
+
+    class _FallbackNoRedirect(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            return None
+
+    def loopback_urlopen(req: urllib.request.Request | str, timeout: float):  # type: ignore
+        return urllib.request.build_opener(
+            urllib.request.ProxyHandler({}), _FallbackNoRedirect()
+        ).open(req, timeout=timeout)
+
 _APP_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _APP_ROOT not in sys.path:  # allow `python3 sage_lib/review_driver.py` (run as script)
     sys.path.insert(0, _APP_ROOT)
@@ -102,7 +127,7 @@ def _api_request(method: str, path: str, body: dict | None = None, timeout: int 
         headers["Content-Type"] = "application/json"
     try:
         req = urllib.request.Request(base + path, data=data, headers=headers, method=method)
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with loopback_urlopen(req, timeout=timeout) as resp:
             raw = resp.read()
             return json.loads(raw) if raw else {}
     except Exception as e:
@@ -447,11 +472,15 @@ def _candidate_ports() -> list[int]:
 
 def _probe(base: str, secret: str) -> bool:
     """True if a KiroCrew gateway is listening at base (any HTTP response, incl.
-    401/404, means it's there; only connection errors mean it isn't)."""
+    401/404, means it's there; only connection errors mean it isn't).
+
+    Proxy-disabled deliberately: ``_gateway_base`` calls this once per candidate
+    port, so a cold resolve that misses sends the secret up to len(candidates)
+    times -- this is the highest-multiplicity secret-bearing send in the app."""
     try:
         req = urllib.request.Request(base + "/api/spawn",
                                      headers={"X-Internal-Secret": secret} if secret else {})
-        with urllib.request.urlopen(req, timeout=3) as resp:
+        with loopback_urlopen(req, timeout=3) as resp:
             return resp.status < 500
     except urllib.error.HTTPError:
         return True   # a gateway responded (e.g. 401/404) — it's the right port

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -53,6 +53,7 @@ from kiro_crew.eval.runner import EvalRunner, format_results, score_by_dimension
 from kiro_crew.eval.scenario import AssertionType, load_scenario, load_scenarios
 from kiro_crew.hooks import safe_read_file
 from kiro_crew.learn import Lesson, LessonStore
+from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.security import (
     BUILTIN_DENY_PATTERNS,
     is_sensitive_path,
@@ -172,7 +173,7 @@ def _spawn(args: argparse.Namespace) -> None:
             headers={"X-Internal-Secret": _internal_secret()},
         )
         try:
-            with urllib.request.urlopen(req, timeout=5) as resp:
+            with loopback_urlopen(req, timeout=5) as resp:
                 data = json.loads(resp.read())
         except urllib.error.HTTPError as e:
             try:
@@ -212,7 +213,7 @@ def _spawn_run(args: argparse.Namespace, base: str) -> None:
         },
     )
     try:
-        with urllib.request.urlopen(req, timeout=5) as resp:
+        with loopback_urlopen(req, timeout=5) as resp:
             result = json.loads(resp.read())
     except urllib.error.HTTPError as e:
         try:
@@ -240,7 +241,7 @@ def _spawn_run(args: argparse.Namespace, base: str) -> None:
         _time.sleep(2)
         poll_req = urllib.request.Request(poll_url, headers={"X-Internal-Secret": secret})
         try:
-            with urllib.request.urlopen(poll_req, timeout=5) as resp:
+            with loopback_urlopen(poll_req, timeout=5) as resp:
                 status = json.loads(resp.read())
         except Exception:
             print("Error: lost connection to gateway", file=sys.stderr)
@@ -1463,7 +1464,7 @@ def _artifact(args: argparse.Namespace) -> None:
             h["Content-Type"] = "application/json"
         req = urllib.request.Request(f"{base}{path}", data=data, headers=h, method=method)
         try:
-            with urllib.request.urlopen(req, timeout=30) as resp:
+            with loopback_urlopen(req, timeout=30) as resp:
                 raw = resp.read()
                 return json.loads(raw) if raw else {}
         except urllib.error.HTTPError as exc:

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -48,6 +48,7 @@ from kiro_crew.history import ConversationLog, HistoryConsolidator
 from kiro_crew.hooks import HookManager, hooks_config_from_config_dict
 from kiro_crew.instances import run_marker
 from kiro_crew.learn import LessonStore
+from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.memory import MemoryStore
 from kiro_crew.preflight import run_preflight_checks
 from kiro_crew.sel import sel
@@ -271,7 +272,7 @@ def _probe_dashboard_health(port: int) -> None:
     """
     try:
         req = urllib.request.Request(f"http://{_CLI_LOOPBACK}:{port}/", method="GET")
-        with urllib.request.urlopen(req, timeout=2) as resp:  # nosemgrep
+        with loopback_urlopen(req, timeout=2) as resp:  # nosemgrep
             body = resp.read(8192).decode("utf-8", errors="replace")
             if DASHBOARD_HTML_NOT_FOUND_MARKER.lower() in body.lower():
                 print(
@@ -319,7 +320,7 @@ def _token(args: argparse.Namespace) -> None:
         url += f"&embed_parent_port={int(epp)}"
     req = urllib.request.Request(url, headers={"X-Local-Secret": secret})
     try:
-        with urllib.request.urlopen(req, timeout=5) as resp:
+        with loopback_urlopen(req, timeout=5) as resp:
             data = json.loads(resp.read())
             token = data.get("token", "")
     except Exception as exc:
@@ -363,7 +364,7 @@ def _logout(port: int) -> None:
         data=b"{}",
     )
     try:
-        with urllib.request.urlopen(req, timeout=5) as resp:
+        with loopback_urlopen(req, timeout=5) as resp:
             data = json.loads(resp.read())
             if data.get("ok"):
                 print("✅ All dashboard sessions revoked.")
@@ -882,7 +883,7 @@ def _probe_gateway_ready(port: int, timeout: int = 3) -> int:
         # Loopback-only probe to our own gateway on 127.0.0.1; the URL is
         # internally derived (never attacker-supplied), so the dynamic-URL SSRF
         # audit rule is a false positive here.
-        with urllib.request.urlopen(url, timeout=timeout) as resp:  # nosemgrep
+        with loopback_urlopen(url, timeout=timeout) as resp:  # nosemgrep
             return int(resp.status)
     except urllib.error.HTTPError as e:
         return int(e.code)
@@ -989,7 +990,7 @@ def _print_token_url(port: int) -> None:
             secret = secret_path.read_text().strip()
             url = f"http://{_CLI_LOOPBACK}:{port}/api/token/local?ttl={_RESTART_TOKEN_TTL}"
             req = urllib.request.Request(url, headers={"X-Local-Secret": secret})
-            with urllib.request.urlopen(req, timeout=3) as resp:
+            with loopback_urlopen(req, timeout=3) as resp:
                 data = json.loads(resp.read())
                 token = data.get("token", "")
             if token:
@@ -1473,7 +1474,7 @@ def _status(args: argparse.Namespace) -> None:
     port = resolve_client_port(getattr(args, "port", None))
     url = f"http://127.0.0.1:{port}/api/status"
     try:
-        with urllib.request.urlopen(url, timeout=3) as resp:
+        with loopback_urlopen(url, timeout=3) as resp:
             data = json.loads(resp.read())
     except urllib.error.HTTPError as e:
         if e.code in (401, 403):

--- a/src/kiro_crew/computer_use/screencast.py
+++ b/src/kiro_crew/computer_use/screencast.py
@@ -61,6 +61,7 @@ from typing import Any, Iterator
 
 from kiro_crew.computer_use.types import MAX_SCREENSHOT_MAX_PX, OBS_SCREENSHOT, Snapshot
 from kiro_crew.config.paths import config_dir
+from kiro_crew.loopback_http import loopback_urlopen
 
 logger = logging.getLogger(__name__)
 
@@ -281,7 +282,7 @@ def _post_frame(payload: dict[str, Any]) -> None:
             method="POST",
         )
         # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- see the Request() justification directly above  # noqa: E501
-        with urllib.request.urlopen(request, timeout=FRAME_POST_TIMEOUT_SECS):
+        with loopback_urlopen(request, timeout=FRAME_POST_TIMEOUT_SECS):
             pass
     except Exception:
         logger.debug("computer-use live frame POST failed", exc_info=True)

--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, Any
 from kiro_crew import platform_compat
 from kiro_crew.config.loader import config_dir, read_local_secret
 from kiro_crew.config.paths import kiro_agents_dir
+from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.sandbox import (
     _AGENT_DENIED_ENV_KEYS,
     SandboxUnavailableError,
@@ -340,7 +341,7 @@ class ScriptContext:
             method="POST",
         )
         try:
-            with urllib.request.urlopen(req, timeout=60) as resp:
+            with loopback_urlopen(req, timeout=60) as resp:
                 return json.loads(resp.read())
         except Exception as exc:
             logger.warning("ScriptContext._post(%s) failed: %s", path, exc)

--- a/src/kiro_crew/cron_trigger.py
+++ b/src/kiro_crew/cron_trigger.py
@@ -8,6 +8,8 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+from kiro_crew.loopback_http import loopback_urlopen
+
 _JOB_ID_RE = re.compile(r"[a-f0-9]{6,12}")
 _TIMEOUT_SECS = 10  # endpoint returns immediately after starting execution
 
@@ -27,7 +29,7 @@ def trigger_cron_job(job_id: str, port: int, secret_path: Path) -> tuple[bool, s
     try:
         # data=b"" is required by urllib to send a POST (not GET)
         req = urllib.request.Request(url, method="POST", data=b"", headers=headers)
-        with urllib.request.urlopen(req, timeout=_TIMEOUT_SECS) as resp:
+        with loopback_urlopen(req, timeout=_TIMEOUT_SECS) as resp:
             body = json.loads(resp.read())
             if body.get("ok"):
                 name = body.get("name", job_id)

--- a/src/kiro_crew/loopback_http.py
+++ b/src/kiro_crew/loopback_http.py
@@ -1,0 +1,86 @@
+"""Loopback HTTP requests with proxies and redirects disabled.
+
+Every request Kiro Crew makes to its own gateway carries ``X-Internal-Secret``,
+which authorises write endpoints on the local dashboard. ``urlopen`` builds its
+opener from ``getproxies()``, and urllib has **no implicit loopback exemption**:
+``proxy_bypass_environment`` returns ``False`` when ``no_proxy`` is unset, and
+``ProxyHandler.proxy_open`` bypasses only the hosts ``no_proxy`` names outright.
+So with ``HTTP_PROXY`` set -- routine in corporate and containerised
+environments -- a request to ``http://127.0.0.1:5476`` is sent to the proxy in
+absolute form, secret header included, in cleartext.
+
+Two things that look like fixes and are not:
+
+* Spelling the host ``127.0.0.1`` instead of ``localhost``. That addresses
+  ``localhost`` resolving to ``::1`` past a v4-only listener -- a real problem,
+  a different one. Both spellings proxy identically.
+* Setting ``no_proxy=localhost``. ``no_proxy`` matches the host **string**, not
+  what it resolves to, so a request to the literal IP still proxies. That
+  spelling is the common corporate default, which makes it the more dangerous
+  of the two: it looks like coverage.
+
+Redirects are refused for the same reason the external bearer-token path in
+``dashboard/handlers/kiro_usage_api.py`` refuses them -- a 3xx from the gateway
+would replay the secret to whatever host ``Location`` names.
+
+This module is a **stdlib-only leaf** and must stay one: it imports
+``urllib.request`` and nothing else. That is what lets the cheapest callers use
+it -- ``cron_trigger`` imports nothing from ``kiro_crew`` at all, and the MCP
+stdio proxies deliberately avoid importing the gateway, since reaching
+``parse_dashboard_url`` through ``dashboard.origin`` costs ~605 ms and 1124
+modules (see the ``dashboard/urls.py`` docstring). Adding an import here that
+pulls aiohttp in behind it would defeat the point.
+"""
+
+import urllib.request
+
+__all__ = ["build_loopback_opener", "loopback_urlopen"]
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Turn a 3xx into an ``HTTPError`` instead of following it.
+
+    Returning ``None`` from ``redirect_request`` is urllib's documented way to
+    refuse a redirect, so the secret is never replayed to a redirected host.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: D102
+        return None
+
+
+def build_loopback_opener() -> urllib.request.OpenerDirector:
+    """Build an opener that ignores proxy environment variables entirely.
+
+    ``ProxyHandler({})`` has to be passed **explicitly**. ``build_opener``
+    displaces one of its default handlers only when a supplied handler
+    *subclasses* that default, and an empty ``ProxyHandler`` registers no
+    ``<scheme>_open`` method at all -- so omitting it leaves the env-derived
+    proxy live. This is exactly why ``kiro_usage_api._build_opener`` still
+    proxies (correctly, for its external target) despite looking similar.
+    """
+    return urllib.request.build_opener(urllib.request.ProxyHandler({}), _NoRedirect())
+
+
+def loopback_urlopen(req: urllib.request.Request | str, timeout: float):
+    """Open ``req`` against the local gateway, ignoring any configured proxy.
+
+    Drop-in for ``urllib.request.urlopen`` at loopback call sites, with one
+    deliberate difference: ``timeout`` is **required**. A request to our own
+    gateway that can hang forever is never what a call site wants, and making
+    it explicit costs nothing -- every existing loopback site already passes
+    one.
+
+    The opener is rebuilt per call rather than cached at module scope. Both
+    handlers are stateless, so a cache would be safe for the FIXED code -- but
+    it would capture ``getproxies()`` at import time, making the module's
+    behaviour depend on when it was first imported and silently defeating any
+    test that sets a proxy variable afterwards. That is not hypothetical: the
+    first version of this module cached the opener, and the regression tests
+    passed even with ``ProxyHandler({})`` deleted. Constructing a few stateless
+    handlers is far cheaper than the loopback round trip that follows.
+
+    Use this for the local gateway ONLY. External requests must keep the
+    default opener, because they genuinely need the corporate proxy to leave
+    the host.
+    """
+    return build_loopback_opener().open(req, timeout=timeout)

--- a/src/kiro_crew/mcp_computer.py
+++ b/src/kiro_crew/mcp_computer.py
@@ -94,6 +94,7 @@ from kiro_crew.computer_use.types import (
     TOOL_SET_VALUE,
     TOOL_TYPE_TEXT,
 )
+from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.mcp_core import (
     _API,
     _http_error_body,
@@ -653,7 +654,7 @@ def _invoke(session_key: str, name: str, args: dict[str, Any]) -> dict[str, Any]
     )
     try:
         # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_API from dashboard.url config) + a fixed internal path; never agent-controlled  # noqa: E501
-        with urllib.request.urlopen(request, timeout=INVOKE_TIMEOUT_SECS) as response:
+        with loopback_urlopen(request, timeout=INVOKE_TIMEOUT_SECS) as response:
             decoded = json.loads(response.read())
     except urllib.error.HTTPError as exc:
         return _http_error_body(exc)

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -56,6 +56,7 @@ from kiro_crew.knowledge.dedup import dedup_sweep
 from kiro_crew.knowledge.embedder import create_embedder_from_config
 from kiro_crew.knowledge.retrieval import HybridRetriever
 from kiro_crew.knowledge.store import KnowledgeStore
+from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.mcp_caller import current_caller
 from kiro_crew.mcp_shared import (
     ToolCancelled,
@@ -2817,7 +2818,7 @@ def _post(path: str, body: dict | None = None, *, timeout: float = 30) -> dict:
     )
     try:
         # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_API from dashboard.url config) + a fixed internal path; never user-controlled  # noqa: E501
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with loopback_urlopen(req, timeout=timeout) as resp:
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:
         # urlopen raises HTTPError on 4xx/5xx; str(e) is only "HTTP Error 400:
@@ -2892,7 +2893,7 @@ def _get(path: str) -> dict:
         headers=headers,
     )
     try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
+        with loopback_urlopen(req, timeout=10) as resp:
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:
         return _http_error_body(e)
@@ -2918,7 +2919,7 @@ def _patch(path: str, body: dict | None = None) -> dict:
     try:
         # _API is the hardcoded loopback dashboard base and `path` is a code
         # literal — never attacker-controlled, so no file:// scheme risk.
-        with urllib.request.urlopen(req, timeout=30) as resp:  # nosemgrep  # noqa: E501
+        with loopback_urlopen(req, timeout=30) as resp:  # nosemgrep  # noqa: E501
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:
         return _http_error_body(e)
@@ -2950,7 +2951,7 @@ def _put(path: str, body: dict | None = None) -> dict:
     try:
         # _API is the hardcoded loopback dashboard base and `path` is a code
         # literal — never attacker-controlled, so no file:// scheme risk.
-        with urllib.request.urlopen(req, timeout=30) as resp:  # nosemgrep  # noqa: E501
+        with loopback_urlopen(req, timeout=30) as resp:  # nosemgrep  # noqa: E501
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:
         return _http_error_body(e)
@@ -2976,7 +2977,7 @@ def _delete(path: str, body: dict | None = None) -> dict:
         method="DELETE",
     )
     try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
+        with loopback_urlopen(req, timeout=10) as resp:
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:
         return _http_error_body(e)
@@ -4958,8 +4959,9 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         # it from the X-Internal-Secret header presence (MCP=agent,
         # dashboard=user). This is more secure than trusting a body field
         # and saves the agent from having to remember to set it.
-        # _post helper sends POST; we need PATCH. Use urllib.request directly
-        # (already imported at module top).
+        # _post helper sends POST; we need PATCH. Build the request directly
+        # and send it through loopback_urlopen, which drops any HTTP_PROXY so
+        # X-Internal-Secret cannot leave the host.
         data = json.dumps(update_body).encode()
         headers = {
             "Content-Type": "application/json",
@@ -4972,7 +4974,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             f"{_API}/api/artifacts/{slug}", data=data, headers=headers, method="PATCH"
         )
         try:
-            with urllib.request.urlopen(req, timeout=30) as http_resp:
+            with loopback_urlopen(req, timeout=30) as http_resp:
                 d = json.loads(http_resp.read())
         except urllib.error.HTTPError as exc:
             try:
@@ -5034,7 +5036,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             f"{_API}/api/artifacts/{slug}", data=data, headers=headers, method="PATCH"
         )
         try:
-            with urllib.request.urlopen(req, timeout=30) as http_resp:
+            with loopback_urlopen(req, timeout=30) as http_resp:
                 d = json.loads(http_resp.read())
         except urllib.error.HTTPError as exc:
             try:

--- a/src/kiro_crew/mcp_playwright_proxy.py
+++ b/src/kiro_crew/mcp_playwright_proxy.py
@@ -24,6 +24,11 @@ import time
 import urllib.request
 from typing import Any
 
+# Stdlib-only leaf (it imports urllib.request and nothing else), so this
+# top-level import does not pull the gateway into this stdio proxy -- the same
+# constraint that makes _internal_secret() reach for the config.paths leaf.
+from kiro_crew.loopback_http import loopback_urlopen
+
 try:
     from PIL import Image
     _HAS_PIL = True
@@ -329,7 +334,7 @@ def _post_frame_to_gateway(img_bytes: bytes, fmt: str, source: str = "agent") ->
                 headers=headers,
                 method="POST",
             )
-            resp = urllib.request.urlopen(req, timeout=2)
+            resp = loopback_urlopen(req, timeout=2)
             try:
                 _record_subscriber_count(resp.read())
             finally:
@@ -371,7 +376,7 @@ def _post_pump_audit() -> bool:
             headers=headers,
             method="POST",
         )
-        resp = urllib.request.urlopen(req, timeout=2)
+        resp = loopback_urlopen(req, timeout=2)
         try:
             status = resp.getcode()
         finally:
@@ -865,7 +870,7 @@ def _try_native_tool_call(msg: dict[str, Any]) -> dict[str, Any] | None:
     )
     try:
         # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (http://127.0.0.1 + the fixed /api/browser/command path from _gateway_command_url); only the port varies, from KIROCREW_PORT local config, never user/agent/request input, so no file:// or arbitrary-read is reachable  # noqa: E501
-        with urllib.request.urlopen(req, timeout=_NATIVE_CALL_TIMEOUT_S) as resp:
+        with loopback_urlopen(req, timeout=_NATIVE_CALL_TIMEOUT_S) as resp:
             payload = json.loads(resp.read() or b"{}")
     except urllib.error.HTTPError as exc:
         # The gateway ANSWERED with a status. Only "there is no panel to drive"

--- a/src/kiro_crew/mcp_shared.py
+++ b/src/kiro_crew/mcp_shared.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Optional
 from kiro_crew import platform_compat
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.dashboard.origin import parse_dashboard_url
+from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.mcp_caller import (
     CallerContext,
     caller_identity_capability,
@@ -437,7 +438,7 @@ def _resolve_excluded_tools(caller_session: str = "") -> set[str]:
             headers=headers,
         )
         try:
-            with urllib.request.urlopen(req, timeout=5) as resp:
+            with loopback_urlopen(req, timeout=5) as resp:
                 policy = json.loads(resp.read())
         except urllib.error.HTTPError as http_exc:
             # 404 = "agent not resolved" (gateway side hasn't registered

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -23,6 +23,7 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
+from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.platform_compat import IS_LINUX, IS_MACOS
 from kiro_crew.pod import launchd
 from kiro_crew.pod import provision as prov
@@ -585,7 +586,7 @@ def health(port: int, timeout: int = 3) -> int:
         # Loopback-only probe to the pod's own gateway on 127.0.0.1; the URL is
         # internally derived (never attacker-supplied), so the dynamic-URL SSRF
         # audit rule is a false positive here.
-        with urllib.request.urlopen(url, timeout=timeout) as resp:  # nosemgrep
+        with loopback_urlopen(url, timeout=timeout) as resp:  # nosemgrep
             return resp.status
     except urllib.error.HTTPError as e:
         return e.code
@@ -612,7 +613,7 @@ def mint_token(cfg: PodConfig, name: str, ttl: str = "2h") -> str:
     try:
         # Loopback-only call to the pod's own gateway on 127.0.0.1; the URL is
         # internally derived, so the dynamic-URL SSRF audit rule is a false positive.
-        with urllib.request.urlopen(req, timeout=5) as resp:  # nosemgrep
+        with loopback_urlopen(req, timeout=5) as resp:  # nosemgrep
             token = json.loads(resp.read()).get("token", "")
     except (urllib.error.URLError, OSError, ValueError) as exc:
         raise PodError(f"token mint failed on :{port} ({name}): {exc}") from exc

--- a/test/test_browser_native_routing.py
+++ b/test/test_browser_native_routing.py
@@ -58,7 +58,7 @@ def _call(op_name="browser_navigate", args=None, req_id=7):
 
 
 class _Resp:
-    """Minimal context-manager stand-in for ``urllib.request.urlopen``."""
+    """Minimal context-manager stand-in for ``loopback_urlopen``."""
 
     def __init__(self, payload: bytes):
         self._payload = payload
@@ -119,7 +119,7 @@ def test_every_mapped_op_routes_native() -> None:
             seen["body"] = json.loads(req.data.decode())
             return _ok("done")
 
-        with _session(), patch.object(proxy.urllib.request, "urlopen", side_effect=_capture):
+        with _session(), patch.object(proxy, "loopback_urlopen", side_effect=_capture):
             out = proxy._try_native_tool_call(_call(tool, args_for[tool]))
         assert out is not None, f"{tool} must be intercepted, not forwarded"
         assert "result" in out, f"{tool} should return an MCP result"
@@ -127,7 +127,7 @@ def test_every_mapped_op_routes_native() -> None:
 
 
 def test_success_is_returned_as_an_mcp_result() -> None:
-    with _session(), patch.object(proxy.urllib.request, "urlopen", return_value=_ok("navigated")):
+    with _session(), patch.object(proxy, "loopback_urlopen", return_value=_ok("navigated")):
         out = proxy._try_native_tool_call(_call())
     assert out is not None
     assert out["result"]["isError"] is False
@@ -144,7 +144,7 @@ def test_unmapped_browser_tool_errors_and_does_not_fall_back() -> None:
     Precondition: a panel has already answered, so a native page IS being driven.
     """
     assert "browser_drag" not in proxy._NATIVE_OPS
-    with _session(), _panel_seen(), patch.object(proxy.urllib.request, "urlopen") as urlopen:
+    with _session(), _panel_seen(), patch.object(proxy, "loopback_urlopen") as urlopen:
         out = proxy._try_native_tool_call(_call("browser_drag", {"startElement": "a"}))
     assert out is not None, "an unmapped browser_* tool must NOT fall through to Playwright"
     assert "error" in out and "result" not in out
@@ -168,7 +168,7 @@ def test_unmapped_browser_tool_falls_back_when_no_panel_has_answered() -> None:
 def test_a_panel_answer_marks_presence_and_arms_the_refusal() -> None:
     """One answered native op flips presence, which then arms the refusal."""
     with _session(), _panel_seen(False):
-        with patch.object(proxy.urllib.request, "urlopen", return_value=_ok({"url": "x"})):
+        with patch.object(proxy, "loopback_urlopen", return_value=_ok({"url": "x"})):
             assert proxy._try_native_tool_call(_call()) is not None
         assert proxy._native_panel_seen is True
         # Now that a native page is proven, an unmapped tool is refused.
@@ -179,7 +179,7 @@ def test_a_panel_answer_marks_presence_and_arms_the_refusal() -> None:
 def test_transport_failure_does_not_mark_presence() -> None:
     """A 503/timeout must NOT arm the refusal -- that is the remote-host case."""
     with _session(), _panel_seen(False):
-        with patch.object(proxy.urllib.request, "urlopen", side_effect=OSError("no panel")):
+        with patch.object(proxy, "loopback_urlopen", side_effect=OSError("no panel")):
             assert proxy._try_native_tool_call(_call()) is None
         assert proxy._native_panel_seen is False
 
@@ -201,7 +201,7 @@ def test_refusal_returns_an_mcp_error_and_does_not_fall_back() -> None:
     payload = json.dumps(
         {"id": "c1", "ok": False, "error": "browser control refused: agent-act-not-authorized"}
     ).encode()
-    with _session(), patch.object(proxy.urllib.request, "urlopen", return_value=_Resp(payload)):
+    with _session(), patch.object(proxy, "loopback_urlopen", return_value=_Resp(payload)):
         out = proxy._try_native_tool_call(_call())
     assert out is not None, "a refusal must NOT fall through to Playwright"
     assert "error" in out and "result" not in out
@@ -225,11 +225,11 @@ def test_only_no_panel_http_statuses_fall_back() -> None:
         )
 
     for code in (503, 504):
-        with _session(), patch.object(proxy.urllib.request, "urlopen", side_effect=_http(code)):
+        with _session(), patch.object(proxy, "loopback_urlopen", side_effect=_http(code)):
             assert proxy._try_native_tool_call(_call()) is None, f"{code} must fall back"
 
     for code in (403, 429, 500):
-        with _session(), patch.object(proxy.urllib.request, "urlopen", side_effect=_http(code)):
+        with _session(), patch.object(proxy, "loopback_urlopen", side_effect=_http(code)):
             out = proxy._try_native_tool_call(_call())
         assert out is not None, f"HTTP {code} must NOT fall back to Playwright"
         assert "error" in out and "result" not in out
@@ -238,7 +238,7 @@ def test_only_no_panel_http_statuses_fall_back() -> None:
 
 def test_undecodable_panel_response_does_not_fall_back() -> None:
     """The panel is reachable but answered garbage -- surface it, never re-route."""
-    with _session(), patch.object(proxy.urllib.request, "urlopen", return_value=_Resp(b"not json")):
+    with _session(), patch.object(proxy, "loopback_urlopen", return_value=_Resp(b"not json")):
         out = proxy._try_native_tool_call(_call())
     assert out is not None and "error" in out
 
@@ -246,7 +246,7 @@ def test_undecodable_panel_response_does_not_fall_back() -> None:
 def test_transport_failure_does_fall_back() -> None:
     """No panel / timeout / connection error -> Playwright is the right target."""
     with _session(), patch.object(
-        proxy.urllib.request, "urlopen", side_effect=OSError("no panel")
+        proxy, "loopback_urlopen", side_effect=OSError("no panel")
     ):
         assert proxy._try_native_tool_call(_call()) is None
 
@@ -266,7 +266,7 @@ def test_empty_session_key_delegates_resolution_to_gateway_via_host_pid() -> Non
         return _ok("navigated")
 
     with patch.object(proxy, "_SESSION_KEY", ""), patch.object(
-        proxy.urllib.request, "urlopen", side_effect=_capture
+        proxy, "loopback_urlopen", side_effect=_capture
     ):
         out = proxy._try_native_tool_call(_call())
     assert out is not None and "result" in out, "an empty key must not short-circuit to Playwright"
@@ -284,7 +284,7 @@ def test_host_pid_is_sent_even_when_session_key_is_known() -> None:
         return _ok("navigated")
 
     with _session("dashboard:chat-1"), patch.object(
-        proxy.urllib.request, "urlopen", side_effect=_capture
+        proxy, "loopback_urlopen", side_effect=_capture
     ):
         assert proxy._try_native_tool_call(_call()) is not None
     assert "host_pid" in seen["body"] and isinstance(seen["body"]["host_pid"], int)
@@ -300,7 +300,7 @@ def test_empty_session_key_still_falls_back_on_no_panel() -> None:
         "http://127.0.0.1/api/browser/command", 503, "no-native-panel", {}, None  # type: ignore[arg-type]
     )
     with patch.object(proxy, "_SESSION_KEY", ""), patch.object(
-        proxy.urllib.request, "urlopen", side_effect=err
+        proxy, "loopback_urlopen", side_effect=err
     ):
         assert proxy._try_native_tool_call(_call()) is None
 
@@ -323,7 +323,7 @@ def test_ref_target_is_translated_to_ref_wire_field() -> None:
         seen["body"] = json.loads(req.data.decode())
         return _ok("clicked")
 
-    with _session(), patch.object(proxy.urllib.request, "urlopen", side_effect=_capture):
+    with _session(), patch.object(proxy, "loopback_urlopen", side_effect=_capture):
         out = proxy._try_native_tool_call(
             _call("browser_click", {"target": "e12", "element": "the Submit button"})
         )
@@ -334,7 +334,7 @@ def test_ref_target_is_translated_to_ref_wire_field() -> None:
 
 
 def test_selector_target_is_refused_not_mis_targeted() -> None:
-    with _session(), patch.object(proxy.urllib.request, "urlopen") as urlopen:
+    with _session(), patch.object(proxy, "loopback_urlopen") as urlopen:
         out = proxy._try_native_tool_call(_call("browser_click", {"target": "#submit-btn"}))
     assert out is not None and "error" in out
     assert "e5" in out["error"]["message"] or "ref" in out["error"]["message"].lower()
@@ -342,14 +342,14 @@ def test_selector_target_is_refused_not_mis_targeted() -> None:
 
 
 def test_missing_required_target_is_refused() -> None:
-    with _session(), patch.object(proxy.urllib.request, "urlopen") as urlopen:
+    with _session(), patch.object(proxy, "loopback_urlopen") as urlopen:
         out = proxy._try_native_tool_call(_call("browser_type", {"text": "hi"}))
     assert out is not None and "error" in out
     urlopen.assert_not_called()
 
 
 def test_stray_target_on_non_element_op_is_refused() -> None:
-    with _session(), patch.object(proxy.urllib.request, "urlopen") as urlopen:
+    with _session(), patch.object(proxy, "loopback_urlopen") as urlopen:
         out = proxy._try_native_tool_call(_call("browser_navigate", {"url": "x", "target": "e1"}))
     assert out is not None and "error" in out
     urlopen.assert_not_called()
@@ -362,7 +362,7 @@ def test_screenshot_result_is_saved_to_a_path() -> None:
     data = base64.b64encode(b"\x89PNGfakebytes").decode()
     payload = _ok({"data": data, "mimeType": "image/png"})
     with _session(), patch.object(
-        proxy.urllib.request, "urlopen", return_value=payload
+        proxy, "loopback_urlopen", return_value=payload
     ), patch.object(proxy, "_save_screenshot", return_value="/tmp/kirocrew-screenshots/s.png") as save:
         out = proxy._try_native_tool_call(_call("browser_take_screenshot", {"type": "png", "scale": "css"}))
     save.assert_called_once()

--- a/test/test_browser_screencast.py
+++ b/test/test_browser_screencast.py
@@ -272,7 +272,7 @@ class TestBrowseSessionKeyResolution:
 
         monkeypatch.setattr(proxy, "_EXTENSION_MODE", False)
         monkeypatch.setattr(proxy.threading, "Thread", _Thread)
-        monkeypatch.setattr(proxy.urllib.request, "urlopen", _fake_urlopen)
+        monkeypatch.setattr(proxy, "loopback_urlopen", _fake_urlopen)
         monkeypatch.setattr(proxy, "_internal_secret", lambda: "secret")
         monkeypatch.setattr(proxy, "_SESSION_KEY", "env-key")
 
@@ -591,7 +591,7 @@ class TestPumpAudit:
 
         calls = []
         monkeypatch.setattr(proxy, "_EXTENSION_MODE", True)
-        monkeypatch.setattr(proxy.urllib.request, "urlopen", lambda *a, **k: calls.append("post"))
+        monkeypatch.setattr(proxy, "loopback_urlopen", lambda *a, **k: calls.append("post"))
         # Extension mode: the user sees their own Chrome; no audit POST, and the
         # caller treats the False return as "do not inject".
         assert proxy._post_pump_audit() is False
@@ -601,14 +601,14 @@ class TestPumpAudit:
         import kiro_crew.mcp_playwright_proxy as proxy
 
         monkeypatch.setattr(proxy, "_EXTENSION_MODE", False)
-        monkeypatch.setattr(proxy.urllib.request, "urlopen", lambda *a, **k: self._resp(200))
+        monkeypatch.setattr(proxy, "loopback_urlopen", lambda *a, **k: self._resp(200))
         assert proxy._post_pump_audit() is True  # gateway acked -> injection allowed
 
     def test_post_pump_audit_false_on_non_2xx(self, monkeypatch):
         import kiro_crew.mcp_playwright_proxy as proxy
 
         monkeypatch.setattr(proxy, "_EXTENSION_MODE", False)
-        monkeypatch.setattr(proxy.urllib.request, "urlopen", lambda *a, **k: self._resp(500))
+        monkeypatch.setattr(proxy, "loopback_urlopen", lambda *a, **k: self._resp(500))
         assert proxy._post_pump_audit() is False  # not acked -> caller skips the injection
 
     def test_post_pump_audit_false_on_failure(self, monkeypatch):
@@ -618,7 +618,7 @@ class TestPumpAudit:
             raise OSError("gateway down")
 
         monkeypatch.setattr(proxy, "_EXTENSION_MODE", False)
-        monkeypatch.setattr(proxy.urllib.request, "urlopen", _boom)
+        monkeypatch.setattr(proxy, "loopback_urlopen", _boom)
         # A failed audit must report False so the pump skips the injection rather
         # than run an unaudited browser_take_screenshot.
         assert proxy._post_pump_audit() is False

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1481,7 +1481,7 @@ class TestLogout:
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
         mock_resp.__exit__ = MagicMock(return_value=False)
 
-        with patch("urllib.request.urlopen", return_value=mock_resp):
+        with patch("kiro_crew.cli_server.loopback_urlopen", return_value=mock_resp):
             _logout(5476)  # Should not raise
 
     def test_logout_gateway_not_running(self, tmp_path, monkeypatch):
@@ -1505,7 +1505,7 @@ class TestLogout:
         from kiro_crew.cli_server import _logout
 
         with patch(
-            "urllib.request.urlopen",
+            "kiro_crew.cli_server.loopback_urlopen",
             side_effect=urllib.error.HTTPError(None, 403, "Forbidden", {}, None),
         ):
             try:
@@ -1524,7 +1524,7 @@ class TestLogout:
         from kiro_crew.cli_server import _logout
 
         with patch(
-            "urllib.request.urlopen",
+            "kiro_crew.cli_server.loopback_urlopen",
             side_effect=urllib.error.URLError("Connection refused"),
         ):
             try:
@@ -1547,7 +1547,7 @@ class TestLogout:
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
         mock_resp.__exit__ = MagicMock(return_value=False)
 
-        with patch("urllib.request.urlopen", return_value=mock_resp):
+        with patch("kiro_crew.cli_server.loopback_urlopen", return_value=mock_resp):
             try:
                 _logout(5476)
                 assert False, "should have exited"
@@ -1566,7 +1566,7 @@ class TestStatus:
         from kiro_crew.cli_server import _status
 
         with patch(
-            "urllib.request.urlopen",
+            "kiro_crew.cli_server.loopback_urlopen",
             side_effect=urllib.error.HTTPError(
                 "http://127.0.0.1:5476/api/status", 403, "Forbidden", {}, None
             ),
@@ -1581,7 +1581,7 @@ class TestStatus:
         from kiro_crew.cli_server import _status
 
         with patch(
-            "urllib.request.urlopen",
+            "kiro_crew.cli_server.loopback_urlopen",
             side_effect=urllib.error.HTTPError(
                 "http://127.0.0.1:5476/api/status", 500, "Internal Server Error", {}, None
             ),
@@ -1596,7 +1596,7 @@ class TestStatus:
         from kiro_crew.cli_server import _status
 
         with patch(
-            "urllib.request.urlopen",
+            "kiro_crew.cli_server.loopback_urlopen",
             side_effect=urllib.error.URLError("Connection refused"),
         ):
             _status(self._make_args())
@@ -1622,7 +1622,7 @@ class TestStatus:
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
         mock_resp.__exit__ = MagicMock(return_value=False)
 
-        with patch("urllib.request.urlopen", return_value=mock_resp):
+        with patch("kiro_crew.cli_server.loopback_urlopen", return_value=mock_resp):
             _status(self._make_args())
         out = capsys.readouterr().out
         assert "1h 0m" in out
@@ -1632,7 +1632,7 @@ class TestStatus:
         """Non-network exceptions should report gateway as running with unexpected response."""
         from kiro_crew.cli_server import _status
 
-        with patch("urllib.request.urlopen", side_effect=RuntimeError("unexpected")):
+        with patch("kiro_crew.cli_server.loopback_urlopen", side_effect=RuntimeError("unexpected")):
             _status(self._make_args())
         out = capsys.readouterr().out
         assert "running" in out
@@ -3718,7 +3718,7 @@ class TestConfigDirOverride:
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
         mock_resp.__exit__ = MagicMock(return_value=False)
 
-        with patch("urllib.request.urlopen", return_value=mock_resp):
+        with patch("kiro_crew.cli_server.loopback_urlopen", return_value=mock_resp):
             _logout(5476)
 
     def test_setup_slack_tokens_writes_to_config_dir(self, tmp_path, monkeypatch):
@@ -3776,7 +3776,7 @@ class TestSpawnCliAuth:
             captured.append(req)
             return mock_resp
 
-        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+        monkeypatch.setattr("kiro_crew.cli_commands.loopback_urlopen", fake_urlopen)
 
         from kiro_crew.cli_commands import _spawn
 
@@ -3803,7 +3803,7 @@ class TestSpawnCliAuth:
             captured.append(req)
             return mock_resp
 
-        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+        monkeypatch.setattr("kiro_crew.cli_commands.loopback_urlopen", fake_urlopen)
 
         from kiro_crew.cli_commands import _spawn_run
 
@@ -3832,7 +3832,7 @@ class TestSpawnCliAuth:
                 fp=None,
             )
 
-        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+        monkeypatch.setattr("kiro_crew.cli_commands.loopback_urlopen", fake_urlopen)
 
         from kiro_crew.cli_commands import _spawn
 
@@ -3865,7 +3865,7 @@ class TestArtifactCli:
         # Surface any HTTP call as a fatal so we can prove the function exited
         # at the security check, not at the network layer.
         monkeypatch.setattr(
-            "urllib.request.urlopen",
+            "kiro_crew.cli_commands.loopback_urlopen",
             lambda *_a, **_kw: pytest.fail("_artifact must refuse before opening any HTTP request"),
         )
 
@@ -3891,7 +3891,7 @@ class TestArtifactCli:
 
         monkeypatch.setattr("kiro_crew.cli_commands.is_sensitive_path", lambda _p: True)
         monkeypatch.setattr(
-            "urllib.request.urlopen",
+            "kiro_crew.cli_commands.loopback_urlopen",
             lambda *_a, **_kw: pytest.fail("_artifact must refuse before opening any HTTP request"),
         )
 
@@ -4221,7 +4221,7 @@ class TestWaitGatewayReady:
         from kiro_crew import cli_server
 
         with patch(
-            "kiro_crew.cli_server.urllib.request.urlopen",
+            "kiro_crew.cli_server.loopback_urlopen",
             side_effect=http.client.BadStatusLine("garbage"),
         ):
             assert cli_server._probe_gateway_ready(7777) == 0
@@ -4345,21 +4345,23 @@ class TestWaitGatewayReady:
         resp = MagicMock(status=200)
         resp.__enter__ = lambda s: s
         resp.__exit__ = MagicMock(return_value=False)
-        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+        with patch("kiro_crew.cli_server.loopback_urlopen", return_value=resp) as mock_open:
             assert cli_server._probe_gateway_ready(7777) == 200
         assert mock_open.call_args.args[0] == "http://127.0.0.1:7777/api/ready"
 
     def test_probe_reports_zero_when_unreachable(self):
         from kiro_crew import cli_server
 
-        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("down")):
+        with patch(
+            "kiro_crew.cli_server.loopback_urlopen", side_effect=urllib.error.URLError("down")
+        ):
             assert cli_server._probe_gateway_ready(7777) == 0
 
     def test_probe_reports_the_http_status_of_a_not_ready_gateway(self):
         from kiro_crew import cli_server
 
         err = urllib.error.HTTPError("u", 503, "not ready", {}, None)
-        with patch("urllib.request.urlopen", side_effect=err):
+        with patch("kiro_crew.cli_server.loopback_urlopen", side_effect=err):
             assert cli_server._probe_gateway_ready(7777) == 503
 
 
@@ -4391,7 +4393,7 @@ class TestPrintTokenUrl:
         mock_resp.__enter__ = lambda s: s
         mock_resp.__exit__ = MagicMock(return_value=False)
 
-        with patch("urllib.request.urlopen", return_value=mock_resp):
+        with patch("kiro_crew.cli_server.loopback_urlopen", return_value=mock_resp):
             _print_token_url(7777)
 
         out = capsys.readouterr().out
@@ -4416,7 +4418,7 @@ class TestPrintTokenUrl:
         mock_resp.__enter__ = lambda s: s
         mock_resp.__exit__ = MagicMock(return_value=False)
 
-        with patch("urllib.request.urlopen", return_value=mock_resp):
+        with patch("kiro_crew.cli_server.loopback_urlopen", return_value=mock_resp):
             _print_token_url(7777)
 
         out = capsys.readouterr().out
@@ -4797,7 +4799,10 @@ class TestTokenCommand:
         )
 
         args = argparse.Namespace(ttl="1h", port=7777)
-        with patch("urllib.request.urlopen", return_value=self._mock_token_response("abc123")):
+        with patch(
+            "kiro_crew.cli_server.loopback_urlopen",
+            return_value=self._mock_token_response("abc123"),
+        ):
             _token(args)
 
         out = capsys.readouterr().out
@@ -4825,7 +4830,10 @@ class TestTokenCommand:
         )
 
         args = argparse.Namespace(ttl="1h", port=7777)
-        with patch("urllib.request.urlopen", return_value=self._mock_token_response("xyz789")):
+        with patch(
+            "kiro_crew.cli_server.loopback_urlopen",
+            return_value=self._mock_token_response("xyz789"),
+        ):
             _token(args)
 
         out = capsys.readouterr().out
@@ -4884,7 +4892,9 @@ class TestTokenCommand:
         from kiro_crew.cli_server import _token
 
         self._stub_token_env(tmp_path, monkeypatch)
-        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("refused")):
+        with patch(
+            "kiro_crew.cli_server.loopback_urlopen", side_effect=urllib.error.URLError("refused")
+        ):
             with pytest.raises(SystemExit) as excinfo:
                 _token(argparse.Namespace(ttl="1h", port=7777))
         assert excinfo.value.code == 1
@@ -4896,7 +4906,9 @@ class TestTokenCommand:
         from kiro_crew.cli_server import _token
 
         self._stub_token_env(tmp_path, monkeypatch)
-        with patch("urllib.request.urlopen", return_value=self._mock_token_response("")):
+        with patch(
+            "kiro_crew.cli_server.loopback_urlopen", return_value=self._mock_token_response("")
+        ):
             with pytest.raises(SystemExit) as excinfo:
                 _token(argparse.Namespace(ttl="1h", port=7777))
         assert excinfo.value.code == 1
@@ -4916,7 +4928,10 @@ class TestTokenCommand:
         from kiro_crew.cli_server import _token
 
         self._stub_token_env(tmp_path, monkeypatch)
-        with patch("urllib.request.urlopen", return_value=self._mock_token_response("eyJa.b")):
+        with patch(
+            "kiro_crew.cli_server.loopback_urlopen",
+            return_value=self._mock_token_response("eyJa.b"),
+        ):
             _token(argparse.Namespace(ttl="1h", port=7777))
         captured = capsys.readouterr()
         lines = [ln for ln in captured.out.splitlines() if ln.strip()]

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -5,7 +5,7 @@ these tests call the handlers DIRECTLY (never through a subprocess) and assert
 on the routed side effects: which collaborator was called, what was printed, and
 which exit code was raised. Everything that would touch the network, the real
 data home, or a live gateway is mocked -- the module's HTTP paths are exercised
-by patching ``urllib.request.urlopen``, and every filesystem write lands in
+by patching ``kiro_crew.cli_commands.loopback_urlopen``, and every filesystem write lands in
 ``tmp_path``.
 
 Follows the style already established by ``test_cli.py`` (``argparse.Namespace``
@@ -157,7 +157,7 @@ class TestSpawnCli:
         payload = {"agents": [{"id": "a1", "task": "do x", "done": True}, {"id": "a2", "task": "y"}]}
         with (
             patch("kiro_crew.cli_commands._internal_secret", return_value="s"),
-            patch("urllib.request.urlopen", return_value=_FakeResponse(payload)),
+            patch("kiro_crew.cli_commands.loopback_urlopen", return_value=_FakeResponse(payload)),
         ):
             cc._spawn(_ns(spawn_action="list", port=1234))
         out = capsys.readouterr().out
@@ -166,7 +166,7 @@ class TestSpawnCli:
     def test_list_empty_says_so(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
             patch("kiro_crew.cli_commands._internal_secret", return_value=""),
-            patch("urllib.request.urlopen", return_value=_FakeResponse({"agents": []})),
+            patch("kiro_crew.cli_commands.loopback_urlopen", return_value=_FakeResponse({"agents": []})),
         ):
             cc._spawn(_ns(spawn_action="list", port=1234))
         assert "No subagents." in capsys.readouterr().out
@@ -177,7 +177,7 @@ class TestSpawnCli:
         err = _http_error(400, json.dumps({"error": "bad spawn"}).encode())
         with (
             patch("kiro_crew.cli_commands._internal_secret", return_value=""),
-            patch("urllib.request.urlopen", side_effect=err),
+            patch("kiro_crew.cli_commands.loopback_urlopen", side_effect=err),
             pytest.raises(SystemExit) as exc,
         ):
             cc._spawn(_ns(spawn_action="list", port=1234))
@@ -189,7 +189,7 @@ class TestSpawnCli:
     ) -> None:
         with (
             patch("kiro_crew.cli_commands._internal_secret", return_value=""),
-            patch("urllib.request.urlopen", side_effect=_http_error(503, b"<html>")),
+            patch("kiro_crew.cli_commands.loopback_urlopen", side_effect=_http_error(503, b"<html>")),
             pytest.raises(SystemExit),
         ):
             cc._spawn(_ns(spawn_action="list", port=1234))
@@ -200,7 +200,7 @@ class TestSpawnCli:
     ) -> None:
         with (
             patch("kiro_crew.cli_commands._internal_secret", return_value=""),
-            patch("urllib.request.urlopen", side_effect=urllib.error.URLError("refused")),
+            patch("kiro_crew.cli_commands.loopback_urlopen", side_effect=urllib.error.URLError("refused")),
             pytest.raises(SystemExit) as exc,
         ):
             cc._spawn(_ns(spawn_action="list", port=4321))
@@ -217,7 +217,7 @@ class TestSpawnCli:
         with (
             patch("kiro_crew.cli_commands._internal_secret", return_value=""),
             patch(
-                "urllib.request.urlopen",
+                "kiro_crew.cli_commands.loopback_urlopen",
                 return_value=_FakeResponse({"id": "ag1", "task": "t"}),
             ) as uo,
         ):
@@ -236,7 +236,7 @@ class TestSpawnCli:
         with (
             patch("kiro_crew.cli_commands._internal_secret", return_value=""),
             patch.object(cc._time, "sleep") as slept,
-            patch("urllib.request.urlopen", side_effect=responses),
+            patch("kiro_crew.cli_commands.loopback_urlopen", side_effect=responses),
         ):
             cc._spawn(_ns(spawn_action="run", port=1, task="t", fire_and_forget=False))
         assert "final answer" in capsys.readouterr().out
@@ -252,7 +252,7 @@ class TestSpawnCli:
         with (
             patch("kiro_crew.cli_commands._internal_secret", return_value=""),
             patch.object(cc._time, "sleep"),
-            patch("urllib.request.urlopen", side_effect=responses),
+            patch("kiro_crew.cli_commands.loopback_urlopen", side_effect=responses),
             pytest.raises(SystemExit) as exc,
         ):
             cc._spawn(_ns(spawn_action="run", port=1, task="t", fire_and_forget=False))
@@ -266,7 +266,7 @@ class TestSpawnCli:
             patch("kiro_crew.cli_commands._internal_secret", return_value=""),
             patch.object(cc._time, "sleep"),
             patch(
-                "urllib.request.urlopen",
+                "kiro_crew.cli_commands.loopback_urlopen",
                 side_effect=[_FakeResponse({"id": "ag4", "task": "t"}), OSError("gone")],
             ),
             pytest.raises(SystemExit),
@@ -278,7 +278,7 @@ class TestSpawnCli:
         err = _http_error(422, json.dumps({"error": "task too long"}).encode())
         with (
             patch("kiro_crew.cli_commands._internal_secret", return_value=""),
-            patch("urllib.request.urlopen", side_effect=err),
+            patch("kiro_crew.cli_commands.loopback_urlopen", side_effect=err),
             pytest.raises(SystemExit),
         ):
             cc._spawn(_ns(spawn_action="run", port=1, task="t", fire_and_forget=True))
@@ -287,7 +287,7 @@ class TestSpawnCli:
     def test_run_unreachable_gateway_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
             patch("kiro_crew.cli_commands._internal_secret", return_value=""),
-            patch("urllib.request.urlopen", side_effect=OSError("no route")),
+            patch("kiro_crew.cli_commands.loopback_urlopen", side_effect=OSError("no route")),
             pytest.raises(SystemExit),
         ):
             cc._spawn(_ns(spawn_action="run", port=9, task="t", fire_and_forget=True))
@@ -1431,7 +1431,7 @@ class _ArtifactHarness:
             patch.object(KiroCrewConfig, "load", return_value=KiroCrewConfig()),
             patch("kiro_crew.cli_commands.parse_dashboard_url", return_value=("localhost", 5476)),
             patch("kiro_crew.cli_commands._internal_secret", return_value="s"),
-            patch("urllib.request.urlopen", side_effect=self._responses),
+            patch("kiro_crew.cli_commands.loopback_urlopen", side_effect=self._responses),
         ]
         started = [p.start() for p in self._patches]
         self.urlopen = started[-1]

--- a/test/test_computer_use_api.py
+++ b/test/test_computer_use_api.py
@@ -22,7 +22,9 @@ pinned ``pytest`` for async fixtures.
 from __future__ import annotations
 
 import dataclasses
+import http.server
 import json
+import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1166,6 +1168,106 @@ class TestLiveViewSuppression:
         monkeypatch.setattr(screencast, "active_scope", _boom)
         assert screencast.emit_snapshot_frame(self._snapshot()) is False
         assert no_real_post == []
+
+
+class TestTheFrameRelayIsNeverProxied:
+    """The relay POST carries the gateway's local secret, so it must not proxy.
+
+    ``urlopen`` builds its opener from ``getproxies()`` and urllib has no implicit
+    loopback exemption, so with ``http_proxy`` set — routine in a container or on a
+    corporate desktop — a POST to ``http://127.0.0.1:<port>`` goes to the proxy in
+    absolute form with ``X-Internal-Secret`` attached, in cleartext. The relay runs
+    through ``loopback_urlopen``, whose opener carries an explicit
+    ``ProxyHandler({})``.
+
+    ``_post_frame`` is called DIRECTLY rather than through ``emit_snapshot_frame``:
+    every other case in this file replaces ``_post_frame`` wholesale, so the
+    transport inside it is the one part of the relay with no coverage at all.
+
+    Both listeners are real sockets on port 0, following ``test_cron_trigger.py`` —
+    the kernel hands out a free port, so no ``xdist_group`` marker is needed.
+    """
+
+    SECRET = "canary-not-a-real-frame-secret"
+
+    # ``getproxies_environment`` ignores uppercase ``HTTP_PROXY`` when
+    # ``REQUEST_METHOD`` is set (the httpoxy CGI guard), so that is cleared too —
+    # otherwise a CI runner exporting it would make this pass vacuously.
+    _PROXY_ENV_KEYS = (
+        "http_proxy",
+        "HTTP_PROXY",
+        "https_proxy",
+        "HTTPS_PROXY",
+        "all_proxy",
+        "ALL_PROXY",
+        "no_proxy",
+        "NO_PROXY",
+        "REQUEST_METHOD",
+    )
+
+    @staticmethod
+    def _serve(sink: list):
+        """A listener that records the secret header it saw, then answers 200."""
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def do_POST(self):  # noqa: N802 - stdlib naming
+                length = int(self.headers.get("Content-Length") or 0)
+                if length:
+                    self.rfile.read(length)
+                sink.append(
+                    {
+                        "requestline": self.requestline,
+                        "secret": self.headers.get("X-Internal-Secret"),
+                    }
+                )
+                self.send_response(200)
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b"ok")
+
+            def log_message(self, fmt, *args):
+                pass  # keep pytest output clean
+
+        server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        return server, server.server_address[1]
+
+    def test_the_secret_reaches_the_gateway_and_never_the_proxy(self, home, monkeypatch):
+        from kiro_crew.computer_use import screencast
+
+        gateway_hits: list[dict] = []
+        proxy_hits: list[dict] = []
+        gateway, gateway_port = self._serve(gateway_hits)
+        proxy, proxy_port = self._serve(proxy_hits)
+        try:
+            for key in self._PROXY_ENV_KEYS:
+                monkeypatch.delenv(key, raising=False)
+            monkeypatch.setenv("http_proxy", f"http://127.0.0.1:{proxy_port}")
+            # The real ``_headers()`` runs, so the header the ingress authenticates
+            # with is the one under test rather than a literal in this file.
+            (home / ".local_secret").write_text(self.SECRET, encoding="utf-8")
+            monkeypatch.setattr(
+                screencast,
+                "_ingress_url",
+                lambda: f"http://127.0.0.1:{gateway_port}{screencast.FRAME_INGRESS_PATH}",
+            )
+
+            screencast._post_frame({"data": "QUJD", "format": "jpeg"})
+
+            assert proxy_hits == [], f"the frame secret reached the proxy: {proxy_hits}"
+            # Positive leg too: ``_post_frame`` swallows every failure, so "the proxy
+            # saw nothing" alone would also pass if the POST had never happened.
+            assert [h["secret"] for h in gateway_hits] == [self.SECRET]
+            # Origin-form request line confirms a direct connection rather than a
+            # proxied one, which is sent absolute-form.
+            assert gateway_hits[0]["requestline"].startswith(
+                f"POST {screencast.FRAME_INGRESS_PATH}"
+            )
+        finally:
+            gateway.shutdown()
+            proxy.shutdown()
 
 
 class TestInvokePublishesTheFrameScope:

--- a/test/test_cron_script.py
+++ b/test/test_cron_script.py
@@ -601,7 +601,7 @@ class TestScriptContextNotify:
         mock_response.read.return_value = b'{"ok": true}'
         mock_response.__enter__ = MagicMock(return_value=mock_response)
         mock_response.__exit__ = MagicMock(return_value=False)
-        with patch("urllib.request.urlopen", return_value=mock_response):
+        with patch("kiro_crew.cron_script.loopback_urlopen", return_value=mock_response):
             result = ctx.notify("hello")
         assert result == {"ok": True}
 
@@ -612,7 +612,7 @@ class TestScriptContextNotify:
         mock_response.read.return_value = b'{"error": "forbidden"}'
         mock_response.__enter__ = MagicMock(return_value=mock_response)
         mock_response.__exit__ = MagicMock(return_value=False)
-        with patch("urllib.request.urlopen", return_value=mock_response):
+        with patch("kiro_crew.cron_script.loopback_urlopen", return_value=mock_response):
             with pytest.raises(RuntimeError, match="forbidden"):
                 ctx.notify("hello")
 
@@ -623,7 +623,9 @@ class TestScriptContextNotify:
         mock_response.read.return_value = b'{"ok": true}'
         mock_response.__enter__ = MagicMock(return_value=mock_response)
         mock_response.__exit__ = MagicMock(return_value=False)
-        with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+        with patch(
+            "kiro_crew.cron_script.loopback_urlopen", return_value=mock_response
+        ) as mock_urlopen:
             ctx.notify("secret AKIA1234567890123456 text")
             # Verify the request was made (redaction happens internally)
             mock_urlopen.assert_called_once()
@@ -1001,14 +1003,16 @@ class TestScriptContextPost:
         mock_response.read.return_value = b'{"status": "delivered"}'
         mock_response.__enter__ = MagicMock(return_value=mock_response)
         mock_response.__exit__ = MagicMock(return_value=False)
-        with patch("urllib.request.urlopen", return_value=mock_response):
+        with patch("kiro_crew.cron_script.loopback_urlopen", return_value=mock_response):
             result = ctx._post("/api/deliver", {"text": "hello"})
         assert result == {"status": "delivered"}
 
     def test_post_failure_returns_error(self):
         job = SimpleNamespace(id="j1", message="test")
         ctx = ScriptContext(job=job)
-        with patch("urllib.request.urlopen", side_effect=Exception("connection refused")):
+        with patch(
+            "kiro_crew.cron_script.loopback_urlopen", side_effect=Exception("connection refused")
+        ):
             result = ctx._post("/api/deliver", {"text": "hello"})
         assert "error" in result
         assert "connection refused" in result["error"]

--- a/test/test_cron_trigger.py
+++ b/test/test_cron_trigger.py
@@ -125,6 +125,84 @@ class TestTriggerCronJob:
         assert "Invalid job ID format" in msg
 
 
+# ── Proxy-Leak Regression ──
+
+
+class _MockProxyHandler(BaseHTTPRequestHandler):
+    """Stand-in proxy that records anything urllib routes to it."""
+
+    hits: list[dict] = []
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length") or 0)
+        if length:
+            self.rfile.read(length)
+        _MockProxyHandler.hits.append(
+            {"requestline": self.requestline, "secret": self.headers.get("X-Internal-Secret")}
+        )
+        self.send_response(200)
+        self.send_header("Content-Length", "2")
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def log_message(self, format, *args):
+        pass
+
+
+_PROXY_ENV_KEYS = (
+    "http_proxy",
+    "HTTP_PROXY",
+    "https_proxy",
+    "HTTPS_PROXY",
+    "all_proxy",
+    "ALL_PROXY",
+    "no_proxy",
+    "NO_PROXY",
+    # getproxies_environment ignores uppercase HTTP_PROXY when REQUEST_METHOD is
+    # set (the httpoxy CGI guard). Clear it so the spelling set below takes
+    # effect regardless of how the developer's shell is configured.
+    "REQUEST_METHOD",
+)
+
+
+@pytest.fixture()
+def mock_proxy():
+    """Start a second real listener standing in for an env-configured proxy."""
+    _MockProxyHandler.hits = []
+    server = HTTPServer(("127.0.0.1", 0), _MockProxyHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server.server_address[1], _MockProxyHandler.hits
+    server.shutdown()
+
+
+class TestSecretNeverReachesAProxy:
+    """The trigger secret must reach the gateway and never a configured proxy.
+
+    urllib has no implicit loopback exemption, so with ``http_proxy`` set this
+    POST is otherwise sent to the proxy in absolute form with the secret header
+    attached. Both listeners bind port 0, so the kernel hands out free ports and
+    no ``xdist_group`` marker is needed.
+    """
+
+    def test_proxy_listener_never_sees_the_secret(self, mock_dashboard, mock_proxy, monkeypatch):
+        port, cfg_dir = mock_dashboard
+        proxy_port, proxy_hits = mock_proxy
+        for key in _PROXY_ENV_KEYS:
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("http_proxy", f"http://127.0.0.1:{proxy_port}")
+        _MockDashboardHandler.last_request_headers = {}
+
+        ok, msg = trigger_cron_job("abc12345", port, cfg_dir / ".local_secret")
+
+        assert ok is True, msg
+        assert proxy_hits == [], f"secret reached the proxy: {proxy_hits}"
+        assert (
+            _MockDashboardHandler.last_request_headers.get("X-Internal-Secret")
+            == _MockDashboardHandler.secret
+        )
+
+
 # ── MCP Tool Tests ──
 
 

--- a/test/test_ephemeral_sessions.py
+++ b/test/test_ephemeral_sessions.py
@@ -569,7 +569,7 @@ class TestLessonsGate:
 class TestMcpCoreSessionKeyPassthrough:
     def test_learn_add_sends_session_key_header(self):
         with (
-            patch("kiro_crew.mcp_core.urllib.request.urlopen") as mock_urlopen,
+            patch("kiro_crew.mcp_core.loopback_urlopen") as mock_urlopen,
             patch.dict("os.environ", {"KIROCREW_SESSION_KEY": "dashboard:e1"}),
         ):
             mock_resp = MagicMock()
@@ -586,7 +586,7 @@ class TestMcpCoreSessionKeyPassthrough:
 
     def test_learn_add_no_session_key_header_when_unset(self):
         with (
-            patch("kiro_crew.mcp_core.urllib.request.urlopen") as mock_urlopen,
+            patch("kiro_crew.mcp_core.loopback_urlopen") as mock_urlopen,
             patch("kiro_crew.mcp_core._resolve_session_key", return_value=""),
         ):
             mock_resp = MagicMock()
@@ -612,7 +612,7 @@ class TestMcpCoreSessionKeyPassthrough:
         import urllib.error
 
         with (
-            patch("kiro_crew.mcp_core.urllib.request.urlopen") as mock_urlopen,
+            patch("kiro_crew.mcp_core.loopback_urlopen") as mock_urlopen,
             patch("kiro_crew.mcp_core._resolve_session_key", return_value="1781215864.487849"),
         ):
             mock_urlopen.side_effect = urllib.error.HTTPError(
@@ -632,7 +632,7 @@ class TestMcpCoreSessionKeyPassthrough:
         import urllib.error
 
         with (
-            patch("kiro_crew.mcp_core.urllib.request.urlopen") as mock_urlopen,
+            patch("kiro_crew.mcp_core.loopback_urlopen") as mock_urlopen,
             patch("kiro_crew.mcp_core._resolve_session_key", return_value=""),
         ):
             mock_urlopen.side_effect = urllib.error.HTTPError(
@@ -654,7 +654,7 @@ class TestMcpCoreSessionKeyPassthrough:
         import urllib.error
 
         with (
-            patch("kiro_crew.mcp_core.urllib.request.urlopen") as mock_urlopen,
+            patch("kiro_crew.mcp_core.loopback_urlopen") as mock_urlopen,
             patch("kiro_crew.mcp_core._resolve_session_key", return_value=""),
         ):
             mock_urlopen.side_effect = urllib.error.HTTPError(
@@ -677,7 +677,7 @@ class TestMcpCoreSessionKeyPassthrough:
         import urllib.error
 
         with (
-            patch("kiro_crew.mcp_core.urllib.request.urlopen") as mock_urlopen,
+            patch("kiro_crew.mcp_core.loopback_urlopen") as mock_urlopen,
             patch("kiro_crew.mcp_core._resolve_session_key", return_value="1781215864.487849"),
         ):
             mock_urlopen.side_effect = urllib.error.HTTPError(

--- a/test/test_identity_topology.py
+++ b/test/test_identity_topology.py
@@ -243,7 +243,7 @@ def test_mcp_shared_policy_walk_reaches_gateway(topo, monkeypatch, view) -> None
     response.__enter__ = MagicMock(return_value=response)
     response.__exit__ = MagicMock(return_value=False)
     urlopen = MagicMock(return_value=response)
-    monkeypatch.setattr(mcp_shared.urllib.request, "urlopen", urlopen)
+    monkeypatch.setattr(mcp_shared, "loopback_urlopen", urlopen)
 
     assert mcp_shared._resolve_excluded_tools() == set()
     # The walk must have RESOLVED a session key and reached the gateway —
@@ -399,7 +399,7 @@ def test_mcp_shared_refuses_symlinked_pid_file(topo, monkeypatch) -> None:
     _wire_common(monkeypatch, topo, "host")
 
     urlopen = MagicMock()
-    monkeypatch.setattr(mcp_shared.urllib.request, "urlopen", urlopen)
+    monkeypatch.setattr(mcp_shared, "loopback_urlopen", urlopen)
 
     # No key resolvable -> startup-race fail-open WITHOUT a policy call and,
     # crucially, WITHOUT the stolen key ever being read through the symlink.

--- a/test/test_loopback_proxy.py
+++ b/test/test_loopback_proxy.py
@@ -1,0 +1,276 @@
+"""The loopback secret must never reach a proxy named by the environment.
+
+Every request to the local gateway carries ``X-Internal-Secret``, which
+authorises write endpoints. ``urlopen`` honours ``HTTP_PROXY`` for loopback
+addresses -- urllib has no implicit loopback exemption -- so a developer or
+container with a proxy configured leaks the secret to it.
+
+The two env shapes guarded here are the two that actually leak, established by
+running a real proxy listener and reading the bytes it received:
+
+* proxy set, ``no_proxy`` unset
+* proxy set, ``no_proxy=localhost``, target spelled ``127.0.0.1`` -- the
+  dangerous one, because ``no_proxy=localhost`` is the common corporate default
+  and looks like coverage while matching on the host string only
+
+Both listeners are real sockets on port 0, following ``test_cron_trigger.py``:
+the kernel hands out a free port, so no ``xdist_group`` marker is needed.
+
+Deliberately NOT written as "call the product function and see where it went via
+``urllib.request.urlopen``": ``urllib.request._opener`` is a process-global
+cache built on the first ``urlopen`` call anywhere in the worker, so under
+``-n auto`` a later ``monkeypatch.setenv`` is invisible through it and the test
+would be order-dependent. The helper owns its own opener, and the control test
+below builds a fresh one, so neither touches that cache.
+"""
+
+import http.server
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.loopback_http import build_loopback_opener, loopback_urlopen
+
+CANARY = "canary-not-a-real-secret"
+SECRET_HEADER = "X-Internal-Secret"
+
+_PROXY_ENV_KEYS = (
+    "http_proxy",
+    "HTTP_PROXY",
+    "https_proxy",
+    "HTTPS_PROXY",
+    "all_proxy",
+    "ALL_PROXY",
+    "no_proxy",
+    "NO_PROXY",
+    # getproxies_environment ignores uppercase HTTP_PROXY when REQUEST_METHOD is
+    # set (the httpoxy CGI guard). Clear it so the parametrised spellings below
+    # behave identically.
+    "REQUEST_METHOD",
+)
+
+
+def _make_handler(sink, redirect_to=None):
+    """Build a handler that records the secret it saw, optionally 302-ing away."""
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_POST(self):  # noqa: N802 - stdlib naming
+            length = int(self.headers.get("Content-Length") or 0)
+            if length:
+                self.rfile.read(length)
+            sink.append(
+                {
+                    "requestline": self.requestline,
+                    "secret": self.headers.get(SECRET_HEADER),
+                }
+            )
+            if redirect_to:
+                self.send_response(302)
+                self.send_header("Location", redirect_to)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("Content-Length", "2")
+            self.end_headers()
+            self.wfile.write(b"ok")
+
+        def log_message(self, fmt, *args):
+            pass  # keep pytest output clean
+
+    return Handler
+
+
+def _serve(sink, redirect_to=None):
+    server = http.server.HTTPServer(("127.0.0.1", 0), _make_handler(sink, redirect_to))
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, server.server_address[1]
+
+
+def _post(url):
+    return urllib.request.Request(
+        url,
+        data=b"{}",
+        headers={"Content-Type": "application/json", SECRET_HEADER: CANARY},
+        method="POST",
+    )
+
+
+@pytest.fixture()
+def listeners():
+    """A stand-in gateway and a stand-in proxy, each recording what it received."""
+    gateway_hits: list[dict] = []
+    proxy_hits: list[dict] = []
+    gateway, gateway_port = _serve(gateway_hits)
+    proxy, proxy_port = _serve(proxy_hits)
+    try:
+        yield {
+            "gateway_hits": gateway_hits,
+            "proxy_hits": proxy_hits,
+            "gateway_port": gateway_port,
+            "proxy_port": proxy_port,
+        }
+    finally:
+        gateway.shutdown()
+        proxy.shutdown()
+
+
+def _set_proxy_env(monkeypatch, proxy_port, spelling, no_proxy=None):
+    for key in _PROXY_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv(spelling, f"http://127.0.0.1:{proxy_port}")
+    if no_proxy is not None:
+        monkeypatch.setenv("no_proxy", no_proxy)
+
+
+class TestLoopbackSecretNeverReachesAProxy:
+    """Regression guard for the loopback-secret-through-HTTP_PROXY leak."""
+
+    @pytest.mark.parametrize("spelling", ["http_proxy", "HTTP_PROXY"])
+    def test_ignores_proxy_when_no_proxy_is_unset(self, monkeypatch, listeners, spelling):
+        """Probe case B: proxy set, no_proxy unset. The bare leak."""
+        _set_proxy_env(monkeypatch, listeners["proxy_port"], spelling)
+
+        with loopback_urlopen(
+            _post(f"http://127.0.0.1:{listeners['gateway_port']}/api/lessons"), timeout=5
+        ) as resp:
+            assert resp.status == 200
+
+        assert listeners["proxy_hits"] == [], (
+            f"secret reached the proxy: {listeners['proxy_hits']}"
+        )
+        assert [h["secret"] for h in listeners["gateway_hits"]] == [CANARY]
+
+    def test_ignores_proxy_when_no_proxy_names_localhost_only(self, monkeypatch, listeners):
+        """Probe case F: no_proxy=localhost does NOT cover the literal 127.0.0.1.
+
+        ``no_proxy`` matches the host string, not what it resolves to. This is
+        the shape an operator is most likely to mistake for safety, so it gets
+        its own test rather than a parameter.
+        """
+        _set_proxy_env(monkeypatch, listeners["proxy_port"], "http_proxy", no_proxy="localhost")
+
+        with loopback_urlopen(
+            _post(f"http://127.0.0.1:{listeners['gateway_port']}/api/lessons"), timeout=5
+        ) as resp:
+            assert resp.status == 200
+
+        assert listeners["proxy_hits"] == [], (
+            f"secret reached the proxy despite no_proxy=localhost: {listeners['proxy_hits']}"
+        )
+        assert [h["secret"] for h in listeners["gateway_hits"]] == [CANARY]
+
+    def test_default_opener_does_leak(self, monkeypatch, listeners):
+        """Canary for the premise: without the helper, the secret DOES proxy.
+
+        Builds a fresh default opener rather than calling ``urlopen``, because
+        the module-global opener is cached on first use per process and would
+        make this order-dependent under xdist.
+
+        If CPython ever adds an implicit loopback exemption this test fails,
+        which is the signal to re-examine whether the helper is still needed --
+        not a reason to delete the guard above.
+        """
+        _set_proxy_env(monkeypatch, listeners["proxy_port"], "http_proxy")
+
+        with urllib.request.build_opener().open(
+            _post(f"http://127.0.0.1:{listeners['gateway_port']}/api/lessons"), timeout=5
+        ) as resp:
+            assert resp.status == 200
+
+        assert [h["secret"] for h in listeners["proxy_hits"]] == [CANARY]
+        assert listeners["gateway_hits"] == [], "the proxy answered, so the gateway saw nothing"
+        # Absolute-form request line is the confirmation it was treated as a
+        # proxied host rather than a direct connection.
+        assert listeners["proxy_hits"][0]["requestline"].startswith("POST http://127.0.0.1:")
+
+    def test_refuses_to_follow_a_redirect(self, monkeypatch, listeners):
+        """A 3xx from the gateway must not replay the secret to Location."""
+        for key in _PROXY_ENV_KEYS:
+            monkeypatch.delenv(key, raising=False)
+        redirect_hits: list[dict] = []
+        target, target_port = _serve(redirect_hits)
+        gateway_hits: list[dict] = []
+        gateway, gateway_port = _serve(
+            gateway_hits, redirect_to=f"http://127.0.0.1:{target_port}/stolen"
+        )
+        try:
+            with pytest.raises(urllib.error.HTTPError) as excinfo:
+                loopback_urlopen(
+                    _post(f"http://127.0.0.1:{gateway_port}/api/lessons"), timeout=5
+                )
+            assert excinfo.value.code == 302
+            assert redirect_hits == [], f"secret followed the redirect: {redirect_hits}"
+        finally:
+            gateway.shutdown()
+            target.shutdown()
+
+
+class TestNoNewBareLoopbackSender:
+    """A new secret-bearing call site must not be able to recreate this leak.
+
+    The helper and its tests pin the helper, not the call sites -- so the next
+    module that reaches for ``urllib.request.urlopen`` while sending a secret header
+    silently reopens the hole, and the failure presents as a hang before it presents
+    as a failure. This gate is what makes the fix stick.
+
+    Deliberately line-level, not file-level: ``cli_server.py`` sends a secret AND
+    legitimately fetches an external update feed, which must keep the proxy.
+    """
+
+    # A bare urlopen inside a secret-sending module is allowed only when one of the
+    # 5 preceding lines names an external target. Semantic rather than exact-text so
+    # an unrelated reformat does not fail CI, and explicit so adding one is a
+    # deliberate edit with a reason.
+    EXTERNAL_MARKERS = ("feed_url",)
+    SECRET_HEADERS = ("X-Internal-Secret", "X-Local-Secret")
+
+    def test_no_bare_urlopen_in_a_secret_sending_module(self):
+        src = Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
+        assert src.is_dir(), f"source tree not found at {src}"
+
+        offenders: list[str] = []
+        for path in src.rglob("*.py"):
+            text = path.read_text(encoding="utf-8", errors="replace")
+            if not any(h in text for h in self.SECRET_HEADERS):
+                continue
+            lines = text.splitlines()
+            for i, line in enumerate(lines):
+                if "urllib.request.urlopen(" not in line:
+                    continue
+                window = "\n".join(lines[max(0, i - 5): i + 1])
+                if any(m in window for m in self.EXTERNAL_MARKERS):
+                    continue
+                offenders.append(f"{path.relative_to(src)}:{i + 1}: {line.strip()}")
+
+        assert offenders == [], (
+            "these call sites send a secret header from a module that also uses a bare "
+            "urlopen; route them through kiro_crew.loopback_http.loopback_urlopen, or add "
+            "an EXTERNAL_MARKERS entry if the target is genuinely external:\n  "
+            + "\n  ".join(offenders)
+        )
+
+
+class TestOpenerShape:
+    """The opener must actually have proxies disabled, not merely appear to."""
+
+    def test_opener_has_no_live_proxy_handler(self, monkeypatch, listeners):
+        """Guards the ``build_opener`` displacement rule.
+
+        ``build_opener`` drops a default handler only when a supplied handler
+        subclasses it, and an empty ``ProxyHandler`` registers no
+        ``<scheme>_open`` method -- so forgetting to pass it leaves the
+        env-derived proxy live while the code still looks hardened.
+        """
+        _set_proxy_env(monkeypatch, listeners["proxy_port"], "http_proxy")
+        live = [
+            h
+            for h in build_loopback_opener().handlers
+            if isinstance(h, urllib.request.ProxyHandler) and h.proxies
+        ]
+        assert live == [], f"opener still carries a populated ProxyHandler: {live}"

--- a/test/test_mcp_artifacts.py
+++ b/test/test_mcp_artifacts.py
@@ -144,7 +144,7 @@ class TestArtifactReferenceLink:
 
     def test_update_non_widget_emits_markdown_link(self) -> None:
         # given an updated text artifact
-        with patch("kiro_crew.mcp_core.urllib.request.urlopen") as urlopen_mock:
+        with patch("kiro_crew.mcp_core.loopback_urlopen") as urlopen_mock:
             urlopen_mock.return_value.__enter__.return_value.read.return_value = (
                 b'{"slug": "log", "version": 5, "name": "Run Log", "kind": "text"}'
             )
@@ -155,7 +155,7 @@ class TestArtifactReferenceLink:
 
     def test_link_falls_back_to_slug_when_name_missing(self) -> None:
         # given an updated non-widget artifact whose response omits 'name'
-        with patch("kiro_crew.mcp_core.urllib.request.urlopen") as urlopen_mock:
+        with patch("kiro_crew.mcp_core.loopback_urlopen") as urlopen_mock:
             urlopen_mock.return_value.__enter__.return_value.read.return_value = (
                 b'{"slug": "anon-doc", "version": 1, "kind": "markdown"}'
             )
@@ -609,7 +609,7 @@ class TestArtifactRevert:
                 "kiro_crew.mcp_core._get",
                 return_value={"slug": "doc", "version": 2, "content": target_content},
             ) as get_mock,
-            patch("kiro_crew.mcp_core.urllib.request.urlopen") as urlopen_mock,
+            patch("kiro_crew.mcp_core.loopback_urlopen") as urlopen_mock,
         ):
             urlopen_mock.return_value.__enter__.return_value.read.return_value = (
                 b'{"slug": "doc", "version": 4}'
@@ -651,7 +651,7 @@ class TestArtifactRevert:
                 "kiro_crew.mcp_core._get",
                 return_value={"slug": "doc", "version": 2, "content": "v2"},
             ),
-            patch("kiro_crew.mcp_core.urllib.request.urlopen") as urlopen_mock,
+            patch("kiro_crew.mcp_core.loopback_urlopen") as urlopen_mock,
         ):
             urlopen_mock.return_value.__enter__.return_value.read.return_value = (
                 b'{"slug": "doc", "version": 4, "source_path": "/home/u/notes/doc.md"}'
@@ -670,7 +670,7 @@ class TestArtifactRevert:
                 "kiro_crew.mcp_core._get",
                 return_value={"slug": "doc", "version": 2, "content": "v2"},
             ),
-            patch("kiro_crew.mcp_core.urllib.request.urlopen") as urlopen_mock,
+            patch("kiro_crew.mcp_core.loopback_urlopen") as urlopen_mock,
         ):
             urlopen_mock.return_value.__enter__.return_value.read.return_value = (
                 b'{"slug": "doc", "version": 4}'  # no source_path

--- a/test/test_mcp_computer.py
+++ b/test/test_mcp_computer.py
@@ -34,9 +34,11 @@ blocking dispatcher.
 from __future__ import annotations
 
 import asyncio
+import http.server
 import inspect
 import json
 import os
+import threading
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -2176,3 +2178,122 @@ class TestTheDriftWalkHonoursTheSnapshotBudget:
             f"the drift/refresh walks used {walks} instead of the snapshot's own 1777 — "
             "an element the model was legitimately shown would be refused"
         )
+
+
+class TestTheInvokeCallIsNeverProxied:
+    """``_invoke``'s HTTP body, exercised for real against two live listeners.
+
+    Every other test in this file patches ``mcp_computer._invoke`` wholesale, so
+    the request-building and opener code inside it had NO coverage — the leak this
+    guards could have been reintroduced without a single failure. That matters
+    more here than at a typical loopback site: this route's request carries
+    ``X-Internal-Secret``, and the gateway handler behind it is the authoritative
+    fail-CLOSED computer-use gate, so a proxy that could answer it is a proxy that
+    could authorise reading a password field.
+
+    Real sockets on port 0 following ``test_cron_trigger.py``: the kernel hands
+    out free ports, so no ``xdist_group`` marker is needed. ``_API`` and
+    ``_internal_secret`` are patched on ``mcp_computer``'s own namespace (it
+    imports both FROM ``mcp_core``, binding local names), which keeps the real
+    secret file out of the test entirely.
+    """
+
+    CANARY = "canary-not-a-real-secret"
+    PROXY_ENV_KEYS = (
+        "http_proxy",
+        "HTTP_PROXY",
+        "https_proxy",
+        "HTTPS_PROXY",
+        "all_proxy",
+        "ALL_PROXY",
+        "no_proxy",
+        "NO_PROXY",
+        # getproxies_environment ignores uppercase HTTP_PROXY when REQUEST_METHOD
+        # is set (the httpoxy CGI guard), which would silently void this test.
+        "REQUEST_METHOD",
+    )
+
+    @staticmethod
+    def _serve(sink: list[dict]):
+        """A listener that records the secret it saw and replies with shim-valid JSON."""
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def do_POST(self):  # noqa: N802 - stdlib naming
+                length = int(self.headers.get("Content-Length") or 0)
+                raw = self.rfile.read(length) if length else b"{}"
+                sink.append(
+                    {
+                        "requestline": self.requestline,
+                        "secret": self.headers.get("X-Internal-Secret"),
+                        "session_key": self.headers.get("X-Session-Key"),
+                        "body": json.loads(raw),
+                    }
+                )
+                payload = b'{"text": "listener-answered"}'
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def log_message(self, fmt, *args):
+                pass  # keep pytest output clean
+
+        server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        return server, server.server_address[1]
+
+    def test_the_secret_reaches_the_gateway_and_not_the_proxy(self, monkeypatch):
+        """``HTTP_PROXY`` set, ``no_proxy`` unset: the shape that actually leaks."""
+        gateway_hits: list[dict] = []
+        proxy_hits: list[dict] = []
+        gateway, gateway_port = self._serve(gateway_hits)
+        proxy, proxy_port = self._serve(proxy_hits)
+        try:
+            for key in self.PROXY_ENV_KEYS:
+                monkeypatch.delenv(key, raising=False)
+            monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{proxy_port}")
+            monkeypatch.setattr(mcp_computer, "_API", f"http://127.0.0.1:{gateway_port}")
+            monkeypatch.setattr(mcp_computer, "_internal_secret", lambda: self.CANARY)
+
+            decoded = mcp_computer._invoke("dashboard:main", TOOL_LIST_APPS, {})
+        finally:
+            gateway.shutdown()
+            proxy.shutdown()
+
+        assert proxy_hits == [], f"the internal secret reached the proxy: {proxy_hits}"
+        assert [h["secret"] for h in gateway_hits] == [self.CANARY]
+        # Relative request line confirms a direct connection rather than the
+        # absolute form urllib emits when it treats the host as proxied.
+        assert gateway_hits[0]["requestline"] == f"POST {mcp_computer.INVOKE_PATH} HTTP/1.1"
+        # The round trip completed through the new opener, so the migration did not
+        # trade the leak for a silently-swallowed transport error — ``_invoke``
+        # returns ``{"error": ...}`` for any failure rather than raising.
+        assert decoded == {"text": "listener-answered"}
+        assert gateway_hits[0]["body"]["session_key"] == "dashboard:main"
+
+    def test_no_proxy_naming_localhost_only_still_does_not_expose_it(self, monkeypatch):
+        """``no_proxy=localhost`` is the common corporate default and looks like
+        coverage, but it matches the host STRING — ``_API`` spelled either way must
+        not depend on it."""
+        gateway_hits: list[dict] = []
+        proxy_hits: list[dict] = []
+        gateway, gateway_port = self._serve(gateway_hits)
+        proxy, proxy_port = self._serve(proxy_hits)
+        try:
+            for key in self.PROXY_ENV_KEYS:
+                monkeypatch.delenv(key, raising=False)
+            monkeypatch.setenv("http_proxy", f"http://127.0.0.1:{proxy_port}")
+            monkeypatch.setenv("no_proxy", "localhost")
+            monkeypatch.setattr(mcp_computer, "_API", f"http://127.0.0.1:{gateway_port}")
+            monkeypatch.setattr(mcp_computer, "_internal_secret", lambda: self.CANARY)
+
+            mcp_computer._invoke("dashboard:main", TOOL_LIST_APPS, {})
+        finally:
+            gateway.shutdown()
+            proxy.shutdown()
+
+        assert proxy_hits == [], f"the secret proxied despite no_proxy=localhost: {proxy_hits}"
+        assert [h["secret"] for h in gateway_hits] == [self.CANARY]

--- a/test/test_mcp_core.py
+++ b/test/test_mcp_core.py
@@ -276,7 +276,7 @@ class TestSessionKeyHeaderError:
         with (
             patch.object(mcp_core, "_resolve_session_key", return_value="dashboard:A — B"),
             patch.object(mcp_core, "_internal_secret", return_value="secret"),
-            patch("urllib.request.urlopen") as mock_urlopen,
+            patch("kiro_crew.mcp_core.loopback_urlopen") as mock_urlopen,
         ):
             result = mcp_core._post("/api/lessons", {"text": "x"})
         assert "error" in result

--- a/test/test_mcp_core_coverage.py
+++ b/test/test_mcp_core_coverage.py
@@ -13,7 +13,7 @@ Focus areas (the largest previously-uncovered blocks):
 * the whole ``workflow_*`` tool family (malformed / failed / transport
   responses included).
 
-Every HTTP call is mocked at ``urllib.request.urlopen`` or at mcp_core's own
+Every HTTP call is mocked at ``mcp_core.loopback_urlopen`` or at mcp_core's own
 ``_post`` / ``_get`` seams — nothing here touches the network, a real gateway,
 a subprocess or a fixed port.
 """
@@ -207,18 +207,18 @@ class TestHttpErrorBody:
 class TestVerbHelpers:
     def test_success_decodes_json_body(self, verb: str):
         fn = getattr(mcp_core, verb)
-        with patch("urllib.request.urlopen", return_value=_FakeResponse({"ok": True})):
+        with patch("kiro_crew.mcp_core.loopback_urlopen", return_value=_FakeResponse({"ok": True})):
             assert fn("/api/thing") == {"ok": True}
 
     def test_http_error_is_decoded_through_http_error_body(self, verb: str):
         fn = getattr(mcp_core, verb)
         err = _http_error(404, b'{"error": "not found"}')
-        with patch("urllib.request.urlopen", side_effect=err):
+        with patch("kiro_crew.mcp_core.loopback_urlopen", side_effect=err):
             assert fn("/api/thing") == {"error": "not found"}
 
     def test_generic_exception_becomes_error_dict(self, verb: str):
         fn = getattr(mcp_core, verb)
-        with patch("urllib.request.urlopen", side_effect=RuntimeError("boom")):
+        with patch("kiro_crew.mcp_core.loopback_urlopen", side_effect=RuntimeError("boom")):
             assert fn("/api/thing") == {"error": "boom"}
 
     def test_non_latin1_session_key_short_circuits(
@@ -226,7 +226,7 @@ class TestVerbHelpers:
     ):
         fn = getattr(mcp_core, verb)
         monkeypatch.setattr(mcp_core, "_resolve_session_key", lambda: "dashboard:chat—1")
-        with patch("urllib.request.urlopen", side_effect=AssertionError("must not be called")):
+        with patch("kiro_crew.mcp_core.loopback_urlopen", side_effect=AssertionError("must not be called")):
             out = fn("/api/thing")
         assert "invalid in HTTP headers" in out["error"]
 
@@ -236,7 +236,7 @@ class TestVerbHelperBodies:
         for verb, method in (("_patch", "PATCH"), ("_put", "PUT")):
             fn = getattr(mcp_core, verb)
             with patch(
-                "urllib.request.urlopen", return_value=_FakeResponse({"ok": True})
+                "kiro_crew.mcp_core.loopback_urlopen", return_value=_FakeResponse({"ok": True})
             ) as m:
                 fn("/api/thing", {"a": 1})
             req = m.call_args[0][0]
@@ -245,14 +245,14 @@ class TestVerbHelperBodies:
             assert req.headers["Content-type"] == "application/json"
 
     def test_delete_without_body_sends_no_content_type(self):
-        with patch("urllib.request.urlopen", return_value=_FakeResponse({"ok": True})) as m:
+        with patch("kiro_crew.mcp_core.loopback_urlopen", return_value=_FakeResponse({"ok": True})) as m:
             mcp_core._delete("/api/thing")
         req = m.call_args[0][0]
         assert req.data is None
         assert "Content-type" not in req.headers
 
     def test_delete_with_body_sends_json(self):
-        with patch("urllib.request.urlopen", return_value=_FakeResponse({"ok": True})) as m:
+        with patch("kiro_crew.mcp_core.loopback_urlopen", return_value=_FakeResponse({"ok": True})) as m:
             mcp_core._delete("/api/thing", {"rule": "x"})
         req = m.call_args[0][0]
         assert json.loads(req.data.decode()) == {"rule": "x"}
@@ -261,24 +261,24 @@ class TestVerbHelperBodies:
 class TestPostTransportClassification:
     def test_connection_refused_is_not_a_transport_error(self):
         err = urllib.error.URLError(ConnectionRefusedError("refused"))
-        with patch("urllib.request.urlopen", side_effect=err):
+        with patch("kiro_crew.mcp_core.loopback_urlopen", side_effect=err):
             out = mcp_core._post("/api/spawn", {})
         assert "transport_error" not in out
         assert out["error"]
 
     def test_other_urlerror_is_flagged_transport_error(self):
         err = urllib.error.URLError(TimeoutError("timed out"))
-        with patch("urllib.request.urlopen", side_effect=err):
+        with patch("kiro_crew.mcp_core.loopback_urlopen", side_effect=err):
             out = mcp_core._post("/api/spawn", {})
         assert out["transport_error"] is True
 
     def test_unexpected_exception_is_flagged_transport_error(self):
-        with patch("urllib.request.urlopen", side_effect=RuntimeError("read timeout")):
+        with patch("kiro_crew.mcp_core.loopback_urlopen", side_effect=RuntimeError("read timeout")):
             out = mcp_core._post("/api/spawn", {})
         assert out == {"error": "read timeout", "transport_error": True}
 
     def test_http_error_is_not_flagged_transport_error(self):
-        with patch("urllib.request.urlopen", side_effect=_http_error(400, b'{"error": "nope"}')):
+        with patch("kiro_crew.mcp_core.loopback_urlopen", side_effect=_http_error(400, b'{"error": "nope"}')):
             out = mcp_core._post("/api/spawn", {})
         assert out == {"error": "nope"}
 

--- a/test/test_mcp_core_wait.py
+++ b/test/test_mcp_core_wait.py
@@ -53,7 +53,7 @@ def test_post_marks_transport_errors_as_uncertain():
     """A failed response does not prove that the gateway rejected the spawn."""
     with patch("kiro_crew.mcp_core._resolve_session_key", return_value=""), \
          patch("kiro_crew.mcp_core._internal_secret", return_value="secret"), \
-         patch("kiro_crew.mcp_core.urllib.request.urlopen", side_effect=TimeoutError("timed out")):
+         patch("kiro_crew.mcp_core.loopback_urlopen", side_effect=TimeoutError("timed out")):
         result = _post("/api/spawn", {"task": "maybe accepted"})
 
     assert result == {"error": "timed out", "transport_error": True}
@@ -64,7 +64,7 @@ def test_post_marks_connection_refusal_as_definite_failure():
     refused = urllib.error.URLError(ConnectionRefusedError("connection refused"))
     with patch("kiro_crew.mcp_core._resolve_session_key", return_value=""), \
          patch("kiro_crew.mcp_core._internal_secret", return_value="secret"), \
-         patch("kiro_crew.mcp_core.urllib.request.urlopen", side_effect=refused):
+         patch("kiro_crew.mcp_core.loopback_urlopen", side_effect=refused):
         result = _post("/api/spawn", {"task": "not accepted"})
 
     assert "connection refused" in result["error"]

--- a/test/test_mcp_shared.py
+++ b/test/test_mcp_shared.py
@@ -876,9 +876,7 @@ class TestPerSessionToolPolicy:
 
             return _Resp(body)
 
-        import urllib.request
-
-        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(mcp_shared, "loopback_urlopen", fake_urlopen)
         monkeypatch.setattr(
             mcp_shared.KiroCrewConfig,
             "load",

--- a/test/test_mcp_shared_cache.py
+++ b/test/test_mcp_shared_cache.py
@@ -93,11 +93,11 @@ class TestSuccessCaching:
     ):
         monkeypatch.setenv("KIROCREW_SESSION_KEY", "subagent:abc")
         urlopen = MagicMock(return_value=_make_http_response({"exclude": ["foo", "bar"]}))
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             assert mcp_shared._resolve_excluded_tools() == {"foo", "bar"}
         # Second call must NOT hit the gateway again.
         urlopen.reset_mock()
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             assert mcp_shared._resolve_excluded_tools() == {"foo", "bar"}
         assert urlopen.call_count == 0
 
@@ -106,7 +106,7 @@ class TestSuccessCaching:
     ):
         monkeypatch.setenv("KIROCREW_SESSION_KEY", "subagent:abc")
         urlopen = MagicMock(return_value=_make_http_response({"exclude": "not-a-list"}))
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             assert mcp_shared._resolve_excluded_tools() == set()
 
     def test_filters_non_string_entries(
@@ -116,7 +116,7 @@ class TestSuccessCaching:
         urlopen = MagicMock(
             return_value=_make_http_response({"exclude": ["foo", 42, None, "bar"]})
         )
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             assert mcp_shared._resolve_excluded_tools() == {"foo", "bar"}
 
 
@@ -132,7 +132,7 @@ class TestShortCacheStartupRace:
         # No session_pid file in cfg_dir → resolver can't find a key.
         # urlopen should never be called.
         urlopen = MagicMock()
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             assert mcp_shared._resolve_excluded_tools() == set()
         assert urlopen.call_count == 0
         # Audit event recorded.
@@ -147,7 +147,7 @@ class TestShortCacheStartupRace:
     ):
         monkeypatch.setenv("KIROCREW_SESSION_KEY", "subagent:abc")
         urlopen = MagicMock(side_effect=_make_http_error(404))
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             assert mcp_shared._resolve_excluded_tools() == set()
         ops = [c.kwargs.get("operation") for c in fake_sel.log_api_access.call_args_list]
         assert "tool_policy.agent_not_resolved" in ops
@@ -160,12 +160,12 @@ class TestShortCacheStartupRace:
         # Trip the short cache, then ensure the next call doesn't re-query.
         monkeypatch.setenv("KIROCREW_SESSION_KEY", "subagent:abc")
         urlopen = MagicMock(side_effect=_make_http_error(404))
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             mcp_shared._resolve_excluded_tools()
         urlopen.reset_mock()
         # A second call inside the cache window is silent — should hit the
         # negative-cache short-circuit and never call urlopen again.
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             assert mcp_shared._resolve_excluded_tools() == set()
         assert urlopen.call_count == 0
         ops = [c.kwargs.get("operation") for c in fake_sel.log_api_access.call_args_list]
@@ -177,7 +177,7 @@ class TestShortCacheStartupRace:
         # Simulate the short TTL expiry by advancing monotonic.
         monkeypatch.setenv("KIROCREW_SESSION_KEY", "subagent:abc")
         urlopen = MagicMock(side_effect=_make_http_error(404))
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             mcp_shared._resolve_excluded_tools()
         # Move time past the short TTL.
         with patch.object(
@@ -188,7 +188,7 @@ class TestShortCacheStartupRace:
             + 1,
         ):
             urlopen.reset_mock()
-            with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+            with patch.object(mcp_shared, "loopback_urlopen", urlopen):
                 mcp_shared._resolve_excluded_tools()
             # Cache window expired → resolver retried (urlopen called once).
             assert urlopen.call_count == 1
@@ -202,7 +202,7 @@ class TestLongCacheFailures:
     def test_500_uses_long_cache(self, fake_sel, patch_session_setup, monkeypatch):
         monkeypatch.setenv("KIROCREW_SESSION_KEY", "subagent:abc")
         urlopen = MagicMock(side_effect=_make_http_error(500))
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             assert mcp_shared._resolve_excluded_tools() == set()
         ops = [c.kwargs.get("operation") for c in fake_sel.log_api_access.call_args_list]
         assert "tool_policy.resolution_failed" in ops
@@ -214,7 +214,7 @@ class TestLongCacheFailures:
     def test_url_error_uses_long_cache(self, fake_sel, patch_session_setup, monkeypatch):
         monkeypatch.setenv("KIROCREW_SESSION_KEY", "subagent:abc")
         urlopen = MagicMock(side_effect=urllib.error.URLError("connection refused"))
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             assert mcp_shared._resolve_excluded_tools() == set()
         assert mcp_shared._last_failure_time > 0
 
@@ -223,10 +223,10 @@ class TestLongCacheFailures:
     ):
         monkeypatch.setenv("KIROCREW_SESSION_KEY", "subagent:abc")
         urlopen = MagicMock(side_effect=_make_http_error(500))
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             mcp_shared._resolve_excluded_tools()
         urlopen.reset_mock()
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             mcp_shared._resolve_excluded_tools()
         assert urlopen.call_count == 0
 
@@ -245,7 +245,7 @@ class TestWarningSuppression:
             mcp_shared._last_failure_time = 0.0
             mcp_shared._last_startup_race_time = 0.0
             mcp_shared._excluded_tools_by_session.clear()
-            with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+            with patch.object(mcp_shared, "loopback_urlopen", urlopen):
                 mcp_shared._resolve_excluded_tools()
 
     def test_first_failures_emit_warnings(
@@ -304,7 +304,7 @@ class TestCachesAreIndependent:
         mcp_shared._last_startup_race_time = mcp_shared.time.monotonic()
         mcp_shared._last_failure_time = 0.0
         urlopen = MagicMock()
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             assert mcp_shared._resolve_excluded_tools() == set()
         assert urlopen.call_count == 0
 
@@ -317,7 +317,7 @@ class TestCachesAreIndependent:
         mcp_shared._last_failure_time = mcp_shared.time.monotonic()
         mcp_shared._last_startup_race_time = 0.0
         urlopen = MagicMock()
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             assert mcp_shared._resolve_excluded_tools() == set()
         assert urlopen.call_count == 0
 
@@ -327,6 +327,6 @@ class TestCachesAreIndependent:
         # Both caches expired (or never set) → resolver MUST query.
         monkeypatch.setenv("KIROCREW_SESSION_KEY", "subagent:abc")
         urlopen = MagicMock(return_value=_make_http_response({"exclude": []}))
-        with patch.object(mcp_shared.urllib.request, "urlopen", urlopen):
+        with patch.object(mcp_shared, "loopback_urlopen", urlopen):
             mcp_shared._resolve_excluded_tools()
         assert urlopen.call_count == 1

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -653,19 +653,19 @@ class TestRuntimeHelpers:
             def __exit__(self, *a: object) -> bool:
                 return False
 
-        monkeypatch.setattr(rt.urllib.request, "urlopen", lambda *a, **k: _Resp())
+        monkeypatch.setattr(rt, "loopback_urlopen", lambda *a, **k: _Resp())
         assert rt.health(7999) == 200
 
         def _raise_http(*a: object, **k: object) -> None:
             raise urllib.error.HTTPError("u", 403, "f", {}, None)  # type: ignore[arg-type]
 
-        monkeypatch.setattr(rt.urllib.request, "urlopen", _raise_http)
+        monkeypatch.setattr(rt, "loopback_urlopen", _raise_http)
         assert rt.health(7999) == 403
 
         def _raise_url(*a: object, **k: object) -> None:
             raise urllib.error.URLError("down")
 
-        monkeypatch.setattr(rt.urllib.request, "urlopen", _raise_url)
+        monkeypatch.setattr(rt, "loopback_urlopen", _raise_url)
         assert rt.health(7999) == 0
 
     def test_mint_token_reads_secret_and_posts(
@@ -687,7 +687,7 @@ class TestRuntimeHelpers:
             def read(self) -> bytes:
                 return b'{"token":"tok-xyz"}'
 
-        monkeypatch.setattr(rt.urllib.request, "urlopen", lambda *a, **k: _Resp())
+        monkeypatch.setattr(rt, "loopback_urlopen", lambda *a, **k: _Resp())
         assert rt.mint_token(c, "demo", "1h") == "tok-xyz"
 
     def test_mint_token_no_secret_raises(
@@ -949,7 +949,7 @@ class TestReviewRound1Fixes:
             captured["url"] = req.full_url  # type: ignore[attr-defined]
             return _Resp()
 
-        monkeypatch.setattr(rt.urllib.request, "urlopen", _urlopen)
+        monkeypatch.setattr(rt, "loopback_urlopen", _urlopen)
         rt.mint_token(c, "demo", "1 h")
         assert "ttl=1%20h" in captured["url"]
 

--- a/test/test_review_driver_loopback.py
+++ b/test/test_review_driver_loopback.py
@@ -1,0 +1,157 @@
+"""``review_driver``'s two loopback call sites must not proxy the gateway secret.
+
+Both carry ``X-Internal-Secret`` to ``http://localhost:<port>``, and urllib has
+no implicit loopback exemption, so with ``HTTP_PROXY`` set the secret goes to
+the proxy in cleartext. The port probe is the worse of the two: ``_gateway_base``
+calls ``_probe`` once per candidate port (``KIROCREW_PORT``, the configured port,
+then six literals), so one cold resolve that misses can send the secret up to
+seven times.
+
+Real sockets on port 0, following ``test_cron_trigger.py`` -- the kernel hands
+out a free port, so no ``xdist_group`` marker is needed. Assertions read what
+each listener actually received rather than inspecting the opener, because the
+opener shape is already covered by ``test_loopback_proxy.py``; what is new here
+is that these two product functions route through it.
+"""
+
+import http.server
+import sys
+import threading
+import urllib.request
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from kiro_crew.apps.builtins.code_review_sage.sage_lib import review_driver
+
+CANARY = "canary-not-a-real-secret"
+SECRET_HEADER = "X-Internal-Secret"
+
+_PROXY_ENV_KEYS = (
+    "http_proxy",
+    "HTTP_PROXY",
+    "https_proxy",
+    "HTTPS_PROXY",
+    "all_proxy",
+    "ALL_PROXY",
+    "no_proxy",
+    "NO_PROXY",
+    # getproxies_environment ignores uppercase HTTP_PROXY when REQUEST_METHOD is
+    # set (the httpoxy CGI guard), which would silently disarm these tests.
+    "REQUEST_METHOD",
+)
+
+
+def _make_handler(sink):
+    """Handler that records the secret it saw and answers with an empty artifact list."""
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def _record_and_reply(self):
+            length = int(self.headers.get("Content-Length") or 0)
+            if length:
+                self.rfile.read(length)
+            sink.append(
+                {"requestline": self.requestline, "secret": self.headers.get(SECRET_HEADER)}
+            )
+            body = b'{"artifacts": []}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        do_GET = _record_and_reply    # noqa: N815 - stdlib naming
+        do_POST = _record_and_reply   # noqa: N815 - stdlib naming
+
+        def log_message(self, fmt, *args):
+            pass  # keep pytest output clean
+
+    return Handler
+
+
+def _serve(sink):
+    server = http.server.HTTPServer(("127.0.0.1", 0), _make_handler(sink))
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, server.server_address[1]
+
+
+@pytest.fixture()
+def listeners(monkeypatch):
+    """A stand-in gateway and a stand-in proxy, with the proxy named by the env."""
+    gateway_hits: list[dict] = []
+    proxy_hits: list[dict] = []
+    gateway, gateway_port = _serve(gateway_hits)
+    proxy, proxy_port = _serve(proxy_hits)
+    for key in _PROXY_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("http_proxy", f"http://127.0.0.1:{proxy_port}")
+    try:
+        yield {
+            "gateway_hits": gateway_hits,
+            "proxy_hits": proxy_hits,
+            "gateway_base": f"http://127.0.0.1:{gateway_port}",
+        }
+    finally:
+        gateway.shutdown()
+        proxy.shutdown()
+
+
+def _assert_reached_gateway_only(listeners):
+    assert listeners["proxy_hits"] == [], f"secret reached the proxy: {listeners['proxy_hits']}"
+    assert [h["secret"] for h in listeners["gateway_hits"]] == [CANARY]
+
+
+class TestReviewDriverLoopbackCallsIgnoreTheProxy:
+    """Regression guard for the two secret-bearing loopback sites in review_driver."""
+
+    def test_api_request_does_not_proxy_the_secret(self, monkeypatch, listeners):
+        monkeypatch.setattr(review_driver, "_gateway_base", lambda: listeners["gateway_base"])
+        monkeypatch.setattr(review_driver, "_local_secret", lambda: CANARY)
+
+        # A real parse of the gateway's body proves the request landed there and
+        # was not merely swallowed by _api_request's blanket except.
+        assert review_driver._api_request("GET", "/api/artifacts?tag=sage-report") == {
+            "artifacts": []
+        }
+        _assert_reached_gateway_only(listeners)
+
+    def test_probe_does_not_proxy_the_secret(self, listeners):
+        """The multiplied site: one miss per candidate port, each a full send."""
+        assert review_driver._probe(listeners["gateway_base"], CANARY) is True
+        _assert_reached_gateway_only(listeners)
+
+    def test_guarded_import_fallback_does_not_proxy_the_secret(self, listeners):
+        """The standalone path must not degrade to a bare, proxy-honouring urlopen.
+
+        Runs the module's real import guard from disk with
+        ``kiro_crew.loopback_http`` poisoned to ImportError, so the ``except``
+        branch defines the fallback and a weakened fallback fails here. The
+        source is sliced at the ``_APP_ROOT`` assignment because everything below
+        it is the ``sage_lib`` import block, which is irrelevant to the guard and
+        costly to re-execute.
+        """
+        src = Path(review_driver.__file__).read_text(encoding="utf-8")
+        head, sep, _ = src.partition("_APP_ROOT = ")
+        assert sep, "the _APP_ROOT anchor moved; re-slice this test"
+        ns: dict = {"__name__": "review_driver_guard_probe"}
+        with mock.patch.dict(sys.modules, {"kiro_crew.loopback_http": None}):
+            # Compiles a slice of THIS repo's own source, read from
+            # review_driver.__file__; no external input reaches it. Running the real
+            # guard is the point -- asserting on the source text instead would pass
+            # against a weakened fallback.
+            # nosemgrep: python.lang.security.audit.exec-detected.exec-detected
+            exec(compile(head, review_driver.__file__, "exec"), ns)  # noqa: S102
+        fallback = ns["loopback_urlopen"]
+        assert fallback.__module__ == "review_driver_guard_probe", (
+            "the real helper was imported, so the fallback branch was never exercised"
+        )
+
+        req = urllib.request.Request(
+            listeners["gateway_base"] + "/api/spawn", headers={SECRET_HEADER: CANARY}
+        )
+        with fallback(req, timeout=5) as resp:
+            assert resp.status == 200
+        _assert_reached_gateway_only(listeners)

--- a/test/test_stale_asset_watchdog.py
+++ b/test/test_stale_asset_watchdog.py
@@ -317,7 +317,7 @@ def test_token_probe_warns_on_stale_dashboard():
 
     stderr_capture = io.StringIO()
 
-    with patch("kiro_crew.cli_server.urllib.request.urlopen", return_value=mock_resp), \
+    with patch("kiro_crew.cli_server.loopback_urlopen", return_value=mock_resp), \
          patch("sys.stderr", stderr_capture):
         _probe_dashboard_health(7777)
 
@@ -336,7 +336,7 @@ def test_token_probe_silent_on_healthy_dashboard():
 
     stderr_capture = io.StringIO()
 
-    with patch("kiro_crew.cli_server.urllib.request.urlopen", return_value=mock_resp), \
+    with patch("kiro_crew.cli_server.loopback_urlopen", return_value=mock_resp), \
          patch("sys.stderr", stderr_capture):
         _probe_dashboard_health(7777)
 
@@ -349,7 +349,7 @@ def test_token_probe_silent_on_network_error():
 
     stderr_capture = io.StringIO()
 
-    with patch("kiro_crew.cli_server.urllib.request.urlopen", side_effect=OSError("connection refused")), \
+    with patch("kiro_crew.cli_server.loopback_urlopen", side_effect=OSError("connection refused")), \
          patch("sys.stderr", stderr_capture):
         _probe_dashboard_health(7777)
 


### PR DESCRIPTION
Closes #2158.

Every request KiroCrew makes to its own gateway carries `X-Internal-Secret`, which authorises write endpoints on the local dashboard. `urlopen` builds its opener from `getproxies()`, and urllib has **no implicit loopback exemption** — `proxy_bypass_environment` returns `False` when `no_proxy` is unset, and `ProxyHandler.proxy_open` bypasses only the hosts `no_proxy` names outright. So with `HTTP_PROXY` set, which is routine in corporate and containerised environments, the secret goes to the proxy in cleartext.

Pre-existing and repo-wide. Not introduced here.

## Observed, not inferred

Two loopback listeners — one standing in for the gateway, one for a proxy named by `HTTP_PROXY` — each recording the secret header it received. Same POST, six configurations, Python 3.12.5:

| | config | received by | leaked |
|---|---|---|---|
| A | no proxy env (control) | gateway | no |
| **B** | **`HTTP_PROXY` set, `no_proxy` unset** | **proxy** | **yes** |
| C | `HTTP_PROXY` set, `no_proxy=127.0.0.1` | gateway | no |
| D | `HTTP_PROXY` set, opener with `ProxyHandler({})` | gateway | no |
| **E** | **`HTTP_PROXY` set, target spelled `localhost`** | **proxy** | **yes** |
| **F** | **`HTTP_PROXY` set, `no_proxy=localhost`, target `127.0.0.1`** | **proxy** | **yes** |

What the proxy printed in case B:

```
POST http://127.0.0.1:12723/api/lessons HTTP/1.1
X-Internal-Secret: <secret>
```

The absolute-form request line is the confirmation: `urlopen` treated loopback as an ordinary proxied host. The gateway received nothing.

## Two things that look like fixes and are not

Both measured still leaking, and both worth knowing before reviewing:

- **Case E — the literal IP does not help.** `localhost` and `127.0.0.1` leak identically. Spelling the host as the literal address addresses DNS resolving to `::1` past a v4-only listener; that is a real problem and a different one.
- **Case F — `no_proxy=localhost` does not help.** `no_proxy` matches the host *string*, not what it resolves to, so a request to the literal IP still proxies. This is the more dangerous of the two, because it is the common corporate default and it looks like coverage.

Together they rule out both the host-spelling and the environment-hygiene approaches, which is why this is fixed in code.

## The fix

A new stdlib-only leaf, `src/kiro_crew/loopback_http.py`, exporting `loopback_urlopen(req, timeout)`.

It passes `ProxyHandler({})` **explicitly**, and that is not optional: `build_opener` displaces one of its defaults only when a supplied handler *subclasses* that default, and an empty `ProxyHandler` registers no `<scheme>_open` method at all — so omitting it leaves the env-derived proxy live while the code looks hardened. This is exactly why `kiro_usage_api._build_opener` still proxies, correctly, for its external target.

It also refuses redirects. A 3xx from the gateway would replay the secret to whatever host `Location` names, and none of the 21 call sites had that protection.

Three constraints shaped where it lives, all of them load-bearing rather than stylistic:

- `cron_trigger.py` imports **nothing** from `kiro_crew` today. It is the cheapest caller and must stay that way.
- `mcp_playwright_proxy.py` deliberately resolves its config dir through the stdlib-only `config.paths` leaf "to avoid importing the gateway into this stdio proxy".
- `dashboard/urls.py`'s own docstring records that reaching `parse_dashboard_url` via `dashboard.origin` costs ~605 ms and 1124 modules.

So `mcp_shared.py` was not viable — it pulls `dashboard.origin`, and aiohttp behind it. The new module imports `urllib.request` and nothing else, which keeps a top-level import free for all callers and satisfies the `top-level-imports` rule outright with no exception path.

`timeout` is required rather than defaulted. Avoids depending on `socket._GLOBAL_DEFAULT_TIMEOUT`, and a call to our own gateway that can hang forever is never what a site wants. **Every one of the 21 sites already passed an explicit timeout**, so this forced no behaviour change.

## Scope

All 21 loopback `urlopen` calls across 9 modules. Every one was verified per-call to target loopback and carry the secret before being migrated.

| module | sites |
|---|---|
| `mcp_core.py` | 7 |
| `cli_commands.py` | 4 |
| `mcp_playwright_proxy.py` | 3 |
| `code_review_sage/sage_lib/review_driver.py` | 2 |
| `mcp_shared.py`, `mcp_computer.py`, `cron_trigger.py`, `cron_script.py`, `computer_use/screencast.py` | 1 each |

**No non-loopback call is touched.** External requests genuinely need the corporate proxy to leave the host, and there were no external `urlopen` calls in these 9 files — checked rather than assumed. Sites deliberately left alone include the embedding-model download, the skills.sh and MCP registry clients, the PagerDuty and vendor chat clients, and `kiro_usage_api`'s external endpoint. `cli_doctor.py` is also untouched: it mixes a loopback probe, a deliberately network-facing host probe, and an external HEAD in one file, so a file-scoped change there would be wrong three ways.

The worst site was the sage port probe. `_gateway_base` walks `_candidate_ports` — `KIROCREW_PORT`, the config port, then the literals `5476, 5477, 5478, 5479, 5480, 5486` — and sent the secret on **every miss**, up to 7 sends per cold resolve.

## Tests

`test/test_loopback_proxy.py` — 6 tests pinning cases B (both `http_proxy` spellings) and F, a canary proving the default opener does leak, a redirect-replay guard, and an opener-shape test that catches the `ProxyHandler` displacement trap directly. Real sockets on port 0 per `test_cron_trigger.py`, so no `xdist_group` marker is needed.

Three coverage gaps closed while here: `mcp_computer` and `computer_use/screencast` had no test reaching their `urlopen` body at all (both patched the enclosing function wholesale), and `review_driver` had no tests whatsoever — the module with the worst site.

`REQUEST_METHOD` is cleared alongside the proxy variables. `getproxies_environment` ignores uppercase `HTTP_PROXY` when it is set (the httpoxy CGI guard), so a CI runner exporting it would otherwise make the test pass vacuously.

### One design note reviewers should see

The first version of the helper cached its opener at module scope. Both handlers are stateless, so that is safe for the *fixed* code — but it captures `getproxies()` at import time, and **the regression tests passed with `ProxyHandler({})` deleted**. The mutation check caught it; a green first run would have shipped a guard that could never fail. The opener is now rebuilt per call, and the reasoning is in the docstring so nobody reintroduces the cache as an optimisation. Constructing a few stateless handlers costs far less than the round trip that follows.

## Verification

- 1251 passed / 3 skipped / 5 xfailed across all 18 affected test files.
- **Identical counts with `http_proxy` and `https_proxy` pointed at the discard port**, which is the real end-to-end proof.
- `isort` clean, `flake8` clean, `mypy` clean across 838 source files.
- Every new guard mutation-proven: revert the one line, watch the guard fail, restore, confirm no markers left.

`test_cron_trigger.py` uses a real socket and stubs no HTTP, so it **already failed** on any machine with `HTTP_PROXY` set and no `no_proxy` — 7 failed / 9 passed at baseline, the 9 being tests that never open a socket. This fixes it rather than breaking it.

One operational note: with the fix reverted, `test_mcp_computer.py` takes 91.9 s instead of 7.3 s, because the leaked request stalls against the stand-in proxy until `INVOKE_TIMEOUT_SECS = 90.0` expires. That costs CI nothing on a healthy tree, but a future regression here will present as a hang before it presents as a failure.

## Not in scope

`localhost` vs `127.0.0.1` host spelling is left exactly as found at every site. It is a separate concern (`::1` resolution), it does nothing for this leak, and changing it here would blur the diff.
