### PR TITLE
fix: stop idle sweep reaping live app-worker sessions as orphaned tabs

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -3285,6 +3285,24 @@ class DashboardState:
         except Exception:
             pass
         self._slots[name] = slot
+        # Publish the updated key set to SessionManager and the surface
+        # registry NOW, not just on the HTTP slot endpoints. Slots born here
+        # programmatically (auto-research campaign workers, cron/workflow
+        # inject, task runner, spec builder) never pass through those
+        # endpoints, so ``_active_dashboard_slots`` stayed stale and the idle
+        # sweep's orphan branch reaped their live sessions as "slot gone" —
+        # killing the companion subagent runtime (and any subagent mid-prompt
+        # on it) along the way. Guarded: tests build this state without a
+        # SessionManager, and a sync failure must never break slot creation.
+        if self.sessions:
+            try:
+                from kiro_crew.dashboard.chat_utils import _sync_dashboard_slots
+
+                _sync_dashboard_slots(self)
+            except Exception:
+                logger.warning(
+                    "get_or_create_slot: active-slot sync failed for %s", name, exc_info=True
+                )
         self.push_slots_update()
         return slot
 

--- a/test/test_slot_sync_on_create.py
+++ b/test/test_slot_sync_on_create.py
@@ -1,0 +1,160 @@
+"""Programmatic slot creation must publish the active-slot set.
+
+The defect these pin: ``get_or_create_slot`` inserted the new slot into
+``state._slots`` and broadcast to websockets, but never published the updated
+key set to ``SessionManager.set_active_dashboard_slots`` — only the HTTP slot
+endpoints did (via ``_sync_dashboard_slots``). Slots created programmatically
+(auto-research campaign workers, cron/workflow inject, the task runner, spec
+builder) never pass through those endpoints, so ``_active_dashboard_slots``
+stayed stale and the idle sweep's orphan branch reaped their LIVE sessions as
+"slot gone".
+
+Observed in production (gateway.log, 2026-08-08): an actively running research
+campaign's session ``dashboard:research-9057ccf5`` was expired as orphaned on
+three consecutive sweeps (16:54:47, 17:04:53, 17:14:56) while its autonudge
+loop was mid-campaign. The first reap's ``reset()`` released the companion
+subagent runtime, killing subagent c6f44344 mid-prompt with
+``AcpProcessDied("Runtime process died during prompt")``.
+
+The busy-guard (see test_session_idle_busy_guard.py) does not cover this: an
+autonudge-driven session is legitimately idle BETWEEN cycles (the semaphore is
+released when a turn ends), which is exactly when the sweep caught it.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.config import KiroCrewConfig
+from kiro_crew.session import SessionManager
+
+
+def _make_state(sessions):
+    """A dashboard state real enough to run the REAL get_or_create_slot."""
+    from kiro_crew.dashboard.state import DashboardState
+
+    st = DashboardState.__new__(DashboardState)
+    st._slots = {}
+    st._slot_counter = 0
+    st.sessions = sessions
+    st.push_slots_update = MagicMock()
+    st._broadcast_chat_message = MagicMock()
+    st._restricted_keys = set()
+    st._ephemeral_keys = set()
+    st._slack_to_slot = {}
+    return st
+
+
+def _mock_provider_factory():
+    def factory(session_key=None, agent=None, channel_id=None, **kwargs):
+        m = AsyncMock()
+        m.start = AsyncMock()
+        m.shutdown = AsyncMock()
+        m.context_usage_pct = lambda: 0.0
+        m.has_active_turn = lambda: False
+        return m
+
+    return factory
+
+
+class TestSlotCreatePublishesActiveSet:
+    def test_programmatic_slot_creation_publishes_its_session_key(self):
+        """The auto-research path: get_or_create_slot(name=...) with no HTTP endpoint."""
+        sessions = MagicMock()
+        sessions.get_slack_link.return_value = ("", "")
+        st = _make_state(sessions)
+
+        st.get_or_create_slot(name="research-abc123", app="auto-research")
+
+        assert sessions.set_active_dashboard_slots.called, (
+            "slot creation must publish the active-slot set to SessionManager"
+        )
+        published = sessions.set_active_dashboard_slots.call_args[0][0]
+        assert "dashboard:research-abc123" in published
+
+    def test_returning_an_existing_slot_does_not_republish(self):
+        """The early return for existing slots leaves the (correct) set alone."""
+        sessions = MagicMock()
+        sessions.get_slack_link.return_value = ("", "")
+        st = _make_state(sessions)
+        st.get_or_create_slot(name="research-abc123")
+        sessions.set_active_dashboard_slots.reset_mock()
+
+        st.get_or_create_slot(name="research-abc123")
+
+        assert not sessions.set_active_dashboard_slots.called
+
+    def test_slot_creation_survives_a_missing_session_manager(self):
+        """Test-constructed states have sessions=None; creation must not raise."""
+        st = _make_state(None)
+
+        slot = st.get_or_create_slot(name="research-abc123")
+
+        assert slot is not None
+        assert "research-abc123" in st._slots
+
+    def test_slot_creation_survives_a_sync_failure(self):
+        """A publish failure must never break slot creation itself."""
+        sessions = MagicMock()
+        sessions.get_slack_link.return_value = ("", "")
+        sessions.set_active_dashboard_slots.side_effect = RuntimeError("boom")
+        st = _make_state(sessions)
+
+        slot = st.get_or_create_slot(name="research-abc123")
+
+        assert slot is not None
+        assert "research-abc123" in st._slots
+
+
+class TestWorkerSessionSurvivesOrphanSweep:
+    @pytest.mark.asyncio
+    async def test_idle_worker_session_is_not_reaped_as_an_orphan(self):
+        """The regression, end to end against a real SessionManager.
+
+        An autonudge worker is idle between cycles (permit released), so the
+        busy-guard does not protect it — only membership in the active-slot
+        set does. Before the fix this test fails: the sweep reaps the session
+        as "slot gone".
+        """
+        cfg = KiroCrewConfig()
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+        st = _make_state(mgr)
+
+        # The stale state the bug depends on: some earlier HTTP-path sync
+        # published a set that predates the worker slot.
+        mgr.set_active_dashboard_slots({"dashboard:tab1"})
+
+        # The campaign body: session runs turns, then idles between cycles.
+        await mgr.get_or_create("dashboard:research-abc123")
+        mgr.release("dashboard:research-abc123")
+
+        # The programmatic slot creation (auto_research handlers.py).
+        st.get_or_create_slot(name="research-abc123", app="auto-research")
+
+        # Orphan branch ignores the clock — pass a timeout no session reaches.
+        await mgr._expire_idle(9999)
+
+        assert "dashboard:research-abc123" in mgr._sessions, (
+            "a live worker session was reaped as an orphaned tab"
+        )
+        await mgr.close_all()
+
+    @pytest.mark.asyncio
+    async def test_genuinely_orphaned_session_is_still_reaped(self):
+        """The fix must not disable the orphan sweep it corrects."""
+        cfg = KiroCrewConfig()
+        mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
+
+        await mgr.get_or_create("dashboard:closed-tab")
+        mgr.release("dashboard:closed-tab")
+        async with mgr._lock:
+            mgr._sessions["dashboard:closed-tab"].last_used = time.monotonic()
+        mgr.set_active_dashboard_slots(set())  # tab really is gone
+
+        await mgr._expire_idle(9999)
+
+        assert "dashboard:closed-tab" not in mgr._sessions
+        await mgr.close_all()


### PR DESCRIPTION
# Live app-worker sessions are reaped as "orphaned tabs" because programmatic slot creation never publishes the active-slot set

## Log evidence (sanitized)

An actively running auto-research campaign had its session expired as orphaned on three consecutive idle sweeps, mid-campaign:

```
16:54:47 WARNING kiro_crew.session: Expiring orphaned dashboard session (slot gone): dashboard:research-<cid>
16:54:47 ERROR kiro_crew.subagent: Subagent <id> failed
  ...
  File ".../kiro_crew/acp/session_handle.py", line 1211, in _dispatch_events
    raise AcpProcessDied("Runtime process died during prompt")
kiro_crew.acp.client.AcpProcessDied: Runtime process died during prompt
17:04:53 WARNING kiro_crew.session: Expiring orphaned dashboard session (slot gone): dashboard:research-<cid>
17:14:56 WARNING kiro_crew.session: Expiring orphaned dashboard session (slot gone): dashboard:research-<cid>
```

The first reap killed a research subagent mid-prompt: `SessionManager.reset()` releases the companion subagent runtime for the reaped key ("Kill the shared subagent runtime associated with this session"), so the in-flight subagent died with `AcpProcessDied` and its cycle's work was lost. The campaign only survived because `reset()` preserves the session_map entry and the next autonudge cycle restored the session — paying a restore each cycle and getting reaped again on every subsequent sweep.

## Root cause

`SessionManager._expire_idle`'s orphan branch reaps any `dashboard:*` session whose key is missing from `_active_dashboard_slots`. That set is only refreshed by `_sync_dashboard_slots(state)`, which is called from the HTTP slot endpoints (create/delete/resume/restore) — the docstring on `set_active_dashboard_slots` says as much.

`DashboardState.get_or_create_slot` itself inserts into `state._slots` and calls `push_slots_update()` (websocket broadcast), but never publishes the key set. Every slot born programmatically — auto-research campaign workers (`auto_research/handlers.py`), `cron_inject.py`, `workflow_inject.py`, the task runner, spec builder, openai-compat — therefore leaves `_active_dashboard_slots` stale, and the sweep sees "slot gone" for a slot that is very much present in `state._slots`.

The existing busy-guard (`sess.semaphore.locked()`) does not cover this: an autonudge-driven worker is legitimately idle *between* cycles, which is exactly when the sweep catches it. The observed reaps line up with the 10-minute sweep cadence.

## Fix

Publish the active-slot set at the single place slots are born: `get_or_create_slot` now calls `_sync_dashboard_slots(self)` (lazy import, same pattern as the existing `effective_session_key` import in this method) right before `push_slots_update()`. Guarded so that:

- states constructed without a `SessionManager` (test fixtures) skip the sync, and
- a sync failure can never break slot creation (logged as a warning).

The early return for existing slots is untouched — the set only changes when a slot is created. Slot *removal* paths already sync explicitly and are unchanged.

## Tests

New `test/test_slot_sync_on_create.py` (6 tests), following the conventions of `test_session_idle_busy_guard.py`:

- programmatic slot creation publishes the slot's session key to `SessionManager`
- returning an existing slot does not republish
- creation survives a missing `SessionManager` and a sync failure
- **end-to-end regression**: with a real `SessionManager`, an idle-between-cycles worker session survives the orphan sweep after its slot is created programmatically (fails before the fix)
- a genuinely orphaned session is still reaped (the sweep is not disabled)

Verified pre-fix failure: with the `state.py` change stashed, 2 of 6 tests fail (the publish assertion and the orphan-survival regression).

```
test/test_slot_sync_on_create.py .......                             6 passed
test/ session+slot neighborhood (idle busy guard, one-conversation,
  session, cleanup)                                                315 passed
test/ -k "slot or dashboard_state or chat_persistence or
  cron_inject or workflow_inject or taskrunner"          1315 passed, 2 skipped
src/kiro_crew/apps/builtins/auto_research + spec_builder routes    269 passed
flake8: clean · mypy state.py: clean
```
