### PR TITLE
fix(gateway): refuse to boot when the data home cannot persist state

### DIFF
--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import ctypes.util
+import errno
 import io
 import logging
 import os
@@ -20,6 +21,7 @@ import stat
 import struct
 import subprocess
 import sys
+import tempfile
 import time
 import zlib
 from ctypes import wintypes  # type aliases only; imports cleanly on every platform
@@ -467,6 +469,82 @@ def try_acquire_lock(fd: int, *, exclusive: bool = False) -> bool:
         return True
     except OSError:
         return False
+
+
+def probe_file_persistence(directory: Path) -> str | None:
+    """Verify that *directory* supports every primitive the Kiro Crew
+    persistence paths depend on: creating a new file (``tempfile.mkstemp``),
+    writing bytes to it, taking an advisory lock (:func:`file_lock`),
+    atomically replacing it (``os.replace``), and removing it — the exact
+    operations ``atomic_write`` and the ``.lock``-file helpers perform.
+
+    Returns ``None`` when all of them work, otherwise a human-readable
+    description of the first failure. A process whose environment breaks any
+    of these primitives cannot save chat history, cron history, or session
+    state — but it CAN still serve traffic and append to already-open log fds,
+    so without this probe it limps along losing writes silently. The known way
+    to get into that state is inheriting a seccomp syscall filter from a
+    sandboxed parent (seccomp survives fork/exec, ``nohup`` included):
+    filtered syscalls fail with ``ENOSYS`` while everything else looks
+    healthy. The returned message names that cause when ``errno`` says so.
+
+    Probe files carry a ``.persistence-probe-`` prefix, and their removal is
+    part of the probed contract: an environment that allows creating files but
+    denies deleting them (delete-scoped ACLs) breaks the atomic
+    rename/replace paths just the same, so a failed cleanup is reported as a
+    preflight failure rather than suppressed. On the failure path probe files
+    are best-effort removed; one may remain only when removal itself is what
+    is broken.
+    """
+    fd: int | None = None
+    path: str | None = None
+    replaced: str | None = None
+    step = "create files in"
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        fd, path = tempfile.mkstemp(dir=directory, prefix=".persistence-probe-")
+        step = "write files in"
+        os.write(fd, b"probe")
+        step = "flush files in"
+        os.fsync(fd)
+        step = "lock files in"
+        with file_lock(fd, exclusive=True):
+            pass
+        os.close(fd)
+        fd = None
+        step = "atomically replace files in"
+        replaced = f"{path}.target"
+        # The same replace primitive atomic_write commits with: plain
+        # os.replace on POSIX, bounded retry over the Windows AV/indexer
+        # sharing-violation window — a healthy Windows data home must not fail
+        # the preflight over that transient. Imported lazily because
+        # atomic_write imports this module at top level.
+        from kiro_crew.atomic_write import replace_with_retry
+
+        replace_with_retry(path, replaced)
+        path = None
+        step = "remove files from"
+        os.unlink(replaced)
+        replaced = None
+    except OSError as exc:
+        hint = ""
+        if exc.errno == errno.ENOSYS:
+            hint = (
+                " (ENOSYS from a basic file syscall usually means this process"
+                " inherited a seccomp filter from a sandboxed parent — e.g. a"
+                " gateway spawned from inside an agent session; start it from a"
+                " regular shell or the system service instead)"
+            )
+        return f"cannot {step} {directory}: {exc}{hint}"
+    finally:
+        if fd is not None:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        for leftover in (path, replaced):
+            if leftover is not None:
+                with contextlib.suppress(OSError):
+                    os.unlink(leftover)
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -5928,6 +5928,37 @@ class GatewayOrchestrator:
         # No-op on Windows (no per-process descriptor rlimit).
         platform_compat.raise_nofile_soft_limit(10240)
 
+        # Refuse to boot when the data home cannot persist state. Every save
+        # path (chat history, cron history, session PIDs) needs file creation +
+        # advisory locking in the data home; when either is broken (e.g. a
+        # seccomp filter inherited from a sandboxed parent turns flock/mkstemp
+        # into ENOSYS) the gateway would still serve traffic while silently
+        # dropping every write — and the very next call below would crash with
+        # a raw traceback anyway. Failing here is loud, early, and actionable.
+        # Off-loop: the probe does real filesystem I/O (mkstemp + flock), which
+        # on a stalled filesystem would otherwise wedge the event loop.
+        def _probe_persistence() -> str | None:
+            return platform_compat.probe_file_persistence(data_home())
+
+        try:
+            persistence_error = await asyncio.to_thread(_probe_persistence)
+        except RuntimeError as exc:
+            # asyncio.to_thread could not get a worker thread (executor
+            # exhaustion/shutdown). A process that cannot spawn one thread at
+            # boot cannot run session pools either — route through the clean
+            # preflight exit below instead of dying with a raw traceback.
+            persistence_error = f"cannot run the persistence preflight: {exc}"
+        if persistence_error is not None:
+            logger.critical(
+                "Persistence preflight failed — refusing to start: %s",
+                persistence_error,
+            )
+            print(
+                f"❌ Cannot persist state: {persistence_error}",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
         # Clean up orphaned kiro-cli processes from previous runs
         from kiro_crew.session import cleanup_orphaned_sessions
 

--- a/test/test_persistence_probe.py
+++ b/test/test_persistence_probe.py
@@ -1,0 +1,267 @@
+"""Tests for the gateway persistence preflight.
+
+``probe_file_persistence`` guards against an environment where basic file
+creation or advisory locking fails (observed: a gateway spawned from inside a
+sandboxed agent session inherits a seccomp filter, so ``mkstemp``/``flock``
+raise ``OSError(ENOSYS)`` while writes to already-open fds keep working). The
+gateway must refuse to boot in that state instead of limping along silently
+losing every save.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import platform_compat
+from kiro_crew.platform_compat import probe_file_persistence
+
+
+class TestProbeFilePersistence:
+    def test_healthy_directory_passes(self, tmp_path: Path) -> None:
+        assert probe_file_persistence(tmp_path) is None
+
+    def test_healthy_directory_leaves_no_probe_file(self, tmp_path: Path) -> None:
+        probe_file_persistence(tmp_path)
+        assert list(tmp_path.iterdir()) == []
+
+    def test_creates_missing_directory(self, tmp_path: Path) -> None:
+        target = tmp_path / "not" / "yet" / "there"
+        assert probe_file_persistence(target) is None
+        assert target.is_dir()
+
+    def test_mkstemp_enosys_reports_create_step_and_sandbox_hint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _enosys(*args: object, **kwargs: object) -> tuple[int, str]:
+            raise OSError(errno.ENOSYS, "Function not implemented")
+
+        monkeypatch.setattr(platform_compat.tempfile, "mkstemp", _enosys)
+        msg = probe_file_persistence(tmp_path)
+        assert msg is not None
+        assert "cannot create files in" in msg
+        assert str(tmp_path) in msg
+        assert "seccomp" in msg
+
+    def test_lock_enosys_reports_lock_step_and_sandbox_hint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import contextlib
+
+        @contextlib.contextmanager
+        def _enosys_lock(fd: int, **kwargs: object):  # type: ignore[no-untyped-def]
+            raise OSError(errno.ENOSYS, "Function not implemented")
+            yield
+
+        monkeypatch.setattr(platform_compat, "file_lock", _enosys_lock)
+        msg = probe_file_persistence(tmp_path)
+        assert msg is not None
+        assert "cannot lock files in" in msg
+        assert "seccomp" in msg
+
+    def test_lock_failure_still_removes_probe_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import contextlib
+
+        @contextlib.contextmanager
+        def _enosys_lock(fd: int, **kwargs: object):  # type: ignore[no-untyped-def]
+            raise OSError(errno.ENOSYS, "Function not implemented")
+            yield
+
+        monkeypatch.setattr(platform_compat, "file_lock", _enosys_lock)
+        probe_file_persistence(tmp_path)
+        assert list(tmp_path.iterdir()) == []
+
+    def test_non_enosys_error_gets_no_sandbox_hint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _eacces(*args: object, **kwargs: object) -> tuple[int, str]:
+            raise OSError(errno.EACCES, "Permission denied")
+
+        monkeypatch.setattr(platform_compat.tempfile, "mkstemp", _eacces)
+        msg = probe_file_persistence(tmp_path)
+        assert msg is not None
+        assert "cannot create files in" in msg
+        assert "seccomp" not in msg
+
+    def test_unlink_failure_reports_remove_step(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Create-allowed/delete-denied environments break atomic renames, so
+        a failed probe-file removal must be a preflight FAILURE, not success."""
+        real_unlink = os.unlink
+
+        def _deny_probe_unlink(path: str | os.PathLike[str], **kwargs: object) -> None:
+            if ".persistence-probe-" in str(path):
+                raise OSError(errno.EACCES, "Operation not permitted")
+            real_unlink(path, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(platform_compat.os, "unlink", _deny_probe_unlink)
+        msg = probe_file_persistence(tmp_path)
+        assert msg is not None
+        assert "cannot remove files from" in msg
+
+    def test_write_failure_reports_write_step(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A byte quota (EDQUOT/ENOSPC) that allows creating empty files but
+        not writing to them must fail the probe."""
+
+        def _no_space(fd: int, data: bytes, **kwargs: object) -> int:
+            raise OSError(errno.ENOSPC, "No space left on device")
+
+        monkeypatch.setattr(platform_compat.os, "write", _no_space)
+        msg = probe_file_persistence(tmp_path)
+        assert msg is not None
+        assert "cannot write files in" in msg
+
+    def test_fsync_failure_reports_flush_step(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Chat history commits with atomic_write(fsync=True): a buffered
+        write can succeed while the flush fails (EIO), so fsync is part of
+        the probed contract."""
+
+        def _eio(fd: int, **kwargs: object) -> None:
+            raise OSError(errno.EIO, "Input/output error")
+
+        monkeypatch.setattr(platform_compat.os, "fsync", _eio)
+        msg = probe_file_persistence(tmp_path)
+        assert msg is not None
+        assert "cannot flush files in" in msg
+
+    def test_replace_failure_reports_replace_step(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``replace_with_retry`` is what atomic_write commits with; if it is
+        broken, the probe must fail even though create/write/lock succeeded."""
+
+        def _no_replace(
+            src: str | os.PathLike[str], dst: str | os.PathLike[str], **kwargs: object
+        ) -> None:
+            raise OSError(errno.EPERM, "Operation not permitted")
+
+        monkeypatch.setattr("kiro_crew.atomic_write.replace_with_retry", _no_replace)
+        msg = probe_file_persistence(tmp_path)
+        assert msg is not None
+        assert "cannot atomically replace files in" in msg
+
+    def test_replace_failure_still_cleans_up_probe_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _no_replace(
+            src: str | os.PathLike[str], dst: str | os.PathLike[str], **kwargs: object
+        ) -> None:
+            raise OSError(errno.EPERM, "Operation not permitted")
+
+        monkeypatch.setattr("kiro_crew.atomic_write.replace_with_retry", _no_replace)
+        probe_file_persistence(tmp_path)
+        assert list(tmp_path.iterdir()) == []
+
+    def test_probe_uses_the_production_replace_primitive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The probe must go through atomic_write.replace_with_retry (which
+        absorbs the transient Windows sharing-violation window), not raw
+        os.replace — otherwise a healthy Windows data home can fail preflight
+        over an AV/indexer touch."""
+        calls: list[tuple[str, str]] = []
+        from kiro_crew import atomic_write
+
+        real = atomic_write.replace_with_retry
+
+        def _spy(src: str | os.PathLike[str], dst: str | os.PathLike[str]) -> None:
+            calls.append((str(src), str(dst)))
+            real(src, dst)
+
+        monkeypatch.setattr("kiro_crew.atomic_write.replace_with_retry", _spy)
+        assert probe_file_persistence(tmp_path) is None
+        assert len(calls) == 1
+        assert ".persistence-probe-" in calls[0][0]
+
+    def test_uncreatable_directory_reports_create_step(self, tmp_path: Path) -> None:
+        if os.name != "posix" or os.geteuid() == 0:
+            pytest.skip("needs a POSIX non-root user for chmod-based denial")
+        parent = tmp_path / "sealed"
+        parent.mkdir()
+        parent.chmod(0o500)
+        try:
+            msg = probe_file_persistence(parent / "child")
+            assert msg is not None
+            assert "cannot create files in" in msg
+        finally:
+            parent.chmod(0o700)
+
+
+class TestGatewayPreflightWiring:
+    """The orchestrator must refuse to boot when the probe reports a failure."""
+
+    def _orchestrator(self):  # type: ignore[no-untyped-def]
+        from kiro_crew.config import KiroCrewConfig
+        from kiro_crew.slack.gateway import GatewayOrchestrator
+
+        return GatewayOrchestrator(KiroCrewConfig(), no_dashboard=True, no_crons=True)
+
+    @pytest.mark.asyncio
+    async def test_run_exits_when_probe_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.slack import gateway as gateway_mod
+
+        monkeypatch.setattr(
+            gateway_mod.platform_compat,
+            "probe_file_persistence",
+            lambda directory: "cannot lock files in /x: [Errno 38] Function not implemented",
+        )
+        with pytest.raises(SystemExit) as excinfo:
+            await self._orchestrator().run()
+        assert excinfo.value.code == 1
+
+    @pytest.mark.asyncio
+    async def test_thread_exhaustion_routes_through_clean_exit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``asyncio.to_thread`` failing to get a worker (RuntimeError) must
+        produce the same clean SystemExit(1) as a probe failure, not a raw
+        traceback."""
+        import asyncio as asyncio_mod
+
+        from kiro_crew.slack import gateway as gateway_mod
+
+        async def _no_thread(fn, *args, **kwargs):  # type: ignore[no-untyped-def]
+            raise RuntimeError("cannot schedule new futures after shutdown")
+
+        monkeypatch.setattr(gateway_mod.asyncio, "to_thread", _no_thread)
+        assert asyncio_mod.to_thread is not None  # confirm only the module ref is patched
+        with pytest.raises(SystemExit) as excinfo:
+            await self._orchestrator().run()
+        assert excinfo.value.code == 1
+
+    @pytest.mark.asyncio
+    async def test_probe_runs_before_orphan_cleanup(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A broken environment must exit BEFORE the first lock consumer runs
+        (the raw-traceback crash this preflight replaces happened inside
+        ``cleanup_orphaned_sessions``)."""
+        from kiro_crew import session as session_mod
+        from kiro_crew.slack import gateway as gateway_mod
+
+        called: list[str] = []
+        monkeypatch.setattr(
+            gateway_mod.platform_compat,
+            "probe_file_persistence",
+            lambda directory: "probe failed",
+        )
+        monkeypatch.setattr(
+            session_mod,
+            "cleanup_orphaned_sessions",
+            lambda: called.append("cleanup"),
+        )
+        with pytest.raises(SystemExit):
+            await self._orchestrator().run()
+        assert called == []


### PR DESCRIPTION
## Problem

A gateway whose environment breaks basic file syscalls still binds its port and serves traffic — but every save silently fails. Chat-slot history writes, cron-history appends, and session-PID tracking all require `tempfile.mkstemp` (via `atomic_write`) plus an advisory lock (`platform_compat.file_lock`) in the data home.

Observed in the wild (Linux dev host, 2026-08-08): a gateway spawned from inside a sandboxed agent session inherits the sandbox's **seccomp filter** — seccomp survives `fork`/`exec`, `nohup`/`disown` included — so `fcntl.flock` and `mkstemp` raise `OSError(ENOSYS)` while writes to already-open fds keep working. The result over one 5-minute lifetime:

- every chat-slot save at shutdown failed (`Failed to save slot ... to history` × N — silent chat-history loss),
- cron-history appends crashed with `[Errno 38] Function not implemented`,
- a second gateway started from the same environment died with a **raw traceback** in `cleanup_orphaned_sessions` instead of anything actionable.

The process never exits on its own — it limps for its whole lifetime dropping writes.

## Fix

- `platform_compat.probe_file_persistence(directory)`: creates a probe file with `mkstemp` and locks it with `file_lock` — the exact two primitives the persistence paths use. Returns `None` on success or a human-readable failure description; when `errno == ENOSYS`, the message names the inherited-seccomp cause and the remedy (start from a regular shell or the system service). Probe file removed in all outcomes.
- `GatewayOrchestrator.run()` runs the probe against `data_home()` **before the first lock consumer** (`cleanup_orphaned_sessions`, where the raw-traceback crash happened). On failure: `CRITICAL` log + one-line stderr message + `SystemExit(1)`.

Fail-loud over fail-silent, matching the repo's existing lock philosophy (`file_lock` already "FAILS CLOSED" on Windows rather than proceeding unserialized) and the pidfd `ENOSYS` probe precedent in `cli.py`.

## Tests

`test/test_persistence_probe.py` (11 tests): healthy dir passes / leaves no litter / creates missing dirs; ENOSYS on create and on lock produce step-specific messages with the seccomp hint; non-ENOSYS errors get no misleading hint; probe file removed even when locking fails; orchestrator wiring — `run()` exits 1 on probe failure and does so **before** `cleanup_orphaned_sessions` runs.

Verified: new module green, `test_no_config_dir_in_async` ratchet green (probe uses `data_home()`, issue #1057), isort/flake8/mypy clean (mypy 1.14.1, CI-parity venv, 847 files). Full suite run: 38,395 passed; 69 failures reproduced identically on clean `origin/main` @ 6590a1ce on the same host (git/network-dependent modules timing out in the sandboxed environment) — environmental, not from this diff.
