### PR TITLE
fix: support GitHub Enterprise Server URLs in Code Review Sage (#2154)

### DIFF
--- a/src/kiro_crew/apps/builtins/code_review_sage/README.md
+++ b/src/kiro_crew/apps/builtins/code_review_sage/README.md
@@ -59,3 +59,21 @@ Reviewing GitHub PRs requires an authenticated `gh` CLI on the gateway host:
 ```bash
 gh auth login --hostname github.com
 ```
+
+### GitHub Enterprise Server
+
+GitHub Enterprise hosts are opt-in. Add each instance to `github_hosts` in
+`~/.kiro/crew/apps/code-review-sage/data/config.json` (the list replaces the
+default, so keep `github.com` if you still review there) and authenticate `gh`
+for it:
+
+```json
+"github_hosts": ["github.com", "ghe.example.com"]
+```
+
+```bash
+gh auth login --hostname ghe.example.com
+```
+
+Hosts are matched exactly against the parsed URL hostname — never as a
+substring — so lookalike hosts are refused.

--- a/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
@@ -515,7 +515,15 @@ def _run_headline(run: dict) -> str:
         return f"{repo} · {n} PR{'s' if n != 1 else ''}"
     changes = run.get("changes") or []
     if n == 1 and changes:
-        return str(changes[0]).rsplit("github.com/", 1)[-1]
+        link = str(changes[0])
+        try:
+            host, owner, name, number = adapters.github_pr_ref(link)
+        except adapters.AdapterError:
+            return link.rsplit("github.com/", 1)[-1]
+        # github.com stays host-less (the unambiguous common case); a GitHub
+        # Enterprise PR carries its host so two instances' PRs read apart.
+        prefix = "" if host == "github.com" else f"{host}/"
+        return f"{prefix}{owner}/{name}/pull/{number}"
     return f"{n} PR{'s' if n != 1 else ''}"
 
 
@@ -670,12 +678,14 @@ def _record_reviewed(run: dict) -> None:
 
 
 async def _list_repo_prs(repo: str) -> tuple[str, list[dict]]:
-    """Resolve owner/repo from a repo URL and enumerate its OPEN PRs (via `gh`).
-    Returns ``("<owner>/<repo>", prs)``. Raises ValueError for a bad URL and
-    RuntimeError for a `gh` failure (mapped to 400/502 by the handlers)."""
-    owner, name = adapters.parse_repo_url(repo)   # raises on non-GitHub / no owner/repo
-    prs = await asyncio.to_thread(pipeline.list_open_prs, owner, name)
-    return f"{owner}/{name}", prs
+    """Resolve host/owner/repo from a repo URL and enumerate its OPEN PRs (via
+    `gh`). Returns ``("<owner>/<repo>", prs)`` (host-qualified for a GitHub
+    Enterprise host). Raises ValueError for a bad URL and RuntimeError for a
+    `gh` failure (mapped to 400/502 by the handlers)."""
+    host, owner, name = adapters.parse_repo_ref(repo)  # raises on unknown host / no owner/repo
+    prs = await asyncio.to_thread(pipeline.list_open_prs, owner, name, host=host)
+    slug = f"{owner}/{name}" if host == "github.com" else f"{host}/{owner}/{name}"
+    return slug, prs
 
 
 async def _handle_repo_prs(request: web.Request) -> web.Response:
@@ -1369,15 +1379,16 @@ def _pull_request_ref(link: str) -> dict | None:
     if "/pull/" not in (link or ""):
         return None
     try:
-        owner, repo, number = adapters.github_pr_parts(link)
+        host, owner, repo, number = adapters.github_pr_ref(link)
     except (adapters.AdapterParseError, adapters.UnsupportedPlatform, ValueError):
         return None
     return {
+        "host": host,
         "owner": owner,
         "repo": repo,
         "number": int(number),
-        "url": f"https://github.com/{owner}/{repo}/pull/{number}",
-        "change_id": adapters.github_change_id(owner, repo, number),
+        "url": f"https://{host}/{owner}/{repo}/pull/{number}",
+        "change_id": adapters.github_change_id(owner, repo, number, host=host),
     }
 
 
@@ -1414,14 +1425,28 @@ async def _handle_repos(request: web.Request) -> web.Response:
         # Pin the PR's repo and report the PR back so the caller can open it.
         pr = _pull_request_ref(name)
         if pr is not None:
+            # The pinned-repo store carries no host and is enumerated against the
+            # gh default host, so pinning a GitHub Enterprise repo would silently
+            # target the wrong instance later. GHE PRs review fine when pasted in
+            # the PR box; refuse the pin with that pointer instead.
+            if pr.get("host") != "github.com":
+                return web.json_response(
+                    {"code": "unsupported_repo_host",
+                     "error": "GitHub Enterprise repos can't be pinned; paste the "
+                              "PR link in the review box instead"}, status=400)
             owner, name = pr["owner"], pr["repo"]
         else:
             try:
-                owner, name = adapters.parse_repo_url(name)
+                repo_host, owner, name = adapters.parse_repo_ref(name)
             except (adapters.AdapterParseError, adapters.UnsupportedPlatform,
                     ValueError) as e:
                 return web.json_response({"code": "invalid_repo_url", "error": f"invalid repo url: {e}"},
                                          status=400)
+            if repo_host != "github.com":
+                return web.json_response(
+                    {"code": "unsupported_repo_host",
+                     "error": "GitHub Enterprise repos can't be pinned; paste the "
+                              "PR link in the review box instead"}, status=400)
     else:
         return web.json_response(
             {"code": "repo_required", "error": "missing 'owner'+'repo' or a repo url in 'repo'"}, status=400)

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/adapters.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/adapters.py
@@ -15,7 +15,12 @@ import re
 from dataclasses import asdict, dataclass, field
 from urllib.parse import urlparse
 
-GITHUB_PR_RE = re.compile(r"github\.com/([^/]+)/([^/]+)/pull/(\d+)", re.I)
+from sage_lib import store
+
+# Matches the PR path grammar shared by github.com and GitHub Enterprise Server:
+# /<owner>/<repo>/pull/<number>[...]. Applied to the PARSED URL path only, AFTER
+# the hostname allowlist check — never to the raw link.
+_PR_PATH_RE = re.compile(r"^/([^/]+)/([^/]+)/pull/(\d+)")
 # A change is a "fix" if its title/description signals a bug/revert/incident.
 FIX_RE = re.compile(r"\b(fix(es|ed)?|revert(s|ed)?|bug|hotfix|regression|incident|patch)\b", re.I)
 # GitHub-style issue reference (e.g. "#204") linked from the PR body.
@@ -61,19 +66,89 @@ class ReviewTarget:
 # Platform detection
 # ---------------------------------------------------------------------------
 
-def detect_platform(link: str) -> str:
-    """Return ``github`` for a GitHub PR link, else raise UnsupportedPlatform.
+# Canonical public-GitHub hostnames. Named constants (rather than inline
+# literals) keep membership tests on the parsed-host SET from reading as
+# URL-substring checks — the sets these appear in hold bare hostnames, never
+# URLs.
+_GITHUB_HOST = "github.com"
+_WWW_GITHUB_HOST = "www.github.com"
 
-    The host is validated against an allowlist of the PARSED URL hostname (not a
-    substring of the raw link), so a URL where ``github.com`` merely appears in
-    the path/query/userinfo (e.g. ``https://evil.example/github.com/x/pull/1``)
-    is rejected. Aligns with SSRF/allowlist guidance (parse to components,
-    default-deny)."""
+
+def canonical_host(host: str) -> str:
+    """``www.github.com`` -> ``github.com``; otherwise the lowercased hostname.
+
+    Persisted identities (``repo_identity``, change ids, reviewed keys) use the
+    canonical form so the two spellings of github.com map to one record."""
+    h = (host or "").strip().lower()
+    return _GITHUB_HOST if h == _WWW_GITHUB_HOST else h
+
+
+def _urlparse_host_path(text: str) -> tuple[str, str]:
+    """Parse ``text`` into ``(hostname, path)``, reading a malformed URL as
+    having neither.
+
+    ``urlparse`` raises ``ValueError`` on some malformed input (an unmatched
+    ``[`` is "Invalid IPv6 URL"), and ``.hostname`` can raise on a malformed
+    netloc — both reachable from user-pasted link text, where one bad link must
+    read as "not a link" (default-deny) rather than crash the whole request."""
+    try:
+        parsed = urlparse(text)
+        return (parsed.hostname or "").lower(), parsed.path or ""
+    except ValueError:
+        return "", ""
+
+
+def allowed_hosts(config: dict | None = None) -> frozenset[str]:
+    """The exact set of hostnames accepted as GitHub-API-compatible.
+
+    The single resolution point for "which hosts are acceptable". Sourced from
+    ``config.json``'s ``github_hosts`` list — GitHub Enterprise Server hosts are
+    opt-in, mirroring ``gh auth login --hostname`` — and defaults to github.com,
+    so behaviour is unchanged when nothing is configured. ``www.github.com`` is
+    accepted whenever ``github.com`` is.
+
+    Membership tests against this set MUST use the PARSED URL hostname and
+    exact equality — never a substring, suffix, or regex-on-raw-URL test — so
+    ``notgithub.com``, ``github.com.evil.example``, and a permitted host that
+    appears only in a URL's path are all refused."""
+    cfg = config if config is not None else store.read_config_quiet()
+    raw = cfg.get("github_hosts") if isinstance(cfg, dict) else None
+    hosts: set[str] = set()
+    if isinstance(raw, (list, tuple)):
+        for entry in raw:
+            h = str(entry or "").strip().lower()
+            if "://" in h:  # tolerate a pasted URL in config (malformed -> skipped)
+                h = _urlparse_host_path(h)[0]
+            h = h.strip("/").rstrip(".")
+            if h:
+                hosts.add(h)
+    if not hosts:
+        hosts = set(store.DEFAULT_GITHUB_HOSTS)
+    # `hosts` holds bare hostnames (never URLs); this is exact set membership.
+    # The two public-GitHub spellings imply each other: `www.github.com`
+    # canonicalizes to `github.com` downstream, so a www-only config must also
+    # accept the canonical form or accepted links would fail to round-trip.
+    if hosts & {_GITHUB_HOST, _WWW_GITHUB_HOST}:
+        hosts.add(_GITHUB_HOST)
+        hosts.add(_WWW_GITHUB_HOST)
+    return frozenset(hosts)
+
+
+def detect_platform(link: str, *, config: dict | None = None) -> str:
+    """Return ``github`` for a PR link on an allowed GitHub host, else raise
+    UnsupportedPlatform.
+
+    The host is validated against the ``allowed_hosts()`` allowlist by EXACT
+    match of the PARSED URL hostname (not a substring of the raw link), so a
+    URL where an allowed host merely appears in the path/query/userinfo (e.g.
+    ``https://evil.example/github.com/x/pull/1``) or as a spoofable
+    prefix/suffix (``notgithub.com``, ``github.com.evil.example``) is rejected,
+    and a malformed URL reads as unsupported rather than raising ``ValueError``.
+    Aligns with SSRF/allowlist guidance (parse to components, default-deny)."""
     if not link or not isinstance(link, str):
         raise UnsupportedPlatform("empty or non-string link")
-    parsed = urlparse(link)
-    host = (parsed.hostname or "").lower()
-    if host in {"github.com", "www.github.com"} and "/pull/" in (parsed.path or ""):
+    host, path = _urlparse_host_path(link)
+    if host in allowed_hosts(config) and "/pull/" in path:
         return "github"
     raise UnsupportedPlatform(f"unsupported link/platform: {link!r} (expected a GitHub PR URL)")
 
@@ -88,32 +163,76 @@ def _sanitize_seg(s: str) -> str:
     return re.sub(r"[^A-Za-z0-9.]", "_", str(s or "")).strip("_") or "unknown"
 
 
-def github_pr_parts(link: str) -> tuple[str, str, str]:
-    """Parse ``(owner, repo, number)`` from a GitHub PR URL. Fails fast."""
-    m = GITHUB_PR_RE.search(link or "")
+def github_pr_ref(link: str, *, config: dict | None = None) -> tuple[str, str, str, str]:
+    """Parse ``(host, owner, repo, number)`` from a PR URL on an allowed GitHub
+    host. Fails fast.
+
+    Host membership uses the same PARSED-hostname exact-match allowlist as
+    ``detect_platform`` (never a substring of the raw link). The host comes
+    back canonicalized (``www.github.com`` -> ``github.com``) so identities
+    derived from it are stable. A scheme-less link (``github.com/o/r/pull/1``)
+    is tolerated by retrying with ``https://``; a malformed link is rejected
+    like any other non-PR link (never a ``ValueError`` out of ``urlparse``)."""
+    if not link or not isinstance(link, str):
+        raise AdapterParseError(f"not a GitHub PR link: {link!r}")
+    text = link.strip()
+    host, path = _urlparse_host_path(text)
+    if not host and "://" not in text:
+        host, path = _urlparse_host_path("https://" + text)
+    if host not in allowed_hosts(config):
+        raise AdapterParseError(f"not a GitHub PR link: {link!r}")
+    m = _PR_PATH_RE.match(path)
     if not m:
         raise AdapterParseError(f"not a GitHub PR link: {link!r}")
     owner, repo, number = m.group(1), m.group(2), m.group(3)
     repo = re.sub(r"\.git$", "", repo)  # tolerate a trailing .git
+    return canonical_host(host), owner, repo, number
+
+
+def github_pr_parts(link: str) -> tuple[str, str, str]:
+    """Parse ``(owner, repo, number)`` from a PR URL on an allowed GitHub host.
+    Fails fast. Callers that need the host use ``github_pr_ref``."""
+    _host, owner, repo, number = github_pr_ref(link)
     return owner, repo, number
 
 
-def parse_repo_url(link: str) -> tuple[str, str]:
-    """Parse ``(owner, repo)`` from a GitHub REPO URL (no ``/pull/``).
+def link_names_a_host(link: str) -> bool:
+    """Whether ``link`` plausibly NAMES a network host — an explicit
+    ``scheme://`` form (even with an unparseable host) or a leading
+    domain-shaped segment (``ghe.corp/…``).
+
+    Callers use this to distinguish a URL whose host failed validation (must
+    FAIL CLOSED — routing it at a default host could cross GitHub instances)
+    from a bare legacy change token (``CR-1``) that carries no host to cross
+    to. Deliberately over-matches: a dot in the first segment reads as a
+    domain, because refusing is the safe side."""
+    if not link or not isinstance(link, str):
+        return False
+    text = link.strip()
+    if _urlparse_host_path(text)[0]:
+        return True
+    if "://" in text:  # a scheme is present but the host is unparseable
+        return True
+    return "." in text.split("/", 1)[0]
+
+
+def parse_repo_ref(link: str, *, config: dict | None = None) -> tuple[str, str, str]:
+    """Parse ``(host, owner, repo)`` from a GitHub REPO URL (no ``/pull/``).
 
     Mirrors ``detect_platform``'s PARSED-hostname allowlist (default-deny,
     SSRF/allowlist guidance) but accepts a bare repo URL like
     ``https://github.com/<owner>/<repo>`` so a batch of that repo's open PRs can
-    be enumerated. Raises ``UnsupportedPlatform`` for a non-GitHub host and
+    be enumerated. Raises ``UnsupportedPlatform`` for a host outside the
+    allowlist (including a malformed URL, which parses to no host) and
     ``AdapterParseError`` when the owner/repo path segments are missing."""
     if not link or not isinstance(link, str):
         raise UnsupportedPlatform("empty or non-string repo link")
-    parsed = urlparse(link)
-    host = (parsed.hostname or "").lower()
-    if host not in {"github.com", "www.github.com"}:
+    host, path = _urlparse_host_path(link)
+    hosts = allowed_hosts(config)
+    if host not in hosts:
         raise UnsupportedPlatform(
-            f"unsupported repo host: {link!r} (expected a github.com repo URL)")
-    path = parsed.path or ""
+            f"unsupported repo host: {link!r} "
+            f"(expected a repo URL on one of: {', '.join(sorted(hosts))})")
     if "/pull/" in path:
         # A PR URL, not a repo URL — route the user to the paste flow so we don't
         # silently review the PR's whole repo.
@@ -126,16 +245,32 @@ def parse_repo_url(link: str) -> tuple[str, str]:
     _seg = re.compile(r"^[A-Za-z0-9._-]+$")
     if owner in (".", "..") or repo in (".", "..") or not (_seg.match(owner) and _seg.match(repo)):
         raise AdapterParseError(f"invalid owner/repo in {link!r}")
+    return canonical_host(host), owner, repo
+
+
+def parse_repo_url(link: str) -> tuple[str, str]:
+    """Parse ``(owner, repo)`` from a GitHub REPO URL (no ``/pull/``). Callers
+    that need the host use ``parse_repo_ref``."""
+    _host, owner, repo = parse_repo_ref(link)
     return owner, repo
 
 
-def github_change_id(owner: str, repo: str, number: str | int) -> str:
+def github_change_id(owner: str, repo: str, number: str | int,
+                     host: str = "github.com") -> str:
     """Filesystem-safe, platform-namespaced change id: ``GH-<owner>-<repo>-<n>``.
-    Unlike a raw URL, this is a valid filename."""
-    return f"GH-{_sanitize_seg(owner)}-{_sanitize_seg(repo)}-{number}"
+    Unlike a raw URL, this is a valid filename.
+
+    A non-github.com (GitHub Enterprise) host gets a leading sanitized host
+    segment (``GH-<host>-<owner>-<repo>-<n>``) so the same owner/repo/number on
+    two hosts cannot share one result file. github.com ids keep the host-less
+    shape byte-identical so already-persisted records still resolve."""
+    h = canonical_host(host)
+    prefix = f"GH-{_sanitize_seg(h)}-" if h and h != "github.com" else "GH-"
+    return f"{prefix}{_sanitize_seg(owner)}-{_sanitize_seg(repo)}-{number}"
 
 
-def github_review_key(owner: str, repo: str, number: str | int) -> str:
+def github_review_key(owner: str, repo: str, number: str | int,
+                      host: str = "github.com") -> str:
     """Collision-free canonical identity for the durable reviewed-index key.
 
     Distinct from ``github_change_id``: that value ALSO names an on-disk result
@@ -150,8 +285,11 @@ def github_review_key(owner: str, repo: str, number: str | int) -> str:
     This key never names a file, so it keeps owner/repo verbatim and joins with
     ``/`` (a character GitHub owner/repo can never contain), giving a lossless,
     unambiguous identity. Owner/repo are lower-cased because GitHub treats them
-    case-insensitively for identity."""
-    return f"github.com/{str(owner).lower()}/{str(repo).lower()}#{number}"
+    case-insensitively for identity. The key is HOST-qualified so the same
+    owner/repo on two GitHub hosts cannot collide; the github.com default keeps
+    already-persisted keys byte-identical."""
+    h = canonical_host(host) or "github.com"
+    return f"{h}/{str(owner).lower()}/{str(repo).lower()}#{number}"
 
 
 # ---------------------------------------------------------------------------
@@ -216,25 +354,28 @@ def parse_github_payload(raw: dict | str, *, link: str | None = None) -> ReviewT
     # hit different result files). The link/html_url fallback below supplies the
     # number when the payload omits it.
     number = _first(raw, "number", default="")
-    owner = repo = ""
+    owner = repo = host = ""
     full = _first(base_repo, "full_name", default="")
     if full and "/" in full:
         owner, repo = full.split("/", 1)
 
-    # Fill any missing part from the link, then from html_url.
+    # Fill any missing part (including the host) from the link, then from
+    # html_url. Without a parseable URL the host defaults to github.com.
     html_url = _first(raw, "html_url", "url", default="")
     for candidate in (link, html_url):
-        if owner and repo and number:
+        if owner and repo and number and host:
             break
         if not candidate:
             continue
         try:
-            lo, lr, ln = github_pr_parts(candidate)
+            lh, lo, lr, ln = github_pr_ref(candidate)
         except AdapterParseError:
             continue
+        host = host or lh
         owner = owner or lo
         repo = repo or lr
         number = number or ln
+    host = host or "github.com"
 
     if not (owner and repo and number):
         raise AdapterParseError(
@@ -276,9 +417,9 @@ def parse_github_payload(raw: dict | str, *, link: str | None = None) -> ReviewT
 
     return ReviewTarget(
         platform="github",
-        repo_identity=f"github.com/{owner}/{repo}",
-        change_id=github_change_id(owner, repo, number),
-        url=html_url or f"https://github.com/{owner}/{repo}/pull/{number}",
+        repo_identity=f"{host}/{owner}/{repo}",
+        change_id=github_change_id(owner, repo, number, host=host),
+        url=html_url or f"https://{host}/{owner}/{repo}/pull/{number}",
         title=title,
         description=description,
         linked_issue=extract_linked_issue(description),

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/discovery.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/discovery.py
@@ -160,14 +160,26 @@ def gh_bin() -> str:
 
 def run_gh_json(path: str, jq: str | None = None, *,
                 timeout: float = GH_TIMEOUT_SEC,
-                paginate: bool = False) -> list[dict]:
+                paginate: bool = False, host: str | None = None) -> list[dict]:
     """Run ``gh api <path>`` and parse the result into a list of dicts.
 
     ``path`` is an API path, never a shell string, and the argv is a LIST (no
-    ``shell=True``). With ``jq`` the output is JSONL (one object per line); each
-    unparseable line is skipped, but output that is entirely unparseable raises
-    rather than masquerading as an empty result."""
+    ``shell=True``). A caller-supplied ``host`` is ALWAYS pinned explicitly via
+    ``--hostname`` — including github.com — so the call can never drift to the
+    ``gh`` CLI's configured default host (``GH_HOST`` / ``gh auth``): a public
+    PR must not be read from an enterprise instance and vice versa. Callers
+    derive the host from a URL that already passed the adapters'
+    parsed-hostname allowlist; with no ``host`` the call targets whatever
+    instance the user's ``gh`` is set up for (dashboard browsing calls). With
+    ``jq`` the output is JSONL (one object per line); each unparseable line is
+    skipped, but output that is entirely unparseable raises rather than
+    masquerading as an empty result."""
     argv = [gh_bin(), "api", path]
+    h = (host or "").strip().lower()
+    if h == "www.github.com":
+        h = "github.com"
+    if h:
+        argv += ["--hostname", h]
     if paginate:
         argv.append("--paginate")
     if jq:

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/pipeline.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/pipeline.py
@@ -56,9 +56,20 @@ def _redact(text: str) -> str:
 # Entry point (b): batch paste
 # ---------------------------------------------------------------------------
 
+#: Extracts the URL embedded in a pasted token so list markers ("- ", "* "),
+#: markdown link syntax ("[PR](https://...)"), autolink brackets ("<https://...>"),
+#: and leading prose ("see https://...") don't void the hostname when the whole
+#: token is urlparse()d. Extraction only LOCATES the candidate — acceptance is
+#: still decided by ``github_pr_ref``'s parsed-hostname allowlist, so a spoof
+#: like ``https://evil.example/github.com/x/pull/1`` extracts as-is and is then
+#: refused on its parsed host.
+_EMBEDDED_URL_RE = re.compile(r"https?://[^\s<>()\[\]\"']+")
+
+
 def parse_batch(text: str) -> list[str]:
     """Split a pasted blob (newline/comma separated) into a de-duplicated,
-    order-preserving list of GitHub PR URLs. Non-PR tokens are dropped."""
+    order-preserving list of PR URLs on allowed GitHub hosts (github.com plus
+    any configured GitHub Enterprise host). Non-PR tokens are dropped."""
     if not text:
         return []
     seen: set[str] = set()
@@ -67,11 +78,17 @@ def parse_batch(text: str) -> list[str]:
         tok = tok.strip()
         if not tok:
             continue
+        # Pasted lists from Slack/issues wrap URLs in bullets, markdown, or
+        # angle brackets; hand the embedded URL (when present) to the parser
+        # instead of the raw token. No match -> raw token, preserving the
+        # schemeless "owner/repo/pull/N" case.
+        m = _EMBEDDED_URL_RE.search(tok)
+        candidate = m.group(0) if m else tok
         try:
-            owner, repo, number = adapters.github_pr_parts(tok)
+            host, owner, repo, number = adapters.github_pr_ref(candidate)
         except adapters.AdapterParseError:
             continue
-        link = f"https://github.com/{owner}/{repo}/pull/{number}"
+        link = f"https://{host}/{owner}/{repo}/pull/{number}"
         key = link.lower()
         if key not in seen:
             seen.add(key)
@@ -79,14 +96,18 @@ def parse_batch(text: str) -> list[str]:
     return out
 
 
-def list_open_prs(owner: str, repo: str, *, timeout: float = 60.0) -> list[dict]:
+def list_open_prs(owner: str, repo: str, *, host: str = "github.com",
+                  timeout: float = 60.0) -> list[dict]:
     """Enumerate a repo's OPEN pull requests via the authenticated ``gh`` CLI.
 
     Deterministic backbone (no LLM): runs ``gh api`` with a LIST argv (never
     ``shell=True``). ``owner``/``repo`` are constrained to ``[^/]+`` by
-    ``adapters.parse_repo_url`` before this is called and are interpolated only
+    ``adapters.parse_repo_ref`` before this is called and are interpolated only
     into the ``gh api`` PATH argument (which `gh` treats as an API path, not a
-    shell command), so there is no shell-injection surface. Returns
+    shell command), so there is no shell-injection surface. ``host`` has passed
+    the same parsed-hostname allowlist; a non-github.com (GitHub Enterprise)
+    host is routed to ITS instance's API via ``--hostname`` (``gh`` must be
+    authenticated for it: ``gh auth login --hostname <host>``). Returns
     ``[{url, number, head_sha, title, author, updated_at, draft}]`` in GitHub's
     order. Raises ``RuntimeError`` (with the stderr tail) if `gh` is missing,
     unauthenticated, times out, or the repo can't be read.
@@ -105,6 +126,13 @@ def list_open_prs(owner: str, repo: str, *, timeout: float = 60.0) -> list[dict]
                 "head_sha: .head.sha, title: .title, author: .user.login, "
                 "updated_at: .updated_at, draft: .draft}",
     ]
+    h = adapters.canonical_host(host)
+    # ALWAYS pin the hostname — including github.com. Omitting the flag lets
+    # the `gh` CLI's configured default host (GH_HOST / `gh auth`) decide, so
+    # a public PR on a machine whose gh defaults to an enterprise instance
+    # would list the WRONG instance's PRs.
+    if h:
+        argv += ["--hostname", h]
     try:
         proc = subprocess.run(argv, capture_output=True, text=True,
                               timeout=timeout, check=False)
@@ -232,9 +260,27 @@ FETCH_SPECS = {
 }
 
 
-def fetch_spec(platform: str) -> str:
-    """FETCH instruction for a platform (GitHub is the only platform)."""
-    return FETCH_SPECS.get(platform, FETCH_SPECS["github"])
+def fetch_spec(platform: str, host: str = "github.com") -> str:
+    """FETCH instruction for a platform (GitHub is the only platform).
+
+    For a GitHub Enterprise host the instruction routes every ``gh api`` call to
+    that instance's API via ``--hostname`` — the host has already passed the
+    adapters' parsed-hostname allowlist, so it is safe to interpolate."""
+    spec = FETCH_SPECS.get(platform, FETCH_SPECS["github"])
+    h = adapters.canonical_host(host)
+    if h:
+        # ALWAYS name the host — including github.com — so the worker's gh
+        # calls can never drift to the CLI's configured default instance.
+        spec += (
+            f". The PR lives on the GitHub host `{h}`: add "
+            f"`--hostname {h}` to EVERY `gh api` call"
+        )
+        if h != "github.com":
+            spec += (
+                f" (`gh` must be authenticated for that host: "
+                f"`gh auth login --hostname {h}`)"
+            )
+    return spec
 
 
 def _comment_body(finding: dict) -> str:

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
@@ -200,8 +200,8 @@ def _cid(link: str) -> str:
     file); otherwise a sanitized fallback (never a raw URL, which is not a valid
     filename)."""
     try:
-        owner, repo, number = pipeline.adapters.github_pr_parts(link)
-        return pipeline.adapters.github_change_id(owner, repo, number)
+        host, owner, repo, number = pipeline.adapters.github_pr_ref(link)
+        return pipeline.adapters.github_change_id(owner, repo, number, host=host)
     except pipeline.adapters.AdapterParseError:
         return results.safe_change_id(link)
 
@@ -227,19 +227,48 @@ def reviewed_key_for(link: str) -> str:
     the sanitized change-id for a non-PR link (defensive; repo-review only ever
     feeds real PR URLs from ``list_open_prs``)."""
     try:
-        owner, repo, number = pipeline.adapters.github_pr_parts(link)
-        return pipeline.adapters.github_review_key(owner, repo, number)
+        host, owner, repo, number = pipeline.adapters.github_pr_ref(link)
+        return pipeline.adapters.github_review_key(owner, repo, number, host=host)
     except pipeline.adapters.AdapterParseError:
         return results.safe_change_id(link)
 
 
+def _confirmed_host(link: str) -> str:
+    """The link's validated GitHub host, or ``""`` for a bare legacy change
+    token that names no host at all.
+
+    FAILS CLOSED: raises ``AdapterError`` when the link NAMES a host that does
+    not (re)validate against ``allowed_hosts()`` — e.g. a GitHub Enterprise
+    host removed from ``github_hosts`` between run start and prompt build, or
+    an unreadable config. Producing a prompt for such a link would let its
+    ``gh api`` calls default to PUBLIC github.com and cross GitHub instances
+    (fetching from — or posting an internal enterprise draft onto — a public
+    same-slug PR). A token that names no host (``CR-1``) has no instance to
+    cross to, so it keeps the legacy default-instructions path: ``""`` here
+    means "no host named", never "failed to resolve" — those two cases are
+    deliberately NOT allowed to look identical."""
+    try:
+        return pipeline.adapters.github_pr_ref(link)[0]
+    except pipeline.adapters.AdapterError:
+        if pipeline.adapters.link_names_a_host(link):
+            raise
+        return ""
+
+
 def _fetch_instruction(link: str) -> str:
-    """Platform-aware FETCH instruction for the gate/deep prompts (GitHub only)."""
+    """Platform-aware FETCH instruction for the gate/deep prompts (GitHub only),
+    carrying the link's confirmed host so the worker pulls the PR from ITS
+    instance's API. Fails closed via ``_confirmed_host`` — no prompt is built
+    for a link whose host cannot be revalidated."""
+    host = _confirmed_host(link)
     try:
         platform = pipeline.adapters.detect_platform(link)
-    except Exception:  # pragma: no cover - defensive (empty/odd link)
+    except Exception:  # a bare legacy token -> default GitHub instructions
         platform = "github"
-    return pipeline.fetch_spec(platform)
+    # An empty host means the token named NO host at all (legacy "CR-1" ids):
+    # those keep the CLI-default flow. A link that NAMES a host — including
+    # github.com — gets it pinned explicitly by fetch_spec.
+    return pipeline.fetch_spec(platform, host=host)
 
 
 def build_consolidation_task(namespace: str, live_path: str, candidate_path: str,
@@ -402,6 +431,22 @@ def build_post_task(change_link: str) -> str:
         "and already redacted in Python — post each one VERBATIM. Do NOT compose, edit, "
         "summarize, truncate, translate, or add to any body.\n"
     )
+    # FAIL CLOSED on host resolution — the host decides which GitHub instance
+    # every `gh api` call in this prompt targets. `_confirmed_host` raises when
+    # the link names a host that no longer revalidates (a GHE host removed from
+    # `github_hosts` mid-run, an unreadable config); producing a prompt then
+    # would let every call default to PUBLIC github.com and post an internal
+    # enterprise draft onto a public same-slug PR. The raise is converted to a
+    # per-change post failure by `post_recorded`. An empty host means the token
+    # named NO host at all (legacy "CR-1" ids) — never a failed resolution.
+    host = _confirmed_host(change_link)
+    if host:
+        # ALWAYS name the host — including github.com — so the poster's gh
+        # calls can never drift to the CLI's configured default instance.
+        _preamble += (
+            f"This PR lives on the GitHub host `{host}`: add "
+            f"`--hostname {host}` to EVERY `gh api` call below.\n"
+        )
     # GitHub's draft is a PENDING review: ONE API call carrying all inline
     # comments + a body, created WITHOUT an `event` key so it is NOT submitted.
     # The envelope is pre-built + redacted in Python (`github_review_payload`);
@@ -645,7 +690,22 @@ def post_recorded(change_id: str, link: str, *, dispatch, root: Path | None = No
         return {"post_ok": False, "post_error": staged, "posted_comments": 0,
                 "design_comment_posted": False, "pending": len(pending),
                 "expected_units": 0, "posted_keys": list(already)}
-    spawn = dispatch(build_post_task(link), timeout)
+    # The prompt builder FAILS CLOSED when the link's host no longer revalidates
+    # (see build_post_task): a prompt built with an unconfirmed host would let
+    # its `gh api` calls default to public github.com and land this draft on a
+    # public same-slug PR. Surface that as a per-change post failure — the
+    # record stays on disk for a retry once the host is configured again.
+    try:
+        post_prompt = build_post_task(link)
+    except pipeline.adapters.AdapterError as exc:
+        refused = f"refusing to post: {exc}"
+        cur["post_ok"] = False
+        cur["post_error"] = refused
+        results.write_result(cur, root, run_id)
+        return {"post_ok": False, "post_error": refused, "posted_comments": 0,
+                "design_comment_posted": False, "pending": len(pending),
+                "expected_units": 0, "posted_keys": list(already)}
+    spawn = dispatch(post_prompt, timeout)
     results.adopt_from_shared(change_id, root, run_id)
     after = results.read_result(change_id, root, run_id) or {}
     ok = bool(spawn.get("ok", False))
@@ -789,7 +849,7 @@ def _draft_confirmed(link: str, payload: dict) -> str:
     if not expected_commit:
         return ""
     try:
-        owner, repo, number = adapters.github_pr_parts(link)
+        host, owner, repo, number = adapters.github_pr_ref(link)
     except Exception:
         return ""        # not a GitHub pull request URL -> nothing to confirm
     try:
@@ -799,7 +859,8 @@ def _draft_confirmed(link: str, payload: dict) -> str:
             # when no jq is given, so page two onward makes the document invalid.
             # `.[]` streams the elements as JSONL instead. A parse failure here reads
             # as "unproven", so a busy pull request would silently never confirm.
-            f"repos/{owner}/{repo}/pulls/{number}/reviews", jq=".[]", paginate=True)
+            f"repos/{owner}/{repo}/pulls/{number}/reviews", jq=".[]", paginate=True,
+            host=host)
     except Exception:
         return ""        # gh unavailable / not authorized / timeout -> unproven
     for rev in reviews:
@@ -817,7 +878,7 @@ def _draft_confirmed(link: str, payload: dict) -> str:
         try:
             comments = discovery.run_gh_json(
                 f"repos/{owner}/{repo}/pulls/{number}/reviews/{rid}/comments",
-                jq=".[]", paginate=True)
+                jq=".[]", paginate=True, host=host)
         except Exception:
             return ""
         want = sorted(
@@ -970,12 +1031,31 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
         # beforehand is a leftover or another worker's plant, and adopting it would put
         # someone else's findings on this pull request. If the slot cannot be cleared, skip
         # adoption rather than trust it.
+        # Build the prompt BEFORE staking the shared slot: the builder FAILS
+        # CLOSED (raises) when the link's host no longer revalidates against
+        # `allowed_hosts()`, and a fetch instruction with an unconfirmed host
+        # would route the worker at public github.com — reviewing (and later
+        # posting about) a same-slug public PR instead of the intended one.
+        try:
+            review_prompt = build_review_task(link)
+        except pipeline.adapters.AdapterError as exc:
+            refused = f"refusing to review: {exc}"
+            progress(change_id, "failed", {"error": refused})
+            return {
+                "change": link, "change_id": change_id,
+                "gate_spawn_ok": False, "gate_error": refused,
+                "gate_verdict": "UNKNOWN", "phase2_ran": False,
+                "deep_spawn_ok": False, "deep_error": refused,
+                "deep_reviewed": False, "result_recorded": False,
+                "design_block": False, "deep_rounds": 0,
+                "skipped_reason": "review_failed",
+            }
         slot_clear = results.stake_shared(change_id, root)
         if _accepts_activity(dispatch):
-            review_spawn = dispatch(build_review_task(link), timeout,
+            review_spawn = dispatch(review_prompt, timeout,
                                     on_activity=report)
         else:
-            review_spawn = dispatch(build_review_task(link), timeout)
+            review_spawn = dispatch(review_prompt, timeout)
         # The worker writes the shared data/results/<id>.json its prompt names;
         # move it into this run's private dir before reading. Without this the
         # run's dir stays empty and a completed review reports no findings.
@@ -1025,8 +1105,15 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
             # failed publish means the record there is not ours, and the follow-up
             # would adopt whatever replaced it -- skip the turn instead.
             published = results.publish_to_shared(change_id, root, run_id)
-            followup = (dispatch(build_review_followup_task(link), timeout)
-                        if published or not run_id else {"ok": False})
+            # Same fail-closed contract as the first pass: no confirmed host, no
+            # follow-up turn. A failed follow-up keeps the first pass's record.
+            try:
+                followup_prompt: str | None = build_review_followup_task(link)
+            except pipeline.adapters.AdapterError:
+                followup_prompt = None
+            followup = (dispatch(followup_prompt, timeout)
+                        if followup_prompt and (published or not run_id)
+                        else {"ok": False})
             if followup.get("ok", False):
                 results.adopt_from_shared(change_id, root, run_id)
                 rev_rec = results.read_result(change_id, root, run_id) or rev_rec

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/store.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/store.py
@@ -71,6 +71,12 @@ DEFAULT_SENSITIVE_GLOBS: list[str] = [
 # composed at review time. Empty by default (OSS); users can map their own repos.
 DEFAULT_RULE_PACKS: dict[str, str] = {}
 
+# Hostnames accepted as GitHub-API-compatible, matched EXACTLY against the
+# parsed URL hostname (see ``adapters.allowed_hosts``). GitHub Enterprise Server
+# users add their instance here, mirroring ``gh auth login --hostname <host>``;
+# ``gh`` must be authenticated for each listed host.
+DEFAULT_GITHUB_HOSTS: list[str] = ["github.com"]
+
 DEFAULT_CONFIG: dict[str, object] = {
     "schema": "code-review-sage-config",
     "version": 1,
@@ -101,6 +107,8 @@ DEFAULT_CONFIG: dict[str, object] = {
     },
     "sensitive_globs": DEFAULT_SENSITIVE_GLOBS,
     "rule_packs": DEFAULT_RULE_PACKS,
+    # GitHub-compatible hosts (github.com + optional GitHub Enterprise Server).
+    "github_hosts": DEFAULT_GITHUB_HOSTS,
     # Settled-change filtering defaults.
     "exclude_settled_by_default": True,
 }
@@ -381,6 +389,21 @@ def load_config(root: Path | None = None) -> dict:
     if not cfg_path.exists():
         ensure_layout(root)
     return json.loads((data_dir(root) / "config.json").read_text(encoding="utf-8"))
+
+
+def read_config_quiet(root: Path | None = None) -> dict:
+    """Best-effort ``config.json`` read with NO side effects.
+
+    Returns ``{}`` when the file is missing, unreadable, not a JSON object, or
+    refused by the no-follow gate — unlike ``load_config`` it never creates the
+    data layout, so pure parsers (e.g. the adapters' host allowlist) can
+    consult configuration without writing to the user's data dir. The read
+    goes through ``read_json_nolink`` because ``config.json`` sits in the
+    worker-reachable data dir: a planted symlink must be refused, never
+    dereferenced. Callers treat ``{}`` as "no configuration" and fall back to
+    their defaults (``allowed_hosts`` -> ``DEFAULT_GITHUB_HOSTS``), so a
+    refusal can only ever narrow behaviour to the github.com default."""
+    return read_json_nolink(data_dir(root) / "config.json", data_dir(root)) or {}
 
 
 def _main() -> int:

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_adapters.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_adapters.py
@@ -1,10 +1,15 @@
 """Unit tests for the source adapters (GitHub + platform detection)."""
 import json
 import unittest
+from unittest import mock
 
 from sage_lib import adapters as A  # noqa: N812
 
 from tests.fixtures import GITHUB_PAYLOAD
+
+# Injected config: github.com plus two GitHub Enterprise Server hosts (a *.ghe.com
+# instance and a fully custom domain).
+GHE_CFG = {"github_hosts": ["github.com", "acme.ghe.com", "git.corp.example"]}
 
 
 class TestPlatformDetection(unittest.TestCase):
@@ -22,6 +27,158 @@ class TestPlatformDetection(unittest.TestCase):
     def test_empty(self):
         with self.assertRaises(A.UnsupportedPlatform):
             A.detect_platform("")
+
+
+class TestAllowedHosts(unittest.TestCase):
+    def test_default_is_github_only(self):
+        self.assertEqual(A.allowed_hosts({}),
+                         frozenset({"github.com", "www.github.com"}))
+
+    def test_configured_ghe_hosts_are_added(self):
+        hosts = A.allowed_hosts(GHE_CFG)
+        for h in ("acme.ghe.com", "git.corp.example", "github.com", "www.github.com"):
+            self.assertIn(h, hosts)
+
+    def test_www_only_config_round_trips(self):
+        # `www.github.com` canonicalizes to `github.com` downstream, so a
+        # www-only config must also accept the canonical form — otherwise an
+        # accepted link fails to resolve on its second pass.
+        self.assertEqual(A.allowed_hosts({"github_hosts": ["www.github.com"]}),
+                         frozenset({"github.com", "www.github.com"}))
+
+    def test_config_entries_are_normalized(self):
+        # A pasted URL, mixed case, and empties are tolerated; the list REPLACES
+        # the default, so an enterprise can lock Sage to its own host.
+        hosts = A.allowed_hosts({"github_hosts": ["https://ACME.ghe.com/", "", None]})
+        self.assertEqual(hosts, frozenset({"acme.ghe.com"}))
+
+    def test_non_list_config_falls_back_to_default(self):
+        self.assertEqual(A.allowed_hosts({"github_hosts": "nonsense"}),
+                         frozenset({"github.com", "www.github.com"}))
+
+    def test_refused_config_read_falls_back_to_default(self):
+        # A no-follow refusal (planted config.json symlink) surfaces as {} from
+        # read_config_quiet: the allowlist must narrow to the github.com
+        # default — a refusal can never widen or empty the allowed set.
+        with mock.patch.object(A.store, "read_config_quiet", return_value={}):
+            self.assertEqual(A.allowed_hosts(),
+                             frozenset({"github.com", "www.github.com"}))
+
+    def test_malformed_config_url_entry_is_skipped(self):
+        # urlparse raises ValueError on an unmatched '[' — a malformed configured
+        # entry must be dropped, not crash host resolution.
+        self.assertEqual(A.allowed_hosts({"github_hosts": ["https://[::1",
+                                                           "acme.ghe.com"]}),
+                         frozenset({"acme.ghe.com"}))
+
+
+class TestEnterpriseHosts(unittest.TestCase):
+    def test_detect_platform_accepts_configured_ghe_pr(self):
+        self.assertEqual(
+            A.detect_platform("https://acme.ghe.com/org/repo/pull/5", config=GHE_CFG),
+            "github")
+
+    def test_detect_platform_accepts_custom_domain(self):
+        self.assertEqual(
+            A.detect_platform("https://git.corp.example/o/r/pull/1", config=GHE_CFG),
+            "github")
+
+    def test_unconfigured_ghe_host_still_rejected(self):
+        with self.assertRaises(A.UnsupportedPlatform):
+            A.detect_platform("https://acme.ghe.com/org/repo/pull/5", config={})
+
+    def test_github_and_www_still_accepted(self):
+        for url in ("https://github.com/o/r/pull/1",
+                    "https://www.github.com/o/r/pull/1"):
+            self.assertEqual(A.detect_platform(url, config=GHE_CFG), "github")
+
+    def test_allowed_host_in_path_is_rejected(self):
+        # The allowlist matches the PARSED hostname, never a substring of the raw
+        # link: an allowed host appearing only in the PATH must be refused.
+        with self.assertRaises(A.UnsupportedPlatform):
+            A.detect_platform("https://evil.example/github.com/x/pull/1",
+                              config=GHE_CFG)
+        with self.assertRaises(A.AdapterParseError):
+            A.github_pr_ref("https://evil.example/github.com/x/y/pull/1",
+                            config=GHE_CFG)
+
+    def test_spoofable_host_shapes_are_rejected(self):
+        # A host that merely embeds a permitted string must be refused: neither a
+        # prefixed spelling nor a permitted-host-as-subdomain may match.
+        for url in ("https://notgithub.com/o/r/pull/1",
+                    "https://github.com.evil.example/o/r/pull/1",
+                    "https://notacme.ghe.com/o/r/pull/1",
+                    "https://acme.ghe.com.evil.example/o/r/pull/1"):
+            with self.assertRaises(A.UnsupportedPlatform):
+                A.detect_platform(url, config=GHE_CFG)
+            with self.assertRaises(A.AdapterParseError):
+                A.github_pr_ref(url, config=GHE_CFG)
+
+    def test_pr_ref_parses_host(self):
+        self.assertEqual(
+            A.github_pr_ref("https://acme.ghe.com/org/repo/pull/5", config=GHE_CFG),
+            ("acme.ghe.com", "org", "repo", "5"))
+
+    def test_pr_ref_canonicalizes_www_and_tolerates_schemeless(self):
+        self.assertEqual(A.github_pr_ref("https://www.github.com/o/r/pull/1")[0],
+                         "github.com")
+        self.assertEqual(A.github_pr_parts("github.com/o/r/pull/1"), ("o", "r", "1"))
+
+    def test_identity_is_host_qualified_for_ghe(self):
+        with mock.patch.object(A.store, "read_config_quiet", return_value=GHE_CFG):
+            t = A.normalize(
+                "https://acme.ghe.com/org/repo/pull/5",
+                {"number": 5, "body": "hello",
+                 "html_url": "https://acme.ghe.com/org/repo/pull/5"})
+        self.assertEqual(t.repo_identity, "acme.ghe.com/org/repo")
+        self.assertEqual(t.change_id, "GH-acme.ghe.com-org-repo-5")
+        self.assertEqual(t.url, "https://acme.ghe.com/org/repo/pull/5")
+
+    def test_github_identity_unchanged(self):
+        # github.com identities stay byte-identical so already-persisted runs
+        # (result files, reviewed.json keys) still resolve.
+        t = A.normalize("https://github.com/org/repo/pull/5",
+                        {"number": 5, "body": "hello",
+                         "html_url": "https://github.com/org/repo/pull/5"})
+        self.assertEqual(t.repo_identity, "github.com/org/repo")
+        self.assertEqual(t.change_id, "GH-org-repo-5")
+        self.assertEqual(A.github_review_key("Org", "Repo", 5),
+                         "github.com/org/repo#5")
+
+    def test_review_key_is_host_qualified(self):
+        self.assertEqual(A.github_review_key("Org", "Repo", 5, host="acme.ghe.com"),
+                         "acme.ghe.com/org/repo#5")
+        # www canonicalizes to github.com, so both spellings share one key.
+        self.assertEqual(A.github_review_key("o", "r", 1, host="www.github.com"),
+                         "github.com/o/r#1")
+
+    def test_change_id_hosts_do_not_collide(self):
+        self.assertNotEqual(
+            A.github_change_id("o", "r", 1),
+            A.github_change_id("o", "r", 1, host="acme.ghe.com"))
+
+    def test_malformed_links_are_rejected_not_crashed_on(self):
+        # urlparse raises ValueError on these shapes ("Invalid IPv6 URL" /
+        # bracketed non-IPv6 netloc). Both entry points sit on user-pasted text,
+        # so a malformed link must read as "not a PR link" — a raised ValueError
+        # would 500 the request and discard every valid link in the batch.
+        for bad in ("https://[::1", "https://[github.com]/o/r/pull/1"):
+            with self.assertRaises(A.UnsupportedPlatform):
+                A.detect_platform(bad)
+            with self.assertRaises(A.AdapterParseError):
+                A.github_pr_ref(bad)
+            with self.assertRaises(A.UnsupportedPlatform):
+                A.parse_repo_ref(bad)
+
+    def test_link_names_a_host_separates_urls_from_bare_tokens(self):
+        # The fail-closed boundary: anything that names a host (parseable or
+        # not) must resolve-or-refuse; a bare change token has no host to cross
+        # GitHub instances with and may keep the legacy path.
+        for named in ("https://acme.ghe.com/o/r/pull/1", "https://[::1",
+                      "ghe.corp/o/r/pull/1", "www.github.com/o/r/pull/1"):
+            self.assertTrue(A.link_names_a_host(named), named)
+        for bare in ("CR-1", "u", "", None, "GH-o-r-1"):
+            self.assertFalse(A.link_names_a_host(bare), bare)
 
 
 class TestFailFast(unittest.TestCase):

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_paste_pr_link.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_paste_pr_link.py
@@ -9,6 +9,7 @@ back so the caller can open it.
 """
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import tempfile
@@ -114,6 +115,38 @@ class TestRepoEndpointWithPullRequest(unittest.IsolatedAsyncioTestCase):
         resp = await routes._handle_repos(_FakeRequest(  # type: ignore[arg-type]
             {"repo": "https://evil.test/kirodotdev/KiroCrew/pull/777"}))
         self.assertEqual(resp.status, 400)
+
+    def _allow_ghe_host(self):
+        # Write the opt-in host into THIS test's isolated config.json, exercising
+        # the real config path the adapters read.
+        cfg_path = store.data_dir() / "config.json"
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+        cfg["github_hosts"] = ["github.com", "acme.ghe.com"]
+        cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+
+    async def test_a_ghe_pull_request_cannot_be_pinned(self):
+        # The pinned-repo store carries no host, so pinning would silently target
+        # the wrong instance later; the refusal points at the PR paste flow.
+        self._allow_ghe_host()
+        resp = await routes._handle_repos(_FakeRequest(  # type: ignore[arg-type]
+            {"repo": "https://acme.ghe.com/o/r/pull/9"}))
+        self.assertEqual(resp.status, 400)
+        self.assertIn("unsupported_repo_host", _text(resp))
+
+    async def test_a_ghe_repo_url_cannot_be_pinned(self):
+        self._allow_ghe_host()
+        resp = await routes._handle_repos(_FakeRequest(  # type: ignore[arg-type]
+            {"repo": "https://acme.ghe.com/o/r"}))
+        self.assertEqual(resp.status, 400)
+        self.assertIn("unsupported_repo_host", _text(resp))
+
+    async def test_pull_request_ref_keeps_the_ghe_host(self):
+        self._allow_ghe_host()
+        ref = routes._pull_request_ref("https://acme.ghe.com/o/r/pull/9")
+        assert ref is not None
+        self.assertEqual(ref["host"], "acme.ghe.com")
+        self.assertEqual(ref["url"], "https://acme.ghe.com/o/r/pull/9")
+        self.assertEqual(ref["change_id"], "GH-acme.ghe.com-o-r-9")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_pipeline.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_pipeline.py
@@ -27,6 +27,53 @@ class TestBatchParse(unittest.TestCase):
     def test_empty(self):
         self.assertEqual(P.parse_batch(""), [])
 
+    def test_a_malformed_link_does_not_sink_the_batch(self):
+        # "https://[::1" makes urlparse raise ValueError. The user-facing failure
+        # this guards: one malformed entry in a pasted batch used to crash the
+        # whole request (HTTP 500), discarding every valid link with it.
+        out = P.parse_batch("https://github.com/o/r/pull/3\n"
+                            "https://[::1\n"
+                            "https://github.com/o/r/pull/4")
+        self.assertEqual(out, ["https://github.com/o/r/pull/3",
+                               "https://github.com/o/r/pull/4"])
+
+    def test_ghe_links_keep_their_host(self):
+        cfg = {"github_hosts": ["github.com", "acme.ghe.com"]}
+        text = ("https://acme.ghe.com/org/repo/pull/9\n"
+                "https://github.com/o/r/pull/3\n"
+                "https://evil.example/github.com/x/y/pull/1")
+        with mock.patch.object(P.adapters.store, "read_config_quiet",
+                               return_value=cfg):
+            out = P.parse_batch(text)
+        # The GHE host survives normalization (flattening it to github.com would
+        # point the review at the wrong instance); the path-spoof is dropped.
+        self.assertEqual(out, ["https://acme.ghe.com/org/repo/pull/9",
+                               "https://github.com/o/r/pull/3"])
+
+    def test_prefixed_tokens_yield_their_embedded_url(self):
+        # Bulleted/markdown lists are the normal clipboard shape from Slack or
+        # an issue. The user-facing failure this guards: every prefixed link
+        # used to be dropped silently, so the batch under-reviewed with no
+        # error. Each shape must yield its embedded PR URL.
+        text = ("- https://github.com/o/r/pull/1\n"
+                "* https://github.com/o/r/pull/2\n"
+                "[PR](https://github.com/o/r/pull/3)\n"
+                "<https://github.com/o/r/pull/4>\n"
+                "see https://github.com/o/r/pull/5\n"
+                "https://github.com/o/r/pull/6")
+        self.assertEqual(P.parse_batch(text),
+                         [f"https://github.com/o/r/pull/{n}"
+                          for n in range(1, 7)])
+
+    def test_prefix_extraction_does_not_weaken_host_matching(self):
+        # Extraction locates the URL; acceptance still runs on the PARSED
+        # hostname. A prefixed path-spoof must stay refused, and a token whose
+        # first URL is hostile must not fall through to a later friendly one.
+        text = ("- https://evil.example/github.com/x/y/pull/1\n"
+                "see https://evil.example/z https://github.com/o/r/pull/2\n"
+                "* https://github.com.evil.example/o/r/pull/3")
+        self.assertEqual(P.parse_batch(text), [])
+
 
 class TestRulePack(unittest.TestCase):
     def test_unmapped_repo_returns_none(self):

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_post_comments.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_post_comments.py
@@ -138,6 +138,35 @@ class TestPostRecorded(_Base):
         self.assertIn("stage", out["post_error"])
         self.assertEqual(out["posted_comments"], 0)
 
+    async def test_an_unresolvable_host_aborts_the_post_fail_closed(self):
+        """A link whose host is no longer in `allowed_hosts()` (the GHE host was
+        removed from `github_hosts` between run start and posting) must abort
+        BEFORE any poster runs. A prompt built anyway would carry no
+        `--hostname`, every `gh api` call in it would default to PUBLIC
+        github.com, and the internal enterprise draft would land on a public
+        same-slug PR — so no dispatch may happen at all."""
+        results.write_result(_record(red=1, yellow=0), self.root, "run-a")
+        calls: list = []
+
+        def dispatch(task, timeout=0):
+            calls.append(task)
+            return {"ok": True, "output": "posted", "error": ""}
+
+        with unittest.mock.patch.object(
+                D.pipeline.adapters.store, "read_config_quiet",
+                return_value={"github_hosts": ["github.com"]}):
+            out = await asyncio.to_thread(
+                D.post_recorded, "CR-1", "https://acme.ghe.com/o/r/pull/1",
+                dispatch=dispatch, confirm=_confirmed, root=self.root,
+                run_id="run-a")
+
+        self.assertFalse(out["post_ok"])
+        self.assertIn("refusing to post", out["post_error"])
+        self.assertFalse(calls)               # nothing was ever dispatched
+        # The record survives for a retry once the host is configured again.
+        rec = results.read_result("CR-1", self.root, "run-a") or {}
+        self.assertEqual(rec.get("post_error"), out["post_error"])
+
     async def test_no_poster_is_spawned_when_there_is_nothing_to_post(self):
         results.write_result(_record(red=0, yellow=0), self.root, "run-a")
         calls: list = []
@@ -822,8 +851,9 @@ class TestPaginationContract(unittest.TestCase):
 
         calls: list[dict] = []
 
-        def run_gh_json(path, jq=None, *, timeout=0, paginate=False):
-            calls.append({"path": path, "jq": jq, "paginate": paginate})
+        def run_gh_json(path, jq=None, *, timeout=0, paginate=False, host=None):
+            calls.append({"path": path, "jq": jq, "paginate": paginate,
+                          "host": host})
             if "/comments" in path:
                 return [{"path": "src/a.py", "line": 4, "body": "widens scope"}]
             return [{"id": 7, "state": "PENDING", "commit_id": "abc123",
@@ -858,7 +888,7 @@ class TestDraftConfirmed(unittest.TestCase):
 
     def _stub(self, reviews, comments):
         """Answer the two `gh api` reads `_draft_confirmed` makes."""
-        def run_gh_json(path, jq=None, *, paginate=False):
+        def run_gh_json(path, jq=None, *, paginate=False, host=None):
             return comments if "/comments" in path else reviews
         return run_gh_json
 

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_repo_review.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_repo_review.py
@@ -50,6 +50,23 @@ class TestParseRepoUrl(unittest.TestCase):
         with self.assertRaises(adapters.AdapterParseError):
             adapters.parse_repo_url("https://github.com/../r")
 
+    def test_rejection_names_the_accepted_hosts(self):
+        # The error must say what IS accepted now that the set is configurable.
+        with self.assertRaises(adapters.UnsupportedPlatform) as ctx:
+            adapters.parse_repo_ref("https://evil.example/o/r", config={})
+        self.assertIn("github.com", str(ctx.exception))
+
+    def test_parse_repo_ref_accepts_configured_ghe_host(self):
+        cfg = {"github_hosts": ["github.com", "acme.ghe.com"]}
+        self.assertEqual(
+            adapters.parse_repo_ref("https://acme.ghe.com/octo/hello", config=cfg),
+            ("acme.ghe.com", "octo", "hello"))
+        # Spoofable shapes stay rejected (exact parsed-hostname match only).
+        for url in ("https://notacme.ghe.com/o/r",
+                    "https://acme.ghe.com.evil.example/o/r"):
+            with self.assertRaises(adapters.UnsupportedPlatform):
+                adapters.parse_repo_ref(url, config=cfg)
+
 
 class TestListOpenPrs(unittest.TestCase):
     def _cp(self, returncode=0, stdout="", stderr=""):
@@ -93,6 +110,22 @@ class TestListOpenPrs(unittest.TestCase):
         self.assertEqual(os.path.basename(captured["argv"][0]), "gh")
         self.assertEqual(captured["argv"][1:3],
                          ["api", "repos/o/r/pulls?state=open&per_page=100"])
+        # github.com is pinned EXPLICITLY too: omitting --hostname would let
+        # the gh CLI's configured default host (GH_HOST) decide the instance.
+        i = captured["argv"].index("--hostname")
+        self.assertEqual(captured["argv"][i + 1], "github.com")
+
+    def test_ghe_host_routes_to_that_instance(self):
+        captured = {}
+
+        def fake_run(argv, **kw):
+            captured["argv"] = argv
+            return self._cp(stdout="")
+        with patch.object(pipeline.subprocess, "run", side_effect=fake_run):
+            pipeline.list_open_prs("o", "r", host="acme.ghe.com")
+        # A GHE repo is enumerated against ITS instance's API, not api.github.com.
+        i = captured["argv"].index("--hostname")
+        self.assertEqual(captured["argv"][i + 1], "acme.ghe.com")
 
     def test_nonzero_exit_raises(self):
         with patch.object(pipeline.subprocess, "run",

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
@@ -5,10 +5,89 @@ import tempfile
 import threading
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from sage_lib import results
 from sage_lib import review_driver as D  # noqa: N812
 from sage_lib import store
+
+
+class TestHostQualifiedIdentity(unittest.TestCase):
+    """Change ids and reviewed keys are the persisted run-scoping keys: a GitHub
+    Enterprise host must qualify them (or two hosts' runs collide in storage),
+    while github.com keys stay byte-identical so old records resolve."""
+
+    GHE_CFG = {"github_hosts": ["github.com", "acme.ghe.com"]}
+
+    def test_github_keys_unchanged(self):
+        self.assertEqual(D.change_id_for("https://github.com/o/r/pull/7"), "GH-o-r-7")
+        self.assertEqual(D.reviewed_key_for("https://github.com/o/r/pull/7"),
+                         "github.com/o/r#7")
+
+    def test_ghe_keys_carry_the_host(self):
+        with mock.patch.object(D.pipeline.adapters.store, "read_config_quiet",
+                               return_value=self.GHE_CFG):
+            self.assertEqual(D.change_id_for("https://acme.ghe.com/o/r/pull/7"),
+                             "GH-acme.ghe.com-o-r-7")
+            self.assertEqual(D.reviewed_key_for("https://acme.ghe.com/o/r/pull/7"),
+                             "acme.ghe.com/o/r#7")
+
+    def test_fetch_and_post_prompts_route_to_the_ghe_api(self):
+        with mock.patch.object(D.pipeline.adapters.store, "read_config_quiet",
+                               return_value=self.GHE_CFG):
+            fetch = D._fetch_instruction("https://acme.ghe.com/o/r/pull/7")
+            post = D.build_post_task("https://acme.ghe.com/o/r/pull/7")
+            gh_fetch = D._fetch_instruction("https://github.com/o/r/pull/7")
+            gh_post = D.build_post_task("https://github.com/o/r/pull/7")
+        self.assertIn("--hostname acme.ghe.com", fetch)
+        self.assertIn("--hostname acme.ghe.com", post)
+        # github.com prompts pin their host EXPLICITLY too — omission would
+        # let the worker's gh CLI default host decide the instance.
+        self.assertIn("--hostname github.com", gh_fetch)
+        self.assertIn("--hostname github.com", gh_post)
+
+    def test_a_bare_change_token_keeps_the_legacy_path(self):
+        # "CR-1" names no host, so there is no GitHub instance to cross to —
+        # builders keep producing default-instruction prompts for it (the
+        # driver's legacy flow relies on this). Only a link that NAMES a host
+        # must resolve-or-refuse.
+        self.assertIn("CR-1", D.build_post_task("CR-1"))
+        self.assertNotIn("--hostname", D.build_post_task("CR-1"))
+        self.assertNotIn("--hostname", D.build_review_task("CR-1"))
+
+    def test_prompt_builders_fail_closed_on_an_unresolvable_host(self):
+        """The leak guard: when the link's host no longer revalidates (e.g. the
+        GHE host was removed from `github_hosts` between run start and this
+        build), every prompt builder must REFUSE — a prompt whose `gh api`
+        calls silently default to public github.com would fetch from, or post
+        an internal enterprise draft onto, a public same-slug PR."""
+        link = "https://acme.ghe.com/o/r/pull/7"
+        with mock.patch.object(D.pipeline.adapters.store, "read_config_quiet",
+                               return_value={"github_hosts": ["github.com"]}):
+            for builder in (D.build_post_task, D._fetch_instruction,
+                            D.build_review_task, D.build_review_followup_task):
+                with self.assertRaises(D.pipeline.adapters.AdapterError):
+                    builder(link)
+                # A scheme is a named host too, even when it cannot be parsed.
+                with self.assertRaises(D.pipeline.adapters.AdapterError):
+                    builder("https://[::1")
+
+    def test_non_github_prompts_always_carry_hostname(self):
+        """The property that prevents the cross-host leak: for a non-github.com
+        link there is no outcome where a prompt exists WITHOUT `--hostname` —
+        either the host revalidates and the flag is embedded, or the builder
+        raises (asserted above). "Resolved as github.com" and "failed to
+        resolve" must never look identical."""
+        with mock.patch.object(D.pipeline.adapters.store, "read_config_quiet",
+                               return_value=self.GHE_CFG):
+            for builder in (D.build_post_task, D._fetch_instruction,
+                            D.build_review_task, D.build_review_followup_task):
+                prompt = builder("https://acme.ghe.com/o/r/pull/7")
+                self.assertIn("--hostname acme.ghe.com", prompt,
+                              f"{builder.__name__} lost the hostname routing")
+                gh = builder("https://github.com/o/r/pull/7")
+                self.assertIn("--hostname github.com", gh,
+                              f"{builder.__name__} left github.com unpinned")
 
 
 def _confirmed(_link, _units):

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_store_selfheal.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_store_selfheal.py
@@ -75,3 +75,47 @@ class TestSeedConfigUpgrade(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestReadConfigQuiet(unittest.TestCase):
+    """read_config_quiet: side-effect-free AND no-follow. config.json sits in
+    the worker-reachable data dir, and the allowlist resolution the adapters
+    run on every pasted URL reads it — so a planted symlink must be refused,
+    never dereferenced into whatever the gateway can read."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.root = Path(self.tmp) / "apps" / "code-review-sage"
+        self.data = self.root / "data"
+        self.data.mkdir(parents=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_normal_config_reads(self):
+        (self.data / "config.json").write_text(
+            json.dumps({"github_hosts": ["github.com"]}), encoding="utf-8")
+        self.assertEqual(store.read_config_quiet(self.root),
+                         {"github_hosts": ["github.com"]})
+
+    def test_missing_config_is_empty_and_creates_nothing(self):
+        shutil.rmtree(self.data)
+        self.assertEqual(store.read_config_quiet(self.root), {})
+        self.assertFalse(self.data.exists())   # never self-heals the layout
+
+    def test_non_dict_payload_is_empty(self):
+        (self.data / "config.json").write_text("[1, 2, 3]", encoding="utf-8")
+        self.assertEqual(store.read_config_quiet(self.root), {})
+
+    def test_symlinked_config_is_refused_not_dereferenced(self):
+        # A worker-planted link pointing OUTSIDE the data dir: the gate must
+        # refuse it, so URL parsing can never make the gateway follow a link
+        # to a blocked credential file.
+        outside = Path(self.tmp) / "outside.json"
+        outside.write_text(json.dumps({"github_hosts": ["evil.example"]}),
+                           encoding="utf-8")
+        try:
+            (self.data / "config.json").symlink_to(outside)
+        except (OSError, NotImplementedError):  # pragma: no cover
+            self.skipTest("symlinks unavailable on this host")
+        self.assertEqual(store.read_config_quiet(self.root), {})


### PR DESCRIPTION
## Problem

Code Review Sage rejects GitHub Enterprise Server PR URLs (e.g. `https://xxx.ghe.com/org/repo/pull/123`): its host validation accepts only `github.com`/`www.github.com`, so GHE users cannot use Sage at all — even though GHE Server exposes the same API surface and URL grammar, differing only in the base host.

## Why it matters

Enterprise users run their code on GHE instances. A hardcoded host literal locks the entire app to public GitHub, with no configuration escape hatch — the same gap `gh auth login --hostname` exists to close for the GitHub CLI.

## Fix (symptoms → root cause → change)

Symptom: every GHE URL fails `detect_platform` / `parse_repo_url`. Root cause: the accepted host was a hardcoded literal set repeated across comparisons, and host was discarded when deriving identities and `gh api` calls. Change:

- **Single resolution point** — `adapters.allowed_hosts()` sources the accepted hosts from `config.json`'s new `github_hosts` list (seeded/upgraded by the existing `_seed_config` path; default `["github.com"]`, so behaviour is unchanged when unconfigured). All host checks (`detect_platform`, new `github_pr_ref`, new `parse_repo_ref`) go through it.
- **Anti-spoofing preserved** — membership is EXACT equality on the PARSED URL hostname, never a substring/regex of the raw link; PR URLs still require the `/pull/` path segment. `https://evil.example/github.com/x/pull/1`, `notgithub.com`, and `github.com.evil.example` are all refused, with explicit negative tests. The explanatory comment stays accurate.
- **Host-qualified identities** — `repo_identity`, `github_change_id`, and `github_review_key` carry the actual host for GHE, so runs for the same org/repo on two hosts cannot collide in storage; github.com identities stay **byte-identical** so already-persisted runs/reviewed-index keys still resolve. The `rsplit("github.com/", 1)` headline reader in `backend/routes.py` now parses host-aware (old behaviour kept as fallback). In-flight claims key on these same values.
- **API base follows the host** — Sage uses the `gh` CLI: `list_open_prs` and the draft read-back (`run_gh_json`) pass `--hostname <host>` for non-github.com hosts, and the fetch/post worker prompts instruct the isolated sessions to do the same, so a GHE PR is fetched from and posted to its own instance's API, never `api.github.com`.
- **Error message** at the repo-URL parser now names the actually-accepted hosts.
- Pinning a GHE repo in the sidebar is refused with a pointer to the PR paste flow (the pinned-repo store carries no host; silently pinning would target the wrong instance). PR paste — single and batch — and repo-URL runs fully support GHE.

Scope guard respected: GitHub-compatible hosts only; no GitLab/Bitbucket; no unrelated refactors.

## Tests

- Accept a `*.ghe.com` PR URL and a fully custom GHE domain (configured); keep accepting `github.com` and `www.github.com`.
- Reject the spoofing shapes: allowed host in the path, `notgithub.com`, `github.com.evil.example` (both prefix and suffix variants, for both the default and a configured GHE host).
- `repo_identity`/change-id/reviewed-key host-qualified for GHE and byte-identical for github.com (adapter, driver, and route layers).
- `--hostname` present in `gh api` argv for GHE and absent for github.com; fetch/post prompts carry the hostname clause only for GHE.
- Config normalization (pasted URL, casing, empties; non-list falls back to default); GHE pin refusal endpoints.

Sage package suite: 657 passed locally (isort/flake8/mypy clean; 5 pre-existing `gh`-binary environment failures in `TestListOpenPrs` fail identically on clean `origin/main`).

## Manual verification

N/A — unit coverage exercises the parsing, identity, and argv construction directly; no GHE instance is reachable from this host.

## Screenshots

N/A — no UI change.

Closes #2154
