### PR TITLE
refactor(core): migrate five inline atomic writes onto the shared helper

### DIFF
--- a/src/kiro_crew/channel.py
+++ b/src/kiro_crew/channel.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 
 logger = logging.getLogger(__name__)
@@ -465,11 +466,10 @@ class ChannelManager:
         """Persist channel state to disk."""
         os.makedirs(self._CHANNELS_DIR, exist_ok=True)
         path = os.path.join(self._CHANNELS_DIR, f"{channel.id}.json")
-        tmp = path + ".tmp"
         try:
-            with open(tmp, "w") as f:
-                json.dump(channel.serialize(), f)
-            os.replace(tmp, path)
+            # No mode=: the hand-rolled open() published at the umask default,
+            # which is what the helper applies when mode is omitted.
+            atomic_write(path, json.dumps(channel.serialize()))
         except Exception:
             logger.exception("Failed to save channel %s", channel.id)
 

--- a/src/kiro_crew/deploy/pending.py
+++ b/src/kiro_crew/deploy/pending.py
@@ -8,16 +8,14 @@ pattern as profiles.py registry.
 """
 from __future__ import annotations
 
-import contextlib
 import json
 import logging
-import os
-import tempfile
 import time
 import uuid
 from pathlib import Path
 from typing import Any
 
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 from kiro_crew.platform_compat import file_lock
 
@@ -46,21 +44,10 @@ def _load_raw() -> list[dict[str, Any]]:
 
 def _save_raw(entries: list[dict[str, Any]]) -> None:
     p = _store_path()
-    p.parent.mkdir(parents=True, exist_ok=True)
-    tmp = tempfile.NamedTemporaryFile(
-        mode="w", dir=str(p.parent), suffix=".tmp", delete=False, encoding="utf-8"
-    )
-    try:
-        tmp.write(json.dumps(entries, indent=2))
-        tmp.flush()
-        os.fsync(tmp.fileno())
-        tmp.close()
-        os.replace(tmp.name, str(p))
-    except BaseException:
-        tmp.close()
-        with contextlib.suppress(OSError):
-            os.unlink(tmp.name)
-        raise
+    # mode=0o600 is NOT optional. NamedTemporaryFile creates its file owner-only
+    # and this function never widened it, so the pending store is 0o600 today.
+    # Omitting the mode would publish it at the umask default (0o644) instead.
+    atomic_write(p, json.dumps(entries, indent=2), fsync=True, mode=0o600)
 
 
 def _prune_expired(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/src/kiro_crew/deploy/profiles.py
+++ b/src/kiro_crew/deploy/profiles.py
@@ -28,11 +28,11 @@ import logging
 import os
 import re
 import sys
-import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Generator
 
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 from kiro_crew.deploy import engine
 from kiro_crew.platform_compat import file_lock
@@ -120,23 +120,12 @@ def locked_registry() -> Generator[dict[str, Any], None, None]:
             reg = load_registry()
             yield reg
             # Persist on clean exit (exceptions skip save, lock still releases)
-            tmp_fd = tempfile.NamedTemporaryFile(
-                mode="w", dir=str(_data_dir()), suffix=".json.tmp",
-                delete=False, encoding="utf-8",
+            # mode=0o600 is NOT optional: NamedTemporaryFile created the temp
+            # owner-only and this never widened it, so the registry (which holds
+            # account ids) is 0o600 today, not the umask default.
+            atomic_write(
+                _registry_path(), json.dumps(reg, indent=2), fsync=True, mode=0o600
             )
-            try:
-                tmp_fd.write(json.dumps(reg, indent=2))
-                tmp_fd.flush()
-                os.fsync(tmp_fd.fileno())
-                tmp_fd.close()
-                os.replace(tmp_fd.name, str(_registry_path()))
-            except BaseException:
-                tmp_fd.close()
-                try:
-                    os.unlink(tmp_fd.name)
-                except OSError:
-                    pass
-                raise
 
 
 def make_entry(name: str, region: str, *, account: str = "", verified_at: str = "",
@@ -201,23 +190,11 @@ def save_registry(reg: dict[str, Any]) -> dict[str, Any]:
     lock_path = _registry_path().with_suffix(".lock")
     with open(lock_path, "w") as fd:
         with file_lock(fd.fileno(), exclusive=True, required=True):
-            tmp_fd = tempfile.NamedTemporaryFile(
-                mode="w", dir=str(_data_dir()), suffix=".json.tmp",
-                delete=False, encoding="utf-8",
+            # mode=0o600: see locked_registry above. Same NamedTemporaryFile
+            # provenance, same owner-only publish mode to preserve.
+            atomic_write(
+                _registry_path(), json.dumps(reg, indent=2), fsync=True, mode=0o600
             )
-            try:
-                tmp_fd.write(json.dumps(reg, indent=2))
-                tmp_fd.flush()
-                os.fsync(tmp_fd.fileno())
-                tmp_fd.close()
-                os.replace(tmp_fd.name, str(_registry_path()))
-            except BaseException:
-                tmp_fd.close()
-                try:
-                    os.unlink(tmp_fd.name)
-                except OSError:
-                    pass
-                raise
     return reg
 
 

--- a/src/kiro_crew/model_registry.py
+++ b/src/kiro_crew/model_registry.py
@@ -37,6 +37,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+from kiro_crew.atomic_write import atomic_write
+
 logger = logging.getLogger(__name__)
 
 _REGISTRY_FILE = Path(__file__).resolve().parent / "model_registry.json"
@@ -241,11 +243,9 @@ def persist_kiro_windows() -> None:
     try:
         snapshot = dict(_KIRO_WINDOWS)  # atomic under the GIL; safe vs. concurrent mutation
         path = _kiro_windows_cache_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".json.tmp")
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(snapshot, f)
-        tmp.replace(path)
+        # No mode=: the hand-rolled open() published at the umask default, which
+        # is what the helper applies when mode is omitted.
+        atomic_write(path, json.dumps(snapshot))
     except OSError:  # pragma: no cover - disk full / perms
         logger.debug("Could not persist kiro window cache", exc_info=True)
 


### PR DESCRIPTION
Five hand-rolled temp-write-and-rename sequences across four files, none of them
behind a named helper, so none was visible to a grep for atomic_write duplicates:
deploy.pending._save_raw, deploy.profiles.locked_registry,
deploy.profiles.save_registry, channel._save_channel and
model_registry._persist_kiro_windows.

Every one misses the Windows os.replace sharing-violation retry the shared helper
carries: a concurrent reader (an indexer, a backup agent, another KiroCrew
process) holding the target open makes os.replace raise PermissionError, and each
copy surfaced that as a failed write. Net -36 lines.

No file overlap with #2037 or #2155, and none of these four needs the bytes,
restrict_to_owner or restrict_on_error capabilities #2037 adds. One ordering
constraint does apply, covered below: #2037 widens the shared helper's cleanup
clause, and three sites here depend on that.

NamedTemporaryFile is a third form of the mode trap

atomic_write falls back to _get_default_mode(), which is 0o666 & ~umask and so
normally 0o644. A site that creates its temp owner-only and never widens it
therefore gets LOOSENED by a migration that omits mode=.

The already-known form of this is tempfile.mkstemp. The three deploy sites here
use tempfile.NamedTemporaryFile(delete=False) instead, which creates at 0o600 for
the same reason and does not contain the string "mkstemp". A checker keyed on that
string reports all three as needing no mode at all. Measured rather than reasoned:
NamedTemporaryFile publishes 0o600, a plain open() publishes 0o644.

So the split is:

- deploy.pending._save_raw, deploy.profiles.locked_registry and
  deploy.profiles.save_registry pass mode=0o600. The profiles registry holds AWS
  account ids, so widening it to world-readable would be a real change and not a
  cosmetic one.
- channel._save_channel and model_registry._persist_kiro_windows used a plain
  open(), which already published at the umask default. They pass no mode, which
  is the same value by a different route.

fsync=True is passed at the three deploy sites, which called os.fsync explicitly.
The other two did not and do not.

Four incidental fixes, all from deleting hand-rolled bookkeeping

- channel._save_channel named its temp "<path>.tmp" and
  model_registry._persist_kiro_windows named its ".json.tmp", both DETERMINISTIC
  siblings of the target. That is verbatim the defect atomic_write's module
  docstring says it exists to close: "instead of deterministic .tmp filenames,
  which cause ENOENT when concurrent writers target the same file". mkstemp is
  random and O_EXCL, so two writers of the same channel id or the same cache can
  no longer collide on one temp name. For these two sites this is the primary
  benefit, since their published mode does not change at all. How reachable that
  collision is in practice depends on call paths I did not trace:
  _save_channel is wired in as a save_fn callback on every Channel, so the
  answer is "wherever a Channel mutates" rather than a single caller.
- channel._save_channel called open(tmp, "w") with no encoding, so it wrote the
  channel state at whatever the process locale happened to be. The helper writes
  UTF-8, which makes the file byte-identical across hosts.
- channel._save_channel had NO temp cleanup: its except logged and swallowed,
  leaving ".../<id>.json.tmp" behind on every failure, next to the real state
  files rather than in a temp directory. The helper unlinks it.
- model_registry._persist_kiro_windows also had no cleanup, so a failed write
  left a .json.tmp beside the cache. Same fix.

The three deploy sites gain none of the above: NamedTemporaryFile already gave
them a random name, an explicit encoding and delete-on-failure semantics. Their
whole benefit is the Windows rename retry.

Two deltas that are not behaviour-preserving

- The two profiles writes happen inside a file_lock(exclusive=True) critical
  section. The helper's os.replace retry sleeps, so on Windows a contended
  rename can extend the lock hold by up to 0.45s (_REPLACE_MAX_ATTEMPTS 10,
  _REPLACE_BACKOFF_SECONDS 0.05). That is bounded and well inside the Windows
  spin budget file_lock itself allows (_WIN_LOCK_TIMEOUT_SECS), and it only
  happens in the case that previously failed the write outright. Stated because
  a reviewer should agree to it rather than discover it.
- pending and profiles cleaned up under except BaseException, three clauses
  between them. #2037 widens the shared helper's clause to match for exactly
  this reason, so once it lands there is no narrowing here. If this merges
  first there is a window where a Ctrl-C mid-write leaves the temp behind; it
  carries the same 0o600 as the target and keeps a .tmp suffix, so it is not
  mistaken for real state.

Testing

1044 tests pass across every channel, deploy, model_registry and pending suite.
The one failure (test_deploy_round30_fixes TestF1NolinkRead, PermissionError on
hardlink) and the one collection error (test_channel_activation) both reproduce
identically on a zero-diff tree, so neither is from this change: the sandbox
cannot create hardlinks.

Modes verified after migration rather than assumed: the pending store and the
profiles registry both still land at 0o600.

Refs #1105

