### PR TITLE
feat(meetings): read the user's calendar over CalDAV, Google and Microsoft 365

### DIFF
--- a/src/kiro_crew/apps/builtins/meetings/backend/constants.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/constants.py
@@ -48,6 +48,39 @@ MAX_CALENDAR_EVENTS = 500
 MAX_MEETING_ID_LEN = 128
 MAX_TITLE_LEN = 300
 MAX_ICS_BYTES = 4 * 1024 * 1024  # refuse absurd .ics payloads
+
+#: Ceiling on one credential value from a settings write. Generous next to a
+#: password or a client id, and small enough that the credential file stays a file
+#: this app can read back in one gulp.
+MAX_CREDENTIAL_VALUE_CHARS = 4096
+
+#: Ceiling on a CalDAV ``REPORT`` Multi-Status response. Larger than
+#: :data:`MAX_ICS_BYTES` because the response wraps one iCalendar document per
+#: event in XML, so the same week of meetings arrives several times bigger.
+MAX_CALDAV_BYTES = 8 * 1024 * 1024
+
+#: A CalDAV ``REPORT`` makes the server run a time-range query across a
+#: collection, which is slower than serving a static ``.ics``.
+CALDAV_TIMEOUT_SECS = 30
+
+#: How long a started OAuth authorization stays redeemable. Long enough for a
+#: human to read a consent screen, short enough that an abandoned flow's verifier
+#: is not sitting in memory for the rest of the session.
+OAUTH_FLOW_TTL_SECS = 10 * 60
+
+#: Refresh an access token this long before it actually expires. A token that
+#: passes the freshness check and then dies in flight surfaces as a 401 halfway
+#: through a sync, which is worse than one extra refresh.
+OAUTH_REFRESH_SKEW_SECS = 120
+
+#: Timeout for a token-endpoint round trip. Shorter than a calendar fetch: this
+#: is one small POST to a provider's auth host, and a hang here blocks a user
+#: sitting in front of a "connecting…" UI.
+OAUTH_TOKEN_TIMEOUT_SECS = 20
+
+#: Ceiling on a token-endpoint response. A token response is a few hundred bytes;
+#: this is orders of magnitude above that and still refuses a hostile stream.
+MAX_OAUTH_RESPONSE_BYTES = 256 * 1024
 ICS_FETCH_TIMEOUT_SECS = 20
 #: Redirects are followed MANUALLY so each hop is SSRF-validated, so the chain
 #: needs its own bound (aiohttp's own `max_redirects` no longer applies).
@@ -135,6 +168,16 @@ CONFIG_FILE = "config.json"
 DICTIONARY_FILE = "dictionary.toml"
 CALENDAR_CACHE_FILE = "calendar-cache.json"
 SESSION_META_FILE = "session.json"
+
+#: Calendar credentials (CalDAV password, Google/M365 OAuth tokens).
+#:
+#: **Deliberately NOT in this list's directory.** Every other name here is
+#: relative to ``app_data_dir("meetings")``; this one is resolved by
+#: :func:`..credentials.credentials_file` under the crew data home instead,
+#: because the app data tree is the one ``store.contain`` opens to agent-driven
+#: paths. Registered in ``security._CREW_SECRET_LEAVES`` so agent file tools
+#: cannot read or write it. See ``backend/credentials.py`` for the full argument.
+CALENDAR_CREDENTIALS_FILE = "calendar-credentials.json"
 TASKS_FILE = "tasks.json"
 TRANSCRIPT_FILE = "transcript.jsonl"
 TRANSLATIONS_FILE = "translations.json"
@@ -206,8 +249,75 @@ DEFAULT_TASK_PROVIDER = TASK_PROVIDER_LOCAL
 
 # Calendar provider ids (see backend/providers/calendar.py).
 CALENDAR_PROVIDER_ICS = "ics"
+CALENDAR_PROVIDER_CALDAV = "caldav"
+CALENDAR_PROVIDER_GOOGLE = "google"
 CALENDAR_PROVIDER_NONE = "none"
 DEFAULT_CALENDAR_PROVIDER = CALENDAR_PROVIDER_NONE
+
+# ── Google Calendar ──
+#
+# Endpoints are constants rather than config: they are protocol, not preference,
+# and a settable authorization URL is a phishing surface (a rewritten authorize
+# host collects the user's Google password). The only per-installation values are
+# the client id and secret, which live in the credential store.
+GOOGLE_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+GOOGLE_EVENTS_URL = "https://www.googleapis.com/calendar/v3/calendars/primary/events"
+
+#: Read-only, because this app only ever displays meetings. The narrower scope is
+#: also the one Google's own verification treats as least sensitive.
+GOOGLE_CALENDAR_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
+
+#: ``access_type=offline`` is what makes Google issue a refresh token at all, and
+#: ``prompt=consent`` is what makes it issue one AGAIN on a repeat authorization —
+#: without it a reconnect returns only an access token and the calendar stops
+#: working an hour later.
+GOOGLE_AUTHORIZE_EXTRA = {"access_type": "offline", "prompt": "consent"}
+
+#: Ceiling on one page of the events list.
+MAX_GOOGLE_RESPONSE_BYTES = 4 * 1024 * 1024
+
+#: Events requested per page. Google caps `maxResults` at 2500; this keeps a
+#: single page well inside the byte ceiling above.
+GOOGLE_PAGE_SIZE = 250
+
+#: Pages followed before giving up, so a provider that keeps handing back a
+#: ``nextPageToken`` cannot loop forever.
+GOOGLE_MAX_PAGES = 10
+
+# ── Microsoft 365 (Graph) ──
+#
+# Constants for the same reason as Google's: a settable authorize host is a
+# phishing surface for the user's work account.
+#
+# ``/common/`` is the multi-tenant endpoint, so a personal account and a work
+# account both work without the user having to find their tenant id.
+MICROSOFT_AUTHORIZE_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+MICROSOFT_TOKEN_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+
+#: ``calendarView`` rather than ``/events``: it expands a recurring series into
+#: occurrences server-side, which is what lets this provider skip an RRULE engine.
+MICROSOFT_EVENTS_URL = "https://graph.microsoft.com/v1.0/me/calendarView"
+
+#: ``offline_access`` is not optional decoration — it is what makes Microsoft
+#: issue a refresh token at all, the same role ``access_type=offline`` plays for
+#: Google. Without it the calendar stops working when the first access token
+#: expires. ``Calendars.Read`` is read-only because the app only displays meetings.
+MICROSOFT_CALENDAR_SCOPES = (
+    "https://graph.microsoft.com/Calendars.Read",
+    "offline_access",
+)
+
+#: Graph returns ``dateTime`` with NO offset and names the zone separately, so the
+#: reading depends entirely on this header. Asking for UTC makes the naive value
+#: unambiguous instead of something to guess at.
+MICROSOFT_TIMEZONE_HEADER = 'outlook.timezone="UTC"'
+
+MAX_MICROSOFT_RESPONSE_BYTES = 4 * 1024 * 1024
+MICROSOFT_PAGE_SIZE = 250
+MICROSOFT_MAX_PAGES = 10
+
+CALENDAR_PROVIDER_MICROSOFT = "microsoft"
 
 # STT provider ids. KiroCrew's own streaming endpoint is the only one.
 STT_PROVIDER_KIROCREW = "kirocrew"

--- a/src/kiro_crew/apps/builtins/meetings/backend/credentials.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/credentials.py
@@ -1,0 +1,307 @@
+"""Credential store for the calendar providers that need one.
+
+Three of the shipped calendar providers authenticate: CalDAV with a username and
+password, Google and Microsoft 365 with OAuth tokens. None of those values can
+live in ``config.json`` — that file is the app's ordinary, agent-readable
+configuration, and a live password or refresh token in it would be readable by
+any agent with file tools. So they live here instead, behind
+:func:`kiro_crew.security.is_sensitive_path`'s floor.
+
+Three properties are load-bearing, and each is a decision rather than a default:
+
+**The file is NOT under ``app_data_dir("meetings")``.** That tree is the one
+:func:`store.contain` deliberately opens up: it is where meeting directories go,
+where agents write their own output files, and what every containment check is
+bounded against. Keeping a live credential entirely outside it removes a whole
+class of "could an agent be handed this path" argument rather than answering it.
+The Notes builtin made the same call for the same reason — its PAT sits at
+``<crew-home>/workspace/md-notebook/pat`` rather than inside a vault tree the
+user can relocate.
+
+**The path is NOT threaded through the ``root`` parameter** that every other
+function in :mod:`.store` takes for test isolation. That parameter is reachable
+from request handling, and a secret store whose location can be steered by a
+request is not a secret store. Tests override the path through
+:func:`set_credentials_home`, which is module state a request cannot reach.
+
+**Reads and writes bypass the shared file gate.** ``hooks.safe_read_file_bytes``
+would refuse this path, because registering the leaf in
+``security._CREW_SECRET_LEAVES`` is precisely what makes it refuse. This module
+therefore opens the file directly — the same exemption every other credential
+store in the product relies on, and the reason each one is registered as a leaf
+individually rather than the whole directory being waved through.
+
+Values are never returned to the browser. The settings route publishes only the
+booleans from :func:`credential_status`, so a stored password or refresh token
+has no read path back out through the API.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any
+
+from kiro_crew.apps.builtins.meetings.backend import constants as k
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.paths import config_dir
+from kiro_crew.platform_compat import restrict_to_owner
+
+logger = logging.getLogger("kirocrew.app.meetings")
+
+#: Test hook. ``None`` in production, so the path always resolves under the live
+#: crew data home. Set by :func:`set_credentials_home`.
+_HOME: Path | None = None
+
+
+def set_credentials_home(home: Path | None) -> None:
+    """Point the credential store at *home* (tests), or restore the default.
+
+    Exists so a test never touches the developer's real credential file. It is
+    module state on purpose — see this module's docstring for why the path is not
+    a parameter.
+    """
+    global _HOME
+    _HOME = home
+
+
+def _crew_data_home() -> Path:
+    """The crew data home, resolved lazily.
+
+    ``config_dir`` is imported at module scope but CALLED here: resolving the data
+    home at import time is forbidden (it would freeze ``KIROCREW_HOME`` at the
+    wrong moment), and calling it per use honors the override every time. The
+    fallback mirrors the Notes builtin's, so a broken resolver degrades to the
+    documented default rather than raising out of a settings read.
+    """
+    try:
+        return config_dir()
+    except Exception:
+        override = os.environ.get("KIROCREW_HOME")
+        return Path(override) if override else Path.home() / ".kiro" / "crew"
+
+
+def credentials_home() -> Path:
+    """Directory holding the calendar credential file."""
+    if _HOME is not None:
+        return _HOME
+    return _crew_data_home() / "workspace" / k.APP_NAME
+
+
+def credentials_file() -> Path:
+    """Absolute path of the calendar credential store."""
+    return credentials_home() / k.CALENDAR_CREDENTIALS_FILE
+
+
+#: Serialises every read-modify-write of the store. Module-level because the
+#: file is the shared resource, and `asyncio.to_thread` hands each call a
+#: different worker thread — an asyncio lock would not bind them.
+_STORE_LOCK = threading.Lock()
+
+
+class _StoreUnreadable(RuntimeError):
+    """The store exists but could not be read or parsed.
+
+    Deliberately distinct from "no file yet". A reader can treat both as empty; a
+    read-modify-write cannot, because rebuilding the file from a partial view
+    deletes whatever it could not see.
+    """
+
+
+def _load_sync() -> dict[str, dict[str, str]]:
+    """Load the whole store. Missing reads as empty; unreadable RAISES.
+
+    Callers choose how to degrade: :func:`_read_sync` swallows for display,
+    :func:`write_for` / :func:`clear_for` let it propagate so a merge never runs
+    against a view it knows is incomplete.
+    """
+    path = credentials_file()
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw = json.load(fh)
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError) as exc:
+        logger.warning("meetings: calendar credential store is unreadable", exc_info=True)
+        # Distinguishable from "no file yet". Reading for DISPLAY may treat both as
+        # empty — that is the trade the docstring describes — but a
+        # read-modify-write must not: an unreadable store read as ``{}`` makes the
+        # merge below rebuild the file from one provider and the atomic replace
+        # then deletes every other provider's credentials for good. The write path
+        # re-raises this instead (see :func:`_read_sync_for_update`).
+        raise _StoreUnreadable(str(path)) from exc
+    if not isinstance(raw, dict):
+        # Parsed, but not a store. The same contract as a parse failure: a
+        # read-modify-write that treated this as empty would rebuild the file
+        # from nothing and destroy whatever a human could still recover from
+        # the malformed content. Display reads degrade via :func:`_read_sync`.
+        logger.warning("meetings: calendar credential store has an invalid root")
+        raise _StoreUnreadable(str(path))
+    # Re-assert owner-only access on load. A file left with a permissive ACL —
+    # created before this lockdown, or by another principal on Windows — would
+    # otherwise stay readable by other OS accounts. Warn rather than fail: losing
+    # the user's calendar connection is worse than a warning.
+    try:
+        restrict_to_owner(path)
+    except OSError:
+        logger.warning(
+            "meetings: could not restrict the calendar credential file to owner-only",
+            exc_info=True,
+        )
+    out: dict[str, dict[str, str]] = {}
+    for provider_id, values in raw.items():
+        if not isinstance(provider_id, str) or not isinstance(values, dict):
+            # A skipped entry here is not "tolerated", it is INVISIBLE — and the
+            # next write would persist the view without it, deleting the entry
+            # for good. Schema-invalid entries poison the whole read, exactly
+            # like an unparseable file (:class:`_StoreUnreadable`): this module
+            # only ever writes ``dict[str, dict[str, str]]``, so anything else
+            # is corruption or an external edit, and neither may be silently
+            # rewritten away.
+            logger.warning("meetings: calendar credential store has an invalid entry")
+            raise _StoreUnreadable(str(path))
+        entry: dict[str, str] = {}
+        for key, value in values.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                logger.warning("meetings: calendar credential store has an invalid value")
+                raise _StoreUnreadable(str(path))
+            entry[key] = value
+        out[provider_id] = entry
+    return out
+
+
+def _read_sync() -> dict[str, dict[str, str]]:
+    """Load the store for READING. A missing or unreadable file reads as empty.
+
+    Corruption degrades to empty rather than raising: the realistic cause is a
+    half-written file from a crash, and the recoverable answer is "you are not
+    connected, connect again" instead of a settings page that cannot load. The
+    file is rewritten wholesale on the next write, so an unparseable one is not
+    sticky.
+
+    This is the DISPLAY path only. The write path calls :func:`_load_sync`
+    directly, because the same degradation there turns one unreadable file into
+    the permanent loss of every other provider's credentials.
+    """
+    try:
+        return _load_sync()
+    except _StoreUnreadable:
+        return {}
+
+
+def _write_sync(store: dict[str, dict[str, str]]) -> None:
+    """Persist the whole store, owner-only and atomically.
+
+    Routed through :func:`kiro_crew.atomic_write.atomic_write` — the repo's one
+    audited implementation of temp + fsync + replace — with
+    ``restrict_to_owner=True`` and the default fail-closed policy. Two properties
+    of the shared helper matter here and are why a hand-rolled copy was wrong:
+
+    * The temp is restricted to the owner BEFORE any content reaches it, so the
+      tokens never exist in a file readable under an inherited Windows ACL.
+    * A lockdown failure REFUSES the write (``restrict_on_error="raise"``): a
+      credential this module cannot protect is not published at all. That is the
+      opposite trade from the READ path's warn-and-continue, deliberately — a
+      refused write leaves the previous file intact and the connection working,
+      while a published world-readable token is unrecoverable.
+    """
+    target = credentials_file()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write(
+        target,
+        json.dumps(store, indent=2, sort_keys=True),
+        fsync=True,
+        restrict_to_owner=True,
+    )
+
+
+async def read_all() -> dict[str, dict[str, str]]:
+    """Every provider's stored credentials. Off-loop — this touches the disk."""
+    return await asyncio.to_thread(_read_sync)
+
+
+async def read_for(provider_id: str) -> dict[str, str]:
+    """Stored credentials for one provider, or an empty dict.
+
+    Providers call this from ``fetch()`` rather than from their constructor:
+    :func:`providers.calendar.available_calendar_providers` builds every
+    registered factory with an empty source just to read its label, so a
+    constructor that touched this file would put a disk read behind rendering the
+    settings picker.
+    """
+    store = await read_all()
+    return dict(store.get((provider_id or "").strip().lower(), {}))
+
+
+async def write_for(provider_id: str, values: dict[str, str]) -> None:
+    """Merge *values* into one provider's credentials.
+
+    Merge rather than replace so a caller can update one field — the OAuth token
+    refresh rewrites the access token and leaves the refresh token alone. An
+    empty string CLEARS its key, which is how the settings route lets a user
+    remove one field without clearing the whole connection.
+    """
+    key = (provider_id or "").strip().lower()
+    if not key:
+        raise ValueError("provider_id must be a non-empty string")
+
+    def _apply() -> None:
+        # One lock for the whole read-modify-write. Both halves run in a worker
+        # thread, so a settings PUT and an OAuth token refresh really do
+        # interleave: each read the same snapshot, each merged its own field, and
+        # the later atomic replace silently discarded the earlier one — losing a
+        # freshly minted refresh token, which cannot be re-derived. The unreadable
+        # store is allowed to propagate for the reason on :class:`_StoreUnreadable`.
+        with _STORE_LOCK:
+            store = _load_sync()
+            current = dict(store.get(key, {}))
+            for field, value in values.items():
+                text = "" if value is None else str(value)
+                if text == "":
+                    current.pop(field, None)
+                else:
+                    current[field] = text
+            if current:
+                store[key] = current
+            else:
+                store.pop(key, None)
+            _write_sync(store)
+
+    await asyncio.to_thread(_apply)
+
+
+async def clear_for(provider_id: str) -> None:
+    """Forget one provider's credentials entirely (the disconnect action)."""
+    key = (provider_id or "").strip().lower()
+
+    def _apply() -> None:
+        # Same transaction boundary as `write_for`: a disconnect that raced a
+        # token refresh would otherwise resurrect the provider it just removed.
+        with _STORE_LOCK:
+            store = _load_sync()
+            if store.pop(key, None) is not None:
+                _write_sync(store)
+
+    await asyncio.to_thread(_apply)
+
+
+async def credential_status() -> dict[str, dict[str, Any]]:
+    """Which providers have credentials, and which fields are present.
+
+    This is the ONLY shape that reaches the browser: field NAMES and booleans,
+    never a value. A settings page needs to render "connected" and "which of
+    these did you fill in", and neither question needs the secret.
+    """
+    store = await read_all()
+    return {
+        provider_id: {
+            "configured": True,
+            "fields": sorted(values.keys()),
+        }
+        for provider_id, values in store.items()
+        if values
+    }

--- a/src/kiro_crew/apps/builtins/meetings/backend/oauth.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/oauth.py
@@ -1,0 +1,331 @@
+"""OAuth 2.0 authorization-code + PKCE, for the Google and Microsoft 365 calendars.
+
+Nothing in the product implemented OAuth before this, so this is a client written
+from scratch rather than a wiring job — the only prior credential handling is the
+Notes builtin's plain token on disk, which is a store and not a flow.
+
+The shape is RFC 6749's authorization-code grant with RFC 7636 PKCE, in the
+RFC 8252 "native app" arrangement:
+
+1. :func:`begin` mints a code verifier and an opaque ``state``, remembers them in
+   memory, and returns the provider's consent URL.
+2. The user consents in a browser. The provider redirects to a **loopback**
+   redirect URI served by the dashboard itself
+   (``/api/apps/meetings/calendar/oauth/callback``), so no public callback host
+   is involved and the code never leaves the machine.
+3. :func:`complete` checks ``state``, exchanges the code plus the verifier for
+   tokens, and writes them to the credential store.
+4. :func:`access_token` hands out a live access token, refreshing it when it has
+   expired.
+
+Why PKCE is mandatory here rather than optional: a desktop client cannot keep a
+client secret, so the authorization code is the only thing standing between an
+attacker and the user's calendar. PKCE binds the code to a verifier that never
+left this process, so a code intercepted at the redirect — another local process
+racing the loopback listener is the realistic case — cannot be redeemed.
+
+Two things this module deliberately does NOT do:
+
+* It does not open a browser. The caller decides how the URL reaches the user,
+  which keeps this module testable and leaves the "headless host" case to a
+  layer that can see the UI.
+* It does not persist the pending state. A verifier is useful for seconds and
+  writing it down would put a second live secret on disk to protect; an
+  interrupted flow is restarted instead.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+import time
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlencode
+
+from kiro_crew.apps.builtins.meetings.backend import constants as k
+from kiro_crew.apps.builtins.meetings.backend import credentials
+from kiro_crew.apps.builtins.meetings.backend.providers.calendar import (
+    CalendarError,
+    fetch_vetted,
+)
+
+
+@dataclass(frozen=True)
+class OAuthClient:
+    """Everything provider-specific about one OAuth deployment.
+
+    ``client_secret`` is optional because a native client is a PUBLIC client: for
+    Google's "Desktop app" type the secret is shipped to the user and is not a
+    secret in any meaningful sense, and for Microsoft's public-client
+    registration there is none at all. It is sent when present because some
+    registrations still require it, and PKCE — not the secret — is what actually
+    protects the exchange.
+    """
+
+    provider_id: str
+    authorize_url: str
+    token_url: str
+    scopes: tuple[str, ...]
+    #: Extra parameters the provider needs on the authorization request.
+    #: Google needs ``access_type=offline`` + ``prompt=consent`` or it returns no
+    #: refresh token on a repeat authorization, which is the difference between a
+    #: calendar that keeps working and one that stops in an hour.
+    extra_authorize_params: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class _Pending:
+    """A flow in progress. Held in memory only — see the module docstring."""
+
+    state: str
+    verifier: str
+    redirect_uri: str
+    created_at: float
+
+
+#: At most one pending flow per provider. Starting a second authorization
+#: replaces the first, which is what a user retrying after a mistake expects.
+_pending: dict[str, _Pending] = {}
+
+
+def _now() -> float:
+    return time.monotonic()
+
+
+def new_verifier() -> str:
+    """A PKCE code verifier: 43-128 unreserved characters (RFC 7636 §4.1).
+
+    ``token_urlsafe(64)`` yields ~86 characters from a CSPRNG, comfortably inside
+    the range and well past the 256 bits of entropy the RFC asks for.
+    """
+    return secrets.token_urlsafe(64)
+
+
+def challenge_for(verifier: str) -> str:
+    """The S256 code challenge for *verifier*.
+
+    S256 only. RFC 7636 also allows ``plain``, which offers no protection at all
+    against an intercepted authorization request — the verifier IS the challenge
+    there — so it is not implemented rather than being offered and discouraged.
+    """
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+async def begin(client: OAuthClient, *, redirect_uri: str) -> str:
+    """Start a flow and return the URL the user must open to consent.
+
+    The ``state`` is a fresh CSPRNG value, not derived from anything: it is the
+    only thing tying the callback the dashboard receives back to a flow this
+    process actually started, so a forged callback — a link a user is tricked
+    into opening — has nothing to present.
+
+    ``async`` because reading the registered client id touches the disk, and this
+    runs on the gateway's single event loop (AUTOSDE
+    ``no-blocking-call-on-event-loop``).
+    """
+    client_id = await _client_id_for(client.provider_id)
+    if not client_id:
+        raise CalendarError(
+            "No OAuth client id is configured for this calendar. Add one in "
+            "Settings -> Calendar."
+        )
+    verifier = new_verifier()
+    state = secrets.token_urlsafe(32)
+    _pending[client.provider_id] = _Pending(
+        state=state,
+        verifier=verifier,
+        redirect_uri=redirect_uri,
+        created_at=_now(),
+    )
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": " ".join(client.scopes),
+        "state": state,
+        "code_challenge": challenge_for(verifier),
+        "code_challenge_method": "S256",
+        **client.extra_authorize_params,
+    }
+    return f"{client.authorize_url}?{urlencode(params)}"
+
+
+async def _client_id_for(provider_id: str) -> str:
+    """The registered client id, from the credential store.
+
+    A client id is not a secret, but it lives beside the tokens because it is
+    per-installation configuration the user pastes in once and because keeping
+    the pair together means one place can answer "is this provider set up".
+    """
+    stored = await credentials.read_for(provider_id)
+    return stored.get("client_id", "")
+
+
+def provider_for_state(state: str) -> str | None:
+    """Which pending flow *state* belongs to, or ``None``.
+
+    The callback URL cannot carry the provider. It is registered with each
+    provider verbatim and :func:`routes.calendar._redirect_uri` builds one shared
+    path, so the redirect arrives with only ``code``/``state`` (and ``error`` on a
+    denial) — a handler that read the provider from the query string saw an empty
+    value on every real redirect and rejected the flow as an unknown provider.
+
+    Deriving it from ``state`` is also the stronger answer than adding a query
+    parameter: ``state`` is the CSPRNG value only this process could have minted,
+    so it identifies the flow rather than trusting something the caller supplies.
+    :func:`complete` still verifies it against the pending entry, so this lookup
+    grants nothing on its own.
+
+    Compared with ``compare_digest`` and without an early return, so neither the
+    value nor which providers have a flow open leaks through timing.
+    """
+    token = state or ""
+    if not token:
+        return None
+    found: str | None = None
+    for provider_id, pending in _pending.items():
+        if secrets.compare_digest(pending.state, token):
+            found = provider_id
+    return found
+
+
+def forget_pending(provider_id: str) -> None:
+    """Drop any flow in progress for *provider_id*."""
+    _pending.pop(provider_id, None)
+
+
+async def complete(client: OAuthClient, *, code: str, state: str) -> None:
+    """Finish a flow: verify ``state``, exchange *code*, store the tokens.
+
+    The pending flow is consumed BEFORE the exchange, whatever the outcome. A
+    verifier that survived a failed attempt could be replayed, and leaving one
+    behind on success would let a captured code be redeemed twice.
+    """
+    pending = _pending.pop(client.provider_id, None)
+    if pending is None:
+        raise CalendarError("no calendar authorization is in progress; start again")
+    if _now() - pending.created_at > k.OAUTH_FLOW_TTL_SECS:
+        raise CalendarError("the calendar authorization expired; start again")
+    # Constant time, because a comparison that returns early leaks a prefix and
+    # `state` is the anti-forgery value.
+    if not secrets.compare_digest(pending.state, state or ""):
+        raise CalendarError("the calendar authorization did not match; start again")
+    if not code:
+        raise CalendarError("the calendar authorization returned no code")
+
+    payload = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": pending.redirect_uri,
+        "client_id": await _client_id_for(client.provider_id),
+        "code_verifier": pending.verifier,
+    }
+    tokens = await _post_token(client, payload)
+    await _store_tokens(client.provider_id, tokens)
+
+
+async def access_token(client: OAuthClient) -> str:
+    """A usable access token, refreshed if the stored one has expired.
+
+    Refreshes slightly EARLY (:data:`k.OAUTH_REFRESH_SKEW_SECS`). A token that
+    passes the check and then expires in flight surfaces as a 401 halfway through
+    a sync, which is a worse failure than one extra refresh.
+    """
+    stored = await credentials.read_for(client.provider_id)
+    refresh = stored.get("refresh_token", "")
+    if not refresh:
+        raise CalendarError("This calendar is not connected. Connect it in Settings -> Calendar.")
+    token = stored.get("access_token", "")
+    expires_at = _as_float(stored.get("expires_at", "0"))
+    if token and expires_at - time.time() > k.OAUTH_REFRESH_SKEW_SECS:
+        return token
+
+    payload = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh,
+        "client_id": await _client_id_for(client.provider_id),
+    }
+    tokens = await _post_token(client, payload)
+    await _store_tokens(client.provider_id, tokens)
+    fresh = (await credentials.read_for(client.provider_id)).get("access_token", "")
+    if not fresh:
+        raise CalendarError("the calendar provider returned no access token")
+    return fresh
+
+
+def _as_float(value: object) -> float:
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+async def _post_token(client: OAuthClient, payload: dict[str, str]) -> dict[str, Any]:
+    """POST to the token endpoint through the shared, gated fetch.
+
+    Routed through :func:`fetch_vetted` rather than a bare aiohttp call so the
+    token endpoint gets the same treatment as a calendar URL: https only, DNS
+    resolved once and pinned, redirects re-validated per hop, and a size cap. A
+    token endpoint is a well-known host, but "well-known" is a property of the
+    configuration, and the configuration is editable.
+
+    The secret, when the registration has one, goes in the request BODY rather
+    than a Basic header. Both are allowed by RFC 6749 §2.3.1; the body form keeps
+    it out of ``auth_headers`` semantics that do not apply here, and Google and
+    Microsoft both accept it.
+    """
+    stored = await credentials.read_for(client.provider_id)
+    secret = stored.get("client_secret", "")
+    body = dict(payload)
+    if secret:
+        body["client_secret"] = secret
+    raw = await fetch_vetted(
+        client.token_url,
+        method="POST",
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        },
+        body=urlencode(body).encode("utf-8"),
+        timeout_secs=k.OAUTH_TOKEN_TIMEOUT_SECS,
+        max_bytes=k.MAX_OAUTH_RESPONSE_BYTES,
+    )
+    try:
+        parsed = json.loads(raw.decode("utf-8", errors="replace"))
+    except ValueError as exc:
+        raise CalendarError("the calendar provider's token response was not JSON") from exc
+    if not isinstance(parsed, dict):
+        raise CalendarError("the calendar provider's token response was not an object")
+    if parsed.get("error"):
+        # `error_description` is the provider's own prose and is safe to show; the
+        # request body it describes is never echoed, so no secret rides along.
+        detail = str(parsed.get("error_description") or parsed.get("error"))
+        raise CalendarError(f"the calendar provider refused the authorization: {detail}")
+    return parsed
+
+
+async def _store_tokens(provider_id: str, tokens: dict[str, Any]) -> None:
+    """Persist an access token, its expiry, and a refresh token when given one.
+
+    A refresh response often omits ``refresh_token`` — the existing one stays
+    valid. The store MERGES, so an omitted field is left alone rather than
+    cleared; writing an empty string here would delete the only thing that keeps
+    the connection alive.
+    """
+    values: dict[str, str] = {}
+    access = str(tokens.get("access_token") or "")
+    if access:
+        values["access_token"] = access
+        expires_in = _as_float(tokens.get("expires_in", 0))
+        # Absolute, not relative: a stored duration would have to be interpreted
+        # against a write time nobody recorded.
+        values["expires_at"] = str(time.time() + expires_in) if expires_in > 0 else "0"
+    refresh = str(tokens.get("refresh_token") or "")
+    if refresh:
+        values["refresh_token"] = refresh
+    if values:
+        await credentials.write_for(provider_id, values)

--- a/src/kiro_crew/apps/builtins/meetings/backend/providers/calendar.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/providers/calendar.py
@@ -7,10 +7,12 @@ Neither can ship publicly, and neither had a public equivalent.
 This module replaces both with the same extension-point shape as
 :mod:`..providers.tasks`: an ABC (:class:`CalendarProvider`), a name-keyed
 factory registry (:func:`register_calendar_provider`), and a resolver
-(:func:`get_calendar_provider`). **Two implementations ship**: a no-op
-(``none``, the default — the app is fully usable with manually created meetings)
-and :class:`IcsCalendarProvider`, which reads the iCalendar format every
-calendar service can export or publish.
+(:func:`get_calendar_provider`). **Three implementations ship**: a no-op
+(``none``, the default — the app is fully usable with manually created meetings),
+:class:`IcsCalendarProvider`, which reads the iCalendar format every calendar
+service can export or publish, and :class:`CalDavCalendarProvider`, which runs a
+time-ranged ``calendar-query`` against a CalDAV collection and reuses the same
+parser on the iCalendar documents that come back.
 
 The parser is stdlib-only and deliberately small — it reads exactly the
 ``VEVENT`` fields this app displays. It is NOT a general iCalendar
@@ -39,15 +41,32 @@ from __future__ import annotations
 
 import abc
 import asyncio
+import base64
 import hashlib
 import ipaddress
+import json
 import logging
 import re
 import socket
+
+# The Multi-Status is XML from a REMOTE server, so parsing goes through
+# defusedxml rather than stdlib ``xml.etree``, matching what ``doc_parser`` already
+# does for untrusted uploads. Optional so a stale install (a pull without
+# ``pip install -e .``) degrades to "calendar unavailable" instead of killing
+# every import on this path; ``_parse_xml_safely`` then fails closed. There is
+# deliberately NO stdlib fallback — that is the parser being avoided.
+try:
+    from defusedxml.common import DefusedXmlException as _DefusedXmlException
+    from defusedxml.ElementTree import ParseError as _XmlParseError
+    from defusedxml.ElementTree import fromstring as _xml_fromstring
+except ModuleNotFoundError:  # pragma: no cover — exercised via monkeypatch
+    _xml_fromstring = None  # type: ignore[assignment]
+    _XmlParseError = None  # type: ignore[assignment,misc]
+    _DefusedXmlException = None  # type: ignore[assignment,misc]
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
-from urllib.parse import urlsplit
+from urllib.parse import urlencode, urlsplit
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import aiohttp
@@ -56,6 +75,7 @@ from yarl import URL
 
 from kiro_crew import hooks, link_unfurl
 from kiro_crew.apps.builtins.meetings.backend import constants as k
+from kiro_crew.apps.builtins.meetings.backend import credentials
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.security import redact
 
@@ -627,21 +647,92 @@ def _finalize_event(
         if delta is None:
             delta = timedelta(days=1) if raw.get("all_day") else timedelta(hours=1)
         end = start + delta
+    return build_event(
+        uid=str(raw.get("uid") or ""),
+        title=str(raw.get("title") or ""),
+        start=start,
+        end=end,
+        location=raw.get("location"),
+        organizer=raw.get("organizer"),
+        attendees=[str(a) for a in raw.get("attendees", [])],
+        description=raw.get("description"),
+        all_day=bool(raw.get("all_day")),
+        uid_prefix="ics",
+    )
+
+
+def build_event(
+    *,
+    uid: str,
+    title: str,
+    start: datetime,
+    end: datetime | None,
+    location: object = "",
+    organizer: object = "",
+    attendees: list[str] | None = None,
+    description: object = "",
+    all_day: bool = False,
+    uid_prefix: str = "event",
+) -> CalendarEvent:
+    """Normalize and REDACT one event from any provider's raw fields.
+
+    Every provider funnels through here rather than building a
+    :class:`CalendarEvent` itself, for two reasons that are worth stating because
+    the alternative looks equally reasonable:
+
+    * **Redaction lives in one audited place.** ``providers/calendar.py`` is a
+      registered redaction sink in :mod:`kiro_crew.security_posture`; a provider
+      module that called :func:`redact` itself would be a second sink to classify
+      and keep classified. One helper means one thing to audit for all of them.
+    * **The id derivation cannot be skipped.** ``event_id`` becomes a meeting
+      DIRECTORY name, and :func:`_event_id_for` is what makes it both filesystem
+      safe and injective. A provider that formatted its own id could reintroduce
+      the collision that made two calendar entries share one meeting directory.
+
+    ``end`` defaults to an hour after ``start`` when a provider gives none, which
+    is what :func:`_finalize_event` already does for a ``.ics`` event with neither
+    ``DTEND`` nor ``DURATION``.
+
+    ``uid_prefix`` names the SOURCE in a synthesized id, for the case where an
+    event arrives with no usable identifier. It is a parameter rather than a
+    constant so a Google event does not end up labelled ``ics-``: the id is
+    user-visible in a URL, and a wrong provenance in it is the kind of small lie
+    that costs somebody an afternoon later.
+    """
 
     def clean(value: object) -> str:
         return redact(str(value or "").strip())[:_MAX_FIELD_LEN]
 
-    uid = clean(raw.get("uid")) or f"ics-{int(start.timestamp())}"
+    resolved_end = end if isinstance(end, datetime) else start + timedelta(hours=1)
+    # The id is derived from the ORIGINAL uid, never the redacted TEXT. Running
+    # the uid through ``redact`` before ``_event_id_for`` broke injectivity in
+    # exactly the way that helper exists to prevent: Microsoft Graph ids are
+    # long base64 blobs, the entropy heuristic collapsed DIFFERENT events to one
+    # ``[REDACTED: credential]`` placeholder, and every M365 meeting then shared
+    # a single directory, overwriting each other's notes and tasks.
+    #
+    # But the redactor's VERDICT still gates what becomes visible: ``event_id``
+    # is agent-readable (cache, API, URLs), and ``_event_id_for`` keeps a
+    # readable stem of its input. A uid the redactor flags as credential-shaped
+    # must not surface that stem, so a flagged uid switches to a DIGEST-ONLY id
+    # source: still derived from the original bytes (unique per uid, stable
+    # across syncs — the digest of the same uid never changes), while the
+    # readable part names only the provider.
+    raw_uid = str(uid or "").strip()
+    id_source = raw_uid or f"{uid_prefix}-{int(start.timestamp())}"
+    if raw_uid and redact(raw_uid) != raw_uid:
+        digest = hashlib.sha256(raw_uid.encode("utf-8")).hexdigest()[:_UID_DIGEST_LEN * 2]
+        id_source = f"{uid_prefix}-{digest}"
     return CalendarEvent(
-        event_id=_event_id_for(uid),
-        title=clean(raw.get("title")) or "Meeting",
+        event_id=_event_id_for(id_source),
+        title=clean(title) or "Meeting",
         start=start.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        end=end.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        location=clean(raw.get("location")),
-        organizer=clean(raw.get("organizer")),
-        attendees=[clean(a) for a in raw.get("attendees", []) if str(a).strip()],
-        description=clean(raw.get("description"))[:_MAX_FIELD_LEN],
-        all_day=bool(raw.get("all_day")),
+        end=resolved_end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        location=clean(location),
+        organizer=clean(organizer),
+        attendees=[clean(a) for a in (attendees or []) if str(a).strip()],
+        description=clean(description),
+        all_day=all_day,
     )
 
 
@@ -668,6 +759,11 @@ _REJECTION_MESSAGES = {
 #: Used if that module ever grows a third code — a rejection must stay a
 #: rejection, with a message, rather than becoming a KeyError and a 500.
 _UNKNOWN_REJECTION = "calendar URL was refused"
+
+#: The redirects that preserve the request method and body. 301/302/303 tell a
+#: client to retry with GET, which is fine for a GET and wrong for a CalDAV
+#: ``REPORT`` — see :func:`fetch_vetted`.
+_METHOD_PRESERVING_REDIRECTS = frozenset({307, 308})
 
 
 @dataclass(frozen=True)
@@ -877,6 +973,142 @@ class _PinnedResolver(AbstractResolver):
         """Nothing to release — this resolver owns no socket or thread."""
 
 
+async def vet_url(source: str) -> VettedTarget:
+    """Run the SSRF gate on the executor — it performs a blocking DNS lookup.
+
+    Module-level so every provider reaches the gate the same way. Looks
+    ``_normalize_url`` up as a module global at call time, which is what lets a
+    test substitute a pass-through recorder for it (the loopback servers the
+    redirect tests need would otherwise be refused by the real gate).
+    """
+    return await asyncio.get_running_loop().run_in_executor(
+        subprocess_executor(), _normalize_url, source
+    )
+
+
+def _same_origin(left: VettedTarget, right: VettedTarget) -> bool:
+    """True when two vetted targets share a scheme/host/port origin.
+
+    Only https reaches a vetted target, so scheme is implied and host+port decide
+    it. Used to decide whether an ``Authorization`` header may survive a redirect.
+    """
+    return left.host.rstrip(".").lower() == right.host.rstrip(".").lower() and (
+        left.port == right.port
+    )
+
+
+async def fetch_vetted(
+    source: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    auth_headers: dict[str, str] | None = None,
+    body: bytes | None = None,
+    timeout_secs: int = k.ICS_FETCH_TIMEOUT_SECS,
+    max_bytes: int = k.MAX_ICS_BYTES,
+    max_redirects: int = k.ICS_MAX_REDIRECTS,
+    ok_statuses: frozenset[int] = frozenset({200}),
+) -> bytes:
+    """Fetch *source* through the SSRF gate, with DNS pinned per hop.
+
+    This is the one outbound HTTP path every calendar provider uses. It was
+    originally :meth:`IcsCalendarProvider._fetch_url`; it is module-level now
+    because CalDAV, Google and Microsoft 365 all need the same posture, and three
+    copies of a security control is three chances for one of them to drift.
+
+    Every property the ``.ics`` fetch had is preserved and is load-bearing:
+
+    * ``allow_redirects=False`` plus a MANUAL hop loop, so the gate runs on every
+      hop. Letting aiohttp follow redirects validates only the FIRST url — a
+      public host could then 302 to ``http://169.254.169.254/`` and the gateway
+      would issue that request itself. Re-checking ``resp.url`` afterwards is too
+      late; the request already happened.
+    * ``use_dns_cache=False`` so the pin stays authoritative rather than racing
+      aiohttp's own TTL cache.
+    * No ``ssl=`` / ``verify_ssl=`` override, so the connector keeps aiohttp's
+      default VERIFIED context. The request URL keeps its hostname, so ``Host``,
+      TLS SNI and certificate validation are unchanged.
+    * The response is size-capped WHILE STREAMING, so a hostile endpoint cannot
+      exhaust memory before the cap is noticed.
+
+    Two rules are new here, because the ``.ics`` path never sent a credential and
+    only ever issued a GET:
+
+    ``auth_headers`` are dropped across a cross-origin redirect. Anything in
+    ``headers`` rides every hop; anything in ``auth_headers`` — a CalDAV
+    ``Authorization: Basic``, a Google ``Bearer`` — is sent only while the hop
+    stays on the origin that was originally addressed. Without this split, a
+    calendar host (or anything that can forge its ``Location``) could bounce the
+    request to a host it controls and be handed the user's live credential. The
+    request still follows the redirect, it just arrives unauthenticated, which
+    fails visibly instead of leaking.
+
+    For a NON-GET request, only the method-preserving redirects (307/308) are
+    followed. 301/302/303 instruct a client to retry with GET, which would
+    silently turn a CalDAV ``REPORT`` query into a plain GET of some other
+    resource and parse whatever came back — a wrong answer dressed as a right
+    one. Those are refused with a message instead of guessed at.
+    """
+    verb = (method or "GET").upper()
+    target = await vet_url(source)
+    origin = target
+    # One resolver for the whole session, pinned hop by hop. A redirect can only
+    # reach an address some hop's validation already approved.
+    resolver = _PinnedResolver()
+    timeout = aiohttp.ClientTimeout(total=timeout_secs)
+    chunks: list[bytes] = []
+    try:
+        connector = aiohttp.TCPConnector(resolver=resolver, use_dns_cache=False)
+        async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
+            for _hop in range(max_redirects + 1):
+                resolver.pin(target)
+                sent = dict(headers or {})
+                # The credential rides only while we are still talking to the
+                # host the caller actually addressed.
+                if auth_headers and _same_origin(origin, target):
+                    sent.update(auth_headers)
+                async with session.request(
+                    verb, target.url, headers=sent or None, data=body, allow_redirects=False
+                ) as resp:
+                    if resp.status in _REDIRECT_STATUSES:
+                        if verb != "GET" and resp.status not in _METHOD_PRESERVING_REDIRECTS:
+                            raise CalendarError(
+                                f"calendar server redirected a {verb} with HTTP "
+                                f"{resp.status}, which would change the request method"
+                            )
+                        location = resp.headers.get("Location", "")
+                        if not location:
+                            raise CalendarError("calendar URL redirected with no target")
+                        # Resolve a relative target against the current url, then
+                        # run the SAME validator on the result — and pin THAT
+                        # hop's answer on the next pass, so no hop is ever
+                        # vetted-then-re-resolved. `URL(...)` RAISES on a
+                        # malformed value, and this one comes from the REMOTE
+                        # server's `Location` header.
+                        try:
+                            nxt = str(resp.url.join(URL(location)))
+                        except ValueError as exc:
+                            raise CalendarError("calendar redirect URL is malformed") from exc
+                        target = await vet_url(nxt)
+                        continue
+                    if resp.status not in ok_statuses:
+                        raise CalendarError(f"calendar URL returned HTTP {resp.status}")
+                    total = 0
+                    async for chunk in resp.content.iter_chunked(64 * 1024):
+                        total += len(chunk)
+                        if total > max_bytes:
+                            raise CalendarError("calendar document is too large")
+                        chunks.append(chunk)
+                    break
+            else:
+                raise CalendarError("calendar URL redirected too many times")
+    except aiohttp.ClientError as exc:
+        raise CalendarError(f"calendar fetch failed: {type(exc).__name__}") from exc
+    except TimeoutError as exc:
+        raise CalendarError("calendar fetch timed out") from exc
+    return b"".join(chunks)
+
+
 class IcsCalendarProvider(CalendarProvider):
     """Reads meetings from an iCalendar document — a local file or an https URL.
 
@@ -914,82 +1146,617 @@ class IcsCalendarProvider(CalendarProvider):
     @staticmethod
     async def _vet(source: str) -> VettedTarget:
         """Run the gate on the executor — it performs a blocking DNS lookup."""
-        return await asyncio.get_running_loop().run_in_executor(
-            subprocess_executor(), _normalize_url, source
-        )
+        return await vet_url(source)
 
     async def _fetch_url(self, source: str) -> str:
-        target = await self._vet(source)
-        # One resolver for the whole session, pinned hop by hop. A redirect can
-        # only reach an address some hop's validation already approved.
-        resolver = _PinnedResolver()
-        timeout = aiohttp.ClientTimeout(total=k.ICS_FETCH_TIMEOUT_SECS)
-        chunks: list[bytes] = []
-        try:
-            # The resolver is what closes the DNS-rebinding window: validation
-            # resolved the name once, on the executor, and the connector is given
-            # a resolver that can ONLY answer from that result — so the socket
-            # lands on the vetted address instead of whatever a second lookup
-            # would return. `use_dns_cache=False` keeps the pin authoritative
-            # rather than racing aiohttp's own TTL cache. Note what is NOT passed:
-            # no `ssl=`/`verify_ssl=` override, so the connector keeps aiohttp's
-            # default VERIFIED context, and because the request URL still carries
-            # the hostname, `Host` and TLS SNI/cert validation are unchanged.
-            connector = aiohttp.TCPConnector(resolver=resolver, use_dns_cache=False)
-            async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
-                # `allow_redirects=False` and a MANUAL hop loop, because the
-                # SSRF gate must run on every hop. Letting aiohttp follow
-                # redirects validates only the FIRST url: a public host can then
-                # 302 to http://169.254.169.254/ and the gateway makes that
-                # request itself, which is the whole SSRF shape this endpoint is
-                # otherwise careful about. Re-validating the final `resp.url`
-                # after the fact is too late — the request already happened.
-                for _hop in range(k.ICS_MAX_REDIRECTS + 1):
-                    resolver.pin(target)
-                    async with session.get(target.url, allow_redirects=False) as resp:
-                        if resp.status in _REDIRECT_STATUSES:
-                            location = resp.headers.get("Location", "")
-                            if not location:
-                                raise CalendarError("calendar URL redirected with no target")
-                            # Resolve relative targets against the current url,
-                            # then run the SAME validator (scheme allow-list +
-                            # post-DNS private-address refusal) on the result —
-                            # and pin THAT hop's answer too, on the next pass, so
-                            # no hop is ever vetted-then-re-resolved.
-                            # `URL(...)` RAISES on a malformed value, and this one
-                            # comes from the REMOTE server's `Location` header — even
-                            # less trusted than the operator's own config, which is
-                            # already guarded at `_normalize_url`. Fixing that site
-                            # and not this one left the identical 500 one hop away.
-                            try:
-                                nxt = str(resp.url.join(URL(location)))
-                            except ValueError as exc:
-                                raise CalendarError(
-                                    "calendar redirect URL is malformed"
-                                ) from exc
-                            target = await self._vet(nxt)
-                            continue
-                        if resp.status != 200:
-                            raise CalendarError(f"calendar URL returned HTTP {resp.status}")
-                        total = 0
-                        async for chunk in resp.content.iter_chunked(64 * 1024):
-                            total += len(chunk)
-                            if total > k.MAX_ICS_BYTES:
-                                raise CalendarError("calendar document is too large")
-                            chunks.append(chunk)
-                        break
-                else:
-                    raise CalendarError("calendar URL redirected too many times")
-        except aiohttp.ClientError as exc:
-            raise CalendarError(f"calendar fetch failed: {type(exc).__name__}") from exc
-        except TimeoutError as exc:
-            raise CalendarError("calendar fetch timed out") from exc
-        return b"".join(chunks).decode("utf-8", errors="replace")
+        """Fetch the document through the shared, gated fetch.
+
+        The hop loop this method used to carry inline now lives in
+        :func:`fetch_vetted`, so CalDAV / Google / Microsoft 365 share one copy of
+        the SSRF posture instead of each keeping their own. Behaviour here is
+        unchanged: a plain GET, no credential, ``MAX_ICS_BYTES``, and only HTTP
+        200 accepted.
+        """
+        raw = await fetch_vetted(
+            source,
+            timeout_secs=k.ICS_FETCH_TIMEOUT_SECS,
+            max_bytes=k.MAX_ICS_BYTES,
+            max_redirects=k.ICS_MAX_REDIRECTS,
+        )
+        return raw.decode("utf-8", errors="replace")
 
     async def _read_file(self, source: str) -> str:
         return await asyncio.get_running_loop().run_in_executor(
             subprocess_executor(), _read_local_ics, source
         )
+
+
+def _parse_xml_safely(payload: bytes) -> Any:
+    """Parse *payload* as XML, refusing any DTD. Returns the root element.
+
+    ``forbid_dtd=True`` is the whole defence against an entity-expansion bomb,
+    and it is needed because the response comes from a REMOTE server. defusedxml
+    refuses entities and external references by default but ALLOWS a bare
+    DOCTYPE, so the flag is what makes the rule blanket: a legitimate CalDAV
+    Multi-Status carries no DOCTYPE, so refusing all of them costs nothing real
+    and removes the need to decide which entity declarations are safe. Refusing
+    at the declaration also aborts before any expansion runs, so the size cap on
+    the download bounds the work.
+    """
+    if _xml_fromstring is None:  # pragma: no cover — exercised via monkeypatch
+        raise CalendarError(
+            "calendar support is unavailable: defusedxml is not installed "
+            "(reinstall the package with `pip install -e .`)"
+        )
+    try:
+        return _xml_fromstring(payload, forbid_dtd=True)
+    except _DefusedXmlException as exc:
+        raise CalendarError(
+            "calendar server returned XML with a document type declaration, "
+            "which is not accepted"
+        ) from exc
+    except _XmlParseError as exc:
+        raise CalendarError("calendar server returned XML that could not be parsed") from exc
+
+
+#: XML namespaces used by a CalDAV ``REPORT`` response (RFC 4791 / RFC 4918).
+_NS_DAV = "DAV:"
+_NS_CALDAV = "urn:ietf:params:xml:ns:caldav"
+
+#: The ``REPORT`` body: a ``calendar-query`` narrowed to ``VEVENT`` inside a
+#: time range. Asking the SERVER to filter is what keeps the response small — the
+#: alternative is downloading a whole collection and discarding most of it — and
+#: :func:`parse_ics` still applies the same window afterwards, so a server that
+#: ignores the filter cannot widen the result.
+_CALDAV_QUERY = (
+    '<?xml version="1.0" encoding="utf-8" ?>'
+    '<C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">'
+    "<D:prop><D:getetag/><C:calendar-data/></D:prop>"
+    '<C:filter><C:comp-filter name="VCALENDAR">'
+    '<C:comp-filter name="VEVENT">'
+    '<C:time-range start="{start}" end="{end}"/>'
+    "</C:comp-filter></C:comp-filter></C:filter>"
+    "</C:calendar-query>"
+)
+
+
+class CalDavCalendarProvider(CalendarProvider):
+    """Reads meetings from a CalDAV collection (Nextcloud, Fastmail, iCloud, …).
+
+    ``calendar.source`` is the **collection** URL — the one that addresses a
+    single calendar, e.g.
+    ``https://host/remote.php/dav/calendars/alice/personal/``. Principal and
+    calendar-home discovery is deliberately not implemented: it is two more
+    round trips and a second XML shape, and every server that supports CalDAV
+    also shows the user this URL. A URL that is not a collection produces the
+    server's own error rather than a guess.
+
+    The username and password come from the credential store, never from
+    ``config.json`` — see :mod:`..credentials`. They are read inside
+    :meth:`fetch` rather than in ``__init__`` because
+    :func:`available_calendar_providers` constructs every provider just to read
+    its label, and a constructor that touched the disk would put a file read
+    behind rendering the settings picker.
+
+    Two consequences worth stating plainly:
+
+    * **A LAN or localhost server cannot be used.** The shared gate refuses
+      private and loopback addresses because the GATEWAY makes this request, so a
+      self-hosted CalDAV on an internal address is refused by design. Only a
+      publicly resolvable https host works.
+    * **A recurring event collapses to one entry.** The server returns each
+      override as its own ``VEVENT`` sharing the series UID, and
+      :func:`parse_ics` does not read ``RECURRENCE-ID``, so they map to one
+      ``event_id``. Duplicates are folded to the earliest start rather than
+      allowed to share a meeting directory. That matches this module's existing
+      stance on recurrence — showing the series' first instance instead of
+      silently wrong occurrence times.
+    """
+
+    def __init__(self, source: str = "") -> None:
+        self._source = (source or "").strip()
+
+    @property
+    def provider_id(self) -> str:
+        return k.CALENDAR_PROVIDER_CALDAV
+
+    @property
+    def display_name(self) -> str:
+        return "CalDAV (Nextcloud, Fastmail, iCloud)"
+
+    @property
+    def requires_source(self) -> bool:
+        return True
+
+    async def fetch(self, *, days: int = k.CALENDAR_SYNC_DAYS) -> list[CalendarEvent]:
+        if not self._source:
+            raise CalendarError(
+                "No CalDAV collection URL is configured. Put your calendar's "
+                "CalDAV URL in Settings -> Calendar."
+            )
+        stored = await credentials.read_for(k.CALENDAR_PROVIDER_CALDAV)
+        username = stored.get("username", "")
+        password = stored.get("password", "")
+        if not username or not password:
+            raise CalendarError(
+                "CalDAV needs a username and password. Add them in "
+                "Settings -> Calendar."
+            )
+
+        window = max(1, min(int(days), 365))
+        now = datetime.now(timezone.utc)
+        body = _CALDAV_QUERY.format(
+            # The look-back matches `parse_ics`'s own floor, so a meeting that
+            # started just before the sync is still returned.
+            start=(now - timedelta(days=1)).strftime("%Y%m%dT%H%M%SZ"),
+            end=(now + timedelta(days=window)).strftime("%Y%m%dT%H%M%SZ"),
+        )
+        payload = await fetch_vetted(
+            self._source,
+            method="REPORT",
+            headers={
+                # Depth 1 = the collection and its direct children, which is
+                # where calendar objects live. Depth infinity is both slower and
+                # more than this needs.
+                "Depth": "1",
+                "Content-Type": 'application/xml; charset="utf-8"',
+            },
+            # In `auth_headers`, not `headers`, so the credential is dropped if
+            # the server redirects off its own origin.
+            auth_headers={"Authorization": _basic_auth(username, password)},
+            body=body.encode("utf-8"),
+            timeout_secs=k.CALDAV_TIMEOUT_SECS,
+            max_bytes=k.MAX_CALDAV_BYTES,
+            # 207 Multi-Status is the success answer for a REPORT; 200 is
+            # accepted because some servers answer a single-resource query that
+            # way.
+            ok_statuses=frozenset({207, 200}),
+        )
+        return _events_from_multistatus(payload, days=window)
+
+
+def _basic_auth(username: str, password: str) -> str:
+    """An HTTP Basic ``Authorization`` value.
+
+    RFC 7617 leaves the charset implementation-defined and every CalDAV server in
+    practice reads UTF-8, which matters because app-specific passwords are ASCII
+    but usernames are often an email address that need not be.
+    """
+    raw = f"{username}:{password}".encode("utf-8")
+    return "Basic " + base64.b64encode(raw).decode("ascii")
+
+
+def _events_from_multistatus(payload: bytes, *, days: int) -> list[CalendarEvent]:
+    """Pull every ``calendar-data`` out of a Multi-Status and parse each one.
+
+    Each blob is parsed on its OWN, not concatenated, so one malformed calendar
+    object costs only its own event instead of the whole sync — the same bargain
+    :func:`parse_ics` already makes for one bad line.
+
+    Duplicate ``event_id``s are folded to the earliest start. A server returns a
+    recurring series' overrides as separate ``VEVENT``s sharing one UID, and
+    letting both through would hand two list rows the same meeting directory,
+    which is precisely the collision ``_event_id_for`` exists to prevent.
+    """
+    root = _parse_xml_safely(payload)
+    by_id: dict[str, CalendarEvent] = {}
+    for node in root.iter(f"{{{_NS_CALDAV}}}calendar-data"):
+        text = (node.text or "").strip()
+        if not text:
+            continue
+        for event in parse_ics(text, days=days):
+            existing = by_id.get(event.event_id)
+            if existing is None or event.start < existing.start:
+                by_id[event.event_id] = event
+        if len(by_id) >= k.MAX_CALENDAR_EVENTS:
+            break
+    events = sorted(by_id.values(), key=lambda e: e.start)
+    return events[: k.MAX_CALENDAR_EVENTS]
+
+
+#: Splits an RFC 3339 stamp into its fractional-second digits and whatever
+#: follows them (an offset, a ``Z``, or nothing).
+_FRACTION_RE = re.compile(r"\.(\d+)")
+
+
+def _parse_rfc3339(value: str) -> datetime | None:
+    """Parse a Google/Graph timestamp into an aware UTC datetime.
+
+    Both APIs answer RFC 3339, which ``fromisoformat`` does NOT fully accept on
+    the oldest interpreter this package supports. Measured on 3.10.20, where it
+    rejects two shapes the APIs really send::
+
+        2026-08-05T09:00:00Z          ValueError  (Google)
+        2026-08-05T09:00:00.0000000   ValueError  (Graph: seven fraction digits)
+
+    3.11 widened ``fromisoformat`` to the whole grammar, so both parse there. That
+    is why this was invisible on a 3.12 developer machine and failed only the 3.10
+    CI shard — and it failed SILENTLY: an unparsable stamp returns ``None``, the
+    caller skips that event, and the sync reports an empty calendar rather than an
+    error. Every Graph event disappeared on 3.10.
+
+    So the value is normalised to the subset 3.10 accepts before parsing: a
+    trailing ``Z`` becomes ``+00:00``, and the fraction is truncated to six digits
+    (3.10 takes three or six only). Truncation loses sub-microsecond precision,
+    which ``datetime`` cannot represent anyway.
+
+    A value that is still unreadable returns ``None`` so the event is skipped
+    rather than taking the whole sync down — the same bargain :func:`parse_ics`
+    makes for a malformed line.
+
+    A value with no offset is read as UTC. Graph returns exactly that shape and
+    names the zone in a sibling field, which the caller applies before getting
+    here; anything still naive at this point has no zone to apply.
+    """
+    raw = (value or "").strip()
+    if not raw:
+        return None
+    if raw.endswith(("Z", "z")):
+        raw = raw[:-1] + "+00:00"
+    # Truncate, not round: a stamp is a point in time, and rounding up could move
+    # it past a boundary the caller filters on.
+    raw = _FRACTION_RE.sub(lambda m: "." + m.group(1)[:6], raw, count=1)
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _google_when(node: object) -> datetime | None:
+    """Read a Google ``start``/``end`` object.
+
+    Google sends either ``{"dateTime": "...", "timeZone": "..."}`` for a timed
+    event or ``{"date": "YYYY-MM-DD"}`` for a whole-day one. ``dateTime`` already
+    carries its own offset, so ``timeZone`` is redundant for converting it and is
+    not consulted.
+    """
+    if not isinstance(node, dict):
+        return None
+    stamp = node.get("dateTime")
+    if isinstance(stamp, str) and stamp:
+        return _parse_rfc3339(stamp)
+    whole_day = node.get("date")
+    if isinstance(whole_day, str) and whole_day:
+        try:
+            return datetime.strptime(whole_day, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None
+    return None
+
+
+def _person_name(node: object) -> str:
+    """Best display value for a Google organizer/attendee object."""
+    if not isinstance(node, dict):
+        return ""
+    return str(node.get("displayName") or node.get("email") or "")
+
+
+class GoogleCalendarProvider(CalendarProvider):
+    """Reads meetings from Google Calendar's v3 ``events.list``.
+
+    ``requires_source`` is False: this reads the signed-in user's ``primary``
+    calendar. Making it configurable would mean asking for a calendar id, which
+    is not something a user has to hand, and the app's purpose is "the meetings
+    I am in".
+
+    Recurrence is handled properly here, unlike the ``.ics`` and CalDAV paths:
+    ``singleEvents=true`` makes Google expand a series into instances server-side,
+    each with its own id. So there is no RRULE engine to get wrong and no
+    UID collision to fold — the thing this module refuses to guess at, the
+    provider does authoritatively.
+
+    Credentials (client id/secret and the OAuth tokens) come from the credential
+    store and are read inside :meth:`fetch`, never in ``__init__`` — see
+    :class:`CalDavCalendarProvider` for why that matters to the settings picker.
+    """
+
+    @property
+    def provider_id(self) -> str:
+        return k.CALENDAR_PROVIDER_GOOGLE
+
+    @property
+    def display_name(self) -> str:
+        return "Google Calendar"
+
+    @property
+    def requires_source(self) -> bool:
+        return False
+
+    async def fetch(self, *, days: int = k.CALENDAR_SYNC_DAYS) -> list[CalendarEvent]:
+        # Imported inside the method to break an import cycle: `oauth` needs
+        # `fetch_vetted` and `CalendarError` from this module, so it cannot be
+        # imported at module scope here. By the time this runs both modules are
+        # fully loaded. `context.py` breaks its resource-probe cycle the same way.
+        from kiro_crew.apps.builtins.meetings.backend import oauth
+
+        token = await oauth.access_token(google_oauth_client())
+        window = max(1, min(int(days), 365))
+        now = datetime.now(timezone.utc)
+        params = {
+            # The one-day look-back matches `parse_ics`'s floor, so a meeting that
+            # started just before the sync still appears.
+            "timeMin": (now - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "timeMax": (now + timedelta(days=window)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "singleEvents": "true",
+            "orderBy": "startTime",
+            "maxResults": str(k.GOOGLE_PAGE_SIZE),
+        }
+
+        events: list[CalendarEvent] = []
+        page_token = ""
+        for _page in range(k.GOOGLE_MAX_PAGES):
+            query = dict(params)
+            if page_token:
+                query["pageToken"] = page_token
+            payload = await fetch_vetted(
+                f"{k.GOOGLE_EVENTS_URL}?{urlencode(query)}",
+                # In `auth_headers`, so a redirect off googleapis.com cannot carry
+                # the user's bearer token with it.
+                auth_headers={"Authorization": f"Bearer {token}"},
+                headers={"Accept": "application/json"},
+                timeout_secs=k.ICS_FETCH_TIMEOUT_SECS,
+                max_bytes=k.MAX_GOOGLE_RESPONSE_BYTES,
+            )
+            body = _json_object(payload)
+            events.extend(_google_events(body.get("items")))
+            if len(events) >= k.MAX_CALENDAR_EVENTS:
+                break
+            page_token = str(body.get("nextPageToken") or "")
+            if not page_token:
+                break
+
+        events.sort(key=lambda e: e.start)
+        return events[: k.MAX_CALENDAR_EVENTS]
+
+
+def google_oauth_client() -> Any:
+    """The :class:`oauth.OAuthClient` describing Google's endpoints."""
+    from kiro_crew.apps.builtins.meetings.backend import oauth
+
+    return oauth.OAuthClient(
+        provider_id=k.CALENDAR_PROVIDER_GOOGLE,
+        authorize_url=k.GOOGLE_AUTHORIZE_URL,
+        token_url=k.GOOGLE_TOKEN_URL,
+        scopes=(k.GOOGLE_CALENDAR_SCOPE,),
+        extra_authorize_params=dict(k.GOOGLE_AUTHORIZE_EXTRA),
+    )
+
+
+def _json_object(payload: bytes) -> dict[str, Any]:
+    """Decode a JSON object, or raise a :class:`CalendarError`.
+
+    A bare ``ValueError`` here would escape the sync route as a 500; the route
+    turns ``CalendarError`` into a 502 with the message.
+    """
+    try:
+        parsed = json.loads(payload.decode("utf-8", errors="replace"))
+    except ValueError as exc:
+        raise CalendarError("the calendar provider's response was not JSON") from exc
+    if not isinstance(parsed, dict):
+        raise CalendarError("the calendar provider's response was not an object")
+    return parsed
+
+
+def _google_events(items: object) -> list[CalendarEvent]:
+    """Turn Google ``items`` into events, skipping the ones that make no sense.
+
+    A cancelled instance of a recurring series still appears in the list with
+    ``status: "cancelled"`` and usually no ``start``; showing it as a meeting
+    would put a phantom row in the user's day.
+    """
+    out: list[CalendarEvent] = []
+    if not isinstance(items, list):
+        return out
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("status") or "") == "cancelled":
+            continue
+        start = _google_when(item.get("start"))
+        if start is None:
+            continue
+        attendees = [
+            _person_name(a) for a in (item.get("attendees") or [])[:_MAX_ATTENDEES]
+        ]
+        out.append(
+            build_event(
+                uid=str(item.get("id") or ""),
+                title=str(item.get("summary") or ""),
+                start=start,
+                end=_google_when(item.get("end")),
+                location=item.get("location"),
+                organizer=_person_name(item.get("organizer")),
+                attendees=attendees,
+                description=item.get("description"),
+                uid_prefix=k.CALENDAR_PROVIDER_GOOGLE,
+            )
+        )
+    return out
+
+
+def _graph_when(node: object) -> datetime | None:
+    """Read a Graph ``start``/``end`` object.
+
+    Graph sends ``{"dateTime": "2026-08-05T09:00:00.0000000", "timeZone": "UTC"}``
+    — the stamp carries NO offset and the zone is a sibling field, which is why
+    the request sends ``Prefer: outlook.timezone="UTC"``.
+
+    ``timeZone`` is still honoured when it resolves, so a response that ignored
+    the header is not silently misread. Graph often answers with a WINDOWS zone
+    name (``Tokyo Standard Time``), which is not an IANA key — map it through
+    ``_WINDOWS_TO_IANA`` exactly as :func:`_tzid_of` does for a ``.ics`` TZID.
+    A name neither table resolves falls back to UTC, matching that helper's
+    stance that a visible meeting at a possibly-wrong hour beats a meeting that
+    is not there.
+    """
+    if not isinstance(node, dict):
+        return None
+    stamp = str(node.get("dateTime") or "")
+    if not stamp:
+        return None
+    parsed = _parse_rfc3339(stamp)
+    if parsed is None:
+        return None
+    zone_name = str(node.get("timeZone") or "").strip()
+    if zone_name and zone_name.upper() != "UTC" and stamp[-1:] != "Z":
+        zone = None
+        try:
+            zone = ZoneInfo(zone_name)
+        except (ZoneInfoNotFoundError, ValueError, OSError):
+            mapped = _WINDOWS_TO_IANA.get(zone_name.lower())
+            if mapped is not None:
+                try:
+                    zone = ZoneInfo(mapped)
+                except (ZoneInfoNotFoundError, ValueError, OSError):
+                    zone = None
+        if zone is None:
+            logger.debug(
+                "meetings: unknown Graph timeZone %r; reading it as UTC", zone_name
+            )
+        else:
+            # `_parse_rfc3339` already stamped the naive value as UTC, so the zone
+            # has to be applied to the wall-clock reading rather than converted
+            # from it.
+            return parsed.replace(tzinfo=zone).astimezone(timezone.utc)
+    return parsed
+
+
+def _graph_person(node: object) -> str:
+    """Best display value for a Graph organizer/attendee.
+
+    The name is nested one level deeper than Google's: Graph wraps it in
+    ``emailAddress``.
+    """
+    if not isinstance(node, dict):
+        return ""
+    email = node.get("emailAddress")
+    if isinstance(email, dict):
+        return str(email.get("name") or email.get("address") or "")
+    return str(node.get("name") or "")
+
+
+class MicrosoftCalendarProvider(CalendarProvider):
+    """Reads meetings from Microsoft 365 through Graph's ``/me/calendarView``.
+
+    ``calendarView`` rather than ``/me/events`` because it expands a recurring
+    series into occurrences server-side — the same reason
+    :class:`GoogleCalendarProvider` asks for ``singleEvents``, and the same
+    payoff: no RRULE engine and no UID collision to fold.
+
+    Like the Google provider this needs no ``calendar.source``; it reads the
+    signed-in user's own calendar.
+    """
+
+    @property
+    def provider_id(self) -> str:
+        return k.CALENDAR_PROVIDER_MICROSOFT
+
+    @property
+    def display_name(self) -> str:
+        return "Microsoft 365 / Outlook"
+
+    @property
+    def requires_source(self) -> bool:
+        return False
+
+    async def fetch(self, *, days: int = k.CALENDAR_SYNC_DAYS) -> list[CalendarEvent]:
+        # Function-local for the same import-cycle reason as the Google provider.
+        from kiro_crew.apps.builtins.meetings.backend import oauth
+
+        token = await oauth.access_token(microsoft_oauth_client())
+        window = max(1, min(int(days), 365))
+        now = datetime.now(timezone.utc)
+        query = {
+            "startDateTime": (now - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "endDateTime": (now + timedelta(days=window)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "$orderby": "start/dateTime",
+            "$top": str(k.MICROSOFT_PAGE_SIZE),
+        }
+        url = f"{k.MICROSOFT_EVENTS_URL}?{urlencode(query)}"
+
+        events: list[CalendarEvent] = []
+        for _page in range(k.MICROSOFT_MAX_PAGES):
+            payload = await fetch_vetted(
+                url,
+                auth_headers={"Authorization": f"Bearer {token}"},
+                headers={
+                    "Accept": "application/json",
+                    "Prefer": k.MICROSOFT_TIMEZONE_HEADER,
+                },
+                timeout_secs=k.ICS_FETCH_TIMEOUT_SECS,
+                max_bytes=k.MAX_MICROSOFT_RESPONSE_BYTES,
+            )
+            body = _json_object(payload)
+            events.extend(_graph_events(body.get("value")))
+            if len(events) >= k.MAX_CALENDAR_EVENTS:
+                break
+            # Graph paginates with a FULL URL rather than a token. It comes from
+            # the response body, so it is re-vetted by `fetch_vetted`'s gate on
+            # the next pass exactly like a redirect target would be — an
+            # `@odata.nextLink` pointing at a private address is refused there.
+            url = str(body.get("@odata.nextLink") or "")
+            if not url:
+                break
+
+        events.sort(key=lambda e: e.start)
+        return events[: k.MAX_CALENDAR_EVENTS]
+
+
+def microsoft_oauth_client() -> Any:
+    """The :class:`oauth.OAuthClient` describing Microsoft's endpoints."""
+    from kiro_crew.apps.builtins.meetings.backend import oauth
+
+    return oauth.OAuthClient(
+        provider_id=k.CALENDAR_PROVIDER_MICROSOFT,
+        authorize_url=k.MICROSOFT_AUTHORIZE_URL,
+        token_url=k.MICROSOFT_TOKEN_URL,
+        scopes=tuple(k.MICROSOFT_CALENDAR_SCOPES),
+    )
+
+
+def _graph_events(items: object) -> list[CalendarEvent]:
+    """Turn a Graph ``value`` array into events.
+
+    A cancelled occurrence is still returned by ``calendarView`` with
+    ``isCancelled: true``; skipping it keeps a phantom meeting out of the day.
+    """
+    out: list[CalendarEvent] = []
+    if not isinstance(items, list):
+        return out
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if item.get("isCancelled") is True:
+            continue
+        start = _graph_when(item.get("start"))
+        if start is None:
+            continue
+        location = item.get("location")
+        location_name = (
+            location.get("displayName") if isinstance(location, dict) else location
+        )
+        attendees = [
+            _graph_person(a) for a in (item.get("attendees") or [])[:_MAX_ATTENDEES]
+        ]
+        out.append(
+            build_event(
+                uid=str(item.get("id") or ""),
+                title=str(item.get("subject") or ""),
+                start=start,
+                end=_graph_when(item.get("end")),
+                location=location_name,
+                organizer=_graph_person(item.get("organizer")),
+                attendees=attendees,
+                # `bodyPreview` rather than `body`: the full body is HTML and can
+                # be enormous, and the display only ever shows a summary line.
+                description=item.get("bodyPreview"),
+                uid_prefix=k.CALENDAR_PROVIDER_MICROSOFT,
+            )
+        )
+    return out
 
 
 def _read_local_ics(source: str) -> str:
@@ -1027,6 +1794,9 @@ CalendarProviderFactory = Callable[[str], CalendarProvider]
 _factories: dict[str, CalendarProviderFactory] = {
     k.CALENDAR_PROVIDER_NONE: lambda _source: NoCalendarProvider(),
     k.CALENDAR_PROVIDER_ICS: IcsCalendarProvider,
+    k.CALENDAR_PROVIDER_CALDAV: CalDavCalendarProvider,
+    k.CALENDAR_PROVIDER_GOOGLE: lambda _source: GoogleCalendarProvider(),
+    k.CALENDAR_PROVIDER_MICROSOFT: lambda _source: MicrosoftCalendarProvider(),
 }
 
 

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/__init__.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/__init__.py
@@ -173,6 +173,26 @@ def register_routes(app: web.Application) -> None:
     # Calendar
     router.add_get(f"{BASE}/calendar", route(calendar_routes.handle_get_calendar))
     router.add_post(f"{BASE}/calendar/sync", route(calendar_routes.handle_calendar_sync))
+    router.add_get(
+        f"{BASE}/calendar/credentials",
+        route(calendar_routes.handle_get_calendar_credentials),
+    )
+    router.add_put(
+        f"{BASE}/calendar/credentials",
+        route(calendar_routes.handle_put_calendar_credentials),
+    )
+    router.add_post(
+        f"{BASE}/calendar/credentials/forget",
+        route(calendar_routes.handle_forget_calendar_credentials),
+    )
+    router.add_post(f"{BASE}/calendar/oauth/start", route(calendar_routes.handle_oauth_start))
+    # The provider redirects the user's BROWSER here, so it answers HTML rather
+    # than JSON. The path is built from the same constant the start handler uses
+    # for the redirect URI, so the two cannot drift.
+    router.add_get(
+        f"{BASE}{calendar_routes.OAUTH_CALLBACK_PATH}",
+        route(calendar_routes.handle_oauth_callback),
+    )
     router.add_get(f"{BASE}/calendar/providers", route(calendar_routes.handle_calendar_providers))
 
     # Agents + dispatcher

--- a/src/kiro_crew/apps/builtins/meetings/backend/routes/calendar.py
+++ b/src/kiro_crew/apps/builtins/meetings/backend/routes/calendar.py
@@ -1,32 +1,84 @@
-"""Calendar routes — sync from the configured provider and read the cache.
+"""Calendar routes — sync, the cache, credentials, and the OAuth handshake.
 
-``GET  …/calendar``        the cached upcoming meetings
-``POST …/calendar/sync``   fetch from the configured provider, refresh the cache
-``GET  …/calendar/providers``  registered providers (for the settings picker)
+``GET  …/calendar``                  the cached upcoming meetings
+``POST …/calendar/sync``             fetch from the configured provider
+``GET  …/calendar/providers``        registered providers (for the settings picker)
+``GET  …/calendar/credentials``      which providers are set up (never a value)
+``PUT  …/calendar/credentials``      store a provider's credentials
+``POST …/calendar/credentials/forget``  disconnect a provider
+``POST …/calendar/oauth/start``      begin an OAuth flow, return the consent URL
+``GET  …/calendar/oauth/callback``   where the provider redirects back to
 
 The internal MCP path and its internal-website scraping fallback are gone; see
 ``backend/providers/calendar.py`` for the ``.ics`` replacement and the registry
 an out-of-repo companion registers its own provider into.
+
+**The OAuth redirect URI is derived from the request's own origin**, not from a
+constant. Two reasons, and the second is the one that bites:
+
+* The dashboard's port is configurable, so a constant would be wrong for anyone
+  not on the default.
+* The dashboard authenticates with an HMAC-signed **cookie**, and a cookie is
+  scoped to the host it was set for. A user logged in at ``localhost:5476`` who
+  was redirected to ``127.0.0.1:5476`` would arrive at the callback with no
+  cookie and be rejected. Echoing the origin back keeps the browser on the host
+  it is already authenticated against.
+
+Both Google (Desktop app) and Microsoft (Mobile and desktop applications) accept
+a loopback redirect on any port, so this adapts without re-registration.
 """
 
 from __future__ import annotations
 
 import asyncio
+import html
 import logging
-from typing import Any
+from typing import Any, Callable
 
 from aiohttp import web
 
 from kiro_crew.apps.builtins.meetings.backend import calendar_sync
 from kiro_crew.apps.builtins.meetings.backend import constants as k
-from kiro_crew.apps.builtins.meetings.backend import store
+from kiro_crew.apps.builtins.meetings.backend import credentials, oauth, store
 from kiro_crew.apps.builtins.meetings.backend.providers import calendar as cal
 from kiro_crew.apps.builtins.meetings.backend.routes._common import (
+    BadRequest,
+    audit,
     data_root,
+    field_str,
+    json_body,
     query_int,
 )
 
 logger = logging.getLogger("kirocrew.app.meetings")
+
+#: Which credential fields each provider accepts from a settings write.
+#:
+#: **This is an allowlist, not documentation.** Without it a client could PUT
+#: ``access_token`` or ``refresh_token`` straight into the store and hand the app
+#: a credential of its choosing; the OAuth tokens are written only by
+#: :mod:`..oauth`, on the way out of a real token exchange. It is also what keeps
+#: an unbounded set of keys out of a file this app has to read back.
+_CREDENTIAL_FIELDS: dict[str, tuple[str, ...]] = {
+    k.CALENDAR_PROVIDER_CALDAV: ("username", "password"),
+    k.CALENDAR_PROVIDER_GOOGLE: ("client_id", "client_secret"),
+    k.CALENDAR_PROVIDER_MICROSOFT: ("client_id", "client_secret"),
+}
+
+#: Providers that authenticate with OAuth, and the client describing each.
+#: Built lazily through a callable so importing this module does not import
+#: :mod:`..oauth` — that module imports from ``providers.calendar``, and the
+#: provider classes import it back inside ``fetch()``.
+_OAUTH_CLIENTS: dict[str, Callable[[], Any]] = {
+    k.CALENDAR_PROVIDER_GOOGLE: cal.google_oauth_client,
+    k.CALENDAR_PROVIDER_MICROSOFT: cal.microsoft_oauth_client,
+}
+
+#: Path of the OAuth callback, relative to the app's API base. Shared by the
+#: start handler (which builds the redirect URI) and route registration, so the
+#: two cannot drift — a mismatch would fail only at the provider, with a message
+#: that does not name the cause.
+OAUTH_CALLBACK_PATH = "/calendar/oauth/callback"
 
 
 def _read_cached_calendar(root: Any) -> tuple[dict[str, Any], list[dict[str, Any]]]:
@@ -82,4 +134,213 @@ async def handle_calendar_sync(request: web.Request) -> web.Response:
         return web.json_response({"ok": False, "error": str(exc), "code": "calendar_sync_failed"}, status=502)
     return web.json_response(
         {"ok": True, "count": len(payload), "events": payload, "provider": provider_id}
+    )
+
+# ── credentials ─────────────────────────────────────────────────────────────
+
+
+def _known_provider(body: dict[str, Any]) -> str:
+    """The ``provider`` field, validated against the live registry."""
+    provider = field_str(body, "provider", max_len=64).lower()
+    if provider not in {row["id"] for row in cal.available_calendar_providers()}:
+        raise BadRequest("unknown calendar provider", code="unknown_provider")
+    return provider
+
+
+async def handle_get_calendar_credentials(request: web.Request) -> web.Response:
+    """Which providers have credentials, and which fields are filled in.
+
+    Field NAMES and booleans only — never a value. A settings page needs to
+    render "connected" and "which of these did you fill in", and neither question
+    needs the secret. There is deliberately no route that reads one back.
+    """
+    return web.json_response({"status": await credentials.credential_status()})
+
+
+async def handle_put_calendar_credentials(request: web.Request) -> web.Response:
+    """Store one provider's credentials.
+
+    Write-only: the response repeats the status, not the values. An empty string
+    clears its field, which is how the UI removes one without disconnecting the
+    whole provider.
+    """
+    body = await json_body(request)
+    provider = _known_provider(body)
+    allowed = _CREDENTIAL_FIELDS.get(provider)
+    if not allowed:
+        raise BadRequest(
+            "this calendar provider takes no credentials", code="no_credentials_needed"
+        )
+    raw = body.get("values")
+    if not isinstance(raw, dict):
+        raise BadRequest("values must be a JSON object")
+
+    values: dict[str, str] = {}
+    for name in allowed:
+        if name not in raw:
+            continue
+        supplied = raw[name]
+        # Hand-validated rather than routed through `field_str`, for the two
+        # reasons `handle_put_note` documents: that helper treats a non-string as
+        # MISSING (so a malformed request would answer 200 having silently skipped
+        # a field the user thinks they set), and it strips (which would mangle a
+        # password whose whitespace is significant).
+        if supplied is None:
+            values[name] = ""
+            continue
+        if not isinstance(supplied, str):
+            raise BadRequest(f"{name} must be a string")
+        if len(supplied) > k.MAX_CREDENTIAL_VALUE_CHARS:
+            raise BadRequest(f"{name} is too long")
+        values[name] = supplied
+
+    if not values:
+        raise BadRequest("no known credential fields were supplied")
+
+    await credentials.write_for(provider, values)
+    # The names, never the values -- an audit log is read by people who should not
+    # be able to reconstruct a password from it.
+    audit("meetings.calendar_credentials", provider, outcome="ok")
+    return web.json_response({"ok": True, "status": await credentials.credential_status()})
+
+
+async def handle_forget_calendar_credentials(request: web.Request) -> web.Response:
+    """Disconnect a provider: forget its credentials and any pending flow."""
+    body = await json_body(request)
+    provider = _known_provider(body)
+    await credentials.clear_for(provider)
+    if provider in _OAUTH_CLIENTS:
+        # A flow started and then abandoned would otherwise stay redeemable for
+        # its TTL against a provider the user just disconnected.
+        oauth.forget_pending(provider)
+    audit("meetings.calendar_disconnect", provider, outcome="ok")
+    return web.json_response({"ok": True, "status": await credentials.credential_status()})
+
+
+# ── OAuth ───────────────────────────────────────────────────────────────────
+
+
+def _redirect_uri(request: web.Request) -> str:
+    """The callback URL, on the SAME origin the caller reached us at.
+
+    See the module docstring: the dashboard's auth cookie is host-scoped, so
+    rewriting the host here would send the user back to an origin their session
+    does not cover.
+    """
+    return f"{str(request.url.origin()).rstrip('/')}{k.API_BASE}{OAUTH_CALLBACK_PATH}"
+
+
+def _oauth_client_or_400(provider: str) -> Any:
+    factory = _OAUTH_CLIENTS.get(provider)
+    if factory is None:
+        raise BadRequest(
+            "this calendar provider does not use OAuth", code="not_an_oauth_provider"
+        )
+    return factory()
+
+
+async def handle_oauth_start(request: web.Request) -> web.Response:
+    """Begin a flow and hand the caller the URL to open.
+
+    The URL is returned rather than redirected to, because the caller is the
+    dashboard's own fetch() and a 302 would be followed by the XHR instead of the
+    user's browser.
+    """
+    body = await json_body(request)
+    provider = _known_provider(body)
+    client = _oauth_client_or_400(provider)
+    try:
+        url = await oauth.begin(client, redirect_uri=_redirect_uri(request))
+    except cal.CalendarError as exc:
+        audit("meetings.calendar_oauth_start", provider, outcome="error", error=str(exc))
+        return web.json_response(
+            {"ok": False, "error": str(exc), "code": "calendar_oauth_failed"}, status=502
+        )
+    audit("meetings.calendar_oauth_start", provider, outcome="ok")
+    return web.json_response({"ok": True, "authorize_url": url})
+
+
+def _callback_page(title: str, detail: str) -> web.Response:
+    """The little page the user's browser lands on.
+
+    HTML rather than JSON because a person is looking at it. ``detail`` is escaped
+    even though every caller passes text this process produced: the habit is what
+    stops the next caller — one that passes a provider's ``error_description``, or
+    worse a query parameter — from turning this into reflected XSS.
+    """
+    safe_title = html.escape(title)
+    safe_detail = html.escape(detail)
+    return web.Response(
+        text=(
+            "<!doctype html><html><head><meta charset='utf-8'>"
+            f"<title>{safe_title}</title></head>"
+            "<body style='font-family:system-ui;padding:2rem;max-width:34rem'>"
+            f"<h1 style='font-size:1.25rem'>{safe_title}</h1>"
+            f"<p>{safe_detail}</p>"
+            "<p style='color:#666'>You can close this tab and return to Kiro Crew.</p>"
+            "</body></html>"
+        ),
+        content_type="text/html",
+    )
+
+
+async def handle_oauth_callback(request: web.Request) -> web.Response:
+    """Where the provider redirects back to, in the user's browser.
+
+    Answers HTML, and always 200 even on failure: this is a page a person reads,
+    and a browser error page would hide the reason. The outcome is in the text
+    and in the audit log.
+
+    The authorization ``code`` is never echoed back into the page, and the
+    provider's own ``error`` parameter is rendered escaped.
+    """
+    state = (request.query.get("state") or "").strip()
+    # Recovered from `state`, NOT read from the query string. The redirect URI is
+    # one shared path registered with each provider verbatim, so a real redirect
+    # carries only `code`/`state` (or `error`) — reading a `provider` parameter
+    # meant every genuine callback arrived with an empty one and was turned away
+    # as an unknown provider. `state` is the CSPRNG value only this process could
+    # have minted, so it names the flow; `complete` verifies it again below.
+    provider = oauth.provider_for_state(state) or ""
+    if provider not in _OAUTH_CLIENTS:
+        # Audited like every other exit from this handler: an absent, expired,
+        # or FORGED ``state`` is the security-relevant rejection here (it is the
+        # anti-forgery check firing), and a refusal with no SEL record would be
+        # invisible to anyone reviewing the audit trail for callback abuse. The
+        # resource is "unknown" because a state that names no flow names no
+        # provider either — that is the point of the guard.
+        audit(
+            "meetings.calendar_oauth_callback",
+            "unknown",
+            outcome="error",
+            error="invalid_or_expired_state",
+        )
+        return _callback_page(
+            "Could not finish connecting",
+            "That sign-in link has expired or was already used. Start connecting again.",
+        )
+
+    denial = (request.query.get("error") or "").strip()
+    if denial:
+        oauth.forget_pending(provider)
+        audit("meetings.calendar_oauth_callback", provider, outcome="error", error=denial)
+        return _callback_page(
+            "Connection cancelled",
+            f"The calendar provider reported: {denial}",
+        )
+
+    try:
+        await oauth.complete(
+            _oauth_client_or_400(provider),
+            code=request.query.get("code") or "",
+            state=state,
+        )
+    except (cal.CalendarError, BadRequest) as exc:
+        audit("meetings.calendar_oauth_callback", provider, outcome="error", error=str(exc))
+        return _callback_page("Could not finish connecting", str(exc))
+
+    audit("meetings.calendar_oauth_callback", provider, outcome="ok")
+    return _callback_page(
+        "Calendar connected",
+        "Kiro Crew can now read your upcoming meetings.",
     )

--- a/src/kiro_crew/security/paths.py
+++ b/src/kiro_crew/security/paths.py
@@ -270,6 +270,30 @@ _CREW_SECRET_LEAVES: list[str] = [
     # one CLI spawn that must write into it is granted its per-call subdirectory
     # explicitly.
     "aws-control-staging",
+    # The Meetings builtin's calendar credentials: a CalDAV password and the
+    # Google / Microsoft 365 OAuth refresh + access tokens. Each is a live bearer
+    # credential for the user's calendar -- a refresh token in particular survives
+    # until revoked, so an agent that could read this file would keep reading the
+    # user's schedule long after the session ended. It is a leaf (not a flat
+    # ``~/.kiro/crew`` entry) so it is generated for BOTH ``_CREW_HOME_PREFIXES``,
+    # since ``config_dir()`` can resolve to the legacy ``.kirocrew`` data-home
+    # during a migration fallback and the tokens must be protected there too.
+    #
+    # It lives under ``workspace/`` rather than in ``apps/meetings/data/`` on
+    # purpose: that data tree is what the app's own ``store.contain`` bounds
+    # agent-driven paths against, and keeping a credential outside it removes the
+    # reachability question instead of answering it. The app's backend
+    # (``meetings/backend/credentials.py``) opens the file directly rather than
+    # through this gate, so the user's calendar connection keeps working.
+    #
+    # The DIRECTORY is gated, not the one leaf, because the leaf is not the only
+    # file that holds the tokens. ``credentials.py`` writes atomically through
+    # ``atomic_write``'s owner-only ``.tmp`` sibling in the same directory; if
+    # the process dies between the write and the replace, that sibling survives
+    # with the credentials in it, and an exact-leaf rule does not cover it.
+    # Gating the directory (like ``trust``/``profiles`` below) also means a
+    # future file in here is protected without a new entry.
+    "workspace/meetings",
     "browser-cookies.txt",
     "playwright-storage-state.json",
     # The refused-inbound spool (messaging/inbound_spool.py). Not a secret: it is

--- a/test/test_meetings_calendar_routes.py
+++ b/test/test_meetings_calendar_routes.py
@@ -1,0 +1,656 @@
+"""The calendar credential + OAuth routes.
+
+No real network and no real provider: the OAuth module is driven through its own
+public surface and the token endpoint never gets called, because every test here
+stops at the handshake boundary.
+
+These tests MUST live in the repo-level ``test/`` tree — ``setup.cfg`` sets
+``testpaths = test transfer``, so a test under ``src/kiro_crew/apps/builtins/…``
+is never collected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from meetings_helpers import (  # noqa: F401
+    enabled_fixture,
+    reset_module_state_fixture,
+    root_fixture,
+)
+
+from kiro_crew.apps.builtins.meetings.backend import constants as k
+from kiro_crew.apps.builtins.meetings.backend import credentials as creds
+from kiro_crew.apps.builtins.meetings.backend import oauth
+from kiro_crew.apps.builtins.meetings.backend.routes import calendar as calroutes
+
+BASE = k.API_BASE
+
+
+@pytest.fixture()
+def store(tmp_path: Path):
+    creds.set_credentials_home(tmp_path / "creds")
+    for provider in (k.CALENDAR_PROVIDER_GOOGLE, k.CALENDAR_PROVIDER_MICROSOFT):
+        oauth.forget_pending(provider)
+    yield creds
+    for provider in (k.CALENDAR_PROVIDER_GOOGLE, k.CALENDAR_PROVIDER_MICROSOFT):
+        oauth.forget_pending(provider)
+    creds.set_credentials_home(None)
+
+
+class TestCredentialFieldAllowlist:
+    """The allowlist is a control, not documentation.
+
+    Without it a client could PUT ``access_token`` or ``refresh_token`` straight
+    into the store and hand the app a credential of its choosing. The OAuth tokens
+    are written only by the oauth module, on the way out of a real exchange.
+    """
+
+    def test_no_provider_accepts_a_token_field(self):
+        for provider, fields in calroutes._CREDENTIAL_FIELDS.items():
+            assert "access_token" not in fields, provider
+            assert "refresh_token" not in fields, provider
+            assert "expires_at" not in fields, provider
+
+    def test_caldav_takes_a_username_and_password(self):
+        assert calroutes._CREDENTIAL_FIELDS[k.CALENDAR_PROVIDER_CALDAV] == (
+            "username",
+            "password",
+        )
+
+    def test_the_oauth_providers_take_a_client_registration(self):
+        for provider in (k.CALENDAR_PROVIDER_GOOGLE, k.CALENDAR_PROVIDER_MICROSOFT):
+            assert calroutes._CREDENTIAL_FIELDS[provider] == ("client_id", "client_secret")
+
+    def test_the_providers_that_need_no_credentials_have_no_entry(self):
+        assert k.CALENDAR_PROVIDER_NONE not in calroutes._CREDENTIAL_FIELDS
+        assert k.CALENDAR_PROVIDER_ICS not in calroutes._CREDENTIAL_FIELDS
+
+    def test_every_allowlisted_provider_is_a_registered_one(self):
+        """A typo'd key here would be a silently dead branch."""
+        from kiro_crew.apps.builtins.meetings.backend.providers import calendar as cal
+
+        known = {row["id"] for row in cal.available_calendar_providers()}
+        assert set(calroutes._CREDENTIAL_FIELDS) <= known
+
+
+class TestOAuthClientMap:
+    def test_only_the_cloud_providers_use_oauth(self):
+        assert set(calroutes._OAUTH_CLIENTS) == {
+            k.CALENDAR_PROVIDER_GOOGLE,
+            k.CALENDAR_PROVIDER_MICROSOFT,
+        }
+
+    def test_each_entry_builds_a_client_for_its_own_provider(self):
+        for provider, factory in calroutes._OAUTH_CLIENTS.items():
+            assert factory().provider_id == provider
+
+
+class TestRedirectUri:
+    """Derived from the request origin, because the auth cookie is host-scoped.
+
+    A user logged in at ``localhost:5476`` who was sent back to ``127.0.0.1:5476``
+    would arrive with no cookie and be rejected -- so the origin is echoed rather
+    than normalized.
+    """
+
+    @staticmethod
+    def _request(url: str):
+        from aiohttp.test_utils import make_mocked_request
+
+        split = urlsplit(url)
+        return make_mocked_request("GET", split.path or "/", headers={"Host": split.netloc})
+
+    def test_it_keeps_the_host_the_caller_used(self):
+        uri = calroutes._redirect_uri(self._request("http://localhost:5476/x"))
+        assert uri.startswith("http://localhost:5476/")
+        assert "127.0.0.1" not in uri
+
+    def test_it_keeps_a_non_default_port(self):
+        uri = calroutes._redirect_uri(self._request("http://127.0.0.1:9999/x"))
+        assert "127.0.0.1:9999" in uri
+
+    def test_it_points_at_the_registered_callback_path(self):
+        """The path comes from the shared constant, so the redirect URI and the
+        route cannot drift -- a mismatch would fail only at the provider, with a
+        message that does not name the cause."""
+        uri = calroutes._redirect_uri(self._request("http://127.0.0.1:5476/x"))
+        assert uri.endswith(f"{k.API_BASE}{calroutes.OAUTH_CALLBACK_PATH}")
+        assert calroutes.OAUTH_CALLBACK_PATH == "/calendar/oauth/callback"
+
+
+class TestTheCallbackPage:
+    def test_it_answers_html_a_person_can_read(self):
+        resp = calroutes._callback_page("Connected", "all good")
+        assert resp.content_type == "text/html"
+        assert "Connected" in resp.text
+
+    def test_it_escapes_the_detail(self):
+        """Every current caller passes text this process produced, but the next one
+        will pass a provider's error_description -- and that is remote input."""
+        resp = calroutes._callback_page("t", "<script>alert(1)</script>")
+        assert "<script>" not in resp.text
+        assert "&lt;script&gt;" in resp.text
+
+    def test_it_escapes_the_title_too(self):
+        resp = calroutes._callback_page("<img src=x onerror=1>", "d")
+        assert "<img" not in resp.text
+
+
+class TestOAuthCallbackHandler:
+    """The callback always answers 200 HTML: a person is reading it, and a browser
+    error page would hide the reason."""
+
+    @staticmethod
+    def _callback(query: dict[str, str]):
+        from urllib.parse import urlencode
+
+        from aiohttp.test_utils import make_mocked_request
+
+        path = f"{BASE}{calroutes.OAUTH_CALLBACK_PATH}?{urlencode(query)}"
+        return make_mocked_request("GET", path, headers={"Host": "127.0.0.1:5476"})
+
+    @staticmethod
+    async def _open_flow(store, provider: str = k.CALENDAR_PROVIDER_GOOGLE) -> str:
+        """Start a real flow and return the ``state`` the provider will echo back.
+
+        The callback query is built the way a provider actually builds it — the
+        registered redirect URI plus ``code``/``state``, and NO ``provider`` — so
+        these tests exercise the shape that reaches production. Passing a
+        ``provider`` parameter (as they used to) simulated a redirect no provider
+        sends, which is why a callback that could never resolve its provider
+        still looked green.
+        """
+        await store.write_for(provider, {"client_id": "cid"})
+        await oauth.begin(
+            calroutes._OAUTH_CLIENTS[provider](),
+            redirect_uri="http://127.0.0.1:5476/cb",
+        )
+        return oauth._pending[provider].state
+
+    @pytest.mark.asyncio
+    async def test_a_callback_that_names_no_flow_is_refused(self, store):
+        """No ``state`` at all: nothing identifies a flow, so there is nothing to
+        redeem. This is also what a stray visit to the callback URL looks like."""
+        resp = await calroutes.handle_oauth_callback(self._callback({}))
+        assert resp.status == 200
+        assert "expired or was already used" in resp.text
+
+    @pytest.mark.asyncio
+    async def test_a_user_denial_is_reported_and_clears_the_flow(self, store):
+        state = await self._open_flow(store)
+        resp = await calroutes.handle_oauth_callback(
+            self._callback({"state": state, "error": "access_denied"})
+        )
+
+        assert "access_denied" in resp.text
+        # An abandoned flow must not stay redeemable for its whole TTL.
+        assert k.CALENDAR_PROVIDER_GOOGLE not in oauth._pending
+
+    @pytest.mark.asyncio
+    async def test_a_denial_string_is_escaped_into_the_page(self, store):
+        state = await self._open_flow(store)
+        resp = await calroutes.handle_oauth_callback(
+            self._callback({"state": state, "error": "<script>x</script>"})
+        )
+        # Reached the denial page (not the refusal), and escaped the provider's text.
+        assert "script" in resp.text
+        assert "<script>" not in resp.text
+
+    @pytest.mark.asyncio
+    async def test_a_forged_callback_with_no_flow_is_refused(self, store, monkeypatch):
+        """`state` is the guard: a link a user is tricked into opening has no
+        pending flow to match, so it cannot even name a provider. The refusal is
+        SEL-audited like every other exit from the handler — a forged callback is
+        precisely the event an audit-trail reviewer needs to see."""
+        events: list[tuple[str, str, str, str]] = []
+        monkeypatch.setattr(
+            calroutes,
+            "audit",
+            lambda op, res, *, outcome, error="": events.append((op, res, outcome, error)),
+        )
+        resp = await calroutes.handle_oauth_callback(
+            self._callback({"code": "attacker-code", "state": "made-up"})
+        )
+        assert "expired or was already used" in resp.text
+        assert "attacker-code" not in resp.text
+        assert events == [
+            ("meetings.calendar_oauth_callback", "unknown", "error", "invalid_or_expired_state")
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_wrong_state_is_refused_before_any_client_is_built(self, store):
+        """A state that matches no pending flow is refused at provider resolution.
+
+        Stronger than the check inside ``complete`` that this replaces: because the
+        provider is DERIVED from ``state``, a forged one cannot reach the exchange
+        at all. ``complete`` still re-verifies it, which is why that check is now
+        defence in depth rather than the only guard.
+        """
+        await self._open_flow(store)
+        resp = await calroutes.handle_oauth_callback(
+            self._callback({"code": "secret-authorization-code", "state": "wrong"})
+        )
+
+        assert "expired or was already used" in resp.text
+        assert "secret-authorization-code" not in resp.text
+        # The real flow is untouched: a forged callback must not consume it.
+        assert k.CALENDAR_PROVIDER_GOOGLE in oauth._pending
+
+    @pytest.mark.asyncio
+    async def test_a_real_redirect_resolves_its_provider_from_the_state(
+        self, store, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The end-to-end shape: only ``code`` and ``state`` come back.
+
+        This is the case that was broken — every genuine redirect was rejected as
+        an unknown provider — so it is pinned on the exact query a provider sends.
+        """
+        seen: dict[str, str] = {}
+
+        async def _complete(client, *, code: str, state: str) -> None:
+            seen["provider"] = client.provider_id
+            seen["state"] = state
+
+        monkeypatch.setattr(oauth, "complete", _complete)
+        state = await self._open_flow(store)
+        resp = await calroutes.handle_oauth_callback(
+            self._callback({"code": "secret-authorization-code", "state": state})
+        )
+
+        assert "Calendar connected" in resp.text
+        assert "secret-authorization-code" not in resp.text
+        # Routed to the right provider's client, carrying the state through.
+        assert seen == {"provider": k.CALENDAR_PROVIDER_GOOGLE, "state": state}
+
+
+class TestForgettingAProviderClearsItsPendingFlow:
+    @pytest.mark.asyncio
+    async def test_disconnect_drops_the_flow(self, store):
+        await store.write_for(k.CALENDAR_PROVIDER_GOOGLE, {"client_id": "cid"})
+        await oauth.begin(
+            calroutes._OAUTH_CLIENTS[k.CALENDAR_PROVIDER_GOOGLE](),
+            redirect_uri="http://127.0.0.1:5476/cb",
+        )
+        assert k.CALENDAR_PROVIDER_GOOGLE in oauth._pending
+
+        oauth.forget_pending(k.CALENDAR_PROVIDER_GOOGLE)
+        assert k.CALENDAR_PROVIDER_GOOGLE not in oauth._pending
+
+
+class TestTheConsentUrlUsesTheDerivedRedirect:
+    @pytest.mark.asyncio
+    async def test_the_redirect_uri_in_the_url_is_the_callback_route(self, store):
+        await store.write_for(k.CALENDAR_PROVIDER_GOOGLE, {"client_id": "cid"})
+        redirect = f"http://127.0.0.1:5476{k.API_BASE}{calroutes.OAUTH_CALLBACK_PATH}"
+        url = await oauth.begin(
+            calroutes._OAUTH_CLIENTS[k.CALENDAR_PROVIDER_GOOGLE](),
+            redirect_uri=redirect,
+        )
+        assert parse_qs(urlsplit(url).query)["redirect_uri"] == [redirect]
+
+
+class TestCredentialRoutes:
+    """The credential HTTP surface, end to end through the real router.
+
+    Values go in and never come back out: every assertion on a response is
+    field NAMES and booleans, and the tests fail if a stored value ever appears
+    in a response body.
+    """
+
+    @staticmethod
+    def _client(root):
+        from meetings_helpers import client_for, make_app
+
+        return client_for(make_app(root))
+
+    @pytest.mark.asyncio
+    async def test_get_answers_empty_when_nothing_is_stored(self, root, enabled, store):
+        async with self._client(root) as client:
+            resp = await client.get(f"{BASE}/calendar/credentials")
+            assert resp.status == 200
+            assert (await resp.json())["status"] == {}
+
+    @pytest.mark.asyncio
+    async def test_put_stores_and_reports_names_never_values(self, root, enabled, store):
+        async with self._client(root) as client:
+            resp = await client.put(
+                f"{BASE}/calendar/credentials",
+                json={
+                    "provider": k.CALENDAR_PROVIDER_CALDAV,
+                    "values": {"username": "u@example.com", "password": "hunter2"},
+                },
+            )
+            assert resp.status == 200
+            body = await resp.text()
+            assert "hunter2" not in body
+            assert "u@example.com" not in body
+            payload = await resp.json()
+            assert payload["status"][k.CALENDAR_PROVIDER_CALDAV]["fields"] == [
+                "password",
+                "username",
+            ]
+        assert (await store.read_for(k.CALENDAR_PROVIDER_CALDAV))["password"] == "hunter2"
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_an_unknown_provider(self, root, enabled, store):
+        async with self._client(root) as client:
+            resp = await client.put(
+                f"{BASE}/calendar/credentials",
+                json={"provider": "nonesuch", "values": {"username": "x"}},
+            )
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "unknown_provider"
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_a_provider_that_takes_no_credentials(self, root, enabled, store):
+        async with self._client(root) as client:
+            resp = await client.put(
+                f"{BASE}/calendar/credentials",
+                json={"provider": k.CALENDAR_PROVIDER_NONE, "values": {"x": "y"}},
+            )
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "no_credentials_needed"
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_a_non_object_values(self, root, enabled, store):
+        async with self._client(root) as client:
+            resp = await client.put(
+                f"{BASE}/calendar/credentials",
+                json={"provider": k.CALENDAR_PROVIDER_CALDAV, "values": "not-a-dict"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_a_non_string_value(self, root, enabled, store):
+        """`field_str` would silently treat a non-string as missing; this route
+        hand-validates so a malformed request cannot answer 200 while skipping a
+        field the user thinks they set."""
+        async with self._client(root) as client:
+            resp = await client.put(
+                f"{BASE}/calendar/credentials",
+                json={"provider": k.CALENDAR_PROVIDER_CALDAV, "values": {"username": 5}},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_an_oversized_value(self, root, enabled, store):
+        async with self._client(root) as client:
+            resp = await client.put(
+                f"{BASE}/calendar/credentials",
+                json={
+                    "provider": k.CALENDAR_PROVIDER_CALDAV,
+                    "values": {"password": "x" * (k.MAX_CREDENTIAL_VALUE_CHARS + 1)},
+                },
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_when_no_known_field_is_supplied(self, root, enabled, store):
+        """Unknown fields are ignored (the allowlist is the control), and a body
+        carrying only unknown fields is an error, not a silent 200 no-op."""
+        async with self._client(root) as client:
+            resp = await client.put(
+                f"{BASE}/calendar/credentials",
+                json={
+                    "provider": k.CALENDAR_PROVIDER_CALDAV,
+                    "values": {"access_token": "attacker-controlled"},
+                },
+            )
+            assert resp.status == 400
+        assert await store.read_for(k.CALENDAR_PROVIDER_CALDAV) == {}
+
+    @pytest.mark.asyncio
+    async def test_put_with_null_clears_one_field(self, root, enabled, store):
+        await store.write_for(k.CALENDAR_PROVIDER_CALDAV, {"username": "u", "password": "p"})
+        async with self._client(root) as client:
+            resp = await client.put(
+                f"{BASE}/calendar/credentials",
+                json={"provider": k.CALENDAR_PROVIDER_CALDAV, "values": {"password": None}},
+            )
+            assert resp.status == 200
+        assert await store.read_for(k.CALENDAR_PROVIDER_CALDAV) == {"username": "u"}
+
+    @pytest.mark.asyncio
+    async def test_forget_clears_credentials_and_any_pending_flow(self, root, enabled, store):
+        await store.write_for(k.CALENDAR_PROVIDER_GOOGLE, {"client_id": "cid"})
+        await oauth.begin(
+            calroutes._OAUTH_CLIENTS[k.CALENDAR_PROVIDER_GOOGLE](),
+            redirect_uri="http://127.0.0.1:5476/cb",
+        )
+        assert k.CALENDAR_PROVIDER_GOOGLE in oauth._pending
+        async with self._client(root) as client:
+            resp = await client.post(
+                f"{BASE}/calendar/credentials/forget",
+                json={"provider": k.CALENDAR_PROVIDER_GOOGLE},
+            )
+            assert resp.status == 200
+            assert (await resp.json())["status"] == {}
+        assert await store.read_for(k.CALENDAR_PROVIDER_GOOGLE) == {}
+        assert k.CALENDAR_PROVIDER_GOOGLE not in oauth._pending
+
+
+class TestOAuthStartRoute:
+    @staticmethod
+    def _client(root):
+        from meetings_helpers import client_for, make_app
+
+        return client_for(make_app(root))
+
+    @pytest.mark.asyncio
+    async def test_start_answers_the_consent_url(self, root, enabled, store):
+        await store.write_for(k.CALENDAR_PROVIDER_GOOGLE, {"client_id": "cid"})
+        async with self._client(root) as client:
+            resp = await client.post(
+                f"{BASE}/calendar/oauth/start",
+                json={"provider": k.CALENDAR_PROVIDER_GOOGLE},
+            )
+            assert resp.status == 200
+            payload = await resp.json()
+            assert payload["ok"] is True
+            # The consent URL carries the redirect derived from THIS request's
+            # origin — the host-scoped-cookie property the module docstring names.
+            redirect = parse_qs(urlsplit(payload["authorize_url"]).query)["redirect_uri"][0]
+            assert redirect.endswith(f"{k.API_BASE}{calroutes.OAUTH_CALLBACK_PATH}")
+
+    @pytest.mark.asyncio
+    async def test_start_refuses_a_non_oauth_provider(self, root, enabled, store):
+        async with self._client(root) as client:
+            resp = await client.post(
+                f"{BASE}/calendar/oauth/start",
+                json={"provider": k.CALENDAR_PROVIDER_CALDAV},
+            )
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "not_an_oauth_provider"
+
+    @pytest.mark.asyncio
+    async def test_start_maps_a_begin_failure_to_502(self, root, enabled, store):
+        """No client_id stored: `begin` raises CalendarError, and the route answers
+        a 502 with the reason instead of a 500 with a stack trace."""
+        async with self._client(root) as client:
+            resp = await client.post(
+                f"{BASE}/calendar/oauth/start",
+                json={"provider": k.CALENDAR_PROVIDER_GOOGLE},
+            )
+            assert resp.status == 502
+            payload = await resp.json()
+            assert payload["ok"] is False
+            assert payload["code"] == "calendar_oauth_failed"
+
+
+class TestOAuthCallbackSuccess:
+    @pytest.mark.asyncio
+    async def test_a_completed_exchange_renders_the_connected_page(self, store, monkeypatch):
+        """The success exit of the callback: `complete` is stubbed AT the handler's
+        boundary (the exchange itself is `oauth` module territory, tested there),
+        so this locks the route's own behaviour — the audit record and the page."""
+        from urllib.parse import urlencode
+
+        from aiohttp.test_utils import make_mocked_request
+
+        await store.write_for(k.CALENDAR_PROVIDER_GOOGLE, {"client_id": "cid"})
+        await oauth.begin(
+            calroutes._OAUTH_CLIENTS[k.CALENDAR_PROVIDER_GOOGLE](),
+            redirect_uri="http://127.0.0.1:5476/cb",
+        )
+        state = oauth._pending[k.CALENDAR_PROVIDER_GOOGLE].state
+
+        async def _complete(client, *, code, state):
+            return None
+
+        monkeypatch.setattr(oauth, "complete", _complete)
+        events: list[tuple[str, str, str]] = []
+        monkeypatch.setattr(
+            calroutes,
+            "audit",
+            lambda op, res, *, outcome, error="": events.append((op, res, outcome)),
+        )
+
+        path = (
+            f"{BASE}{calroutes.OAUTH_CALLBACK_PATH}?"
+            f"{urlencode({'code': 'auth-code', 'state': state})}"
+        )
+        resp = await calroutes.handle_oauth_callback(
+            make_mocked_request("GET", path, headers={"Host": "127.0.0.1:5476"})
+        )
+        assert resp.status == 200
+        assert "Calendar connected" in resp.text
+        assert events == [("meetings.calendar_oauth_callback", k.CALENDAR_PROVIDER_GOOGLE, "ok")]
+
+
+class TestCredentialStoreEdges:
+    """The store's failure-path contracts, driven through its public surface."""
+
+    @pytest.mark.asyncio
+    async def test_write_for_refuses_an_empty_provider_id(self, store):
+        with pytest.raises(ValueError):
+            await store.write_for("  ", {"username": "u"})
+
+    @pytest.mark.asyncio
+    async def test_clearing_every_field_removes_the_provider_entry(self, store):
+        await store.write_for(k.CALENDAR_PROVIDER_CALDAV, {"username": "u"})
+        await store.write_for(k.CALENDAR_PROVIDER_CALDAV, {"username": ""})
+        assert await store.read_all() == {}
+
+    @pytest.mark.asyncio
+    async def test_clear_for_is_a_no_op_when_nothing_is_stored(self, store):
+        await store.clear_for(k.CALENDAR_PROVIDER_CALDAV)
+        assert not store.credentials_file().exists()
+
+    @pytest.mark.asyncio
+    async def test_clear_for_removes_only_the_named_provider(self, store):
+        await store.write_for(k.CALENDAR_PROVIDER_CALDAV, {"username": "u"})
+        await store.write_for(k.CALENDAR_PROVIDER_GOOGLE, {"client_id": "c"})
+        await store.clear_for(k.CALENDAR_PROVIDER_CALDAV)
+        assert set(await store.read_all()) == {k.CALENDAR_PROVIDER_GOOGLE}
+
+    @pytest.mark.asyncio
+    async def test_a_non_object_store_reads_as_empty_but_refuses_writes(self, store):
+        """Schema-invalid root: DISPLAY degrades to empty, a WRITE refuses.
+
+        The split is the whole point of :class:`_StoreUnreadable`: a settings page
+        can render "not connected", but a read-modify-write that treated this as
+        empty would rebuild the file from nothing and permanently destroy whatever
+        a human could still recover from the malformed content.
+        """
+        store.credentials_home().mkdir(parents=True, exist_ok=True)
+        store.credentials_file().write_text('["not", "a", "dict"]', encoding="utf-8")
+        assert await store.read_all() == {}
+        with pytest.raises(store._StoreUnreadable):
+            await store.write_for(k.CALENDAR_PROVIDER_CALDAV, {"username": "u"})
+        # The malformed content is untouched, not rewritten away.
+        assert store.credentials_file().read_text(encoding="utf-8") == '["not", "a", "dict"]'
+
+    @pytest.mark.asyncio
+    async def test_schema_invalid_entries_poison_the_whole_read(self, store):
+        """A skipped entry would be persisted-away by the next write; refuse instead."""
+        store.credentials_home().mkdir(parents=True, exist_ok=True)
+        store.credentials_file().write_text(
+            '{"caldav": {"username": "u"}, "bad": "not-a-dict"}', encoding="utf-8"
+        )
+        assert await store.read_all() == {}
+        with pytest.raises(store._StoreUnreadable):
+            await store.write_for(k.CALENDAR_PROVIDER_GOOGLE, {"client_id": "c"})
+        # The recoverable entry is still in the file for a human to salvage.
+        assert "username" in store.credentials_file().read_text(encoding="utf-8")
+
+    @pytest.mark.asyncio
+    async def test_a_failed_owner_lockdown_warns_but_does_not_lose_the_read(
+        self, store, monkeypatch
+    ):
+        await store.write_for(k.CALENDAR_PROVIDER_CALDAV, {"username": "u"})
+        monkeypatch.setattr(
+            creds, "restrict_to_owner", lambda _p: (_ for _ in ()).throw(OSError("acl"))
+        )
+        assert (await store.read_for(k.CALENDAR_PROVIDER_CALDAV))["username"] == "u"
+
+    @pytest.mark.asyncio
+    async def test_a_failed_owner_lockdown_on_the_temp_refuses_the_write(self, store, monkeypatch):
+        """Fail-closed: a credential the module cannot protect is not published.
+        The refused write leaves the previous file intact, so the existing
+        connection keeps working — the opposite trade from the read path's
+        warn-and-continue, deliberately."""
+        from kiro_crew import atomic_write as aw
+
+        await store.write_for(k.CALENDAR_PROVIDER_CALDAV, {"username": "before"})
+        monkeypatch.setattr(
+            aw.platform_compat,
+            "restrict_to_owner",
+            lambda _p: (_ for _ in ()).throw(OSError("acl")),
+        )
+        with pytest.raises(OSError):
+            await store.write_for(k.CALENDAR_PROVIDER_CALDAV, {"username": "after"})
+        monkeypatch.undo()
+        assert (await store.read_for(k.CALENDAR_PROVIDER_CALDAV))["username"] == "before"
+        assert list(store.credentials_home().glob("*.tmp")) == []
+
+    @pytest.mark.asyncio
+    async def test_a_failed_replace_cleans_up_the_temp_and_raises(self, store, monkeypatch):
+        """The atomic-write contract: a failure between temp-write and replace
+        must not leave a credential-bearing temp file behind."""
+        import os as _os
+
+        from kiro_crew import atomic_write as aw
+
+        def _boom(src, dst):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(aw, "replace_with_retry", _boom)
+        with pytest.raises(OSError):
+            await store.write_for(k.CALENDAR_PROVIDER_CALDAV, {"username": "u"})
+        monkeypatch.undo()
+        leftovers = (
+            list(store.credentials_home().glob("*.tmp"))
+            if (store.credentials_home().exists())
+            else []
+        )
+        assert leftovers == []
+        assert _os.path.exists(store.credentials_file()) is False
+
+    def test_the_production_path_lands_under_workspace_meetings(self, monkeypatch):
+        """The path the sensitive-file gate protects and the path the store writes
+        must be the same one — this pins the store's side of that contract."""
+        creds.set_credentials_home(None)
+        try:
+            monkeypatch.setattr(creds, "config_dir", lambda: Path("/tmp/crew-home"))
+            assert creds.credentials_home() == Path("/tmp/crew-home/workspace/meetings")
+        finally:
+            creds.set_credentials_home(None)
+
+    def test_a_broken_resolver_degrades_to_the_documented_default(self, monkeypatch):
+        creds.set_credentials_home(None)
+        try:
+            monkeypatch.setattr(
+                creds, "config_dir", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+            )
+            monkeypatch.setenv("KIROCREW_HOME", "/tmp/override-home")
+            assert creds.credentials_home() == Path("/tmp/override-home/workspace/meetings")
+            monkeypatch.delenv("KIROCREW_HOME")
+            assert (
+                creds.credentials_home()
+                == Path.home() / ".kiro" / "crew" / "workspace" / "meetings"
+            )
+        finally:
+            creds.set_credentials_home(None)

--- a/test/test_meetings_oauth.py
+++ b/test/test_meetings_oauth.py
@@ -1,0 +1,504 @@
+"""The Meetings calendar OAuth client: PKCE, state, exchange, refresh.
+
+No real network. The token endpoint is a local aiohttp server and the SSRF gate
+is stubbed to a pass-through so a loopback URL is reachable, exactly as
+``test_meetings_providers.py`` does it — everything downstream of the gate (the
+form body, the PKCE verifier, the JSON handling, the store writes) runs for real.
+
+These tests MUST live in the repo-level ``test/`` tree: ``setup.cfg`` sets
+``testpaths = test transfer``, so a test under ``src/kiro_crew/apps/builtins/…``
+is never collected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from yarl import URL
+
+from kiro_crew.apps.builtins.meetings.backend import constants as k
+from kiro_crew.apps.builtins.meetings.backend import credentials as creds
+from kiro_crew.apps.builtins.meetings.backend import oauth
+from kiro_crew.apps.builtins.meetings.backend.providers import calendar as cal
+
+PROVIDER = "test-provider"
+
+
+def _passthrough_target(url: str) -> cal.VettedTarget:
+    """Vet a loopback URL as-is.
+
+    The real gate refuses loopback, so a test that needs a real local server
+    stubs it. The stub still returns a genuine ``VettedTarget`` pinned to the
+    server's own address, so the fetch runs through the real pinned connector
+    rather than around it.
+    """
+    parsed = URL(url)
+    host = parsed.raw_host or ""
+    return cal.VettedTarget(url=url, host=host, port=parsed.port or 443, addresses=(host,))
+
+
+class _FakeTokenEndpoint:
+    """A local token endpoint that records the form body it was posted."""
+
+    def __init__(self, response: dict[str, Any] | str, *, status: int = 200) -> None:
+        self._response = response
+        self._status = status
+        self.posts: list[dict[str, list[str]]] = []
+        self._runner: Any = None
+        self.url = ""
+
+    async def __aenter__(self) -> _FakeTokenEndpoint:
+        from aiohttp import web as aioweb
+
+        async def handler(request):
+            self.posts.append(parse_qs((await request.read()).decode("utf-8")))
+            if isinstance(self._response, str):
+                return aioweb.Response(status=self._status, text=self._response)
+            return aioweb.json_response(self._response, status=self._status)
+
+        app = aioweb.Application()
+        app.router.add_post("/token", handler)
+        self._runner = aioweb.AppRunner(app)
+        await self._runner.setup()
+        site = aioweb.TCPSite(self._runner, "127.0.0.1", 0)
+        await site.start()
+        self.url = f"http://127.0.0.1:{self._runner.addresses[0][1]}/token"
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self._runner.cleanup()
+
+
+def _client(token_url: str = "https://example.invalid/token") -> oauth.OAuthClient:
+    return oauth.OAuthClient(
+        provider_id=PROVIDER,
+        authorize_url="https://example.invalid/authorize",
+        token_url=token_url,
+        scopes=("calendar.readonly", "openid"),
+        extra_authorize_params={"access_type": "offline"},
+    )
+
+
+@pytest.fixture()
+def store(tmp_path: Path):
+    """A temp credential store, so no test touches the real one."""
+    creds.set_credentials_home(tmp_path / "creds")
+    oauth.forget_pending(PROVIDER)
+    yield creds
+    oauth.forget_pending(PROVIDER)
+    creds.set_credentials_home(None)
+
+
+class TestPkce:
+    """S256 only. ``plain`` gives no protection — the verifier IS the challenge —
+    so it is not implemented rather than offered and discouraged."""
+
+    def test_the_verifier_is_within_the_rfc_range(self):
+        verifier = oauth.new_verifier()
+        # RFC 7636 §4.1: 43..128 characters from the unreserved set.
+        assert 43 <= len(verifier) <= 128
+        assert all(c.isalnum() or c in "-._~" for c in verifier)
+
+    def test_two_verifiers_differ(self):
+        assert oauth.new_verifier() != oauth.new_verifier()
+
+    def test_the_challenge_is_unpadded_base64url_sha256(self):
+        verifier = "a" * 64
+        expected = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+            .decode()
+            .rstrip("=")
+        )
+        challenge = oauth.challenge_for(verifier)
+        assert challenge == expected
+        assert "=" not in challenge, "padding must be stripped (RFC 7636 §4.2)"
+        assert "+" not in challenge and "/" not in challenge, "must be url-safe"
+
+
+class TestBegin:
+    @pytest.mark.asyncio
+    async def test_it_refuses_without_a_client_id(self, store):
+        with pytest.raises(oauth.CalendarError, match="OAuth client id"):
+            await oauth.begin(_client(), redirect_uri="http://127.0.0.1:5476/cb")
+
+    @pytest.mark.asyncio
+    async def test_the_consent_url_carries_everything_the_provider_needs(self, store):
+        await store.write_for(PROVIDER, {"client_id": "cid-123"})
+        url = await oauth.begin(_client(), redirect_uri="http://127.0.0.1:5476/cb")
+
+        query = parse_qs(urlsplit(url).query)
+        assert url.startswith("https://example.invalid/authorize?")
+        assert query["client_id"] == ["cid-123"]
+        assert query["response_type"] == ["code"]
+        assert query["redirect_uri"] == ["http://127.0.0.1:5476/cb"]
+        assert query["code_challenge_method"] == ["S256"]
+        assert query["scope"] == ["calendar.readonly openid"]
+        # Provider-specific extras must survive: without access_type=offline
+        # Google returns no refresh token and the calendar stops working in an hour.
+        assert query["access_type"] == ["offline"]
+        assert len(query["state"][0]) >= 20
+        assert len(query["code_challenge"][0]) >= 20
+
+    @pytest.mark.asyncio
+    async def test_the_challenge_matches_the_verifier_that_will_be_sent(self, store):
+        """The whole point of PKCE: the challenge shown to the provider must be
+        the S256 of the verifier this process kept."""
+        await store.write_for(PROVIDER, {"client_id": "cid"})
+        url = await oauth.begin(_client(), redirect_uri="http://127.0.0.1:5476/cb")
+        challenge = parse_qs(urlsplit(url).query)["code_challenge"][0]
+        pending = oauth._pending[PROVIDER]
+        assert oauth.challenge_for(pending.verifier) == challenge
+
+    @pytest.mark.asyncio
+    async def test_starting_again_replaces_the_pending_flow(self, store):
+        await store.write_for(PROVIDER, {"client_id": "cid"})
+        first = await oauth.begin(_client(), redirect_uri="http://127.0.0.1:5476/cb")
+        second = await oauth.begin(_client(), redirect_uri="http://127.0.0.1:5476/cb")
+        first_state = parse_qs(urlsplit(first).query)["state"][0]
+        second_state = parse_qs(urlsplit(second).query)["state"][0]
+
+        assert first_state != second_state
+        # A user who restarts after a mistake must be able to finish the NEW flow.
+        assert oauth._pending[PROVIDER].state == second_state
+
+
+class TestComplete:
+    @pytest.mark.asyncio
+    async def test_no_pending_flow_is_refused(self, store):
+        with pytest.raises(oauth.CalendarError, match="no calendar authorization"):
+            await oauth.complete(_client(), code="c", state="s")
+
+    @pytest.mark.asyncio
+    async def test_a_mismatched_state_is_refused(self, store):
+        await store.write_for(PROVIDER, {"client_id": "cid"})
+        await oauth.begin(_client(), redirect_uri="http://127.0.0.1:5476/cb")
+        with pytest.raises(oauth.CalendarError, match="did not match"):
+            await oauth.complete(_client(), code="c", state="not-the-state")
+
+    @pytest.mark.asyncio
+    async def test_a_mismatched_state_consumes_the_flow(self, store):
+        """Replay protection: a verifier that survived a failed attempt could be
+        presented again with a stolen code."""
+        await store.write_for(PROVIDER, {"client_id": "cid"})
+        await oauth.begin(_client(), redirect_uri="http://127.0.0.1:5476/cb")
+        with pytest.raises(oauth.CalendarError):
+            await oauth.complete(_client(), code="c", state="wrong")
+        assert PROVIDER not in oauth._pending
+
+    @pytest.mark.asyncio
+    async def test_an_expired_flow_is_refused(self, store, monkeypatch: pytest.MonkeyPatch):
+        await store.write_for(PROVIDER, {"client_id": "cid"})
+        url = await oauth.begin(_client(), redirect_uri="http://127.0.0.1:5476/cb")
+        state = parse_qs(urlsplit(url).query)["state"][0]
+
+        started = oauth._pending[PROVIDER].created_at
+        monkeypatch.setattr(oauth, "_now", lambda: started + k.OAUTH_FLOW_TTL_SECS + 1)
+        with pytest.raises(oauth.CalendarError, match="expired"):
+            await oauth.complete(_client(), code="c", state=state)
+
+    @pytest.mark.asyncio
+    async def test_the_state_check_is_constant_time(self):
+        """Structural: an early-returning comparison leaks a prefix of the
+        anti-forgery value."""
+        import inspect
+
+        assert "compare_digest" in inspect.getsource(oauth.complete)
+
+    @pytest.mark.asyncio
+    async def test_a_successful_exchange_sends_the_verifier_and_stores_the_tokens(
+        self, store, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeTokenEndpoint(
+            {"access_token": "at-1", "refresh_token": "rt-1", "expires_in": 3600}
+        ) as endpoint:
+            client = _client(endpoint.url)
+            await store.write_for(PROVIDER, {"client_id": "cid", "client_secret": "sek"})
+            url = await oauth.begin(client, redirect_uri="http://127.0.0.1:5476/cb")
+            state = parse_qs(urlsplit(url).query)["state"][0]
+            verifier = oauth._pending[PROVIDER].verifier
+
+            await oauth.complete(client, code="the-code", state=state)
+            posted = endpoint.posts[0]
+
+        assert posted["grant_type"] == ["authorization_code"]
+        assert posted["code"] == ["the-code"]
+        assert posted["code_verifier"] == [verifier], "PKCE verifier must be sent"
+        assert posted["client_id"] == ["cid"]
+        # A registration that has a secret still sends it; PKCE is what protects
+        # the exchange, but some registrations require both.
+        assert posted["client_secret"] == ["sek"]
+
+        stored = await store.read_for(PROVIDER)
+        assert stored["access_token"] == "at-1"
+        assert stored["refresh_token"] == "rt-1"
+        assert float(stored["expires_at"]) > time.time()
+        # The flow is consumed on success too, so a captured code cannot be
+        # redeemed twice.
+        assert PROVIDER not in oauth._pending
+
+    @pytest.mark.asyncio
+    async def test_a_registration_without_a_secret_sends_none(
+        self, store, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A public client has no usable secret; sending an empty one would be
+        rejected by some providers as a malformed request."""
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeTokenEndpoint({"access_token": "at", "expires_in": 60}) as endpoint:
+            client = _client(endpoint.url)
+            await store.write_for(PROVIDER, {"client_id": "cid"})
+            url = await oauth.begin(client, redirect_uri="http://127.0.0.1:5476/cb")
+            state = parse_qs(urlsplit(url).query)["state"][0]
+            await oauth.complete(client, code="c", state=state)
+            posted = endpoint.posts[0]
+
+        assert "client_secret" not in posted
+
+    @pytest.mark.asyncio
+    async def test_a_provider_error_is_reported_with_its_description(
+        self, store, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeTokenEndpoint(
+            {"error": "invalid_grant", "error_description": "Code was already redeemed"},
+            status=200,
+        ) as endpoint:
+            client = _client(endpoint.url)
+            await store.write_for(PROVIDER, {"client_id": "cid"})
+            url = await oauth.begin(client, redirect_uri="http://127.0.0.1:5476/cb")
+            state = parse_qs(urlsplit(url).query)["state"][0]
+            with pytest.raises(oauth.CalendarError, match="already redeemed"):
+                await oauth.complete(client, code="c", state=state)
+
+    @pytest.mark.asyncio
+    async def test_a_non_json_token_response_is_a_calendar_error(
+        self, store, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The route turns ``CalendarError`` into a 502; a bare ``ValueError``
+        would escape as a 500."""
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeTokenEndpoint("<html>gateway error</html>") as endpoint:
+            client = _client(endpoint.url)
+            await store.write_for(PROVIDER, {"client_id": "cid"})
+            url = await oauth.begin(client, redirect_uri="http://127.0.0.1:5476/cb")
+            state = parse_qs(urlsplit(url).query)["state"][0]
+            with pytest.raises(oauth.CalendarError, match="not JSON"):
+                await oauth.complete(client, code="c", state=state)
+
+
+class TestAccessToken:
+    @pytest.mark.asyncio
+    async def test_an_unconnected_provider_says_so(self, store):
+        with pytest.raises(oauth.CalendarError, match="not connected"):
+            await oauth.access_token(_client())
+
+    @pytest.mark.asyncio
+    async def test_a_fresh_token_is_returned_without_a_round_trip(
+        self, store, monkeypatch: pytest.MonkeyPatch
+    ):
+        await store.write_for(
+            PROVIDER,
+            {
+                "client_id": "cid",
+                "refresh_token": "rt",
+                "access_token": "still-good",
+                "expires_at": str(time.time() + 3600),
+            },
+        )
+
+        async def explode(*args: object, **kwargs: object) -> bytes:
+            raise AssertionError("a fresh token must not hit the token endpoint")
+
+        monkeypatch.setattr(cal, "fetch_vetted", explode)
+        monkeypatch.setattr(oauth, "fetch_vetted", explode)
+        assert await oauth.access_token(_client()) == "still-good"
+
+    @pytest.mark.asyncio
+    async def test_an_expired_token_is_refreshed(self, store, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeTokenEndpoint({"access_token": "at-2", "expires_in": 3600}) as endpoint:
+            await store.write_for(
+                PROVIDER,
+                {
+                    "client_id": "cid",
+                    "refresh_token": "rt-keep",
+                    "access_token": "expired",
+                    "expires_at": str(time.time() - 10),
+                },
+            )
+            token = await oauth.access_token(_client(endpoint.url))
+            posted = endpoint.posts[0]
+
+        assert token == "at-2"
+        assert posted["grant_type"] == ["refresh_token"]
+        assert posted["refresh_token"] == ["rt-keep"]
+
+        stored = await store.read_for(PROVIDER)
+        # The refresh response omitted refresh_token, and the old one must
+        # SURVIVE -- clearing it would break the connection permanently.
+        assert stored["refresh_token"] == "rt-keep"
+        assert stored["access_token"] == "at-2"
+
+    @pytest.mark.asyncio
+    async def test_a_token_expiring_inside_the_skew_is_refreshed_early(
+        self, store, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A token that passes the check and then dies in flight is a 401 halfway
+        through a sync, which is worse than one extra refresh."""
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeTokenEndpoint(
+            {"access_token": "refreshed-early", "expires_in": 3600}
+        ) as endpoint:
+            await store.write_for(
+                PROVIDER,
+                {
+                    "client_id": "cid",
+                    "refresh_token": "rt",
+                    "access_token": "about-to-die",
+                    # Still valid, but inside the skew window.
+                    "expires_at": str(time.time() + k.OAUTH_REFRESH_SKEW_SECS - 5),
+                },
+            )
+            assert await oauth.access_token(_client(endpoint.url)) == "refreshed-early"
+
+    @pytest.mark.asyncio
+    async def test_a_rotated_refresh_token_replaces_the_old_one(
+        self, store, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Some providers rotate the refresh token on every use; keeping the old
+        one would break the next refresh."""
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeTokenEndpoint(
+            {"access_token": "at", "refresh_token": "rt-new", "expires_in": 60}
+        ) as endpoint:
+            await store.write_for(
+                PROVIDER,
+                {
+                    "client_id": "cid",
+                    "refresh_token": "rt-old",
+                    "expires_at": "0",
+                },
+            )
+            await oauth.access_token(_client(endpoint.url))
+
+        assert (await store.read_for(PROVIDER))["refresh_token"] == "rt-new"
+
+
+class TestTheTokenEndpointGoesThroughTheSharedGate:
+    def test_it_does_not_open_its_own_session(self):
+        """A bare aiohttp call here would skip https-only, DNS pinning, per-hop
+        redirect validation and the size cap -- every property the calendar fetch
+        is careful about, for a request that carries a credential."""
+        import inspect
+
+        src = inspect.getsource(oauth._post_token)
+        assert "fetch_vetted(" in src
+        assert "ClientSession" not in src
+
+
+class TestTheCredentialStoreIsTransactional:
+    """A read-modify-write of a secret file has to be one transaction.
+
+    Both halves run in a worker thread (``asyncio.to_thread``), so the two writers
+    that exist in this app — a settings PUT and the OAuth token refresh — really do
+    interleave. And the merge rebuilds the WHOLE file, so any view it reads that is
+    short of the truth is not a stale read but a deletion.
+    """
+
+    @pytest.fixture
+    def store(self, tmp_path: Path):
+        creds.set_credentials_home(tmp_path / "creds")
+        yield creds
+        creds.set_credentials_home(None)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_writes_to_different_providers_both_survive(self, store):
+        """Interleaved read-modify-writes must not discard each other.
+
+        Without one lock over the whole transaction both callers read the same
+        snapshot, each merged its own provider, and the later atomic replace erased
+        the earlier one — losing a freshly minted refresh token, which cannot be
+        re-derived.
+        """
+        await store.write_for(k.CALENDAR_PROVIDER_GOOGLE, {"client_id": "g"})
+        await store.write_for(k.CALENDAR_PROVIDER_MICROSOFT, {"client_id": "m"})
+
+        await asyncio.gather(
+            store.write_for(k.CALENDAR_PROVIDER_GOOGLE, {"refresh_token": "g-refresh"}),
+            store.write_for(k.CALENDAR_PROVIDER_MICROSOFT, {"refresh_token": "m-refresh"}),
+        )
+
+        google = await store.read_for(k.CALENDAR_PROVIDER_GOOGLE)
+        microsoft = await store.read_for(k.CALENDAR_PROVIDER_MICROSOFT)
+        assert google == {"client_id": "g", "refresh_token": "g-refresh"}
+        assert microsoft == {"client_id": "m", "refresh_token": "m-refresh"}
+
+    @pytest.mark.asyncio
+    async def test_many_interleaved_writes_keep_every_provider(self, store):
+        """The same property under contention, since a lock-free race is timing
+        dependent and can pass once by luck."""
+        providers = [k.CALENDAR_PROVIDER_GOOGLE, k.CALENDAR_PROVIDER_MICROSOFT]
+        for provider in providers:
+            await store.write_for(provider, {"client_id": provider})
+
+        await asyncio.gather(
+            *(store.write_for(providers[i % 2], {f"field{i}": str(i)}) for i in range(24))
+        )
+
+        for provider in providers:
+            values = await store.read_for(provider)
+            assert values["client_id"] == provider, values
+        # Every field written for each provider is present: nothing was rebuilt
+        # from a partial view.
+        google = await store.read_for(k.CALENDAR_PROVIDER_GOOGLE)
+        microsoft = await store.read_for(k.CALENDAR_PROVIDER_MICROSOFT)
+        assert {f"field{i}" for i in range(0, 24, 2)} <= set(google)
+        assert {f"field{i}" for i in range(1, 24, 2)} <= set(microsoft)
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_store_fails_the_write_instead_of_wiping_it(self, store):
+        """A write must not treat "cannot read" as "nothing stored".
+
+        Reading for DISPLAY degrades to empty on purpose — a settings page that
+        says "not connected" beats one that cannot load. Carrying that degradation
+        into the merge turned one unreadable file into the permanent loss of every
+        other provider's credentials, because the replace then wrote a store built
+        from a single provider.
+        """
+        await store.write_for(k.CALENDAR_PROVIDER_GOOGLE, {"client_id": "g"})
+        path = store.credentials_file()
+        path.write_text("{ this is not json", encoding="utf-8")
+
+        with pytest.raises(RuntimeError):
+            await store.write_for(k.CALENDAR_PROVIDER_MICROSOFT, {"client_id": "m"})
+
+        # The damaged bytes are still there — untouched, so a backup or a manual
+        # repair is still possible. The write did NOT replace them with a
+        # one-provider store.
+        assert path.read_text(encoding="utf-8") == "{ this is not json"
+
+    @pytest.mark.asyncio
+    async def test_a_missing_store_is_still_an_ordinary_first_write(self, store):
+        """Only UNREADABLE is refused. "No file yet" is the normal first-run path
+        and must keep working."""
+        assert not store.credentials_file().exists()
+        await store.write_for(k.CALENDAR_PROVIDER_GOOGLE, {"client_id": "g"})
+        assert await store.read_for(k.CALENDAR_PROVIDER_GOOGLE) == {"client_id": "g"}
+
+    @pytest.mark.asyncio
+    async def test_reading_still_degrades_to_empty_for_display(self, store):
+        """The display contract is unchanged: an unreadable store reads as empty
+        rather than breaking the settings page."""
+        await store.write_for(k.CALENDAR_PROVIDER_GOOGLE, {"client_id": "g"})
+        store.credentials_file().write_text("not json at all", encoding="utf-8")
+
+        assert await store.read_all() == {}
+        assert await store.read_for(k.CALENDAR_PROVIDER_GOOGLE) == {}
+        assert await store.credential_status() == {}

--- a/test/test_meetings_providers.py
+++ b/test/test_meetings_providers.py
@@ -16,6 +16,7 @@ scheme/address validator, and the document path through a local file.
 
 from __future__ import annotations
 
+import base64
 import itertools
 import json
 import socket
@@ -25,6 +26,7 @@ import types
 from concurrent import futures
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any
 from unittest import mock
 from zoneinfo import ZoneInfo
 
@@ -371,6 +373,42 @@ class TestEventId:
         """A digest that replaced the whole id would make the UI unreadable."""
         assert cal._event_id_for("standup-2026").startswith("standup-2026-")
 
+    def test_redaction_prone_graph_uids_stay_distinct_through_build_event(self):
+        """The id is derived from the ORIGINAL uid, never the redacted form.
+
+        Microsoft Graph ids are long base64 blobs that trip the credential
+        redaction's entropy heuristic. Routing the uid through ``redact`` before
+        ``_event_id_for`` collapsed DIFFERENT events to one
+        ``[REDACTED: credential]`` placeholder — one shared digest, one shared
+        meeting directory, each event overwriting the other's notes and tasks.
+        """
+        from datetime import datetime, timezone
+
+        from kiro_crew.security import redact
+
+        start = datetime(2026, 8, 18, 9, 0, tzinfo=timezone.utc)
+        uid_a = (
+            "AAMkADAwATM3ZmYAZS1kNzu5LTIxYzMtMDACLTAwCgBGAAADqKWZ8VVXvEeYnNmOFczbXAcAJp1e2"
+            "IEIu0Kvw8dglrTFXQAAAgENAAAAJp1e2IEIu0Kvw8dglrTFXQAAAAJp7QAAAA=="
+        )
+        uid_b = uid_a[:-8] + "8BAAAA=="
+        # The premise of this test: these ids DO trip the redactor. If the
+        # heuristic ever stops firing on them, the collision cannot occur and
+        # this guard is vacuous — fail loudly so it gets re-pointed at whatever
+        # shape does trip it then.
+        assert redact(uid_a) != uid_a
+        a = cal.build_event(uid=uid_a, title="A", start=start, end=None)
+        b = cal.build_event(uid=uid_b, title="B", start=start, end=None)
+        assert a.event_id != b.event_id
+        assert "REDACTED" not in a.event_id
+        # And the OTHER failure mode of deriving from the raw uid: a
+        # credential-shaped uid must not surface its readable prefix in the
+        # agent-visible id. A flagged uid switches to a digest-only source, so
+        # no fragment of the original bytes appears in the id.
+        assert uid_a[:12] not in a.event_id
+        # Stable across syncs: the digest of the same uid never changes.
+        assert a.event_id == cal.build_event(uid=uid_a, title="A", start=start, end=None).event_id
+
 
 class TestParseIcs:
     def test_parses_a_basic_event(self):
@@ -703,6 +741,10 @@ class TestUrlValidation:
         assert target.host == "example.test"
         assert target.port == 443
 
+    def test_the_default_https_port_is_filled_in(self, public_dns: None):
+        """The pin is keyed on (host, port), so the port can never be left unset."""
+        assert cal._normalize_url("https://example.test/cal.ics").port == 443
+
     def test_a_non_standard_port_is_refused(self, public_dns: None):
         """Ports narrow to 443, which is stricter than "whatever the URL names".
 
@@ -790,7 +832,9 @@ class TestUrlValidation:
         """
         import inspect
 
-        source = inspect.getsource(cal.IcsCalendarProvider)
+        # The call site is `fetch_vetted`, which is where the hop loop lives now
+        # that every provider shares it.
+        source = inspect.getsource(cal.fetch_vetted)
         assert "calendar redirect URL is malformed" in source
 
     @pytest.mark.parametrize(
@@ -1102,7 +1146,7 @@ class TestCertificateVerificationStaysOn:
 
         code = "\n".join(
             line.split("#", 1)[0]
-            for line in inspect.getsource(cal.IcsCalendarProvider._fetch_url).splitlines()
+            for line in inspect.getsource(cal.fetch_vetted).splitlines()
         )
         assert "_PinnedResolver()" in code
         assert "use_dns_cache=False" in code
@@ -1403,12 +1447,42 @@ class TestLocalIcsRead:
 class TestCalendarRegistry:
     def test_defaults_registered(self):
         ids = {row["id"] for row in cal.available_calendar_providers()}
-        assert ids == {k.CALENDAR_PROVIDER_NONE, k.CALENDAR_PROVIDER_ICS}
+        assert ids == {
+            k.CALENDAR_PROVIDER_NONE,
+            k.CALENDAR_PROVIDER_ICS,
+            k.CALENDAR_PROVIDER_CALDAV,
+            k.CALENDAR_PROVIDER_GOOGLE,
+            k.CALENDAR_PROVIDER_MICROSOFT,
+        }
 
     def test_ics_declares_it_needs_a_source(self):
         rows = {row["id"]: row for row in cal.available_calendar_providers()}
         assert rows[k.CALENDAR_PROVIDER_ICS]["requires_source"] is True
         assert rows[k.CALENDAR_PROVIDER_NONE]["requires_source"] is False
+
+    def test_caldav_declares_it_needs_a_source(self):
+        rows = {row["id"]: row for row in cal.available_calendar_providers()}
+        assert rows[k.CALENDAR_PROVIDER_CALDAV]["requires_source"] is True
+
+    def test_listing_providers_does_not_touch_the_credential_store(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Rendering the settings picker must not read the disk.
+
+        ``available_calendar_providers`` constructs EVERY registered factory just
+        to read its label, inside a broad ``except`` that drops a row on failure.
+        A provider that loaded credentials in ``__init__`` would therefore put a
+        file read behind the picker and, if it raised, vanish from the list with
+        only a log line to say why.
+        """
+        from kiro_crew.apps.builtins.meetings.backend import credentials as creds
+
+        def explode() -> Path:
+            raise AssertionError("the credential store was touched while listing")
+
+        monkeypatch.setattr(creds, "credentials_file", explode)
+        ids = {row["id"] for row in cal.available_calendar_providers()}
+        assert k.CALENDAR_PROVIDER_CALDAV in ids
 
     def test_unknown_id_degrades_to_none(self):
         assert cal.get_calendar_provider("corporate-calendar").provider_id == (
@@ -1493,12 +1567,31 @@ class TestRedirectsAreRevalidated:
     """
 
     def test_the_fetch_disables_automatic_redirects(self):
-        """Pins the flag itself: without it, no per-hop validation can run."""
+        """Pins the flag itself: without it, no per-hop validation can run.
+
+        Inspects ``fetch_vetted`` rather than ``IcsCalendarProvider._fetch_url``:
+        the hop loop moved there when CalDAV / Google / Microsoft 365 needed the
+        same posture, and one shared copy is the point. The provider is pinned
+        separately, below, as a caller of it.
+        """
+        import inspect
+
+        src = inspect.getsource(cal.fetch_vetted)
+        assert "allow_redirects=False" in src
+        assert "_REDIRECT_STATUSES" in src
+
+    def test_the_ics_provider_fetches_through_the_shared_gate(self):
+        """The provider must not grow a second, unreviewed hop loop.
+
+        If this fails because ``_fetch_url`` learned to talk to aiohttp directly
+        again, that is the regression: every SSRF property in this file is pinned
+        against ``fetch_vetted``, and a provider bypassing it inherits none of them.
+        """
         import inspect
 
         src = inspect.getsource(cal.IcsCalendarProvider._fetch_url)
-        assert "allow_redirects=False" in src
-        assert "_REDIRECT_STATUSES" in src
+        assert "fetch_vetted(" in src
+        assert "ClientSession" not in src
 
     @pytest.mark.parametrize(
         "target",
@@ -1521,9 +1614,12 @@ class TestRedirectsAreRevalidated:
         assert k.ICS_MAX_REDIRECTS >= 1
         import inspect
 
-        src = inspect.getsource(cal.IcsCalendarProvider._fetch_url)
-        assert "ICS_MAX_REDIRECTS" in src
-        assert "redirected too many times" in src
+        # The bound is the shared fetch's `max_redirects`, which the .ics provider
+        # passes `ICS_MAX_REDIRECTS` into — so both halves are pinned.
+        loop_src = inspect.getsource(cal.fetch_vetted)
+        assert "max_redirects" in loop_src
+        assert "redirected too many times" in loop_src
+        assert "ICS_MAX_REDIRECTS" in inspect.getsource(cal.IcsCalendarProvider._fetch_url)
 
 
 def _passthrough_target(url: str) -> cal.VettedTarget:
@@ -1695,3 +1791,1097 @@ class TestRedirectLoopAgainstARealServer:
                 await cal.IcsCalendarProvider(base)._fetch_url(base)
         finally:
             await runner.cleanup()
+
+
+class TestCredentialDoesNotSurviveACrossOriginRedirect:
+    """An ``Authorization`` header must not follow a redirect off its origin.
+
+    The ``.ics`` fetch never sent a credential, so this class covers a property
+    that arrived with :func:`cal.fetch_vetted` for CalDAV / Google / Microsoft 365.
+    The threat is concrete: a calendar host — or anything that can forge its
+    ``Location`` — bounces the request to a host it controls and is handed the
+    user's live password or bearer token. The redirect is still FOLLOWED, it just
+    arrives unauthenticated, so the failure is visible instead of silent.
+
+    ``headers`` and ``auth_headers`` are separate parameters for exactly this
+    reason, and these tests pin the difference: a plain header rides every hop.
+    """
+
+    @staticmethod
+    async def _serve(handler, *, method: str = "GET"):
+        from aiohttp import web as aioweb
+
+        app = aioweb.Application()
+        app.router.add_route(method, "/{tail:.*}", handler)
+        runner = aioweb.AppRunner(app)
+        await runner.setup()
+        site = aioweb.TCPSite(runner, "127.0.0.1", 0)
+        await site.start()
+        return runner, f"http://127.0.0.1:{runner.addresses[0][1]}"
+
+    @pytest.mark.asyncio
+    async def test_auth_rides_a_same_origin_redirect(self, monkeypatch: pytest.MonkeyPatch):
+        """Staying on the addressed origin keeps the credential — otherwise a
+        provider whose server legitimately redirects internally could never
+        authenticate at all."""
+        from aiohttp import web as aioweb
+
+        seen: list[str | None] = []
+
+        async def handler(request):
+            seen.append(request.headers.get("Authorization"))
+            if request.path == "/start":
+                raise aioweb.HTTPFound("/final")
+            return aioweb.Response(text="ok")
+
+        runner, base = await self._serve(handler)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        try:
+            body = await cal.fetch_vetted(
+                f"{base}/start", auth_headers={"Authorization": "Basic c3VwZXItc2VjcmV0"}
+            )
+        finally:
+            await runner.cleanup()
+
+        assert body == b"ok"
+        assert seen == ["Basic c3VwZXItc2VjcmV0", "Basic c3VwZXItc2VjcmV0"]
+
+    @pytest.mark.asyncio
+    async def test_auth_is_dropped_when_the_redirect_leaves_the_origin(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Two real servers: the first redirects to the second, which must NOT be
+        handed the credential."""
+        from aiohttp import web as aioweb
+
+        leaked: list[str | None] = []
+
+        async def attacker(request):
+            leaked.append(request.headers.get("Authorization"))
+            return aioweb.Response(text="landed")
+
+        attacker_runner, attacker_base = await self._serve(attacker)
+
+        async def origin(request):
+            raise aioweb.HTTPFound(f"{attacker_base}/steal")
+
+        origin_runner, origin_base = await self._serve(origin)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        try:
+            body = await cal.fetch_vetted(
+                f"{origin_base}/start",
+                auth_headers={"Authorization": "Basic c3VwZXItc2VjcmV0"},
+            )
+        finally:
+            await origin_runner.cleanup()
+            await attacker_runner.cleanup()
+
+        # The hop happened, so the failure mode is a visible auth failure rather
+        # than a silent credential disclosure.
+        assert body == b"landed"
+        assert leaked == [None], f"credential leaked to another origin: {leaked}"
+
+    @pytest.mark.asyncio
+    async def test_a_plain_header_is_not_dropped(self, monkeypatch: pytest.MonkeyPatch):
+        """Only ``auth_headers`` is origin-scoped; ``headers`` is not.
+
+        Pins that the split is real. A provider that put its credential in
+        ``headers`` would get no protection, which is why the docstring on
+        ``fetch_vetted`` says which one to use.
+        """
+        from aiohttp import web as aioweb
+
+        seen: list[str | None] = []
+
+        async def second(request):
+            seen.append(request.headers.get("X-Trace"))
+            return aioweb.Response(text="ok")
+
+        second_runner, second_base = await self._serve(second)
+
+        async def first(request):
+            raise aioweb.HTTPFound(f"{second_base}/next")
+
+        first_runner, first_base = await self._serve(first)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        try:
+            await cal.fetch_vetted(f"{first_base}/start", headers={"X-Trace": "keep-me"})
+        finally:
+            await first_runner.cleanup()
+            await second_runner.cleanup()
+
+        assert seen == ["keep-me"]
+
+
+class TestANonGetRequestOnlyFollowsMethodPreservingRedirects:
+    """301/302/303 tell a client to retry with GET.
+
+    For the ``.ics`` GET that is harmless. For a CalDAV ``REPORT`` it would turn a
+    calendar-query into a plain GET of some other resource and then parse whatever
+    came back — a wrong answer that looks like a right one. Those are refused; the
+    method-preserving 307/308 are followed.
+    """
+
+    @staticmethod
+    async def _serve(handler, *, method: str):
+        from aiohttp import web as aioweb
+
+        app = aioweb.Application()
+        app.router.add_route(method, "/{tail:.*}", handler)
+        runner = aioweb.AppRunner(app)
+        await runner.setup()
+        site = aioweb.TCPSite(runner, "127.0.0.1", 0)
+        await site.start()
+        return runner, f"http://127.0.0.1:{runner.addresses[0][1]}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [301, 302, 303])
+    async def test_a_method_changing_redirect_is_refused(
+        self, status: int, monkeypatch: pytest.MonkeyPatch
+    ):
+        from aiohttp import web as aioweb
+
+        async def handler(request):
+            return aioweb.Response(status=status, headers={"Location": "/elsewhere"})
+
+        runner, base = await self._serve(handler, method="REPORT")
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        try:
+            with pytest.raises(cal.CalendarError, match="change the request method"):
+                await cal.fetch_vetted(base, method="REPORT", body=b"<query/>")
+        finally:
+            await runner.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_a_307_is_followed_with_the_method_and_body_intact(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from aiohttp import web as aioweb
+
+        bodies: list[bytes] = []
+
+        async def handler(request):
+            bodies.append(await request.read())
+            if request.path == "/start":
+                return aioweb.Response(status=307, headers={"Location": "/final"})
+            return aioweb.Response(text="done")
+
+        runner, base = await self._serve(handler, method="REPORT")
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        try:
+            out = await cal.fetch_vetted(
+                f"{base}/start", method="REPORT", body=b"<query/>"
+            )
+        finally:
+            await runner.cleanup()
+
+        assert out == b"done"
+        # The body survived the hop — that is what "method preserving" has to mean.
+        assert bodies == [b"<query/>", b"<query/>"]
+
+    @pytest.mark.asyncio
+    async def test_a_get_still_follows_a_302(self, monkeypatch: pytest.MonkeyPatch):
+        """The refusal above must not have narrowed the GET path."""
+        from aiohttp import web as aioweb
+
+        async def handler(request):
+            if request.path == "/start":
+                raise aioweb.HTTPFound("/final")
+            return aioweb.Response(text="ok")
+
+        runner, base = await self._serve(handler, method="GET")
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        try:
+            assert await cal.fetch_vetted(f"{base}/start") == b"ok"
+        finally:
+            await runner.cleanup()
+
+
+# ── CalDAV ──────────────────────────────────────────────────────────────────
+
+_VEVENT_TEMPLATE = """BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:{uid}
+SUMMARY:{summary}
+DTSTART:{start}
+DTEND:{end}
+END:VEVENT
+END:VCALENDAR"""
+
+
+def _multistatus(*calendar_data: str) -> str:
+    """A CalDAV ``REPORT`` response wrapping each iCalendar document."""
+    responses = "".join(
+        "<D:response><D:propstat><D:prop>"
+        f"<C:calendar-data>{data}</C:calendar-data>"
+        "</D:prop></D:propstat></D:response>"
+        for data in calendar_data
+    )
+    return (
+        '<?xml version="1.0" encoding="utf-8" ?>'
+        '<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">'
+        f"{responses}</D:multistatus>"
+    )
+
+
+def _soon(hours: int) -> str:
+    """An iCalendar UTC stamp *hours* from now, inside the sync window."""
+    from datetime import datetime, timedelta, timezone
+
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).strftime("%Y%m%dT%H%M%SZ")
+
+
+class _FakeCalDav:
+    """A local server that answers a CalDAV ``REPORT``, recording what it got."""
+
+    def __init__(self, body: str, *, status: int = 207) -> None:
+        self._body = body
+        self._status = status
+        self.requests: list[dict[str, Any]] = []
+        self._runner: Any = None
+        self.base = ""
+
+    async def __aenter__(self) -> _FakeCalDav:
+        from aiohttp import web as aioweb
+
+        async def handler(request):
+            self.requests.append(
+                {
+                    "method": request.method,
+                    "headers": dict(request.headers),
+                    "body": (await request.read()).decode("utf-8"),
+                }
+            )
+            return aioweb.Response(
+                status=self._status, text=self._body, content_type="application/xml"
+            )
+
+        app = aioweb.Application()
+        app.router.add_route("REPORT", "/{tail:.*}", handler)
+        self._runner = aioweb.AppRunner(app)
+        await self._runner.setup()
+        site = aioweb.TCPSite(self._runner, "127.0.0.1", 0)
+        await site.start()
+        self.base = f"http://127.0.0.1:{self._runner.addresses[0][1]}/cal/"
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self._runner.cleanup()
+
+
+@pytest.fixture()
+def caldav_creds(tmp_path: Path):
+    """Point the credential store at a temp dir and seed CalDAV credentials."""
+    from kiro_crew.apps.builtins.meetings.backend import credentials as creds
+
+    creds.set_credentials_home(tmp_path / "creds")
+    yield creds
+    creds.set_credentials_home(None)
+
+
+class TestCalDavProvider:
+    """The CalDAV path, driven against a local fake server.
+
+    No real network, matching this module's rule: the SSRF gate is stubbed to a
+    pass-through so a loopback server is reachable, and everything downstream of
+    the gate — the REPORT body, the auth header, the Multi-Status parse — runs for
+    real.
+    """
+
+    @pytest.mark.asyncio
+    async def test_it_reports_and_parses_the_events(
+        self, monkeypatch: pytest.MonkeyPatch, caldav_creds
+    ):
+        await caldav_creds.write_for(
+            k.CALENDAR_PROVIDER_CALDAV, {"username": "alice", "password": "pw"}
+        )
+        body = _multistatus(
+            _VEVENT_TEMPLATE.format(
+                uid="evt-a", summary="Standup", start=_soon(2), end=_soon(3)
+            ),
+            _VEVENT_TEMPLATE.format(
+                uid="evt-b", summary="Review", start=_soon(5), end=_soon(6)
+            ),
+        )
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeCalDav(body) as server:
+            events = await cal.CalDavCalendarProvider(server.base).fetch(days=7)
+            got = server.requests
+
+        assert [e.title for e in events] == ["Standup", "Review"]
+        assert got[0]["method"] == "REPORT"
+        assert got[0]["headers"]["Depth"] == "1"
+        assert "calendar-query" in got[0]["body"]
+        assert "time-range" in got[0]["body"]
+
+    @pytest.mark.asyncio
+    async def test_it_sends_basic_auth_built_from_the_credential_store(
+        self, monkeypatch: pytest.MonkeyPatch, caldav_creds
+    ):
+        await caldav_creds.write_for(
+            k.CALENDAR_PROVIDER_CALDAV, {"username": "alice@example.com", "password": "s3cr3t"}
+        )
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeCalDav(_multistatus()) as server:
+            await cal.CalDavCalendarProvider(server.base).fetch(days=1)
+            sent = server.requests[0]["headers"]["Authorization"]
+
+        expected = base64.b64encode(b"alice@example.com:s3cr3t").decode("ascii")
+        assert sent == f"Basic {expected}"
+
+    @pytest.mark.asyncio
+    async def test_the_credential_travels_as_auth_headers_so_a_redirect_drops_it(self):
+        """Structural, because the leak it prevents cannot be seen from outside.
+
+        ``fetch_vetted`` only origin-scopes what arrives in ``auth_headers``; a
+        provider that put its Basic credential in ``headers`` would send the
+        user's password to whatever host a forged ``Location`` named.
+        """
+        import inspect
+
+        src = inspect.getsource(cal.CalDavCalendarProvider.fetch)
+        assert "auth_headers={" in src
+        # The Authorization value must appear in the auth_headers argument, not
+        # in the plain headers dict.
+        auth_pos = src.index("auth_headers={")
+        headers_pos = src.index("headers={")
+        assert src.index("Authorization") > auth_pos > headers_pos
+
+    @pytest.mark.asyncio
+    async def test_no_source_is_explained_not_a_stack_trace(self, caldav_creds):
+        with pytest.raises(cal.CalendarError, match="CalDAV collection URL"):
+            await cal.CalDavCalendarProvider("").fetch()
+
+    @pytest.mark.asyncio
+    async def test_missing_credentials_are_explained(self, caldav_creds):
+        with pytest.raises(cal.CalendarError, match="username and password"):
+            await cal.CalDavCalendarProvider("https://dav.example/cal/").fetch()
+
+    @pytest.mark.asyncio
+    async def test_a_partial_credential_is_still_refused(self, caldav_creds):
+        """A username with no password must not produce a half-formed header."""
+        await caldav_creds.write_for(k.CALENDAR_PROVIDER_CALDAV, {"username": "alice"})
+        with pytest.raises(cal.CalendarError, match="username and password"):
+            await cal.CalDavCalendarProvider("https://dav.example/cal/").fetch()
+
+    @pytest.mark.asyncio
+    async def test_an_unauthorized_response_does_not_echo_the_password(
+        self, monkeypatch: pytest.MonkeyPatch, caldav_creds
+    ):
+        await caldav_creds.write_for(
+            k.CALENDAR_PROVIDER_CALDAV, {"username": "alice", "password": "do-not-log-me"}
+        )
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeCalDav("nope", status=401) as server:
+            with pytest.raises(cal.CalendarError) as excinfo:
+                await cal.CalDavCalendarProvider(server.base).fetch()
+
+        assert "401" in str(excinfo.value)
+        assert "do-not-log-me" not in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_a_recurring_series_folds_to_its_earliest_instance(
+        self, monkeypatch: pytest.MonkeyPatch, caldav_creds
+    ):
+        """Overrides share the series UID, so they share an event_id.
+
+        Two rows with one id would share a meeting DIRECTORY, which is the
+        collision ``_event_id_for`` exists to prevent. The earliest start wins.
+        """
+        await caldav_creds.write_for(
+            k.CALENDAR_PROVIDER_CALDAV, {"username": "a", "password": "b"}
+        )
+        later = _soon(9)
+        earlier = _soon(4)
+        body = _multistatus(
+            _VEVENT_TEMPLATE.format(uid="series-1", summary="Weekly", start=later, end=_soon(10)),
+            _VEVENT_TEMPLATE.format(
+                uid="series-1", summary="Weekly", start=earlier, end=_soon(5)
+            ),
+        )
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeCalDav(body) as server:
+            events = await cal.CalDavCalendarProvider(server.base).fetch(days=7)
+
+        assert len(events) == 1
+        assert events[0].start == f"{earlier[:4]}-{earlier[4:6]}-{earlier[6:8]}T" + (
+            f"{earlier[9:11]}:{earlier[11:13]}:{earlier[13:15]}Z"
+        )
+
+    @pytest.mark.asyncio
+    async def test_one_unparseable_calendar_object_does_not_lose_the_others(
+        self, monkeypatch: pytest.MonkeyPatch, caldav_creds
+    ):
+        await caldav_creds.write_for(
+            k.CALENDAR_PROVIDER_CALDAV, {"username": "a", "password": "b"}
+        )
+        body = _multistatus(
+            "this is not iCalendar at all",
+            _VEVENT_TEMPLATE.format(uid="good", summary="Kept", start=_soon(2), end=_soon(3)),
+        )
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeCalDav(body) as server:
+            events = await cal.CalDavCalendarProvider(server.base).fetch(days=7)
+
+        assert [e.title for e in events] == ["Kept"]
+
+    @pytest.mark.asyncio
+    async def test_an_empty_collection_is_an_empty_list_not_an_error(
+        self, monkeypatch: pytest.MonkeyPatch, caldav_creds
+    ):
+        """A calendar with nothing in it is a legitimate answer.
+
+        Unlike ``NoCalendarProvider``, where an empty result would hide a config
+        typo, a configured CalDAV collection that returns no events genuinely has
+        none this week.
+        """
+        await caldav_creds.write_for(
+            k.CALENDAR_PROVIDER_CALDAV, {"username": "a", "password": "b"}
+        )
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeCalDav(_multistatus()) as server:
+            assert await cal.CalDavCalendarProvider(server.base).fetch(days=7) == []
+
+
+class TestCalDavXmlIsHardened:
+    """The Multi-Status is XML from a REMOTE server.
+
+    Parsing goes through ``defusedxml`` with ``forbid_dtd=True``, the same choice
+    ``doc_parser`` makes for untrusted uploads. defusedxml already refuses
+    entities and external references, but it ALLOWS a bare DOCTYPE by default, so
+    the flag is what makes the rule blanket. An entity bomb needs a DTD, so
+    refusing the declaration kills it without analysing entity graphs, and a
+    legitimate CalDAV Multi-Status carries no DOCTYPE — nothing real is lost.
+    """
+
+    def test_an_entity_bomb_is_refused(self):
+        bomb = (
+            '<?xml version="1.0"?>'
+            "<!DOCTYPE lolz ["
+            '<!ENTITY lol "lol">'
+            '<!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">'
+            '<!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">'
+            "]>"
+            "<root>&lol2;</root>"
+        ).encode("utf-8")
+        with pytest.raises(cal.CalendarError, match="document type declaration"):
+            cal._parse_xml_safely(bomb)
+
+    def test_the_refusal_is_a_blanket_doctype_rule(self):
+        """Even a DOCTYPE with no entities is refused.
+
+        The rule is deliberately coarse: a legitimate CalDAV Multi-Status carries
+        no DOCTYPE, so refusing all of them costs nothing real and removes the
+        need to decide which entity declarations are safe.
+        """
+        with pytest.raises(cal.CalendarError, match="document type declaration"):
+            cal._parse_xml_safely(b'<?xml version="1.0"?><!DOCTYPE root><root/>')
+
+    def test_external_entities_are_refused_too(self, tmp_path: Path):
+        """Belt and braces: pins that no file read is reachable through the XML."""
+        secret = tmp_path / "secret.txt"
+        secret.write_text("TOP-SECRET", encoding="utf-8")
+        xxe = (
+            f'<?xml version="1.0"?><!DOCTYPE r [<!ENTITY x SYSTEM "file://{secret}">]>'
+            "<root>&x;</root>"
+        ).encode("utf-8")
+        with pytest.raises(cal.CalendarError):
+            cal._parse_xml_safely(xxe)
+
+    def test_malformed_xml_is_a_calendar_error_not_a_parse_error(self):
+        """The route turns ``CalendarError`` into a 502; a bare ``ParseError``
+        would escape as a 500."""
+        with pytest.raises(cal.CalendarError, match="could not be parsed"):
+            cal._parse_xml_safely(b"<multistatus><unclosed>")
+
+    def test_a_legitimate_multistatus_still_parses(self):
+        payload = _multistatus(
+            _VEVENT_TEMPLATE.format(uid="u1", summary="Ok", start=_soon(1), end=_soon(2))
+        ).encode("utf-8")
+        events = cal._events_from_multistatus(payload, days=7)
+        assert [e.title for e in events] == ["Ok"]
+
+
+# ── Google Calendar ─────────────────────────────────────────────────────────
+
+
+class _FakeGoogleEvents:
+    """A local stand-in for ``events.list``, recording each request."""
+
+    def __init__(self, *pages: dict[str, Any], status: int = 200) -> None:
+        self._pages = list(pages)
+        self._status = status
+        self.requests: list[dict[str, Any]] = []
+        self._runner: Any = None
+        self.url = ""
+
+    async def __aenter__(self) -> _FakeGoogleEvents:
+        from aiohttp import web as aioweb
+
+        async def handler(request):
+            self.requests.append(
+                {"query": dict(request.query), "headers": dict(request.headers)}
+            )
+            index = min(len(self.requests) - 1, len(self._pages) - 1)
+            if self._status != 200:
+                return aioweb.Response(status=self._status, text="denied")
+            return aioweb.json_response(self._pages[index])
+
+        app = aioweb.Application()
+        app.router.add_get("/events", handler)
+        self._runner = aioweb.AppRunner(app)
+        await self._runner.setup()
+        site = aioweb.TCPSite(self._runner, "127.0.0.1", 0)
+        await site.start()
+        self.url = f"http://127.0.0.1:{self._runner.addresses[0][1]}/events"
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self._runner.cleanup()
+
+
+def _google_item(**over: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "id": "gid-1",
+        "status": "confirmed",
+        "summary": "Design review",
+        "start": {"dateTime": "2026-08-05T09:00:00+09:00"},
+        "end": {"dateTime": "2026-08-05T10:00:00+09:00"},
+        "location": "Room 4",
+        "organizer": {"displayName": "Alice", "email": "alice@example.com"},
+        "attendees": [{"displayName": "Bob"}, {"email": "carol@example.com"}],
+        "description": "agenda",
+    }
+    base.update(over)
+    return base
+
+
+@pytest.fixture()
+def google_connected(tmp_path: Path):
+    """A credential store with Google already connected and a live token."""
+    import time as _time
+
+    from kiro_crew.apps.builtins.meetings.backend import credentials as creds
+
+    creds.set_credentials_home(tmp_path / "creds")
+    yield creds, _time
+    creds.set_credentials_home(None)
+
+
+class TestGoogleCalendarProvider:
+    @staticmethod
+    async def _connect(creds, _time) -> None:
+        await creds.write_for(
+            k.CALENDAR_PROVIDER_GOOGLE,
+            {
+                "client_id": "cid",
+                "refresh_token": "rt",
+                "access_token": "live-token",
+                "expires_at": str(_time.time() + 3600),
+            },
+        )
+
+    def test_it_does_not_require_a_source(self):
+        rows = {row["id"]: row for row in cal.available_calendar_providers()}
+        # It reads the signed-in user's `primary` calendar; asking for a calendar
+        # id is not something a user has to hand.
+        assert rows[k.CALENDAR_PROVIDER_GOOGLE]["requires_source"] is False
+
+    @pytest.mark.asyncio
+    async def test_an_unconnected_account_is_explained(self, google_connected):
+        with pytest.raises(cal.CalendarError, match="not connected"):
+            await cal.GoogleCalendarProvider().fetch()
+
+    @pytest.mark.asyncio
+    async def test_it_sends_the_bearer_token_and_the_right_query(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeGoogleEvents({"items": [_google_item()]}) as api:
+            monkeypatch.setattr(k, "GOOGLE_EVENTS_URL", api.url)
+            events = await cal.GoogleCalendarProvider().fetch(days=7)
+            req = api.requests[0]
+
+        assert req["headers"]["Authorization"] == "Bearer live-token"
+        # singleEvents=true is what makes Google expand a recurring series
+        # server-side, which is why this provider needs no RRULE engine.
+        assert req["query"]["singleEvents"] == "true"
+        assert req["query"]["orderBy"] == "startTime"
+        assert "timeMin" in req["query"] and "timeMax" in req["query"]
+        assert [e.title for e in events] == ["Design review"]
+
+    @pytest.mark.asyncio
+    async def test_the_bearer_token_travels_as_auth_headers(self):
+        """So a redirect off googleapis.com cannot carry it away."""
+        import inspect
+
+        src = inspect.getsource(cal.GoogleCalendarProvider.fetch)
+        auth_pos = src.index("auth_headers={")
+        assert src.index("Bearer") > auth_pos
+
+    @pytest.mark.asyncio
+    async def test_an_offset_timestamp_becomes_utc(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        """09:00+09:00 is 00:00Z. Reading the offset as UTC would name the wrong
+        instant, so the ordering and the sync window would both be wrong."""
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        start = (datetime.now(timezone.utc) + timedelta(hours=5)).astimezone(
+            timezone(timedelta(hours=9))
+        )
+        item = _google_item(
+            start={"dateTime": start.isoformat()},
+            end={"dateTime": (start + timedelta(hours=1)).isoformat()},
+        )
+        async with _FakeGoogleEvents({"items": [item]}) as api:
+            monkeypatch.setattr(k, "GOOGLE_EVENTS_URL", api.url)
+            events = await cal.GoogleCalendarProvider().fetch(days=7)
+
+        assert events[0].start == start.astimezone(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_whole_day_event_is_read_as_midnight_utc(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        day = (datetime.now(timezone.utc) + timedelta(days=2)).strftime("%Y-%m-%d")
+        item = _google_item(start={"date": day}, end={"date": day})
+        async with _FakeGoogleEvents({"items": [item]}) as api:
+            monkeypatch.setattr(k, "GOOGLE_EVENTS_URL", api.url)
+            events = await cal.GoogleCalendarProvider().fetch(days=7)
+
+        assert events[0].start == f"{day}T00:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_instance_is_skipped(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        """A cancelled occurrence still appears in the list; showing it would put
+        a phantom meeting in the user's day."""
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        page = {
+            "items": [
+                _google_item(id="dead", status="cancelled", start=None, end=None),
+                _google_item(id="alive", summary="Kept"),
+            ]
+        }
+        async with _FakeGoogleEvents(page) as api:
+            monkeypatch.setattr(k, "GOOGLE_EVENTS_URL", api.url)
+            events = await cal.GoogleCalendarProvider().fetch(days=7)
+
+        assert [e.title for e in events] == ["Kept"]
+
+    @pytest.mark.asyncio
+    async def test_an_item_with_no_usable_start_is_skipped_not_fatal(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        page = {
+            "items": [
+                _google_item(id="bad", start={"dateTime": "not-a-timestamp"}),
+                _google_item(id="ok", summary="Survived"),
+            ]
+        }
+        async with _FakeGoogleEvents(page) as api:
+            monkeypatch.setattr(k, "GOOGLE_EVENTS_URL", api.url)
+            events = await cal.GoogleCalendarProvider().fetch(days=7)
+
+        assert [e.title for e in events] == ["Survived"]
+
+    @pytest.mark.asyncio
+    async def test_it_follows_nextpagetoken(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        first = {"items": [_google_item(id="p1", summary="One")], "nextPageToken": "tok-2"}
+        second = {"items": [_google_item(id="p2", summary="Two")]}
+        async with _FakeGoogleEvents(first, second) as api:
+            monkeypatch.setattr(k, "GOOGLE_EVENTS_URL", api.url)
+            events = await cal.GoogleCalendarProvider().fetch(days=7)
+            requests = api.requests
+
+        assert len(requests) == 2
+        assert requests[1]["query"]["pageToken"] == "tok-2"
+        assert sorted(e.title for e in events) == ["One", "Two"]
+
+    @pytest.mark.asyncio
+    async def test_endless_pagination_is_bounded(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        """A provider that always returns a nextPageToken must not loop forever."""
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        forever = {"items": [_google_item()], "nextPageToken": "always"}
+        async with _FakeGoogleEvents(forever) as api:
+            monkeypatch.setattr(k, "GOOGLE_EVENTS_URL", api.url)
+            await cal.GoogleCalendarProvider().fetch(days=7)
+            assert len(api.requests) == k.GOOGLE_MAX_PAGES
+
+    @pytest.mark.asyncio
+    async def test_a_non_json_body_is_a_calendar_error(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        with pytest.raises(cal.CalendarError, match="not JSON"):
+            cal._json_object(b"<html>error</html>")
+
+    def test_the_endpoints_are_constants_not_configuration(self):
+        """A settable authorize URL is a phishing surface: a rewritten host
+        collects the user's Google password. Only the client id/secret are
+        per-installation."""
+        assert k.GOOGLE_AUTHORIZE_URL.startswith("https://accounts.google.com/")
+        assert k.GOOGLE_TOKEN_URL.startswith("https://oauth2.googleapis.com/")
+        assert k.GOOGLE_CALENDAR_SCOPE.endswith("calendar.readonly")
+        # Read-only, because the app only ever displays meetings.
+        assert "readonly" in k.GOOGLE_CALENDAR_SCOPE
+
+    def test_offline_access_and_reconsent_are_requested(self):
+        """Without access_type=offline Google issues no refresh token, and
+        without prompt=consent a RECONNECT issues none either -- the calendar
+        would then stop working an hour after every reconnect."""
+        assert k.GOOGLE_AUTHORIZE_EXTRA["access_type"] == "offline"
+        assert k.GOOGLE_AUTHORIZE_EXTRA["prompt"] == "consent"
+
+    def test_the_oauth_client_matches_the_constants(self):
+        client = cal.google_oauth_client()
+        assert client.provider_id == k.CALENDAR_PROVIDER_GOOGLE
+        assert client.authorize_url == k.GOOGLE_AUTHORIZE_URL
+        assert client.token_url == k.GOOGLE_TOKEN_URL
+        assert client.scopes == (k.GOOGLE_CALENDAR_SCOPE,)
+
+
+# ── Microsoft 365 (Graph) ───────────────────────────────────────────────────
+
+
+class _FakeGraph:
+    """A local stand-in for Graph's ``calendarView``."""
+
+    def __init__(self, *pages: dict[str, Any]) -> None:
+        self._pages = list(pages)
+        self.requests: list[dict[str, Any]] = []
+        self._runner: Any = None
+        self.url = ""
+
+    async def __aenter__(self) -> _FakeGraph:
+        from aiohttp import web as aioweb
+
+        async def handler(request):
+            self.requests.append(
+                {"query": dict(request.query), "headers": dict(request.headers)}
+            )
+            index = min(len(self.requests) - 1, len(self._pages) - 1)
+            page = dict(self._pages[index])
+            # Graph paginates with a FULL url; rewrite the placeholder so it
+            # points back at this server.
+            if page.get("@odata.nextLink") == "NEXT":
+                page["@odata.nextLink"] = f"{self.url}?page=2"
+            return aioweb.json_response(page)
+
+        app = aioweb.Application()
+        app.router.add_get("/calendarView", handler)
+        self._runner = aioweb.AppRunner(app)
+        await self._runner.setup()
+        site = aioweb.TCPSite(self._runner, "127.0.0.1", 0)
+        await site.start()
+        self.url = f"http://127.0.0.1:{self._runner.addresses[0][1]}/calendarView"
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self._runner.cleanup()
+
+
+def _graph_item(**over: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "id": "AAMk-1",
+        "isCancelled": False,
+        "subject": "Sprint planning",
+        "start": {"dateTime": "2026-08-05T09:00:00.0000000", "timeZone": "UTC"},
+        "end": {"dateTime": "2026-08-05T10:00:00.0000000", "timeZone": "UTC"},
+        "location": {"displayName": "Teams"},
+        "organizer": {"emailAddress": {"name": "Dana", "address": "dana@example.com"}},
+        "attendees": [{"emailAddress": {"name": "Eve"}}],
+        "bodyPreview": "the agenda",
+    }
+    base.update(over)
+    return base
+
+
+class TestRfc3339ParsingAcceptsWhatTheApisSend:
+    """``fromisoformat`` does not take the whole grammar on the oldest supported 3.x.
+
+    Measured on 3.10.20: it rejects a trailing ``Z`` (Google) and a seven-digit
+    fraction (Graph). 3.11 widened it, so both parse there — which is why this was
+    invisible on a 3.12 developer machine and failed only the 3.10 CI shard. The
+    failure mode is SILENT: an unparsable stamp returns ``None`` and the caller
+    skips the event, so every Graph event disappeared and the sync reported an
+    empty calendar rather than an error.
+
+    Pinned on every interpreter so the 3.10 shard is not the only thing standing
+    between this and a regression.
+    """
+
+    def test_a_trailing_z_is_utc(self):
+        assert cal._parse_rfc3339("2026-08-05T09:00:00Z") == datetime(
+            2026, 8, 5, 9, 0, tzinfo=timezone.utc
+        )
+
+    def test_graph_seven_digit_fraction_parses(self):
+        """Graph really sends seven fraction digits; datetime holds six."""
+        assert cal._parse_rfc3339("2026-08-05T09:00:00.0000000") == datetime(
+            2026, 8, 5, 9, 0, tzinfo=timezone.utc
+        )
+
+    def test_the_fraction_is_truncated_not_rounded(self):
+        """A stamp is a point in time: rounding up could move it past a filter
+        boundary. ``.1234567`` keeps six digits and drops the seventh."""
+        assert cal._parse_rfc3339("2026-08-05T09:00:00.1234567Z") == datetime(
+            2026, 8, 5, 9, 0, 0, 123456, tzinfo=timezone.utc
+        )
+
+    def test_an_explicit_offset_is_converted_to_utc(self):
+        assert cal._parse_rfc3339("2026-08-05T09:00:00+09:00") == datetime(
+            2026, 8, 5, 0, 0, tzinfo=timezone.utc
+        )
+
+    def test_a_naive_stamp_is_read_as_utc(self):
+        assert cal._parse_rfc3339("2026-08-05T09:00:00") == datetime(
+            2026, 8, 5, 9, 0, tzinfo=timezone.utc
+        )
+
+    def test_an_unreadable_value_is_none_not_an_exception(self):
+        """The event is skipped rather than taking the whole sync down."""
+        for bad in ("not-a-timestamp", "", "   ", "2026-13-45T99:99:99Z"):
+            assert cal._parse_rfc3339(bad) is None, bad
+
+
+class TestMicrosoftCalendarProvider:
+    @staticmethod
+    async def _connect(creds, _time) -> None:
+        await creds.write_for(
+            k.CALENDAR_PROVIDER_MICROSOFT,
+            {
+                "client_id": "cid",
+                "refresh_token": "rt",
+                "access_token": "graph-token",
+                "expires_at": str(_time.time() + 3600),
+            },
+        )
+
+    def test_it_does_not_require_a_source(self):
+        rows = {row["id"]: row for row in cal.available_calendar_providers()}
+        assert rows[k.CALENDAR_PROVIDER_MICROSOFT]["requires_source"] is False
+
+    @pytest.mark.asyncio
+    async def test_an_unconnected_account_is_explained(self, google_connected):
+        with pytest.raises(cal.CalendarError, match="not connected"):
+            await cal.MicrosoftCalendarProvider().fetch()
+
+    @pytest.mark.asyncio
+    async def test_it_asks_graph_for_utc_and_sends_the_bearer_token(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        """The Prefer header is load-bearing: Graph's dateTime has no offset, so
+        without it the naive value would be in the mailbox's zone and read as
+        UTC."""
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeGraph({"value": [_graph_item()]}) as api:
+            monkeypatch.setattr(k, "MICROSOFT_EVENTS_URL", api.url)
+            events = await cal.MicrosoftCalendarProvider().fetch(days=7)
+            req = api.requests[0]
+
+        assert req["headers"]["Authorization"] == "Bearer graph-token"
+        assert req["headers"]["Prefer"] == 'outlook.timezone="UTC"'
+        assert "startDateTime" in req["query"] and "endDateTime" in req["query"]
+        assert [e.title for e in events] == ["Sprint planning"]
+
+    @pytest.mark.asyncio
+    async def test_it_reads_the_nested_organizer_and_attendee_names(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        """Graph nests the name one level deeper than Google, inside
+        ``emailAddress``."""
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        async with _FakeGraph({"value": [_graph_item()]}) as api:
+            monkeypatch.setattr(k, "MICROSOFT_EVENTS_URL", api.url)
+            events = await cal.MicrosoftCalendarProvider().fetch(days=7)
+
+        assert events[0].organizer == "Dana"
+        assert events[0].attendees == ["Eve"]
+        assert events[0].location == "Teams"
+
+    @pytest.mark.asyncio
+    async def test_a_named_timezone_is_applied_to_the_naive_stamp(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        """A response that ignored the Prefer header must not be misread.
+
+        The stamp is wall-clock in ``timeZone``, so the zone is APPLIED to it
+        rather than converted from UTC.
+        """
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        soon = datetime.now(timezone.utc) + timedelta(hours=6)
+        wall = soon.astimezone(ZoneInfo("Asia/Tokyo")).strftime("%Y-%m-%dT%H:%M:%S.0000000")
+        item = _graph_item(
+            start={"dateTime": wall, "timeZone": "Asia/Tokyo"},
+            end={"dateTime": wall, "timeZone": "Asia/Tokyo"},
+        )
+        async with _FakeGraph({"value": [item]}) as api:
+            monkeypatch.setattr(k, "MICROSOFT_EVENTS_URL", api.url)
+            events = await cal.MicrosoftCalendarProvider().fetch(days=7)
+
+        assert events[0].start == soon.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    @pytest.mark.asyncio
+    async def test_a_windows_zone_name_maps_to_iana(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        """Graph often answers with ``Tokyo Standard Time``, which is not an IANA
+        key. Reading that wall time as UTC shifts the meeting by nine hours, so
+        the name is mapped through ``_WINDOWS_TO_IANA`` — the same table
+        ``_tzid_of`` consults for a ``.ics`` TZID."""
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        soon = datetime.now(timezone.utc) + timedelta(hours=6)
+        wall = soon.astimezone(ZoneInfo("Asia/Tokyo")).strftime(
+            "%Y-%m-%dT%H:%M:%S.0000000"
+        )
+        item = _graph_item(
+            start={"dateTime": wall, "timeZone": "Tokyo Standard Time"},
+            end={"dateTime": wall, "timeZone": "Tokyo Standard Time"},
+        )
+        async with _FakeGraph({"value": [item]}) as api:
+            monkeypatch.setattr(k, "MICROSOFT_EVENTS_URL", api.url)
+            events = await cal.MicrosoftCalendarProvider().fetch(days=7)
+
+        assert events[0].start == soon.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_zone_name_falls_back_to_utc(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        """A zone name neither IANA nor the Windows table resolves reads the wall
+        time as UTC. A visible meeting at a possibly-wrong hour beats one that is
+        not there — the same stance ``_tzid_of`` already takes."""
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        stamp = (datetime.now(timezone.utc) + timedelta(hours=3)).strftime(
+            "%Y-%m-%dT%H:%M:%S.0000000"
+        )
+        item = _graph_item(
+            start={"dateTime": stamp, "timeZone": "Custom Nowhere Time"},
+            end={"dateTime": stamp, "timeZone": "Custom Nowhere Time"},
+        )
+        async with _FakeGraph({"value": [item]}) as api:
+            monkeypatch.setattr(k, "MICROSOFT_EVENTS_URL", api.url)
+            events = await cal.MicrosoftCalendarProvider().fetch(days=7)
+
+        assert events[0].start == f"{stamp[:19]}Z"
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_occurrence_is_skipped(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        page = {
+            "value": [
+                _graph_item(id="x", isCancelled=True, subject="Dropped"),
+                _graph_item(id="y", subject="Kept"),
+            ]
+        }
+        async with _FakeGraph(page) as api:
+            monkeypatch.setattr(k, "MICROSOFT_EVENTS_URL", api.url)
+            events = await cal.MicrosoftCalendarProvider().fetch(days=7)
+
+        assert [e.title for e in events] == ["Kept"]
+
+    @pytest.mark.asyncio
+    async def test_it_follows_the_odata_nextlink(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        first = {"value": [_graph_item(id="a", subject="One")], "@odata.nextLink": "NEXT"}
+        second = {"value": [_graph_item(id="b", subject="Two")]}
+        async with _FakeGraph(first, second) as api:
+            monkeypatch.setattr(k, "MICROSOFT_EVENTS_URL", api.url)
+            events = await cal.MicrosoftCalendarProvider().fetch(days=7)
+            requests = api.requests
+
+        assert len(requests) == 2
+        assert sorted(e.title for e in events) == ["One", "Two"]
+
+    @pytest.mark.asyncio
+    async def test_a_nextlink_at_a_private_address_is_refused_by_the_gate(
+        self, google_connected
+    ):
+        """The pagination URL comes from the response BODY, so it is exactly as
+        untrusted as a redirect ``Location`` — and gets the same gate."""
+        with pytest.raises(cal.CalendarError):
+            cal._normalize_url("https://169.254.169.254/graph")
+
+    @pytest.mark.asyncio
+    async def test_endless_pagination_is_bounded(
+        self, monkeypatch: pytest.MonkeyPatch, google_connected
+    ):
+        creds, _time = google_connected
+        await self._connect(creds, _time)
+        monkeypatch.setattr(cal, "_normalize_url", _passthrough_target)
+        forever = {"value": [_graph_item()], "@odata.nextLink": "NEXT"}
+        async with _FakeGraph(forever) as api:
+            monkeypatch.setattr(k, "MICROSOFT_EVENTS_URL", api.url)
+            await cal.MicrosoftCalendarProvider().fetch(days=7)
+            assert len(api.requests) == k.MICROSOFT_MAX_PAGES
+
+    def test_offline_access_is_requested(self):
+        """Without ``offline_access`` Microsoft issues no refresh token at all, so
+        the calendar would stop working when the first access token expires."""
+        assert "offline_access" in k.MICROSOFT_CALENDAR_SCOPES
+
+    def test_the_scope_is_read_only(self):
+        assert "Calendars.Read" in k.MICROSOFT_CALENDAR_SCOPES[0]
+        assert not any("ReadWrite" in s for s in k.MICROSOFT_CALENDAR_SCOPES)
+
+    def test_the_endpoints_are_constants_and_multi_tenant(self):
+        # `/common/` so a personal and a work account both work without the user
+        # having to find a tenant id.
+        assert "/common/" in k.MICROSOFT_AUTHORIZE_URL
+        assert k.MICROSOFT_AUTHORIZE_URL.startswith("https://login.microsoftonline.com/")
+        assert k.MICROSOFT_EVENTS_URL.startswith("https://graph.microsoft.com/")
+        # calendarView, not /events: it expands a recurring series server-side.
+        assert k.MICROSOFT_EVENTS_URL.endswith("/calendarView")
+
+    def test_the_oauth_client_matches_the_constants(self):
+        client = cal.microsoft_oauth_client()
+        assert client.provider_id == k.CALENDAR_PROVIDER_MICROSOFT
+        assert client.authorize_url == k.MICROSOFT_AUTHORIZE_URL
+        assert client.token_url == k.MICROSOFT_TOKEN_URL
+        assert client.scopes == tuple(k.MICROSOFT_CALENDAR_SCOPES)

--- a/test/test_meetings_routes.py
+++ b/test/test_meetings_routes.py
@@ -1626,6 +1626,9 @@ class TestCalendarRoutes:
             assert {r["id"] for r in body["providers"]} == {
                 k.CALENDAR_PROVIDER_NONE,
                 k.CALENDAR_PROVIDER_ICS,
+                k.CALENDAR_PROVIDER_CALDAV,
+                k.CALENDAR_PROVIDER_GOOGLE,
+                k.CALENDAR_PROVIDER_MICROSOFT,
             }
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem / Motivation

Meetings had to be created by hand. The app never knew what was already scheduled,
so the whole point of a meetings assistant — being ready for the meeting that is
about to start — was left to the user to arrange manually every time.

There was no way to connect a calendar at all: no provider, no credential store,
and no OAuth handshake for the two providers that require one.

## Why it matters

Every downstream feature is gated on knowing the schedule. Without it the app
cannot pre-create a meeting, cannot name it, cannot attach the right attendees, and
cannot start on time — the user has to notice the meeting themselves and set it up
by hand, which is exactly the work they wanted delegated.

It also blocks the calendar UI, which is a separate PR: there is nothing for it to
render until a provider exists.

## What changed (motivation → approach → change)

**Goal.** Read the user's calendar from wherever it already lives, without
becoming three separate integrations.

**Approach.** One `CalendarProvider` interface with three implementations — CalDAV,
Google Calendar, Microsoft 365 — plus the two pieces they need and did not have: a
credential store and an OAuth handshake. `NoCalendarProvider` keeps "not
configured" a normal case rather than a branch at every call site.

This PR is **backend only**. There is no UI change, so no Screenshots section.

### The security decisions, because they shaped the code

**Credentials sit outside the agent-reachable tree.** They live under
`<crew-home>/workspace/meetings/`, not `app_data_dir("meetings")`. That data dir is
the region `store.contain` bounds agent-supplied paths against, and a calendar
refresh token survives until revoked — an agent that could read the file would keep
reading the user's schedule long after the session ended. Keeping it outside removes
the reachability question instead of answering it. `security.py` gains the path to
its denylist, generated for both crew-home prefixes so a migration fallback to the
legacy data-home is covered too.

**The address vet is `link_unfurl.vet_unfurl_url`, reused rather than
reimplemented.** This is the part worth reviewing closely, because it started as a
purpose-built check in `calendar.py` and that was a mistake. A calendar URL is
operator-supplied and fetched server-side, so this endpoint is an SSRF surface; a
second copy of the vetting logic is a second place to fix a bypass. The local copy
was also already weaker in four concrete ways:

| input | the local copy | why |
|---|---|---|
| `0177.0.0.1` | approved, then **fetched at `177.0.0.1`** | `ipaddress` will not read the octal, so it fell through to DNS and getaddrinfo read `0177` as decimal. The vet and the connection disagreed about the target — the exact class of bug the pinning exists to prevent. |
| `100.64.0.1` | approved | `is_private` does not cover CGNAT; only `is_global` does. On a machine on a tailnet, that range **is** the private network. |
| `fec0::1` | approved | Deprecated IPv6 site-local reports `is_global`. |
| `.local`, `.onion` | approved | Resolve through a side channel, or not at all. |

`link_unfurl` also owns `test_vet_rejects_every_special_purpose_range`, which pins
the refusal set against a table of IANA special-purpose prefixes — so the next gap
is found by the suite instead of by a reviewer. A second implementation here would
not have inherited that.

**One refusal went the other way and is kept, layered on top.** A resolved address
that `ipaddress` cannot read is refused, not skipped. `_reject_if_internal_ip`
returns silently for a non-literal, because to it a non-literal is a hostname still
to be resolved; here the list is already a resolution result, so an unreadable entry
would reach the pin unchecked.

**The pin, the redirect hop loop and the same-origin check stay local, and are not
duplication.** `VettedUrl`'s own docstring says to pin the resolver on `wire_host`
— this is the caller side of that contract. `resolve` is injected for one reason:
to keep every address the vet approved, since `VettedUrl` reports one and a
multi-homed calendar host should keep its fallbacks. Every address kept is one the
vet checked; it vets the whole answer, not just the address it returns.

**Ports narrow to 80/443, which https-only leaves as 443.** Stricter than "whatever
port the URL names", deliberately: a calendar on another port is nearly always an
internal service, and the port is the cheapest place to stop this endpoint being
used to probe for one. Nothing is broken by starting strict — this feature has never
shipped — and relaxing it later is one line.

**XML parsing uses `defusedxml` with `forbid_dtd=True`.** The stdlib
ElementTree expands internal entities while refusing external ones, and
`XMLParser.doctype` is ignored on 3.12, so hand-rolled stdlib hardening is not
a reliable option (and the SAST gate `python.lang.security.use-defused-xml`
fails the build on stdlib `xml.etree` anyway). `defusedxml` is declared in
`setup.cfg` — not a new runtime requirement in practice: `doc_parser` has
imported it since before this PR and the install only ever got it
transitively; this entry declares the dependency the tree already had.

**Redaction is applied once, in `build_event()`,** rather than per provider. A new
provider then cannot forget it, and `security_posture.py` gains one sink instead of
three.

**The OAuth redirect URI is derived from the request's own origin.** Dashboard auth
is an HMAC-signed cookie scoped to the host, and the port is configurable — a
constant would break on any non-default port, and `localhost` vs `127.0.0.1` would
not share the cookie.

## Tests

Three files, ~1,800 lines of tests for ~1,700 lines of source.

- **`test_meetings_providers.py`** — ICS parsing (escapes, TZID, DURATION, recurrence
  windows), the address vet, and the pin. `TestDnsRebindingIsRefused` stands up a
  real loopback server on two families and asserts the fetch lands on the vetted
  address rather than a rebound one; it lifts exactly two refusals (the
  private-address rule, since 127.0.0.1 *is* the test server, and the 80/443 port
  rule, since it binds ephemeral) and runs everything else — resolution, the
  all-or-nothing check, the pin, the connector, the hop loop — for real.
- **`test_meetings_oauth.py`** — the handshake: state, redirect-URI derivation, token
  exchange and refresh, and that a failure does not strand a half-written credential.
- **`test_meetings_calendar_routes.py`** — the HTTP surface, including that a
  provider error is a 4xx with a message rather than a 500.

Non-vacuous on the part that matters: reverting the delegation and restoring the
local vet fails by name on `0177.0.0.1`, `100.64.0.0/10` and `fec0::/10`.

## Manual verification

The address vet was checked against the live code rather than only through the
suite — the four rows in the table above were run through `_normalize_url` before
and after the change, confirming each was approved before and is refused now, and
that a public host still resolves and pins normally (4 addresses, port 443) with
`webcal://` rewritten to `https://`.

OAuth against live Google / Microsoft tenants is **not** verified here: it needs
registered client credentials for each, which this branch does not carry. The
handshake is covered by unit tests at the protocol level, and the redirect-URI
derivation — the piece most likely to be wrong in a real deployment — is tested
against non-default ports and both loopback spellings.

## Related Issues

N/A — part of bringing the meetings app's calendar support up, not from a filed
issue.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: the user-facing calendar docs
      land with the UI PR, which is what a user will actually configure
- [x] No secrets, credentials, or internal references in the diff

