### PR TITLE
fix(i18n): add the five missing Korean sendToInstanceSubmenu keys

### DIFF
--- a/website/src/i18n/locales/ko.json
+++ b/website/src/i18n/locales/ko.json
@@ -5484,6 +5484,13 @@
       "undo_remove": "삭제 취소",
       "will_be_removed_on_save": "저장할 때 삭제됩니다."
     },
+    "sendToInstanceSubmenu": {
+      "failed": "실패",
+      "not_connected": "연결되지 않음",
+      "send_a_copy_to": "복사본 보내기",
+      "sent": "전송됨",
+      "unknown_error": "알 수 없는 오류"
+    },
     "sessionActionsMenu": {
       "bring_back_to_main": "메인 창으로 되돌리기",
       "close_session": "세션 닫기",


### PR DESCRIPTION
## Problem

`catalogParity > ko > has no key missing relative to en` fails on `main`, so
**Frontend Tests is red on every open PR**, and Coverage Gate fails downstream of it:

```
AssertionError: missing 5 key(s), e.g. components.sendToInstanceSubmenu.failed,
components.sendToInstanceSubmenu.not_connected,
components.sendToInstanceSubmenu.send_a_copy_to,
components.sendToInstanceSubmenu.sent, components.sendToInstanceSubmenu.unknown_error
```

## Why it matters

It is a base breakage, not a per-PR defect: it costs every author a red check they
did not cause and cannot fix from their branch, and it trains people to ignore a red
Frontend Tests — which is exactly when a real frontend regression slips through.

## Fix (symptoms → root cause → change)

**Symptom:** `ko` is the only locale failing parity, on five keys under one new
namespace.

**Root cause:** `en.json` gained `components.sendToInstanceSubmenu` with the
send-a-copy-to-instance submenu, and `ko.json` was not updated in the same change.
The other translated catalogs have it; `ko` alone was missed.

**Change:** add the five keys to `ko.json` with real Korean text, in the same
alphabetical position `en.json` uses (between `secretField` and
`sessionActionsMenu`):

| key | en | ko |
|---|---|---|
| `failed` | Failed | 실패 |
| `not_connected` | not connected | 연결되지 않음 |
| `send_a_copy_to` | Send a copy to | 복사본 보내기 |
| `sent` | Sent | 전송됨 |
| `unknown_error` | Unknown error | 알 수 없는 오류 |

Translations, not English placeholders, and matched to the catalog's existing tone
(it already uses 실패 for failures, 전송 for send, 오류 for errors).

## Tests

No new tests — `catalogParity` already covers this and is the check that was failing.
`npx vitest run src/i18n/` → **38 files / 597 tests pass** (1 expected-fail
unchanged). Verified the failure reproduces on pristine `origin/main` in a throwaway
worktree before fixing, so the provenance is not in doubt.

## Manual verification

N/A — a locale-only data fix fully covered by the parity gate.

## Screenshots

N/A — no visual change beyond the five submenu strings rendering in Korean instead of
being absent.

## Note

There is a separate open PR (#2246) for an earlier, unrelated `ko` gap. This one is
independent and deliberately minimal so it can land immediately and unblock the other
open PRs. Worth a look while you are here: #2246 adds `notificationsPanel.preset_pulse`,
which no longer exists in `en.json` — as written it may now trip the dead-keys gate.
