### PR TITLE
fix(auto-tag): suppress trivial workspace basenames from session tags

### DIFF
--- a/src/kiro_crew/dashboard/chat_auto_tag.py
+++ b/src/kiro_crew/dashboard/chat_auto_tag.py
@@ -31,6 +31,15 @@ from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 logger = logging.getLogger(__name__)
 
+# Basenames that carry no useful signal — suppress auto-tagging for these.
+# Includes the default workspace dir names plus trivial path components.
+_TRIVIAL_BASENAMES = frozenset({
+    ".", "~",
+    "workspace", "workspaces", "workplace",
+    "kirocrew-workspace",
+    "default",
+})
+
 
 async def maybe_auto_tag(state: Any, slot: Any) -> None:
     """Derive a tag from the slot's project directory and apply it.
@@ -64,7 +73,7 @@ async def _auto_tag_inner(state: Any, slot: Any) -> None:
     if not project:
         return
     tag_name = os.path.basename(project)
-    if not tag_name or tag_name in (".", "~"):
+    if not tag_name or tag_name in _TRIVIAL_BASENAMES:
         return
 
     # Redact credential/exfiltration patterns from derived name, then apply

--- a/test/test_tag_session.py
+++ b/test/test_tag_session.py
@@ -137,6 +137,18 @@ class TestAutoTagDerivation:
         assert len(state._tags) == 1
         assert state._tags[0]["name"] == "DisapereBackend"
 
+    @pytest.mark.parametrize("name", ["workspace", "workspaces", "workplace", "kirocrew-workspace", "default"])
+    async def test_trivial_workspace_basenames_are_noop(self, patch_save_slot, name):
+        """Default/generic workspace dir names carry no signal — suppress them."""
+        state = _make_state()
+        slot = _make_slot(project=f"/home/user/.kiro/crew/{name}")
+
+        await maybe_auto_tag(state, slot)
+
+        assert len(state._tags) == 0
+        assert len(slot.tags) == 0
+        patch_save_slot.assert_not_awaited()
+
 
 # ── Idempotency ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

Sessions auto-tagged with `workspace` (the basename of the default workspace directory) — every session got the same tag, making it useless noise in the sidebar.

## Why it matters

Tags exist to help users filter and identify sessions at a glance. A tag that every session carries provides zero signal and clutters the UI.

## Fix

Expanded the trivial-basename check in `chat_auto_tag.py` from just `.`/`~` to a `frozenset` of generic workspace dir names (`workspace`, `workspaces`, `workplace`, `kirocrew-workspace`, `default`). Sessions with these basenames are now silently skipped — only sessions with a meaningful project name get auto-tagged.

## Tests

- `test_trivial_workspace_basenames_are_noop` — parametrized across all 5 suppressed names, verifies no tag definition is created and no slot persistence fires.

## Manual verification

N/A — unit coverage sufficient (the function is pure async logic with mocked I/O, no rendering surface).
