### PR TITLE
fix(markdown): bold, italic and strikethrough in CJK prose

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -50,6 +50,8 @@
         "react-virtuoso": "4.18.3",
         "rehype-katex": "^7.0.1",
         "rehype-raw": "^7.0.0",
+        "remark-cjk-friendly": "^2.3.1",
+        "remark-cjk-friendly-gfm-strikethrough": "^2.3.1",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "roughjs": "4.6.6",
@@ -7029,6 +7031,18 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -9444,6 +9458,51 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-to-markdown-cjk-friendly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown-cjk-friendly/-/mdast-util-to-markdown-cjk-friendly-1.0.0.tgz",
+      "integrity": "sha512-BoaAm8mlJ+LAYz0Qs532Y3ciTuQYgBUPZcSFbvC/ZKmEMAKgulw84YvQK1gI34t/vL2euSfuaWlqczkTBgamkw==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown": "^2.1.2",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mdast-util-to-markdown-cjk-friendly-gfm-strikethrough": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown-cjk-friendly-gfm-strikethrough/-/mdast-util-to-markdown-cjk-friendly-gfm-strikethrough-1.0.0.tgz",
+      "integrity": "sha512-1ePVfB4P/vz3xSsm6H3D32r6VYGErxclnuLLFK02/2ReF+UdEKm7caulK6Vm0LBIp5gPRtB2Z1OYDznCkX3k2w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.2",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/mdast-util-to-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
@@ -9570,6 +9629,77 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly/-/micromark-extension-cjk-friendly-2.0.1.tgz",
+      "integrity": "sha512-OkzoYVTL1ChbvQ8Cc1ayTIz7paFQz8iS9oIYmewncweUSwmWR+hkJF9spJ1lxB90XldJl26A1F4IkPOKS3bDXw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.1.0",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-chunked": "^2.0.1",
+        "micromark-util-resolve-all": "^2.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "micromark": "^4.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly-gfm-strikethrough": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly-gfm-strikethrough/-/micromark-extension-cjk-friendly-gfm-strikethrough-2.0.1.tgz",
+      "integrity": "sha512-wVC0zwjJNqQeX+bb07YTPu/CvSAyCTafyYb7sMhX1r62/Lw5M/df3JyYaANyp8g15c1ypJRFSsookTqA1IDsUg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.1.0",
+        "get-east-asian-width": "^1.4.0",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-character": "^2.1.1",
+        "micromark-util-chunked": "^2.0.1",
+        "micromark-util-resolve-all": "^2.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "micromark": "^4.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly-util/-/micromark-extension-cjk-friendly-util-3.0.1.tgz",
+      "integrity": "sha512-GcbXqTTHOsiZHyF753oIddP/J2eH8j9zpyQPhkof6B2JNxfEJabnQqxbCgzJNuNes0Y2jTNJ3LiYPSXr6eJA8w==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.4.0",
+        "micromark-util-character": "^2.1.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -11532,6 +11662,50 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-cjk-friendly": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/remark-cjk-friendly/-/remark-cjk-friendly-2.3.1.tgz",
+      "integrity": "sha512-f+pKZRxCRwNEGFBKNRAZAqU91GIK1SAo3ZyFHWRUgC9zcxRR0BXKd6YwqgSsxtW0rNpUDtONj7H5nje2WL3fcA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown-cjk-friendly": "1.0.0",
+        "micromark-extension-cjk-friendly": "2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/remark-cjk-friendly-gfm-strikethrough": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/remark-cjk-friendly-gfm-strikethrough/-/remark-cjk-friendly-gfm-strikethrough-2.3.1.tgz",
+      "integrity": "sha512-JE3TGgouk/sy92SemNMEUhO5mNP4on04cmzOV3s3R5Dbk160ewmpM4tgPiinKKvoJ5UW2fTu7FOYsjVbusSA9w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown-cjk-friendly-gfm-strikethrough": "1.0.0",
+        "micromark-extension-cjk-friendly-gfm-strikethrough": "2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
       }
     },
     "node_modules/remark-gfm": {

--- a/website/package.json
+++ b/website/package.json
@@ -81,6 +81,8 @@
     "react-virtuoso": "4.18.3",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",
+    "remark-cjk-friendly": "^2.3.1",
+    "remark-cjk-friendly-gfm-strikethrough": "^2.3.1",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "roughjs": "4.6.6",

--- a/website/src/components/MarkdownRenderer.tsx
+++ b/website/src/components/MarkdownRenderer.tsx
@@ -4,6 +4,8 @@ import { Paperclip, X, Download, Plus, Minus, Search, Folder } from 'lucide-reac
 import ReactMarkdown from 'react-markdown'
 import type { Components, ExtraProps } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import remarkCjkFriendly from 'remark-cjk-friendly'
+import remarkCjkFriendlyGfmStrikethrough from 'remark-cjk-friendly-gfm-strikethrough'
 import remarkMath from 'remark-math'
 import rehypeRaw from 'rehype-raw'
 import rehypeKatex from 'rehype-katex'
@@ -1054,7 +1056,23 @@ export function rehypeSanitize() {
   }
 }
 
-const REMARK_PLUGINS: PluggableList = [remarkGfm, [remarkMath, { singleDollarTextMath: false }]]
+// CommonMark has a known emphasis defect (commonmark/commonmark-spec#650): a
+// closing `**` is only right-flanking when it is NOT preceded by punctuation, or
+// IS followed by whitespace/punctuation. `**中文（带括号）。**这句` fails both —
+// preceded by `。`, followed by the letter `这` — so it renders as literal
+// asterisks. English prose sidesteps this by putting a space after the `**`; CJK
+// cannot, because a space there is visibly wrong.
+//
+// `remark-cjk-friendly` implements the CJK-friendly flanking amendment. ORDER IS
+// LOAD-BEARING: it must run BEFORE remark-gfm (it changes how emphasis
+// delimiters are classified), and the strikethrough companion AFTER, because it
+// extends gfm's own `~~` construct.
+const REMARK_PLUGINS: PluggableList = [
+  remarkCjkFriendly,
+  remarkGfm,
+  remarkCjkFriendlyGfmStrikethrough,
+  [remarkMath, { singleDollarTextMath: false }],
+]
 const REHYPE_PLUGINS: PluggableList = [[rehypeRaw, { passThrough: ['math', 'inlineMath'] }], rehypeSanitize, rehypeKatex]
 
 // Matches one source line break plus any leading tabs/spaces, so a trailing

--- a/website/src/test/cjkFriendlyEmphasis.test.tsx
+++ b/website/src/test/cjkFriendlyEmphasis.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import MarkdownRenderer from '../components/MarkdownRenderer'
+
+/**
+ * CommonMark's emphasis flanking rules (commonmark/commonmark-spec#650) refuse to
+ * close a `**` that is preceded by punctuation and followed by a letter. CJK prose
+ * hits that on every `**粗体（括号）。**后续` — and unlike English it cannot insert
+ * a space after the `**` to disambiguate, because the space is visible and wrong.
+ *
+ * These assert the rendered DOM, not the plugin's presence, so they fail if the
+ * plugin is dropped OR ordered wrongly relative to remark-gfm.
+ */
+const renderMd = (src: string) => render(<MarkdownRenderer content={src} />)
+
+describe('CJK-friendly emphasis', () => {
+  it('bolds a run ending in ideographic punctuation', () => {
+    for (const [src, text] of [
+      ['**中文文本（带括号）。**这句子继续也没问题。', '中文文本（带括号）。'],
+      ['**日本語の文章（括弧付き）。**この文が続きます。', '日本語の文章（括弧付き）。'],
+      ['**중요 안내(괄호 포함)**를 참고. ', '중요 안내(괄호 포함)'],
+      ['**重要提示（Important Notice）：**请注意。', '重要提示（Important Notice）：'],
+    ] as const) {
+      const { container } = renderMd(src)
+      expect(container.querySelector('strong')?.textContent).toBe(text)
+      expect(container.textContent).not.toContain('**')
+    }
+  })
+
+  it('italicises a run ending in ideographic punctuation', () => {
+    const { container } = renderMd('*这是斜体文字（带括号）。*这句子继续。')
+    expect(container.querySelector('em')?.textContent).toBe('这是斜体文字（带括号）。')
+    expect(container.textContent).not.toContain('*')
+  })
+
+  it('strikes through a run ending in ideographic punctuation', () => {
+    // Needs the gfm-strikethrough companion, which must run AFTER remark-gfm.
+    const { container } = renderMd('~~删除的文字（带括号）。~~这个句子是正确的。')
+    expect(container.querySelector('del')?.textContent).toBe('删除的文字（带括号）。')
+    expect(container.textContent).not.toContain('~~')
+  })
+
+  it('handles the full-width closing bracket as the boundary', () => {
+    const { container } = renderMd('**中文（括号）**后续')
+    expect(container.querySelector('strong')?.textContent).toBe('中文（括号）')
+  })
+
+  // ── unchanged behaviour ──
+  it('leaves ASCII emphasis exactly as CommonMark specifies', () => {
+    const { container } = renderMd('**bold** and *italic* and ~~struck~~')
+    expect([...container.querySelectorAll('strong,em,del')].map((n) => n.textContent)).toEqual([
+      'bold',
+      'italic',
+      'struck',
+    ])
+  })
+
+  it('still does NOT emphasise an intra-word ASCII underscore run', () => {
+    const { container } = renderMd('snake_case_name stays plain')
+    expect(container.querySelector('em')).toBeNull()
+    expect(container.textContent).toContain('snake_case_name')
+  })
+
+  it('leaves a lone asterisk that opens nothing as literal text', () => {
+    const { container } = renderMd('2 * 3 = 6')
+    expect(container.querySelector('em')).toBeNull()
+    expect(container.textContent).toContain('2 * 3 = 6')
+  })
+
+  it('does not touch emphasis markers inside a code span or fence', () => {
+    const { container } = renderMd('`**中文（括号）。**` 和\n\n```\n**中文（括号）。**\n```\n')
+    expect(container.querySelector('strong')).toBeNull()
+    expect(container.textContent).toContain('**中文（括号）。**')
+  })
+})


### PR DESCRIPTION
## Problem

Bold, italic and strikethrough silently fail in Chinese, Japanese and Korean
prose. Measured against the current renderer:

| Input | Renders as |
|---|---|
| `**中文文本（带括号）。**这句子继续也没问题。` | literal `**`, no bold |
| `**重要提示（Important Notice）：**请注意。` | literal `**` |
| `*这是斜体文字（带括号）。*这句子继续。` | literal `*` |
| `~~删除的文字（带括号）。~~这个句子是正确的。` | literal `~~` |
| `**日本語の文章（括弧付き）。**この文が続きます。` | literal `**` |

## Why it matters

This is not an exotic shape — it is how CJK prose is normally written. An
emphasised phrase ends in `。`, `：`, `）` or `、` and the sentence continues
immediately with no space. Every agent message in Chinese that bolds a phrase
before a full stop shows raw asterisks to the user.

## Fix (symptom → root cause → change)

The defect is in CommonMark, not in our renderer
([commonmark/commonmark-spec#650](https://github.com/commonmark/commonmark-spec/issues/650)).
A closing `**` is right-flanking only when it is **not** preceded by punctuation,
**or** is followed by whitespace/punctuation. In `…（带括号）。**这句子` the run is
preceded by `。` and followed by the letter `这`, so it satisfies neither clause
and cannot close. English prose never notices, because `**bold.** tail` puts a
space after the delimiter; in CJK that space is visibly wrong, so authors do not
write it and the emphasis just breaks.

Adopts the two upstream plugins that implement the CJK-friendly flanking
amendment — the same pair Vercel's Streamdown ships as `@streamdown/cjk`:

```ts
const REMARK_PLUGINS: PluggableList = [
  remarkCjkFriendly,                    // BEFORE gfm: reclassifies emphasis delimiters
  remarkGfm,
  remarkCjkFriendlyGfmStrikethrough,    // AFTER gfm: extends gfm's own `~~`
  [remarkMath, { singleDollarTextMath: false }],
]
```

Order is load-bearing in both directions, which is why the tests assert rendered
DOM rather than plugin presence — they fail if either plugin is dropped **or**
mis-ordered.

### Deliberately NOT adopted from the same upstream package

`@streamdown/cjk` also ships autolink boundary handling. I unpacked and measured
it (`@streamdown/cjk@1.0.3`) before deciding: it splits a URL at the **first**
character in a fixed 20-character CJK punctuation set, unconditionally and with
no evidence test. Measured consequences on live URLs:

| Input | `@streamdown/cjk` |
|---|---|
| `https://zh.wikipedia.org/wiki/苹果（公司）` | → `…/wiki/苹果` ❌ |
| `https://ja.wikipedia.org/wiki/モーニング娘。` | → `…/wiki/モーニング娘` ❌ |
| `https://zh.wikipedia.org/wiki/我，机器人` | → `…/wiki/我` ❌ |

It also cannot repair the code-span pairing that a swallowed backtick shifts,
because it runs after tokenization: for
`（https://…/pull/2137，`96ed647b`）` it fixes the href but the code spans stay
gone. That problem is handled at the source level in #2171 with an evidence-based
cut, and the two changes touch disjoint code paths.

## Tests

`website/src/test/cjkFriendlyEmphasis.test.tsx` — 8 tests.

Four assert the fix across bold (zh/ja/ko/mixed), italic, strikethrough, and a
full-width closing bracket as the boundary. **Verified to have discriminating
power**: with the two plugins removed, exactly those four fail and the other four
pass.

Four are controls that must not move: ASCII `**bold** / *italic* / ~~struck~~`
unchanged, `snake_case_name` still not italicised, a lone `2 * 3 = 6` still
literal, and emphasis markers inside a code span or fence still untouched.

## Manual verification

N/A — the defect is textual and the rendered-DOM assertions pin it exactly. No
UI surface, layout or styling changed.

## CI note

An earlier revision of this PR was red on `catalogParity > ko` and, via
`frontend-test=failure -- failing closed`, on `Coverage Gate`. Both traced to a
single cause outside this diff: `feat(instances): send a copy of a session to
another instance` translated 12 locales and missed `ko` alone. That has since
landed on main as #2327, so this branch is rebased onto it and no locale file is
touched here.

Full suite on the current base: **853 files, 11357 tests, zero failures**.
`tsc -b` clean. eslint reports no new findings (one pre-existing `jsx-a11y`
warning at `MarkdownRenderer.tsx:599`, untouched).
