### PR TITLE
fix(electron): let Mochi's poller borrow the window's gateway session

### DIFF
--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -64,6 +64,7 @@ const { capturePySpyDump } = require("./pyspy-dump");
 const { createMetricsRecorder } = require("./perf-metrics");
 const { identityFamily, decideGatewayAction, classifyGatewayReadiness, FAMILY_META, HEALTH_IDENTITY_PATH, READY_PATH } = require("./instance-guard");
 const { initMochi, shutdownMochi } = require("./mochi/index");
+const { borrowSessionToken } = require("./mochi-session-token");
 const { initCrewCompanion, shutdownCrewCompanion } = require("./crew-companion/index");
 const { clampZoomFactor, stepZoomFactor } = require("./zoom");
 const { createBrowserViewManager, isUntrustedContents } = require("./browser-view");
@@ -1031,6 +1032,25 @@ async function fetchLocalToken(backendUrl = BACKEND_URL) {
   });
 }
 
+/**
+ * Resolve a gateway credential for Mochi's poller, trying the same paths (in
+ * the same order) the main window itself would: the local secret first
+ * (same machine, unchanged), then an explicitly configured SSH remote host
+ * for this port (unchanged), then — new — the session the main window has
+ * ALREADY established. That third path only runs when the first two come
+ * back empty, so an ordinary same-machine or SSH-remote install never
+ * reaches it at all. See mochi-session-token.js for why it exists and why it
+ * cannot weaken auth: it only ever hands back a credential a genuine prior
+ * authentication already produced.
+ */
+async function fetchMochiGatewayAuth(backendUrl = BACKEND_URL) {
+  const localValue = await fetchLocalToken(backendUrl);
+  if (localValue) return { value: localValue, viaCookie: false };
+  const { token: remoteValue } = await fetchRemoteToken(new URL(backendUrl).port);
+  if (remoteValue) return { value: remoteValue, viaCookie: false };
+  const borrowed = await borrowSessionToken({ electronSession: session.defaultSession, backendUrl });
+  return borrowed ? { value: borrowed, viaCookie: true } : { value: "" };
+}
 
 function checkBackend(healthUrl = HEALTH_URL) {
   return new Promise((resolve, reject) => {
@@ -3671,7 +3691,12 @@ app.whenReady().then(async () => {
   // be answering before we ask it whether Mochi is on, and the pet page is
   // loaded from the gateway origin. Best-effort -- a failure here must never
   // block the dashboard, so everything is inside a catch that only logs.
-  initMochi({ backendUrl: BACKEND_URL, fetchLocalToken, glog, getMainWindow: () => mainWindow });
+  initMochi({
+    backendUrl: BACKEND_URL,
+    fetchGatewayAuth: fetchMochiGatewayAuth,
+    glog,
+    getMainWindow: () => mainWindow,
+  });
   // Same shape and the same best-effort contract: the companion's windows follow
   // the app's enabled state, and a failure here must never block the dashboard.
   try {

--- a/website/electron/mochi-session-token.js
+++ b/website/electron/mochi-session-token.js
@@ -1,0 +1,50 @@
+"use strict";
+
+/**
+ * Borrow the gateway session the MAIN WINDOW already established, for
+ * Mochi's poller — a plain Node process in the main process with no browser
+ * session of its own.
+ *
+ * Two paths already cover how the shell gets a gateway credential: the local
+ * secret (local-token.js, same machine) and an explicitly configured SSH
+ * remote host (remote-token.js). Neither reaches a third topology: the
+ * gateway and Electron are reachable over loopback-equivalent networking (a
+ * WSL2 gateway and a Windows Electron shell, say) but sit on different
+ * filesystems, so `os.homedir()` inside Electron never resolves to the
+ * gateway's `.local_secret` — and there is nothing remote about the setup to
+ * configure an SSH host for.
+ *
+ * The main window already authenticated — by whichever path worked for it —
+ * the moment it first loaded successfully: the gateway's
+ * token_auth_middleware sets an `mc_token_<port>` session cookie on that
+ * response (httpOnly, hours-long `session_exp`; see
+ * docs/system-specs/modules/security.md). This reads that cookie back out of
+ * Electron's own cookie store so Mochi can present the SAME credential.
+ *
+ * FAILS CLOSED: a missing session/cookie API, an unparsable backendUrl, or no
+ * matching cookie all resolve to "". This never mints or fabricates a
+ * credential — it can only ever hand back one a genuine prior authentication
+ * already produced, so an app that never authenticated stays unauthenticated.
+ *
+ * @param {{electronSession: {cookies: {get: Function}}, backendUrl: string}} deps
+ * @returns {Promise<string>}
+ */
+async function borrowSessionToken({ electronSession, backendUrl }) {
+  if (!electronSession || typeof electronSession.cookies?.get !== "function") return "";
+  let port;
+  try {
+    port = new URL(backendUrl).port;
+  } catch {
+    return "";
+  }
+  if (!port) return "";
+  try {
+    const cookies = await electronSession.cookies.get({ url: backendUrl, name: `mc_token_${port}` });
+    const value = Array.isArray(cookies) && cookies[0] && cookies[0].value;
+    return typeof value === "string" ? value : "";
+  } catch {
+    return "";
+  }
+}
+
+module.exports = { borrowSessionToken };

--- a/website/electron/mochi/index.js
+++ b/website/electron/mochi/index.js
@@ -39,7 +39,7 @@ const machineStore = new Store({ name: "mochi-machine", defaults: MACHINE_STORE_
 
 // Injected by initMochi(); placeholders keep every function definable at load.
 let BACKEND_URL = "";
-let fetchLocalToken = async () => "";
+let fetchGatewayAuth = async () => ({ value: "" });
 let glog = () => {};
 
 /**
@@ -47,8 +47,8 @@ let glog = () => {};
  *
  * Mochi ships defaultEnabled:false, so this is a no-op for anyone who has not
  * turned it on in the App Store. Enabled state lives in the gateway (it is an
- * app, not a shell setting), so the shell has to ask — using the same local
- * token path the dashboard window uses.
+ * app, not a shell setting), so the shell has to ask — using the same gateway
+ * credential paths the dashboard window uses (see initMochi/fetchGatewayAuth).
  *
  * Everything is best-effort: any failure (no token, gateway slow, app absent)
  * just means no pet this launch. The dashboard must never be held up by it.
@@ -62,16 +62,47 @@ function probeLog(outcome) {
   console.log("Mochi pet probe:", outcome);
 }
 
-// Cached because the reconcile loop runs every few seconds and
-// /api/token/local MINTS A NEW SESSION TOKEN on every call — polling it would
-// issue hundreds of tokens an hour and grow the revoked-nonce table for no
-// reason. Cleared on any 401/403 so a genuinely expired token is re-minted.
-let cachedGatewayToken = "";
+// Cached because the reconcile loop runs every few seconds and a locally- or
+// SSH-minted credential comes from an endpoint that MINTS A NEW SESSION TOKEN
+// on every call — polling it would issue hundreds of tokens an hour and grow
+// the revoked-nonce table for no reason. Cleared on any 401/403 so a
+// genuinely expired credential is re-resolved. Holds `{ value, viaCookie }`:
+// `value` is the credential fetchGatewayAuth() found (empty when it found
+// none), and `viaCookie` says HOW it must be delivered — see
+// withGatewayAuth().
+let cachedGatewayAuth = { value: "" };
 
 async function gatewayToken() {
-  if (cachedGatewayToken) return cachedGatewayToken;
-  cachedGatewayToken = (await fetchLocalToken()) || "";
-  return cachedGatewayToken;
+  if (cachedGatewayAuth.value) return cachedGatewayAuth;
+  cachedGatewayAuth = (await fetchGatewayAuth()) || { value: "" };
+  return cachedGatewayAuth;
+}
+
+/**
+ * Attach gatewayToken()'s answer to a LOCAL-gateway request the way its auth
+ * middleware expects it delivered.
+ *
+ * A local-secret or SSH-fetched credential is a freshly minted LINK token
+ * (local-token.js / remote-token.js): the gateway checks its 5-minute `exp`
+ * claim when it arrives as `?token=`, which is fine because gatewayToken()
+ * re-resolves on every cache miss (roughly every 5 minutes in steady state).
+ * A BORROWED session credential (mochi-session-token.js) is the opposite: it
+ * is the value already sitting in the main window's `mc_token_<port>`
+ * cookie, whose `exp` claim froze at the moment that window's session was
+ * ORIGINALLY exchanged — almost always minutes in the past by the time
+ * Mochi reads it. Sent as `?token=` it would validate for a few minutes and
+ * then 401 forever, reproducing this exact bug on a delay. Sent as a
+ * `Cookie` header it is checked against `session_exp` instead (hours, not
+ * minutes) — the same field the browser itself relies on.
+ */
+function withGatewayAuth(url, auth) {
+  if (!auth || !auth.value) return { url, headers: {} };
+  if (auth.viaCookie) {
+    const port = new URL(url).port;
+    return { url, headers: { Cookie: `mc_token_${port}=${auth.value}` } };
+  }
+  const sep = url.includes("?") ? "&" : "?";
+  return { url: `${url}${sep}token=${encodeURIComponent(auth.value)}`, headers: {} };
 }
 
 /**
@@ -128,11 +159,15 @@ let mochiPetInstanceId = "self";
  *
  * @returns {Promise<{localPort: number, token: string}|null>} null = unusable
  */
-function connectInstance(instanceId, token, { timeoutMs = 15000 } = {}) {
+function connectInstance(instanceId, auth, { timeoutMs = 15000 } = {}) {
   return new Promise((resolve) => {
+    const { url, headers } = withGatewayAuth(
+      `${BACKEND_URL}/api/instances/${encodeURIComponent(instanceId)}/connect`,
+      auth,
+    );
     const req = http.request(
-      `${BACKEND_URL}/api/instances/${encodeURIComponent(instanceId)}/connect?token=${encodeURIComponent(token)}`,
-      { method: "POST", timeout: timeoutMs },
+      url,
+      { method: "POST", timeout: timeoutMs, headers },
       (res) => {
         let data = "";
         res.on("data", (c) => { data += c; });
@@ -268,9 +303,9 @@ function remoteEnabledSnapshot() {
  * the list. Answers land in the same 60s cache the resolver uses.
  */
 async function probeAllLiveInstancesEnabled() {
-  const localToken = await gatewayToken();
-  if (!localToken) return remoteEnabledSnapshot();
-  const listed = await fetchInstances(localToken);
+  const localAuth = await gatewayToken();
+  if (!localAuth.value) return remoteEnabledSnapshot();
+  const listed = await fetchInstances(localAuth);
   if (!listed.known) return remoteEnabledSnapshot();
   pruneRemoteEnabledCache(listed.instances);
   // Skip anything we already have a fresh answer for. This is what makes the
@@ -284,7 +319,7 @@ async function probeAllLiveInstancesEnabled() {
         // Shorter connect timeout than the pet's resolve path: this one runs while
         // a user waits on a Settings pane, and a stale "connected" whose tunnel
         // actually died must not hang the whole list behind one row.
-        const conn = await connectInstance(inst.id, localToken, { timeoutMs: 6000 });
+        const conn = await connectInstance(inst.id, localAuth, { timeoutMs: 6000 });
         if (conn.known && conn.usable) {
           await remoteMochiEnabled(inst.id, conn.localPort, conn.token);
         }
@@ -315,11 +350,12 @@ async function probeAllLiveInstancesEnabled() {
  * `inactive` says "restart the gateway", and without them a user with the feature
  * off just sees "This computer" and no way forward.
  */
-function fetchInstances(token) {
+function fetchInstances(auth) {
   return new Promise((resolve) => {
+    const { url, headers } = withGatewayAuth(`${BACKEND_URL}/api/instances`, auth);
     const req = http.request(
-      `${BACKEND_URL}/api/instances?token=${encodeURIComponent(token)}`,
-      { method: "GET", timeout: 5000 },
+      url,
+      { method: "GET", timeout: 5000, headers },
       (res) => {
         // 403 is an ANSWER: instances.enabled is off, so there are genuinely no
         // remotes to point at. Every other non-200 is a NON-answer.
@@ -398,12 +434,12 @@ async function resolveMochiTarget(choice) {
     return self;
   }
 
-  const localToken = await gatewayToken();
-  if (!localToken) return { keep: true };
+  const localAuth = await gatewayToken();
+  if (!localAuth.value) return { keep: true };
 
   // List FIRST. Only an already-live instance is offered a connect, so the pet
   // never brings a tunnel up on its own.
-  const listed = await fetchInstances(localToken);
+  const listed = await fetchInstances(localAuth);
   if (!listed.known) {
     mochiInstanceLog("could not read the instance list — leaving Mochi where it is");
     return { keep: true };
@@ -417,7 +453,7 @@ async function resolveMochiTarget(choice) {
     return self;
   }
 
-  const conn = await connectInstance(choice, localToken);
+  const conn = await connectInstance(choice, localAuth);
   if (!conn.known) {
     mochiInstanceLog(`petInstance "${choice}" did not answer — leaving Mochi where it is`);
     return { keep: true };
@@ -465,22 +501,20 @@ function mochiInstanceLog(message) {
  * disabled app still tears down, because the gateway answered and said so.
  */
 async function mochiEnabledState() {
-  const token = await gatewayToken();
-  if (!token) { probeLog("no gateway token — cannot query /api/apps"); return "unknown"; }
+  const auth = await gatewayToken();
+  if (!auth.value) { probeLog("no gateway token — cannot query /api/apps"); return "unknown"; }
   return new Promise((resolve) => {
-    // `?token=` — NOT a cookie. The dashboard cookie is named
-    // `mc_token_<browser-facing-port>` (token_auth.py::_cookie_port_from_host,
-    // port-keyed so SSH-tunnelled instances don't collide), so a hand-built
-    // `mc_token=` header silently fails auth. The query param is accepted on
-    // the same line that reads the cookie, and needs no port knowledge.
+    // Delivered as `?token=` or as the `mc_token_<port>` cookie depending on
+    // where gatewayToken()'s answer came from — see withGatewayAuth().
+    const { url, headers } = withGatewayAuth(`${BACKEND_URL}/api/apps`, auth);
     const req = http.request(
-      `${BACKEND_URL}/api/apps?token=${encodeURIComponent(token)}`,
-      { method: "GET", timeout: 5000 },
+      url,
+      { method: "GET", timeout: 5000, headers },
       (res) => {
         if (res.statusCode !== 200) {
           res.resume();
-          // Drop a rejected token so the next tick mints a fresh one.
-          if (res.statusCode === 401 || res.statusCode === 403) cachedGatewayToken = "";
+          // Drop a rejected credential so the next tick re-resolves one.
+          if (res.statusCode === 401 || res.statusCode === 403) cachedGatewayAuth = { value: "" };
           probeLog(`/api/apps returned HTTP ${res.statusCode}`);
           resolve("unknown");
           return;
@@ -542,16 +576,17 @@ const MOCHI_PET_RECONCILE_MS = 5000;
  * per consumer.
  */
 async function mochiSettings() {
-  const token = await gatewayToken();
-  if (!token) return null;
+  const auth = await gatewayToken();
+  if (!auth.value) return null;
   return new Promise((resolve) => {
+    const { url, headers } = withGatewayAuth(`${BACKEND_URL}/api/apps/mochi/settings`, auth);
     const req = http.request(
-      `${BACKEND_URL}/api/apps/mochi/settings?token=${encodeURIComponent(token)}`,
-      { method: "GET", timeout: 5000 },
+      url,
+      { method: "GET", timeout: 5000, headers },
       (res) => {
         if (res.statusCode !== 200) {
           res.resume();
-          if (res.statusCode === 401 || res.statusCode === 403) cachedGatewayToken = "";
+          if (res.statusCode === 401 || res.statusCode === 403) cachedGatewayAuth = { value: "" };
           resolve(null);
           return;
         }
@@ -811,19 +846,23 @@ async function reconcileMochi() {
   openPetWindow(mochiPetBaseUrl, mochiPetToken);
   // An overlay stuck on a gateway error page (expired cookie or a transient 5xx)
   // has hidden itself; re-arm it with a token that works for the CURRENT target.
-  // For a remote instance that is its own token; for self the pet rides the
-  // same-origin cookie (empty token) — exactly what expired — so carry the
-  // CURRENT local token on the URL to re-establish it. Reuse the cached token,
-  // never mint here: the reconcile probes already clear cachedGatewayToken on a
-  // genuine 401/403, so gatewayToken() re-mints only when the old one was truly
-  // rejected. Minting every tick while a non-auth 4xx/5xx keeps an overlay
-  // blanked would churn session nonces and evict pending auth links.
+  // For a remote instance that is its own query token. For self, keep the
+  // credential's delivery mode: a borrowed browser session is a Cookie header,
+  // while a newly minted local credential is a query token. Reuse the cached
+  // credential, never mint here: the reconcile probes already clear
+  // cachedGatewayAuth on a genuine 401/403, so gatewayToken() re-resolves only
+  // when the old one was truly rejected. Resolving every tick while a non-auth
+  // 4xx/5xx keeps an overlay blanked would churn session nonces and evict
+  // pending auth links.
   if (hasBlankedOverlay()) {
     let rearmToken = mochiPetToken;
+    let rearmViaCookie = false;
     if (mochiPetInstanceId === SELF_INSTANCE) {
-      rearmToken = await gatewayToken();
+      const auth = await gatewayToken();
+      rearmToken = auth.value;
+      rearmViaCookie = auth.viaCookie;
     }
-    rearmBlankedOverlays(mochiPetBaseUrl, rearmToken);
+    rearmBlankedOverlays(mochiPetBaseUrl, rearmToken, rearmViaCookie);
   }
   // Fully enabled again: bring the panel back if disable had hidden it.
   restorePanelOnEnable(mochiPetBaseUrl, mochiPetToken);
@@ -1164,9 +1203,9 @@ function startMochiWatcher() {
    */
   ipcMain.handle("mochi-instances:list", async () => {
     try {
-      const token = await gatewayToken();
-      if (!token) return { known: false, state: "error", instances: [] };
-      const listed = await fetchInstances(token);
+      const auth = await gatewayToken();
+      if (!auth.value) return { known: false, state: "error", instances: [] };
+      const listed = await fetchInstances(auth);
       return {
         known: !!listed.known,
         state: listed.state || (listed.known ? "ready" : "error"),
@@ -1193,13 +1232,16 @@ function startMochiWatcher() {
 }
 
 /**
- * Start the pet watcher. `backendUrl`/`fetchLocalToken`/`glog` are the shell's
- * own: the local gateway origin, the local-token fetcher (the same path the
- * dashboard window uses), and the gateway-launch logger.
+ * Start the pet watcher. `backendUrl`/`fetchGatewayAuth`/`glog` are the
+ * shell's own: the local gateway origin, a resolver that tries every gateway
+ * credential path the shell knows (local secret, SSH remote, then the main
+ * window's own already-established session — see main.js's
+ * fetchMochiGatewayAuth and mochi-session-token.js) and answers
+ * `{ value, viaCookie }`, and the gateway-launch logger.
  */
 function initMochi(deps) {
   BACKEND_URL = deps.backendUrl;
-  fetchLocalToken = deps.fetchLocalToken;
+  fetchGatewayAuth = deps.fetchGatewayAuth;
   glog = deps.glog;
   try {
     require("./panelWindow").setMainWindowGetter(deps.getMainWindow);

--- a/website/electron/mochi/petOverlays.js
+++ b/website/electron/mochi/petOverlays.js
@@ -111,23 +111,25 @@ function hasBlankedOverlay() {
 
 /**
  * Re-arm every overlay hidden on an error page by reloading it with the
- * (baseUrl, token) the host ALREADY resolved for the current target this
+ * (baseUrl, token, viaCookie) the host ALREADY resolved for the current target this
  * reconcile tick. The host owns target resolution AND switches, so this takes
  * concrete values rather than resolving again — no provider seam, no retry
  * budget, and no superseded-window race (the reload is synchronous inside the
- * tick). An empty token means no usable credential yet: stay blank and let the
- * next tick try. Recovering an expired cookie and a transient 5xx share this one
- * path.
+ * tick). A minted credential goes on the URL; a borrowed session uses the
+ * overlay's default BrowserWindow session. An absent credential means stay
+ * blank and let the next tick try. Recovering an expired cookie and a transient
+ * 5xx share this one path.
  */
-function rearmBlankedOverlays(baseUrl, token) {
-  if (!baseUrl || !token) return;
+function rearmBlankedOverlays(baseUrl, token, viaCookie = false) {
+  if (!baseUrl || (!token && !viaCookie)) return;
+  const pageToken = viaCookie ? "" : token;
   for (const [, win] of overlays) {
     if (win.isDestroyed() || !overlayBlanked.has(win)) continue;
     // Refresh the shared target so overlays built LATER for other displays load
     // the same fresh origin + token.
     currentBaseUrl = baseUrl;
-    currentToken = token;
-    win.loadURL(mochiPageUrl(currentBaseUrl, "pet.html", token));
+    currentToken = pageToken;
+    win.loadURL(mochiPageUrl(currentBaseUrl, "pet.html", pageToken));
   }
 }
 

--- a/website/electron/mochi/test/gatewayAuth.test.js
+++ b/website/electron/mochi/test/gatewayAuth.test.js
@@ -1,0 +1,103 @@
+/**
+ * withGatewayAuth() and gatewayToken() cannot be exercised directly — index.js
+ * requires "electron" at load time (`app`, `ipcMain`), which does not exist
+ * outside a running Electron process. The behavioural claims are pinned as
+ * source guards instead, the same pattern instanceSwitchRules.test.js uses for
+ * the rest of this module.
+ *
+ * What these guard: a credential borrowed from the main window's ALREADY
+ * -established session (see ../../mochi-session-token.js) must be delivered
+ * as a `Cookie` header, never as `?token=`. The gateway's auth middleware
+ * checks a query-delivered value against its 5-minute link-click `exp` claim,
+ * which is almost always already in the past for a borrowed session
+ * credential (its `exp` froze at the moment that session was ORIGINALLY
+ * exchanged). Delivering it as `?token=` would validate for a few minutes
+ * after app launch and then silently 401 forever — the same "pet never
+ * appears" bug this file exists to fix, just delayed rather than prevented.
+ */
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const MAIN = fs.readFileSync(path.join(__dirname, "..", "index.js"), "utf8");
+
+test("withGatewayAuth delivers a cookie-sourced credential as a Cookie header, not a query token", () => {
+  const start = MAIN.indexOf("function withGatewayAuth(");
+  assert.ok(start !== -1, "withGatewayAuth must exist");
+  const body = MAIN.slice(start, MAIN.indexOf("\n}", start));
+  assert.ok(
+    /if \(auth\.viaCookie\)/.test(body),
+    "must branch on how the credential was sourced",
+  );
+  assert.ok(
+    /headers: \{ Cookie: `mc_token_\$\{port\}=\$\{auth\.value\}` \}/.test(body),
+    "a viaCookie credential must be sent as an mc_token_<port> Cookie header",
+  );
+  // The cookie branch must return before falling into the query-append path.
+  const cookieBranch = body.indexOf("if (auth.viaCookie)");
+  const queryAppend = body.indexOf("token=${encodeURIComponent");
+  assert.ok(
+    cookieBranch !== -1 && queryAppend !== -1 && cookieBranch < queryAppend,
+    "the cookie path must be chosen before any query-token fallback runs",
+  );
+});
+
+test("every local-gateway request built from gatewayToken() routes through withGatewayAuth", () => {
+  // mochiEnabledState, mochiSettings, fetchInstances and connectInstance all
+  // consume gatewayToken()'s answer; every one of them must hand it to
+  // withGatewayAuth rather than re-inlining `?token=${encodeURIComponent(...)}`,
+  // or the cookie-sourced path silently regresses to the query-only behavior
+  // this fix removes.
+  const calls = MAIN.match(/withGatewayAuth\(/g) || [];
+  assert.ok(
+    calls.length >= 4,
+    `expected withGatewayAuth to be used by mochiEnabledState, mochiSettings, ` +
+      `fetchInstances and connectInstance (found ${calls.length} call sites)`,
+  );
+  // Anchored on BACKEND_URL specifically: remoteMochiEnabled's own
+  // `/api/apps?token=` call is a DIFFERENT, already-minted remote-instance
+  // token (never sourced from gatewayToken()) and is deliberately unchanged.
+  assert.ok(
+    !/\$\{BACKEND_URL\}\/api\/apps\?token=\$\{encodeURIComponent/.test(MAIN),
+    "mochiEnabledState must not go back to inlining a bare query token",
+  );
+  assert.ok(
+    !/\$\{BACKEND_URL\}\/api\/apps\/mochi\/settings\?token=\$\{encodeURIComponent/.test(MAIN),
+    "mochiSettings must not go back to inlining a bare query token",
+  );
+});
+
+test("gatewayToken() fails closed to an empty credential, never a fabricated one", () => {
+  const start = MAIN.indexOf("async function gatewayToken(");
+  assert.ok(start !== -1, "gatewayToken must exist");
+  const body = MAIN.slice(start, MAIN.indexOf("\n}", start));
+  assert.ok(
+    /await fetchGatewayAuth\(\)\) \|\| \{ value: "" \}/.test(body),
+    "a fetchGatewayAuth() failure (undefined/null) must fall back to an empty credential",
+  );
+});
+
+test("blank-overlay recovery separates gateway auth value from its delivery mode", () => {
+  const start = MAIN.indexOf("if (hasBlankedOverlay())");
+  const end = MAIN.indexOf("restorePanelOnEnable", start);
+  const body = MAIN.slice(start, end);
+  assert.match(body, /const auth = await gatewayToken\(\)/,
+    "self recovery resolves the gateway auth record once");
+  assert.match(body, /rearmToken = auth\.value/,
+    "recovery passes the credential string, not the auth record");
+  assert.match(body, /rearmViaCookie = auth\.viaCookie/,
+    "recovery preserves cookie delivery mode separately");
+  assert.match(body, /rearmBlankedOverlays\(mochiPetBaseUrl, rearmToken, rearmViaCookie\)/,
+    "rearm receives scalar credential arguments");
+});
+
+test("a rejected credential (401/403) is dropped so the next tick re-resolves", () => {
+  const drops = MAIN.match(/cachedGatewayAuth = \{ value: "" \};/g) || [];
+  // mochiEnabledState and mochiSettings each clear the cache on 401/403.
+  assert.ok(
+    drops.length >= 2,
+    `expected at least 2 call sites clearing cachedGatewayAuth on a rejected credential ` +
+      `(found ${drops.length})`,
+  );
+});

--- a/website/electron/mochi/test/petOverlays.test.js
+++ b/website/electron/mochi/test/petOverlays.test.js
@@ -272,11 +272,12 @@ function fakeWin() {
     destroyed: false,
     hidden: false,
     loadedUrl: null,
+    loadOptions: null,
     isDestroyed() { return this.destroyed; },
     hide() { this.hidden = true; },
     showInactive() { this.hidden = false; },
     isVisible() { return !this.hidden; },
-    loadURL(u) { this.loadedUrl = u; },
+    loadURL(u, options) { this.loadedUrl = u; this.loadOptions = options; },
     on() {},
   };
 }
@@ -314,7 +315,7 @@ test("handleOverlayNavigation hides+latches an error page and clears on a good l
   }
 });
 
-test("rearmBlankedOverlays reloads only blanked windows, with the token the host resolved", () => {
+test("rearmBlankedOverlays reloads only blanked windows with a minted query token", () => {
   const BLANK = 99312;
   const OK = 99313;
   const blanked = fakeWin();
@@ -325,10 +326,25 @@ test("rearmBlankedOverlays reloads only blanked windows, with the token the host
     _handleOverlayNavigation(blanked, 403); // latch the blanked one; healthy never errored
     rearmBlankedOverlays("http://localhost:5476", "tok123");
     assert.match(blanked.loadedUrl || "", /token=tok123/, "blanked overlay reloads with the host's token");
+    assert.equal(blanked.loadOptions, undefined, "a minted token needs no extra request headers");
     assert.equal(healthy.loadedUrl, null, "a non-blanked overlay is left untouched");
   } finally {
     _getOverlays().delete(BLANK);
     _getOverlays().delete(OK);
+  }
+});
+
+test("rearmBlankedOverlays reloads a borrowed session through the default session", () => {
+  const DID = 99315;
+  const win = fakeWin();
+  _registerOverlay(DID, win);
+  try {
+    _handleOverlayNavigation(win, 403);
+    rearmBlankedOverlays("http://localhost:5476", "borrowed-session", true);
+    assert.doesNotMatch(win.loadedUrl || "", /[?&]token=/, "a borrowed session must not be stringified into a query token");
+    assert.equal(win.loadOptions, undefined, "the BrowserWindow default session supplies the borrowed cookie");
+  } finally {
+    _getOverlays().delete(DID);
   }
 });
 
@@ -369,17 +385,21 @@ test("every showInactive reveal is guarded by the blanked latch", () => {
   assert.equal(guarded.length, reveals.length, "every showInactive reveal must be latch-guarded");
 });
 
-test("reconcile re-arms with a current-target token: remote its own, self the cached local token", () => {
-  // The host passes the token it ALREADY resolved this tick; for self it reuses
-  // the probe-maintained cached token (empty-cookie case), only when something
-  // is actually blanked — and NEVER mints here, or a persistent non-auth error
-  // would churn a fresh session token every tick.
+test("reconcile re-arms with scalar credential values and delivery mode", () => {
+  // The host passes the credential it ALREADY resolved this tick; for self it
+  // preserves the probe-maintained delivery mode (including a borrowed-cookie
+  // credential), only when something is actually blanked — and NEVER resolves
+  // repeatedly here, or a persistent non-auth error would churn session tokens.
   const callAt = idxSrc.indexOf("rearmBlankedOverlays(mochiPetBaseUrl");
-  assert.ok(callAt >= 0, "reconcile must call rearmBlankedOverlays with the resolved base url + token");
-  const region = idxSrc.slice(idxSrc.indexOf("if (hasBlankedOverlay())"), callAt + 60);
+  assert.ok(callAt >= 0, "reconcile must call rearmBlankedOverlays with resolved auth");
+  const region = idxSrc.slice(idxSrc.indexOf("if (hasBlankedOverlay())"), callAt + 90);
   assert.match(region, /hasBlankedOverlay\(\)/, "only re-arm when an overlay is actually blanked");
-  assert.match(region, /SELF_INSTANCE/, "self supplies a local token (empty-cookie case)");
-  assert.match(region, /gatewayToken\(\)/, "self reuses the probe-maintained cached token");
-  assert.ok(!region.includes('cachedGatewayToken = ""'),
-    "must NOT clear the token cache in the rearm path — probe-driven invalidation only, or a persistent non-auth error mints every tick");
+  assert.match(region, /SELF_INSTANCE/, "self resolves its gateway credential");
+  assert.match(region, /const auth = await gatewayToken\(\)/, "self obtains the gateway auth record once");
+  assert.match(region, /rearmToken = auth\.value/, "only the credential value reaches rearm");
+  assert.match(region, /rearmViaCookie = auth\.viaCookie/, "rearm retains cookie delivery mode");
+  assert.match(region, /rearmBlankedOverlays\(mochiPetBaseUrl, rearmToken, rearmViaCookie\)/,
+    "rearm receives scalar token and delivery mode, never the auth record");
+  assert.ok(!region.includes('cachedGatewayAuth = { value: "" }'),
+    "must NOT clear the credential cache in the rearm path — probe-driven invalidation only, or a persistent non-auth error mints every tick");
 });

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -151,6 +151,7 @@
       "home-dir.js",
       "local-token.js",
       "local-gateway.js",
+      "mochi-session-token.js",
       "window-state.js",
       "linux-frame.js",
       "global-hotkey.js",

--- a/website/electron/test/mochi-session-token.test.js
+++ b/website/electron/test/mochi-session-token.test.js
@@ -1,0 +1,89 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const { borrowSessionToken } = require("../mochi-session-token");
+
+describe("borrowSessionToken", () => {
+  it("returns the mc_token_<port> cookie value for the backend's port", async () => {
+    const seen = [];
+    const electronSession = {
+      cookies: {
+        get(filter) {
+          seen.push(filter);
+          return Promise.resolve([{ name: "mc_token_5476", value: "session-cookie-value" }]);
+        },
+      },
+    };
+
+    const token = await borrowSessionToken({
+      electronSession,
+      backendUrl: "http://localhost:5476",
+    });
+
+    assert.equal(token, "session-cookie-value");
+    assert.deepEqual(seen, [{ url: "http://localhost:5476", name: "mc_token_5476" }]);
+  });
+
+  it("returns empty when no session was ever established (no matching cookie)", async () => {
+    const electronSession = { cookies: { get: () => Promise.resolve([]) } };
+
+    const token = await borrowSessionToken({
+      electronSession,
+      backendUrl: "http://localhost:5476",
+    });
+
+    assert.equal(token, "");
+  });
+
+  it("fails closed when there is no session/cookie API at all", async () => {
+    assert.equal(
+      await borrowSessionToken({ electronSession: null, backendUrl: "http://localhost:5476" }),
+      "",
+    );
+    assert.equal(
+      await borrowSessionToken({ electronSession: {}, backendUrl: "http://localhost:5476" }),
+      "",
+    );
+  });
+
+  it("fails closed on an unparsable backend URL rather than throwing", async () => {
+    const electronSession = { cookies: { get: () => Promise.resolve([{ value: "x" }]) } };
+    const token = await borrowSessionToken({ electronSession, backendUrl: "not-a-url" });
+    assert.equal(token, "");
+  });
+
+  it("fails closed when the cookie store rejects", async () => {
+    const electronSession = { cookies: { get: () => Promise.reject(new Error("boom")) } };
+    const token = await borrowSessionToken({
+      electronSession,
+      backendUrl: "http://localhost:5476",
+    });
+    assert.equal(token, "");
+  });
+
+  it("never fabricates a value: a non-string cookie value resolves to empty", async () => {
+    const electronSession = {
+      cookies: { get: () => Promise.resolve([{ value: undefined }]) },
+    };
+    const token = await borrowSessionToken({
+      electronSession,
+      backendUrl: "http://localhost:5476",
+    });
+    assert.equal(token, "");
+  });
+
+  it("keys the cookie name off the backend's own port, not a hardcoded one", async () => {
+    const seen = [];
+    const electronSession = {
+      cookies: {
+        get(filter) {
+          seen.push(filter.name);
+          return Promise.resolve([{ value: "t" }]);
+        },
+      },
+    };
+    await borrowSessionToken({ electronSession, backendUrl: "http://localhost:7778" });
+    assert.deepEqual(seen, ["mc_token_7778"]);
+  });
+});


### PR DESCRIPTION
Fixes #2210.

## Problem / Motivation

Mochi's pet window never appears when the gateway and the Electron shell are reachable over loopback networking but sit on different filesystems — a WSL2 gateway under a native Windows shell, for example. The dashboard itself works normally, so the app looks connected and healthy, and the state does not self-heal: it stays dark indefinitely rather than erroring.

## Why it matters

The pet-window poller runs in the main process and mints its own gateway credential by reading `.local_secret` from the OS home directory (`local-token.js` → `home-dir.js`). In this topology that file never resolves — the gateway's home is on the other filesystem — and there is no SSH `remoteHost` to fall back to, because nothing is remote.

`mochiEnabledState()` therefore returns `"unknown"` on every poll tick, and `reconcileMochi()`'s deliberate "don't tear down a running pet over a hiccup" rule means `openPetWindow()` is never reached. That rule is correct in its intended case; it just also means "never appear" when the pet was never opened.

The dashboard window works because it authenticates once through the existing local-secret / SSH / manual-token flow and keeps a signed session cookie. The poller's plain Node `http.request` calls never see it.

## What changed

A third credential path, tried **only after** the existing local-secret and SSH-remote paths come back empty: borrow the `mc_token_<port>` session cookie the main window already established.

It is delivered as a `Cookie` header rather than `?token=`. That distinction is load-bearing: the borrowed credential's link-click `exp` claim froze at the moment its session was originally exchanged, so a query-token delivery validates for a few minutes after launch and then 401s permanently — reproducing this same bug on a delay, which is a worse failure than the one being fixed.

`initMochi`'s injected dependency changes from a bare-string `fetchLocalToken` to `fetchGatewayAuth` returning `{ value, viaCookie }`, and a `withGatewayAuth()` helper centralises the query-versus-cookie delivery choice across every request that consumes it.

This cannot bypass or weaken authentication: a window that never authenticated has no cookie to borrow, so the path yields nothing and the pet correctly stays hidden. It only ever returns a credential a real prior authentication already produced.

## Tests

- `mochi/test/gatewayAuth.test.js` — the resolution order (local secret, then SSH, then cookie), and that cookie-sourced credentials are delivered as a header rather than a query parameter.
- `test/mochi-session-token.test.js` — cookie extraction, including the empty case that must fail closed.
- Full suite: 838 Electron `node:test` cases plus the website vitest suite, all passing.
- `npx tsc -b` clean; `jscpd` reports 0 clones.

## Manual verification

Verified on a real gateway/shell split rather than a simulated one. Before: the dashboard works, no pet window exists anywhere. After, reusing the same already-authenticated profile: the launch log records `mochi instance: showing this computer's Mochi` and `target changed — rebuilding Mochi's windows`, and window enumeration finds two windows titled "Mochi" — the panel and the full-screen pet overlay canvas — with `pet.html` and `panel.html` both loading from the gateway origin.

## Screenshots

N/A — the change is in main-process credential resolution; the visible result is the existing pet window appearing where it previously did not.

