### PR TITLE
fix: use nearest-rank context percentiles

### DIFF
--- a/src/kiro_crew/dashboard/handlers/usage.py
+++ b/src/kiro_crew/dashboard/handlers/usage.py
@@ -466,7 +466,7 @@ def context_occupancy(days: int = 14) -> dict[str, Any]:
     def _q(q: float) -> float:
         # Nearest-rank on the sorted samples: these are exact per-turn values,
         # not histogram buckets, so no interpolation is warranted.
-        idx = min(len(pcts) - 1, max(0, int(round(q * (len(pcts) - 1)))))
+        idx = min(len(pcts) - 1, max(0, math.ceil(q * len(pcts)) - 1))
         return round(pcts[idx], 1)
 
     sessions = sorted(

--- a/test/metrics/test_context_occupancy.py
+++ b/test/metrics/test_context_occupancy.py
@@ -66,6 +66,24 @@ class TestContextOccupancyBasics:
         assert out["p50_pct"] == 50.0
         assert out["max_pct"] == 90.0
 
+    @pytest.mark.parametrize(
+        ("occupancies", "field", "expected"),
+        [
+            ([10, 20, 30, 40], "p50_pct", 20.0),
+            ([10, 20, 30, 40, 50, 60], "p90_pct", 60.0),
+        ],
+    )
+    def test_percentiles_use_nearest_rank(
+        self, _isolated_shards, occupancies, field, expected
+    ):
+        """Select the value at ceil(percentile * sample count), 1-indexed."""
+        _write(
+            _isolated_shards,
+            [_row("chat-1", pct * 10_000) for pct in occupancies],
+        )
+
+        assert usage_mod.context_occupancy(14)[field] == expected
+
     def test_peak_is_per_session_not_global(self, _isolated_shards):
         _write(_isolated_shards, [
             _row("chat-hot", 950_000),


### PR DESCRIPTION
## Problem / Motivation

`context_occupancy()` documents its p50 and p90 aggregation as nearest-rank, but calculates the sample index with `round(q * (n - 1))`. That is a different order-statistic rule, and Python's ties-to-even behavior makes boundary results especially unintuitive.

For example:

- Four samples `[10, 20, 30, 40]` currently produce p50 = `30`; nearest-rank produces `20`.
- Six samples `[10, 20, 30, 40, 50, 60]` currently produce p90 = `50`; nearest-rank produces `60`.

## Why it matters

The Telemetry page uses these values to summarize context-window occupancy. Returning percentiles from a different method than the documented contract can misstate the distribution, particularly for small sample counts where each order statistic has substantial weight.

## What changed (motivation → approach → change)

The implementation now converts the one-indexed nearest rank `ceil(q * n)` to a zero-based index with `ceil(q * n) - 1`, while retaining the existing defensive bounds.

Regression tests exercise the four-sample p50 and six-sample p90 cases. Both fail under the previous formula and pass with the nearest-rank calculation.

## Tests

- `pytest test/metrics/test_context_occupancy.py test/metrics/test_context_trace.py -n0 -q --no-cov` — 25 passed
- `pytest test/metrics -q --no-cov` — 336 passed, 1 skipped
- `isort --check-only src/kiro_crew test`
- `flake8 src/kiro_crew test`
- `mypy --platform linux src/kiro_crew`
- `git diff --check`

## Manual verification

N/A — the production aggregation path is exercised directly with synthetic persisted token rows, including the discriminating boundary sample sizes.

## Related Issues

Fixes #2193

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing affected tests pass and new regression tests cover the corrected behavior
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (not applicable: implementation now matches the existing documented method)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — repository template currently contains a placeholder pending OSPO wording.
