### PR TITLE
feat(telegram): add /model picker, /yolo, and a Bot API command menu

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -282,8 +282,15 @@ are also accepted for muscle-memory parity with Telegram, which uses `/` only.
 
 The prefix is recognized only when the original text is not itself a command,
 and the payload after it is **turn content, never a command**: `/queue /new`
-queues the literal text `/new`. A bare `/steer` or `/queue` with no body is
-treated as an ordinary message.
+queues the literal text `/new`.
+
+A bare `/steer` or `/queue` carrying no message body matches neither the command
+parser nor the override parser. **Telegram** answers it with the directive's
+usage, because the alternative is handing the literal string `/queue` to the
+model, which then answers it as chat text — indistinguishable, to the user, from
+the feature not existing. **Discord** still treats the bare token as an ordinary
+message; the two channels therefore diverge on this one case until the guard is
+ported.
 
 ### Hard cancel: `/stop`
 

--- a/src/kiro_crew/docs/telegram-integration.md
+++ b/src/kiro_crew/docs/telegram-integration.md
@@ -54,13 +54,34 @@ log.
 
 ## Commands
 
+The bot publishes this list through `setMyCommands` at startup, so typing `/`
+in Telegram offers them as autocomplete — `COMMAND_SPEC` in
+`telegram/commands.py` is the single source behind both that menu and `/help`.
+
 - `/new` (or `/start`) — start a fresh conversation
 - `/compact` — free up room when the context fills
+- `/model` — pick the model from an inline-button list. Button-only on purpose:
+  the choices are what this account's backend actually advertised, so there is
+  no model name to guess and no typo to reject mid-conversation. The pick is
+  applied to the running session in place when one is idle, and is remembered
+  for the conversation's later sessions (it outlives `/new`, and is held in
+  memory, so a gateway restart returns to the configured default).
+- `/yolo [on|off|renew]` — report or change the auto-approve grant. This is the
+  SAME process-wide grant the dashboard toggle and Slack's `/kirocrew yolo`
+  drive, so it expires on one clock everywhere. It does not weaken the
+  PreToolUse gate: sensitive-path, governance-ceiling and deny-list blocks still
+  refuse a tool.
+- `/link` / `/unlink` — mirror this conversation's dashboard tab here, or stop
+- `/stop` (or `/cancel`) — stop the current reply and clear the queue
 - `/steer <msg>` — while a reply is generating, fold this message into it
   (overrides `queue_mode` for this message)
 - `/queue <msg>` — while a reply is generating, hold this message and answer
   it after the current turn (overrides `queue_mode` for this message)
 - `/help` — list the commands
+
+`/steer` and `/queue` are absent from the `/` menu because the Telegram client
+SENDS a menu entry the moment it is tapped, and both need a message body to act
+on — a menu row for them would only ever produce the usage hint.
 
 ## Settings & reference
 

--- a/src/kiro_crew/safety_override.py
+++ b/src/kiro_crew/safety_override.py
@@ -927,3 +927,37 @@ def grant_declared_yolo() -> ActivationResult:
         "the declared grant falls back to the ad-hoc duration"
     )
     return so.activate(SafetyOverride._DECLARED_SOURCE)
+
+
+# ── User-facing grant-lifetime text (channel-neutral) ──
+
+NO_EXPIRY_TEXT = "stays on until Kiro Crew restarts"
+
+
+def fmt_grant_duration(secs: int) -> str:
+    """Render an ad-hoc TTL for a user-facing message (e.g. "6h", "30min")."""
+    if secs % 3600 == 0:
+        return f"{secs // 3600}h"
+    return f"{secs // 60}min"
+
+
+def describe_grant_lifetime() -> str:
+    """Describe the LIVE grant's lifetime truthfully.
+
+    A grant can have no timed expiry at all, in which case ``remaining_secs()``
+    is -1. Claiming such a grant "auto-expires" would tell the operator the
+    skip-every-approval mode disarms itself when it never does.
+    """
+    so = safety_override()
+    if not so.is_active():
+        return "off"
+    if so.is_permanent:
+        return NO_EXPIRY_TEXT
+    return f"{max(0, so.remaining_secs()) // 60}min remaining"
+
+
+def describe_new_grant(result_ttl: int) -> str:
+    """Describe the lifetime of a grant that was just created."""
+    if result_ttl <= 0:
+        return NO_EXPIRY_TEXT
+    return f"auto-expires in {fmt_grant_duration(result_ttl)}"

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -89,6 +89,8 @@ from kiro_crew.providers.base import (
 from kiro_crew.safety_override import (
     SafetyOverride,
     apply_config_duration,
+    describe_grant_lifetime,
+    describe_new_grant,
     grant_declared_yolo,
     safety_override,
 )
@@ -506,38 +508,6 @@ _trusted_sessions: set[str] = set()
 # (agent.yolo_duration, default 6h) — a per-surface TTL made the behavior
 # unpredictable without buying security. Read the live value, never this.
 _YOLO_TTL_SECS = SafetyOverride._ADHOC_TTL_DEFAULT
-
-
-def _fmt_duration(secs: int) -> str:
-    """Render an ad-hoc TTL for a user-facing message (e.g. "6h", "30min")."""
-    if secs % 3600 == 0:
-        return f"{secs // 3600}h"
-    return f"{secs // 60}min"
-
-
-_NO_EXPIRY_TEXT = "stays on until Kiro Crew restarts"
-
-
-def describe_grant_lifetime() -> str:
-    """Describe the LIVE grant's lifetime truthfully.
-
-    A grant can have no timed expiry at all, in which case ``remaining_secs()``
-    is -1. Claiming such a grant "auto-expires" would tell the operator the
-    skip-every-approval mode disarms itself when it never does.
-    """
-    so = safety_override()
-    if not so.is_active():
-        return "off"
-    if so.is_permanent:
-        return _NO_EXPIRY_TEXT
-    return f"{max(0, so.remaining_secs()) // 60}min remaining"
-
-
-def describe_new_grant(result_ttl: int) -> str:
-    """Describe the lifetime of a grant that was just created."""
-    if result_ttl <= 0:
-        return _NO_EXPIRY_TEXT
-    return f"auto-expires in {_fmt_duration(result_ttl)}"
 
 
 # Allowed user IDs for Slack access (set by gateway at startup).

--- a/src/kiro_crew/telegram/client.py
+++ b/src/kiro_crew/telegram/client.py
@@ -572,6 +572,18 @@ class TelegramClient:
                 f"Telegram file download transport error ({type(exc).__name__})"
             ) from None
 
+    async def set_my_commands(self, commands: list[dict[str, str]]) -> bool:
+        """Publish the bot's ``/`` autocomplete menu (``setMyCommands``).
+
+        Telegram REPLACES the whole default-scope menu on each call, so the full
+        list must be sent every time — that is also what retires a command the
+        bot no longer serves. An empty list is refused rather than sent, because
+        Telegram would read it as "this bot has no commands" and wipe the menu.
+        """
+        if not commands:
+            return False
+        return bool(await self._api("setMyCommands", {"commands": commands}))
+
     # ── Polling loop ──
 
     async def _call_raw(self, method: str, params: dict, timeout: int = 15) -> Any:

--- a/src/kiro_crew/telegram/commands.py
+++ b/src/kiro_crew/telegram/commands.py
@@ -3,6 +3,8 @@
 Commands:
   /new         — start a fresh session (advances the generation counter)
   /compact     — trigger context compaction
+  /model       — pick the model from an inline-button list
+  /yolo        — auto-approve every tool for a bounded window
   /link        — mirror this conversation's dashboard tab back here
   /unlink      — stop mirroring
   /stop        — stop the current reply and clear the queue (alias: /cancel)
@@ -13,12 +15,17 @@ override the global ``messaging.queue_mode`` for that one message):
   /queue <msg> — hold this message and answer it after the current turn
   /steer <msg> — fold this message into the running turn right now
 
+``COMMAND_SPEC`` is the single source of truth behind both the ``/help`` card
+and the Bot API ``/`` menu, so the two cannot drift apart.
+
 Per-conversation generation + awaiting-compact state lives in the shared
 ``messaging.conversation.ConversationState`` (re-exported here so existing
 callers importing it from this module keep working).
 """
 
 from __future__ import annotations
+
+import re
 
 from kiro_crew.messaging.conversation import ConversationState  # noqa: F401
 
@@ -30,10 +37,15 @@ _HELP_ALIASES = frozenset(("/help",))
 _LINK_ALIASES = frozenset(("/link",))
 _UNLINK_ALIASES = frozenset(("/unlink",))
 _STOP_ALIASES = frozenset(("/stop", "/cancel"))
+# ``/models`` (plural) is a typo-safe alias, not a separate command: without it
+# the message falls through to the model as ordinary chat text, which reads as
+# "the feature isn't installed" rather than "you typed it wrong".
+_MODEL_ALIASES = frozenset(("/model", "/models"))
+_YOLO_ALIASES = frozenset(("/yolo",))
 
 
 def parse_command(text: str) -> str | None:
-    """Return 'new', 'compact', 'link', 'unlink', 'help', 'stop', or None."""
+    """Return the command name for *text*, or None when it is not a command."""
     stripped = text.strip()
     # Telegram commands always start with /
     cmd = stripped.split()[0].lower() if stripped.startswith("/") else ""
@@ -45,11 +57,21 @@ def parse_command(text: str) -> str | None:
         return "link"
     if cmd in _UNLINK_ALIASES:
         return "unlink"
+    if cmd in _MODEL_ALIASES:
+        return "model"
+    if cmd in _YOLO_ALIASES:
+        return "yolo"
     if cmd in _HELP_ALIASES:
         return "help"
     if cmd in _STOP_ALIASES:
         return "stop"
     return None
+
+
+def parse_command_argument(text: str) -> str:
+    """Return the text following a command token (``""`` when there is none)."""
+    parts = text.strip().split(None, 1)
+    return parts[1].strip() if len(parts) == 2 else ""
 
 
 _QUEUE_ALIASES = frozenset(("/queue",))
@@ -75,3 +97,76 @@ def parse_mid_turn_override(text: str) -> tuple[str | None, str]:
     if cmd in _STEER_ALIASES:
         return "steer", rest
     return None, text
+
+
+def is_bare_mid_turn_override(text: str) -> bool:
+    """True for a lone ``/queue`` / ``/steer`` carrying no message body.
+
+    Those two are prefixes, not standalone commands, so the bare token matches
+    neither :func:`parse_command` nor :func:`parse_mid_turn_override` and would
+    otherwise reach the model as ordinary chat text — the user sees an answer to
+    the literal string "/queue" instead of being told they left the message off.
+    """
+    parts = text.strip().split()
+    return len(parts) == 1 and parts[0].lower() in (_QUEUE_ALIASES | _STEER_ALIASES)
+
+
+# ── Command catalogue (help card + Bot API menu) ──
+
+#: Ordered ``(command, description)`` rows rendered by BOTH ``/help`` and the
+#: Bot API ``/`` menu. Names carry no leading slash because ``setMyCommands``
+#: rejects one. ``/queue`` and ``/steer`` are deliberately absent: the Telegram
+#: client SENDS a menu entry on tap, and a bare ``/queue`` has no message body
+#: to act on, so listing them would put a dead entry in the menu — they stay
+#: documented in the help card's footer instead.
+COMMAND_SPEC: tuple[tuple[str, str], ...] = (
+    ("new", "Start a fresh conversation"),
+    ("compact", "Compress the context when it gets long"),
+    ("model", "Choose the model from a list"),
+    ("yolo", "Auto-approve every tool for a while (on / off / renew)"),
+    ("link", "Mirror this conversation's dashboard tab here"),
+    ("unlink", "Stop mirroring the dashboard tab"),
+    ("stop", "Stop the current reply and clear the queue"),
+    ("help", "Show the command list"),
+)
+
+# Bot API limits on a setMyCommands entry.
+_BOT_COMMAND_RE = re.compile(r"^[a-z0-9_]{1,32}$")
+_BOT_COMMAND_DESC_LIMIT = 256
+_BOT_COMMAND_MAX = 100
+
+
+def bot_command_payload() -> list[dict[str, str]]:
+    """``COMMAND_SPEC`` shaped as a Bot API ``setMyCommands`` array.
+
+    Rows that violate the Bot API's own constraints (name ``[a-z0-9_]{1,32}``,
+    non-empty description) are skipped rather than sent: Telegram rejects the
+    WHOLE array on a single bad row, so one malformed entry would otherwise cost
+    the user the entire menu.
+    """
+    rows: list[dict[str, str]] = []
+    for name, desc in COMMAND_SPEC:
+        if not _BOT_COMMAND_RE.match(name) or not desc:
+            continue
+        rows.append({"command": name, "description": desc[:_BOT_COMMAND_DESC_LIMIT]})
+        if len(rows) >= _BOT_COMMAND_MAX:
+            break
+    return rows
+
+
+_HELP_HEADER = "🦞 Kiro Crew — Telegram"
+_HELP_FOOTER = (
+    "While a reply is running, prefix a message to control it:\n"
+    "/queue <msg> — answer it after the current turn\n"
+    "/steer <msg> — fold it into the running turn now\n"
+    "\n"
+    "Just send a message to chat. Replies stream in real-time."
+)
+
+
+def build_help_text() -> str:
+    """Render the ``/help`` card from :data:`COMMAND_SPEC`."""
+    lines = [_HELP_HEADER, "", "Commands:"]
+    lines += [f"/{name} — {desc}" for name, desc in COMMAND_SPEC]
+    lines += ["", _HELP_FOOTER]
+    return "\n".join(lines)

--- a/src/kiro_crew/telegram/gateway.py
+++ b/src/kiro_crew/telegram/gateway.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 from kiro_crew.messaging.driver import APPROVAL_AUTO, APPROVAL_INTERACTIVE
 from kiro_crew.telegram.client import TelegramAuthError, TelegramClient
+from kiro_crew.telegram.commands import bot_command_payload
 from kiro_crew.telegram.transport import TelegramTransport
 from kiro_crew.telegram.transport_dispatch import TelegramDispatcher
 
@@ -110,6 +111,16 @@ async def maybe_start_telegram(orch: "GatewayOrchestrator") -> "TelegramClient |
         except Exception as exc:
             startup_error = f"Telegram unreachable at startup ({type(exc).__name__})"
             logger.warning("%s — starting polling anyway (will retry).", startup_error)
+
+        if token_ok:
+            # Publish the "/" autocomplete menu so the commands are discoverable
+            # in the Telegram client instead of only via /help. Best-effort and
+            # gated on a proven token: a failure here costs autocomplete, never
+            # the channel, and an unreachable Telegram would fail anyway.
+            try:
+                await client.set_my_commands(bot_command_payload())
+            except Exception:
+                logger.warning("Telegram: setMyCommands failed", exc_info=True)
 
         await transport.connect()  # starts the long-polling loop
         assert client is not None  # constructed above; narrows the Optional for mypy

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -4,7 +4,7 @@
 hands the ``InboundMessage`` to :meth:`TelegramDispatcher.handle_message`,
 which mirrors the Slack transport dispatch:
 
-    command intercept (/new, /compact, /help)
+    command intercept (/new, /compact, /model, /yolo, /help)
     -> construct TelegramRenderer + on_turn_start (immediate ack placeholder)
     -> session acquire -> context build
     -> TurnDriver.run(provider, renderer)   # shared redaction + approval ladder
@@ -12,8 +12,9 @@ which mirrors the Slack transport dispatch:
     -> renderer.close() + session release   # in finally
 
 ``on_callback`` resolves interactive tool approvals (``a:<rid>:<1|0>`` ->
-``TelegramApprovalDecider.resolve_global``) and re-injects ``[OPTIONS:]``
-choices (``opt:<i>``) as fresh turns.
+``TelegramApprovalDecider.resolve_global``), applies ``/model`` picks
+(``m:<index>``) and re-injects ``[OPTIONS:]`` choices (``opt:<i>``) as fresh
+turns.
 
 Dependency direction is ``telegram -> messaging`` (allowed). The security
 ``tool_gate`` and spawn auto-approve are wired inline off ``ctx_builder.hooks``
@@ -46,12 +47,16 @@ from kiro_crew.messaging.link import (
     seed_generation,
 )
 from kiro_crew.messaging.transport import InboundMessage
+from kiro_crew.safety_override import describe_grant_lifetime, safety_override
 from kiro_crew.security import redact, redact_local_paths
 from kiro_crew.sel import sel
 from kiro_crew.telegram.attachments import process_telegram_attachments
 from kiro_crew.telegram.commands import (
     ConversationState,
+    build_help_text,
+    is_bare_mid_turn_override,
     parse_command,
+    parse_command_argument,
     parse_mid_turn_override,
 )
 from kiro_crew.telegram.renderer import TelegramApprovalDecider, TelegramRenderer
@@ -87,23 +92,7 @@ _MAX_COLLAPSE = 50
 # losing the second album entirely. Mirrors discord/transport_dispatch.py.
 _MAX_COLLAPSED_ATTACHMENTS = IngestLimits().max_attachments
 
-_HELP_TEXT = """\
-🦞 Kiro Crew — Telegram
-
-Commands:
-/new — Start a fresh conversation
-/compact — Compress context (when it gets long)
-/link — Mirror this conversation's dashboard tab here
-/unlink — Stop mirroring
-/stop — Stop the current reply and clear the queue
-/help — Show this message
-
-While a reply is running, prefix a message to control it:
-/queue <msg> — answer it after the current turn
-/steer <msg> — fold it into the running turn now
-
-Just send a message to chat. Replies stream in real-time.
-"""
+_HELP_TEXT = build_help_text()
 
 
 def _short(text: str, limit: int = 40) -> str:
@@ -187,6 +176,29 @@ class _QueueReceipt:
     texts: list[str]
 
 
+# How long a /model picker stays pressable, and how many pickers are retained.
+# Both are bounds on unbounded growth (one entry per press-less /model), not UX
+# knobs: an expired or evicted picker answers "reopen /model" rather than acting
+# on a stale list.
+_MODEL_PICKER_TTL_SECS = 300.0
+_MODEL_PICKER_MAX = 50
+#: Buttons a picker shows. Telegram renders a one-per-row keyboard fine at this
+#: size, and the list is the account's own model set, not a catalogue.
+_MODEL_PICKER_LIMIT = 24
+
+
+@dataclass
+class _ModelPicker:
+    """A posted /model keyboard, resolving a button index back to a model id."""
+
+    route: tuple[str, str]
+    chat_id: int
+    message_id: int
+    created_at: float
+    #: ``(model_id, label)`` in button order. ``model_id`` "" is the Auto row.
+    choices: tuple[tuple[str, str], ...]
+
+
 class TelegramDispatcher:
     """Coordinates Telegram turns onto the shared ``TurnDriver``.
 
@@ -229,6 +241,15 @@ class TelegramDispatcher:
         # start, popped in finally. Records text only — no buffer slicing, so
         # none of the old steer-split fragility.
         self._active_renderers: dict[str, TelegramRenderer] = {}
+        # route -> the model id the user picked with /model, applied to every
+        # session this conversation starts from now on. Keyed by ROUTE, not
+        # session_key, so the choice survives /new and the idle/daily rotation
+        # (a model is a preference about the peer, not about one session).
+        self._model_pref: dict[tuple[str, str], str] = {}
+        # Live /model pickers awaiting a button press. Telegram caps
+        # callback_data at 64 bytes and model ids routinely exceed that, so the
+        # button carries an INDEX into this table instead of the id itself.
+        self._model_pickers: dict[str, _ModelPicker] = {}
 
     # ── Turn dispatch (transport's dispatch callback) ──────────────────────
 
@@ -314,6 +335,26 @@ class TelegramDispatcher:
         if cmd == "stop":
             await self._handle_stop(route, chat_id)
             return
+        if cmd == "model":
+            await self._handle_model(route, chat_id, parse_command_argument(text))
+            return
+        if cmd == "yolo":
+            await self._handle_yolo(
+                chat_id, parse_command_argument(text), user_id, thread=reply_thread
+            )
+            return
+        # A lone "/queue" / "/steer" is a directive missing its message body.
+        # Answering with the usage beats forwarding the token to the model, which
+        # would answer the literal string and read as a broken feature. Gated on
+        # interpret_as_command so a caption on an attachment is never read as a
+        # bare directive -- that would answer with usage and drop the file.
+        if interpret_as_command and override_mode is None and is_bare_mid_turn_override(text):
+            await self._reply(
+                chat_id,
+                "Those take a message: /queue <msg> or /steer <msg>.",
+                thread=reply_thread,
+            )
+            return
 
         # ── Mid-turn concurrency: check the CURRENT-generation key for an
         # in-flight turn BEFORE any idle/daily rotation. Rotating first could
@@ -369,7 +410,14 @@ class TelegramDispatcher:
             # on_turn_start is idempotent so the driver's later call no-ops.
             await renderer.on_turn_start()
             provider, is_new, resumed = await self.sessions.get_or_create(
-                session_key, agent=agent, channel_id=channel_id
+                session_key,
+                agent=agent,
+                channel_id=channel_id,
+                # "" is the Auto row's stored value; collapse it to None so Auto
+                # means "as if never picked". get_or_create gates its own model
+                # resolution on `model is None`, so passing "" would skip that
+                # and land on the provider factory's narrower fallback instead.
+                model=self._model_pref.get(route) or None,
             )
             _acquired = True
             if is_new:
@@ -430,6 +478,11 @@ class TelegramDispatcher:
                     and self.ctx_builder.hooks.auto_approve_subagent_spawn
                     and title == "spawn_run"
                 ),
+                # /yolo: read the grant per request, not once at boot, so turning
+                # it on (or letting it expire) takes effect on the very next tool
+                # instead of after a gateway restart. TurnDriver runs the
+                # PreToolUse gate BEFORE this, so a hard deny still wins.
+                auto_approve_session=lambda: safety_override().is_active(),
                 tool_gate=_tool_gate,
             )
             accumulated = await driver.run(full_message)
@@ -795,6 +848,238 @@ class TelegramDispatcher:
             thread=thread,
         )
 
+    # ── /yolo (global auto-approve grant) ──────────────────────────────────
+
+    async def _handle_yolo(
+        self, chat_id: int, arg: str, user_id: int, *, thread: int | None = None
+    ) -> None:
+        """Report or change the global auto-approve grant.
+
+        Reads and writes the process-wide :func:`safety_override` grant — the
+        SAME one the dashboard toggle and Slack's ``/kirocrew yolo`` drive, so a
+        grant taken here shows up (and expires) everywhere. Reachable only by an
+        allow-listed Telegram user, because ``transport.receive`` is
+        deny-by-default and owner-only before dispatch ever runs.
+
+        Turning it on does NOT weaken the PreToolUse security gate: the
+        sensitive-path keystone, governance ceiling and deny-list all run ahead
+        of the auto-approve ladder in ``TurnDriver``, so a hard DENY still wins.
+
+        The three grant mutators run off-loop: ``activate`` resolves the ad-hoc
+        duration through a live config read and every one of them writes a SEL
+        record (activation's is ``critical=True``), so calling them inline would
+        put filesystem latency on the event loop and stall every other chat and
+        heartbeat task on a slow disk.
+        """
+        so = safety_override()
+        action = arg.strip().lower().split()[0] if arg.strip() else ""
+
+        if action in ("on", "off", "renew"):
+            outcome = "allowed"
+            if action == "on":
+                if so.is_active():
+                    reply = f"🟢 YOLO is already ON ({describe_grant_lifetime()})."
+                elif (await asyncio.to_thread(so.activate, "telegram")).active:
+                    reply = (
+                        f"🟢 YOLO ON ({describe_grant_lifetime()}) — every tool "
+                        f"auto-approves. Denied-by-policy tools are still blocked."
+                    )
+                else:
+                    reply = "❌ Couldn't turn YOLO on (audit system unavailable)."
+                    outcome = "denied"
+            elif action == "off":
+                # Unconditional: deactivate() also zeroes the deadline of a
+                # grant that already lapsed, which closes the renew grace
+                # window so a later "/yolo renew" cannot resurrect it, and
+                # records the operator's decision either way.
+                await asyncio.to_thread(so.deactivate, "telegram")
+                reply = "🔴 YOLO OFF — tools ask for approval again."
+            else:
+                renewed = (await asyncio.to_thread(so.renew, "telegram")).renewed
+                reply = (
+                    f"🟢 YOLO renewed ({describe_grant_lifetime()})."
+                    if renewed
+                    else "🔴 YOLO is not active — use /yolo on first."
+                )
+            sel().log_api_access(
+                caller=str(user_id),
+                operation="telegram.yolo_mode",
+                outcome=outcome,
+                source="telegram",
+                resources=f"yolo_{action}",
+            )
+            await self._reply(chat_id, reply, thread=thread)
+            return
+
+        status = f"ON 🟢 ({describe_grant_lifetime()})" if so.is_active() else "OFF 🔴"
+        await self._reply(
+            chat_id,
+            f"YOLO is {status}.\nUsage: /yolo on | off | renew",
+            thread=thread,
+        )
+
+    # ── /model (inline-button model picker) ────────────────────────────────
+
+    def _model_choices(self, session_key: str) -> tuple[tuple[str, str], ...]:
+        """``(model_id, label)`` rows to offer for this session.
+
+        The ONLY source is what this session's backend advertised at
+        ``session/new`` — the set THIS account may actually use, carrying the
+        backend's own ids. That is deliberate on both counts: a static catalogue
+        would offer models the account cannot reach (a refusal mid-conversation),
+        and its display keys would need per-backend translation before the wire,
+        whereas an advertised id is what ``set_model`` accepts verbatim.
+
+        Returns just the Auto row when nothing is advertised (no live session
+        yet), which the caller reads as "there is nothing to pick".
+        """
+        rows: list[tuple[str, str]] = [("", "Auto (let the backend choose)")]
+        provider = self.sessions.get_provider(session_key)
+        advertised = getattr(provider, "available_models", None)
+        if not callable(advertised):
+            return tuple(rows)
+        try:
+            entries = [m for m in advertised() if isinstance(m, dict)]
+        except Exception:  # pragma: no cover - defensive
+            logger.warning("telegram /model: available_models failed", exc_info=True)
+            return tuple(rows)
+        for entry in entries:
+            model_id = str(entry.get("modelId") or "").strip()
+            # "auto" is already offered as the first row; listing it twice would
+            # give the same choice two buttons.
+            if not model_id or model_id == "auto":
+                continue
+            rows.append((model_id, str(entry.get("name") or model_id)))
+        return tuple(rows[:_MODEL_PICKER_LIMIT])
+
+    def _prune_model_pickers(self, now: float) -> None:
+        """Drop expired pickers, then the oldest ones past the retention cap."""
+        for token, picker in list(self._model_pickers.items()):
+            if now - picker.created_at > _MODEL_PICKER_TTL_SECS:
+                self._model_pickers.pop(token, None)
+        while len(self._model_pickers) > _MODEL_PICKER_MAX:
+            oldest = min(self._model_pickers, key=lambda t: self._model_pickers[t].created_at)
+            self._model_pickers.pop(oldest, None)
+
+    async def _handle_model(self, route: tuple[str, str], chat_id: int, arg: str) -> None:
+        """Post the model keyboard (or report the current pick for a bare arg).
+
+        Deliberately button-only: a free-text model id means guessing at names
+        the user has no way to enumerate, and a typo lands as a rejected
+        ``set_model`` mid-conversation. Any argument is treated as "show me the
+        list" rather than parsed.
+        """
+        assert self.client is not None
+        session_key = self._session_key(route)
+        thread = self._route_thread(route)
+        choices = self._model_choices(session_key)
+        if len(choices) <= 1:
+            await self._reply(
+                chat_id,
+                "No model list available yet — send a message first, then /model.",
+                thread=thread,
+            )
+            return
+
+        current = self._model_pref.get(route, "")
+        current_label = next(
+            (label for mid, label in choices if mid == current),
+            current or "Auto",
+        )
+        header = f"Current model: {current_label}\nPick one:"
+        if arg.strip():
+            # An argument is not an id to apply — say so once, then show the
+            # list anyway so the message is still a step forward.
+            header = f"/model takes no argument — pick from the list.\n\n{header}"
+        keyboard = [
+            [{"text": f"{'• ' if mid == current else ''}{label}", "callback_data": f"m:{index}"}]
+            for index, (mid, label) in enumerate(choices)
+        ]
+        message_id = await self._reply(
+            chat_id,
+            header,
+            thread=thread,
+            reply_markup={"inline_keyboard": keyboard},
+        )
+        if message_id is None:
+            return
+        now = time.time()
+        self._prune_model_pickers(now)
+        self._model_pickers[f"{chat_id}:{message_id}"] = _ModelPicker(
+            route=route,
+            chat_id=chat_id,
+            message_id=message_id,
+            created_at=now,
+            choices=choices,
+        )
+
+    async def _apply_model(self, route: tuple[str, str], model_id: str) -> str:
+        """Record *model_id* for *route* and push it to the live session.
+
+        *model_id* comes verbatim from the session's advertised list, so it is
+        already the id this backend accepts — no canonical translation, which
+        would differ per backend and could mangle an id that was correct.
+
+        The preference is stored unconditionally so it reaches the NEXT session
+        even when there is nothing live to switch (the common case right after
+        ``/new``). When a session does exist, the switch is attempted in place —
+        ``session/set_model`` carries the conversation across — and the semaphore
+        is taken atomically so the switch cannot interleave JSON-RPC with a turn
+        on the same stdio channel.
+
+        Returns the user-facing outcome line.
+        """
+        label = model_id or "Auto"
+        self._model_pref[route] = model_id
+        session_key = self._session_key(route)
+        live = self.sessions.has_session(session_key)
+        # Two different promises, because the preference reaches a session only
+        # at creation: ``get_or_create`` returns a reused session from its fast
+        # path before it consults ``model=``. With nothing live the next message
+        # starts the session, so it genuinely lands then; with a session already
+        # up, only a fresh conversation picks it up.
+        deferred = f"✅ Model set to {label} — it applies to your next message."
+        next_new = (
+            f"✅ Model set to {label} — this conversation keeps its current "
+            f"model; the switch applies to your next one (/new)."
+        )
+        # Auto has no ACP id meaning "let the backend choose", so it can only be
+        # recorded; the next session start resolves it from config. Claiming a
+        # live switch here would be a lie.
+        if not model_id:
+            return next_new if live else deferred
+        if not live:
+            return deferred
+        if not await self.sessions.try_acquire(session_key):
+            return (
+                f"✅ Model set to {label}, but a reply is still running — this "
+                f"conversation keeps its current model; the switch applies to "
+                f"your next one (/new)."
+            )
+        try:
+            provider = self.sessions.get_provider(session_key)
+            set_model = getattr(getattr(provider, "client", None), "set_model", None)
+            if set_model is None:
+                return next_new
+            await set_model(model_id)
+        except Exception as exc:
+            logger.warning(
+                "telegram /model: live set_model failed for %s: %s",
+                session_key,
+                type(exc).__name__,
+                exc_info=True,
+            )
+            # The stored preference still stands, so the next session gets it —
+            # but do not claim the running conversation switched when it did not.
+            return (
+                f"⚠️ Couldn't switch this conversation to {label} "
+                f"({type(exc).__name__}) — it applies to your next "
+                f"conversation (/new)."
+            )
+        finally:
+            self.sessions.release(session_key)
+        return f"✅ Now using {label}."
+
     # ── Inline-button handler (client's on_callback) ───────────────────────
 
     async def on_callback(self, cb: "TelegramCallback") -> None:
@@ -883,6 +1168,48 @@ class TelegramDispatcher:
                 verdict = "⌛ This approval already expired."
             await self.client.edit_message(
                 cb.chat_id, cb.message_id, verdict, reply_markup={"inline_keyboard": []}
+            )
+            return
+
+        # Model pick: "m:<index>" into the picker posted on this message.
+        if data.startswith("m:"):
+            token = f"{cb.chat_id}:{cb.message_id}"
+            picker = self._model_pickers.get(token)
+            expired = picker is not None and (
+                time.time() - picker.created_at > _MODEL_PICKER_TTL_SECS
+            )
+            try:
+                index = int(data[2:])
+            except ValueError:
+                index = -1
+            if picker is None or expired or not (0 <= index < len(picker.choices)):
+                # Covers expired, evicted, and already-consumed alike — the
+                # wording must not claim "expired" for a picker that was simply
+                # used, which is what a double-press hits.
+                self._model_pickers.pop(token, None)
+                await self.client.edit_message(
+                    cb.chat_id,
+                    cb.message_id,
+                    "⌛ This model list is no longer active — send /model again.",
+                    reply_markup={"inline_keyboard": []},
+                )
+                return
+            # Consume the picker BEFORE applying: the switch takes a round-trip,
+            # and a second press in that window would otherwise apply twice.
+            self._model_pickers.pop(token, None)
+            model_id, label = picker.choices[index]
+            outcome = await self._apply_model(picker.route, model_id)
+            sel().log_api_access(
+                caller=str(cb.user_id) or "unknown",
+                operation="telegram.set_model",
+                outcome="allowed",
+                source="telegram",
+                resources=f"model={label}",
+            )
+            # One edit carries both the result text and the retired keyboard, so
+            # the buttons never outlive the choice they represent.
+            await self.client.edit_message(
+                cb.chat_id, cb.message_id, outcome, reply_markup={"inline_keyboard": []}
             )
             return
 

--- a/test/test_slack_handler_coverage.py
+++ b/test/test_slack_handler_coverage.py
@@ -24,6 +24,7 @@ import pytest
 from conftest import MockSlackClient
 from kiro_crew.cron import CronJob, CronSchedule, CronStoreBusy
 from kiro_crew.providers.base import LLMEvent
+from kiro_crew.safety_override import NO_EXPIRY_TEXT, fmt_grant_duration
 from kiro_crew.slack import handler as h
 
 
@@ -1738,11 +1739,11 @@ class TestPureHelpers:
         assert "full reasoning" in out
 
     def test_fmt_duration(self):
-        assert h._fmt_duration(7200) == "2h"
-        assert h._fmt_duration(1800) == "30min"
+        assert fmt_grant_duration(7200) == "2h"
+        assert fmt_grant_duration(1800) == "30min"
 
     def test_describe_new_grant(self):
-        assert h.describe_new_grant(0) == h._NO_EXPIRY_TEXT
+        assert h.describe_new_grant(0) == NO_EXPIRY_TEXT
         assert h.describe_new_grant(3600) == "auto-expires in 1h"
 
     def test_describe_grant_lifetime_off(self):

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -10,6 +10,7 @@ turn + callback routing (transport_dispatch.py).
 from __future__ import annotations
 
 import asyncio
+import time
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
@@ -35,8 +36,13 @@ from kiro_crew.telegram.client import (
     truncate_html_safe,
 )
 from kiro_crew.telegram.commands import (
+    COMMAND_SPEC,
     ConversationState,
+    bot_command_payload,
+    build_help_text,
+    is_bare_mid_turn_override,
     parse_command,
+    parse_command_argument,
     parse_mid_turn_override,
 )
 from kiro_crew.telegram.renderer import (
@@ -59,6 +65,7 @@ from kiro_crew.telegram.transport import (
     forum_gate_outcome,
 )
 from kiro_crew.telegram.transport_dispatch import (
+    _MODEL_PICKER_TTL_SECS,
     _STEER_ACK_EMOJI,
     TelegramDispatcher,
     _user_safe_failure_reason,
@@ -168,11 +175,25 @@ class _Ev:
 class FakeProvider:
     supports_steer = True
 
-    def __init__(self, reply: str = "Answer") -> None:
+    def __init__(self, reply: str = "Answer", models: list | None = None) -> None:
         self._reply = reply
         self.steered: list = []
         self.cancelled = 0
         self.active_turn = True  # gates _handle_busy's live-turn steer check
+        # Models the backend "advertised" at session init, plus the ids a
+        # /model press pushed through session/set_model.
+        self.advertised: list = list(models or [])
+        self.set_models: list[str] = []
+        self.set_model_error: Exception | None = None
+        self.client = SimpleNamespace(set_model=self._set_model)
+
+    def available_models(self) -> list:
+        return list(self.advertised)
+
+    async def _set_model(self, model_id: str) -> None:
+        if self.set_model_error is not None:
+            raise self.set_model_error
+        self.set_models.append(model_id)
 
     def has_active_turn(self) -> bool:
         return self.active_turn
@@ -214,6 +235,7 @@ class FakeSessions:
         self.successes: list[str] = []
         self.failures: list[str] = []
         self.last_agent: Any = None
+        self.last_model: Any = None
         self.raise_on_get = raise_on_get
         self._busy = False
         self._has = True
@@ -222,8 +244,11 @@ class FakeSessions:
         self.mirror_links: dict[str, Any] = {}
         self._pid: Any = None
 
-    async def get_or_create(self, key: str, *, agent: Any = None, channel_id: Any = None) -> Any:
+    async def get_or_create(
+        self, key: str, *, agent: Any = None, channel_id: Any = None, model: Any = None
+    ) -> Any:
         self.last_agent = agent
+        self.last_model = model
         if self.raise_on_get:
             raise RuntimeError("cold-start failed")
         return FakeProvider(), True, False
@@ -396,6 +421,72 @@ class TestParseCommand:
     def test_mid_turn_override_none_without_body(self) -> None:
         # A bare directive with no message body is not an override.
         assert parse_mid_turn_override("/queue") == (None, "/queue")
+
+    def test_model_and_yolo(self) -> None:
+        assert parse_command("/model") == "model"
+        assert parse_command("/models") == "model"  # typo-safe alias
+        assert parse_command("/yolo") == "yolo"
+        assert parse_command("/yolo on") == "yolo"
+
+    def test_command_argument(self) -> None:
+        assert parse_command_argument("/yolo on") == "on"
+        assert parse_command_argument("/yolo   on  ") == "on"
+        assert parse_command_argument("/yolo") == ""
+
+    def test_bare_mid_turn_override_is_flagged(self) -> None:
+        # A lone directive must be recognised so it can get a usage hint instead
+        # of reaching the model as the literal string "/queue".
+        assert is_bare_mid_turn_override("/queue") is True
+        assert is_bare_mid_turn_override("  /STEER ") is True
+        assert is_bare_mid_turn_override("/queue do this") is False
+        assert is_bare_mid_turn_override("/new") is False
+        assert is_bare_mid_turn_override("hello") is False
+
+
+class TestCommandCatalogue:
+    """COMMAND_SPEC is the one source behind /help AND the Bot API menu."""
+
+    def test_help_card_lists_every_spec_row(self) -> None:
+        help_text = build_help_text()
+        for name, desc in COMMAND_SPEC:
+            assert f"/{name} — {desc}" in help_text
+
+    def test_every_spec_row_is_a_real_command(self) -> None:
+        # A menu entry the parser does not recognise would send the user's tap
+        # straight to the model as chat text.
+        for name, _desc in COMMAND_SPEC:
+            assert parse_command(f"/{name}") is not None, name
+
+    def test_menu_excludes_body_taking_directives(self) -> None:
+        # The Telegram client SENDS a menu entry on tap, so /queue and /steer —
+        # which are prefixes needing a message body — must not be listed.
+        names = {name for name, _ in COMMAND_SPEC}
+        assert "queue" not in names and "steer" not in names
+        # They stay documented in the help card's footer.
+        assert "/queue <msg>" in build_help_text()
+
+    def test_payload_matches_bot_api_shape(self) -> None:
+        payload = bot_command_payload()
+        assert payload[0] == {"command": "new", "description": "Start a fresh conversation"}
+        assert len(payload) == len(COMMAND_SPEC)
+        for row in payload:
+            assert set(row) == {"command", "description"}
+            assert row["command"] == row["command"].lower()
+            assert row["command"].lstrip("/") == row["command"]  # no leading slash
+            assert 1 <= len(row["command"]) <= 32
+            assert 1 <= len(row["description"]) <= 256
+
+    def test_malformed_row_is_dropped_not_sent(self, monkeypatch: Any) -> None:
+        # Telegram rejects the WHOLE array on one bad row, so a malformed entry
+        # must be skipped rather than cost the user the entire menu.
+        from kiro_crew.telegram import commands as tg_commands
+
+        monkeypatch.setattr(
+            tg_commands,
+            "COMMAND_SPEC",
+            (("new", "ok"), ("Bad-Name", "rejected by the Bot API"), ("blank", "")),
+        )
+        assert tg_commands.bot_command_payload() == [{"command": "new", "description": "ok"}]
 
 
 class TestConversationState:
@@ -2113,6 +2204,38 @@ class TestTelegramMidTurn:
             "the command confirmation must not be sent for an attachment caption"
         )
 
+    def test_bare_directive_caption_on_attachment_is_content_not_a_command(
+        self,
+    ) -> None:
+        """A photo captioned "/queue" must be ingested, not answered with usage.
+
+        Same loss as the "/new" caption above and the same cause: the bare
+        "/queue" | "/steer" guard returns BEFORE attachment ingestion, so a
+        caption read as a directive silently discards the file. ``attachments``
+        make the message content-bearing, which is exactly what
+        ``interpret_as_command`` encodes.
+        """
+        d, cli, _ = _dispatcher({7})
+        photos = [{"file_id": "p1", "file_name": "a.jpg", "mime_type": "image/jpeg"}]
+
+        async def _go() -> None:
+            await d.handle_message(
+                InboundMessage(
+                    channel_type="telegram",
+                    user_id="7",
+                    conversation_id="7",
+                    text="/queue",
+                    attachments=photos,
+                )
+            )
+
+        asyncio.run(_go())
+
+        assert not any("Those take a message" in t for t, _ in cli.sent), (
+            "the bare-directive usage reply must not fire for an attachment "
+            "caption -- that path returns before ingestion and drops the photo"
+        )
+
     def test_attachment_message_is_queued_not_steered(self) -> None:
         """A mid-turn message carrying files must NEVER take the steer path.
 
@@ -3248,3 +3371,315 @@ class TestUserSafeFailureReason:
 
     def test_empty_message_returns_none(self) -> None:
         assert _user_safe_failure_reason(AcpError("   \n ", transient=False)) is None
+# ── /yolo + /model (transport_dispatch.py) ─────────────────────────────────
+
+
+def _dm(text: str, uid: str = "7") -> InboundMessage:
+    return InboundMessage(
+        channel_type="telegram", user_id=uid, conversation_id=uid, text=text
+    )
+
+
+def _press(data: str, *, message_id: int = 101, uid: int = 7, label: str = "") -> Any:
+    return SimpleNamespace(
+        callback_query_id="q1",
+        user_id=uid,
+        chat_id=uid,
+        message_id=message_id,
+        data=data,
+        label=label,
+        chat_type="private",
+    )
+
+
+class TestYoloCommand:
+    """/yolo drives the SAME process-wide grant as the dashboard and Slack."""
+
+    def _reset(self) -> Any:
+        from kiro_crew.safety_override import safety_override
+
+        so = safety_override()
+        if so.is_active():
+            so.deactivate("test")
+        return so
+
+    def test_bare_yolo_reports_status_without_changing_it(self) -> None:
+        so = self._reset()
+        d, cli, _ = _dispatcher({7})
+        try:
+            asyncio.run(d.handle_message(_dm("/yolo")))
+            assert "OFF" in cli.sent[-1][0]
+            assert "Usage: /yolo on | off | renew" in cli.sent[-1][0]
+            assert so.is_active() is False, "a status read must not arm the grant"
+        finally:
+            self._reset()
+
+    def test_on_then_off_round_trips_the_grant(self) -> None:
+        so = self._reset()
+        d, cli, _ = _dispatcher({7})
+        try:
+            asyncio.run(d.handle_message(_dm("/yolo on")))
+            assert so.is_active() is True
+            assert "ON" in cli.sent[-1][0]
+
+            asyncio.run(d.handle_message(_dm("/yolo off")))
+            assert so.is_active() is False
+            assert "OFF" in cli.sent[-1][0]
+        finally:
+            self._reset()
+
+    def test_off_on_a_lapsed_grant_closes_the_renew_grace_window(self) -> None:
+        """"/yolo off" must revoke a grant whose TTL already elapsed.
+
+        ``deactivate()`` zeroes the past deadline, and that is what shuts the
+        5-minute renew grace window. Skipping the call for a lapsed grant left
+        it renewable, so a later "/yolo renew" silently restored auto-approval
+        after the operator had been told "YOLO OFF".
+        """
+        so = self._reset()
+        d, cli, _ = _dispatcher({7})
+        try:
+            asyncio.run(d.handle_message(_dm("/yolo on")))
+            assert so.is_active() is True
+
+            # Lapse the grant but stay inside the renew grace window.
+            so._expires_at = time.monotonic() - 10
+            assert so.is_active() is False, "precondition: the grant has lapsed"
+
+            asyncio.run(d.handle_message(_dm("/yolo off")))
+            assert "OFF" in cli.sent[-1][0]
+
+            assert so.renew("test").renewed is False, (
+                "an explicitly revoked grant must not be resurrectable by renew "
+                "just because its TTL happened to elapse before the off"
+            )
+            assert so.is_active() is False
+        finally:
+            self._reset()
+
+    def test_unknown_argument_falls_back_to_status(self) -> None:
+        so = self._reset()
+        d, cli, _ = _dispatcher({7})
+        try:
+            asyncio.run(d.handle_message(_dm("/yolo maybe")))
+            assert so.is_active() is False, "an unrecognised verb must never arm the grant"
+            assert "Usage:" in cli.sent[-1][0]
+        finally:
+            self._reset()
+
+    def test_grant_is_read_per_request_not_captured_at_boot(self) -> None:
+        # The predicate handed to TurnDriver must consult the LIVE grant, or
+        # /yolo would only take effect after a gateway restart. Mutating the
+        # grant between calls proves the closure is not a captured snapshot.
+        so = self._reset()
+        d, _cli, _sess = _dispatcher({7})
+        captured: list = []
+
+        class _Recorder:
+            def __init__(self, *a: Any, **kw: Any) -> None:
+                captured.append(kw.get("auto_approve_session"))
+
+            async def run(self, message: str) -> str:
+                return "ok"
+
+        try:
+            with patch("kiro_crew.telegram.transport_dispatch.TurnDriver", _Recorder):
+                asyncio.run(d.handle_message(_dm("hi")))
+            predicate = captured[0]
+            assert predicate is not None
+            assert predicate() is False
+            so.activate("test")
+            assert predicate() is True, "the predicate must re-read the grant, not cache it"
+        finally:
+            self._reset()
+
+
+class TestModelPicker:
+    """/model is button-only: the user picks from what the backend advertised."""
+
+    _MODELS = [
+        {"modelId": "claude-opus-5", "name": "Opus 5"},
+        {"modelId": "gpt-5.6-sol", "name": "GPT 5.6 Sol"},
+    ]
+
+    def _with_models(self, models: list | None = None) -> Any:
+        d, cli, sess = _dispatcher({7})
+        sess._gp.advertised = list(self._MODELS if models is None else models)
+        return d, cli, sess
+
+    def test_posts_one_button_per_model_plus_auto(self) -> None:
+        d, cli, _ = self._with_models()
+        asyncio.run(d.handle_message(_dm("/model")))
+        text, markup = cli.sent[-1]
+        rows = markup["inline_keyboard"]
+        assert [r[0]["callback_data"] for r in rows] == ["m:0", "m:1", "m:2"]
+        assert "Auto" in rows[0][0]["text"]
+        assert "Opus 5" in rows[1][0]["text"]
+        assert "Current model:" in text
+
+    def test_callback_data_stays_inside_the_64_byte_cap(self) -> None:
+        # Telegram rejects callback_data over 64 bytes and real model ids run
+        # long, which is why the button carries an index, never the id.
+        long_id = "a" * 300
+        d, cli, _ = self._with_models([{"modelId": long_id, "name": long_id}])
+        asyncio.run(d.handle_message(_dm("/model")))
+        for row in cli.sent[-1][1]["inline_keyboard"]:
+            assert len(row[0]["callback_data"].encode()) <= 64
+
+    def test_press_switches_the_live_session_and_stores_the_pick(self) -> None:
+        d, cli, sess = self._with_models()
+        asyncio.run(d.handle_message(_dm("/model")))
+        picker_mid = cli.sent[-1] and 101
+        asyncio.run(d.on_callback(_press("m:2", message_id=picker_mid)))
+        assert sess._gp.set_models == ["gpt-5.6-sol"]
+        assert d._model_pref[("direct", "7")] == "gpt-5.6-sol"
+        assert "Now using gpt-5.6-sol" in cli.edits[-1][1]
+        assert cli.edits[-1][2] == {"inline_keyboard": []}, "the keyboard must be retired"
+
+    def test_pick_flows_into_the_next_session(self) -> None:
+        # The stored preference is only useful if session creation consumes it.
+        d, cli, sess = self._with_models()
+        asyncio.run(d.handle_message(_dm("/model")))
+        asyncio.run(d.on_callback(_press("m:2")))
+        asyncio.run(d.handle_message(_dm("hi")))
+        assert sess.last_model == "gpt-5.6-sol"
+
+    def test_auto_is_recorded_without_a_wire_call(self) -> None:
+        # There is no ACP id meaning "let the backend choose", so Auto can only
+        # be recorded — claiming a live switch would be a lie.
+        d, cli, sess = self._with_models()
+        asyncio.run(d.handle_message(_dm("/model")))
+        asyncio.run(d.on_callback(_press("m:0")))
+        assert sess._gp.set_models == []
+        assert d._model_pref[("direct", "7")] == ""
+        # A session is live here, and get_or_create returns a reused session
+        # before it reads `model=`, so the pick CANNOT land on the next message —
+        # promising that would be the same lie in different words.
+        assert "/new" in cli.edits[-1][1]
+        assert "next message" not in cli.edits[-1][1]
+
+    def test_auto_with_no_live_session_does_promise_the_next_message(self) -> None:
+        # The mirror case: with nothing live, the next message is what creates
+        # the session, so it really does consume the preference then.
+        d, cli, sess = self._with_models()
+        asyncio.run(d.handle_message(_dm("/model")))
+        sess._has = False
+        asyncio.run(d.on_callback(_press("m:0")))
+        assert "next message" in cli.edits[-1][1]
+
+    def test_auto_reaches_session_creation_as_none_not_empty_string(self) -> None:
+        # Auto must mean "as if never picked". get_or_create gates its own model
+        # resolution on `model is None`, so handing it the Auto row's stored ""
+        # would skip that resolution and land on the provider factory's narrower
+        # fallback — a different model than an untouched conversation gets.
+        d, cli, sess = self._with_models()
+        asyncio.run(d.handle_message(_dm("/model")))
+        asyncio.run(d.on_callback(_press("m:0")))
+        asyncio.run(d.handle_message(_dm("hi")))
+        assert sess.last_model is None
+
+    def test_failed_switch_does_not_claim_success(self) -> None:
+        d, cli, sess = self._with_models()
+        sess._gp.set_model_error = RuntimeError("model not available")
+        asyncio.run(d.handle_message(_dm("/model")))
+        asyncio.run(d.on_callback(_press("m:2")))
+        outcome = cli.edits[-1][1]
+        assert "Couldn't switch" in outcome and "Now using" not in outcome
+
+    def test_busy_session_defers_instead_of_racing_the_turn(self) -> None:
+        d, cli, sess = self._with_models()
+        asyncio.run(d.handle_message(_dm("/model")))
+        sess._busy = True  # try_acquire refuses -> no JSON-RPC on a live channel
+        asyncio.run(d.on_callback(_press("m:2")))
+        assert sess._gp.set_models == []
+        assert "still running" in cli.edits[-1][1]
+        assert d._model_pref[("direct", "7")] == "gpt-5.6-sol"
+
+    def test_advertised_id_is_sent_verbatim(self) -> None:
+        # An advertised id is already what this backend accepts. Routing it
+        # through the canonical registry would REWRITE some ids into a different
+        # model (model_registry.to_acp_id("opus-4.8-1m") == "claude-opus-4.8"),
+        # so the picked id must reach set_model untouched.
+        d, cli, sess = self._with_models([{"modelId": "opus-4.8-1m", "name": "Opus 4.8 (1M)"}])
+        asyncio.run(d.handle_message(_dm("/model")))
+        asyncio.run(d.on_callback(_press("m:1")))
+        assert sess._gp.set_models == ["opus-4.8-1m"]
+
+    def test_no_advertised_models_asks_for_a_message_first(self) -> None:
+        d, cli, _ = self._with_models([])
+        asyncio.run(d.handle_message(_dm("/model")))
+        assert "send a message first" in cli.sent[-1][0]
+        assert cli.sent[-1][1] is None, "no keyboard when there is nothing to pick"
+
+    def test_expired_picker_refuses_to_act_on_a_stale_list(self) -> None:
+        d, cli, sess = self._with_models()
+        asyncio.run(d.handle_message(_dm("/model")))
+        picker = d._model_pickers["7:101"]
+        picker.created_at -= _MODEL_PICKER_TTL_SECS + 1
+        asyncio.run(d.on_callback(_press("m:2")))
+        assert sess._gp.set_models == []
+        assert "no longer active" in cli.edits[-1][1]
+
+    def test_unknown_picker_is_reported_not_ignored(self) -> None:
+        d, cli, sess = self._with_models()
+        asyncio.run(d.on_callback(_press("m:0", message_id=999)))
+        assert sess._gp.set_models == []
+        assert "no longer active" in cli.edits[-1][1]
+
+    def test_out_of_range_index_cannot_pick_a_model(self) -> None:
+        d, cli, sess = self._with_models()
+        asyncio.run(d.handle_message(_dm("/model")))
+        asyncio.run(d.on_callback(_press("m:99")))
+        assert sess._gp.set_models == []
+        assert "no longer active" in cli.edits[-1][1]
+
+    def test_second_press_cannot_apply_twice(self) -> None:
+        d, cli, sess = self._with_models()
+        asyncio.run(d.handle_message(_dm("/model")))
+        asyncio.run(d.on_callback(_press("m:2")))
+        asyncio.run(d.on_callback(_press("m:2")))
+        assert sess._gp.set_models == ["gpt-5.6-sol"], "the picker must be single-use"
+
+
+class TestBareMidTurnDirective:
+    def test_bare_queue_gets_usage_not_a_model_turn(self) -> None:
+        d, cli, sess = _dispatcher({7})
+        asyncio.run(d.handle_message(_dm("/queue")))
+        assert "Those take a message" in cli.sent[-1][0]
+        assert sess.successes == [], "the bare token must never reach the model"
+
+    def test_queue_with_a_body_still_runs_as_content(self) -> None:
+        d, _cli, sess = _dispatcher({7})
+        asyncio.run(d.handle_message(_dm("/queue do the thing")))
+        assert sess.successes == ["telegram:kirocrew:direct:7"]
+
+
+class TestSetMyCommands:
+    def test_empty_list_is_refused_so_the_menu_is_never_wiped(self) -> None:
+        # Telegram reads an empty array as "this bot has no commands" and clears
+        # the menu, so an empty payload must not reach the wire.
+        client = TelegramClient(token="t")
+        calls: list = []
+
+        async def _api(method: str, params: dict, *a: Any, **kw: Any) -> Any:
+            calls.append(method)
+            return True
+
+        client._api = _api  # type: ignore[assignment]
+        assert asyncio.run(client.set_my_commands([])) is False
+        assert calls == []
+
+    def test_publishes_the_catalogue(self) -> None:
+        client = TelegramClient(token="t")
+        sent: list = []
+
+        async def _api(method: str, params: dict, *a: Any, **kw: Any) -> Any:
+            sent.append((method, params))
+            return True
+
+        client._api = _api  # type: ignore[assignment]
+        assert asyncio.run(client.set_my_commands(bot_command_payload())) is True
+        assert sent[0][0] == "setMyCommands"
+        assert {"command": "model", "description": "Choose the model from a list"} in sent[0][1][
+            "commands"
+        ]


### PR DESCRIPTION
## What is the problem?

Telegram carries the thinnest command surface of any KiroCrew channel, and none of it is discoverable.

Concretely, three gaps:

1. **Nothing is discoverable.** The bot never called the Bot API's `setMyCommands`, so typing `/` in a Telegram client offered no autocomplete at all. The only way to learn a command existed was to already know `/help`.
2. **No way to see or change the model.** Every other surface can pick a model; from Telegram the model was whatever config resolved at session start, with no way to see it or change it without leaving for the dashboard.
3. **No way to change the tool-approval mode.** The dashboard has a YOLO toggle and Slack has `/kirocrew yolo`; Telegram had neither, so approving tools one at a time was the only option.

A fourth, smaller one surfaced while fixing the first: a bare `/queue` or `/steer` (a prefix directive with no message body) matched neither the command parser nor the override parser, so the literal string `/queue` was sent to the model, which then answered it as chat text.

## Why this issue matters to the user

Telegram is the surface people actually use away from their desk, and it was the one where they had the least control. A user on their phone could not tell what the bot could do, could not move a conversation onto a cheaper or stronger model, and could not stop approving tools individually — each of those meant putting the phone down and opening the dashboard.

The `setMyCommands` gap is the sharpest of the three because it hides the other features too: commands that already worked (`/compact`, `/link`, `/stop`) were invisible to anyone who had not read the docs.

## How our fix solves it

**Symptom → root cause → change**, per gap:

**Menu.** Symptom: no `/` autocomplete. Root cause: nothing in the codebase ever called `setMyCommands` — a grep for it across the repo returned zero hits. Change: `TelegramClient.set_my_commands()` plus one best-effort call at gateway startup, gated on the token having already proven out via `get_me()`. The obvious failure mode of adding a second command list is drift against `/help`, so `COMMAND_SPEC` in `telegram/commands.py` is the single source both are derived from, and a test asserts every menu row is a command the parser actually recognises.

`/queue` and `/steer` are deliberately **excluded** from the menu: the Telegram client *sends* a menu entry the moment it is tapped, and both need a message body to act on, so a menu row for them could only ever produce an error. They stay documented in the help card's footer — and the bare-token case now answers with the usage instead of handing `/queue` to the model.

**`/model`.** Symptom: no model control. Root cause: no command existed. Change: an inline-keyboard picker. Two design decisions carry real weight:

- *Button-only, never free text.* The user cannot enumerate model ids, so a text argument would be guesswork, and a typo would land as a rejected `set_model` mid-conversation.
- *The id is sent verbatim.* The choices come only from what this session's backend advertised (`provider.available_models()`), so they are already the ids this backend accepts. Routing them through the canonical registry would **rewrite some into a different model** — `model_registry.to_acp_id("opus-4.8-1m")` returns `"claude-opus-4.8"`. A test locks this: reintroducing the translation fails it.

`callback_data` carries `m:<index>` into a TTL'd picker table rather than the id itself, because Telegram caps `callback_data` at 64 bytes and real ids exceed that. The pick is applied to the running session in place via `session/set_model` when it is idle (the semaphore is taken atomically so the switch cannot interleave JSON-RPC with a turn on the same stdio channel), and is remembered per conversation route so it outlives `/new`.

**`/yolo`.** Symptom: no approval control. Root cause: no command existed. Change: `/yolo on|off|renew` plus a bare status read, driving the **same** process-wide `safety_override()` grant as the dashboard toggle and Slack, so it expires on one clock everywhere.

The non-obvious part is where it is applied. Telegram's `approval_mode` is resolved **once at gateway boot** (`_resolve_approval_mode`), so routing YOLO through it would have required a restart to take effect. Instead it goes through `TurnDriver`'s `auto_approve_session` predicate, which is read per permission request. Crucially this does **not** weaken the security gate: in `messaging/driver.py` the PreToolUse gate runs first (deny returns at :403-406) and `auto_approve_session` is only consulted at :430, so a sensitive-path, governance-ceiling or deny-list block still refuses the tool with the grant active.

**One supporting move:** `describe_grant_lifetime` / `describe_new_grant` moved from `slack/handler.py` into `safety_override.py`. They are channel-neutral text about the grant, and Telegram must not import `kiro_crew.slack` (the module's documented dependency direction is `telegram -> messaging`). `slack/handler.py` re-exports them so `slack/events.py` and the existing test are unaffected.

## What tests we did

**Automated** — 33 new tests in `test/test_telegram.py`, plus one import fix in `test/test_slack_handler_coverage.py` for the moved helpers.

What the load-bearing ones lock in:

| Test | Invariant |
|---|---|
| `test_advertised_id_is_sent_verbatim` | the picked id reaches `set_model` untranslated — fails if `to_acp_id` is reintroduced |
| `test_auto_reaches_session_creation_as_none_not_empty_string` | Auto passes `None`, not `""`, so it resolves like an untouched conversation |
| `test_grant_is_read_per_request_not_captured_at_boot` | the YOLO predicate re-reads the live grant instead of caching a boot snapshot |
| `test_second_press_cannot_apply_twice` | the picker is single-use; a double-press cannot apply twice |
| `test_callback_data_stays_inside_the_64_byte_cap` | button payloads stay within the Bot API limit even for a 300-char model id |
| `test_busy_session_defers_instead_of_racing_the_turn` | a busy session defers rather than interleaving JSON-RPC with a live turn |
| `test_every_spec_row_is_a_real_command` | no menu row can send an unparsed token to the model |
| `test_malformed_row_is_dropped_not_sent` | one bad row cannot cost the user the whole menu (Telegram rejects the entire array) |
| `test_empty_list_is_refused_so_the_menu_is_never_wiped` | an empty payload never reaches the wire |
| `test_bare_queue_gets_usage_not_a_model_turn` | a bare directive never reaches the model as literal text |

**Six of these are mutation-verified** — the production code was deliberately broken and each test confirmed to fail: the YOLO predicate wiring, `model=` reaching session creation, the Auto→`None` collapse, the picker's single-use pop, the bare-directive guard, and the verbatim-id path.

**Gates:** `isort`, `flake8`, `mypy` (846 files) all clean; 520 targeted tests pass. The two frontend gates do not apply — zero `website/` files are touched.

**Pre-existing failure, explicitly not mine:** `TestTelegramMidTurn::test_concurrent_queue_adds_share_one_receipt` is flaky on this host. Because this change touches `handle_message` — exactly that test's path — I reverted the telegram subsystem to `main` and re-ran: it fails **5/8 runs on unmodified main**, versus 2/8 on this branch. Pre-existing, and left alone rather than widening this PR. Worth its own issue.

## Manual verification

**Not done, and I want to be straight about it.** The user-visible surface here is a Telegram client — an inline keyboard and a `/` autocomplete menu — which cannot be captured without a live bot token and a pod, so there are no screenshots. Unit coverage coincidentally cannot reach the two things a human would check by eye: that Telegram actually renders the published menu, and that the keyboard lays out readably on a phone.

Both are worth a real-device pass before this is relied on. Everything asserted above is from unit tests and code reading, not from a running bot.

## Any other suggestions on the work

- **`_model_pref` is in-memory only**, so a gateway restart returns the conversation to the configured default. This is deliberate for a first cut and reversible: the only reader is the `get_or_create(model=...)` argument, so a durable store swaps in behind that one lookup without touching the picker, the callback contract, or the wire format. No schema or API commitment is made here.
- **Telegram is still missing `/sessions` and `/agent`**, both of which already exist on Discord (`discord/session_resume.py`) and Slack (`slack/sessions_view.py`) and would be ports rather than new designs.
- **`/voice` is absent on Telegram** — `voice_reply.py` is used by the dashboard and Slack only, while Telegram natively supports `sendVoice`.
