### PR TITLE
refactor: share one env allowlist matching helper (#2220)

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/profile.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/profile.py
@@ -80,6 +80,7 @@ from fnmatch import fnmatch
 from pathlib import Path
 from typing import Callable
 
+from kiro_crew import platform_compat
 from kiro_crew.sandbox import resource_limit_preexec, sandboxed_spawn_argv
 
 from ...spine import agent_discovery
@@ -401,10 +402,14 @@ def _measure_env(tree: Path) -> dict[str, str]:
     # credentials to agent-authored test code. Raised by review of this branch.
     #
     # A few HOST variables are still required for a subprocess to run at all (PATH) or to
-    # behave like a normal user session (HOME, TMPDIR, locale). Those are copied through
-    # by NAME, so the set is auditable and cannot silently grow to include a credential.
+    # behave like a normal user session (HOME, TMPDIR, locale). Those are matched against
+    # the named allowlist above via the shared convention (exact on POSIX, case-folded on
+    # Windows — see platform_compat.env_key_allowed), so the set is auditable and cannot
+    # silently grow to include a credential.
     env: dict[str, str] = {
-        name: os.environ[name] for name in _MEASURE_ENV_PASSTHROUGH if name in os.environ
+        name: value
+        for name, value in os.environ.items()
+        if platform_compat.env_key_allowed(name, _MEASURE_ENV_PASSTHROUGH)
     }
     env["PYTHONHASHSEED"] = "0"
     env["PYTHONDONTWRITEBYTECODE"] = "1"

--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -2092,30 +2092,19 @@ _WINDOWS_SAFE_ENV_KEYS = (
 _SAFE_ENV_KEYS = _POSIX_SAFE_ENV_KEYS + (
     _WINDOWS_SAFE_ENV_KEYS if platform_compat.IS_WINDOWS else ()
 )
-_SAFE_ENV_KEYS_FOLDED = frozenset(name.upper() for name in _SAFE_ENV_KEYS)
 
 
 def _is_safe_env_key(key: str) -> bool:
     """Whether *key* is allowlisted, honoring Windows' case-insensitive env.
 
-    On Windows, environment names are case-INSENSITIVE and CPython's
-    ``os.environ`` upper-cases every key, so ``os.environ.items()`` yields
-    ``SYSTEMROOT`` — never the ``SystemRoot`` spelling Microsoft documents and
-    that these allowlists write. A literal membership test therefore drops
-    exactly the variables the allowlist was extended to carry, and the failure
-    is silent at the boundary and only surfaces in the child as an unrelated
-    error: without ``SystemRoot`` a spawned ``git`` cannot initialize Winsock,
-    so a fetch dies with ``getaddrinfo() thread failed to start``.
-
-    Folding on Windows only, rather than upper-casing the lists, keeps POSIX
-    exact: ``PATH`` and ``Path`` are genuinely different variables there, and a
-    case-insensitive match would let a lookalike through. Mirrors
-    ``apps.registry._is_safe_env_key`` and
-    ``kiro_prerequisite._allowlisted_env``.
+    Thin wrapper binding this module's allowlist to the shared matching
+    convention — exact on POSIX, case-folded on Windows. The rationale (why a
+    literal membership test silently drops ``SystemRoot`` on Windows, so a
+    spawned ``git`` cannot initialize Winsock and a fetch dies with
+    ``getaddrinfo() thread failed to start``, and why POSIX must stay exact)
+    lives on :func:`platform_compat.env_key_allowed`.
     """
-    if platform_compat.IS_WINDOWS:
-        return key.upper() in _SAFE_ENV_KEYS_FOLDED
-    return key in _SAFE_ENV_KEYS
+    return platform_compat.env_key_allowed(key, _SAFE_ENV_KEYS)
 
 
 def _build_env(*, with_credentials: bool = False) -> dict:

--- a/src/kiro_crew/apps/registry.py
+++ b/src/kiro_crew/apps/registry.py
@@ -172,29 +172,15 @@ _SAFE_ENV_KEYS = frozenset(
 )
 
 
-#: Case-folded view of the allowlist, for the Windows match below.
-_SAFE_ENV_KEYS_FOLDED = frozenset(k.upper() for k in _SAFE_ENV_KEYS)
-
-
 def _is_safe_env_key(key: str) -> bool:
     """Whether *key* is allowlisted, honoring Windows' case-insensitive env.
 
-    On Windows, environment variable names are case-INSENSITIVE and CPython's
-    ``os.environ`` upper-cases every key, so ``os.environ.items()`` yields
-    ``SYSTEMROOT`` — never the ``SystemRoot`` spelling Microsoft documents and that
-    this allowlist (and ``kiro_prerequisite``'s) writes. A literal membership test
-    therefore dropped exactly the variables it was extended to carry, and the
-    failure is silent at the boundary and fatal in the child: a Windows process
-    without ``SystemRoot`` cannot resolve side-by-side assemblies and dies before
-    ``main()``.
-
-    Folding on Windows only, rather than upper-casing the list, keeps POSIX exact:
-    ``PATH`` and ``Path`` are genuinely different variables there, and a
-    case-insensitive match would let a lookalike through.
+    Thin wrapper binding this module's allowlist to the shared matching
+    convention — exact on POSIX, case-folded on Windows. The rationale (why a
+    literal membership test silently drops ``SystemRoot`` on Windows, and why
+    POSIX must stay exact) lives on :func:`platform_compat.env_key_allowed`.
     """
-    if platform_compat.IS_WINDOWS:
-        return key.upper() in _SAFE_ENV_KEYS_FOLDED
-    return key in _SAFE_ENV_KEYS
+    return platform_compat.env_key_allowed(key, _SAFE_ENV_KEYS)
 
 
 def minimal_env(**extra: str) -> dict[str, str]:

--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -869,7 +869,14 @@ async def _run_json(
         # in glab's own config (reachable via GLAB_CONFIG_DIR), which is scoped to
         # the host it was created for.
         allowed_env_keys = allowed_env_keys - {"GITLAB_TOKEN"}
-    base_env = {key: value for key, value in os.environ.items() if key in allowed_env_keys}
+    # Matching follows the shared convention (exact on POSIX, case-folded on
+    # Windows — see platform_compat.env_key_allowed) so the filter never
+    # depends on the allowlist's casing agreeing with what os.environ yields.
+    base_env = {
+        key: value
+        for key, value in os.environ.items()
+        if platform_compat.env_key_allowed(key, allowed_env_keys)
+    }
     base_env.update(
         {
             "GH_PAGER": "cat",

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -809,24 +809,18 @@ def _allowlisted_env(
 ) -> dict[str, str]:
     """Filter *environ* down to *allowed*, honoring Windows' case-insensitive env.
 
-    Windows environment names are case-INSENSITIVE and CPython upper-cases every
-    key, so ``os.environ.items()`` yields ``SYSTEMROOT`` — never the
-    ``SystemRoot`` spelling Microsoft documents and these allowlists write. A
-    literal membership test therefore drops exactly the variables it was
-    extended to carry, and the failure is silent at the boundary and fatal in the
-    child: a Windows process launched without ``SystemRoot`` cannot load system
-    DLLs, so probe and sign-in spawns die with an unrelated-looking error.
-
-    Folding on Windows only, rather than upper-casing the lists, keeps POSIX
-    exact: ``PATH`` and ``Path`` are genuinely different variables there, and a
-    case-insensitive match would let a lookalike through. Mirrors
-    ``apps.registry._is_safe_env_key``.
+    Thin wrapper binding this module's allowlists to the shared matching
+    convention — exact on POSIX, case-folded on Windows. The rationale (why a
+    literal membership test silently drops ``SystemRoot`` on Windows, killing
+    probe and sign-in spawns with an unrelated-looking error, and why POSIX
+    must stay exact) lives on :func:`platform_compat.env_key_allowed`.
     """
 
-    if not platform_compat.IS_WINDOWS:
-        return {key: value for key, value in environ.items() if key in allowed}
-    folded = {name.upper() for name in allowed}
-    return {key: value for key, value in environ.items() if key.upper() in folded}
+    return {
+        key: value
+        for key, value in environ.items()
+        if platform_compat.env_key_allowed(key, allowed)
+    }
 
 
 def _probe_env(environ: MutableMapping[str, str], search_path: str) -> dict[str, str]:

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -12,6 +12,7 @@ import asyncio
 import contextlib
 import ctypes.util
 import errno
+import functools
 import io
 import logging
 import os
@@ -786,6 +787,41 @@ def _descendants_from_parent_map(root_pid: int, parent_map: dict[int, int]) -> l
                 result.append(child_pid)
                 frontier.append(child_pid)
     return result
+
+
+@functools.lru_cache(maxsize=None)
+def _folded_env_allowlist(allowed: frozenset[str] | tuple[str, ...]) -> frozenset[str]:
+    """Upper-cased view of *allowed*, cached per allowlist constant."""
+    return frozenset(name.upper() for name in allowed)
+
+
+def env_key_allowed(key: str, allowed: frozenset[str] | tuple[str, ...]) -> bool:
+    """Whether env-var *key* is in *allowed*, honoring Windows' case-insensitive env.
+
+    On Windows, environment variable names are case-INSENSITIVE and CPython's
+    ``os.environ`` upper-cases every key, so ``os.environ.items()`` yields
+    ``SYSTEMROOT`` — never the ``SystemRoot`` spelling Microsoft documents and
+    that env allowlists are written in. A literal membership test therefore
+    drops exactly the variables the allowlist was extended to carry, and the
+    failure is silent at the boundary and only surfaces in the spawned child as
+    an unrelated-looking error: a Windows process without ``SystemRoot`` cannot
+    resolve side-by-side assemblies or initialize Winsock, so it dies before
+    ``main()`` or fails a fetch with ``getaddrinfo() thread failed to start``.
+
+    Folding on Windows only, rather than upper-casing the allowlists, keeps
+    POSIX exact: ``PATH`` and ``Path`` are genuinely different variables there,
+    and a case-insensitive match would let a lookalike through.
+
+    This is the single shared membership predicate for subprocess env
+    allowlists. Each caller keeps its own *allowed* set — the sets are
+    deliberately different trust boundaries — and only the matching convention
+    is shared, so correctness never depends on an individual allowlist's
+    casing. *allowed* must be hashable (a frozenset or tuple); the folded view
+    is cached per distinct allowlist value.
+    """
+    if IS_WINDOWS:
+        return key.upper() in _folded_env_allowlist(allowed)
+    return key in allowed
 
 
 _TRUSTED_SYSTEM_BIN_DIRS = ("/usr/bin", "/bin", "/usr/sbin", "/sbin", "/run/current-system/sw/bin")

--- a/test/test_env_allowlist_consolidation.py
+++ b/test/test_env_allowlist_consolidation.py
@@ -1,0 +1,228 @@
+"""The shared env-allowlist membership convention: ``platform_compat.env_key_allowed``.
+
+Five subprocess env allowlists delegate their matching to this one predicate —
+``apps.registry._is_safe_env_key``, ``kiro_prerequisite._allowlisted_env``,
+dev_fleet's ``_is_safe_env_key``, the auto-improvement github_repo profile's
+measurement passthrough, and the source-provider CLI env filter. Each keeps its
+OWN allowlist (they are deliberately different trust boundaries); only the
+matching convention is shared: exact on POSIX, case-folded on Windows, because
+CPython's ``os.environ`` upper-cases every key there and a literal test against
+Microsoft's documented mixed-case spelling (``SystemRoot``) silently drops the
+variable the allowlist is meant to carry.
+
+These tests pin two things:
+1. the convention itself, under a simulated Windows AND a simulated POSIX; and
+2. per-site parity — each call site's admitted key set equals what its own
+   private matching logic admits, so the consolidation is behavior-preserving.
+   The wrapper sites (registry, kiro_prerequisite, dev_fleet) carry the
+   fold-on-Windows oracle; the two sites whose allowlists are written
+   upper-case-exact (github_repo profile, source_providers) carry the exact
+   oracle on BOTH platforms, evaluated against the upper-cased key spelling a
+   real Windows ``os.environ`` yields — which is exactly why the shared fold
+   admits the same set there.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kiro_crew import kiro_prerequisite, platform_compat
+from kiro_crew.apps import registry
+from kiro_crew.apps.builtins.auto_improvement.profiles.github_repo import profile as gh_profile
+from kiro_crew.apps.builtins.dev_fleet import server as dev_fleet_server
+from kiro_crew.dashboard.handlers import source_providers
+
+
+def _oracle_admitted(
+    environ: dict[str, str], allowed, *, windows: bool, folds_on_windows: bool
+) -> set[str]:
+    """A call site's own matching logic, re-stated as the parity oracle.
+
+    Sites that fold carry ``folds_on_windows=True`` (upper-case fold on the
+    Windows arm); sites whose allowlists are written upper-case-exact carry
+    ``False`` (exact membership on both arms). Kept independent of the shared
+    helper so the tests compare it against each site's own convention, never
+    against itself.
+    """
+    if windows and folds_on_windows:
+        folded = {name.upper() for name in allowed}
+        return {key for key in environ if key.upper() in folded}
+    return {key for key in environ if key in allowed}
+
+
+# POSIX-shaped synthetic environ: mixed-case lookalikes are possible there and
+# must be told apart, and credential-bearing names must never be admitted.
+_POSIX_ENVIRON = {
+    "PATH": "/usr/bin",
+    "Path": "/sneaky-posix-lookalike",
+    "SystemRoot": r"C:\Windows",
+    "ComSpec": r"C:\Windows\System32\cmd.exe",
+    "HOME": "/home/u",
+    "LANG": "C.UTF-8",
+    "TEMP": "/tmp",
+    "GITHUB_TOKEN": "ghp_secret",
+    "AWS_SECRET_ACCESS_KEY": "secret",
+    "SLACK_BOT_TOKEN": "xoxb-secret",
+    "SSH_AUTH_SOCK": "/tmp/agent.sock",
+}
+
+# Windows-shaped synthetic environ: CPython's os.environ upper-cases every key
+# there, so this is the only spelling a filter ever sees at runtime.
+_WINDOWS_ENVIRON = {
+    "PATH": r"C:\Windows\System32",
+    "SYSTEMROOT": r"C:\Windows",
+    "COMSPEC": r"C:\Windows\System32\cmd.exe",
+    "USERPROFILE": r"C:\Users\me",
+    "APPDATA": r"C:\Users\me\AppData\Roaming",
+    "TEMP": r"C:\Temp",
+    "HOME": r"C:\Users\me",
+    "LANG": "C.UTF-8",
+    "GITHUB_TOKEN": "ghp_secret",
+    "AWS_SECRET_ACCESS_KEY": "secret",
+    "SLACK_BOT_TOKEN": "xoxb-secret",
+    "SSH_AUTH_SOCK": "/tmp/agent.sock",
+}
+
+
+def _environ_for(windows: bool) -> dict[str, str]:
+    return _WINDOWS_ENVIRON if windows else _POSIX_ENVIRON
+
+
+class TestEnvKeyAllowedConvention:
+    """The predicate itself, on both simulated platforms."""
+
+    def test_windows_matches_the_spelling_os_environ_yields(self, monkeypatch) -> None:
+        """A mixed-case allowlist entry must match the upper-cased runtime key.
+
+        ``os.environ`` upper-cases every key on Windows, so the filter sees
+        ``SYSTEMROOT`` while the allowlist writes Microsoft's documented
+        ``SystemRoot``. Folding is what keeps the two ends agreeing.
+        """
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+        allowed = frozenset({"SystemRoot", "PATH"})
+        assert platform_compat.env_key_allowed("SYSTEMROOT", allowed)
+        assert platform_compat.env_key_allowed("SystemRoot", allowed)
+        assert platform_compat.env_key_allowed("systemroot", allowed)
+        assert not platform_compat.env_key_allowed("SLACK_BOT_TOKEN", allowed)
+
+    def test_windows_fold_widens_case_never_the_key_set(self, monkeypatch) -> None:
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+        allowed = frozenset({"SystemRoot", "PATH", "TEMP"})
+        for secret in ("GITHUB_TOKEN", "AWS_SECRET_ACCESS_KEY", "SSH_AUTH_SOCK"):
+            assert not platform_compat.env_key_allowed(secret, allowed)
+
+    def test_posix_stays_exact(self, monkeypatch) -> None:
+        """``PATH`` and ``Path`` are genuinely different variables on POSIX.
+
+        A case-insensitive match there would let a lookalike through, so the
+        fold is Windows-only.
+        """
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+        allowed = frozenset({"SystemRoot", "PATH"})
+        assert platform_compat.env_key_allowed("PATH", allowed)
+        assert not platform_compat.env_key_allowed("Path", allowed)
+        assert platform_compat.env_key_allowed("SystemRoot", allowed)
+        assert not platform_compat.env_key_allowed("SYSTEMROOT", allowed)
+
+    def test_accepts_tuple_and_frozenset_allowlists(self, monkeypatch) -> None:
+        """Call sites keep their existing constant shapes (dev_fleet uses a tuple)."""
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+        assert platform_compat.env_key_allowed("SYSTEMROOT", ("SystemRoot",))
+        assert platform_compat.env_key_allowed("SYSTEMROOT", frozenset({"SystemRoot"}))
+
+
+@pytest.mark.parametrize("windows", [True, False], ids=["windows", "posix"])
+class TestCallSiteParity:
+    """Per-site parity: each site admits exactly what its own oracle admits.
+
+    The environ is platform-shaped (upper-cased keys on the Windows arm, the
+    spelling a real ``os.environ`` yields there), so the exact-oracle sites'
+    equality is a real claim about runtime behavior, not folding compared to
+    itself.
+    """
+
+    def test_apps_registry(self, monkeypatch, windows: bool) -> None:
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", windows)
+        environ = _environ_for(windows)
+        admitted = {k for k in environ if registry._is_safe_env_key(k)}
+        assert admitted == _oracle_admitted(
+            environ, registry._SAFE_ENV_KEYS, windows=windows, folds_on_windows=True
+        )
+
+    def test_kiro_prerequisite_probe_allowlist(self, monkeypatch, windows: bool) -> None:
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", windows)
+        environ = _environ_for(windows)
+        filtered = kiro_prerequisite._allowlisted_env(
+            dict(environ), kiro_prerequisite._PROBE_ENV_KEYS
+        )
+        assert set(filtered) == _oracle_admitted(
+            environ,
+            kiro_prerequisite._PROBE_ENV_KEYS,
+            windows=windows,
+            folds_on_windows=True,
+        )
+
+    def test_dev_fleet(self, monkeypatch, windows: bool) -> None:
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", windows)
+        environ = _environ_for(windows)
+        admitted = {k for k in environ if dev_fleet_server._is_safe_env_key(k)}
+        assert admitted == _oracle_admitted(
+            environ,
+            dev_fleet_server._SAFE_ENV_KEYS,
+            windows=windows,
+            folds_on_windows=True,
+        )
+
+    def test_github_repo_profile_measurement_passthrough(
+        self, monkeypatch, tmp_path, windows: bool
+    ) -> None:
+        """The passthrough allowlist is upper-case-exact, so its oracle is exact
+        membership on both platforms — the shared fold must admit the same set."""
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", windows)
+        environ = _environ_for(windows)
+        monkeypatch.setattr(gh_profile.os, "environ", dict(environ))
+        env = gh_profile._measure_env(tmp_path)
+        # _measure_env layers pinned measurement variables and PYTHONPATH on top
+        # of the passthrough; only the keys sourced from the environ are the
+        # allowlist's admitted set.
+        admitted = set(env) & set(environ)
+        assert admitted == _oracle_admitted(
+            environ,
+            gh_profile._MEASURE_ENV_PASSTHROUGH,
+            windows=windows,
+            folds_on_windows=False,
+        )
+
+    def test_source_providers_base_allowlist(self, monkeypatch, windows: bool) -> None:
+        """The provider allowlist is upper-case-exact (lower-case proxy twins are
+        listed explicitly), so its oracle is exact membership on both platforms.
+        The provider CLI path is POSIX-only at runtime (Windows raises before the
+        env filter), so the Windows arm additionally pins that the shared fold
+        does not widen the set even if that guard ever moves."""
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", windows)
+        environ = _environ_for(windows)
+        admitted = {
+            k
+            for k in environ
+            if platform_compat.env_key_allowed(k, source_providers._PROVIDER_BASE_ENV_KEYS)
+        }
+        assert admitted == _oracle_admitted(
+            environ,
+            source_providers._PROVIDER_BASE_ENV_KEYS,
+            windows=windows,
+            folds_on_windows=False,
+        )
+
+    def test_no_secret_admitted_by_any_site(self, monkeypatch, windows: bool) -> None:
+        """The fold must never turn a credential-bearing name into a match."""
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", windows)
+        secrets = {"GITHUB_TOKEN", "AWS_SECRET_ACCESS_KEY", "SLACK_BOT_TOKEN"}
+        for allowed in (
+            registry._SAFE_ENV_KEYS,
+            kiro_prerequisite._PROBE_ENV_KEYS,
+            dev_fleet_server._SAFE_ENV_KEYS,
+            gh_profile._MEASURE_ENV_PASSTHROUGH,
+            source_providers._PROVIDER_BASE_ENV_KEYS,
+        ):
+            for secret in secrets:
+                assert not platform_compat.env_key_allowed(secret, allowed)


### PR DESCRIPTION
## Problem
On Windows, CPython's `os.environ` upper-cases every key, so an exact membership test against Microsoft's documented mixed-case spelling (e.g. `SystemRoot`) silently drops the variable the allowlist was extended to carry. The failure surfaces only in the spawned child as an unrelated-looking error (a process without `SystemRoot` cannot resolve side-by-side assemblies or initialize Winsock). Three independent copies of the same case-folding filter exist on main (`apps/registry._is_safe_env_key`, `kiro_prerequisite._allowlisted_env`, dev_fleet `server._is_safe_env_key`), and two further allowlists (`auto_improvement` github_repo profile, `dashboard/handlers/source_providers.py`) work only by accident because they happen to be written uppercase-exact.

## Why it matters
This is a repeatedly-rediscovered bug class: correctness currently depends on each author remembering the casing convention at every new filter site, and the failure mode is silent. A future allowlist written with the documented mixed-case spelling but matched exactly reintroduces the bug with no test to catch it.

## Fix (symptoms → root cause → change)
Symptom: Windows children die with unrelated-looking errors when an allowlisted variable is dropped. Root cause: the matching convention (exact on POSIX, case-folded on Windows) is duplicated in three places and absent in two, so it drifts and depends on casing luck. Change: move the convention into one shared predicate, `platform_compat.env_key_allowed(key, allowed)` (`platform_compat` is the natural home — it already carries the `SystemRoot` platform knowledge in `_windows_system_dirs`, and imports only stdlib plus the stdlib-only `executors`, so all five sites can import it without a cycle). The three duplicated helpers become thin wrappers keeping their public names; the two uppercase-exact filters now route through the helper. Every call site keeps its own allowlist contents — the sets are deliberately different trust boundaries; only the matching logic is shared. The duplicated rationale comments are consolidated onto the helper's docstring.

No admitted key set changes: the fold runs only on Windows, where `os.environ` keys are already upper-cased, and the two converted sites' allowlists are written uppercase-exact (the lower-case proxy names in the provider set have their upper-case twins listed explicitly), so folding admits exactly what exact matching admitted. The provider CLI path additionally raises on Windows before its filter is reached.

## Tests
`test/test_env_allowlist_consolidation.py` (new):
- Convention tests under simulated Windows and POSIX: the documented mixed-case spelling matches the upper-cased runtime key on Windows; POSIX stays exact (`Path` lookalike rejected); the fold widens case, never the key set (credential names never admitted).
- Per-site parity tests: each of the five call sites' admitted key set equals its own site-specific oracle (fold oracle for the three wrapper sites, exact oracle on both platforms for the two uppercase-exact sites), evaluated against a platform-shaped environ (upper-cased keys on the Windows arm, as a real `os.environ` yields there).

Existing tests pass untouched — including `test_apps_registry.py`'s `TestMinimalEnvHonorsWindowsCaseInsensitivity` and `test_dev_fleet_app.py`'s `test_is_safe_env_key_*`, which import the wrapped helpers by name.

## Manual verification
N/A — unit coverage sufficient: the change is a pure, synchronous membership predicate exercised directly under both simulated platforms, and full-suite parity was verified locally (identical failure set on branch vs clean main; the 69 local failures are host sandbox-unavailability issues present on main).

## Screenshots
N/A — no user-visible UI change.

Closes #2220
