### PR TITLE
fix(test): isolate doctor embeddings tests from leaked LLAMA_CPP_LIB_PATH

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4017,16 +4017,37 @@ class TestDoctorEmbeddings:
         _pin_default_config(monkeypatch)
 
     @staticmethod
-    def _run_doctor(tmp_path, monkeypatch, *, runtime_ok: bool, model_present: bool, platform_supported: bool = True, missing_libs: dict | None = None, loader_setdefaults: str = ""):
+    def _run_doctor(tmp_path, monkeypatch, *, runtime_ok: bool, model_present: bool, platform_supported: bool = True, missing_libs: dict | None = None, loader_setdefaults: str = "", lib_path_override: str | None = None):
         """Run _doctor with the embeddings runtime/model state stubbed.
 
         ``loader_setdefaults`` reproduces the real loader's side effect of
         ``setdefault``-ing LLAMA_CPP_LIB_PATH to its own bundled libs dir, which
         is what makes reading that var after the load call ambiguous.
+
+        ``lib_path_override`` controls the LLAMA_CPP_LIB_PATH the doctor sees:
+        ``None`` (default) CLEARS it — the var LEAKS between tests otherwise,
+        because both the ``loader_setdefaults`` path and the real embeddings
+        loader plant it via ``os.environ.setdefault`` (invisible to
+        monkeypatch teardown), so whichever test ran first in the pytest
+        worker poisoned override-sensitive assertions (shard-layout-dependent
+        CI failures). A string sets the override deliberately, via monkeypatch
+        so it is restored on teardown.
         """
         agent_file = tmp_path / "kirocrew.json"
         _healthy_agent_file(agent_file)
         import kiro_crew.cli_doctor as doc
+
+        if lib_path_override is None:
+            # setenv FIRST so monkeypatch records a teardown action even when
+            # the var is ABSENT: delenv(raising=False) on a missing var
+            # registers nothing, so the loader_setdefaults path's direct
+            # os.environ.setdefault would still leak into later tests in
+            # workers where the var was never set (GPT review). The
+            # setenv+delenv pair restores the original state either way.
+            monkeypatch.setenv("LLAMA_CPP_LIB_PATH", "")
+            monkeypatch.delenv("LLAMA_CPP_LIB_PATH", raising=False)
+        else:
+            monkeypatch.setenv("LLAMA_CPP_LIB_PATH", lib_path_override)
 
         def _load():
             if loader_setdefaults:
@@ -4104,6 +4125,7 @@ class TestDoctorEmbeddings:
             runtime_ok=False,
             model_present=False,
             missing_libs={"macos_arm64": ["libllama.dylib"]},
+            lib_path_override="/opt/my-gpu-llama",
         )
         out = capsys.readouterr().out
         assert "/opt/my-gpu-llama" in out


### PR DESCRIPTION
## Problem

`test_cli.py::TestDoctorEmbeddings::test_doctor_names_the_missing_native_libs` fails on current `main` — visible on main's own `Backend Tests (3.12, 1)` (run 31259141604, commit `c831e58`) with `Coverage Gate` failing downstream — and on PR branches based on current main (observed on #2121, shards 3.10/1 and 3.12/1). Reproduced locally on a pristine `origin/main` checkout.

## Why it matters

A red shard on main fails every downstream PR's CI roll, and a failed CI blocks the fork AI-review pipeline from re-stamping — the same cascade #2184 fixed for the kiroignore tests. Because the failure is shard-layout-dependent, it strikes intermittently and looks like a PR-specific problem to each author it hits.

## Fix (symptoms → root cause → change)

The doctor (from #2196) deliberately suppresses the missing-libs diagnosis when `LLAMA_CPP_LIB_PATH` is set — under an override the bundled tree isn't what failed. The test asserts the diagnosis prints, but never controls that env var, and the var **leaks into the pytest worker two ways**:

- the class's own `loader_setdefaults` test plants it via `os.environ.setdefault` — invisible to monkeypatch teardown, so it persists for the rest of the worker's life;
- the real embeddings loader does the same `setdefault` in any earlier test that exercises it.

Whether a polluting test runs first depends on the shard layout — which is why main's shard 1 is red while other shards (and pre-#2196 layouts) passed.

Fix: `_run_doctor` gains an explicit `lib_path_override` parameter. `None` (default) **clears** the var via `monkeypatch.delenv` — isolating every doctor test from ambient state and registering a teardown restore so in-test `setdefault`s no longer leak forward; a string sets the override deliberately, which the existing `test_doctor_blames_the_override_dir_not_the_bundled_tree` now uses.

## Tests

The changed file is tests: 9/9 in `TestDoctorEmbeddings` and 244 passed in `test_cli.py`, verified **both** with a clean environment and with `LLAMA_CPP_LIB_PATH` pre-poisoned in the parent process (the previously failing condition).

## Manual verification

N/A — unit coverage sufficient; the failure and fix are fully captured by running the suite under the poisoned environment.

## Screenshots

N/A — no user-visible UI change.
