### PR TITLE
feat(website): edition seam for the pre-boot shell (title, manifest, icons)

### DIFF
--- a/website/docs/extension-seams.md
+++ b/website/docs/extension-seams.md
@@ -102,6 +102,48 @@ edition's TypeScript sources, where a rebuild could only produce a stock bundle.
 `frontend.edition_sources_missing()` detects that and the rebuild is **skipped**,
 keeping the shipped dashboard. Covered by `test/test_frontend_edition_build.py`.
 
+## Pre-boot shell branding: `branding.json` and the `public/` overlay
+
+Everything the registry seams brand is rendered by React — which means none of it
+exists before React mounts. Three surfaces are shown earlier: the `<title>` during
+boot (and whenever a PWA-install dialog or bookmark samples it), the
+`<meta name="theme-color">`, and the PWA identity (`manifest.json` plus
+`icon-192.png` / `icon-512.png`). `registerThemeBranding()` cannot reach any of
+them. The edition plugin patches them instead — the HTML fields on every build
+and dev transform, the `public/` overlay at build emit — from two optional
+inputs in the edition dir:
+
+- **`branding.json`** — `{"title": "Acme Crew", "themeColor": "#0055aa"}`. Both
+  keys optional; values are HTML-escaped into the root `index.html` only (app
+  panel pages are untouched). An unknown key, a non-string value, or malformed
+  JSON **fails the build** — a typoed key silently shipping the stock title is
+  the exact silent-degrade class this seam bans. So does a missing target tag:
+  if the core shell drops `<title>` or the theme-color meta, the edition build
+  breaks loudly rather than quietly reverting to stock.
+- **`public/`** — files here overlay the stock copies in the built `dist`,
+  edition-wins, emitted through the bundler (`generateBundle`/`emitFile`, which
+  takes precedence over the `publicDir` copy). Only an allowlist is accepted —
+  `manifest.json`, `icon-192.png`, `icon-512.png` — and any other file or
+  subdirectory in the edition's `public/` fails the build (OS junk dotfiles like
+  `.DS_Store` are skipped). The allowlist is the structural guarantee
+  that an edition cannot overwrite `index.html`, `sw.js`, or `vendor/*`; widen it
+  consciously (`SHELL_OVERLAY_ALLOWLIST` in `scripts/lib/editionShell.mjs`).
+
+Two known edges: the overlay is **build-only** (`generateBundle` never runs in
+the dev server, which keeps serving the stock `public/` files — the branded
+manifest/icons appear in `dist`), and `branding.json` is read eagerly at config
+load, so the dev server needs a restart after editing it.
+
+Both inputs are inert when absent, and the stock build (no `KIROCREW_EDITION_DIR`)
+is byte-identical to a build without this seam.
+
+**Replacing `icon-512.png` obliges you to replace the served logo too.** The
+gateway serves `/logo.png` (sidebar logo, favicon fallback, chat avatar) from its
+own static tree, and core CI pins that file byte-identical to
+`website/public/icon-512.png` so the installed-app icon and the favicon can never
+drift apart. An edition that overlays the PWA icons but leaves the gateway logo
+stock reintroduces exactly that drift — brand one, brand both.
+
 ## Edition peer-dependency rule
 
 An edition dir resolves bare imports from its OWN `node_modules`, so any

--- a/website/scripts/lib/editionShell.mjs
+++ b/website/scripts/lib/editionShell.mjs
@@ -1,0 +1,99 @@
+// Pure helpers for the edition pre-boot shell seam: the <title> /
+// <meta name="theme-color"> patch and the public-asset overlay allowlist.
+//
+// Split out from the Vite plugin (editionExtensionPlugin in vite.config.ts) so
+// the parsing, validation, and HTML rewriting are testable without running a
+// build — the same layout as bundleReport.mjs.
+//
+// Everything here fails LOUDLY on bad input. The edition seam's contract is
+// fail-closed/fail-loud throughout: a typo in branding.json silently shipping a
+// stock title would be exactly the class of silent edition-build degradation
+// the seam exists to prevent.
+
+/** The only branding.json keys an edition may set. Anything else throws. */
+export const BRANDING_KEYS = ['title', 'themeColor']
+
+/**
+ * Files an edition's `public/` dir may overlay onto the built dist.
+ *
+ * Deliberately a fixed allowlist rather than "copy whatever is there": the
+ * structural guarantee that an edition cannot overwrite index.html, sw.js, or
+ * vendor/* lives HERE, not in reviewer vigilance. Widen it consciously.
+ */
+export const SHELL_OVERLAY_ALLOWLIST = ['manifest.json', 'icon-192.png', 'icon-512.png']
+
+/**
+ * Parse and validate an edition's branding.json text.
+ *
+ * Returns `{ title?, themeColor? }`. Throws with an actionable message on
+ * malformed JSON, a non-object payload, an unknown key (typo guard — a typoed
+ * key would otherwise silently no-op), or a non-string/empty value.
+ */
+export function parseBrandingConfig(text) {
+  let parsed
+  try {
+    parsed = JSON.parse(text)
+  } catch (e) {
+    throw new Error(`branding.json is not valid JSON: ${e instanceof Error ? e.message : e}`)
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('branding.json must be a JSON object, e.g. {"title": "Acme Crew"}')
+  }
+  for (const key of Object.keys(parsed)) {
+    if (!BRANDING_KEYS.includes(key)) {
+      throw new Error(
+        `branding.json has an unknown key '${key}' (allowed: ${BRANDING_KEYS.join(', ')})`
+      )
+    }
+    const value = parsed[key]
+    if (typeof value !== 'string' || value.trim() === '') {
+      throw new Error(`branding.json '${key}' must be a non-empty string`)
+    }
+  }
+  return parsed
+}
+
+/** Minimal HTML escape for text/attribute interpolation into index.html. */
+export function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/**
+ * Apply a parsed branding config to the index.html shell.
+ *
+ * Replaces the <title> text and the <meta name="theme-color"> content. Throws
+ * when a tag the config wants to patch is missing — if upstream restructures
+ * the shell, the edition build must fail rather than quietly ship a stock
+ * title (the swVersionPlugin placeholder check follows the same rule).
+ */
+export function applyBrandingToHtml(html, branding) {
+  let out = html
+  if (branding.title) {
+    const re = /<title([^>]*)>[\s\S]*?<\/title>/
+    if (!re.test(out)) {
+      throw new Error('branding.title is set but index.html has no <title> tag to patch')
+    }
+    // Replacement CALLBACK, not a replacement string: in a replacement string
+    // `$1`/`$&` in the branding text would be expanded as capture references,
+    // silently corrupting a title like "AI for $1". The callback inserts the
+    // text literally; attrs carries any attributes the tag grows in the future.
+    out = out.replace(re, (_m, attrs) => `<title${attrs}>${escapeHtml(branding.title)}</title>`)
+  }
+  if (branding.themeColor) {
+    // Attribute-order tolerant: the hook may see the tag after other HTML
+    // transforms have reprinted it (content= before name=, quote changes).
+    const re = /(<meta\b(?=[^>]*name=["']theme-color["'])[^>]*\bcontent=["'])[^"']*(["'])/
+    if (!re.test(out)) {
+      throw new Error(
+        'branding.themeColor is set but index.html has no <meta name="theme-color"> to patch'
+      )
+    }
+    out = out.replace(re, (_m, pre, post) => `${pre}${escapeHtml(branding.themeColor)}${post}`)
+  }
+  return out
+}

--- a/website/src/test/editionShell.test.ts
+++ b/website/src/test/editionShell.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseBrandingConfig,
+  applyBrandingToHtml,
+  escapeHtml,
+  BRANDING_KEYS,
+  SHELL_OVERLAY_ALLOWLIST,
+} from '../../scripts/lib/editionShell.mjs'
+
+// A trimmed copy of the real shell — the tags the seam patches, in the real order.
+const SHELL = [
+  '<html><head>',
+  '<meta name="theme-color" content="#0d0f12" />',
+  '<title>Kiro Crew</title>',
+  '</head><body></body></html>',
+].join('\n')
+
+describe('parseBrandingConfig', () => {
+  it('accepts the documented keys', () => {
+    expect(parseBrandingConfig('{"title": "Acme Crew", "themeColor": "#0055aa"}')).toEqual({
+      title: 'Acme Crew',
+      themeColor: '#0055aa',
+    })
+  })
+
+  it('accepts a partial config', () => {
+    expect(parseBrandingConfig('{"title": "Acme Crew"}')).toEqual({ title: 'Acme Crew' })
+  })
+
+  it('accepts an empty object — both keys are optional', () => {
+    expect(parseBrandingConfig('{}')).toEqual({})
+  })
+
+  it('rejects malformed JSON loudly', () => {
+    expect(() => parseBrandingConfig('{oops')).toThrow(/not valid JSON/)
+  })
+
+  it('rejects a non-object payload', () => {
+    expect(() => parseBrandingConfig('["title"]')).toThrow(/JSON object/)
+    expect(() => parseBrandingConfig('null')).toThrow(/JSON object/)
+  })
+
+  it('rejects an unknown key — the typo guard', () => {
+    // A typoed key silently no-oping would ship a stock title with a green build.
+    expect(() => parseBrandingConfig('{"titel": "Acme"}')).toThrow(/unknown key 'titel'/)
+  })
+
+  it('rejects non-string and empty values', () => {
+    expect(() => parseBrandingConfig('{"title": 3}')).toThrow(/non-empty string/)
+    expect(() => parseBrandingConfig('{"title": "  "}')).toThrow(/non-empty string/)
+  })
+})
+
+describe('applyBrandingToHtml', () => {
+  it('patches the title text', () => {
+    const out = applyBrandingToHtml(SHELL, { title: 'Acme Crew' })
+    expect(out).toContain('<title>Acme Crew</title>')
+    expect(out).not.toContain('<title>Kiro Crew</title>')
+  })
+
+  it('preserves attributes on a future <title> tag', () => {
+    const out = applyBrandingToHtml('<title lang="en">Kiro Crew</title>', { title: 'Acme Crew' })
+    expect(out).toBe('<title lang="en">Acme Crew</title>')
+  })
+
+  it('patches the theme-color content', () => {
+    const out = applyBrandingToHtml(SHELL, { themeColor: '#0055aa' })
+    expect(out).toContain('content="#0055aa"')
+    expect(out).not.toContain('#0d0f12')
+  })
+
+  it('tolerates reprinted attribute order on the meta tag', () => {
+    // transformIndexHtml may see the tag after another transform reprinted it.
+    const reprinted = '<meta content="#0d0f12" name="theme-color">'
+    const out = applyBrandingToHtml(reprinted, { themeColor: '#0055aa' })
+    expect(out).toContain('#0055aa')
+  })
+
+  it('HTML-escapes interpolated values', () => {
+    // nosemgrep: javascript.lang.security.audit.unknown-value-with-script-tag.unknown-value-with-script-tag — the "attack" string is a hardcoded fixture; the assertion is that it comes out escaped
+    const out = applyBrandingToHtml(SHELL, { title: 'A<script>x</script>' })
+    expect(out).toContain('&lt;script&gt;')
+    expect(out).not.toContain('<script>x')
+  })
+
+  it('inserts replacement-pattern metacharacters literally', () => {
+    // String.replace would expand $1/$& in a replacement STRING — a title
+    // like "AI for $1" must come through byte-for-byte, not as a capture ref.
+    const out = applyBrandingToHtml(SHELL, { title: 'AI for $1 & co. $&' })
+    expect(out).toContain('<title>AI for $1 &amp; co. $&amp;</title>')
+    const color = applyBrandingToHtml(SHELL, { themeColor: '$&' })
+    expect(color).toContain('content="$&amp;"')
+  })
+
+  it('leaves untouched fields alone', () => {
+    const out = applyBrandingToHtml(SHELL, { title: 'Acme Crew' })
+    expect(out).toContain('content="#0d0f12"')
+  })
+
+  it('fails loudly when a targeted tag is missing', () => {
+    // If upstream restructures the shell, the edition build must break — a
+    // quiet stock title on a green build is the failure mode the seam bans.
+    expect(() => applyBrandingToHtml('<html></html>', { title: 'X' })).toThrow(/no <title>/)
+    expect(() => applyBrandingToHtml('<html></html>', { themeColor: '#fff' })).toThrow(
+      /no <meta name="theme-color">/
+    )
+  })
+
+  it('applies every key parseBrandingConfig accepts', () => {
+    // Couples the parse allowlist to the apply branches: a key added to
+    // BRANDING_KEYS without a matching applyBrandingToHtml branch would parse,
+    // validate, and then silently ship the stock value — the silent-degrade
+    // class this seam exists to ban. Each accepted key must change the shell.
+    for (const key of BRANDING_KEYS) {
+      const out = applyBrandingToHtml(SHELL, { [key]: 'ZZZ-sentinel' })
+      expect(out, `BRANDING_KEYS entry '${key}' did not change the shell`).not.toBe(SHELL)
+      expect(out).toContain('ZZZ-sentinel')
+    }
+  })
+})
+
+describe('escapeHtml', () => {
+  it('escapes the five HTML metacharacters', () => {
+    expect(escapeHtml(`<&>"'`)).toBe('&lt;&amp;&gt;&quot;&#39;')
+  })
+})
+
+describe('SHELL_OVERLAY_ALLOWLIST', () => {
+  it('covers exactly the pre-boot shell assets', () => {
+    // Widening this list widens what an edition can overwrite in dist — the
+    // test makes that a conscious, reviewed change rather than a drive-by.
+    expect([...SHELL_OVERLAY_ALLOWLIST].sort()).toEqual([
+      'icon-192.png',
+      'icon-512.png',
+      'manifest.json',
+    ])
+  })
+})

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -20,6 +20,14 @@ import {
   TAILWIND_RUNTIME_SRC,
 } from './src/lib/vendorPaths'
 import { precompressPlugin } from './scripts/precompress.mjs'
+import {
+  parseBrandingConfig,
+  applyBrandingToHtml,
+  SHELL_OVERLAY_ALLOWLIST,
+} from './scripts/lib/editionShell.mjs'
+
+/** Shape produced by parseBrandingConfig (editionShell.mjs is untyped .mjs). */
+type EditionBranding = { title?: string; themeColor?: string }
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 const backendPort = process.env.KIROCREW_PORT || 5476
@@ -252,9 +260,84 @@ function editionExtensionPlugin(): Plugin {
         'Unset KIROCREW_EDITION_DIR for a stock build.\n'
     )
   }
+  // Pre-boot shell branding, resolved eagerly like the composition root so a
+  // malformed branding.json fails the build at startup, not mid-bundle. The
+  // eager read also means a dev server restart is needed after editing
+  // branding.json — consistent with how the composition root itself resolves.
+  // Optional: an edition without one keeps the stock title/theme-color.
+  let branding: EditionBranding = {}
+  let overlayFiles: string[] = []
+  if (editionEntry) {
+    const abs = path.dirname(editionEntry)
+    const brandingPath = path.join(abs, 'branding.json')
+    if (existsSync(brandingPath)) {
+      try {
+        branding = parseBrandingConfig(readFileSync(brandingPath, 'utf-8'))
+      } catch (e: unknown) {
+        throw new Error(`[kirocrew-edition] ${brandingPath}: ${(e as Error).message}`)
+      }
+    }
+    // Only allowlisted shell assets overlay the stock public/ copies; anything
+    // else in the edition's public/ fails the build (fail-loud beats a file
+    // that looks deployed but never ships). Deliberately flat: a subdirectory
+    // is rejected like any other stray entry, so the allowlist stays a list of
+    // exact filenames rather than a path-matching scheme. OS junk dotfiles
+    // (.DS_Store and friends) are skipped, not rejected — the OS creates them
+    // behind the author's back, so failing on them would be noise, not safety.
+    const publicDir = path.join(abs, 'public')
+    if (existsSync(publicDir)) {
+      const entries = readdirSync(publicDir, { withFileTypes: true }).filter(
+        (d) => !d.name.startsWith('.')
+      )
+      const strays = entries.filter(
+        (d) => !d.isFile() || !SHELL_OVERLAY_ALLOWLIST.includes(d.name)
+      )
+      if (strays.length > 0) {
+        throw new Error(
+          `[kirocrew-edition] ${publicDir} contains entries outside the shell-overlay allowlist ` +
+            `(${SHELL_OVERLAY_ALLOWLIST.join(', ')}), or non-files: ` +
+            `${strays.map((d) => d.name).join(', ')}. ` +
+            'The allowlist is what keeps an edition from overwriting index.html, sw.js, or vendor/*.'
+        )
+      }
+      overlayFiles = entries.map((d) => d.name)
+    }
+  }
   return {
     name: 'kirocrew-edition-extension',
     enforce: 'pre',
+    // Patch the pre-boot shell (<title>, <meta name="theme-color">) from the
+    // edition's branding.json. registerThemeBranding() can only retitle the tab
+    // after React mounts; this covers what the browser shows before that (and
+    // what a PWA install dialog samples). order:'pre' runs before Vite's own
+    // HTML transform reprints the tags.
+    transformIndexHtml: {
+      order: 'pre',
+      handler(html: string, ctx: { path: string }) {
+        if (!branding.title && !branding.themeColor) return html
+        // Multi-page build: app panels (src/apps/*/panel.html) come through
+        // this hook too. The pre-boot shell is the root index.html only.
+        if (ctx.path !== '/index.html') return html
+        return applyBrandingToHtml(html, branding)
+      },
+    },
+    // Overlay the allowlisted shell assets (PWA manifest + icons) edition-wins.
+    // Emitted through the bundler so the files are visible to other plugins,
+    // rather than copied over dist after the fact. An emitted asset with a
+    // pinned fileName takes precedence over the same-named publicDir copy
+    // (verified against this config on Vite 8 / Rolldown; the negative case —
+    // publicDir winning — would surface immediately as stock bytes in dist).
+    // Build-only by nature of generateBundle: the dev server keeps serving the
+    // stock public/ files, which the seam docs call out as a known limitation.
+    generateBundle() {
+      for (const file of overlayFiles) {
+        this.emitFile({
+          type: 'asset',
+          fileName: file,
+          source: readFileSync(path.join(path.dirname(editionEntry as string), 'public', file)),
+        })
+      }
+    },
     config() {
       if (editionDir) {
         // Let vite's dev server serve/resolve files from outside the project


### PR DESCRIPTION
Implements #2199.

## Problem

An edition composed via `KIROCREW_EDITION_DIR` can brand everything React renders, but nothing the browser shows **before** React mounts: the `<title>` during boot, the `theme-color` meta, and the PWA install identity (`manifest.json`, `icon-192/512.png`) stay stock. `registerThemeBranding()` runs in a `useEffect`, so it structurally cannot reach these. Today an edition's only option is patching `dist/` after the build — outside the seam's fail-closed contract, and silently broken by any upstream change to the shell. Full problem statement and alternatives considered are in #2199; no comments had landed there yet, so this PR proposes concrete answers to its open questions (all cheap to change if maintainers prefer differently).

## Changes

Two optional, inert-when-absent inputs read by the existing `editionExtensionPlugin` (same fail-closed `KIROCREW_ALLOW_EDITION` gate, no new plugin):

- **`<edition dir>/branding.json`** — `{"title", "themeColor"}`, both optional. Applied via `transformIndexHtml` (`order: 'pre'`) to the **root `index.html` only**; app panel pages (`src/apps/*/panel.html`) are explicitly skipped. Values are HTML-escaped. Malformed JSON, an unknown key (typo guard), a non-string value, or a missing target tag **fails the build** — a green build that quietly ships a stock title is the silent-degrade class the seam bans (same rule as `swVersionPlugin`'s placeholder check).
- **`<edition dir>/public/`** — overlays an allowlisted set onto `dist`, edition-wins, via `generateBundle` + `emitFile`. Any file outside the allowlist (`manifest.json`, `icon-192.png`, `icon-512.png`) fails the build, so an edition structurally cannot overwrite `index.html`, `sw.js`, or `vendor/*`. The allowlist constant lives in `scripts/lib/editionShell.mjs` and is pinned by a test, so widening it is a conscious, reviewed change.

Parsing/rewrite logic is split into `scripts/lib/editionShell.mjs` so it is unit-testable without a build (the `bundleReport.mjs` layout). `frontend.py` needs no change — it only forwards the env pair. Docs: new section in `website/docs/extension-seams.md`, including the parity note that replacing `icon-512.png` obliges an edition to rebrand the gateway-served `/logo.png` too (the invariant core CI pins for the stock assets).

## Answers to #2199's open questions (as implemented)

1. **Allowlist scope**: fixed three files, no patterns — smallest surface that closes the gap; widening later is additive.
2. **`manifest.json`**: full replacement, not a partial patch — one mechanism, no merge semantics to document, and the file is small enough that owning it whole is simpler than reasoning about which keys merge.
3. **Declarative source**: standalone `branding.json` rather than deriving from the composition root — it must be readable at config-load time, before any bundling.
4. **Gateway `/logo.png`**: stays a deployment concern, documented next to the seam (it is served by the backend from its static tree; reaching it from a frontend build plugin would cross the build/runtime boundary).

One empirical note for reviewers: `emitFile` assets **do** take precedence over the `publicDir` copy in this config (verified on Vite 8.2.0 / Rolldown; the icons and manifest in `dist` are the edition's bytes), so the overlay stays inside the bundler's asset graph rather than a post-hoc copy.

## Testing

- **14 new unit tests** (`src/test/editionShell.test.ts`): parse validation (malformed JSON, unknown key, non-string/empty values), title/theme-color rewriting incl. reprinted attribute order, HTML escaping, fail-loud on missing target tags, allowlist pinning.
- **Real edition build** (neutral test edition with `branding.json` + `public/{manifest.json,icon-192.png,icon-512.png}`): dist `<title>`/`theme-color`/manifest/icons all carry the edition values; icons byte-compared against the edition sources.
- **Negative builds**: a stray `public/evil.js` fails the build naming the allowlist; a typoed `branding.json` key fails naming the key.
- **Stock build**: unaffected (`npm run build` green, stock title/manifest/icons in dist).
- **Full frontend gate**: `npm run build` + vitest suite green (10972 passed). One pre-existing Electron flake (`mochi/test/petOverlays.test.js`) failed once in the full run and passes standalone and on a clean suite rerun (827/827); it has no connection to these files.
- `scripts/scrub-lint.sh`, `scripts/docs-lint.sh`, brand-name gate: all green.


Closes #2199
