### PR TITLE
fix(weixin): reuse one X-WECHAT-UIN per process so iLink keeps the session

### DIFF
--- a/src/kiro_crew/weixin/client.py
+++ b/src/kiro_crew/weixin/client.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import functools
 import json
 import logging
 import secrets
@@ -82,7 +83,16 @@ def _json_dumps(payload: Dict[str, Any]) -> str:
     return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
 
 
-def _random_wechat_uin() -> str:
+@functools.lru_cache(maxsize=1)
+def _wechat_uin() -> str:
+    """One random UIN per process, generated on first use and then reused.
+
+    iLink binds a bot session to the ``X-WECHAT-UIN`` it saw at authorization.
+    Generating a fresh value per request made the first ``getupdates``
+    long-poll after a QR login return ``-14`` (:data:`SESSION_EXPIRED_ERRCODE`),
+    which parked the poll loop for 10 minutes and made the channel look like it
+    had never connected.
+    """
     value = struct.unpack(">I", secrets.token_bytes(4))[0]
     return base64.b64encode(str(value).encode("utf-8")).decode("ascii")
 
@@ -96,7 +106,7 @@ def _headers(token: Optional[str], body: str) -> Dict[str, str]:
         "Content-Type": "application/json",
         "AuthorizationType": "ilink_bot_token",
         "Content-Length": str(len(body.encode("utf-8"))),
-        "X-WECHAT-UIN": _random_wechat_uin(),
+        "X-WECHAT-UIN": _wechat_uin(),
         "iLink-App-Id": ILINK_APP_ID,
         "iLink-App-ClientVersion": str(ILINK_APP_CLIENT_VERSION),
     }

--- a/test/test_weixin.py
+++ b/test/test_weixin.py
@@ -65,6 +65,19 @@ def test_headers_carry_required_ilink_fields():
     assert h["X-WECHAT-UIN"]
 
 
+def test_headers_reuse_one_uin_across_requests():
+    """iLink binds the bot session to the UIN seen at authorization.
+
+    Re-rolling ``X-WECHAT-UIN`` per request made the first ``getupdates``
+    long-poll after a QR login come back ``-14`` (session expired), so every
+    request in a process must present the same UIN.
+    """
+    first = _headers("abc123", "{}")["X-WECHAT-UIN"]
+    assert all(_headers("abc123", "{}")["X-WECHAT-UIN"] == first for _ in range(5))
+    # Independent of token/body, since it identifies the client, not the call.
+    assert _headers(None, '{"k":1}')["X-WECHAT-UIN"] == first
+
+
 def test_headers_omit_authorization_without_credential():
     assert "Authorization" not in _headers(None, "{}")
 


### PR DESCRIPTION
## Problem

The WeChat (iLink) channel never stays connected. Every QR login succeeds — the token lands in `.env`, `weixin.account_id` is written — and then the **first** `getupdates` long-poll comes back `ret == -14` (`SESSION_EXPIRED_ERRCODE`):

```
WARNING kiro_crew.weixin.transport: weixin: session expired (-14); pausing — re-login via Settings QR.
```

The poll loop then sleeps 600s, so the channel looks like it never connected and re-scanning inside that window doesn't help either.

## Root cause

`_headers()` runs for **every** request, and it called `_random_wechat_uin()` inline, so no two requests ever presented the same `X-WECHAT-UIN`:

```python
>>> from kiro_crew.weixin.client import _headers
>>> _headers("tok", "{}")["X-WECHAT-UIN"], _headers("tok", "{}")["X-WECHAT-UIN"]
('MzcxMjA1MDAyOQ==', 'MTg2NzA3OTEzOQ==')   # same token, different UIN
```

iLink binds a bot session to the UIN it saw at authorization. The next request after the QR handshake — the first long-poll — therefore arrives with an unknown UIN and the session is treated as expired.

## Fix

Generate the UIN once per process and reuse it. It identifies the client, not the call, so it should not vary per request.

Ruled out before landing on this: a stale sync cursor (`transport._sync_buf` starts `""` and is never persisted), a stale token (`.env` was rewritten with a fresh 58-char token on each scan), and gateway restarts (reproduced with no restart at all between scan and failure).

## Verification

Reproduced and fixed against a live WeChat account on `0.1.3`, then ported to `main`:

- **Before:** three consecutive QR logins expired 16s, 26s and 16s after authorization. Each scan minted a new `account_id`, confirming genuinely new bot instances rather than stale credentials.
- **After:** the channel connects and stays up — a persistent HTTPS connection to `ilinkai.weixin.qq.com`, zero `-14` for the whole observation window, and inbound messages reach `messaging.dispatch` and get replies.

New test `test_headers_reuse_one_uin_across_requests` fails on unpatched code (`assert False`) and passes with the fix, so it actually pins the regression.

Gates run from the worktree per `skills/kirocrew-dev/kirocrew-worktree-dev` (branch off `origin/main` @ 22cd154):

| Gate | Result |
|---|---|
| `pytest` (full) | 38188 passed, 125 failed |
| `test/test_weixin*.py` | 106 passed |
| `isort --check-only` | pass |
| `flake8` | pass |
| `mypy src/kiro_crew/` | pass — no issues in 846 files |
| `scripts/scrub-lint.sh --no-history` | pass |
| `scripts/docs-lint.sh` | pass (188 files) |

**About the 125 failures:** all are `SandboxUnavailableError` / subagent tests, none WeChat-related. This host's kernel blocks unprivileged user namespaces (`unshare(CLONE_NEWNS)` → EPERM), so the sandbox backend can't start. Per the skill's triage rule I compared against a clean tree rather than calling them flaky — `test_subagent.py test_app_backend.py test_context.py` gives **32 failed / 186 passed on this branch and 32 failed / 186 passed on unmodified `origin/main`**, i.e. pre-existing and environment-specific.

Frontend gates (`tsc -b`, `vitest`) weren't run — this change is backend-only and touches no `website/` code. Happy to run them if you'd rather have the full matrix.

## Notes

Two adjacent things I noticed while debugging but did **not** change here, happy to file separately if useful:

- `transport.authorize()` logs allowlist denials only via `sel().log_api_access(...)`, with no logger output — a rejected sender makes the channel look completely inert, and the real `user_id` is only recoverable by grepping the audit log. The dashboard field also invites a nickname while iLink expects an `...@im.wechat` id.
- The in-process cache means a gateway restart mints a new UIN, which presumably still forces a re-scan. Persisting the UIN next to the token would fix that too; I kept this patch minimal instead.