### PR TITLE
fix(browser): omit storageState when the file is absent

### DIFF
--- a/src/kiro_crew/browser/setup.py
+++ b/src/kiro_crew/browser/setup.py
@@ -747,14 +747,23 @@ def generate_playwright_config(engine: str | None = None) -> Path:
     if engine == "chromium":
         launch_options["channel"] = "chromium"
 
+    # Only attach ``storageState`` when the file actually exists. Playwright
+    # raises ENOENT at context creation if ``storageState`` points at a missing
+    # file, and the sole writer of it — ``refresh_storage_state()`` — is a no-op
+    # in the OSS build (no SSO cookie source), so on a stock install the file is
+    # never created. Omitting it yields a clean, empty context instead of a
+    # launch failure; if a cookie source is ever wired, the next config regen
+    # picks the file up. See #2209.
+    context_options: dict[str, Any] = {}
+    if Path(storage_state).exists():
+        context_options["storageState"] = storage_state
+
     config = {
         "browser": {
             "browserName": engine,
             "isolated": True,
             "launchOptions": launch_options,
-            "contextOptions": {
-                "storageState": storage_state,
-            },
+            "contextOptions": context_options,
         },
         "capabilities": ["network", "storage"],
     }

--- a/test/test_browser_setup.py
+++ b/test/test_browser_setup.py
@@ -618,25 +618,52 @@ class TestGeneratePlaywrightConfig:
         assert not any("remote-debugging-port" in a for a in args)
 
     def test_config_has_correct_structure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         config_path = generate_playwright_config()
         config = json.loads(config_path.read_text(encoding="utf-8"))
         assert "browser" in config
         assert "capabilities" in config
         assert config["browser"]["browserName"] == "chromium"
-        assert "storageState" in config["browser"]["contextOptions"]
+        # A fresh home has no storage-state file, so storageState is omitted:
+        # attaching a path to a missing file makes Playwright raise ENOENT at
+        # context creation. contextOptions is still present (as an empty dict).
+        # See #2209.
+        assert "contextOptions" in config["browser"]
+        assert "storageState" not in config["browser"]["contextOptions"]
 
-    def test_storage_state_path_is_absolute(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    def test_storage_state_absolute_and_attached_when_file_exists(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         # The config path now derives from config_dir(), which reads KIROCREW_HOME
         # first (the conftest autouse fixture pins it). Clear it so config_dir()
         # resolves from the patched Path.home -> ~/.kiro/crew under tmp_path.
         monkeypatch.delenv("KIROCREW_HOME", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # storageState is only attached when the file exists (#2209); seed it so
+        # this exercises the present-branch and the path is absolute.
+        state_file = config_dir() / "playwright-storage-state.json"
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text('{"cookies": [], "origins": []}', encoding="utf-8")
         config_path = generate_playwright_config()
         config = json.loads(config_path.read_text(encoding="utf-8"))
         storage_state = config["browser"]["contextOptions"]["storageState"]
         assert storage_state.startswith(str(tmp_path))
         assert "playwright-storage-state.json" in storage_state
+
+    def test_storage_state_omitted_when_file_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Regression for #2209: with no storage-state file on disk (the OSS
+        # default — refresh_storage_state() is a no-op), the generated config must
+        # NOT reference it. Playwright raises ENOENT at context creation for a
+        # storageState pointing at a missing file, which broke every browser_*
+        # call on a stock install.
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert not (config_dir() / "playwright-storage-state.json").exists()
+        config = json.loads(generate_playwright_config().read_text(encoding="utf-8"))
+        assert "storageState" not in config["browser"]["contextOptions"]
 
     def test_config_written_to_kirocrew_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         # Data home moved from top-level ~/.kirocrew to ~/.kiro/crew (config_dir()).


### PR DESCRIPTION
## Problem

With **Browser Mode** enabled in the default headless mode (Attach-to-my-browser off — the agent drives a separate Chromium Kiro Crew launches), every `browser_*` call fails at launch with:

```
Error reading storage state from <config_dir>/playwright-storage-state.json:
ENOENT: no such file or directory
```

The browser binary launches, but Playwright cannot build a context because the generated config points `contextOptions.storageState` at a file that does not exist.

## Why it matters

On a stock open-source install, headless Browser Mode is the default path for anyone not using the Chrome-extension attach mode. The browser is non-functional out of the box, and the error names a file the product never creates — so there is no obvious user remedy.

## Fix (symptom → root cause → change)

- **Symptom:** `ENOENT` on `playwright-storage-state.json` at every headless launch.
- **Root cause:** `generate_playwright_config()` (`src/kiro_crew/browser/setup.py`) *unconditionally* writes `contextOptions.storageState = <config_dir>/playwright-storage-state.json`, but the only writer of that file — `refresh_storage_state()` — is a no-op in the OSS build (`"browser auth not available in OSS"`, no SSO cookie source). So the file is never created, and Playwright errors on a missing `storageState` path.
- **Change:** attach `storageState` only when the file actually exists; otherwise emit an empty `contextOptions`, so the browser launches with a clean context. Self-heals: if a cookie source is ever wired and `refresh_storage_state()` writes the file, the next config regeneration picks it up.

## Tests

- `test_config_has_correct_structure` — updated: a fresh home has no storage-state file, so `storageState` is omitted (was previously asserting it is always present — that encoded the bug).
- `test_storage_state_absolute_and_attached_when_file_exists` (renamed from `test_storage_state_path_is_absolute`) — seeds the file to cover the present branch (path attached and absolute).
- `test_storage_state_omitted_when_file_missing` — new regression: no file on disk ⇒ `storageState` not referenced.

Full `test/test_browser_setup.py`: **115 passed**.

## Manual verification

Reproduced the `ENOENT` launch failure on a stock install, applied the change, and confirmed a live `browser_navigate` to `https://example.com` then succeeds (page title "Example Domain") where it previously failed at context creation.

## Screenshots

N/A — backend-only change (Playwright config generation); no user-visible UI surface.
