### PR TITLE
fix(meetings): show the newest speech in the live caption

### DIFF
--- a/website/src/apps/meetings/components/BroadcastBar.tsx
+++ b/website/src/apps/meetings/components/BroadcastBar.tsx
@@ -30,7 +30,14 @@ export default function BroadcastBar({ onSend, caption, disabled }: Props) {
     <div className="flex-none px-6 py-3 border-t border-border bg-bg">
       {caption && (
         <div
-          className="text-[12px] text-muted truncate mb-2"
+          // Wraps rather than clipping to one line: `truncate` set
+          // `white-space: nowrap`, so a caption longer than the bar was cut with
+          // an ellipsis — and `text-overflow` shows a string's HEAD, which pinned
+          // the display to the oldest speech. `line-clamp-2` keeps this bar from
+          // growing without limit and pushing the composer off-screen, since the
+          // bar is `flex-none` and cannot shrink. Pairing matches
+          // `issue-radar/components/IssueDetail.tsx`.
+          className="text-[12px] text-muted break-words line-clamp-2 mb-2"
           aria-live="polite"
           data-testid="meetings-caption"
         >

--- a/website/src/apps/meetings/hooks/useMeetingTranscription.ts
+++ b/website/src/apps/meetings/hooks/useMeetingTranscription.ts
@@ -60,10 +60,57 @@ const CLOSE_GRACE_MS = 8_000
  */
 const DISPATCH_RETRY_DELAYS_MS = [400, 1_200, 3_000]
 
+/**
+ * How much of the transcript the live caption may carry, in characters.
+ *
+ * The caption element is two lines tall, so this only has to be the right order
+ * of magnitude — the hard bound on the rendered height is the `line-clamp-2` in
+ * `BroadcastBar.tsx`. What this constant guarantees is that the text inside
+ * those lines stays RECENT.
+ */
+export const CAPTION_WINDOW_CHARS = 240
+
+/**
+ * The recent tail of the transcript, for the "Heard: …" caption.
+ *
+ * Trimming from the FRONT is the entire point. The finals array accumulates for
+ * the whole meeting, and the caption used to receive all of it — which read as a
+ * caption that froze on the meeting's opening sentence and never updated again,
+ * because the element clipped its overflow with `text-overflow: ellipsis` and
+ * that shows a string's HEAD. A live caption has to show the newest speech, so
+ * the oldest is what gets dropped.
+ *
+ * Whole segments are kept wherever possible so the caption never begins
+ * mid-sentence; only a single over-long segment is cut, and then at a word
+ * boundary.
+ */
+export function captionWindow(finals: readonly string[], partial = ''): string {
+  const segments = [...finals, partial].map((s) => s.trim()).filter(Boolean)
+  if (segments.length === 0) return ''
+
+  const kept: string[] = []
+  let length = 0
+  for (let i = segments.length - 1; i >= 0; i--) {
+    // +1 for the space this segment would be joined with.
+    const cost = segments[i].length + (kept.length === 0 ? 0 : 1)
+    if (length + cost > CAPTION_WINDOW_CHARS) break
+    kept.unshift(segments[i])
+    length += cost
+  }
+  if (kept.length > 0) return kept.join(' ')
+
+  // Even the newest segment alone overflows the window: keep its tail, cut at a
+  // word boundary so no word is split mid-token. A segment with no spaces at all
+  // is returned as-is rather than mangled.
+  const tail = segments[segments.length - 1].slice(-CAPTION_WINDOW_CHARS)
+  const firstSpace = tail.indexOf(' ')
+  return firstSpace === -1 ? tail : tail.slice(firstSpace + 1)
+}
+
 interface Options {
   /** The meeting whose dispatch endpoint receives each final segment. */
   meetingId: string
-  /** Called with the live caption (accumulated finals + the current partial). */
+  /** Called with the recent tail of the transcript (see `captionWindow`). */
   onCaption: (text: string) => void
   /**
    * Called once per committed final segment, BEFORE it is dispatched.
@@ -232,8 +279,7 @@ export function useMeetingTranscription({ meetingId, onCaption, onFinal, onError
       }
       if (msg.type === 'partial') {
         lastPartial = msg.text || ''
-        const prefix = finalsRef.current.join(' ')
-        onCaptionRef.current(prefix ? `${prefix} ${lastPartial}`.trim() : lastPartial)
+        onCaptionRef.current(captionWindow(finalsRef.current, lastPartial))
         return
       }
       if (msg.type === 'final') {
@@ -241,7 +287,7 @@ export function useMeetingTranscription({ meetingId, onCaption, onFinal, onError
         lastPartial = ''
         if (!text) return
         finalsRef.current.push(text)
-        onCaptionRef.current(finalsRef.current.join(' '))
+        onCaptionRef.current(captionWindow(finalsRef.current))
         // The caller's duplicate check gates the dispatch: an overlapping final
         // still belongs in the caption (above), but must not be sent to the
         // agents a second time.

--- a/website/src/test/MeetingsBroadcastBar.test.tsx
+++ b/website/src/test/MeetingsBroadcastBar.test.tsx
@@ -67,6 +67,23 @@ describe('BroadcastBar', () => {
     expect(caption.getAttribute('aria-live')).toBe('polite')
   })
 
+  it('wraps the caption instead of clipping it to a single line', () => {
+    // `truncate` carried `white-space: nowrap` plus an ellipsis, and
+    // `text-overflow` shows a string's HEAD — so a caption longer than the bar
+    // displayed the oldest speech and looked like it had stopped updating.
+    // `line-clamp-2` bounds the height: this bar is `flex-none`, so an unbounded
+    // caption would push the composer off-screen.
+    //
+    // Asserted by class name because the vitest env computes no layout and does
+    // not load index.css — the same reasoning recorded in
+    // `ChatSidebar.scrollbar.test.tsx`.
+    render(<BroadcastBar onSend={vi.fn()} caption="Alice said hello" />)
+    const caption = screen.getByTestId('meetings-caption')
+    expect(caption.className).not.toContain('truncate')
+    expect(caption.className).toContain('break-words')
+    expect(caption.className).toContain('line-clamp-2')
+  })
+
   it('renders no caption row when there is nothing to show', () => {
     render(<BroadcastBar onSend={vi.fn()} />)
     expect(screen.queryByTestId('meetings-caption')).toBeNull()

--- a/website/src/test/MeetingsSessionLogic.test.ts
+++ b/website/src/test/MeetingsSessionLogic.test.ts
@@ -13,6 +13,10 @@ import {
   newSegmentText,
   resolveEnabledAgents,
 } from '../apps/meetings/hooks/useMeetingSession'
+import {
+  CAPTION_WINDOW_CHARS,
+  captionWindow,
+} from '../apps/meetings/hooks/useMeetingTranscription'
 import type { AgentDef, MeetingsConfig } from '../apps/meetings/api'
 import { readFileSync } from 'node:fs'
 import EN_CATALOG from '../i18n/locales/en.json'
@@ -525,5 +529,62 @@ describe('starting before the config loads does not persist an empty roster', ()
     const startCall = SessionSource.match(/const startMutation[\s\S]*?\n  \}\)/)
     expect(startCall, 'no startMutation found').not.toBeNull()
     expect(startCall![0]).not.toMatch(/enabledIds\.length/)
+  })
+})
+
+describe('the live caption shows the newest speech, not the meeting opening', () => {
+  // `finalsRef` accumulates every final segment and is cleared only by `start()`,
+  // so by mid-meeting it holds the entire transcript. It used to be handed to the
+  // caption verbatim, into an element that clipped its overflow — and
+  // `text-overflow: ellipsis` shows a string's HEAD. The visible caption was
+  // therefore the meeting's first sentence, frozen for its whole duration.
+
+  const SEGMENTS = Array.from(
+    { length: 40 },
+    (_, i) => `segment ${i} with several spoken words in it`,
+  )
+
+  it('drops the oldest segments once the window is full', () => {
+    const out = captionWindow(SEGMENTS)
+    expect(out).toContain('segment 39')
+    // The defect, stated as an assertion: the opening of the meeting must be gone.
+    expect(out).not.toContain('segment 0 ')
+  })
+
+  it('bounds what the caption element is asked to render', () => {
+    expect(captionWindow(SEGMENTS).length).toBeLessThanOrEqual(CAPTION_WINDOW_CHARS)
+  })
+
+  it('leaves a transcript that already fits completely alone', () => {
+    // The common case must not be trimmed at all.
+    expect(captionWindow(['hello there', 'how are you'])).toBe('hello there how are you')
+  })
+
+  it('keeps the in-flight partial at the end', () => {
+    expect(captionWindow(['committed words'], 'and the partial')).toBe(
+      'committed words and the partial',
+    )
+    expect(captionWindow([], 'partial only')).toBe('partial only')
+    expect(captionWindow([])).toBe('')
+  })
+
+  it('keeps the tail, not the head, when one segment alone overflows', () => {
+    const long = Array.from({ length: 60 }, (_, i) => `word${i}`).join(' ')
+    expect(long.length).toBeGreaterThan(CAPTION_WINDOW_CHARS)
+    const out = captionWindow([long])
+    expect(out.length).toBeLessThanOrEqual(CAPTION_WINDOW_CHARS)
+    // A suffix of the segment: the newest words survive, the oldest are cut.
+    expect(long.endsWith(out)).toBe(true)
+    // And cut at a word boundary, so the caption never opens mid-token.
+    expect(out.startsWith('word')).toBe(true)
+  })
+
+  it('routes both caption call sites through the bounded window', () => {
+    // Exporting the helper is not enough. A call site left on the raw
+    // accumulation would restore the bug while every assertion above still
+    // passed, so the guard is on the source itself.
+    expect(TranscriptionSource).not.toContain("finalsRef.current.join(' ')")
+    expect(TranscriptionSource).toContain('captionWindow(finalsRef.current, lastPartial)')
+    expect(TranscriptionSource).toContain('captionWindow(finalsRef.current)')
   })
 })


### PR DESCRIPTION
Fixes #2021 (the caption item; see scope note below).

## Problem

The `Heard: …` caption in the meeting broadcast bar stops updating a few seconds into a meeting and then never changes again.

Two things combine to cause it.

`useMeetingTranscription` accumulates every final segment in `finalsRef`, which is cleared only by `start()`:

```ts
finalsRef.current.push(text)
onCaptionRef.current(finalsRef.current.join(' '))   // the whole meeting so far
```

So by mid-meeting the `caption` prop holds the entire transcript. The caption element then carried `truncate` — Tailwind's `overflow: hidden` + `text-overflow: ellipsis` + `white-space: nowrap`. An ellipsis shows a string's **head**, so what stayed on screen was the meeting's opening sentence, unchanged for its whole duration, with the rest of the transcript growing invisibly behind the clip.

`caption` has exactly one consumer, this element. `onFinal` dispatches segments to the agents on a separate path, so the accumulation existed solely to feed a one-line element that displayed its oldest words.

The issue reports this as horizontal overflow. The visible symptom on current `main` is an ellipsis-clip rather than text painted past the viewport, and I could not verify the reporter's exact rendering. Either way the underlying defect is the same one and is what this fixes: the caption cannot wrap, and it shows the wrong end of the transcript.

## Fix

`captionWindow()` trims the accumulation from the front to a recent window. Whole segments are kept wherever they fit so the caption never opens mid-sentence; only a single over-long segment is cut, and then at a word boundary. The element wraps instead of clipping.

`line-clamp-2` bounds the rendered height. This matters: the bar is `flex-none` and cannot shrink, so removing `truncate` on its own would let a long caption push the composer off-screen — a worse regression than the bug. The character budget keeps the text *recent*; the clamp is the hard limit on *height*. `break-words line-clamp-2` matches the existing pairing in `apps/issue-radar/components/IssueDetail.tsx`.

`break-words` rather than `break-all`, for the reason already recorded in `components/RunInTerminalConfirm.tsx`: wrap at spaces so a token is never split mid-word. The caption is word-level speech-to-text output, and `overflow-wrap: break-word` still breaks a single unbreakable token as a last resort.

## Tests

`captionWindow` is exported and unit-tested directly, following the note at the top of `MeetingsSessionLogic.test.ts` that these tests bind to the shipping code rather than a copy that can drift. Six cases: the oldest segments are dropped once the window is full, the length is bounded, a transcript that already fits is left byte-identical, the in-flight partial stays at the end, and an over-long single segment keeps its **tail** cut at a word boundary. A seventh asserts on the hook source that both call sites actually route through the helper — exporting it while leaving one call site on the raw accumulation would restore the bug with every other assertion still green.

The wrapping change is asserted by class name. The vitest environment is happy-dom, which computes no layout, and `index.css` is not loaded — the same limitation recorded in `ChatSidebar.scrollbar.test.tsx`. I verified this rather than assuming it: in that environment a `nowrap` div and a wrapped div come out with identical geometry, all zero. So the class assertion pins the fix against accidental deletion and is not evidence about rendering.

All 7 new assertions fail against unmodified `main` (67 passed / 7 failed), so they detect the bug rather than merely describing it.

- `npx vitest run src/test/Meetings*` → 111 passed
- full frontend suite → 824 files, 10,965 passed, 0 failures
- `tsc -b` clean, `eslint` clean on all four files, brand-name gate clean

## Scope

Issue #2021 contains three items. This PR addresses only the caption. The live transcript/notes streaming view is a feature request and is deliberately untouched. The `Mode 'meetings/meetings-note-taker' not found` report is a separate backend defect — `test/test_meetings_agent_names.py` already exists, so it may already be covered; I did not investigate it.

One honest limitation: this makes the caption behave like a live caption, showing recent speech. It does not give the user a way to read the transcript scrollback, which is what the out-of-scope feature request asks for.
