### PR TITLE
fix(lessons): attach a NOT-clause to an already-stored rule

### DIFF
--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -1331,7 +1331,11 @@ def _learn(args: argparse.Namespace) -> None:
                     category=category,
                     negative=negative,
                 )
-                jsonl_store.save(lesson)
+                # save_or_enrich, not save: `learn add --negative` is explicit user
+                # intent, so a re-submitted rule should get the clause attached
+                # rather than be skipped as a duplicate. save() keeps the skip
+                # semantics for automatic writers.
+                jsonl_store.save_or_enrich(lesson)
                 neg = f" ({lesson.negative})" if lesson.negative else ""
                 print(f"Saved: {lesson.rule}{neg} [{lesson.category}]")
 

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -898,11 +898,14 @@ async def api_lessons_create(request: web.Request) -> web.Response:
             negative=negative,
             ts=datetime.now(timezone.utc).isoformat(),
         )
-        if scope == "workspace":
-            ws = cleaned.get("workspace")
-            _get_lessons(state, ws).save(lesson)
-        else:
-            state.lessons.save(lesson)
+        store = _get_lessons(state, cleaned.get("workspace")) if scope == "workspace" else (
+            state.lessons
+        )
+        # save_or_enrich, not save: a re-submit of a stored rule carrying a new
+        # NOT-clause has to attach it rather than be skipped as a duplicate.
+        # Off the loop because it reads the file and rewrites it whole -- the
+        # same reason dashboard/ws.py offloads load_all.
+        await asyncio.to_thread(store.save_or_enrich, lesson)
     state.push_refresh("lessons")
     return web.json_response({"ok": True})
 
@@ -938,11 +941,14 @@ async def api_lessons_delete(request: web.Request) -> web.Response:
     if vs_lessons:
         ok = await asyncio.to_thread(vs.delete_lesson, rule_sub)
     else:
-        if scope == "workspace":
-            ws = body.get("workspace")
-            ok = _get_lessons(state, ws).remove(rule_sub)
-        else:
-            ok = state.lessons.remove(rule_sub)
+        store = _get_lessons(state, body.get("workspace")) if scope == "workspace" else (
+            state.lessons
+        )
+        # Off the loop. remove() now takes the store's shared lock, which a worker
+        # thread can be holding across file I/O for a concurrent save_or_enrich --
+        # so calling it inline would let one lessons write stall every task on the
+        # event loop. Same reason api_lessons_create offloads its write.
+        ok = await asyncio.to_thread(store.remove, rule_sub)
     if ok:
         state.push_refresh("lessons")
     return web.json_response({"ok": ok})

--- a/src/kiro_crew/learn.py
+++ b/src/kiro_crew/learn.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 
 import json
 import logging
+import stat
 import threading
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
+
+from kiro_crew.atomic_write import atomic_write
 
 try:
     from kiro_crew.config.loader import config_dir as _config_dir
@@ -36,6 +39,25 @@ _DEFAULT_DIR = Path.home() / ".kiro" / "crew"
 _LESSONS_FILE = "lessons.jsonl"
 _MAX_LESSONS_IN_CONTEXT = 50
 _MAX_LESSONS_TOTAL = 200  # prune oldest when exceeded
+
+# One lock PER FILE, shared by every LessonStore instance addressing it. A
+# per-instance lock serializes nothing when two instances point at the same file --
+# and they do: DashboardState.lessons and context.get_lessons_for() construct
+# separate instances over the same global store. Without this, the atomic
+# enrich-or-insert below is atomic only against itself, so a dashboard refinement
+# racing a consolidation write could still lose a clause.
+#
+# Still in-process only. threading.Lock does not span processes, so the CLI and the
+# gateway remain last-writer-wins against each other; the per-write temp name below
+# is what keeps that case from corrupting the file rather than merely losing an edit.
+_PATH_LOCKS: dict[Path, threading.Lock] = {}
+_PATH_LOCKS_GUARD = threading.Lock()
+
+
+def _lock_for(path: Path) -> threading.Lock:
+    """Return the process-wide lock for *path*, creating it on first use."""
+    with _PATH_LOCKS_GUARD:
+        return _PATH_LOCKS.setdefault(path, threading.Lock())
 
 
 # ── Types ──
@@ -97,42 +119,163 @@ class LessonStore:
         else:
             self._dir = _DEFAULT_DIR
         self._path = self._dir / _LESSONS_FILE
-        self._lock = threading.Lock()
+        self._lock = _lock_for(self._path)
         # mtime-based cache: (mtime, lessons)
         self._cache: tuple[float, list[Lesson]] | None = None
 
-    def save(self, lesson: Lesson) -> None:
-        """Append a lesson, skipping near-duplicates and pruning if over limit."""
-        with self._lock:
-            existing = self.load_all()
-            new_lower = lesson.rule.lower().strip()
-            for ex in existing:
-                if ex.rule.lower().strip() == new_lower:
-                    logger.debug("Skipping duplicate lesson: %s", lesson.rule)
-                    return
-            existing.append(lesson)
-            if len(existing) > _MAX_LESSONS_TOTAL:
-                existing = existing[-_MAX_LESSONS_TOTAL:]
-            self._dir.mkdir(parents=True, exist_ok=True)
-            self._path.write_text(
-                "".join(json.dumps(asdict(le)) + "\n" for le in existing),
-                encoding="utf-8",
-            )
-            self._cache = None  # invalidate
-        logger.info("Saved lesson: %s", lesson.rule)
+    def _write_all(self, lessons: list[Lesson]) -> None:
+        """Replace the file atomically. The caller MUST hold ``self._lock``.
 
-    def remove(self, rule_substring: str) -> bool:
-        """Remove lessons whose rule contains *rule_substring*. Returns True if any removed."""
-        lessons = self.load_all()
-        lower = rule_substring.lower()
-        kept = [le for le in lessons if lower not in le.rule.lower()]
-        if len(kept) == len(lessons):
-            return False
-        self._dir.mkdir(parents=True, exist_ok=True)
-        self._path.write_text(
-            "".join(json.dumps(asdict(le)) + "\n" for le in kept), encoding="utf-8"
+        tmp + ``os.replace`` rather than ``write_text`` for two reasons. A reader
+        can observe this file without the lock (``load_all`` takes none), and
+        ``atomic_write`` renames a unique temp file over the target, so a reader sees
+        either the whole old file or the whole new one -- never a half-written one.
+        That is what makes the unlocked read in ``load_all`` safe, so no lock has to
+        be added there, and a crash mid-write can no longer truncate the store.
+
+        Uses the repo's ``atomic_write`` rather than a hand-rolled temp + rename.
+        Hand-rolling it re-introduced three problems the shared helper already
+        solves: a temp name that two writers could collide on (it uses
+        ``tempfile.mkstemp``), a bare ``os.replace`` that raises ``PermissionError``
+        when Windows Search or AV holds a handle (it uses ``replace_with_retry``),
+        and a replacement inode carrying umask permissions instead of the store's
+        (it applies ``mode`` via ``fchmod_safe``).
+
+        The mode is read off the existing file so a restrictive store stays
+        restrictive -- ``write_text`` used to preserve it implicitly by reusing the
+        inode, and swapping the inode silently dropped it. A store being created for
+        the first time gets ``0o600``: lesson text is personal content, and nothing
+        else needs to read it.
+
+        ``newline=""`` keeps the bytes exact. The default would apply
+        universal-newline translation on write, and this file is read, edited and
+        written back on every save.
+        """
+        try:
+            mode = stat.S_IMODE(self._path.stat().st_mode)
+        except OSError:
+            mode = 0o600
+        atomic_write(
+            self._path,
+            "".join(json.dumps(asdict(le)) + "\n" for le in lessons),
+            mode=mode,
+            newline="",
         )
         self._cache = None  # invalidate
+
+    def save(self, lesson: Lesson) -> None:
+        """Insert *lesson*, skipping a rule that is already stored.
+
+        Deliberately does NOT enrich. Most callers here are automatic --
+        consolidation, task-runner extraction, onboarding import -- and an
+        automatic writer must not replace a NOT-clause a human authored. Only an
+        explicit refinement (the /api/lessons route, ``kirocrew learn add``)
+        should attach a clause, and those call :meth:`save_or_enrich`.
+
+        Kept returning ``None`` so every existing caller is unaffected.
+        """
+        self._insert_or_enrich(lesson, enrich=False)
+
+    def save_or_enrich(self, lesson: Lesson) -> str:
+        """Insert *lesson*, or attach its NOT-clause to the record holding the same
+        rule, in ONE lock acquisition. Returns ``inserted``/``enriched``/``unchanged``.
+
+        For EXPLICIT refinement only -- see :meth:`save` for why automatic writers
+        must not reach this.
+
+        Re-submitting a rule to attach a NOT-clause used to store nothing: the
+        duplicate check matched on the rule alone and returned before looking at
+        ``negative``, so the clause was dropped behind an HTTP 200.
+        """
+        return self._insert_or_enrich(lesson, enrich=True)
+
+    def _insert_or_enrich(self, lesson: Lesson, *, enrich: bool) -> str:
+        """Shared body for :meth:`save` and :meth:`save_or_enrich`.
+
+        The single lock acquisition is the load-bearing part. Doing enrich and
+        insert as two separate locked calls let a concurrent writer insert the
+        same rule in the gap, so the second call saw a duplicate and skipped --
+        dropping the clause exactly as before, just less often. The whole
+        read-decide-write sequence runs inside the lock, so there is no gap.
+
+        Matching is ``lower()``, deliberately NOT ``casefold()``. This reversed an
+        earlier decision in the same change, so the reasoning matters: ``casefold()``
+        maps ``ß`` to ``ss`` in order to match a stored "Straße" against a submitted
+        "STRASSE" -- but the very same mapping makes "Maße" and "Masse" compare EQUAL,
+        and those are different German words. Under ``casefold()`` a clause submitted
+        for "Masse" attached itself to the stored "Maße" and the intended lesson was
+        never created: the wrong rule enriched, the right one discarded.
+
+        The two behaviours are inseparable -- both come from the one ß rule -- so this
+        is a trade, not a fix. ``lower()`` is the safe side of it: it never conflates
+        two distinct rules, and its cost is a MISSED enrichment (a ß case-variant
+        inserts a second row) rather than a corrupted one. Losing a refinement is
+        recoverable; silently rewriting the wrong lesson is not.
+
+        A re-submit carrying NO clause never strips one that is already stored --
+        it reports ``unchanged``, matching the vector store for the same case.
+        """
+        with self._lock:
+            # A whitespace-only clause is no clause. Same defect as the vector store's:
+            # `--negative "   "` is truthy, so it would replace a real stored clause
+            # with blanks. Normalised here too, because both stores are reached
+            # directly by the CLI, the route, consolidation and the task runner.
+            # isinstance FIRST for the same reason as the vector store: consolidation
+            # hands over the LLM's own value, and .strip() on a non-string would
+            # abort the run with AttributeError.
+            wanted_negative = (
+                lesson.negative.strip() or None if isinstance(lesson.negative, str) else None
+            )
+            # load_all() is called under the lock deliberately: it takes no lock of
+            # its own, so this is not a re-entrant acquisition on a non-reentrant
+            # Lock. Do NOT call save() from in here for the same reason.
+            existing = self.load_all()
+            wanted = lesson.rule.lower().strip()
+            updated: list[Lesson] = []
+            matched = False
+            outcome = "inserted"
+            for le in existing:
+                if not matched and le.rule.lower().strip() == wanted:
+                    matched = True
+                    if not enrich or wanted_negative is None or le.negative == wanted_negative:
+                        outcome = "unchanged"
+                        updated.append(le)
+                    else:
+                        outcome = "enriched"
+                        # Build a REPLACEMENT record rather than mutating in place:
+                        # load_all() hands back the cached objects, so an in-place
+                        # edit followed by a failed write would leave the cache
+                        # advertising a clause that was never persisted -- and that
+                        # cache feeds context injection.
+                        updated.append(replace(le, negative=wanted_negative))
+                    continue
+                updated.append(le)
+            if outcome == "unchanged":
+                return outcome  # nothing to write; leave the file untouched
+            if not matched:
+                # Insert the normalised clause too, so a whitespace-only one is stored
+                # as absent rather than as blanks.
+                updated.append(replace(lesson, negative=wanted_negative))
+                if len(updated) > _MAX_LESSONS_TOTAL:
+                    updated = updated[-_MAX_LESSONS_TOTAL:]
+            self._write_all(updated)
+        logger.info("%s lesson: %s", outcome.capitalize(), lesson.rule)
+        return outcome
+
+    def remove(self, rule_substring: str) -> bool:
+        """Remove lessons whose rule contains *rule_substring*. Returns True if any removed.
+
+        Holds the lock. It previously did an unlocked read-modify-write, so a
+        concurrent ``save`` could be lost outright -- and without that lock the
+        atomicity :meth:`save_or_enrich` claims would not actually hold.
+        """
+        with self._lock:
+            lessons = self.load_all()
+            lower = rule_substring.lower()
+            kept = [le for le in lessons if lower not in le.rule.lower()]
+            if len(kept) == len(lessons):
+                return False
+            self._write_all(kept)
         return True
 
     def load_all(self) -> list[Lesson]:

--- a/src/kiro_crew/taskrunner.py
+++ b/src/kiro_crew/taskrunner.py
@@ -1265,13 +1265,20 @@ class TaskRunner:
                     rule, category, negative, "task_runner",
                 )
             else:
-                self._lesson_store.save(
+                # Offloaded for the same reason as write_lesson above, and now
+                # necessarily so: LessonStore locks per PATH, so instances in
+                # different components share one lock. A dashboard writer holding
+                # it across its read-and-rewrite would stall this loop if save()
+                # ran here. The lock is what makes the write atomic, so the fix is
+                # to move the caller off the loop rather than to weaken it.
+                await asyncio.to_thread(
+                    self._lesson_store.save,
                     Lesson(
                         ts=datetime.now(tz=timezone.utc).isoformat(),
                         rule=rule,
                         category=category,
                         negative=negative,
-                    )
+                    ),
                 )
             logger.info("Lesson extracted from task %d: %s", task.index, rule)
             if run:

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -11,6 +11,7 @@ time-decay retrieval via FAISS (falls back to FTS5 without embeddings).
 
 from __future__ import annotations
 
+import hashlib
 import heapq
 import json
 import logging
@@ -239,6 +240,62 @@ _MIGRATIONS: list[tuple[int, str, "Callable[[sqlite3.Connection], None] | None"]
 ]
 
 _MAX_BACKFILLS_PER_CALL = 5  # cap lazy embedding backfills to bound latency
+
+# Joins a lesson's rule to its NOT-clause in the single stored value. Extracted
+# from the f-string that composes it because write_lesson now also has to READ it
+# back, to tell "<rule>" apart from "<rule><sep><negative>" when deciding whether
+# a bare re-submit would strip a clause that is already stored.
+_LESSON_NEGATIVE_SEP = " — NOT: "
+
+
+def _lesson_slug(rule: str) -> str:
+    """The key slug write_lesson derives for *rule*. Single source of truth."""
+    return hashlib.md5(rule.encode(), usedforsecurity=False).hexdigest()[:12]
+
+
+def _split_stored(existing_val: str, rule_norm: str, existing_key: str) -> tuple[str | None, bool]:
+    """Split a stored lesson value against a normalized rule.
+
+    Returns ``(base, stored_clause)``: the stored spelling of the rule, and whether
+    a NOT-clause follows it. ``(None, False)`` means this row is not that rule.
+
+    The separator is stored IN-BAND and unescaped, so the value alone is ambiguous:
+    ``A — NOT: B`` is either rule ``A`` with clause ``B``, or a bare rule whose text
+    happens to contain the separator. No amount of text parsing settles that -- both
+    readings are valid, and picking either one by itself loses data in the other case
+    (silently dropping a clause update one way, OVERWRITING an unrelated rule the
+    other). Two review rounds demanded exactly opposite behaviour on the same text
+    for that reason.
+
+    The row itself carries the answer: the key is ``md5(rule)`` taken at write time,
+    in the rule's stored casing. So a candidate prefix is the rule only when it
+    hashes to this row's key. That is exact rather than heuristic, and it is why
+    every separator boundary can be tried safely.
+
+    Rows keyed some other way -- the onboarding import uses sha256, and legacy
+    migrations set their own keys -- match only on the whole value. For those a
+    case-variant re-submit onto an EXISTING clause will not enrich. That is a missed
+    enrichment, never an overwrite: the ambiguous branch always declines. Tracked in
+    the follow-up issue together with the storage-format fix.
+
+    Case-insensitivity here is ``lower()``, not ``casefold()`` -- see write_lesson for
+    why. ``casefold()``'s ß-to-ss expansion conflates "Maße" with "Masse", which would
+    make this function confidently return the WRONG row's spelling as ``base``.
+    """
+    stripped = existing_val.strip()
+    if stripped.lower() == rule_norm:
+        return stripped, False  # the whole value is the rule; no clause
+    slug = existing_key.split(".", 1)[-1]
+    idx = stripped.find(_LESSON_NEGATIVE_SEP)
+    while idx != -1:
+        prefix = stripped[:idx].strip()
+        # Compare whole prefixes, never a slice at len(rule_norm): lower() can still
+        # CHANGE length ("İ" -> "i" + combining dot), so a length-based slice cuts in
+        # the wrong place for exactly the case-variant inputs this serves.
+        if prefix.lower() == rule_norm and _lesson_slug(prefix) == slug:
+            return prefix, True  # the key confirms prefix IS the rule
+        idx = stripped.find(_LESSON_NEGATIVE_SEP, idx + 1)
+    return None, False
 
 
 # ── Helpers ──
@@ -1810,9 +1867,29 @@ class VectorMemoryStore:
         this write is detected and the vector is left NULL for the backfill
         instead of being committed into the wrong space.
         """
-        import hashlib
-
         rule_lower = rule.lower()
+        # lower(), deliberately NOT casefold(). casefold() maps ß to ss, which matches
+        # "Straße" against "STRASSE" -- but the same mapping makes "Maße" and "Masse"
+        # compare EQUAL, and those are different words, so a clause submitted for one
+        # attached itself to the other and the intended lesson was never created. The
+        # two behaviours are inseparable, so this is a trade: lower() never conflates
+        # distinct rules, and its cost is a missed enrichment rather than a corrupted
+        # one. Keep both stores on the same function.
+        rule_norm = rule.strip().lower()
+        # A whitespace-only clause is no clause. `--negative "   "` is truthy, so
+        # without this it composed "<rule> — NOT:    " and REPLACED a real stored
+        # clause with blanks -- silent loss of the guidance the user had saved.
+        #
+        # isinstance FIRST, because this normalisation is what makes a non-string
+        # reachable as a crash: consolidation passes the LLM's own
+        # item.get("negative") straight through (history.py), so a model emitting
+        # `"negative": 123` would hit .strip() and abort the whole run with
+        # AttributeError. Before this normalisation existed an int only ever reached
+        # an f-string, which interpolated it harmlessly -- so the guard is paying for
+        # the strip, not for a pre-existing hole. A non-string is not usable
+        # guidance, and str()-ifying it would store a repr as if the user wrote it,
+        # so treat it as absent.
+        negative = negative.strip() or None if isinstance(negative, str) else None
         rule_words = self._lesson_keywords(rule_lower)
         # Same reasoning as write_episodic: carry the space generation to the write
         # so a swap landing between the embed and the lock cannot commit a vector
@@ -1841,9 +1918,9 @@ class VectorMemoryStore:
         # then set_semantic refused the replacement, and the route still returned
         # HTTP 200 with no lesson stored. Validating here makes the whole call a
         # no-op when the replacement cannot land.
-        slug = hashlib.md5(rule.encode(), usedforsecurity=False).hexdigest()[:12]
+        slug = _lesson_slug(rule)
         key = f"lesson.{slug}"
-        value = rule if not negative else f"{rule} — NOT: {negative}"
+        value = rule if not negative else f"{rule}{_LESSON_NEGATIVE_SEP}{negative}"
         confidence = 1.0 if source == "user_explicit" else 0.9
         preflight = self.validate_semantic(key, value, confidence, source)
         if preflight is not None:
@@ -1868,8 +1945,88 @@ class VectorMemoryStore:
                         )
                     self.db.commit()
 
-        for existing in self.get_lessons():
-            existing_val = str(json.loads(existing["value_json"]))
+        # TWO PASSES, and the order is load-bearing.
+        #
+        # Pass 1 resolves THIS lesson. Pass 2 runs the generic dedup rules, and those
+        # can `return False` on an UNRELATED row -- a superset whose text contains our
+        # rule. get_lessons() orders by md5 key, so whether such a row is scanned
+        # before ours is effectively random, and doing both in one loop made the
+        # outcome depend on that order: an unrelated superset seen first discarded an
+        # enrichment we had already selected, and the clause was dropped on HTTP 200.
+        # Resolving the exact match first makes the result order-independent, and
+        # pass 2 is skipped entirely once pass 1 claims the write.
+        lesson_rows = self.get_lessons()
+
+        def _as_text(row: dict) -> str | None:
+            """The row's value as lesson TEXT, or None when it is not text.
+
+            set_semantic accepts any object, so an import or a legacy migration can
+            leave a dict or list under a lesson.* key. str() would render a Python
+            repr, and every text comparison here -- the substring dedup and the
+            keyword overlap -- would then match against that repr. Skipping is the
+            honest reading: it is not lesson text.
+
+            The onboarding import does store lessons as a dict
+            (``{"rule", "category", "negative"}``), so a re-submit cannot enrich an
+            imported lesson and inserts a second row instead. That is pre-existing
+            and left alone here -- see the follow-up issue; reading that shape needs
+            the normalized-text path this PR deliberately does not add.
+            """
+            decoded = json.loads(row["value_json"])
+            return decoded if isinstance(decoded, str) else None
+
+        matched = False
+        for existing in lesson_rows:
+            existing_val = _as_text(existing)
+            if existing_val is None:
+                continue
+
+            # Key equality FIRST: md5(rule) identifies THIS lesson exactly, whatever
+            # the stored value contains. Otherwise defer to _split_stored, which
+            # confirms a candidate prefix against the row's own key rather than
+            # guessing a reading of the in-band separator.
+            if existing["key"] == key:
+                base: str | None = rule.strip()
+                stored_clause = existing_val != base
+            else:
+                base, stored_clause = _split_stored(existing_val, rule_norm, existing["key"])
+            if base is None:
+                continue
+
+            if not negative and stored_clause:
+                # A BARE re-submit of a rule that already carries a clause. Writing
+                # the bare value would delete the stored negative, so keep what is
+                # there. This is also what the call did before the fix, so no caller
+                # sees a change here.
+                logger.info(
+                    "Keeping the stored NOT-clause on %r; re-submit carried none",
+                    existing["key"],
+                )
+                _flush_backfills()
+                return False
+            # Recompose from the STORED base so a case-variant re-submit attaches its
+            # clause without silently re-casing the rule -- again matching
+            # LessonStore, which keeps the stored spelling.
+            target = base if not negative else f"{base}{_LESSON_NEGATIVE_SEP}{negative}"
+            if target == existing_val:
+                _flush_backfills()
+                return False  # byte-identical row already stored
+            # The preflight above validated the value built from the SUBMITTED rule;
+            # this one differs, so validate what is actually written.
+            if self.validate_semantic(existing["key"], target, confidence, source):
+                _flush_backfills()
+                return False
+            # Write back under the EXISTING key -- a case-variant would otherwise
+            # insert a second row for the same lesson under a different md5. The
+            # shared tail below does the write.
+            key, value = existing["key"], target
+            matched = True
+            break
+
+        for existing in [] if matched else lesson_rows:
+            existing_val = _as_text(existing)
+            if existing_val is None:
+                continue
             existing_lower = existing_val.lower()
 
             # Substring dedup

--- a/test/test_api_input_validation.py
+++ b/test/test_api_input_validation.py
@@ -157,4 +157,6 @@ class TestLessonsCreateTypeValidation:
         ):
             resp = await api_lessons_create(request)
         assert resp.status == 200
-        request.app["state"].lessons.save.assert_called_once()
+        # save_or_enrich, not save: the route switched so a re-submitted rule can have
+        # a NOT-clause attached instead of being skipped as a duplicate.
+        request.app["state"].lessons.save_or_enrich.assert_called_once()

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -1220,8 +1220,8 @@ class TestLearnCli:
         with _LearnHarness() as h:
             h.vs.write_lesson.return_value = False
             cc._learn(_ns(learn_action="add", rule="do x", category="knowledge", negative=None))
-        h.jsonl.save.assert_called_once()
-        saved = h.jsonl.save.call_args[0][0]
+        h.jsonl.save_or_enrich.assert_called_once()
+        saved = h.jsonl.save_or_enrich.call_args[0][0]
         assert saved.rule == "do x" and saved.category == "knowledge"
         assert "Saved: do x [knowledge]" in capsys.readouterr().out
 

--- a/test/test_learn.py
+++ b/test/test_learn.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import stat
+import sys
+import threading
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
+from kiro_crew.atomic_write import replace_with_retry
 from kiro_crew.learn import _DEFAULT_DIR, Lesson, LessonStore
 
 
@@ -149,3 +155,340 @@ class TestImportPurity:
         # Restore the module to its normal state for other tests.
         importlib.reload(learn_mod)
         assert learn_mod._DEFAULT_DIR == Path.home() / ".kiro" / "crew"
+
+
+class TestSaveOrEnrich:
+    """Re-submitting a rule to attach a NOT-clause must store the clause.
+
+    The duplicate check matched on the rule alone and returned before looking at
+    ``negative``, so the clause was dropped and the route still answered 200.
+    """
+
+    def test_attaches_a_clause_to_an_existing_rule(self, tmp_path: Path) -> None:
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("Pin the port", "tool"))
+
+        assert store.save_or_enrich(_make_lesson("Pin the port", "tool", "Do not autopick")) == (
+            "enriched"
+        )
+
+        records = store.load_all()
+        assert len(records) == 1, "must enrich in place, not append a second record"
+        assert records[0].negative == "Do not autopick"
+
+    def test_replaces_an_existing_clause(self, tmp_path: Path) -> None:
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("Pin the port", "tool", "Old reason"))
+
+        assert store.save_or_enrich(_make_lesson("Pin the port", "tool", "New reason")) == (
+            "enriched"
+        )
+        assert [le.negative for le in store.load_all()] == ["New reason"]
+
+    def test_a_bare_resubmit_never_strips_a_stored_clause(self, tmp_path: Path) -> None:
+        """No clause supplied must not blank one that is already stored."""
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("Pin the port", "tool", "Do not autopick"))
+
+        assert store.save_or_enrich(_make_lesson("Pin the port", "tool")) == "unchanged"
+        assert [le.negative for le in store.load_all()] == ["Do not autopick"]
+
+    def test_inserts_when_no_rule_matches(self, tmp_path: Path) -> None:
+        store = LessonStore(base_dir=tmp_path)
+        assert store.save_or_enrich(_make_lesson("Pin the port", "tool")) == "inserted"
+        assert len(store.load_all()) == 1
+
+    def test_requires_an_exact_rule_not_a_superset(self, tmp_path: Path) -> None:
+        """A stored rule that merely CONTAINS the submitted one is a different lesson."""
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("Pin the port in every environment", "tool"))
+
+        assert store.save_or_enrich(_make_lesson("Pin the port", "tool", "Do not autopick")) == (
+            "inserted"
+        )
+
+        records = store.load_all()
+        assert len(records) == 2
+        assert records[0].negative is None, "the superset record must be untouched"
+
+    def test_distinct_words_differing_only_by_sharp_s_are_not_conflated(
+        self, tmp_path: Path
+    ) -> None:
+        """"Maße" (dimensions) and "Masse" (mass) are DIFFERENT rules. casefold() maps ß
+        to ss, so under it these compared equal and a clause submitted for "Masse"
+        attached itself to the stored "Maße" while the intended lesson was never
+        created -- the wrong rule enriched, the right one discarded. lower() keeps them
+        distinct."""
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("Ma\u00dfe", "tool"))
+
+        store.save_or_enrich(_make_lesson("Masse", "tool", "Do not confuse with volume"))
+
+        records = store.load_all()
+        rules = {le.rule for le in records}
+        assert rules == {"Ma\u00dfe", "Masse"}, f"distinct rules were conflated: {rules}"
+        stored_masse = next(le for le in records if le.rule == "Masse")
+        assert stored_masse.negative == "Do not confuse with volume"
+        stored_masze = next(le for le in records if le.rule == "Ma\u00dfe")
+        assert stored_masze.negative is None, "the clause landed on the wrong rule"
+
+    def test_a_sharp_s_case_variant_inserts_rather_than_enriching(self, tmp_path: Path) -> None:
+        """The cost of choosing lower(): a stored "Straße" and a submitted "STRASSE" no
+        longer compare equal, so this inserts a second row instead of enriching. That is
+        the deliberate trade -- a missed enrichment is recoverable, conflating "Maße"
+        with "Masse" is not. ASCII case variants still enrich (see the test above this
+        one in the class)."""
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("Stra\u00dfe", "tool"))
+
+        store.save_or_enrich(_make_lesson("STRASSE", "tool", "Do not misspell"))
+
+        records = store.load_all()
+        assert len(records) == 2, f"expected the miss, not a conflation: {records}"
+        assert {le.rule for le in records} == {"Stra\u00dfe", "STRASSE"}
+        stored_original = next(le for le in records if le.rule == "Stra\u00dfe")
+        assert stored_original.negative is None, "the clause must not land on the ß row"
+
+    def test_idempotent_when_the_clause_is_already_present(self, tmp_path: Path) -> None:
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("Pin the port", "tool", "Do not autopick"))
+
+        assert store.save_or_enrich(
+            _make_lesson("Pin the port", "tool", "Do not autopick")
+        ) == "unchanged"
+        assert len(store.load_all()) == 1
+
+    def test_a_whitespace_only_clause_never_overwrites_a_stored_one(self, tmp_path: Path) -> None:
+        """Same defect class as the vector store's: a truthy blank clause replaced a
+        real stored one. Both stores are reached directly by the CLI, the route,
+        consolidation and the task runner, so both normalise."""
+        store = LessonStore(base_dir=tmp_path)
+        store.save_or_enrich(_make_lesson("Pin the port", "tool", "Do not autopick"))
+
+        assert store.save_or_enrich(_make_lesson("Pin the port", "tool", "   ")) == "unchanged"
+        assert [le.negative for le in store.load_all()] == ["Do not autopick"]
+
+    def test_a_whitespace_only_clause_is_not_stored_on_insert(self, tmp_path: Path) -> None:
+        store = LessonStore(base_dir=tmp_path)
+        assert store.save_or_enrich(_make_lesson("Pin the port", "tool", "  \t ")) == "inserted"
+        assert [le.negative for le in store.load_all()] == [None], "blanks were persisted"
+
+    def test_a_non_string_clause_does_not_crash_the_write(self, tmp_path: Path) -> None:
+        """Same defect class as the vector store's: consolidation hands over the LLM's own
+        value, so .strip() on an int would abort the run with AttributeError."""
+        store = LessonStore(base_dir=tmp_path)
+        assert store.save_or_enrich(_make_lesson("Pin the port", "tool", 123)) == "inserted"
+        assert [le.negative for le in store.load_all()] == [None]
+
+    def test_a_non_string_clause_never_overwrites_a_stored_one(self, tmp_path: Path) -> None:
+        store = LessonStore(base_dir=tmp_path)
+        store.save_or_enrich(_make_lesson("Pin the port", "tool", "Do not autopick"))
+
+        assert store.save_or_enrich(_make_lesson("Pin the port", "tool", 123)) == "unchanged"
+        assert [le.negative for le in store.load_all()] == ["Do not autopick"]
+
+    def test_save_still_returns_none(self, tmp_path: Path) -> None:
+        """save() delegates but keeps its signature, so existing callers are unaffected."""
+        store = LessonStore(base_dir=tmp_path)
+        assert store.save(_make_lesson("Pin the port", "tool")) is None
+
+    def test_save_does_not_overwrite_a_stored_clause(self, tmp_path: Path) -> None:
+        """An AUTOMATIC writer must not replace a clause a human authored.
+
+        save() is reached by consolidation, task-runner extraction and onboarding
+        import. If it enriched, any of those arriving with its own negative for an
+        already-stored rule would silently replace the human's wording. Only
+        explicit refinement -- the route and `learn add` -- may enrich.
+        """
+        store = LessonStore(base_dir=tmp_path)
+        store.save_or_enrich(_make_lesson("Pin the port", "tool", "Human wrote this"))
+
+        store.save(_make_lesson("Pin the port", "tool", "Machine wrote this"))
+
+        records = store.load_all()
+        assert len(records) == 1
+        assert records[0].negative == "Human wrote this", "an automatic writer overwrote a human"
+
+    def test_save_still_skips_a_plain_duplicate(self, tmp_path: Path) -> None:
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("Pin the port", "tool"))
+        store.save(_make_lesson("Pin the port", "tool"))
+        assert len(store.load_all()) == 1
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX mode bits are not meaningful on Windows: os.chmod only toggles the "
+        "read-only flag, so the file reports 0o666 whatever mode was requested",
+    )
+    def test_a_restrictive_store_mode_survives_a_write(self, tmp_path: Path) -> None:
+        """Swapping the inode used to drop the store's permissions.
+
+        write_text reused the existing inode, so a 0600 store stayed 0600 implicitly.
+        A temp-file rename installs a NEW inode carrying umask permissions (0644
+        under the usual 0022), which would widen a private lessons file on the next
+        save. The mode is now read off the destination and reapplied.
+        """
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("Pin the port", "tool"))
+        store._path.chmod(0o600)
+
+        store.save_or_enrich(_make_lesson("Pin the port", "tool", "Do not autopick"))
+
+        assert stat.S_IMODE(store._path.stat().st_mode) == 0o600, "permissions widened"
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX mode bits are not meaningful on Windows (reports 0o666 regardless)",
+    )
+    def test_a_new_store_is_not_world_readable(self, tmp_path: Path) -> None:
+        """Lesson text is personal content; a store created fresh defaults to 0600."""
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("Pin the port", "tool"))
+
+        assert stat.S_IMODE(store._path.stat().st_mode) == 0o600
+
+    def test_the_rename_goes_through_the_windows_retry_helper(self, tmp_path: Path) -> None:
+        """A bare os.replace raises PermissionError when Windows Search or AV holds a
+        handle. The repo's replace_with_retry exists for exactly that; this pins that
+        the store's write routes through it rather than hand-rolling the rename."""
+        store = LessonStore(base_dir=tmp_path)
+        with patch(
+            "kiro_crew.atomic_write.replace_with_retry", wraps=replace_with_retry
+        ) as spy:
+            store.save(_make_lesson("Pin the port", "tool"))
+        assert spy.called, "the write bypassed replace_with_retry"
+
+
+class TestConcurrentClauseAttach:
+    """One lock acquisition, not two.
+
+    Doing this as enrich-then-insert took the lock twice. Two concurrent posts of
+    the same rule with different clauses interleaved in the gap: both enrich checks
+    missed, the first insert appended, the second saw a duplicate and skipped -- so
+    one clause was lost behind a 200.
+    """
+
+    def test_concurrent_attaches_never_lose_a_record(self, tmp_path: Path) -> None:
+        store = LessonStore(base_dir=tmp_path)
+        outcomes: list[str] = []
+        barrier = threading.Barrier(8)
+
+        def _attach(i: int) -> None:
+            barrier.wait()  # maximise overlap inside the critical section
+            outcomes.append(store.save_or_enrich(_make_lesson("Pin the port", "tool", f"no {i}")))
+
+        threads = [threading.Thread(target=_attach, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        records = store.load_all()
+        assert len(records) == 1, f"the same rule must collapse to one record, got {records}"
+        # Exactly one writer inserts; every other either enriches or finds its own
+        # clause already stored. A dropped clause would show up as a record whose
+        # negative is None despite every writer supplying one.
+        assert outcomes.count("inserted") == 1, f"expected a single insert, got {outcomes}"
+        assert records[0].negative is not None, "a clause was dropped"
+        assert records[0].negative.startswith("no ")
+
+    def test_concurrent_save_and_remove_do_not_lose_the_write(self, tmp_path: Path) -> None:
+        """remove() used to rewrite the file with no lock at all, so a concurrent
+        save could be lost outright."""
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("Keep me", "tool"))
+        barrier = threading.Barrier(2)
+
+        def _add() -> None:
+            barrier.wait()
+            store.save_or_enrich(_make_lesson("Added under contention", "tool"))
+
+        def _drop() -> None:
+            barrier.wait()
+            store.remove("nothing matches this")
+
+        threads = [threading.Thread(target=_add), threading.Thread(target=_drop)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        rules = {le.rule for le in store.load_all()}
+        assert rules == {"Keep me", "Added under contention"}, f"lost a write: {rules}"
+
+    def test_separate_instances_on_one_file_share_a_lock(self, tmp_path: Path) -> None:
+        """Two instances over the same file must serialize against each other.
+
+        DashboardState.lessons and context.get_lessons_for() build separate instances
+        over the same global store. With a per-instance lock they serialized against
+        nothing, so a dashboard refinement racing a consolidation write could lose a
+        clause -- and both composed the same pid-named temp file, so one os.replace
+        consumed the other's.
+        """
+        a = LessonStore(base_dir=tmp_path)
+        b = LessonStore(base_dir=tmp_path)
+        assert a._lock is b._lock, "instances on one file must share the lock"
+
+        different = LessonStore(base_dir=tmp_path / "other")
+        assert different._lock is not a._lock, "a different file must not share it"
+
+    def test_concurrent_writes_from_separate_instances_lose_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        stores = [LessonStore(base_dir=tmp_path) for _ in range(6)]
+        barrier = threading.Barrier(len(stores))
+
+        def _add(i: int) -> None:
+            barrier.wait()
+            stores[i].save_or_enrich(_make_lesson(f"rule {i}", "tool"))
+
+        threads = [threading.Thread(target=_add, args=(i,)) for i in range(len(stores))]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        rules = {le.rule for le in stores[0].load_all()}
+        assert rules == {f"rule {i}" for i in range(len(stores))}, f"lost a write: {rules}"
+        assert list(tmp_path.rglob("*.tmp")) == [], "a temp file survived"
+
+
+class TestAtomicWrite:
+    """The live file is swapped, never written in place.
+
+    load_all() reads without the lock, so a partial write would be observable, and
+    a crash mid-write could truncate the store.
+    """
+
+    def test_leaves_no_temp_file_behind(self, tmp_path: Path) -> None:
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("Pin the port", "tool"))
+        store.save_or_enrich(_make_lesson("Pin the port", "tool", "Do not autopick"))
+        store.remove("Pin")
+
+        strays = list(tmp_path.rglob("*.tmp"))
+        assert strays == [], f"os.replace should consume the temp file, found {strays}"
+
+    def test_a_failed_swap_leaves_the_store_and_cache_intact(self, tmp_path: Path) -> None:
+        """A failed install must not leave the clause visible via the cache either.
+
+        load_all() returns the cached objects, so an in-place mutation followed by a
+        failed write would advertise an unpersisted clause to every later reader --
+        including context injection.
+        """
+        store = LessonStore(base_dir=tmp_path)
+        store.save(_make_lesson("Pin the port", "tool"))
+        store.load_all()  # prime the cache
+
+        # Patched inside atomic_write, which is where the rename now happens. This is
+        # the real seam: learn.py no longer touches os itself.
+        with patch(
+            "kiro_crew.atomic_write.replace_with_retry", side_effect=OSError("disk full")
+        ):
+            with pytest.raises(OSError):
+                store.save_or_enrich(_make_lesson("Pin the port", "tool", "Do not autopick"))
+
+        assert all(le.negative is None for le in store.load_all()), "cache advertises a lost write"
+        store._cache = None
+        assert all(le.negative is None for le in store.load_all()), "file was modified"
+        assert list(tmp_path.rglob("*.tmp")) == [], "temp file survived a failed swap"

--- a/test/test_lesson_contradiction.py
+++ b/test/test_lesson_contradiction.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,7 +16,12 @@ from kiro_crew.providers.base import (
     EVENT_TEXT_CHUNK,
     EVENT_TOOL_CALL,
 )
-from kiro_crew.vector_memory import VectorMemoryStore
+from kiro_crew.vector_memory import (
+    _LESSON_NEGATIVE_SEP,
+    VectorMemoryStore,
+    _lesson_slug,
+    _split_stored,
+)
 
 
 class _FakeBgSession:
@@ -412,6 +419,44 @@ class TestApiLessonsCreateForwardsNegative:
         assert records[0].negative == self._NEGATIVE
 
 
+class TestApiLessonsDeleteOffloadsRemove:
+    """remove() must not run on the event loop.
+
+    It now takes the store's shared lock, which a worker thread can hold across file
+    I/O for a concurrent save_or_enrich -- so calling it inline would let one lessons
+    write stall every task on the loop. There was no coverage of this route at all
+    before, so the offload would otherwise have shipped untested.
+    """
+
+    @pytest.mark.asyncio
+    async def test_remove_runs_off_the_event_loop(self):
+        from kiro_crew.dashboard.handlers import cron
+
+        loop_thread = threading.get_ident()
+        seen: dict[str, int] = {}
+
+        class _RecordingStore:
+            def remove(self, rule_sub):  # noqa: ANN001 - test double
+                seen["remove"] = threading.get_ident()
+                return True
+
+        state = MagicMock()
+        state.lessons = _RecordingStore()
+        request = MagicMock()
+        request.app = {"state": state}
+        request.headers = {"X-Session-Key": "dashboard:ui"}
+        request.json = AsyncMock(return_value={"rule": "pin the port"})
+
+        with patch.object(cron, "_get_memory", return_value=MagicMock(vector_store=None)), \
+             patch.object(cron, "_is_restricted_session", return_value=False), \
+             patch.object(cron, "_sel"):
+            resp = await cron.api_lessons_delete(request)
+
+        assert resp.status == 200
+        assert "remove" in seen, "the JSONL remove path was never reached"
+        assert seen["remove"] != loop_thread, "remove must run off the event loop"
+
+
 class TestWriteLessonRejectionPreflight:
     """write_lesson must not delete a superseded lesson for a value it will reject.
 
@@ -472,5 +517,429 @@ class TestWriteLessonRejectionPreflight:
             stored = [json.loads(r["value_json"]) for r in store.get_lessons()]
             assert len(stored) == 1
             assert "— NOT: Do not rely on the auto-picked port" in stored[0]
+        finally:
+            store.close()
+
+
+class TestSplitStored:
+    """Direct truth table for the separator matcher. Four review rounds each found one
+    more instance of this class, because the separator is stored IN-BAND and unescaped:
+    `A — NOT: B` is either rule `A` with clause `B`, or a bare rule containing the
+    separator. The row's key (md5 of the rule at write time) is what settles it, so
+    these cases are pinned in BOTH directions."""
+
+    SEP = _LESSON_NEGATIVE_SEP
+
+    def _key(self, rule):
+        return f"lesson.{_lesson_slug(rule)}"
+
+    def test_bare_rule_same_case(self):
+        assert _split_stored("Pin the port", "pin the port", self._key("Pin the port")) == (
+            "Pin the port", False
+        )
+
+    def test_bare_rule_case_variant(self):
+        assert _split_stored("PIN THE PORT", "pin the port", self._key("PIN THE PORT")) == (
+            "PIN THE PORT", False
+        )
+
+    def test_rule_with_clause(self):
+        rule = "Pin the port"
+        stored = f"{rule}{self.SEP}Do not autopick"
+        assert _split_stored(stored, "pin the port", self._key(rule)) == (rule, True)
+
+    def test_rule_with_clause_case_variant(self):
+        rule = "PIN THE PORT"
+        stored = f"{rule}{self.SEP}Do not autopick"
+        assert _split_stored(stored, "pin the port", self._key(rule)) == (rule, True)
+
+    def test_rule_containing_the_separator_bare(self):
+        rule = f"Write 'A{self.SEP}B' verbatim"
+        assert _split_stored(rule, rule.lower(), self._key(rule)) == (rule, False)
+
+    def test_rule_containing_the_separator_with_a_clause(self):
+        """split(SEP, 1) truncated at the rule's OWN separator, so the row never matched
+        and the clause update was dropped."""
+        rule = f"Write 'A{self.SEP}B' verbatim"
+        stored = f"{rule}{self.SEP}Do not paraphrase"
+        assert _split_stored(stored, rule.lower(), self._key(rule)) == (rule, True)
+
+    def test_a_bare_separator_bearing_rule_is_not_treated_as_an_enriched_row(self):
+        """The INVERSE of the case above. Stored `A — NOT: B` is a bare rule whose text
+        contains the separator. Submitting rule `A` must NOT match it -- doing so
+        recomposed `A — NOT: <new>` and OVERWROTE an unrelated lesson. The key is what
+        distinguishes the two: md5 of the whole value, not of the prefix."""
+        stored = f"A{self.SEP}B"
+        assert _split_stored(stored, "a", self._key(stored)) == (None, False)
+
+    def test_the_prefix_matches_only_when_the_key_confirms_it(self):
+        """Same text, same submitted rule, different stored key -> opposite answers. This
+        is the whole disambiguation in one pair of assertions, and it is why the two
+        contradictory review rounds can both be satisfied."""
+        stored = f"A{self.SEP}B"
+        assert _split_stored(stored, "a", self._key("A")) == ("A", True)
+        assert _split_stored(stored, "a", self._key(stored)) == (None, False)
+
+    def test_a_row_keyed_another_way_declines_rather_than_overwrites(self):
+        """Import rows are keyed on sha256 and legacy migrations set their own keys. The
+        prefix cannot be confirmed, so the ambiguous branch declines: a missed
+        enrichment, never an overwrite."""
+        stored = f"Pin the port{self.SEP}Do not autopick"
+        assert _split_stored(stored, "pin the port", "lesson.aabbccddeeff0011") == (None, False)
+
+    def test_distinct_words_differing_only_by_sharp_s_do_not_match(self):
+        """The precise site of the conflation, with no embedding or dedup involved.
+        "Maße".casefold() and "Masse".casefold() are both "masse", so under casefold this
+        returned ("Maße", False) and the caller then recomposed a clause submitted for
+        "Masse" onto the stored "Maße". lower() keeps them apart."""
+        assert _split_stored("Ma\u00dfe", "masse", self._key("Ma\u00dfe")) == (None, False)
+        # and the same rule still matches itself
+        assert _split_stored("Ma\u00dfe", "ma\u00dfe", self._key("Ma\u00dfe")) == ("Ma\u00dfe", False)
+
+    def test_an_ascii_case_variant_still_matches(self):
+        """The trade only costs the ß case: ordinary case variation is unaffected."""
+        assert _split_stored("PIN THE PORT", "pin the port", self._key("PIN THE PORT")) == (
+            "PIN THE PORT", False
+        )
+
+    def test_case_folding_that_changes_length_is_not_sliced_by_normalised_length(self):
+        """lower() can still CHANGE length: "İ" (U+0130) lowercases to "i" plus a
+        combining dot, 1 codepoint to 2. Matching by prefix length would cut mid-string,
+        which is why whole prefixes are compared instead."""
+        rule = "\u0130stanbul rule"
+        assert len(rule.lower()) > len(rule)
+        stored = f"{rule}{self.SEP}Nicht anders"
+        assert _split_stored(stored, rule.lower(), self._key(rule)) == (rule, True)
+
+    def test_an_unrelated_rule_does_not_match(self):
+        stored = f"Other rule{self.SEP}clause"
+        assert _split_stored(stored, "pin the port", self._key("Other rule")) == (None, False)
+
+    def test_a_clause_containing_the_separator_is_not_mistaken_for_the_rule(self):
+        rule = "Pin the port"
+        stored = f"{rule}{self.SEP}Not 'X{self.SEP}Y'"
+        assert _split_stored(stored, "pin the port", self._key(rule)) == (rule, True)
+
+
+class TestWriteLessonAttachesNegativeToStoredRule:
+    """Re-submitting a stored rule with a NOT-clause must store the clause.
+
+    The key is md5(rule), so a re-submit lands on the same row and set_semantic
+    upserts it. What blocked that was the substring dedup returning False first --
+    and it ALWAYS fired, because the stored value is either the bare rule or
+    "<rule> - NOT: <clause>" and both contain the rule.
+    """
+
+    @staticmethod
+    def _store(tmp_path):
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db")
+        store.init()
+        store.embed_fn = lambda t: [0.1] * 384
+        return store
+
+    @staticmethod
+    def _values(store):
+        return [str(json.loads(row["value_json"])) for row in store.get_lessons()]
+
+    def test_attaches_a_clause_to_a_stored_rule(self, tmp_path):
+        store = self._store(tmp_path)
+        try:
+            assert store.write_lesson("Pin the port", "tool") is True
+            # Before the fix this returned False and stored nothing.
+            assert store.write_lesson("Pin the port", "tool", "Do not autopick") is True
+
+            values = self._values(store)
+            assert len(values) == 1, f"must upsert the same row, got {values}"
+            assert "Do not autopick" in values[0]
+        finally:
+            store.close()
+
+    def test_replaces_an_existing_clause(self, tmp_path):
+        store = self._store(tmp_path)
+        try:
+            store.write_lesson("Pin the port", "tool", "Old reason")
+            assert store.write_lesson("Pin the port", "tool", "New reason") is True
+
+            values = self._values(store)
+            assert len(values) == 1
+            assert "New reason" in values[0]
+            assert "Old reason" not in values[0]
+        finally:
+            store.close()
+
+    def test_a_bare_resubmit_never_strips_a_stored_clause(self, tmp_path):
+        """Falling through unconditionally would upsert the bare rule and delete the
+        clause. This is the regression that guards that."""
+        store = self._store(tmp_path)
+        try:
+            store.write_lesson("Pin the port", "tool", "Do not autopick")
+            assert store.write_lesson("Pin the port", "tool") is False
+
+            values = self._values(store)
+            assert len(values) == 1
+            assert "Do not autopick" in values[0], "the stored clause was stripped"
+        finally:
+            store.close()
+
+    def test_identical_resubmit_is_a_noop(self, tmp_path):
+        store = self._store(tmp_path)
+        try:
+            store.write_lesson("Pin the port", "tool", "Do not autopick")
+            assert store.write_lesson("Pin the port", "tool", "Do not autopick") is False
+            assert len(self._values(store)) == 1
+        finally:
+            store.close()
+
+    def test_a_case_variant_resubmit_attaches_its_clause(self, tmp_path):
+        """The key is md5(rule) and md5 is case-SENSITIVE, so matching on key equality
+        missed a case-only refinement: it computed a different key, fell into the
+        substring dedup, and lost the clause exactly as before the fix."""
+        store = self._store(tmp_path)
+        try:
+            assert store.write_lesson("Pin the port", "tool") is True
+            assert store.write_lesson("pin the port", "tool", "Do not autopick") is True
+
+            values = self._values(store)
+            assert len(values) == 1, f"a case variant must not insert a second row: {values}"
+            assert "Do not autopick" in values[0]
+            assert values[0].startswith("Pin the port"), "must keep the stored spelling"
+        finally:
+            store.close()
+
+    def test_distinct_words_differing_only_by_sharp_s_are_not_conflated(self, tmp_path):
+        """"Maße" and "Masse" are different words. Under casefold() the whole-value branch
+        matched them and the tail recomposed the clause onto the STORED "Maße" spelling,
+        so the intended "Masse" lesson never landed. The key confirmation does not save
+        this -- it guards only the prefix branch.
+
+        Driven with a text-discriminating embed_fn on purpose: the class fixture returns
+        a CONSTANT vector, which makes cosine similarity 1.0 for every pair, so semantic
+        dedup would delete a row here for reasons unrelated to the matcher and the test
+        would pass or fail without telling us anything about lower() vs casefold()."""
+        store = self._store(tmp_path)
+        try:
+            store.embed_fn = lambda t: [1.0 if i == hash(t) % 384 else 0.0 for i in range(384)]
+            assert store.write_lesson("Ma\u00dfe", "tool") is True
+            store.write_lesson("Masse", "tool", "Do not confuse with volume")
+
+            values = self._values(store)
+            assert any(v == "Ma\u00dfe" for v in values), f"the stored rule was rewritten: {values}"
+            assert any(
+                v.startswith("Masse") and v.endswith("Do not confuse with volume")
+                for v in values
+            ), f"the clause landed on the wrong rule: {values}"
+        finally:
+            store.close()
+
+    def test_a_sharp_s_case_variant_inserts_rather_than_enriching(self, tmp_path):
+        """The deliberate cost of lower(): a ß case-variant no longer enriches. A missed
+        enrichment is the acceptable side of the trade; conflating distinct rules is not.
+        Discriminating embed_fn for the same reason as the test above."""
+        store = self._store(tmp_path)
+        try:
+            store.embed_fn = lambda t: [1.0 if i == hash(t) % 384 else 0.0 for i in range(384)]
+            assert store.write_lesson("Stra\u00dfe", "tool") is True
+            store.write_lesson("STRASSE", "tool", "Do not misspell")
+
+            values = self._values(store)
+            assert any(v == "Stra\u00dfe" for v in values), f"stored spelling lost: {values}"
+        finally:
+            store.close()
+            store.close()
+
+    def test_a_rule_containing_the_separator_still_matches(self, tmp_path):
+        """The base is derived by splitting on the separator, so a rule that CONTAINS
+        it would be truncated and the exact match would miss. Key equality is checked
+        first precisely so this case never reaches the split."""
+        store = self._store(tmp_path)
+        try:
+            rule = "Write 'A \u2014 NOT: B' verbatim"
+            assert store.write_lesson(rule, "tool") is True
+            assert store.write_lesson(rule, "tool", "Do not paraphrase") is True
+
+            values = self._values(store)
+            assert len(values) == 1, f"expected one row, got {values}"
+            assert values[0].endswith("Do not paraphrase")
+            assert values[0].startswith(rule), "the rule text was truncated"
+        finally:
+            store.close()
+
+    def test_an_object_valued_lesson_row_is_skipped_not_stringified(self, tmp_path):
+        """set_semantic accepts any object, so an import or legacy migration can leave a
+        non-string under a lesson.* key. str() would render a Python repr and every text
+        comparison in the dedup scan would match against that repr instead of lesson
+        text. Values with no lesson shape at all stay skipped -- only the import's
+        documented {"rule": ...} shape is read (see the imported-lesson test below)."""
+        store = self._store(tmp_path)
+        try:
+            # A list, and a dict carrying no string rule: neither is lesson text.
+            assert store.set_semantic("lesson.listrow", ["Pin the port"], 1.0, "migration") is None
+            assert store.set_semantic("lesson.norule", {"category": "x"}, 1.0, "migration") is None
+            # Must not raise, and must not let either repr interfere with a real write.
+            assert store.write_lesson("Pin the port", "tool", "Do not autopick") is True
+
+            texts = [
+                v for v in (json.loads(r["value_json"]) for r in store.get_lessons())
+                if isinstance(v, str)
+            ]
+            assert any("Do not autopick" in t for t in texts), f"clause not stored: {texts}"
+        finally:
+            store.close()
+
+    def test_an_unrelated_superset_cannot_discard_the_enrichment(self, tmp_path):
+        """The generic dedup rules can refuse on an UNRELATED row -- a superset whose
+        text contains our rule. get_lessons() orders by md5 key, so whether that row
+        is scanned before ours is effectively random; resolving the exact match in its
+        own pass first is what makes the outcome independent of row order."""
+        store = self._store(tmp_path)
+        try:
+            # Store the exact rule AND a superset that contains it. The superset is
+            # written first so it exists as a competing row.
+            assert store.write_lesson("Pin the port in every environment", "tool") is True
+            assert store.set_semantic(
+                f"lesson.{hashlib.md5(b'Pin the port', usedforsecurity=False).hexdigest()[:12]}",
+                "Pin the port",
+                1.0,
+                "user_explicit",
+            ) is None
+
+            assert store.write_lesson("Pin the port", "tool", "Do not autopick") is True
+
+            values = self._values(store)
+            enriched = [v for v in values if "Do not autopick" in v]
+            assert enriched, f"the superset row discarded the enrichment: {values}"
+            assert enriched[0].startswith("Pin the port")
+        finally:
+            store.close()
+
+    def test_a_whitespace_only_clause_never_overwrites_a_stored_one(self, tmp_path):
+        """`--negative "   "` is truthy, so it composed "<rule> - NOT:    " and replaced
+        a real stored clause with blanks -- silent loss of saved guidance."""
+        store = self._store(tmp_path)
+        try:
+            store.write_lesson("Pin the port", "tool", "Do not autopick")
+            assert store.write_lesson("Pin the port", "tool", "   ") is False
+
+            values = self._values(store)
+            assert len(values) == 1
+            assert "Do not autopick" in values[0], f"clause overwritten by blanks: {values}"
+        finally:
+            store.close()
+
+    def test_a_whitespace_only_clause_is_not_stored_on_insert(self, tmp_path):
+        store = self._store(tmp_path)
+        try:
+            assert store.write_lesson("Pin the port", "tool", "  \t ") is True
+            values = self._values(store)
+            assert values == ["Pin the port"], f"blanks were persisted: {values}"
+        finally:
+            store.close()
+
+    def test_a_case_variant_of_a_rule_containing_the_separator_is_enriched(self, tmp_path):
+        """A rule that itself contains the separator, re-submitted in a different case.
+        The whole stored value is compared before any split, so the split cannot
+        truncate it."""
+        store = self._store(tmp_path)
+        try:
+            rule = "Write 'A \u2014 NOT: B' verbatim"
+            assert store.write_lesson(rule, "tool") is True
+            assert store.write_lesson(rule.upper(), "tool", "Do not paraphrase") is True
+
+            values = self._values(store)
+            assert len(values) == 1, f"a second row was inserted: {values}"
+            assert values[0].endswith("Do not paraphrase")
+            assert values[0].startswith(rule), "the stored spelling was not kept"
+        finally:
+            store.close()
+
+    def test_a_clause_on_a_separator_bearing_rule_can_be_updated(self, tmp_path):
+        """End-to-end for the blocking finding, and the case the reduced scope could not
+        serve: a rule already carrying a clause, re-submitted in a different case with a
+        NEW clause. The helper being correct does not prove write_lesson threads it
+        through, so this drives the real store."""
+        store = self._store(tmp_path)
+        try:
+            rule = f"Write 'A{_LESSON_NEGATIVE_SEP}B' verbatim"
+            assert store.write_lesson(rule, "tool", "Do not paraphrase") is True
+            assert store.write_lesson(rule.upper(), "tool", "Do not translate") is True
+
+            values = self._values(store)
+            assert len(values) == 1, f"a duplicate row was inserted: {values}"
+            assert values[0].endswith("Do not translate"), f"clause not updated: {values}"
+            assert values[0].startswith(rule), "the stored spelling was not kept"
+        finally:
+            store.close()
+
+    def test_the_reported_blocking_case_stored_clause_plus_case_variant(self, tmp_path):
+        """The exact scenario GPT reported: stored `Pin — NOT: Old`, submitted `pin` with
+        `New`. Before the scan was restored this fell through to the substring dedup,
+        which returned False and left `Old` while losing `New` behind an HTTP 200."""
+        store = self._store(tmp_path)
+        try:
+            assert store.write_lesson("Pin the port", "tool", "Old clause") is True
+            assert store.write_lesson("pin the port", "tool", "New clause") is True
+
+            values = self._values(store)
+            assert len(values) == 1, f"a duplicate row was inserted: {values}"
+            assert values[0].endswith("New clause"), f"the new clause was lost: {values}"
+            assert values[0].startswith("Pin the port"), "the stored spelling was not kept"
+        finally:
+            store.close()
+
+    def test_a_bare_separator_bearing_rule_is_never_overwritten(self, tmp_path):
+        """A lesson whose own text contains the separator must not be mistaken for `A`
+        carrying clause `B`. This is the guard that keeps the reduced scope safe: with
+        no prefix matching there is nothing to misread, and submitting `A` inserts its
+        own row rather than recomposing over this one."""
+        store = self._store(tmp_path)
+        try:
+            bare = f"A{_LESSON_NEGATIVE_SEP}B"
+            assert store.write_lesson(bare, "tool") is True
+            store.write_lesson("A", "tool", "Do not use A")
+
+            values = self._values(store)
+            assert any(v == bare for v in values), f"the bare rule was overwritten: {values}"
+        finally:
+            store.close()
+
+    def test_a_non_string_clause_does_not_crash_the_write(self, tmp_path):
+        """Consolidation passes the LLM's own item.get("negative") straight through, so a
+        model emitting `"negative": 123` reaches the store as an int. The whitespace
+        normalisation calls .strip(), which would raise AttributeError and abort the
+        whole consolidation run. A non-string is not usable guidance, so it is treated
+        as absent rather than str()-ified into stored text."""
+        store = self._store(tmp_path)
+        try:
+            assert store.write_lesson("Pin the port", "tool", 123) is True  # type: ignore[arg-type]
+
+            values = self._values(store)
+            assert values == ["Pin the port"], f"the non-string leaked into the value: {values}"
+        finally:
+            store.close()
+
+    def test_a_non_string_clause_never_overwrites_a_stored_one(self, tmp_path):
+        """Same guard, destructive direction: a malformed clause must not blank out real
+        stored guidance."""
+        store = self._store(tmp_path)
+        try:
+            store.write_lesson("Pin the port", "tool", "Do not autopick")
+            store.write_lesson("Pin the port", "tool", {"oops": 1})  # type: ignore[arg-type]
+
+            values = self._values(store)
+            assert len(values) == 1
+            assert "Do not autopick" in values[0], f"clause lost to a non-string: {values}"
+        finally:
+            store.close()
+
+    def test_a_genuinely_different_rule_is_still_deduped(self, tmp_path):
+        """The same-key shortcut must not weaken the substring dedup for a DIFFERENT
+        rule that an existing lesson already covers."""
+        store = self._store(tmp_path)
+        try:
+            assert store.write_lesson("Pin the port in every environment", "tool") is True
+            # Different rule => different md5 => the shortcut does not apply, and the
+            # substring dedup should still refuse it.
+            assert store.write_lesson("Pin the port", "tool", "Do not autopick") is False
+            assert len(self._values(store)) == 1
         finally:
             store.close()


### PR DESCRIPTION
Closes #2157.

Re-submitting a rule to attach a NOT-clause silently stored nothing, in **both** stores, and the route still answered HTTP 200. This is the natural way a user or a model refines a lesson, and it is what `learn_add`'s own field description steers models toward.

## Vector store

The issue proposed a new atomic enrich path. Reading the code showed one is not needed: the lesson key is `md5(rule)`, so a re-submitted rule already lands on the same row, and `_write_semantic` does a locked `SELECT`-then-`UPSERT` where a `user_explicit` source wins its conflict check. The write was already atomic.

What blocked it was the substring dedup returning `False` before the loop reached that upsert — and it **always** fired, because the stored value is either the bare rule or `<rule> — NOT: <clause>`, and both contain the rule. Recognising our own row and falling through to the upsert is the core of the fix.

Matching a row is **exact, never a guess**, in two forms:

- **key equality** (`md5(rule)`) — identifies this lesson whatever the value holds.
- **`_split_stored`** — for a case variant (md5 is case-sensitive) it compares the whole stored value, and to attach a clause to a rule that already carries one it walks every separator boundary and accepts a candidate prefix **only when that prefix hashes to the row's own key**.

That key confirmation is the load-bearing part, because the separator is stored **in-band and unescaped**: `A — NOT: B` is either rule `A` with clause `B`, or a bare rule whose own text contains the separator. Two review rounds on this PR demanded opposite readings of that same text. The value alone cannot settle it; the row's key can. Mutation-proven in both directions — dropping the key confirmation fails **4** tests (it overwrites an unrelated rule), disabling the boundary scan fails **6** (it drops a clause update).

**One trap, surfaced by reading rather than testing.** Falling through unconditionally would let a *bare* re-submit of a rule that already carries a clause upsert the bare value and **delete the stored negative**. That case keeps what is stored — which is also what the old code did by refusing, so no caller sees a change there.

## JSONL store

`save()` matched on the rule alone and returned before looking at `negative`. Replaced with `save_or_enrich()`, doing enrich-or-insert in **one lock acquisition**.

The single acquisition is load-bearing. As two calls — enrich, then insert — a concurrent writer inserting the same rule in the gap made the second call see a duplicate and skip, dropping the clause exactly as before, just less often. `test_concurrent_attaches_never_lose_a_record` drives 8 threads through a barrier to pin it.

`save()` keeps its signature and delegates, so **all existing callers are untouched**.

## Case matching is `lower()`, deliberately not `casefold()`

This reversed an earlier decision inside this PR, so the reasoning is recorded rather than buried.

`casefold()` maps `ß` to `ss`, which matches a stored `Straße` against a submitted `STRASSE`. The **same** mapping makes `Maße` and `Masse` compare equal, and those are different German words — so a clause submitted for `Masse` attached itself to the stored `Maße` and the intended lesson was never created. Wrong rule enriched, right one discarded, and `get_lessons_context()` then injects that wrong guidance as authoritative.

The two behaviours are inseparable — one ß rule produces both — so this is a **trade, not a fix**:

| | `casefold()` | `lower()` (shipped) |
|---|---|---|
| `Straße` / `STRASSE` | enriches | **misses** — inserts a second row |
| `Maße` / `Masse` | **conflates** — wrong rule enriched | keeps distinct |

`lower()` is the safe side: a missed enrichment leaves both lessons intact and is recoverable by re-submitting; a conflated one is not. Applied in both stores so they cannot drift. Reverting either to `casefold()` fails **5** tests.

## Both stores reject a non-string clause

Consolidation passes the LLM's own `item.get("negative")` straight through (`history.py`), so a model emitting `"negative": 123` reaches the stores as an int. The whitespace normalisation added in this PR put `.strip()` in front of that and so **introduced** an `AttributeError` that aborted the whole consolidation run — it did not exist on `main`, where the value only ever reached an f-string. Both stores now check `isinstance` first and treat a non-string as absent rather than `str()`-ifying a repr into stored guidance. Reverting either guard fails **4** tests.

## Atomic writes, and why `load_all` still needs no lock

Writes go through the repo's existing `atomic_write()` helper instead of `write_text` — `mkstemp`, the destination's mode reapplied via `fchmod_safe`, then `replace_with_retry`. Using the existing helper rather than a hand-rolled `tmp` + `os.replace` closed three separate review findings at once (Windows retry, mode preservation, temp-name collision).

`load_all()` reads without the lock, and the replace is atomic on POSIX and Windows, so a reader sees either the whole old file or the whole new one. That is what makes the unlocked read safe. A crash mid-write can no longer truncate the store.

The locks are `threading.Lock` in a module-level `path → lock` registry, so two `LessonStore` instances on the same file share one. They do **not** span processes: the CLI and the gateway write this file from different processes, so cross-process behaviour is last-writer-wins. Stated as a known limit, not quietly fixed.

## `remove()` now holds the lock

It did an unlocked read-modify-write, so a concurrent `save` could be lost outright. This is a **prerequisite** of the fix rather than adjacent cleanup: without it the atomicity `save_or_enrich` claims would not hold.

## Route, CLI, and task runner

The route and the CLI both call `save_or_enrich`, and the route offloads it — and `remove` — with `asyncio.to_thread`, matching how `dashboard/ws.py` offloads `load_all`. The route previously did a whole-file read and rewrite directly on the event loop.

`taskrunner._extract_lesson` also called `save()` **on the event loop**, and the shared per-path lock made that a problem it was not before: a dashboard writer holding the lock across its read-and-rewrite would stall the loop. It is now offloaded the same way — matching the `write_lesson` call directly above it, which was already offloaded for the same reason. The lock is what makes the write atomic, so the caller moves off the loop rather than the lock being weakened.

That is the only loop-thread caller: `history._save_lessons` already runs through `run_in_embed_pool`, and the onboarding import is a synchronous CLI path.

## Verification

- **1109 passed / 10 skipped** across the lesson, contradiction, vector-store, validation, CLI, history, onboarding, context, task-runner and boot-path suites.
- `isort`, `flake8`, `mypy` (852 files) clean.
- Every guard mutation-proven **individually**, with the counts above. Two POSIX-only mode assertions are `skipif`-gated on Windows, where `os.chmod` only toggles the read-only flag so a file reports `0o666` whatever mode is requested.

## Known residuals, deliberately not fixed here

- **A ß case-variant no longer enriches** — the accepted cost of `lower()` above. Inserts a second row; never conflates.
- **Onboarding-import rows are not enriched.** The import writes `{"rule", "category", "negative"}` as a dict under a `sha256(rule)` key, so key equality can never reach it and the non-string guard skips it. Pre-existing — on `main` the dict is `str()`-ified into a repr that also fails to match and can spuriously match unrelated rules. Tracked in #2321 with the real fix: take the clause **out of band**, as `LessonStore` already does with separate `rule`/`negative` fields, which retires `_split_stored` entirely.
- **`write_lesson`'s bool conflates refused, deduped and no-op**, so the CLI writes a redundant JSONL record for a benign no-op and the route answers `{"ok": true}` even when validation refused the value. Tracked in #2325. Not here: 5 call sites and ~110 assertions depend on the bool, and 3 callers test it in a bare `if` where a tuple is always truthy and mypy flags only one — silent inversion in the same diff as a data-loss fix is a bad trade.
- **A non-string `rule` crashes at `rule.lower()`** in consolidation. Genuinely pre-existing (identical on `main`) and input validation rather than clause handling, so out of scope for this PR.

