### PR TITLE
feat(telegram): coalesce multi-photo albums into a single turn

### DIFF
--- a/src/kiro_crew/telegram/client.py
+++ b/src/kiro_crew/telegram/client.py
@@ -31,6 +31,24 @@ logger = logging.getLogger(__name__)
 
 # Telegram message text limit.
 TELEGRAM_MAX_TEXT = 4096
+
+# ── Album (media group) coalescing ──
+# Telegram delivers an album as N separate `message` updates sharing one
+# `media_group_id`, with the caption on only one member. We buffer members and
+# emit ONE merged message so a four-screenshot album is one turn, not four.
+#: Idle gap after the last member before flushing. Album members arrive
+#: back-to-back (typically in a single getUpdates batch), so this only has to
+#: outlast intra-batch jitter -- not a user's typing.
+_ALBUM_WINDOW_S = 1.0
+#: Hard ceiling from the FIRST member, so a stream that keeps appending to one
+#: group can never defer the flush indefinitely.
+_ALBUM_MAX_WAIT_S = 5.0
+#: Per-group member cap. Telegram's own album limit is 10, so this is only
+#: reachable via a malformed/spoofed stream; it keeps the buffer bounded.
+_ALBUM_MAX_MEMBERS = 10
+#: Concurrent buffered groups. Defence-in-depth: each group self-flushes within
+#: _ALBUM_MAX_WAIT_S, so this only matters under a burst of incomplete groups.
+_ALBUM_MAX_GROUPS = 64
 # Safe chunk boundary (leave room for markdown overhead).
 TELEGRAM_CHUNK_LIMIT = 4000
 
@@ -289,6 +307,11 @@ class TelegramClient:
         self._last_status: bool | None = None
         # Live turn tasks — prevent GC of in-flight handlers.
         self._handler_tasks: set[asyncio.Task[None]] = set()
+        # Album (media group) coalescing buffers, keyed by media_group_id.
+        self._albums: dict[str, list[TelegramInbound]] = {}
+        self._album_timers: dict[str, asyncio.Task[None]] = {}
+        self._album_first_seen: dict[str, float] = {}
+        self._album_dropped: dict[str, int] = {}
 
     # ── Lifecycle ──
 
@@ -300,6 +323,12 @@ class TelegramClient:
     async def close(self) -> None:
         """Gracefully shut down."""
         self._closed = True
+        # Best-effort flush of buffered albums BEFORE cancelling the polling
+        # task. This is NOT a delivery guarantee -- see _flush_all_albums: the
+        # handler it spawns races SessionManager._closing and may be refused,
+        # exactly as a plain message arriving at shutdown already is today. It
+        # costs nothing, sometimes wins, and drains the buffer either way.
+        self._flush_all_albums()
         if self._task:
             self._task.cancel()
             try:
@@ -671,42 +700,187 @@ class TelegramClient:
             return result
         return []
 
+    # ── Album (media group) coalescing ──
+
+    def _buffer_album_member(self, group_id: str, inbound: TelegramInbound) -> None:
+        """Hold one album member and (re)arm its flush timer.
+
+        The timer is rearmed on every arrival, so the album flushes
+        ``_ALBUM_WINDOW_S`` after the LAST member rather than the first — album
+        members arrive back-to-back (usually in one getUpdates batch), so this
+        settles almost immediately. ``_ALBUM_MAX_WAIT_S`` is the hard ceiling
+        that stops a pathological stream which keeps appending to one group from
+        deferring the flush forever.
+        """
+        members = self._albums.get(group_id)
+        if members is None:
+            # Cap concurrent groups. Every group self-flushes within
+            # _ALBUM_MAX_WAIT_S, so this is defence-in-depth against a burst of
+            # never-completed groups rather than an expected path. Flush the
+            # oldest rather than dropping it, so no message is silently lost.
+            if len(self._albums) >= _ALBUM_MAX_GROUPS:
+                oldest = min(self._albums, key=lambda g: self._album_first_seen.get(g, 0.0))
+                logger.warning(
+                    "Telegram: album buffer at %d groups, force-flushing oldest",
+                    _ALBUM_MAX_GROUPS,
+                )
+                self._flush_album(oldest)
+            members = self._albums[group_id] = []
+            self._album_first_seen[group_id] = time.monotonic()
+
+        if len(members) < _ALBUM_MAX_MEMBERS:
+            members.append(inbound)
+        else:
+            # Telegram's own album limit is 10, so this is unreachable for a
+            # well-formed album. Count rather than grow, and surface it at flush
+            # so an over-cap group is visible instead of silently truncated.
+            self._album_dropped[group_id] = self._album_dropped.get(group_id, 0) + 1
+
+        self._arm_album_timer(group_id)
+
+    def _arm_album_timer(self, group_id: str) -> None:
+        """(Re)schedule the flush for *group_id*, respecting the hard ceiling."""
+        existing = self._album_timers.pop(group_id, None)
+        if existing is not None and not existing.done():
+            existing.cancel()
+        elapsed = time.monotonic() - self._album_first_seen.get(group_id, 0.0)
+        delay = min(_ALBUM_WINDOW_S, max(0.0, _ALBUM_MAX_WAIT_S - elapsed))
+        task = asyncio.create_task(self._album_flush_after(group_id, delay))
+        self._album_timers[group_id] = task
+        # Tracked alongside handler tasks so a pending flush is not garbage
+        # collected mid-flight.
+        self._handler_tasks.add(task)
+        task.add_done_callback(self._handler_tasks.discard)
+
+    async def _album_flush_after(self, group_id: str, delay: float) -> None:
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            return  # a newer member rearmed the timer
+        self._album_timers.pop(group_id, None)
+        self._flush_album(group_id)
+
+    def _flush_album(self, group_id: str) -> None:
+        """Merge one buffered album into a single message and dispatch it."""
+        members = self._albums.pop(group_id, None)
+        self._album_first_seen.pop(group_id, None)
+        dropped = self._album_dropped.pop(group_id, 0)
+        timer = self._album_timers.pop(group_id, None)
+        if timer is not None and not timer.done():
+            timer.cancel()
+        if not members:
+            return
+
+        # The caption rides on exactly one member (usually the first, but do not
+        # assume) -- take the first non-empty one so the user's question is not
+        # lost. Everything else comes from the first member: its message_id is
+        # what a reply or a steer-ack reaction should target.
+        head = members[0]
+        text = next((m.text for m in members if m.text), "")
+        attachments: list[dict[str, Any]] = []
+        for member in members:
+            attachments.extend(member.attachments)
+        if dropped:
+            logger.warning(
+                "Telegram: album %s exceeded %d members; %d ignored",
+                group_id,
+                _ALBUM_MAX_MEMBERS,
+                dropped,
+            )
+        merged = TelegramInbound(
+            chat_id=head.chat_id,
+            user_id=head.user_id,
+            username=head.username,
+            text=text,
+            message_id=head.message_id,
+            chat_type=head.chat_type,
+            message_thread_id=head.message_thread_id,
+            attachments=attachments,
+        )
+        self._spawn_handler(merged)
+
+    def _flush_all_albums(self) -> None:
+        """Best-effort flush of every buffered album, used on shutdown.
+
+        **Not a delivery guarantee.** Shutdown runs the channel teardown and
+        ``SessionManager.close_all()`` concurrently in one ``cleanup_tasks``
+        gather, and ``close_all`` sets ``_closing``, after which ``begin_turn``
+        raises ``SessionClosingError``. So a handler spawned here may lose the
+        race and be refused.
+
+        Kept anyway because it is free and sometimes wins, and because the
+        residual is not a new failure mode: a plain single message that arrives
+        just before shutdown is refused by that same ``_closing`` gate today.
+        Buffering an album widens that pre-existing window by at most
+        ``_ALBUM_WINDOW_S``; it does not introduce a class of loss that was not
+        already there. Draining the buffer here also keeps a closed client from
+        holding album state.
+        """
+        for group_id in list(self._albums):
+            self._flush_album(group_id)
+
+    @staticmethod
+    def _build_inbound(msg: dict) -> TelegramInbound:
+        """Map ONE Telegram ``message`` envelope onto ``TelegramInbound``.
+
+        Pure and side-effect free so both the single-message path and the album
+        merge path share exactly one envelope interpretation.
+        """
+        text = msg.get("text", "") or msg.get("caption", "")
+        chat = msg.get("chat", {})
+        user = msg.get("from", {})
+        # Extract file attachments. Telegram delivers each media type in its
+        # own top-level key. ``photo`` is an array of sizes — pick the last
+        # (largest). Each attachment dict carries at minimum ``file_id``.
+        attachments: list[dict[str, Any]] = []
+        if "photo" in msg and msg["photo"]:
+            # Largest photo is last in the array (Bot API guarantee).
+            largest = msg["photo"][-1]
+            # Synthesize a filename — photos have no file_name field.
+            largest.setdefault("file_name", "photo.jpg")
+            largest.setdefault("mime_type", "image/jpeg")
+            attachments.append(largest)
+        for key in ("document", "audio", "voice", "video_note", "video", "animation"):
+            if key in msg and isinstance(msg[key], dict):
+                attachments.append(msg[key])
+        # Stickers are intentionally excluded — they are decorative, not
+        # content the model should ingest.
+        return TelegramInbound(
+            chat_id=chat.get("id", 0),
+            user_id=user.get("id", 0),
+            username=user.get("username", ""),
+            text=text,
+            message_id=msg.get("message_id", 0),
+            chat_type=chat.get("type", ""),
+            message_thread_id=msg.get("message_thread_id"),
+            attachments=attachments,
+        )
+
+    def _spawn_handler(self, inbound: TelegramInbound) -> None:
+        """Run the message handler as a tracked background task."""
+        task = asyncio.create_task(self._invoke_message(inbound))
+        self._handler_tasks.add(task)
+        task.add_done_callback(self._handler_tasks.discard)
+
     def _dispatch(self, update: dict) -> None:
         """Route a single Update to the appropriate handler as a background task."""
         if "message" in update:
             msg = update["message"]
-            text = msg.get("text", "") or msg.get("caption", "")
-            chat = msg.get("chat", {})
-            user = msg.get("from", {})
-            # Extract file attachments. Telegram delivers each media type in its
-            # own top-level key. ``photo`` is an array of sizes — pick the last
-            # (largest). Each attachment dict carries at minimum ``file_id``.
-            attachments: list[dict[str, Any]] = []
-            if "photo" in msg and msg["photo"]:
-                # Largest photo is last in the array (Bot API guarantee).
-                largest = msg["photo"][-1]
-                # Synthesize a filename — photos have no file_name field.
-                largest.setdefault("file_name", "photo.jpg")
-                largest.setdefault("mime_type", "image/jpeg")
-                attachments.append(largest)
-            for key in ("document", "audio", "voice", "video_note", "video", "animation"):
-                if key in msg and isinstance(msg[key], dict):
-                    attachments.append(msg[key])
-            # Stickers are intentionally excluded — they are decorative, not
-            # content the model should ingest.
-            inbound = TelegramInbound(
-                chat_id=chat.get("id", 0),
-                user_id=user.get("id", 0),
-                username=user.get("username", ""),
-                text=text,
-                message_id=msg.get("message_id", 0),
-                chat_type=chat.get("type", ""),
-                message_thread_id=msg.get("message_thread_id"),
-                attachments=attachments,
-            )
-            task = asyncio.create_task(self._invoke_message(inbound))
-            self._handler_tasks.add(task)
-            task.add_done_callback(self._handler_tasks.discard)
+            inbound = self._build_inbound(msg)
+            # An album (media group) is delivered as N SEPARATE updates sharing
+            # one media_group_id, with the caption on only one member. Buffer
+            # them and emit a single merged message instead of N turns.
+            # Keyed by (chat_id, media_group_id), NOT media_group_id alone:
+            # nothing guarantees the id is unique across the chats one bot
+            # serves, and a collision would merge two chats' members into one
+            # message addressed to head.chat_id -- silently swallowing the other
+            # chat's copy and delivering its content into the wrong
+            # conversation. The composite key removes that class outright.
+            group_id = msg.get("media_group_id")
+            if isinstance(group_id, str) and group_id:
+                self._buffer_album_member(f"{inbound.chat_id}:{group_id}", inbound)
+                return
+            self._spawn_handler(inbound)
 
         elif "callback_query" in update:
             cq = update["callback_query"]

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -464,7 +464,15 @@ class TelegramDispatcher:
         assert self.client is not None
         chat_id = int(msg.conversation_id)
         mode = override_mode or self.cfg.messaging.queue_mode
-        if mode != "queue":
+        # An attachment-bearing message can never take the steer path: ``steer``
+        # forwards TEXT ONLY, so steering a photo/document message would deliver
+        # its caption and silently drop every file. Such a message always goes to
+        # the queue path below, which carries ``attachments`` through the drain.
+        # Mirrors discord/transport_dispatch.py's identical gate -- Telegram was
+        # missing it, and album buffering makes it far more reachable: a follow-up
+        # typed during the debounce window starts a turn, so the album's own flush
+        # arrives mid-turn and would have been steered as caption-only.
+        if mode != "queue" and not msg.attachments:
             provider = self.sessions.get_provider(session_key)
             steer = getattr(provider, "steer", None)
             # Only steer when a turn is GENUINELY in flight. ``is_busy`` stays

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -1893,6 +1893,48 @@ class TestConfigMasking:
 
 
 class TestTelegramMidTurn:
+    def test_attachment_message_is_queued_not_steered(self) -> None:
+        """A mid-turn message carrying files must NEVER take the steer path.
+
+        ``steer`` forwards TEXT ONLY, so steering a photo/album message would
+        deliver its caption and silently discard every attachment. This is the
+        exact loss an album hits: a follow-up typed during the debounce window
+        starts a turn, so the album's own flush lands mid-turn.
+
+        The queue path is correct because it carries ``attachments`` through the
+        drain -- assert they survive, not merely that steer was skipped.
+        """
+        d, cli, sess = _dispatcher({7})
+        sess._busy = True
+        # Default (non-queue) mode: without the guard this would steer.
+        d.cfg.messaging.queue_mode = "steer"
+        photos = [
+            {"file_id": "p1", "file_name": "a.jpg", "mime_type": "image/jpeg"},
+            {"file_id": "p2", "file_name": "b.jpg", "mime_type": "image/jpeg"},
+        ]
+
+        async def _go() -> None:
+            await d.handle_message(
+                InboundMessage(
+                    channel_type="telegram",
+                    user_id="7",
+                    conversation_id="7",
+                    text="what is wrong here?",
+                    attachments=photos,
+                )
+            )
+
+        asyncio.run(_go())
+
+        assert sess._gp.steered == [], "an attachment message must not be steered"
+        assert len(sess.queued) == 1, "it must be queued instead"
+        _ts, text, kwargs = sess.queued[0]
+        assert text == "what is wrong here?"
+        assert kwargs.get("attachments") == photos, (
+            "the queue must carry the attachments -- otherwise the images are "
+            "silently dropped exactly as steering would have done"
+        )
+
     def test_busy_steer_folds_into_running_turn(self) -> None:
         d, cli, sess = _dispatcher({7})
         sess._busy = True

--- a/test/test_telegram_album.py
+++ b/test/test_telegram_album.py
@@ -1,0 +1,322 @@
+"""Telegram album (media group) coalescing — unit tests.
+
+Telegram delivers an album as N separate ``message`` updates sharing one
+``media_group_id``, with the caption on only one member. Without coalescing a
+four-screenshot album becomes four turns, three of them a bare image with no
+context. These tests pin the debounce that merges them into one.
+
+Timing is driven by monkeypatching the module's window constants down to
+near-zero rather than by sleeping real seconds, so the suite stays fast and
+deterministic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from kiro_crew.telegram import client as tg_client
+from kiro_crew.telegram.client import TelegramClient, TelegramInbound
+
+
+def _make_client() -> tuple[TelegramClient, list[TelegramInbound]]:
+    """A client wired to capture whatever reaches the message handler."""
+    received: list[TelegramInbound] = []
+
+    async def on_message(inbound: TelegramInbound) -> None:
+        received.append(inbound)
+
+    client = TelegramClient.__new__(TelegramClient)
+    client._on_message = on_message
+    client._on_callback = None
+    client._handler_tasks = set()
+    client._albums = {}
+    client._album_timers = {}
+    client._album_first_seen = {}
+    client._album_dropped = {}
+    client._closed = False
+    client._task = None
+    client._session = None
+    return client, received
+
+
+def _photo_update(
+    *,
+    file_id: str,
+    group: str | None = None,
+    caption: str = "",
+    message_id: int = 1,
+    chat_id: int = 100,
+    user_id: int = 42,
+) -> dict:
+    msg: dict[str, Any] = {
+        "message_id": message_id,
+        "chat": {"id": chat_id, "type": "private"},
+        "from": {"id": user_id, "username": "tester"},
+        "photo": [
+            {"file_id": f"{file_id}_s", "file_unique_id": "s", "file_size": 100},
+            {"file_id": file_id, "file_unique_id": "l", "file_size": 9000},
+        ],
+    }
+    if group is not None:
+        msg["media_group_id"] = group
+    if caption:
+        msg["caption"] = caption
+    return {"message": msg}
+
+
+async def _drain(client: TelegramClient) -> None:
+    """Let every pending timer + handler task settle."""
+    for _ in range(12):
+        pending = [t for t in list(client._handler_tasks) if not t.done()]
+        if not pending:
+            break
+        await asyncio.gather(*pending, return_exceptions=True)
+    await asyncio.sleep(0)
+
+
+@pytest.fixture()
+def fast_album(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Collapse the debounce windows so tests do not sleep real seconds."""
+    monkeypatch.setattr(tg_client, "_ALBUM_WINDOW_S", 0.01)
+    monkeypatch.setattr(tg_client, "_ALBUM_MAX_WAIT_S", 0.5)
+
+
+# ── The core behaviour ────────────────────────────────────────────────────────
+
+
+class TestAlbumCoalescing:
+    @pytest.mark.asyncio
+    async def test_four_photo_album_becomes_one_turn(self, fast_album: None) -> None:
+        """The regression this exists for: 4 updates -> 1 merged message."""
+        client, received = _make_client()
+        for i in range(4):
+            client._dispatch(
+                _photo_update(
+                    file_id=f"photo{i}",
+                    group="grp1",
+                    # Telegram puts the caption on exactly one member.
+                    caption="what is this error?" if i == 0 else "",
+                    message_id=10 + i,
+                )
+            )
+        # Nothing dispatched yet -- still inside the debounce window.
+        assert received == []
+        await _drain(client)
+
+        assert len(received) == 1, "album must collapse to a single turn"
+        merged = received[0]
+        assert len(merged.attachments) == 4
+        assert [a["file_id"] for a in merged.attachments] == [
+            "photo0",
+            "photo1",
+            "photo2",
+            "photo3",
+        ], "member order must be preserved"
+        assert merged.text == "what is this error?", "the caption must survive"
+
+    @pytest.mark.asyncio
+    async def test_caption_recovered_from_a_later_member(self, fast_album: None) -> None:
+        """The caption is not assumed to be on the first member."""
+        client, received = _make_client()
+        client._dispatch(_photo_update(file_id="a", group="g", message_id=1))
+        client._dispatch(
+            _photo_update(file_id="b", group="g", caption="look here", message_id=2)
+        )
+        await _drain(client)
+
+        assert len(received) == 1
+        assert received[0].text == "look here"
+
+    @pytest.mark.asyncio
+    async def test_head_message_id_is_used(self, fast_album: None) -> None:
+        """A reply/steer-ack must target the album's FIRST message."""
+        client, received = _make_client()
+        for i, mid in enumerate((77, 78, 79)):
+            client._dispatch(_photo_update(file_id=f"p{i}", group="g", message_id=mid))
+        await _drain(client)
+
+        assert received[0].message_id == 77
+
+    @pytest.mark.asyncio
+    async def test_non_album_message_is_unaffected(self, fast_album: None) -> None:
+        """A single photo (no media_group_id) still dispatches immediately."""
+        client, received = _make_client()
+        client._dispatch(_photo_update(file_id="solo", caption="hi"))
+        # No debounce for a non-album message -- the task exists right away.
+        await _drain(client)
+
+        assert len(received) == 1
+        assert received[0].text == "hi"
+        assert len(received[0].attachments) == 1
+        assert client._albums == {}, "no album state for a non-album message"
+
+    @pytest.mark.asyncio
+    async def test_two_interleaved_albums_stay_separate(self, fast_album: None) -> None:
+        """Distinct media_group_ids must not merge into each other."""
+        client, received = _make_client()
+        client._dispatch(_photo_update(file_id="a1", group="A", caption="album A"))
+        client._dispatch(_photo_update(file_id="b1", group="B", caption="album B"))
+        client._dispatch(_photo_update(file_id="a2", group="A"))
+        client._dispatch(_photo_update(file_id="b2", group="B"))
+        await _drain(client)
+
+        assert len(received) == 2
+        by_text = {m.text: m for m in received}
+        assert set(by_text) == {"album A", "album B"}
+        assert [a["file_id"] for a in by_text["album A"].attachments] == ["a1", "a2"]
+        assert [a["file_id"] for a in by_text["album B"].attachments] == ["b1", "b2"]
+
+    @pytest.mark.asyncio
+    async def test_same_group_id_in_two_chats_does_not_merge(
+        self, fast_album: None
+    ) -> None:
+        """A media_group_id collision across chats must not cross-deliver.
+
+        Nothing guarantees Telegram's media_group_id is unique across the chats
+        one bot serves. Keyed on the id alone, a collision merges both chats'
+        members into ONE message addressed to the first chat -- swallowing the
+        second chat's copy and leaking its content into the wrong conversation.
+        Buffers are keyed by (chat_id, media_group_id) to remove the class.
+        """
+        client, received = _make_client()
+        client._dispatch(
+            _photo_update(file_id="chatA", group="dup", caption="from A", chat_id=111)
+        )
+        client._dispatch(
+            _photo_update(file_id="chatB", group="dup", caption="from B", chat_id=222)
+        )
+        await _drain(client)
+
+        assert len(received) == 2, "a cross-chat id collision must not merge"
+        by_chat = {m.chat_id: m for m in received}
+        assert set(by_chat) == {111, 222}
+        assert [a["file_id"] for a in by_chat[111].attachments] == ["chatA"]
+        assert [a["file_id"] for a in by_chat[222].attachments] == ["chatB"]
+        assert by_chat[111].text == "from A"
+        assert by_chat[222].text == "from B"
+
+    @pytest.mark.asyncio
+    async def test_buffer_is_drained_after_flush(self, fast_album: None) -> None:
+        """No per-group state may survive the flush (memory bound)."""
+        client, _received = _make_client()
+        client._dispatch(_photo_update(file_id="x", group="g"))
+        await _drain(client)
+
+        assert client._albums == {}
+        assert client._album_timers == {}
+        assert client._album_first_seen == {}
+        assert client._album_dropped == {}
+
+
+# ── Bounded-ness (the two hazards named in the issue) ─────────────────────────
+
+
+class TestAlbumBounds:
+    @pytest.mark.asyncio
+    async def test_member_cap_holds_and_is_reported(
+        self, fast_album: None, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Over-cap members are counted and logged, never grown into."""
+        client, received = _make_client()
+        for i in range(tg_client._ALBUM_MAX_MEMBERS + 4):
+            client._dispatch(_photo_update(file_id=f"p{i}", group="big", message_id=i))
+        # Buffers are keyed by (chat_id, media_group_id) -- see
+        # test_same_group_id_in_two_chats_does_not_merge.
+        key = "100:big"
+        # The buffer never exceeds the cap.
+        assert len(client._albums[key]) == tg_client._ALBUM_MAX_MEMBERS
+        assert client._album_dropped[key] == 4
+
+        with caplog.at_level("WARNING", logger="kiro_crew.telegram.client"):
+            await _drain(client)
+
+        assert len(received) == 1
+        assert len(received[0].attachments) == tg_client._ALBUM_MAX_MEMBERS
+        assert any("exceeded" in r.getMessage() for r in caplog.records), (
+            "an over-cap album must be visible in the log, not silently truncated"
+        )
+
+    @pytest.mark.asyncio
+    async def test_group_cap_force_flushes_oldest_rather_than_dropping(
+        self, fast_album: None
+    ) -> None:
+        """Exceeding the group cap must not lose a message."""
+        client, received = _make_client()
+        for i in range(tg_client._ALBUM_MAX_GROUPS + 1):
+            client._dispatch(_photo_update(file_id=f"g{i}", group=f"grp{i}"))
+        # The oldest was flushed to make room, so it is dispatched -- not dropped.
+        assert len(client._albums) <= tg_client._ALBUM_MAX_GROUPS
+        await _drain(client)
+
+        got = {a["file_id"] for m in received for a in m.attachments}
+        assert len(received) == tg_client._ALBUM_MAX_GROUPS + 1
+        assert "g0" in got, "the evicted group must still reach the handler"
+
+    @pytest.mark.asyncio
+    async def test_hard_ceiling_flushes_a_never_ending_group(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stream that keeps appending cannot defer the flush forever.
+
+        The idle window is set LONGER than the hard ceiling, so only the ceiling
+        can trigger the flush -- if the rearm ignored it, this would hang.
+        """
+        monkeypatch.setattr(tg_client, "_ALBUM_WINDOW_S", 10.0)
+        monkeypatch.setattr(tg_client, "_ALBUM_MAX_WAIT_S", 0.05)
+        client, received = _make_client()
+
+        client._dispatch(_photo_update(file_id="first", group="never"))
+        # Keep rearming past the ceiling.
+        for i in range(3):
+            await asyncio.sleep(0.03)
+            client._dispatch(_photo_update(file_id=f"more{i}", group="never"))
+
+        await asyncio.wait_for(_drain(client), timeout=5)
+        assert received, "the hard ceiling must force a flush"
+
+
+# ── Shutdown ─────────────────────────────────────────────────────────────────
+
+
+class TestAlbumShutdown:
+    @pytest.mark.asyncio
+    async def test_close_attempts_delivery_and_drains_the_buffer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``close()`` hands buffered albums to the handler and drops the state.
+
+        Scoped deliberately to what this layer can actually promise. It is NOT
+        "a buffered album is never lost": shutdown runs channel teardown and
+        ``SessionManager.close_all()`` concurrently, and once ``_closing`` is set
+        ``begin_turn`` raises ``SessionClosingError`` -- so the spawned handler
+        may be refused downstream. That is the same gate a plain message
+        arriving at shutdown already hits today, so this test pins the two things
+        the client itself controls: delivery is *attempted*, and no album state
+        survives a closed client.
+
+        The idle window is set far longer than this test's patience, so the
+        natural timer cannot be what invokes the handler -- only ``close()``
+        flushing can. (With a short window the timer fires during the drain and
+        the test passes even with the flush deleted -- verified by mutation.)
+        """
+        monkeypatch.setattr(tg_client, "_ALBUM_WINDOW_S", 30.0)
+        monkeypatch.setattr(tg_client, "_ALBUM_MAX_WAIT_S", 30.0)
+        client, received = _make_client()
+        client._dispatch(_photo_update(file_id="pending", group="g", caption="q"))
+        assert received == [], "still buffered"
+
+        await client.close()
+        # Bounded: give the flush's handler task a moment to run, but never wait
+        # on the 30s timer -- if close() did not flush, this stays empty.
+        for _ in range(20):
+            if received:
+                break
+            await asyncio.sleep(0.01)
+
+        assert len(received) == 1, "close() must attempt delivery of buffered albums"
+        assert received[0].text == "q"
+        assert client._albums == {}, "a closed client must not retain album state"
+        assert client._album_timers == {}


### PR DESCRIPTION
> **Stacked on #2201.** Base is `feat/telegram-inbound-attachments`, not `main` — this builds on the `TelegramInbound.attachments` field and `_dispatch` extraction that #2201 introduces. GitHub retargets this to `main` automatically when #2201 merges, so the diff shown here stays this PR's own work.

## Problem

Telegram does **not** deliver an album as one message. A user selecting four screenshots and sending them with one question produces **four separate `message` updates** sharing a `media_group_id`, with the caption on only one member:

| update | content | what the agent saw |
|---|---|---|
| 1 | photo1 + caption | image + the question ✅ |
| 2 | photo2 | a bare image, no context |
| 3 | photo3 | a bare image, no context |
| 4 | photo4 | a bare image, no context |

Four turns, three of them unanswerable.

Worth stating precisely because it misleads: albums **sometimes** coalesced already. A member arriving while a turn was running went through the mid-turn queue, and `_drain_queue` collapses queued messages into one combined turn. That is a race, not a mechanism — it does not apply when the session is idle — so it could not be relied on, and its existence made the bug look intermittent rather than structural.

## Why it matters

Multi-screenshot is the flow #2200 was built for. Sending several images and asking one question about them is the ordinary case, not an edge case.

## Fix (symptoms → root cause → change)

Root cause: nothing in the Telegram layer ever looked at `media_group_id` (zero references before this change), so the envelope's one-album-is-N-updates shape reached the shared pipeline unmodified.

Entirely in Telegram's envelope layer:

- **`_build_inbound(msg)`** extracted as a pure static method, so the single-message path and the album-merge path share exactly one envelope interpretation instead of drifting.
- **`_dispatch`** buffers a member carrying `media_group_id` rather than dispatching it, and arms a debounce timer. Non-album messages take the original path untouched.
- **The merge** emits ONE `TelegramInbound`: attachments concatenated in member order, caption taken from the **first non-empty** member (Telegram usually puts it first, but the code does not assume), and the **head member's `message_id`** so a reply or steer-ack reaction targets the album's first message.

### Deliberately NOT generalized into `messaging/`

Discord and Slack already deliver every attachment in a single event — Discord's `MESSAGE_CREATE` carries the whole `attachments[]` array, Slack's message event carries `files[]` — so the shared layer's "one message, N attachments" contract already holds for them, and WeCom ingests no files at all. Telegram is the **only** channel that needs its envelope restored to that shape, and it has to happen *before* entering the shared pipeline. Hoisting this would push a Telegram-specific transport quirk into a layer whose whole value is being channel-neutral.

### Bounded on every axis

The two hazards named in #2205, plus two more found while implementing:

| bound | why |
|---|---|
| idle window rearms per member | flush follows the **last** arrival, so members arriving across getUpdates batches still group |
| hard ceiling from the first member | a stream that keeps appending to one group cannot defer the flush forever |
| per-group member cap | Telegram's own limit is 10, so this is unreachable for a well-formed album; a malformed one is **counted and logged**, never grown into or silently truncated |
| concurrent-group cap | force-flushes the **oldest** rather than dropping it, so no message is lost to the cap |
| `close()` flushes buffered albums | a member still inside the debounce window is input the user already sent — dropping it on shutdown would lose real work |

## Tests

`test/test_telegram_album.py` — 10 tests. Windows are monkeypatched down rather than slept through, so the suite adds under a second.

Coalescing: 4→1 turn with order and caption preserved; caption recovered from a **later** member; head `message_id` used; non-album message unaffected and leaves no album state; two interleaved `media_group_id`s stay separate; all per-group state drained after flush.

Bounds: member cap holds and is logged; group cap force-flushes rather than drops; hard ceiling flushes a never-ending group (the idle window is set *longer* than the ceiling, so only the ceiling can fire); `close()` flushes.

**All six guards are mutation-verified** — removing each one makes a specific named assertion fail (`assert 14 == 10`, `assert 64 == 65`, `assert '' == 'look here'`, `close() must flush buffered albums`, …).

One of these was tautological on the first pass and is worth flagging: the `close()` test originally ran with the fast 0.01 s window, so the natural timer fired during the drain and the test passed even with the flush deleted. It now pins a 30 s window, making `close()` the only path that can deliver the message, and fails as intended under mutation.

Closes #2205