### PR TITLE
feat(telegram): inbound attachment support (image vision, documents, audio transcription)

### DIFF
--- a/src/kiro_crew/discord/attachments.py
+++ b/src/kiro_crew/discord/attachments.py
@@ -1,29 +1,36 @@
 """Discord-specific adapter over channel-neutral attachment ingestion.
 
-Discord owns the envelope mapping, CDN download callback, and voice-message
-transcription. Classification, limits, signature validation, extraction,
-redaction, rejection text, and temp-file ownership stay in
-``kiro_crew.messaging.attachments``.
+Discord owns only what is genuinely Discord-shaped: the envelope mapping and the
+signed-CDN download callback. Classification, limits, signature validation,
+extraction, redaction, rejection text, transcription and temp-file ownership all
+stay in ``kiro_crew.messaging.attachments``.
 """
 
 from __future__ import annotations
 
-import asyncio
-import logging
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.messaging.attachments import (
     Attachment,
     IngestResult,
+    append_attachment_context,
     ingest_attachments,
+    transcribe_audio_attachments,
 )
-from kiro_crew.transcribe import is_available as stt_available
-from kiro_crew.transcribe import transcribe_audio
+
+# ``append_attachment_context`` is channel-neutral and lives in
+# ``messaging.attachments``; it is re-exported here so existing
+# ``from kiro_crew.discord.attachments import append_attachment_context``
+# callers keep resolving. Declared in ``__all__`` rather than carrying a
+# blanket ``# noqa: F401`` on the import block, which would also suppress
+# genuine unused-import warnings for the names above that ARE used.
+__all__ = [
+    "append_attachment_context",
+    "process_discord_attachments",
+]
 
 if TYPE_CHECKING:
     from kiro_crew.discord.client import DiscordClient
-
-logger = logging.getLogger(__name__)
 
 
 def _to_attachment(raw: Any) -> Attachment:
@@ -73,49 +80,9 @@ async def process_discord_attachments(
         source="discord",
         handle_audio=True,
     )
-
-    if not result.audio_paths:
-        return result
-
-    try:
-        available = await asyncio.to_thread(stt_available)
-    except Exception:
-        logger.exception("Discord: failed to check speech-to-text availability")
-        available = False
-
-    if not available:
-        result.rejections.extend(
-            "[Audio attachment — transcription is unavailable]"
-            for _ in result.audio_paths
-        )
-        return result
-
-    for path in result.audio_paths:
-        try:
-            transcript = await transcribe_audio(path)
-        except Exception:
-            logger.exception("Discord: audio transcription raised")
-            transcript = None
-        if transcript:
-            result.text_blocks.append(
-                "[Voice memo transcription]\n"
-                f"{transcript}\n"
-                "[End of transcription]"
-            )
-        else:
-            result.rejections.append("[Audio attachment — transcription failed]")
-
-    return result
+    return await transcribe_audio_attachments(result, "Discord")
 
 
-def append_attachment_context(text: str, result: IngestResult) -> str:
-    """Append prompt-ready attachment material using Slack's proven layout."""
-    if result.image_paths:
-        paths_text = "\n".join(result.image_paths)
-        text = f"{text}\n{paths_text}" if text else paths_text
-
-    blocks = [*result.text_blocks, *result.rejections]
-    if blocks:
-        blocks_text = "\n\n".join(blocks)
-        text = f"{text}\n\n{blocks_text}" if text else blocks_text
-    return text
+# append_attachment_context is re-exported from messaging.attachments (imported above).
+# Kept in this module's public API so existing `from kiro_crew.discord.attachments
+# import append_attachment_context` continues to resolve without a code change.

--- a/src/kiro_crew/messaging/attachments.py
+++ b/src/kiro_crew/messaging/attachments.py
@@ -44,6 +44,7 @@ import tempfile
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 
+from kiro_crew import transcribe
 from kiro_crew.doc_parser import extract_text, is_parseable_document
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
@@ -483,3 +484,71 @@ def cleanup(paths: list[str]) -> None:
             os.unlink(p)
         except OSError:
             pass
+
+
+async def transcribe_audio_attachments(result: IngestResult, source: str) -> IngestResult:
+    """Transcribe every audio path on *result* in place, then return it.
+
+    Channel-neutral second half of audio ingestion: :func:`ingest_attachments`
+    (with ``handle_audio=True``) downloads audio and hands back
+    :attr:`IngestResult.audio_paths`; this turns those paths into prompt-ready
+    transcript blocks, or into visible rejections when speech-to-text is
+    unavailable or fails.
+
+    Lives here rather than in each channel adapter so the transcript wording and
+    the STT-unavailable handling cannot drift between channels — Discord and
+    Telegram previously carried byte-identical copies of this block.
+
+    ``source`` names the channel for log lines only; it does not change behaviour.
+    """
+    if not result.audio_paths:
+        return result
+
+    try:
+        available = await asyncio.to_thread(transcribe.is_available)
+    except Exception:
+        logger.exception("%s: failed to check speech-to-text availability", source)
+        available = False
+
+    if not available:
+        result.rejections.extend(
+            "[Audio attachment — transcription is unavailable]" for _ in result.audio_paths
+        )
+        return result
+
+    for path in result.audio_paths:
+        try:
+            transcript = await transcribe.transcribe_audio(path)
+        except Exception:
+            logger.exception("%s: audio transcription raised", source)
+            transcript = None
+        if transcript:
+            result.text_blocks.append(
+                f"[Voice memo transcription]\n{transcript}\n[End of transcription]"
+            )
+        else:
+            result.rejections.append("[Audio attachment — transcription failed]")
+
+    return result
+
+
+def append_attachment_context(text: str, result: IngestResult) -> str:
+    """Append prompt-ready attachment material to the user's message text.
+
+    Image paths are appended as bare lines (the ACP encoder's path regex picks
+    them up and inlines each as a base64 image content block). Text and
+    rejection blocks follow, separated by blank lines for prompt readability.
+
+    Channel-neutral: every transport that ingests attachments uses this same
+    layout, so the model sees a consistent attachment presentation regardless
+    of whether the user sent from Slack, Discord, or Telegram.
+    """
+    if result.image_paths:
+        paths_text = "\n".join(result.image_paths)
+        text = f"{text}\n{paths_text}" if text else paths_text
+
+    blocks = [*result.text_blocks, *result.rejections]
+    if blocks:
+        blocks_text = "\n\n".join(blocks)
+        text = f"{text}\n\n{blocks_text}" if text else blocks_text
+    return text

--- a/src/kiro_crew/telegram/attachments.py
+++ b/src/kiro_crew/telegram/attachments.py
@@ -1,0 +1,136 @@
+"""Telegram-specific adapter over channel-neutral attachment ingestion.
+
+Telegram owns only what is genuinely Telegram-shaped: the envelope mapping
+(photo/document/audio/voice/video → shared ``Attachment``) and the two-step
+``getFile`` download callback. Classification, limits, signature validation,
+extraction, redaction, rejection text, transcription and temp-file ownership all
+stay in ``kiro_crew.messaging.attachments``.
+
+Mirrors ``kiro_crew.discord.attachments`` — same shared pipeline, only the
+envelope shape and the download auth differ.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+from typing import TYPE_CHECKING, Any
+
+from kiro_crew.messaging.attachments import (
+    Attachment,
+    IngestResult,
+    append_attachment_context,
+    ingest_attachments,
+    transcribe_audio_attachments,
+)
+
+if TYPE_CHECKING:
+    from kiro_crew.telegram.client import TelegramClient
+
+# ``append_attachment_context`` is channel-neutral and lives in
+# ``messaging.attachments``; re-exported here so a caller can take the whole
+# ingest+append pair from one module (mirrors ``discord.attachments``).
+# Declared in ``__all__`` rather than carrying a blanket ``# noqa: F401`` on
+# the import block, which would also suppress genuine unused-import warnings
+# for the names above that ARE used.
+__all__ = [
+    "append_attachment_context",
+    "process_telegram_attachments",
+]
+
+
+#: Extensions for the mimetypes Telegram delivers WITHOUT a ``file_name`` --
+#: voice notes and video_notes carry only ``file_id`` + ``mime_type``. Pinned
+#: rather than left to ``mimetypes.guess_extension`` because that maps
+#: ``audio/ogg`` to ``.oga``, which some transcription backends reject.
+_MIME_EXT_OVERRIDES = {
+    "audio/ogg": ".ogg",
+    "audio/mpeg": ".mp3",
+    "audio/mp4": ".m4a",
+    "audio/x-wav": ".wav",
+    "audio/wav": ".wav",
+    "video/mp4": ".mp4",
+    "video/quicktime": ".mov",
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+}
+
+
+def _ext_for_mime(mimetype: str) -> str:
+    """A concrete file extension for *mimetype*, defaulting to ``.bin``."""
+    if not mimetype:
+        return ".bin"
+    override = _MIME_EXT_OVERRIDES.get(mimetype.lower())
+    if override:
+        return override
+    return mimetypes.guess_extension(mimetype.lower()) or ".bin"
+
+
+def _to_attachment(raw: Any) -> Attachment:
+    """Map one Telegram file object onto the shared neutral shape.
+
+    Telegram's file objects vary by type:
+    - Photo: ``file_id``, ``file_unique_id``, ``width``, ``height``,
+      ``file_size`` — no ``file_name``/``mime_type``, so ``_dispatch``
+      synthesizes them.
+    - Document/Audio/Voice/Video: adds ``file_name`` and ``mime_type``.
+
+    The download URL is NOT on the object — it requires a ``getFile`` round
+    trip — so ``file_id`` is carried in ``Attachment.url`` and the download
+    callback resolves it.
+    """
+    if not isinstance(raw, dict):
+        return Attachment(name="unknown")
+
+    mime_type = raw.get("mime_type")
+    mimetype = mime_type if isinstance(mime_type, str) else ""
+    file_name = raw.get("file_name")
+    if isinstance(file_name, str) and file_name:
+        name = file_name
+    else:
+        # Voice notes and video_notes have NO file_name. A literal "file"
+        # fallback gave the downloaded temp file a ".file" suffix, and the
+        # transcription backend keys off the extension -- so the voice memo was
+        # downloaded, handed over, and then rejected as an unknown format.
+        # Derive the extension from mime_type instead.
+        name = f"file{_ext_for_mime(mimetype)}"
+    file_id = raw.get("file_id")
+    url = file_id if isinstance(file_id, str) else ""
+    file_size = raw.get("file_size")
+    size = (
+        file_size
+        if isinstance(file_size, int) and not isinstance(file_size, bool) and file_size >= 0
+        else 0
+    )
+    suffix = name.rsplit(".", 1)[-1] if "." in name else ""
+    return Attachment(
+        name=name,
+        mimetype=mimetype,
+        size=size,
+        url=url,
+        suffix_hint=suffix,
+    )
+
+
+async def process_telegram_attachments(
+    client: "TelegramClient",
+    raw_attachments: list[Any],
+) -> IngestResult:
+    """Ingest Telegram files and transcribe any audio/voice attachments.
+
+    Telegram voice messages are ``audio/ogg`` (Opus in an OGG container), so the
+    shared classifier's normal ``audio/`` rule already covers them — no
+    channel-specific mimetype override is needed. The returned temp paths stay
+    caller-owned and must outlive the consuming turn.
+    """
+
+    async def _download(file_id: str, dest: str) -> None:
+        """Download callback: resolves ``file_id`` via Telegram's getFile."""
+        await client.download_file(file_id, dest)
+
+    result = await ingest_attachments(
+        [_to_attachment(raw) for raw in raw_attachments],
+        download=_download,
+        source="telegram",
+        handle_audio=True,
+    )
+    return await transcribe_audio_attachments(result, "Telegram")

--- a/src/kiro_crew/telegram/client.py
+++ b/src/kiro_crew/telegram/client.py
@@ -20,7 +20,7 @@ import logging
 import os
 import re
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable
 
 import aiohttp
@@ -31,6 +31,24 @@ logger = logging.getLogger(__name__)
 
 # Telegram message text limit.
 TELEGRAM_MAX_TEXT = 4096
+
+# ── Album (media group) coalescing ──
+# Telegram delivers an album as N separate `message` updates sharing one
+# `media_group_id`, with the caption on only one member. We buffer members and
+# emit ONE merged message so a four-screenshot album is one turn, not four.
+#: Idle gap after the last member before flushing. Album members arrive
+#: back-to-back (typically in a single getUpdates batch), so this only has to
+#: outlast intra-batch jitter -- not a user's typing.
+_ALBUM_WINDOW_S = 1.0
+#: Hard ceiling from the FIRST member, so a stream that keeps appending to one
+#: group can never defer the flush indefinitely.
+_ALBUM_MAX_WAIT_S = 5.0
+#: Per-group member cap. Telegram's own album limit is 10, so this is only
+#: reachable via a malformed/spoofed stream; it keeps the buffer bounded.
+_ALBUM_MAX_MEMBERS = 10
+#: Concurrent buffered groups. Defence-in-depth: each group self-flushes within
+#: _ALBUM_MAX_WAIT_S, so this only matters under a burst of incomplete groups.
+_ALBUM_MAX_GROUPS = 64
 # Safe chunk boundary (leave room for markdown overhead).
 TELEGRAM_CHUNK_LIMIT = 4000
 
@@ -229,6 +247,11 @@ class TelegramInbound:
     # Forum-topic id in a supergroup (Bot API ``message_thread_id``); None in a
     # 1:1 DM or the supergroup's General topic.
     message_thread_id: int | None = None
+    #: Raw file attachment dicts extracted from the Telegram update (photo,
+    #: document, audio, voice, video_note, video, animation). Each dict carries
+    #: at minimum ``file_id`` and ``file_unique_id``; optional fields include
+    #: ``file_size``, ``mime_type``, ``file_name``, and ``width``/``height``.
+    attachments: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass
@@ -284,6 +307,11 @@ class TelegramClient:
         self._last_status: bool | None = None
         # Live turn tasks — prevent GC of in-flight handlers.
         self._handler_tasks: set[asyncio.Task[None]] = set()
+        # Album (media group) coalescing buffers, keyed by media_group_id.
+        self._albums: dict[str, list[TelegramInbound]] = {}
+        self._album_timers: dict[str, asyncio.Task[None]] = {}
+        self._album_first_seen: dict[str, float] = {}
+        self._album_dropped: dict[str, int] = {}
 
     # ── Lifecycle ──
 
@@ -295,6 +323,12 @@ class TelegramClient:
     async def close(self) -> None:
         """Gracefully shut down."""
         self._closed = True
+        # Best-effort flush of buffered albums BEFORE cancelling the polling
+        # task. This is NOT a delivery guarantee -- see _flush_all_albums: the
+        # handler it spawns races SessionManager._closing and may be refused,
+        # exactly as a plain message arriving at shutdown already is today. It
+        # costs nothing, sometimes wins, and drains the buffer either way.
+        self._flush_all_albums()
         if self._task:
             self._task.cancel()
             try:
@@ -479,6 +513,65 @@ class TelegramClient:
             },
         )
 
+    # ── File download (attachment ingestion) ──
+
+    #: The only host Telegram file downloads may resolve to. A redirect or
+    #: different host means the URL is not from Telegram and must be refused.
+    _FILE_HOST = "api.telegram.org"
+
+    async def download_file(self, file_id: str, dest: str) -> None:
+        """Download a Telegram file by ``file_id`` to *dest*.
+
+        Two-step process per Bot API docs:
+        1. ``getFile(file_id)`` → returns a ``File`` object with ``file_path``
+        2. Construct ``https://api.telegram.org/file/bot<token>/<file_path>``
+           and download the bytes.
+
+        Host-allowlisted: only ``api.telegram.org`` is accepted. Redirects are
+        refused so a compromised file_path cannot exfiltrate data via an open
+        redirect. Errors raise token-free messages (the download URL contains
+        the bot token, so aiohttp's default exception str() must never propagate).
+        """
+        result = await self._api("getFile", {"file_id": file_id})
+        if not result or not isinstance(result, dict):
+            raise ValueError(f"getFile returned no result for file_id={file_id!r}")
+        file_path = result.get("file_path", "")
+        if not file_path:
+            raise ValueError(f"getFile returned empty file_path for file_id={file_id!r}")
+
+        url = f"https://api.telegram.org/file/bot{self._token}/{file_path}"
+
+        session = await self._ensure_session()
+        try:
+            async with session.get(
+                url,
+                proxy=self._proxy,
+                timeout=aiohttp.ClientTimeout(total=60),
+                allow_redirects=False,
+            ) as resp:
+                if 300 <= resp.status < 400:
+                    raise ValueError("refusing redirected Telegram file URL")
+                if resp.status >= 400:
+                    # Token-free error: aiohttp's ClientResponseError embeds the
+                    # full URL (which contains the bot token) in its str().
+                    raise ValueError(
+                        f"Telegram file download failed (status {resp.status})"
+                    )
+                # Offload file I/O to a worker thread — a large attachment on
+                # slow/FUSE storage must not block the gateway event loop.
+                # Mirrors discord/client.py's download_attachment pattern.
+                fh = await asyncio.to_thread(open, dest, "wb")
+                try:
+                    async for chunk in resp.content.iter_chunked(65536):
+                        await asyncio.to_thread(fh.write, chunk)
+                finally:
+                    await asyncio.to_thread(fh.close)
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            # Strip the token-bearing URL from transport exceptions.
+            raise ValueError(
+                f"Telegram file download transport error ({type(exc).__name__})"
+            ) from None
+
     # ── Polling loop ──
 
     async def _call_raw(self, method: str, params: dict, timeout: int = 15) -> Any:
@@ -607,25 +700,191 @@ class TelegramClient:
             return result
         return []
 
+    # ── Album (media group) coalescing ──
+
+    def _buffer_album_member(self, group_id: str, inbound: TelegramInbound) -> None:
+        """Hold one album member and (re)arm its flush timer.
+
+        The timer is rearmed on every arrival, so the album flushes
+        ``_ALBUM_WINDOW_S`` after the LAST member rather than the first — album
+        members arrive back-to-back (usually in one getUpdates batch), so this
+        settles almost immediately. ``_ALBUM_MAX_WAIT_S`` is the hard ceiling
+        that stops a pathological stream which keeps appending to one group from
+        deferring the flush forever.
+        """
+        members = self._albums.get(group_id)
+        if members is None:
+            # Cap concurrent groups. Every group self-flushes within
+            # _ALBUM_MAX_WAIT_S, so this is defence-in-depth against a burst of
+            # never-completed groups rather than an expected path. Flush the
+            # oldest rather than dropping it, so no message is silently lost.
+            if len(self._albums) >= _ALBUM_MAX_GROUPS:
+                oldest = min(self._albums, key=lambda g: self._album_first_seen.get(g, 0.0))
+                logger.warning(
+                    "Telegram: album buffer at %d groups, force-flushing oldest",
+                    _ALBUM_MAX_GROUPS,
+                )
+                self._flush_album(oldest)
+            members = self._albums[group_id] = []
+            self._album_first_seen[group_id] = time.monotonic()
+
+        if len(members) < _ALBUM_MAX_MEMBERS:
+            members.append(inbound)
+        else:
+            # Telegram's own album limit is 10, so this is unreachable for a
+            # well-formed album. Count rather than grow, and surface it at flush
+            # so an over-cap group is visible instead of silently truncated.
+            self._album_dropped[group_id] = self._album_dropped.get(group_id, 0) + 1
+
+        self._arm_album_timer(group_id)
+
+    def _arm_album_timer(self, group_id: str) -> None:
+        """(Re)schedule the flush for *group_id*, respecting the hard ceiling."""
+        existing = self._album_timers.pop(group_id, None)
+        if existing is not None and not existing.done():
+            existing.cancel()
+        elapsed = time.monotonic() - self._album_first_seen.get(group_id, 0.0)
+        delay = min(_ALBUM_WINDOW_S, max(0.0, _ALBUM_MAX_WAIT_S - elapsed))
+        task = asyncio.create_task(self._album_flush_after(group_id, delay))
+        self._album_timers[group_id] = task
+        # Tracked alongside handler tasks so a pending flush is not garbage
+        # collected mid-flight.
+        self._handler_tasks.add(task)
+        task.add_done_callback(self._handler_tasks.discard)
+
+    async def _album_flush_after(self, group_id: str, delay: float) -> None:
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            return  # a newer member rearmed the timer
+        self._album_timers.pop(group_id, None)
+        self._flush_album(group_id)
+
+    def _flush_album(self, group_id: str) -> None:
+        """Merge one buffered album into a single message and dispatch it."""
+        members = self._albums.pop(group_id, None)
+        self._album_first_seen.pop(group_id, None)
+        dropped = self._album_dropped.pop(group_id, 0)
+        timer = self._album_timers.pop(group_id, None)
+        if timer is not None and not timer.done():
+            timer.cancel()
+        if not members:
+            return
+
+        # Usually the caption rides on exactly one member, but Telegram Desktop
+        # and Android let the user caption individual items of a media group --
+        # so join every non-empty caption in album order rather than taking the
+        # first. For the single-caption case this is identical; for the
+        # per-item case it is the difference between the model seeing all of
+        # the user's words and silently seeing only the first.
+        # Everything else comes from the first member: its message_id is what a
+        # reply or a steer-ack reaction should target.
+        head = members[0]
+        text = "\n\n".join(m.text for m in members if m.text)
+        attachments: list[dict[str, Any]] = []
+        for member in members:
+            attachments.extend(member.attachments)
+        if dropped:
+            logger.warning(
+                "Telegram: album %s exceeded %d members; %d ignored",
+                group_id,
+                _ALBUM_MAX_MEMBERS,
+                dropped,
+            )
+        merged = TelegramInbound(
+            chat_id=head.chat_id,
+            user_id=head.user_id,
+            username=head.username,
+            text=text,
+            message_id=head.message_id,
+            chat_type=head.chat_type,
+            message_thread_id=head.message_thread_id,
+            attachments=attachments,
+        )
+        self._spawn_handler(merged)
+
+    def _flush_all_albums(self) -> None:
+        """Best-effort flush of every buffered album, used on shutdown.
+
+        **Not a delivery guarantee.** Shutdown runs the channel teardown and
+        ``SessionManager.close_all()`` concurrently in one ``cleanup_tasks``
+        gather, and ``close_all`` sets ``_closing``, after which ``begin_turn``
+        raises ``SessionClosingError``. So a handler spawned here may lose the
+        race and be refused.
+
+        Kept anyway because it is free and sometimes wins, and because the
+        residual is not a new failure mode: a plain single message that arrives
+        just before shutdown is refused by that same ``_closing`` gate today.
+        Buffering an album widens that pre-existing window by at most
+        ``_ALBUM_WINDOW_S``; it does not introduce a class of loss that was not
+        already there. Draining the buffer here also keeps a closed client from
+        holding album state.
+        """
+        for group_id in list(self._albums):
+            self._flush_album(group_id)
+
+    @staticmethod
+    def _build_inbound(msg: dict) -> TelegramInbound:
+        """Map ONE Telegram ``message`` envelope onto ``TelegramInbound``.
+
+        Pure and side-effect free so both the single-message path and the album
+        merge path share exactly one envelope interpretation.
+        """
+        text = msg.get("text", "") or msg.get("caption", "")
+        chat = msg.get("chat", {})
+        user = msg.get("from", {})
+        # Extract file attachments. Telegram delivers each media type in its
+        # own top-level key. ``photo`` is an array of sizes — pick the last
+        # (largest). Each attachment dict carries at minimum ``file_id``.
+        attachments: list[dict[str, Any]] = []
+        if "photo" in msg and msg["photo"]:
+            # Largest photo is last in the array (Bot API guarantee).
+            largest = msg["photo"][-1]
+            # Synthesize a filename — photos have no file_name field.
+            largest.setdefault("file_name", "photo.jpg")
+            largest.setdefault("mime_type", "image/jpeg")
+            attachments.append(largest)
+        for key in ("document", "audio", "voice", "video_note", "video", "animation"):
+            if key in msg and isinstance(msg[key], dict):
+                attachments.append(msg[key])
+        # Stickers are intentionally excluded — they are decorative, not
+        # content the model should ingest.
+        return TelegramInbound(
+            chat_id=chat.get("id", 0),
+            user_id=user.get("id", 0),
+            username=user.get("username", ""),
+            text=text,
+            message_id=msg.get("message_id", 0),
+            chat_type=chat.get("type", ""),
+            message_thread_id=msg.get("message_thread_id"),
+            attachments=attachments,
+        )
+
+    def _spawn_handler(self, inbound: TelegramInbound) -> None:
+        """Run the message handler as a tracked background task."""
+        task = asyncio.create_task(self._invoke_message(inbound))
+        self._handler_tasks.add(task)
+        task.add_done_callback(self._handler_tasks.discard)
+
     def _dispatch(self, update: dict) -> None:
         """Route a single Update to the appropriate handler as a background task."""
         if "message" in update:
             msg = update["message"]
-            text = msg.get("text", "")
-            chat = msg.get("chat", {})
-            user = msg.get("from", {})
-            inbound = TelegramInbound(
-                chat_id=chat.get("id", 0),
-                user_id=user.get("id", 0),
-                username=user.get("username", ""),
-                text=text,
-                message_id=msg.get("message_id", 0),
-                chat_type=chat.get("type", ""),
-                message_thread_id=msg.get("message_thread_id"),
-            )
-            task = asyncio.create_task(self._invoke_message(inbound))
-            self._handler_tasks.add(task)
-            task.add_done_callback(self._handler_tasks.discard)
+            inbound = self._build_inbound(msg)
+            # An album (media group) is delivered as N SEPARATE updates sharing
+            # one media_group_id, with the caption on only one member. Buffer
+            # them and emit a single merged message instead of N turns.
+            # Keyed by (chat_id, media_group_id), NOT media_group_id alone:
+            # nothing guarantees the id is unique across the chats one bot
+            # serves, and a collision would merge two chats' members into one
+            # message addressed to head.chat_id -- silently swallowing the other
+            # chat's copy and delivering its content into the wrong
+            # conversation. The composite key removes that class outright.
+            group_id = msg.get("media_group_id")
+            if isinstance(group_id, str) and group_id:
+                self._buffer_album_member(f"{inbound.chat_id}:{group_id}", inbound)
+                return
+            self._spawn_handler(inbound)
 
         elif "callback_query" in update:
             cq = update["callback_query"]

--- a/src/kiro_crew/telegram/transport.py
+++ b/src/kiro_crew/telegram/transport.py
@@ -67,7 +67,7 @@ TELEGRAM_CAPABILITIES = TransportCapabilities(
     streaming=True,
     edit=True,
     reactions=True,  # setMessageReaction — used for the steer-ack receipt
-    files_inbound=False,  # photos/stickers are dropped in receive(), matching prior behavior
+    files_inbound=True,  # photos/documents ingested via telegram/attachments.py
     files_outbound=False,
     rich_blocks=False,
     threads=True,
@@ -210,13 +210,13 @@ class TelegramTransport(MessagingTransport):
         The low-level client long-polls and normalizes updates into
         ``TelegramInbound``; this adapter maps that onto the neutral
         ``InboundMessage``, enforces deny-by-default auth, and hands an
-        authorized message to the turn dispatcher. Non-text updates
-        (photos/stickers) are dropped.
+        authorized message to the turn dispatcher. Attachment-only messages
+        (no text/caption) are accepted; sticker-only messages are dropped.
         """
         if not isinstance(raw_envelope, TelegramInbound):
             return
         inbound = raw_envelope
-        if not inbound.text:
+        if not inbound.text and not inbound.attachments:
             return
         # Chat-type gate (fail closed). A bot added to a group receives every
         # message and its replies land in that chat, so we serve ONLY a real
@@ -252,6 +252,7 @@ class TelegramTransport(MessagingTransport):
             thread_id=(str(inbound.message_thread_id) if inbound.message_thread_id else None),
             message_id=inbound.message_id,
             chat_type=inbound.chat_type,
+            attachments=list(inbound.attachments),
         )
         if not self.authorize(msg):
             return

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -31,6 +31,8 @@ from typing import TYPE_CHECKING, Any
 
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
+from kiro_crew.messaging.attachments import IngestLimits, append_attachment_context
+from kiro_crew.messaging.attachments import cleanup as cleanup_attachments
 from kiro_crew.messaging.driver import APPROVAL_INTERACTIVE, TurnDriver
 from kiro_crew.messaging.identity import channel_inbound_permitted, publish_turn_identity
 from kiro_crew.messaging.link import (
@@ -44,6 +46,7 @@ from kiro_crew.messaging.link import (
 )
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.sel import sel
+from kiro_crew.telegram.attachments import process_telegram_attachments
 from kiro_crew.telegram.commands import (
     ConversationState,
     parse_command,
@@ -75,6 +78,12 @@ _DEFAULT_KIROCREW_AGENT = "kirocrew"
 # A single human won't realistically burst past this mid-turn; anything beyond
 # stays queued and drains after the next turn (logged for observability).
 _MAX_COLLAPSE = 50
+
+# Keep queue collapse within the shared ingestion layer's per-turn file cap.
+# Without this, two queued 10-photo albums would concatenate to 20 attachments
+# in one turn and ingest_attachments would silently process only the first 10,
+# losing the second album entirely. Mirrors discord/transport_dispatch.py.
+_MAX_COLLAPSED_ATTACHMENTS = IngestLimits().max_attachments
 
 _HELP_TEXT = """\
 🦞 Kiro Crew — Telegram
@@ -235,12 +244,17 @@ class TelegramDispatcher:
         # payload is replayed as pure content, so a queued "/new" reaches the
         # model as text instead of executing on drain.
         override_mode = None
-        if interpret_commands and parse_command(text) is None:
+        # Attachments make this a content-bearing turn, not a control command:
+        # a caption of "/new" would otherwise intercept and return BEFORE
+        # attachment ingestion, silently discarding the photo the user attached
+        # to it. Mirrors discord/transport_dispatch.py's interpret_as_command.
+        interpret_as_command = interpret_commands and not msg.attachments
+        if interpret_as_command and parse_command(text) is None:
             override_mode, text = parse_mid_turn_override(text)
 
         # ── Command intercept (no LLM session needed; skipped for override
         # payloads and drained queue content — see above) ──
-        cmd = parse_command(text) if interpret_commands and override_mode is None else None
+        cmd = parse_command(text) if interpret_as_command and override_mode is None else None
         if cmd == "new":
             self._conv.bump_gen(route)
             await self._reply(chat_id, "✅ New conversation started.", thread=reply_thread)
@@ -309,6 +323,7 @@ class TelegramDispatcher:
         # on _acquired so we never release a semaphore we didn't hold. Mirrors
         # slack/transport_dispatch.py.
         _acquired = False
+        attachment_temp_paths: list[str] = []
         try:
             # Ack placeholder first (before the potentially slow cold-start);
             # on_turn_start is idempotent so the driver's later call no-ops.
@@ -319,6 +334,15 @@ class TelegramDispatcher:
             _acquired = True
             if is_new:
                 await self.sessions.set_channel(session_key, channel_id)
+            # ── Attachment ingestion (mirrors Discord) ──
+            if msg.attachments:
+                attachment_result = await process_telegram_attachments(
+                    self.client, msg.attachments
+                )
+                attachment_temp_paths = list(attachment_result.temp_paths)
+                text = append_attachment_context(text, attachment_result)
+            if not text:
+                return
             # Publish this turn's session identity so managed MCP tools resolve
             # X-Session-Key; one shared writer lives in messaging.identity.
             await publish_turn_identity(self.sessions, session_key)
@@ -421,6 +445,7 @@ class TelegramDispatcher:
             self._active_renderers.pop(session_key, None)
             if _acquired:
                 self.sessions.release(session_key)
+            await asyncio.to_thread(cleanup_attachments, attachment_temp_paths)
 
         # Now that the turn is released, run anything that queued during it
         # (queue_mode == "queue"). ``drain`` is False for drained turns so the
@@ -450,7 +475,15 @@ class TelegramDispatcher:
         assert self.client is not None
         chat_id = int(msg.conversation_id)
         mode = override_mode or self.cfg.messaging.queue_mode
-        if mode != "queue":
+        # An attachment-bearing message can never take the steer path: ``steer``
+        # forwards TEXT ONLY, so steering a photo/document message would deliver
+        # its caption and silently drop every file. Such a message always goes to
+        # the queue path below, which carries ``attachments`` through the drain.
+        # Mirrors discord/transport_dispatch.py's identical gate -- Telegram was
+        # missing it, and album buffering makes it far more reachable: a follow-up
+        # typed during the debounce window starts a turn, so the album's own flush
+        # arrives mid-turn and would have been steered as caption-only.
+        if mode != "queue" and not msg.attachments:
             provider = self.sessions.get_provider(session_key)
             steer = getattr(provider, "steer", None)
             # Only steer when a turn is GENUINELY in flight. ``is_busy`` stays
@@ -497,7 +530,10 @@ class TelegramDispatcher:
         # bubble. If the turn finished in the window the message is not queued, so
         # we run it now (re-entering handle_message, which re-strips the directive
         # and runs it as a fresh turn) instead of stranding it.
-        if not await self._enqueue_with_receipt(session_key, chat_id, text, thread=thread):
+        if not await self._enqueue_with_receipt(
+            session_key, chat_id, text, thread=thread,
+            attachments=list(msg.attachments) if msg.attachments else None,
+        ):
             await self.handle_message(msg)
 
     async def _drain_queue(
@@ -520,59 +556,96 @@ class TelegramDispatcher:
         receipt and drain after the next turn. Only the queued text is replayed
         (matching what ``enqueue`` persists for DM channels: text only).
         """
-        texts: list[str] = []
-        remainder: list[tuple[str, str, dict]] = []
-        async with self._receipt_lock:
-            # Drain the ENTIRE queue under the lock, then split: the first
-            # _MAX_COLLAPSE messages collapse into this turn; the rest are
-            # re-enqueued IN ORIGINAL ORDER (the queue is now empty, so
-            # re-adding preserves FIFO) to drain after the next turn. This
-            # bounds the combined prompt without dropping or reordering surplus.
-            while True:
-                item = self.sessions.dequeue(session_key)
-                if item is None:
-                    break
-                if len(texts) < _MAX_COLLAPSE:
-                    texts.append(item[1])
-                else:
-                    remainder.append(item)
-            for _ts, rtext, _kw in remainder:
-                self.sessions.enqueue(session_key, str(time.time()), rtext, force=True)
-            if texts:
-                await self._receipt_flip_locked(session_key, chat_id, texts, len(remainder))
-        if not texts:
-            return
-        if remainder:
-            logger.debug(
-                "telegram: drain hit collapse cap=%d for %s; %d message(s) "
-                "deferred (in order) to the next turn",
-                _MAX_COLLAPSE,
-                session_key,
-                len(remainder),
+        # Iterate rather than recurse: one burst can span multiple
+        # attachment-capped turns, and a message deferred by the cap must drain
+        # in THIS pump rather than waiting for unrelated future user input.
+        # Mirrors the Discord drain.
+        while True:
+            texts: list[str] = []
+            all_attachments: list[Any] = []
+            remainder: list[tuple[str, str, dict]] = []
+            defer_rest = False
+            async with self._receipt_lock:
+                # Drain the ENTIRE queue under the lock, then split: the first
+                # _MAX_COLLAPSE messages collapse into this turn; the rest are
+                # re-enqueued IN ORIGINAL ORDER (the queue is now empty, so
+                # re-adding preserves FIFO) to drain after the next turn. This
+                # bounds the combined prompt without dropping or reordering surplus.
+                while True:
+                    item = self.sessions.dequeue(session_key)
+                    if item is None:
+                        break
+                    item_attachments = list(item[2].get("attachments") or [])
+                    # Never collapse past the shared ingestion cap: the extra files
+                    # would be dropped inside ingest_attachments with the user given
+                    # no indication, so defer instead. Mirrors the Discord drain.
+                    exceeds_attachment_cap = bool(
+                        texts
+                        and item_attachments
+                        and len(all_attachments) + len(item_attachments)
+                        > _MAX_COLLAPSED_ATTACHMENTS
+                    )
+                    if (
+                        not defer_rest
+                        and len(texts) < _MAX_COLLAPSE
+                        and not exceeds_attachment_cap
+                    ):
+                        texts.append(item[1])
+                        all_attachments.extend(item_attachments)
+                    else:
+                        # Once one message no longer fits, defer it AND everything
+                        # behind it, so queue order stays exact.
+                        defer_rest = True
+                        remainder.append(item)
+                for _ts, rtext, rkw in remainder:
+                    self.sessions.enqueue(
+                        session_key, str(time.time()), rtext, force=True,
+                        attachments=list(rkw.get("attachments") or []),
+                    )
+                if texts:
+                    await self._receipt_flip_locked(session_key, chat_id, texts, len(remainder))
+            if not texts:
+                return
+            if remainder:
+                logger.debug(
+                    "telegram: drain deferred %d message(s) for %s to respect the "
+                    "collapse cap (%d) / attachment cap (%d); they drain in the "
+                    "next iteration of this pump, in order",
+                    len(remainder),
+                    session_key,
+                    _MAX_COLLAPSE,
+                    _MAX_COLLAPSED_ATTACHMENTS,
+                )
+            combined = "\n\n".join(texts)
+            await self.handle_message(
+                TelegramInboundMessage(
+                    channel_type="telegram",
+                    user_id=str(user_id),
+                    conversation_id=str(chat_id),
+                    text=combined,
+                    # Carry the turn's ORIGINAL route so the drained turn resolves to
+                    # the SAME forum session key -- a plain DM-shaped InboundMessage
+                    # would drain a queued forum message under the DM key instead.
+                    thread_id=thread,
+                    chat_type=chat_type,
+                    attachments=all_attachments,
+                ),
+                drain=False,
+                # Drained payloads are pure turn content: a queued "/new" must reach
+                # the model as literal text, not execute as a command on drain.
+                interpret_commands=False,
             )
-        combined = "\n\n".join(texts)
-        await self.handle_message(
-            TelegramInboundMessage(
-                channel_type="telegram",
-                user_id=str(user_id),
-                conversation_id=str(chat_id),
-                text=combined,
-                # Carry the turn's ORIGINAL route so the drained turn resolves to
-                # the SAME forum session key -- a plain DM-shaped InboundMessage
-                # would drain a queued forum message under the DM key instead.
-                thread_id=thread,
-                chat_type=chat_type,
-            ),
-            drain=False,
-            # Drained payloads are pure turn content: a queued "/new" must reach
-            # the model as literal text, not execute as a command on drain.
-            interpret_commands=False,
-        )
 
     # ── Mid-turn queue receipt (single, in-place, persistent record) ───────
 
     async def _enqueue_with_receipt(
-        self, session_key: str, chat_id: int, text: str, *, thread: int | None = None
+        self,
+        session_key: str,
+        chat_id: int,
+        text: str,
+        *,
+        thread: int | None = None,
+        attachments: list[Any] | None = None,
     ) -> bool:
         """Atomically enqueue a mid-turn message and create/grow its collapsing
         "⏳ Queued (N): …" receipt, under ``_receipt_lock``.
@@ -587,7 +660,10 @@ class TelegramDispatcher:
         """
         assert self.client is not None
         async with self._receipt_lock:
-            if not self.sessions.enqueue(session_key, str(time.time()), text, force=False):
+            if not self.sessions.enqueue(
+                session_key, str(time.time()), text, force=False,
+                attachments=list(attachments or []),
+            ):
                 return False
             receipt = self._queue_receipts.get(session_key)
             if receipt is None:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4109,6 +4109,18 @@ class TestDoctorEmbeddings:
         after the CPU arch instead of the packaging rule that dropped the file
         on every arch.
         """
+        # This test asserts the NO-override branch, so the var must be absent.
+        # It is not, reliably: the doctor branches on LLAMA_CPP_LIB_PATH and the
+        # value can arrive from outside this test -- a dev shell that exports it,
+        # or the sibling override test, whose helper sets it via a raw
+        # os.environ.setdefault that escapes pytest teardown. Either way the
+        # doctor takes the "libs load from the override dir" path and this
+        # assertion can never match. Clearing it here (mirroring the sibling,
+        # which explicitly setenv-s) makes the expectation independent of both
+        # the ambient environment and test order -- pytest-split reshuffles
+        # shards whenever the suite test count changes, so the leak surfaced on
+        # an unrelated PR that merely added tests elsewhere.
+        monkeypatch.delenv("LLAMA_CPP_LIB_PATH", raising=False)
         self._run_doctor(
             tmp_path,
             monkeypatch,

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -667,10 +667,10 @@ class TestDiscordAttachmentAdapter:
             return "spoken words"
 
         monkeypatch.setattr(
-            "kiro_crew.discord.attachments.stt_available", lambda: True
+            "kiro_crew.transcribe.is_available", lambda: True
         )
         monkeypatch.setattr(
-            "kiro_crew.discord.attachments.transcribe_audio", _transcribe
+            "kiro_crew.transcribe.transcribe_audio", _transcribe
         )
 
         result = await process_discord_attachments(
@@ -704,7 +704,7 @@ class TestDiscordAttachmentAdapter:
             return False
 
         monkeypatch.setattr(
-            "kiro_crew.discord.attachments.stt_available", _available
+            "kiro_crew.transcribe.is_available", _available
         )
         result = await process_discord_attachments(
             client,  # type: ignore[arg-type]

--- a/test/test_messaging_attachments.py
+++ b/test/test_messaging_attachments.py
@@ -29,6 +29,8 @@ from kiro_crew.messaging.attachments import (
     VIDEO,
     Attachment,
     IngestLimits,
+    IngestResult,
+    append_attachment_context,
     classify,
     cleanup,
     ingest_attachments,
@@ -501,3 +503,51 @@ class TestBlockingWorkLeavesTheEventLoop:
         # 150ms of blocking work at a 5ms tick interval leaves room for ~20+
         # ticks when offloaded; a frozen loop yields approximately none.
         assert during >= 5, f"loop was starved during the blocking read (ticks={during})"
+
+
+# ── append_attachment_context (shared utility) ────────────────────────────────
+
+
+class TestAppendAttachmentContext:
+    """append_attachment_context is channel-neutral and lives in messaging/."""
+
+    def test_image_paths_appended(self):
+        result = IngestResult(image_paths=["/tmp/a.png", "/tmp/b.jpg"])
+        out = append_attachment_context("hello", result)
+        assert out == "hello\n/tmp/a.png\n/tmp/b.jpg"
+
+    def test_text_blocks_appended(self):
+        result = IngestResult(text_blocks=["[File: x.txt]\ncontent"])
+        out = append_attachment_context("msg", result)
+        assert out == "msg\n\n[File: x.txt]\ncontent"
+
+    def test_rejections_appended(self):
+        result = IngestResult(rejections=["[Video not supported]"])
+        out = append_attachment_context("msg", result)
+        assert out == "msg\n\n[Video not supported]"
+
+    def test_all_combined(self):
+        result = IngestResult(
+            image_paths=["/tmp/img.png"],
+            text_blocks=["[File: a.txt]\nhi"],
+            rejections=["[nope]"],
+        )
+        out = append_attachment_context("user text", result)
+        assert "/tmp/img.png" in out
+        assert "[File: a.txt]\nhi" in out
+        assert "[nope]" in out
+
+    def test_empty_text_with_images(self):
+        result = IngestResult(image_paths=["/tmp/x.png"])
+        out = append_attachment_context("", result)
+        assert out == "/tmp/x.png"
+
+    def test_empty_result_returns_text_unchanged(self):
+        result = IngestResult()
+        assert append_attachment_context("unchanged", result) == "unchanged"
+
+    def test_reexport_from_discord(self):
+        """discord/attachments re-exports the same function."""
+        from kiro_crew.discord.attachments import append_attachment_context as discord_fn
+
+        assert discord_fn is append_attachment_context

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -1893,6 +1893,147 @@ class TestConfigMasking:
 
 
 class TestTelegramMidTurn:
+    def test_drain_defers_past_the_attachment_cap(self) -> None:
+        """Queue collapse must not exceed the shared ingestion file cap.
+
+        Two queued 10-photo albums. Concatenating them hands 20 attachments to
+        one turn and ingest_attachments silently processes only the first
+        max_attachments, so the second album vanishes with no indication. The
+        drain must defer the overflowing message (and everything behind it, to
+        keep FIFO exact) AND then keep pumping so the deferred album runs in a
+        second turn -- deferring without looping just strands it until the user
+        happens to send something else.
+        """
+        from kiro_crew.messaging.attachments import IngestLimits
+
+        cap = IngestLimits().max_attachments
+        d, cli, sess = _dispatcher({7})
+        album_a = [{"file_id": f"a{i}", "file_name": f"a{i}.jpg",
+                    "mime_type": "image/jpeg"} for i in range(cap)]
+        album_b = [{"file_id": f"b{i}", "file_name": f"b{i}.jpg",
+                    "mime_type": "image/jpeg"} for i in range(cap)]
+        # Two albums already sitting in the queue when the turn ends.
+        sess.queued = [
+            (str(1), "album A", {"attachments": album_a}),
+            (str(2), "album B", {"attachments": album_b}),
+        ]
+        sess._busy = False
+
+        seen: list[tuple[str, int]] = []
+        original = d.handle_message
+
+        async def _spy(msg, **kw):  # type: ignore[no-untyped-def]
+            seen.append((msg.text, len(msg.attachments)))
+            return None  # don't run a real turn
+
+        async def _go() -> None:
+            d.handle_message = _spy  # type: ignore[assignment]
+            try:
+                await d._drain_queue("k", 7, 7)
+            finally:
+                d.handle_message = original  # type: ignore[assignment]
+
+        asyncio.run(_go())
+
+        # Cap first, and over EVERY turn: without this ordering a cap regression
+        # merges both albums into one turn and would trip the pump-count
+        # assertion instead, leaving the cap itself unpinned.
+        assert seen, "the drain must run at least one turn"
+        for i, (_t, n) in enumerate(seen):
+            assert n <= cap, (
+                f"turn {i} carried {n} attachments, over the cap of {cap} -- "
+                "ingestion would silently drop the excess"
+            )
+        assert len(seen) == 2, (
+            "the drain must keep pumping: the deferred album has to run in a "
+            "SECOND turn of this same drain, not wait for unrelated user input"
+        )
+        first_text, _ = seen[0]
+        second_text, _ = seen[1]
+        assert "album A" in first_text and "album B" not in first_text, (
+            "album B must be deferred whole, not partially merged"
+        )
+        assert "album B" in second_text, "album B must drain in the second turn"
+        assert not sess.queued, "the queue must be empty once the pump finishes"
+
+    def test_command_caption_on_attachment_is_content_not_a_command(self) -> None:
+        """A photo captioned "/new" must be ingested, not intercepted.
+
+        The command intercept returns BEFORE attachment ingestion, so treating a
+        caption as a command silently discards the file the user attached to it.
+        Attachments make the message content-bearing; Discord already gated on
+        this via interpret_as_command.
+        """
+        d, cli, sess = _dispatcher({7})
+        photos = [{"file_id": "p1", "file_name": "a.jpg", "mime_type": "image/jpeg"}]
+        before_gen = d._conv.current_gen(d._route_key(
+            chat_type="private", user_id=7, chat_id=7, thread=None,
+        ))
+
+        async def _go() -> None:
+            await d.handle_message(
+                InboundMessage(
+                    channel_type="telegram",
+                    user_id="7",
+                    conversation_id="7",
+                    text="/new",
+                    attachments=photos,
+                )
+            )
+
+        asyncio.run(_go())
+
+        route = d._route_key(chat_type="private", user_id=7, chat_id=7, thread=None)
+        assert d._conv.current_gen(route) == before_gen, (
+            "/new as an attachment caption must NOT start a new conversation -- "
+            "that path returns before ingestion and drops the photo"
+        )
+        assert not any("New conversation started" in t for t, _ in cli.sent), (
+            "the command confirmation must not be sent for an attachment caption"
+        )
+
+    def test_attachment_message_is_queued_not_steered(self) -> None:
+        """A mid-turn message carrying files must NEVER take the steer path.
+
+        ``steer`` forwards TEXT ONLY, so steering a photo/album message would
+        deliver its caption and silently discard every attachment. This is the
+        exact loss an album hits: a follow-up typed during the debounce window
+        starts a turn, so the album's own flush lands mid-turn.
+
+        The queue path is correct because it carries ``attachments`` through the
+        drain -- assert they survive, not merely that steer was skipped.
+        """
+        d, cli, sess = _dispatcher({7})
+        sess._busy = True
+        # Default (non-queue) mode: without the guard this would steer.
+        d.cfg.messaging.queue_mode = "steer"
+        photos = [
+            {"file_id": "p1", "file_name": "a.jpg", "mime_type": "image/jpeg"},
+            {"file_id": "p2", "file_name": "b.jpg", "mime_type": "image/jpeg"},
+        ]
+
+        async def _go() -> None:
+            await d.handle_message(
+                InboundMessage(
+                    channel_type="telegram",
+                    user_id="7",
+                    conversation_id="7",
+                    text="what is wrong here?",
+                    attachments=photos,
+                )
+            )
+
+        asyncio.run(_go())
+
+        assert sess._gp.steered == [], "an attachment message must not be steered"
+        assert len(sess.queued) == 1, "it must be queued instead"
+        _ts, text, kwargs = sess.queued[0]
+        assert text == "what is wrong here?"
+        assert kwargs.get("attachments") == photos, (
+            "the queue must carry the attachments -- otherwise the images are "
+            "silently dropped exactly as steering would have done"
+        )
+
     def test_busy_steer_folds_into_running_turn(self) -> None:
         d, cli, sess = _dispatcher({7})
         sess._busy = True
@@ -2118,20 +2259,36 @@ class TestTelegramMidTurn:
         assert len(sends) == 1
         assert len(grows) == 3
 
-    def test_drain_caps_collapse_and_defers_remainder(self) -> None:
+    def test_drain_caps_collapse_and_drains_remainder_in_order(self) -> None:
         d, cli, sess = _dispatcher({7})
-        # 52 queued -> the collapse cap (50) drains 50 into one turn and leaves
-        # the 2-message remainder queued IN ORDER for the next turn (a 2+ item
-        # remainder is what exposes any FIFO reordering of the surplus).
+        # 52 queued -> the collapse cap (50) puts 50 into the first turn and
+        # defers the 2-message remainder. The drain then keeps pumping, so the
+        # remainder runs in a SECOND turn of the same drain rather than waiting
+        # for unrelated future input. A 2+ item remainder is what exposes any
+        # FIFO reordering of the surplus.
         sess.queued = [(f"t{i}", f"m{i}", {}) for i in range(52)]
+        seen: list[str] = []
+        original = d.handle_message
+
+        async def _spy(msg, **kw):  # type: ignore[no-untyped-def]
+            seen.append(msg.text)
+            return None  # don't run a real turn
 
         async def _go() -> None:
-            await d._drain_queue("telegram:kirocrew:direct:7", 7, 7)
+            d.handle_message = _spy  # type: ignore[assignment]
+            try:
+                await d._drain_queue("telegram:kirocrew:direct:7", 7, 7)
+            finally:
+                d.handle_message = original  # type: ignore[assignment]
 
         asyncio.run(_go())
-        # surplus (m50, m51) is deferred IN ORIGINAL ORDER, not dropped/reordered
-        assert [text for _ts, text, _ in sess.queued] == ["m50", "m51"]
-        assert sess.successes == ["telegram:kirocrew:direct:7"]  # one combined turn
+
+        assert len(seen) == 2, "cap-deferred surplus must drain in a second turn"
+        # First turn takes exactly the cap, in order.
+        assert seen[0].split("\n\n") == [f"m{i}" for i in range(50)]
+        # Surplus drains next, IN ORIGINAL ORDER -- not dropped, not reordered.
+        assert seen[1].split("\n\n") == ["m50", "m51"]
+        assert not sess.queued, "the queue must be empty once the pump finishes"
 
     def test_flip_count_reflects_answered_not_full_queue(self) -> None:
         d, cli, sess = _dispatcher({7})

--- a/test/test_telegram_album.py
+++ b/test/test_telegram_album.py
@@ -1,0 +1,344 @@
+"""Telegram album (media group) coalescing — unit tests.
+
+Telegram delivers an album as N separate ``message`` updates sharing one
+``media_group_id``, with the caption on only one member. Without coalescing a
+four-screenshot album becomes four turns, three of them a bare image with no
+context. These tests pin the debounce that merges them into one.
+
+Timing is driven by monkeypatching the module's window constants down to
+near-zero rather than by sleeping real seconds, so the suite stays fast and
+deterministic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from kiro_crew.telegram import client as tg_client
+from kiro_crew.telegram.client import TelegramClient, TelegramInbound
+
+
+def _make_client() -> tuple[TelegramClient, list[TelegramInbound]]:
+    """A client wired to capture whatever reaches the message handler."""
+    received: list[TelegramInbound] = []
+
+    async def on_message(inbound: TelegramInbound) -> None:
+        received.append(inbound)
+
+    client = TelegramClient.__new__(TelegramClient)
+    client._on_message = on_message
+    client._on_callback = None
+    client._handler_tasks = set()
+    client._albums = {}
+    client._album_timers = {}
+    client._album_first_seen = {}
+    client._album_dropped = {}
+    client._closed = False
+    client._task = None
+    client._session = None
+    return client, received
+
+
+def _photo_update(
+    *,
+    file_id: str,
+    group: str | None = None,
+    caption: str = "",
+    message_id: int = 1,
+    chat_id: int = 100,
+    user_id: int = 42,
+) -> dict:
+    msg: dict[str, Any] = {
+        "message_id": message_id,
+        "chat": {"id": chat_id, "type": "private"},
+        "from": {"id": user_id, "username": "tester"},
+        "photo": [
+            {"file_id": f"{file_id}_s", "file_unique_id": "s", "file_size": 100},
+            {"file_id": file_id, "file_unique_id": "l", "file_size": 9000},
+        ],
+    }
+    if group is not None:
+        msg["media_group_id"] = group
+    if caption:
+        msg["caption"] = caption
+    return {"message": msg}
+
+
+async def _drain(client: TelegramClient) -> None:
+    """Let every pending timer + handler task settle."""
+    for _ in range(12):
+        pending = [t for t in list(client._handler_tasks) if not t.done()]
+        if not pending:
+            break
+        await asyncio.gather(*pending, return_exceptions=True)
+    await asyncio.sleep(0)
+
+
+@pytest.fixture()
+def fast_album(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Collapse the debounce windows so tests do not sleep real seconds."""
+    monkeypatch.setattr(tg_client, "_ALBUM_WINDOW_S", 0.01)
+    monkeypatch.setattr(tg_client, "_ALBUM_MAX_WAIT_S", 0.5)
+
+
+# ── The core behaviour ────────────────────────────────────────────────────────
+
+
+class TestAlbumCoalescing:
+    @pytest.mark.asyncio
+    async def test_four_photo_album_becomes_one_turn(self, fast_album: None) -> None:
+        """The regression this exists for: 4 updates -> 1 merged message."""
+        client, received = _make_client()
+        for i in range(4):
+            client._dispatch(
+                _photo_update(
+                    file_id=f"photo{i}",
+                    group="grp1",
+                    # Telegram puts the caption on exactly one member.
+                    caption="what is this error?" if i == 0 else "",
+                    message_id=10 + i,
+                )
+            )
+        # Nothing dispatched yet -- still inside the debounce window.
+        assert received == []
+        await _drain(client)
+
+        assert len(received) == 1, "album must collapse to a single turn"
+        merged = received[0]
+        assert len(merged.attachments) == 4
+        assert [a["file_id"] for a in merged.attachments] == [
+            "photo0",
+            "photo1",
+            "photo2",
+            "photo3",
+        ], "member order must be preserved"
+        assert merged.text == "what is this error?", "the caption must survive"
+
+    @pytest.mark.asyncio
+    async def test_caption_recovered_from_a_later_member(self, fast_album: None) -> None:
+        """The caption is not assumed to be on the first member."""
+        client, received = _make_client()
+        client._dispatch(_photo_update(file_id="a", group="g", message_id=1))
+        client._dispatch(
+            _photo_update(file_id="b", group="g", caption="look here", message_id=2)
+        )
+        await _drain(client)
+
+        assert len(received) == 1
+        assert received[0].text == "look here"
+
+    @pytest.mark.asyncio
+    async def test_every_per_item_caption_survives(self, fast_album: None) -> None:
+        """Telegram Desktop/Android allow a caption per media-group item.
+
+        Keeping only the first would silently drop the user's own words for
+        items 2..N, so every caption must reach the merged turn, in album order.
+        """
+        client, received = _make_client()
+        client._dispatch(
+            _photo_update(file_id="a", group="g", caption="first shot", message_id=1)
+        )
+        client._dispatch(_photo_update(file_id="b", group="g", message_id=2))
+        client._dispatch(
+            _photo_update(file_id="c", group="g", caption="and this one", message_id=3)
+        )
+        await _drain(client)
+
+        assert len(received) == 1
+        assert received[0].text == "first shot\n\nand this one", (
+            "every per-item caption must survive, in album order"
+        )
+
+    @pytest.mark.asyncio
+    async def test_head_message_id_is_used(self, fast_album: None) -> None:
+        """A reply/steer-ack must target the album's FIRST message."""
+        client, received = _make_client()
+        for i, mid in enumerate((77, 78, 79)):
+            client._dispatch(_photo_update(file_id=f"p{i}", group="g", message_id=mid))
+        await _drain(client)
+
+        assert received[0].message_id == 77
+
+    @pytest.mark.asyncio
+    async def test_non_album_message_is_unaffected(self, fast_album: None) -> None:
+        """A single photo (no media_group_id) still dispatches immediately."""
+        client, received = _make_client()
+        client._dispatch(_photo_update(file_id="solo", caption="hi"))
+        # No debounce for a non-album message -- the task exists right away.
+        await _drain(client)
+
+        assert len(received) == 1
+        assert received[0].text == "hi"
+        assert len(received[0].attachments) == 1
+        assert client._albums == {}, "no album state for a non-album message"
+
+    @pytest.mark.asyncio
+    async def test_two_interleaved_albums_stay_separate(self, fast_album: None) -> None:
+        """Distinct media_group_ids must not merge into each other."""
+        client, received = _make_client()
+        client._dispatch(_photo_update(file_id="a1", group="A", caption="album A"))
+        client._dispatch(_photo_update(file_id="b1", group="B", caption="album B"))
+        client._dispatch(_photo_update(file_id="a2", group="A"))
+        client._dispatch(_photo_update(file_id="b2", group="B"))
+        await _drain(client)
+
+        assert len(received) == 2
+        by_text = {m.text: m for m in received}
+        assert set(by_text) == {"album A", "album B"}
+        assert [a["file_id"] for a in by_text["album A"].attachments] == ["a1", "a2"]
+        assert [a["file_id"] for a in by_text["album B"].attachments] == ["b1", "b2"]
+
+    @pytest.mark.asyncio
+    async def test_same_group_id_in_two_chats_does_not_merge(
+        self, fast_album: None
+    ) -> None:
+        """A media_group_id collision across chats must not cross-deliver.
+
+        Nothing guarantees Telegram's media_group_id is unique across the chats
+        one bot serves. Keyed on the id alone, a collision merges both chats'
+        members into ONE message addressed to the first chat -- swallowing the
+        second chat's copy and leaking its content into the wrong conversation.
+        Buffers are keyed by (chat_id, media_group_id) to remove the class.
+        """
+        client, received = _make_client()
+        client._dispatch(
+            _photo_update(file_id="chatA", group="dup", caption="from A", chat_id=111)
+        )
+        client._dispatch(
+            _photo_update(file_id="chatB", group="dup", caption="from B", chat_id=222)
+        )
+        await _drain(client)
+
+        assert len(received) == 2, "a cross-chat id collision must not merge"
+        by_chat = {m.chat_id: m for m in received}
+        assert set(by_chat) == {111, 222}
+        assert [a["file_id"] for a in by_chat[111].attachments] == ["chatA"]
+        assert [a["file_id"] for a in by_chat[222].attachments] == ["chatB"]
+        assert by_chat[111].text == "from A"
+        assert by_chat[222].text == "from B"
+
+    @pytest.mark.asyncio
+    async def test_buffer_is_drained_after_flush(self, fast_album: None) -> None:
+        """No per-group state may survive the flush (memory bound)."""
+        client, _received = _make_client()
+        client._dispatch(_photo_update(file_id="x", group="g"))
+        await _drain(client)
+
+        assert client._albums == {}
+        assert client._album_timers == {}
+        assert client._album_first_seen == {}
+        assert client._album_dropped == {}
+
+
+# ── Bounded-ness (the two hazards named in the issue) ─────────────────────────
+
+
+class TestAlbumBounds:
+    @pytest.mark.asyncio
+    async def test_member_cap_holds_and_is_reported(
+        self, fast_album: None, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Over-cap members are counted and logged, never grown into."""
+        client, received = _make_client()
+        for i in range(tg_client._ALBUM_MAX_MEMBERS + 4):
+            client._dispatch(_photo_update(file_id=f"p{i}", group="big", message_id=i))
+        # Buffers are keyed by (chat_id, media_group_id) -- see
+        # test_same_group_id_in_two_chats_does_not_merge.
+        key = "100:big"
+        # The buffer never exceeds the cap.
+        assert len(client._albums[key]) == tg_client._ALBUM_MAX_MEMBERS
+        assert client._album_dropped[key] == 4
+
+        with caplog.at_level("WARNING", logger="kiro_crew.telegram.client"):
+            await _drain(client)
+
+        assert len(received) == 1
+        assert len(received[0].attachments) == tg_client._ALBUM_MAX_MEMBERS
+        assert any("exceeded" in r.getMessage() for r in caplog.records), (
+            "an over-cap album must be visible in the log, not silently truncated"
+        )
+
+    @pytest.mark.asyncio
+    async def test_group_cap_force_flushes_oldest_rather_than_dropping(
+        self, fast_album: None
+    ) -> None:
+        """Exceeding the group cap must not lose a message."""
+        client, received = _make_client()
+        for i in range(tg_client._ALBUM_MAX_GROUPS + 1):
+            client._dispatch(_photo_update(file_id=f"g{i}", group=f"grp{i}"))
+        # The oldest was flushed to make room, so it is dispatched -- not dropped.
+        assert len(client._albums) <= tg_client._ALBUM_MAX_GROUPS
+        await _drain(client)
+
+        got = {a["file_id"] for m in received for a in m.attachments}
+        assert len(received) == tg_client._ALBUM_MAX_GROUPS + 1
+        assert "g0" in got, "the evicted group must still reach the handler"
+
+    @pytest.mark.asyncio
+    async def test_hard_ceiling_flushes_a_never_ending_group(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stream that keeps appending cannot defer the flush forever.
+
+        The idle window is set LONGER than the hard ceiling, so only the ceiling
+        can trigger the flush -- if the rearm ignored it, this would hang.
+        """
+        monkeypatch.setattr(tg_client, "_ALBUM_WINDOW_S", 10.0)
+        monkeypatch.setattr(tg_client, "_ALBUM_MAX_WAIT_S", 0.05)
+        client, received = _make_client()
+
+        client._dispatch(_photo_update(file_id="first", group="never"))
+        # Keep rearming past the ceiling.
+        for i in range(3):
+            await asyncio.sleep(0.03)
+            client._dispatch(_photo_update(file_id=f"more{i}", group="never"))
+
+        await asyncio.wait_for(_drain(client), timeout=5)
+        assert received, "the hard ceiling must force a flush"
+
+
+# ── Shutdown ─────────────────────────────────────────────────────────────────
+
+
+class TestAlbumShutdown:
+    @pytest.mark.asyncio
+    async def test_close_attempts_delivery_and_drains_the_buffer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``close()`` hands buffered albums to the handler and drops the state.
+
+        Scoped deliberately to what this layer can actually promise. It is NOT
+        "a buffered album is never lost": shutdown runs channel teardown and
+        ``SessionManager.close_all()`` concurrently, and once ``_closing`` is set
+        ``begin_turn`` raises ``SessionClosingError`` -- so the spawned handler
+        may be refused downstream. That is the same gate a plain message
+        arriving at shutdown already hits today, so this test pins the two things
+        the client itself controls: delivery is *attempted*, and no album state
+        survives a closed client.
+
+        The idle window is set far longer than this test's patience, so the
+        natural timer cannot be what invokes the handler -- only ``close()``
+        flushing can. (With a short window the timer fires during the drain and
+        the test passes even with the flush deleted -- verified by mutation.)
+        """
+        monkeypatch.setattr(tg_client, "_ALBUM_WINDOW_S", 30.0)
+        monkeypatch.setattr(tg_client, "_ALBUM_MAX_WAIT_S", 30.0)
+        client, received = _make_client()
+        client._dispatch(_photo_update(file_id="pending", group="g", caption="q"))
+        assert received == [], "still buffered"
+
+        await client.close()
+        # Bounded: give the flush's handler task a moment to run, but never wait
+        # on the 30s timer -- if close() did not flush, this stays empty.
+        for _ in range(20):
+            if received:
+                break
+            await asyncio.sleep(0.01)
+
+        assert len(received) == 1, "close() must attempt delivery of buffered albums"
+        assert received[0].text == "q"
+        assert client._albums == {}, "a closed client must not retain album state"
+        assert client._album_timers == {}

--- a/test/test_telegram_attachments.py
+++ b/test/test_telegram_attachments.py
@@ -1,0 +1,424 @@
+"""Telegram inbound attachment support — unit tests.
+
+Covers:
+- Client ``_dispatch`` extraction of photos, documents, audio, voice, video
+- ``TelegramInbound.attachments`` population and ``caption`` fallback
+- ``telegram/attachments.py`` — ``_to_attachment`` mapping + ``process_telegram_attachments``
+- ``transport.receive()`` accepting attachment-only messages
+- Capability flag ``files_inbound=True``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.messaging.attachments import cleanup
+from kiro_crew.telegram.attachments import (
+    _to_attachment,
+    append_attachment_context,
+    process_telegram_attachments,
+)
+from kiro_crew.telegram.client import TelegramClient, TelegramInbound
+from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES
+
+# ── Capability declaration ─────────────────────────────────────────────────────
+
+
+class TestCapabilityFlag:
+    def test_files_inbound_enabled(self):
+        assert TELEGRAM_CAPABILITIES.files_inbound is True
+
+    def test_files_outbound_still_disabled(self):
+        assert TELEGRAM_CAPABILITIES.files_outbound is False
+
+
+# ── Client _dispatch extracts attachments from Telegram updates ────────────────
+
+
+class TestDispatchExtraction:
+    """Test that _dispatch populates TelegramInbound.attachments correctly."""
+
+    def _make_client(self) -> tuple[TelegramClient, list[TelegramInbound]]:
+        """Build a client that captures dispatched inbound messages."""
+        received: list[TelegramInbound] = []
+
+        async def on_message(inbound: TelegramInbound) -> None:
+            received.append(inbound)
+
+        client = TelegramClient.__new__(TelegramClient)
+        client._on_message = on_message
+        client._on_callback = None
+        client._handler_tasks = set()
+        return client, received
+
+    def _run(self, client: TelegramClient, update: dict) -> None:
+        """Dispatch one update and drain the created task."""
+        async def _go():
+            client._dispatch(update)
+            tasks = list(client._handler_tasks)
+            if tasks:
+                await asyncio.gather(*tasks)
+        asyncio.run(_go())
+
+    def _base_update(self, **media: Any) -> dict:
+        return {
+            "message": {
+                "message_id": 1,
+                "chat": {"id": 100, "type": "private"},
+                "from": {"id": 42, "username": "testuser"},
+                **media,
+            }
+        }
+
+    def test_photo_extracts_largest(self):
+        client, received = self._make_client()
+        update = self._base_update(
+            caption="look at this",
+            photo=[
+                {"file_id": "small", "file_unique_id": "s1", "width": 90, "height": 90, "file_size": 1000},
+                {"file_id": "medium", "file_unique_id": "m1", "width": 320, "height": 320, "file_size": 5000},
+                {"file_id": "large", "file_unique_id": "l1", "width": 800, "height": 800, "file_size": 50000},
+            ],
+        )
+        self._run(client, update)
+        assert len(received) == 1
+        inbound = received[0]
+        assert inbound.text == "look at this"
+        assert len(inbound.attachments) == 1
+        assert inbound.attachments[0]["file_id"] == "large"
+        assert inbound.attachments[0]["mime_type"] == "image/jpeg"
+        assert inbound.attachments[0]["file_name"] == "photo.jpg"
+
+    def test_document_extracted(self):
+        client, received = self._make_client()
+        update = self._base_update(
+            text="here's the doc",
+            document={
+                "file_id": "doc1",
+                "file_unique_id": "d1",
+                "file_name": "report.pdf",
+                "mime_type": "application/pdf",
+                "file_size": 100000,
+            },
+        )
+        self._run(client, update)
+        assert len(received) == 1
+        assert len(received[0].attachments) == 1
+        assert received[0].attachments[0]["file_name"] == "report.pdf"
+
+    def test_voice_extracted(self):
+        client, received = self._make_client()
+        update = self._base_update(
+            voice={
+                "file_id": "voice1",
+                "file_unique_id": "v1",
+                "mime_type": "audio/ogg",
+                "file_size": 8000,
+                "duration": 5,
+            },
+        )
+        self._run(client, update)
+        assert len(received) == 1
+        # No text or caption → text is empty, but attachment is present
+        assert received[0].text == ""
+        assert len(received[0].attachments) == 1
+        assert received[0].attachments[0]["mime_type"] == "audio/ogg"
+
+    def test_caption_used_when_no_text(self):
+        client, received = self._make_client()
+        update = self._base_update(
+            caption="my caption",
+            document={"file_id": "f1", "file_unique_id": "u1", "file_name": "x.txt", "mime_type": "text/plain"},
+        )
+        self._run(client, update)
+        assert received[0].text == "my caption"
+
+    def test_sticker_not_extracted(self):
+        client, received = self._make_client()
+        update = self._base_update(
+            sticker={"file_id": "stk1", "file_unique_id": "s1", "type": "regular"},
+        )
+        self._run(client, update)
+        assert len(received) == 1
+        # Sticker-only → no text AND no attachments
+        assert received[0].text == ""
+        assert received[0].attachments == []
+
+    def test_video_extracted(self):
+        client, received = self._make_client()
+        update = self._base_update(
+            caption="check this",
+            video={
+                "file_id": "vid1",
+                "file_unique_id": "v1",
+                "mime_type": "video/mp4",
+                "file_size": 500000,
+            },
+        )
+        self._run(client, update)
+        assert len(received) == 1
+        assert received[0].text == "check this"
+        assert len(received[0].attachments) == 1
+        assert received[0].attachments[0]["mime_type"] == "video/mp4"
+
+
+# ── _to_attachment normalization ───────────────────────────────────────────────
+
+
+class TestToAttachment:
+    def test_maps_photo(self):
+        raw = {
+            "file_id": "abc123",
+            "file_unique_id": "u1",
+            "file_name": "photo.jpg",
+            "mime_type": "image/jpeg",
+            "file_size": 50000,
+        }
+        att = _to_attachment(raw)
+        assert att.name == "photo.jpg"
+        assert att.mimetype == "image/jpeg"
+        assert att.size == 50000
+        assert att.url == "abc123"  # file_id is the "url" for Telegram
+        assert att.suffix_hint == "jpg"
+
+    def test_maps_document_with_no_name(self):
+        raw = {"file_id": "x", "file_unique_id": "u", "mime_type": "application/pdf"}
+        att = _to_attachment(raw)
+        # The synthesized fallback carries the mime-derived extension, so the
+        # downloaded temp file is named for what it actually is -- doc_parser and
+        # the transcription backend both key off the suffix.
+        assert att.name == "file.pdf"
+        assert att.mimetype == "application/pdf"
+
+    def test_voice_without_file_name_gets_a_real_audio_suffix(self):
+        """Voice/video notes carry no file_name -- the suffix must come from mime.
+
+        A literal fallback produced a ".file" temp path, and the transcription
+        backend keys off the extension, so the memo was downloaded and then
+        rejected as an unknown format. Assert the SUFFIX the ingestion layer will
+        actually put on the temp file, not just the synthesized name.
+        """
+        from kiro_crew.messaging.attachments import safe_suffix
+
+        cases = {
+            "audio/ogg": ".ogg",      # Telegram voice notes
+            "video/mp4": ".mp4",      # video_note
+            "audio/mpeg": ".mp3",
+        }
+        for mime, want in cases.items():
+            att = _to_attachment(
+                {"file_id": "x", "file_unique_id": "u", "mime_type": mime, "file_size": 10}
+            )
+            got = safe_suffix(att.suffix_hint or att.name.rsplit(".", 1)[-1])
+            assert got == want, f"{mime}: temp file would be {got}, expected {want}"
+
+    def test_unknown_mime_without_file_name_falls_back_to_bin(self):
+        att = _to_attachment({"file_id": "x", "file_unique_id": "u"})
+        assert att.name.endswith(".bin")
+
+    def test_non_dict_returns_unknown(self):
+        att = _to_attachment("not a dict")
+        assert att.name == "unknown"
+
+    def test_missing_size_defaults_zero(self):
+        raw = {"file_id": "x", "file_unique_id": "u", "file_name": "a.txt", "mime_type": "text/plain"}
+        att = _to_attachment(raw)
+        assert att.size == 0
+
+
+# ── process_telegram_attachments ───────────────────────────────────────────────
+
+
+class TestProcessTelegramAttachments:
+    @pytest.mark.asyncio
+    async def test_image_downloaded(self):
+        """An image attachment is downloaded and its path returned."""
+        png_header = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        client = MagicMock()
+
+        async def fake_download(file_id: str, dest: str) -> None:
+            with open(dest, "wb") as f:
+                f.write(png_header)
+
+        client.download_file = AsyncMock(side_effect=fake_download)
+
+        attachments = [
+            {
+                "file_id": "photo_abc",
+                "file_unique_id": "u1",
+                "file_name": "photo.jpg",
+                "mime_type": "image/jpeg",
+                "file_size": len(png_header),
+            }
+        ]
+        result = await process_telegram_attachments(client, attachments)
+        assert len(result.image_paths) == 1
+        assert os.path.exists(result.image_paths[0])
+        # Clean up
+        for p in result.temp_paths:
+            os.unlink(p)
+
+    @pytest.mark.asyncio
+    async def test_document_extracted(self):
+        """A text document is read and injected as a text block."""
+        client = MagicMock()
+
+        async def fake_download(file_id: str, dest: str) -> None:
+            with open(dest, "w") as f:
+                f.write("hello world")
+
+        client.download_file = AsyncMock(side_effect=fake_download)
+
+        attachments = [
+            {
+                "file_id": "doc1",
+                "file_unique_id": "u2",
+                "file_name": "notes.txt",
+                "mime_type": "text/plain",
+                "file_size": 11,
+            }
+        ]
+        result = await process_telegram_attachments(client, attachments)
+        assert len(result.text_blocks) == 1
+        assert "hello world" in result.text_blocks[0]
+        assert result.image_paths == []
+
+    @pytest.mark.asyncio
+    async def test_video_rejected(self):
+        """Video attachments produce a rejection, not a download."""
+        client = MagicMock()
+        client.download_file = AsyncMock()
+
+        attachments = [
+            {
+                "file_id": "vid1",
+                "file_unique_id": "u3",
+                "file_name": "clip.mp4",
+                "mime_type": "video/mp4",
+                "file_size": 500000,
+            }
+        ]
+        result = await process_telegram_attachments(client, attachments)
+        assert result.image_paths == []
+        assert len(result.rejections) == 1
+        assert "video" in result.rejections[0].lower()
+        client.download_file.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_voice_transcribed_when_available(self):
+        """Voice attachments trigger transcription when STT is available."""
+        ogg_data = b"OggS" + b"\x00" * 100  # fake OGG header
+        client = MagicMock()
+
+        async def fake_download(file_id: str, dest: str) -> None:
+            with open(dest, "wb") as f:
+                f.write(ogg_data)
+
+        client.download_file = AsyncMock(side_effect=fake_download)
+
+        attachments = [
+            {
+                "file_id": "voice1",
+                "file_unique_id": "u4",
+                "file_name": "file",
+                "mime_type": "audio/ogg",
+                "file_size": len(ogg_data),
+            }
+        ]
+        with patch("kiro_crew.transcribe.is_available", return_value=True), \
+             patch("kiro_crew.transcribe.transcribe_audio", return_value="hello from voice"):
+            result = await process_telegram_attachments(client, attachments)
+
+        assert len(result.text_blocks) == 1
+        assert "hello from voice" in result.text_blocks[0]
+        assert "transcription" in result.text_blocks[0].lower()
+        # ingest_attachments transfers ownership of the downloaded audio to the
+        # caller (it stays in result.audio_paths for transcription), so the test
+        # must delete it or every run leaves an orphan in TMPDIR.
+        assert result.temp_paths, "the audio file should still be caller-owned"
+        cleanup(result.temp_paths)
+        assert not any(os.path.exists(p) for p in result.temp_paths)
+
+    @pytest.mark.asyncio
+    async def test_voice_rejected_when_stt_unavailable(self):
+        """Voice attachments produce a rejection when STT is not available."""
+        ogg_data = b"OggS" + b"\x00" * 100
+        client = MagicMock()
+
+        async def fake_download(file_id: str, dest: str) -> None:
+            with open(dest, "wb") as f:
+                f.write(ogg_data)
+
+        client.download_file = AsyncMock(side_effect=fake_download)
+
+        attachments = [
+            {
+                "file_id": "voice2",
+                "file_unique_id": "u5",
+                "file_name": "file",
+                "mime_type": "audio/ogg",
+                "file_size": len(ogg_data),
+            }
+        ]
+        with patch("kiro_crew.transcribe.is_available", return_value=False):
+            result = await process_telegram_attachments(client, attachments)
+
+        assert len(result.rejections) == 1
+        assert "unavailable" in result.rejections[0].lower()
+        # Caller-owned even on the unavailable path: the file was downloaded
+        # before the STT check, so it must still be cleaned up.
+        assert result.temp_paths, "the audio file should still be caller-owned"
+        cleanup(result.temp_paths)
+        assert not any(os.path.exists(p) for p in result.temp_paths)
+
+
+# ── append_attachment_context re-export ────────────────────────────────────────
+
+
+class TestReExport:
+    def test_telegram_exports_shared_function(self):
+        from kiro_crew.messaging.attachments import append_attachment_context as shared_fn
+
+        assert append_attachment_context is shared_fn
+
+    def test_transcription_block_is_shared_not_duplicated(self):
+        """Both channel adapters must call the SHARED transcription helper.
+
+        Design Review flagged that Telegram's transcription block was a
+        byte-for-byte copy of Discord's, so the transcript wording and the
+        STT-unavailable handling could drift between channels. Guard the fix at
+        the source level: neither adapter may re-implement the loop, and both
+        must delegate to ``transcribe_audio_attachments``.
+        """
+        import inspect
+
+        from kiro_crew.discord import attachments as discord_att
+        from kiro_crew.telegram import attachments as tg_att
+
+        cases = (
+            (discord_att, discord_att.process_discord_attachments),
+            (tg_att, tg_att.process_telegram_attachments),
+        )
+        for mod, fn in cases:
+            # Scope the delegation check to the FUNCTION BODY, not the module:
+            # the module always mentions the helper on its import line, so a
+            # module-level substring check passes even when the call site is
+            # gone (verified by mutation -- it did).
+            fn_src = inspect.getsource(fn)
+            assert (
+                "transcribe_audio_attachments" in fn_src
+            ), f"{mod.__name__}: the helper must be CALLED, not merely imported"
+            # And the duplicated implementation's tell-tale strings must be
+            # absent from the whole module.
+            mod_src = inspect.getsource(mod)
+            assert (
+                "[End of transcription]" not in mod_src
+            ), f"{mod.__name__} still inlines the transcript block"
+            assert (
+                "stt_available" not in mod_src
+            ), f"{mod.__name__} still does its own STT-availability check"


### PR DESCRIPTION
> **Scope note:** #2213 (album coalescing) was merged into this branch and then squashed in, since the repo enforces one commit per PR. This PR is now the single change that lands both on `main`. Closes #2200 and #2205.

## Problem

Telegram users sending photos, documents, or voice memos got **no response**: `transport.receive()` returned early on `if not inbound.text`, so every non-text message was dropped silently, with no explanation.

Worse for the primary use case — Telegram does not deliver an album as one message. Selecting four screenshots and sending them with one question produces **four separate `message` updates** sharing a `media_group_id`, with the caption on only one member:

| update | content | what the agent saw |
|---|---|---|
| 1 | photo1 + caption | image + the question |
| 2 | photo2 | a bare image, no context |
| 3 | photo3 | a bare image, no context |
| 4 | photo4 | a bare image, no context |

## Why it matters

Screenshots are the reason to send an image to an assistant at all. Discord already supported inbound attachments; Telegram users were locked out, and multi-image — the ordinary case — was structurally broken rather than merely unsupported.

## Fix (symptoms → root cause → change)

Root cause was two layers: nothing extracted file metadata from Telegram updates, and nothing ever looked at `media_group_id` (zero references before this change), so the envelope's one-album-is-N-updates shape reached the shared pipeline unmodified.

**Generalized into the shared layer** — so wording and handling cannot drift between channels:

- `append_attachment_context()` hoisted out of `discord/attachments.py` into `messaging/attachments.py`.
- `transcribe_audio_attachments()` hoisted likewise. Both channel adapters carried byte-identical STT-availability + transcription loops (flagged by Design Review); each now ends in one delegating call, so the transcript wording, the STT-unavailable rejection text, and the off-loop availability check exist in exactly one place.

**Telegram-specific:**

- `telegram/attachments.py` maps photo/document/audio/voice/video onto the shared `Attachment` shape.
- `TelegramClient` extracts `photo[-1]` (largest), document, audio, voice, video, animation; uses `caption` as the text fallback; downloads via `getFile` with host allowlisting, **token-free** error messages (the download URL embeds the bot token, so aiohttp's default exception text would leak it into `gateway.log`), and file I/O offloaded to `asyncio.to_thread` so a 20 MB document cannot stall the gateway event loop.
- `TelegramTransport`: `files_inbound=True`, accepts attachment-only messages.
- `TelegramDispatcher` ingests after session acquire and propagates attachments through the mid-turn queue and drain.

**Album coalescing — envelope layer only, deliberately not generalized.** Discord's `MESSAGE_CREATE` carries the whole `attachments[]` array and Slack's message event carries `files[]`, so the shared layer's "one message, N attachments" contract already holds for them, and WeCom ingests no files. Telegram is the only channel needing its envelope restored to that shape, and it must happen *before* entering the shared pipeline; hoisting it would push a transport quirk into the layer whose whole value is being channel-neutral.

- `_dispatch` buffers members keyed by **`(chat_id, media_group_id)`**. Keying on the id alone would merge two chats' members into one message addressed to `head.chat_id` — leaking content across a conversation boundary and swallowing the second chat's copy.
- The merge concatenates attachments in member order, takes the caption from the **first non-empty** member (not assumed to be first), and keeps the **head `message_id`** so a reply or steer-ack targets the album's first message.
- Bounded on every axis: per-member rearming window (flush follows the *last* arrival), hard ceiling from the first member (an endless stream cannot defer the flush forever), per-group member cap (logged when hit, never silently truncated), concurrent-group cap that **force-flushes the oldest rather than dropping it**, and a best-effort flush on `close()`.

**Channel parity gap restored.** `discord/transport_dispatch.py` gates steering on `and not msg.attachments`; Telegram never had it. `steer` forwards **text only**, so an attachment message arriving mid-turn was steered caption-only and silently lost every file. Album buffering made this routinely reachable — a follow-up typed during the debounce window starts a turn, so the album's own flush lands mid-turn. Telegram now gates identically, and such a message always takes the queue path, which carries attachments.

## Known residual — tracked in #2217

An inbound message arriving inside the shutdown window is refused by `SessionManager._closing` and lost. This is **pre-existing and channel-agnostic**: shutdown runs channel teardown and `close_all()` concurrently, so a plain single message in that window is refused identically today with no attachments involved. Buffering widens it by at most the debounce interval. The proposed "flush before `close_all()`" reorder does not fix it — `close()` never awaits handler tasks, so delivering would require awaiting an unbounded agent turn against the existing `timeout=2.0`. The real fix is durable inbound persistence (#2217). Documented in code and pinned by test rather than claimed away.

## Tests

`test/test_telegram_attachments.py` (18) — dispatch extraction, `_to_attachment` normalization, ingest end-to-end (image download, document text extraction, video rejection, voice transcription with and without STT), capability flags.

`test/test_telegram_album.py` (11) — 4→1 turn with order and caption preserved; caption recovered from a *later* member; head `message_id`; non-album message unaffected; interleaved groups separate; **same group id in two chats does not merge**; buffer fully drained; member cap logged; group cap force-flushes; hard ceiling flushes a never-ending group; `close()` attempts delivery.

`test/test_messaging_attachments.py` (+7) — the hoisted `append_attachment_context`.

`test/test_telegram.py` (+1) — an attachment message is queued, not steered, and the attachments **survive the queue** (the weaker "steer was skipped" assertion would pass even if the queue dropped them).

All guards are mutation-verified: removing each makes a specific named assertion fail. Two tests were tautological on the first pass and were fixed — the `close()` test passed with the flush deleted because the fast test window let the natural timer fire, and a contract test asserted on module source where the import line alone satisfied it.
