### PR TITLE
docs: add edition authoring guide to extension seams

### DIFF
--- a/website/docs/extension-seams.md
+++ b/website/docs/extension-seams.md
@@ -116,6 +116,102 @@ silently empty data, and they appear only at runtime, only in the edition build.
 package to that list**, and the edition should declare these as peer deps. The
 dedupe is harmless in the stock single-`node_modules` build.
 
+## Authoring an edition: the build pitfalls
+
+The seams above make an edition build possible; this section is what makes a
+first one work. Each pitfall below is silent or misleading at the moment it is
+introduced, and every one was hit in practice by a real downstream edition.
+
+### Theme CSS: never rely on load order, take specificity
+
+An edition that registers a theme (`registerTheme()`) ships that theme's CSS
+block in its own file, imported from its composition root. In the current
+build that CSS lands in the entry chunk's stylesheet, which `index.html` links
+**before** the chunk carrying the core's `index.css` — but chunk order is an
+artifact of the build, not a contract. What is contractual is the cascade: the
+core's default palette block sets the theme variables on
+`:root, [data-theme="dark"], …`, and `:root` is specificity (0,1,0). An edition
+block headed `[data-theme="acme"]` is also (0,1,0), so whichever stylesheet
+loads later wins — today that is the core, and every variable its default block
+also sets silently overrides the edition's. Nothing errors: the picker shows
+the theme, the palette stays stock.
+
+The built-in themes never hit this because their blocks live in `index.css`
+itself, after the default block — same sheet, later, wins.
+
+Prescription: prefix the edition's theme selectors with `html`, which wins on
+specificity regardless of load order:
+
+```css
+/* loses: (0,1,0), and the core's :root default block loads later */
+[data-theme='acme'] { --accent: #0055aa; }
+
+/* wins: (0,1,1) beats (0,1,0) in either load order */
+html[data-theme='acme'] { --accent: #0055aa; }
+```
+
+### Bare imports: the edition dir needs its own `node_modules`
+
+The composition root lives outside the SPA root, and Node-style resolution
+walks **up from the importing file** — it never reaches
+`website/node_modules` from a sibling repo. The first bare specifier in the
+edition (`import { Sparkles } from 'lucide-react'`) fails the build:
+
+```
+[vite]: Rolldown failed to resolve import "lucide-react" from
+"<edition dir>/extensions.tsx".
+```
+
+Give the edition dir its own `node_modules`: either a real install that
+declares the shared packages as peer dependencies, or a build-script symlink to
+`website/node_modules`. Either way, read the "Edition peer-dependency rule"
+above — once two `node_modules` trees exist, every context-carrying singleton
+must stay deduplicated or hooks bind to a second React.
+
+### Typecheck the edition, or ship ReferenceErrors
+
+The core's `tsc -b` covers `website/src` only (`tsconfig.app.json` has
+`"include": ["src"]`), so the edition's sources are outside every typecheck the
+core runs. The bundler does not fill the gap: TypeScript is erased, and a free
+identifier — a typo like `registerThemee` — compiles into the bundle as an
+assumed **global**. The build succeeds, `tsc -b` stays green, and the app
+throws `ReferenceError` at module load. Because the composition root runs
+before `App` mounts, that is a blank page, not a broken widget.
+
+Give the edition a `tsconfig.json` that extends the core's and run it in the
+edition's own build or CI (`npx tsc -p <edition>/tsconfig.json`) — the core
+will never run it for you:
+
+```jsonc
+{
+  "extends": "../KiroCrew/website/tsconfig.app.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // Without vite/client, every `import.meta.env` the edition touches
+    // (directly or via a core module it imports) is a TS2339 false positive.
+    "types": ["vite/client"]
+  },
+  "include": ["."]
+}
+```
+
+`extends` keeps the `@/*` path mapping working (TypeScript resolves inherited
+`paths` relative to the config that declares them), so the edition's
+`import { registerTheme } from '@/hooks/useTheme'` typechecks against the real
+core sources. With this in place the typo above is caught at build time:
+`TS2552: Cannot find name 'registerThemee'. Did you mean 'registerTheme'?`
+
+### A default theme needs configuration, not a seam
+
+To make the edition's theme the default, do not look for a frontend seam —
+seed `dashboard.theme_color` (and `theme_mode`) in the deployment's
+`config.json`. The dashboard applies the server value from
+`GET /api/theme/boot` over any stored client choice and writes it back, so a
+fresh install lands on the edition's theme and the user keeps free choice from
+then on. One caveat: the very first paint, before that response arrives, uses
+the compiled-in default (`DEFAULT_COLOR_THEME`); a returning visitor is
+unaffected because the applied value persists in `localStorage`.
+
 ## Collision policy
 
 `apps/seamCollision.ts` is the one policy every registrar routes rejections

--- a/website/docs/theming-contract.md
+++ b/website/docs/theming-contract.md
@@ -230,6 +230,10 @@ wrapper for the same reason.
 Registration is read at module load (see `src/extensions.ts`); registering after
 the shell has rendered does not take effect until the next theme switch.
 
+Authoring a compiled (edition) theme end to end — CSS specificity against the
+core palette, module resolution, typechecking — is covered in
+[extension-seams § Authoring an edition](extension-seams.md#authoring-an-edition-the-build-pitfalls).
+
 ## Checker (advisory)
 
 ```bash


### PR DESCRIPTION
## Problem

`website/docs/extension-seams.md` documents the nine registry seams and the composition-root mechanics thoroughly, but not the build environment an edition actually lands in. A first edition build hits four pitfalls, and each one is silent or misleading at the moment it is introduced — the build succeeds (or fails pointing somewhere unhelpful) and the wrong result ships. All four were hit in practice while building a downstream edition against these seams; this PR documents them where the next edition author will look, in the same spirit as #1466 (edition-composition gaps found by auditing a real downstream edition — that one fixed core code; this one is docs-only).

## The four pitfalls (each reproduced against a neutral test edition)

**1. Theme CSS: `:root`-equal specificity silently loses.** An edition registering a theme (`registerTheme()`) naturally writes `[data-theme='acme'] { --accent: … }` — specificity (0,1,0), the same as the core's default palette block headed `:root, [data-theme="dark"], …`. The edition's CSS lands in the entry chunk, linked **before** the chunk carrying the core's `index.css`, so the core's default block wins at equal specificity and every variable it also sets overrides the edition's. Nothing errors: the picker shows the theme, the palette stays stock. Built-in themes never hit this (their blocks live in `index.css` itself, after the default block). Prescription: `html[data-theme='acme']` — (0,1,1) wins in either load order.

*Repro:* edition CSS with `[data-theme='acme']{--accent:#0055aa}` → build → the dist links `main-*.css` (edition rule) before `src-*.css` (core `:root,…{--accent:#00d492…}`).

**2. Bare imports need the edition's own `node_modules`.** Node-style resolution walks up from the importing file and never reaches `website/node_modules` from a sibling dir. First bare specifier fails the build:

```
[vite]: Rolldown failed to resolve import "lucide-react" from "<edition dir>/extensions.tsx".
```

Prescription: the edition dir gets its own `node_modules` (peer-dep install or a build-script symlink), tied back to the existing "Edition peer-dependency rule" section — two `node_modules` trees is exactly when `resolve.dedupe` starts to matter.

**3. Typecheck the edition, or ship ReferenceErrors.** `tsconfig.app.json` has `"include": ["src"]`, so edition sources are outside every typecheck the core runs, and the bundler compiles a free identifier (a typo like `registerThemee`) into the bundle as an assumed global. Build exit 0, `tsc -b` exit 0, `ReferenceError` at module load — and since the composition root runs before `App` mounts, that is a blank page. Prescription: an edition `tsconfig.json` extending the core's, with `"types": ["vite/client"]` (without it, every `import.meta.env` reached through core imports is a TS2339 false positive). Verified: the typo is then caught as `TS2552: Cannot find name 'registerThemee'. Did you mean 'registerTheme'?`

**4. A default theme is configuration, not a missing seam.** The natural instinct is to look for a frontend seam; the answer is seeding `dashboard.theme_color` in deployment config, which `GET /api/theme/boot` already applies over the stored client choice. Documented with the one caveat (first paint before the boot response uses the compiled-in default).

## Changes

- `website/docs/extension-seams.md`: new section **"Authoring an edition: the build pitfalls"**, placed right after "Edition peer-dependency rule" (+96 lines)
- `website/docs/theming-contract.md`: one cross-reference line at the end of the compiled-seam (chat loader) section (+4 lines)

Docs-only; no code changes.

## Verification

- Every claim reproduced against a scratch edition (an `extensions.tsx` + theme CSS in a temp dir, built with `KIROCREW_EDITION_DIR`/`KIROCREW_ALLOW_EDITION=1`): the dist stylesheet order and the winning core block for pitfall 1, the exact resolver error for pitfall 2, the green build + green `tsc -b` + typo shipped verbatim in the bundle for pitfall 3, and the prescriptions confirmed to fix each (specificity prefix, symlinked `node_modules`, the tsconfig catching TS2552).
- `scripts/docs-lint.sh` ✓, brand-name gate ✓.
