### PR TITLE
fix(test): kiroignore walk tests broke when cdk.out joined HARD_SKIP_DIRS

### DIFF
--- a/test/test_knowledge_kiroignore.py
+++ b/test/test_knowledge_kiroignore.py
@@ -219,9 +219,15 @@ class TestWalkHonoursKiroIgnore:
         (root / "docs").mkdir(parents=True)
         (root / "docs" / "design.md").write_text("# Design")
         (root / "README.md").write_text("# Readme")
-        (root / "cdk.out" / "asset.abc123").mkdir(parents=True)
-        (root / "cdk.out" / "manifest.json").write_text("{}")
-        (root / "cdk.out" / "asset.abc123" / "bundle.md").write_text("generated")
+        # DELIBERATELY not ``cdk.out``: that directory joined HARD_SKIP_DIRS
+        # (never walked, regardless of .kiroignore) in the same-day change
+        # that skips CDK output by default — a canary inside it is invisible
+        # even with no rule file, which inverts what these tests assert.
+        # ``synth.out`` is generated-output-shaped but NOT default-skipped,
+        # so discovery vs .kiroignore-driven exclusion stays observable.
+        (root / "synth.out" / "asset.abc123").mkdir(parents=True)
+        (root / "synth.out" / "manifest.json").write_text("{}")
+        (root / "synth.out" / "asset.abc123" / "bundle.md").write_text("generated")
         (root / "coverage").mkdir()
         (root / "coverage" / "report.md").write_text("generated")
         return root
@@ -236,7 +242,7 @@ class TestWalkHonoursKiroIgnore:
         assert any("report.md" in p for p in paths)
 
     def test_matching_paths_are_excluded(self, project):
-        (project / ".kiroignore").write_text("cdk.out/\n/coverage/\n")
+        (project / ".kiroignore").write_text("synth.out/\n/coverage/\n")
         paths = self._walk_paths(project)
         assert any("design.md" in p for p in paths)
         assert any("README.md" in p for p in paths)
@@ -246,7 +252,7 @@ class TestWalkHonoursKiroIgnore:
 
     def test_ignored_directories_are_pruned_from_the_walk(self, project, monkeypatch):
         """The tree must never be DESCENDED, not merely filtered after the fact."""
-        (project / ".kiroignore").write_text("cdk.out/\n")
+        (project / ".kiroignore").write_text("synth.out/\n")
         visited: list[str] = []
         real_walk = os.walk
 
@@ -259,7 +265,7 @@ class TestWalkHonoursKiroIgnore:
 
         monkeypatch.setattr(fw_mod.os, "walk", spy)
         self._walk_paths(project)
-        assert not any("cdk.out" in v for v in visited)
+        assert not any("synth.out" in v for v in visited)
         assert any(v.endswith("docs") for v in visited)
 
     def test_the_rule_file_itself_is_not_indexed(self, project):
@@ -276,7 +282,7 @@ class TestWalkHonoursKiroIgnore:
     def test_malformed_file_degrades_without_losing_valid_rules(self, project):
         """A junk line costs that line only; the scan never raises."""
         path = project / ".kiroignore"
-        path.write_bytes(b"cdk.out/\n\xff\xfe not utf-8 \xff\n[unclosed\n")
+        path.write_bytes(b"synth.out/\n\xff\xfe not utf-8 \xff\n[unclosed\n")
         paths = self._walk_paths(project)
         assert not any("bundle.md" in p for p in paths)
         # Everything the valid rule did not name is still discovered.
@@ -284,7 +290,7 @@ class TestWalkHonoursKiroIgnore:
         assert any("report.md" in p for p in paths)
 
     def test_unreadable_rule_file_never_fails_the_scan(self, project, monkeypatch):
-        (project / ".kiroignore").write_text("cdk.out/\n")
+        (project / ".kiroignore").write_text("synth.out/\n")
 
         def boom(*a, **kw):
             raise OSError("nope")


### PR DESCRIPTION
## Problem

`test_knowledge_kiroignore.py::TestWalkHonoursKiroIgnore::test_no_kiroignore_leaves_discovery_unchanged` and `::test_unreadable_rule_file_never_fails_the_scan` fail deterministically on current `main` (reproduced on Linux 3.12 locally and on CI's ubuntu-3.10 and Windows shard 2). Every PR branch based on current main inherits the failures, and a failed CI blocks the fork AI-review pipeline from re-stamping — so this breaks readiness for unrelated PRs (observed on #2121).

## Why it matters

Main's own CI runs keep getting superseded by rapid merges, so the breakage is mostly visible on downstream PRs — each of which pays a full red CI roll and a review-lane deadlock for an upstream problem. Until fixed, no PR based on current main can reach `readiness: passed`.

## Fix (symptoms → root cause → change)

Two same-morning merges conflict **semantically** while each passed CI against a main that lacked the other:

- #2100 (`f3861e6`) added the kiroignore walk tests, using `cdk.out/asset.abc123/bundle.md` as the canary that must be **discoverable when no `.kiroignore` exists**.
- #2098 (`8b33899`) added `cdk.out` to `HARD_SKIP_DIRS` — never walked, regardless of any rule file.

So the canary is invisible even with no `.kiroignore`, inverting exactly what the two failing tests assert. The fix keeps both features' semantics and changes only the **fixture**: the walk tests now use `synth.out/` — generated-output-shaped but not in `HARD_SKIP_DIRS` — so default discovery vs `.kiroignore`-driven exclusion stays observable. The matcher-level tests keep their literal `cdk.out` rule strings (rule-text semantics are unaffected by `HARD_SKIP_DIRS`), and a fixture comment documents why `cdk.out` must not be used there.

## Tests

The changed file *is* tests: 32/32 pass in `test_knowledge_kiroignore.py` (was 30 pass / 2 fail), and the full knowledge/folder-watcher sweep is green (645 passed). The two previously-failing tests now genuinely exercise their stated contracts.

## Manual verification

N/A — unit coverage sufficient: the failure and fix are both fully captured by the test run itself.

## Screenshots

N/A — no user-visible UI change.
