### PR TITLE
docs: document the Windows NSIS build path in electron README (#2211)

### DIFF
--- a/website/electron/README.md
+++ b/website/electron/README.md
@@ -1,7 +1,8 @@
 # KiroCrew Desktop (Electron)
 
-Desktop shell for the Kiro Crew web dashboard on macOS and Linux. It
-automatically starts `kirocrew gateway` and connects to `localhost:5476`.
+Desktop shell for the Kiro Crew web dashboard on macOS, Linux, and Windows
+(Windows is in preview — see the build note below). It automatically starts
+`kirocrew gateway` and connects to `localhost:5476`.
 
 ## Quick Start
 
@@ -59,6 +60,35 @@ npm run dist
 ```
 
 Output goes to `electron/dist/`.
+
+## Build Windows Installer (NSIS)
+
+The Windows desktop build is wired end to end: `package.json` declares an
+`nsis` target under `build.win`, and `packaging/build-desktop.sh` has a full
+Windows branch. Run it from Git Bash (or MSYS/Cygwin — the script normalizes
+those to `windows`) at the repo root:
+
+```bash
+bash packaging/build-desktop.sh
+```
+
+Notes:
+
+- **The build must run natively on Windows**, not cross-built from macOS or
+  Linux: the script provisions a Windows python-build-standalone interpreter
+  via `uv` and executes its `python.exe` to install and verify the bundled
+  backend, then runs `electron-builder --win` to produce the NSIS installer.
+- **Signing is optional for a local build.** The `signtoolOptions.sign` hook
+  (`scripts/sign-windows.js`) skips cleanly when none of the
+  `WINDOWS_SIGNING_*` environment variables are set, so a credential-less
+  build produces a working unsigned installer. (Setting only some of the five
+  variables is treated as a misconfiguration and fails the build.)
+- The result is an assisted (non-one-click, per-user) NSIS installer,
+  `KiroCrew Setup <version>.exe` (nightly builds:
+  `KiroCrew Nightly Setup <version>.exe`), in `website/electron/dist/`.
+
+See `../../docs/guides/windows-install.md` for the CI-built installer and the
+current Windows support status.
 
 ## Updating
 


### PR DESCRIPTION
## Summary

`website/electron/README.md` said the desktop shell targets macOS and Linux only, but a Windows build is wired end to end. This PR is documentation only — no build script or packaging behaviour changes.

- Platform line now includes Windows, marked as preview to match `docs/guides/windows-install.md` (CI-artifact installer, no auto-update yet).
- New **Build Windows Installer (NSIS)** section, with every claim verified against the sources:
  - `website/electron/package.json` declares `build.win` with an `nsis` target and a `signtoolOptions.sign` hook (`nsis.oneClick: false`, `perMachine: false` → assisted, per-user installer).
  - `packaging/build-desktop.sh` normalizes MINGW/MSYS/Cygwin `uname` to `windows`, provisions a Windows python-build-standalone interpreter via `uv`, executes its `python.exe` to install and verify the bundled backend, then runs `electron-builder --win` — so the build must run natively on Windows.
  - `website/electron/scripts/sign-windows.js` skips cleanly when none of the five `WINDOWS_SIGNING_*` vars are set (unsigned local builds work); a partial set throws.
  - Installer lands in `website/electron/dist/` as `KiroCrew Setup <version>.exe` (nightly: `KiroCrew Nightly Setup <version>.exe`, per the `PRODUCT_NAME` override in `build-desktop.sh`).

## Testing

- Backend gates: `isort` / `flake8` / `mypy` clean; `pytest` 38520 passed — the 65 failures are pre-existing host-environment issues (sandbox backend unavailable, git/gh shelling) in modules untouched by this change.
- Frontend gates: `npx tsc -b` clean; `vitest` 11338 passed — the 2 failures are the pre-existing `ko` i18n catalog-parity drift on main.
- Brand-name gate and docs lint pass; relative link `../../docs/guides/windows-install.md` verified to resolve.
- Pre-push review fleet: one Medium finding (installer path vantage) and two advisories (preview wording, nightly filename) — all three applied.

No UI change; no screenshots.

Closes #2211
