### PR TITLE
test: make restore yield assertion deterministic

### DIFF
--- a/test/test_open_slots_persistence.py
+++ b/test/test_open_slots_persistence.py
@@ -723,9 +723,9 @@ def test_reseed_skips_unicode_digit_key_without_crashing(tmp_path, monkeypatch):
 def test_restore_open_slots_async_yields_between_tabs(tmp_path, monkeypatch):
     """The async restore must hand the loop back per tab so the heartbeat can run.
 
-    Pins the actual crash mechanism: a coroutine running concurrently with the
-    restore has to get scheduled. If restore ever goes back to blocking straight
-    through, the ticker records no ticks and this fails.
+    Pins the actual crash mechanism: a queued observer coroutine must run while
+    restoration is active. If restore ever goes back to blocking straight
+    through, the observer never runs and this fails.
     """
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
     state = _make_state(tmp_path / "sessions")
@@ -736,35 +736,24 @@ def test_restore_open_slots_async_yields_between_tabs(tmp_path, monkeypatch):
     )
 
     state2 = _make_state(tmp_path / "sessions")
-    ticks = 0
 
     async def _drive():
-        stop = False
+        observer_ran = asyncio.Event()
 
-        async def ticker():
-            nonlocal ticks
-            while not stop:
-                ticks += 1
-                await asyncio.sleep(0)
+        async def observer():
+            observer_ran.set()
 
-        t = asyncio.create_task(ticker())
-        await asyncio.sleep(0)  # let the ticker reach its first await
+        observer_task = asyncio.create_task(observer())
         restored = await restore_open_slots_async(state2)
-        stop = True
-        t.cancel()
-        # `cancel()` only requests cancellation; without awaiting it the ticker is
-        # still live when `asyncio.run` tears the loop down, leaving a "coroutine
-        # ignored GeneratorExit" for a later test to trip over.
-        try:
-            await t
-        except asyncio.CancelledError:
-            pass
-        return restored
+        # Awaiting the task below would schedule it even if restore had starved
+        # the loop, so capture the observation before that cleanup point.
+        ran_during_restore = observer_ran.is_set()
+        await observer_task
+        return restored, ran_during_restore
 
-    restored = asyncio.run(_drive())
+    restored, ran_during_restore = asyncio.run(_drive())
     assert restored == 6
-    # One yield per tab at minimum; the ticker interleaves on each.
-    assert ticks >= 6, f"restore starved the loop (ticks={ticks})"
+    assert ran_during_restore, "restore starved the loop"
 
 
 def test_restore_reads_transcript_before_backfilling_tab_id(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem / Motivation

`test_restore_open_slots_async_yields_between_tabs` asserted an exact minimum
number of scheduler ticks. Windows CI can validly schedule the companion task
one fewer time, which made the test flaky despite `restore_open_slots_async`
still yielding to the event loop.

## Why it matters

The test protects the event-loop handoff that lets the heartbeat run during
open-slot restoration. A host-dependent tick count creates false CI failures
and obscures regressions in that watchdog safety behavior.

## What changed (motivation -> approach -> change)

The symptom was a host-specific scheduler count, while the behavior under test
is whether another coroutine runs before restoration returns. The test now
queues a one-shot observer before restoring slots and captures whether it ran
before cleanup can schedule it. This directly proves the required handoff
without depending on incidental event-loop interleavings.

## Tests

- Updated `test_restore_open_slots_async_yields_between_tabs` to use the
  one-shot observer assertion.
- `.venv/bin/python -m pytest test/test_open_slots_persistence.py -n0 -q`
  (47 passed).
- `isort`, `flake8`, scoped Python 3.14 `black`, and `git diff --check` pass
  for the changed file.
- A mutation check confirmed the focused test fails when the production
  `await asyncio.sleep(0)` is removed.

The broader local gates are not clean in this checkout for unrelated, unchanged
baseline failures: backend integration cases outside this file, macOS `xattr`
mypy stubs in `hooks.py`, and the existing website unit-literal threshold. CI
will run the repository matrix for this test-only change.

## Manual verification

N/A — unit coverage is sufficient because this change only makes an existing
unit test deterministic.

## Screenshots / video

N/A — test-only change with no user-visible UI impact.

## Related Issues

Fixes #1718

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Targeted existing tests pass and the revised test covers the regression
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation unchanged because product behavior is unchanged
- [x] No secrets, credentials, or internal references in the diff
