### PR TITLE
fix(telemetry): record canonical session sources in usage rows

### DIFF
--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -371,7 +371,7 @@ Each row (`_build_token_record`) carries:
 | `credits` | float | kiro-cli per-turn credit spend (float-coerced) |
 | `turns` | int | provider `num_turns` |
 | `duration_ms` | int | provider-reported turn duration (`0` on ACP) |
-| `surface` | str | **(#647)** dispatch origin — `dashboard`, `cron`, `subagent`, `monitor`, `heartbeat`, `webhook`, `task_runner`, `workflow`; `""` if unset |
+| `surface` | str | **(#647, #1551)** canonical dispatch/session source. Dashboard-backed turns derive the source from the effective session key through `telemetry_channel_of` (so linked Slack/Telegram sessions retain their transport); Task Runner writes `taskrunner`; other writers use their dispatch origin (`cron`, `subagent`, `monitor`, `heartbeat`, `webhook`, `workflow`, …). `""` if unset |
 | `agent` | str | **(#647)** agent id resolved for the turn; `""` if unset |
 | `context_used` | int | **(#647)** context-window tokens occupied after the turn (int-coerced) |
 | `context_window` | int | **(#647)** served context-window size in tokens (int-coerced) |
@@ -390,10 +390,11 @@ are read from the provider at the persist call site via
 `acp/session_provider.py`) behind `getattr` guards and returns `(0, 0)` on any
 missing accessor or exception — so non-ACP providers and test doubles record
 zeros and the analytics helper never breaks the turn it measures. `surface`
-lets background turn-dispatch surfaces (cron/subagent/monitor/heartbeat/webhook/
-task_runner/workflow) attribute their spend; zero-token surfaces (cron
-`script=`/`command=` modes, heartbeat maintenance ticks) never call a model and
-must not write a row.
+lets channel-backed turns and background dispatch surfaces (cron/subagent/
+monitor/heartbeat/webhook/taskrunner/workflow) retain their canonical source;
+`context_occupancy` normalizes the historical `task_runner` spelling to
+`taskrunner` when rows are read. Zero-token surfaces (cron `script=`/`command=`
+modes, heartbeat maintenance ticks) never call a model and must not write a row.
 
 **Per-turn injection breakdown (`ctx_blocks` / `phase`).** `ctx_blocks` is
 produced by `context_blocks.split_blocks(prompt, user_chars=…)`, which attributes
@@ -521,13 +522,15 @@ from fields the row store already carries — no new instrumentation:
 | `conversations` | EVERY session in the window (not a top-N), each with its `category`, the unollapsed `channel` beneath it, peak occupancy, span, per-turn growth rate, and a projected turns-to-compaction. Named `conversations` for payload compatibility; the entity is a session |
 | `by_category` | same shape as `by_model`, keyed by `usage.session_category(slot)` — the taxonomy the panel groups by: `bg` for an unattended session (cron, heartbeat, task runner), otherwise the transport (`dashboard`, `telegram`, `slack`, …) |
 
-**Channel comes from the slot key, not from `surface`.** `surface` cannot
-separate transports: `chat_runner` stamps `surface="dashboard"` for every turn
-that flows through it regardless of where the message arrived from, so a
-Telegram turn is booked as dashboard spend (observable in the row store as a
-`telegram_*` slot carrying `surface="dashboard"`). The slot key is assigned by
-the transport that created the session and is therefore the only field that
-distinguishes them.
+**Channel comes from the slot key, not from `surface`.** New writes now derive
+`surface` from the effective session identity, but historical rows may contain a
+wrong, non-empty value (for example a Telegram turn stamped `dashboard`). The
+row format has no schema version or writer/trust marker that distinguishes those
+legacy values from corrected writes. Cost/category attribution therefore keeps
+the slot key authoritative; preferring a non-empty `surface` would silently
+misattribute existing history. The stored slot/session key remains stable across
+the write-side correction and is still the compatibility boundary for this
+reader.
 
 **A conversation's `title` is attached by the endpoint, from two sources in
 order.** `cost_breakdown` names nothing — slot keys are all the row store holds.
@@ -562,10 +565,14 @@ two or three points.
 Tests: `test/test_usage.py` (`TestReadContextTokens`,
 `TestBuildTokenRecordContextFields`, `TestBuildTokenRecordCtxBlocks`,
 `TestPersistTokenRecord*`), `test/metrics/test_context_occupancy.py`
-(aggregation, skips, latest-turn wins), `test/metrics/test_cost_breakdown.py`
+(aggregation, skips, latest-turn wins, historical Task Runner spelling),
+`test/metrics/test_cost_breakdown.py`
 (channel attribution incl. the bare dashboard slot form, no-truncation,
 prior-window deltas, band bucketing, post-compaction slope, growth
-withholding, non-finite rejection) and `test/metrics/test_telemetry_titles.py`
+withholding, non-finite rejection), `test/test_dashboard_chat.py` (effective
+session source at the dashboard write site),
+`test/test_turn_duration_task_runner.py` (canonical Task Runner writes), and
+`test/metrics/test_telemetry_titles.py`
 (title redaction + cache purity, and the closed-conversation fallback: the
 canonical transcript key, live-wins-over-persisted, one read per shared
 transcript, and no title where the metadata line names none), plus the

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -150,7 +150,7 @@ from kiro_crew.llm_helpers import (
     transient_retry_delay,
 )
 from kiro_crew.messaging.identity import publish_turn_identity
-from kiro_crew.messaging.link import SLACK_NAMESPACE
+from kiro_crew.messaging.link import SLACK_NAMESPACE, telemetry_channel_of
 from kiro_crew.messaging.renderer import chunk_text
 from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.platform import redact_via_context
@@ -4946,7 +4946,10 @@ async def _run_chat(
                         _record_model,
                         event,
                         provider=_provider_name,
-                        surface="dashboard",
+                        # The row stays keyed by its dashboard slot for title and
+                        # navigation joins; source follows the session the turn
+                        # actually ran on, including linked channel sessions.
+                        surface=telemetry_channel_of(session_key),
                         # Resolved agent, not the slot alias: resolve_agent_bindings
                         # maps e.g. "default" to "kirocrew" before dispatch, so the
                         # alias would credit an agent that never ran.

--- a/src/kiro_crew/dashboard/handlers/usage.py
+++ b/src/kiro_crew/dashboard/handlers/usage.py
@@ -312,6 +312,18 @@ _BACKGROUND_CHANNELS = frozenset(
 NAVIGABLE_CATEGORY = "dashboard"
 
 
+_LEGACY_TELEMETRY_SURFACES = {"task_runner": "taskrunner"}
+
+
+def _canonical_telemetry_surface(surface: str) -> str:
+    """Return the operational telemetry spelling used for new and stored rows.
+
+    The alias keeps historical token shards comparable with current writes;
+    artifact use-case labels are a separate schema and are not normalized here.
+    """
+    return _LEGACY_TELEMETRY_SURFACES.get(surface, surface)
+
+
 def is_session_slot(slot: str) -> bool:
     """Whether *slot* is a session in its own right, and so earns a row."""
     return bool(slot) and telemetry_channel_of(slot) not in _NON_SESSION_CHANNELS
@@ -446,7 +458,9 @@ def context_occupancy(days: int = 14) -> dict[str, Any]:
                                 "window": window,
                                 "agent": str(obj.get("agent") or ""),
                                 "model": str(obj.get("model") or ""),
-                                "surface": str(obj.get("surface") or ""),
+                                "surface": _canonical_telemetry_surface(
+                                    str(obj.get("surface") or "")
+                                ),
                             }
                         )
         except (OSError, UnicodeDecodeError):
@@ -589,10 +603,11 @@ def cost_breakdown(days: int = SPEND_WINDOW_DAYS) -> dict[str, Any]:
       model switch, which on real data moved the bill far more than usage volume
       did, and a single-user store is small enough to render complete.
     * ``channel`` is derived from the session key, NOT read from the row's
-      ``surface`` field. Each persist site passes a hardcoded surface, so every
-      turn routed through the dashboard chat runner is stamped ``dashboard``
-      whatever transport the human used -- the field cannot separate a Telegram
-      turn from a browser one, and the key can.
+      ``surface`` field. Historical rows can carry a wrong but non-empty value
+      such as ``dashboard`` for a Telegram turn, and the token-row schema has no
+      version or writer marker that distinguishes them from trustworthy rows.
+      The key therefore remains authoritative until the store gains such a
+      boundary; a surface-first fallback would silently misattribute history.
     * Context bands are absolute token counts rather than occupancy ratios:
       spend tracks how many tokens get re-sent, and window sizes differ per
       model, so a ratio would average incomparable populations.

--- a/src/kiro_crew/task_executor.py
+++ b/src/kiro_crew/task_executor.py
@@ -18,6 +18,7 @@ from kiro_crew.config.loader import KiroCrewConfig
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY, fire_tool_hooks, get_global_hook_store
 from kiro_crew.llm_helpers import provider_last_turn_usage, stream_and_collect_json
+from kiro_crew.messaging.link import telemetry_channel_of
 from kiro_crew.providers.base import (
     EVENT_COMPLETE,
     EVENT_PERMISSION_REQUEST,
@@ -551,7 +552,7 @@ async def execute_task(
                     "",
                     _complete_event,
                     provider=_usage_cfg.agent.provider,
-                    surface="task_runner",
+                    surface=telemetry_channel_of(session_key),
                     agent=read_effective_agent(client) or agent or "",
                     context_used=_used,
                     context_window=_window,
@@ -559,7 +560,7 @@ async def execute_task(
                     model_source=client,
                 )
             except Exception:
-                logger.debug("usage row (task_runner) persist failed", exc_info=True)
+                logger.debug("usage row (taskrunner) persist failed", exc_info=True)
 
         except AcpProcessDied:
             recoveries += 1
@@ -887,7 +888,7 @@ async def self_review(
                 "",
                 provider_last_turn_usage(client),
                 provider=_rv_cfg.agent.provider,
-                surface="task_runner",
+                surface=telemetry_channel_of(review_key),
                 agent=read_effective_agent(client) or agent or "",
                 context_used=_used,
                 context_window=_window,

--- a/test/metrics/test_context_occupancy.py
+++ b/test/metrics/test_context_occupancy.py
@@ -188,3 +188,16 @@ class TestContextOccupancyLatestWins:
         # ...while the peak still remembers how close the session got.
         assert s["peak_pct"] == 90.0
         assert s["turns"] == 2
+
+    @pytest.mark.parametrize("stored_surface", ["task_runner", "taskrunner"])
+    def test_taskrunner_surface_uses_canonical_spelling(
+        self, _isolated_shards, stored_surface
+    ):
+        _write(
+            _isolated_shards,
+            [_row("taskrunner:run:task0", 500_000, surface=stored_surface)],
+        )
+
+        session = usage_mod.context_occupancy(14)["sessions"][0]
+
+        assert session["surface"] == "taskrunner"

--- a/test/metrics/test_cost_breakdown.py
+++ b/test/metrics/test_cost_breakdown.py
@@ -61,11 +61,11 @@ class TestChannelAttribution:
         for key in ("chat-1-2", "telegram_9", "subagent:a", "_hb", "junk"):
             assert telemetry_channel_of(key) in TELEMETRY_CHANNELS
 
-    def test_telegram_spend_is_not_booked_as_dashboard(self, store):
-        """Both rows carry surface="dashboard" -- only the key can separate them.
+    def test_historical_wrong_surface_telegram_is_not_booked_as_dashboard(self, store):
+        """Both historical rows say dashboard; only the key can separate them.
 
-        Every persist site passes a hardcoded surface, so the chat runner stamps
-        "dashboard" whatever transport the human used.
+        The row schema has no writer marker, so a non-empty surface does not prove
+        that the row came from a corrected write site.
         """
         store([
             _row(slot="chat-1-1700000000", credits=10.0, surface="dashboard"),
@@ -229,6 +229,8 @@ class TestConversations:
         assert json.dumps(d).lower().count("subagent") == 0
 
     def test_an_unrecognised_surface_stays_visible_instead_of_becoming_bg(self, store):
+        # A known, non-empty row surface is deliberately not authoritative: old
+        # rows have no trust marker and can carry the same kind of wrong value.
         # The whole point of deciding `bg` by DENYLIST is that a surface nobody
         # taught the classifier about shows up under its own category, where it
         # can be noticed and fixed. `telemetry_channel_of` answers `other` for a
@@ -239,7 +241,11 @@ class TestConversations:
         store([
             _row(slot="chat-1-1", credits=1.0),
             _row(slot="cron:default:nightly", credits=2.0),
-            _row(slot="some-surface-nobody-taught-us-about", credits=3.0),
+            _row(
+                slot="some-surface-nobody-taught-us-about",
+                credits=3.0,
+                surface="telegram",
+            ),
         ])
         rows = {r["slot"]: r for r in usage_mod.cost_breakdown(7)["conversations"]}
         assert rows["cron:default:nightly"]["category"] == "bg"

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -3752,6 +3752,95 @@ class TestTokenPersistenceBackfill:
         assert slot.model == "claude-opus-4.6"
 
 
+class TestTokenUsageSurface:
+    """Usage rows record the slot's effective session source."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("slot_key", "linked_session_key", "expected"),
+        [
+            ("named-dashboard-tab", "", "dashboard"),
+            ("slack-tab", "slack:1234567890.123456", "slack"),
+            ("telegram-tab", "telegram:123:456", "telegram"),
+        ],
+    )
+    async def test_completion_uses_effective_session_identity(
+        self,
+        tmp_path,
+        monkeypatch,
+        slot_key,
+        linked_session_key,
+        expected,
+    ):
+        from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+        complete = LLMEvent(
+            kind=EVENT_COMPLETE,
+            usage=TurnUsage(input_tokens=1, output_tokens=1, duration_ms=25),
+        )
+        state = TestTokenPersistenceBackfill._make_state_for_run_chat(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot(slot_key)
+        slot._titled = True
+        slot.linked_session_key = linked_session_key
+        client = TestTokenPersistenceBackfill._make_mock_client(
+            [LLMEvent(kind=EVENT_TEXT_CHUNK, text="ok"), complete]
+        )
+        client.context_used_tokens = MagicMock(return_value=10)
+        client.context_window_tokens = MagicMock(return_value=100)
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+
+        persist = AsyncMock()
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner.persist_token_record_async", persist
+        )
+
+        from kiro_crew.dashboard.chat import _run_chat
+
+        await _run_chat(state, slot, "hello")
+
+        assert persist.await_args.args[0] == slot_key
+        assert persist.await_args.kwargs["surface"] == expected
+
+    @pytest.mark.asyncio
+    async def test_completion_keeps_source_of_session_that_ran(self, tmp_path, monkeypatch):
+        """A mid-turn rebind must not move the completed turn's attribution."""
+        from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+        complete = LLMEvent(
+            kind=EVENT_COMPLETE,
+            usage=TurnUsage(input_tokens=1, output_tokens=1, duration_ms=25),
+        )
+        state = TestTokenPersistenceBackfill._make_state_for_run_chat(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("channel-tab")
+        slot._titled = True
+        slot.linked_session_key = "slack:1234567890.123456"
+        client = TestTokenPersistenceBackfill._make_mock_client([])
+        client.context_used_tokens = MagicMock(return_value=10)
+        client.context_window_tokens = MagicMock(return_value=100)
+
+        async def _stream(_message):
+            # _run_chat has already selected the Slack session for this turn.
+            slot.linked_session_key = "telegram:123:456"
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="ok")
+            yield complete
+
+        client.stream = _stream
+        client.stream_command = _stream
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+
+        persist = AsyncMock()
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner.persist_token_record_async", persist
+        )
+
+        from kiro_crew.dashboard.chat import _run_chat
+
+        await _run_chat(state, slot, "hello")
+
+        assert persist.await_args.args[0] == slot.key
+        assert persist.await_args.kwargs["surface"] == "slack"
+
+
 class TestKiroBackfillProfileGuard:
     """Regression tests for the kiro/acp backfill must NOT store a
     resolved Bedrock inference-profile id into slot.model.

--- a/test/test_turn_duration_task_runner.py
+++ b/test/test_turn_duration_task_runner.py
@@ -1,4 +1,4 @@
-"""Turn wall-clock accounting for the task_runner dispatch surface (issue #647).
+"""Turn wall-clock accounting for the taskrunner dispatch surface (issue #647).
 
 ``task_executor`` persists a per-turn usage row at two sites — the main
 execution turn in :func:`execute_task` and the separate model turn in
@@ -115,7 +115,7 @@ async def _run_execute_task(monkeypatch: pytest.MonkeyPatch, provider_ms: int) -
         None,  # test_cmd
         "",  # work_dir
         AsyncMock(),  # on_notify (unused on the happy path)
-        "task-test:task1",
+        "taskrunner:task-test:task1",
     )
     assert ok is True
     assert len(captured) == 1, "execute_task must persist exactly one row per turn"
@@ -144,7 +144,9 @@ async def _run_self_review(monkeypatch: pytest.MonkeyPatch, provider_ms: int) ->
     sessions.release = MagicMock()
     sessions.reset = AsyncMock()
 
-    ok = await task_executor.self_review(run, task, sessions, "agentX", "task-test:task1")
+    ok = await task_executor.self_review(
+        run, task, sessions, "agentX", "taskrunner:task-test:task1"
+    )
     assert ok is True
     assert len(captured) == 1, "self_review must persist exactly one row per turn"
     return captured[0]
@@ -154,7 +156,7 @@ async def _run_self_review(monkeypatch: pytest.MonkeyPatch, provider_ms: int) ->
 async def test_execute_task_records_local_wall_clock(monkeypatch: pytest.MonkeyPatch) -> None:
     # Provider silent (the acp reality) -> the row's duration is the local clock.
     record = await _run_execute_task(monkeypatch, provider_ms=0)
-    assert record["surface"] == "task_runner"
+    assert record["surface"] == "taskrunner"
     assert isinstance(record["duration_ms"], int)
     assert record["duration_ms"] >= 1, "execute_task turn must record a non-zero local duration"
 
@@ -170,7 +172,7 @@ async def test_execute_task_provider_duration_wins(monkeypatch: pytest.MonkeyPat
 @pytest.mark.asyncio
 async def test_self_review_records_local_wall_clock(monkeypatch: pytest.MonkeyPatch) -> None:
     record = await _run_self_review(monkeypatch, provider_ms=0)
-    assert record["surface"] == "task_runner"
+    assert record["surface"] == "taskrunner"
     assert isinstance(record["duration_ms"], int)
     assert record["duration_ms"] >= 1, "self_review turn must record a non-zero local duration"
 


### PR DESCRIPTION
## Problem

Usage rows written by dashboard-backed channel sessions persisted `surface=dashboard` even when the turn actually executed on another transport such as Slack or Telegram. That corrupted the persisted source for new non-dashboard conversations.

Task Runner also persisted `task_runner`, while the canonical telemetry session taxonomy uses `taskrunner`.

## Change

- Derive the persisted source from the turn's **captured execution session identity**, rather than mutable slot state at completion, so a mid-turn channel rebind cannot reattribute an already-running turn.
- Preserve the existing persisted dashboard slot key for title, navigation, and historical joins.
- Classify Task Runner execution and self-review rows through the bounded telemetry classifier, producing canonical `taskrunner`.
- Normalize historical `task_runner` to `taskrunner` at the read boundary.
- Add regression coverage for dashboard, linked Slack/Telegram sessions, mid-turn rebinding, both Task Runner write paths, and historical compatibility.
- Update the metrics system spec with the write-side and compatibility boundaries.

## Compatibility boundary

This fixes source attribution for new writes.

Historical rows can already contain a wrong but non-empty `surface`, and the existing row format has no schema version or writer/trust marker that distinguishes those legacy values from newly trustworthy ones.

Therefore this PR deliberately does **not** make persisted `surface` authoritative retroactively for spend/category attribution. The existing slot-key compatibility path remains authoritative there.

The turn-metric `infer_use_case()` taxonomy is also unchanged.

## Validation

- Telemetry / usage / dashboard / Task Runner targeted suites: 579 passed, 1 skipped
- Surface attribution regressions, including mid-turn rebind: 4 passed with `RuntimeWarning` promoted to error
- isort passed
- flake8 passed
- mypy Linux target passed across 849 source files
- docs lint passed across 189 Markdown files
- brand gate passed
- `git diff --check` passed

## Related issues

Refs #1551

Related #1743: fixes only the `task_runner` / `taskrunner` spelling split; broader taxonomy consolidation remains out of scope.