### PR TITLE
fix: resolve trusted system binaries on non-FHS hosts

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -628,9 +628,12 @@ that must not change, because the SPA's per-origin `localStorage` is keyed on it
    that does not resolve there counts as absent rather than falling back.
    `listening_pid_tool_available()` performs the same pinned resolution, so it
    distinguishes "no listener" from "lookup tool missing" without disagreeing
-   with the lookup it describes. A host that installs the tool outside those
-   directories (NixOS, a Homebrew or conda prefix) therefore reads as not having
-   it; `trusted_system_bin()` logs a warning once per name when the tool is on
+   with the lookup it describes. The pinned set is the FHS directories plus
+   `/run/current-system/sw/bin`, which is root-owned and rewritten only by a
+   system rebuild. A tool installed anywhere else — a Homebrew or conda prefix —
+   still reads as absent, and deliberately so: those prefixes are writable by the
+   invoking user, which is the exposure the pin exists to close.
+   `trusted_system_bin()` logs a warning once per name when the tool is on
    `PATH` but not resolvable under the pin, and `tool_outside_trusted_dirs()`
    lets `stop` name where the tool actually is rather than tell an operator who
    already has it to install it. That case carries SEL

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -1099,7 +1099,13 @@ async def _run_process(
                 extra_visible_dirs=extra_visible_dirs,
             )
             if spawn_argv and not os.path.isabs(spawn_argv[0]):
-                resolved_wrapper = shutil.which(spawn_argv[0], path=os.defpath)
+                # Off the loop: a miss walks the whole ``PATH`` once per name to
+                # report where the tool actually is, so a stalled network mount
+                # anywhere on it would otherwise freeze the gateway rather than
+                # just this probe.
+                resolved_wrapper = await asyncio.to_thread(
+                    platform_compat.trusted_system_bin, spawn_argv[0]
+                )
                 if not resolved_wrapper:
                     raise OSError(f"sandbox wrapper is unavailable: {spawn_argv[0]}")
                 spawn_argv[0] = resolved_wrapper

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -710,7 +710,7 @@ def _descendants_from_parent_map(root_pid: int, parent_map: dict[int, int]) -> l
     return result
 
 
-_TRUSTED_SYSTEM_BIN_DIRS = ("/usr/bin", "/bin", "/usr/sbin", "/sbin")
+_TRUSTED_SYSTEM_BIN_DIRS = ("/usr/bin", "/bin", "/usr/sbin", "/sbin", "/run/current-system/sw/bin")
 
 # Windows argv carries a bare name (``taskkill``) while the file on disk carries
 # an extension (``taskkill.exe``), so a trusted lookup must try the suffixes the

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -2339,9 +2339,8 @@ class TestKiroPrerequisiteWorkflow:
         ) -> tuple[list[str], dict[str, str], None]:
             return [wrapper, *argv], {"PATH": "/trusted/bin"}, None
 
-        def which(executable: str, *, path: str | None = None) -> str:
-            assert executable == wrapper
-            assert path == os.defpath
+        def trusted(name: str) -> str:
+            assert name == wrapper
             return f"/usr/bin/{wrapper}"
 
         async def spawn(*argv: str, **_kwargs: Any) -> _Process:
@@ -2349,7 +2348,11 @@ class TestKiroPrerequisiteWorkflow:
             return _Process()
 
         monkeypatch.setattr(prerequisite_module, "sandboxed_spawn_argv", sandbox)
-        monkeypatch.setattr(prerequisite_module.shutil, "which", which)
+        monkeypatch.setattr(
+            prerequisite_module.platform_compat,
+            "trusted_system_bin",
+            trusted,
+        )
         monkeypatch.setattr(asyncio, "create_subprocess_exec", spawn)
 
         result = await _run_process(
@@ -2364,6 +2367,102 @@ class TestKiroPrerequisiteWorkflow:
         # fragment, then the resolved sandbox wrapper.
         wrapper_index = 4 + len(prerequisite_module.resource_limit_supervisor_argv())
         assert captured["spawn_argv"][wrapper_index] == f"/usr/bin/{wrapper}"
+
+    @pytest.mark.skipif(
+        platform_compat.IS_WINDOWS,
+        reason="Windows does not wrap the probe in the POSIX sandbox launcher",
+    )
+    @pytest.mark.asyncio
+    async def test_probe_reports_an_unresolvable_sandbox_wrapper(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A wrapper the pin cannot resolve fails with a named cause rather than
+        # falling back to whatever PATH offers.
+
+        def sandbox(
+            argv: list[str],
+            **_kwargs: Any,
+        ) -> tuple[list[str], dict[str, str], None]:
+            return ["systemd-run", *argv], {"PATH": "/trusted/bin"}, None
+
+        spawn = AsyncMock(side_effect=OSError("an unresolvable wrapper was spawned"))
+        monkeypatch.setattr(prerequisite_module, "sandboxed_spawn_argv", sandbox)
+        monkeypatch.setattr(
+            prerequisite_module.platform_compat,
+            "trusted_system_bin",
+            lambda _name: None,
+        )
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", spawn)
+
+        result = await _run_process(
+            "/fixed/kiro-cli",
+            ["--version"],
+            env={"PATH": "/trusted/bin"},
+            timeout_secs=1,
+        )
+
+        assert result.ok is False
+        assert result.error == "sandbox wrapper is unavailable: systemd-run"
+        spawn.assert_not_awaited()
+
+    @pytest.mark.skipif(
+        platform_compat.IS_WINDOWS,
+        reason="Windows does not wrap the probe in the POSIX sandbox launcher",
+    )
+    @pytest.mark.asyncio
+    async def test_wrapper_resolution_does_not_block_event_loop(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A miss walks the whole PATH to report where the tool is, so the lookup
+        # has to run off the loop or a stalled mount freezes the gateway.
+        lookup_started = threading.Event()
+        release_lookup = threading.Event()
+
+        def sandbox(
+            argv: list[str],
+            **_kwargs: Any,
+        ) -> tuple[list[str], dict[str, str], None]:
+            return ["systemd-run", *argv], {"PATH": "/trusted/bin"}, None
+
+        def slow_lookup(_name: str) -> str | None:
+            lookup_started.set()
+            assert release_lookup.wait(timeout=1)
+            return "/usr/bin/systemd-run"
+
+        monkeypatch.setattr(prerequisite_module, "sandboxed_spawn_argv", sandbox)
+        monkeypatch.setattr(
+            prerequisite_module.platform_compat,
+            "trusted_system_bin",
+            slow_lookup,
+        )
+        monkeypatch.setattr(
+            asyncio,
+            "create_subprocess_exec",
+            AsyncMock(side_effect=OSError("spawn is not the subject here")),
+        )
+
+        process_task = asyncio.create_task(
+            _run_process(
+                "/fixed/kiro-cli",
+                ["--version"],
+                env={"PATH": "/trusted/bin"},
+                timeout_secs=1,
+            )
+        )
+        assert await asyncio.to_thread(lookup_started.wait, 1)
+        ticked_during_lookup = False
+
+        async def tick_lookup() -> None:
+            nonlocal ticked_during_lookup
+            await asyncio.sleep(0)
+            ticked_during_lookup = True
+
+        await tick_lookup()
+        assert ticked_during_lookup
+        release_lookup.set()
+        assert (await process_task).ok is False
 
     @pytest.mark.skipif(
         platform_compat.IS_WINDOWS,

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -2333,6 +2333,32 @@ def test_trusted_system_bin_rejects_a_name_not_in_system_dirs(tmp_path, monkeypa
     assert platform_compat.trusted_system_bin("ps") is not None
 
 
+def test_trusted_system_bin_dirs_are_not_limited_to_fhs():
+    # A distribution may keep ps/lsof/systemd-run outside /usr/{s}bin; an
+    # FHS-only pin resolves nothing at all there.
+    from kiro_crew import platform_compat
+
+    fhs = {"/usr/bin", "/bin", "/usr/sbin", "/sbin"}
+    assert set(platform_compat._TRUSTED_SYSTEM_BIN_DIRS) - fhs
+
+
+def test_trusted_system_bin_resolves_outside_fhs(tmp_path, monkeypatch):
+    # A tool reachable only through a non-FHS pinned directory still resolves.
+    from kiro_crew import platform_compat
+
+    if platform_compat.IS_WINDOWS:  # pragma: no cover - POSIX lookup
+        pytest.skip("POSIX binary resolution")
+
+    system_dir = tmp_path / "sw" / "bin"
+    system_dir.mkdir(parents=True)
+    tool = system_dir / "definitely-not-a-system-tool"
+    tool.write_text("#!/bin/sh\nexit 0\n")
+    tool.chmod(0o755)
+
+    monkeypatch.setattr(platform_compat, "_TRUSTED_SYSTEM_BIN_DIRS", (str(system_dir),))
+    assert platform_compat.trusted_system_bin("definitely-not-a-system-tool") == str(tool)
+
+
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason=(


### PR DESCRIPTION
### What is the problem?

`trusted_system_bin()` pins OS-introspection spawns to fixed system directories
so a gateway `PATH` that leads with same-uid-writable dirs cannot decide what
runs (#1503, #1621). The set is FHS-only, and on NixOS `/usr/bin` holds a single
file — `env`. `ps`, `lsof` and `systemd-run` live under
`/run/current-system/sw/bin`, so the pin resolves **nothing**, and this assertion
fails on `main`:

```python
# test/test_platform_compat.py::test_trusted_system_bin_rejects_a_name_not_in_system_dirs
assert platform_compat.trusted_system_bin("ps") is not None
```

`kiro_prerequisite._run_process` then resolves its sandbox wrapper through a
**second** lookup the #1621 sweep did not reach, because it goes through
`os.defpath` rather than `PATH`:

```python
resolved_wrapper = shutil.which(spawn_argv[0], path=os.defpath)   # "/bin:/usr/bin"
```

### Why this issue matters to the user

The sandbox layer emits `systemd-run` as a bare name, so every `kiro-cli
--version` probe raises, `_audited_probe` degrades it to `ok=False`, and
`/api/kiro-prerequisite` reports a working install as `installed: false`. The
dashboard pins the user to the full-screen first-run *Install Kiro CLI* gate, and
**Check again re-runs the same failing probe** — no in-product way out, while
`kirocrew doctor` reports the CLI fine.

Beyond setup, the wholesale pin failure also takes `process_owner_uid`,
`find_listening_pids` and `process_command_line`, so the port-trust gate reads a
live gateway as not-owned and `kirocrew stop` degrades — the outcome the #1621
design review predicted for this host class.

### How our fix solves it

1. `_TRUSTED_SYSTEM_BIN_DIRS` gains `/run/current-system/sw/bin` — a root-owned
   symlink into the booted system generation, rewritten only by a system rebuild,
   so it carries the same "no same-uid process can plant a binary here" property
   the FHS entries are chosen for. No trust is widened; `PATH` still decides
   nothing.
2. `kiro_prerequisite._run_process` resolves through `trusted_system_bin()`.
   `AGENTS.md`'s shim table already requires it for spawning a system tool, and
   one lookup on the pin plus one on `os.defpath` lets the two disagree about
   which directories are trustworthy. The lookup runs off the event loop: this is
   the only caller reaching the pin from a coroutine, and a miss walks the whole
   `PATH` once per name to report where the tool actually is, so a stalled network
   mount anywhere on `PATH` would freeze the gateway rather than just this probe.
   The absolute-path case still skips the thread hop, matching how `sandbox.py`
   resolves its own spawn target.
3. `docs/system-specs/modules/cli.md` documented the old behaviour by name
   ("A host that installs the tool outside those directories (NixOS, …) therefore
   reads as not having it"), so it is corrected in the same commit.

**Existing hosts are unaffected:** the new entry is appended last, so on an FHS
host every lookup resolves exactly where it did before; and the probe's set
becomes a strict superset of `os.defpath`, so it can only resolve more than it
used to, never less.

**On the mechanism.** This deepens the fixed-directory approach the #1621 design
review warned about, rather than its preferred form — resolving `PATH` candidates
and accepting only root-owned, non-user-writable files. That changes how the seam
decides trust, so it seemed a maintainer's call rather than a contributor's;
happy to replace this with that version.

Worth noting that the general form would not rescue the other hosts the review
named. Homebrew's prefix is writable by the invoking user by design and conda
prefixes normally live under `$HOME`, so an ownership check refuses both — and
should, since a same-uid-writable prefix is what the pin exists to refuse. macOS
also ships `ps`, `lsof` and `netstat` in `/usr/bin` regardless. What makes this
host class different is that the tools stay root-managed and simply live outside
the FHS paths.

### What tests we did

`test/test_platform_compat.py`:
- `test_trusted_system_bin_dirs_are_not_limited_to_fhs` — mutation-checked:
  removing the entry fails it.
- `test_trusted_system_bin_resolves_outside_fhs` — a tool reachable only through
  a non-FHS pinned directory still resolves.

`test/test_kiro_prerequisite.py`:
- `test_probe_reports_an_unresolvable_sandbox_wrapper` — an unresolvable wrapper
  degrades to the named error and never spawns. `spawn.assert_not_awaited()` is
  what stops a silent `PATH` fallback from passing.
- `test_probe_resolves_sandbox_wrapper_before_supervisor_exec` asserted
  `path == os.defpath` and so pinned the old behaviour; it now asserts the pin.
- `test_wrapper_resolution_does_not_block_event_loop` — a slow lookup still lets
  the loop tick, in the style of the neighbouring
  `test_sandbox_preparation_and_cleanup_do_not_block_event_loop`.
  Mutation-checked: dropping the thread hop fails it.

**Results on `fc5bfe49`:** the two affected modules plus `test_spawn_audit`,
`test_platform_compat_coverage`, `test_macos_process_table` and
`test_dev_fleet_node_toolchain` → **605 passed, 1 failed**. The failure is
`test_dedupes_pids_from_lsof_output`, which fails on `main` too on this host
because **`lsof` is not installed** — it fakes `check_output` but not the binary
resolution, so it depends on the host having the tool. Filed as a note on the
issue.
`test_trusted_system_bin_rejects_a_name_not_in_system_dirs` goes from failing on
`main` to passing.

**Manual verification:** against a real gateway, `/api/kiro-prerequisite` flips
from `installed: false` to `installed: true`, and the dashboard gate moves from
*"Get Kiro CLI — Required"* to *"Kiro CLI was found on this host — Complete"*.

**Gates:** `flake8`, `isort`, `mypy` (on the changed module), `scripts/docs-lint.sh`
and the brand gate all clean. `black` reports these files as needing reformatting,
but does so on the **unmodified** files at `main` as well (black 26.5.1), and none
of its hunks fall inside this diff — so I have not reformatted, same call #1621
made.

**Not run:** macOS and Windows. The change is POSIX-list-only; the Windows branch
resolves through `_windows_system_dirs()`, untouched.

### Related Issues

Fixes #2302
Follows up #1503 / #1621

### Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated — `docs/system-specs/modules/cli.md`
- [x] No secrets, credentials, or internal references in the diff
