### PR TITLE
fix: stop two tests leaking state outside their own sandbox

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/conftest.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/conftest.py
@@ -25,13 +25,31 @@ any repository's config, and mirrors what several tests in this directory alread
 (``test_suite_scope.py``, ``test_dogfood_learnings.py``). ``autouse`` + ``session`` scope so a
 test that shells out to git cannot forget it. Deliberately NOT a real address, so a commit
 that escaped a temporary directory would be obvious in a log.
+
+## Why the data home is redirected here
+
+``store.data_dir()`` resolves to the OPERATOR's live app directory, so a test that writes
+``store.config_path()`` without redirecting it replaces the repository the app is configured
+against. ``write_json_atomic`` REPLACES the document rather than merging, so the live
+``target_url``/``target_display`` are dropped and ``clone`` is left naming a pytest temporary
+directory that is reaped when the session ends. The app's page then renders with no repository,
+and calibration refuses because the configured clone no longer exists.
+
+Nothing in the suite fails when that happens — the damage lands outside the assertions — so the
+redirect is ``autouse``: a per-file opt-in fixture only protects the files that remember to ask
+for it. Several files here already define their own ``data_home`` fixture; those still work,
+because a function-scoped ``monkeypatch.setattr`` on the same attribute simply wins over this
+one.
 """
 
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
+
+from ..backend import store
 
 #: Git reads these before falling back to config files or the system account, so they make the
 #: identity explicit and hermetic on every host.
@@ -54,3 +72,36 @@ def _git_identity_for_production_commit_paths() -> None:
     """
     for key, value in _GIT_IDENTITY.items():
         os.environ.setdefault(key, value)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_app_data_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the app's data root and clone scratch at this test's temp directory.
+
+    Only ``data_dir`` is redirected, not ``workspace_dir``: every other path in
+    :mod:`..backend.store` derives from it, so one seam covers config, the per-repo
+    subtree, sessions and logs. Files that additionally want ``workspace_dir ==
+    data_dir`` (so flat fixture paths and the per-repo layout coincide) keep pinning
+    it themselves.
+
+    ``AUTO_IMPROVEMENT_SCRATCH`` moves clones out of ``~/.autoimprove-scratch`` for the
+    same reason: a test that clones into the real scratch root leaves a tree the app
+    then refuses to reuse, because setup compares the requested URL against the
+    push-neutralized origin the app itself wrote.
+
+    ``KIROCREW_HOME`` is the outer fence, and it is the one that matters most. Patching
+    ``data_dir`` only redirects callers that go through :mod:`..backend.store`, while
+    ``do_not_pollute_paths`` reaches the operator's home directly through
+    ``config.loader.config_dir()`` — and that resolver is not a read: on the default
+    path it migrates a legacy home, writes a recovery breadcrumb outside ``~/.kiro/``,
+    and sweeps archive leftovers. Pointing the variable at a temp directory redirects
+    every reader of the home, including the ones no fixture knows about.
+    """
+    data = tmp_path / "app-data-home"
+    data.mkdir(parents=True, exist_ok=True)
+    home = tmp_path / "kirocrew-home"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("KIROCREW_HOME", str(home))
+    monkeypatch.setattr(store, "data_dir", lambda: data)
+    monkeypatch.setenv("AUTO_IMPROVEMENT_SCRATCH", str(tmp_path / "app-scratch"))
+    return data

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_data_home_isolation.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_data_home_isolation.py
@@ -1,0 +1,70 @@
+"""The app's tests must never write to the operator's live data home.
+
+A leak here is silent: the assertions of the test that leaks still pass, and the damage
+shows up later as an app configured against a reaped temporary directory. These tests fail
+if the autouse redirect in ``conftest.py`` is removed or stops covering a path, which is the
+only signal the suite can give for damage that lands outside its own assertions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..backend import store
+
+
+class TestTheDataHomeIsRedirected:
+    """Every store path a test can reach must resolve inside the test's temp dir."""
+
+    def test_the_data_root_is_the_tests_temp_dir(self, tmp_path: Path) -> None:
+        assert store.data_dir().is_relative_to(tmp_path), (
+            f"store.data_dir() resolved to {store.data_dir()}, outside {tmp_path} — "
+            "the autouse redirect in conftest is not in effect"
+        )
+
+    def test_the_config_path_is_the_tests_temp_dir(self, tmp_path: Path) -> None:
+        # config.json is the file that actually got clobbered: it names the repository the
+        # app is turned loose on, so a stray write retargets the operator's app.
+        assert store.config_path().is_relative_to(tmp_path)
+
+    def test_the_clone_scratch_root_is_the_tests_temp_dir(self, tmp_path: Path) -> None:
+        # Clones are large and, once created, the app refuses to reuse them under a
+        # different requested URL — so a leaked clone is not merely litter.
+        assert store.scratch_dir().is_relative_to(tmp_path)
+
+    def test_the_config_home_resolver_is_the_tests_temp_dir(self, tmp_path: Path) -> None:
+        # The strongest of these: `config_dir()` is reached by code that never touches
+        # `store` (`do_not_pollute_paths` is one), and on the default path it MUTATES the
+        # operator's home — legacy migration, a recovery breadcrumb written outside
+        # `~/.kiro/`, and a sweep that deletes archive leftovers. Redirecting `data_dir`
+        # alone leaves that path pointed at the real home.
+        from kiro_crew.config.loader import config_dir
+
+        assert Path(config_dir()).is_relative_to(tmp_path)
+
+
+class TestAProductionConfigWriteStaysInTheTempDir:
+    """The exact shape that leaked: a test writing config through the production helper."""
+
+    def test_write_json_atomic_to_config_path_lands_in_the_temp_dir(
+        self, tmp_path: Path
+    ) -> None:
+        target = store.config_path()
+        # Checked BEFORE writing, deliberately. A test that verifies isolation must not
+        # depend on isolation to be harmless: asserting after the write would clobber the
+        # operator's config on the very run where the redirect is broken — the failure it
+        # exists to report.
+        assert target.is_relative_to(tmp_path), (
+            f"refusing to write {target}: outside {tmp_path}, so the redirect is broken"
+        )
+        store.write_json_atomic(target, {"clone": str(tmp_path / "clone"), "branch": "work"})
+        assert target.is_file()
+        assert (store.read_json(target, {}) or {}).get("branch") == "work"
+
+    def test_the_redirect_is_per_test_so_writes_do_not_accumulate(
+        self, tmp_path: Path
+    ) -> None:
+        # A fresh temp root per test is what keeps one test's config from being read as
+        # another's fixture state; a session-scoped redirect would still isolate the
+        # operator but let tests see each other's writes.
+        assert not store.config_path().exists()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4015,6 +4015,13 @@ class TestDoctorEmbeddings:
     def _hermetic_config(self, monkeypatch):
         """Pin config to a pristine default (see ``_pin_default_config``)."""
         _pin_default_config(monkeypatch)
+        # LLAMA_CPP_LIB_PATH selects between two mutually exclusive diagnoses: name the
+        # missing bundled libs, or blame the operator's override directory. Which branch a
+        # test exercises is therefore part of its scenario, not an ambient property of the
+        # host — and the variable is easy to inherit, because the real loader sets it to its
+        # own bundled libs dir the first time embeddings load. Cleared per test; the tests
+        # that exercise the override branch set it themselves.
+        monkeypatch.delenv("LLAMA_CPP_LIB_PATH", raising=False)
 
     @staticmethod
     def _run_doctor(tmp_path, monkeypatch, *, runtime_ok: bool, model_present: bool, platform_supported: bool = True, missing_libs: dict | None = None, loader_setdefaults: str = ""):
@@ -4030,7 +4037,12 @@ class TestDoctorEmbeddings:
 
         def _load():
             if loader_setdefaults:
-                os.environ.setdefault("LLAMA_CPP_LIB_PATH", loader_setdefaults)
+                # Through monkeypatch, not a bare os.environ write: the real loader's
+                # setdefault is a process-wide mutation, and reproducing it literally leaked
+                # the variable into every later test in the same worker, flipping them onto
+                # the override branch depending on distribution order.
+                if "LLAMA_CPP_LIB_PATH" not in os.environ:
+                    monkeypatch.setenv("LLAMA_CPP_LIB_PATH", loader_setdefaults)
             return object if runtime_ok else None
 
         monkeypatch.setattr(doc, "_load_llama_class", _load)


### PR DESCRIPTION
## 1. What is the problem?

Two tests mutate state they do not own. Both are silent: nothing in the suite fails,
and the damage lands on something else later.

**(a) The Auto-Improvement tests overwrite the operator's live app config.**
`store.data_dir()` resolves to the real `apps/auto-improvement/data/` directory, and
several tests write `store.config_path()` without redirecting it —
`test_dogfood_learnings.py` does it three times:

```python
store.write_json_atomic(
    store.config_path(),                       # the operator's live config
    {"clone": str(clone), "branch": branch, "origin_url": str(upstream)},
)
```

`write_json_atomic` **replaces** the document rather than merging, so after a full test
run the live config reads:

```json
{
  "clone": "/tmp/pytest-of-<user>/pytest-1392/popen-gw13/test_a_rollback_restores_the_b0/clone",
  "branch": "work",
  "origin_url": "/tmp/pytest-of-<user>/.../upstream.git"
}
```

`target_url` and `target_display` are gone, and `clone` names a pytest temp directory
that is reaped when the session ends. The only autouse fixture in that directory sets a
git identity; nothing redirects the data home. Clones are exposed the same way —
`scratch_dir()` defaults to `~/.autoimprove-scratch` unless `AUTO_IMPROVEMENT_SCRATCH`
is set.

**(b) `TestDoctorEmbeddings` leaks `LLAMA_CPP_LIB_PATH` into the worker process.**
`_run_doctor`'s stub reproduced the loader's side effect with a bare `os.environ` write:

```python
os.environ.setdefault("LLAMA_CPP_LIB_PATH", loader_setdefaults)
```

`monkeypatch` never sees it, so it is never undone. That variable selects between two
**mutually exclusive** diagnoses — name the missing bundled libs, or blame the
operator's override directory — so once it is set,
`test_doctor_names_the_missing_native_libs` takes the override branch and its assertion
can no longer hold. The same test also failed outright on any host whose shell exports
the variable, because it never established the absence of the variable as part of its
own scenario. This is the currently-red `Backend Tests` shard, and it is red on `main`
too ([31259141604](https://github.com/kirodotdev/KiroCrew/actions/runs/31259141604),
[31258930563](https://github.com/kirodotdev/KiroCrew/actions/runs/31258930563)).

## 2. Why this issue matters to the user

**(a)** makes the app unusable on any machine that runs the suite, and it fails in a way
that gives the operator nothing to act on:

- The page renders with **no repository configured** — the input is an empty
  placeholder, and the base-branch picker shows the test's `work` branch.
- The workspace key moves from `<owner>_<repo>__main` to `default__work__…`, so the
  ruler, findings ledger and PR queue all appear empty. That data is intact, just
  addressed under a different key.
- `POST /calibrate` refuses, correctly: `refusing to calibrate: could not check out work
  (fatal: cannot change to '/tmp/pytest-of-.../clone': No such file or directory) — the
  ruler would be proven against the wrong revision`

Reconfiguring by hand does not hold — the next test run clobbers it again. Three
separate pytest sessions were observed overwriting the same live config within one hour.

**(b)** costs every contributor CI time on a red shard that has nothing to do with their
change, and it is worse than a plain flake: because it depends on both ambient
environment and shard distribution, re-running sometimes "fixes" it, which trains people
to retry instead of reading it.

## 3. How our fix solves it

Both are fixed by removing the out-of-sandbox write, not by relaxing an assertion. No
production code changes; no assertion was edited.

**(a) An autouse fixture in the app's `tests/conftest.py`** redirects `store.data_dir`
to the test's own `tmp_path` and points `AUTO_IMPROVEMENT_SCRATCH` at a temp scratch
root.

- `data_dir` is the right seam: every other path in `backend/store.py` derives from it,
  so one redirect covers config, the per-repo subtree, sessions and logs. No module
  binds it by value — every caller goes through the `store` attribute — so
  `monkeypatch.setattr` reaches all of them.
- **Autouse**, not opt-in: a per-file fixture only protects files that remember to ask,
  and this failure is silent, so remembering is exactly what cannot be relied on. Files
  that already define their own `data_home` fixture keep working, because a
  function-scoped `monkeypatch.setattr` on the same attribute wins.
- `workspace_dir` is deliberately left alone, so files that pin `workspace_dir ==
  data_dir` for path convenience keep that behaviour.
- **`KIROCREW_HOME` is the outer fence, and it is the load-bearing one.** Patching
  `data_dir` only redirects callers that go through `backend/store.py`, while
  `do_not_pollute_paths()` reaches the home directly via `config.loader.config_dir()`
  — and that resolver is not a read. On the default path it runs
  `_maybe_migrate_legacy_home()`, writes a recovery breadcrumb outside `~/.kiro/`, and
  calls `_sweep_ungated_archive_leftovers()`, which deletes. Pointing the variable at a
  temp directory redirects every reader of the home, including ones no fixture knows
  about.

**A guard test file** (`test_data_home_isolation.py`) pins the property, because a
pure-isolation fix changes no output — no existing assertion can fail if it regresses.
Its write-path test checks the destination **before** writing: a test that verifies
isolation must not depend on isolation to be harmless, or it clobbers the operator's
config on exactly the run where the redirect is broken. That was found by
mutation-testing the guard.

**(b) Two changes, each covering a different failure path.** The class's autouse fixture
now clears `LLAMA_CPP_LIB_PATH`, making the variable's state part of each scenario
rather than a property of the host — the tests that exercise the override branch set it
themselves. And the loader stub writes through `monkeypatch.setenv` instead of
`os.environ`, so the simulated side effect is undone and cannot reach later tests in the
worker.

## 4. What tests we did

**(a) Before/after proof.** The same previously-leaking test, the same seeded
`KIROCREW_HOME`, run in both trees:

| Tree | Test result | Seeded config afterwards |
|---|---|---|
| `main` (no fix) | pass | **clobbered** with `pytest-1497/.../clone` |
| this branch | pass | **intact** |

The test passes in both columns. That is the point — the suite has no signal for this
damage, which is why the guard tests exist.

**(a) Mutation-verified guard.** Flipping the fixture to `autouse=False` fails all five
guard tests; restoring it passes all five. Re-verified after hardening the write path,
confirming the mutation run no longer writes outside `tmp_path`.

**(b) Mutation matrix.** Each half of the fix carries a distinct failure mode:

| Scenario | Original | Fixed | delenv removed | `setenv` reverted |
|---|---|---|---|---|
| names test alone, var **unset** | pass | pass | — | — |
| setdefault test → names test, var unset | **fail** | pass | — | **fail** |
| names test alone, var **set** | **fail** | pass | **fail** | — |

**(a) Mutation matrix for the home fence.** With the process-level `KIROCREW_HOME`
pointed at a throwaway directory (so the mutation cannot touch a real home):

| Fixture state | Guard tests |
|---|---|
| fence present | 6 passed |
| `setenv("KIROCREW_HOME", ...)` removed | **1 failed** (the config-home guard), 5 passed |
| restored | 6 passed |

The original code passes only in the first row, which is why this survived: it needs a
clean ambient environment *and* a distribution order that separates the two tests.

**Gates**

| Gate | Result |
|---|---|
| `auto_improvement` tests | 871 passed, 2 skipped |
| `test/test_cli.py` | 244 passed, 2 skipped |
| isort | clean |
| flake8 | clean |
| mypy 1.14.1 (the `pyproject.toml` pin) | no issues in 847 files |

Stated plainly: the **full** local backend suite was not run to completion. An earlier
attempt reached 99% with zero failures and then stopped advancing while this host was
saturated by a concurrent build (load average above 100), and the host is still loaded.
CI's `Backend Tests` shards are the arbiter.

## 5. Any other suggestions on the work

One thing reviewers should know, found while reading the Coverage Gate log: CI's
`BACKEND_DESELECTS` excludes `test_dogfood_learnings.py` — the file holding the three
leaking writes — so defect (a) was **structurally invisible to CI**. It only ever
damaged developers running the suite locally, which is why it survived. The new
`test_data_home_isolation.py` is *not* deselected, so from here CI does police the
property even though it still never runs the test that was leaking.

Two adjacent defects in the Auto-Improvement app were found while diagnosing this, and
are deliberately **not** in this PR:

1. **`POST /setup-clone` cannot recover a repo it already cloned.** It compares the
   requested URL against the existing clone's origin, which the app itself set to the
   `DISABLED_NO_PUSH` sentinel, and refuses: `Existing clone at … has origin
   'DISABLED_NO_PUSH', which does not match the requested 'git@github.com:…' — refusing
   to reuse it.` Once config is lost, the only supported recovery is deleting the clone.
   The guard is right to distrust a mismatched origin; it should recognise its own
   sentinel.
2. **The calibration floor never reaches the band.** `backend/runner.py` reads
   `getattr(profile.calibration, "noise_floor", 0.0)` while the dataclass field is
   `floor`, so a configured `noiseFloorSeconds` silently becomes `0.0` and the band is
   bare 2σ. The only test covering that path uses a fake with a `noise_floor` attribute
   the real class does not have, so the wrong name reads as correct.

A third, larger question for separate discussion: `measure_canary` returns `ok=False`
whenever `benchmarkCommand` is set, so an attributable metric and a calibrated ruler are
currently mutually exclusive.

