### PR TITLE
fix: report consolidation backoff refusals and pre-check maybe_consolidate (#2135)

### DIFF
--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -673,8 +673,10 @@ def _consolidate_cmd(args) -> None:
                     print(f"  {key}: no unconsolidated messages, skipping")
                     continue
                 print(f"  {key}: consolidating {count} messages...")
-                await consolidator.consolidate_now(key)
-                print(f"  {key}: done ✓")
+                if await consolidator.consolidate_now(key):
+                    print(f"  {key}: done ✓")
+                else:
+                    print(f"  {key}: skipped (consolidation retry backoff)")
             except Exception:
                 logger.debug("consolidate (or SEL) failed for %s", key, exc_info=True)
 

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -4157,6 +4157,15 @@ class HistoryConsolidator:
         prefs_off = self._prefs_offset.get(key, 0)
         if total - prefs_off < _CONSOLIDATION_THRESHOLD:
             return
+        # Cheap pre-check mirroring the other automatic entry points. This
+        # runs on every user turn, so during a backoff window every message
+        # past the threshold would otherwise schedule a task whose snapshot
+        # takes the per-file lock (the same one appends contend on) and reads
+        # the transcript, only to be refused by the gate inside _consolidate().
+        # retry_eligible costs one metadata-line read and no transcript read;
+        # the inner gate remains the enforcement backstop.
+        if not self.retry_eligible(key, message_count=total):
+            return
         self._running.add(key)
         t = asyncio.create_task(self._consolidate(key, include_history=False))
         self._tasks.add(t)
@@ -4273,23 +4282,29 @@ class HistoryConsolidator:
 
         t.add_done_callback(_on_done)
 
-    async def consolidate_now(self, key: str) -> None:
+    async def consolidate_now(self, key: str) -> bool:
         """Consolidate a session synchronously (blocking).
 
         Unlike consolidate_session() which is fire-and-forget, this awaits
         completion. Used by the CLI command.
+
+        Returns ``False`` when the consolidation retry backoff refused the
+        span — so the CLI can report the skip instead of a false success —
+        and ``True`` for every other completion (including the nothing-to-do
+        and sensitive-session skips, which were already reported as done).
 
         Safety: defense-in-depth — the consolidation retry backoff is also
         checked inside _consolidate(), and _run_skill_detection() re-checks
         the sensitive-session guard over its own window.
         """
         if self._log.unconsolidated_count(key) < 1:
-            return
+            return True
         messages = self._log._read_messages(key)
         if _session_touched_sensitive(messages):
             logger.info("consolidate_now skipped for %s: sensitive session", key)
-            return
-        await self._consolidate(key, include_history=True)
+            return True
+        outcome = await self._consolidate(key, include_history=True)
+        return outcome is not _CONSOLIDATION_REFUSED
 
     async def _consolidate(
         self, key: str, include_history: bool = True
@@ -4332,12 +4347,13 @@ class HistoryConsolidator:
                 return None
             # Retry-eligibility choke point: every entry point funnels through
             # this function, so a span inside its durable backoff is refused
-            # here — before anything that can bill a provider turn — even when
-            # the caller carries no pre-check of its own (maybe_consolidate's
-            # preferences/projects path). Callers keep their cheaper pre-checks
-            # as scheduling short-circuits and UX (the idle sweep's per-tick
-            # skip, the dashboard trigger's 429); this gate is the enforcement
-            # that holds when a new entry point forgets one. The count comes
+            # here — before anything that can bill a provider turn — even if a
+            # caller carries no pre-check of its own (a future entry point, or
+            # a pre-check that raced the backoff being recorded). Callers keep
+            # their cheaper pre-checks as scheduling short-circuits and UX (the
+            # idle sweep's per-tick skip, maybe_consolidate's per-turn skip,
+            # the dashboard trigger's 429); this gate is the enforcement that
+            # holds when a new entry point forgets one. The count comes
             # from the atomic snapshot above — the same consistent read the
             # rest of this function uses — and retry_eligible costs one
             # metadata-line read, so no second transcript read lands on the

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -1336,6 +1336,8 @@ class TestConsolidationOffset:
     def _make_consolidator(self, msg_count=_CONSOLIDATION_THRESHOLD):
         log = MagicMock()
         log._read_messages = MagicMock(return_value=[{}] * msg_count)
+        # A fresh span is eligible; maybe_consolidate's pre-check reads this.
+        log.consolidation_retry_state.return_value = (0, 0.0)
         return HistoryConsolidator(log=log, memory=MagicMock(), sessions=None)
 
     def test_offset_advances_on_success(self):

--- a/test/test_history_consolidation_retry.py
+++ b/test/test_history_consolidation_retry.py
@@ -1651,32 +1651,64 @@ class TestConsolidateIsTheEligibilityChokePoint:
 
     @pytest.mark.asyncio
     async def test_maybe_consolidate_is_refused_inside_the_backoff(self, tmp_path):
-        """The preferences/projects path has no pre-check of its own — the
-        inner gate is the only thing covering it."""
+        """The prefs/projects path carries the same cheap pre-check as the
+        other automatic entry points, so a backed-off span never even
+        schedules a task (this path runs on every user turn)."""
         log = _seed_log(tmp_path, count=history_mod._CONSOLIDATION_THRESHOLD)
         c = _make_consolidator(log)
         self._arm_backoff(log)
 
         with patch.object(c, "_call_llm", new_callable=AsyncMock) as spy:
             c.maybe_consolidate(KEY)
-            assert c._tasks, "premise broken: the threshold did not schedule a task"
+            assert not c._tasks, "a backed-off span still scheduled a task"
+
+        spy.assert_not_awaited()
+        assert KEY not in c._running
+        assert log.consolidation_retry_state(KEY, _total(log))[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_the_inner_gate_backstops_a_caller_without_a_pre_check(
+        self, tmp_path
+    ):
+        """A caller whose pre-check misses — a future entry point without one,
+        or a pre-check that raced the backoff being recorded — still cannot
+        bill the span: the gate inside _consolidate is the enforcement, the
+        pre-checks are scheduling short-circuits. The first retry_eligible
+        answer (the pre-check) lies True; the second (the inner gate) tells
+        the truth."""
+        log = _seed_log(tmp_path, count=history_mod._CONSOLIDATION_THRESHOLD)
+        c = _make_consolidator(log)
+        self._arm_backoff(log)
+
+        with (
+            patch.object(c, "_call_llm", new_callable=AsyncMock) as spy,
+            patch.object(c, "retry_eligible", side_effect=[True, False]),
+        ):
+            c.maybe_consolidate(KEY)
+            assert c._tasks, "premise broken: the bypassed pre-check did not schedule"
             await asyncio.gather(*list(c._tasks), return_exceptions=True)
 
         spy.assert_not_awaited()
-        assert log.consolidation_retry_state(KEY, _total(log))[0] == 1
+        assert KEY not in c._running, "the refusal leaked the running claim"
+        assert KEY not in c._prefs_offset, "a refused pass advanced the prefs offset"
 
     @pytest.mark.asyncio
     async def test_a_refusal_does_not_strand_the_key_in_running(self, tmp_path):
         """Callers add the key to _running before the task and rely on
         done-callbacks to release it; a refusal path that skipped the release
-        would wedge consolidation for the session permanently."""
+        would wedge consolidation for the session permanently. The pre-check
+        is bypassed (first retry_eligible answer lies True) so the inner
+        gate's refusal path actually runs."""
         log = _seed_log(tmp_path, count=history_mod._CONSOLIDATION_THRESHOLD)
         c = _make_consolidator(log)
         self._arm_backoff(log)
 
-        with patch.object(c, "_call_llm", new_callable=AsyncMock):
+        with (
+            patch.object(c, "_call_llm", new_callable=AsyncMock),
+            patch.object(c, "retry_eligible", side_effect=[True, False]),
+        ):
             c.maybe_consolidate(KEY)
-            assert c._tasks, "premise broken: the threshold did not schedule a task"
+            assert c._tasks, "premise broken: the bypassed pre-check did not schedule"
             await asyncio.gather(*list(c._tasks), return_exceptions=True)
 
         assert KEY not in c._running, "the refusal leaked the running claim"
@@ -1713,14 +1745,19 @@ class TestConsolidateIsTheEligibilityChokePoint:
         """Advancing the offset on a refusal marks the window consolidated with
         no pass run — once the backoff expires the threshold test would skip it
         until a whole new threshold of messages accumulates, silently dropping
-        its preference/project extraction."""
+        its preference/project extraction. The pre-check is bypassed (first
+        retry_eligible answer lies True) so the inner gate's refusal path
+        actually runs."""
         log = _seed_log(tmp_path, count=history_mod._CONSOLIDATION_THRESHOLD)
         c = _make_consolidator(log)
         self._arm_backoff(log)
 
-        with patch.object(c, "_call_llm", new_callable=AsyncMock) as spy:
+        with (
+            patch.object(c, "_call_llm", new_callable=AsyncMock) as spy,
+            patch.object(c, "retry_eligible", side_effect=[True, False]),
+        ):
             c.maybe_consolidate(KEY)
-            assert c._tasks, "premise broken: the threshold did not schedule a task"
+            assert c._tasks, "premise broken: the bypassed pre-check did not schedule"
             await asyncio.gather(*list(c._tasks), return_exceptions=True)
 
         spy.assert_not_awaited()
@@ -1730,10 +1767,41 @@ class TestConsolidateIsTheEligibilityChokePoint:
         # delayed the extraction rather than dropping it.
         with history_mod.allow_on_loop_persist():
             log.update_metadata(KEY, {"consolidation_retry_at": time.time() - 1})
-        with patch.object(c, "_call_llm", AsyncMock(return_value={"noop": True})) as spy:
+        with patch.object(
+            c, "_call_llm", AsyncMock(return_value={"noop": True})
+        ) as spy:
             c.maybe_consolidate(KEY)
             assert c._tasks, "the un-advanced offset did not re-arm the threshold"
             await asyncio.gather(*list(c._tasks), return_exceptions=True)
 
         spy.assert_awaited_once()
         assert c._prefs_offset.get(KEY) == history_mod._CONSOLIDATION_THRESHOLD
+
+    @pytest.mark.asyncio
+    async def test_consolidate_now_reports_a_refusal(self, tmp_path):
+        """consolidate_now's only caller is the CLI, which used to print
+        'done ✓' unconditionally; the returned False is what lets it report
+        the backoff skip instead of a false success."""
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+        self._arm_backoff(log)
+
+        with patch.object(c, "_call_llm", new_callable=AsyncMock) as spy:
+            assert await c.consolidate_now(KEY) is False
+
+        spy.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_consolidate_now_reports_success_outside_the_backoff(
+        self, tmp_path
+    ):
+        log = _seed_log(tmp_path)
+        c = _make_consolidator(log)
+
+        with patch.object(
+            c, "_call_llm", AsyncMock(return_value={"history_entry": "x"})
+        ) as spy:
+            assert await c.consolidate_now(KEY) is True
+
+        spy.assert_awaited_once()
+        assert log.unconsolidated_count(KEY) == 0


### PR DESCRIPTION
## Summary

Follow-up to #2307 (the single-choke-point fix for #2135), landing the pre-push model-review fixes that were in flight when #2307 merged. The duplicate PR #2312 carrying them was auto-closed when the cleanup job pruned the merged branch; this re-lands exactly that 4-file delta on current main.

Refs #2135

## What changed

Both items are Opus-reviewer CONCERNs against the merged implementation (GPT reviewer had no findings):

1. **`maybe_consolidate` gains the same cheap pre-check the other automatic entry points carry.** It runs on every user turn, so during a backoff window every message past the threshold scheduled a task whose snapshot takes the per-file append lock and reads the transcript, only to be refused by the inner gate. The pre-check is one metadata-line read and no transcript read; the inner gate stays as the enforcement backstop.
2. **`consolidate_now` propagates the refusal (`-> bool`)** so `kirocrew consolidate` prints `skipped (consolidation retry backoff)` instead of a false `done ✓`. Before #2307 that path had no gate at all, so `done ✓` was truthful; after it, a refusal was silently indistinguishable from success.

Comment inside `_consolidate`'s gate updated to match (all current callers now carry pre-checks; the gate covers future ones and races).

## Tests

The choke-point test class is reworked to match: the backoff test now asserts `maybe_consolidate` schedules NO task; a new backstop test bypasses the pre-check (`retry_eligible` side_effect `[True, False]`) proving the inner gate alone refuses, releases `_running`, and leaves `_prefs_offset` untouched; the strand and prefs-offset tests adopt the same bypass premise; two new tests pin `consolidate_now`'s return value both sides of the backoff. Mock-log fixtures gain the `consolidation_retry_state` stub the new pre-check reads.

## Verification

272 tests across the touched files pass; isort/flake8 clean on changed files; mypy reports nothing in `history.py`/`cli.py`.
