### PR TITLE
fix(usage): retain Auto model attribution

### DIFF
--- a/docs/system-specs/modules/metrics.md
+++ b/docs/system-specs/modules/metrics.md
@@ -364,7 +364,7 @@ Each row (`_build_token_record`) carries:
 | `ts` | str | ISO-8601 local timestamp of the turn |
 | `slot` | str | chat slot / session key |
 | `provider` | str | LLM backend (`acp` / `claude_code` / `bedrock` / …), `""` if unknown |
-| `model` | str | model id for the turn |
+| `model` | str | resolved model id for the turn; `"auto"` when the completed turn only exposes the Auto request; `""` if no model source is available |
 | `input` / `output` | int | prompt / completion tokens (structurally `0` on the ACP backend — kiro-cli bills credits only) |
 | `cache_create` / `cache_read` | int | cache-write / cache-read tokens |
 | `cost` | float | provider-reported USD cost (`0.0` on ACP) |

--- a/src/kiro_crew/dashboard/handlers/usage.py
+++ b/src/kiro_crew/dashboard/handlers/usage.py
@@ -954,30 +954,53 @@ def read_effective_model(source: object) -> str:
         for attr in ("_resolved_model_id", "_model"):
             for node in chain:
                 candidate = getattr(node, attr, "")
-                if isinstance(candidate, str) and candidate and candidate != "auto":
+                if (
+                    isinstance(candidate, str)
+                    and candidate
+                    and candidate.strip().lower() != "auto"
+                ):
                     return candidate
     except Exception:
         pass
     return ""
 
 
-def _resolve_model(model: str, model_source: object) -> str:
-    """Resolve the model to record, treating the ``"auto"`` sentinel as unresolved.
+def _source_requests_auto(source: object) -> bool:
+    """Whether the provider chain still reports Auto as its model request.
 
-    ``"auto"`` is not a model — it means "let the backend choose" — so recording
-    it would put a non-model value in the attribution dimension. Several
-    surfaces pass it verbatim (``agent.model`` defaults to ``"auto"``, and the
-    task runner forwards that value), so gating only on an empty string lets it
-    through. When the caller's value is unresolved we take the provider's
-    resolved id; if that is unavailable the field stays blank, which is what
-    ``test_late_backfill_skips_auto_sentinel`` requires ("the record stays blank
-    until a real model is known").
+    This is deliberately separate from :func:`read_effective_model`: ``auto``
+    is not a resolved model id, but it is useful attribution when a completed
+    turn has no more specific id from the backend. A blank request does not
+    prove Auto was selected, so it remains blank in the row store.
     """
-    if (model or "").strip().lower() not in ("", "auto"):
+    try:
+        return any(
+            isinstance(candidate := getattr(node, "_model", ""), str)
+            and candidate.strip().lower() == "auto"
+            for node in _wrapper_chain(source)
+        )
+    except Exception:
+        return False
+
+
+def _resolve_model(model: str, model_source: object) -> str:
+    """Resolve the model to record, retaining a known Auto selection.
+
+    A concrete resolved id remains the preferred accounting dimension. When a
+    completed Auto turn exposes no concrete id, ``"auto"`` still distinguishes
+    that deliberate backend choice from an unavailable model source. A blank
+    caller value with no Auto request remains blank because it carries no model
+    information at all.
+    """
+    requested = (model or "").strip().lower()
+    if requested not in ("", "auto"):
         return model
-    if model_source is None:
-        return "" if (model or "").strip().lower() == "auto" else model
-    return read_effective_model(model_source)
+    resolved = read_effective_model(model_source) if model_source is not None else ""
+    if resolved:
+        return resolved
+    if requested == "auto" or _source_requests_auto(model_source):
+        return "auto"
+    return ""
 
 
 def _coerce_int(value: Any) -> int:

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -3676,10 +3676,12 @@ class TestTokenPersistenceBackfill:
         assert slot.model == "opus-4.8-1m"
 
     @pytest.mark.asyncio
-    async def test_late_backfill_skips_auto_sentinel(self, tmp_path, monkeypatch):
-        """The sentinel value 'auto' (CC's pre-init placeholder) must not be
-        persisted as the model -- the record stays blank until a real model
-        is known.
+    async def test_auto_sentinel_reaches_persistence_fallback(self, tmp_path, monkeypatch):
+        """An unresolved Auto request delegates to the recorder's fallback.
+
+        The slot remains blank because it has no concrete model id to persist,
+        while the client lets the usage recorder distinguish Auto from an
+        unavailable model source.
         """
         from kiro_crew.providers.base import EVENT_COMPLETE, LLMEvent
 
@@ -3697,7 +3699,7 @@ class TestTokenPersistenceBackfill:
         captured: list[tuple] = []
 
         async def _fake_persist(k, m, e, provider="", **kwargs):
-            captured.append((k, m, provider))
+            captured.append((k, m, provider, kwargs["model_source"]))
 
         monkeypatch.setattr(
             "kiro_crew.dashboard.chat_runner.persist_token_record_async", _fake_persist
@@ -3709,6 +3711,7 @@ class TestTokenPersistenceBackfill:
 
         assert len(captured) == 1
         assert captured[0][1] == ""
+        assert captured[0][3] is client
         assert slot.model == ""
 
     @pytest.mark.asyncio

--- a/test/test_usage.py
+++ b/test/test_usage.py
@@ -1202,18 +1202,32 @@ class TestModelSourceFallback:
         )
         assert self._row(shard_dir)["model"] == "claude-opus-4.8"
 
-    def test_auto_without_resolvable_source_records_blank(self, tmp_path, monkeypatch):
-        # Matches test_late_backfill_skips_auto_sentinel's contract: the record
-        # stays blank until a real model is known -- never the sentinel itself.
+    def test_auto_without_resolvable_source_records_auto(self, tmp_path, monkeypatch):
+        # `auto` records the explicit backend-selection mode even when the
+        # backend does not disclose the concrete model for this completed turn.
         shard_dir = _patch_shard_layout(monkeypatch, tmp_path)
         persist_token_record(
             "slot", "auto", self._event(), provider="acp", surface="task_runner"
         )
-        assert self._row(shard_dir)["model"] == ""
+        assert self._row(shard_dir)["model"] == "auto"
 
     def test_auto_is_case_and_space_insensitive(self, tmp_path, monkeypatch):
         shard_dir = _patch_shard_layout(monkeypatch, tmp_path)
         persist_token_record(
             "slot", "  AUTO ", self._event(), provider="acp", surface="cron"
         )
-        assert self._row(shard_dir)["model"] == ""
+        assert self._row(shard_dir)["model"] == "auto"
+
+    def test_auto_source_fills_empty_model(self, tmp_path, monkeypatch):
+        # Dashboard slots use an empty override for Auto while the live client
+        # retains the request sentinel.
+        shard_dir = _patch_shard_layout(monkeypatch, tmp_path)
+        persist_token_record(
+            "dashboard:auto",
+            "",
+            self._event(),
+            provider="acp",
+            surface="dashboard",
+            model_source=_Inner("  AUTO "),
+        )
+        assert self._row(shard_dir)["model"] == "auto"


### PR DESCRIPTION
## Problem / Motivation

Dashboard sessions switched to Auto can write token-usage rows with an empty model field when the backend has not exposed a concrete resolved model ID.

## Why it matters

Those rows lose the deliberate Auto selection, so per-model cost analysis cannot distinguish Auto-backed turns from turns with no model source at all.

## What changed (motivation → approach → change)

The recorder already prefers a concrete resolved ID from the provider chain. When no resolved ID exists, it now records auto only when either the caller or the provider chain explicitly reports the Auto sentinel; genuinely unavailable model sources remain blank. The dashboard flow continues to pass the live client into that resolver, and the row-store contract documents the distinction.

## Tests

- python -m pytest test/test_usage.py test/test_dashboard_chat.py -n0 -q (606 passed)
- Added JSONL regression coverage for explicit Auto, normalized Auto, and dashboard's empty override with an Auto provider request.
- Updated the dashboard persistence test to assert that it passes the live client to the recorder fallback.
- isort --check-only, flake8, documentation lint, brand check, and diff check passed.
- mypy src/kiro_crew/dashboard/handlers/usage.py remains blocked by three existing macOS os.*xattr stub errors in src/kiro_crew/hooks.py, outside this change.

## Manual verification

N/A - the persistence boundary and dashboard wiring are fully covered by focused unit tests.

## Related Issues

Fixes #2251

## Checklist

- [x] Single commit with Conventional Commits title: fix(usage): retain auto model attribution
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (row-store contract)
- [x] No secrets, credentials, or internal references in the diff