### PR TITLE
ci(review): switch Opus reviewer from opus-5 to opus-4.8 for faster reviews

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -156,8 +156,7 @@ jobs:
           # message via the SHA-scoped markers required by FINAL OUTPUT below —
           # the same robust pattern design-review.yml and codex-review.yml use.
           claude_args: |
-            --model us.anthropic.claude-opus-5
-            --fallback-model us.anthropic.claude-opus-4-8
+            --model us.anthropic.claude-opus-4-8
             --max-turns 120
             --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*)"
           prompt: |

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -215,8 +215,7 @@ jobs:
           # message via the SHA-scoped markers required by FINAL OUTPUT below —
           # the same robust pattern claude-review.yml and codex-review.yml use.
           claude_args: |
-            --model us.anthropic.claude-opus-5
-            --fallback-model us.anthropic.claude-opus-4-8
+            --model us.anthropic.claude-opus-4-8
             --max-turns 120
             --allowedTools "Read,Grep,Glob"
           prompt: |


### PR DESCRIPTION
## Problem

The Opus 5 reviewer takes **10-19 minutes** per run and produces no blocking findings 87% of the time (3 blocking out of 23 completed runs). It's the slowest check in the CI pipeline and rarely catches issues that GPT or deterministic tooling misses.

## Why it matters

Every PR waits for the Opus review before readiness can pass. Cutting the per-turn latency by 2-3x directly reduces the wall-clock time every contributor waits.

## Fix

**Symptom**: Opus review is the bottleneck — 10-19 min for a mostly-clean verdict.
**Root cause**: Opus 5 is a larger model with higher per-turn latency than needed for AUTOSDE-rules-driven code review.
**Change**: Switch from `us.anthropic.claude-opus-5` to `us.anthropic.claude-opus-4-8` in both:
- `claude-review.yml` (same-repo)
- `fork-opus-review.yml` (fork pipeline)

The `--fallback-model` line is removed since we're now on the former fallback as primary.

The check-run name stays `Opus 5 Review` — it's a stable branch-protection identifier referenced by `pr-readiness.yml`, not a version badge. Changing it would cascade to branch rules, readiness, and the fork pipeline.

## Tests

N/A — model selection is a CI configuration, not application code.

## Manual verification

- Measured 20 recent Opus runs: 87% (15/23) success with no findings, typical duration 10-19 min
- Opus 4.8 retains the same tool-use capability (Read/Grep/Glob/Bash) and AUTOSDE-rules comprehension
- The structured FINDING BAR + budget cap are prompt-level controls that work identically across model versions
