### PR TITLE
fix(dev-fleet): pass Windows platform env vars to build subprocesses

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -123,7 +123,7 @@ def _resolve_primary_checkout(path: str) -> str:
     git = _trusted_bin("git")
     if git is None:
         return path
-    env = {k: v for k, v in os.environ.items() if k in _SAFE_ENV_KEYS}
+    env = {k: v for k, v in os.environ.items() if _is_safe_env_key(k)}
     env["PATH"] = _TRUSTED_PATH
     try:
         out = subprocess.run(
@@ -2059,10 +2059,63 @@ def _load_cfg():
 # worktree-controlled code (pip/npm builds, pod CLI). The gateway's full
 # environment carries credentials (Slack/cloud tokens) that build scripts
 # must never be able to read.
-_SAFE_ENV_KEYS = (
+_POSIX_SAFE_ENV_KEYS = (
     "PATH", "HOME", "USER", "LOGNAME", "SHELL", "LANG", "LC_ALL", "TMPDIR",
     "XDG_RUNTIME_DIR", "DBUS_SESSION_BUS_ADDRESS",
 )
+
+# Windows counterparts of the POSIX set above, written in the spelling Microsoft
+# documents. Matching is case-folded on Windows (see :func:`_is_safe_env_key`),
+# so these do not have to be upper-cased to survive ``os.environ``.
+#
+# SystemRoot is load-bearing, not cosmetic: Winsock locates its socket catalog
+# through it, so a child without it cannot resolve names at all. libcurl's
+# threaded resolver reports that as ``getaddrinfo() thread failed to start``,
+# which is what a credential-bearing ``git fetch`` fails with here. The rest
+# keep git and the node/pip toolchains functional: git reads its global config
+# through USERPROFILE, npm and pip need APPDATA/LOCALAPPDATA plus a writable
+# TEMP, PATHEXT is required to resolve ``.exe``/``.cmd`` at all, and
+# NUMBER_OF_PROCESSORS sizes build parallelism.
+#
+# This is platform parity, not a wider boundary: USERPROFILE/APPDATA are the
+# Windows equivalents of the POSIX HOME already allowlisted above, and every
+# name here is a platform path rather than a secret. No credential-bearing
+# variable is added, so build steps still cannot read Slack/cloud tokens.
+_WINDOWS_SAFE_ENV_KEYS = (
+    "SystemRoot", "SystemDrive", "windir", "ComSpec", "PATHEXT",
+    "USERPROFILE", "HOMEDRIVE", "HOMEPATH",
+    "APPDATA", "LOCALAPPDATA", "ProgramData",
+    "ProgramFiles", "ProgramFiles(x86)", "ProgramW6432",
+    "TEMP", "TMP", "NUMBER_OF_PROCESSORS", "PROCESSOR_ARCHITECTURE",
+)
+
+_SAFE_ENV_KEYS = _POSIX_SAFE_ENV_KEYS + (
+    _WINDOWS_SAFE_ENV_KEYS if platform_compat.IS_WINDOWS else ()
+)
+_SAFE_ENV_KEYS_FOLDED = frozenset(name.upper() for name in _SAFE_ENV_KEYS)
+
+
+def _is_safe_env_key(key: str) -> bool:
+    """Whether *key* is allowlisted, honoring Windows' case-insensitive env.
+
+    On Windows, environment names are case-INSENSITIVE and CPython's
+    ``os.environ`` upper-cases every key, so ``os.environ.items()`` yields
+    ``SYSTEMROOT`` — never the ``SystemRoot`` spelling Microsoft documents and
+    that these allowlists write. A literal membership test therefore drops
+    exactly the variables the allowlist was extended to carry, and the failure
+    is silent at the boundary and only surfaces in the child as an unrelated
+    error: without ``SystemRoot`` a spawned ``git`` cannot initialize Winsock,
+    so a fetch dies with ``getaddrinfo() thread failed to start``.
+
+    Folding on Windows only, rather than upper-casing the lists, keeps POSIX
+    exact: ``PATH`` and ``Path`` are genuinely different variables there, and a
+    case-insensitive match would let a lookalike through. Mirrors
+    ``apps.registry._is_safe_env_key`` and
+    ``kiro_prerequisite._allowlisted_env``.
+    """
+    if platform_compat.IS_WINDOWS:
+        return key.upper() in _SAFE_ENV_KEYS_FOLDED
+    return key in _SAFE_ENV_KEYS
 
 
 def _build_env(*, with_credentials: bool = False) -> dict:
@@ -2103,7 +2156,7 @@ def _build_env(*, with_credentials: bool = False) -> dict:
     never coexists with credentials. Both mechanisms must keep holding; do not
     remove one on the assumption that the other covers it.
     """
-    out = {k: v for k, v in os.environ.items() if k in _SAFE_ENV_KEYS}
+    out = {k: v for k, v in os.environ.items() if _is_safe_env_key(k)}
     out["PATH"] = _TRUSTED_PATH if with_credentials else _build_path()
     out.update(_GIT_ENV_NEUTRALIZERS)
     if with_credentials and _GIT_TRUSTED_HELPERS:

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -921,6 +921,76 @@ def test_build_env_excludes_credentials(monkeypatch):
     assert mod._build_env(with_credentials=True)["PATH"] == mod._TRUSTED_PATH
 
 
+def test_is_safe_env_key_matches_documented_spelling_on_windows():
+    """A mixed-case allowlist entry must still match what ``os.environ`` yields.
+
+    The allowlists write ``SystemRoot`` (Microsoft's documented spelling) while
+    CPython's ``os.environ`` upper-cases every key on Windows. Folding is what
+    keeps the two ends agreeing; without it the filter drops exactly the
+    variables it was extended to carry.
+    """
+    assert "SystemRoot" in mod._WINDOWS_SAFE_ENV_KEYS
+    if platform_compat.IS_WINDOWS:
+        # The spelling os.environ actually yields.
+        assert mod._is_safe_env_key("SYSTEMROOT")
+        # And the documented spelling, so either end may be written.
+        assert mod._is_safe_env_key("SystemRoot")
+    assert not mod._is_safe_env_key("SLACK_BOT_TOKEN")
+
+
+def test_is_safe_env_key_stays_exact_on_posix():
+    """Folding is Windows-only — POSIX names are case-SENSITIVE.
+
+    ``PATH`` and ``Path`` are genuinely different variables there, so a
+    case-insensitive match would let a lookalike through.
+    """
+    assert mod._is_safe_env_key("PATH")
+    if not platform_compat.IS_WINDOWS:
+        assert not mod._is_safe_env_key("Path")
+        # The Windows set must not leak into POSIX matching at all.
+        assert not mod._is_safe_env_key("SystemRoot")
+
+
+def test_windows_safe_env_keys_carry_no_credentials():
+    """The Windows additions are platform paths, never secret-bearing vars."""
+    for key in mod._WINDOWS_SAFE_ENV_KEYS:
+        for marker in ("TOKEN", "SECRET", "PASSWORD", "CREDENTIAL", "APIKEY"):
+            assert marker not in key.upper(), f"{key!r} looks credential-bearing"
+
+
+def test_safe_env_keys_platform_composition():
+    """The POSIX set always applies; the Windows set only on Windows."""
+    posix = set(mod._POSIX_SAFE_ENV_KEYS)
+    windows = set(mod._WINDOWS_SAFE_ENV_KEYS)
+    active = set(mod._SAFE_ENV_KEYS)
+
+    assert not (posix & windows), "the two sets must stay disjoint"
+    assert posix <= active
+    if platform_compat.IS_WINDOWS:
+        assert windows <= active
+    else:
+        assert not (windows & active)
+
+
+@pytest.mark.skipif(
+    not platform_compat.IS_WINDOWS, reason="Windows-only env semantics"
+)
+def test_build_env_carries_systemroot_on_windows(monkeypatch):
+    """SYSTEMROOT must reach every build/fetch child.
+
+    Winsock locates its socket catalog through it, so a child without it cannot
+    resolve names at all — libcurl reports that as ``getaddrinfo() thread failed
+    to start`` and the Pull step fails before it reaches the network.
+    """
+    monkeypatch.setenv("SYSTEMROOT", r"C:\WINDOWS")
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-secret")
+
+    for env in (mod._build_env(), mod._build_env(with_credentials=True), mod._pod_env()):
+        assert env["SYSTEMROOT"] == r"C:\WINDOWS"
+        # Widening the allowlist must not have widened it to credentials.
+        assert "SLACK_BOT_TOKEN" not in env
+
+
 def test_read_pin_strict_rejects_symlinked_env(tmp_path):
     """A symlinked pin file must raise, never be read (Codex R24 #2)."""
     import kiro_crew.apps.builtins.dev_fleet.server as mod


### PR DESCRIPTION
## Problem

On Windows, Dev Fleet's **Pull + Build** fails at the very first step with what looks like a network or DNS fault:

```
fatal: unable to access 'https://github.com/kirodotdev/KiroCrew.git/': getaddrinfo() thread failed to start
```

It is neither. The failure is deterministic, entirely local, and reproduces on every attempt while the same `git fetch` from a terminal succeeds.

`_build_env()` filters the gateway environment through `_SAFE_ENV_KEYS`, which lists POSIX names only:

```python
_SAFE_ENV_KEYS = (
    "PATH", "HOME", "USER", "LOGNAME", "SHELL", "LANG", "LC_ALL", "TMPDIR",
    "XDG_RUNTIME_DIR", "DBUS_SESSION_BUS_ADDRESS",
)
```

None of those except `PATH` exist on Windows, so **every Dev Fleet subprocess there is spawned with exactly one environment variable**.

## Why it matters

Pull + Build is the primary way a Windows user syncs and rebuilds, and it is unusable — the first step dies before it reaches the network. The error text actively misleads: it points at DNS or connectivity, so the natural response is to investigate the network, a proxy, or (as happened here) an unrelated process leak. Nothing in the message suggests a dropped environment variable.

## Fix (symptom → root cause → change)

Losing `SystemRoot` is the load-bearing failure: Winsock locates its socket catalog through it, so the child cannot resolve names at all, and libcurl's threaded resolver surfaces that as the message above — before the request reaches the network.

The same gap breaks the steps that follow the fetch: git reads its global config through `USERPROFILE`, npm and pip need `APPDATA`/`LOCALAPPDATA` plus a writable `TEMP`, and `PATHEXT` is required to resolve `.exe`/`.cmd` at all. Fixing only `SystemRoot` would move the failure one step later rather than remove it.

Two changes:

1. **`_WINDOWS_SAFE_ENV_KEYS`** — 18 platform variables, applied **only** on Windows, leaving POSIX behaviour byte-for-byte unchanged.
2. **`_is_safe_env_key()`** — both filter sites now route through a helper that **case-folds on Windows and stays exact on POSIX**, instead of a literal membership test.

That second part is what makes the allowlist safe to extend. `os.environ` upper-cases every key on Windows, so an exact test against the documented `"SystemRoot"` spelling silently drops the variable it was added to carry — the same trap this PR is fixing. Folding on Windows only keeps POSIX strict, where `PATH` and `Path` are genuinely different variables and a case-insensitive match would let a lookalike through.

The helper deliberately mirrors `apps.registry._is_safe_env_key` and `kiro_prerequisite._allowlisted_env`, which already solve this for their own allowlists, so all three share one convention rather than three. Hoisting them onto a single shared filter is tracked separately in #2220 — it is a cross-cutting refactor and would have delayed this fix.

## Why this does not widen the security boundary

The allowlist exists to keep credentials (Slack / cloud tokens) out of subprocesses that execute worktree-controlled code. This change preserves that:

- Every name added is a **platform path**, not a secret.
- `USERPROFILE` / `APPDATA` are the Windows equivalents of the POSIX `HOME` the allowlist **already** passes — parity, not a new capability.
- No credential-bearing variable is added, and a test asserts none of the added names contain `TOKEN` / `SECRET` / `PASSWORD` / `CREDENTIAL` / `APIKEY`.
- The credential tier still gates on `with_credentials`, and `_TRUSTED_PATH` pinning is untouched.
- Case-folding is scoped to Windows, so it cannot loosen matching on POSIX.

## Manual verification

Three-way controlled comparison against the real `_build_env(with_credentials=True)`, running the Pull step's own fetch:

| environment | result |
|---|---|
| current allowlist (no `SystemRoot`) | `rc=128` — `getaddrinfo() thread failed to start` |
| current allowlist **+ `SystemRoot`** | `rc=0` |
| full inherited environment | `rc=0` |
| **fixed `_build_env(with_credentials=True)`** | `rc=0` |

Isolating single variables confirmed `SystemRoot` is the one Winsock needs — adding `windir` or `SystemDrive` alone still fails. Re-run after the folding refactor: still `rc=0`, with `_is_safe_env_key` matching both `"SYSTEMROOT"` and `"SystemRoot"` and rejecting `SLACK_BOT_TOKEN`.

Local gates: 8 tests pass in `test_dev_fleet_app.py` covering this surface, `isort` and `flake8` clean, `mypy` reports nothing on the changed file. (`mypy` run locally on Windows reports 157 pre-existing errors for POSIX-only stubs — `fcntl`, `resource`, `os.fork`, `signal.SIGKILL` — across 35 untouched files; CI runs `backend-lint` on `ubuntu-latest`, where those resolve.)

## Tests

- `test_is_safe_env_key_matches_documented_spelling_on_windows` — the folding contract: the allowlist may be written in either spelling and still match what `os.environ` yields.
- `test_is_safe_env_key_stays_exact_on_posix` — folding is Windows-only; `Path` must not match `PATH`, and the Windows set must not leak into POSIX matching.
- `test_windows_safe_env_keys_carry_no_credentials` — no secret-bearing names.
- `test_safe_env_keys_platform_composition` — POSIX set always applies, Windows set only on Windows, sets stay disjoint.
- `test_build_env_carries_systemroot_on_windows` — `SystemRoot` reaches all three env tiers (`_build_env()`, `_build_env(with_credentials=True)`, `_pod_env()`) while a token does not.

## Screenshots

N/A — no user-visible UI change. The diff touches one backend module and its test.
