### PR TITLE
fix(discord): continue the connected session when a reply arrives

### DIFF
--- a/src/kiro_crew/dashboard/chat_mirror.py
+++ b/src/kiro_crew/dashboard/chat_mirror.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from typing import Any
 
 from aiohttp import web
 
@@ -38,6 +39,7 @@ from kiro_crew.messaging.link import SLACK_NAMESPACE, ChannelLink
 from kiro_crew.messaging.renderer import chunk_text
 from kiro_crew.platform.context import redact_via_context
 from kiro_crew.sel import sel
+from kiro_crew.session_map import ConversationOwnershipConflict
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +87,27 @@ async def api_channel_targets(request: web.Request) -> web.Response:
         except Exception:
             logger.warning("channel-targets: failed to enumerate %s", channel_type, exc_info=True)
     return web.json_response(targets)
+
+
+def _resumes_inbound(transport: Any) -> bool:
+    """Does a binding on this transport actually route replies back to the session?
+
+    Only a transport whose inbound path resolves the mirror binding may claim
+    ``accepts_inbound``. Discord's dispatcher looks the conversation up; the
+    others build a session key from the route and never consult the binding, so
+    a reply there runs in a SEPARATE session no matter what the binding says.
+    Claiming inbound for them would not make replies come back — it would only
+    make the dashboard say they do, and the slot row would report
+    ``direction: both`` on a promise nothing keeps.
+
+    Reads the capability rather than testing ``channel_type == "discord"``, so a
+    transport earns the claim by declaring it next to its own inbound path. The
+    ``getattr`` chain is the conservative branch: a transport with no capability
+    object at all degrades to outbound-only.
+    """
+    return bool(
+        getattr(getattr(transport, "capabilities", None), "supports_session_resume", False)
+    )
 
 
 async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
@@ -239,6 +262,51 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
         thread_id=thread_id,
     )
 
+    # Refuse an occupied conversation BEFORE anything is posted into it. The
+    # authoritative check is the atomic one inside ``set_mirror_link`` at the
+    # bottom, but that fires only after the link notice and the whole catch-up
+    # transcript have already been delivered — and a binding can be unwound
+    # while posted messages cannot. So ask the same question here, at the first
+    # point the real location is known, and answer with the same 409.
+    #
+    # ``accepts_inbound`` is threaded through so this asks the writer's EXACT
+    # question. Without it the precheck would refuse where the writer allows —
+    # rejecting a second outbound-only mirror on transports that cannot resume at
+    # all, whose in-channel link handlers do not translate the refusal because
+    # they can never provoke it.
+    #
+    # Degrades open on anything it cannot interpret: a SessionManager double that
+    # lacks the accessor simply gets no precheck, and the writer still enforces.
+    # That trades a late refusal for a missing one, never a wrong binding.
+    #
+    # The ``isinstance`` is load-bearing, not defensive clutter. A stubbed
+    # SessionManager answers with a Mock, and a Mock is TRUTHY — read as a rival
+    # list it would refuse every connect in every test double's world, and the
+    # refusal would look like a real conflict. Only an actual list is an answer.
+    try:
+        rivals = state.sessions.mirror_claim_blockers(
+            session_key, link, accepts_inbound=_resumes_inbound(transport)
+        )
+    except Exception:
+        logger.debug("mirror-link: occupancy precheck unavailable", exc_info=True)
+        rivals = None
+    occupants = list(rivals) if isinstance(rivals, list) else []
+    if occupants:
+        sel().log_api_access(
+            caller="dashboard",
+            operation="chat.mirror_link",
+            outcome="denied",
+            source="dashboard",
+            resources=f"{slot.key} -> {channel_type}:{conversation_id} (occupied)",
+        )
+        return web.json_response(
+            {
+                "error": "another session is already linked to this conversation",
+                "code": "conversation_occupied",
+            },
+            status=409,
+        )
+
     try:
         # Recheck at the actual send boundary as well: target resolution can
         # yield while governance is updated.
@@ -384,10 +452,37 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
         except Exception:
             logger.debug("mirror-link context delivery failed", exc_info=True)
 
-    state.sessions.set_mirror_link(
-        session_key,
-        link,
-    )
+    try:
+        state.sessions.set_mirror_link(
+            session_key,
+            link,
+            # Mark the binding inbound-capable only where the transport's inbound
+            # path actually resolves it. Without this the connect writes an
+            # outbound-only binding, ``resumed_session`` skips it, and the user's
+            # reply starts a brand-new session with none of this transcript.
+            accepts_inbound=_resumes_inbound(transport),
+        )
+    except ConversationOwnershipConflict:
+        # The precheck above covers the common case; this is the genuine race —
+        # someone claimed the conversation while we were delivering. Report the
+        # same conflict rather than a 500, so the client offers "unlink there
+        # first" instead of inviting a retry of a request that is behaving
+        # correctly.
+        logger.info("mirror-link refused: conversation claimed during delivery")
+        sel().log_api_access(
+            caller="dashboard",
+            operation="chat.mirror_link",
+            outcome="denied",
+            source="dashboard",
+            resources=f"{slot.key} -> {channel_type}:{conversation_id} (raced)",
+        )
+        return web.json_response(
+            {
+                "error": "another session claimed this conversation",
+                "code": "conversation_occupied",
+            },
+            status=409,
+        )
     sel().log_api_access(
         caller="dashboard",
         operation="chat.mirror_link",

--- a/src/kiro_crew/discord/session_resume.py
+++ b/src/kiro_crew/discord/session_resume.py
@@ -14,6 +14,7 @@ from kiro_crew.messaging.driver import sanitize_channel_replay_text
 from kiro_crew.messaging.link import ChannelLink
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
+from kiro_crew.session_map import ConversationOwnershipConflict
 
 if TYPE_CHECKING:
     from kiro_crew.discord.client import DiscordClient, DiscordInteraction
@@ -147,13 +148,13 @@ class DiscordSessionResume:
     def leave_resumed_session(self, channel_id: str) -> str | None:
         key = self.resumed_session(channel_id)
         if key is not None:
-            # Free the LOCATION, not just the resume binding: the dashboard's
-            # mirror-link endpoint performs no occupancy check, so an outbound
-            # mirror can be laid onto a conversation a resumed session already
-            # holds. This early path bypasses the dispatcher's own sweep —
-            # clearing only *key* here would leave that mirror occupying the
-            # location and reproduce the "already attached" refusal after an
-            # apparently successful unlink.
+            # Free the LOCATION, not just the resume binding: a session map can
+            # hold co-located bindings — one written before conversations became
+            # exclusive, or hand-edited — so an outbound mirror can sit on a
+            # conversation a resumed session also holds. This early path bypasses
+            # the dispatcher's own sweep — clearing only *key* here would leave
+            # that mirror occupying the location and reproduce the "already
+            # attached" refusal after an apparently successful unlink.
             cleared = self.sessions.clear_mirror_links_at(self.link_for(channel_id))
             logger.info(
                 "discord: released resumed session %s (cleared bindings: %s)",
@@ -450,6 +451,23 @@ class DiscordSessionResume:
                     accepts_inbound=True,
                 )
                 self._push_slots()
+            except ConversationOwnershipConflict:
+                # `_binding_conflict` already checked, twice — but it and the
+                # dashboard connect endpoint evaluate under different locks, so
+                # this precheck can lose the race. The atomic claim inside
+                # `set_mirror_link` is what catches it. This is an ordinary
+                # conflict, not a fault: say so in the precheck's own words
+                # instead of the generic failure text below, which would send the
+                # user off to retry a command that is working.
+                logger.debug("discord resume: lost the claim race for this conversation")
+                await client.edit_message(
+                    interaction.channel_id,
+                    interaction.message_id,
+                    "🧵 Another session just connected here. "
+                    "Run `!unlink`, then `!sessions` to resume this one.",
+                    components=[],
+                )
+                return
             except Exception:
                 logger.exception("discord resume: failed to persist binding")
                 await client.edit_message(

--- a/src/kiro_crew/discord/transport.py
+++ b/src/kiro_crew/discord/transport.py
@@ -70,6 +70,11 @@ DISCORD_CAPABILITIES = TransportCapabilities(
     max_message_chars=DISCORD_CHUNK_LIMIT,
     max_buttons=5,  # per action row (max 5 rows -> 25 total)
     supports_proactive_send=True,
+    # The one transport whose inbound path resolves the mirror binding: a message
+    # in a bound conversation routes to the owning session via
+    # `DiscordSessionResume.resumed_session`, so a dashboard connect here can
+    # honestly claim `accepts_inbound`.
+    supports_session_resume=True,
 )
 
 

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -57,6 +57,7 @@ from kiro_crew.messaging.link import (
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
+from kiro_crew.session_map import ConversationOwnershipConflict
 
 if TYPE_CHECKING:
     from kiro_crew.config.loader import KiroCrewConfig
@@ -953,7 +954,20 @@ class DiscordDispatcher:
             )
             return
         key = self._session_key(user_id, thread_id)
-        self.sessions.set_mirror_link(key, ChannelLink("discord", channel_id=channel_id))
+        try:
+            self.sessions.set_mirror_link(key, ChannelLink("discord", channel_id=channel_id))
+        except ConversationOwnershipConflict:
+            # The resumed-session check above covers an inbound owner. This
+            # catches an occupant that check cannot see — an outbound-only
+            # dashboard mirror already pointing here. Same instruction either
+            # way, and reporting it beats surfacing a traceback as a generic
+            # command failure.
+            logger.info("discord link refused: conversation already held")
+            await self.client.send_message(
+                channel_id,
+                "⚠️ Another session is already linked here. Send `!unlink` first.",
+            )
+            return
         # Drop any pre-unification row so a stale binding cannot outlive the
         # rebind (reads prefer the channel key, but a leftover row would still
         # answer a clear).

--- a/src/kiro_crew/messaging/transport.py
+++ b/src/kiro_crew/messaging/transport.py
@@ -51,6 +51,18 @@ class TransportCapabilities:
       chunker counts chars and cannot see bytes.
     * ``supports_proactive_send`` — gates mirror-link creation (HTTP 400) and
       the outbound mirror leg (skipped).
+    * ``supports_session_resume`` — gates whether connecting a channel from the
+      dashboard marks the binding as an INBOUND resume target
+      (``accepts_inbound``), and therefore whether the slot row reports
+      ``direction: both``. Only a transport whose inbound path actually resolves
+      the mirror binding may declare it: Discord's dispatcher looks the
+      conversation up (``DiscordSessionResume.resumed_session``), while Telegram
+      and the rest derive a session key from the route alone and never consult
+      the binding. Declaring it where it is not honoured makes the dashboard
+      promise a two-way link whose replies silently start a separate session —
+      which is exactly what this flag exists to prevent. Slack is out of scope
+      here: it routes inbound through its own ``_thread_to_session`` index and
+      never sets the marker.
 
     ASPIRATIONAL (declared, honest, but nothing reads them yet — the
     capability-gated interface work will consume them; do NOT write code that
@@ -82,6 +94,10 @@ class TransportCapabilities:
     max_buttons: int = 3  # interactive choices per prompt (WhatsApp reply buttons = 3)
     # send-policy
     supports_proactive_send: bool = True  # WhatsApp: False outside the 24h window
+    # inbound-routing policy. Default False: a transport that forgets to declare
+    # it gets an outbound-only binding, which is merely less capable — declaring
+    # it wrongly would promise a two-way link that silently drops replies.
+    supports_session_resume: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -95,6 +111,7 @@ class TransportCapabilities:
             "max_message_chars": self.max_message_chars,
             "max_buttons": self.max_buttons,
             "supports_proactive_send": self.supports_proactive_send,
+            "supports_session_resume": self.supports_session_resume,
         }
 
 

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -4010,6 +4010,18 @@ class SessionManager:
             inbound_only=inbound_only,
         )
 
+    def mirror_claim_blockers(
+        self,
+        key: str,
+        link: ChannelLink,
+        *,
+        accepts_inbound: bool = False,
+    ) -> list[str]:
+        """Sessions that must stop *key* from binding *link*, or [] if it is free."""
+        return self._session_map.mirror_claim_blockers(
+            key, link, accepts_inbound=accepts_inbound
+        )
+
     def clear_mirror_link(self, key: str) -> bool:
         """Remove a session's outbound mirror binding. Returns True iff present."""
         return self._session_map.clear_mirror_link(key)

--- a/src/kiro_crew/session_map.py
+++ b/src/kiro_crew/session_map.py
@@ -38,6 +38,28 @@ def _kiro_sessions_dir() -> Path:
     return _KIRO_SESSIONS_DIR if _KIRO_SESSIONS_DIR is not None else kiro_sessions_dir()
 
 
+class ConversationOwnershipConflict(RuntimeError):
+    """Raised when a second session tries to bind a conversation already held.
+
+    One conversation belongs to at most one session. That is not a policy
+    preference — it is what makes an inbound reply routable at all. The inbound
+    resolver (``find_mirror_sessions(link, inbound_only=True)`` behind
+    ``DiscordSessionResume.resumed_session``) refuses to choose between two
+    candidates and returns ``None``, and "no owner" and "two owners" land on the
+    same ``None``. So a duplicate binding does not send the reply to the wrong
+    session, it sends it to NO session: the message silently starts a fresh
+    conversation, which is the very bug an inbound binding exists to prevent.
+
+    Enforced on the WRITER, deliberately. Readers stay permissive and keep
+    reporting every owner they find, so a map written before this check existed
+    still makes the resolver fail closed and still lets in-channel conflict
+    detection see the duplicate. Callers translate this into their own surface's
+    refusal — an HTTP 409, or the channel's own "run `!unlink` first" — never a
+    500 or a generic failure, which would send the user off to retry a command
+    that is working exactly as intended.
+    """
+
+
 class SessionMap:
     """Persistent mapping of session_key → kiro-cli session ID.
 
@@ -416,6 +438,13 @@ class SessionMap:
         messages arriving from that exact channel location may be routed back to
         *key*. Ordinary dashboard mirrors remain outbound-only. Slack keeps its
         dedicated reverse index and therefore ignores this flag.
+
+        Raises :class:`ConversationOwnershipConflict` when another session already
+        holds this exact location AND the conversation is inbound-committed —
+        either this claim is inbound-capable, or an occupant already is. See
+        :meth:`mirror_claim_blockers`: exclusivity exists to keep inbound routing
+        unambiguous, so it is scoped to that, and two outbound-only mirrors on one
+        conversation stay as permitted as they were before this rule.
         """
         if link is None:
             self.clear_mirror_link(key)
@@ -424,6 +453,12 @@ class SessionMap:
             self.set_slack_link(key, link.thread_id or "", link.channel_id)
             return
         key = canonical_key(key)
+        rivals = self.mirror_claim_blockers(key, link, accepts_inbound=accepts_inbound)
+        if rivals:
+            raise ConversationOwnershipConflict(
+                f"{link.channel_type} conversation is already held by "
+                f"{len(rivals)} other session(s)"
+            )
         entry = self._ensure_entry(key)
         entry["mirror"] = link.to_dict()
         if accepts_inbound:
@@ -431,6 +466,71 @@ class SessionMap:
         else:
             entry.pop("mirror_accepts_inbound", None)
         self._save()
+
+    def mirror_claim_blockers(
+        self,
+        key: str,
+        link: ChannelLink,
+        *,
+        accepts_inbound: bool = False,
+    ) -> list[str]:
+        """Sessions that must stop *key* from binding *link*, or ``[]`` if it is free.
+
+        The single definition of "this conversation is taken", shared by the
+        atomic check inside :meth:`set_mirror_link` and by the dashboard
+        endpoint's precheck. They must ask the same question with the same
+        arguments: a backstop whose idea of "occupied" differs from the precheck
+        it backs looks like coverage while diverging from it in exactly the cases
+        that matter.
+
+        Exclusivity is owed to INBOUND routing, so it is scoped to it. A
+        conversation is exclusive when it is inbound-committed — either this claim
+        is inbound-capable, or an existing occupant already is. That is precisely
+        when a second binding does harm: the inbound resolver refuses to choose
+        between two candidates and returns ``None``, and "no owner" and "two
+        owners" are the same ``None`` to it, so the reply silently starts a fresh
+        session instead of resuming.
+
+        Two outbound-only mirrors on one conversation are left alone. They are
+        merely noisy — both write out, nobody reads back — and refusing them
+        would reach transports that cannot resume at all, whose in-channel link
+        handlers do not translate this refusal because they can never provoke it.
+
+        The occupancy scan itself is UNFILTERED once the conversation is
+        inbound-committed: an outbound-only occupant counts. Narrowing that too
+        would let an in-channel ``!link`` land a second binding on a conversation
+        the dashboard is resuming through, which is the collision that strands the
+        reply.
+
+        A rebind by the SAME session is not a rivalry, and three spellings can all
+        mean "me": the canonical key, the row the binding actually lives on today
+        (a pre-unification ``dashboard:`` row, which only ``_mirror_key`` can
+        identify), and any other spelling that canonicalizes to this key. Deriving
+        the legacy name unconditionally instead of asking ``_mirror_key`` would
+        excuse a row that is NOT this session's binding, letting a genuine
+        duplicate persist.
+
+        CONTRACT FOR A NEW TRANSPORT: declaring
+        ``TransportCapabilities.supports_session_resume`` makes its conversations
+        inbound-committable, and therefore makes this refusal reachable from that
+        transport's own in-channel link handler. Translate it there into a
+        followable message, as ``discord/transport_dispatch.py`` does — an uncaught
+        raise inside a channel handler is a dropped task and a silent no-reply.
+        """
+        key = canonical_key(key)
+        selves = {key, self._mirror_key(key)}
+        rivals = [
+            other
+            for other in self.find_mirror_sessions(link)
+            if other not in selves and canonical_key(other) != key
+        ]
+        if not rivals:
+            return []
+        if accepts_inbound or any(
+            (self._data.get(other) or {}).get("mirror_accepts_inbound") for other in rivals
+        ):
+            return rivals
+        return []
 
     def _mirror_key(self, key: str) -> str:
         """The key a session's mirror binding is actually stored under.

--- a/test/test_capability_ledger.py
+++ b/test/test_capability_ledger.py
@@ -33,6 +33,11 @@ ENFORCED = {
     "max_message_chars",
     # Gates mirror-link creation (HTTP 400) and the outbound mirror leg.
     "supports_proactive_send",
+    # Gates whether a dashboard connect marks the binding as an inbound resume
+    # target (``accepts_inbound``) in dashboard/chat_mirror.py, and therefore
+    # whether the slot row reports ``direction: both``. Only a transport whose
+    # inbound path resolves the mirror binding may declare it.
+    "supports_session_resume",
 }
 
 #: Declared honestly, read by nothing yet. The capability-gated interface
@@ -115,3 +120,57 @@ class TestCorrectedDeclarations:
         assert DISCORD_CAPABILITIES.files_outbound is False
         assert SLACK_CAPABILITIES.files_inbound is True
         assert SLACK_CAPABILITIES.files_outbound is True
+
+
+class TestSessionResumeIsDeclaredOnlyWhereItIsHonoured:
+    """``supports_session_resume`` is a promise the INBOUND path has to keep.
+
+    A dashboard connect on a transport declaring it marks the binding
+    ``accepts_inbound``, and the slot row then reports ``direction: both`` — the
+    dashboard is telling the user that replies come back here. That is only true
+    where the transport's inbound path resolves the mirror binding. Discord's
+    does (``DiscordSessionResume.resumed_session``); every other transport builds
+    a session key from the route alone and never looks the binding up, so a reply
+    there runs in a SEPARATE session with none of this conversation's history.
+
+    This pins the current set. A new transport declaring the flag fails here, and
+    that is the point: the author has to come and confirm its inbound path really
+    resolves the binding rather than inheriting a promise the code cannot keep.
+    """
+
+    def test_discord_declares_it(self) -> None:
+        from kiro_crew.discord.transport import DISCORD_CAPABILITIES
+
+        assert DISCORD_CAPABILITIES.supports_session_resume is True, (
+            "Discord stopped declaring session resume — dashboard connects there "
+            "would silently become outbound-only and replies would stop resuming"
+        )
+
+    def test_no_other_transport_declares_it(self) -> None:
+        from kiro_crew.slack.transport import SLACK_CAPABILITIES
+        from kiro_crew.teams.transport import TEAMS_CAPABILITIES
+        from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES
+        from kiro_crew.webex.transport import WEBEX_CAPABILITIES
+        from kiro_crew.wecom.transport import WECOM_CAPABILITIES
+        from kiro_crew.weixin.transport import WEIXIN_CAPABILITIES
+
+        others = {
+            "slack": SLACK_CAPABILITIES,
+            "teams": TEAMS_CAPABILITIES,
+            "telegram": TELEGRAM_CAPABILITIES,
+            "webex": WEBEX_CAPABILITIES,
+            "wecom": WECOM_CAPABILITIES,
+            "weixin": WEIXIN_CAPABILITIES,
+        }
+        claiming = [name for name, caps in others.items() if caps.supports_session_resume]
+        assert claiming == [], (
+            f"{claiming} declare session resume, but their inbound paths derive a "
+            "session key from the route and never resolve the mirror binding — the "
+            "dashboard would promise a two-way link that drops replies. Slack is "
+            "separate: it routes inbound through its own thread index and never "
+            "sets `accepts_inbound`."
+        )
+
+    def test_the_default_is_off(self) -> None:
+        """A transport that forgets the flag must degrade to outbound-only."""
+        assert TransportCapabilities().supports_session_resume is False

--- a/test/test_chat_mirror.py
+++ b/test/test_chat_mirror.py
@@ -29,7 +29,9 @@ def _make_mirror_app(state):
     return app
 
 
-def _fake_transport(channel_type="telegram", proactive=True, max_message_chars=4096):
+def _fake_transport(
+    channel_type="telegram", proactive=True, max_message_chars=4096, session_resume=False
+):
     return SimpleNamespace(
         channel_type=channel_type,
         capabilities=SimpleNamespace(
@@ -38,6 +40,7 @@ def _fake_transport(channel_type="telegram", proactive=True, max_message_chars=4
             # backfill chunks to it instead of truncating, so the fake needs it
             # to exercise that path rather than the getattr fallback.
             max_message_chars=max_message_chars,
+            supports_session_resume=session_resume,
         ),
         send_message=AsyncMock(return_value="mid-1"),
         configured_targets=MagicMock(
@@ -669,3 +672,186 @@ class TestMirrorBackfillFidelity:
             "the link was persisted before delivery finished"
         )
         assert order.count("send") >= 3, "announcement + both messages should have been sent"
+
+
+class TestInboundClaimFollowsTheCapability:
+    """Connecting claims INBOUND only where the transport's inbound path honours it.
+
+    This is the fix for the reported bug. Without the claim the connect writes an
+    outbound-only binding, the channel's inbound resolver skips it, and the user's
+    reply starts a brand-new session with none of this transcript.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_resume_capable_transport_gets_an_inbound_binding(
+        self, tmp_path, monkeypatch
+    ):
+        state = _prep(tmp_path, monkeypatch)
+        state.register_channel_transport(_fake_transport("discord", session_resume=True))
+        state.sessions.set_mirror_link = MagicMock()
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "discord", "target_id": "user:123"},
+            )
+            assert resp.status == 200
+        assert state.sessions.set_mirror_link.call_args.kwargs["accepts_inbound"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_transport_that_cannot_resume_stays_outbound_only(
+        self, tmp_path, monkeypatch
+    ):
+        """Degrade, never over-promise.
+
+        Telegram builds its session key from the route and never consults the
+        binding, so claiming inbound would not make replies come back — it would
+        only make the slot row say they do.
+        """
+        state = _prep(tmp_path, monkeypatch)
+        state.register_channel_transport(_fake_transport("telegram", session_resume=False))
+        state.sessions.set_mirror_link = MagicMock()
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "telegram", "target_id": "user:123"},
+            )
+            assert resp.status == 200
+        assert state.sessions.set_mirror_link.call_args.kwargs["accepts_inbound"] is False
+
+    @pytest.mark.asyncio
+    async def test_an_occupied_conversation_is_refused_before_anything_is_posted(
+        self, tmp_path, monkeypatch
+    ):
+        """A binding can be unwound; posted messages cannot.
+
+        The authoritative check is atomic inside ``set_mirror_link``, but that
+        fires only after the link notice and the whole catch-up transcript have
+        been delivered. So the same question is asked at the first point the real
+        location is known, and nothing is sent into a conversation this session
+        does not get to own.
+        """
+        transport = _fake_transport("discord", session_resume=True)
+        state = _prep(tmp_path, monkeypatch)
+        state.register_channel_transport(transport)
+        state.sessions.mirror_claim_blockers = MagicMock(return_value=["dashboard:someone-else"])
+        state.sessions.set_mirror_link = MagicMock()
+        slot = state.get_or_create_slot("s1")
+        slot.messages.extend(
+            [
+                {"role": "user", "content": "private"},
+                {"role": "assistant", "content": "transcript"},
+            ]
+        )
+
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "discord", "target_id": "user:123"},
+            )
+            assert resp.status == 409
+            assert (await resp.json())["code"] == "conversation_occupied"
+
+        assert transport.send_message.await_count == 0, (
+            "the transcript was delivered into a conversation another session owns"
+        )
+        state.sessions.set_mirror_link.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_stubbed_session_manager_does_not_read_as_occupied(
+        self, tmp_path, monkeypatch
+    ):
+        """A Mock is truthy, and truthy must not mean "taken".
+
+        Read as a rival list, a stubbed accessor's Mock would refuse every connect
+        and the refusal would look like a real conflict. Only an actual list is an
+        answer; anything else means "no precheck", and the writer still enforces.
+        """
+        state = _prep(tmp_path, monkeypatch)
+        state.register_channel_transport(_fake_transport("discord", session_resume=True))
+        state.sessions.mirror_claim_blockers = MagicMock(return_value=MagicMock())
+        state.sessions.set_mirror_link = MagicMock()
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "discord", "target_id": "user:123"},
+            )
+            assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_a_governance_denial_persists_no_inbound_binding(self, tmp_path, monkeypatch):
+        """The write that grants inbound capability must stay behind the gate.
+
+        Persisting is the side effect that matters: a binding written for a
+        message governance went on to deny would leave the conversation connected
+        AND inbound-capable, so the channel would keep resuming a session policy
+        had just refused. The endpoint's existing fail-closed path is what
+        prevents it — this pins that the strengthened write inherits it.
+        """
+        transport = _fake_transport("discord", session_resume=True)
+
+        def _permits(*args, **kwargs):
+            # Keyed on "has anything been delivered yet?", not a call count, so
+            # the denial lands on the first in-loop unit regardless of how many
+            # messages the backfill selects.
+            return SimpleNamespace(
+                permitted=not transport.send_message.await_args_list,
+                rule="",
+                layer="",
+                reason="",
+            )
+
+        monkeypatch.setattr("kiro_crew.platform.governance_profiles.governance_permits", _permits)
+        state = _prep(tmp_path, monkeypatch)
+        state.register_channel_transport(transport)
+        state.sessions.set_mirror_link = MagicMock()
+        slot = state.get_or_create_slot("s1")
+        slot.messages.extend(
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi there"},
+            ]
+        )
+
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "discord", "target_id": "user:123"},
+            )
+            assert resp.status == 403
+
+        state.sessions.set_mirror_link.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_the_precheck_asks_the_writers_exact_question(self, tmp_path, monkeypatch):
+        """The precheck must pass the claim's inbound intent, not just the location.
+
+        Drop the argument and the precheck answers a different question from the
+        writer it backs -- refusing where the writer allows, which would newly
+        reject a second outbound-only mirror on transports that cannot resume at
+        all. The sentinel default is what makes omission detectable: a plain
+        ``False`` default would make "passed False" and "not passed" identical, so
+        the test would pass against the very divergence it exists to catch.
+        """
+        sentinel = object()
+        seen: list[object] = []
+
+        def _blockers(key, link, *, accepts_inbound=sentinel):
+            seen.append(accepts_inbound)
+            return []
+
+        state = _prep(tmp_path, monkeypatch)
+        # Discord declares session resume, so a threaded argument is True here and
+        # an omitted one would fall to the default -- two distinguishable states.
+        state.register_channel_transport(_fake_transport("discord", session_resume=True))
+        state.sessions.mirror_claim_blockers = _blockers
+        state.sessions.set_mirror_link = MagicMock()
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "discord", "target_id": "user:123"},
+            )
+            assert resp.status == 200
+        assert seen == [True], (
+            f"the precheck did not ask the writer's question with this claim's "
+            f"inbound intent: {seen}"
+        )

--- a/test/test_discord.py
+++ b/test/test_discord.py
@@ -59,6 +59,7 @@ from kiro_crew.discord.transport_dispatch import (
 from kiro_crew.messaging.attachments import cleanup
 from kiro_crew.messaging.link import ChannelLink, legacy_dashboard_mirror_key
 from kiro_crew.messaging.transport import InboundMessage
+from kiro_crew.session_map import ConversationOwnershipConflict
 
 _PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
 
@@ -247,6 +248,20 @@ class FakeSessions:
         *,
         accepts_inbound: bool = False,
     ) -> None:
+        # Interface parity with the real SessionMap: a conversation is exclusive
+        # once it is inbound-committed — this claim is inbound-capable, or an
+        # occupant already is. Two outbound-only mirrors stay allowed. A fake that
+        # accepts what production refuses lets a test go green against a state the
+        # product cannot reach.
+        rivals = [
+            other for other, held in self.mirror_links.items() if other != key and held == link
+        ]
+        if rivals and (
+            accepts_inbound or any(other in self.inbound_mirror_keys for other in rivals)
+        ):
+            raise ConversationOwnershipConflict(
+                f"{getattr(link, 'channel_type', '?')} conversation is already held"
+            )
         self.mirror_links[key] = link
         if accepts_inbound:
             self.inbound_mirror_keys.add(key)
@@ -1604,13 +1619,15 @@ class TestDispatcher:
     @pytest.mark.asyncio
     async def test_unlink_frees_location_in_one_shot_with_resumed_session(self) -> None:
         # A resumed session AND an outbound dashboard mirror can co-occupy a
-        # location (the dashboard mirror-link endpoint performs no occupancy
-        # check). The resumed-session early path must still free the WHOLE
-        # location — one `!unlink`, not two.
+        # location: a session map can hold co-located bindings written before
+        # conversations became exclusive. The resumed-session early path must
+        # still free the WHOLE location — one `!unlink`, not two. The rows go in
+        # directly because `set_mirror_link` refuses to create this state.
         d, cli, sess = _dispatcher({"u1"})
         loc = ChannelLink("discord", channel_id="c1")
-        sess.set_mirror_link("dashboard:resumed", loc, accepts_inbound=True)
-        sess.set_mirror_link("dashboard:chat-9", loc)
+        sess.mirror_links["dashboard:resumed"] = loc
+        sess.inbound_mirror_keys.add("dashboard:resumed")
+        sess.mirror_links["dashboard:chat-9"] = loc
         await d.handle_message(self._msg("!unlink"))
         assert sess.mirror_links == {}
         assert any("Left the resumed session" in t for t, _ in cli.sent)
@@ -1622,11 +1639,13 @@ class TestDispatcher:
         # Duplicate inbound bindings make the resume resolver fail closed
         # (routing denied), so the resumed-session path cannot release them —
         # the dispatcher sweep is the repair, and the reply says how much it
-        # cleared instead of a bare ✅ that reads as "just yours".
+        # cleared instead of a bare ✅ that reads as "just yours". The rows go in
+        # directly because `set_mirror_link` refuses to create this state.
         d, cli, sess = _dispatcher({"u1"})
         loc = ChannelLink("discord", channel_id="c1")
-        sess.set_mirror_link("dashboard:wedged-a", loc, accepts_inbound=True)
-        sess.set_mirror_link("dashboard:wedged-b", loc, accepts_inbound=True)
+        for wedged in ("dashboard:wedged-a", "dashboard:wedged-b"):
+            sess.mirror_links[wedged] = loc
+            sess.inbound_mirror_keys.add(wedged)
         await d.handle_message(self._msg("!unlink"))
         assert sess.mirror_links == {}
         assert any("Unlinked (2 bindings)" in t for t, _ in cli.sent)
@@ -1635,11 +1654,13 @@ class TestDispatcher:
     async def test_new_frees_whole_location_when_leaving_resumed_session(self) -> None:
         # `!new` releases a resumed session through the same whole-location
         # sweep as `!unlink`: a co-located outbound mirror must not leak into
-        # the fresh conversation the command starts.
+        # the fresh conversation the command starts. The rows go in directly
+        # because `set_mirror_link` refuses to create this state.
         d, cli, sess = _dispatcher({"u1"})
         loc = ChannelLink("discord", channel_id="c1")
-        sess.set_mirror_link("dashboard:resumed", loc, accepts_inbound=True)
-        sess.set_mirror_link("dashboard:bystander", loc)
+        sess.mirror_links["dashboard:resumed"] = loc
+        sess.inbound_mirror_keys.add("dashboard:resumed")
+        sess.mirror_links["dashboard:bystander"] = loc
         await d.handle_message(self._msg("!new"))
         assert sess.mirror_links == {}
         assert any("left the resumed session" in t for t, _ in cli.sent)

--- a/test/test_discord_sessions.py
+++ b/test/test_discord_sessions.py
@@ -10,6 +10,7 @@ from kiro_crew.discord.commands import parse_command, parse_command_argument
 from kiro_crew.discord.transport_dispatch import DiscordDispatcher
 from kiro_crew.messaging.link import ChannelLink
 from kiro_crew.messaging.transport import InboundMessage
+from kiro_crew.session_map import ConversationOwnershipConflict
 
 
 class _Client:
@@ -102,6 +103,20 @@ class _Sessions:
         *,
         accepts_inbound: bool = False,
     ) -> None:
+        # Interface parity with the real SessionMap: a conversation is exclusive
+        # once it is inbound-committed — this claim is inbound-capable, or an
+        # occupant already is. Two outbound-only mirrors are still allowed.
+        # Without the rule here, the in-channel `!link` refusal path is
+        # unreachable and a test for it would pass against unguarded production
+        # code; with it WIDER than production, a test would pass against a
+        # refusal production never makes.
+        rivals = [
+            other for other, held in self.mirror_links.items() if other != key and held == link
+        ]
+        if rivals and (accepts_inbound or any(other in self.inbound_keys for other in rivals)):
+            raise ConversationOwnershipConflict(
+                f"{link.channel_type} conversation is already held by {rivals[0]}"
+            )
         self.mirror_links[key] = link
         if accepts_inbound:
             self.inbound_keys.add(key)
@@ -1040,13 +1055,15 @@ async def test_choice_refusal_for_outbound_mirror_names_unlink() -> None:
 
 @pytest.mark.asyncio
 async def test_leave_resumed_session_frees_whole_location() -> None:
-    # The resumed-session release must clear co-located occupants too: the
-    # dashboard mirror-link endpoint performs no occupancy check, so an
-    # outbound mirror can share the location with the resume binding.
+    # The resumed-session release must clear co-located occupants too. A session
+    # map can hold that state — written before conversations became exclusive, or
+    # hand-edited — and the release has to free all of it. `set_mirror_link`
+    # refuses to create it, so the rows go in directly.
     dispatcher, client, sessions = _dispatcher({"u1"}, _log())
     loc = ChannelLink(channel_type="discord", channel_id="c1")
-    sessions.set_mirror_link("dashboard:resumed", loc, accepts_inbound=True)
-    sessions.set_mirror_link("dashboard:bystander", loc)
+    sessions.mirror_links["dashboard:resumed"] = loc
+    sessions.inbound_keys.add("dashboard:resumed")
+    sessions.mirror_links["dashboard:bystander"] = loc
 
     released = dispatcher._session_resume.leave_resumed_session("c1")
 
@@ -1112,3 +1129,125 @@ async def test_new_leaves_resumed_session_and_advances_native_generation() -> No
     assert "dashboard:chat-1" not in sessions.mirror_links
     assert dispatcher._session_key("u1") != old_key
     assert "left the resumed session" in client.sent[-1][0]
+
+
+class TestDashboardConnectedConversationResumes:
+    """The reported bug: replying to a message from Kiro Crew forked a new session.
+
+    A dashboard session connected to a Discord conversation, sent into it, and
+    the user replied there. Instead of continuing that session, the reply started
+    a brand-new one with no history — so the user was answered by an agent that
+    had never seen the conversation it was replying inside.
+
+    The inbound resolver was never at fault. ``resumed_session`` filters on the
+    binding's inbound marker, and the dashboard's connect never set it, so the
+    resolver correctly found no owner and the dispatcher fell through to Discord's
+    own route-derived session key. These tests pin the marker's effect on routing
+    from both sides.
+    """
+
+    @pytest.mark.asyncio
+    async def test_reply_resumes_the_connected_session(self) -> None:
+        dispatcher, _client, sessions = _dispatcher({"u1"}, _log())
+        # What a dashboard connect leaves behind once the transport declares
+        # `supports_session_resume` — the binding plus its inbound marker.
+        sessions.set_mirror_link(
+            "dashboard:chat-1",
+            ChannelLink(channel_type="discord", channel_id="c1"),
+            accepts_inbound=True,
+        )
+
+        assert dispatcher._session_resume.resumed_session("c1") == "dashboard:chat-1"
+        assert dispatcher._inbound_session_key("u1", "c1") == "dashboard:chat-1"
+
+    @pytest.mark.asyncio
+    async def test_an_outbound_only_binding_still_forks(self) -> None:
+        """The bug's exact mechanism, pinned so the marker cannot be dropped.
+
+        Same binding, no inbound marker — which is all main's connect could
+        write. The reply must NOT resolve to the connected session, and the key
+        the dispatcher falls back to is a Discord-native one, i.e. a different
+        conversation with none of the dashboard transcript. This is the
+        before-state; `accepts_inbound` is the whole difference.
+        """
+        dispatcher, _client, sessions = _dispatcher({"u1"}, _log())
+        sessions.set_mirror_link(
+            "dashboard:chat-1",
+            ChannelLink(channel_type="discord", channel_id="c1"),
+        )
+
+        assert dispatcher._session_resume.resumed_session("c1") is None
+        forked = dispatcher._inbound_session_key("u1", "c1")
+        assert forked != "dashboard:chat-1"
+        assert forked.startswith("discord:")
+
+    @pytest.mark.asyncio
+    async def test_two_owners_route_nowhere_which_is_why_exclusivity_ships_here(
+        self,
+    ) -> None:
+        """Why the ownership rule belongs with the inbound marker.
+
+        "No owner" and "two owners" land on the same ``None``. So setting the
+        inbound marker without enforcing one-session-per-conversation would not
+        fix the fork — it would only move it: a duplicated binding sends the
+        reply to NO session, silently forking exactly as before, and now with no
+        way for the user to tell why.
+        """
+        dispatcher, _client, sessions = _dispatcher({"u1"}, _log())
+        link = ChannelLink(channel_type="discord", channel_id="c1")
+        # Planted past the writer's guard: the state a map file can still hold.
+        sessions.mirror_links["dashboard:chat-1"] = link
+        sessions.inbound_keys.add("dashboard:chat-1")
+        sessions.mirror_links["dashboard:chat-2"] = link
+        sessions.inbound_keys.add("dashboard:chat-2")
+
+        assert dispatcher._session_resume.resumed_session("c1") is None
+        assert dispatcher._inbound_session_key("u1", "c1").startswith("discord:")
+
+    @pytest.mark.asyncio
+    async def test_inchannel_link_reports_the_refusal_instead_of_failing(self) -> None:
+        """`!link` must translate the conflict, not drop the handler task.
+
+        Reaching it takes the ambiguous state, and that is the point. A SINGLE
+        inbound owner is caught by the `resumed_session` precheck at the top of
+        `_handle_link`, which returns early. TWO inbound owners make
+        `resumed_session` return None -- it refuses to pick -- so the precheck
+        waves the command through and `set_mirror_link` is what refuses. Uncaught,
+        that raise propagates out of the command handler: the task is logged and
+        dropped, and the user gets no reply at all to a `!link` they just typed.
+        """
+        dispatcher, client, sessions = _dispatcher({"u1"}, _log())
+        loc = ChannelLink(channel_type="discord", channel_id="c1")
+        # Planted past the writer's guard: the duplicate state a map file can
+        # still hold, and the only state that reaches the handler's writer.
+        for occupant in ("dashboard:chat-7", "dashboard:chat-8"):
+            sessions.mirror_links[occupant] = loc
+            sessions.inbound_keys.add(occupant)
+        assert dispatcher._session_resume.resumed_session("c1") is None, (
+            "setup no longer produces the ambiguous state this test needs"
+        )
+
+        await dispatcher.handle_message(_message("!link"))
+
+        assert any("already linked" in text for text, _ in client.sent), (
+            f"the refusal was not reported to the channel: {client.sent}"
+        )
+        assert set(sessions.mirror_links) == {"dashboard:chat-7", "dashboard:chat-8"}, (
+            "an occupant was displaced, or the link was written anyway"
+        )
+
+    @pytest.mark.asyncio
+    async def test_two_outbound_mirrors_are_still_allowed(self) -> None:
+        """Exclusivity is owed to inbound routing, so it is scoped to it.
+
+        Two outbound-only mirrors on one conversation are merely noisy -- both
+        write out, nobody reads back -- so they stay allowed. Refusing them would
+        reach every transport that cannot resume at all, whose in-channel link
+        handlers do not translate the refusal because they can never provoke it.
+        """
+        _dispatcher_, _client, sessions = _dispatcher({"u1"}, _log())
+        loc = ChannelLink(channel_type="discord", channel_id="c1")
+        sessions.set_mirror_link("dashboard:chat-1", loc)
+        # Must not raise.
+        sessions.set_mirror_link("dashboard:chat-2", loc)
+        assert sessions.find_mirror_sessions(loc, inbound_only=True) == []

--- a/test/test_messaging_transport.py
+++ b/test/test_messaging_transport.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import fields
 
 import pytest
 
@@ -39,18 +40,16 @@ class TestTransportCapabilities:
         d = cap.to_dict()
         assert d["streaming"] is True
         assert d["max_message_chars"] == 2000
-        assert set(d) == {
-            "streaming",
-            "edit",
-            "reactions",
-            "files_inbound",
-            "files_outbound",
-            "rich_blocks",
-            "threads",
-            "max_message_chars",
-            "max_buttons",
-            "supports_proactive_send",
-        }
+        # Compared against the DATACLASS FIELDS, not a hand-maintained list. The
+        # hardcoded set this replaces could not catch the defect it looked like it
+        # was guarding: a field added to the dataclass but forgotten in
+        # ``to_dict`` left keys == list and PASSED, while every legitimate
+        # addition failed it as pure bookkeeping. Against the fields, an omission
+        # fails and an addition wired through both places passes.
+        assert set(d) == {f.name for f in fields(TransportCapabilities)}, (
+            "to_dict() and the dataclass have diverged — a capability that is "
+            "not serialised is invisible to every consumer reading the dict form"
+        )
 
 
 class TestInboundMessage:

--- a/test/test_session_map_mirror.py
+++ b/test/test_session_map_mirror.py
@@ -18,7 +18,7 @@ from kiro_crew.messaging.link import (
     legacy_dashboard_mirror_key,
     release_conversation_location,
 )
-from kiro_crew.session_map import SessionMap
+from kiro_crew.session_map import ConversationOwnershipConflict, SessionMap
 
 
 @pytest.fixture()
@@ -26,6 +26,24 @@ def session_map(tmp_path):
     """A SessionMap backed by a temp directory."""
     with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
         yield SessionMap()
+
+
+def plant_binding(session_map, key, link, *, accepts_inbound=False):
+    """Write a binding straight into the map, bypassing the writer's exclusivity.
+
+    ``set_mirror_link`` refuses to put a second session on an inbound-committed
+    conversation, so co-located rows cannot be *created* through it. They can
+    still EXIST: a ``session_map.json`` written before conversations became
+    exclusive, or hand-edited, can hold two owners. Readers and sweeps have to
+    cope with that state — the resolver's fail-closed branch and the in-channel
+    conflict detection both depend on seeing every owner — so the tests below
+    plant the rows directly.
+    """
+    entry = session_map._ensure_entry(key)
+    entry["mirror"] = link.to_dict()
+    if accepts_inbound:
+        entry["mirror_accepts_inbound"] = True
+    session_map._save()
 
 
 class TestNonSlackMirror:
@@ -140,8 +158,11 @@ class TestMirrorReverseLookup:
 
     def test_duplicate_locations_are_explicit_not_arbitrarily_resolved(self, session_map):
         link = ChannelLink(channel_type="discord", channel_id="dm-1")
-        session_map.set_mirror_link("dashboard:chat-1", link, accepts_inbound=True)
-        session_map.set_mirror_link("dashboard:chat-2", link, accepts_inbound=True)
+        # Planted, not written: see plant_binding. A map holding two owners still
+        # reports BOTH, so the resolver refuses to pick one instead of guessing —
+        # the reader is permissive where the writer is strict.
+        plant_binding(session_map, "dashboard:chat-1", link, accepts_inbound=True)
+        plant_binding(session_map, "dashboard:chat-2", link, accepts_inbound=True)
 
         assert session_map.find_mirror_sessions(link, inbound_only=True) == [
             "dashboard:chat-1",
@@ -197,10 +218,12 @@ class TestClearMirrorLinksAt:
     def test_clears_every_spelling_at_the_location(self, session_map):
         # The stale-mirror shape: rows under key spellings the conversation no
         # longer derives (rotated generation, pre-unification dashboard row)
-        # plus a dashboard session mirroring in — all at one location.
-        session_map.set_mirror_link("discord:agent:direct:u1", self.LINK)
-        session_map.set_mirror_link("dashboard:discord_agent_direct_u1", self.LINK)
-        session_map.set_mirror_link("dashboard:chat-3", self.LINK)
+        # plus a dashboard session mirroring in — all at one location. Planted
+        # directly: the writer now refuses co-location, but a map file can still
+        # hold it and the sweep has to free all of it.
+        plant_binding(session_map, "discord:agent:direct:u1", self.LINK)
+        plant_binding(session_map, "dashboard:discord_agent_direct_u1", self.LINK)
+        plant_binding(session_map, "dashboard:chat-3", self.LINK)
         cleared = session_map.clear_mirror_links_at(self.LINK)
         assert sorted(cleared) == [
             "dashboard:chat-3",
@@ -286,10 +309,11 @@ class TestReleaseConversationLocation:
     def test_stranded_and_foreign_rows_are_counted(self, session_map):
         # Own binding + a row stranded under a rotated-generation spelling +
         # a dashboard session mirroring in: one call frees the location and
-        # the reply owns up to the full count.
-        session_map.set_mirror_link(self.KEY, self.LINK)
-        session_map.set_mirror_link(f"{self.KEY}:gen1", self.LINK)
-        session_map.set_mirror_link("dashboard:chat-9", self.LINK)
+        # the reply owns up to the full count. Planted directly — the writer
+        # refuses co-location, but the sweep has to cope with a map that holds it.
+        plant_binding(session_map, self.KEY, self.LINK)
+        plant_binding(session_map, f"{self.KEY}:gen1", self.LINK)
+        plant_binding(session_map, "dashboard:chat-9", self.LINK)
         reply, swept = release_conversation_location(
             session_map, key=self.KEY, location=self.LINK, channel="discord"
         )
@@ -378,3 +402,139 @@ class TestLegacyDashboardSpelling:
         # Only a channel key has a legacy twin; a dashboard session must not
         # inherit a binding from some unrelated sanitized name.
         assert session_map.get_mirror_link("dashboard:chat-1") is None
+
+
+class TestConversationOwnership:
+    """One conversation, at most one session — enforced on the writer.
+
+    Not a policy preference. The inbound resolver refuses to choose between two
+    candidates, and "no owner" and "two owners" are the same ``None`` to it, so a
+    duplicate binding does not misroute a reply — it unroutes it, and the reply
+    silently starts a fresh session. Marking a binding inbound-capable without
+    this rule would move the fork rather than fix it.
+    """
+
+    LINK = ChannelLink(channel_type="discord", channel_id="dm-1")
+
+    def test_a_second_session_is_refused(self, session_map):
+        session_map.set_mirror_link("dashboard:chat-1", self.LINK, accepts_inbound=True)
+        with pytest.raises(ConversationOwnershipConflict):
+            session_map.set_mirror_link("dashboard:chat-2", self.LINK, accepts_inbound=True)
+        # The incumbent is untouched — a refusal never half-applies.
+        assert session_map.find_mirror_sessions(self.LINK) == ["dashboard:chat-1"]
+
+    def test_an_outbound_claim_over_an_inbound_occupant_is_refused(self, session_map):
+        """The scan stays UNFILTERED once the conversation is inbound-committed.
+
+        An in-channel ``!link`` is an outbound claim. Letting it land a second
+        binding on a conversation the dashboard is resuming through is the exact
+        collision that leaves the resolver two candidates and strands the reply.
+        """
+        session_map.set_mirror_link("dashboard:chat-1", self.LINK, accepts_inbound=True)
+        with pytest.raises(ConversationOwnershipConflict):
+            session_map.set_mirror_link("discord:agent:direct:u1", self.LINK)
+
+    def test_an_inbound_claim_over_an_outbound_occupant_is_refused(self, session_map):
+        session_map.set_mirror_link("discord:agent:direct:u1", self.LINK)
+        with pytest.raises(ConversationOwnershipConflict):
+            session_map.set_mirror_link("dashboard:chat-1", self.LINK, accepts_inbound=True)
+
+    def test_two_outbound_mirrors_are_left_alone(self, session_map):
+        """Exclusivity is owed to inbound routing, so it is scoped to it.
+
+        Two outbound-only mirrors are merely noisy — both write out, nobody reads
+        back — so they stay allowed. Refusing them would reach every transport that
+        cannot resume at all (Telegram, Teams, Webex, WeCom, Weixin), whose
+        in-channel link handlers do not translate this refusal because they can
+        never provoke it.
+        """
+        session_map.set_mirror_link("dashboard:chat-1", self.LINK)
+        # Must not raise.
+        session_map.set_mirror_link("dashboard:chat-2", self.LINK)
+        assert sorted(session_map.find_mirror_sessions(self.LINK)) == [
+            "dashboard:chat-1",
+            "dashboard:chat-2",
+        ]
+
+    def test_a_non_resuming_transport_is_never_refused(self, session_map):
+        """Pins the blast radius: a Telegram chat cannot become inbound-committed.
+
+        ``telegram/transport_dispatch.py`` calls ``set_mirror_link`` without
+        catching this exception, and an uncaught raise inside a channel command
+        handler is a dropped task and a silent no-reply. It stays unreachable
+        because Telegram does not declare ``supports_session_resume``, so the
+        dashboard never marks its bindings inbound and nothing else does either.
+        """
+        chat = ChannelLink(channel_type="telegram", channel_id="55", thread_id=None)
+        session_map.set_mirror_link("dashboard:chat-1", chat)
+        # Two dashboard sessions mirroring one Telegram chat: allowed before this
+        # rule, allowed after it.
+        session_map.set_mirror_link("dashboard:chat-2", chat)
+        assert len(session_map.find_mirror_sessions(chat)) == 2
+
+    def test_the_same_session_may_rebind_itself(self, session_map):
+        """A reconnect is not a rivalry."""
+        session_map.set_mirror_link("dashboard:chat-1", self.LINK)
+        session_map.set_mirror_link("dashboard:chat-1", self.LINK, accepts_inbound=True)
+        assert session_map.find_mirror_sessions(self.LINK, inbound_only=True) == [
+            "dashboard:chat-1"
+        ]
+
+    def test_a_session_may_supersede_its_own_legacy_row(self, session_map):
+        """The self-set has to include the row the binding actually lives on.
+
+        A pre-unification ``dashboard:`` row IS this session's binding, and only
+        ``_mirror_key`` can say so. Deriving the legacy name unconditionally would
+        excuse rows that are not this session's; not consulting it at all makes a
+        session a rival to itself and refuses its own reconnect.
+        """
+        key = "discord:agent:direct:u1"
+        plant_binding(session_map, legacy_dashboard_mirror_key(key), self.LINK)
+        # Must not raise: the only occupant is this same session, older spelling.
+        session_map.set_mirror_link(key, self.LINK, accepts_inbound=True)
+        assert key in session_map.find_mirror_sessions(self.LINK, inbound_only=True)
+
+    def test_an_unrelated_location_is_never_a_rival(self, session_map):
+        session_map.set_mirror_link("dashboard:chat-1", self.LINK)
+        elsewhere = ChannelLink(channel_type="discord", channel_id="dm-2")
+        session_map.set_mirror_link("dashboard:chat-2", elsewhere, accepts_inbound=True)
+        assert session_map.find_mirror_sessions(elsewhere) == ["dashboard:chat-2"]
+
+    def test_a_different_channel_type_at_the_same_id_is_not_a_rival(self, session_map):
+        session_map.set_mirror_link("dashboard:chat-1", self.LINK)
+        same_id_other_channel = ChannelLink(channel_type="telegram", channel_id="dm-1")
+        session_map.set_mirror_link("dashboard:chat-2", same_id_other_channel)
+        assert session_map.find_mirror_sessions(same_id_other_channel) == ["dashboard:chat-2"]
+
+    def test_readers_still_report_every_owner_of_a_pre_existing_duplicate(self, session_map):
+        """Enforce on the writer; keep the reader permissive.
+
+        A map written before this check can hold two owners. If the reader hid
+        one, the resolver would stop failing closed and start routing a reply to
+        an arbitrary session, and the in-channel conflict detection that tells the
+        user to `!unlink` would see nothing to report.
+        """
+        plant_binding(session_map, "dashboard:chat-1", self.LINK, accepts_inbound=True)
+        plant_binding(session_map, "dashboard:chat-2", self.LINK, accepts_inbound=True)
+        assert session_map.find_mirror_sessions(self.LINK, inbound_only=True) == [
+            "dashboard:chat-1",
+            "dashboard:chat-2",
+        ]
+
+    def test_an_inbound_binding_on_a_never_saved_session_survives_a_reload(
+        self, session_map, tmp_path
+    ):
+        """The loader drops a row with no ``sid``, which would lose the binding.
+
+        A dashboard connect can be the first thing that ever writes a row for a
+        session, so the row it creates has to be a shape ``_load`` accepts.
+        Otherwise the binding is correct in memory, correct on disk, and silently
+        gone after the next restart — the fork would come back on reboot only.
+        """
+        session_map.set_mirror_link("dashboard:brand-new", self.LINK, accepts_inbound=True)
+        with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
+            reloaded = SessionMap()
+        assert reloaded.find_mirror_sessions(self.LINK, inbound_only=True) == [
+            "dashboard:brand-new"
+        ]
+        assert reloaded.mirror_accepts_inbound("dashboard:brand-new") is True


### PR DESCRIPTION
<!-- pr-body:discord-session-resume -->
## Problem

Reply to a message KiroCrew sent you in Discord and you get answered by an agent
that has never seen the conversation it is replying inside. The reply does not
continue the session that sent the message — it starts a brand-new one with no
history.

Slack has always continued the session on a thread reply, so the two channels
behave differently in a way nothing explains to the user.

## Why it matters

Discord is the surface where this is hardest to notice and most damaging. The
dashboard session keeps its transcript and looks fine; the Discord side quietly
becomes a second, empty conversation. Anything the user said in the dashboard is
gone from the agent's view, so it re-asks answered questions, loses the task it
was given, and re-does or contradicts work. From the user's seat this reads as
amnesia rather than a routing bug, so it does not get reported as one.

It also makes "connect this session to Discord" a promise the product does not
keep. Connecting is offered as a way to keep working somewhere else; a reply that
forks is the one thing that cannot happen for that to be true.

## Fix (symptom → root cause → change)

**The inbound resolver was never at fault.** `DiscordSessionResume.resumed_session`
looks the conversation up by binding value and deliberately fails closed, and it
does so correctly.

**The binding it looks for was never marked inbound-capable.** `resumed_session`
filters on `mirror_accepts_inbound`, and on `main` exactly one writer in the whole
repo ever set that marker: the in-channel `!sessions` picker. The dashboard's
connect endpoint called `set_mirror_link(session_key, link)` with no
`accepts_inbound` at all, so a conversation the dashboard was talking to held an
*outbound-only* binding. `resumed_session` skipped it, returned `None`, and the
dispatcher fell through to `self._session_key(user_id, thread_id)` — Discord's own
route-derived key. A different session, hence no history.

**Slack cannot exhibit this**, which is why the two diverged: `set_slack_link` has
no direction parameter. One write populates the thread index and serves both legs,
so the dashboard makes a Slack thread inbound-resolvable as a side effect it cannot
opt out of.

The change:

1. **`TransportCapabilities.supports_session_resume`** (new, default `False`,
   declared only by Discord). The connect derives `accepts_inbound` from it via
   `_resumes_inbound(transport)`, so the binding is marked inbound-capable exactly
   where the transport's inbound path actually resolves it. This is a capability
   rather than a `channel_type == "discord"` test so a transport earns the claim by
   declaring it next to its own inbound path. Default-off means a transport that
   forgets it degrades to outbound-only — less capable, rather than promising a
   two-way link that silently drops replies. Telegram and the rest build a session
   key from the route and never consult the binding, so claiming inbound for them
   would not make replies come back; it would only make the dashboard say they do.

2. **One session per conversation**, enforced inside `SessionMap.set_mirror_link`
   via a new `ConversationOwnershipConflict`.

### Why the ownership rule is in this PR and not a follow-up

Setting the marker is not safe on its own. `resumed_session` returns `None` for
**both** "no owner" and "two owners" — it refuses to choose rather than routing a
reply to an arbitrary session. So a duplicated inbound binding does not misroute
the reply, it *unroutes* it: the message silently starts a fresh session exactly as
before, and now with nothing to tell the user why.

That state is newly reachable precisely because of change 1. Discord binds a
**channel**, and a DM has exactly one — whereas a dashboard send to Slack creates a
fresh thread that contends with nothing. Two dashboard sessions connected to one
Discord conversation would both carry the marker, and the fork would come back
wearing a different hat. Shipping the marker without exclusivity would move the bug
rather than fix it, so the two belong in one change.

Scoping of that rule, deliberately narrow:

- **Enforced on the writer, not the reader.** A `session_map.json` written before
  this rule can still hold two owners, and readers keep reporting both — that is
  what makes the resolver fail closed and lets in-channel conflict detection tell
  the user to `!unlink`. Hiding a duplicate would start routing replies arbitrarily.
- **Exclusivity is owed to inbound routing, so it is scoped to it.** A conversation
  is exclusive once it is *inbound-committed* — this claim is inbound-capable, or an
  occupant already is. Two outbound-only mirrors stay as permitted as they were:
  they are merely noisy, and refusing them would change behaviour on transports that
  cannot resume at all. Telegram's in-channel `/link` does not translate this
  refusal, and under this scoping it can never provoke one.
- **Unfiltered once inbound-committed.** An outbound-only occupant still blocks an
  inbound claim, and an outbound `!link` is refused on a conversation the dashboard
  is resuming through. That is the collision that strands a reply.
- **Each surface translates the refusal** — HTTP 409 `conversation_occupied` from the
  endpoint, "run `!unlink` first" in Discord. An uncaught raise inside a channel
  command handler is a dropped task and a silent no-reply.

The endpoint also gains an occupancy **precheck** at the first point the real
conversation is known, before the link notice and catch-up transcript are delivered.
The authoritative check is the atomic one in the writer, but that fires only after
delivery — and a binding can be unwound while posted messages cannot. Precheck and
writer call the same predicate with the same arguments, so they cannot drift into
disagreeing about what "occupied" means.

**Deliberately not in scope.** The claim-before-deliver reordering (with rollback)
that would close the remaining race — where a conversation is claimed *during* this
connect's delivery — is not here. That window is pre-existing; today it silently
double-binds, and after this change it is detected and answered with a 409. Closing
it properly needs snapshot/rollback machinery that belongs with the takeover work.

No multi-channel behaviour is added: a session still holds **one binding per
channel**, exactly as on `main`. No UI files change.

## Tests

- `test/test_discord_sessions.py::TestDashboardConnectedConversationResumes` — the
  reported bug from both sides: a marked binding resolves to the connected session;
  an outbound-only one still forks (the before-state, so the marker cannot be
  dropped unnoticed); two owners route nowhere, which is the ownership rule's
  justification as an executable assertion; `!link` translates the conflict instead
  of dropping the handler task; two outbound mirrors remain allowed.
- `test/test_session_map_mirror.py::TestConversationOwnership` — the rule at the
  storage layer: refusal in both directions, self-rebind and legacy-row supersede
  permitted, unrelated locations and other channel types unaffected, readers still
  reporting every owner of a pre-existing duplicate, a non-resuming transport never
  refused, and an inbound binding on a never-before-saved session surviving a reload
  (the loader drops a row without `sid`, which would lose the binding on restart
  only).
- `test/test_chat_mirror.py::TestInboundClaimFollowsTheCapability` — the connect
  claims inbound for a resume-capable transport and not otherwise; an occupied
  conversation is refused *before* anything is posted; a stubbed SessionManager's
  truthy `Mock` is not read as "occupied"; the precheck asks the writer's exact
  question; and a governance denial mid-delivery persists no binding.
- `test/test_capability_ledger.py::TestSessionResumeIsDeclaredOnlyWhereItIsHonoured`
  — Discord declares the capability, no other transport does, and the dataclass
  default is off. The middle case is the valuable one: a future transport declaring
  it fails here until someone confirms its inbound path resolves the binding.
- `test/test_messaging_transport.py` — `to_dict` is now compared against
  `fields(TransportCapabilities)`. The hand-maintained key set it replaces could not
  catch the defect it appeared to guard: a field added to the dataclass but omitted
  from `to_dict` left keys equal to the list and passed, while every correct addition
  failed it as bookkeeping.

Three existing tests had their **setup** changed, not their assertions: they built
co-located bindings through `set_mirror_link`, which now refuses to create that
state, so they plant the rows directly — the shape a map file can still hold, which
readers and sweeps must keep coping with. One stale comment asserting the connect
endpoint performs no occupancy check was corrected, since this change makes it false.

## Manual verification

N/A — unit coverage is sufficient and the alternative is not better evidence.
Reproducing by hand needs a live Discord bot, a real DM, and a dashboard connect,
and it would exercise the same two decisions the tests pin directly: whether the
persisted binding carries the inbound marker, and which session key the dispatcher
resolves. Both are asserted against production functions rather than stubs.

Every mechanism was additionally proven non-vacuous by reverting it and confirming
the tests fail: the inbound claim, Discord's declaration, the capability default, the
ownership guard (removed, widened, and narrowed — three separate mutations), the
self-set's legacy-row handling, the endpoint precheck, its `Mock`-truthiness guard,
its argument threading, and the `!link` translation. 11 of 11 caught.

## Screenshots

No frontend file changes. The user-visible consequence is that a connected Discord
row now renders through the existing `direction: 'both'` path — the two-way chip in
`InboundLinkChip.tsx` and the "Release" verb in `LinkedSurfacesSection.tsx` — instead
of the one-way mirror rendering. Both are existing components on `main`, already
reachable there via the in-channel `!sessions` picker, exercised by existing frontend
tests, and reached here through the same wire field (`direction`, derived from the
inbound marker in `dashboard/state.py`, which is unchanged). There is no new or
changed component to capture.
