### PR TITLE
fix(apps): send the host theme to MCP apps instead of hardcoding dark

### DIFF
--- a/website/src/components/McpAppFrame.tsx
+++ b/website/src/components/McpAppFrame.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Maximize2, Minimize2, Shrink, Expand } from 'lucide-react'
 import { IconButton, IconButtonGroup } from './ui'
 import { useDialogFocusTrap } from '../hooks/useDialogFocusTrap'
+import { useTheme } from '../hooks/useTheme'
 import { i18nT } from '../i18n/t'
 import {
   buildMcpAppSrcdoc,
@@ -364,6 +365,17 @@ export default function McpAppFrame({ payload }: { payload: McpAppRenderPayload 
   const presentationRef = useRef<Presentation>(presentation)
   presentationRef.current = presentation
 
+  // The app styles itself from `hostContext.theme` alone: this host injects no
+  // CSS into the srcdoc (see mcpAppSrcdoc.ts), so a hardcoded value left every
+  // app dark regardless of the user's theme. `ResolvedMode` is already exactly
+  // 'dark' | 'light', so it maps 1:1 onto the protocol field.
+  //
+  // Mirrored like `presentation` above because the bridge effect below closes
+  // over `[]` — it must not re-subscribe when the theme changes.
+  const { theme } = useTheme()
+  const themeRef = useRef(theme)
+  themeRef.current = theme
+
   // --- `wide`: breaking out of the chat column -------------------------------
   // The frame's width ceiling is not its own: the transcript row wrapper caps it
   // at `--mc-content-width` (default 900px, user-configurable), so on a wide
@@ -529,7 +541,7 @@ export default function McpAppFrame({ payload }: { payload: McpAppRenderPayload 
                 hostInfo: { name: 'kirocrew', version: '0.1' },
                 hostCapabilities: HOST_CAPABILITIES,
                 hostContext: {
-                  theme: 'dark',
+                  theme: themeRef.current,
                   platform: 'web',
                   displayMode: PROTOCOL_MODE[presentationRef.current],
                   availableDisplayModes: AVAILABLE_DISPLAY_MODES,
@@ -791,6 +803,7 @@ export default function McpAppFrame({ payload }: { payload: McpAppRenderPayload 
           method: N_HOST_CONTEXT_CHANGED,
           // Partial context update — only the changed fields, per spec.
           params: {
+            theme: themeRef.current,
             displayMode: PROTOCOL_MODE[next],
             containerDimensions: dimensionsFor(next, wideWidth),
           },
@@ -799,6 +812,25 @@ export default function McpAppFrame({ payload }: { payload: McpAppRenderPayload 
       )
     } catch { /* frame torn down */ }
   }, [])
+
+  // A theme switch must reach an app that is ALREADY mounted — fixing only the
+  // initialize reply above would leave the bug reachable by toggling the theme
+  // with an app open.
+  //
+  // Routed through `notifyHostContext` rather than its own postMessage so the
+  // frame keeps exactly one outbound post site: that one already carries the
+  // navigated-away guard and the wildcard-origin review annotation, and adding a
+  // second would mean re-auditing a null-origin sandboxed target.
+  //
+  // Compares against the last theme SENT rather than using a first-run flag:
+  // StrictMode remounts effects, and a boolean would post a spurious update on
+  // the second mount.
+  const sentThemeRef = useRef(theme)
+  useEffect(() => {
+    if (sentThemeRef.current === theme) return
+    sentThemeRef.current = theme
+    notifyHostContext(presentationRef.current, wideWidthRef.current)
+  }, [theme, notifyHostContext])
 
   // Host-initiated presentation change (the header controls).
   // The app MUST be told: it may gate an editable surface on the mode, and a

--- a/website/src/test/McpAppFrame.test.tsx
+++ b/website/src/test/McpAppFrame.test.tsx
@@ -4,6 +4,7 @@ import { act } from '@testing-library/react'
 import McpAppFrame from '../components/McpAppFrame'
 import type { McpAppRenderPayload } from '../lib/mcpAppSrcdoc'
 import { __resetRevealedForTests } from '../components/mcpAppReveal'
+import { useTheme } from '../hooks/useTheme'
 
 function payload(over: Partial<McpAppRenderPayload> = {}): McpAppRenderPayload {
   return {
@@ -1061,5 +1062,71 @@ describe('McpAppFrame — app log forwarding', () => {
         expect(scroller.style.overflowY).not.toBe('hidden')
       } finally { restore.reverse().forEach((f) => f()) }
     })
+  })
+})
+
+
+// The app has no other styling signal: this host injects no CSS into the srcdoc,
+// so `hostContext.theme` is the whole contract. It was a hardcoded 'dark', which
+// left every MCP app dark-on-light for a light-theme user (#2110). The
+// pre-existing initialize test asserts displayMode, availableDisplayModes and
+// containerDimensions but never theme -- that gap is how this shipped, so these
+// assert the field itself.
+describe('McpAppFrame — host theme', () => {
+  beforeEach(() => {
+    __resetRevealedForTests()
+    localStorage.clear()
+  })
+
+  function initReply(win: { postMessage: ReturnType<typeof vi.fn> }) {
+    dispatchFromApp({ jsonrpc: '2.0', id: 1, method: 'ui/initialize' }, win)
+    return win.postMessage.mock.calls[0][0]
+  }
+
+  it.each(['light', 'dark'] as const)(
+    'reports the host theme as %s in the ui/initialize reply',
+    (mode) => {
+      // An explicit preference resolves synchronously, with no matchMedia dependency.
+      localStorage.setItem('mc-theme', mode)
+      const { container } = renderWithProviders(<McpAppFrame payload={payload()} />)
+      const win = stubContentWindow(container.querySelector('iframe')!)
+
+      expect(initReply(win).result.hostContext.theme).toBe(mode)
+    },
+  )
+
+  it('pushes a host-context-changed carrying the new theme when the user switches', async () => {
+    localStorage.setItem('mc-theme', 'dark')
+    // Sibling consumer inside the same ThemeProvider, so the flip goes through
+    // the real setter the theme toggle uses rather than a synthetic event.
+    function ThemeFlip() {
+      const { setTheme } = useTheme()
+      return <button onClick={() => setTheme('light')}>flip</button>
+    }
+    const { container, getByText } = renderWithProviders(
+      <><ThemeFlip /><McpAppFrame payload={payload()} /></>,
+    )
+    const win = stubContentWindow(container.querySelector('iframe')!)
+    initReply(win)
+    win.postMessage.mockClear()
+
+    await act(async () => { getByText('flip').click() })
+
+    const notes = win.postMessage.mock.calls
+      .map(([m]) => m)
+      .filter((m) => m?.method === 'ui/notifications/host-context-changed')
+    expect(notes.length).toBeGreaterThan(0)
+    expect(notes[notes.length - 1].params.theme).toBe('light')
+  })
+
+  it('does not announce a theme change on first mount', () => {
+    localStorage.setItem('mc-theme', 'light')
+    const { container } = renderWithProviders(<McpAppFrame payload={payload()} />)
+    const win = stubContentWindow(container.querySelector('iframe')!)
+
+    // Nothing is posted before the app speaks: a spurious notification on mount
+    // (what a first-run boolean flag would produce under StrictMode's double
+    // effect invocation) would show up here.
+    expect(win.postMessage).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Fixes #2110.

## Problem

Every MCP app renders in dark mode regardless of the user's theme, so a
light-theme user gets dark-on-light app surfaces — both inline in the chat
transcript and in the side panel. Reported against the desktop app on the stable
channel.

`website/src/components/McpAppFrame.tsx` answered `ui/initialize` with a literal:

```ts
hostContext: {
  theme: 'dark',        // ← every other field on this object is live host state
  platform: 'web',
  displayMode: PROTOCOL_MODE[presentationRef.current],
  ...
}
```

## Why it matters

`hostContext.theme` is the app's **only** styling signal. This host deliberately
injects no CSS into the app's document — `website/src/lib/mcpAppSrcdoc.ts` contains
no theme, `color-scheme` or `prefers-color-scheme` rules anywhere — so an app that
wants to match the host has nothing else to read. A hardcoded value is therefore
not a cosmetic default; it is the whole contract being wrong for every light-theme
user, in a shipped build.

## Fix (symptom → root cause → change)

- **Symptom:** apps are dark even when the dashboard is light.
- **Root cause:** the field was never wired to anything. Not a stale value or a bad
  default — there was no theme input to the frame at all.
- **Change:** read the live theme and send it.

`ResolvedMode` is already exactly `'dark' | 'light'`
(`website/src/hooks/useTheme.tsx:32`), so it maps 1:1 onto the protocol field with
no translation invented. `WidgetFrame` — the sibling iframe host in the same
directory — already consumes `useTheme()` for the same purpose, so this follows an
established pattern rather than introducing one.

Three deliberate details, each matching a convention already in this file:

1. **The value is mirrored into a ref.** The inbound message bridge closes over
   `[]` on purpose ("must not re-subscribe per mode"), so it reads
   `themeRef.current` exactly as it already reads `presentationRef.current` and
   `wideWidthRef.current`.
2. **Theme is also pushed on `ui/notifications/host-context-changed`.** Fixing only
   the `initialize` reply would leave the bug reachable by toggling the theme with
   an app already open. This routes through the existing `notifyHostContext` rather
   than adding a second `postMessage`, so the frame keeps exactly **one** outbound
   post site — that one already carries the navigated-away guard and the
   wildcard-origin review annotation, and a new one would mean re-auditing a
   null-origin sandboxed target.
3. **The change effect compares against the last theme *sent*,** not a first-run
   boolean. Under StrictMode's double effect invocation a flag would post a
   spurious host-context update on the second mount — the same hazard the existing
   comment on `goTo` documents.

## Tests

`website/src/test/McpAppFrame.test.tsx`, new `McpAppFrame — host theme` block, 4 cases:

- parametrized `light` / `dark`: the `ui/initialize` reply reports the host theme
- a theme switch pushes a `host-context-changed` carrying the new theme — driven
  through the real `setTheme` setter from a sibling consumer in the same
  `ThemeProvider`, not a synthetic event
- first mount posts nothing, pinning detail 3 above

**Verified meaningful, not merely green.** With `McpAppFrame.tsx` reverted to `main`
in the same tree, 2 of the 4 fail — the light-theme assertion with
`expected 'dark' to be 'light'`, which is literally the reported bug, and the
live-update assertion with `expected 0 to be greater than 0`. The two that pass
pre-fix are the ones that should: `dark` coincides with the hardcoded value, and the
mount guard is an anti-regression assertion rather than a bug detector.

Worth noting why this shipped: the pre-existing `initialize` test asserted
`displayMode`, `availableDisplayModes` and `containerDimensions` — every
`hostContext` field **except** `theme`.

File total 55 passed. `tsc -b` clean. eslint 0 errors (2 a11y warnings, identical to
the unmodified file — same rules, line numbers shifted by the added lines).

## Manual verification

Full frontend suite: **10,957 passed**. One unrelated failure in
`src/test/App.test.tsx` ("Kiro credits pill") is pre-existing — the unmodified tree
fails the same test (2 in that file when run in isolation). That surface is being
rewritten by open PR #2168.

I also checked the hook is safe to add here, since `useTheme()` **throws** outside a
`ThemeProvider`: both production render sites (`pages/chat/SidePanel.tsx:688`,
`pages/chat/ToolCallLine.tsx:478`) sit under the root provider at `main.tsx:98`, all
`McpAppFrame` tests use `renderWithProviders` (which wraps `ThemeProvider`), and
`sidePanelAddMenu.test.tsx` mocks the component out entirely.

## Screenshots

N/A, and I want to be explicit rather than quietly omit them. The user-visible change
is inside a third-party MCP app's own document: the host sends a different string in a
JSON-RPC payload and the app restyles itself from it. There is no KiroCrew surface
whose rendering changes, so a screenshot would show an app I do not control theming
itself — evidence about that app, not about this diff. The contract this PR changes is
asserted directly in the tests above. Happy to capture one against a specific MCP app
if a maintainer names the one they want to see.
