### PR TITLE
fix(workflows): thread extra_env through both agent adapters

### DIFF
--- a/src/kiro_crew/workflows/agent_exec.py
+++ b/src/kiro_crew/workflows/agent_exec.py
@@ -52,12 +52,18 @@ def build_agent_fn(
     default_agent: Optional[str] = None,
     default_model: Optional[str] = None,
     cwd: Optional[str] = None,
+    extra_env: Optional[dict[str, str]] = None,
 ) -> AgentFn:
     """Return an ``agent_fn`` that runs each workflow agent step through a model.
 
     ``sessions`` is a ``SessionManager``-like object exposing
     ``async get_or_create(key, *, agent, model, cwd, ...) -> (provider, *_)`` and
     ``release(key, *, cleanup=True)``. Injected so tests can pass a fake.
+
+    ``extra_env`` is a run-level environment pin threaded into every spawned
+    session, mirroring ``default_agent``/``default_model``/``cwd``. It is a
+    per-run pin rather than a per-call override because ``WorkflowContext.agent()``
+    exposes no ``env=`` parameter (that Protocol is frozen).
     """
 
     # Per-run, 0-based ephemeral session index (not a module-global, so each run
@@ -75,6 +81,7 @@ def build_agent_fn(
             agent=opts.get("agent") or default_agent,
             model=opts.get("model") or default_model,
             cwd=opts.get("cwd") or cwd,
+            extra_env=extra_env,
         )
         # Wall clock for THIS agent turn only (not the whole workflow run):
         # acp leaves TurnUsage.duration_ms at 0, so without this the row's

--- a/src/kiro_crew/workflows/agent_pool.py
+++ b/src/kiro_crew/workflows/agent_pool.py
@@ -86,12 +86,14 @@ class _WorkflowSessionWorker:
         agent: Optional[str],
         model: Optional[str],
         cwd: Optional[str],
+        extra_env: Optional[dict[str, str]] = None,
     ) -> None:
         self._sessions = sessions
         self._key = key
         self._agent = agent
         self._model = model
         self._cwd = cwd
+        self._extra_env = extra_env
         self._provider: Any = None
 
     async def start(self) -> None:
@@ -101,6 +103,7 @@ class _WorkflowSessionWorker:
             agent=self._agent,
             model=self._model,
             cwd=self._cwd,
+            extra_env=self._extra_env,
         )
         self._provider = provider
 
@@ -180,6 +183,7 @@ def build_pooled_agent_fn(
     default_agent: Optional[str] = None,
     default_model: Optional[str] = None,
     cwd: Optional[str] = None,
+    extra_env: Optional[dict[str, str]] = None,
     max_workers: int = 4,
     max_starting: int = 2,
     max_identities: int = 8,
@@ -214,6 +218,7 @@ def build_pooled_agent_fn(
                 agent=agent,
                 model=model,
                 cwd=work_dir,
+                extra_env=extra_env,
             )
 
         return WorkerPool(
@@ -270,6 +275,7 @@ def build_pooled_agent_fn(
             agent=opts.get("agent") or default_agent,
             model=opts.get("model") or default_model,
             cwd=opts.get("cwd") or cwd,
+            extra_env=extra_env,
         )
         try:
             return await _run_step(provider, prompt)
@@ -289,6 +295,7 @@ def build_pooled_agent_fn(
                 agent=opts.get("agent") or default_agent,
                 model=opts.get("model") or default_model,
                 cwd=opts.get("cwd") or cwd,
+                extra_env=extra_env,
             )
             return await _run_step(provider, prompt)
         # Ephemeral default path: run on a warm worker from the sub-pool matching

--- a/test/test_workflows_agent_exec.py
+++ b/test/test_workflows_agent_exec.py
@@ -36,8 +36,10 @@ class FakeSessions:
         self.created: list[tuple[str, dict]] = []
         self.released: list[str] = []
 
-    async def get_or_create(self, key, *, agent=None, model=None, cwd=None, **kw):
-        self.created.append((key, {"agent": agent, "model": model, "cwd": cwd}))
+    async def get_or_create(self, key, *, agent=None, model=None, cwd=None, extra_env=None, **kw):
+        self.created.append(
+            (key, {"agent": agent, "model": model, "cwd": cwd, "extra_env": extra_env})
+        )
         return FakeProvider(key), True, False
 
     def release(self, key, *, cleanup=False):
@@ -109,10 +111,35 @@ async def test_opts_and_defaults_flow_into_get_or_create() -> None:
     fn = build_agent_fn(sessions, run_id="wf_z", default_agent="researcher", default_model="m1")
 
     await fn("p", {})  # uses defaults
-    assert sessions.created[-1][1] == {"agent": "researcher", "model": "m1", "cwd": None}
+    assert sessions.created[-1][1] == {
+        "agent": "researcher", "model": "m1", "cwd": None, "extra_env": None
+    }
 
     await fn("p", {"agent": "coder", "model": "m2", "cwd": "/tmp/x"})  # opts override
-    assert sessions.created[-1][1] == {"agent": "coder", "model": "m2", "cwd": "/tmp/x"}
+    assert sessions.created[-1][1] == {
+        "agent": "coder", "model": "m2", "cwd": "/tmp/x", "extra_env": None
+    }
+
+
+async def test_extra_env_run_level_pin_flows_into_get_or_create() -> None:
+    """Issue #2207: a run-level extra_env pin reaches every spawned session,
+    just like default_agent/default_model/cwd (WorkflowContext.agent has no
+    per-call env= override, so this is a run-level pin)."""
+    env = {"CORRELATION_ID": "abc123", "MC_ENDPOINT": "https://example.test"}
+    sessions = FakeSessions()
+    fn = build_agent_fn(sessions, run_id="wf_env", extra_env=env)
+
+    await fn("ephemeral step", {})
+    assert sessions.created[-1][1]["extra_env"] == env
+
+    # also on a named (stateful) session
+    await fn("chain step", {"session": "chain-A"})
+    assert sessions.created[-1][1]["extra_env"] == env
+
+    # default (no pin) stays None — no accidental env leakage
+    plain = FakeSessions()
+    await build_agent_fn(plain, run_id="wf_plain")("p", {})
+    assert plain.created[-1][1]["extra_env"] is None
 
 
 async def test_end_to_end_through_runner() -> None:

--- a/test/test_workflows_agent_pool.py
+++ b/test/test_workflows_agent_pool.py
@@ -47,13 +47,17 @@ class _FakeSessions:
         # Every (agent, model, cwd) identity a cold-started worker was created
         # with — so a test can assert per-call overrides reach get_or_create.
         self.created_identities: list[tuple] = []
+        # extra_env seen on each cold start (issue #2207) — index-aligned with
+        # created_identities so a test can assert the run-level env pin threads through.
+        self.created_extra_env: list = []
 
-    async def get_or_create(self, key, *, agent=None, model=None, cwd=None):
+    async def get_or_create(self, key, *, agent=None, model=None, cwd=None, extra_env=None):
         # A live key returns instantly (SessionManager's warm per-key fast path).
         if key in self.live:
             return (self.live[key],)
         self.cold_starts += 1
         self.created_identities.append((agent, model, cwd))
+        self.created_extra_env.append(extra_env)
         prov = _FakeProvider(tag=key)
         self.live[key] = prov
         self.keys_seen.add(key)
@@ -307,7 +311,7 @@ class _ClockSessions:
         self.cold_starts = 0
         self.live: dict[str, "_ClockProvider"] = {}
 
-    async def get_or_create(self, key, *, agent=None, model=None, cwd=None):
+    async def get_or_create(self, key, *, agent=None, model=None, cwd=None, extra_env=None):
         if key in self.live:
             return (self.live[key],)
         self.cold_starts += 1
@@ -507,6 +511,38 @@ async def test_worker_pool_send_timeout_reaches_worker(monkeypatch):
             await wp.send("wedged")
     finally:
         await wp.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_extra_env_pin_reaches_all_three_pool_call_sites():
+    """Issue #2207: a run-level extra_env pin threads into every get_or_create the
+    pooled adapter makes — the warm pooled worker, the named-session bypass, and
+    the identity-cap unpooled overflow."""
+    env = {"CORRELATION_ID": "xyz", "MC_ENDPOINT": "https://example.test"}
+    sessions = _FakeSessions()
+    # max_identities=1 so a second distinct identity overflows to the unpooled path.
+    agent_fn, pool = build_pooled_agent_fn(
+        sessions, run_id="renv", max_workers=1, max_identities=1, extra_env=env
+    )
+
+    await agent_fn("pooled default", {})                 # warm pooled worker
+    await agent_fn("named chain", {"session": "chain-A"})  # named-session bypass
+    await agent_fn("overflow", {"model": "other-model"})   # unpooled overflow valve
+
+    # All three cold starts carried the run-level env pin.
+    assert sessions.created_extra_env, "no sessions were created"
+    assert all(e == env for e in sessions.created_extra_env), sessions.created_extra_env
+    await pool.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_no_extra_env_pin_stays_none():
+    """Default (no pin) must not inject env — no accidental leakage."""
+    sessions = _FakeSessions()
+    agent_fn, pool = build_pooled_agent_fn(sessions, run_id="rnone", max_workers=1)
+    await agent_fn("p", {})
+    assert sessions.created_extra_env == [None]
+    await pool.shutdown()
 
 
 def test_max_turns_constant_is_shared_with_agent_exec():


### PR DESCRIPTION
## What

`SessionManager.get_or_create()` accepts `extra_env` and merges it into the
spawned agent process environment, but neither workflow agent adapter forwards
it. So a workflow run's spawned sessions cannot receive environment variables,
even though cron jobs (`job.env`) and app lifecycle scripts already can.

## Fix

`build_agent_fn` and `build_pooled_agent_fn` now take a run-level `extra_env`
pin, mirroring the existing `default_agent` / `default_model` / `cwd` pins, and
thread it into every `get_or_create` call:

- `agent_exec.py`: the single call in `build_agent_fn`.
- `agent_pool.py`: all three sites, the warm pooled worker cold start
  (`_WorkflowSessionWorker.start`), the named-session bypass, and the
  identity-cap unpooled overflow.

It is a run-level pin rather than a per-call override because
`WorkflowContext.agent()` exposes no `env=` parameter and that Protocol is
frozen (asserted by `test_workflows_conformance.py`). Extending it would be a
materially larger change, so this keeps the fix consistent with how the other
run-level defaults already behave.

## Tests

New tests cover all four `get_or_create` sites across both adapters, plus the
default case where no pin is set (stays `None`, no accidental env leakage). The
two test session fakes were updated to mirror the real `get_or_create`
signature.

Local gates pass: isort, flake8, mypy, and the `test_workflows_agent_exec` +
`test_workflows_agent_pool` suites (26 tests).

Closes #2207