### PR TITLE
fix: enforce consolidation retry eligibility inside _consolidate (#2135)

### DIFF
--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -65,6 +65,18 @@ ARCHIVE_RETENTION_DAYS = 7
 # make a right-most-dot parse attribute a segment to the wrong session.
 ARCHIVE_SEGMENT_DELIMITER = "__"
 _CONSOLIDATION_THRESHOLD = 30  # preferences/projects update threshold (messages)
+
+
+# Returned by _consolidate when its retry-eligibility gate refuses the span.
+# Distinct from None (a pass that ran, or found nothing to do) so callers'
+# done-callbacks can tell a refusal from a completed pass: a refusal must not
+# advance their bookkeeping (offsets, throttles) as if the window had been
+# processed, and raising instead would log a routine backoff as a task failure.
+class _ConsolidationRefusedSentinel:
+    __slots__ = ()
+
+
+_CONSOLIDATION_REFUSED = _ConsolidationRefusedSentinel()
 # Persistent retry accounting for history consolidation. A pass spends a billed
 # LLM turn BEFORE it can write the durable "consolidated" marker, so any failure
 # in between leaves the span unconsolidated — and every entry point (the 60s
@@ -4005,7 +4017,9 @@ class HistoryConsolidator:
         """True when *key* may spend a billed consolidation turn right now.
 
         Every automatic entry point consults this so a span whose consolidation
-        keeps failing backs off instead of re-billing an LLM turn on each sweep.
+        keeps failing backs off instead of re-billing an LLM turn on each sweep,
+        and _consolidate() itself enforces it as the final gate, so an entry
+        point without a pre-check of its own still cannot bypass the backoff.
         A span at :data:`_CONSOLIDATION_MAX_ATTEMPTS` is refused: the abandon path
         normally writes the marker (which also clears the accounting), so reaching
         here at the cap means even that write failed, and refusing keeps a broken
@@ -4149,7 +4163,16 @@ class HistoryConsolidator:
 
         def _on_done(fut: asyncio.Task, k: str = key, off: int = total) -> None:  # type: ignore[type-arg]
             self._tasks.discard(fut)
-            if not fut.cancelled() and fut.exception() is None:
+            if (
+                not fut.cancelled()
+                and fut.exception() is None
+                # A refusal ran no pass over the window. Advancing the offset
+                # anyway would mark the window consolidated, so once the
+                # backoff expires the threshold test skips it until a whole new
+                # threshold of messages accumulates — silently dropping its
+                # preference/project extraction.
+                and fut.result() is not _CONSOLIDATION_REFUSED
+            ):
                 self._prefs_offset[k] = off
 
         t.add_done_callback(_on_done)
@@ -4185,7 +4208,13 @@ class HistoryConsolidator:
                 ts: float = captured_now,
             ) -> None:
                 self._tasks.discard(fut)
-                if not fut.cancelled() and fut.exception() is None:
+                if (
+                    not fut.cancelled()
+                    and fut.exception() is None
+                    # A refusal is not a completed pass; setting the throttle
+                    # for it would delay the retry past the backoff deadline.
+                    and fut.result() is not _CONSOLIDATION_REFUSED
+                ):
                     self._history_consolidated[k] = ts
 
             t.add_done_callback(_on_idle_done)
@@ -4208,9 +4237,10 @@ class HistoryConsolidator:
         if unconsolidated < 1:
             return
         # This path consults no time-based throttle at all — every session expiry
-        # for the same key fires a fresh consolidation — so the durable backoff is
-        # the only thing standing between a repeatedly failing span and one billed
-        # LLM turn per expiry.
+        # for the same key fires a fresh consolidation — so the durable backoff
+        # stands between a repeatedly failing span and one billed LLM turn per
+        # expiry. Checked here (as well as inside _consolidate()) so the skip is
+        # logged before a task is ever scheduled.
         if not self.retry_eligible(key, message_count=total):
             logger.info(
                 "consolidate_session skipped for %s: consolidation retry backoff", key
@@ -4235,7 +4265,9 @@ class HistoryConsolidator:
                 return
             exc = fut.exception()
             if exc is None:
-                self._history_consolidated[k] = _time.time()
+                # A refusal is not a completed pass; leave the throttle unset.
+                if fut.result() is not _CONSOLIDATION_REFUSED:
+                    self._history_consolidated[k] = _time.time()
             else:
                 logger.warning("consolidate_session failed for %s: %s", k, exc)
 
@@ -4247,7 +4279,9 @@ class HistoryConsolidator:
         Unlike consolidate_session() which is fire-and-forget, this awaits
         completion. Used by the CLI command.
 
-        Safety: defense-in-depth — also checked inside _consolidate().
+        Safety: defense-in-depth — the consolidation retry backoff is also
+        checked inside _consolidate(), and _run_skill_detection() re-checks
+        the sensitive-session guard over its own window.
         """
         if self._log.unconsolidated_count(key) < 1:
             return
@@ -4257,8 +4291,14 @@ class HistoryConsolidator:
             return
         await self._consolidate(key, include_history=True)
 
-    async def _consolidate(self, key: str, include_history: bool = True) -> None:
-        """Run LLM consolidation for a session."""
+    async def _consolidate(
+        self, key: str, include_history: bool = True
+    ) -> _ConsolidationRefusedSentinel | None:
+        """Run LLM consolidation for a session.
+
+        Returns :data:`_CONSOLIDATION_REFUSED` when the retry-eligibility gate
+        refuses the span; every other completion returns ``None``.
+        """
         # Capture the gateway loop so the thread-offloaded _process_auto_skills
         # can schedule the async dedupe judge back onto it.
         self._event_loop = asyncio.get_running_loop()
@@ -4289,7 +4329,28 @@ class HistoryConsolidator:
                 generation_at_snapshot,
             ) = await asyncio.to_thread(self._log.snapshot_for_consolidation, key)
             if not unconsolidated:
-                return
+                return None
+            # Retry-eligibility choke point: every entry point funnels through
+            # this function, so a span inside its durable backoff is refused
+            # here — before anything that can bill a provider turn — even when
+            # the caller carries no pre-check of its own (maybe_consolidate's
+            # preferences/projects path). Callers keep their cheaper pre-checks
+            # as scheduling short-circuits and UX (the idle sweep's per-tick
+            # skip, the dashboard trigger's 429); this gate is the enforcement
+            # that holds when a new entry point forgets one. The count comes
+            # from the atomic snapshot above — the same consistent read the
+            # rest of this function uses — and retry_eligible costs one
+            # metadata-line read, so no second transcript read lands on the
+            # event loop. The refusal returns a sentinel rather than raising:
+            # the finally block still releases self._running and the callers'
+            # done-callbacks run normally (so the key is never stranded), while
+            # the sentinel lets those callbacks tell a refusal from a completed
+            # pass and leave their bookkeeping untouched.
+            if not self.retry_eligible(key, message_count=total):
+                logger.info(
+                    "_consolidate refused for %s: consolidation retry backoff", key
+                )
+                return _CONSOLIDATION_REFUSED
             # Freeze the whole span identity from that one snapshot. The offset is
             # derived rather than returned because the snapshot slices at it
             # (``messages[offset:]``), so the subtraction is exact and comes from
@@ -4429,7 +4490,7 @@ class HistoryConsolidator:
                 # on a widening interval instead of on every 60s tick.
                 if include_history:
                     await self._note_environment_failure(key, str(exc))
-                return
+                return None
             billed = True
             if not result:
                 # The turn reached the provider and produced nothing usable, so it
@@ -4442,7 +4503,7 @@ class HistoryConsolidator:
                     await self._note_failed_attempt(
                         key, attempted, "empty LLM result"
                     )
-                return
+                return None
 
             if entry := result.get("history_entry"):
                 # Offloaded to a worker thread: append_history takes a blocking
@@ -4536,6 +4597,7 @@ class HistoryConsolidator:
             raise
         finally:
             self._running.discard(key)
+        return None
 
     async def _run_skill_detection(self, key: str) -> None:
         """Detect a reusable skill from the FULL session (bounded window).

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -1404,6 +1404,8 @@ class TestConsolidationDoesNotBlockLoop:
             [{"role": "user", "content": "hi"}], 1, 0
         )
         log.get_metadata.return_value = {}
+        # A fresh span is eligible; _consolidate's inner gate reads this.
+        log.consolidation_retry_state.return_value = (0, 0.0)
 
         memory = MagicMock()
         memory.read_preferences.return_value = ""
@@ -1451,6 +1453,8 @@ class TestConsolidationDoesNotBlockLoop:
             [{"role": "user", "content": "hi"}], 1, 0
         )
         log.get_metadata.return_value = {}
+        # A fresh span is eligible; _consolidate's inner gate reads this.
+        log.consolidation_retry_state.return_value = (0, 0.0)
 
         memory = MagicMock()
         memory.read_preferences.return_value = ""

--- a/test/test_history_atomic_rewrite.py
+++ b/test/test_history_atomic_rewrite.py
@@ -66,6 +66,8 @@ class TestMarkConsolidatedOffloaded:
             [{"role": "user", "content": "hi"}], 1, 0
         )
         log.get_metadata.return_value = {}
+        # A fresh span is eligible; _consolidate's inner gate reads this.
+        log.consolidation_retry_state.return_value = (0, 0.0)
         log.mark_consolidated.side_effect = lambda *a, **k: mark_thread_id.__setitem__(
             "id", threading.get_ident()
         )

--- a/test/test_history_consolidation_retry.py
+++ b/test/test_history_consolidation_retry.py
@@ -1597,3 +1597,143 @@ class TestTheManualTriggerClaimsAtomically:
             resp = await api_memory_consolidate(request)  # type: ignore[arg-type]
             assert resp.status == 200
             await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+
+class TestConsolidateIsTheEligibilityChokePoint:
+    """_consolidate() enforces retry eligibility itself.
+
+    The caller pre-checks are scheduling short-circuits and UX; the gate inside
+    the operation is what guarantees an entry point without one (the
+    preferences/projects path, or a future caller) cannot re-bill a backed-off
+    span.
+    """
+
+    def _arm_backoff(self, log: ConversationLog, attempts: int = 1) -> None:
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": attempts,
+                    "consolidation_retry_at": time.time() + 3600,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_direct_call_inside_the_backoff_bills_nothing(self, tmp_path):
+        """No caller pre-check at all — the inner gate alone must refuse."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        self._arm_backoff(log)
+
+        with patch.object(c, "_call_llm", new_callable=AsyncMock) as spy:
+            await c._consolidate(KEY, include_history=True)
+
+        spy.assert_not_awaited()
+        # The refusal is free: nothing reached the provider, so nothing is
+        # charged and the span's accounting is untouched.
+        assert log.consolidation_retry_state(KEY, _total(log))[0] == 1
+        assert log.unconsolidated_count(KEY) == 3
+
+    @pytest.mark.asyncio
+    async def test_a_direct_call_on_a_fresh_span_still_consolidates(self, tmp_path):
+        """The eval runner calls _consolidate directly to bypass the message
+        threshold; a fresh span carries no backoff, so the gate lets it pass."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(
+            c, "_call_llm", AsyncMock(return_value={"history_entry": "x"})
+        ) as spy:
+            await c._consolidate(KEY, include_history=True)
+
+        spy.assert_awaited_once()
+        assert log.unconsolidated_count(KEY) == 0
+
+    @pytest.mark.asyncio
+    async def test_maybe_consolidate_is_refused_inside_the_backoff(self, tmp_path):
+        """The preferences/projects path has no pre-check of its own — the
+        inner gate is the only thing covering it."""
+        log = _seed_log(tmp_path, count=history_mod._CONSOLIDATION_THRESHOLD)
+        c = _make_consolidator(log)
+        self._arm_backoff(log)
+
+        with patch.object(c, "_call_llm", new_callable=AsyncMock) as spy:
+            c.maybe_consolidate(KEY)
+            assert c._tasks, "premise broken: the threshold did not schedule a task"
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+        spy.assert_not_awaited()
+        assert log.consolidation_retry_state(KEY, _total(log))[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_a_refusal_does_not_strand_the_key_in_running(self, tmp_path):
+        """Callers add the key to _running before the task and rely on
+        done-callbacks to release it; a refusal path that skipped the release
+        would wedge consolidation for the session permanently."""
+        log = _seed_log(tmp_path, count=history_mod._CONSOLIDATION_THRESHOLD)
+        c = _make_consolidator(log)
+        self._arm_backoff(log)
+
+        with patch.object(c, "_call_llm", new_callable=AsyncMock):
+            c.maybe_consolidate(KEY)
+            assert c._tasks, "premise broken: the threshold did not schedule a task"
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+        assert KEY not in c._running, "the refusal leaked the running claim"
+
+        # Once the backoff expires the same key is dispatchable again, which
+        # it would not be if the refusal above had left the claim in place.
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(KEY, {"consolidation_retry_at": time.time() - 1})
+        with patch.object(
+            c, "_call_llm", AsyncMock(return_value={"history_entry": "x"})
+        ) as spy:
+            c.consolidate_session(KEY)
+            assert c._tasks, "a released key was still refused after the backoff"
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+        spy.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_maybe_consolidate_proceeds_outside_the_backoff(self, tmp_path):
+        """The gate delays rather than disables the prefs/projects path."""
+        log = _seed_log(tmp_path, count=history_mod._CONSOLIDATION_THRESHOLD)
+        c = _make_consolidator(log)
+
+        with patch.object(c, "_call_llm", AsyncMock(return_value={"noop": True})) as spy:
+            c.maybe_consolidate(KEY)
+            assert c._tasks, "premise broken: the threshold did not schedule a task"
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+        spy.assert_awaited_once()
+        assert c._prefs_offset.get(KEY) == history_mod._CONSOLIDATION_THRESHOLD
+        assert KEY not in c._running
+
+    @pytest.mark.asyncio
+    async def test_a_refusal_does_not_advance_the_prefs_offset(self, tmp_path):
+        """Advancing the offset on a refusal marks the window consolidated with
+        no pass run — once the backoff expires the threshold test would skip it
+        until a whole new threshold of messages accumulates, silently dropping
+        its preference/project extraction."""
+        log = _seed_log(tmp_path, count=history_mod._CONSOLIDATION_THRESHOLD)
+        c = _make_consolidator(log)
+        self._arm_backoff(log)
+
+        with patch.object(c, "_call_llm", new_callable=AsyncMock) as spy:
+            c.maybe_consolidate(KEY)
+            assert c._tasks, "premise broken: the threshold did not schedule a task"
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+        spy.assert_not_awaited()
+        assert KEY not in c._prefs_offset, "a refused pass advanced the prefs offset"
+
+        # Once the backoff expires the SAME window is retried — the refusal
+        # delayed the extraction rather than dropping it.
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(KEY, {"consolidation_retry_at": time.time() - 1})
+        with patch.object(c, "_call_llm", AsyncMock(return_value={"noop": True})) as spy:
+            c.maybe_consolidate(KEY)
+            assert c._tasks, "the un-advanced offset did not re-arm the threshold"
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+        spy.assert_awaited_once()
+        assert c._prefs_offset.get(KEY) == history_mod._CONSOLIDATION_THRESHOLD


### PR DESCRIPTION
## Problem

The consolidation retry-eligibility guard is enforced at each CALLER rather than inside the operation it protects. `maybe_consolidate` (the preferences/projects path) reaches `_consolidate(include_history=False)` with no eligibility check at all, and any future entry point can silently reopen the unbounded-retry / re-billing hole the guard exists to close. `consolidate_now`'s docstring already claims the inner check exists — it did not.

## Why it matters

A span whose consolidation keeps failing is supposed to back off instead of re-billing an LLM turn on every sweep. With the guard only at the callers, one unguarded path (or one forgotten pre-check in a new caller) re-bills a provider turn per trigger, indefinitely — real money for a turn that produces nothing durable.

## Fix (symptoms → root cause → change)

Symptom: an unguarded entry point can spend billed turns on a backed-off span. Root cause: the invariant is conventional (every caller must remember to check) rather than structural (the operation enforces it). Change: `_consolidate` now consults `retry_eligible` itself, immediately after its atomic `snapshot_for_consolidation` and before anything that can bill a provider turn.

- The `message_count` for the check is derived from the same one-lock-hold snapshot the rest of the function uses — no second transcript read lands on the event loop (`retry_eligible` costs one metadata-line read, which is loop-safe by design and pinned by an existing test).
- The refusal is a cheap `return`, not a raise: the existing `finally` block releases `self._running`, and every caller's done-callback runs normally, so the key is never stranded.
- All caller pre-checks are KEPT as defense in depth: `check_idle_sessions` keeps its per-tick short-circuit, `consolidate_session` keeps its check and its `skipped: consolidation retry backoff` log line, and the dashboard trigger keeps its 429 pre-check.
- `consolidate_now`'s defense-in-depth docstring sentence is now true, and the `consolidate_session` comment that called the caller check "the only thing" is corrected.
- `eval/runner.py`'s deliberate direct `_consolidate` call is unaffected: a fresh eval span carries no backoff, so the gate lets it pass (locked by a test).

This is a behaviour-preserving structural change: outside the backoff window no caller observes a different outcome.

## Tests

New `TestConsolidateIsTheEligibilityChokePoint` in `test/test_history_consolidation_retry.py`:
- a direct `_consolidate` call inside the backoff performs no provider call and charges nothing (the accounting is untouched);
- a direct call on a fresh span still consolidates (the eval-runner pattern);
- `maybe_consolidate` — the previously unguarded path — is refused inside the backoff;
- a refusal does not strand the key in `_running`, and the same key is dispatchable again once the backoff expires;
- `maybe_consolidate` proceeds unchanged outside the backoff (the gate delays, never disables).

Three existing loop-offload tests gained a `consolidation_retry_state` stub on their `MagicMock` logs (the inner gate now reads it).

Gates: pytest (targeted history/eval files all green; full-suite failures are host-environment-only and reproduce identically on clean `origin/main`), isort, flake8, mypy, brand gate — all green.

## Manual verification

N/A — unit coverage sufficient: the change is a pure control-flow gate on an internal method, and every entry point plus the refusal/release path is exercised by unit tests.

Closes #2135
