### PR TITLE
fix(dashboard): re-render an edited local image instead of the previous bytes

### DIFF
--- a/website/eslint.i18n.config.js
+++ b/website/eslint.i18n.config.js
@@ -270,8 +270,15 @@ export default [
               // A URL query built from an already-encoded value, e.g.
               // `${PATH}?id=${encodeURIComponent(x)}`. A request path is a server
               // contract; translating it would 404. Full-string for the same reason as
-              // above; the literals that reach the linter here are `?id=` and `?since=`.
-              String.raw`^\?[a-z_]+=$`,
+              // above; the literals that reach the linter here are `?id=`, `?since=`
+              // and `&v=`.
+              //
+              // The leading character is `[?&]`, not `?` alone: a CONTINUATION
+              // parameter is exactly the same server contract as the first one, and a
+              // URL carrying two parameters has to spell one of them with `&`. The
+              // shape stays just as tight — prose takes neither a leading `?`/`&` nor
+              // a trailing `=`, so this still reports real copy.
+              String.raw`^[?&][a-z_]+=$`,
 
               // A catalog KEY assembled at runtime, e.g.
               // `apps.crewCompanion.state.${slot}`. Translating a key would break the

--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -153,6 +153,24 @@ export const BasePathCtx = createContext<string | null>(null)
 export const CompactImagesCtx = createContext<boolean>(false)
 
 /**
+ * A per-message token appended to local image URLs.
+ *
+ * `/api/file-raw?path=…` addresses a file by PATH, so every impression of a file
+ * an agent rewrites across turns resolves to one URL — and a browser treats one
+ * URL in one document as one resource. The second `<img>` is then served from the
+ * in-document memory cache with no network request at all, so the new message
+ * paints the OLD bytes. Measured in Chrome: without a distinct URL the edited
+ * file is never re-fetched, and no HTTP cache header changes that — `ETag`,
+ * `Cache-Control: no-cache` and even `no-store` are not consulted, because the
+ * request is never made.
+ *
+ * Making the URL per-message gives each impression its own cache entry, so a new
+ * message shows the current bytes while an earlier one keeps what it fetched.
+ * Stable within a message, so re-renders and streaming do not re-request.
+ */
+export const ImageVersionCtx = createContext<string | null>(null)
+
+/**
  * Per-consumer override for rendered markdown LINKS.
  *
  * A provider returns its own element for the hrefs it wants to own, or null to
@@ -683,6 +701,7 @@ function ImgWithFallback({
   const [loaded, setLoaded] = useState(false)
   const basePath = useContext(BasePathCtx)
   const compact = useContext(CompactImagesCtx)
+  const version = useContext(ImageVersionCtx)
   if (!src) return null
   const isLocal = src.startsWith('/') || src.startsWith('~') || src.startsWith('.')
     || (basePath && !src.startsWith('http'))
@@ -694,6 +713,10 @@ function ImgWithFallback({
     } else {
       url = `/api/file-raw?path=${encodeURIComponent(src)}`
     }
+    // See ImageVersionCtx: without this every impression of a rewritten file
+    // shares one cache entry and a new message renders the previous bytes. The
+    // backend reads only `path`, so the extra parameter is inert server-side.
+    if (version) url += `&v=${encodeURIComponent(version)}`
   } else {
     url = src
   }
@@ -1696,6 +1719,10 @@ export default memo(function MarkdownRenderer({ content, streaming = false, onFi
           lightbox scoping on the div above is unaffected) and lives in this module
           so a caller that mocks it in tests never needs to re-export the context. */}
       <CompactImagesCtx.Provider value={compactImages}>
+      {/* ImageVersionCtx: scopes local image URLs to this message so an agent
+          rewriting one file across turns is not served the previous bytes from
+          the in-document resource cache. */}
+      <ImageVersionCtx.Provider value={messageTs ?? null}>
         {blocks.map((block, i) => (
           // Key on startLine (stable across streaming) instead of block.type, so
           // a code -> diff reclassification mid-stream doesn't unmount the
@@ -1720,6 +1747,7 @@ export default memo(function MarkdownRenderer({ content, streaming = false, onFi
             softBreaks={softBreaks}
           />
         ))}
+      </ImageVersionCtx.Provider>
       </CompactImagesCtx.Provider>
       </PathActionCtx.Provider>
       </PathProbeCtx.Provider>

--- a/website/src/test/MarkdownRenderer.imageVersion.test.tsx
+++ b/website/src/test/MarkdownRenderer.imageVersion.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import MarkdownRenderer from '../components/MarkdownRenderer'
+
+/**
+ * REGRESSION GUARD — an edited local image must not render its previous bytes.
+ *
+ * `/api/file-raw?path=…` addresses a file by PATH. The agent-authoring flow
+ * rewrites ONE file across turns (the image-authoring skill mandates keeping a
+ * single editable source and showing it as `![alt](/abs/path.svg)`), so every
+ * impression used to resolve to the same URL — and a browser treats one URL in
+ * one document as one resource.
+ *
+ * Measured in real Chrome, not assumed: with an identical URL the second <img>
+ * is served from the in-document cache with NO network request, so a new message
+ * paints the old bytes. No response header changes that, because the request is
+ * never issued — `ETag`, `Cache-Control: no-cache` and `no-store` were each
+ * tested and each left the render stale. Only a distinct URL re-fetches, and it
+ * also lets an earlier impression keep the bytes it originally loaded.
+ *
+ * These tests assert the URL is scoped per message and stable within one, which
+ * is the mechanism. They cannot observe the browser cache itself.
+ */
+
+function srcOf(container: HTMLElement): string {
+  const img = container.querySelector('img')
+  if (!img) throw new Error('no <img> rendered')
+  return img.getAttribute('src') || ''
+}
+
+const SVG = '![diagram](/Users/me/work/logo.svg)'
+
+describe('local image URLs are scoped to the message that renders them', () => {
+  it('PREMISE: a local image path renders through the file-raw endpoint', () => {
+    const { container } = render(<MarkdownRenderer content={SVG} messageTs="2026-08-08T00:00:00Z" />)
+    expect(srcOf(container)).toContain('/api/file-raw?path=')
+    expect(srcOf(container)).toContain(encodeURIComponent('/Users/me/work/logo.svg'))
+  })
+
+  it('gives two messages distinct URLs for the SAME path', () => {
+    // The fix. Same file, two turns: the later impression must be able to reach
+    // the current bytes rather than inheriting the earlier resource.
+    const a = render(<MarkdownRenderer content={SVG} messageTs="2026-08-08T00:00:01Z" />)
+    const b = render(<MarkdownRenderer content={SVG} messageTs="2026-08-08T00:00:02Z" />)
+    expect(srcOf(a.container)).not.toBe(srcOf(b.container))
+  })
+
+  it('keeps the URL stable within one message', () => {
+    // Re-render and streaming must NOT change the URL, or every keystroke of a
+    // streaming message would re-request the image.
+    const { container, rerender } = render(
+      <MarkdownRenderer content={SVG} messageTs="2026-08-08T00:00:03Z" />,
+    )
+    const before = srcOf(container)
+    rerender(<MarkdownRenderer content={SVG} messageTs="2026-08-08T00:00:03Z" streaming />)
+    expect(srcOf(container)).toBe(before)
+  })
+
+  it('leaves remote images untouched', () => {
+    const { container } = render(
+      <MarkdownRenderer content="![x](https://example.com/a.png)" messageTs="2026-08-08T00:00:04Z" />,
+    )
+    expect(srcOf(container)).toBe('https://example.com/a.png')
+  })
+
+  it('adds nothing when the caller has no message context', () => {
+    // FileViewer and ContentRenderer render markdown outside a transcript. They
+    // pass no messageTs, and their URLs must not change.
+    const { container } = render(<MarkdownRenderer content={SVG} />)
+    expect(srcOf(container)).toBe(`/api/file-raw?path=${encodeURIComponent('/Users/me/work/logo.svg')}`)
+  })
+})


### PR DESCRIPTION
Fixes #1625.

## Problem

An agent authors an SVG, then edits it, and the new message still shows the first version.

The image-authoring flow keeps **one** editable source and shows it as `![alt](/abs/path.svg)`, so an edit overwrites the same file and every turn renders the same URL:

```ts
url = `/api/file-raw?path=${encodeURIComponent(src)}`   // path in, path out
```

`/api/file-raw` addresses a file by path, with no version discriminator — and a browser treats one URL in one document as one resource. The second `<img>` is served from the in-document cache **with no network request at all**, so the new message paints the old bytes.

## The obvious fix does not work

My first attempt was a content-derived `ETag` plus a revalidate directive on the handler. I tested it in real Chrome before writing it, driving the exact sequence — load the image, rewrite the file, append a *new* `<img>` at the same URL — with v1 at 10×10 and v2 at 40×40 so `naturalWidth` reports which bytes were painted:

| response headers | second impression | requests for the file |
|---|---|---|
| none (current `main`) | 10px — **stale** | 1 |
| `ETag` + `Cache-Control: no-cache` + `Last-Modified` | 10px — **stale** | 1 |
| `Cache-Control: no-store` | 10px — **stale** | 1 |
| distinct URL per message | **40px — fresh** | 2 |

The header approaches all fail for the same reason: the request is never issued, so the cache directives are never consulted. Shipping them would have added a conditional request to every `file-raw` consumer — attachments, previews, thumbnails — and fixed nothing.

Worth noting the last row also fixes the second half of the report. With distinct URLs each impression is its own cache entry, so the earlier message keeps the bytes it loaded (`firstAfterEdit=10`) while the new one shows current content. That is the reporter's stated expectation, without content-addressed storage.

## Fix

`ImageVersionCtx` carries the message timestamp to `ImgWithFallback`, which appends it to local `file-raw` URLs. It rides a context because react-markdown component overrides cannot receive custom props — the same reason `BasePathCtx` and `CompactImagesCtx` exist, and `MarkdownRenderer` already has `messageTs` in scope at that point for `WidgetFrame`.

Frontend-only: the handler reads just `path`, so the extra parameter is inert server-side.

## Correcting the issue's diagnosis

The issue suggests the SVG node is "keyed by something stable across edits (e.g. message/position id) rather than the content version." That is not the cause, which is why @bayshanhai-dev's component-level investigation could not reproduce it — their tests were sound, just aimed at the wrong path. I ran the controls:

- literal inline `<svg>` markup re-renders correctly on edit, and two impressions of different markup stay distinct
- `<mcwidget>` → `WidgetFrame` already keys on `contentHash(html)`

Both are content-derived already. The defect is only on the `![](path)` → `file-raw` path.

## Tests

`website/src/test/MarkdownRenderer.imageVersion.test.tsx`, 5 cases. Against unmodified `main` exactly one fails — "gives two messages distinct URLs for the SAME path" — while the other four pass on both sides, which is what I wanted: they are invariants (the premise, URL stability within a message, remote URLs untouched, and no change for callers without message context), so a future change that breaks one is a real regression rather than a restatement of the fix.

URL stability within a message is the assertion worth keeping: without it, a per-render token would re-request the image on every streaming update.

- new suite: 5 passed
- full frontend suite: 825 files, 10,970 passed, 0 failures
- `tsc -b` clean; eslint warning count unchanged from `main` (2 before, 2 after — both pre-existing)

## Limitations

Stated plainly rather than left to be found in review:

- If an agent rewrites the same file **twice within one message**, the token does not change and that case is still stale. The common flow is one edit per turn.
- An earlier impression keeps its bytes only while its cache entry lives; after eviction it re-fetches and gets current content, since one file holds one version. Per-turn historical snapshots would need content-addressed storage — a design change, not a bug fix, and worth a separate issue if wanted.
- The measurements above are Chrome. The mechanism (a document-level resource cache keyed by URL) is not Chrome-specific, but I verified only Chrome.


## Why this touches `eslint.i18n.config.js`

The i18n gate flagged the one line this fix adds:

```
components/MarkdownRenderer.tsx:719  disallow literal string: url += `&v=${encodeURIComponent(version)}`
```

The query-string exemption already covers `?id=` and `?since=` with `^\?[a-z_]+=$`, on the stated grounds that a request path is a server contract and translating it would 404. A URL carrying a *second* parameter has to spell it with `&`, which is the same contract, so the leading character is now `[?&]`. The shape stays as tight — prose takes neither a leading `?`/`&` nor a trailing `=`, so real copy is still reported.

I considered the alternatives rather than reaching for the config first. Any two-parameter URL needs one `&` somewhere, so reordering only moves the literal to `&path=`. Switching to `URLSearchParams` removes the literal but encodes spaces as `+` instead of `%20`, which changes the wire format of a **file path** — and `pinnedPrompt.test.ts` pins `%20` for the sibling helper, so that is a behavioural risk for no benefit. The gate's own message names this exclusion as the intended route for a string that is genuinely not copy.

Verified by reproducing the gate locally with `I18N_BASE_REF` set, the way CI drives it:

| | `[added-lines]` | `[vs-base]` |
|---|---|---|
| without the widening | 1 untranslated | 1 file worse |
| with it | **0** | **0** |

Both ceilings stay under budget (329/394 in ALL-CAPS constants, 580/1037 overall), and the strict config reports nothing on any line this branch wrote.

## Note on the first push

The branch originally carried two commits — I branched it off the #2021 branch by mistake instead of `main`. It is now rebased onto current `main` (where #2195 has since landed) as a single commit.

One pre-existing failure is unrelated to this PR: `catalogParity.test.ts > ko` reports 6 English keys with no Korean translation (`pages.artifactsPage.*`, `pages.chat.recoveryCard.session_busy_continuing`, `pages.settings.notificationsPanel.preset_pulse`). I confirmed it reproduces with zero files differing from `main`.
