### PR TITLE
fix: allowlist agent-document route for internal-secret auth (#2197)

### DIFF
--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -322,6 +322,10 @@ _STRICT_INTERNAL_API_PATHS = frozenset(
         "/api/slack/reactions",
         "/api/slack-profile",  # MCP-only (slack_profile tool); no browser caller
         "/api/sessions/summarize",  # MCP-only (list_sessions summarize leg); internal-secret, no browser caller
+        # MCP-only (knowledge_add_document tool); no browser caller — the
+        # dashboard ingests via its own cookie-authed knowledge routes. Same
+        # wiring class as "/api/notifications/agent" above.
+        "/api/knowledge/agent-document",
         "/api/mcp/servers",
     }
 )

--- a/test/test_mcp_knowledge_add_document.py
+++ b/test/test_mcp_knowledge_add_document.py
@@ -3,6 +3,10 @@
 A title is free-form, so it can carry a credential. It reaches the SEL audit log
 AND the tool result that is rendered into chat and persisted in the transcript --
 a wider audience than the audit log. Both take the redacted form.
+
+Also pins the auth wiring for the tool's gateway leg: the route must sit on the
+internal-secret allowlist or every MCP call falls through to cookie auth and
+403s with "Token required".
 """
 from __future__ import annotations
 
@@ -33,3 +37,24 @@ def test_an_ordinary_title_is_returned_unchanged():
     out = _add("Design Review Notes")
     assert "Design Review Notes" in out
     assert "3 chunk(s)" in out
+
+
+def test_a_denied_gateway_response_surfaces_a_clear_error():
+    """When no usable credential reaches the gateway, the tool must say so
+    plainly instead of pretending the document was added.
+
+    The allowlist wiring that makes the gateway accept the tool's handshake is
+    pinned in test_token_auth.py (test_knowledge_agent_document_is_registered_
+    internal_path), next to the middleware it exercises.
+    """
+    with patch("kiro_crew.mcp_core._post",
+               return_value={"error": "Token required"}) as post, \
+            patch("kiro_crew.mcp_core.sel"):
+        out = _call_tool_inner("knowledge_add_document",
+                               {"title": "Runbook", "content": "body text",
+                                "source_uri": "chat://x"})
+    assert out == "Could not add the document: Token required"
+    # The write goes through _post, the helper that attaches the
+    # X-Internal-Secret handshake — the authenticated client, not a bare one.
+    post.assert_called_once()
+    assert post.call_args.args[0] == "/api/knowledge/agent-document"

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -851,6 +851,39 @@ async def test_sessions_summarize_is_registered_internal_path() -> None:
     assert denied.status == 403
 
 
+@pytest.mark.asyncio
+async def test_knowledge_agent_document_is_registered_internal_path() -> None:
+    """Regression: the MCP-only /api/knowledge/agent-document route
+    (knowledge_add_document tool) MUST be in the strict internal allowlist.
+    Its sole caller authenticates with X-Internal-Secret and sends no browser
+    token, so if the route is missing from the allowlist it falls through to
+    cookie auth and every call is denied with 403 "Token required".
+
+    Drives the REAL _STRICT_INTERNAL_API_PATHS from server.py through the
+    middleware so a future edit that drops the entry fails here."""
+    from kiro_crew.dashboard.server import _STRICT_INTERNAL_API_PATHS
+
+    assert "/api/knowledge/agent-document" in _STRICT_INTERNAL_API_PATHS
+    secret = "test-secret-123"
+    mw = token_auth_middleware(internal_paths=_STRICT_INTERNAL_API_PATHS, internal_secret=secret)
+    # Internal secret on loopback → granted (the MCP _post path).
+    ok = await mw(
+        _make_request(
+            path="/api/knowledge/agent-document",
+            method="POST",
+            headers={"X-Internal-Secret": secret},
+        ),
+        _ok_handler,
+    )
+    assert ok.status == 200
+    # No token / no secret → denied: the fix authenticates the caller, it must
+    # not open an unauthenticated route.
+    denied = await mw(
+        _make_request(path="/api/knowledge/agent-document", method="POST"), _ok_handler
+    )
+    assert denied.status == 403
+
+
 # -- Property 9b: mixed_internal_paths (loopback MCP + non-loopback browser) --
 
 


### PR DESCRIPTION
## Problem / Motivation

The `knowledge_add_document` MCP tool fails every call from a dashboard chat session with `Could not add the document: Token required`. The agent can never add a document to the knowledge library through the tool; only folder-based ingestion (KnowledgeWatcher) works.

## Why it matters

The tool is completely non-functional — 100% failure rate for a shipped capability. Every agent that tries to persist a load-bearing document loses that work, and the error message points at a missing token the MCP process has no way to supply.

## What changed (motivation → approach → change)

- **Symptom:** every `knowledge_add_document` call returns 403 `Token required`.
- **Root cause:** the tool's gateway leg (`mcp_core._post` → `POST /api/knowledge/agent-document`) already attaches the `X-Internal-Secret` handshake, but `token_auth` middleware only honors that header for paths on the internal allowlists. `/api/knowledge/agent-document` was on **neither** `_STRICT_INTERNAL_API_PATHS` nor `_MIXED_INTERNAL_API_PATHS`, so the request fell through to cookie auth — which an MCP process can never satisfy — and was default-denied. Same wiring class as the `/api/artifact-folders` and `/api/notifications/agent` regressions documented in the list itself.
- **Change:** add the exact path to `_STRICT_INTERNAL_API_PATHS` (strict, not mixed: `grep` finds no browser caller of this route — the dashboard ingests through its own cookie-authed knowledge routes). `token_auth.py` is untouched, no auth check is weakened: non-loopback access to the path stays hard-denied, and a credential-less loopback call still falls through to cookie auth and is refused.

## Tests

- `test/test_token_auth.py::test_knowledge_agent_document_is_registered_internal_path` — drives the REAL `_STRICT_INTERNAL_API_PATHS` through the middleware (mirrors the `/api/sessions/summarize` precedent test): asserts the entry exists, that loopback + `X-Internal-Secret` is granted, and that a credential-less request is still denied 403.
- `test/test_mcp_knowledge_add_document.py::test_a_denied_gateway_response_surfaces_a_clear_error` — asserts the tool routes the write through `_post` (the authenticated client) to this exact path and surfaces a plain error when the gateway refuses.

Pre-push review (model-pinned GPT + Opus contracts) returned no blocking findings. One residual-class suggestion (an invariant test asserting every `mcp_core` gateway path is covered by an allowlist) is deliberately left out of this minimal fix; all 29 current paths were hand-verified covered.

## Manual verification

N/A — unit coverage sufficient: the failing hop was middleware admission, which the new test drives with the real production path set. Folder ingestion (the reported workaround) is untouched; all knowledge/watcher suites pass (888 tests).

## Related Issues

Closes #2197

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: the token-auth doc references the allowlist constants without enumerating entries
- [x] No secrets, credentials, or internal references in the diff
