### PR TITLE
feat(messaging): enforce max_buttons as the capability seam

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -34,7 +34,8 @@ Slack's transport path is gated behind the `messaging.use_transport` config flag
 | `messaging/__init__.py` | Package facade re-exporting the public contracts, approval-mode constants, and Layer-3 helpers |
 | `messaging/transport.py` | **Layer 1** — `MessagingTransport` ABC + the `TransportCapabilities`, `InboundMessage`, and `ConfiguredChannelTarget` value objects (stdlib-only) |
 | `messaging/driver.py` | **Layer 2** — `TurnDriver` (channel-neutral turn loop), approval-mode constants, `_redact` helper |
-| `messaging/renderer.py` | **Layer 2b** — `Renderer` ABC, `OutputEvent`, output-kind constants + `OUTPUT_KINDS`, `chunk_text` helper |
+| `messaging/renderer.py` | **Layer 2b** — `Renderer` ABC, `OutputEvent`, output-kind constants + `OUTPUT_KINDS`, `chunk_text` helper, `apply_options_cap`/`cap_choices`/`format_overflow` (`max_buttons` enforcement) |
+| `messaging/display_safety.py` | `strip_ansi` / `canonicalize_display` / `redact_for_display` — credential redaction against the form a platform RENDERS, not the bytes sent. Hoisted out of `slack/format.py` when the shared overflow sink began writing choice text into the parsed body on every widget channel |
 | `messaging/link.py` | **Layer 3** — session-key namespacing (`session_key`/`canonical_key`/`legacy_key`/`is_legacy_slack_key`) + `ChannelLink` + DM-scope key derivation / `should_rotate_generation` |
 | `messaging/conversation.py` | `ConversationState` — per-conversation rotating *generation* bookkeeping (advanced by `/new` and idle/daily reset), seeded from the persisted session map |
 | `slack/transport.py` | Slack reference `MessagingTransport` (`SlackTransport`) over `SlackClientOps` |
@@ -63,7 +64,7 @@ Declares what a channel can do. Defaults are deliberately conservative (the What
 | `rich_blocks` | `False` | feature flag |
 | `threads` | `False` | feature flag |
 | `max_message_chars` | `4096` | quantitative — Slack ~40000, Telegram 4096, Discord 2000, WhatsApp 4096 |
-| `max_buttons` | `3` | interactive choices per prompt (WhatsApp reply buttons = 3) |
+| `max_buttons` | `3` | TOTAL interactive choices per prompt (WhatsApp reply buttons = 3); enforced via `apply_options_cap` — overflow degrades to a numbered text list |
 | `supports_proactive_send` | `True` | send-policy (WhatsApp: `False` outside its 24h window) |
 
 `to_dict()` serializes all fields. The integer *parameters* (not booleans) capture where channels differ quantitatively so the `Renderer` can chunk / degrade rather than assume a single shape.

--- a/src/kiro_crew/discord/renderer.py
+++ b/src/kiro_crew/discord/renderer.py
@@ -36,7 +36,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.constants import OPTIONS_RE_TRAILER, split_trailing_protocol_suffix
-from kiro_crew.messaging.renderer import Renderer
+from kiro_crew.messaging.renderer import Renderer, apply_options_cap
 from kiro_crew.messaging.transport import TransportCapabilities
 
 if TYPE_CHECKING:
@@ -114,7 +114,9 @@ def build_option_components(options: list[str]) -> list[dict] | None:
     ``custom_id`` is the index only (``opt:<i>``) -- Discord caps it at 100
     chars and the label is recovered from the button text at interaction time.
     Up to 5 buttons per action row, max 5 rows (25 options); labels cap at 80
-    chars per the component spec.
+    chars per the component spec. The ``max_buttons`` cap is applied UPSTREAM
+    via ``apply_options_cap`` (overflow degrades to numbered text); the
+    ``[:25]`` below is the platform hard-limit backstop only.
     """
     if not options:
         return None
@@ -339,7 +341,12 @@ class DiscordRenderer(Renderer):
         # seal -- so the choices ship as buttons on the sealed message instead of
         # being frozen as literal protocol text the user cannot act on.
         body_raw, opts = _extract_options("".join(self._buf))
+        body_raw, opts = apply_options_cap(body_raw, opts, self.capabilities)
         self._buf = [body_raw]
+        # apply_options_cap may EXPAND the body (numbered overflow lines), and
+        # the rotation above ran before that expansion -- re-check, or a
+        # near-limit answer with over-cap options seals past the transport cap.
+        await self._rotate_on_length()
         components = build_option_components(opts) if opts else None
         sealed = bool(self._segment_text().strip()) or components is not None
         await self._seal_current(components=components)
@@ -521,6 +528,7 @@ class DiscordRenderer(Renderer):
         # Extract the trailing [OPTIONS:] BEFORE length rotation (see the
         # Telegram renderer's rationale).
         body_raw, opts = _extract_options("".join(self._buf))
+        body_raw, opts = apply_options_cap(body_raw, opts, self.capabilities)
         self._buf = [body_raw]
         components = build_option_components(opts) if opts else None
         # No-rotation fallback: steers were injected but no marker rotated —

--- a/src/kiro_crew/discord/transport.py
+++ b/src/kiro_crew/discord/transport.py
@@ -68,7 +68,11 @@ DISCORD_CAPABILITIES = TransportCapabilities(
     rich_blocks=False,
     threads=True,
     max_message_chars=DISCORD_CHUNK_LIMIT,
-    max_buttons=5,  # per action row (max 5 rows -> 25 total)
+    # 25 = TOTAL interactive choices (5 buttons/row x 5 action rows -- the
+    # platform max the renderer actually ships). The previous 5 was the
+    # per-row layout number, not a total. Enforced via apply_options_cap in
+    # the renderer; overflow degrades to a numbered text list.
+    max_buttons=25,
     supports_proactive_send=True,
     # The one transport whose inbound path resolves the mirror binding: a message
     # in a bound conversation routes to the owning session via

--- a/src/kiro_crew/messaging/display_safety.py
+++ b/src/kiro_crew/messaging/display_safety.py
@@ -1,0 +1,150 @@
+"""Redaction against what a chat platform will DISPLAY, not the bytes it is sent.
+
+Every channel scans outbound text for credentials, but a scan of the literal
+bytes is not enough on any platform that renders markup away: ``AKIA**REST**``
+and ``[AKIA](https://x)REST`` match no credential pattern as written, yet the
+reader sees an intact key once the delimiters are stripped at render time. The
+transformation happens AFTER the scan, so the scan has to anticipate it.
+
+This lives in ``messaging`` rather than in one channel package because the
+hazard is not Slack-specific: Telegram (MarkdownV2) and Discord (Markdown)
+collapse the same emphasis, code-span and link syntax. It was written for
+Slack first and hoisted here when :func:`kiro_crew.messaging.renderer.
+format_overflow` began putting LLM-authored choice text into the message BODY
+on every widget-capable channel -- the shared sink cannot depend on each
+renderer remembering to canonicalise, which is the same reasoning that put the
+``max_buttons`` cap in shared code.
+
+Stdlib-only leaf: it takes the redactor as a parameter rather than importing
+``kiro_crew.security``, so it stays importable from anywhere and each caller
+keeps its own (possibly session-scoped) redactor.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Callable
+
+_ANSI_SGR = re.compile(r"\x1b\[[0-9;]*m")
+
+# Delimiter runs the platforms consume at render time. ``||`` is Discord's
+# spoiler: the reader clicks it and the delimiters vanish, joining the halves --
+# the same splitter property as ``**``, which is why it belongs in this run
+# rather than in a pass of its own.
+#
+# The pipe counts only in PAIRS. A lone ``|`` is literal text on every channel
+# here (Telegram's body goes out as HTML, where ``||`` is not spoiler markup
+# either, and Slack renders it as-is), so collapsing single pipes would only
+# widen the canonical form for no display that matches it. Slack link internals
+# (``<url|label>``) are already consumed by ``_SLACK_LINK`` before this runs.
+_EMPHASIS_RUN = re.compile(r"(?:[*_~`]|\|\|)+")
+# ``[label](url)`` (Markdown) and ``<url|label>`` (Slack mrkdwn). Both DISPLAY only
+# the label, so the url is invisible to a reader and the label joins whatever
+# surrounds it -- which makes them a splitter, exactly like ``**``.
+#
+# The opening delimiter is excluded from every inner class (no ``[`` inside the
+# Markdown label, no ``<`` inside the Slack one). That is not cosmetic: with ``[``
+# allowed, input like ``[[[[[[...`` makes each start position consume the whole
+# remaining string before failing to find ``]``, so the scan is quadratic in the
+# length of attacker-supplied text (CodeQL ``py/polynomial-redos``). Excluding it
+# makes a failed start fail immediately, which matters because this runs on every
+# outbound message. A label containing a literal ``[`` is simply not collapsed --
+# safe, since the fallback is to scan the text as written.
+_MD_LINK = re.compile(r"\[([^\[\]\n]*)\]\(([^()\n]*)\)")
+_SLACK_LINK = re.compile(r"<([^<>|\n]*)\|([^<>\n]*)>")
+
+
+def strip_ansi(text: str) -> str:
+    """Remove SGR colour escapes.
+
+    Public because redaction call sites need it: this strip can *reassemble* a
+    credential that escape sequences had broken up, so a caller that redacts
+    around a conversion has to normalise with the SAME function first, or the
+    secret slips through the regex and is put back together afterwards.
+    """
+    return _ANSI_SGR.sub("", text)
+
+
+def _strip_format_chars(text: str) -> str:
+    """Drop Unicode *format* characters (category ``Cf``) and soft hyphens.
+
+    The delimiter families above are visible markup a platform consumes. This is
+    the invisible half of the same hazard, and it is strictly worse: a
+    zero-width space, joiner, bidi mark or BOM between two halves of a key is
+    rendered as NOTHING, so the reader sees an intact credential with no click
+    and no markup, while every literal scan sees it broken. ``Cf`` is the
+    principled set -- it is exactly Unicode's "format" category (ZWSP, ZWNJ,
+    ZWJ, word joiner, bidi controls, BOM, soft hyphen) and contains nothing a
+    reader can see.
+
+    The ASCII fast path is sound, not an approximation: the ASCII range holds no
+    ``Cf`` code point at all (the C0 controls are ``Cc``), so ordinary traffic
+    never pays for the per-character walk.
+    """
+    if text.isascii():
+        return text
+    return "".join(ch for ch in text if unicodedata.category(ch) != "Cf")
+
+
+def canonicalize_display(text: str) -> str:
+    """Reduce *text* to what the platform will actually SHOW a reader.
+
+    Three families, one property: the platform removes them at render time, so a
+    credential broken across them is whole on screen while every literal scan
+    sees it broken.
+
+    * **links** collapse to their label -- ``[AKIA](https://x)REST`` displays as
+      the joined key, with the url nowhere in sight;
+    * **emphasis / code / spoiler delimiters** vanish -- ``AKIA**REST**`` and
+      Discord's ``AKIA||REST||`` likewise;
+    * **invisible format characters** were never rendered at all -- see
+      :func:`_strip_format_chars`.
+
+    Links are reduced FIRST: a url can itself contain ``_`` or ``~``, and dropping
+    those before the url is removed would corrupt the label boundaries. Format
+    characters are dropped LAST, so a delimiter run that a zero-width character
+    had split (``*``+ZWSP+``*``) is still recognised as the run it renders as.
+    """
+    out = _MD_LINK.sub(r"\1", text)
+    out = _SLACK_LINK.sub(r"\2", out)
+    out = _EMPHASIS_RUN.sub("", out)
+    return _strip_format_chars(out)
+
+
+def redact_for_display(text: str, redactor: Callable[[str], str]) -> tuple[str, bool]:
+    """Redact *text* against what the platform will DISPLAY, not just the bytes.
+
+    Two normalisations, for the same underlying reason: a transformation applied
+    *after* the scan can reassemble a credential the scanner saw as broken.
+
+    1. **ANSI escapes** -- stripped outright, because they are display noise with
+       no meaning to preserve.
+    2. **Link markup and emphasis/code delimiters** -- these DO carry meaning, so
+       they cannot simply be deleted. Instead the canonical (display) form is
+       scanned as well. Neither ``AKIA**<rest>**`` nor ``[AKIA](https://x)<rest>``
+       matches a credential pattern as written, yet the platform renders the
+       markup away and shows the reader an intact key.
+
+    When the canonical form reveals a secret that the literal form hid, the
+    canonical text is emitted -- so the message loses that markup. That is
+    deliberate and one-directional: formatting is worth less than a credential, and
+    the downgrade only happens on a message that actually contains one.
+
+    Returns:
+        ``(safe_text, redacted)``. ``redacted`` is True when the redactor changed
+        anything, by either route -- callers that already published the text rely
+        on it to go back and replace what is visible.
+    """
+    stripped = strip_ansi(text or "")
+    safe = redactor(stripped)
+    changed = safe != stripped
+
+    canonical = canonicalize_display(safe)
+    if canonical != safe:
+        canonical_safe = redactor(canonical)
+        if canonical_safe != canonical:
+            # The markup was hiding a credential from the scan. Emit the canonical,
+            # redacted form: losing formatting beats leaking the key.
+            return canonical_safe, True
+    return safe, changed

--- a/src/kiro_crew/messaging/renderer.py
+++ b/src/kiro_crew/messaging/renderer.py
@@ -5,14 +5,18 @@ The ``TurnDriver`` consumes provider events and emits the channel-neutral
 that maps those abstract events onto its native surface.
 
 ``prompt_choice`` is a FIRST-CLASS event (not generic "permission text"):
-each Renderer maps it to its native interactive widget. NOTE: despite the
-existence of ``capabilities.max_buttons``, no renderer reads it today — the
-caps are hardcoded per channel (Slack ``choices[:10]``, Discord
-``options[:25]``, Telegram uncapped) and the no-widget channels strip the
-trailer unconditionally. Capping on the declared value and degrading to a
-numbered text reply is the INTENDED contract, tracked in the capability
-ledger (``test/test_capability_ledger.py``); do not write code that assumes
-it is already enforced.
+each Renderer maps it to its native interactive widget. ``[OPTIONS: a | b]``
+trailers are the TEXT path: each widget-capable renderer re-parses the
+trailer from its own accumulated text and MUST route the parsed list through
+:func:`apply_options_cap` before building widgets, so at most
+``capabilities.max_buttons`` choices render interactively and the remainder
+degrades to a numbered text list the user can answer by typing. The cap is
+ENFORCED (see ``test/test_capability_ledger.py``) and pinned per channel by
+the cross-channel contract test in ``test/test_options_cap_contract.py`` —
+a widget-capable renderer that skips the helper fails that test.
+Channels declaring ``max_buttons=0`` render no widget and today strip the
+trailer entirely; the numbered-text fallback for them lands with the
+approval-ladder work.
 """
 
 from __future__ import annotations
@@ -21,7 +25,9 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+from kiro_crew.messaging.display_safety import redact_for_display
 from kiro_crew.messaging.transport import TransportCapabilities
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 # Abstract output event kinds.
 TEXT_CHUNK = "text_chunk"
@@ -79,6 +85,107 @@ def chunk_text(text: str, max_chars: int) -> list[str]:
     if max_chars <= 0 or len(text) <= max_chars:
         return [text]
     return [text[i : i + max_chars] for i in range(0, len(text), max_chars)]
+
+
+def cap_choices(
+    choices: list[str], capabilities: TransportCapabilities
+) -> tuple[list[str], list[str]]:
+    """Split a parsed ``[OPTIONS:]`` list at ``capabilities.max_buttons``.
+
+    Returns ``(kept, overflow)``. ``max_buttons <= 0`` keeps nothing (the
+    zero-widget channels own their trailer handling). Pure — callers that
+    must transform choices before display (Slack redacts at the sink) split
+    here and format overflow themselves via :func:`format_overflow`.
+    """
+    n = capabilities.max_buttons
+    if n <= 0:
+        return [], choices
+    return choices[:n], choices[n:]
+
+
+def _default_redactor(text: str) -> str:
+    """The same pair ``TurnDriver`` streams provider text through.
+
+    Module scope on purpose: ``security`` is a pure-regex module with no vendor
+    dependencies, and ``messaging.driver`` already imports it from here, so this
+    adds no import-time cost and nothing that could touch an event loop.
+    """
+    out, _ = redact_exfiltration_urls(text or "")
+    out, _ = redact_credentials(out)
+    return out
+
+
+def _display_safe(choice: str) -> str:
+    """Redact *choice* against what the platform will SHOW, then defang mentions.
+
+    Order matters. Redaction runs FIRST, on the canonical display form, because
+    the ZWSP insertion below is itself a transformation applied after the scan
+    -- exactly the class of reassembly hazard the display redactor exists to
+    close, and inserting the ZWSP first could split a key so the regex stops
+    matching it while the platform still renders it whole.
+    """
+    safe, _ = redact_for_display(choice or "", _default_redactor)
+    return safe.replace("@", "@\u200b").replace("<!", "<\u200b!")
+
+
+def format_overflow(overflow: list[str], start: int) -> str:
+    """Number overflow choices continuing after ``start`` widget slots.
+
+    Widget + text form ONE list: ``start=3`` yields ``4. …``. The user
+    answers an overflow choice by typing it — a typed reply is a plain
+    message on every channel, so no reply-parser is required.
+
+    Two sanitisations happen at this sink, both because overflow lands in the
+    message BODY while the widget path put the same text in a plain-text
+    label:
+
+    * **credentials, in DISPLAY form.** The body is markdown-parsed, so a key
+      split by a code span or emphasis (``AKIA`` + backtick + rest) is whole on
+      screen while the driver's byte-level stream redactor saw it broken.
+      Slack's widget path already routes choices through the display redactor
+      for this reason; overflow must not be the hole that reopens it on
+      Telegram and Discord, which have no display-state pass of their own.
+      Enforcing it HERE rather than per renderer is the same argument that put
+      the cap in shared code: a channel cannot forget what it does not call.
+    * **mention syntax.** Widget labels render as plain text, but the body is
+      where the platforms parse mentions — a prompt-injected ``@everyone`` /
+      ``<!channel>`` choice would otherwise mass-notify. ZWSP insertion
+      matches the precedent in ``discord/session_resume.py``: ``@\\u200b``
+      breaks discord/telegram @-mentions and slack ``<@U…>``; ``<\\u200b!``
+      breaks slack broadcast ranges (``<!channel>``, ``<!here>``,
+      ``<!everyone>``).
+    """
+    return "\n".join(f"{start + i + 1}. {_display_safe(c)}" for i, c in enumerate(overflow))
+
+
+def apply_options_cap(
+    body: str, choices: list[str], capabilities: TransportCapabilities
+) -> tuple[str, list[str]]:
+    """Enforce ``capabilities.max_buttons`` on a parsed ``[OPTIONS:]`` list.
+
+    The ``max_buttons`` analogue of :func:`chunk_text`. Widget-capable
+    renderers call this between parsing the trailer and building the native
+    widget, so the cap lives in shared code and the per-channel contract
+    test can pin it.
+
+    Returns ``(body, kept_choices)``:
+
+    * ``len(choices) <= max_buttons`` — byte-identical pass-through.
+    * overflow — the first ``max_buttons`` choices are kept for the widget;
+      the remainder is appended to ``body`` as a numbered text list
+      (numbering continues after the widget slots). Previously overflow was
+      silently dropped: the user never learned those choices existed.
+    * ``max_buttons <= 0`` — returns ``(body, [])``; zero-widget channels
+      own their trailer handling (today: strip).
+    """
+    if capabilities.max_buttons <= 0:
+        return body, []
+    kept, overflow = cap_choices(choices, capabilities)
+    if not overflow:
+        return body, kept
+    lines = format_overflow(overflow, start=len(kept))
+    sep = "\n\n" if body and not body.endswith("\n") else "\n" if body else ""
+    return f"{body}{sep}{lines}", kept
 
 
 class Renderer(ABC):

--- a/src/kiro_crew/messaging/transport.py
+++ b/src/kiro_crew/messaging/transport.py
@@ -64,13 +64,19 @@ class TransportCapabilities:
       here: it routes inbound through its own ``_thread_to_session`` index and
       never sets the marker.
 
+    * ``max_buttons`` — TOTAL interactive choices a renderer may present for
+      one ``[OPTIONS:]`` trailer (not a per-row layout number — row packing
+      stays channel-internal). Widget-capable renderers route the parsed
+      list through ``messaging.renderer.apply_options_cap``, which keeps the
+      first N for the widget and degrades the remainder to a numbered text
+      list in the body. Channels declaring 0 render no widget (trailer
+      stripped; text fallback arrives with the approval-ladder work).
+
     ASPIRATIONAL (declared, honest, but nothing reads them yet — the
     capability-gated interface work will consume them; do NOT write code that
     assumes they are enforced):
 
     * ``streaming``, ``edit``, ``reactions``, ``rich_blocks``, ``threads``
-    * ``max_buttons`` — per-renderer caps are currently hardcoded
-      (slack ``[:10]``, discord ``[:25]``); no renderer reads this field.
     * ``files_inbound`` / ``files_outbound`` — split because one boolean was
       undecidable: discord ingests attachments but cannot upload, slack does
       both. Inbound = the transport ingests user attachments into the turn;
@@ -91,7 +97,7 @@ class TransportCapabilities:
     threads: bool = False
     # parameters (channels differ widely -- NOT booleans)
     max_message_chars: int = 4096  # CHARS. Slack path caps 3900, Telegram 4000, Discord 1900
-    max_buttons: int = 3  # interactive choices per prompt (WhatsApp reply buttons = 3)
+    max_buttons: int = 3  # TOTAL interactive choices per prompt (WhatsApp reply buttons = 3)
     # send-policy
     supports_proactive_send: bool = True  # WhatsApp: False outside the 24h window
     # inbound-routing policy. Default False: a transport that forgets to declare

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -517,6 +517,22 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "the same output-boundary reason as the app activity log.",
     ),
     (
+        "Shared options-overflow sink",
+        "messaging/renderer.py",
+        "The one place LLM-authored [OPTIONS:] choices that do not fit a channel's "
+        "interactive widget are written into the message BODY (format_overflow, "
+        "reached from apply_options_cap on slack/telegram/discord). That crosses a "
+        "boundary the widget path does not: a widget label is plain text, while the "
+        "body is markdown-parsed, so a key split by a code span, emphasis or a "
+        "Discord spoiler is broken to every byte-level scan -- including the "
+        "TurnDriver's streaming redactor -- and whole on screen once the platform "
+        "drops the delimiters. Choices are therefore redacted here in DISPLAY form "
+        "(messaging/display_safety.py) BEFORE mention syntax is defanged, since the "
+        "ZWSP insertion is itself a post-scan transformation. Enforced at this sink "
+        "rather than per renderer for the same reason the max_buttons cap lives in "
+        "shared code: a channel cannot forget what it does not call.",
+    ),
+    (
         "Slack render pipeline",
         "slack/format.py",
         "The Slack RENDERING boundary: text that is converted to mrkdwn goes "
@@ -703,6 +719,11 @@ NON_EGRESS_REDACTION_MODULES: frozenset[str] = frozenset(
         # egress boundary; the modules that CALL it (mochi routes/hooks) are the
         # registered sinks.
         "apps/builtins/mochi/redact.py",
+        # Same shape: applies a redactor the CALLER injects, to scan the form a
+        # platform will actually render (markup collapsed, ANSI stripped). It owns
+        # no output of its own -- the registered sinks are the modules that call
+        # it (slack/format.py, messaging/renderer.py).
+        "messaging/display_safety.py",
         "autonudge_authz.py",
         "acp/_dispatch.py",
         "acp/client.py",

--- a/src/kiro_crew/slack/format.py
+++ b/src/kiro_crew/slack/format.py
@@ -7,6 +7,8 @@ import re
 from typing import Callable, NamedTuple
 
 from kiro_crew.constants import OPTIONS_RE_LINE
+from kiro_crew.messaging.display_safety import redact_for_display, strip_ansi
+from kiro_crew.messaging.renderer import cap_choices, format_overflow
 from kiro_crew.platform.context import redact_via_context
 
 logger = logging.getLogger(__name__)
@@ -83,8 +85,23 @@ def build_options_blocks(
     *,
     redactor: Callable[[str], str] | None = None,
 ) -> list[dict]:
-    """Build Slack Block Kit checkboxes + Send button for multi-select OPTIONS."""
-    safe = _redact_choices(choices[:10], redactor)  # checkboxes support up to 10
+    """Build Slack Block Kit checkboxes + Send button for multi-select OPTIONS.
+
+    This is the single chokepoint for every Slack producer of OPTIONS blocks
+    (renderer footer, legacy handler, cron delivery, subagent footer,
+    send_message, dashboard mirror), so the ``max_buttons`` cap lives HERE:
+    the first ``SLACK_CAPABILITIES.max_buttons`` choices render as checkbox
+    options (the platform caps a checkboxes element at 10) and any overflow
+    degrades to a numbered context block the user can answer by typing.
+    Overflow is redacted like the widget labels — same LLM-authored text,
+    same wire.
+    """
+    # Circular import: slack/transport.py imports SLACK_MSG_LIMIT from this
+    # module at top level, so the capabilities object must be imported lazily.
+    from kiro_crew.slack.transport import SLACK_CAPABILITIES
+
+    kept, overflow = cap_choices(choices, SLACK_CAPABILITIES)
+    safe = _redact_choices(kept, redactor)
     options = [
         {
             "text": {"type": "plain_text", "text": choice[:75]},
@@ -92,7 +109,7 @@ def build_options_blocks(
         }
         for choice in safe
     ]
-    return [
+    blocks: list[dict] = [
         {
             "type": "actions",
             "elements": [
@@ -110,6 +127,51 @@ def build_options_blocks(
             ],
         },
     ]
+    if overflow:
+        # Chunk instead of slicing: a single [:2900] would re-create the
+        # silent data loss this cap exists to remove, one layer down. Slack
+        # caps a context mrkdwn element at ~3000 chars; pack WHOLE numbered
+        # lines (never split a choice mid-line) into up to three blocks.
+        # BOUNDED: Slack rejects messages over 50 blocks outright — an
+        # unbounded loop would make a pathological trailer delete the whole
+        # footer. When even three blocks overflow, the tail is dropped with
+        # a VISIBLE count marker; never silent.
+        lines = format_overflow(_redact_choices(overflow, redactor), start=len(safe)).split("\n")
+        packed: list[str] = []
+        shown = 0
+        for line in lines:
+            if packed and len(packed[-1]) + 1 + len(line) <= 2900:
+                packed[-1] += "\n" + line
+            elif len(packed) < 3:
+                # A single absurd choice can exceed a whole block: truncate
+                # WITH a visible marker (the widget path truncates labels at
+                # [:75] similarly, but there the ellipsis is implied by the
+                # platform; here we own the rendering).
+                packed.append(line if len(line) <= 2900 else line[:2899] + "…")
+            else:
+                break
+            shown += 1
+        for piece in packed:
+            blocks.append(
+                {
+                    "type": "context",
+                    "elements": [{"type": "mrkdwn", "text": piece}],
+                }
+            )
+        omitted = len(overflow) - shown
+        if omitted > 0:
+            blocks.append(
+                {
+                    "type": "context",
+                    "elements": [
+                        {
+                            "type": "mrkdwn",
+                            "text": f"_…{omitted} more choices omitted (list too long)_",
+                        }
+                    ],
+                }
+            )
+    return blocks
 
 
 def escape_mrkdwn(text: str) -> str:
@@ -149,12 +211,20 @@ def build_options_selected_blocks(
     *,
     redactor: Callable[[str], str] | None = None,
 ) -> list[dict]:
-    """Render OPTIONS as static text with selected choices highlighted."""
+    """Render OPTIONS as static text with selected choices highlighted.
+
+    Input arrives re-derived from the rendered message's blocks, so it is
+    already ≤ the cap; the shared ``cap_choices`` keeps the two paths driven
+    by one value so they cannot drift.
+    """
+    from kiro_crew.slack.transport import SLACK_CAPABILITIES  # circular (see above)
+
     if isinstance(selected_indices, int):
         selected_indices = [selected_indices]
     selected_set = set(selected_indices)
+    kept, _ = cap_choices(choices, SLACK_CAPABILITIES)
     parts = []
-    for i, choice in enumerate(_redact_choices(choices[:10], redactor)):
+    for i, choice in enumerate(_redact_choices(kept, redactor)):
         # Slice THEN escape -- the opposite order from redaction above, and for
         # the mirror-image reason. Redaction runs before slicing because a cut
         # can leave a credential prefix its regex no longer matches; escaping
@@ -412,17 +482,6 @@ def _convert_tables(text: str) -> str:
     return "\n".join(result)
 
 
-def strip_ansi(text: str) -> str:
-    """Remove SGR colour escapes.
-
-    Public because redaction call sites need it: this strip can *reassemble* a
-    credential that escape sequences had broken up, so a caller that redacts
-    around a conversion has to normalise with the SAME function first, or the
-    secret slips through the regex and is put back together afterwards.
-    """
-    return re.sub(r"\x1b\[[0-9;]*m", "", text)
-
-
 # ── Mermaid → text ──
 
 _MERMAID_BLOCK_RE = re.compile(r"```mermaid\s*\n(.*?)```", re.DOTALL)
@@ -554,80 +613,6 @@ def split_message(text: str, limit: int = SLACK_MSG_LIMIT) -> list[str]:
             parts.append(text[:cut])
         text = remainder
     return parts
-
-
-_EMPHASIS_RUN = re.compile(r"[*_~`]+")
-# ``[label](url)`` (Markdown) and ``<url|label>`` (Slack mrkdwn). Both DISPLAY only
-# the label, so the url is invisible to a reader and the label joins whatever
-# surrounds it -- which makes them a splitter, exactly like ``**``.
-#
-# The opening delimiter is excluded from every inner class (no ``[`` inside the
-# Markdown label, no ``<`` inside the Slack one). That is not cosmetic: with ``[``
-# allowed, input like ``[[[[[[...`` makes each start position consume the whole
-# remaining string before failing to find ``]``, so the scan is quadratic in the
-# length of attacker-supplied text (CodeQL ``py/polynomial-redos``). Excluding it
-# makes a failed start fail immediately, which matters because this runs on every
-# outbound message. A label containing a literal ``[`` is simply not collapsed --
-# safe, since the fallback is to scan the text as written.
-_MD_LINK = re.compile(r"\[([^\[\]\n]*)\]\(([^()\n]*)\)")
-_SLACK_LINK = re.compile(r"<([^<>|\n]*)\|([^<>\n]*)>")
-
-
-def _canonicalize_display(text: str) -> str:
-    """Reduce *text* to what Slack will actually SHOW a reader.
-
-    Two families of markup, one property: Slack removes them at render time, so a
-    credential broken across them is whole on screen while every literal scan sees
-    it broken.
-
-    * **links** collapse to their label -- ``[AKIA](https://x)REST`` displays as
-      the joined key, with the url nowhere in sight;
-    * **emphasis / code delimiters** vanish -- ``AKIA**REST**`` likewise.
-
-    Links are reduced FIRST: a url can itself contain ``_`` or ``~``, and dropping
-    those before the url is removed would corrupt the label boundaries.
-    """
-    out = _MD_LINK.sub(r"\1", text)
-    out = _SLACK_LINK.sub(r"\2", out)
-    return _EMPHASIS_RUN.sub("", out)
-
-
-def redact_for_display(text: str, redactor: Callable[[str], str]) -> tuple[str, bool]:
-    """Redact *text* against what Slack will actually DISPLAY, not just the bytes.
-
-    Two normalisations, for the same underlying reason: a transformation applied
-    *after* the scan can reassemble a credential the scanner saw as broken.
-
-    1. **ANSI escapes** -- stripped outright, because they are display noise with
-       no meaning to preserve.
-    2. **Link markup and emphasis/code delimiters** -- these DO carry meaning, so
-       they cannot simply be deleted. Instead the canonical (display) form is
-       scanned as well. Neither ``AKIA**<rest>**`` nor ``[AKIA](https://x)<rest>``
-       matches a credential pattern as written, yet Slack renders the markup away
-       and shows the reader an intact key.
-
-    When the canonical form reveals a secret that the literal form hid, the
-    canonical text is emitted -- so the message loses that markup. That is
-    deliberate and one-directional: formatting is worth less than a credential, and
-    the downgrade only happens on a message that actually contains one.
-
-    Returns:
-        ``(safe_text, redacted)``. ``redacted`` is True when the redactor changed
-        anything, by either route -- callers that already published the text rely
-        on it to go back and replace what is visible.
-    """
-    stripped = strip_ansi(text or "")
-    safe = redactor(stripped)
-    changed = safe != stripped
-
-    canonical = _canonicalize_display(safe)
-    if canonical != safe:
-        canonical_safe = redactor(canonical)
-        if canonical_safe != canonical:
-            # The markup was hiding a credential from the scan. Emit the canonical,
-            # redacted form: losing formatting beats leaking the key.
-            return canonical_safe, True
-    return safe, changed
 
 
 def _render_blocks(

--- a/src/kiro_crew/slack/transport.py
+++ b/src/kiro_crew/slack/transport.py
@@ -46,7 +46,11 @@ SLACK_CAPABILITIES = TransportCapabilities(
     rich_blocks=True,
     threads=True,
     max_message_chars=SLACK_MSG_LIMIT,
-    max_buttons=5,
+    # 10 = the platform cap on a checkboxes element's options[] — the widget
+    # Slack actually renders for [OPTIONS:]. The previous 5 was copied from
+    # the 5-buttons-per-actions-row limit, which does not govern checkboxes.
+    # Enforced at build_options_blocks (slack/format.py) via cap_choices.
+    max_buttons=10,
     supports_proactive_send=True,
 )
 

--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -31,7 +31,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.constants import OPTIONS_RE_TRAILER, split_trailing_protocol_suffix
-from kiro_crew.messaging.renderer import Renderer
+from kiro_crew.messaging.renderer import Renderer, apply_options_cap
 from kiro_crew.messaging.transport import TransportCapabilities
 
 if TYPE_CHECKING:
@@ -520,7 +520,12 @@ class TelegramRenderer(Renderer):
         # seal -- so the choices ship as a keyboard on the sealed message instead of
         # being frozen as literal protocol text the user cannot act on.
         body_raw, opts = _extract_options("".join(self._buf))
+        body_raw, opts = apply_options_cap(body_raw, opts, self.capabilities)
         self._buf = [body_raw]
+        # apply_options_cap may EXPAND the body (numbered overflow lines), and
+        # the rotation above ran before that expansion -- re-check, or a
+        # near-limit answer with over-cap options seals past the transport cap.
+        await self._rotate_on_length()
         keyboard = build_inline_keyboard(opts) if opts else None
         sealed = bool(self._segment_text().strip()) or keyboard is not None
         await self._seal_current(keyboard=keyboard)
@@ -758,6 +763,7 @@ class TelegramRenderer(Renderer):
         # overflows, rotation would otherwise seal the options text into an
         # earlier message and the keyboard would never attach.
         body_raw, opts = _extract_options("".join(self._buf))
+        body_raw, opts = apply_options_cap(body_raw, opts, self.capabilities)
         self._buf = [body_raw]
         keyboard = build_inline_keyboard(opts) if opts else None
         # No-rotation fallback: steers were injected but kiro-cli emitted no

--- a/src/kiro_crew/telegram/transport.py
+++ b/src/kiro_crew/telegram/transport.py
@@ -61,8 +61,12 @@ DispatchFn = Callable[[InboundMessage], Awaitable[None]]
 # message_thread_id, receive() populates InboundMessage.thread_id, and
 # forum_gate_outcome authorizes on it. (This was previously declared False —
 # wrongly; declarations must match the code, not the DM-only common case.)
-# max_buttons=8 is Telegram's per-row limit; NOTE the renderer does not yet
-# apply it (see the capability ledger — the field is aspirational).
+# max_buttons=25: TOTAL interactive choices per prompt (the renderer packs 2
+# per row -> up to 13 scrollable rows), parity with discord's platform-
+# practical total. Enforced via apply_options_cap; overflow degrades to a
+# numbered text list. The genuinely unbounded keyboard was the defect this
+# closes (huge lists 400); 9-25 choice keyboards worked before and still do.
+# (The old declared 8 was a mislabeled per-row number, never a chosen total.)
 TELEGRAM_CAPABILITIES = TransportCapabilities(
     streaming=True,
     edit=True,
@@ -72,7 +76,7 @@ TELEGRAM_CAPABILITIES = TransportCapabilities(
     rich_blocks=False,
     threads=True,
     max_message_chars=TELEGRAM_CHUNK_LIMIT,
-    max_buttons=8,
+    max_buttons=25,
     supports_proactive_send=True,
 )
 

--- a/test/test_capability_ledger.py
+++ b/test/test_capability_ledger.py
@@ -38,6 +38,14 @@ ENFORCED = {
     # whether the slot row reports ``direction: both``. Only a transport whose
     # inbound path resolves the mirror binding may declare it.
     "supports_session_resume",
+    # TOTAL interactive choices per [OPTIONS:] prompt. Widget-capable
+    # renderers (slack/discord/telegram) route the parsed list through
+    # messaging.renderer.apply_options_cap / cap_choices; overflow degrades
+    # to a numbered text list instead of being silently dropped. Pinned per
+    # channel by test_options_cap_contract.py. Channels declaring 0 render
+    # no widget (trailer stripped; their text fallback is the
+    # approval-ladder work).
+    "max_buttons",
 }
 
 #: Declared honestly, read by nothing yet. The capability-gated interface
@@ -51,7 +59,6 @@ ASPIRATIONAL = {
     "files_outbound",
     "rich_blocks",
     "threads",
-    "max_buttons",
 }
 
 
@@ -120,6 +127,24 @@ class TestCorrectedDeclarations:
         assert DISCORD_CAPABILITIES.files_outbound is False
         assert SLACK_CAPABILITIES.files_inbound is True
         assert SLACK_CAPABILITIES.files_outbound is True
+
+    def test_max_buttons_declares_totals_the_renderers_ship(self) -> None:
+        # The field is TOTAL choices, not a per-row layout number. The old
+        # values mixed the two: slack declared 5 (a buttons-per-actions-row
+        # limit that does not govern its checkboxes widget) while shipping
+        # 10; discord declared 5 (per row) while shipping 25 total; telegram
+        # declared 8 (a mislabeled per-row number) while enforcing nothing.
+        # Declare what ships: slack/discord keep their shipped maxima, and
+        # telegram gets the same platform-practical 25 so previously-working
+        # 9-25 choice keyboards keep working — only the genuinely unbounded
+        # tail (the API-400 defect) degrades to text.
+        from kiro_crew.discord.transport import DISCORD_CAPABILITIES
+        from kiro_crew.slack.transport import SLACK_CAPABILITIES
+        from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES
+
+        assert SLACK_CAPABILITIES.max_buttons == 10  # checkboxes options[] cap
+        assert DISCORD_CAPABILITIES.max_buttons == 25  # 5 rows x 5 buttons
+        assert TELEGRAM_CAPABILITIES.max_buttons == 25  # 2/row, parity with discord
 
 
 class TestSessionResumeIsDeclaredOnlyWhereItIsHonoured:

--- a/test/test_options_buttons.py
+++ b/test/test_options_buttons.py
@@ -89,8 +89,14 @@ class TestBuildOptionsBlocks:
     def test_max_ten_choices(self):
         choices = [f"C{i}" for i in range(15)]
         blocks = build_options_blocks(choices)
-        opts = blocks[0]["elements"][0]["options"]
+        actions = next(b for b in blocks if b["type"] == "actions")
+        opts = actions["elements"][0]["options"]
         assert len(opts) == 10
+        # Overflow no longer vanishes: choices 11-15 degrade to a numbered
+        # context block the user can answer by typing.
+        overflow = next(b for b in blocks if b["type"] == "context")
+        assert "11. C10" in overflow["elements"][0]["text"]
+        assert "15. C14" in overflow["elements"][0]["text"]
 
     def test_truncates_long_choice_text(self):
         long = "x" * 100

--- a/test/test_options_cap_contract.py
+++ b/test/test_options_cap_contract.py
@@ -1,0 +1,375 @@
+"""Cross-channel contract: ``max_buttons`` is ENFORCED, per channel.
+
+The capability ledger (``test_capability_ledger.py``) says the field is
+enforced; THIS file is what makes that claim unforgeable. For every channel
+declaring ``max_buttons > 0`` it drives the real options path with an
+over-cap list and pins:
+
+1. exactly ``max_buttons`` choices render interactively, and
+2. the overflow degrades to a numbered text list (numbering continues after
+   the widget slots) instead of being silently dropped — the pre-enforcement
+   behavior lost choices without any user-visible signal.
+
+``test_every_widget_channel_is_pinned_here`` is the ratchet: a channel that
+starts declaring ``max_buttons > 0`` without a pin in this file fails it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from kiro_crew.messaging.renderer import apply_options_cap, cap_choices
+from kiro_crew.messaging.transport import TransportCapabilities
+
+#: channel_type -> the test class below that pins its enforcement.
+PINNED_WIDGET_CHANNELS = {"slack", "discord", "telegram"}
+
+
+def _all_channel_capabilities() -> dict[str, TransportCapabilities]:
+    from kiro_crew.discord.transport import DISCORD_CAPABILITIES
+    from kiro_crew.slack.transport import SLACK_CAPABILITIES
+    from kiro_crew.teams.transport import TEAMS_CAPABILITIES
+    from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES
+    from kiro_crew.webex.transport import WEBEX_CAPABILITIES
+    from kiro_crew.wecom.transport import WECOM_CAPABILITIES
+    from kiro_crew.weixin.transport import WEIXIN_CAPABILITIES
+
+    return {
+        "slack": SLACK_CAPABILITIES,
+        "discord": DISCORD_CAPABILITIES,
+        "telegram": TELEGRAM_CAPABILITIES,
+        "teams": TEAMS_CAPABILITIES,
+        "webex": WEBEX_CAPABILITIES,
+        "wecom": WECOM_CAPABILITIES,
+        "weixin": WEIXIN_CAPABILITIES,
+    }
+
+
+class TestRatchet:
+    def test_every_widget_channel_is_pinned_here(self) -> None:
+        widget_channels = {
+            name for name, caps in _all_channel_capabilities().items() if caps.max_buttons > 0
+        }
+        assert widget_channels == PINNED_WIDGET_CHANNELS, (
+            "A channel's max_buttons declaration changed. Every channel "
+            "declaring max_buttons > 0 must have an enforcement pin in this "
+            f"file. unpinned={widget_channels - PINNED_WIDGET_CHANNELS} "
+            f"stale={PINNED_WIDGET_CHANNELS - widget_channels}"
+        )
+
+
+class TestSharedHelper:
+    def test_under_cap_is_byte_identical(self) -> None:
+        caps = TransportCapabilities(max_buttons=3)
+        body, kept = apply_options_cap("Choose.", ["A", "B"], caps)
+        assert body == "Choose."
+        assert kept == ["A", "B"]
+
+    def test_overflow_degrades_to_numbered_text_continuing_the_widget_slots(self) -> None:
+        caps = TransportCapabilities(max_buttons=2)
+        body, kept = apply_options_cap("Pick one.", ["A", "B", "C", "D"], caps)
+        assert kept == ["A", "B"]
+        assert body == "Pick one.\n\n3. C\n4. D"
+
+    def test_zero_cap_keeps_nothing_and_leaves_body_alone(self) -> None:
+        caps = TransportCapabilities(max_buttons=0)
+        body, kept = apply_options_cap("Text.", ["A", "B"], caps)
+        assert body == "Text."
+        assert kept == []
+
+    def test_cap_choices_splits_without_formatting(self) -> None:
+        caps = TransportCapabilities(max_buttons=1)
+        kept, overflow = cap_choices(["A", "B", "C"], caps)
+        assert kept == ["A"]
+        assert overflow == ["B", "C"]
+
+    def test_overflow_neutralizes_mass_mention_syntax(self) -> None:
+        # Regression (review round 2): overflow lands in the message BODY
+        # where platforms parse mentions — unlike widget labels, which render
+        # as plain text. A prompt-injected choice must not mass-notify.
+        from kiro_crew.messaging.renderer import format_overflow
+
+        out = format_overflow(["ping @everyone now", "or <!channel> maybe"], start=1)
+        assert "@everyone" not in out
+        assert "<!channel>" not in out
+        # The text stays human-readable — only the trigger syntax is broken.
+        assert "everyone" in out and "channel" in out
+
+    def test_overflow_redacts_credentials_in_their_DISPLAY_form(self) -> None:
+        # Regression (review round 5): overflow lands in the markdown-parsed
+        # BODY, so a key split by a code span or emphasis is broken to every
+        # byte-level scan (the driver's stream redactor included) and WHOLE on
+        # screen once the platform drops the delimiters. Slack's widget path
+        # already routes choices through the display redactor for exactly this
+        # reason; the shared sink has to close the same hole for telegram and
+        # discord, which have no display-state pass of their own.
+        from kiro_crew.messaging.renderer import format_overflow
+
+        split = "AKIA`" + "`IOSFODNN7EXAMPLE"
+        out = format_overflow([f"Retry with {split}"], start=1)
+        assert "IOSFODNN7EXAMPLE" not in out, (
+            "a backtick-split key survived the overflow sink — the platform "
+            "strips the delimiters and shows the reader an intact credential"
+        )
+
+    def test_overflow_redaction_runs_before_mention_defanging(self) -> None:
+        # Both sanitisations transform the text; if the ZWSP went in first it
+        # could split a key so the regex stops matching while the platform
+        # still renders it whole. Pin the order with a choice that needs both.
+        from kiro_crew.messaging.renderer import format_overflow
+
+        out = format_overflow(["@everyone use AKIA*IOSFODNN7EXAMPLE*"], start=0)
+        assert "@everyone" not in out
+        assert "IOSFODNN7EXAMPLE" not in out
+
+    def test_overflow_redacts_a_spoiler_split_key(self) -> None:
+        # Regression (review round 6): ``||…||`` is Discord's spoiler. The
+        # reader clicks it, the delimiters vanish and the halves join — the
+        # same splitter property as ``**``, but it was missing from the
+        # canonicaliser's delimiter run, so round 5's fix had a hole exactly
+        # one delimiter family wide.
+        from kiro_crew.messaging.renderer import format_overflow
+
+        out = format_overflow(["Retry with AKIA||IOSFODNN7EXAMPLE||"], start=0)
+        assert "IOSFODNN7EXAMPLE" not in out, (
+            "a spoiler-split key survived — Discord joins the halves when the "
+            "reader reveals the spoiler"
+        )
+
+    def test_overflow_redacts_an_invisible_character_split_key(self) -> None:
+        # The invisible half of the same hazard, and worse than the markup half:
+        # a zero-width character renders as NOTHING, so the reader sees an
+        # intact key with no click and no markup while every literal scan sees
+        # it broken. Pre-existing in the display redactor; closed here because
+        # this sink is what puts LLM-authored choice text into the body.
+        from kiro_crew.messaging.renderer import format_overflow
+
+        for name, ch in (
+            ("ZWSP", "\u200b"),
+            ("ZWNJ", "\u200c"),
+            ("word joiner", "\u2060"),
+            ("BOM", "\ufeff"),
+            ("soft hyphen", "\u00ad"),
+        ):
+            out = format_overflow([f"Retry with AKIA{ch}IOSFODNN7EXAMPLE"], start=0)
+            assert "IOSFODNN7EXAMPLE" not in out, f"{name} split the key past the scan"
+
+    def test_non_ascii_text_is_not_mangled(self) -> None:
+        """The format-character filter must not touch visible non-ASCII text."""
+        from kiro_crew.messaging.renderer import format_overflow
+
+        out = format_overflow(["重新部署到主分支", "café — naïve"], start=0)
+        assert out == "1. 重新部署到主分支\n2. café — naïve"
+
+    def test_a_lone_pipe_is_left_alone(self) -> None:
+        """The pipe counts only in pairs — pinned so the boundary is deliberate.
+
+        A single ``|`` is literal on every channel here, so collapsing it would
+        widen the canonical form with no rendering that matches it. This also
+        keeps ordinary table-ish text intact.
+        """
+        from kiro_crew.messaging.display_safety import canonicalize_display
+
+        assert canonicalize_display("a|b") == "a|b"
+        assert canonicalize_display("a||b") == "ab"
+
+    def test_clean_choices_are_untouched_by_the_redactor(self) -> None:
+        """The sink must not mangle ordinary text — no false-positive damage."""
+        from kiro_crew.messaging.renderer import format_overflow
+
+        out = format_overflow(["Rebase onto main", "Skip the `--force` flag"], start=2)
+        assert out == "3. Rebase onto main\n4. Skip the `--force` flag"
+
+
+class TestSlackEnforcement:
+    def _choices(self, n: int) -> list[str]:
+        return [f"Choice {i}" for i in range(1, n + 1)]
+
+    def test_widget_caps_at_declared_and_overflow_is_visible(self) -> None:
+        from kiro_crew.slack.format import build_options_blocks
+        from kiro_crew.slack.transport import SLACK_CAPABILITIES
+
+        n = SLACK_CAPABILITIES.max_buttons
+        blocks = build_options_blocks(self._choices(n + 3))
+        actions = next(b for b in blocks if b["type"] == "actions")
+        opts = actions["elements"][0]["options"]
+        assert len(opts) == n
+        overflow = next(b for b in blocks if b["type"] == "context")
+        text = overflow["elements"][0]["text"]
+        # Numbering continues after the widget slots; every dropped choice shows.
+        assert f"{n + 1}. Choice {n + 1}" in text
+        assert f"{n + 3}. Choice {n + 3}" in text
+
+    def test_under_cap_emits_no_overflow_block(self) -> None:
+        from kiro_crew.slack.format import build_options_blocks
+
+        blocks = build_options_blocks(self._choices(2))
+        assert [b["type"] for b in blocks] == ["actions"]
+
+    def test_huge_overflow_is_chunked_not_sliced(self) -> None:
+        # Regression (review round 1): a single [:2900] slice re-created the
+        # silent data loss the cap exists to remove. Every overflow choice
+        # must reach the wire, across as many context blocks as needed.
+        from kiro_crew.slack.format import build_options_blocks
+        from kiro_crew.slack.transport import SLACK_CAPABILITIES
+
+        n = SLACK_CAPABILITIES.max_buttons
+        long = [f"Choice {i} " + "x" * 140 for i in range(1, n + 41)]
+        blocks = build_options_blocks(long)
+        ctx = [b for b in blocks if b["type"] == "context"]
+        assert len(ctx) >= 2, "one sliced block would drop tail choices"
+        joined = "".join(b["elements"][0]["text"] for b in ctx)
+        assert f"{n + 40}." in joined, "the LAST overflow choice must survive"
+
+    def test_pathological_overflow_is_bounded_with_visible_truncation(self) -> None:
+        # Regression (review round 3): unbounded context blocks blow Slack's
+        # 50-block message limit — the API rejects the WHOLE message and every
+        # choice disappears. The block budget is capped and the tail drop is
+        # VISIBLE (counted marker), never silent.
+        from kiro_crew.slack.format import build_options_blocks
+        from kiro_crew.slack.transport import SLACK_CAPABILITIES
+
+        n = SLACK_CAPABILITIES.max_buttons
+        huge = [f"Choice {i} " + "x" * 140 for i in range(1, n + 201)]
+        blocks = build_options_blocks(huge)
+        ctx = [b for b in blocks if b["type"] == "context"]
+        assert len(ctx) <= 4, "block budget must be bounded"
+        assert len(blocks) <= 5
+        marker = ctx[-1]["elements"][0]["text"]
+        assert "omitted" in marker
+        # The marker counts what was dropped — no silent loss.
+        assert any(ch.isdigit() for ch in marker)
+
+    def test_single_oversized_choice_truncates_with_visible_marker(self) -> None:
+        # Regression (review round 4): one absurd >2900-char choice was
+        # sliced with no signal. The cut must be visible.
+        from kiro_crew.slack.format import build_options_blocks
+        from kiro_crew.slack.transport import SLACK_CAPABILITIES
+
+        n = SLACK_CAPABILITIES.max_buttons
+        choices = [f"Choice {i}" for i in range(1, n + 1)] + ["y" * 4000]
+        blocks = build_options_blocks(choices)
+        ctx = [b for b in blocks if b["type"] == "context"]
+        text = ctx[0]["elements"][0]["text"]
+        assert len(text) <= 2900
+        assert text.endswith("…"), "truncation must be visible, not silent"
+
+
+class TestTelegramEnforcement:
+    def test_steer_seal_near_limit_with_overflow_stays_under_transport_cap(self) -> None:
+        # Regression (review round 1): on_steer_consumed ran _rotate_on_length
+        # BEFORE apply_options_cap expanded the body with numbered overflow, so
+        # a near-limit pre-steer answer sealed past the transport cap.
+        from test_telegram import FakeClient
+
+        from kiro_crew.messaging.renderer import STEER_CONSUMED, TEXT_CHUNK, OutputEvent
+        from kiro_crew.telegram.client import TELEGRAM_CHUNK_LIMIT
+        from kiro_crew.telegram.renderer import TelegramRenderer
+        from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES
+
+        n = TELEGRAM_CAPABILITIES.max_buttons
+        trailer = " | ".join(f"Choice number {i} with a long label" for i in range(1, n + 9))
+        near_limit = "x" * (TELEGRAM_CHUNK_LIMIT - 60)
+        cli = FakeClient()
+        r = TelegramRenderer(  # type: ignore[arg-type]
+            cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0"
+        )
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.dispatch(
+                OutputEvent(kind=TEXT_CHUNK, text=f"{near_limit}\n\n[OPTIONS: {trailer}]")
+            )
+            await r.dispatch(OutputEvent(kind=STEER_CONSUMED, text="steered"))
+
+        asyncio.run(_go())
+        for text, _ in cli.sent:
+            assert len(text) <= TELEGRAM_CHUNK_LIMIT
+        for _, text, _ in cli.edits:
+            assert len(text) <= TELEGRAM_CHUNK_LIMIT
+
+    def test_keyboard_caps_at_declared_and_overflow_is_visible(self) -> None:
+        from test_telegram import FakeClient
+
+        from kiro_crew.messaging.renderer import DONE, TEXT_CHUNK, OutputEvent
+        from kiro_crew.telegram.renderer import TelegramRenderer
+        from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES
+
+        n = TELEGRAM_CAPABILITIES.max_buttons
+        trailer = " | ".join(f"Choice {i}" for i in range(1, n + 4))
+        cli = FakeClient()
+        r = TelegramRenderer(  # type: ignore[arg-type]
+            cli, 55, TELEGRAM_CAPABILITIES, session_key="telegram:1:0"
+        )
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.dispatch(OutputEvent(kind=TEXT_CHUNK, text=f"Pick.\n\n[OPTIONS: {trailer}]"))
+            await r.dispatch(OutputEvent(kind=DONE, stop_reason=""))
+
+        asyncio.run(_go())
+        kb = cli.final_markup()
+        labels = [b["text"] for row in kb["inline_keyboard"] for b in row]
+        assert len(labels) == n, "telegram keyboard was uncapped before enforcement"
+        assert labels == [f"Choice {i}" for i in range(1, n + 1)]
+        final = cli.final_text()
+        assert f"{n + 1}. Choice {n + 1}" in final
+        assert f"{n + 3}. Choice {n + 3}" in final
+
+
+class TestDiscordEnforcement:
+    def test_buttons_cap_at_declared_and_overflow_is_visible(self) -> None:
+        import pytest_asyncio  # noqa: F401  (asyncio runner parity with test_discord)
+        from test_discord import FakeClient
+
+        from kiro_crew.discord.renderer import DiscordRenderer
+        from kiro_crew.discord.transport import DISCORD_CAPABILITIES
+
+        n = DISCORD_CAPABILITIES.max_buttons
+        trailer = " | ".join(f"Choice {i}" for i in range(1, n + 4))
+        cli = FakeClient()
+        r = DiscordRenderer(  # type: ignore[arg-type]
+            cli, "chan1", DISCORD_CAPABILITIES, session_key="discord:u:c"
+        )
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk(f"Pick.\n\n[OPTIONS: {trailer}]")
+            await r.on_done()
+
+        asyncio.run(_go())
+        comps = cli.final_components()
+        labels = [b["label"] for row in comps for b in row["components"]]
+        assert len(labels) == n
+        final = cli.final_text()
+        assert f"{n + 1}. Choice {n + 1}" in final
+        assert f"{n + 3}. Choice {n + 3}" in final
+
+    def test_overflow_credential_is_redacted_on_the_real_render_path(self) -> None:
+        """End-to-end: discord has no display-state pass of its own.
+
+        Before enforcement the 26th+ choices were dropped entirely, so there
+        was no exposure; routing them into the parsed body is what opened the
+        surface this closes.
+        """
+        import pytest_asyncio  # noqa: F401  (asyncio runner parity with test_discord)
+        from test_discord import FakeClient
+
+        from kiro_crew.discord.renderer import DiscordRenderer
+        from kiro_crew.discord.transport import DISCORD_CAPABILITIES
+
+        n = DISCORD_CAPABILITIES.max_buttons
+        leaked = "AKIA`" + "`IOSFODNN7EXAMPLE"
+        choices = [f"Choice {i}" for i in range(1, n + 1)] + [f"Retry with {leaked}"]
+        cli = FakeClient()
+        r = DiscordRenderer(  # type: ignore[arg-type]
+            cli, "chan1", DISCORD_CAPABILITIES, session_key="discord:u:c"
+        )
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.on_text_chunk("Pick.\n\n[OPTIONS: " + " | ".join(choices) + "]")
+            await r.on_done()
+
+        asyncio.run(_go())
+        assert "IOSFODNN7EXAMPLE" not in cli.final_text()

--- a/test/test_slack_render_pipeline.py
+++ b/test/test_slack_render_pipeline.py
@@ -777,8 +777,12 @@ class TestEmphasisDelimiterRedaction:
         before failing, which is quadratic in attacker-supplied text on the egress
         path (CodeQL ``py/polynomial-redos``). Excluding those delimiters makes a
         doomed start fail in constant time.
+
+        The patterns live in ``messaging.display_safety`` rather than here: the
+        hazard is not Slack-specific (Telegram and Discord collapse the same
+        syntax), and the shared overflow sink needs the canonicaliser too.
         """
-        from kiro_crew.slack import format as fmt
+        from kiro_crew.messaging import display_safety as fmt
 
         classes = re.findall(r"\[\^((?:\\.|[^\]\\])*)\]", getattr(fmt, pattern_name).pattern)
         assert len(classes) == len(required), (

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -888,7 +888,7 @@ class TestTransportAuth:
         assert TELEGRAM_CAPABILITIES.streaming is True
         assert TELEGRAM_CAPABILITIES.edit is True
         assert TELEGRAM_CAPABILITIES.max_message_chars == TELEGRAM_CHUNK_LIMIT
-        assert TELEGRAM_CAPABILITIES.max_buttons == 8
+        assert TELEGRAM_CAPABILITIES.max_buttons == 25
 
 
 class TestTransportReceive:


### PR DESCRIPTION
## Problem

`capabilities.max_buttons` promised behavior no code performed. The renderer docstring claimed choices are "capped at `capabilities.max_buttons`, degrading to a numbered text reply" — measured reality: **zero renderers read the field**. Slack hardcoded `[:10]`, discord `[:25]`, telegram shipped **uncapped** inline keyboards. Worse, overflow was **silent data loss**: slack dropped choices 11+ and discord 26+ with no signal — the `[OPTIONS:]` trailer was already stripped from the body, so the user could not even read the dropped choices. All three declarations were also wrong (slack declared 5/shipped 10; discord declared 5-per-row/shipped 25 total; telegram declared 8/enforced nothing).

## Why it matters

This is the reference enforcement seam for the capability-gated interface work: every later phase (approval ladder, `!yolo`, attachments) copies this pattern of *declaration → shared gate → per-channel contract pin*. Until one field is genuinely enforced, plugin-declared capabilities (Feishu is next) are documentation, not contracts. And telegram's uncapped keyboard is a live defect — a large choice list fails the send with an API 400.

## Fix (symptoms → root cause → change)

Root cause: `[OPTIONS:]` is not an event — it rides inside `TEXT_CHUNK` text and each renderer re-parses it from its own private buffer, so no shared code ever saw the choice list. Slack additionally has **five** producer paths (renderer footer, legacy handler, cron delivery, subagent footer, `send_message`, dashboard mirror), only one of which is driver-driven — so a pipeline-filter seam would leave four slack paths uncapped.

The seam that fits the real topology:

1. **Shared pure helpers** in `messaging/renderer.py` — `cap_choices` / `format_overflow` / `apply_options_cap`, the `max_buttons` analogue of `chunk_text`. First N choices keep the widget; overflow appends to the body as a numbered list whose numbering continues after the widget slots. Typed replies are plain messages on every channel, so overflow is answerable today — no reply-parser needed.
2. **One chokepoint call per channel**: slack `build_options_blocks` (covers all five producers; overflow is packed into redacted, size-bounded context blocks below the checkboxes (whole lines, max 3 blocks + a visible counted-truncation marker — Slack rejects >50-block messages outright, so the budget is capped; round 3)), discord + telegram at both `_extract_options` call sites.
3. **The cannot-forget mechanism** is `test_options_cap_contract.py`: it drives each widget channel's *real* render path with over-cap input and pins `widget count == declared` + overflow visible. Its `TestRatchet` asserts the set of channels declaring `max_buttons > 0` equals the set pinned there — a new widget channel fails until it adopts the seam.
4. **Semantics + declarations corrected** (`max_buttons` = TOTAL, not per-row): slack 5→10, discord 5→25 (both "declare what ships" — zero behavior change below the cap), telegram 8→25 (parity with discord; the old 8 was a mislabeled per-row number, and capping at 8 would have regressed previously-working 9-25 choice keyboards — review round 2). Only telegram's genuinely unbounded tail (the API-400 defect) changes behavior.
5. **Ledger flip**: `max_buttons` moves ASPIRATIONAL → ENFORCED with the behavior cited, per the ratchet's same-change rule; new declaration pin added to `TestCorrectedDeclarations`. All stale "no renderer reads it" docs rewritten (`messaging/renderer.py`, `messaging/transport.py`, telegram transport comment, docs table).

Out of scope, deliberately: the four `max_buttons=0` channels keep stripping the trailer — their numbered-text fallback belongs to phase 3 (approval ladder), which adds the inbound reply path the degradation deserves there.

## Tests

- `test/test_options_cap_contract.py` (new): shared-helper unit pins (byte-identity under cap, numbering continuation, zero-cap), per-channel enforcement through the real render paths, and the `TestRatchet` coverage lock. **Enforcement tests proven red pre-fix**: slack `StopIteration` (no overflow block), telegram "keyboard was uncapped", discord missing `26. Choice 26`.
- `test/test_capability_ledger.py`: `max_buttons` ENFORCED entry + `test_max_buttons_declares_totals_the_renderers_ship`.
- `test/test_options_buttons.py::test_max_ten_choices` updated: locates the actions block structurally and now also pins overflow visibility (was: overflow vanishes).

Local: 488 (options/ledger/telegram/discord/messaging suites) + 756 (slack handler/gateway + four zero-channels + link) green with `-n 0`; isort/flake8 clean; mypy clean on all four changed source files (the 3 pre-existing `hooks.py` xattr errors are on main, outside this diff).

## Manual verification

N/A — unit coverage exercises the full render paths (fake clients capture final message text + widget payloads); no UI surface changed on the dashboard side.

## Screenshots

N/A — messaging-channel wire payloads only; no dashboard UI change.

