### PR TITLE
fix: wire queued-message inline edit in split-view ChatPane

### DIFF
--- a/website/integration/ChatPaneQueueEdit.integration.test.tsx
+++ b/website/integration/ChatPaneQueueEdit.integration.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * ChatPane queue edit wiring — regression test for
+ * https://github.com/kirodotdev/KiroCrew/issues/2240
+ *
+ * QueueStack's inline edit (Pencil -> EditInput -> commit) was fully built and
+ * unit-tested, and ChatPage passes `onEdit` — but ChatPane (split view, ⌘D)
+ * did not, so the Pencil never rendered in split panes. These tests pin the
+ * ChatPane-level wiring end to end: the affordance renders, a commit PATCHes
+ * the backend, and the store is left to the authoritative `queue_edit` WS
+ * echo (a rejected PATCH restores the typed text into the composer).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { http, HttpResponse } from 'msw'
+import { renderWithProviders, createTestStore } from './helpers'
+import { server } from './mocks/server'
+import ChatPane from '../src/components/ChatPane'
+import type { ChatMessage } from '../src/types'
+
+// Mock framer-motion so QueueStack renders its children directly (same
+// pattern as QueueStackInterrupt.integration.test.tsx).
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: any) => <>{children}</>,
+  motion: {
+    div: React.forwardRef(({ children, ...props }: any, ref: any) => (
+      <div ref={ref} {...props}>{children}</div>
+    )),
+  },
+  useMotionValue: () => ({ set: vi.fn(), get: () => 0, jump: vi.fn() }),
+  useSpring: () => ({ set: vi.fn(), get: () => 0, jump: vi.fn() }),
+}))
+
+const SLOT = 'pane-edit-test'
+
+function queuedMsg(queueId: string, content: string): ChatMessage {
+  return { role: 'queued', content, cls: 'msg msg-queued', meta: { queueId } } as ChatMessage
+}
+
+/** Seed the slot's hydration endpoint with one queued message. */
+function mockSlotDetail(messages: ChatMessage[]) {
+  server.use(
+    http.get('/api/chat/slots/' + SLOT, () => HttpResponse.json({ messages })),
+  )
+}
+
+describe('ChatPane — queued message inline edit (issue #2240)', () => {
+  beforeEach(() => {
+    mockSlotDetail([queuedMsg('q1', 'original queued text')])
+  })
+
+  it('renders the edit affordance on a queued message (regression: onEdit was not passed)', async () => {
+    renderWithProviders(<ChatPane slotKey={SLOT} />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Edit queued message')).toBeInTheDocument()
+    })
+  })
+
+  it('commits an edit: PATCHes the queue item; the store is left to the WS echo', async () => {
+    let patched: { url: string; body: any } | null = null
+    server.use(
+      http.patch('/api/chat/slots/' + SLOT + '/queue/q1', async ({ request }) => {
+        patched = { url: request.url, body: await request.json() }
+        return HttpResponse.json({ ok: true })
+      }),
+    )
+
+    const store = createTestStore()
+    const user = userEvent.setup()
+    renderWithProviders(<ChatPane slotKey={SLOT} />, { store })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Edit queued message')).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText('Edit queued message'))
+
+    const input = await screen.findByRole('textbox', { name: 'Edit queued message' })
+    await user.clear(input)
+    await user.type(input, 'rewritten before running{Enter}')
+
+    await waitFor(() => {
+      expect(patched).not.toBeNull()
+      expect(patched!.body).toEqual({ content: 'rewritten before running' })
+    })
+
+    // No client-side dispatch: the authoritative queue_edit WS broadcast is
+    // the only store writer (no WS in this harness, so content is unchanged).
+    // A local dispatch here could race a concurrent edit with stale text.
+    const msgs = store.getState().chat.slotMessages[SLOT] || []
+    const edited = msgs.find(m => m.role === 'queued' && (m.meta as any)?.queueId === 'q1')
+    expect(edited?.content).toBe('original queued text')
+  })
+
+  it('does not update the store when the PATCH fails (no stale-rollback race)', async () => {
+    server.use(
+      http.patch('/api/chat/slots/' + SLOT + '/queue/q1', () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 }),
+      ),
+    )
+
+    const store = createTestStore()
+    const user = userEvent.setup()
+    renderWithProviders(<ChatPane slotKey={SLOT} />, { store })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Edit queued message')).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText('Edit queued message'))
+
+    const input = await screen.findByRole('textbox', { name: 'Edit queued message' })
+    await user.clear(input)
+    await user.type(input, 'edit that will fail{Enter}')
+
+    // The store is only written after a successful PATCH, so a failure leaves
+    // the queued message untouched - the card keeps showing what the agent
+    // will actually receive, and a delayed rejection can never clobber a
+    // later successful edit.
+    await waitFor(() => {
+      const msgs = store.getState().chat.slotMessages[SLOT] || []
+      const m = msgs.find(x => x.role === 'queued' && (x.meta as any)?.queueId === 'q1')
+      expect(m?.content).toBe('original queued text')
+    })
+
+    // The rejection must not swallow the typed edit: the editor is already
+    // closed, so the replacement text is restored into the pane's composer.
+    await waitFor(() => {
+      const composer = screen.getByRole('textbox', { name: 'Message input' }) as HTMLTextAreaElement
+      expect(composer.value).toBe('edit that will fail')
+    })
+  })
+
+
+  it('does not restore into the composer on a transport-ambiguous failure', async () => {
+    // A network-level failure (request never sent, or response lost after the
+    // server committed) is ambiguous: restoring could duplicate a committed
+    // edit. Only a real HTTP rejection proves the edit was not committed, so
+    // the transport case skips the restore - the card keeps showing the old
+    // text, which is the user's cue to retry.
+    server.use(
+      http.patch('/api/chat/slots/' + SLOT + '/queue/q1', () => HttpResponse.error()),
+    )
+
+    const store = createTestStore()
+    const user = userEvent.setup()
+    renderWithProviders(<ChatPane slotKey={SLOT} />, { store })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Edit queued message')).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText('Edit queued message'))
+    const input = await screen.findByRole('textbox', { name: 'Edit queued message' })
+    await user.clear(input)
+    await user.type(input, 'transport limbo edit{Enter}')
+
+    // Give the rejection time to propagate, then assert the composer stayed empty.
+    await new Promise(r => setTimeout(r, 200))
+    const composer = screen.getByRole('textbox', { name: 'Message input' }) as HTMLTextAreaElement
+    expect(composer.value).toBe('')
+  })
+
+  it('does not PATCH on an empty edit (trim guard)', async () => {
+    const patchSpy = vi.fn()
+    server.use(
+      http.patch('/api/chat/slots/' + SLOT + '/queue/q1', () => {
+        patchSpy()
+        return HttpResponse.json({ ok: true })
+      }),
+    )
+
+    const user = userEvent.setup()
+    renderWithProviders(<ChatPane slotKey={SLOT} />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Edit queued message')).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText('Edit queued message'))
+
+    const input = await screen.findByRole('textbox', { name: 'Edit queued message' })
+    await user.clear(input)
+    await user.keyboard('{Enter}')
+
+    expect(patchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/website/src/components/ChatPane.tsx
+++ b/website/src/components/ChatPane.tsx
@@ -24,7 +24,7 @@ import { useAppSelector, useAppDispatch, store } from '../store'
 import { retireStatelessQuestion, captureStatelessCard, capturePendingAskId, selectSlotMessages, selectSlotStreamState, selectComposerBusy, hydrateSlotMessages, appendSlotMessage, requestStop, cancelQueuedMessage, setAgentSwitchNotice } from '../store/chatSlice'
 import { agentSwitchFailureMessage } from '../utils/agentSwitchFeedback'
 import { triggerRefresh } from '../store/dashboardSlice'
-import { api } from '../api/client'
+import { api, ApiError } from '../api/client'
 import { resolveAskAfterSend } from '../lib/resolveAskAfterSend'
 import { classifyDrop } from '../utils/dropClassify'
 import { serializeDirTokens, spliceDirTokens } from '../utils/fileTokens'
@@ -342,6 +342,32 @@ export default function ChatPane({
     }),
     [slotKey, toolDisclosure, setToolDisclosureFor],
   )
+  // Mirrors ChatPage's handleEditQueued. No client-side dispatch at all: the
+  // queue_edit WS broadcast - which this client also receives - is the single
+  // authoritative store update. Any local dispatch (optimistic or
+  // post-response) can race a concurrent edit: a delayed response committing
+  // after a later successful edit would overwrite newer content with stale
+  // text, diverging from the backend queue.
+  // Live view of this pane's queued cards for the edit-failure guard below:
+  // the .catch closure predates the WS echo, so it must read the CURRENT
+  // queue through a ref rather than the captured render's value.
+  const onEditQueued = useCallback((queueId: string, content: string) => {
+    const trimmed = content.trim()
+    if (!trimmed) return
+    api.editQueuedMessage(slotKey, queueId, trimmed).catch((err) => {
+      // A rejected PATCH must not swallow the replacement text - but only an
+      // HTTP rejection (ApiError: the server answered and refused) proves the
+      // edit was not committed. A transport-level failure is ambiguous: the
+      // server may have committed and broadcast before the response was lost,
+      // and restoring then would duplicate committed text. So restore into
+      // this pane's composer (appending if the user typed something meanwhile,
+      // same recovery as the failed-send path above) only on a proven
+      // rejection; on the ambiguous transport case the card keeps its old
+      // text, which is the user's cue to retry.
+      if (!(err instanceof ApiError)) return
+      setInput((prev) => (prev.trim() ? `${prev}\n${trimmed}` : trimmed))
+    })
+  }, [slotKey])
 
   const ddInputCls = 'w-full px-2 py-1 text-[13px] font-body bg-bg border border-border rounded text-text outline-none focus:border-accent'
 
@@ -401,7 +427,7 @@ export default function ChatPane({
 
         <SubagentDeliveryProgress count={systemDeliveryCount} />
         {queuedMessages.length > 0 && (
-          <QueueStack messages={queuedMessages} onCancel={onCancelQueued} onInterrupt={onInterruptQueued} onReorder={onReorderQueued} />
+          <QueueStack messages={queuedMessages} onCancel={onCancelQueued} onInterrupt={onInterruptQueued} onEdit={onEditQueued} onReorder={onReorderQueued} />
         )}
 
         {/* The pending ask_question card renders per pane: in split mode the

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -15,7 +15,7 @@ import { useChatPopouts } from '../hooks/useChatPopouts'
 import {
   switchSlot, createSlot, deleteSlot, fetchHistory, loadOlderMessages, isSupersededPagingRejection,
   appendMessage, appendSlotMessage, resumeFromHistory, forkSlot,
-  setSlotRunning, startLocalTurn, syncSlotRunningFromServer, setPendingInput, setAgentSwitchNotice, resolveByApprovalId, clearPendingPermissions, cancelQueuedMessage, editQueuedMessage,
+  setSlotRunning, startLocalTurn, syncSlotRunningFromServer, setPendingInput, setAgentSwitchNotice, resolveByApprovalId, clearPendingPermissions, cancelQueuedMessage,
   selectComposerBusy,
   selectContinuable,
   selectTurnInterrupted,
@@ -32,7 +32,7 @@ import { addNotification, removeNotificationByTs } from '../store/notificationsS
 import { onTerminalReady, sendToTerminalSession } from '../utils/terminalRegistry'
 import { interceptSlashCommand, isInterceptedSlashCommand } from './chat/ChatInput'
 import { sseSlotTitle, triggerRefresh } from '../store/dashboardSlice'
-import { api } from '../api/client'
+import { api, ApiError } from '../api/client'
 import { resolveAskAfterSend } from '../lib/resolveAskAfterSend'
 import type { PlanStepInput } from '../api/client'
 import { useProvider } from '../providers'
@@ -5331,10 +5331,46 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     if (!activeSlot) return
     const trimmed = content.trim()
     if (!trimmed) return
-    // Optimistically update the card; WS event reconciles other clients
-    dispatch(editQueuedMessage({ slot: activeSlot, queue_id: queueId, content: trimmed }))
-    api.editQueuedMessage(activeSlot, queueId, trimmed).catch(() => {})
-  }, [activeSlot, dispatch])
+    // No client-side dispatch: the queue_edit WS broadcast is the single
+    // authoritative store update (a local dispatch can race a concurrent
+    // edit and overwrite newer content with stale text). A rejected PATCH
+    // must not swallow the replacement text either: the inline editor has
+    // already closed, so restore it - into the live composer while this slot
+    // is still on screen (merging with text the user typed meanwhile),
+    // otherwise into the slot's saved draft.
+    const slot = activeSlot
+    api.editQueuedMessage(slot, queueId, trimmed).catch((err) => {
+      // Only an HTTP rejection (ApiError: the server answered and refused)
+      // proves the edit was not committed. A transport-level failure is
+      // ambiguous - the server may have committed and broadcast before the
+      // response was lost - and restoring then would duplicate committed
+      // text. Restore only on the proven rejection; on the ambiguous case
+      // the card keeps its old text, which is the user's cue to retry.
+      if (!(err instanceof ApiError)) return
+      // The composer is live for `slot` only when BOTH refs agree: activeSlot
+      // advances during render while composerSlotRef lags until the
+      // outgoing-slot persist effect runs. Testing activeSlotRef alone would
+      // either type into the slot the user just switched to, or let that
+      // pending effect flush stale text over the restored edit. Same contract
+      // as the failed-send and voice-transcript recovery paths above.
+      const onScreen = slot === activeSlotRef.current && composerSlotRef.current === slot
+      if (onScreen) {
+        // Functional update: two pending edits rejecting in one React batch
+        // would both read the same stale inputRef, the second overwriting the
+        // first edit's recovered text. `prev` chains the recoveries instead.
+        setInput(prev => mergeIntoDraft(prev, trimmed))
+      } else {
+        const merged = mergeIntoDraft(drafts.current[slot], trimmed)
+        setDraft(drafts.current, slot, merged)
+        // Mid-switch guard: if the composer still belongs to `slot`, the
+        // outgoing-slot persist effect will flush inputRef.current into
+        // drafts[slot] and overwrite the merge. Carry the merged value into
+        // inputRef too so the flush preserves it.
+        if (composerSlotRef.current === slot) inputRef.current = merged
+        saveDrafts()
+      }
+    })
+  }, [activeSlot, saveDrafts])
 
   const handleReorderQueued = useCallback((queueId: string, direction: 'next' | 'later') => {
     if (!activeSlot) return

--- a/website/src/test/ChatPageCoverage.test.tsx
+++ b/website/src/test/ChatPageCoverage.test.tsx
@@ -38,6 +38,7 @@ import { Provider } from 'react-redux'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { createTestStore } from './helpers'
 import { ApiError } from '../api/client'
+import { editQueuedMessage } from '../store/chatSlice'
 import { ThemeProvider } from '../hooks/useTheme'
 import type { RootState } from '../store'
 import type { ChatMessage } from '../types'
@@ -653,7 +654,7 @@ describe('ChatPage queued-message controls', () => {
   })
 
   it('editing a queued card trims the text and ignores a whitespace-only edit', async () => {
-    renderChatPage([queued('q1', 'run the migration')])
+    const { store } = renderChatPage([queued('q1', 'run the migration')])
     await waitFor(() => expect(queueProps).not.toBeNull())
     const editSpy = apiSpy('editQueuedMessage')
 
@@ -662,6 +663,16 @@ describe('ChatPage queued-message controls', () => {
 
     act(() => queueProps!.onEdit('q1', '  deploy instead  '))
     await waitFor(() => expect(editSpy).toHaveBeenCalledWith('chat-1', 'q1', 'deploy instead'))
+
+    // The card is NOT repainted client-side: the authoritative `queue_edit` WS
+    // broadcast is the single writer, so a local dispatch cannot race a
+    // concurrent echo (same contract as the merged queue-reorder PR #2250).
+    expect(queueProps!.messages[0].content).toBe('run the migration')
+
+    // Replaying that echo exactly as the WS handler does lands the edit.
+    act(() => {
+      store.dispatch(editQueuedMessage({ slot: 'chat-1', queue_id: 'q1', content: 'deploy instead' }))
+    })
     await waitFor(() => expect(queueProps!.messages[0].content).toBe('deploy instead'))
   })
 

--- a/website/src/test/ChatPageW3Coverage.test.tsx
+++ b/website/src/test/ChatPageW3Coverage.test.tsx
@@ -33,6 +33,7 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { createTestStore } from './helpers'
 import { ThemeProvider } from '../hooks/useTheme'
 import { i18nT } from '../i18n/t'
+import { editQueuedMessage } from '../store/chatSlice'
 import { store as appStore } from '../store'
 import type { RootState } from '../store'
 import type { ChatMessage } from '../types'
@@ -560,11 +561,20 @@ describe('ChatPage — queued message actions', () => {
   })
 
   it('editing a queued card trims and commits, and refuses a blank edit', async () => {
-    await renderWithQueue()
+    const { store } = await renderWithQueue()
     act(() => { queueProps!.onEdit('q1', '   ') })
     expect(apiSpy('editQueuedMessage')).not.toHaveBeenCalled()
     act(() => { queueProps!.onEdit('q1', '  run the tests twice  ') })
     expect(apiMocks.editQueuedMessage).toHaveBeenCalledWith('chat-1', 'q1', 'run the tests twice')
+    // The card is NOT repainted client-side: the authoritative `queue_edit` WS
+    // broadcast is the single writer, so a local dispatch cannot race a
+    // concurrent echo (same contract as the merged queue-reorder PR #2250).
+    expect(queueProps!.messages.find(m => m.meta?.queueId === 'q1')?.content)
+      .toBe('run the tests')
+    // Replaying that echo exactly as the WS handler does lands the edit.
+    act(() => {
+      store.dispatch(editQueuedMessage({ slot: 'chat-1', queue_id: 'q1', content: 'run the tests twice' }))
+    })
     await waitFor(() =>
       expect(queueProps!.messages.find(m => m.meta?.queueId === 'q1')?.content)
         .toBe('run the tests twice'),


### PR DESCRIPTION
## Problem / Motivation

In the split view (Cmd+D), queued messages cannot be edited: the Pencil affordance never appears on queue cards. The same cards in the single-chat view show it and editing works there. Observable symptom: queue a message while a pane's agent is busy, hover/expand the queue card in a split pane - cancel (X) and send-now (Zap) are present, edit is not.

## Why it matters

The inline-edit path is fully built and unit-tested (EditInput in QueueStack, `PATCH /api/chat/slots/{slot}/queue/{queue_id}`, the `queue_edit` WS event, the store action) - but split-view users cannot reach it. In a split pane the only remedy for a stale queued message is cancel-and-retype. Split view is precisely where queueing is heaviest, since each pane can have its own busy agent.

## What changed (motivation -> approach -> change)

Symptom: no Pencil in split panes. Root cause: `QueueStack` renders the edit affordance only when an `onEdit` prop is provided, and `ChatPane.tsx` passed `onCancel` and `onInterrupt` but not `onEdit` - while `ChatPage.tsx` (single-chat view) passes all three. Change: add an `onEditQueued` callback in ChatPane (trim guard, then the `api.editQueuedMessage` PATCH) and pass it to `QueueStack`; align ChatPage's `handleEditQueued` on the same model.

Update model, settled through the AI review iterations on this PR: the handlers only fire the PATCH - there is no client-side store dispatch (optimistic or post-response), because either can race a concurrent edit and overwrite newer content with stale text. The `queue_edit` WS broadcast is the single authoritative store writer, the same pattern #2250 landed for `queue_reorder`. Note this deliberately removes the optimistic dispatch that `main`'s `ChatPage.handleEditQueued` ships today, for parity with the merged #2250 model. A rejected PATCH does not swallow the replacement text: the inline editor has closed by then, so the text is restored into the composer (or the slot's saved draft in ChatPage when the user has switched slots), the same recovery as failed sends. The residual WS-down staleness window this shares with the whole queue event family is tracked at the reconnect layer in #2348.

## Tests

New `website/integration/ChatPaneQueueEdit.integration.test.tsx` (4 tests), pinning the ChatPane-level wiring end to end:

- the edit affordance renders on a queued message in a ChatPane (the regression: with `onEdit` missing this button never mounted)
- committing an edit PATCHes `/api/chat/slots/{slot}/queue/{queue_id}` with the trimmed content (asserted via msw); the store is left to the authoritative `queue_edit` WS echo
- a failed PATCH (500) leaves the store untouched and restores the typed text into the pane's composer
- an empty edit is a no-op (trim guard: no PATCH fired)

Full frontend gate run locally: `tsc -b` clean, `vitest run` 829 files / 11061 tests passed.

## Manual verification

Not performed against a live gateway: per `skills/kirocrew-dev/kirocrew-worktree-dev`, making a worktree live swaps the code behind the real dashboard and data home, which I avoided on this machine. The integration tests exercise the full wiring (render -> click -> type -> PATCH -> store) against the real component tree.

## Screenshots / video

The affordance is the existing QueueStack Pencil button, unchanged from the single-chat view - this PR provides the callback that lets it mount in split panes. Captured from the real component (dark theme): the pencil now rendering on a queued message in a pane, and the same inline EditInput open.

![Queued message in a split pane: Edit pencil affordance, and the inline EditInput open](https://github.com/el-pedrito/KiroCrew/raw/291c2e7f/temp-screenshots/queue-edit-pane/inline-edit-dark.png)

(Evidence image committed on a side branch of the fork, commit-SHA-pinned, to avoid resetting this PR's CI approval with a no-op push.)

## Related Issues

Fixes #2240

## Checklist

- [x] Single commit with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (N/A - behavior now matches the documented main-view behavior)
- [x] No secrets, credentials, or internal references in the diff



