### PR TITLE
fix(sidebar): preserve relevance order in active-session search results

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -711,9 +711,22 @@ function ChatSidebar({
   // Ephemeral: reset on every query change so a fresh search shows all groups.
   const [collapsedHistoryGroups, setCollapsedHistoryGroups] = useState<Set<string>>(() => new Set())
   useEffect(() => { setCollapsedHistoryGroups(new Set()) }, [historyFilter])
-  const slotSearchKeys = useDebouncedSessionSearch(
+  // Backend relevance rank per slot key (0 = best). A Map instead of a Set so
+  // `filteredSlots` can ORDER matches by the backend's ranking (title matches
+  // carry a strong field boost server-side) rather than re-sorting them by
+  // date, which buries a title match below every fresher session that merely
+  // mentions the query in its body. First-wins on canonical-key collisions so
+  // a duplicate file cannot demote the better-ranked entry.
+  const slotSearchRanks = useDebouncedSessionSearch(
     slotFilter,
-    sessions => new Set(sessions.map(s => s.key.replace(/^dashboard_/, ''))),
+    sessions => {
+      const ranks = new Map<string, number>()
+      sessions.forEach((s, i) => {
+        const key = s.key.replace(/^dashboard_/, '')
+        if (!ranks.has(key)) ranks.set(key, i)
+      })
+      return ranks
+    },
   )
   const [renamingSlot, setRenamingSlot] = useState<string | null>(null)
   // In board view a multi-tag chat renders once per matching column, so
@@ -987,7 +1000,7 @@ function ChatSidebar({
   const creatingSlot = useAppSelector(s => s.chat.creatingSlot)
   const connected = useConnected()
   // O(1) lookup set for the filter predicate (mirrors the `pinned` and
-  // `slotSearchKeys` patterns elsewhere in this file).
+  // `slotSearchRanks` patterns elsewhere in this file).
   const unreadSet = useMemo(() => new Set(unreadSlots), [unreadSlots])
   // Heartbeat that re-evaluates recency even when nothing else re-renders.
   // Sidebar interactions (new messages, status changes, opening the menu) all
@@ -1468,19 +1481,23 @@ function ChatSidebar({
 
   const filteredSlots = useMemo(() => {
     const activeFilterDefs = SESSION_FILTERS.filter(filterDef => activeFilters.has(filterDef.key))
+    // Active content search: order by the backend's relevance ranking instead
+    // of the sidebar sort (mirrors the Older Sessions lane and the command
+    // palette). Pinning stays a reachability promise for browsing, not a
+    // ranking hint inside explicit search results.
+    const searchRanked = slotFilter.trim().length >= SEARCH_MIN_CHARS ? slotSearchRanks : null
     return enrichedSlots
       .filter(slot => {
         if (activeFilterDefs.length > 0 && !activeFilterDefs.some(filterDef => slot[filterDef.key])) return false
         if (!slotFilter) return true
-        if (slotFilter.trim().length >= SEARCH_MIN_CHARS) {
-          if (slotSearchKeys) return slotSearchKeys.has(slot.key)
-          return ((slot.title || '') + slot.key + (slot.agent || '')).toLowerCase().includes(slotFilter.toLowerCase())
-        }
+        if (searchRanked) return searchRanked.has(slot.key)
         return ((slot.title || '') + slot.key + (slot.agent || '')).toLowerCase().includes(slotFilter.toLowerCase())
       })
-      .sort((a, b) => comparePinnedThenSort(a, b, sortKey, pinned))
+      .sort((a, b) => searchRanked
+        ? (searchRanked.get(a.key) ?? Infinity) - (searchRanked.get(b.key) ?? Infinity)
+        : comparePinnedThenSort(a, b, sortKey, pinned))
   },
-    [enrichedSlots, slotFilter, slotSearchKeys, pinned, sortKey, activeFilters]
+    [enrichedSlots, slotFilter, slotSearchRanks, pinned, sortKey, activeFilters]
   )
 
   // Folder IDs whose sessions are excluded from the flat lane because the

--- a/website/src/test/ChatSidebar.slotSearchOrder.test.tsx
+++ b/website/src/test/ChatSidebar.slotSearchOrder.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * Test: active-session search results preserve the backend's relevance order.
+ *
+ * Regression for the ranking bug where `filteredSlots` collapsed the
+ * `/api/sessions/search` response into a membership Set and re-sorted the
+ * matches with `comparePinnedThenSort` (pinned first, then date-desc by
+ * default), burying a title match (which the backend ranks first via the
+ * `_TITLE_BOOST` field boost in `search_sessions`) below fresher — or merely
+ * pinned — sessions that only mention the query in their body content.
+ *
+ * The mocked `/api/sessions/search` response deliberately returns the
+ * relevance-ranked list with the title match FIRST but with the OLDEST
+ * `last_ts`, while one content-only decoy is PINNED and the other is the
+ * freshest — so the old pin+date re-sort would demote the title match to
+ * last. The assertions lock the rendered DOM order to the backend order.
+ *
+ * The companion lane (Older Sessions) has the same contract in
+ * ChatSidebar.historySearchOrder.test.tsx; mock scaffolding mirrors that file.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+
+// Relevance-ranked backend response: title match first (oldest slot), then the
+// content-only mentions (pinned / fresher). Backend keys carry the
+// `dashboard_` prefix that the sidebar strips to map them onto slot keys.
+// Single source of truth — the mock AND the fixture-validity guard both read
+// this constant, so editing it cannot silently defuse the guard.
+const { SEARCH_FIXTURE, sessionsSearchMock } = vi.hoisted(() => {
+  const SEARCH_FIXTURE = [
+    // Backend rank 1: title match (10x field boost) — oldest of the three.
+    { key: 'dashboard_chat-target', title: 'Managing session overload strategies', modified: 1_000_000 },
+    // Backend ranks 2-3: content-only matches — pinned and/or fresher.
+    { key: 'dashboard_chat-pinned', title: 'Pinned unrelated title', modified: 3_000_000, snippet: 'we discussed session overload here' },
+    { key: 'dashboard_chat-fresh', title: 'Fresh unrelated title', modified: 2_000_000, snippet: 'more session overload chatter' },
+  ]
+  return {
+    SEARCH_FIXTURE,
+    sessionsSearchMock: vi.fn().mockResolvedValue({ sessions: SEARCH_FIXTURE }),
+  }
+})
+
+// Mock API client (sidebar fires fetch calls on mount). importOriginal keeps
+// non-`api` exports (e.g. SEARCH_MIN_CHARS used by the search debounce) real.
+vi.mock('../api/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: {
+      ...Object.fromEntries(
+        [
+          'sessions', 'chatSlots', 'chatSlotDetail', 'createChatSlot', 'deleteChatSlot',
+          'resumeChatSlot', 'deleteSession', 'agentDetail', 'spawnList', 'fetchHistory',
+          'renameSlot', 'forkSession',
+        ].map(k => [k, vi.fn().mockResolvedValue({})]),
+      ),
+      chatFolders: vi.fn().mockResolvedValue([]),
+      sessionsSearch: sessionsSearchMock,
+    },
+  }
+})
+
+// Browser API stubs
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }) as unknown as typeof fetch
+
+import ChatSidebar from '../pages/ChatSidebar'
+import type { ChatSlot } from '../types'
+import type { RootState } from '../store'
+
+const slot = (key: string, title: string, lastTs: string, pinned = false): ChatSlot => ({
+  key, title, messages: 1, running: false, mode: '', created: '', last_ts: lastTs, pinned,
+} as ChatSlot)
+
+// Slot-side mirror of SEARCH_FIXTURE: the title match is the OLDEST and
+// unpinned; both decoys would outrank it under pin-first + date-desc.
+const SLOTS = [
+  slot('chat-target', 'Managing session overload strategies', '2026-01-01T00:00:00Z'),
+  slot('chat-pinned', 'Pinned unrelated title', '2026-03-01T00:00:00Z', true),
+  slot('chat-fresh', 'Fresh unrelated title', '2026-02-01T00:00:00Z'),
+]
+
+function renderSidebar() {
+  const store = createTestStore({
+    dashboard: {
+      status: { platform: 'darwin' },
+      connected: true,
+      slots: SLOTS,
+      approvalMode: 'normal', channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+      slotsLoaded: true,
+    } as unknown as RootState['dashboard'],
+    chat: {
+      activeSlot: 'chat-target',
+      messages: [], slotRunning: false, slotStopping: false, slotState: 'idle',
+      slotStatusDetail: {}, slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+      lastChunkSeq: undefined,
+      history: [], historyHasMore: false, historyOffset: 0,
+      pendingInput: null, slotContextPct: {}, voicePlaying: false, voiceAudio: null,
+      subagents: {}, toolLog: [], activityOpen: false, activityTab: 'tools', slotActivity: {}, slotHistory: [],
+      slotMessages: {}, slotLoading: false,
+    } as unknown as RootState['chat'],
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={SLOTS}
+              activeSlot={'chat-target'}
+              unreadSlots={[]}
+              history={[]}
+              historyHasMore={false}
+              defaultAgent={'default'}
+              installedAgents={[]}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('ChatSidebar – active-session search preserves backend relevance order', () => {
+  beforeEach(() => {
+    sessionsSearchMock.mockClear()
+    localStorage.clear()
+  })
+
+  it('renders search results in backend order, not re-sorted by pin/date', async () => {
+    renderSidebar()
+
+    fireEvent.change(screen.getByPlaceholderText(/search sessions/i), {
+      target: { value: 'session overload' },
+    })
+
+    // The search is debounced (250ms) before hitting the mocked endpoint.
+    await waitFor(() => expect(sessionsSearchMock).toHaveBeenCalledWith('session overload'))
+
+    // Once the ranked response lands, all three matches render — in backend
+    // order. compareDocumentPosition bit 4 (DOCUMENT_POSITION_FOLLOWING) means
+    // the argument comes AFTER `this`.
+    await waitFor(() => {
+      const target = screen.getByText('Managing session overload strategies')
+      const pinnedDecoy = screen.getByText('Pinned unrelated title')
+      const fresh = screen.getByText('Fresh unrelated title')
+      expect(target.compareDocumentPosition(pinnedDecoy) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+      expect(pinnedDecoy.compareDocumentPosition(fresh) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+  })
+
+  it('pin-first + date-desc re-sort would have inverted this fixture (guards fixture validity)', () => {
+    // Validate that the fixture actually exercises the regression: under the
+    // old ordering (pinned first, then last_ts desc) the title match lands
+    // LAST. Derived from the SAME constants the mock serves — if someone edits
+    // the fixture such that pin/date order equals relevance order, the main
+    // assertion above would pass vacuously and this guard fails instead.
+    const oldOrder = [...SLOTS]
+      .sort((a, b) => {
+        const pa = a.pinned ? 0 : 1
+        const pb = b.pinned ? 0 : 1
+        if (pa !== pb) return pa - pb
+        return new Date(b.last_ts!).getTime() - new Date(a.last_ts!).getTime()
+      })
+      .map(s => s.key)
+    const backendOrder = SEARCH_FIXTURE.map(s => s.key.replace(/^dashboard_/, ''))
+    expect(backendOrder[0]).toBe('chat-target')
+    expect(oldOrder[oldOrder.length - 1]).toBe('chat-target')
+    expect(oldOrder).not.toEqual(backendOrder)
+  })
+})


### PR DESCRIPTION
## Problem

The sessions sidebar's **active-session search** ("Search sessions…") discards the backend's relevance ranking. `/api/sessions/search` deliberately ranks results — `search_sessions` in `history.py` gives title hits a 10x field boost (`_TITLE_BOOST`) precisely so a session *named* after the query outranks sessions that merely mention it in message content. But the sidebar collapsed the ranked response into a membership `Set` and re-sorted the matches with `comparePinnedThenSort` (pinned first, then date-desc by default).

Observable defect: type `overl` while a session titled "managing kiro crew session overload" exists. During the 250ms debounce the client-side title-substring fallback shows it as the only match — then the server response lands and the pin/date re-sort buries it below every fresher session whose *body* happens to contain "overl…" (overly, overlap, …). The best match visibly "falls down" the list mid-keystroke.

## Fix

`useDebouncedSessionSearch`'s slots transform now returns a `Map<slotKey, rank>` (first-wins on canonical-key collisions) instead of a `Set`, and `filteredSlots` orders by that rank while a content search is active — falling back to the existing pinned+sort ordering otherwise. Filtering semantics are unchanged (same membership test, same substring fallback while the response is in flight or below `SEARCH_MIN_CHARS`).

This is the exact companion of #2226, which fixed the same bug in the **Older Sessions** lane (`sortedHistory` re-sorting relevance-ranked results by date). The command palette's sessions provider already preserves backend order and biases title matches upward — the three surfaces now agree.

Pinned rows intentionally do NOT float above search results: pinning is a reachability promise for browsing (per `sessionOrder.ts`'s own comment), not a ranking hint inside an explicit search — the regression test locks this with a pinned decoy.

## Tests

- New `ChatSidebar.slotSearchOrder.test.tsx`, mirroring `ChatSidebar.historySearchOrder.test.tsx` (#2226): a ranked mock response whose title match is the *oldest and unpinned* slot, with a pinned decoy and a fresher decoy ranked below it. Asserts rendered DOM order equals backend order, plus a fixture-validity guard proving the old pin+date sort would have inverted the fixture.
- Mutation-checked: the test fails against the unfixed `ChatSidebar.tsx`.
- `tsc -b` clean, eslint 0 errors, full vitest suite green apart from the pre-existing `catalogParity` ko failure (29 missing `pages.sessionStorage.*` keys), which reproduces identically on clean `origin/main`.
