### PR TITLE
fix: guard _run_cmd proc.kill() against already-reaped children (#2096)

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -880,7 +880,10 @@ async def _run_cmd(
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except asyncio.TimeoutError:
             await _kill_tree(proc.pid)
-            proc.kill()
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
             await proc.wait()
             return -1, "", f"timeout ({timeout}s)"
         except asyncio.CancelledError:
@@ -888,7 +891,13 @@ async def _run_cmd(
             # runs in its own process group and would outlive us (a canceled
             # rebase never reaches its --abort path, wedging the worktree).
             await _kill_tree(proc.pid)
-            proc.kill()
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                # Already reaped: an unguarded kill here would REPLACE the
+                # in-flight CancelledError with ProcessLookupError, swallowing
+                # the cancellation (#2096).
+                pass
             await proc.wait()
             raise
         return proc.returncode or 0, (stdout or b"").decode(errors="replace"), (stderr or b"").decode(errors="replace")

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -1183,6 +1183,52 @@ def test_build_env_pins_git_protocols():
     _assert_git_neutralizers(env)
 
 
+# --- cancellation survives an already-reaped child (#2096) ---
+@pytest.mark.asyncio
+async def test_run_cmd_cancel_with_reaped_child_propagates_cancellation(monkeypatch):
+    """Cancelling _run_cmd whose child was already reaped must raise
+    CancelledError, not ProcessLookupError.
+
+    An unguarded ``proc.kill()`` in the CancelledError branch raises
+    ProcessLookupError on a reaped child, REPLACING the in-flight
+    cancellation; ``_status_refresher``'s broad handler then swallows it
+    and loops forever, hanging ``dev_fleet_cleanup``'s ``await bg_task``
+    and the whole pytest-asyncio loop teardown (#2096).
+    """
+    entered = asyncio.Event()  # deterministic rendezvous, no sleeps
+
+    class FakeProc:
+        pid = 12345
+        returncode = None
+
+        async def communicate(self):
+            entered.set()
+            await asyncio.Event().wait()  # block until cancelled
+
+        def kill(self):
+            raise ProcessLookupError  # child already reaped
+
+        async def wait(self):
+            return 0
+
+    async def fake_spawn(*args, **kwargs):
+        return FakeProc()
+
+    monkeypatch.setattr(
+        mod, "sandboxed_spawn_argv",
+        lambda cmd, mode, *, env=None, **kw: (cmd, env, None),
+    )
+    monkeypatch.setattr(mod, "create_subprocess_limited", fake_spawn)
+    monkeypatch.setattr(mod, "_kill_tree", AsyncMock())
+
+    task = asyncio.ensure_future(mod._run_cmd(["/bin/true"]))
+    # Bounded so a future early-return in _run_cmd fails fast, not a hang.
+    await asyncio.wait_for(entered.wait(), timeout=5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
 # --- stream-overrun subprocess reaping (Codex R34 #2) ---
 @pytest.mark.asyncio
 async def test_start_run_readline_overrun_kills_process_tree(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes the macOS Gateway Tests flake where the dev-fleet status refresher hangs loop teardown and two unrelated HMAC tests time out.

**Root cause:** in `_run_cmd` (`src/kiro_crew/apps/builtins/dev_fleet/server.py`), the `asyncio.TimeoutError` and `asyncio.CancelledError` branches called `proc.kill()` unguarded. When the child has already been reaped by the time the branch runs, `kill()` raises `ProcessLookupError`. In the `CancelledError` branch that exception **replaces** the in-flight cancellation, so the awaiting caller sees an ordinary error instead of `CancelledError`. `_status_refresher`'s broad `while True` handler then logs it and loops back to sleep — the cancellation is swallowed — and `dev_fleet_cleanup`'s `await bg_task` never returns, hanging pytest-asyncio loop teardown. The two HMAC tests merely share that loop. The macOS-only manifestation is timing (children reaped faster relative to cancellation delivery), not platform behaviour.

**Fix:** wrap both `proc.kill()` calls in `try/except ProcessLookupError: pass`, mirroring the file's existing convention in `dev_fleet_cleanup`. The trailing `raise` in the `CancelledError` branch is preserved — cancellation still propagates. The except is exact (`ProcessLookupError` only): a real `PermissionError`/`OSError` still surfaces, and `await proc.wait()` is untouched (safe on a reaped child).

## Testing

- New deterministic regression test `test_run_cmd_cancel_with_reaped_child_propagates_cancellation`: fake proc whose `kill()` raises `ProcessLookupError`, event-based rendezvous (no sleeps / wall-clock races per testing-conventions Determinism), asserts the awaiter receives `CancelledError`. **Verified to fail on unfixed code** (raises `ProcessLookupError`) and pass with the fix.
- `test/test_dev_fleet_app.py` + `test_dev_fleet_node_toolchain.py`: all green locally.
- isort / flake8 clean on changed files; full-suite pytest failure set byte-identical to clean-main baseline on this host (env-only: sandbox backend unavailable), zero deltas from this change.
- Pre-push dual-model review (GPT + Opus contracts): both VERDICT CLEAN; two non-blocking test polish notes applied.

## Follow-up (out of scope here)

- `_start_run`'s timeout branch (~line 1042) has a sibling unguarded `proc.kill()` — same defect class, but there a `ProcessLookupError` escapes as a plain error rather than swallowing a cancellation. Worth guarding for consistency in a separate change.
- `_status_refresher`'s broad exception handler could arguably be narrowed so an escaping non-`CancelledError` can't re-loop forever; deliberately not restructured in this fix to keep surface minimal.

Closes #2096
