### PR TITLE
fix(knowledge): run the ingest-path item deletes off the event loop

### DIFF
--- a/src/kiro_crew/knowledge/folder_watcher.py
+++ b/src/kiro_crew/knowledge/folder_watcher.py
@@ -18,7 +18,7 @@ from kiro_crew.sel import sel
 
 from .chunker import CHUNK_TOKEN_SIZE, MAX_CHUNKS_PER_FILE
 from .dedup import dedup_document
-from .ingestion import DUPLICATE_JOB_STATUS
+from .ingestion import DUPLICATE_JOB_STATUS, run_to_completion
 from .kiroignore import KIROIGNORE_FILENAME
 from .kiroignore import load as load_kiroignore
 from .readers import FileReader
@@ -748,23 +748,31 @@ class FolderWatcher:
     async def _handle_deleted(self, source_id: str, file_path: str, state: dict):
         """Archive items for a deleted file and remove state row."""
         item_ids = json.loads(state.get("item_ids", "[]"))
-        if item_ids:
-            # The file is gone from THIS folder; a copy another source holds survives.
-            self.store.delete_items_batch(item_ids, owner_source_id=source_id)
-        else:
-            # No group to detach -- which is exactly the case for a file that LOST a
-            # dedup: its row is 'deduped' with an empty group, while this source is
-            # still recorded as a location of the winner's items. That claim is what
-            # would later hand this source a document whose file is gone, so it is
-            # released by content hash. Nothing is deleted: the items are the winner's.
-            # The TEXT hash, not the bytes one: this resolves items, and for a PDF or
-            # HTML file the two differ.
-            self.store.detach_source_location_by_hash(
-                source_id, state.get("text_hash") or "")
-        self.store.db.execute(
-            "DELETE FROM folder_file_state WHERE source_id = ? AND file_path = ?",
-            (source_id, file_path))
-        self.store.db.commit()
+
+        def _archive_and_forget() -> None:
+            # ONE off-loop hop: delete_items_batch rebuilds the entity graph and
+            # cannot run on the loop, and the folder_file_state removal must
+            # travel with it -- a cancellation between the two would leave a
+            # state row pointing at item_ids that are already gone.
+            if item_ids:
+                # The file is gone from THIS folder; a copy another source holds survives.
+                self.store.delete_items_batch(item_ids, owner_source_id=source_id)
+            else:
+                # No group to detach -- which is exactly the case for a file that LOST a
+                # dedup: its row is 'deduped' with an empty group, while this source is
+                # still recorded as a location of the winner's items. That claim is what
+                # would later hand this source a document whose file is gone, so it is
+                # released by content hash. Nothing is deleted: the items are the winner's.
+                # The TEXT hash, not the bytes one: this resolves items, and for a PDF or
+                # HTML file the two differ.
+                self.store.detach_source_location_by_hash(
+                    source_id, state.get("text_hash") or "")
+            self.store.db.execute(
+                "DELETE FROM folder_file_state WHERE source_id = ? AND file_path = ?",
+                (source_id, file_path))
+            self.store.db.commit()
+
+        await run_to_completion(_archive_and_forget)
         logger.info("Deleted file removed: %s (%d items)", file_path, len(item_ids))
 
     async def _ingest_file(self, file_path: str, source_id: str, namespace: str, props: dict,

--- a/src/kiro_crew/knowledge/ingestion.py
+++ b/src/kiro_crew/knowledge/ingestion.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from pathlib import Path
 from uuid import uuid4
@@ -42,6 +43,35 @@ DUPLICATE_JOB_STATUS = 'skipped_duplicate'
 
 DEFAULT_MAX_INGEST_FILE_MB = 100.0
 _MB = 1024 * 1024
+
+
+async def run_to_completion(fn: Callable[[], None]) -> None:
+    """Run ``fn`` on a worker thread, guaranteed to run even if cancelled.
+
+    A bare ``await asyncio.to_thread(fn)`` can drop ``fn`` entirely: when
+    cancellation arrives while the work item is still QUEUED in the executor,
+    the wrapped future is cancelled before ``fn`` ever starts. The ingestion
+    finalizers pair a committed delete with its state finalization, so a
+    skipped finalizer strands committed data (the next scan re-ingests
+    alongside it -> duplicates). Shield the worker task; on cancellation,
+    wait for it to finish, then re-raise.
+    """
+    task = asyncio.ensure_future(asyncio.to_thread(fn))
+    try:
+        await asyncio.shield(task)
+    except asyncio.CancelledError:
+        # The finalizer is bounded sync DB work: drain it even under repeated
+        # cancellation, then let the cancellation proceed.
+        while not task.done():
+            try:
+                await asyncio.wait([task])
+            except asyncio.CancelledError:
+                continue
+        exc = task.exception()
+        if exc is not None:
+            # Retrieve + surface the failure; the CancelledError still wins.
+            logger.error("Finalizer failed during cancellation: %s", exc)
+        raise
 
 
 class FileTooLargeError(RuntimeError):
@@ -506,29 +536,45 @@ class IngestionPipeline:
 
         # 6. Finalize
         now = datetime.now().isoformat()
+
+        def _finalize() -> None:
+            # Runs OFF the loop as ONE hop: delete_items_batch rebuilds the entire
+            # entity graph (store._load_graph) inside its own BEGIN/COMMIT, which
+            # wedged the event loop past the stall watchdog on large libraries.
+            # The delete and the state finalization travel together so a
+            # cancellation (gateway shutdown) lands entirely before or entirely
+            # after this hop -- a delete that commits while sync_status/job
+            # finalization is skipped would make the next scan re-ingest
+            # alongside the already-committed new items (duplicates). The
+            # worker's thread-local connection is autocommit
+            # (isolation_level=None), so no enclosing transaction spans this,
+            # and WAL + busy_timeout=10000 rides out write-lock contention.
+            if processed == total:
+                self.store.delete_items_batch(_old_item_ids, owner_source_id=source_id)
+                if existing:
+                    self.store.update_source(source_id, properties=json.dumps({**props, 'content_hash': content_hash, **meta}))
+                self.store.db.execute("UPDATE sources SET sync_status = 'synced' WHERE id = ?", (source_id,))
+                self.store.update_source(source_id, last_synced=now)
+            elif processed < total:
+                # Partial failure: remove only items created during THIS ingestion call
+                after_ids = {r["id"] for r in self.store.db.execute(
+                    "SELECT id FROM items WHERE source_id = ?", (source_id,),
+                ).fetchall()}
+                self.store.delete_items_batch(list(after_ids - _before_ids))
+                self.store.db.execute("UPDATE sources SET sync_status = 'error' WHERE id = ?", (source_id,))
+            self.store.db.execute(
+                "UPDATE ingestion_jobs SET status = ?, items_processed = ?, updated_at = ? WHERE id = ?",
+                (_job_status(processed, total), processed, now, job_id))
+            self.store.db.commit()
+
+        await run_to_completion(_finalize)
         if processed == total:
-            self.store.delete_items_batch(_old_item_ids, owner_source_id=source_id)
-            if existing:
-                self.store.update_source(source_id, properties=json.dumps({**props, 'content_hash': content_hash, **meta}))
-            self.store.db.execute("UPDATE sources SET sync_status = 'synced' WHERE id = ?", (source_id,))
-            self.store.update_source(source_id, last_synced=now)
-            # Generate file-level summary from chunk summaries
+            # File-level summary from chunk summaries. Best-effort, and AFTER the
+            # finalize hop so a failure or cancel here cannot strand the job row.
             try:
                 await self.generate_source_summary(source_id)
             except Exception:
                 logger.debug("Source summary generation skipped for %s", source_id, exc_info=True)
-        elif processed < total:
-            # Partial failure: remove only items created during THIS ingestion call
-            after_ids = {r["id"] for r in self.store.db.execute(
-                "SELECT id FROM items WHERE source_id = ?", (source_id,),
-            ).fetchall()}
-            new_ids = list(after_ids - _before_ids)
-            self.store.delete_items_batch(new_ids)
-            self.store.db.execute("UPDATE sources SET sync_status = 'error' WHERE id = ?", (source_id,))
-        self.store.db.execute(
-            "UPDATE ingestion_jobs SET status = ?, items_processed = ?, updated_at = ? WHERE id = ?",
-            (_job_status(processed, total), processed, now, job_id))
-        self.store.db.commit()
         # Cross-source dedup for whole-source ingests (upload / remote / chat). Folder-file
         # ingests (old_item_ids is a list) are swept by FolderWatcher at end of scan.
         if processed == total and old_item_ids is None:
@@ -642,26 +688,40 @@ class IngestionPipeline:
                 logger.exception("Failed to process chunk %d of text '%s'", i, title)
 
         now = datetime.now().isoformat()
+
+        def _finalize() -> None:
+            # ONE off-loop hop for the delete + state finalization, mirroring
+            # _ingest_file_body: delete_items_batch rebuilds the entity graph and
+            # cannot run on the loop, and splitting it from the finalization
+            # would let a cancellation commit the delete while leaving the job
+            # 'processing' and the source unsynced (re-ingest -> duplicates).
+            # Worker connection is autocommit; WAL + busy_timeout absorb
+            # write-lock contention.
+            if processed == total:
+                self.store.delete_items_batch(_old_item_ids, owner_source_id=source_id)
+                self.store.db.execute("UPDATE sources SET sync_status = 'synced' WHERE id = ?", (source_id,))
+                self.store.update_source(source_id, last_synced=now)
+            elif processed < total:
+                # Partial failure: remove only items created during THIS call so we
+                # never delete another item group sharing this source_id.
+                after_ids = {r["id"] for r in self.store.db.execute(
+                    "SELECT id FROM items WHERE source_id = ?", (source_id,),
+                ).fetchall()}
+                self.store.delete_items_batch(list(after_ids - _before_ids))
+                self.store.db.execute("UPDATE sources SET sync_status = 'error' WHERE id = ?", (source_id,))
+            self.store.db.execute(
+                "UPDATE ingestion_jobs SET status = ?, items_total = ?, items_processed = ?, updated_at = ? WHERE id = ?",
+                (_job_status(processed, total), total, processed, now, job_id))
+            self.store.db.commit()
+
+        await run_to_completion(_finalize)
         if processed == total:
-            self.store.delete_items_batch(_old_item_ids, owner_source_id=source_id)
-            self.store.db.execute("UPDATE sources SET sync_status = 'synced' WHERE id = ?", (source_id,))
-            self.store.update_source(source_id, last_synced=now)
+            # Best-effort, and AFTER the finalize hop so a failure or cancel here
+            # cannot strand the job row.
             try:
                 await self.generate_source_summary(source_id)
             except Exception:
                 logger.debug("Source summary generation skipped for %s", source_id, exc_info=True)
-        elif processed < total:
-            # Partial failure: remove only items created during THIS call so we
-            # never delete another item group sharing this source_id.
-            after_ids = {r["id"] for r in self.store.db.execute(
-                "SELECT id FROM items WHERE source_id = ?", (source_id,),
-            ).fetchall()}
-            self.store.delete_items_batch(list(after_ids - _before_ids))
-            self.store.db.execute("UPDATE sources SET sync_status = 'error' WHERE id = ?", (source_id,))
-        self.store.db.execute(
-            "UPDATE ingestion_jobs SET status = ?, items_total = ?, items_processed = ?, updated_at = ? WHERE id = ?",
-            (_job_status(processed, total), total, processed, now, job_id))
-        self.store.db.commit()
         # Cross-source dedup for whole-source ingests (upload / remote / chat).
         # Group-level replaces (old_item_ids provided -- e.g. a single artifact's
         # group within the aggregate Artifacts source) defer to the folder-scan

--- a/test/test_knowledge_delete_off_loop.py
+++ b/test/test_knowledge_delete_off_loop.py
@@ -1,0 +1,150 @@
+"""``delete_items_batch`` must never run on the event loop.
+
+It rebuilds the entire entity graph (``store._load_graph``: clear + two full table
+scans) inside its own ``BEGIN``/``COMMIT``, so on a large library it blocks the loop
+past the stall watchdog. The watchdog then exits, the supervisor respawns, and the
+fresh process runs the same scan -- a crash loop, observed repeatedly against a
+2900-document folder source with the frozen stack pinning
+``store.delete_items_batch <- ingestion._ingest_file_body <- folder_watcher._do_scan``.
+
+Two tests, deliberately different in kind:
+
+* the AST ratchet pins every call site at once and fails if any future edit calls it
+  straight from a coroutine body, including sites this PR has not seen;
+* the behavioural test proves the offload is real rather than lexical -- it asserts
+  the THREAD the call lands on, so a refactor that keeps ``asyncio.to_thread`` in the
+  source but hands it something already-invoked still fails.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import pathlib
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew.knowledge.folder_watcher import FolderWatcher
+from kiro_crew.knowledge.store import KnowledgeStore
+
+# A nested def / lambda is a separate execution frame -- a sync helper or a thread
+# target -- so a call inside one is not running on the loop. Mirrors the scoping the
+# repo's other on-loop guards use.
+_NESTED_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+
+_SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+
+
+def _on_loop_call_sites(name: str) -> list[str]:
+    """Every lexical call to *name* directly inside an ``async def`` body."""
+    found: list[str] = []
+    for path in sorted(_SRC.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(errors="replace"))
+        except SyntaxError:  # pragma: no cover - syntax is enforced elsewhere
+            continue
+        for fn in (n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef)):
+            stack = list(fn.body)
+            while stack:
+                node = stack.pop()
+                if isinstance(node, _NESTED_SCOPES):
+                    continue
+                stack.extend(ast.iter_child_nodes(node))
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                called = (
+                    func.attr if isinstance(func, ast.Attribute)
+                    else getattr(func, "id", None)
+                )
+                if called == name:
+                    found.append(
+                        f"{path.relative_to(_SRC)}:{node.lineno} in async {fn.name}")
+    return found
+
+
+def test_delete_items_batch_is_never_called_on_the_event_loop():
+    """Ratchet: hand it to a worker, never call it from a coroutine body."""
+    offenders = _on_loop_call_sites("delete_items_batch")
+    assert offenders == [], (
+        "delete_items_batch runs on the event loop at:\n  "
+        + "\n  ".join(offenders)
+        + "\nOffload it: await asyncio.to_thread(store.delete_items_batch, ids, ...). "
+          "The connection is autocommit (isolation_level=None), so no enclosing "
+          "transaction spans the call and the worker's thread-local connection may "
+          "take the write lock on its own."
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_deleted_runs_the_delete_off_the_loop_thread(tmp_path, monkeypatch):
+    """The offload is real: the delete executes on some other thread."""
+    store = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    try:
+        source_id = store.add_source("src", "local_folder", str(tmp_path))
+        item_id = store.add_item("title", "body", "doc", source_id=source_id)
+
+        seen_threads: list[int] = []
+        real = store.delete_items_batch
+
+        def recording(*args, **kwargs):
+            seen_threads.append(threading.get_ident())
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(store, "delete_items_batch", recording)
+
+        watcher = FolderWatcher(store, MagicMock())
+        await watcher._handle_deleted(
+            source_id, "gone.md", {"item_ids": json.dumps([item_id])})
+
+        assert seen_threads, (
+            "delete_items_batch was never called -- this test no longer exercises "
+            "the deleted-file path and would pass vacuously")
+        assert threading.get_ident() not in seen_threads, (
+            "delete_items_batch ran on the event-loop thread; it must be handed to "
+            "asyncio.to_thread")
+    finally:
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_finalizer_runs_even_when_cancelled_while_queued():
+    """A cancellation landing while the finalizer is still QUEUED in the
+    executor must not skip it (GPT round-2 finding on #2336): a bare
+    ``await asyncio.to_thread(fn)`` cancels the queued future before ``fn``
+    starts, stranding the committed new items with no state finalization.
+
+    Deterministic setup: a 1-worker executor whose only worker is held by a
+    blocker, so the finalizer is provably queued when the cancel arrives.
+    """
+    import asyncio
+    from concurrent.futures import ThreadPoolExecutor
+
+    from kiro_crew.knowledge.ingestion import run_to_completion
+
+    loop = asyncio.get_running_loop()
+    pool = ThreadPoolExecutor(max_workers=1)
+    loop.set_default_executor(pool)
+    try:
+        gate = threading.Event()
+        ran = threading.Event()
+
+        # Occupy the single worker so the finalizer sits in the queue.
+        blocker = loop.run_in_executor(None, gate.wait)
+        await asyncio.sleep(0)  # let the blocker claim the worker
+
+        task = asyncio.ensure_future(run_to_completion(ran.set))
+        await asyncio.sleep(0)  # finalizer submitted, still queued
+        task.cancel()
+        gate.set()  # release the worker AFTER the cancel landed
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert ran.is_set(), (
+            "finalizer was skipped by a cancellation that arrived while it "
+            "was queued; run_to_completion must drain it before re-raising")
+        await blocker
+    finally:
+        pool.shutdown(wait=True)


### PR DESCRIPTION
## Problem

`delete_items_batch` rebuilds the **entire entity graph** — `store._load_graph` clears it and reloads from two full table scans — inside its own `BEGIN`/`COMMIT`. Five callers invoked it directly from a coroutine body, so on a large library each call blocked the gateway's single event loop past the stall watchdog. The watchdog exits, the supervisor respawns, and the fresh process runs the same scan: a crash loop.

Captured five separate times against a 2911-document / 14034-item folder source, always the same frame:

```
store.py            delete_items_batch
ingestion.py        _ingest_file_body
ingestion.py        ingest_file
folder_watcher.py   _ingest_file
folder_watcher.py   _do_scan
watcher.py          _scan
asyncio/events.py   _run              <- on the loop, no worker boundary
```

The cadence tightened from 1h44m to ~7m as the gateway kept respawning into the same boot scan, and only settled once the changed-file backlog drained. The ingest path runs on **every scan that sees a changed file**, so it fires far more often than the dedup path.

Not covered by #2175 — that PR wraps the dedup block, which is a different call site in the same function.

## Fix

Five sites, each handed to `asyncio.to_thread`:

| file | function | site |
|---|---|---|
| `ingestion.py` | `_ingest_file_body` | success path + partial-failure cleanup |
| `ingestion.py` | `ingest_text` | success path + partial-failure cleanup |
| `folder_watcher.py` | `_handle_deleted` | deleted-file archive |

## Why this is safe to move (the non-obvious part)

I expected to have to restructure the commit boundary, because the deletes sit mid-way through a block that ends in `db.commit()` and `store.db` is thread-local — a worker gets a *different* connection, which would mean either a write-lock conflict or a split transaction.

Neither applies. The connection is opened `isolation_level=None`:

```python
conn = sqlite3.connect(self._db_path, timeout=30, isolation_level=None)
conn.execute("PRAGMA journal_mode=WAL")
conn.execute("PRAGMA busy_timeout=10000")
```

That is autocommit. No enclosing transaction spans these calls — the surrounding `db.commit()` calls are no-ops and the block was never atomic — so nothing is being split. `delete_items_batch`'s own `BEGIN`/`COMMIT` is self-contained and runs entirely on the worker's connection, and WAL + `busy_timeout=10000` rides out any transient contention rather than erroring.

## Tests

Two, deliberately different in kind:

- **AST ratchet** — pins every call site at once and fails on any future call from a coroutine body, including sites this PR never saw. Skips nested `def`/`lambda` scopes, matching the repo's other on-loop guards.
- **Behavioural** — asserts the *thread* the call lands on, so a refactor that keeps `asyncio.to_thread` in the source but hands it an already-invoked result still fails. Also asserts the recorder is non-empty so it cannot pass vacuously.

Both proven red against the pre-fix code:

```
E  AssertionError: delete_items_batch runs on the event loop at:
     knowledge/folder_watcher.py:737 in async _handle_deleted
E  AssertionError: delete_items_batch ran on the event-loop thread; it must be
   handed to asyncio.to_thread
2 failed
```

## Verification

- `test/test_knowledge_delete_off_loop.py` + `test_folder_watcher.py` + `test_no_blocking_call_on_loop.py` — 79 passed
- broader `-k "knowledge or ingest or watcher"` selection — ran to completion with zero failures (7 skips)
- `isort --check-only src/kiro_crew test`, `flake8 src/kiro_crew test` — clean
- `mypy` on both changed files — clean
- AST scan confirms **0** on-loop `delete_items_batch` sites remain

Backend-only change; no frontend gates implicated. Local runs used a borrowed Python 3.14 venv, so CI is authoritative for version-sensitive lanes.

## Follow-up, not in scope

The `enumerate_docs` N+1 in the dedup path (2912 synchronous queries per call, measured 1.32s idle on this corpus, re-run per changed file) is the other half of this defect class and wants a hoist + batch. It carries a real correctness caveat — `_collapse_doc` mutates `folder_file_state` mid-loop, so a hoisted snapshot goes stale — so it belongs in its own change.
