### PR TITLE
fix(mcp): read official registry responses to EOF instead of one chunk

### DIFF
--- a/src/kiro_crew/mcp_providers/official.py
+++ b/src/kiro_crew/mcp_providers/official.py
@@ -45,6 +45,10 @@ _HTTP_TIMEOUT_SECS = 10.0
 # User-Agent for our requests (good citizenship).
 _USER_AGENT = "KiroCrew/1.0 (mcp-discovery)"
 
+# Per-iteration read size for the EOF loop below. The cap on TOTAL size
+# is _MAX_RESPONSE_BYTES; this only bounds one read call.
+_READ_CHUNK_BYTES = 64 * 1024
+
 # Maximum response body size (5 MiB) — a search page or single server doc
 # is a few KB; anything bigger is malformed or hostile.
 _MAX_RESPONSE_BYTES = 5 * 1024 * 1024
@@ -87,11 +91,16 @@ async def _fetch_json(url: str) -> Any | None:
                     return None
                 if resp.status != 200:
                     raise ProviderUnavailableError(f"registry returned HTTP {resp.status}")
-                # Bound the read — resp.text() would buffer unbounded.
-                body = await resp.content.read(_MAX_RESPONSE_BYTES + 1)
-                if len(body) > _MAX_RESPONSE_BYTES:
-                    raise ProviderUnavailableError("registry response too large")
-                return json.loads(body.decode("utf-8"))
+                # Read to EOF in bounded chunks; a single read(n) can return a partial body.
+                body = bytearray()
+                while True:
+                    chunk = await resp.content.read(_READ_CHUNK_BYTES)
+                    if not chunk:
+                        break
+                    body.extend(chunk)
+                    if len(body) > _MAX_RESPONSE_BYTES:
+                        raise ProviderUnavailableError("registry response too large")
+                return json.loads(bytes(body).decode("utf-8"))
     except ProviderUnavailableError:
         raise
     except (aiohttp.ClientError, asyncio.TimeoutError, json.JSONDecodeError, OSError) as exc:

--- a/test/test_mcp_providers.py
+++ b/test/test_mcp_providers.py
@@ -384,6 +384,110 @@ class TestOfficialTransport:
 
 
 # ---------------------------------------------------------------------------
+# _fetch_json body read — fakes replace only aiohttp's ClientSession, so the
+# status branches, the chunked EOF read loop, the size cap, and the JSON parse
+# all run for real. Every other class in this file patches _fetch_json itself,
+# which is why the read path needs its own coverage here.
+# ---------------------------------------------------------------------------
+
+
+class _FakeContent:
+    """StreamReader stand-in: returns queued chunks, then b'' (EOF)."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = list(chunks)
+
+    async def read(self, n: int) -> bytes:
+        return self._chunks.pop(0) if self._chunks else b""
+
+
+class _FakeResp:
+    def __init__(self, status: int, chunks: list[bytes]) -> None:
+        self.status = status
+        self.content = _FakeContent(chunks)
+
+    async def __aenter__(self) -> "_FakeResp":
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+
+class _FakeSession:
+    def __init__(self, resp: _FakeResp) -> None:
+        self._resp = resp
+
+    def get(self, url: str, headers: dict | None = None) -> _FakeResp:
+        return self._resp
+
+    async def __aenter__(self) -> "_FakeSession":
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+
+def _patch_session(monkeypatch, resp: _FakeResp) -> None:
+    """Route _fetch_json's ClientSession construction to a canned response."""
+    monkeypatch.setattr(official_mod.aiohttp, "ClientSession", lambda timeout: _FakeSession(resp))
+
+
+class TestFetchJsonRead:
+    @pytest.mark.asyncio
+    async def test_multi_chunk_body_is_read_to_eof(self, monkeypatch):
+        # Split mid-string, mimicking the truncation seen in the field: a
+        # single read(n) returning only the first chunk left an unterminated
+        # JSON string.
+        doc = b'{"servers": [{"name": "io.github.acme/weather"}]}'
+        _patch_session(monkeypatch, _FakeResp(200, [doc[:20], doc[20:]]))
+
+        data = await official_mod._fetch_json("https://registry.example/servers")
+
+        assert data == {"servers": [{"name": "io.github.acme/weather"}]}
+
+    @pytest.mark.asyncio
+    async def test_many_small_chunks(self, monkeypatch):
+        # Chunk-boundary positions must not matter: byte-at-a-time is the
+        # pathological fragmentation.
+        doc = b'{"servers": []}'
+        chunks = [doc[i : i + 1] for i in range(len(doc))]
+        _patch_session(monkeypatch, _FakeResp(200, chunks))
+
+        data = await official_mod._fetch_json("https://registry.example/servers")
+
+        assert data == {"servers": []}
+
+    @pytest.mark.asyncio
+    async def test_size_cap_rejected_mid_stream(self, monkeypatch):
+        # One byte past the cap, delivered across two chunks so the check
+        # fires mid-stream rather than on a single oversized read.
+        over = official_mod._MAX_RESPONSE_BYTES + 1
+        _patch_session(monkeypatch, _FakeResp(200, [b"[", b"1" * (over - 1)]))
+
+        with pytest.raises(ProviderUnavailableError, match="too large"):
+            await official_mod._fetch_json("https://registry.example/servers")
+
+    @pytest.mark.asyncio
+    async def test_size_cap_boundary_allowed(self, monkeypatch):
+        # Exactly _MAX_RESPONSE_BYTES is allowed — the cap rejects only
+        # strictly-larger bodies (same contract as the pre-loop code).
+        cap = official_mod._MAX_RESPONSE_BYTES
+        doc = b'["' + b"x" * (cap - 4) + b'"]'
+        assert len(doc) == cap
+        _patch_session(monkeypatch, _FakeResp(200, [doc[: cap // 2], doc[cap // 2 :]]))
+
+        data = await official_mod._fetch_json("https://registry.example/servers")
+
+        assert isinstance(data, list) and len(data[0]) == cap - 4
+
+    @pytest.mark.asyncio
+    async def test_404_returns_none(self, monkeypatch):
+        _patch_session(monkeypatch, _FakeResp(404, []))
+
+        assert await official_mod._fetch_json("https://registry.example/gone") is None
+
+
+# ---------------------------------------------------------------------------
 # Registry fan-out
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem / Motivation

Searching for MCP servers in **Agent Capabilities → Connections → MCP Servers → Add Server** returns **0 results / No servers found** for common queries like `aws`, `slack`, and `github` — while a direct request to `registry.modelcontextprotocol.io` returns 17+ entries for the same queries.

The UI shows no error. The only trace is in the gateway log:

```
WARNING kiro_crew.mcp_providers.base:
MCP provider official failed for query 'aws'
...
kiro_crew.mcp_providers.base.ProviderUnavailableError:
Unterminated string starting at: line 1 column 11988 (char 11987)
```

What made it hard to see: whether a query fails depends on response SIZE, not the query text. A zero-hit query produces a small response that fits in one chunk and parses fine, so the provider looks healthy exactly when it has
nothing to show.

## Why it matters

Discovery through the official registry is the default path for adding an MCP server from the dashboard. With this bug, every common query silently comes back empty, and the failure renders as an ordinary 0-result search — a user has no reason to suspect a bug rather than an empty registry.

## What changed (motivation → approach → change)

**Root cause.** `_fetch_json()` in `src/kiro_crew/mcp_providers/official.py` reads the response body with a single call:

```python
body = await resp.content.read(_MAX_RESPONSE_BYTES + 1)
```

`aiohttp.StreamReader.read(n)` returns up to `n` bytes and may return only the currently buffered chunk before EOF — ~12 KB in the failing requests. Registry responses of 16–29 KB get truncated mid-JSON, `json.loads` raises `Unterminated string`, and the `JSONDecodeError` is converted to `ProviderUnavailableError`. `ProviderRegistry.search()` then catches it for fault isolation and returns an empty list for the provider — which is why the UI shows 0 results instead of an error.

**The change.** Replace the single read with a loop that accumulates chunks until EOF, reading `_READ_CHUNK_BYTES` (64 KiB) per iteration and enforcing the existing `_MAX_RESPONSE_BYTES` (5 MiB) cap on the accumulated total. The original bounded-read guarantee is preserved — it now applies to the whole body instead of just the first chunk. The 404 → `None` and non-200 → `ProviderUnavailableError` paths are unchanged.

## Tests

`test/test_mcp_providers.py`, new `TestFetchJsonRead` class, five tests using fake aiohttp session/response objects — no network required:

- `test_multi_chunk_body_is_read_to_eof` — a body delivered in multiple chunks is fully assembled and parsed; this is the regression test for the bug.
- `test_many_small_chunks` — assembly holds under heavy fragmentation, not just a two-chunk split.
- `test_size_cap_rejected_mid_stream` — a body exceeding `_MAX_RESPONSE_BYTES` raises `ProviderUnavailableError` while streaming, pinning the guarantee the  old single-read enforced.
- `test_size_cap_boundary_allowed` — a body of exactly `_MAX_RESPONSE_BYTES` is accepted, pinning the cap as inclusive.
- `test_404_returns_none` — the not-found path is unaffected by the loop.

Non-vacuous: temporarily reverting official.py to the original single-read implementation causes four of the five new tests to fail; only the status-only 404 test continues to pass.

## Manual verification

Verified against the live registry: searching `aws` from the dashboard's Add Server dialog now returns the entries the registry holds, where it previously showed "No servers found", and `gateway.log` no longer records `ProviderUnavailableError` for the query. As a control, the same endpoint fetched directly with `curl` returns the same entry count.
<img width="1504" height="907" alt="Screenshot 2026-08-09 at 1 00 56" src="https://github.com/user-attachments/assets/145816ca-7701-4e3e-ad31-bf32a6fee12b" />


## Related Issues

Fixes #2222

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing docs
      describe the provider's read internals
- [x] No secrets, credentials, or internal references in the diff