### PR TITLE
fix(mcp): emit oauthScopes and oauth.clientId that kiro-cli actually reads

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -58,7 +58,7 @@ from kiro_crew.config.paths import (
     kiro_agents_dir,
 )
 from kiro_crew.env import augmented_path
-from kiro_crew.mcp_utils import mcp_server_alias
+from kiro_crew.mcp_utils import kiro_oauth_wire_entry, mcp_server_alias
 from kiro_crew.platform import current_context
 from kiro_crew.platform import redact_via_context as redact
 from kiro_crew.platform import safe_context_call
@@ -1745,6 +1745,19 @@ def _norm_mcp_spec(spec: Any) -> Any:
     return {k: v for k, v in spec.items() if not (k in ("env", "args") and not v)}
 
 
+def _alias_family_base(key: str) -> str:
+    """Strip a collision suffix, yielding the alias its family is named for.
+
+    ``_normalize_mcp_server_keys`` preserves a server whose alias is already held
+    by a different spec under the lowest free ``<alias>-<n>``, so that key is the
+    only name for a server no source spells. Callers resolving ownership through
+    it must still confirm identity: sharing a family means sharing an alias, not
+    being the same server.
+    """
+    base, _, tail = key.rpartition("-")
+    return base if base and tail.isdigit() else key
+
+
 def _normalize_mcp_server_keys(config: dict) -> None:
     """Rewrite any slash-containing ``mcpServers`` key to its slash-free alias.
 
@@ -2314,12 +2327,92 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
         return shutil.which(cmd, path=augmented_path(base))
 
     valid_servers: dict[str, Any] = {}
-    for name, spec in config.get("mcpServers", {}).items():
+    # The store is keyed by its own RAW name, but ``name`` below iterates the
+    # config, whose slashed keys a previous pass rewrote to their alias
+    # (``_normalize_mcp_server_keys``). Looking the store up by the raw key alone
+    # would miss the owner of an aliased entry and fall through to "unmanaged",
+    # preserving the previously-rendered wire hints -- so an edit that cleared them
+    # would answer 200 and never take effect. Alias-keyed for that reason, and the
+    # mapping skips a malformed value for the same reason the merge does.
+    #
+    # A LIST per alias, not one entry: the mapping is many-to-one, so two store
+    # names can share an alias. Keeping only the last would strip the other server
+    # of its owner entirely, and the identity check below would then read it as
+    # unmanaged rather than simply looking at the next candidate.
+    _store_by_alias: dict[str, list[dict]] = {}
+    for _n, _s in kirocrew_mcp.items():
+        if isinstance(_s, dict):
+            _store_by_alias.setdefault(mcp_server_alias(_n), []).append(_s)
+    _cfg_servers: dict[str, Any] = config.get("mcpServers", {})
+    for name, spec in _cfg_servers.items():
         if not isinstance(spec, dict):
             continue
-        # Remote Streamable HTTP servers — preserve as-is (url-based, no command)
+        # Remote Streamable HTTP servers — preserved as-is except for the OAuth
+        # hints, which are renamed to the fields kiro-cli actually deserializes.
+        # This is the one boundary where the internal spelling (``scopes`` /
+        # ``clientId``, what mcp.json and the UI use) becomes the wire spelling,
+        # so every source file keeps one shape and only the emitted spec changes.
+        #
+        # The dashboard store's own entry answers both ownership and source. A
+        # usable dict means the store owns this name and states its hints (in
+        # either spelling -- the scope-toggle preservation rule copies a global
+        # spec in verbatim, so a store entry can legitimately hold wire form).
+        # Anything else -- absent, or a malformed value the merge above skipped
+        # and which therefore supplied nothing -- means we own nothing here, and
+        # the entry's own wire values are the only copy of configuration written
+        # in a file we do not control.
         if spec.get("url"):
-            valid_servers[name] = spec
+            # An entry with no store owner is unmanaged: its own wire values are
+            # the only copy of configuration written in a file we do not control,
+            # so they are preserved verbatim. That includes a server defined only
+            # in the agent config itself (``kiro-cli mcp add --agent kirocrew``, a
+            # hand-edit) -- the rebuild merges onto that file, so clearing its
+            # hints here would destroy the only copy. Narrowing a grant is the
+            # editor's job, where the change is explicit and reversible.
+            # A malformed store value contributes nothing -- and "nothing"
+            # includes no veto over the alias lookup, so it cannot shadow a
+            # usable slashed owner that aliases onto this name. It still does not
+            # confer ownership: a name with no usable entry anywhere stays
+            # unmanaged, because the fallback yields ``None`` too.
+            #
+            # ``mcp_server_alias`` is many-to-one, so an alias match is NOT an
+            # identity match: an unrelated user-owned name can collide with a
+            # managed one. A binding that GRANTS -- these hints are credentials
+            # and requested access -- therefore also demands transport identity,
+            # or one server's grant lands on another's. (The disabled guard below
+            # is the opposite direction and stays name-only on purpose: see there.)
+            _store_entry = kirocrew_mcp.get(name)
+            if not isinstance(_store_entry, dict):
+                _url = spec.get("url")
+                _candidates = [
+                    c
+                    for c in _store_by_alias.get(mcp_server_alias(name), ())
+                    if c.get("url") == _url
+                ]
+                # Nothing in a name says whether normalization minted it or a user
+                # typed it, and a url is not an identity when two owners share one.
+                # So the collision family is searched only with corroboration that
+                # a mint was actually forced -- the plain alias is held by a
+                # DIFFERENT transport -- and only when exactly one owner answers.
+                # An ambiguous or uncorroborated family leaves the entry unmanaged,
+                # because preserving a grant costs less than moving one.
+                if not _candidates:
+                    _base = _alias_family_base(name)
+                    _held = _cfg_servers.get(_base)
+                    if (
+                        _base != name
+                        and isinstance(_held, dict)
+                        and _held.get("url") != _url
+                    ):
+                        _candidates = [
+                            c
+                            for c in _store_by_alias.get(_base, ())
+                            if c.get("url") == _url
+                        ]
+                _store_entry = _candidates[0] if len(_candidates) == 1 else None
+            valid_servers[name] = kiro_oauth_wire_entry(
+                spec, store_entry=_store_entry, server=name
+            )
             continue
         # Build candidate specs in priority order: the merged winner first,
         # then the same server from each source as a resolution fallback.
@@ -2397,15 +2490,52 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
     # These are explicitly installed by the user via `aim mcp install` or
     # manual mcp.json edits — unlike managed servers, they should always
     # be registered regardless of fresh/existing config state.
+    #
+    # ``kirocrew_mcp`` is in this chain for the same reason: it holds every entry
+    # the user added through the dashboard, including Connections providers. It
+    # was omitted originally, and because ``tools`` is a CLOSED allowlist (no
+    # wildcard) the result was silent and total — kiro-cli mounted a connected
+    # provider and exposed none of its tools, so a fully consented Notion
+    # connection still answered "I don't have a Notion integration". The entry
+    # reached ``mcpServers`` (via the merges above) but never ``tools``.
     _shared_added: list[str] = []
     _shared_removed: list[str] = []
     _shared_not_auto: list[str] = []
-    for name, spec in itertools.chain(extra_shared_mcp.items(), shared_mcp.items()):
+    # ``disabled`` is TIGHTEST-WINS across scopes, because the scopes disagree by
+    # design: ``POST /api/mcp/toggle enabled:false`` writes ``disabled: true``
+    # into the kiro global ONLY, so a same-named dashboard-store entry legitimately
+    # carries no such key -- and this chain visits the store LAST. Judging each
+    # spec in isolation would let that final entry undo the earlier removal,
+    # clear the flag off the emitted spec, and re-add the ref to BOTH lists.
+    # ``allowedTools`` is the one path that never reaches the PreToolUse gate, so
+    # the operator's disable would be silently void for every tool on that server.
+    #
+    # Both sides are keyed by the ALIAS, not the raw key, because that is the
+    # identity the emitted ref carries and the mapping is many-to-one: a slashed
+    # global key and a slash-free store key are different dict keys that mount the
+    # same ``@ref``. Comparing raw keys would let the alias-spelled entry look
+    # like a different server and re-add the ref the disable just removed.
+    #
+    # Unlike the OAuth-hint binding above, this match deliberately does NOT also
+    # demand transport identity. The two run in opposite directions: over-matching
+    # here only over-disables -- an availability cost, no privilege gained --
+    # while under-matching would let an operator's disable be missed on the one
+    # path (``allowedTools``) that never reaches the PreToolUse gate. Denying is
+    # allowed to be loose; granting is not.
+    _disabled_anywhere = {
+        mcp_server_alias(srv)
+        for scope in (extra_shared_mcp, shared_mcp, kirocrew_mcp)
+        for srv, srv_spec in scope.items()
+        if isinstance(srv_spec, dict) and srv_spec.get("disabled")
+    }
+    for name, spec in itertools.chain(
+        extra_shared_mcp.items(), shared_mcp.items(), kirocrew_mcp.items()
+    ):
         if not isinstance(spec, dict) or name in managed_names:
             continue
         alias = mcp_server_alias(name)
         ref = f"@{alias}"
-        if spec.get("disabled"):
+        if spec.get("disabled") or alias in _disabled_anywhere:
             for key in ("tools", "allowedTools"):
                 lst = config.get(key)
                 if lst is not None and ref in lst:

--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -18,7 +18,12 @@ from kiro_crew.config.paths import data_home, kiro_agents_dir
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.mcp_gateway import is_gateway_supported
 from kiro_crew.mcp_gateway.backend import MCP_APPS_ENV_FLAG, mcp_apps_env_override
-from kiro_crew.mcp_utils import mcp_server_alias
+from kiro_crew.mcp_utils import (
+    INTERNAL_CLIENT_ID_KEY,
+    INTERNAL_SCOPES_KEY,
+    apply_kiro_oauth_hints,
+    mcp_server_alias,
+)
 from kiro_crew.platform.governance import may_skip_gate_now
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
@@ -696,6 +701,7 @@ async def api_mcp_sync(request: web.Request) -> web.Response:
     """
     from kiro_crew.mcp_discovery import (  # noqa: F811
         discover_servers_to_sync,
+        kirocrew_managed_names,
         register_servers_for_cc,
         sync_to_agent_config,
     )
@@ -714,9 +720,93 @@ async def api_mcp_sync(request: web.Request) -> web.Response:
             except (FileNotFoundError, json.JSONDecodeError):
                 gdata = {"mcpServers": {}}
             gservers = gdata.setdefault("mcpServers", {})
+            # The kiro-global mcp.json is NOT ours. Discovery merges every scope,
+            # so a name the user configured only in their own global file reaches
+            # this sync set exactly like a managed one -- and the branch below
+            # RECONSTRUCTS the entry, so it would replace their url and OAuth
+            # fields with whatever the merged view produced. Base only ever
+            # CREATED missing entries here; the gate keeps that guarantee for
+            # names we do not own while still letting a managed entry re-sync,
+            # which is the whole point of the scope fix.
+            _managed = kirocrew_managed_names()
             for s in to_sync:
-                if s.name not in gservers:
-                    entry: dict[str, Any] = {"command": s.command}
+                if s.is_remote:
+                    current = gservers.get(s.name)
+                    if isinstance(current, dict) and s.name not in _managed:
+                        continue
+                    entry: dict[str, Any] = dict(current) if isinstance(current, dict) else {}
+                    for key in ("command", "args", "env", "type"):
+                        entry.pop(key, None)
+                    entry["url"] = s.url
+                    # A headers map is scoped to the HOST it was typed for. The
+                    # overlay below deliberately carries a credential the user put
+                    # in their own global file across a sync -- but that copy was
+                    # issued by, and for, the url already on disk. When the store
+                    # moves a managed server to a different url, keeping the map
+                    # stops being preservation and becomes forwarding: the user's
+                    # Authorization value gets written beside an origin that never
+                    # saw it, and the next session sends it there. So the map only
+                    # survives when the url is unchanged, and the test sits ahead
+                    # of BOTH write branches -- a header-less discovery never runs
+                    # the overlay, so a guard inside it would miss the entry that
+                    # simply rode along in ``dict(current)``. Dropping costs a
+                    # re-auth, which the user can redo; a leaked bearer cannot be
+                    # called back. An entry with no url on disk is treated the same
+                    # way: nothing proves that map belongs to where we are pointing.
+                    if not (isinstance(current, dict) and current.get("url") == s.url):
+                        entry.pop("headers", None)
+                    # Discovery coerces only a FALSY headers value, so a truthy
+                    # non-dict from a hand-edited entry arrives here as-is. It
+                    # carries no usable credential, so it reads as "discovery
+                    # said nothing" and leaves the on-disk map alone rather than
+                    # aborting a sync that covers every other server too.
+                    _discovered = s.headers if isinstance(s.headers, dict) else {}
+                    if _discovered:
+                        # Overlay, never replace. Discovery reads the MERGED view,
+                        # which takes the store's copy of the entry, so a header
+                        # the user hand-added to their own global file is absent
+                        # from the discovered map while still present in
+                        # ``current``. Assigning wholesale would delete exactly the
+                        # global-only credential the empty-map guard below exists
+                        # to protect -- and this write path only became reachable
+                        # for existing entries here, so it has to be as
+                        # conservative as the base ref's create-only behaviour.
+                        _prior = entry.get("headers")
+                        entry["headers"] = {
+                            **(_prior if isinstance(_prior, dict) else {}),
+                            **_discovered,
+                        }
+                    # An empty discovered header map is NOT an instruction to
+                    # delete. Discovery reads the dashboard's own mcp.json, so a
+                    # server of the same name carrying an Authorization header in
+                    # the user's global ~/.kiro/settings/mcp.json legitimately
+                    # arrives here header-less. Popping on that would erase the
+                    # only copy of a credential the user typed, silently and with
+                    # nothing to restore it from.
+                    #
+                    # scopes/clientId below are handled the opposite way ON
+                    # PURPOSE: those are written only by flows that own the whole
+                    # OAuth request, so absent means the request was narrowed and
+                    # the old grant must stop being asked for. Getting a stale
+                    # scope wrong over-requests access; getting a header wrong
+                    # destroys it.
+                    #
+                    # Both hints therefore always SPEAK here -- an empty list or
+                    # id is a real "no longer requested", not silence -- while
+                    # ``apply_kiro_oauth_hints`` edits ``oauth`` surgically, so a
+                    # sub-key we do not own (``issuer``, ...) is not collateral.
+                    entry.pop(INTERNAL_SCOPES_KEY, None)
+                    entry.pop(INTERNAL_CLIENT_ID_KEY, None)
+                    entry = apply_kiro_oauth_hints(
+                        entry,
+                        scopes=list(s.scopes),
+                        client_id=s.client_id,
+                        server=s.name,
+                    )
+                    if current != entry:
+                        gservers[s.name] = entry
+                elif s.name not in gservers:
+                    entry = {"command": s.command}
                     if s.args:
                         entry["args"] = s.args
                     if s.env:

--- a/src/kiro_crew/dashboard/handlers/mcp_custom.py
+++ b/src/kiro_crew/dashboard/handlers/mcp_custom.py
@@ -31,6 +31,12 @@ from kiro_crew.dashboard.handlers.mcp import (
     _is_valid_mcp_name,
     _replace_kirocrew_spec,
 )
+from kiro_crew.mcp_utils import (
+    INTERNAL_CLIENT_ID_KEY,
+    INTERNAL_SCOPES_KEY,
+    KIRO_OAUTH_KEY,
+    KIRO_SCOPES_KEY,
+)
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
@@ -43,7 +49,13 @@ _MAX_SERVERS_PER_ADD = 20
 # are rejected by name rather than silently dropped or passed through to
 # the process spawner.
 _STDIO_KEYS = {"command", "args", "env"}
-_REMOTE_KEYS = {"url"}
+# ``scopes`` and ``clientId`` are OAuth hints carried to the runtime verbatim.
+# Kiro Crew validates only their SHAPE and never interprets them: the runtime
+# owns the authorization exchange, so scope narrowing and client registration
+# are its decisions, not ours.  A clientId is a public OAuth identifier — the
+# corresponding secret never lives in an MCP spec — so neither key is redacted.
+_REMOTE_ONLY_KEYS = {"scopes", "clientId"}
+_REMOTE_KEYS = {"url"} | _REMOTE_ONLY_KEYS
 _ALLOWED_SPEC_KEYS = _STDIO_KEYS | _REMOTE_KEYS
 
 
@@ -81,11 +93,45 @@ def _validate_spec(spec: object, carried_keys: frozenset[str] = frozenset()) -> 
             return "'url' must be an http(s) URL"
         for key in _STDIO_KEYS & set(spec):
             return f"'{key}' is not valid on a remote (url) server"
+        # One shape rule per hint, applied to BOTH spellings. The wire spellings
+        # are tolerated by name so an unmodified round trip still saves, but
+        # tolerating a key is not the same as accepting any value in it -- without
+        # this, the same field is accepted or rejected purely by which spelling
+        # the caller used, and an invalid value reaches disk under a 200.
+        for scopes_key in ("scopes", KIRO_SCOPES_KEY):
+            if scopes_key in spec:
+                scopes = spec[scopes_key]
+                if not isinstance(scopes, list) or any(
+                    not isinstance(scope, str) or not scope.strip() for scope in scopes
+                ):
+                    return f"'{scopes_key}' must be a list of non-empty strings"
+        if "clientId" in spec:
+            client_id = spec["clientId"]
+            if not isinstance(client_id, str) or not client_id.strip():
+                return "'clientId' must be a non-empty string"
+        if KIRO_OAUTH_KEY in spec:
+            oauth = spec[KIRO_OAUTH_KEY]
+            if not isinstance(oauth, dict):
+                return f"'{KIRO_OAUTH_KEY}' must be an object"
+            # Only the hints are ours to shape-check; unrelated sub-keys
+            # (``issuer``, ...) belong to the runtime and pass through.
+            if INTERNAL_CLIENT_ID_KEY in oauth:
+                nested_id = oauth[INTERNAL_CLIENT_ID_KEY]
+                if not isinstance(nested_id, str) or not nested_id.strip():
+                    return f"'{KIRO_OAUTH_KEY}.clientId' must be a non-empty string"
+            if KIRO_SCOPES_KEY in oauth:
+                nested = oauth[KIRO_SCOPES_KEY]
+                if not isinstance(nested, list) or any(
+                    not isinstance(scope, str) or not scope.strip() for scope in nested
+                ):
+                    return f"'{KIRO_OAUTH_KEY}.{KIRO_SCOPES_KEY}' must be a list of non-empty strings"
         return None
 
     command = spec["command"]
     if not isinstance(command, str) or not command.strip():
         return "'command' must be a non-empty string"
+    for key in sorted(_REMOTE_ONLY_KEYS & set(spec)):
+        return f"'{key}' is not valid on a stdio (command) server"
     args = spec.get("args", [])
     if not isinstance(args, list) or any(not isinstance(a, str) for a in args):
         return "'args' must be a list of strings"
@@ -99,14 +145,101 @@ def _validate_spec(spec: object, carried_keys: frozenset[str] = frozenset()) -> 
 
 def _clean_spec(spec: dict) -> dict:
     """Normalized copy of a validated spec (drops empty optionals)."""
+    out: dict = {}
     if "url" in spec:
-        return {"url": spec["url"]}
-    out: dict = {"command": spec["command"].strip()}
+        out["url"] = spec["url"]
+        if spec.get("scopes"):
+            out["scopes"] = list(spec["scopes"])
+        if spec.get("clientId"):
+            out["clientId"] = spec["clientId"]
+        return out
+    out["command"] = spec["command"].strip()
     if spec.get("args"):
         out["args"] = list(spec["args"])
     if spec.get("env"):
         out["env"] = dict(spec["env"])
     return out
+
+
+def _resolve_oauth_hints(spec: dict, submitted: dict, existing: dict) -> str | None:
+    """Let the submitted spec decide the OAuth hints, wire sibling included.
+
+    Returns an error message when the submission tries to change an ``oauth``
+    sub-key that is not one of the hints, or None on success.
+
+    The store speaks ONE spelling (``scopes`` / ``clientId``); the wire spelling
+    exists only in the emitted agent spec. But the scope-toggle preservation rule
+    copies a global server's spec into the store verbatim, so an entry can already
+    hold the wire form -- and those keys fall outside the editable set, so plain
+    carried-key restoration puts them back untouched. With no internal key on disk
+    the reader correctly falls through to that sibling, and the hint the user just
+    removed keeps being requested while the API answers 200.
+
+    So a wire hint is NOT foreign configuration to be carried: it is this entry's
+    own hint in the other spelling. When the submitted spec states neither
+    spelling of a hint, the field is cleared and the sibling goes with it; when it
+    states either, that is authoritative. Sub-keys of ``oauth`` we never owned
+    (``issuer``) always survive, matching the emit boundary's surgical edit.
+
+    Tolerating the wire keys on input keeps an unmodified GET -> PUT round trip
+    working; it does not make them a second editable vocabulary, because nothing
+    here interprets them beyond "this hint is still stated".
+    """
+    if "url" not in spec:
+        return None  # stdio entries carry no OAuth hints
+    submitted_oauth = submitted.get(KIRO_OAUTH_KEY)
+    prior = existing.get(KIRO_OAUTH_KEY)
+
+    # Sub-keys that are neither hint belong to other flows, so they follow the
+    # carried-key rule: matching what is already on disk is fine, anything else is
+    # refused. A key with no prior value cannot be stored either -- accepting it
+    # and writing nothing would turn an explicit refusal into a silent success.
+    _prior_others = {
+        k: v
+        for k, v in (prior if isinstance(prior, dict) else {}).items()
+        if k not in (INTERNAL_CLIENT_ID_KEY, KIRO_SCOPES_KEY)
+    }
+    if isinstance(submitted_oauth, dict):
+        for k, value in submitted_oauth.items():
+            if k in (INTERNAL_CLIENT_ID_KEY, KIRO_SCOPES_KEY):
+                continue
+            if k not in _prior_others or _prior_others[k] != value:
+                return (
+                    f"'{KIRO_OAUTH_KEY}.{k}' is managed by other flows and cannot be"
+                    " edited here — revert it to save"
+                )
+
+    # The scopes hint has TWO wire spellings -- top-level and nested under
+    # ``oauth`` -- and the reader falls through to either. Both therefore obey one
+    # statement test, or a clear would drop the spelling it happened to check and
+    # leave the other standing for the reader to resurrect.
+    scopes_stated = (
+        INTERNAL_SCOPES_KEY in submitted
+        or KIRO_SCOPES_KEY in submitted
+        or (isinstance(submitted_oauth, dict) and KIRO_SCOPES_KEY in submitted_oauth)
+    )
+    if not scopes_stated:
+        spec.pop(KIRO_SCOPES_KEY, None)
+    elif KIRO_SCOPES_KEY in submitted and INTERNAL_SCOPES_KEY not in submitted:
+        spec[KIRO_SCOPES_KEY] = submitted[KIRO_SCOPES_KEY]
+
+    # Rebuilt rather than carried: only sub-keys that are neither hint survive
+    # untouched, and each hint is re-added solely when the submission states it in
+    # a wire spelling AND leaves the internal one unstated. The internal spelling
+    # is the one the store and the editor speak, so stating it settles the hint
+    # outright -- copying a wire sibling back would leave the reader a fallback
+    # that outlives the value it was told to use.
+    siblings = dict(_prior_others)
+    if isinstance(submitted_oauth, dict):
+        if INTERNAL_CLIENT_ID_KEY in submitted_oauth and INTERNAL_CLIENT_ID_KEY not in submitted:
+            siblings[INTERNAL_CLIENT_ID_KEY] = submitted_oauth[INTERNAL_CLIENT_ID_KEY]
+        if KIRO_SCOPES_KEY in submitted_oauth and INTERNAL_SCOPES_KEY not in submitted:
+            siblings[KIRO_SCOPES_KEY] = submitted_oauth[KIRO_SCOPES_KEY]
+    if siblings:
+        spec[KIRO_OAUTH_KEY] = siblings
+    else:
+        spec.pop(KIRO_OAUTH_KEY, None)
+    return None
 
 
 def _load_kirocrew_config_strict() -> dict | None:
@@ -295,9 +428,13 @@ async def api_mcp_custom_update(request: web.Request) -> web.Response:
         carried = {
             k: v
             for k, v in existing.items()
-            if k not in _ALLOWED_SPEC_KEYS and k != "disabled"
+            if k not in _ALLOWED_SPEC_KEYS
+            and k != "disabled"
+            and k not in (KIRO_SCOPES_KEY, KIRO_OAUTH_KEY)
         }
-        err = _validate_spec(submitted, frozenset(carried))
+        err = _validate_spec(
+            submitted, frozenset(carried) | {KIRO_SCOPES_KEY, KIRO_OAUTH_KEY}
+        )
         if err:
             return web.json_response({"error": err}, status=400)
         assert isinstance(submitted, dict)  # narrowed by _validate_spec
@@ -312,6 +449,11 @@ async def api_mcp_custom_update(request: web.Request) -> web.Response:
                 )
         spec = _clean_spec(submitted)
         spec.update(carried)  # preserved verbatim, never dropped
+        _oauth_err = _resolve_oauth_hints(spec, submitted, existing)
+        if _oauth_err:
+            return web.json_response(
+                {"error": _oauth_err, "code": "oauth_field_not_editable"}, status=400
+            )
         replaced = _replace_kirocrew_spec(name, spec)
     if not replaced:
         return web.json_response({"error": f"server '{name}' not found"}, status=404)

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -31,7 +31,7 @@ from kiro_crew import platform_compat
 from kiro_crew.config.paths import data_home, kiro_agents_dir
 from kiro_crew.env import augmented_path
 from kiro_crew.hooks import safe_read_file
-from kiro_crew.mcp_utils import mcp_server_alias
+from kiro_crew.mcp_utils import kiro_entry_client_id, kiro_entry_scopes, mcp_server_alias
 from kiro_crew.sandbox import (
     SandboxUnavailableError,
     create_subprocess_limited,
@@ -365,6 +365,11 @@ class McpServerInfo:
     env: dict[str, str] = field(default_factory=dict)
     url: str = ""
     headers: dict[str, str] = field(default_factory=dict)
+    # Remote-only OAuth hints carried verbatim to the runtime, which owns the
+    # authorization exchange. Kiro Crew never enforces scopes and never registers
+    # a client — it only refuses to lose these fields while syncing.
+    scopes: list[str] = field(default_factory=list)
+    client_id: str = ""
     status: str = "unknown"  # unknown | ok | error | probing | outdated | disabled
     tools: list[str] = field(default_factory=list)
     error: str = ""
@@ -406,6 +411,17 @@ class McpServerInfo:
             d["url"] = self.url
             if self.headers:
                 d["headers"] = self.headers
+            # Not redacted: requested scopes and a public OAuth client id are
+            # non-secret configuration the user needs to see.
+            #
+            # These are the INTERNAL key names, matching the dashboard's
+            # ``McpServer`` type. This dict is an API response, never a file
+            # kiro-cli reads, so it must NOT be translated to the wire names —
+            # ``kiro_oauth_wire_entry`` is applied on the emit paths instead.
+            if self.scopes:
+                d["scopes"] = list(self.scopes)
+            if self.client_id:
+                d["clientId"] = self.client_id
         if self.disabled_tools:
             d["disabledTools"] = self.disabled_tools
         if self.disabled:
@@ -585,6 +601,29 @@ def _load_mcp_json() -> dict[str, Any]:
     return merged
 
 
+def _spec_scopes(spec: dict) -> list[str]:
+    """Requested OAuth scopes from a spec, dropping anything malformed.
+
+    On-disk specs are untrusted (hand-edited files, other tools), so a
+    non-list or a list with non-string members degrades to "no scopes"
+    rather than propagating a bad shape into the agent config.
+
+    Reads kiro-cli's ``oauthScopes`` as well as Kiro Crew's internal ``scopes``:
+    files we emit for kiro-cli carry the former, so a discovery pass that knew
+    only the latter would report a scoped server as unscoped.
+    """
+    return kiro_entry_scopes(spec)
+
+
+def _spec_client_id(spec: dict) -> str:
+    """Public OAuth client id from a spec, or "" when absent/malformed.
+
+    Accepts kiro-cli's nested ``oauth.clientId`` as well as the internal
+    top-level key, for the same round-trip reason as ``_spec_scopes``.
+    """
+    return kiro_entry_client_id(spec)
+
+
 def _server_from_spec(name: str, spec: dict, source: str) -> McpServerInfo:
     return McpServerInfo(
         name=name,
@@ -593,6 +632,8 @@ def _server_from_spec(name: str, spec: dict, source: str) -> McpServerInfo:
         env=spec.get("env", {}),
         url=spec.get("url", ""),
         headers=spec.get("headers", {}),
+        scopes=_spec_scopes(spec),
+        client_id=_spec_client_id(spec),
         source=source,
     )
 
@@ -1544,7 +1585,7 @@ def discover_servers_to_sync() -> list[McpServerInfo]:
     """Find MCP servers in mcp.json that need syncing to the agent config.
 
     Returns new servers not yet in the agent config, plus existing servers
-    whose env, command, or args have diverged from the mcp.json source.
+    whose source-owned transport fields have diverged from mcp.json.
     """
     agent_cfg = _load_agent_config()
     agent_mcp = agent_cfg.get("mcpServers", {})
@@ -1562,18 +1603,39 @@ def discover_servers_to_sync() -> list[McpServerInfo]:
             command=spec.get("command", ""),
             args=spec.get("args"),
             env=spec.get("env") or {},
+            url=spec.get("url", ""),
+            headers=spec.get("headers") or {},
+            scopes=_spec_scopes(spec),
+            client_id=_spec_client_id(spec),
             source="discovered",
         )
         if name not in agent_names:
             out.append(info)
         else:
-            # Include existing local servers with divergent command or env.
             # Args divergence is intentionally excluded: user-customized
             # args (e.g. --include-tools additions) are preserved by
             # install_agent()'s setdefault merge, so triggering a full
             # rebuild on args-only differences is wasted work.
             existing = agent_mcp[name]
-            if not isinstance(existing, dict) or info.is_remote:
+            if not isinstance(existing, dict):
+                continue
+            if info.is_remote:
+                existing_headers = existing.get("headers") or {}
+                # scopes/clientId are source-owned transport fields like url and
+                # headers: a registry Connect that adds or changes them must
+                # re-sync, or the agent config keeps authorizing the old shape.
+                #
+                # Reaching this set is not permission to rewrite anything: each
+                # consumer guards its own surface, so the two that Kiro Crew does
+                # not own -- the kiro-global file and the Claude Code sidecar --
+                # decide for themselves what an existing entry allows.
+                if (
+                    existing.get("url", "") != info.url
+                    or existing_headers != info.headers
+                    or _spec_scopes(existing) != info.scopes
+                    or _spec_client_id(existing) != info.client_id
+                ):
+                    out.append(info)
                 continue
             existing_env = existing.get("env", {})
             if not isinstance(existing_env, dict):
@@ -1699,6 +1761,31 @@ def sync_to_agent_config(servers: list[McpServerInfo]) -> bool:
     return added or bool(servers)
 
 
+def kirocrew_managed_names() -> set[str]:
+    """Server names the dashboard store owns, and may therefore be rewritten.
+
+    A usable dict under the ``kirocrew`` scope (``<data home>/mcp.json``) is the
+    one signal that Kiro Crew owns a name -- the same discriminator the agent-spec
+    emit path uses for its OAuth hints, so ownership means one thing everywhere.
+
+    Every write to a config surface we do NOT own -- the kiro-global
+    ``mcp.json``, the Claude Code ``~/.mcp.json`` sidecar -- must be gated on
+    this. Discovery merges ALL scopes, so a name present only in a user's global
+    file reaches the sync set exactly like a managed one; without the gate a
+    Kiro Crew sync would rewrite a server the user configured by hand, and the
+    fields it reconstructs (url, OAuth hints) would silently replace theirs.
+
+    A malformed store value is skipped for the same reason the merge skips it: it
+    contributed nothing, so it cannot make the name ours.
+    """
+    by_source = _load_mcp_json_by_source()
+    return {
+        name
+        for name, spec in by_source.get(SCOPE_KIROCREW, {}).items()
+        if isinstance(spec, dict)
+    }
+
+
 def register_servers_for_cc(
     servers: list[McpServerInfo],
     mcp_json_path: Path | None = None,
@@ -1707,6 +1794,9 @@ def register_servers_for_cc(
 
     Adds entries without removing existing ones. CC-side complement
     to sync_to_agent_config() which handles kiro-side registration.
+
+    A remote that already has an entry is left alone entirely -- see the loop
+    below for why this surface is add-only for remotes.
 
     Returns True if any servers were added or updated.
     """
@@ -1722,12 +1812,29 @@ def register_servers_for_cc(
 
     mcp = existing.setdefault("mcpServers", {})
     changed = False
+    # OAuth hints ride along when a remote is first registered, and only for a
+    # name we own -- see kirocrew_managed_names.
+    _managed = kirocrew_managed_names()
 
     for s in servers:
         if s.is_remote:
+            # Add-only: a remote already present here keeps whatever it holds.
+            # This writer rebuilds an entry from scratch rather than merging into
+            # it, and ownership on this surface is name-only -- a managed
+            # server's moved url is indistinguishable from a user's own
+            # same-named entry -- so rewriting one could silently replace
+            # configuration nobody here authored. Propagating a changed remote
+            # shape needs a record of which entries we wrote, and waits for it.
+            if s.name in mcp:
+                continue
             entry: dict = {"url": s.url}
             if s.headers:
                 entry["headers"] = s.headers
+            if s.name in _managed:
+                if s.scopes:
+                    entry["scopes"] = list(s.scopes)
+                if s.client_id:
+                    entry["clientId"] = s.client_id
         else:
             entry = {"command": s.command, "args": s.args or [], "type": "stdio"}
             if s.env:

--- a/src/kiro_crew/mcp_utils.py
+++ b/src/kiro_crew/mcp_utils.py
@@ -9,7 +9,280 @@ that workaround.
 
 from __future__ import annotations
 
+import logging
 import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Kiro Crew's internal names for the two OAuth hints on a remote MCP entry.
+#: These are the names used in ``mcp.json``, the custom-server API and the UI
+#: types.  They are NOT the names kiro-cli parses -- see
+#: :func:`kiro_oauth_wire_entry` for the translation and why it matters.
+INTERNAL_SCOPES_KEY = "scopes"
+INTERNAL_CLIENT_ID_KEY = "clientId"
+
+#: The names kiro-cli's ``RemoteMcpServerConfig`` / ``OAuthConfig`` actually
+#: deserialize.  Anything else in a remote entry is accepted and dropped on the
+#: floor, which is a SILENT failure: an entry carrying ``scopes`` authorizes
+#: with the provider's default grant instead of the scopes the card promised.
+KIRO_SCOPES_KEY = "oauthScopes"
+KIRO_OAUTH_KEY = "oauth"
+
+
+def _scopes_shape(raw: object) -> str:
+    """A scope value's SHAPE for a log line, carrying none of its members.
+
+    The field is hand-editable, so it can hold arbitrary JSON -- describing the
+    shape keeps an accidentally-pasted token out of the log entirely instead of
+    trusting the value to be harmless.
+    """
+    if not isinstance(raw, list):
+        return type(raw).__name__
+    bad = [
+        f"[{i}]:{type(scope).__name__}"
+        for i, scope in enumerate(raw)
+        if not isinstance(scope, str) or not scope.strip()
+    ]
+    return f"list[{len(raw)}] with {', '.join(bad)}" if bad else f"list[{len(raw)}]"
+
+
+def _wire_scopes(raw: object, *, server: str = "") -> list[str] | None:
+    """The ``oauthScopes`` value for an internal ``scopes``, or None to omit it.
+
+    Returns None -- meaning "emit no scope request" -- for anything that is not a
+    non-empty list of non-empty strings. Partial forwarding is not an option: a
+    hand-edited ``scopes: ["read", 7]`` emitted as-is makes kiro-cli reject the
+    WHOLE agent spec ("expected a sequence" of strings), which drops every one of
+    Kiro Crew's MCP tools, not just this server's. Omitting the field instead
+    costs this entry the provider's default grant and leaves the rest working.
+
+    All-or-nothing on purpose, matching the custom-server API's validation
+    contract: a list with one bad member is a malformed request, not a request
+    for the members that happen to be well-formed. Emitting the good subset
+    would silently narrow (or broaden) the grant relative to what was written.
+
+    Degrading is deliberate, but it is not free: the entry ends up authorizing
+    with the provider's default grant, which can be WIDER than the list on disk.
+    A malformed value therefore warns, so the swap is diagnosable from the log
+    rather than only from a provider's consent screen. Absent and empty stay
+    silent -- neither is a mistake, they are "no request" and "stop requesting".
+
+    ``server`` names the entry in that warning, and an empty one suppresses it:
+    the callers that pass a name are the ones writing a spec a provider will be
+    asked with, while a comparison or UI read of the same value changes no grant
+    and would only duplicate the line.
+    """
+    if raw is None or raw == []:
+        return None
+    if isinstance(raw, list) and all(
+        isinstance(scope, str) and scope.strip() for scope in raw
+    ):
+        return list(raw)
+    if server:
+        logger.warning(
+            "MCP server %s declares a malformed OAuth scope list (%s); requesting "
+            "the provider's default grant instead, which may be broader than the "
+            "scopes written on disk. Fix the value to request specific scopes.",
+            server,
+            _scopes_shape(raw),
+        )
+    return None
+
+
+#: Sentinel for "no internal source spoke about this hint" -- deliberately
+#: distinct from ``[]`` / ``""``, which mean "a source spoke, and it says none".
+#: Collapsing the two loses data in one direction or leaks stale permissions in
+#: the other, so :func:`apply_kiro_oauth_hints` keeps them apart.
+_NO_SOURCE: Any = object()
+
+
+def apply_kiro_oauth_hints(
+    entry: dict[str, Any],
+    *,
+    scopes: Any = _NO_SOURCE,
+    client_id: Any = _NO_SOURCE,
+    server: str = "",
+) -> dict[str, Any]:
+    """Reconcile kiro-cli's OAuth wire keys on ``entry`` against a source value.
+
+    The single merge rule shared by every writer of a remote MCP entry -- the
+    agent-spec emit path and the ``mcp.json`` sync path -- so the semantics
+    cannot drift between them.
+
+    Each hint is in one of THREE states, and conflating any two of them either
+    destroys the user's configuration or keeps requesting access they removed:
+
+    * a VALID value -> write the wire key from it.
+    * an EMPTY or malformed value (``[]``, ``""``, a non-string member) -> the
+      source is speaking, and it says "none", so DELETE the wire key. Without
+      this, a ``dict.update()``-based merge could never narrow a grant, because
+      ``update`` cannot remove a key -- a widened-then-narrowed scope list would
+      keep authorizing the scopes the user took away.
+    * ``_NO_SOURCE`` (argument omitted) -> nothing authoritative spoke, so
+      PRESERVE whatever wire value is already there, verbatim. An entry can be
+      hand-authored directly in wire form with no internal spelling anywhere, and
+      for that entry the wire value IS the source; rebuilding it from a source
+      that does not exist would delete the only copy.
+
+    The preserved value is NOT re-validated. A wire-only entry is the user's own
+    text in the file kiro-cli reads, so the choice is between leaving it exactly
+    as written and silently deleting configuration we did not author -- the same
+    class of loss this three-state split exists to prevent.
+
+    ``oauth`` is always edited surgically: only ``clientId`` belongs to us, so
+    any other sub-key (``issuer``, ...) survives, and the mapping is dropped only
+    once nothing is left in it.
+    """
+    out = dict(entry)
+
+    if scopes is not _NO_SOURCE:
+        wire_scopes = _wire_scopes(scopes, server=server)
+        if wire_scopes is None:
+            out.pop(KIRO_SCOPES_KEY, None)
+        else:
+            out[KIRO_SCOPES_KEY] = wire_scopes
+
+    if client_id is not _NO_SOURCE:
+        raw_oauth = out.get(KIRO_OAUTH_KEY)
+        oauth = dict(raw_oauth) if isinstance(raw_oauth, dict) else {}
+        oauth.pop("clientId", None)
+        if isinstance(client_id, str) and client_id.strip():
+            oauth["clientId"] = client_id
+        if oauth:
+            out[KIRO_OAUTH_KEY] = oauth
+        else:
+            out.pop(KIRO_OAUTH_KEY, None)
+
+    return out
+
+
+def kiro_oauth_wire_entry(
+    entry: dict[str, Any], *, store_entry: dict[str, Any] | None, server: str = ""
+) -> dict[str, Any]:
+    """Translate a remote MCP entry into the OAuth shape kiro-cli parses.
+
+    ``scopes`` -> ``oauthScopes``, and ``clientId`` -> ``oauth.clientId``. Both
+    internal names are dropped from the result: kiro-cli ignores unknown keys
+    silently, so leaving them would keep two spellings of one fact around with
+    only one of them load-bearing.
+
+    ``store_entry`` is the dashboard store's own entry for this server
+    (``<data home>/mcp.json``), and it answers BOTH questions at once -- who owns
+    the entry, and what the owner says. A usable dict means the store owns this
+    name and IS the source; ``None`` (or any non-dict, which the merge skipped
+    and which therefore supplied nothing) means we own nothing here:
+
+    ======================  ==================  ============================
+    store_entry             states              result
+    ======================  ==================  ============================
+    dict                    valid hint          wire key rebuilt from it
+    dict                    empty hint          wire key DELETED
+    dict                    no hint at all      wire key DELETED
+    None / non-dict         --                  wire value PRESERVED verbatim
+    ======================  ==================  ============================
+
+    The store is read through :func:`kiro_entry_scopes` /
+    :func:`kiro_entry_client_id`, so it is authoritative in EITHER spelling. That
+    matters because the store does not only receive internal-form writes: the
+    scope-toggle preservation rule copies a global server's spec into the store
+    verbatim to keep it configured, and a global entry can be hand-authored in
+    wire form. Such a copy is ours to manage and states its hints in the wire
+    spelling; reading only the internal one would see "no hints" and delete the
+    very configuration the copy exists to preserve.
+
+    The source is read from the STORE, never from ``entry``, because ``entry`` is
+    the merged spec ``rebuild_agent_config`` assembles -- the previously-rendered
+    wire keys folded together with the store via ``dict.update()``. Reading hints
+    off that would let a stale render outvote the store and pin every future
+    session to the grant the entry was first rendered with.
+
+    For an unmanaged entry an absent hint is silence, not removal, so the
+    existing wire value stands -- deleting it would destroy the only copy of
+    configuration written in a file we do not own. An internal spelling found
+    there is still translated, since kiro-cli would otherwise ignore it.
+
+    ``oauth`` is edited surgically in both regimes: only ``clientId`` is ours, so
+    sibling sub-keys (``issuer``, ...) always survive. Safe on a stdio entry or
+    one with neither spelling.
+    """
+    out = dict(entry)
+    entry_scopes = out.pop(INTERNAL_SCOPES_KEY, _NO_SOURCE)
+    entry_client_id = out.pop(INTERNAL_CLIENT_ID_KEY, _NO_SOURCE)
+
+    if isinstance(store_entry, dict):
+        # Owned: the store speaks, in whichever spelling it holds. "No hint" and
+        # "empty hint" are the same answer here -- both mean stop requesting it --
+        # so the readers' absent-or-empty -> [] / "" collapse is exactly right.
+        return apply_kiro_oauth_hints(
+            out,
+            scopes=kiro_entry_scopes(store_entry, server=server),
+            client_id=kiro_entry_client_id(store_entry),
+            server=server,
+        )
+
+    return apply_kiro_oauth_hints(
+        out, scopes=entry_scopes, client_id=entry_client_id, server=server
+    )
+
+
+def kiro_entry_scopes(entry: dict[str, Any], *, server: str = "") -> list[str]:
+    """The OAuth scopes a remote MCP entry requests, either spelling.
+
+    Reads an already-translated entry as well as an internal one so a spec
+    round-tripped through disk still reports the access it asks for. That
+    round-trip is also what makes an unmanaged entry a fixed point on the sync
+    path: its hand-authored wire values read back unchanged, so a re-sync
+    rewrites the same request instead of narrowing it.
+
+    Validates through :func:`_wire_scopes`, the SAME contract the emit path uses,
+    so a malformed list is omitted here too. Reading it as the well-formed subset
+    while the emitted spec omits the field entirely would make discovery report
+    an access level no file asks for and no session receives -- and a sync acting
+    on that would propagate the truncated grant as if it were complete.
+
+    Precedence keys on the internal key's PRESENCE, not its value. When
+    ``scopes`` exists its validated value is FINAL -- including ``[]``, which is
+    the custom-server API's explicit clear. An entry can hold both spellings (the
+    scope-toggle preservation rule copies a global spec into the store in wire
+    form, and the API then edits it in internal form), and falling through on an
+    empty internal value would resurrect the stale wire sibling and keep
+    requesting access the user just cleared. Wire spellings are consulted only
+    when the internal key is absent entirely.
+    """
+    if INTERNAL_SCOPES_KEY in entry:
+        validated = _wire_scopes(entry[INTERNAL_SCOPES_KEY], server=server)
+        return validated if validated is not None else []
+
+    # Between the two WIRE spellings a fall-through is correct: neither is a
+    # deliberate clear, so the first one that validates is the request.
+    wire_candidates: list[object] = [entry.get(KIRO_SCOPES_KEY)]
+    oauth = entry.get(KIRO_OAUTH_KEY)
+    if isinstance(oauth, dict):
+        wire_candidates.append(oauth.get(KIRO_SCOPES_KEY))
+    for raw in wire_candidates:
+        validated = _wire_scopes(raw, server=server)
+        if validated is not None:
+            return validated
+    return []
+
+
+def kiro_entry_client_id(entry: dict[str, Any]) -> str:
+    """The public OAuth client id on a remote MCP entry, either spelling.
+
+    Same presence rule as :func:`kiro_entry_scopes`: when ``clientId`` exists its
+    value is final, so an explicit empty (or an explicit ``null``) clears rather
+    than falling through to a stale ``oauth.clientId`` sibling.
+    """
+    if INTERNAL_CLIENT_ID_KEY in entry:
+        raw = entry[INTERNAL_CLIENT_ID_KEY]
+        return raw if isinstance(raw, str) and raw.strip() else ""
+    oauth = entry.get(KIRO_OAUTH_KEY)
+    if isinstance(oauth, dict):
+        raw = oauth.get("clientId")
+        if isinstance(raw, str) and raw.strip():
+            return raw
+    return ""
 
 
 def mcp_server_alias(name: str) -> str:

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -1635,6 +1635,709 @@ class TestToolBloatFixes:
         assert "@kirocrew-cron" not in config["allowedTools"]
         assert "@kirocrew-core" not in config["allowedTools"]
 
+    def test_dashboard_added_remote_server_reaches_the_tools_allowlist(self, tmp_path: Path):
+        """A Connections provider (or any dashboard-added MCP entry) must land in
+        `tools`, not just `mcpServers`.
+
+        `tools` is a CLOSED allowlist with no wildcard, so an entry present in
+        `mcpServers` but absent from `tools` is mounted with none of its tools
+        exposed — the model then truthfully reports it has no such integration
+        even though the provider is fully connected. This shipped unnoticed
+        because nothing asserted the registration; that is what this test pins.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        (user_home / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"notion": {"url": "https://mcp.notion.com/mcp"}}})
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        config = json.loads(path.read_text(encoding="utf-8"))
+
+        assert "notion" in config["mcpServers"]
+        assert "@notion" in config["tools"]
+
+    def test_disabled_dashboard_remote_server_is_removed_from_tools(self, tmp_path: Path):
+        """Disconnect must be the inverse: a disabled entry loses its ref, so a
+        disconnected provider cannot keep exposing tools."""
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        (user_home / "mcp.json").write_text(
+            json.dumps(
+                {"mcpServers": {"notion": {"url": "https://mcp.notion.com/mcp", "disabled": True}}}
+            )
+        )
+        kiro_dir = tmp_path / "kiro_agents"
+        kiro_dir.mkdir(exist_ok=True)
+        (kiro_dir / "kirocrew.json").write_text(
+            json.dumps({"tools": ["@notion"], "allowedTools": [], "mcpServers": {}})
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        config = json.loads(path.read_text(encoding="utf-8"))
+
+        assert "@notion" not in config["tools"]
+
+    def test_removed_oauth_hints_do_not_survive_a_rebuild_of_a_managed_entry(
+        self, tmp_path: Path
+    ):
+        """Row 3 of the ownership table, through the real rebuild.
+
+        The dashboard store owns this name, and the custom-update API removes a
+        hint by DELETING the key. Since the previously-rendered config is the
+        merge base and ``dict.update()`` cannot remove anything, absence has to
+        mean removed here or the last-rendered grant stays in the spec forever.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        # Dashboard store: the hints were removed, so the keys are simply gone.
+        (user_home / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"notion": {"url": "https://mcp.notion.com/mcp"}}})
+        )
+        kiro_dir = tmp_path / "kiro_agents"
+        kiro_dir.mkdir(exist_ok=True)
+        # Previous render, still carrying the hints it was built with.
+        (kiro_dir / "kirocrew.json").write_text(
+            json.dumps(
+                {
+                    "tools": [],
+                    "allowedTools": [],
+                    "mcpServers": {
+                        "notion": {
+                            "url": "https://mcp.notion.com/mcp",
+                            "oauthScopes": ["read", "write"],
+                            "oauth": {"clientId": "stale-id", "issuer": "https://issuer"},
+                        }
+                    },
+                }
+            )
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["notion"]
+
+        assert "oauthScopes" not in entry
+        assert entry.get("oauth") == {"issuer": "https://issuer"}, "issuer is the user's"
+
+    def test_an_unmanaged_wire_only_entry_keeps_its_oauth_hints(self, tmp_path: Path):
+        """Row 4 of the ownership table, through the real rebuild.
+
+        This server is defined only in kiro-cli's own settings file, hand-authored
+        in the wire spelling. Nothing of ours owns it, so the wire values are the
+        only copy and deleting them destroys configuration we never wrote. The
+        entry is byte-identical to row 3's -- ownership is the ONLY difference.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        (user_home / "mcp.json").write_text(json.dumps({"mcpServers": {}}))
+        (tmp_path / "fake_kiro_mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "handmade": {
+                            "url": "https://mcp.example.com/mcp",
+                            "oauthScopes": ["read:user"],
+                            "oauth": {"clientId": "hand-authored", "issuer": "https://issuer"},
+                        }
+                    }
+                }
+            )
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["handmade"]
+
+        assert entry["oauthScopes"] == ["read:user"]
+        assert entry["oauth"] == {"clientId": "hand-authored", "issuer": "https://issuer"}
+
+    def test_a_malformed_store_value_does_not_confer_ownership(self, tmp_path: Path):
+        """A non-dict store value must not mark a global entry as ours.
+
+        Membership is not ownership. The merge skips a malformed
+        ``kirocrew_mcp`` value entirely, so it contributes no hints and cannot be
+        the source of truth for any — yet a bare `name in kirocrew_mcp` test
+        would read the collision as "the store owns this" and delete the global
+        entry's hand-authored wire hints on behalf of a store entry that does not
+        really exist.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        # Hand-edited garbage under the same name as the global server below.
+        (user_home / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"handmade": "not-a-dict"}})
+        )
+        (tmp_path / "fake_kiro_mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "handmade": {
+                            "url": "https://mcp.example.com/mcp",
+                            "oauthScopes": ["read:user"],
+                            "oauth": {"clientId": "hand-authored", "issuer": "https://issuer"},
+                        }
+                    }
+                }
+            )
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["handmade"]
+
+        assert entry["oauthScopes"] == ["read:user"]
+        assert entry["oauth"] == {"clientId": "hand-authored", "issuer": "https://issuer"}
+
+    def test_a_globally_disabled_server_is_not_remounted_by_the_store_entry(
+        self, tmp_path: Path
+    ):
+        """An operator disable must survive a same-named dashboard-store entry.
+
+        `POST /api/mcp/toggle enabled:false` writes `disabled: true` into the
+        kiro-global mcp.json ONLY. The store entry for the same name carries no
+        `disabled` key, so a chain that visits the store last would re-mount the
+        server AND auto-approve it -- and auto-approve is the one path that never
+        reaches the PreToolUse gate, so the operator's disable would be silently
+        void for every tool on that server.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        # Store entry: no `disabled` key at all.
+        (user_home / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"notion": {"url": "https://mcp.notion.com/mcp"}}})
+        )
+        # Kiro global: the operator's disable lives here and only here.
+        (tmp_path / "fake_kiro_mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "notion": {"url": "https://mcp.notion.com/mcp", "disabled": True}
+                    }
+                }
+            )
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        config = json.loads(path.read_text(encoding="utf-8"))
+
+        assert "@notion" not in config.get("tools", []), "disabled server must not mount"
+        assert "@notion" not in config.get("allowedTools", []), "and must not be auto-approved"
+        # The other half of the same bug: the enabled branch also cleared the flag
+        # off the emitted spec, so kiro-cli itself never saw the disable either.
+        entry = config.get("mcpServers", {}).get("notion")
+        assert entry is None or entry.get("disabled") is True, "the flag must reach the spec"
+
+    def test_a_disabled_server_stays_disabled_when_the_store_uses_the_alias_key(
+        self, tmp_path: Path
+    ):
+        """The tightest-wins gate must compare names in ONE form.
+
+        Agent refs are written as ``@<mcp_server_alias(name)>``, which is
+        many-to-one: ``acme:@acme/notion`` and ``acme-notion`` are different
+        store keys that produce the SAME ``@acme-notion`` ref. A guard that
+        collects raw keys but emits aliased refs therefore misses the
+        equivalence -- the global's disable removes the ref, then the
+        alias-keyed store entry (visited last) re-adds it to tools AND
+        allowedTools, which is the auto-approve path that never reaches the
+        PreToolUse gate.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        # Store entry keyed by the ALIAS form, with no `disabled` key.
+        (user_home / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"acme-notion": {"url": "https://mcp.acme.com/mcp"}}})
+        )
+        # Kiro global keyed by the SLASHED form -- the operator's disable.
+        (tmp_path / "fake_kiro_mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "acme:@acme/notion": {
+                            "url": "https://mcp.acme.com/mcp",
+                            "disabled": True,
+                        }
+                    }
+                }
+            )
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        config = json.loads(path.read_text(encoding="utf-8"))
+
+        assert "@acme-notion" not in config.get("tools", []), "disabled server must not mount"
+        assert "@acme-notion" not in config.get(
+            "allowedTools", []
+        ), "and must not be auto-approved"
+
+    def test_an_agent_config_only_server_keeps_its_oauth_hints_verbatim(self, tmp_path: Path):
+        """The agent config is a merge source, so its own entries are preserved.
+
+        A remote server can be defined only in the agent config -- added with
+        ``kiro-cli mcp add --agent kirocrew``, or hand-edited in. No mcp.json scope
+        declares it and no store entry owns it, so the file is the ONLY copy of its
+        OAuth hints. The rebuild merges onto that file, so rewriting the hints here
+        would destroy them with nothing to restore from.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        (user_home / "mcp.json").write_text(json.dumps({"mcpServers": {}}))
+        (tmp_path / "fake_kiro_mcp.json").write_text(json.dumps({"mcpServers": {}}))
+
+        path = _run_install(tmp_path, cfg_dir)
+        config = json.loads(path.read_text(encoding="utf-8"))
+        hand_added = {
+            "url": "https://mcp.handadded.com/mcp",
+            "oauthScopes": ["hand:read"],
+            "oauth": {"clientId": "hand-client", "issuer": "https://issuer.example"},
+        }
+        config.setdefault("mcpServers", {})["handadded"] = dict(hand_added)
+        path.write_text(json.dumps(config), encoding="utf-8")
+
+        for _ in range(2):
+            path = _run_install(tmp_path, cfg_dir)
+            entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["handadded"]
+            assert entry["oauthScopes"] == ["hand:read"], "the only copy must survive"
+            assert entry["oauth"]["clientId"] == "hand-client"
+            assert entry["oauth"]["issuer"] == "https://issuer.example"
+
+    def test_a_store_clear_persists_across_a_later_rebuild(self, tmp_path: Path):
+        """Narrowing a grant is the store's job, and the rebuild honours it.
+
+        The store states the hints, so it owns them: once it stops stating them the
+        emitted spec stops requesting them, and stays that way on every later
+        rebuild rather than being refilled from the previous render.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "fake_kiro_mcp.json").write_text(json.dumps({"mcpServers": {}}))
+        store = user_home / "mcp.json"
+        url = "https://mcp.acme.com/mcp"
+
+        store.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "acme": {"url": url, "scopes": ["acme:read"], "clientId": "acme-client"}
+                    }
+                }
+            )
+        )
+        path = _run_install(tmp_path, cfg_dir)
+        entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["acme"]
+        assert entry["oauthScopes"] == ["acme:read"]
+        assert entry["oauth"]["clientId"] == "acme-client"
+
+        # The editor clears both hints: the store entry survives, stating neither.
+        store.write_text(json.dumps({"mcpServers": {"acme": {"url": url}}}))
+        for _ in range(2):
+            path = _run_install(tmp_path, cfg_dir)
+            entry = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["acme"]
+            assert "oauthScopes" not in entry, "the clear must not be refilled"
+            assert "clientId" not in entry.get("oauth", {}), "nor the client id"
+
+    def test_a_slash_keyed_remote_survives_repeated_rebuilds(self, tmp_path: Path):
+        """Key normalization and the store lookup must agree on the name form.
+
+        ``_normalize_mcp_server_keys`` rewrites a slashed key to its alias, so
+        the NEXT rebuild reads the aliased key off disk while the source still
+        declares the slashed one, and the merge re-inserts the slashed spelling
+        alongside it. Both must converge on one entry carrying the source's hints:
+        an equivalent pair collapses onto the canonical alias, so a repeated
+        rebuild neither grows ``mcpServers`` nor accumulates ``tools`` refs.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        (user_home / "mcp.json").write_text(json.dumps({"mcpServers": {}}))
+        (tmp_path / "fake_kiro_mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "acme:@acme/notion": {
+                            "url": "https://mcp.acme.com/mcp",
+                            "oauthScopes": ["acme:read"],
+                            "oauth": {"clientId": "acme-client"},
+                        }
+                    }
+                }
+            )
+        )
+
+        counts: list[int] = []
+        for _ in range(3):
+            path = _run_install(tmp_path, cfg_dir)
+            config = json.loads(path.read_text(encoding="utf-8"))
+            servers = config.get("mcpServers", {})
+            counts.append(len(servers))
+            entry = servers.get("acme-notion")
+            assert entry is not None, "the aliased server must stay mounted"
+            assert entry.get("oauthScopes") == ["acme:read"], "a live source keeps its scopes"
+            assert entry.get("oauth", {}).get("clientId") == "acme-client"
+            assert not [k for k in servers if k.startswith("acme-notion-")], (
+                f"no duplicate sibling may be minted, got {sorted(servers)}"
+            )
+        assert counts[0] == counts[1] == counts[2], f"entry count must not grow: {counts}"
+
+    def test_a_slashed_store_name_owns_its_aliased_config_entry(self, tmp_path: Path):
+        """The store lookup must use the same name form as the ownership test.
+
+        The store keeps its own raw (slashed) key while normalization rewrites the
+        config key to the alias. Looking the store up by the raw key alone misses
+        the owner of the aliased entry, so it reads as unmanaged and the
+        previously-rendered wire hints are preserved verbatim -- an editor clear
+        answers 200 and never takes effect, and the now-divergent specs stop
+        deduping, minting a fresh sibling on every rebuild.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "fake_kiro_mcp.json").write_text(json.dumps({"mcpServers": {}}))
+        store = user_home / "mcp.json"
+        url = "https://mcp.acme.com/mcp"
+
+        # Rebuild 1: the store states scopes, so the emitted spec carries them.
+        store.write_text(
+            json.dumps({"mcpServers": {"acme/notion": {"url": url, "scopes": ["acme:read"]}}})
+        )
+        path = _run_install(tmp_path, cfg_dir)
+        assert json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["acme-notion"][
+            "oauthScopes"
+        ] == ["acme:read"]
+
+        # The user clears the hints in the editor: the store entry keeps its raw
+        # slashed key and simply no longer states any scopes.
+        store.write_text(json.dumps({"mcpServers": {"acme/notion": {"url": url}}}))
+        path = _run_install(tmp_path, cfg_dir)
+        servers = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]
+
+        assert "oauthScopes" not in servers["acme-notion"], "the cleared scopes must not survive"
+        assert not [k for k in servers if k.startswith("acme-notion-")], (
+            f"no duplicate sibling may be minted, got {sorted(servers)}"
+        )
+
+    def test_a_malformed_exact_name_does_not_hide_a_valid_aliased_owner(self, tmp_path: Path):
+        """A malformed store value contributes nothing -- including no veto.
+
+        The store can hold a usable slashed entry whose alias collides with a
+        malformed value under the alias key itself. The malformed value states
+        nothing, so it must not stand in for the real owner: gating the alias
+        lookup on absence alone lets it shadow that owner, the entry reads as
+        unmanaged, and the previously-rendered hints survive a clear.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "fake_kiro_mcp.json").write_text(json.dumps({"mcpServers": {}}))
+        store = user_home / "mcp.json"
+        url = "https://mcp.acme.com/mcp"
+
+        store.write_text(
+            json.dumps(
+                {"mcpServers": {"acme:@acme/notion": {"url": url, "scopes": ["acme:read"]}}}
+            )
+        )
+        path = _run_install(tmp_path, cfg_dir)
+        assert json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["acme-notion"][
+            "oauthScopes"
+        ] == ["acme:read"]
+
+        # The owner clears its scopes; a malformed value now sits under the alias.
+        store.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "acme:@acme/notion": {"url": url},
+                        "acme-notion": "not-a-dict",
+                    }
+                }
+            )
+        )
+        path = _run_install(tmp_path, cfg_dir)
+        servers = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]
+
+        assert "oauthScopes" not in servers["acme-notion"], (
+            "the valid aliased owner's clear must apply"
+        )
+        assert not [k for k in servers if k.startswith("acme-notion-")], (
+            f"no duplicate sibling may be minted, got {sorted(servers)}"
+        )
+
+    def test_an_alias_match_binds_hints_only_to_the_same_server(self, tmp_path: Path):
+        """One rule for every alias binding, keyed on the direction of the effect.
+
+        ``mcp_server_alias`` is many-to-one, so two unrelated names can collide on
+        one alias. A binding that GRANTS something (OAuth hints) must therefore
+        also match transport identity -- otherwise a managed server's credentials
+        land on a different, user-owned server. A binding that DENIES something
+        (the disabled guard) deliberately stays name-only: over-matching there
+        merely over-disables, while under-matching would let an operator's disable
+        be missed, which is the hole the tightest-wins rule closes.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        user_url = "https://user.example.com/mcp"
+        managed_url = "https://managed.example.com/mcp"
+
+        # GRANT site: a managed slashed entry aliases onto a user-owned global name.
+        (user_home / "mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "foo/bar": {
+                            "url": managed_url,
+                            "scopes": ["managed:read"],
+                            "clientId": "managed-client",
+                        }
+                    }
+                }
+            )
+        )
+        (tmp_path / "fake_kiro_mcp.json").write_text(
+            json.dumps({"mcpServers": {"foo-bar": {"url": user_url}}})
+        )
+        path = _run_install(tmp_path, cfg_dir)
+        servers = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]
+        theirs = next(e for e in servers.values() if e.get("url") == user_url)
+        assert "oauthScopes" not in theirs, "a different server must not receive these scopes"
+        assert "clientId" not in theirs.get("oauth", {}), "nor this client id"
+
+        # GRANT site, legitimate case: the aliased entry IS this server (same url).
+        (user_home / "mcp.json").write_text(
+            json.dumps(
+                {"mcpServers": {"foo/bar": {"url": user_url, "scopes": ["managed:read"]}}}
+            )
+        )
+        (tmp_path / "fake_kiro_mcp.json").write_text(
+            json.dumps({"mcpServers": {"foo-bar": {"url": user_url}}})
+        )
+        path = _run_install(tmp_path, cfg_dir)
+        servers = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]
+        assert any(e.get("oauthScopes") == ["managed:read"] for e in servers.values()), (
+            "the same server's hints must still bind through the alias"
+        )
+
+    def test_the_disabled_guard_stays_name_based_across_an_alias_collision(
+        self, tmp_path: Path
+    ):
+        """Over-denying is safe; under-denying is the hole tightest-wins closes."""
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        (user_home / "mcp.json").write_text(
+            json.dumps(
+                {"mcpServers": {"foo/bar": {"url": "https://m.example.com/mcp", "disabled": True}}}
+            )
+        )
+        (tmp_path / "fake_kiro_mcp.json").write_text(
+            json.dumps({"mcpServers": {"foo-bar": {"url": "https://u.example.com/mcp"}}})
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        config = json.loads(path.read_text(encoding="utf-8"))
+
+        assert "@foo-bar" not in config.get("tools", []), "the disable reaches the shared ref"
+        assert "@foo-bar" not in config.get("allowedTools", []), "and never auto-approves"
+
+    def test_a_hand_named_suffix_is_not_claimed_by_the_alias_family(self, tmp_path: Path):
+        """A ``-n`` name a user chose is theirs; the family search must not claim it.
+
+        Nothing distinguishes a name normalization minted from one a user typed, so
+        the family search needs corroboration that a mint actually happened. Absent
+        it, a store entry at the same transport would rewrite a hand-authored
+        entry's grant and inject its own client identity into a file we do not own.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        url = "https://mcp.notion.com/mcp"
+        (tmp_path / "fake_kiro_mcp.json").write_text(
+            json.dumps(
+                {"mcpServers": {"notion-2": {"url": url, "oauthScopes": ["hand:write"]}}}
+            )
+        )
+        (user_home / "mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "notion": {
+                            "url": url,
+                            "scopes": ["store:read"],
+                            "clientId": "store-client",
+                        }
+                    }
+                }
+            )
+        )
+        path = _run_install(tmp_path, cfg_dir)
+        hand = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]["notion-2"]
+        assert hand.get("oauthScopes") == ["hand:write"], f"hand-authored grant rewritten: {hand}"
+        assert "oauth" not in hand, f"store client identity injected: {hand}"
+
+    def test_two_owners_sharing_alias_and_url_keep_their_own_grants(self, tmp_path: Path):
+        """Transport identity alone cannot break a tie between two owners.
+
+        When two store names share both an alias and a url, picking the first
+        candidate is an insertion-order coin flip -- one owner's grant lands in the
+        other's slot. An ambiguous family match must resolve to no owner instead.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "fake_kiro_mcp.json").write_text(json.dumps({"mcpServers": {}}))
+        url = "https://shared.example.com/mcp"
+        (user_home / "mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "foo-bar": {"url": url, "scopes": ["b:read"]},
+                        "foo/bar": {"url": url, "scopes": ["a:read"]},
+                    }
+                }
+            )
+        )
+        counts: list[int] = []
+        for _ in range(3):
+            path = _run_install(tmp_path, cfg_dir)
+            servers = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]
+            counts.append(len(servers))
+            grants = [
+                tuple(e["oauthScopes"])
+                for e in servers.values()
+                if e.get("url") == url and "oauthScopes" in e
+            ]
+            assert grants.count(("a:read",)) <= 1, f"a grant duplicated across slots: {servers}"
+            assert grants.count(("b:read",)) <= 1, f"a grant duplicated across slots: {servers}"
+        assert counts[0] == counts[-1] == counts[1], f"entry count must not grow: {counts}"
+
+    def test_a_suffixed_alias_keeps_its_managed_owner(self, tmp_path: Path):
+        """A collision-suffixed entry is still the same server, so still owned.
+
+        When a managed name's alias is already held by a genuinely different
+        server, normalization preserves the managed one under a numeric suffix.
+        That suffixed key matches neither the store key nor its alias, so an
+        ownership lookup that stops there reads the entry as unmanaged and
+        preserves hints the store no longer states -- the clear stops applying to
+        exactly the server the store owns.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        user_url = "https://user.example.com/mcp"
+        managed_url = "https://managed.example.com/mcp"
+        store = user_home / "mcp.json"
+
+        (tmp_path / "fake_kiro_mcp.json").write_text(
+            json.dumps({"mcpServers": {"foo-bar": {"url": user_url}}})
+        )
+        store.write_text(
+            json.dumps(
+                {"mcpServers": {"foo/bar": {"url": managed_url, "scopes": ["managed:read"]}}}
+            )
+        )
+        path = _run_install(tmp_path, cfg_dir)
+        servers = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]
+        assert any(
+            e.get("url") == managed_url and e.get("oauthScopes") == ["managed:read"]
+            for e in servers.values()
+        ), "the managed server's hints render somewhere"
+
+        # The store clears the grant; the managed entry lives under the suffix.
+        store.write_text(json.dumps({"mcpServers": {"foo/bar": {"url": managed_url}}}))
+        path = _run_install(tmp_path, cfg_dir)
+        servers = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]
+
+        stale = [
+            k
+            for k, e in servers.items()
+            if e.get("url") == managed_url and "oauthScopes" in e
+        ]
+        assert not stale, f"the owner's clear must reach its suffixed entry, stale in {stale}"
+
+    def test_two_store_owners_sharing_one_alias_both_stay_resolvable(self, tmp_path: Path):
+        """An alias index must not drop an owner just because another shares its alias.
+
+        Two store entries can alias to the same slug, so keying the index by alias
+        alone keeps only one of them. The other server's collision-suffixed entry
+        then finds a candidate whose transport does not match, reads as unmanaged,
+        and keeps a grant its owner cleared -- and because the stale copy no longer
+        dedups against the freshly rendered one, each rebuild mints another sibling.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "fake_kiro_mcp.json").write_text(json.dumps({"mcpServers": {}}))
+        store = user_home / "mcp.json"
+        url_a = "https://a.example.com/mcp"
+        url_b = "https://b.example.com/mcp"
+
+        store.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "foo/bar": {"url": url_a, "scopes": ["a:read"]},
+                        "foo-bar": {"url": url_b, "scopes": ["b:read"]},
+                    }
+                }
+            )
+        )
+        path = _run_install(tmp_path, cfg_dir)
+        first = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]
+        assert any(e.get("url") == url_a for e in first.values()), "both servers render"
+        assert any(e.get("url") == url_b for e in first.values())
+
+        # Owner A clears its grant; B keeps its own.
+        store.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "foo/bar": {"url": url_a},
+                        "foo-bar": {"url": url_b, "scopes": ["b:read"]},
+                    }
+                }
+            )
+        )
+        counts: list[int] = []
+        for _ in range(2):
+            path = _run_install(tmp_path, cfg_dir)
+            servers = json.loads(path.read_text(encoding="utf-8"))["mcpServers"]
+            counts.append(len(servers))
+            stale = [k for k, e in servers.items() if e.get("url") == url_a and "oauthScopes" in e]
+            assert not stale, f"owner A's clear must apply, stale in {stale}"
+            assert any(
+                e.get("url") == url_b and e.get("oauthScopes") == ["b:read"]
+                for e in servers.values()
+            ), "owner B keeps its own grant"
+        assert counts[0] == counts[1], f"entry count must not grow: {counts}"
+
+    def test_an_enabled_store_server_still_mounts_with_a_global_sibling(self, tmp_path: Path):
+        """The tightest-wins gate must not break the enabled path it guards.
+
+        Same two-scope shape as the test above with nothing disabled anywhere --
+        this is the case the slice exists to fix, so it must keep working.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        user_home = tmp_path / "kirocrew_home"
+        user_home.mkdir(parents=True, exist_ok=True)
+        (user_home / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"notion": {"url": "https://mcp.notion.com/mcp"}}})
+        )
+        (tmp_path / "fake_kiro_mcp.json").write_text(
+            json.dumps({"mcpServers": {"notion": {"url": "https://mcp.notion.com/mcp"}}})
+        )
+
+        path = _run_install(tmp_path, cfg_dir)
+        config = json.loads(path.read_text(encoding="utf-8"))
+
+        assert "@notion" in config["tools"]
+
     def test_malformed_allowedtools_entries_are_dropped(self, tmp_path: Path):
         """A non-string allowedTools entry (hand-edited config) must be dropped,
         not crash rebuild via may_skip_gate's ref.startswith()."""
@@ -3237,6 +3940,24 @@ class TestRefreshDynamicFieldsStripsStaleUrl:
         _refresh_dynamic_fields(config)
         # A genuine remote server is not a managed one — its url must survive.
         assert config["mcpServers"]["deepwiki"]["url"] == "https://mcp.deepwiki.com/mcp"
+
+    def test_non_managed_server_oauth_hints_preserved(self):
+        """scopes/clientId are passthrough — the runtime, not Kiro Crew, uses them."""
+        from kiro_crew.agent import _refresh_dynamic_fields
+
+        config = {
+            "mcpServers": {
+                "github": {
+                    "url": "https://api.githubcopilot.com/mcp/",
+                    "scopes": ["read:user", "read:org"],
+                    "clientId": "public-client-id",
+                },
+            }
+        }
+        _refresh_dynamic_fields(config)
+        entry = config["mcpServers"]["github"]
+        assert entry["scopes"] == ["read:user", "read:org"]
+        assert entry["clientId"] == "public-client-id"
 
     def test_refresh_strips_legacy_denied_commands(self):
         # Upgrade path: an existing config injected by an older build carries a

--- a/test/test_connections_kiro_spec_fields.py
+++ b/test/test_connections_kiro_spec_fields.py
@@ -1,0 +1,451 @@
+"""Drift guards for the agent-spec fields kiro-cli actually deserializes.
+
+kiro-cli accepts an unknown key in an MCP entry and drops it silently, so a spec
+carrying the wrong name for an OAuth hint is not a parse error -- it is a
+successful authorization for the WRONG access, with nothing in any log to say so.
+That failure mode is why these are tests and not a comment: the shape is only
+verifiable against the binary, and a rename back to the internal spelling would
+otherwise be invisible until a user noticed a provider had over-broad access.
+
+The names asserted here were established by differential validation against
+kiro-cli 2.16.2 (``kiro-cli agent validate`` on a spec with a WRONG-TYPED value:
+a recognised field reports a type error, an ignored one passes silently):
+
+    scopes: 12345            -> accepted   => ignored
+    oauthScopes: 12345       -> "expected a sequence"
+    clientId: 12345          -> accepted   => ignored
+    oauth: {clientId: 12345} -> "expected a string"
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from kiro_crew.mcp_utils import (
+    kiro_entry_client_id,
+    kiro_entry_scopes,
+    kiro_oauth_wire_entry,
+)
+
+# ── FIX 1: the emitted OAuth keys ──
+
+
+def test_wire_entry_renames_scopes_to_the_field_kiro_cli_parses() -> None:
+    out = _emit_owned({"url": "https://x/mcp", "scopes": ["read"]})
+    assert out["oauthScopes"] == ["read"]
+    # The internal spelling must be GONE, not merely shadowed: kiro-cli ignores
+    # it, so leaving it keeps a second, non-load-bearing copy of the request.
+    assert "scopes" not in out
+
+
+def test_wire_entry_nests_client_id_under_oauth() -> None:
+    out = _emit_owned({"url": "https://x/mcp", "clientId": "abc"})
+    assert out["oauth"] == {"clientId": "abc"}
+    assert "clientId" not in out
+
+
+def test_wire_entry_leaves_other_shapes_alone() -> None:
+    for store in ({}, None):
+        stdio = {"command": "srv", "args": ["--x"]}
+        assert kiro_oauth_wire_entry(stdio, store_entry=store) == stdio
+        bare = {"url": "https://x/mcp"}
+        assert kiro_oauth_wire_entry(bare, store_entry=store) == bare
+
+
+def test_wire_entry_preserves_other_oauth_subkeys_and_drops_an_empty_dict() -> None:
+    out = _emit_owned(
+        {"url": "https://x/mcp", "oauth": {"issuer": "https://i"}, "clientId": "abc"}
+    )
+    assert out["oauth"] == {"issuer": "https://i", "clientId": "abc"}
+    # A clientId-only oauth dict is ours entirely, so a source that says "no
+    # clientId" must remove the key rather than leave `oauth: {}` behind.
+    gone = _emit_owned({"url": "https://x/mcp", "oauth": {"clientId": "old"}, "clientId": ""})
+    assert "oauth" not in gone
+
+
+def test_wire_entry_drops_an_empty_scope_list() -> None:
+    # An empty list is not "no scopes requested" to kiro-cli -- it documents an
+    # explicit empty request. Providers with no scopes must emit no key at all,
+    # matching what the registry says about them.
+    out = _emit_owned({"url": "https://x/mcp", "scopes": []})
+    assert "oauthScopes" not in out and "scopes" not in out
+
+
+def test_entry_readers_accept_both_spellings() -> None:
+    assert kiro_entry_scopes({"scopes": ["a"]}) == ["a"]
+    assert kiro_entry_scopes({"oauthScopes": ["b"]}) == ["b"]
+    assert kiro_entry_scopes({"oauth": {"oauthScopes": ["c"]}}) == ["c"]
+    assert kiro_entry_scopes({"scopes": "nope"}) == []
+    assert kiro_entry_client_id({"clientId": "a"}) == "a"
+    assert kiro_entry_client_id({"oauth": {"clientId": "b"}}) == "b"
+    assert kiro_entry_client_id({"clientId": 5}) == ""
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# The OWNERSHIP decision table. Every row below must hold SIMULTANEOUSLY --
+# each is the failure mode that appears when the discriminator collapses into
+# a simpler one, and fixing any row in isolation has historically re-broken
+# another. ``managed`` (does the dashboard store own this name?) is the
+# discriminator; internal-key presence is NOT.
+#
+#   managed     + hint valid    -> rebuilt from source     (row 1)
+#   managed     + hint emptied  -> wire key deleted        (row 2)
+#   managed     + hint absent   -> wire key deleted        (row 3)
+#   NOT managed + hint absent   -> wire value preserved    (row 4)
+#   any row                     -> oauth.issuer survives   (row 5)
+#   any path                    -> one malformed contract  (row 6)
+#   any row                     -> second pass is a no-op  (row 7)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _emit_owned(store_entry: dict[str, Any]) -> dict[str, Any]:
+    """Emit a store entry that has not been merged with a prior render.
+
+    The store entry is its own source, which is what the store holds before
+    ``rebuild_agent_config`` folds the last render in on top of it.
+    """
+    return kiro_oauth_wire_entry(store_entry, store_entry=store_entry)
+
+
+def _rendered_then_updated(
+    rendered: dict[str, Any], source: dict[str, Any], *, managed: bool = True
+) -> dict[str, Any]:
+    """The entry shape agent.py emits: last render, ``update``-ed by mcp.json.
+
+    ``source`` doubles as the store entry, because that is exactly what it is at
+    the real call site -- the value merged in from ``<data home>/mcp.json``.
+    """
+    merged = dict(rendered)
+    merged.update(source)
+    return kiro_oauth_wire_entry(merged, store_entry=source if managed else None)
+
+
+# ── Row 1: managed + hints present -> rebuilt to the source's values ──
+
+
+def test_row1_a_changed_scope_list_overwrites_the_previously_rendered_one() -> None:
+    out = _rendered_then_updated(
+        {"url": "https://x/mcp", "oauthScopes": ["read:old"], "oauth": {"clientId": "old-id"}},
+        {"url": "https://x/mcp", "scopes": ["read:new"], "clientId": "new-id"},
+    )
+    assert out["oauthScopes"] == ["read:new"]
+    assert out["oauth"] == {"clientId": "new-id"}
+
+
+def test_row1_a_widened_then_narrowed_scope_list_is_actually_narrowed() -> None:
+    """The failure this guards is over-request, not a crash.
+
+    Keeping the rendered value would pin every future session to the widest
+    grant the entry was ever rendered with, so a user who narrows their scopes
+    keeps authorizing the ones they removed with nothing to show it.
+    """
+    out = _rendered_then_updated(
+        {"url": "https://x/mcp", "oauthScopes": ["read", "write", "admin"]},
+        {"url": "https://x/mcp", "scopes": ["read"]},
+    )
+    assert out["oauthScopes"] == ["read"]
+
+
+# ── Row 2: managed + explicitly emptied -> wire keys deleted ──
+
+
+def test_row2_an_emptied_source_removes_the_rendered_wire_keys() -> None:
+    out = _rendered_then_updated(
+        {"url": "https://x/mcp", "oauthScopes": ["read"], "oauth": {"clientId": "old-id"}},
+        {"url": "https://x/mcp", "scopes": [], "clientId": ""},
+    )
+    assert "oauthScopes" not in out
+    assert "oauth" not in out
+    assert out == {"url": "https://x/mcp"}
+
+
+def test_row2b_an_explicit_clear_beats_a_stale_wire_sibling_in_the_same_store() -> None:
+    """Precedence is KEY PRESENCE, not value truthiness.
+
+    A store entry can hold both spellings at once: the scope-toggle preservation
+    rule copies a global spec in wire form, then the custom-server API clears the
+    scopes in internal form. An empty internal value that fell through to its wire
+    sibling would resurrect the very grant the user just cleared -- and silently,
+    since the card would still read as scoped.
+    """
+    store = {
+        "url": "https://x/mcp",
+        "scopes": [],
+        "oauthScopes": ["read", "write"],
+        "clientId": "",
+        "oauth": {"clientId": "stale-id", "issuer": "https://i"},
+    }
+    assert kiro_entry_scopes(store) == []
+    assert kiro_entry_client_id(store) == ""
+
+    out = _emit_owned(store)
+    assert "oauthScopes" not in out
+    assert out["oauth"] == {"issuer": "https://i"}, "issuer is the user's"
+
+
+def test_row2b_an_explicit_null_also_clears_rather_than_falling_through() -> None:
+    """``None`` is a present key, so it is a clear -- not an absent one."""
+    store = {"url": "https://x/mcp", "scopes": None, "oauthScopes": ["stale"]}
+    assert kiro_entry_scopes(store) == []
+    assert "oauthScopes" not in _emit_owned(store)
+    store_cid = {"url": "https://x/mcp", "clientId": None, "oauth": {"clientId": "stale"}}
+    assert kiro_entry_client_id(store_cid) == ""
+    assert "oauth" not in _emit_owned(store_cid)
+
+
+# ── Row 3: managed + hints ABSENT -> wire keys deleted ──
+
+
+def test_row3_hints_removed_through_the_api_do_not_survive_the_rebuild() -> None:
+    """The custom-update API removes a hint by DELETING the key, not emptying it.
+
+    The dashboard store owns this entry, and ``dict.update()`` cannot remove a
+    key, so treating absence as silence would leave the last-rendered grant in
+    the spec permanently -- every future session would keep requesting access
+    the user removed through the UI, with nothing anywhere to show it.
+    """
+    out = _rendered_then_updated(
+        {"url": "https://x/mcp", "oauthScopes": ["read"], "oauth": {"clientId": "old-id"}},
+        {"url": "https://x/mcp"},
+    )
+    assert "oauthScopes" not in out
+    assert "oauth" not in out
+    assert out == {"url": "https://x/mcp"}
+
+
+def test_row3_a_managed_entry_with_no_hints_at_all_emits_none() -> None:
+    out = _emit_owned({"url": "https://x/mcp"})
+    assert out == {"url": "https://x/mcp"}
+
+
+# ── Row 4: NOT managed -> wire values preserved verbatim ──
+
+
+def test_row4_an_unmanaged_wire_only_entry_keeps_its_hints_verbatim() -> None:
+    """A file we do not own may be hand-authored directly in wire form.
+
+    There the wire value is the only copy, so deleting on absence destroys
+    configuration we never wrote. Ownership is what separates this from row 3 --
+    the two entries are INDISTINGUISHABLE by key presence alone.
+    """
+    wire_only = {
+        "url": "https://x/mcp",
+        "oauthScopes": ["read:user"],
+        "oauth": {"clientId": "hand-authored", "issuer": "https://i"},
+    }
+    assert kiro_oauth_wire_entry(wire_only, store_entry=None) == wire_only
+
+
+def test_row4_an_unmanaged_entry_survives_the_rendered_merge_path() -> None:
+    out = _rendered_then_updated(
+        {"url": "https://x/mcp", "oauthScopes": ["read:user"], "oauth": {"clientId": "hand"}},
+        {"url": "https://x/mcp", "headers": {"X-Tenant": "acme"}},
+        managed=False,
+    )
+    assert out["oauthScopes"] == ["read:user"]
+    assert out["oauth"] == {"clientId": "hand"}
+
+
+def test_row4_an_unmanaged_internal_spelling_is_still_translated() -> None:
+    """Unmanaged means "absence is silence", not "never translate".
+
+    kiro-cli ignores the internal spelling, so a hand-written ``scopes`` in a
+    file we do not own would be silently dropped if we left it alone.
+    """
+    out = kiro_oauth_wire_entry(
+        {"url": "https://x/mcp", "scopes": ["read"], "clientId": "cid"}, store_entry=None
+    )
+    assert out["oauthScopes"] == ["read"]
+    assert out["oauth"] == {"clientId": "cid"}
+    assert "scopes" not in out and "clientId" not in out
+
+
+def test_row3_vs_row4_same_entry_opposite_outcomes() -> None:
+    """The discriminator itself: one entry, two regimes, two correct answers.
+
+    The entry is a previous render carrying wire hints. Owned by a store that
+    states none, it is a removal; owned by nobody, it is the only copy.
+    """
+    rendered = {"url": "https://x/mcp", "oauthScopes": ["read"], "oauth": {"clientId": "cid"}}
+    owned_says_none = kiro_oauth_wire_entry(dict(rendered), store_entry={"url": "https://x/mcp"})
+    assert "oauthScopes" not in owned_says_none
+    assert "oauth" not in owned_says_none
+    assert kiro_oauth_wire_entry(dict(rendered), store_entry=None) == rendered
+
+
+# ── Row 5: oauth.issuer survives every row ──
+
+
+def test_row5_an_unrelated_oauth_subkey_survives_every_regime() -> None:
+    """Only ``clientId`` is ours; ``issuer`` is the user's in all four rows."""
+    base = {"url": "https://x/mcp", "oauth": {"issuer": "https://i", "clientId": "old"}}
+    # row 1 -- rebuilt
+    row1 = _rendered_then_updated(base, {"clientId": "new"})
+    assert row1["oauth"] == {"issuer": "https://i", "clientId": "new"}
+    # row 2 -- explicitly emptied
+    row2 = _rendered_then_updated(base, {"clientId": ""})
+    assert row2["oauth"] == {"issuer": "https://i"}
+    # row 3 -- an owned store that states nothing at all
+    row3 = kiro_oauth_wire_entry(dict(base), store_entry={"url": "https://x/mcp"})
+    assert row3["oauth"] == {"issuer": "https://i"}
+    # row 4 -- unmanaged, untouched
+    row4 = kiro_oauth_wire_entry(dict(base), store_entry=None)
+    assert row4["oauth"] == {"issuer": "https://i", "clientId": "old"}
+
+
+# ── Row 6: ONE malformed-scope contract on every path ──
+
+
+def test_row6_a_malformed_scope_member_omits_the_field_entirely() -> None:
+    """kiro-cli rejects the WHOLE spec on a bad oauthScopes, dropping every tool.
+
+    Forwarding the well-formed subset is also refused: it would silently request
+    something other than what the file asks for.
+    """
+    for bad in (["read", 7], ["read", ""], ["read", "   "], ["read", None], "read", 7, {}):
+        out = _emit_owned({"url": "https://x/mcp", "scopes": bad})
+        assert "oauthScopes" not in out, bad
+        assert "scopes" not in out, bad
+
+
+def test_row6_emit_and_readback_agree_on_every_malformed_shape() -> None:
+    """The emit path and the discovery/sync readback share one contract.
+
+    A readback that kept the well-formed subset while emit omitted the field
+    would report an access level no file asks for and no session receives, and a
+    sync acting on that difference would propagate the truncated grant as if it
+    were the complete one.
+    """
+    for bad in (["read", 7], ["read", ""], ["read", "   "], ["read", None], "read", 7, {}, None):
+        emitted = _emit_owned({"url": "https://x/mcp", "scopes": bad})
+        assert "oauthScopes" not in emitted, bad
+        assert kiro_entry_scopes({"scopes": bad}) == [], bad
+        assert kiro_entry_scopes({"oauthScopes": bad}) == [], bad
+        assert kiro_entry_scopes({"oauth": {"oauthScopes": bad}}) == [], bad
+
+
+def test_row6_a_clean_scope_list_agrees_on_every_path() -> None:
+    clean = ["read:user", "read:org"]
+    out = _emit_owned({"url": "https://x/mcp", "scopes": clean})
+    assert out["oauthScopes"] == clean
+    assert kiro_entry_scopes(out) == clean
+    assert kiro_entry_scopes({"scopes": clean}) == clean
+
+
+def test_row6_a_malformed_member_does_not_leave_a_stale_rendered_list_standing() -> None:
+    out = _rendered_then_updated(
+        {"url": "https://x/mcp", "oauthScopes": ["read", "write"]},
+        {"url": "https://x/mcp", "scopes": ["read", 7]},
+    )
+    assert "oauthScopes" not in out
+
+
+def test_row6_a_blank_client_id_is_treated_as_absent() -> None:
+    for bad in ("", "   ", 5, None, []):
+        out = _emit_owned({"url": "https://x/mcp", "clientId": bad})
+        assert "oauth" not in out, bad
+        assert "clientId" not in out, bad
+        assert kiro_entry_client_id({"clientId": bad}) == "", bad
+
+
+# ── Row 7: a second pass is a no-op (the render converges) ──
+
+
+def test_row7_a_second_rebuild_is_a_no_op_for_every_row() -> None:
+    """Emit is a fixed point: render again over the same store and nothing moves.
+
+    A rule that is correct once but not stable would oscillate the emitted spec
+    on every gateway start, which is how a wrong grant becomes intermittent
+    rather than reproducible.
+    """
+    cases = [
+        # (label, source store entry, managed)
+        ("row1", {"url": "https://x/mcp", "scopes": ["read"], "clientId": "cid"}, True),
+        ("row2", {"url": "https://x/mcp", "scopes": [], "clientId": ""}, True),
+        ("row3", {"url": "https://x/mcp"}, True),
+        ("row4", {"url": "https://x/mcp"}, False),
+    ]
+    for label, source, managed in cases:
+        # First render starts from a previously-rendered entry carrying wire keys.
+        rendered = {
+            "url": "https://x/mcp",
+            "oauthScopes": ["stale"],
+            "oauth": {"clientId": "stale-id", "issuer": "https://i"},
+        }
+        first = _rendered_then_updated(rendered, source, managed=managed)
+        second = _rendered_then_updated(first, source, managed=managed)
+        assert first == second, label
+        # And the issuer is still there in all four (row 5 under iteration).
+        assert second["oauth"]["issuer"] == "https://i", label
+
+
+def test_row7_readback_of_an_emitted_entry_matches_what_was_requested() -> None:
+    """Convergence on the sync side: the readback of a render is a fixed point.
+
+    ``discover_servers_to_sync`` compares the readback of the agent entry with
+    the readback of mcp.json, so a render whose readback did not equal its own
+    source would re-flag for sync on every single pass.
+    """
+    for scopes, client_id in ((["read"], "cid"), ([], ""), (["a", "b"], "x")):
+        source = {"url": "https://x/mcp", "scopes": scopes, "clientId": client_id}
+        emitted = _emit_owned(source)
+        assert kiro_entry_scopes(emitted) == scopes
+        assert kiro_entry_client_id(emitted) == client_id
+
+
+# ── Row 8: an OWNED store entry states its hints in EITHER spelling ──
+#
+# The scope-toggle preservation rule copies a global server's spec into the store
+# verbatim so toggling its globals off does not lose the config. That copy is a
+# dict in the store -- so it is ours -- but it carries whatever spelling the
+# global used, which for a hand-authored entry is the WIRE one. Reading only the
+# internal spelling would see "no hints" on an owned entry and delete exactly the
+# configuration the copy exists to preserve.
+
+
+def test_row8_an_owned_store_entry_in_wire_form_keeps_its_hints() -> None:
+    preserved_copy = {
+        "url": "https://x/mcp",
+        "oauthScopes": ["read:user"],
+        "oauth": {"clientId": "hand-authored", "issuer": "https://i"},
+    }
+    out = _emit_owned(preserved_copy)
+    assert out["oauthScopes"] == ["read:user"]
+    assert out["oauth"] == {"clientId": "hand-authored", "issuer": "https://i"}
+
+
+def test_row8_a_wire_form_store_entry_survives_the_rendered_merge_path() -> None:
+    """The shape agent.py actually emits, with the copy as the store entry."""
+    store = {
+        "url": "https://x/mcp",
+        "oauthScopes": ["read:user"],
+        "oauth": {"clientId": "hand-authored"},
+    }
+    out = _rendered_then_updated(
+        {"url": "https://x/mcp", "oauthScopes": ["stale"], "oauth": {"clientId": "stale-id"}},
+        store,
+    )
+    assert out["oauthScopes"] == ["read:user"]
+    assert out["oauth"] == {"clientId": "hand-authored"}
+
+
+def test_row8_does_not_resurrect_row3_the_store_must_be_the_one_speaking() -> None:
+    """A stale RENDER in wire form still loses to an owned store that says none.
+
+    Row 8 reads wire spellings off the STORE only. Reading them off the merged
+    entry would let the previous render outvote the store and undo row 3.
+    """
+    out = _rendered_then_updated(
+        {"url": "https://x/mcp", "oauthScopes": ["stale"], "oauth": {"clientId": "stale-id"}},
+        {"url": "https://x/mcp"},
+    )
+    assert "oauthScopes" not in out
+    assert "oauth" not in out
+
+
+def test_row8_an_internal_store_spelling_still_wins_over_a_wire_render() -> None:
+    out = _rendered_then_updated(
+        {"url": "https://x/mcp", "oauthScopes": ["stale"]},
+        {"url": "https://x/mcp", "scopes": ["fresh"]},
+    )
+    assert out["oauthScopes"] == ["fresh"]

--- a/test/test_mcp_custom_api.py
+++ b/test/test_mcp_custom_api.py
@@ -134,6 +134,39 @@ class TestCustomAdd:
         finally:
             await client.close()
 
+    async def test_remote_spec_keeps_scopes_and_client_id(self, sandbox, fake_sel):
+        """A Connect writes the card's promised access; the entry must carry it."""
+        spec = {
+            "url": "https://api.githubcopilot.com/mcp/",
+            "scopes": ["read:user", "read:org"],
+            "clientId": "public-client-id",
+        }
+        client = await _client()
+        try:
+            resp = await client.post("/api/mcp/custom", json={"servers": {"github": spec}})
+            assert resp.status == 200
+            entry = _written(sandbox)["github"]
+            assert entry["scopes"] == ["read:user", "read:org"]
+            assert entry["clientId"] == "public-client-id"
+        finally:
+            await client.close()
+
+    async def test_remote_spec_drops_empty_oauth_hints(self, sandbox, fake_sel):
+        """Empty optionals are dropped, matching args/env — no noise keys on disk."""
+        spec = {"url": "https://mcp.example.com/sse", "scopes": [], "clientId": ""}
+        client = await _client()
+        try:
+            resp = await client.post("/api/mcp/custom", json={"servers": {"remote": spec}})
+            assert resp.status == 400, "an empty clientId is malformed, not an omission"
+            spec.pop("clientId")
+            resp = await client.post("/api/mcp/custom", json={"servers": {"remote": spec}})
+            assert resp.status == 200
+            entry = _written(sandbox)["remote"]
+            assert "scopes" not in entry
+            assert "clientId" not in entry
+        finally:
+            await client.close()
+
     async def test_multi_add_writes_all(self, sandbox, fake_sel):
         client = await _client()
         try:
@@ -198,6 +231,14 @@ class TestCustomAdd:
             ({"command": "npx", "env": {"K": 1}}, "string values"),
             ({"url": "ftp://mcp.example.com"}, "http(s)"),
             ({"url": "https://x.example", "env": {"K": "v"}}, "not valid on a remote"),
+            ({"url": "https://x.example", "scopes": "read"}, "list of non-empty strings"),
+            ({"url": "https://x.example", "scopes": ["read", 7]}, "list of non-empty strings"),
+            ({"url": "https://x.example", "scopes": ["read", ""]}, "list of non-empty strings"),
+            ({"url": "https://x.example", "clientId": ""}, "'clientId' must be a non-empty"),
+            ({"url": "https://x.example", "clientId": "   "}, "'clientId' must be a non-empty"),
+            ({"url": "https://x.example", "clientId": 42}, "'clientId' must be a non-empty"),
+            ({"command": "npx", "scopes": ["read"]}, "not valid on a stdio"),
+            ({"command": "npx", "clientId": "public-id"}, "not valid on a stdio"),
             ("npx -y thing", "must be an object"),
         ],
     )
@@ -361,6 +402,34 @@ class TestCustomGet:
         finally:
             await client.close()
 
+    async def test_oauth_hints_round_trip_without_echoing_authorization(
+        self, sandbox, fake_sel
+    ):
+        """scopes/clientId survive GET→PUT unchanged, alongside a header entry."""
+        entry = {
+            "url": "https://api.githubcopilot.com/mcp/",
+            "headers": {"Authorization": "Bearer custom-secret"},
+            "scopes": ["read:user"],
+            "clientId": "public-client-id",
+        }
+        sandbox.kirocrew_json.write_text(json.dumps({"mcpServers": {"github": entry}}))
+        client = await _client()
+        try:
+            resp = await client.get("/api/mcp/custom/github")
+            assert resp.status == 200
+            body = await resp.json()
+            assert body["spec"]["scopes"] == ["read:user"]
+            assert body["spec"]["clientId"] == "public-client-id"
+
+            resp = await client.put("/api/mcp/custom/github", json={"spec": body["spec"]})
+            assert resp.status == 200
+            written = _written(sandbox)["github"]
+            assert written["scopes"] == ["read:user"]
+            assert written["clientId"] == "public-client-id"
+            assert written["headers"] == {"Authorization": "Bearer custom-secret"}
+        finally:
+            await client.close()
+
     async def test_unknown_404_and_bad_name_400(self, sandbox, fake_sel):
         client = await _client()
         try:
@@ -480,6 +549,311 @@ class TestCarriedKeyRoundTrip:
             assert "managed by other flows" in (await resp.json())["error"]
             entry = json.loads(sandbox.kirocrew_json.read_text(encoding="utf-8"))["mcpServers"]["weather"]
             assert entry["disabledTools"] == ["dangerous_tool"]
+        finally:
+            await client.close()
+
+    async def test_clearing_oauth_hints_defeats_a_carried_wire_sibling(self, sandbox, fake_sel):
+        """An explicit clear must actually stop the grant being requested.
+
+        The scope-toggle preservation rule copies a global server's spec into the
+        store verbatim, so the entry can hold the WIRE spelling. Those keys sit
+        outside the editable set, so carried-key restoration puts them back
+        untouched -- and with the internal key absent from disk the reader falls
+        through to the sibling, so the cleared grant keeps being requested while
+        the API answers 200 and looks like it worked.
+        """
+        from kiro_crew.mcp_utils import kiro_entry_client_id, kiro_entry_scopes
+
+        sandbox.kirocrew_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "weather": {
+                            "url": "https://mcp.acme.com/mcp",
+                            "oauthScopes": ["acme:read"],
+                            "oauth": {"clientId": "acme-client", "issuer": "https://iss"},
+                        }
+                    }
+                }
+            )
+        )
+        client = await _client()
+        try:
+            resp = await client.put(
+                "/api/mcp/custom/weather",
+                json={"spec": {"url": "https://mcp.acme.com/mcp", "scopes": []}},
+            )
+            assert resp.status == 200
+            entry = _written(sandbox)["weather"]
+            assert kiro_entry_scopes(entry) == [], "the cleared scopes must not come back"
+            assert kiro_entry_client_id(entry) == "", "nor the cleared client id"
+            assert entry.get("oauth", {}).get("issuer") == "https://iss", (
+                "a sibling sub-key we never owned still survives"
+            )
+        finally:
+            await client.close()
+
+    async def test_clearing_oauth_hints_also_drops_the_nested_wire_sibling(
+        self, sandbox, fake_sel
+    ):
+        """The reader falls through to ``oauth.oauthScopes`` too, so a clear must reach it."""
+        from kiro_crew.mcp_utils import kiro_entry_scopes
+
+        sandbox.kirocrew_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "weather": {
+                            "url": "https://mcp.acme.com/mcp",
+                            "oauth": {
+                                "oauthScopes": ["acme:read"],
+                                "issuer": "https://iss",
+                            },
+                        }
+                    }
+                }
+            )
+        )
+        client = await _client()
+        try:
+            resp = await client.put(
+                "/api/mcp/custom/weather",
+                json={"spec": {"url": "https://mcp.acme.com/mcp"}},
+            )
+            assert resp.status == 200
+            entry = _written(sandbox)["weather"]
+            assert kiro_entry_scopes(entry) == [], "a nested wire sibling must not survive"
+            assert entry.get("oauth", {}).get("issuer") == "https://iss", (
+                "an unrelated oauth sub-key still survives"
+            )
+        finally:
+            await client.close()
+
+    async def test_malformed_wire_oauth_fields_are_rejected_like_internal_ones(
+        self, sandbox, fake_sel
+    ):
+        """Both spellings of a hint answer to one shape rule.
+
+        The wire spellings are editable on this path, so tolerating them by name
+        (so an unmodified round trip still saves) must not also skip their shape
+        check -- otherwise the same field is accepted or rejected depending only
+        on which spelling the caller used, and an invalid value reaches disk
+        under a 200.
+        """
+        url = "https://mcp.acme.com/mcp"
+        for bad in (
+            {"oauthScopes": [123]},
+            {"oauthScopes": "not-a-list"},
+            {"oauthScopes": [""]},
+            {"oauth": {"clientId": {}}},
+            {"oauth": {"clientId": ""}},
+            {"oauth": "not-a-dict"},
+        ):
+            sandbox.kirocrew_json.write_text(
+                json.dumps({"mcpServers": {"weather": {"url": url}}})
+            )
+            client = await _client()
+            try:
+                resp = await client.put(
+                    "/api/mcp/custom/weather", json={"spec": {"url": url, **bad}}
+                )
+                assert resp.status == 400, f"{bad} must be rejected, got {resp.status}"
+                assert _written(sandbox)["weather"] == {"url": url}, "disk must be untouched"
+            finally:
+                await client.close()
+
+    async def test_valid_wire_oauth_fields_still_round_trip(self, sandbox, fake_sel):
+        """The shape check must not break the preservation path it guards."""
+        url = "https://mcp.acme.com/mcp"
+        sandbox.kirocrew_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "weather": {
+                            "url": url,
+                            "oauthScopes": ["acme:read"],
+                            "oauth": {"clientId": "acme-client", "issuer": "https://iss"},
+                        }
+                    }
+                }
+            )
+        )
+        client = await _client()
+        try:
+            got = await (await client.get("/api/mcp/custom/weather")).json()
+            resp = await client.put("/api/mcp/custom/weather", json={"spec": got["spec"]})
+            assert resp.status == 200
+            entry = _written(sandbox)["weather"]
+            assert entry["oauthScopes"] == ["acme:read"]
+            assert entry["oauth"]["clientId"] == "acme-client"
+            assert entry["oauth"]["issuer"] == "https://iss"
+        finally:
+            await client.close()
+
+    async def test_editing_a_wire_sibling_value_persists(self, sandbox, fake_sel):
+        """Stated-is-authoritative covers a VALUE change, not just presence.
+
+        A preserved entry can hold the wire spelling, so the editor's only way to
+        narrow that grant is to change the wire value. Honouring absence but
+        dropping an edit would be the same silent 200 as a dropped clear.
+        """
+        url = "https://mcp.acme.com/mcp"
+        for before, submit, expect_scopes in (
+            # nested wire sibling edited in place
+            (
+                {"oauth": {"oauthScopes": ["a"], "issuer": "https://iss"}},
+                {"oauth": {"oauthScopes": ["b"], "issuer": "https://iss"}},
+                ["b"],
+            ),
+            # top-level wire spelling edited in place
+            ({"oauthScopes": ["a"]}, {"oauthScopes": ["b"]}, ["b"]),
+        ):
+            sandbox.kirocrew_json.write_text(
+                json.dumps({"mcpServers": {"weather": {"url": url, **before}}})
+            )
+            client = await _client()
+            try:
+                resp = await client.put(
+                    "/api/mcp/custom/weather", json={"spec": {"url": url, **submit}}
+                )
+                assert resp.status == 200, f"{submit} rejected: {await resp.text()}"
+                entry = _written(sandbox)["weather"]
+                from kiro_crew.mcp_utils import kiro_entry_scopes
+
+                assert kiro_entry_scopes(entry) == expect_scopes, (
+                    f"{submit} must persist, got {entry}"
+                )
+            finally:
+                await client.close()
+
+    async def test_editing_a_nested_client_id_persists(self, sandbox, fake_sel):
+        """Same rule for the other hint, and unrelated sub-keys survive."""
+        from kiro_crew.mcp_utils import kiro_entry_client_id
+
+        url = "https://mcp.acme.com/mcp"
+        sandbox.kirocrew_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "weather": {
+                            "url": url,
+                            "oauth": {"clientId": "old-client", "issuer": "https://iss"},
+                        }
+                    }
+                }
+            )
+        )
+        client = await _client()
+        try:
+            resp = await client.put(
+                "/api/mcp/custom/weather",
+                json={
+                    "spec": {
+                        "url": url,
+                        "oauth": {"clientId": "new-client", "issuer": "https://iss"},
+                    }
+                },
+            )
+            assert resp.status == 200
+            entry = _written(sandbox)["weather"]
+            assert kiro_entry_client_id(entry) == "new-client"
+            assert entry["oauth"]["issuer"] == "https://iss"
+        finally:
+            await client.close()
+
+    async def test_editing_a_non_hint_oauth_subkey_is_rejected_not_silently_reverted(
+        self, sandbox, fake_sel
+    ):
+        """A sub-key we do not own follows the carried-key rule: refuse, don't revert.
+
+        ``issuer`` is written by other flows, so it is not editable here -- but the
+        answer must say so. Silently restoring the on-disk value would report
+        success for a change that never happened.
+        """
+        url = "https://mcp.acme.com/mcp"
+        sandbox.kirocrew_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "weather": {
+                            "url": url,
+                            "oauth": {"clientId": "c", "issuer": "https://old"},
+                        }
+                    }
+                }
+            )
+        )
+        client = await _client()
+        try:
+            resp = await client.put(
+                "/api/mcp/custom/weather",
+                json={"spec": {"url": url, "oauth": {"clientId": "c", "issuer": "https://new"}}},
+            )
+            assert resp.status == 400, f"expected refusal, got {resp.status}"
+            entry = _written(sandbox)["weather"]
+            assert entry["oauth"]["issuer"] == "https://old", "disk must be untouched"
+        finally:
+            await client.close()
+
+    async def test_adding_a_non_hint_oauth_subkey_is_refused_not_dropped(self, sandbox, fake_sel):
+        """A stated sub-key we cannot store must be refused, not accepted and dropped.
+
+        The editor is a raw JSON field, so a sub-key with no prior value on disk is
+        reachable. Base answered 400 for an unknown key; accepting it and writing
+        nothing turns that explicit refusal into a silent no-op.
+        """
+        url = "https://mcp.acme.com/mcp"
+        sandbox.kirocrew_json.write_text(json.dumps({"mcpServers": {"weather": {"url": url}}}))
+        client = await _client()
+        try:
+            resp = await client.put(
+                "/api/mcp/custom/weather",
+                json={"spec": {"url": url, "oauth": {"issuer": "https://new"}}},
+            )
+            assert resp.status == 400, f"expected refusal, got {resp.status}"
+            assert "oauth" not in _written(sandbox)["weather"]
+        finally:
+            await client.close()
+
+    async def test_an_internal_clear_outranks_a_round_tripped_wire_sibling(self, sandbox, fake_sel):
+        """Stating the internal spelling settles BOTH wire spellings.
+
+        The editor prefills the whole spec, so a user clearing scopes submits
+        ``scopes: []`` next to the nested wire hint the GET handed them. Copying
+        that sibling back would let the reader fall through to it and resurrect the
+        grant the submission just cleared.
+        """
+        from kiro_crew.mcp_utils import kiro_entry_scopes
+
+        url = "https://mcp.acme.com/mcp"
+        sandbox.kirocrew_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "weather": {
+                            "url": url,
+                            "oauth": {"oauthScopes": ["stale:read"], "issuer": "https://iss"},
+                        }
+                    }
+                }
+            )
+        )
+        client = await _client()
+        try:
+            resp = await client.put(
+                "/api/mcp/custom/weather",
+                json={
+                    "spec": {
+                        "url": url,
+                        "scopes": [],
+                        "oauth": {"oauthScopes": ["stale:read"], "issuer": "https://iss"},
+                    }
+                },
+            )
+            assert resp.status == 200, await resp.text()
+            entry = _written(sandbox)["weather"]
+            assert kiro_entry_scopes(entry) == [], f"clear did not take effect: {entry}"
+            assert entry["oauth"]["issuer"] == "https://iss", "unowned sub-key must survive"
         finally:
             await client.close()
 

--- a/test/test_mcp_discovery.py
+++ b/test/test_mcp_discovery.py
@@ -102,6 +102,34 @@ class TestMcpServerInfo:
         info = McpServerInfo(name="x", command="cmd", url="http://localhost")
         assert info.is_remote is False
 
+    def test_remote_oauth_hints_surface_unredacted(self) -> None:
+        info = McpServerInfo(
+            name="github",
+            url="https://api.githubcopilot.com/mcp/",
+            scopes=["read:user", "read:org"],
+            client_id="Iv1.public-identifier",
+        )
+        d = info.to_dict()
+        assert d["scopes"] == ["read:user", "read:org"]
+        assert d["clientId"] == "Iv1.public-identifier"
+
+    def test_oauth_hints_default_empty_and_are_omitted(self) -> None:
+        info = McpServerInfo(name="x", url="https://mcp.example.com")
+        assert info.scopes == []
+        assert info.client_id == ""
+        d = info.to_dict()
+        assert "scopes" not in d
+        assert "clientId" not in d
+
+    def test_oauth_hints_omitted_on_stdio_rows(self) -> None:
+        """to_dict gates them behind url, so a stdio row never advertises them."""
+        info = McpServerInfo(
+            name="x", command="cmd", scopes=["read"], client_id="public-id"
+        )
+        d = info.to_dict()
+        assert "scopes" not in d
+        assert "clientId" not in d
+
 
 class TestListServers:
     def setup_method(self) -> None:
@@ -598,6 +626,241 @@ class TestDiscoverNew:
         assert len(new) == 1
         assert new[0].name == "brand-new"
         assert new[0].source == "discovered"
+
+    def test_discover_new_remote_preserves_url_and_headers(self, tmp_path, monkeypatch) -> None:
+        agent_dir = tmp_path / "agents"
+        agent_dir.mkdir()
+        (agent_dir / "defaults.json").write_text(json.dumps({"mcpServers": {}}))
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        mcp_json = tmp_path / "mcp.json"
+        headers = {"Authorization": "Bearer sync-secret", "X-Tenant": "acme"}
+        mcp_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "remote": {
+                            "url": "https://mcp.example.com/v1",
+                            "headers": headers,
+                        }
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr("kiro_crew.mcp_discovery._MCP_JSON_PATHS", (mcp_json,))
+
+        result = discover_servers_to_sync()
+
+        assert len(result) == 1
+        assert result[0].name == "remote"
+        assert result[0].is_remote is True
+        assert result[0].command == ""
+        assert result[0].url == "https://mcp.example.com/v1"
+        assert result[0].headers == headers
+
+    def test_discover_flags_existing_remote_url_change(self, tmp_path, monkeypatch) -> None:
+        agent_dir = tmp_path / "agents"
+        agent_dir.mkdir()
+        headers = {"Authorization": "Bearer sync-secret"}
+        cfg = {
+            "mcpServers": {
+                "remote": {"url": "https://mcp.example.com/v1", "headers": headers}
+            }
+        }
+        (agent_dir / "defaults.json").write_text(json.dumps(cfg))
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        mcp_json = tmp_path / "mcp.json"
+        mcp_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "remote": {
+                            "url": "https://mcp.example.com/v2",
+                            "headers": headers,
+                        }
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr("kiro_crew.mcp_discovery._MCP_JSON_PATHS", (mcp_json,))
+
+        result = discover_servers_to_sync()
+
+        assert len(result) == 1
+        assert result[0].url == "https://mcp.example.com/v2"
+
+    def test_discover_flags_existing_remote_headers_change(self, tmp_path, monkeypatch) -> None:
+        agent_dir = tmp_path / "agents"
+        agent_dir.mkdir()
+        cfg = {
+            "mcpServers": {
+                "remote": {
+                    "url": "https://mcp.example.com/v1",
+                    "headers": {"Authorization": "Bearer old"},
+                }
+            }
+        }
+        (agent_dir / "defaults.json").write_text(json.dumps(cfg))
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        mcp_json = tmp_path / "mcp.json"
+        mcp_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "remote": {
+                            "url": "https://mcp.example.com/v1",
+                            "headers": {"Authorization": "Bearer new"},
+                        }
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr("kiro_crew.mcp_discovery._MCP_JSON_PATHS", (mcp_json,))
+
+        result = discover_servers_to_sync()
+
+        assert len(result) == 1
+        assert result[0].headers == {"Authorization": "Bearer new"}
+
+    def test_discover_new_remote_preserves_scopes_and_client_id(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        agent_dir = tmp_path / "agents"
+        agent_dir.mkdir()
+        (agent_dir / "defaults.json").write_text(json.dumps({"mcpServers": {}}))
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        mcp_json = tmp_path / "mcp.json"
+        mcp_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "remote": {
+                            "url": "https://mcp.example.com/v1",
+                            "scopes": ["read:user", "read:org"],
+                            "clientId": "public-client-id",
+                        }
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr("kiro_crew.mcp_discovery._MCP_JSON_PATHS", (mcp_json,))
+
+        result = discover_servers_to_sync()
+
+        assert len(result) == 1
+        assert result[0].scopes == ["read:user", "read:org"]
+        assert result[0].client_id == "public-client-id"
+
+    def test_discover_flags_existing_remote_scopes_change(self, tmp_path, monkeypatch) -> None:
+        """A Connect that widens or narrows scopes must re-sync, not be ignored."""
+        agent_dir = tmp_path / "agents"
+        agent_dir.mkdir()
+        cfg = {
+            "mcpServers": {
+                "remote": {"url": "https://mcp.example.com/v1", "scopes": ["read"]}
+            }
+        }
+        (agent_dir / "defaults.json").write_text(json.dumps(cfg))
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        mcp_json = tmp_path / "mcp.json"
+        mcp_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "remote": {
+                            "url": "https://mcp.example.com/v1",
+                            "scopes": ["read", "write"],
+                        }
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr("kiro_crew.mcp_discovery._MCP_JSON_PATHS", (mcp_json,))
+
+        result = discover_servers_to_sync()
+
+        assert len(result) == 1
+        assert result[0].scopes == ["read", "write"]
+
+    def test_discover_flags_existing_remote_client_id_change(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        agent_dir = tmp_path / "agents"
+        agent_dir.mkdir()
+        cfg = {
+            "mcpServers": {
+                "remote": {"url": "https://mcp.example.com/v1", "clientId": "old-id"}
+            }
+        }
+        (agent_dir / "defaults.json").write_text(json.dumps(cfg))
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        mcp_json = tmp_path / "mcp.json"
+        mcp_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "remote": {"url": "https://mcp.example.com/v1", "clientId": "new-id"}
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr("kiro_crew.mcp_discovery._MCP_JSON_PATHS", (mcp_json,))
+
+        result = discover_servers_to_sync()
+
+        assert len(result) == 1
+        assert result[0].client_id == "new-id"
+
+    def test_discover_no_resync_when_oauth_hints_match(self, tmp_path, monkeypatch) -> None:
+        """Equal hints must not churn: an unchanged entry stays out of the sync set."""
+        agent_dir = tmp_path / "agents"
+        agent_dir.mkdir()
+        entry = {
+            "url": "https://mcp.example.com/v1",
+            "scopes": ["read"],
+            "clientId": "public-client-id",
+        }
+        (agent_dir / "defaults.json").write_text(json.dumps({"mcpServers": {"remote": entry}}))
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        mcp_json = tmp_path / "mcp.json"
+        mcp_json.write_text(json.dumps({"mcpServers": {"remote": entry}}))
+        monkeypatch.setattr("kiro_crew.mcp_discovery._MCP_JSON_PATHS", (mcp_json,))
+
+        assert discover_servers_to_sync() == []
+
+    @pytest.mark.parametrize(
+        "spec_extra,expected_scopes,expected_client_id",
+        [
+            ({"scopes": "read"}, [], ""),
+            # A partially-valid list degrades to NO scopes, never to its
+            # well-formed subset: truncating it would propagate a request the
+            # file never made, and would disagree with the emit path, which
+            # omits the field entirely on any malformed member.
+            ({"scopes": ["read", 7]}, [], ""),
+            ({"scopes": ["read", "  "]}, [], ""),
+            ({"scopes": None}, [], ""),
+            ({"clientId": 42}, [], ""),
+            ({"clientId": "   "}, [], ""),
+            ({"clientId": None}, [], ""),
+        ],
+    )
+    def test_discover_degrades_malformed_oauth_hints(
+        self, tmp_path, monkeypatch, spec_extra, expected_scopes, expected_client_id
+    ) -> None:
+        """Hand-edited mcp.json must not propagate a bad shape into the agent config."""
+        agent_dir = tmp_path / "agents"
+        agent_dir.mkdir()
+        (agent_dir / "defaults.json").write_text(json.dumps({"mcpServers": {}}))
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        mcp_json = tmp_path / "mcp.json"
+        spec = {"url": "https://mcp.example.com/v1", **spec_extra}
+        mcp_json.write_text(json.dumps({"mcpServers": {"remote": spec}}))
+        monkeypatch.setattr("kiro_crew.mcp_discovery._MCP_JSON_PATHS", (mcp_json,))
+
+        result = discover_servers_to_sync()
+
+        assert len(result) == 1
+        assert result[0].scopes == expected_scopes
+        assert result[0].client_id == expected_client_id
 
     def test_discover_none_when_all_known(self, tmp_path, monkeypatch) -> None:
         agent_dir = tmp_path / "agents"

--- a/test/test_mcp_sync_agent.py
+++ b/test/test_mcp_sync_agent.py
@@ -55,6 +55,410 @@ def _load(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+async def _sync_one_remote(remote, mcp_env, *, owned: bool = True) -> dict:
+    """Run api_mcp_sync over one remote server and return its written global entry.
+
+    ``owned`` marks the name as managed by Kiro Crew, which is the regime every caller
+    here exercises: writes to the kiro-global mcp.json are gated on ownership, so
+    an unowned name is deliberately left untouched (see
+    TestGlobalWritesAreOwnershipGated).
+    """
+    from kiro_crew.dashboard.handlers.mcp import api_mcp_sync
+    from kiro_crew.mcp_discovery import SCOPE_KIROCREW
+
+    req = MagicMock()
+    req.app = {"state": MagicMock()}
+    _store = {remote.name: {"url": "https://store"}} if owned else {}
+    with (
+        patch("kiro_crew.mcp_discovery.discover_servers_to_sync", return_value=[remote]),
+        patch("kiro_crew.mcp_discovery.sync_to_agent_config", return_value=True),
+        patch("kiro_crew.mcp_discovery.register_servers_for_cc"),
+        patch(
+            "kiro_crew.mcp_discovery._load_mcp_json_by_source",
+            return_value={SCOPE_KIROCREW: _store},
+        ),
+        patch("kiro_crew.dashboard.handlers.mcp._get_mcp_lock") as mock_lock,
+        patch("kiro_crew.dashboard.handlers.mcp._write_mcp_json") as mock_write,
+        patch("kiro_crew.dashboard.handlers.mcp._sync_mcp_to_agent_batch"),
+        patch(
+            "kiro_crew.dashboard.handlers.sessions._reset_all_sessions",
+            new_callable=AsyncMock,
+            return_value=1,
+        ),
+    ):
+        mock_lock.return_value = AsyncMock()
+        resp = await api_mcp_sync(req)
+
+    assert resp.status == 200
+    return mock_write.call_args.args[0]["mcpServers"][remote.name]
+
+
+class TestGlobalWritesAreOwnershipGated:
+    """Every write to a config surface we do NOT own is gated on ownership.
+
+    Two such surfaces are touched here: the kiro-global ``mcp.json`` (through
+    ``api_mcp_sync``) and the Claude Code ``~/.mcp.json`` sidecar (through
+    ``register_servers_for_cc``). Both are fed by the SAME source --
+    ``discover_servers_to_sync``, which merges every scope -- so a name the user
+    configured only in their own global file arrives exactly like a managed one.
+
+    Parametrized on purpose: the gate was previously reasoned about one write site
+    at a time, so a per-site test lets the next site ship ungated. This asserts
+    the property across all of them at once.
+    """
+
+    @staticmethod
+    def _own(names: set[str]):
+        """Patch the store scope so ``kirocrew_managed_names`` sees exactly ``names``."""
+        from kiro_crew.mcp_discovery import SCOPE_KIROCREW
+
+        return patch(
+            "kiro_crew.mcp_discovery._load_mcp_json_by_source",
+            return_value={SCOPE_KIROCREW: {n: {"url": "https://store"} for n in names}},
+        )
+
+    async def _kiro_global(self, *, managed: bool, mcp_env) -> dict:
+        """Sync a remote whose url differs from the user's global entry."""
+        from kiro_crew.mcp_discovery import McpServerInfo
+
+        _, mcp_json = mcp_env
+        data = _load(mcp_json)
+        data["mcpServers"]["handmade"] = {
+            "url": "https://user.example.com/mcp",
+            "headers": {"Authorization": "Bearer user-typed"},
+            "oauthScopes": ["user:scope"],
+            "oauth": {"clientId": "user-client", "issuer": "https://user-issuer"},
+        }
+        mcp_json.write_text(json.dumps(data))
+        remote = McpServerInfo(
+            name="handmade",
+            url="https://kirocrew.example.com/mcp",
+            scopes=["kirocrew:scope"],
+            client_id="kirocrew-client",
+            source="discovered",
+        )
+        return await _sync_one_remote(remote, mcp_env, owned=managed)
+
+    def _cc_sidecar(self, *, managed: bool, tmp_path) -> dict:
+        """Register a remote into the CC sidecar."""
+        from kiro_crew.mcp_discovery import McpServerInfo, register_servers_for_cc
+
+        sidecar = tmp_path / "cc.json"
+        remote = McpServerInfo(
+            name="handmade",
+            url="https://kirocrew.example.com/mcp",
+            scopes=["kirocrew:scope"],
+            client_id="kirocrew-client",
+            source="discovered",
+        )
+        with self._own({"handmade"} if managed else set()):
+            register_servers_for_cc([remote], mcp_json_path=sidecar)
+        return json.loads(sidecar.read_text())["mcpServers"]["handmade"]
+
+    @pytest.mark.asyncio
+    async def test_an_unmanaged_name_is_never_modified_at_any_global_write_site(
+        self, mcp_env, tmp_path
+    ):
+        """The user's own global config is not ours to rewrite."""
+        # Site 1 -- kiro-global mcp.json: the entry must come back byte-identical.
+        entry = await self._kiro_global(managed=False, mcp_env=mcp_env)
+        assert entry == {
+            "url": "https://user.example.com/mcp",
+            "headers": {"Authorization": "Bearer user-typed"},
+            "oauthScopes": ["user:scope"],
+            "oauth": {"clientId": "user-client", "issuer": "https://user-issuer"},
+        }
+
+        # Site 2 -- CC sidecar: our OAuth hints are not written for a name we do
+        # not own. (The wholesale rebuild of the entry itself is pre-existing
+        # behaviour on the base ref, unchanged here.)
+        cc = self._cc_sidecar(managed=False, tmp_path=tmp_path)
+        assert "scopes" not in cc
+        assert "clientId" not in cc
+
+    @pytest.mark.asyncio
+    async def test_a_managed_name_still_syncs_at_every_global_write_site(
+        self, mcp_env, tmp_path
+    ):
+        """The gate must not disable the re-sync this change exists to deliver."""
+        entry = await self._kiro_global(managed=True, mcp_env=mcp_env)
+        assert entry["url"] == "https://kirocrew.example.com/mcp"
+        assert entry["oauthScopes"] == ["kirocrew:scope"]
+        assert entry["oauth"]["clientId"] == "kirocrew-client"
+        assert entry["oauth"]["issuer"] == "https://user-issuer", "sub-key still survives"
+
+        cc = self._cc_sidecar(managed=True, tmp_path=tmp_path)
+        assert cc["scopes"] == ["kirocrew:scope"]
+        assert cc["clientId"] == "kirocrew-client"
+
+    def test_a_malformed_store_value_does_not_make_a_name_managed(self, tmp_path):
+        """Same discriminator as the agent-spec path: a non-dict is not ownership."""
+        from kiro_crew.mcp_discovery import SCOPE_KIROCREW, kirocrew_managed_names
+
+        with patch(
+            "kiro_crew.mcp_discovery._load_mcp_json_by_source",
+            return_value={SCOPE_KIROCREW: {"good": {"url": "https://x"}, "bad": "not-a-dict"}},
+        ):
+            assert kirocrew_managed_names() == {"good"}
+
+
+class TestExactNameOwnershipIsHistoryDependent:
+    """The exact-name gate cannot separate "ours, moved" from "the user's, colliding".
+
+    Ownership is name presence in the store, so both of these reach the write with
+    the SAME on-disk state -- a global entry at url A, that name in the store, and
+    a discovered url B:
+
+    * LEGITIMATE: a managed server whose store url moved A -> B. The global entry
+      at A is our own earlier emit and MUST be rewritten, or the re-sync this
+      change exists to deliver never propagates and kiro-cli keeps running a url
+      the dashboard no longer shows.
+    * HARMFUL: the user hand-authored a global server at A whose name collides
+      with a managed one. Rewriting destroys config we did not author.
+
+    No content test separates them, because the minimal entry ``{"url": ...}`` is
+    exactly what BOTH produce: our emitter writes it for a managed server carrying
+    no OAuth hints, and it is also the smallest thing a user can type for a remote
+    server. The difference is authorship history, which nothing on disk records --
+    see the module note on the escalation. These tests pin today's behaviour so a
+    future change to it is deliberate rather than incidental.
+    """
+
+    @staticmethod
+    async def _sync_over_global(entry: dict, mcp_env) -> dict:
+        """Sync a managed remote at url B over an existing global ``entry``."""
+        from kiro_crew.mcp_discovery import McpServerInfo
+
+        _, mcp_json = mcp_env
+        data = _load(mcp_json)
+        data["mcpServers"]["collide"] = entry
+        mcp_json.write_text(json.dumps(data))
+        remote = McpServerInfo(
+            name="collide", url="https://b.example.net/mcp", source="discovered"
+        )
+        return await _sync_one_remote(remote, mcp_env, owned=True)
+
+    @pytest.mark.asyncio
+    async def test_a_managed_url_move_propagates(self, mcp_env):
+        """Direction (b): the case that MUST keep working (round-16 contract)."""
+        written = await self._sync_over_global({"url": "https://a.example.com/mcp"}, mcp_env)
+        assert written["url"] == "https://b.example.net/mcp", (
+            "a managed server's url legitimately moves; refusing to write it "
+            "would strand kiro-cli on the old transport"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_colliding_hand_authored_global_entry_is_rewritten(self, mcp_env):
+        """Direction (a): the harm, recorded as current behaviour.
+
+        Reachability is bounded but not closed: ``POST /api/mcp/custom`` refuses a
+        name that ``_find_server_spec_anywhere`` finds in ANY scope -- the kiro
+        global file included -- so no dashboard path creates a store entry on top
+        of a hand-authored global one. What remains is the user editing their own
+        global file AFTER the managed entry exists.
+        """
+        written = await self._sync_over_global(
+            {
+                "url": "https://a.example.com/mcp",
+                "oauthScopes": ["user:scope"],
+                "oauth": {"clientId": "user-client", "issuer": "https://user-issuer"},
+            },
+            mcp_env,
+        )
+        assert written["url"] == "https://b.example.net/mcp"
+        assert written.get("oauthScopes") != ["user:scope"], "the user's hint is not kept"
+        assert written["oauth"]["issuer"] == "https://user-issuer", (
+            "a sub-key we never owned still survives the surgical edit"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_non_hint_oauth_subkey_is_not_authorship_evidence(self, mcp_env):
+        """Why "preserve an entry carrying ``issuer``" is not the fix here.
+
+        A non-hint sub-key looks like a fingerprint -- no writer here emits one,
+        and the custom-server editor refuses a submission that introduces one. It
+        is still not authorship: a MANAGED entry legitimately carries ``issuer``
+        once a user adds it, which is the entire reason ``apply_kiro_oauth_hints``
+        edits ``oauth`` surgically instead of replacing it. Preserving on that
+        signal would strand every managed server whose ``oauth`` a user has ever
+        touched, so the same state has to keep syncing --
+        ``test_a_managed_name_still_syncs_at_every_global_write_site`` and
+        ``test_sync_keeps_unrelated_oauth_subkeys_while_rewriting_client_id`` pin
+        it from the other side.
+        """
+        written = await self._sync_over_global(
+            {"url": "https://a.example.com/mcp", "oauth": {"issuer": "https://i"}},
+            mcp_env,
+        )
+        assert written["url"] == "https://b.example.net/mcp"
+        assert written["oauth"] == {"issuer": "https://i"}
+
+    @pytest.mark.asyncio
+    async def test_a_bare_url_collision_remains_undecidable(self, mcp_env):
+        """The residual case, unchanged and deliberately so.
+
+        A minimal ``{"url": ...}`` entry is both what this emitter writes for a
+        managed server carrying no OAuth hints and the smallest thing a user can
+        hand-type, and nothing on disk records authorship -- ``McpServerInfo``
+        carries discovery origin, not authorship. So the managed url still
+        propagates, which is what keeps ``test_a_managed_url_move_propagates``
+        true. Closing this needs a provenance record, an on-disk format change.
+        """
+        written = await self._sync_over_global({"url": "https://a.example.com/mcp"}, mcp_env)
+        assert written == {"url": "https://b.example.net/mcp"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("site", ["kiro_global", "cc_sidecar"])
+    async def test_a_managed_url_move_reaches_only_the_surface_that_re_syncs(
+        self, site, mcp_env, tmp_path
+    ):
+        """Both global surfaces are asserted together so neither drifts silently.
+
+        The exact-name shape exists at both, but they answer it differently.
+        The kiro-global file re-syncs, so a managed server's moved url reaches
+        disk there -- without that this slice's scope fix never propagates. The
+        Claude Code sidecar is add-only for remotes, so an entry already present
+        keeps what it holds; re-syncing it needs a record of which entries we
+        wrote. Pinning both here means a change to either one has to say so.
+        """
+        if site == "kiro_global":
+            written = await self._sync_over_global({"url": "https://a.example.com/mcp"}, mcp_env)
+            assert written["url"] == "https://b.example.net/mcp"
+        else:
+            from kiro_crew.mcp_discovery import McpServerInfo, register_servers_for_cc
+
+            sidecar = tmp_path / "cc.json"
+            sidecar.write_text(
+                json.dumps({"mcpServers": {"collide": {"url": "https://a.example.com/mcp"}}})
+            )
+            remote = McpServerInfo(
+                name="collide", url="https://b.example.net/mcp", source="discovered"
+            )
+            with TestGlobalWritesAreOwnershipGated._own({"collide"}):
+                register_servers_for_cc([remote], mcp_json_path=sidecar)
+            written = json.loads(sidecar.read_text())["mcpServers"]["collide"]
+            assert written == {"url": "https://a.example.com/mcp"}
+
+    def test_an_unmanaged_remote_keeps_its_sidecar_entry(self, tmp_path, monkeypatch):
+        """The sidecar is add-only for remotes, so a present entry is untouched.
+
+        ``register_servers_for_cc`` builds each remote entry from scratch, so
+        anything it rewrote would lose the fields it does not reconstruct. It
+        rewrites nothing that is already there: the user's own server, credential
+        header and all, survives a sync verbatim -- even though the entry does
+        diverge from the discovered source and does enter the sync set for the
+        surfaces that can act on it.
+        """
+        from kiro_crew import mcp_discovery as md
+
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        # The agent config holds an OLDER url, so divergence genuinely exists.
+        (agents / "defaults.json").write_text(
+            json.dumps({"mcpServers": {"handmade": {"url": "https://old.example/mcp"}}})
+        )
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        user_entry = {
+            "url": "https://user.example.com/mcp",
+            "headers": {"Authorization": "Bearer user-typed"},
+        }
+        source = tmp_path / "user_mcp.json"
+        source.write_text(json.dumps({"mcpServers": {"handmade": user_entry}}))
+        monkeypatch.setattr(md, "_MCP_JSON_PATHS", (source,))
+        # Present in the user's kiro-global scope only — never in the store.
+        monkeypatch.setattr(
+            md,
+            "_load_mcp_json_by_source",
+            lambda: {
+                md.SCOPE_KIROCREW: {},
+                md.SCOPE_KIRO_GLOBAL: {"handmade": user_entry},
+                md.SCOPE_CC_GLOBAL: {},
+            },
+        )
+
+        to_sync = md.discover_servers_to_sync()
+
+        sidecar = tmp_path / "cc.json"
+        sidecar.write_text(json.dumps({"mcpServers": {"handmade": user_entry}}))
+        md.register_servers_for_cc(to_sync, mcp_json_path=sidecar)
+        written = json.loads(sidecar.read_text())["mcpServers"]["handmade"]
+        assert written == user_entry, "url and credential header survive the sync"
+
+    def test_a_managed_remote_is_not_re_synced_to_the_sidecar(
+        self, tmp_path, monkeypatch
+    ):
+        """Ownership is name-only, so even a server we own does not rewrite here.
+
+        The divergence still has to reach the surfaces that can act on it -- the
+        agent config and the kiro-global file -- so the server does enter the sync
+        set. The sidecar simply declines it: with ownership established by name
+        alone, "our managed server moved" and "a different server the user named
+        the same" are the same input, and this writer replaces an entry rather
+        than merging into it. Propagating a changed remote shape to this surface
+        arrives with the provenance record that makes the two distinguishable.
+        """
+        from kiro_crew import mcp_discovery as md
+
+        agents = tmp_path / "agents"
+        agents.mkdir()
+        (agents / "defaults.json").write_text(
+            json.dumps({"mcpServers": {"owned": {"url": "https://old.example/mcp"}}})
+        )
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        store_entry = {"url": "https://new.example.net/mcp"}
+        source = tmp_path / "store_mcp.json"
+        source.write_text(json.dumps({"mcpServers": {"owned": store_entry}}))
+        monkeypatch.setattr(md, "_MCP_JSON_PATHS", (source,))
+        monkeypatch.setattr(
+            md,
+            "_load_mcp_json_by_source",
+            lambda: {
+                md.SCOPE_KIROCREW: {"owned": store_entry},
+                md.SCOPE_KIRO_GLOBAL: {},
+                md.SCOPE_CC_GLOBAL: {},
+            },
+        )
+
+        to_sync = md.discover_servers_to_sync()
+
+        assert [s.name for s in to_sync] == ["owned"], (
+            "the divergence must still reach the agent config and kiro-global"
+        )
+        assert to_sync[0].url == "https://new.example.net/mcp"
+
+        stale = {"url": "https://old.example/mcp", "disabledTools": ["danger"]}
+        sidecar = tmp_path / "cc.json"
+        sidecar.write_text(json.dumps({"mcpServers": {"owned": stale}}))
+        changed = md.register_servers_for_cc(to_sync, mcp_json_path=sidecar)
+        assert changed is False
+        assert json.loads(sidecar.read_text())["mcpServers"]["owned"] == stale
+
+    def test_a_remote_with_no_sidecar_entry_is_still_registered(self, tmp_path):
+        """Add-only is not no-op: a name absent here is registered as base does.
+
+        The hints ride along on this path only, so a first registration still
+        carries the scopes the card asked for.
+        """
+        from kiro_crew.mcp_discovery import McpServerInfo, register_servers_for_cc
+
+        sidecar = tmp_path / "cc.json"
+        sidecar.write_text(json.dumps({"mcpServers": {}}))
+        remote = McpServerInfo(
+            name="fresh",
+            url="https://fresh.example.net/mcp",
+            scopes=["read:me"],
+            client_id="cid",
+            source="discovered",
+        )
+        with TestGlobalWritesAreOwnershipGated._own({"fresh"}):
+            assert register_servers_for_cc([remote], mcp_json_path=sidecar) is True
+        assert json.loads(sidecar.read_text())["mcpServers"]["fresh"] == {
+            "url": "https://fresh.example.net/mcp",
+            "scopes": ["read:me"],
+            "clientId": "cid",
+        }
+
+
 class TestSyncMcpToAgent:
     def test_enable_adds_server_and_tool_refs(self, mcp_env):
         agent_cfg, _ = mcp_env
@@ -301,6 +705,305 @@ class TestApiMcpSyncToolsUpdate:
 
         assert resp.status == 200
         mock_batch.assert_called_once_with(["aws-outlook-mcp"], enabled=True)
+
+    @pytest.mark.asyncio
+    async def test_sync_survives_a_malformed_discovered_header_map(self, mcp_env):
+        """A hand-edited non-dict ``headers`` must not abort the whole sync.
+
+        Discovery coerces only a FALSY headers value, so a truthy non-dict (a
+        string, a list) reaches the writer as-is. Such a value carries no usable
+        credential, so it is read as "discovery said nothing" and the on-disk map
+        is preserved -- the same ranking the empty-map case uses. Rejecting the
+        sync instead would let one typo in one entry block every other server's
+        legitimate re-sync.
+        """
+        from kiro_crew.mcp_discovery import McpServerInfo
+
+        _, mcp_json = mcp_env
+        data = _load(mcp_json)
+        data["mcpServers"]["remote"] = {
+            "url": "https://mcp.example.com/v1",
+            "headers": {"Authorization": "Bearer user-typed"},
+        }
+        mcp_json.write_text(json.dumps(data))
+
+        for bad in ("not-a-dict", ["Authorization", "Bearer x"]):
+            remote = McpServerInfo(
+                name="remote",
+                url="https://mcp.example.com/v1",
+                headers=bad,  # type: ignore[arg-type]
+                source="discovered",
+            )
+            written = await _sync_one_remote(remote, mcp_env)
+            assert written["headers"] == {"Authorization": "Bearer user-typed"}, (
+                f"a malformed {type(bad).__name__} must preserve the on-disk map"
+            )
+
+    def test_discovery_can_deliver_a_non_dict_header_map(self, tmp_path: Path):
+        """The writer's guard is reachable: discovery does not coerce a truthy non-dict."""
+        from kiro_crew.mcp_discovery import discover_servers_to_sync
+
+        with (
+            patch(
+                "kiro_crew.mcp_discovery._load_mcp_json",
+                return_value={"remote": {"url": "https://mcp.example.com/v1", "headers": "bad"}},
+            ),
+            patch("kiro_crew.mcp_discovery._load_agent_config", return_value={"mcpServers": {}}),
+        ):
+            out = discover_servers_to_sync()
+        assert [s.headers for s in out] == ["bad"], "a truthy non-dict passes through unchanged"
+
+    @pytest.mark.asyncio
+    async def test_sync_preserves_a_global_only_header(self, mcp_env):
+        """A credential the user typed into their own global file must survive.
+
+        Discovery reads the MERGED view, so the store's header map is what arrives
+        here; a header present only in the kiro-global file is absent from it.
+        Replacing the map wholesale would delete that credential outright.
+        """
+        from kiro_crew.mcp_discovery import McpServerInfo
+
+        _, mcp_json = mcp_env
+        data = _load(mcp_json)
+        data["mcpServers"]["remote"] = {
+            "url": "https://mcp.example.com/v1",
+            "headers": {"Authorization": "Bearer user-typed"},
+        }
+        mcp_json.write_text(json.dumps(data))
+        remote = McpServerInfo(
+            name="remote",
+            url="https://mcp.example.com/v1",
+            headers={"X-Tenant": "acme"},
+            source="discovered",
+        )
+        written = await _sync_one_remote(remote, mcp_env)
+        assert written["headers"] == {
+            "Authorization": "Bearer user-typed",
+            "X-Tenant": "acme",
+        }, "discovered headers overlay, they do not replace"
+
+    @pytest.mark.asyncio
+    async def test_sync_does_not_forward_a_global_only_header_to_a_new_host(self, mcp_env):
+        """A header map is scoped to the host it was typed for.
+
+        The overlay above deliberately carries a credential the user typed into
+        their own global file across a sync. That preservation may not survive a
+        change of ``url``: the bearer was issued by -- and for -- the OLD origin,
+        so writing it beside a NEW one turns "we kept your credential" into "we
+        sent your credential somewhere else". Dropping it costs a re-auth, which
+        is recoverable; forwarding it is not.
+        """
+        from kiro_crew.mcp_discovery import McpServerInfo
+
+        _, mcp_json = mcp_env
+        data = _load(mcp_json)
+        data["mcpServers"]["remote"] = {
+            "url": "https://old.example.com/v1",
+            "headers": {"Authorization": "Bearer user-typed"},
+        }
+        mcp_json.write_text(json.dumps(data))
+        remote = McpServerInfo(
+            name="remote",
+            url="https://new.example.net/v1",
+            headers={"X-Tenant": "acme"},
+            source="discovered",
+        )
+        written = await _sync_one_remote(remote, mcp_env)
+        assert written["url"] == "https://new.example.net/v1"
+        assert written["headers"] == {"X-Tenant": "acme"}, (
+            "the bearer was typed for old.example.com -- carrying it onto "
+            "new.example.net hands the credential to a different origin"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_url_move_drops_prior_headers_even_when_discovery_is_silent(self, mcp_env):
+        """The leak also runs through the header-less branch.
+
+        With no discovered headers the overlay never executes, so the prior map
+        simply rides along in the copied entry -- same forwarded credential, via
+        a path the overlay's guard never sees. The url test has to sit ahead of
+        both branches, not inside one.
+        """
+        from kiro_crew.mcp_discovery import McpServerInfo
+
+        _, mcp_json = mcp_env
+        data = _load(mcp_json)
+        data["mcpServers"]["remote"] = {
+            "url": "https://old.example.com/v1",
+            "headers": {"Authorization": "Bearer user-typed"},
+        }
+        mcp_json.write_text(json.dumps(data))
+        remote = McpServerInfo(
+            name="remote", url="https://new.example.net/v1", source="discovered"
+        )
+        written = await _sync_one_remote(remote, mcp_env)
+        assert written["url"] == "https://new.example.net/v1"
+        assert "headers" not in written, (
+            "a credential with no proven relationship to the destination host "
+            "must not be written beside it"
+        )
+
+    @pytest.mark.asyncio
+    async def test_sync_writes_remote_url_and_headers_to_global_config(self, mcp_env):
+        """A remote sync must never be serialized as an empty stdio command."""
+        from kiro_crew.mcp_discovery import McpServerInfo
+
+        _, mcp_json = mcp_env
+        data = _load(mcp_json)
+        data["mcpServers"]["remote"] = {
+            "url": "https://mcp.example.com/v1",
+            "headers": {"Authorization": "Bearer old"},
+            "disabled": True,
+            "disabledTools": ["write"],
+        }
+        mcp_json.write_text(json.dumps(data))
+        remote = McpServerInfo(
+            name="remote",
+            url="https://mcp.example.com/v2",
+            headers={"Authorization": "Bearer current"},
+            source="discovered",
+        )
+        written = await _sync_one_remote(remote, mcp_env)
+        assert written == {
+            "url": "https://mcp.example.com/v2",
+            "headers": {"Authorization": "Bearer current"},
+            "disabled": True,
+            "disabledTools": ["write"],
+        }
+        assert "command" not in written
+
+    @pytest.mark.asyncio
+    async def test_sync_writes_remote_oauth_hints_to_global_config(self, mcp_env):
+        """Hints reach kiro-cli in the WIRE spellings, or the grant is never requested.
+
+        kiro-cli only deserializes ``oauthScopes`` and ``oauth.clientId`` and drops
+        unknown keys silently, so asserting the internal ``scopes``/``clientId``
+        spellings here would guard the bug instead of the fix.
+        """
+        from kiro_crew.mcp_discovery import McpServerInfo
+
+        remote = McpServerInfo(
+            name="remote",
+            url="https://api.githubcopilot.com/mcp/",
+            scopes=["read:user", "read:org"],
+            client_id="public-client-id",
+            source="discovered",
+        )
+        written = await _sync_one_remote(remote, mcp_env)
+        assert written == {
+            "url": "https://api.githubcopilot.com/mcp/",
+            "oauthScopes": ["read:user", "read:org"],
+            "oauth": {"clientId": "public-client-id"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_sync_removes_oauth_hints_dropped_upstream(self, mcp_env):
+        """Absent upstream means REMOVED, so narrowing a scope actually narrows it."""
+        from kiro_crew.mcp_discovery import McpServerInfo
+
+        _, mcp_json = mcp_env
+        data = _load(mcp_json)
+        data["mcpServers"]["remote"] = {
+            "url": "https://mcp.example.com/v1",
+            "scopes": ["read", "write"],
+            "clientId": "stale-id",
+            "disabledTools": ["write"],
+        }
+        mcp_json.write_text(json.dumps(data))
+        remote = McpServerInfo(
+            name="remote", url="https://mcp.example.com/v1", source="discovered"
+        )
+        written = await _sync_one_remote(remote, mcp_env)
+        assert written == {
+            "url": "https://mcp.example.com/v1",
+            "disabledTools": ["write"],
+        }
+
+    @pytest.mark.asyncio
+    async def test_sync_preserves_a_header_discovery_cannot_see(self, mcp_env):
+        """A header-less discovered remote must NOT erase a configured header.
+
+        Discovery reads the dashboard's own mcp.json. A server of the same name
+        carrying an Authorization header in the user's global
+        ~/.kiro/settings/mcp.json therefore arrives here header-less, and popping
+        on that would destroy the only copy of a credential the user typed --
+        silently, with nothing to restore it from.
+        """
+        _, mcp_json = mcp_env
+        data = _load(mcp_json)
+        data["mcpServers"]["remote"] = {
+            "url": "https://mcp.example.com/v1",
+            "headers": {"Authorization": "Bearer user-typed"},
+        }
+        mcp_json.write_text(json.dumps(data))
+        from kiro_crew.mcp_discovery import McpServerInfo
+
+        remote = McpServerInfo(
+            name="remote", url="https://mcp.example.com/v1", source="discovered"
+        )
+        written = await _sync_one_remote(remote, mcp_env)
+        assert written["headers"] == {"Authorization": "Bearer user-typed"}
+
+    @pytest.mark.asyncio
+    async def test_sync_keeps_unrelated_oauth_subkeys_while_rewriting_client_id(self, mcp_env):
+        """Only ``clientId`` under ``oauth`` is ours; ``issuer`` is the user's.
+
+        Deleting the whole mapping to rewrite our one sub-key destroys hand-set
+        configuration a sync has no business touching.
+        """
+        _, mcp_json = mcp_env
+        data = _load(mcp_json)
+        data["mcpServers"]["remote"] = {
+            "url": "https://mcp.example.com/v1",
+            "oauthScopes": ["read"],
+            "oauth": {"issuer": "https://issuer.example.com", "clientId": "old-id"},
+        }
+        mcp_json.write_text(json.dumps(data))
+        from kiro_crew.mcp_discovery import McpServerInfo
+
+        remote = McpServerInfo(
+            name="remote",
+            url="https://mcp.example.com/v1",
+            scopes=["read", "write"],
+            client_id="new-id",
+            source="discovered",
+        )
+        written = await _sync_one_remote(remote, mcp_env)
+        assert written["oauthScopes"] == ["read", "write"]
+        assert written["oauth"] == {"issuer": "https://issuer.example.com", "clientId": "new-id"}
+
+    @pytest.mark.asyncio
+    async def test_sync_omits_a_malformed_scope_list_instead_of_truncating_it(self, mcp_env):
+        """Row 6 on the sync path: one validation contract, emit and readback.
+
+        A partially-valid list must never be silently narrowed into a different
+        grant. Reading ``["read", 7]`` as ``["read"]`` while the emit path omits
+        the field entirely would make the synced file request access the source
+        never asked for, and the agent spec request none -- two different answers
+        from one line of config.
+        """
+        _, mcp_json = mcp_env
+        data = _load(mcp_json)
+        data["mcpServers"]["remote"] = {
+            "url": "https://mcp.example.com/v1",
+            "scopes": ["read", 7],
+        }
+        mcp_json.write_text(json.dumps(data))
+        from kiro_crew.mcp_discovery import _spec_scopes
+
+        assert _spec_scopes(data["mcpServers"]["remote"]) == [], "readback must omit, not truncate"
+
+        from kiro_crew.mcp_discovery import McpServerInfo
+
+        remote = McpServerInfo(
+            name="remote",
+            url="https://mcp.example.com/v1",
+            scopes=_spec_scopes(data["mcpServers"]["remote"]),
+            source="discovered",
+        )
+        written = await _sync_one_remote(remote, mcp_env)
+        assert "oauthScopes" not in written
+        assert "scopes" not in written
 
     @pytest.mark.asyncio
     async def test_sync_no_tools_update_when_nothing_discovered(self, mcp_env):


### PR DESCRIPTION
# fix(mcp): emit oauthScopes and oauth.clientId that kiro-cli actually reads

## Problem

KiroCrew wrote the OAuth hints on a remote MCP entry under `scopes` and a
top-level `clientId`. kiro-cli's `RemoteMcpServerConfig` / `OAuthConfig`
deserialize **`oauthScopes`** and **nested `oauth.clientId`**, and an unknown key
in an MCP entry is accepted and dropped on the floor.

So every scope request KiroCrew has ever emitted was discarded before it reached
a provider. No parse error, no warning, nothing in any log — the authorization
simply succeeded against the provider's *default* grant instead of the scopes
that were configured.

## Why it matters

A silently-ignored scope field is worse than a rejected one. The failure mode is
"a successful authorization for the wrong access", which is invisible from our
side and only observable by inspecting the grant at the provider. The shape is
verifiable only against the kiro-cli binary, so nothing in the codebase could
have caught the drift.

The names asserted in the new tests were established by differential validation
against kiro-cli 2.16.2 (`kiro-cli agent validate` on a spec with a wrong-typed
value: a recognized field reports a type error, an ignored one passes silently):

```
scopes: 12345            -> accepted   => ignored
oauthScopes: 12345       -> "expected a sequence"
clientId: 12345          -> accepted   => ignored
oauth: {clientId: 12345} -> "expected a string"
```

## Fix

**Symptom -> root cause -> change**

| Symptom | Root cause | Change |
|---|---|---|
| Configured scopes never reach the provider; grant is always the provider default | Emitted key was `scopes`, which kiro-cli ignores | `kiro_oauth_wire_entry()` translates `scopes` -> `oauthScopes` and `clientId` -> `oauth.clientId` on **both** emit paths: the agent-spec writer in `agent.py` and the remote branch of `api_mcp_sync` |
| A spec round-tripped through disk reported "no scopes" | Readers knew only the internal spelling | `kiro_entry_scopes()` / `kiro_entry_client_id()` accept either spelling |
| Editing scopes in `mcp.json` left the agent config authorizing the old shape | `discover_servers_to_sync` skipped every remote server outright | Remote divergence now compares `url`, `headers`, scopes and clientId — all source-owned transport fields — and re-syncs on a change. Absent upstream means **removed**, so dropping a scope actually narrows the request |
| Hints were lost between discovery and emission | `McpServerInfo` had nowhere to carry them | Added `scopes: list[str]` / `client_id: str` passthrough fields, surfaced in `to_dict()` under the internal names (it is an API response, not a file kiro-cli reads) |
| A malformed hand-edited spec could propagate a bad shape into the agent config | No validation | On-disk specs are untrusted: a non-list, or a list with non-string members, degrades to "no scopes". The custom-server API rejects malformed `scopes`/`clientId` with a 400, and rejects either key on a stdio server |
| A changed scope list kept authorizing the scopes the entry was FIRST rendered with | The wire key was only written when absent, and `rebuild_agent_config` merges mcp.json into the previously-rendered config with `dict.update()` — so both spellings arrive at once and the stale wire value won | `apply_kiro_oauth_hints()` owns one merge rule shared by every writer, and **ownership** decides what an absent hint means (see the table below) |
| Hints removed through the custom-update API survived every later rebuild | The API deletes the key rather than emptying it, so a rule keyed on "does an internal key exist" read the removal as "no source spoke" and preserved the stale wire value — permanently, since `update()` cannot remove a key | For a **managed** entry the dashboard store is the whole truth: absent means removed, so the wire key is deleted |
| A wire-only global entry — hand-authored in `oauthScopes` / `oauth.clientId`, no internal source — had its hints stripped on every rebuild | The opposite error: treating "no internal source" as deletion, when for that entry the wire value *is* the source | For an **unmanaged** entry absence means silence, so the wire value is preserved verbatim |
| Rewriting our `clientId` on the sync path deleted the user's whole `oauth` mapping, `issuer` included | `api_mcp_sync` popped `KIRO_OAUTH_KEY` wholesale before rebuilding | The sync path routes through the same helper, which edits `oauth` surgically — only `clientId` is ours, every other sub-key survives, and the mapping is dropped only once empty |
| A hand-edited `scopes: ["read", 7]` made kiro-cli reject the entire agent spec, silently dropping every Kiro Crew MCP tool | The list was forwarded verbatim into `oauthScopes` | Emit only when every member is a non-empty string; otherwise omit the field |
| Discovery read that same list as `["read"]` while emit omitted it — two answers from one line of config | The readback filtered per-member while the emit path was all-or-nothing | One validation contract (`_wire_scopes`) on emit, discovery and sync readback alike. The well-formed subset is never emitted or reported: it is a grant no file asked for |
| An empty discovered header map deleted a configured auth header, unrecoverably | `api_mcp_sync` popped `headers` when discovery reported none | Discovery reads the dashboard's own mcp.json, so a same-named server whose `Authorization` lives in the user's global `~/.kiro/settings/mcp.json` legitimately arrives header-less. Headers are now preserve-and-**overlay**: discovered keys are merged over the entry already on disk rather than replacing the map. Discovery reads the MERGED view, which takes the store's copy, so a header the user hand-added to their own global file is absent from the discovered map while still present on disk — and this writer only became able to touch an *existing* entry in this change, so wholesale assignment would delete exactly the credential the empty-map guard exists to protect. Scopes stay authoritative-delete on purpose: a stale scope over-requests access, a lost header destroys it. A **malformed** discovered map (a hand-edited non-dict, which discovery coerces only when falsy) is read the same way as an empty one — it carries no usable credential, so the on-disk map is left alone rather than aborting a sync that covers every other server |
| A server the operator disabled could be re-mounted **and auto-approved** by a same-named dashboard-store entry | Adding `kirocrew_mcp` to the tools-allowlist chain made the store the LAST scope visited. `POST /api/mcp/toggle enabled:false` writes `disabled: true` into the kiro global only, so the store entry has no such key — its pass took the enabled branch, cleared the flag off the emitted spec and re-added the ref to `tools` **and** `allowedTools`, the one path that never reaches the PreToolUse gate | `disabled` is now **tightest-wins**: the set of names carrying `disabled` in any scope is computed before the chain, and a name in it takes the removal branch on every pass regardless of which spec is being visited. Both the set and the membership test are keyed by `mcp_server_alias`, not the raw dict key — that mapping is many-to-one, so a slashed global key and a slash-free store key are different keys that mount the same `@ref`, and comparing raw keys let the alias-spelled entry look like a different server and re-add the ref the disable had just removed |

### The ownership decision table

The discriminator is **who owns the entry**, not whether the entry carries an
internal key. One parameter carries both the ownership answer and the source:
`store_entry`, the dashboard store's own entry for that server.

| `store_entry` | states | result |
|---|---|---|
| dict | valid hint | wire key rebuilt from it |
| dict | empty hint | wire key **deleted** |
| dict | no hint at all | wire key **deleted** |
| `None` / non-dict | — | wire value **preserved verbatim** |

Preserve-verbatim covers an entry no store owns, **including one defined only in
the agent config itself** — added with `kiro-cli mcp add --agent kirocrew`, or
hand-edited in. The rebuild merges onto that file, so it is the only copy of that
server's hints; rewriting them at rebuild time would destroy them with nothing to
restore from. Narrowing a grant is the store's job, where the change is explicit
and reversible, and a store that stops stating a hint stops requesting it on every
later rebuild. Sub-keys we never owned (`oauth.issuer`) survive under every row,
because the hints are edited surgically.

**Name form is part of the rule.** `_normalize_mcp_server_keys` rewrites a
slashed `mcpServers` key to its slash-free alias, and `mcp_server_alias` is
many-to-one — so the config key on the *next* rebuild is the alias while the store
still holds the slashed spelling. The store lookup is therefore alias-keyed: a
raw-key-only lookup misses the owner of an aliased entry, reads it as unmanaged,
and preserves the previously-rendered hints — so a clear the user made in the
editor answers 200 and never takes effect. A malformed value under the alias key
does not block that lookup either: "contributes nothing" includes casting no veto,
so it cannot shadow a usable slashed owner. It still confers no ownership — with no
usable entry under either spelling the fallback yields `None` and the name stays
unmanaged.

**One rule for every alias binding, keyed on the direction of the effect.**
`mcp_server_alias` is many-to-one, so an alias match is not an identity match —
two unrelated names can collide on one alias. The rule follows from what the
binding does:

| Binding | Direction | Rule |
|---|---|---|
| OAuth hints ← store entry (emit path) | **grants** credentials and requested access | alias match **plus** transport identity (`url`) — otherwise one server's grant lands on another's |
| `disabled` ← any scope (tools-allowlist chain) | **denies** a mount and auto-approve | alias match **only**, deliberately: over-matching costs availability, while under-matching would let an operator's disable be missed on `allowedTools`, the one path that never reaches the PreToolUse gate |

Denying is allowed to be loose; granting is not. Both halves are pinned by tests,
so a future alias site has a stated rule to follow rather than a precedent to
guess at.

The same rule decides what an alias match may be built from. A store name maps
many-to-one onto an alias, and a numeric suffix (`foo-bar-2`) is minted when the
plain alias is already held, so neither a url nor a name is an identity on its
own: a user can type `foo-2` themselves, and two owners can share one endpoint.
A grant therefore crosses into the collision family only with corroboration that
a mint was actually forced — the plain alias is held by a *different* transport —
and only when exactly one owner answers. An ambiguous or uncorroborated family
leaves the entry unmanaged, because preserving a grant costs less than moving
one. Without that, one server's scopes and client identity land in another's
slot, and the entry keeps re-minting siblings because it never matches the copy
it should have collapsed onto.

**The editor's clear reaches the wire spelling too.** A store entry can already
hold the wire form (the scope-toggle preservation rule copies a global spec in
verbatim), and those keys fall outside the editable set, so plain carried-key
restoration put them back untouched — the hint the user removed kept being
requested while the API answered 200. A wire hint is not foreign configuration to
be carried; it is this entry's own hint in the other spelling. So when the
submitted spec states neither spelling of a hint, the sibling goes with it
(`_resolve_oauth_hints`); when it states either, that is authoritative. The wire
keys stay *tolerated on input* so an unmodified `GET` → `PUT` round trip still
validates, which is not the same as making them a second editable vocabulary —
nothing outside `mcp_utils` interprets them. The scopes hint has **two** wire
spellings (top-level `oauthScopes` and nested `oauth.oauthScopes`, both of which
the reader falls through to), so a single statement test governs both: dropping
only the spelling that happened to be checked would leave the other standing for
the reader to resurrect. Stating the *internal* spelling settles the hint
outright and suppresses both wire spellings — the editor prefills the whole spec,
so a user clearing scopes submits `scopes: []` next to the wire sibling the `GET`
handed them, and copying that sibling back would resurrect the grant the
submission just cleared.

A sub-key of `oauth` that is neither hint (`issuer`) belongs to another flow, so
it follows the carried-key rule in full: matching what is on disk is fine,
anything else is refused. That includes a sub-key with **no** prior value — it
cannot be stored either, and accepting it would turn an explicit refusal into a
silent success. Tolerating a wire key by name is not the same as
accepting any value in it: both spellings of each hint answer to **one shape
rule** in the validator, so a malformed `oauthScopes` or `oauth.clientId` is
rejected exactly as its internal twin is, rather than reaching disk under a 200.

A usable dict means the store owns this name and is the source; `None` — or a
malformed value the merge skipped, which therefore supplied nothing — means we own
nothing here. Ownership and source are deliberately **not** two parameters: a
separate `managed` flag was derivable from `store_entry` at the call site, and
that redundancy is what let the two disagree.

The store is read in **either spelling** (`kiro_entry_scopes` /
`kiro_entry_client_id`), because it does not only receive internal-form writes:
the scope-toggle preservation rule in
`src/kiro_crew/dashboard/handlers/mcp.py` copies a global server's spec into the
store verbatim to keep it configured when its globals are toggled off, and a
global entry can be hand-authored in wire form. Such a copy is ours to manage and
states its hints in the wire spelling, so reading only the internal one would see
"no hints" on an owned entry and delete the very configuration the copy exists to
preserve. Where an entry holds both spellings the **internal** one wins, keyed on
the internal key's **presence** rather than its value: `scopes: []` from the
custom-server API is a deliberate clear and is final, so it cannot fall through to
a stale `oauthScopes` sibling and resurrect the grant the user just removed. Wire
spellings are read only when the internal key is absent entirely.

The source is read from the **store**, never from the entry being emitted: that
entry is the merged spec `rebuild_agent_config` assembles (the previous render
folded together with the store via `dict.update()`), so reading hints off it would
let a stale render outvote the store.

Enforced in `kiro_oauth_wire_entry()`, whose `store_entry` argument is
keyword-only and **required**, so no call site can silently inherit a default. The
emit site passes `store_entry=kirocrew_mcp.get(name)`.

**The same ownership question gates every write to a surface we do not own.**
`kirocrew_managed_names()` (in `src/kiro_crew/mcp_discovery.py`) answers it once,
from the store scope with the same `isinstance(..., dict)` discriminator, and both
global-write sites consult it:

| Write site | Surface | Gate |
|---|---|---|
| `api_mcp_sync` (`handlers/mcp.py`) | kiro-global `~/.kiro/settings/mcp.json` | An existing entry for an unmanaged name is **skipped entirely**. The base ref only ever *created* missing entries here; the gate restores that guarantee while still letting a managed entry re-sync |
| `register_servers_for_cc` (`mcp_discovery.py`) | Claude Code `~/.mcp.json` sidecar | **Add-only for remotes**: a name already present is skipped before the entry is even built, so nothing existing is rewritten. The OAuth hints this change adds are written on that add path only, and only for managed names |

Discovery merges *all* scopes, so both sites receive unmanaged names from the same
feeder — which is why this is one predicate applied at both, not a per-site patch.
`test_an_unmanaged_name_is_never_modified_at_any_global_write_site` asserts the
property across both sites in a single test, so a future write site cannot ship
with the gate applied to only one of them.

The dashboard store (`mcp_custom.py`) and the agent config (`agent.py`) are
KiroCrew-owned surfaces and are not gated by this predicate; the agent config has
its own ownership rules above (the wire-key table, and disabled-tightest-wins).

The sync path needs no ownership argument: the readers accept either spelling, so
an unmanaged entry's hand-authored wire values read back unchanged and a re-sync
rewrites the same request — it is already a fixed point.

Only the **emitted** files are translated. Every source file, the custom-server
API and the UI types keep one spelling, so there is exactly one internal-to-wire
boundary rather than a second spelling scattered through the codebase.

Scoping note: `mcp_tool_aliases()`, the primitive, lands here fully tested.
Injecting the table into the agent spec needs the per-provider tool lists, which
arrive with the registry, so wiring it now would mean importing a symbol that
does not exist yet.

## Behavior change for existing custom-MCP users

**This PR changes observable behavior on `main`, deliberately.** A user who
already has a custom remote MCP server configured with `scopes` will find that
scope request *actually transmitted* to the provider on the next authorization —
previously it was dropped and the provider applied its default grant. The
practical effect is that a re-authorization may present a different consent
screen than it did before, listing the scopes that were configured all along.

This is the fix working as intended: the entry now requests what it says it
requests. No migration is needed and no stored grant is invalidated — existing
tokens keep working until they are re-authorized. It is called out here because
the change is user-visible and cannot be feature-flagged without leaving the
underlying bug in place.

Everything else in this PR is either a pure fix or lands dark.

## Tests

All new tests fail if the fix is reverted.

* `test/test_connections_kiro_spec_fields.py` (new) — the wire shape (rename,
  nesting, both-spelling readers) plus the **ownership decision table**, whose
  nine rows must hold simultaneously. Each row is a failure mode that appears
  when the discriminator collapses into a simpler one, and fixing any row alone
  has demonstrably re-broken another:

  | Row | Case | Expected | Test |
  |---|---|---|---|
  | 1 | managed + hint valid | rebuilt from source | `test_row1_a_changed_scope_list_overwrites_the_previously_rendered_one`, `test_row1_a_widened_then_narrowed_scope_list_is_actually_narrowed` |
  | 2 | managed + hint emptied (`[]` / `""`) | wire key deleted | `test_row2_an_emptied_source_removes_the_rendered_wire_keys` |
  | 2b | managed + **explicit clear alongside a stale wire sibling in the same store entry** | wire key deleted (presence beats truthiness) | `test_row2b_an_explicit_clear_beats_a_stale_wire_sibling_in_the_same_store`, `test_row2b_an_explicit_null_also_clears_rather_than_falling_through` |
  | 3 | managed + hint **absent** (removed via API) | wire key deleted | `test_row3_hints_removed_through_the_api_do_not_survive_the_rebuild`, `test_row3_a_managed_entry_with_no_hints_at_all_emits_none`, and end-to-end `test_agent.py::test_removed_oauth_hints_do_not_survive_a_rebuild_of_a_managed_entry` |
  | 4 | **not** managed (wire-only) | preserved verbatim | `test_row4_an_unmanaged_wire_only_entry_keeps_its_hints_verbatim`, `test_row4_an_unmanaged_entry_survives_the_rendered_merge_path`, `test_row4_an_unmanaged_internal_spelling_is_still_translated`, and end-to-end `test_agent.py::test_an_unmanaged_wire_only_entry_keeps_its_oauth_hints` |
  | 3 vs 4 | the discriminator itself | one entry, two regimes, two correct answers | `test_row3_vs_row4_same_entry_opposite_outcomes` |
  | 5 | `oauth.issuer` under every row | always survives | `test_row5_an_unrelated_oauth_subkey_survives_every_regime`, `test_mcp_sync_agent.py::test_sync_keeps_unrelated_oauth_subkeys_while_rewriting_client_id` |
  | 6 | malformed scope list | omitted identically by emit **and** readback | `test_row6_emit_and_readback_agree_on_every_malformed_shape`, `test_row6_a_malformed_scope_member_omits_the_field_entirely`, `test_row6_a_clean_scope_list_agrees_on_every_path`, `test_row6_a_malformed_member_does_not_leave_a_stale_rendered_list_standing`, `test_row6_a_blank_client_id_is_treated_as_absent`, plus `test_mcp_sync_agent.py::test_sync_omits_a_malformed_scope_list_instead_of_truncating_it` and the `test_mcp_discovery.py::test_discover_degrades_malformed_oauth_hints` rows |
  | 7 | second pass over the same store | no-op (render converges) | `test_row7_a_second_rebuild_is_a_no_op_for_every_row`, `test_row7_readback_of_an_emitted_entry_matches_what_was_requested` |
  | 8 | **owned** store entry holding hints in **wire** form (a scope-toggle preservation copy) | hints kept | `test_row8_an_owned_store_entry_in_wire_form_keeps_its_hints`, `test_row8_a_wire_form_store_entry_survives_the_rendered_merge_path`, `test_row8_does_not_resurrect_row3_the_store_must_be_the_one_speaking`, `test_row8_an_internal_store_spelling_still_wins_over_a_wire_render` |

  Rows 3, 4 and 8 are the load-bearing set: as *entries* rows 3 and 4 are
  byte-identical, so any rule reading only the entry must get one of them wrong;
  and row 8 is an owned entry that looks hint-less to an internal-only reader.

* `test/test_mcp_sync_agent.py` — `api_mcp_sync` emits the wire names, drops hints
  removed upstream, preserves a header discovery cannot see, keeps an unrelated
  `oauth.issuer` while rewriting the `clientId` it owns, and omits a malformed
  scope list rather than truncating it.
* `test/test_mcp_discovery.py` — dataclass defaults, `to_dict()` gating (a stdio
  row never advertises OAuth hints), and nine `discover_servers_to_sync` cases
  covering remote url/headers/scopes/clientId divergence, the no-resync case
  when everything matches, and malformed-hint degradation.
* `test/test_mcp_custom_api.py` — round-trip through GET/PUT, plus eight
  validation cases for malformed `scopes`/`clientId` and for either key on a
  stdio server.
* `test/test_agent.py` — a dashboard-added remote server reaches the closed
  `tools` allowlist (and a disabled one loses its ref); OAuth hints survive
  `_refresh_dynamic_fields`; the two ownership rows above, which pin the
  `store_entry=kirocrew_mcp.get(name)` wiring rather than just the helper;
  `test_a_malformed_store_value_does_not_confer_ownership`, which pins that a
  non-dict store value colliding with a wire-configured global entry does **not**
  make it managed; and the disabled-tightest-wins pair —
  `test_a_globally_disabled_server_is_not_remounted_by_the_store_entry` (an
  operator disable in the kiro global is not undone by a same-named store entry,
  and the flag still reaches the emitted spec) plus
  `test_an_enabled_store_server_still_mounts_with_a_global_sibling` (the gate does
  not break the enabled path it guards).

**Gates:** isort, flake8, mypy (853 files) clean. Targeted suite for every file
this PR touches, plus `test/test_security_posture.py`,
`test/test_spawn_audit.py` and `test/test_handlers_mcp_coverage.py`:
**588 passed**, 4 skipped.

Full backend suite: **39,178 passed / 66 failed**, all 66 pre-existing
host-environment failures in unrelated subsystems (ops-mission-control ledger
git sync, auto-improvement `gh` paths, terminal commands, service) — every one
traces to this host having no user-namespace sandbox
(`SandboxUnavailableError: unshare(CLONE_NEWUSER) failed with errno 1 (EPERM)`).
Zero failures in any file this PR touches. Net regressions: zero.

### Three further changes in this revision

* **A malformed scope field now warns.** Degrading a present-but-invalid
  `scopes` to the provider's default grant stays deliberate — forwarding the bad
  shape makes kiro-cli reject the whole spec and drop every MCP tool — but the
  swap can widen the grant relative to the file, so it is no longer silent.
  `_wire_scopes` logs the server and the offending value's SHAPE (never its
  members, since the field is hand-editable and could hold a pasted token).
  Absent and empty stay silent: those are "no request" and "stop requesting",
  not mistakes.
* **The Claude Code sidecar keeps base's add-only behaviour; re-sync there is
  deferred.** Ownership on `~/.mcp.json` can only be established by name, and
  `register_servers_for_cc` rebuilds a remote entry from scratch rather than
  merging into it — so "our managed server moved" and "a different server the
  user happened to name the same" arrive as the same input. Rather than pick a
  side, this slice removes the write: a remote that already has an entry there is
  left alone entirely, exactly as on the base ref, where a divergent existing
  remote could never reach that writer. New servers are still registered, and the
  OAuth hints ride that add path so a first registration carries the scopes the
  card asked for. Propagating a *changed* remote shape to this surface arrives
  with the provenance record that makes the two cases distinguishable. Re-sync on
  the surfaces Kiro Crew can actually own — the agent config and the kiro-global
  file, the latter ownership-gated per the table above — is unaffected, which is
  what makes the scope fix propagate at all.
* **`mcp_tool_aliases()` is removed.** It had no call site on this branch — its
  consumer needs the per-provider tool lists that arrive with the Connections
  registry slice, so the primitive lands there with the code that uses it
  instead of sitting dead here.

### Open design question (unchanged, for a maintainer)

An exact-name collision between a managed server and a hand-authored global
entry of the same name still resolves in favour of the managed source. This is
not a discriminator we failed to find — the two candidate signals are
**refuted**, not merely absent:

* **Transport match** ("preserve unless the existing url equals the managed
  one") is the exact negation of `test_a_managed_url_move_propagates`: adopting
  it means a managed server's url change never reaches kiro-cli.
* **A non-hint `oauth` sub-key** looks like an authorship fingerprint, since no
  writer here emits one and the custom-server editor refuses a submission that
  introduces one. But a *managed* entry legitimately carries `issuer` once a
  user adds it — that is the whole reason `apply_kiro_oauth_hints` edits `oauth`
  surgically — so preserving on that signal strands every managed server whose
  `oauth` a user has ever touched.
  `test_a_non_hint_oauth_subkey_is_not_authorship_evidence` pins the refutation
  so the remedy is not proposed again.

What remains is the bare `{"url": ...}` case, which is genuinely undecidable on
disk: that entry is both what this emitter writes for a hint-less managed server
and the smallest thing a user can hand-type, and nothing on disk records
authorship (`McpServerInfo.source` is discovery origin, not authorship). Closing
it needs a provenance record — an on-disk format change, which belongs in its
own PR rather than this one. Exposure is bounded meanwhile: `POST
/api/mcp/custom` refuses a name found in any scope including the kiro global, so
no dashboard path can create the collision; the residual window is a user
editing their own global file after the managed entry exists, and disconnecting
the managed server returns the name to unmanaged.

## Manual verification

The emitted shape was validated against the real binary rather than only against
our own tests — `kiro-cli agent validate` on a generated spec, using the
wrong-typed-value technique in the table above to distinguish a field kiro-cli
parses from one it silently ignores. Confirmed that `oauthScopes` and
`oauth.clientId` are recognized and that the previous `scopes` / top-level
`clientId` spellings pass validation while being discarded.

Round-tripped a remote entry through the custom-server API (add -> GET -> PUT)
and confirmed the hints survive unchanged on disk, and that editing scopes in
`mcp.json` now triggers a re-sync into the agent config instead of leaving the
old shape in place.

## Screenshots

N/A — backend behavior fix, no UI change.

---

## Note for the wave-2 slice: chat banner suppression was removed from this PR

Chat banner suppression (`_drain_session_init_oauth_requests` /
`_connections_managed_mcp_names` in `chat_runner.py`, plus its
`test_mcp_oauth_banner.py` coverage) was cut from this slice during local review
and needs to land in a later wave, **after** the provider registry.

**Reviewer reasoning.** The predicate treated *every* `mcpServers` key in the
dashboard's `<data home>/mcp.json` as Connections-managed. But that file is also
where `/api/mcp/custom` writes, so an arbitrary user-added remote MCP server was
classified as managed and had its session-init OAuth banner suppressed too. For
a Connections provider that is correct — the card owns the consent flow. For a
hand-added custom server the chat banner is its **only** authorization path, so
suppressing it left the user with no way to authorize the server and no
indication anything was wrong. The failure is silent and the user-visible symptom
(a server that simply never works) points nowhere near the cause.

A correct predicate has to distinguish *provider-registry-backed* entries from
arbitrary custom ones, which means reading the registry — slice A's content. Two
things to keep when it lands:

* Keep the suppression scoped to session init. The mid-turn
  `EVENT_MCP_OAUTH_REQUEST` handler should still emit unconditionally: it fires
  when a live token expires under a running turn, where the banner is the timely
  signal and the turn is already blocked on it.
* Keep the fail-open behaviour and the alias matching. `rebuild_agent_config`
  registers servers under `mcp_server_alias(key)`, so the `serverName` kiro-cli
  reports is the ALIAS while the dashboard writes the raw key — matching one form
  only would look correct for simple names and quietly fail for scoped ones
  (`npm:@playwright/mcp` → `playwright-mcp`).
* Test both directions. A one-sided test passes just as happily against
  "suppress everything", which is exactly the bug that got this cut.

Removing it also dropped a function-level import of `handlers.mcp` from
`chat_runner.py`, which violated the top-level-imports rule.
