### PR TITLE
fix: spend the full compaction budget and unpin the OpenAI-compat turn cap (#2183)

### DIFF
--- a/docs/system-specs/modules/providers.md
+++ b/docs/system-specs/modules/providers.md
@@ -46,7 +46,7 @@ class LLMProvider(ABC):
     # Optional (have defaults):
     async def stream_command(command: str) -> AsyncIterator[LLMEvent]
     async def compact(context: str = "") -> None
-    async def wait_for_compaction(timeout: float = 120.0) -> dict
+    async def wait_for_compaction(timeout: float = COMPACT_WAIT_TIMEOUT_SECS) -> dict
     async def cancel(*, wait_ack_timeout: float = 0.0) -> CancelOutcome
     def is_alive() -> bool
     def touch_activity() -> None

--- a/docs/system-specs/modules/slack-gateway.md
+++ b/docs/system-specs/modules/slack-gateway.md
@@ -314,7 +314,7 @@ Triggers in-place ACP `/compact` on the current thread's session:
 
 1. Adds ♻️ reaction, posts "Compacting context…"
 2. Streams `/compact` command, waits for `compaction_status` event
-3. Falls back to `wait_for_compaction(timeout=120s)` if no inline status
+3. Falls back to `wait_for_compaction()` (shared `COMPACT_WAIT_TIMEOUT_SECS` budget) if no inline status
 4. Posts result (✅/❌) + timing footer
 5. On failure: removes session to force clean restart
 

--- a/src/kiro_crew/dashboard/openai_compat.py
+++ b/src/kiro_crew/dashboard/openai_compat.py
@@ -26,6 +26,7 @@ from kiro_crew.context import _neutralize_structural_markers
 from kiro_crew.dashboard.chat_runner import _run_chat
 from kiro_crew.dashboard.kiro_readiness import reject_if_kiro_unverified
 from kiro_crew.dashboard.state import DashboardState, _normalize_slot_key
+from kiro_crew.dashboard.turn_dispatch import chat_turn_timeout_secs
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 from kiro_crew.validation import _AGENT_NAME_RE
@@ -375,8 +376,14 @@ async def api_completions(request: web.Request) -> web.StreamResponse:
         resources=f"slot={slot.key} agent={agent}",
     )
 
-    # Launch the chat
-    task = asyncio.create_task(asyncio.wait_for(_run_chat(state, slot, prompt), timeout=300))
+    # Launch the chat, bounded by the standard chat-turn ceiling. A fixed
+    # 300s cap here would race COMPACT_WAIT_TIMEOUT_SECS: a /compact prompt
+    # phase plus the full compaction wait always exceeds it, so the outer
+    # cancel would surface as an HTTP 500 instead of the graceful
+    # compaction-timeout result.
+    task = asyncio.create_task(
+        asyncio.wait_for(_run_chat(state, slot, prompt), timeout=chat_turn_timeout_secs())
+    )
     slot.task = task
     state._background_tasks.add(task)
     task.add_done_callback(state._background_tasks.discard)

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -329,10 +329,12 @@ HEARTBEAT_KEY = "_hb"
 _CONTEXT_WARN_PCT = 70.0
 _CONTEXT_COMPACT_PCT = 80.0
 
-# Reserve subtracted from the remaining ``COMPACT_WAIT_TIMEOUT_SECS`` budget
-# when the kiro-cli in-place path waits for the async
-# ``_kiro.dev/compaction/status`` result. It keeps the inner wait's graceful
-# "no result" diagnostic landing before the outer ``asyncio.wait_for`` fires.
+# Headroom ADDED to the outer ``asyncio.wait_for`` cap around the kiro-cli
+# in-place compact, so the inner status wait can spend the FULL remaining
+# ``COMPACT_WAIT_TIMEOUT_SECS`` budget and its graceful "no result"
+# diagnostic still lands before the outer cap fires. Subtracting it from the
+# inner wait instead would cut short a compaction completing in the final
+# seconds of the shared budget.
 _COMPACT_RESULT_WAIT_MARGIN_SECS = 5.0
 
 # Minimum inner status wait even when the /compact prompt turn has consumed
@@ -344,15 +346,16 @@ _COMPACT_RESULT_WAIT_FLOOR_SECS = 5.0
 def _compact_result_wait_secs(elapsed: float) -> float:
     """Inner deadline for the async compaction-status wait.
 
-    Derived from what remains of the shared ``COMPACT_WAIT_TIMEOUT_SECS``
-    budget after ``elapsed`` seconds, minus a small margin so the inner
-    timeout fires before the outer ``asyncio.wait_for`` and its diagnostic
-    ("compaction reported no result") survives, clamped to a floor so the
-    wait can never be zero or negative.
+    The FULL remainder of the shared ``COMPACT_WAIT_TIMEOUT_SECS`` budget
+    after ``elapsed`` seconds — never less, so a compaction completing in the
+    final seconds of the budget is not abandoned early. The outer
+    ``asyncio.wait_for`` carries ``_COMPACT_RESULT_WAIT_MARGIN_SECS`` of
+    headroom on top, keeping this wait's graceful "no result" diagnostic
+    reachable. Clamped to a floor so the wait can never be zero or negative.
     """
     return max(
         _COMPACT_RESULT_WAIT_FLOOR_SECS,
-        COMPACT_WAIT_TIMEOUT_SECS - elapsed - _COMPACT_RESULT_WAIT_MARGIN_SECS,
+        COMPACT_WAIT_TIMEOUT_SECS - elapsed,
     )
 
 
@@ -3147,7 +3150,7 @@ class SessionManager:
         hangs holding the semaphore until the 2h prompt timeout, and the
         recycle that would have rescued it gives up at its own acquire
         timeout. Observed in production 2026-08-05: a ``/compact`` reported
-        ``completed`` 161s in, 41s after the async wait (then a fixed 120s)
+        ``completed`` 161s in, 41s after the async wait
         had already declared timeout.
         """
         try:
@@ -3194,7 +3197,13 @@ class SessionManager:
                 if status != "completed":
                     raise RuntimeError(f"compaction reported {status or 'no result'}")
 
-            await asyncio.wait_for(_run(), timeout=COMPACT_WAIT_TIMEOUT_SECS)
+            # Margin headroom on top of the shared budget: the inner status
+            # wait spends the full remaining budget, so this outer backstop
+            # must land strictly AFTER it for the graceful "no result"
+            # diagnostic to stay reachable.
+            await asyncio.wait_for(
+                _run(), timeout=COMPACT_WAIT_TIMEOUT_SECS + _COMPACT_RESULT_WAIT_MARGIN_SECS
+            )
         except (Exception, asyncio.TimeoutError):
             logger.warning(
                 "Session %s in-place /compact failed after %.0fs — recycling "

--- a/test/test_compaction_wait_budget.py
+++ b/test/test_compaction_wait_budget.py
@@ -12,8 +12,8 @@ they keep holding if the budget is later tuned.
 
 from __future__ import annotations
 
+import ast
 import inspect
-import re
 from pathlib import Path
 
 import pytest
@@ -65,37 +65,42 @@ def test_inner_status_wait_spends_the_remaining_shared_budget():
     """The in-place path's async status wait derives from what remains of the
     shared budget — no fixed slice may strand budget while a still-running
     compaction is abandoned and its session recycled."""
-    from kiro_crew.session import (
-        _COMPACT_RESULT_WAIT_MARGIN_SECS,
-        _compact_result_wait_secs,
-    )
+    from kiro_crew.session import _compact_result_wait_secs
 
-    assert (
-        _compact_result_wait_secs(0.0)
-        == COMPACT_WAIT_TIMEOUT_SECS - _COMPACT_RESULT_WAIT_MARGIN_SECS
-    )
+    assert _compact_result_wait_secs(0.0) == COMPACT_WAIT_TIMEOUT_SECS
     # Shrinks as the /compact prompt turn consumes the budget.
     assert _compact_result_wait_secs(30.0) < _compact_result_wait_secs(0.0)
 
 
-def test_inner_status_wait_fires_before_the_outer_cap():
-    """The margin keeps the inner timeout landing strictly before the outer
-    ``asyncio.wait_for``, so the graceful "no result" diagnostic stays
-    reachable at every elapsed point where the budget is not nearly spent."""
+def test_inner_status_wait_spends_the_full_remaining_budget():
+    """The inner wait never truncates the shared budget: at every elapsed
+    point it gets AT LEAST the remaining budget, so a compaction completing
+    in the final seconds is not abandoned early."""
+    from kiro_crew.session import _compact_result_wait_secs
+
+    step = COMPACT_WAIT_TIMEOUT_SECS / 20
+    elapsed = 0.0
+    while elapsed < COMPACT_WAIT_TIMEOUT_SECS:
+        remaining = COMPACT_WAIT_TIMEOUT_SECS - elapsed
+        assert _compact_result_wait_secs(elapsed) >= remaining
+        elapsed += step
+
+
+def test_inner_status_wait_lands_before_the_outer_cap():
+    """The outer ``asyncio.wait_for`` carries the margin as headroom, so the
+    inner timeout lands strictly before it and the graceful "no result"
+    diagnostic stays reachable while the prompt phase is within budget."""
     from kiro_crew.session import (
-        _COMPACT_RESULT_WAIT_FLOOR_SECS,
         _COMPACT_RESULT_WAIT_MARGIN_SECS,
         _compact_result_wait_secs,
     )
 
     assert _COMPACT_RESULT_WAIT_MARGIN_SECS > 0
+    outer_cap = COMPACT_WAIT_TIMEOUT_SECS + _COMPACT_RESULT_WAIT_MARGIN_SECS
     step = COMPACT_WAIT_TIMEOUT_SECS / 20
     elapsed = 0.0
-    while True:
-        remaining = COMPACT_WAIT_TIMEOUT_SECS - elapsed
-        if remaining <= _COMPACT_RESULT_WAIT_FLOOR_SECS + _COMPACT_RESULT_WAIT_MARGIN_SECS:
-            break
-        assert _compact_result_wait_secs(elapsed) < remaining
+    while elapsed < COMPACT_WAIT_TIMEOUT_SECS:
+        assert elapsed + _compact_result_wait_secs(elapsed) < outer_cap
         elapsed += step
 
 
@@ -112,18 +117,36 @@ def test_inner_status_wait_never_below_floor_or_non_positive():
         assert _compact_result_wait_secs(elapsed) == _COMPACT_RESULT_WAIT_FLOOR_SECS
 
 
-def test_no_hardcoded_120s_wait_reappears():
-    """Regression guard for issue #2183: no call site may re-pin the old
-    120-second wait. Call sites inherit the shared default instead of
-    restating the budget."""
-    pattern = re.compile(r"wait_for_compaction\(\s*timeout\s*=\s*120(?:\.0?)?\s*\)")
-    offenders = [
-        f"{path.relative_to(_SRC_ROOT.parent.parent)}:{i}"
-        for path in sorted(_SRC_ROOT.rglob("*.py"))
-        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
-        if pattern.search(line)
-    ]
+def test_no_call_site_pins_a_shorter_wait():
+    """Regression guard for issue #2183: no production call site may pass an
+    explicit numeric-literal timeout below the shared budget — keyword or
+    positional, int or float. Call sites inherit the
+    shared default instead of restating the budget. Non-literal arguments
+    (e.g. session.py's remaining-budget variable) are intentionally exempt:
+    they are derived from the shared budget and covered by the tests above.
+    """
+    offenders: list[str] = []
+    for path in sorted(_SRC_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name != "wait_for_compaction":
+                continue
+            args = list(node.args[:1]) + [kw.value for kw in node.keywords if kw.arg == "timeout"]
+            for arg in args:
+                try:
+                    value = ast.literal_eval(arg)
+                except (ValueError, SyntaxError):
+                    continue  # non-literal (derived) timeouts are exempt
+                if isinstance(value, (int, float)) and value < COMPACT_WAIT_TIMEOUT_SECS:
+                    offenders.append(
+                        f"{path.relative_to(_SRC_ROOT.parent.parent)}:{node.lineno}"
+                        f" (timeout={value})"
+                    )
     assert not offenders, (
-        "Hardcoded 120s compaction wait reintroduced (delete the timeout "
-        f"argument so the shared default applies): {offenders}"
+        "Compaction wait shorter than the shared budget reintroduced (delete "
+        f"the timeout argument so the shared default applies): {offenders}"
     )

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -1350,6 +1350,9 @@ class TestCompactCallback:
         """A still-running turn (semaphore held) must NEVER be killed for
         compaction: after COMPACT_WAIT_TIMEOUT_SECS the attempt is deferred —
         session intact, no callback — and re-triggered at the next turn end."""
+        # Only the outer cap is scaled: the inner status wait clamps to
+        # _COMPACT_RESULT_WAIT_FLOOR_SECS (5s) — patch that too if a test
+        # needs the inner wait itself to time out quickly.
         monkeypatch.setattr("kiro_crew.session.COMPACT_WAIT_TIMEOUT_SECS", 0.1)
         mgr = SessionManager(cfg, provider_factory=_mock_provider_factory())
         # Hold the semaphore and never release -> simulates a long-running turn.
@@ -3313,6 +3316,8 @@ class TestCompactTimeout:
 
         with (
             patch("kiro_crew.session._is_claude_backend", return_value=True),
+            # Only the outer cap is scaled — see _COMPACT_RESULT_WAIT_FLOOR_SECS
+            # note above if the inner wait must time out quickly.
             patch("kiro_crew.session.COMPACT_WAIT_TIMEOUT_SECS", 0.05),
         ):
             await mgr._compact_session("k1", 92.0)


### PR DESCRIPTION
## Summary

Follow-up to #2310 (unified compaction wait budget). The pre-push model review of that change surfaced two reachable defects, but #2310 merged before the fixes could be amended in. This PR lands them:

1. **Inner status wait no longer truncates the shared budget** — `session.py`'s in-place path subtracted a 5s diagnostic margin from the inner `wait_for_compaction` deadline, so a compaction completing in the final ~5s of the shared `COMPACT_WAIT_TIMEOUT_SECS` budget was classified as failed and its session recycled. The margin is now headroom **added to the outer** `asyncio.wait_for` cap: the inner wait spends the full remaining budget and the graceful "no result" diagnostic stays reachable at every point where the prompt phase is within budget.

2. **OpenAI-compat endpoint turn cap unpinned** — `dashboard/openai_compat.py` bounded `_run_chat` at a fixed 300s, which a `/compact` prompt phase plus the full compaction wait always exceeds; the outer cancel surfaced as HTTP 500 (blocking) / `server_error` (streaming) instead of the graceful compaction-timeout result. It now uses the standard configurable `chat_turn_timeout_secs()` ceiling like every other dashboard turn.

Also from that review:
- The regression guard now parses production call sites with `ast` and rejects **any** numeric-literal timeout below the shared budget (keyword or positional), replacing the narrow `timeout=120` regex.
- `docs/system-specs/modules/providers.md` and `slack-gateway.md` no longer publish the old 120s signature.
- The `COMPACT_WAIT_TIMEOUT_SECS` monkeypatch sites in `test/test_session.py` note the inner wait clamps to `_COMPACT_RESULT_WAIT_FLOOR_SECS`.

Behaviour change remains one-directional: nothing waits less than before; completions landing in the final seconds of the budget now succeed instead of recycling the session.

## Testing
- `isort` / `flake8` / `mypy` clean (851 files)
- `pytest test/test_compaction_wait_budget.py test/test_session.py test/test_openai_compat.py test/test_turn_dispatch.py` — 308 passed
- Full suite failure set matches the origin/main environmental baseline on this host (sandbox backend unavailable, /tmp uid mapping)

Refs #2183