### PR TITLE
fix: never adopt a draining gateway; bounded recovery for adopted local gateways

### DIFF
--- a/website/electron/README.md
+++ b/website/electron/README.md
@@ -13,7 +13,10 @@ npx electron .
 
 The app will:
 
-1. Reuse an existing gateway if one is already reachable
+1. Reuse an existing gateway if one is already reachable and actually serving
+   (`/api/ready` 200) — a gateway draining after `/api/shutdown` still answers
+   `/api/status`, so it is never adopted; the app waits for the port to clear
+   and spawns fresh instead
 2. Launch `kirocrew gateway` when needed
 3. Show a loading screen while the backend boots
 4. Load the dashboard

--- a/website/electron/gateway-recovery.js
+++ b/website/electron/gateway-recovery.js
@@ -28,16 +28,98 @@
  *                                       path). false on the reuse path — a
  *                                       gateway was already answering at boot
  *                                       (remote tunnel or external gateway).
- * @returns {"respawn" | "reconnect"}
+ * @param {boolean} [o.reusedLocalGateway=false]  true only when the reuse
+ *                                       decision positively identified the
+ *                                       port-holder as a LOCAL same-family
+ *                                       Kiro Crew process (localOwner
+ *                                       "kirocrew"/"service" + same-family
+ *                                       health). A tunnel or an unidentified
+ *                                       holder never sets this.
+ * @returns {"respawn" | "reconnect-bounded" | "reconnect"}
  *   "respawn"   — we own the child: kill the wedged tree, free the port, spawn a
  *                 fresh backend, re-run the boot flow.
- *   "reconnect" — we do NOT own the port-holder: never kill it or spawn locally;
- *                 re-probe until the external gateway / tunnel heals, then
- *                 reconnect (re-fetching a token, since the drop likely
- *                 invalidated the old one).
+ *   "reconnect-bounded" — we adopted a LOCAL same-family gateway we do not own.
+ *                 Never kill it, but its death is not a tunnel blip: nothing
+ *                 will ever bring it back, so wait a BOUNDED interval for it to
+ *                 recover, then (once the port clears on its own) spawn our own
+ *                 backend. Waiting forever here is the dead-window
+ *                 bug: the shell classified a dead local gateway as "a gateway
+ *                 we did not spawn (remote tunnel)" and never respawned.
+ *   "reconnect" — genuinely external holder (tunnel / unidentified): never kill
+ *                 it or spawn locally; re-probe until the external gateway /
+ *                 tunnel heals, then reconnect (re-fetching a token, since the
+ *                 drop likely invalidated the old one).
  */
-function chooseRecoveryStrategy({ weSpawnedGateway }) {
-  return weSpawnedGateway ? "respawn" : "reconnect";
+function chooseRecoveryStrategy({ weSpawnedGateway, reusedLocalGateway = false }) {
+  if (weSpawnedGateway) return "respawn";
+  if (reusedLocalGateway) return "reconnect-bounded";
+  return "reconnect";
 }
 
-module.exports = { chooseRecoveryStrategy };
+// launchd throttles KeepAlive respawns to ~10s between starts; systemd's
+// default RestartSec is far shorter. 15s covers both with margin, and the
+// cost of over-waiting lands only on the orphan case (a one-time delay
+// before we spawn), never on a live rebind (we adopt the instant it binds).
+const SERVICE_REBIND_GRACE_MS = 15_000;
+
+/**
+ * After a SERVICE-classified port-holder releases the port, the OS service
+ * manager (launchd KeepAlive / systemd Restart=) may be about to respawn it:
+ * at the moment the socket closes, a transient release during a service
+ * restart is indistinguishable from a permanent exit. Spawning immediately
+ * races the manager for the port — one side loses with EADDRINUSE.
+ *
+ * But "service-classified" does not guarantee a manager will respawn it: an
+ * orphaned gateway reparents to init (PPID 1) and classifies as
+ * service-managed too, and an orphan has no KeepAlive — nothing will ever
+ * rebind. So: wait a bounded grace for a rebind, report "rebound" the moment
+ * something takes the port back (the caller adopts/reconnects to it), and
+ * report "spawn" only when the grace expires with the port still free.
+ *
+ * Pure/injectable so the decision is unit-testable without Electron.
+ *
+ * @param {object} o
+ * @param {() => Promise<boolean>} o.isPortBound  does the port have a LISTEN owner again?
+ * @param {(ms:number) => Promise<void>} o.sleep
+ * @param {number} [o.graceMs]
+ * @param {number} [o.pollMs]
+ * @returns {Promise<"rebound" | "spawn">}
+ */
+async function waitForServiceRebind({ isPortBound, sleep, graceMs = SERVICE_REBIND_GRACE_MS, pollMs = 500 }) {
+  const deadline = Date.now() + graceMs;
+  for (;;) {
+    if (await isPortBound()) return "rebound";
+    if (Date.now() >= deadline) return "spawn";
+    await sleep(pollMs);
+  }
+}
+
+// A graceful gateway stop releases the LISTEN socket EARLY — the process keeps
+// running to drain in-flight turns and flush session files, and it holds the
+// exclusive gateway.lock flock for its full lifetime. So "port is free" does
+// NOT mean "safe to spawn": a replacement started in that window is refused by
+// the singleton lock and exits, then the incumbent exits — leaving no gateway
+// at all. This helper waits (bounded) for the captured incumbent pids to
+// actually die; the kernel releases the flock atomically on process exit.
+// Pure/injectable for unit tests. 15s comfortably covers the backend's
+// graceful-stop budget (drain ≤5s + flush) after the port has already cleared.
+const INCUMBENT_EXIT_GRACE_MS = 15_000;
+
+async function waitForProcessExit({ pids, isAlive, sleep, timeoutMs = INCUMBENT_EXIT_GRACE_MS, pollMs = 250 }) {
+  const watched = (pids || []).filter((p) => Number.isInteger(p) && p > 0);
+  if (!watched.length) return "exited";
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (!watched.some((p) => isAlive(p))) return "exited";
+    if (Date.now() >= deadline) return "timeout";
+    await sleep(pollMs);
+  }
+}
+
+module.exports = {
+  chooseRecoveryStrategy,
+  waitForServiceRebind,
+  waitForProcessExit,
+  SERVICE_REBIND_GRACE_MS,
+  INCUMBENT_EXIT_GRACE_MS,
+};

--- a/website/electron/instance-guard.js
+++ b/website/electron/instance-guard.js
@@ -35,6 +35,46 @@ const { channelForVersion } = require("./auto-update");
 // "unidentified" and silently disable the takeover path (caught in review).
 const HEALTH_IDENTITY_PATH = "/api/health";
 
+// The endpoint that distinguishes a SERVING gateway from one that is merely
+// alive. /api/status and /api/health both keep answering 200 while the backend
+// DRAINS after POST /api/shutdown, so a boot probe against either happily
+// adopts a gateway that is seconds from exiting ("reusing existing gateway" →
+// the gateway dies → the shell waits on a port nothing will ever answer
+// again). /api/ready flips to 503 the moment shutdown_event is set, and its
+// payload carries `shutting_down: true` for loopback callers.
+const READY_PATH = "/api/ready";
+
+/**
+ * Classify a gateway's `GET /api/ready` answer for the boot-time
+ * adopt-or-wait decision.
+ *
+ * Fail-open by design: only a POSITIVE shutting-down signal refuses adoption.
+ * Everything ambiguous (legacy gateway without the endpoint, unparseable body,
+ * transport error mapped to a null status) preserves the historical reuse
+ * behavior, mirroring decideGatewayAction's every-ambiguity-reuses contract.
+ *
+ * @param {number|null|undefined} statusCode  HTTP status, or null/undefined
+ *        when the probe itself failed (error/timeout)
+ * @param {{ready?:boolean, shutting_down?:boolean}|null} payload
+ *        parsed response JSON, or null when unparseable
+ * @returns {"ready"|"shutting-down"|"starting"|"unknown"}
+ *   "ready"         — 200: serving, safe to adopt.
+ *   "shutting-down" — 503 with the shutdown marker: the gateway is draining
+ *                     after /api/shutdown and will exit; adopting it strands
+ *                     the shell on a dying port. Do NOT adopt.
+ *   "starting"      — 503 without the marker: booting (session restore etc.);
+ *                     adopting is fine, the splash already waits for ready.
+ *   "unknown"       — anything else (404 legacy, proxy error, failed probe):
+ *                     keep the historical adopt behavior.
+ */
+function classifyGatewayReadiness(statusCode, payload) {
+  if (statusCode === 200) return "ready";
+  if (statusCode === 503) {
+    return payload && payload.shutting_down === true ? "shutting-down" : "starting";
+  }
+  return "unknown";
+}
+
 // Identity families. stable + insider are ONE app (the production install)
 // on two update lanes; nightly is a separate side-by-side install. Both
 // share the bundle id, so the app NAME is the takeover-targeting handle.
@@ -103,4 +143,11 @@ function decideGatewayAction(ownVersion, remoteHealth, { localOwner = "unknown" 
   return { action: "takeover-prompt", otherFamily: remote, otherVersion: remoteHealth.version };
 }
 
-module.exports = { identityFamily, decideGatewayAction, FAMILY_META, HEALTH_IDENTITY_PATH };
+module.exports = {
+  identityFamily,
+  decideGatewayAction,
+  classifyGatewayReadiness,
+  FAMILY_META,
+  HEALTH_IDENTITY_PATH,
+  READY_PATH,
+};

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -31,10 +31,10 @@ const { waitForGateway, describeGatewayFailure, tailLines, isPortInUse } = requi
 const { describeSandboxProfileNeed } = require("./sandbox-profile");
 const { sanitizeWindowState, captureWindowState } = require("./window-state");
 const { createLivenessMonitor } = require("./gateway-liveness");
-const { chooseRecoveryStrategy } = require("./gateway-recovery");
+const { chooseRecoveryStrategy, waitForServiceRebind, waitForProcessExit } = require("./gateway-recovery");
 const { capturePySpyDump } = require("./pyspy-dump");
 const { createMetricsRecorder } = require("./perf-metrics");
-const { identityFamily, decideGatewayAction, FAMILY_META, HEALTH_IDENTITY_PATH } = require("./instance-guard");
+const { identityFamily, decideGatewayAction, classifyGatewayReadiness, FAMILY_META, HEALTH_IDENTITY_PATH, READY_PATH } = require("./instance-guard");
 const { initMochi, shutdownMochi } = require("./mochi/index");
 const { initCrewCompanion, shutdownCrewCompanion } = require("./crew-companion/index");
 const { clampZoomFactor, stepZoomFactor } = require("./zoom");
@@ -201,6 +201,25 @@ let gatewayProcess = null;
 // fix on a dropped tunnel is to re-probe and reconnect once it heals, not to
 // force-stop the port or spawn a (nonexistent, in remote mode) local backend.
 let weSpawnedGateway = false;
+// True only on the reuse path when the port-holder was POSITIVELY identified as
+// a local same-family Kiro Crew process (same-family /api/health + a "kirocrew"
+// or "service" LISTEN owner). Distinguishes "we adopted a local gateway" from
+// "we connected to a tunnel / external gateway" for recovery: an adopted local
+// gateway that dies will never come back on its own, so recovery must wait
+// BOUNDED and then respawn — never the indefinite tunnel-heal wait, which
+// leaves the shell dead until the user manually relaunches.
+// KNOWN RESIDUAL (Windows): classifyPortOwner cannot positively identify
+// owners there (no lsof/ps), so this flag never sets and an adopted draining
+// gateway still falls into the indefinite "reconnect" wait — deliberately
+// conservative until the Windows-native owner probe lands.
+let reusedLocalGateway = false;
+// True when the adopted holder was specifically SERVICE-classified (PPID = init:
+// a real launchd/systemd unit — or an orphan, which reparents to init and is
+// indistinguishable at classify time). If that gateway later releases the port,
+// a real service manager may be about to respawn it, so recovery must offer a
+// bounded rebind grace before spawning locally — spawning immediately races the
+// manager for the bind and one side dies with EADDRINUSE.
+let reusedServiceGateway = false;
 // Post-handoff backend liveness monitor (primary window only). Detects a wedged
 // gateway — alive TCP socket, frozen event loop — that the spawn 'exit' watcher
 // can't, since the process never exits. See gateway-liveness.js.
@@ -278,6 +297,28 @@ function fetchHealthInfo(healthUrl = `${BACKEND_URL}${HEALTH_IDENTITY_PATH}`) {
   });
 }
 
+// Is the answering gateway actually SERVING, or draining after /api/shutdown?
+// /api/status and /api/health both stay 200 through a graceful drain, so they
+// cannot make this call — /api/ready flips to 503 with `shutting_down: true`
+// the moment shutdown_event is set (see handlers/core.py api_ready). Resolves
+// to a classifyGatewayReadiness verdict; never rejects (probe failures map to
+// "unknown", which adopts — fail-open like every other ambiguity in the guard).
+function fetchGatewayReadiness(readyUrl = `${BACKEND_URL}${READY_PATH}`) {
+  return new Promise((resolve) => {
+    const req = http.get(readyUrl, { timeout: 2000 }, (res) => {
+      let body = "";
+      res.on("data", (c) => { body += c; });
+      res.on("end", () => {
+        let payload = null;
+        try { payload = JSON.parse(body); } catch { /* non-JSON body — classify on status alone */ }
+        resolve(classifyGatewayReadiness(res.statusCode, payload));
+      });
+    });
+    req.on("error", () => resolve("unknown"));
+    req.on("timeout", () => { req.destroy(); resolve("unknown"); });
+  });
+}
+
 // Ask the OTHER channel app to quit through its normal lifecycle (its
 // before-quit stops its own gateway). Never kill the gateway out from under
 // its shell — the shell's exit watcher would treat that as a crash.
@@ -308,6 +349,41 @@ function probeGatewayPortOwner(port) {
   });
 }
 
+// Is `pid` still running? Signal 0 probes without delivering: ESRCH means dead,
+// EPERM means alive but not ours (still holding its locks) — treat as alive.
+function _pidAlive(pid) {
+  try { process.kill(pid, 0); return true; }
+  catch (e) { return !!(e && e.code === "EPERM"); }
+}
+
+// Best-effort capture of the pids LISTENing on our port, for the incumbent-exit
+// wait below. Must be called while the port is still bound — after it clears,
+// lsof can no longer name the draining process. Empty on probe failure or
+// Windows (no lsof): the exit wait then degrades to a no-op, same as today.
+async function snapshotPortPids(port) {
+  try { return await _lsofListenPids(port); } catch { return []; }
+}
+
+// A draining gateway releases its LISTEN socket EARLY but holds the exclusive
+// gateway.lock flock until the process exits (turn drain + session flush run
+// after the socket closes). Spawning on "port is free" alone races that lock:
+// the replacement is refused and exits, then the incumbent exits — no gateway.
+// Wait (bounded) for the captured incumbent pids to die before spawning; the
+// kernel releases the flock atomically on exit. On timeout, spawn anyway and
+// let the child's own honest lock-refusal error surface through the existing
+// gatewayStartFailure watcher — better than silently hanging here forever.
+async function waitForIncumbentExit(pids, label) {
+  const verdict = await waitForProcessExit({
+    pids,
+    isAlive: _pidAlive,
+    sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+  });
+  if (verdict === "timeout") {
+    glog(`${label}: incumbent gateway process still alive after the exit grace (port already free) — spawning anyway; a lock refusal will surface via the start-failure watcher`);
+  }
+  return verdict;
+}
+
 // Budget: the other app's graceful gateway stop runs up to 15s
 // (POST /api/shutdown -> SIGTERM -> SIGKILL) after the quit event lands,
 // so the wait must comfortably exceed it.
@@ -335,7 +411,7 @@ async function waitForPortFree(maxWaitMs = 30000) {
   }
 }
 
-async function resolveGatewayConflict() {
+async function resolveGatewayConflict(rebindDepth = 0) {
   const health = await fetchHealthInfo();
   // A remote host configured for THIS port means the user deliberately pointed
   // this app at a gateway on another machine, so the local holder is a tunnel
@@ -347,9 +423,82 @@ async function resolveGatewayConflict() {
   const localOwner = remoteHost ? "foreign" : await probeGatewayPortOwner(PORT);
   const decision = decideGatewayAction(app.getVersion(), health, { localOwner });
   if (decision.action === "reuse") {
+    // Adopt-or-wait: the /api/status probe that got us here stays 200 while the
+    // backend DRAINS after POST /api/shutdown, so "answering" is not "serving".
+    // Adopting a draining gateway strands the shell: seconds later the process
+    // exits and nothing ever answers this port again (a relaunch arriving
+    // seconds into a graceful stop reads "reusing existing gateway" and then
+    // goes dark). Only a positive shutting-down verdict refuses; every ambiguity
+    // (legacy gateway, probe failure) keeps the historical adopt behavior.
+    // A configured remote host is exempt: its port-holder is a tunnel by
+    // construction, so "wait for the port to clear, then spawn fresh" can never
+    // apply — adopting and letting the reconnect path wait out the remote
+    // restart is the only correct move there.
+    let adoptedDraining = false;
+    const readiness = remoteHost ? "unknown" : await fetchGatewayReadiness();
+    if (readiness === "shutting-down") {
+      glog(`gateway on :${PORT} answers but /api/ready reports shutting-down — refusing to adopt a draining gateway`);
+      sendStatus("Waiting for the previous gateway to exit…");
+      // Capture the draining process NOW, while it still owns the LISTEN
+      // socket — needed below to wait out its gateway.lock after the port clears.
+      const drainingPids = await snapshotPortPids(PORT);
+      if (await waitForPortFree()) {
+        if (localOwner === "service") {
+          // A SERVICE-classified holder that released its port may be mid-restart
+          // (kirocrew restart bounces the launchd/systemd unit): the manager is
+          // about to respawn it, and spawning now races that rebind — one side
+          // exits with EADDRINUSE. But orphans (reparented to init) classify as
+          // service too and have no manager to respawn them, so don't exempt —
+          // grace-wait: adopt a rebind, spawn only if the port stays free.
+          sendStatus("Waiting for the gateway to restart…");
+          const verdict = await waitForServiceRebind({
+            isPortBound: async () => (await probeGatewayPortOwner(PORT)) !== "none",
+            sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+          });
+          if (verdict === "rebound") {
+            // Whatever re-bound the port has NOT been validated: it could be a
+            // foreign process, a different-family gateway, or another draining
+            // gateway. Do not assert "reuse" — re-run the full decision table
+            // (identity + readiness) against the new holder. Depth-capped: one
+            // re-entry per boot; a second rebind-into-drain falls through to
+            // the adopt-anyway path rather than looping.
+            if (rebindDepth < 1) {
+              glog(`service rebind: :${PORT} re-bound within the grace window — re-validating the new holder`);
+              return resolveGatewayConflict(rebindDepth + 1);
+            }
+            glog(`service rebind: :${PORT} re-bound again at depth ${rebindDepth} — treating as adopt-anyway to avoid a validation loop`);
+          } else {
+            glog(`service rebind: :${PORT} stayed free past the grace window (no manager respawned it) — spawning fresh`);
+          }
+        }
+        if (localOwner !== "service" || (await probeGatewayPortOwner(PORT)) === "none") {
+          // Port free ≠ lock free: wait for the draining process itself to
+          // exit so the replacement is not refused by the singleton lock.
+          await waitForIncumbentExit(drainingPids, "drain");
+          glog(`drain complete: :${PORT} released — spawning a fresh gateway`);
+          return "spawn";
+        }
+      }
+      // The drain is stuck holding the socket past the graceful-stop budget.
+      // Spawning now would only hit EADDRINUSE, and evicting is not ours to do
+      // (we did not spawn this gateway). Adopt as before — loudly — and let the
+      // liveness recovery below handle its eventual death with a bounded wait.
+      glog(`drain wait timed out — :${PORT} still held; adopting anyway (recovery will respawn if it dies)`);
+      adoptedDraining = true;
+    }
     glog(`reusing existing gateway on :${PORT} (${decision.reason}) — bundled backend NOT spawned`);
     weSpawnedGateway = false; // reuse path — recovery must not kill/respawn a gateway we don't own
-    sendStatus("Gateway already running ✓");
+    // A same-family gateway held by a local Kiro Crew process is OURS in spirit
+    // even though we didn't spawn it: if it dies, no tunnel will resurrect it,
+    // so recovery may respawn after a bounded wait. Anything less positively
+    // identified (tunnel, no visible owner, probe failure) keeps the
+    // never-respawn external classification.
+    reusedLocalGateway = decision.reason === "same-family"
+      && (localOwner === "kirocrew" || localOwner === "service");
+    reusedServiceGateway = reusedLocalGateway && localOwner === "service";
+    // A gateway we adopted mid-drain is not a success to celebrate: recovery
+    // may immediately retract it. Keep the status neutral for that case.
+    sendStatus(adoptedDraining ? "Connecting to the existing gateway…" : "Gateway already running ✓");
     return "reuse";
   }
   const other = FAMILY_META[decision.otherFamily];
@@ -624,6 +773,8 @@ function spawnGateway(resolve) {
         });
         gatewayProcess = child;
         weSpawnedGateway = true; // we own this child — recovery may kill+respawn it
+        reusedLocalGateway = false; // ownership transitioned: no longer on an adopted gateway
+        reusedServiceGateway = false; // ditto — stale service classification must not outlive the adoption
         // The child inherits its own dup of the fd; close our copy so it doesn't leak.
         if (typeof childOut === "number") { try { fs.closeSync(childOut); } catch { /* ignore */ } }
 
@@ -1582,11 +1733,11 @@ function fadeLoadingScreen(wc, timeoutMs = 8000) {
  *
  * @param {Electron.BaseWindow} parentWin
  * @param {{title:string, message:string, logTail:string, logPath:string,
- *          portConflict:boolean, port:number}} opts
+ *          portConflict:boolean, port:number, noRetry?:boolean}} opts
  * @returns {Promise<'retry'|'force-retry'|'reveal'|'quit'>}
  */
 function showGatewayErrorDialog(parentWin, opts) {
-  const { title, message, logTail, logPath, portConflict } = opts;
+  const { title, message, logTail, logPath, portConflict, noRetry = false } = opts;
   return new Promise((resolve) => {
     const dark = nativeTheme.shouldUseDarkColors;
     const hasParent = parentWin && !parentWin.isDestroyed();
@@ -1603,9 +1754,11 @@ function showGatewayErrorDialog(parentWin, opts) {
     const esc = (s) => String(s)
       .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
     // The primary action depends on whether the port is held: a plain retry
-    // can't clear a port conflict, so offer force-stop instead.
-    const primaryAction = portConflict ? "force-retry" : "retry";
-    const primaryLabel = portConflict ? "Force-stop &amp; Retry" : "Retry";
+    // can't clear a port conflict, so offer force-stop instead. A TERMINAL
+    // caller (one that quits on every action) passes noRetry — showing a
+    // "Retry" button it would ignore contradicts the dialog's own message.
+    const primaryAction = noRetry ? "quit" : (portConflict ? "force-retry" : "retry");
+    const primaryLabel = noRetry ? "Quit" : (portConflict ? "Force-stop &amp; Retry" : "Retry");
     const fg = dark ? "#e2e8f0" : "#1e293b";
     const muted = dark ? "#94a3b8" : "#64748b";
     const html = `<!DOCTYPE html><html><head><style>
@@ -1633,7 +1786,7 @@ function showGatewayErrorDialog(parentWin, opts) {
       <div class="row">
         <button class="ok" onclick="act('${primaryAction}')">${primaryLabel}</button>
         <button class="cancel" onclick="act('reveal')">Reveal Log</button>
-        <button class="cancel" onclick="act('quit')">Quit</button>
+        ${noRetry ? "" : `<button class="cancel" onclick="act('quit')">Quit</button>`}
       </div>
       <script>
         function act(a){ document.title = 'mc-action:' + a; window.close(); }
@@ -1762,10 +1915,20 @@ async function recoverWedgedGateway(win) {
   // fell through to showUnrecoverableGatewayError, which QUIT the app on any
   // button (that was the "crash on Retry"). Instead: leave the tunnel alone and
   // re-probe until it heals, then reconnect.
-  if (chooseRecoveryStrategy({ weSpawnedGateway }) === "reconnect") {
+  const strategy = chooseRecoveryStrategy({ weSpawnedGateway, reusedLocalGateway });
+  if (strategy === "reconnect") {
     glog("liveness: backend unresponsive on a gateway we did not spawn (remote tunnel / external gateway) — waiting for it to recover instead of killing the port");
     if (!win || win.isDestroyed() || isQuitting) return;
     return reconnectExternalGateway(win);
+  }
+  // An ADOPTED local same-family gateway (reuse path, but the holder was a
+  // local Kiro Crew process) gets neither the kill (we don't own it) nor the
+  // indefinite tunnel wait (nothing external will bring it back): bounded
+  // wait, then respawn once the port clears on its own.
+  if (strategy === "reconnect-bounded") {
+    glog("liveness: backend unresponsive on an adopted local Kiro Crew gateway — bounded wait, then respawn");
+    if (!win || win.isDestroyed() || isQuitting) return;
+    return reconnectOrRespawnAdoptedGateway(win);
   }
   glog("liveness: backend unresponsive — force-killing wedged gateway and restarting");
   // Capture the frozen stack from OUTSIDE the wedged process BEFORE the kill.
@@ -1834,25 +1997,136 @@ async function reconnectExternalGateway(win) {
   return showLoadingThenConnect(win, BACKEND_URL);
 }
 
+// How long recovery waits for an ADOPTED local gateway to answer again before
+// concluding it is gone for good. A local gateway's plausible comebacks (a
+// long GC pause, a graceful drain we adopted mid-flight finishing + something
+// relaunching it) resolve well inside this; a tunnel-style multi-minute outage
+// cannot happen to a process on this machine.
+const ADOPTED_RECOVERY_WAIT_MS = 30_000;
+
 /**
- * Terminal state: a wedged gateway is holding the port and cannot be killed
- * (uninterruptible kernel sleep — e.g. a blocking close() on a dead socket).
- * No respawn can succeed until the OS reaps it, which only a restart guarantees.
- * Tell the user plainly instead of looping a doomed retry.
+ * Recover an ADOPTED local same-family gateway (reuse path, port held by a
+ * local Kiro Crew process we did not spawn). We must not kill the holder — but
+ * unlike a tunnel, a dead local gateway will never come back on its own, so the
+ * indefinite reconnectExternalGateway loop is exactly the observed failure:
+ * adopt a draining gateway, classify its death as "remote tunnel", and wait
+ * forever for a comeback a local process cannot make. Instead: re-probe for
+ * a bounded interval; if the backend answers, reconnect; otherwise wait for
+ * the port to clear (the dying process releasing its socket) and spawn our
+ * own backend.
+ * If the port never clears, the holder is alive-but-unresponsive and not ours
+ * to kill — surface the honest restart-required dialog instead of spinning.
  */
-async function showUnrecoverableGatewayError(win, port) {
+async function reconnectOrRespawnAdoptedGateway(win) {
+  const wc = win.webContents;
+  try { wc.loadFile(path.join(__dirname, "loading.html")); } catch { /* window may be mid-teardown */ }
+  if (!win || win.isDestroyed() || isQuitting) return;
+  win.show();
+  sendStatus("Gateway stopped responding — waiting for it to recover…");
+  const deadline = Date.now() + ADOPTED_RECOVERY_WAIT_MS;
+  while (Date.now() < deadline) {
+    if (!win || win.isDestroyed() || isQuitting) return;
+    let healthy = false;
+    try { await checkBackend(HEALTH_URL); healthy = true; } catch { /* still down */ }
+    if (healthy) {
+      glog("liveness: adopted local gateway answering again — reconnecting");
+      gatewayStartFailure = null;
+      return showLoadingThenConnect(win, BACKEND_URL);
+    }
+    await new Promise((r) => setTimeout(r, 2500));
+  }
+  if (!win || win.isDestroyed() || isQuitting) return;
+  glog(`liveness: adopted local gateway did not recover within ${ADOPTED_RECOVERY_WAIT_MS}ms — waiting for :${PORT} to clear, then spawning our own backend`);
+  sendStatus("Waiting for the previous gateway to exit…");
+  // Capture the incumbent NOW, while it may still own the LISTEN socket —
+  // needed below to wait out its gateway.lock after the port clears.
+  const incumbentPids = await snapshotPortPids(PORT);
+  if (!(await waitForPortFree())) {
+    glog(`liveness: :${PORT} still held by a process we did not spawn — surfacing port-held instead of waiting forever`);
+    // No stop was attempted on this path (the holder is not ours to evict), so
+    // the "wedged, restart your computer" copy would be false — use the honest
+    // port-held variant: quit the holder and relaunch.
+    return showUnrecoverableGatewayError(win, PORT, "held");
+  }
+  if (!win || win.isDestroyed() || isQuitting) return;
+  if (reusedServiceGateway) {
+    // The dead gateway was SERVICE-classified: a real launchd/systemd unit is
+    // (or may be) about to respawn it, and spawning immediately races that
+    // rebind for the port. Orphans classify as service too but nothing rebinds
+    // them — so grace-wait: reconnect to a rebind, spawn only on a quiet port.
+    glog(`liveness: adopted gateway was service-managed — waiting a bounded grace for its manager to respawn it before spawning our own`);
+    sendStatus("Waiting for the gateway to restart…");
+    const verdict = await waitForServiceRebind({
+      isPortBound: async () => (await probeGatewayPortOwner(PORT)) !== "none",
+      sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+    });
+    if (win.isDestroyed() || isQuitting) return;
+    if (verdict === "rebound") {
+      // Validate the new holder through the SAME identity table the boot path
+      // uses — owner probe + /api/health family check + readiness — not a
+      // weaker ad-hoc test: a cross-family gateway that rebinds here must hit
+      // the same takeover guard as at boot, not get silently reconnected to.
+      const owner = await probeGatewayPortOwner(PORT);
+      const health = await fetchHealthInfo();
+      const decision = decideGatewayAction(app.getVersion(), health, { localOwner: owner });
+      const readiness = await fetchGatewayReadiness();
+      if (decision.action === "reuse" && readiness !== "shutting-down") {
+        glog(`liveness: service manager re-bound :${PORT} (owner=${owner}, reason=${decision.reason}, readiness=${readiness}) — reconnecting to the restarted gateway`);
+        reusedLocalGateway = decision.reason === "same-family" && (owner === "kirocrew" || owner === "service");
+        reusedServiceGateway = reusedLocalGateway && owner === "service";
+        gatewayStartFailure = null;
+        return showLoadingThenConnect(win, BACKEND_URL);
+      }
+      glog(`liveness: :${PORT} was re-bound by an unusable holder (owner=${owner}, action=${decision.action}, readiness=${readiness}) — cannot reconnect or spawn over it`);
+      return showUnrecoverableGatewayError(win, PORT, "held");
+    }
+    glog(`liveness: :${PORT} stayed free past the rebind grace — no manager respawned it; spawning our own backend`);
+  }
+  // Port free ≠ lock free: the incumbent may still be flushing sessions while
+  // holding gateway.lock. Wait for the process itself before spawning.
+  await waitForIncumbentExit(incumbentPids, "liveness");
+  sendStatus("Starting a fresh gateway…");
+  gatewayStartFailure = null;
+  await startGateway(); // spawn a fresh child (port is confirmed free)
+  if (win.isDestroyed() || isQuitting) return;
+  return showLoadingThenConnect(win, BACKEND_URL);
+}
+
+/**
+ * Terminal state, two variants:
+ *  - "wedged" (default): a force-stop was actually attempted and the holder
+ *    survived it (uninterruptible kernel sleep). Only a machine restart clears
+ *    it, and the copy says so.
+ *  - "held": port ${port} is occupied by a process this app will not evict
+ *    (an unresponsive previous gateway, a foreign process, or a cross-family
+ *    gateway that grabbed the port). No stop was attempted — telling the user
+ *    to reboot would be false and needlessly heavy; quitting the holder and
+ *    relaunching suffices.
+ */
+async function showUnrecoverableGatewayError(win, port, variant = "wedged") {
   if (!win || win.isDestroyed()) return;
   let logTail = "";
   try { logTail = tailLines(fs.readFileSync(gatewayLogPath(), "utf8"), 60); } catch { /* no log yet */ }
+  const wedged = variant === "wedged";
   const action = await showGatewayErrorDialog(win, {
-    title: `Kiro Crew — backend stuck on port ${port}`,
-    message: `The Kiro Crew backend is wedged and cannot be stopped — it is in an `
-      + `uninterruptible state and is still holding port ${port}, so it can't be `
-      + `force-stopped or restarted in place. Restart your computer to clear it. `
-      + `(This is a known backend hang; see the launch log below for the cause.)`,
+    title: wedged
+      ? `Kiro Crew — backend stuck on port ${port}`
+      : `Kiro Crew — port ${port} is in use`,
+    message: wedged
+      ? `The Kiro Crew backend is wedged and cannot be stopped — it is in an `
+        + `uninterruptible state and is still holding port ${port}, so it can't be `
+        + `force-stopped or restarted in place. Restart your computer to clear it. `
+        + `(This is a known backend hang; see the launch log below for the cause.)`
+      : `Another process is holding port ${port}, so Kiro Crew can't reconnect to `
+        + `it or start its own backend there. Quit the process using port ${port} `
+        + `(the launch log below names it — look for the "port-owner:" line), `
+        + `then reopen this app.`,
     logTail,
     logPath: gatewayLogPath(),
-    portConflict: false, // hide "Force-stop & Retry" — it cannot work here
+    portConflict: false,
+    // This caller is TERMINAL — it quits on every action — so never render a
+    // "Retry" primary it would ignore: the truthful primary here is Quit.
+    noRetry: true,
     port,
   });
   if (win.isDestroyed()) return;

--- a/website/electron/test/gateway-recovery.test.js
+++ b/website/electron/test/gateway-recovery.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
-const { chooseRecoveryStrategy } = require("../gateway-recovery");
+const { chooseRecoveryStrategy, waitForServiceRebind, waitForProcessExit } = require("../gateway-recovery");
 
 describe("chooseRecoveryStrategy", () => {
   it("respawns when we own the spawned gateway", () => {
@@ -23,5 +23,140 @@ describe("chooseRecoveryStrategy", () => {
     assert.equal(chooseRecoveryStrategy({}), "reconnect");
     assert.equal(chooseRecoveryStrategy({ weSpawnedGateway: undefined }), "reconnect");
     assert.equal(chooseRecoveryStrategy({ weSpawnedGateway: null }), "reconnect");
+  });
+
+  // Regression guard for the adopted-gateway dead window: a relaunch adopted
+  // a same-family local gateway mid-drain; when it died, recovery classified
+  // it as "a gateway we did not spawn (remote tunnel)" and waited FOREVER for
+  // a comeback that a local process can never make on its own. An adopted
+  // LOCAL gateway must get the bounded wait-then-respawn strategy instead.
+  it("bounded reconnect-then-respawn for an adopted local same-family gateway", () => {
+    assert.equal(
+      chooseRecoveryStrategy({ weSpawnedGateway: false, reusedLocalGateway: true }),
+      "reconnect-bounded",
+    );
+  });
+
+  // The never-evict/never-respawn behavior is preserved ONLY for genuinely
+  // external gateways: reuse without the positive local-family identification
+  // stays on the indefinite tunnel-heal wait.
+  it("keeps the indefinite reconnect for external/tunnel gateways", () => {
+    assert.equal(
+      chooseRecoveryStrategy({ weSpawnedGateway: false, reusedLocalGateway: false }),
+      "reconnect",
+    );
+    assert.equal(chooseRecoveryStrategy({ weSpawnedGateway: false }), "reconnect");
+  });
+
+  // Owning the spawned child always wins: the kill+respawn path is safe (and
+  // correct) for a process we created, regardless of any stale adoption flag.
+  it("respawn takes precedence over the adopted-local classification", () => {
+    assert.equal(
+      chooseRecoveryStrategy({ weSpawnedGateway: true, reusedLocalGateway: true }),
+      "respawn",
+    );
+  });
+});
+
+describe("waitForServiceRebind", () => {
+  const instantSleep = () => Promise.resolve();
+
+  // A service-managed holder that released its port mid-restart is respawned
+  // by its manager (launchd KeepAlive / systemd Restart=). Spawning locally in
+  // that window races the manager for the bind — one side exits EADDRINUSE —
+  // so a rebind within the grace must be adopted, never raced.
+  it("reports rebound as soon as the port is bound again", async () => {
+    let probes = 0;
+    const verdict = await waitForServiceRebind({
+      isPortBound: async () => ++probes >= 3, // rebinds on the third probe
+      sleep: instantSleep,
+      graceMs: 10_000,
+    });
+    assert.equal(verdict, "rebound");
+    assert.equal(probes, 3);
+  });
+
+  // The service classification also matches orphans (a gateway reparented to
+  // init has PPID 1 but no manager), so the grace must EXPIRE into a local
+  // spawn — a blanket "never respawn after a service holder" would recreate
+  // the adopted-gateway dead window for orphan exits.
+  it("reports spawn when the grace expires with the port still free", async () => {
+    const t0 = Date.now();
+    let now = t0;
+    const realNow = Date.now;
+    Date.now = () => now;
+    try {
+      const verdict = await waitForServiceRebind({
+        isPortBound: async () => false,
+        sleep: async () => { now += 1_000; },
+        graceMs: 5_000,
+      });
+      assert.equal(verdict, "spawn");
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  // An immediate rebind (manager beat our first probe) short-circuits without
+  // sleeping at all.
+  it("adopts an already-rebound port without waiting", async () => {
+    let slept = false;
+    const verdict = await waitForServiceRebind({
+      isPortBound: async () => true,
+      sleep: async () => { slept = true; },
+      graceMs: 10_000,
+    });
+    assert.equal(verdict, "rebound");
+    assert.equal(slept, false);
+  });
+});
+
+describe("waitForProcessExit", () => {
+  // A graceful stop releases the LISTEN socket before the process exits, and
+  // the gateway.lock flock is held for the process lifetime. Spawning on
+  // port-free alone gets the replacement refused by the singleton lock; these
+  // tests lock in the wait-for-exit gate that closes that window.
+  it("returns exited once every watched pid is dead", async () => {
+    const alive = new Set([111, 222]);
+    let polls = 0;
+    const verdict = await waitForProcessExit({
+      pids: [111, 222],
+      isAlive: (p) => alive.has(p),
+      sleep: async () => { polls += 1; if (polls === 1) alive.delete(111); if (polls === 2) alive.delete(222); },
+      timeoutMs: 60_000,
+    });
+    assert.equal(verdict, "exited");
+  });
+
+  it("returns timeout when a pid outlives the grace (spawn proceeds, lock refusal surfaces honestly)", async () => {
+    let now = Date.now();
+    const realNow = Date.now;
+    Date.now = () => now;
+    try {
+      const verdict = await waitForProcessExit({
+        pids: [111],
+        isAlive: () => true,
+        sleep: async () => { now += 1_000; },
+        timeoutMs: 5_000,
+      });
+      assert.equal(verdict, "timeout");
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  // Empty/invalid pid sets (probe failed, Windows without lsof) degrade to a
+  // no-op — same behavior as before this gate existed, never a hang.
+  it("degrades to exited immediately with no watchable pids", async () => {
+    let slept = false;
+    for (const pids of [[], null, undefined, [0, -3, NaN]]) {
+      const verdict = await waitForProcessExit({
+        pids,
+        isAlive: () => { throw new Error("must not be called"); },
+        sleep: async () => { slept = true; },
+      });
+      assert.equal(verdict, "exited");
+    }
+    assert.equal(slept, false);
   });
 });

--- a/website/electron/test/instance-guard.test.js
+++ b/website/electron/test/instance-guard.test.js
@@ -6,7 +6,14 @@
 
 const { test } = require("node:test");
 const assert = require("node:assert");
-const { identityFamily, decideGatewayAction, FAMILY_META, HEALTH_IDENTITY_PATH } = require("../instance-guard");
+const {
+  identityFamily,
+  decideGatewayAction,
+  classifyGatewayReadiness,
+  FAMILY_META,
+  HEALTH_IDENTITY_PATH,
+  READY_PATH,
+} = require("../instance-guard");
 
 test("identityFamily maps channels to bundle-identity families", () => {
   assert.equal(identityFamily("0.1.0-nightly.20260722120000"), "nightly");
@@ -126,4 +133,60 @@ test("identity probe targets /api/health, never the /api/status liveness URL", (
   // every gateway as "unidentified" and silently disables the takeover path.
   assert.equal(HEALTH_IDENTITY_PATH, "/api/health");
   assert.notEqual(HEALTH_IDENTITY_PATH, "/api/status");
+});
+
+// ── Readiness: adopting must be gated on SERVING, not merely ANSWERING ──────
+// /api/status and /api/health both stay 200 while the backend drains after
+// POST /api/shutdown, so a relaunch during a graceful stop used to adopt the
+// dying gateway ("reusing existing gateway — bundled backend NOT spawned") and
+// then wait on a port nothing would ever answer again. Only /api/ready flips
+// to 503 with `shutting_down: true` the moment shutdown is requested.
+
+test("readiness probe targets /api/ready, never the drain-blind status/health URLs", () => {
+  assert.equal(READY_PATH, "/api/ready");
+  assert.notEqual(READY_PATH, "/api/status");
+  assert.notEqual(READY_PATH, HEALTH_IDENTITY_PATH);
+});
+
+test("a serving gateway (200) is ready to adopt", () => {
+  assert.equal(classifyGatewayReadiness(200, { ready: true }), "ready");
+});
+
+test("a draining gateway (503 + shutting_down) refuses adoption", () => {
+  // The incident shape: a relaunch arriving seconds into a graceful stop.
+  // Adopting here is the root cause of the dead-window bug.
+  assert.equal(
+    classifyGatewayReadiness(503, { ready: false, shutting_down: true }),
+    "shutting-down",
+  );
+});
+
+test("a booting gateway (503 without the marker) is adoptable — the splash already waits", () => {
+  assert.equal(
+    classifyGatewayReadiness(503, { ready: false, startup_complete: false }),
+    "starting",
+  );
+});
+
+test("a detail-withheld 503 payload stays adoptable (marker gated on check_host)", () => {
+  // A disallowed-Host caller gets only {"ready": false}; without the positive
+  // shutdown marker the classification must fail open to the historical adopt.
+  assert.equal(classifyGatewayReadiness(503, { ready: false }), "starting");
+});
+
+test("an unparseable 503 body classifies on status alone, never refuses", () => {
+  assert.equal(classifyGatewayReadiness(503, null), "starting");
+});
+
+test("legacy gateways and failed probes keep the historical adopt behavior", () => {
+  assert.equal(classifyGatewayReadiness(404, null), "unknown"); // no /api/ready endpoint
+  assert.equal(classifyGatewayReadiness(null, null), "unknown"); // probe error/timeout
+  assert.equal(classifyGatewayReadiness(undefined, null), "unknown");
+});
+
+test("only a POSITIVE boolean marker refuses — truthy junk does not", () => {
+  // The payload is remote input; a string "false" or 1 must not flip the
+  // refuse-to-adopt path.
+  assert.equal(classifyGatewayReadiness(503, { shutting_down: "false" }), "starting");
+  assert.equal(classifyGatewayReadiness(503, { shutting_down: 1 }), "starting");
 });


### PR DESCRIPTION
## Problem / Motivation

I hit this twice on my machine today: relaunching the desktop app shortly after (or during) a quit left me staring at a dead dashboard — once for about 80 seconds, and once for a full **67 minutes** until I manually relaunched. The launcher log shows exactly what happened. At `15:37:15` EDT the old gateway logged `shutdown requested via /api/shutdown — triggering graceful stop`; four seconds later, at `2026-08-08T19:37:19.645Z`, the relaunching shell logged `port-owner: :5476 held by SERVICE-MANAGED KiroCrew pid=37874 (...) — reuse, never evict` followed by `reusing existing gateway on :5476 (same-family) — bundled backend NOT spawned`. The adopted gateway then finished dying, and at `19:37:53.210Z` the liveness recovery logged `backend unresponsive on a gateway we did not spawn (remote tunnel / external gateway) — waiting for it to recover instead of killing the port`. The next line in the log is `20:44:19.475Z no gateway on :5476 — spawning bundled backend` — my manual relaunch, 67 minutes later. An earlier occurrence the same day (`16:34:47Z` adopt → `16:36:04Z` fresh spawn) shows the same shape with an 80-second window.

## Why it matters

A relaunch that races a graceful shutdown — which is exactly what a quick quit-and-reopen, an updater restart, or a Dock relaunch produces — silently strands the app on a port nothing will ever answer again, with no error, no recovery, and no hint beyond an eternal loading screen. The dead window lasts until the user figures out they need to quit and relaunch again, and there is nothing telling them that.

## What changed (motivation → approach → change)

Root cause 1 (adoption): the reuse decision is gated on `checkBackend()`, which probes `/api/status` — an endpoint that keeps answering 200 while the backend **drains** after `POST /api/shutdown` (`/api/health` behaves the same; both are liveness). So "a gateway is answering" gets conflated with "a gateway is serving", and the shell adopts a process that is seconds from exiting. The backend already exposes the right signal: `/api/ready` flips to 503 with `shutting_down: true` the moment `shutdown_event` is set (`handlers/core.py::api_ready`). The fix probes `/api/ready` after the reuse decision and, on a **positive** shutting-down verdict, refuses to adopt: it waits (bounded, reusing the existing `waitForPortFree`) for the draining gateway to release the port, then spawns fresh. Every ambiguous outcome — a legacy gateway without the endpoint, a 503 without the marker (booting, which is fine to adopt since the splash already waits for readiness), an unreachable probe — keeps the historical adopt behavior, mirroring the fail-open contract of `decideGatewayAction`. Configured remote hosts skip the probe entirely: their port-holder is a tunnel by construction, so "wait for the port to clear, then spawn" can never apply there. The classification is a pure function (`classifyGatewayReadiness` in `instance-guard.js`) so the decision table is unit-tested without Electron.

Root cause 2 (the forever-wait): once the adopted gateway died, `chooseRecoveryStrategy({ weSpawnedGateway: false })` returned `"reconnect"` — the indefinite tunnel-heal wait — because the recovery fork only knew "ours" vs "not ours". But an adopted **local same-family** gateway is not a tunnel: when it dies, nothing external will ever bring it back, so waiting forever is guaranteed to produce exactly the dead window I hit. `chooseRecoveryStrategy` now takes a second input, `reusedLocalGateway`, set only when the reuse decision positively identified the port-holder as a local same-family Kiro Crew process (same-family `/api/health` identity **and** a `kirocrew`/`service` LISTEN owner from `classifyPortOwner`). For that case recovery waits a bounded 30s for the gateway to answer again, then waits for the port to clear on its own and spawns a fresh backend — it still never kills a process it did not spawn, and if the port never clears (an alive-but-wedged holder) it surfaces the honest restart-required dialog instead of spinning. Genuinely external gateways — tunnels, unidentified holders, anything less than positively-identified-local — keep the never-evict, never-respawn behavior completely unchanged.

**Update (GPT review round):** spawn-after-port-clear now runs a bounded service-rebind grace when the released holder was SERVICE-classified. A real launchd/systemd unit mid-restart gets adopted the moment its manager re-binds the port (no EADDRINUSE race); an orphan (reparents to init, classifies as service, but has no manager) lets the grace expire and we spawn — preserving the dead-window fix. Pure `waitForServiceRebind` helper + 3 unit tests.

**Update (GPT round 4):** both spawn-after-port-clear paths now wait for the incumbent PROCESS to exit, not just the port — a graceful stop releases the socket early while the process still holds the exclusive gateway.lock flock through turn drain and session flush, so spawning on port-free alone got the replacement refused by the singleton lock. Incumbent pids are snapshotted while the port is still bound; the bounded wait (`waitForProcessExit`, 15s) covers the post-socket drain budget, degrades to a no-op when pids can't be captured (Windows), and on expiry spawns anyway so the child's honest lock-refusal error surfaces via the start-failure watcher. Three unit tests.

## Tests

All in the existing `node:test` suites (`npm test --prefix electron`, 838 passing). `test/instance-guard.test.js`: decision table for `classifyGatewayReadiness` — 200 adopts; 503 + `shutting_down: true` refuses (the live-incident shape); 503 without the marker (booting / detail-withheld / unparseable body) stays adoptable; 404/failed-probe stays adoptable (legacy fail-open); truthy-junk markers (`"false"`, `1`) never refuse; plus a pin that `READY_PATH` is `/api/ready` and never the drain-blind `/api/status`/`/api/health`. `test/gateway-recovery.test.js`: `reusedLocalGateway: true` yields the new `"reconnect-bounded"` strategy (regression guard for the 67-minute window); external/tunnel reuse keeps the indefinite `"reconnect"`; `weSpawnedGateway: true` still wins with `"respawn"`; and the existing default-to-reconnect pins are untouched and green.

## Manual verification

I read the shipped incident straight out of my own `~/Library/Logs/Kiro Crew Nightly/gateway-launch.log` (timestamps quoted above) and traced both code paths against it: with this change, the `19:37:19Z` boot would have gotten `shutting-down` from `/api/ready` (the backend was 4s into its drain), waited for pid 37874 to release `:5476`, and spawned fresh — and even if adoption had somehow still happened, the `19:37:53Z` liveness failure would have classified as `reconnect-bounded` (same-family + SERVICE-MANAGED owner were both positively identified in the log) and respawned within ~60s instead of 67 minutes. The full spawn/adopt/recovery matrix beyond that needs a real quit-relaunch race to exercise end-to-end, which is inherently timing-dependent; the pure decision functions covering both forks are unit-tested exhaustively.

## Related Issues

None open that I could find — searched for launcher/gateway-reuse/api-ready PRs and issues before starting.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


