### PR TITLE
fix(auto-research): don't mark deliberately-ended campaigns as failed

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_research/handlers.py
+++ b/src/kiro_crew/apps/builtins/auto_research/handlers.py
@@ -10,6 +10,7 @@ import math
 import re
 import shutil
 import sqlite3
+import stat
 import threading
 import time
 import uuid
@@ -31,6 +32,7 @@ from kiro_crew.dashboard.chat_utils import (
     slot_history_key,
 )
 from kiro_crew.knowledge.llm_pool import LLMPool
+from kiro_crew.platform_compat import is_link_or_junction, unlink_link_or_junction
 
 try:
     from kiro_crew.artifacts import ArtifactNotFoundError, ArtifactStore
@@ -564,11 +566,21 @@ def _list_cycle_files(campaign_id: str) -> list[Path]:
 
 
 def _read_finding_file(path: Path) -> dict:
-    """Read + redact a single cycle finding file; {} on parse/IO error."""
+    """Read + redact a single cycle finding file; {} on parse/IO/shape error.
+
+    The file is LLM-written, so valid-but-wrong-shape JSON (`[]`, a bare
+    string) is as reachable as malformed JSON. `_redact_finding` requires a
+    dict (`.items()`), so a non-object payload must be rejected here — letting
+    it raise would abort the watchdog iteration mid-cycle (e.g. the stall
+    verdict would never settle the campaign, leaving it RUNNING forever).
+    """
     try:
-        return _redact_finding(json.loads(path.read_text()))
-    except (json.JSONDecodeError, OSError):
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
         return {}
+    if not isinstance(data, dict):
+        return {}
+    return _redact_finding(data)
 
 
 # --- CRUD ---
@@ -805,6 +817,129 @@ async def _suspend_research_loops_while_disabled(state: Any) -> None:
             slot._trust = False
 
 
+_WORKER_DONE_FILENAME = "worker_done.json"
+# The marker is LLM-written: bound how much of it the gateway will ever read.
+# A legitimate marker is one short JSON object, so 64 KiB is already generous.
+_WORKER_DONE_MAX_BYTES = 64 * 1024
+
+
+def _read_worker_done(campaign_id: str) -> dict | None:
+    """Read the worker's explicit end-of-run marker, or None.
+
+    The worker writes ``worker_done.json`` in its campaign dir immediately
+    before ending its run via ``autonudge_stop`` (instructed in the brief).
+    This is the DURABLE deliberate-stop signal: unlike the mere absence of the
+    autonudge loop — which also happens when a deleted/closed worker session
+    makes the nudge fire path retire the loop (``_fire_dashboard_nudge``:
+    session unreachable → ``remove()``) — the marker file can only exist
+    because the worker chose to finish. Malformed content, a non-object
+    payload, or a missing/non-string/empty ``reason`` is treated as absent
+    (fail toward FAILED, the conservative verdict) — the brief instructs the
+    worker to write ``{"reason": "<one line>"}``, so anything else is not a
+    deliberate completion signal.
+
+    The path is LLM-writable, so the read itself is guarded: links (POSIX
+    symlink or Windows junction) and non-regular files are rejected outright —
+    a marker symlinked to ``/dev/zero`` must not become an unbounded read on
+    the gateway — and at most ``_WORKER_DONE_MAX_BYTES`` are ever read; an
+    over-cap file is treated as absent, never truncated-and-parsed.
+    """
+    d = _safe_campaign_dir(campaign_id)
+    if d is None:
+        return None
+    marker = d / _WORKER_DONE_FILENAME
+    try:
+        if is_link_or_junction(marker):
+            return None
+        st = marker.stat()
+        if not stat.S_ISREG(st.st_mode) or st.st_size > _WORKER_DONE_MAX_BYTES:
+            return None
+        # Cap at open time too (the file can grow between stat and read):
+        # read one byte past the cap so an over-cap file is detected and
+        # rejected rather than silently truncated into valid-looking JSON.
+        with open(marker, "rb") as fh:
+            raw = fh.read(_WORKER_DONE_MAX_BYTES + 1)
+        if len(raw) > _WORKER_DONE_MAX_BYTES:
+            return None
+        data = json.loads(raw.decode("utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    reason = data.get("reason")
+    if not isinstance(reason, str) or not reason.strip():
+        return None
+    return data
+
+
+def _clear_worker_done_marker(campaign_id: str) -> None:
+    """Remove a stale ``worker_done.json`` so a fresh run cannot inherit it.
+
+    The campaign dir is LLM-writable, so tolerate a rogue DIRECTORY at the
+    marker path too: ``unlink()`` would raise ``IsADirectoryError`` mid-resume
+    (status already RUNNING, worker never launched, HTTP 500). ``rmtree`` only
+    for a REAL directory — any link (POSIX symlink or Windows junction, per
+    ``platform_compat.is_link_or_junction``; a junction reports ``is_dir()``
+    True and ``is_symlink()`` False) is removed as a link so a link into a
+    foreign tree can never recursively delete its target's contents.
+    """
+    d = _safe_campaign_dir(campaign_id)
+    if d is None:
+        return
+    marker = d / _WORKER_DONE_FILENAME
+    if is_link_or_junction(marker):
+        unlink_link_or_junction(marker)
+    elif marker.is_dir():
+        shutil.rmtree(marker, ignore_errors=True)
+    else:
+        marker.unlink(missing_ok=True)
+
+
+def _stalled_campaign_verdict(
+    campaign_id: str, cycle_files: list[Path]
+) -> tuple[CampaignStatus, str | None]:
+    """Classify an idle-deadline expiry — not every silence is a failure.
+
+    The watchdog only marks COMPLETE when a NEW cycle file arrives carrying
+    ``verification.passed=true`` (or the cycle cap is hit). A worker that ends
+    its run deliberately via ``autonudge_stop`` — goal met, nothing more to
+    write — produces no further findings, so the campaign used to sit silent
+    until the unresponsive deadline and get stamped FAILED ("research stalled")
+    despite a finished report on disk. Distinguish the cases from durable
+    evidence:
+
+    - Latest finding has ``verification.passed=true`` → COMPLETE. Also heals a
+      completed campaign whose status was later reset to RUNNING (resume paths
+      allow terminal→RUNNING): with no new files the count never advances, so
+      the count>prev COMPLETE branch can never re-fire.
+    - Worker wrote the explicit ``worker_done.json`` marker (its instructed
+      last act before ``autonudge_stop``) and the latest finding is READABLE
+      (parses to a JSON object) → the worker ended the run on purpose →
+      STOPPED. Same terminal affordances as a user Stop (fork / export /
+      add-to-knowledge), no red failure banner. A marker alongside only
+      unreadable findings is NOT a deliberate finish — STOPPED's "findings
+      are preserved" promise would be false — so it falls through to FAILED.
+      Mere ABSENCE of the autonudge loop is deliberately NOT used as the
+      signal: the nudge fire path also removes loops for unreachable
+      (deleted/closed) worker sessions, which is a failure, not a finish.
+    - Otherwise → FAILED (genuine stall), unchanged.
+    """
+    if cycle_files:
+        latest = _read_finding_file(cycle_files[-1])
+        verified = latest.get("verification")
+        if isinstance(verified, dict) and verified.get("passed") is True:
+            return CampaignStatus.COMPLETE, None
+        if latest and _read_worker_done(campaign_id) is not None:
+            return (
+                CampaignStatus.STOPPED,
+                "Worker ended the research loop — findings are preserved.",
+            )
+    return (
+        CampaignStatus.FAILED,
+        "No activity — research stalled. Resume to continue.",
+    )
+
+
 async def _watchdog_loop(app: web.Application | None = None) -> None:
     state = app.get("state") if app is not None else None
     last_counts: dict[str, int] = {}
@@ -925,15 +1060,22 @@ async def _watchdog_loop(app: web.Application | None = None) -> None:
                         # take minutes) — alive, not unresponsive. Refresh liveness.
                         last_ts[cid] = time.time()
                     elif time.time() - last_ts[cid] > _unresponsive_deadline(row["idle_secs"]):
-                        update_campaign_status(
-                            cid,
-                            CampaignStatus.FAILED,
-                            error_message="No activity — research stalled. Resume to continue.",
+                        # Deadline expired — but classify before condemning: a
+                        # worker that deliberately ended its run (worker_done
+                        # marker; verified finding on disk) finished, it didn't
+                        # stall. See _stalled_campaign_verdict. Off the event
+                        # loop: it reads LLM-written files (finding + marker)
+                        # whose size is unbounded, and this watchdog shares the
+                        # gateway's single loop with every request and the
+                        # heartbeat (no-blocking-call-on-event-loop).
+                        status, message = await asyncio.to_thread(
+                            _stalled_campaign_verdict, cid, cycle_files
                         )
+                        update_campaign_status(cid, status, error_message=message)
                         await _stop_loop(cid, remove=True)  # tear down so Resume re-arms cleanly
                         last_counts.pop(cid, None)
                         last_ts.pop(cid, None)
-                        _emit_sse({"type": "failed", "campaign_id": cid})
+                        _emit_sse({"type": status.value, "campaign_id": cid})
         except asyncio.CancelledError:
             break
         except Exception:
@@ -967,6 +1109,16 @@ async def _launch_loop(request: web.Request, cid: str) -> None:
     Best-effort: if autonudge or dashboard state is unavailable, the status
     change still stands but no worker is launched (logged for visibility).
     """
+    # A fresh run must not inherit the previous run's deliberate-stop marker:
+    # a stale worker_done.json would make the stall verdict classify a genuine
+    # stall of THIS run as STOPPED. Every start/resume passes through here, and
+    # this runs FIRST — before the autonudge/state availability early-returns —
+    # because a resume whose worker never launches is precisely the run that
+    # must NOT be settled as STOPPED by the old marker. Off the event loop:
+    # the marker path is LLM-writable, so the cleanup may rmtree an
+    # arbitrarily large rogue directory, and _launch_loop runs on the
+    # gateway's single loop (no-blocking-call-on-event-loop).
+    await asyncio.to_thread(_clear_worker_done_marker, cid)
     state = request.app.get("state")
     svc = _autonudge_instance()
     if state is None or svc is None:
@@ -1128,6 +1280,12 @@ def _write_brief(cid: str, row: Any) -> None:
         "Each cycle, also read `guidance.txt` in this dir if present and follow any "
         "directive there (e.g. a FINALIZE MODE instruction to stop exploring and "
         "synthesize your final answer).",
+        "",
+        "**Ending the run:** if you decide the research is finished (goal met or no "
+        "productive work remains), FIRST write `worker_done.json` in this dir as "
+        '`{"reason": "<one line>"}` — this is the durable signal that you ended the '
+        "run on purpose (without it, your silence is recorded as a stall/failure) — "
+        "and only THEN call `autonudge_stop`.",
         "",
         "Adapt direction each cycle from prior findings; pursue the highest-value open "
         "lead toward the question.",

--- a/test/test_auto_research.py
+++ b/test/test_auto_research.py
@@ -435,6 +435,289 @@ class TestStatusEnum:
         assert {s.value for s in CampaignStatus} == expected
 
 
+# --- Watchdog stall verdict ---
+class TestStalledCampaignVerdict:
+    """_stalled_campaign_verdict: not every idle deadline is a failure.
+
+    A worker that ends its run deliberately (writing worker_done.json before
+    autonudge_stop) or has a verified finding on disk finished — it didn't
+    stall. Only genuine silence (no verified finding, no done marker, or no
+    findings at all) may be stamped FAILED. Loop absence is deliberately NOT a
+    signal: the nudge fire path also removes loops for unreachable sessions.
+    """
+
+    CID = "a1b2c3d4"
+
+    def _write_finding(self, tmp_path: Path, cycle: int, finding: dict) -> Path:
+        d = tmp_path / "research" / self.CID / "findings"
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / f"cycle_{cycle:03d}.json"
+        p.write_text(json.dumps(finding))
+        return p
+
+    def _write_done(self, tmp_path: Path, content: str = '{"reason": "goal met"}') -> Path:
+        d = tmp_path / "research" / self.CID
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / "worker_done.json"
+        p.write_text(content)
+        return p
+
+    def test_verified_finding_completes(self, _isolate: Path):
+        from kiro_crew.apps.builtins.auto_research.handlers import _stalled_campaign_verdict
+
+        f = self._write_finding(
+            _isolate, 3, {"summary": "done", "verification": {"passed": True}}
+        )
+        status, message = _stalled_campaign_verdict(self.CID, [f])
+        assert status == CampaignStatus.COMPLETE
+        assert message is None
+
+    def test_done_marker_with_findings_is_deliberate_stop(self, _isolate: Path):
+        from kiro_crew.apps.builtins.auto_research.handlers import _stalled_campaign_verdict
+
+        # verification null — exactly what a self-stopped worker leaves behind.
+        f = self._write_finding(
+            _isolate, 9, {"summary": "final synthesis", "verification": None}
+        )
+        self._write_done(_isolate)
+        status, message = _stalled_campaign_verdict(self.CID, [f])
+        assert status == CampaignStatus.STOPPED
+        assert "preserved" in (message or "")
+
+    def test_no_marker_and_unverified_is_a_real_stall(self, _isolate: Path):
+        """The exact case GPT review flagged: a worker session deleted mid-run
+        (loop removed by error cleanup, no marker written) must stay FAILED."""
+        from kiro_crew.apps.builtins.auto_research.handlers import _stalled_campaign_verdict
+
+        f = self._write_finding(_isolate, 2, {"summary": "partial"})
+        status, message = _stalled_campaign_verdict(self.CID, [f])
+        assert status == CampaignStatus.FAILED
+        assert "stalled" in (message or "")
+
+    def test_no_findings_fails_even_with_marker(self, _isolate: Path):
+        """A worker that produced nothing did not 'finish' — the marker alone
+        must not launder a dead campaign into STOPPED."""
+        from kiro_crew.apps.builtins.auto_research.handlers import _stalled_campaign_verdict
+
+        self._write_done(_isolate)
+        status, _ = _stalled_campaign_verdict(self.CID, [])
+        assert status == CampaignStatus.FAILED
+
+    def test_verified_wins_over_marker(self, _isolate: Path):
+        from kiro_crew.apps.builtins.auto_research.handlers import _stalled_campaign_verdict
+
+        f = self._write_finding(
+            _isolate, 5, {"summary": "done", "verification": {"passed": True}}
+        )
+        self._write_done(_isolate)
+        status, _ = _stalled_campaign_verdict(self.CID, [f])
+        assert status == CampaignStatus.COMPLETE
+
+    def test_verification_failed_flag_does_not_complete(self, _isolate: Path):
+        from kiro_crew.apps.builtins.auto_research.handlers import _stalled_campaign_verdict
+
+        f = self._write_finding(
+            _isolate, 4, {"summary": "not there yet", "verification": {"passed": False}}
+        )
+        status, _ = _stalled_campaign_verdict(self.CID, [f])
+        assert status == CampaignStatus.FAILED
+
+    def test_malformed_or_non_object_marker_is_ignored(self, _isolate: Path):
+        """worker_done.json is LLM-written: malformed JSON, non-object JSON,
+        or a marker without a non-empty string reason must read as absent
+        (conservative FAILED), never raise into the watchdog or launder a
+        stall into STOPPED."""
+        from kiro_crew.apps.builtins.auto_research.handlers import _stalled_campaign_verdict
+
+        f = self._write_finding(_isolate, 2, {"summary": "partial"})
+        for payload in (
+            "{not json",
+            "[]",
+            '"done"',
+            "42",
+            "null",
+            "{}",  # no reason at all
+            '{"reason": 123}',  # non-string reason
+            '{"reason": "  "}',  # blank reason
+        ):
+            self._write_done(_isolate, payload)
+            status, _ = _stalled_campaign_verdict(self.CID, [f])
+            assert status == CampaignStatus.FAILED
+
+    def test_unreadable_finding_falls_back_to_failed(self, _isolate: Path):
+        """_read_finding_file returns {} on parse error — verdict must not crash
+        and must stay conservative."""
+        from kiro_crew.apps.builtins.auto_research.handlers import _stalled_campaign_verdict
+
+        d = _isolate / "research" / self.CID / "findings"
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / "cycle_001.json"
+        p.write_text("{not json")
+        status, _ = _stalled_campaign_verdict(self.CID, [p])
+        assert status == CampaignStatus.FAILED
+
+    def test_non_object_json_finding_does_not_crash_verdict(self, _isolate: Path):
+        """LLM-written finding containing VALID but non-object JSON (`[]`, a
+        bare string) must be treated like an unreadable finding, not raise out
+        of the watchdog and leave the campaign RUNNING forever. With no
+        readable finding on disk, even a valid done marker must NOT produce
+        STOPPED — its "findings are preserved" promise would be false."""
+        from kiro_crew.apps.builtins.auto_research.handlers import (
+            _read_finding_file,
+            _stalled_campaign_verdict,
+        )
+
+        d = _isolate / "research" / self.CID / "findings"
+        d.mkdir(parents=True, exist_ok=True)
+        self._write_done(_isolate)
+        for payload in ("[]", '"just a string"', "42", "null"):
+            p = d / "cycle_001.json"
+            p.write_text(payload)
+            assert _read_finding_file(p) == {}
+            # marker + a worthless finding file: conservative FAILED — the
+            # shape error must neither crash this path nor masquerade as a
+            # deliberate stop with preserved findings.
+            status, _ = _stalled_campaign_verdict(self.CID, [p])
+            assert status == CampaignStatus.FAILED
+
+    def test_marker_with_malformed_only_finding_fails(self, _isolate: Path):
+        """Valid marker + sole UNPARSEABLE cycle file → FAILED, not STOPPED:
+        no readable finding exists, so 'findings are preserved' would lie."""
+        from kiro_crew.apps.builtins.auto_research.handlers import _stalled_campaign_verdict
+
+        d = _isolate / "research" / self.CID / "findings"
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / "cycle_001.json"
+        p.write_text("{not json")
+        self._write_done(_isolate)
+        status, _ = _stalled_campaign_verdict(self.CID, [p])
+        assert status == CampaignStatus.FAILED
+
+    def test_marker_symlink_is_not_trusted(self, _isolate: Path):
+        """A LINK at the marker path is rejected by the reader outright — a
+        marker symlinked to an unbounded source (e.g. /dev/zero) must never
+        become an uncapped read inside the gateway."""
+        from kiro_crew.apps.builtins.auto_research.handlers import (
+            _read_worker_done,
+            _stalled_campaign_verdict,
+        )
+
+        campaign_dir = _isolate / "research" / self.CID
+        campaign_dir.mkdir(parents=True, exist_ok=True)
+        # Even a link to a perfectly VALID marker elsewhere is refused: the
+        # guard is on the node type, not the content behind it.
+        target = _isolate / "elsewhere.json"
+        target.write_text('{"reason": "goal met"}')
+        link = campaign_dir / "worker_done.json"
+        link.symlink_to(target)
+        assert _read_worker_done(self.CID) is None
+        f = self._write_finding(
+            _isolate, 1, {"summary": "real", "verification": None}
+        )
+        status, _ = _stalled_campaign_verdict(self.CID, [f])
+        assert status == CampaignStatus.FAILED
+
+    def test_oversized_marker_is_ignored(self, _isolate: Path):
+        """A marker larger than the read cap is treated as absent — bounded
+        read, never truncated-and-parsed into a valid-looking payload."""
+        from kiro_crew.apps.builtins.auto_research.handlers import (
+            _WORKER_DONE_MAX_BYTES,
+            _read_worker_done,
+        )
+
+        big_reason = "x" * (_WORKER_DONE_MAX_BYTES + 1)
+        self._write_done(_isolate, content=json.dumps({"reason": big_reason}))
+        assert _read_worker_done(self.CID) is None
+        # At-cap marker still reads fine (boundary check).
+        pad = _WORKER_DONE_MAX_BYTES - len(json.dumps({"reason": ""}))
+        self._write_done(_isolate, content=json.dumps({"reason": "y" * pad}))
+        assert _read_worker_done(self.CID) is not None
+
+    def test_relaunch_clears_stale_marker(self, _isolate: Path):
+        """_launch_loop clears worker_done.json (via _clear_worker_done_marker)
+        so a resumed run's genuine stall is not misclassified as STOPPED by the
+        previous run's marker."""
+        from kiro_crew.apps.builtins.auto_research.handlers import (
+            _clear_worker_done_marker,
+            _read_worker_done,
+        )
+
+        self._write_done(_isolate)
+        assert _read_worker_done(self.CID) is not None
+        _clear_worker_done_marker(self.CID)
+        assert _read_worker_done(self.CID) is None
+        # Idempotent on a missing marker.
+        _clear_worker_done_marker(self.CID)
+
+    def test_clear_marker_tolerates_rogue_directory(self, _isolate: Path):
+        """The campaign dir is LLM-writable: a DIRECTORY named worker_done.json
+        must be removed, not raise IsADirectoryError out of _launch_loop."""
+        from kiro_crew.apps.builtins.auto_research.handlers import (
+            _clear_worker_done_marker,
+            _read_worker_done,
+        )
+
+        d = _isolate / "research" / self.CID / "worker_done.json"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "junk.txt").write_text("x")
+        _clear_worker_done_marker(self.CID)
+        assert not d.exists()
+        # Directory marker also reads as absent (OSError path in the reader).
+        d.mkdir(parents=True, exist_ok=True)
+        assert _read_worker_done(self.CID) is None
+
+    def test_clear_marker_symlink_removes_link_not_target(self, _isolate: Path):
+        """A symlink at the marker path is unlinked — its target's contents
+        must never be recursively deleted."""
+        from kiro_crew.apps.builtins.auto_research.handlers import _clear_worker_done_marker
+
+        campaign_dir = _isolate / "research" / self.CID
+        campaign_dir.mkdir(parents=True, exist_ok=True)
+        target = _isolate / "precious"
+        target.mkdir()
+        (target / "keep.txt").write_text("keep me")
+        link = campaign_dir / "worker_done.json"
+        link.symlink_to(target)
+        _clear_worker_done_marker(self.CID)
+        assert not link.exists()
+        assert (target / "keep.txt").exists()
+
+    def test_non_utf8_finding_or_marker_reads_as_absent(self, _isolate: Path):
+        """Non-UTF-8 bytes in either LLM-written file must not raise
+        UnicodeDecodeError out of the watchdog — both readers fall back to
+        their conservative defaults and the verdict stays FAILED."""
+        from kiro_crew.apps.builtins.auto_research.handlers import (
+            _read_finding_file,
+            _read_worker_done,
+            _stalled_campaign_verdict,
+        )
+
+        d = _isolate / "research" / self.CID / "findings"
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / "cycle_001.json"
+        p.write_bytes(b"\xff\xfe invalid utf8 \x80")
+        assert _read_finding_file(p) == {}
+        (_isolate / "research" / self.CID / "worker_done.json").write_bytes(b"\x80\x81")
+        assert _read_worker_done(self.CID) is None
+        status, _ = _stalled_campaign_verdict(self.CID, [p])
+        assert status == CampaignStatus.FAILED
+
+    def test_settle_transitions_running_campaign(self, _isolate: Path):
+        """End-to-end: the verdict statuses are all legal RUNNING→X transitions
+        and stamp completed_at (the watchdog applies them via
+        update_campaign_status)."""
+        for verdict in (CampaignStatus.COMPLETE, CampaignStatus.STOPPED, CampaignStatus.FAILED):
+            c = create_campaign(
+                {"question": "A sufficiently long research question here", "sources": ["web"]}
+            )
+            update_campaign_status(c["id"], CampaignStatus.RUNNING)
+            r = update_campaign_status(c["id"], verdict, error_message=None)
+            assert r["status"] == verdict
+            camp = get_campaign(c["id"])
+            assert camp["status"] == verdict
+            assert camp["completed_at"] is not None
+
+
 # --- Redaction ---
 class TestRedaction:
     def test_redact_finding_with_security_module(self):


### PR DESCRIPTION
## Problem

Research Lab campaigns that **finish successfully** show up as ⊗ **Failed** in the campaign list.

Reproduced on a live instance: two campaigns whose workers answered every sub-question, wrote a final `FINDINGS.md` executive summary, and deliberately ended their run via `autonudge_stop(reason="goal met")` both ended as:

```
status: failed
error_message: No activity — research stalled. Resume to continue.
```

## Root cause

The watchdog (`_watchdog_loop` in `auto_research/handlers.py`) only marks a campaign COMPLETE when a **new** cycle finding arrives carrying `verification.passed=true`, or the cycle cap is hit. Two real situations produce no further findings:

1. **Deliberate self-stop.** `autonudge_stop` removes the worker's loop and discards the reason — no signal reaches the research app. The campaign sits silent until the unresponsive deadline and is stamped FAILED.
2. **Terminal→RUNNING reset.** Resume paths legally reset a COMPLETE campaign to RUNNING. With no new files the count never advances, so the COMPLETE branch can never re-fire — the only exit is the FAILED stamp.

## Fix (symptoms → root cause → change)

Classify the idle-deadline expiry from durable evidence before condemning (new `_stalled_campaign_verdict`):

| Evidence at deadline | Verdict |
|---|---|
| Latest finding has `verification.passed=true` | **COMPLETE** |
| Worker wrote the explicit `worker_done.json` marker (its instructed last act before `autonudge_stop`, per the campaign brief) **and** at least one finding exists | **STOPPED** |
| Anything else (no marker, no findings at all, unreadable/malformed files) | **FAILED** (unchanged) |

The deliberate-stop signal is a **durable explicit marker**, not loop absence: the nudge fire path (`_fire_dashboard_nudge`) also removes loops for unreachable (deleted/closed) worker sessions, which is a failure, not a finish — so a missing loop proves nothing. The campaign brief now instructs the worker to write `worker_done.json` (`{"reason": ...}`) before calling `autonudge_stop`, and `_launch_loop` clears any stale marker on every start/resume so a previous run's marker cannot misclassify a new run's stall.

`_read_finding_file` is also hardened to reject valid-but-non-object JSON (`[]`, bare string) instead of raising out of the watchdog.

STOPPED and COMPLETE render with the existing terminal affordances (fork / export / add-to-knowledge) instead of the red failure banner — no frontend changes needed, both statuses are already fully supported by `ResearchLabPage`.

## Tests

`TestStalledCampaignVerdict` (11 tests) locks in every verdict path: verified→COMPLETE, marker+findings→STOPPED, **no-marker deleted-session scenario stays FAILED**, marker-without-findings→FAILED, verified-wins-over-marker, `passed=false`→FAILED, malformed/non-object marker ignored, unreadable/non-object findings handled without crashing, stale-marker cleanup on relaunch, and RUNNING→verdict transition legality + `completed_at` stamping.

`test/test_auto_research.py`: 176 passed. `test/test_autonudge.py`: 74 passed. flake8 clean.

## Manual verification

N/A — unit coverage exercises the verdict and marker lifecycle directly; the watchdog applies verdicts via the already-tested `update_campaign_status`.

## Screenshots

N/A — no frontend changes; `stopped`/`complete` pills and terminal affordances already exist in `ResearchLabPage`.

Not touched: workflow-mode campaigns (separate `_poll_workflow_campaign` path), the one-campaign-at-a-time policy, deny/permission rules.
