### PR TITLE
fix: Enforce consolidation retry eligibility inside _consolidate as a single choke point (#2135)

### DIFF
--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -673,8 +673,10 @@ def _consolidate_cmd(args) -> None:
                     print(f"  {key}: no unconsolidated messages, skipping")
                     continue
                 print(f"  {key}: consolidating {count} messages...")
-                await consolidator.consolidate_now(key)
-                print(f"  {key}: done ✓")
+                if await consolidator.consolidate_now(key):
+                    print(f"  {key}: done ✓")
+                else:
+                    print(f"  {key}: skipped (consolidation retry backoff)")
             except Exception:
                 logger.debug("consolidate (or SEL) failed for %s", key, exc_info=True)
 

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -65,6 +65,18 @@ ARCHIVE_RETENTION_DAYS = 7
 # make a right-most-dot parse attribute a segment to the wrong session.
 ARCHIVE_SEGMENT_DELIMITER = "__"
 _CONSOLIDATION_THRESHOLD = 30  # preferences/projects update threshold (messages)
+
+
+# Returned by _consolidate when its retry-eligibility gate refuses the span.
+# Distinct from None (a pass that ran, or found nothing to do) so callers'
+# done-callbacks can tell a refusal from a completed pass: a refusal must not
+# advance their bookkeeping (offsets, throttles) as if the window had been
+# processed, and raising instead would log a routine backoff as a task failure.
+class _ConsolidationRefusedSentinel:
+    __slots__ = ()
+
+
+_CONSOLIDATION_REFUSED = _ConsolidationRefusedSentinel()
 # Persistent retry accounting for history consolidation. A pass spends a billed
 # LLM turn BEFORE it can write the durable "consolidated" marker, so any failure
 # in between leaves the span unconsolidated — and every entry point (the 60s
@@ -4005,7 +4017,9 @@ class HistoryConsolidator:
         """True when *key* may spend a billed consolidation turn right now.
 
         Every automatic entry point consults this so a span whose consolidation
-        keeps failing backs off instead of re-billing an LLM turn on each sweep.
+        keeps failing backs off instead of re-billing an LLM turn on each sweep,
+        and _consolidate() itself enforces it as the final gate, so an entry
+        point without a pre-check of its own still cannot bypass the backoff.
         A span at :data:`_CONSOLIDATION_MAX_ATTEMPTS` is refused: the abandon path
         normally writes the marker (which also clears the accounting), so reaching
         here at the cap means even that write failed, and refusing keeps a broken
@@ -4143,13 +4157,31 @@ class HistoryConsolidator:
         prefs_off = self._prefs_offset.get(key, 0)
         if total - prefs_off < _CONSOLIDATION_THRESHOLD:
             return
+        # Cheap pre-check mirroring the other automatic entry points. This
+        # runs on every user turn, so during a backoff window every message
+        # past the threshold would otherwise schedule a task whose snapshot
+        # takes the per-file lock (the same one appends contend on) and reads
+        # the transcript, only to be refused by the gate inside _consolidate().
+        # retry_eligible costs one metadata-line read and no transcript read;
+        # the inner gate remains the enforcement backstop.
+        if not self.retry_eligible(key, message_count=total):
+            return
         self._running.add(key)
         t = asyncio.create_task(self._consolidate(key, include_history=False))
         self._tasks.add(t)
 
         def _on_done(fut: asyncio.Task, k: str = key, off: int = total) -> None:  # type: ignore[type-arg]
             self._tasks.discard(fut)
-            if not fut.cancelled() and fut.exception() is None:
+            if (
+                not fut.cancelled()
+                and fut.exception() is None
+                # A refusal ran no pass over the window. Advancing the offset
+                # anyway would mark the window consolidated, so once the
+                # backoff expires the threshold test skips it until a whole new
+                # threshold of messages accumulates — silently dropping its
+                # preference/project extraction.
+                and fut.result() is not _CONSOLIDATION_REFUSED
+            ):
                 self._prefs_offset[k] = off
 
         t.add_done_callback(_on_done)
@@ -4185,7 +4217,13 @@ class HistoryConsolidator:
                 ts: float = captured_now,
             ) -> None:
                 self._tasks.discard(fut)
-                if not fut.cancelled() and fut.exception() is None:
+                if (
+                    not fut.cancelled()
+                    and fut.exception() is None
+                    # A refusal is not a completed pass; setting the throttle
+                    # for it would delay the retry past the backoff deadline.
+                    and fut.result() is not _CONSOLIDATION_REFUSED
+                ):
                     self._history_consolidated[k] = ts
 
             t.add_done_callback(_on_idle_done)
@@ -4208,9 +4246,10 @@ class HistoryConsolidator:
         if unconsolidated < 1:
             return
         # This path consults no time-based throttle at all — every session expiry
-        # for the same key fires a fresh consolidation — so the durable backoff is
-        # the only thing standing between a repeatedly failing span and one billed
-        # LLM turn per expiry.
+        # for the same key fires a fresh consolidation — so the durable backoff
+        # stands between a repeatedly failing span and one billed LLM turn per
+        # expiry. Checked here (as well as inside _consolidate()) so the skip is
+        # logged before a task is ever scheduled.
         if not self.retry_eligible(key, message_count=total):
             logger.info(
                 "consolidate_session skipped for %s: consolidation retry backoff", key
@@ -4235,30 +4274,46 @@ class HistoryConsolidator:
                 return
             exc = fut.exception()
             if exc is None:
-                self._history_consolidated[k] = _time.time()
+                # A refusal is not a completed pass; leave the throttle unset.
+                if fut.result() is not _CONSOLIDATION_REFUSED:
+                    self._history_consolidated[k] = _time.time()
             else:
                 logger.warning("consolidate_session failed for %s: %s", k, exc)
 
         t.add_done_callback(_on_done)
 
-    async def consolidate_now(self, key: str) -> None:
+    async def consolidate_now(self, key: str) -> bool:
         """Consolidate a session synchronously (blocking).
 
         Unlike consolidate_session() which is fire-and-forget, this awaits
         completion. Used by the CLI command.
 
-        Safety: defense-in-depth — also checked inside _consolidate().
+        Returns ``False`` when the consolidation retry backoff refused the
+        span — so the CLI can report the skip instead of a false success —
+        and ``True`` for every other completion (including the nothing-to-do
+        and sensitive-session skips, which were already reported as done).
+
+        Safety: defense-in-depth — the consolidation retry backoff is also
+        checked inside _consolidate(), and _run_skill_detection() re-checks
+        the sensitive-session guard over its own window.
         """
         if self._log.unconsolidated_count(key) < 1:
-            return
+            return True
         messages = self._log._read_messages(key)
         if _session_touched_sensitive(messages):
             logger.info("consolidate_now skipped for %s: sensitive session", key)
-            return
-        await self._consolidate(key, include_history=True)
+            return True
+        outcome = await self._consolidate(key, include_history=True)
+        return outcome is not _CONSOLIDATION_REFUSED
 
-    async def _consolidate(self, key: str, include_history: bool = True) -> None:
-        """Run LLM consolidation for a session."""
+    async def _consolidate(
+        self, key: str, include_history: bool = True
+    ) -> _ConsolidationRefusedSentinel | None:
+        """Run LLM consolidation for a session.
+
+        Returns :data:`_CONSOLIDATION_REFUSED` when the retry-eligibility gate
+        refuses the span; every other completion returns ``None``.
+        """
         # Capture the gateway loop so the thread-offloaded _process_auto_skills
         # can schedule the async dedupe judge back onto it.
         self._event_loop = asyncio.get_running_loop()
@@ -4289,7 +4344,29 @@ class HistoryConsolidator:
                 generation_at_snapshot,
             ) = await asyncio.to_thread(self._log.snapshot_for_consolidation, key)
             if not unconsolidated:
-                return
+                return None
+            # Retry-eligibility choke point: every entry point funnels through
+            # this function, so a span inside its durable backoff is refused
+            # here — before anything that can bill a provider turn — even if a
+            # caller carries no pre-check of its own (a future entry point, or
+            # a pre-check that raced the backoff being recorded). Callers keep
+            # their cheaper pre-checks as scheduling short-circuits and UX (the
+            # idle sweep's per-tick skip, maybe_consolidate's per-turn skip,
+            # the dashboard trigger's 429); this gate is the enforcement that
+            # holds when a new entry point forgets one. The count comes
+            # from the atomic snapshot above — the same consistent read the
+            # rest of this function uses — and retry_eligible costs one
+            # metadata-line read, so no second transcript read lands on the
+            # event loop. The refusal returns a sentinel rather than raising:
+            # the finally block still releases self._running and the callers'
+            # done-callbacks run normally (so the key is never stranded), while
+            # the sentinel lets those callbacks tell a refusal from a completed
+            # pass and leave their bookkeeping untouched.
+            if not self.retry_eligible(key, message_count=total):
+                logger.info(
+                    "_consolidate refused for %s: consolidation retry backoff", key
+                )
+                return _CONSOLIDATION_REFUSED
             # Freeze the whole span identity from that one snapshot. The offset is
             # derived rather than returned because the snapshot slices at it
             # (``messages[offset:]``), so the subtraction is exact and comes from
@@ -4429,7 +4506,7 @@ class HistoryConsolidator:
                 # on a widening interval instead of on every 60s tick.
                 if include_history:
                     await self._note_environment_failure(key, str(exc))
-                return
+                return None
             billed = True
             if not result:
                 # The turn reached the provider and produced nothing usable, so it
@@ -4442,7 +4519,7 @@ class HistoryConsolidator:
                     await self._note_failed_attempt(
                         key, attempted, "empty LLM result"
                     )
-                return
+                return None
 
             if entry := result.get("history_entry"):
                 # Offloaded to a worker thread: append_history takes a blocking
@@ -4536,6 +4613,7 @@ class HistoryConsolidator:
             raise
         finally:
             self._running.discard(key)
+        return None
 
     async def _run_skill_detection(self, key: str) -> None:
         """Detect a reusable skill from the FULL session (bounded window).

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -1336,6 +1336,8 @@ class TestConsolidationOffset:
     def _make_consolidator(self, msg_count=_CONSOLIDATION_THRESHOLD):
         log = MagicMock()
         log._read_messages = MagicMock(return_value=[{}] * msg_count)
+        # A fresh span is eligible; maybe_consolidate's pre-check reads this.
+        log.consolidation_retry_state.return_value = (0, 0.0)
         return HistoryConsolidator(log=log, memory=MagicMock(), sessions=None)
 
     def test_offset_advances_on_success(self):
@@ -1404,6 +1406,8 @@ class TestConsolidationDoesNotBlockLoop:
             [{"role": "user", "content": "hi"}], 1, 0
         )
         log.get_metadata.return_value = {}
+        # A fresh span is eligible; _consolidate's inner gate reads this.
+        log.consolidation_retry_state.return_value = (0, 0.0)
 
         memory = MagicMock()
         memory.read_preferences.return_value = ""
@@ -1451,6 +1455,8 @@ class TestConsolidationDoesNotBlockLoop:
             [{"role": "user", "content": "hi"}], 1, 0
         )
         log.get_metadata.return_value = {}
+        # A fresh span is eligible; _consolidate's inner gate reads this.
+        log.consolidation_retry_state.return_value = (0, 0.0)
 
         memory = MagicMock()
         memory.read_preferences.return_value = ""

--- a/test/test_history_atomic_rewrite.py
+++ b/test/test_history_atomic_rewrite.py
@@ -66,6 +66,8 @@ class TestMarkConsolidatedOffloaded:
             [{"role": "user", "content": "hi"}], 1, 0
         )
         log.get_metadata.return_value = {}
+        # A fresh span is eligible; _consolidate's inner gate reads this.
+        log.consolidation_retry_state.return_value = (0, 0.0)
         log.mark_consolidated.side_effect = lambda *a, **k: mark_thread_id.__setitem__(
             "id", threading.get_ident()
         )

--- a/test/test_history_consolidation_retry.py
+++ b/test/test_history_consolidation_retry.py
@@ -1597,3 +1597,211 @@ class TestTheManualTriggerClaimsAtomically:
             resp = await api_memory_consolidate(request)  # type: ignore[arg-type]
             assert resp.status == 200
             await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+
+class TestConsolidateIsTheEligibilityChokePoint:
+    """_consolidate() enforces retry eligibility itself.
+
+    The caller pre-checks are scheduling short-circuits and UX; the gate inside
+    the operation is what guarantees an entry point without one (the
+    preferences/projects path, or a future caller) cannot re-bill a backed-off
+    span.
+    """
+
+    def _arm_backoff(self, log: ConversationLog, attempts: int = 1) -> None:
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(
+                KEY,
+                {
+                    "consolidation_attempts": attempts,
+                    "consolidation_retry_at": time.time() + 3600,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_direct_call_inside_the_backoff_bills_nothing(self, tmp_path):
+        """No caller pre-check at all — the inner gate alone must refuse."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        self._arm_backoff(log)
+
+        with patch.object(c, "_call_llm", new_callable=AsyncMock) as spy:
+            await c._consolidate(KEY, include_history=True)
+
+        spy.assert_not_awaited()
+        # The refusal is free: nothing reached the provider, so nothing is
+        # charged and the span's accounting is untouched.
+        assert log.consolidation_retry_state(KEY, _total(log))[0] == 1
+        assert log.unconsolidated_count(KEY) == 3
+
+    @pytest.mark.asyncio
+    async def test_a_direct_call_on_a_fresh_span_still_consolidates(self, tmp_path):
+        """The eval runner calls _consolidate directly to bypass the message
+        threshold; a fresh span carries no backoff, so the gate lets it pass."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(
+            c, "_call_llm", AsyncMock(return_value={"history_entry": "x"})
+        ) as spy:
+            await c._consolidate(KEY, include_history=True)
+
+        spy.assert_awaited_once()
+        assert log.unconsolidated_count(KEY) == 0
+
+    @pytest.mark.asyncio
+    async def test_maybe_consolidate_is_refused_inside_the_backoff(self, tmp_path):
+        """The prefs/projects path carries the same cheap pre-check as the
+        other automatic entry points, so a backed-off span never even
+        schedules a task (this path runs on every user turn)."""
+        log = _seed_log(tmp_path, count=history_mod._CONSOLIDATION_THRESHOLD)
+        c = _make_consolidator(log)
+        self._arm_backoff(log)
+
+        with patch.object(c, "_call_llm", new_callable=AsyncMock) as spy:
+            c.maybe_consolidate(KEY)
+            assert not c._tasks, "a backed-off span still scheduled a task"
+
+        spy.assert_not_awaited()
+        assert KEY not in c._running
+        assert log.consolidation_retry_state(KEY, _total(log))[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_the_inner_gate_backstops_a_caller_without_a_pre_check(
+        self, tmp_path
+    ):
+        """A caller whose pre-check misses — a future entry point without one,
+        or a pre-check that raced the backoff being recorded — still cannot
+        bill the span: the gate inside _consolidate is the enforcement, the
+        pre-checks are scheduling short-circuits. The first retry_eligible
+        answer (the pre-check) lies True; the second (the inner gate) tells
+        the truth."""
+        log = _seed_log(tmp_path, count=history_mod._CONSOLIDATION_THRESHOLD)
+        c = _make_consolidator(log)
+        self._arm_backoff(log)
+
+        with (
+            patch.object(c, "_call_llm", new_callable=AsyncMock) as spy,
+            patch.object(c, "retry_eligible", side_effect=[True, False]),
+        ):
+            c.maybe_consolidate(KEY)
+            assert c._tasks, "premise broken: the bypassed pre-check did not schedule"
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+        spy.assert_not_awaited()
+        assert KEY not in c._running, "the refusal leaked the running claim"
+        assert KEY not in c._prefs_offset, "a refused pass advanced the prefs offset"
+
+    @pytest.mark.asyncio
+    async def test_a_refusal_does_not_strand_the_key_in_running(self, tmp_path):
+        """Callers add the key to _running before the task and rely on
+        done-callbacks to release it; a refusal path that skipped the release
+        would wedge consolidation for the session permanently. The pre-check
+        is bypassed (first retry_eligible answer lies True) so the inner
+        gate's refusal path actually runs."""
+        log = _seed_log(tmp_path, count=history_mod._CONSOLIDATION_THRESHOLD)
+        c = _make_consolidator(log)
+        self._arm_backoff(log)
+
+        with (
+            patch.object(c, "_call_llm", new_callable=AsyncMock),
+            patch.object(c, "retry_eligible", side_effect=[True, False]),
+        ):
+            c.maybe_consolidate(KEY)
+            assert c._tasks, "premise broken: the bypassed pre-check did not schedule"
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+        assert KEY not in c._running, "the refusal leaked the running claim"
+
+        # Once the backoff expires the same key is dispatchable again, which
+        # it would not be if the refusal above had left the claim in place.
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(KEY, {"consolidation_retry_at": time.time() - 1})
+        with patch.object(
+            c, "_call_llm", AsyncMock(return_value={"history_entry": "x"})
+        ) as spy:
+            c.consolidate_session(KEY)
+            assert c._tasks, "a released key was still refused after the backoff"
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+        spy.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_maybe_consolidate_proceeds_outside_the_backoff(self, tmp_path):
+        """The gate delays rather than disables the prefs/projects path."""
+        log = _seed_log(tmp_path, count=history_mod._CONSOLIDATION_THRESHOLD)
+        c = _make_consolidator(log)
+
+        with patch.object(c, "_call_llm", AsyncMock(return_value={"noop": True})) as spy:
+            c.maybe_consolidate(KEY)
+            assert c._tasks, "premise broken: the threshold did not schedule a task"
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+        spy.assert_awaited_once()
+        assert c._prefs_offset.get(KEY) == history_mod._CONSOLIDATION_THRESHOLD
+        assert KEY not in c._running
+
+    @pytest.mark.asyncio
+    async def test_a_refusal_does_not_advance_the_prefs_offset(self, tmp_path):
+        """Advancing the offset on a refusal marks the window consolidated with
+        no pass run — once the backoff expires the threshold test would skip it
+        until a whole new threshold of messages accumulates, silently dropping
+        its preference/project extraction. The pre-check is bypassed (first
+        retry_eligible answer lies True) so the inner gate's refusal path
+        actually runs."""
+        log = _seed_log(tmp_path, count=history_mod._CONSOLIDATION_THRESHOLD)
+        c = _make_consolidator(log)
+        self._arm_backoff(log)
+
+        with (
+            patch.object(c, "_call_llm", new_callable=AsyncMock) as spy,
+            patch.object(c, "retry_eligible", side_effect=[True, False]),
+        ):
+            c.maybe_consolidate(KEY)
+            assert c._tasks, "premise broken: the bypassed pre-check did not schedule"
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+        spy.assert_not_awaited()
+        assert KEY not in c._prefs_offset, "a refused pass advanced the prefs offset"
+
+        # Once the backoff expires the SAME window is retried — the refusal
+        # delayed the extraction rather than dropping it.
+        with history_mod.allow_on_loop_persist():
+            log.update_metadata(KEY, {"consolidation_retry_at": time.time() - 1})
+        with patch.object(
+            c, "_call_llm", AsyncMock(return_value={"noop": True})
+        ) as spy:
+            c.maybe_consolidate(KEY)
+            assert c._tasks, "the un-advanced offset did not re-arm the threshold"
+            await asyncio.gather(*list(c._tasks), return_exceptions=True)
+
+        spy.assert_awaited_once()
+        assert c._prefs_offset.get(KEY) == history_mod._CONSOLIDATION_THRESHOLD
+
+    @pytest.mark.asyncio
+    async def test_consolidate_now_reports_a_refusal(self, tmp_path):
+        """consolidate_now's only caller is the CLI, which used to print
+        'done ✓' unconditionally; the returned False is what lets it report
+        the backoff skip instead of a false success."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        self._arm_backoff(log)
+
+        with patch.object(c, "_call_llm", new_callable=AsyncMock) as spy:
+            assert await c.consolidate_now(KEY) is False
+
+        spy.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_consolidate_now_reports_success_outside_the_backoff(
+        self, tmp_path
+    ):
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(
+            c, "_call_llm", AsyncMock(return_value={"history_entry": "x"})
+        ) as spy:
+            assert await c.consolidate_now(KEY) is True
+
+        spy.assert_awaited_once()
+        assert log.unconsolidated_count(KEY) == 0


### PR DESCRIPTION
## Summary

Makes `_consolidate` the single enforcement point for the consolidation retry-eligibility backoff (added by #2038), closing the gap where a caller without a pre-check — today `maybe_consolidate`'s preferences/projects path, tomorrow any new entry point — could silently re-bill a backed-off span.

Closes #2135

## What changed

- **Inner gate** (`src/kiro_crew/history.py`, `_consolidate`): after the atomic `snapshot_for_consolidation` read (same consistent count the rest of the function uses — no second transcript read on the event loop), a span inside its backoff is refused before anything that can bill a provider turn. The refusal returns a `_CONSOLIDATION_REFUSED` sentinel rather than raising, so the `finally` still releases `self._running` and every caller's done-callback runs normally.
- **Done-callbacks** distinguish refusal from a completed pass: `maybe_consolidate` does not advance `_prefs_offset` (which would silently drop the window's extraction), and the idle/session paths do not set their throttles (which would delay the retry past the backoff deadline).
- **Caller pre-checks are kept** (defense in depth, per the issue): dashboard 429, idle-sweep per-tick skip, `consolidate_session`'s log line — all unchanged. `maybe_consolidate` additionally gains the same cheap pre-check (one metadata-line read), because it runs on every user turn and would otherwise schedule a task that takes the per-file append lock and reads the transcript once per message for the whole backoff window, only to be refused.
- **`consolidate_now` propagates the outcome** (`-> bool`) so `kirocrew consolidate` prints `skipped (consolidation retry backoff)` instead of a false `done ✓`.
- **Docstrings/comments**: `consolidate_now`'s defense-in-depth claim is now true; `retry_eligible`'s docstring documents the inner gate.

## Tests

New `TestConsolidateIsTheEligibilityChokePoint` (7 tests): direct `_consolidate` call inside backoff bills nothing and leaves accounting untouched; fresh-span direct call still consolidates (the eval-runner harness at `src/kiro_crew/eval/runner.py:312` keeps working); `maybe_consolidate` refused inside backoff without scheduling; an inner-gate backstop test that bypasses the pre-check (`retry_eligible` side_effect `[True, False]`) and proves the gate alone refuses, releases `_running`, and leaves `_prefs_offset` untouched; the same window is retried once the backoff expires; `consolidate_now` returns `False` on refusal / `True` on success. Existing mock-log tests gained the `consolidation_retry_state` stub the new reads require.

## Pre-push review (two model-pinned reviewers)

- GPT reviewer (gpt-5.6-sol, codex-review contract): **NO FINDINGS**.
- Opus reviewer (claude-opus-5, claude-review + AUTOSDE contract): 0 BLOCKING, 2 CONCERNs — both fixed in this PR (the `maybe_consolidate` pre-check and the `consolidate_now` → CLI propagation above). 2 ADVISORYs, both deliberately not taken:
  - *Dashboard handler 429 scope* (`include_history and not retry_eligible(...)`): letting a prefs-only manual API trigger through the pre-check is existing behaviour, the UI always sends `include_history: true`, and the inner gate now makes the pass safe. Widening the 429 changes observable API behaviour, which this PR deliberately avoids.
  - *Sentinel vs bool return*: the sentinel keeps `None` meaning "a pass ran (or found nothing)" exactly as before, so no caller's truthiness assumptions change; identity comparison is sound in the one-process production model, and a reloaded `kiro_crew.history` namespace would break far more than this comparison.

## Verification

- `isort` clean; `flake8`/`mypy` findings on this branch are byte-identical to the `origin/main` baseline (changed files clean).
- Full `pytest`: 38k+ passed; the only failures are the host's pre-existing `SandboxUnavailableError`-class environmental set, identical on a clean `origin/main` worktree, and each flaky diff passes in isolation. All 272 tests in the touched files pass.

## Behaviour notes

Behaviour-preserving outside a backoff window. Inside one, two intentional changes: `kirocrew consolidate` reports the skip truthfully, and `maybe_consolidate` stops scheduling doomed per-turn tasks.
