### PR TITLE
fix(knowledge): run per-file dedup off the event loop

### DIFF
--- a/src/kiro_crew/knowledge/folder_watcher.py
+++ b/src/kiro_crew/knowledge/folder_watcher.py
@@ -533,12 +533,28 @@ class FolderWatcher:
         # copy collapses any matching one-shot upload. O(k*n) over the k changed files
         # rather than a full O(n^2) corpus sweep (knowledge/dedup.py).
         if getattr(self.pipeline, "_dedup_enabled", True):
-            for fpath in ingested_paths:
-                try:
-                    dedup_document(self.store, source_id, file_path=fpath, apply=True)
-                except Exception:
-                    logger.debug("Per-file dedup skipped for %s", fpath, exc_info=True)
+            # Offloaded in ONE hop for all k files: dedup_document rebuilds the entire
+            # entity graph per collapse (_load_graph), so the cost scales with the
+            # corpus AND the number of duplicates found. Run inline it stalls the loop
+            # past the loop-stall watchdog on a large KB and the supervisor respawns
+            # straight into the same scan -- a crash loop. Mirrors the already-offloaded
+            # dedup sites in ingestion.py and watcher.py; the RLock-guarded graph plus
+            # thread-local sqlite connections make this thread-safe.
+            await asyncio.to_thread(self._dedup_ingested, source_id, ingested_paths)
         return stats
+
+    def _dedup_ingested(self, source_id: str, paths: list[str]) -> None:
+        """Targeted cross-source dedup for each freshly ingested path.
+
+        Synchronous by design and always reached through ``asyncio.to_thread`` --
+        it is the blocking half of the scan and must never run on the event loop.
+        One path's failure must not abandon the rest, so each is guarded.
+        """
+        for fpath in paths:
+            try:
+                dedup_document(self.store, source_id, file_path=fpath, apply=True)
+            except Exception:
+                logger.debug("Per-file dedup skipped for %s", fpath, exc_info=True)
 
     def _walk(self, root: str, ignore_patterns: list[str], extra_skip_dirs: set[str],
               include_extensions: set[str] | None = None,

--- a/test/test_folder_watcher.py
+++ b/test/test_folder_watcher.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import json
 import sqlite3
+import threading
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -656,6 +657,44 @@ class TestAsyncToThread:
 
         stats = await fw.scan_source(source)
         assert stats["new"] == 1
+
+    @pytest.mark.asyncio
+    async def test_per_file_dedup_runs_off_the_event_loop(
+            self, store, pipeline, vault, monkeypatch):
+        """Per-file dedup must never execute on the event-loop thread.
+
+        ``dedup_document`` rebuilds the entire entity graph on every collapse it
+        applies (``_load_graph``), so its cost scales with the corpus and with the
+        number of duplicates found. Run inline it stalls the loop past the loop-stall
+        watchdog and the supervisor respawns into the very same scan -- a crash loop.
+
+        Asserting the THREAD rather than the call shape is what keeps this
+        non-vacuous: a refactor that keeps calling ``dedup_document`` but drops the
+        ``asyncio.to_thread`` hop still fails here.
+        """
+        fw = FolderWatcher(store, pipeline)
+        source_id = store.add_source("test", "local_folder", str(vault))
+        source = {"id": source_id, "uri": str(vault),
+                  "source_type": "local_folder", "properties": "{}"}
+
+        async def fake_ingest(path, **kwargs):
+            store.add_item("title", "content", "doc", source_id=source_id)
+            return "job1"
+        pipeline.ingest_file = fake_ingest
+
+        dedup_threads: list[int] = []
+        monkeypatch.setattr(
+            "kiro_crew.knowledge.folder_watcher.dedup_document",
+            lambda *a, **kw: dedup_threads.append(threading.get_ident()))
+
+        await fw.scan_source(source)
+
+        assert dedup_threads, (
+            "dedup_document was never called -- this test no longer exercises the "
+            "per-file dedup path and would pass vacuously")
+        assert threading.get_ident() not in dedup_threads, (
+            "dedup_document ran on the event-loop thread; it must be offloaded via "
+            "asyncio.to_thread (see ingestion.py / watcher.py for the precedent)")
 
 
 class TestDeleteSourceCascade:


### PR DESCRIPTION
## Problem

`FolderWatcher._do_scan` called `dedup_document` in a bare synchronous loop inside a coroutine body, so the entire per-file dedup pass executed on the gateway's single event loop.

`dedup_document` rebuilds the **whole entity graph on every collapse it applies** — `_collapse_doc` → `delete_items_batch` → `_load_graph`, which clears the graph and rebuilds it from two full table scans. The cost therefore scales with both the corpus size and the number of duplicates found, not with the `k` changed files.

On a large source this stalls the loop past the loop-stall watchdog. The watchdog dumps stacks and exits, the supervisor respawns, and the fresh process runs the same scan — a crash loop. Observed repeatedly against a 2000-file folder source. The captured frozen stack:

```
knowledge/store.py:590   _load_graph
knowledge/store.py:856   delete_items_batch
knowledge/dedup.py:643   _collapse_doc
knowledge/dedup.py:820   dedup_document
knowledge/folder_watcher.py:312  _do_scan
knowledge/watcher.py:232 _scan
asyncio/events.py:88     _run          <- on the loop, no worker boundary
```

## Why the gate did not catch it

This violates `no-blocking-call-on-event-loop` in `AUTOSDE.yaml` — both "large synchronous file IO" and its reachability clause ("a sync helper called transitively from an async handler, a periodic task, or a cron tick").

The deterministic gate `test/test_no_blocking_call_on_loop.py` structurally cannot flag it: its banned list is `subprocess.*` / `os.wait*` / `time.sleep`, and its docstring deliberately assigns blocking DB and file IO to the judgment tier instead. So a synchronous SQLite full-table-scan loop is invisible to it.

## Fix

Extract the loop into `_dedup_ingested` and hand it to `asyncio.to_thread` in **one hop for all k files**, not k hops.

This is not a new pattern — the three other dedup call sites are already offloaded with this exact rationale, so this was a single missed site:

- `ingestion.py` (×2): `await asyncio.to_thread(self._maybe_dedup, ...)`, commented *"Offloaded so a large source's dedup cannot stall the loop (RLock-guarded graph + thread-local sqlite make this thread-safe)"*
- `watcher.py`: the periodic `dedup_sweep` is already `to_thread`-wrapped

Thread-safety holds for the same documented reasons: the entity graph is `RLock`-guarded (`SimpleDiGraph._lock`, whose comment already anticipates concurrent traversal from an executor thread) and `KnowledgeStore.db` is a thread-local connection, so the worker uses its own connection to the same WAL db. The preceding `store.db.commit()` makes the scan's writes visible to it.

## Test

`test_per_file_dedup_runs_off_the_event_loop` asserts the **thread** `dedup_document` runs on, not the call shape — a refactor that keeps the call but drops the `to_thread` hop still fails. It also asserts the recorder is non-empty so it cannot pass vacuously if the path stops being exercised.

Proven red against the inline form:

```
E  AssertionError: dedup_document ran on the event-loop thread; it must be
   offloaded via asyncio.to_thread (see ingestion.py / watcher.py for the precedent)
1 failed
```

## Verification

- `test/test_folder_watcher.py` — 53 passed
- `test/test_no_blocking_call_on_loop.py` + `test/test_persist_off_loop.py` — green (95 total with the above)
- `flake8`, `isort --check-only`, `mypy` — clean on both changed files
- Full backend suite deferred to CI: the dev host was under extreme load (load avg ~150, swap 4.4/6 GB) and an xdist run there risks a swap spiral. No frontend files changed, so `tsc` / `vitest` are not implicated.

## Deliberately not in scope

The per-collapse `_load_graph` amplification is now off the loop but still rebuilds the graph once per collapsed duplicate — `delete_items_batch`'s docstring promises "one graph reload" and the per-document caller defeats that. Hoisting it to one reload per batch touches a store API shared by five `_load_graph` call sites and carries a stale-graph risk on the exception path, so it belongs in its own change.
