### PR TITLE
ci(review): rename the Opus review lane from 'Opus 5' to 'Opus 4.8'

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,4 +1,4 @@
-name: Opus 5 Review
+name: Opus 4.8 Review
 
 # Semantic AI review layer. Replicates ONLY the AutoSDE rules that cannot be
 # expressed as a grep (aria-label on icon-only buttons, no-emoji-as-icons,
@@ -36,18 +36,18 @@ concurrency:
 jobs:
   claude-review:
     # Model-NAMED check on purpose: this repo names reviewers by their model
-    # ("Opus 5 Review", "GPT 5.6 Review") rather than by vendor/harness. Branch
+    # ("Opus 4.8 Review", "GPT 5.6 Review") rather than by vendor/harness. Branch
     # protection keys its required status check on this job name, so if the
     # --model below is bumped and this name changes with it, the required-check
     # list AND the `workflow_run.workflows:` array in pr-readiness.yml must be
     # updated in the same change.
-    name: Opus 5 Review
+    name: Opus 4.8 Review
     runs-on: ubuntu-latest
     # Same-repo PRs only (not forks). Fork PRs get NO OIDC/secrets access from
     # GitHub, so the Bedrock role assumption below can never succeed — without
     # this guard the review step is skipped and the fail-closed gate turns the
     # required check RED on every external contribution. Skipping the whole job
-    # instead reports the required "Opus 5 Review" check as "skipped", which
+    # instead reports the required "Opus 4.8 Review" check as "skipped", which
     # branch protection treats as satisfied. Mirrors the fork guard in
     # codex-review.yml and design-review.yml. Dependabot PRs are same-repo
     # (branch lives in this repo) so they still enter the job and are handled by
@@ -129,7 +129,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Opus 5 review
+      - name: Opus 4.8 review
         id: review
         if: github.actor != 'dependabot[bot]' && steps.human_override.outputs.active != 'true'
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
@@ -400,7 +400,7 @@ jobs:
       # [OPUS-REVIEWED] marker parsed for THIS head — an errored or partial
       # transcript posts NOTHING (see the incomplete early-out below), so no raw
       # model/error text can leak.
-      - name: Post Opus 5 review summary
+      - name: Post Opus 4.8 review summary
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -443,13 +443,13 @@ jobs:
           MARKER="<!-- claude-ai-review -->"
           {
             echo "$MARKER"
-            echo "## Opus 5 Review — $verdict"
+            echo "## Opus 4.8 Review — $verdict"
             echo
             echo "_Reviewed \`$HEAD\` — this comment is updated in place on each push._"
             echo
             case "$kind" in
               override)
-                echo "Human judgment by @$OVERRIDE_ACTOR overrides the Opus 5 finding for \`$HEAD\`; [the recorded reason]($source_url) is authoritative for this commit."
+                echo "Human judgment by @$OVERRIDE_ACTOR overrides the Opus 4.8 finding for \`$HEAD\`; [the recorded reason]($source_url) is authoritative for this commit."
                 ;;
               blocked)
                 cat claude-review-output.md
@@ -483,10 +483,10 @@ jobs:
           if [ -n "$existing" ] && [ "$existing" != "null" ]; then
             gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
               --field body="$(cat /tmp/claude-summary.md)" >/dev/null || true
-            echo "Updated existing Opus 5 summary comment #$existing"
+            echo "Updated existing Opus 4.8 summary comment #$existing"
           else
             gh pr comment "$PR" --body-file /tmp/claude-summary.md || true
-            echo "Created new Opus 5 summary comment"
+            echo "Created new Opus 4.8 summary comment"
           fi
 
       # Fail-CLOSED gate on two SHA-scoped markers parsed from the captured
@@ -497,7 +497,7 @@ jobs:
       #     This is the ONLY thing that blocks the merge. There is deliberately
       #     no label-scanning backstop, so a label the model chooses can never
       #     override the contract.
-      - name: Gate on Opus 5 review
+      - name: Gate on Opus 4.8 review
         if: always()
         env:
           HEAD: ${{ github.event.pull_request.head.sha }}
@@ -507,37 +507,37 @@ jobs:
           OVERRIDE_ACTOR: ${{ steps.human_override.outputs.actor }}
         run: |
           if [ "$HUMAN_OVERRIDE" = "true" ]; then
-            echo "Human judgment by $OVERRIDE_ACTOR overrides Opus 5 for $HEAD. Passing gate."
+            echo "Human judgment by $OVERRIDE_ACTOR overrides Opus 4.8 for $HEAD. Passing gate."
             exit 0
           fi
           if [ "$ACTOR" = "dependabot[bot]" ]; then
-            echo "Dependabot PR ($ACTOR): Opus 5 AI review skipped (no Bedrock secrets/OIDC). Passing gate."
+            echo "Dependabot PR ($ACTOR): Opus 4.8 AI review skipped (no Bedrock secrets/OIDC). Passing gate."
             exit 0
           fi
           if [ "$REVIEW_OUTCOME" != "success" ]; then
-            echo "::error::Opus 5 review step did not succeed (outcome=$REVIEW_OUTCOME) for $HEAD. Failing closed."
+            echo "::error::Opus 4.8 review step did not succeed (outcome=$REVIEW_OUTCOME) for $HEAD. Failing closed."
             exit 1
           fi
           if [ ! -s claude-review-output.md ]; then
-            echo "::error::Opus 5 review produced no output for $HEAD (empty transcript capture). Failing closed — re-run or inspect the Opus 5 review step logs."
+            echo "::error::Opus 4.8 review produced no output for $HEAD (empty transcript capture). Failing closed — re-run or inspect the Opus 4.8 review step logs."
             exit 1
           fi
           # Positive proof the review ran for THIS commit (fail closed).
           if ! grep -Fq "[OPUS-REVIEWED] $HEAD" claude-review-output.md; then
-            echo "::error::Opus 5 review did not complete for $HEAD (no [OPUS-REVIEWED] marker). Failing closed — re-run the workflow or inspect the Opus 5 review step logs."
+            echo "::error::Opus 4.8 review did not complete for $HEAD (no [OPUS-REVIEWED] marker). Failing closed — re-run the workflow or inspect the Opus 4.8 review step logs."
             echo "--- review output ---"
             cat claude-review-output.md
             exit 1
           fi
           # Block ONLY on the contract-gated marker.
           if grep -Fq "[BLOCK-MERGE] $HEAD" claude-review-output.md; then
-            echo "::error::Opus 5 review flagged a blocking issue on $HEAD — see the posted review summary."
+            echo "::error::Opus 4.8 review flagged a blocking issue on $HEAD — see the posted review summary."
             exit 1
           fi
           # Advisory coherence signal (never fails the build): a BLOCKING-labelled
           # finding without the marker means the model's label and its verdict
           # disagree. Worth tuning the prompt over; not worth blocking a merge.
           if grep -qE '^[[:space:]]*[-*]?[[:space:]]*(\*\*)?BLOCKING\b' claude-review-output.md; then
-            echo "::warning::Opus 5 emitted a BLOCKING-labelled finding for $HEAD without the [BLOCK-MERGE] marker. Gate passes on the marker; review the prompt if this recurs."
+            echo "::warning::Opus 4.8 emitted a BLOCKING-labelled finding for $HEAD without the [BLOCK-MERGE] marker. Gate passes on the marker; review the prompt if this recurs."
           fi
-          echo "Opus 5 review completed for $HEAD with no blocking findings."
+          echo "Opus 4.8 review completed for $HEAD with no blocking findings."

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -28,7 +28,7 @@ jobs:
       # Deterministic replication of the blocking rules from
       # website/AUTOSDE.yaml. These catch the unambiguous cases; the semantic
       # half (aria-label on icon-only buttons, no-emoji, template-literal HTML)
-      # is covered by the auto-running Opus 5 review in claude-review.yml.
+      # is covered by the auto-running Opus 4.8 review in claude-review.yml.
       - name: Check frontend blocking rules
         if: contains(steps.changed.outputs.files, 'website/src/')
         working-directory: website

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -6,7 +6,7 @@ name: GPT 5.6 Review
 # authenticates to Bedrock with the OIDC role's SigV4 credentials via the AWS
 # SDK credential chain. No proxy, no bearer token, no OpenAI API key.
 #
-# Verdict model is BINARY (BLOCKING / FINDING) and identical to the Opus 5
+# Verdict model is BINARY (BLOCKING / FINDING) and identical to the Opus 4.8
 # reviewer's. Two structural changes vs. the original three-pass design:
 #   * pass 2 is a FALSIFICATION pass, not a second discovery pass. The old
 #     "find what pass 1 missed" instruction was a recall ratchet that only ever
@@ -365,7 +365,7 @@ jobs:
       # Assume the Bedrock role only now, immediately before the step that calls
       # Bedrock, to minimize the window the credentials exist in the job
       # environment. Uses a DEDICATED least-privilege role (GPT/Mantle only,
-      # pull_request-scoped) so a leaked token can't reach the Opus 5 reviewer's model access.
+      # pull_request-scoped) so a leaked token can't reach the Opus 4.8 reviewer's model access.
       - uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         if: github.actor != 'dependabot[bot]' && steps.human_override.outputs.active != 'true'
         with:

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -1,6 +1,6 @@
-name: Fork Opus 5 Review
+name: Fork Opus 4.8 Review
 
-# STAGE 2 (privileged) of the fork AI-review pipeline — the Opus 5 reviewer.
+# STAGE 2 (privileged) of the fork AI-review pipeline — the Opus 4.8 reviewer.
 # Triggered by the completion of "Fork AI Review (collect)" (Stage 1). Runs from
 # the DEFAULT branch with secrets + OIDC. It NEVER checks out or executes the
 # fork's code.
@@ -21,7 +21,7 @@ name: Fork Opus 5 Review
 #
 # Mirrors claude-review.yml's contract (model, [OPUS-REVIEWED]/[BLOCK-MERGE]
 # markers, fail-closed gate). claude-review.yml is UNCHANGED and owns same-repo
-# PRs. The fork check-run is named exactly "Opus 5 Review" so branch protection
+# PRs. The fork check-run is named exactly "Opus 4.8 Review" so branch protection
 # is satisfied on either path. (Follow-up: extract a shared prompt file so the
 # fork and same-repo prompts cannot drift.)
 
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
   fork-opus-review:
-    name: Fork Opus 5 Review
+    name: Fork Opus 4.8 Review
     runs-on: ubuntu-latest
     # Runaway/hang backstop only, NOT a per-review budget: the review
     # self-terminates well before this. Set at 90 min (matches claude-review.yml)
@@ -119,7 +119,7 @@ jobs:
         run: |
           set -uo pipefail
           id="$(gh api --method POST "repos/$REPO/check-runs" \
-            -f name="Opus 5 Review" -f head_sha="$HEAD" -f status="in_progress" \
+            -f name="Opus 4.8 Review" -f head_sha="$HEAD" -f status="in_progress" \
             --jq '.id')"
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
@@ -199,7 +199,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Opus 5 review
+      - name: Opus 4.8 review
         id: review
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         with:
@@ -485,7 +485,7 @@ jobs:
           fi
           {
             echo "$MARKER"
-            echo "## Opus 5 Review (fork) — $verdict"
+            echo "## Opus 4.8 Review (fork) — $verdict"
             echo
             echo "_Reviewed \`$HEAD\` via the fork AI-review pipeline; updated in place on each push._"
             echo
@@ -499,7 +499,7 @@ jobs:
               echo
               echo "</details>"
             else
-              echo "_No completed Opus verdict for this commit; see the Fork Opus 5 Review job logs._"
+              echo "_No completed Opus verdict for this commit; see the Fork Opus 4.8 Review job logs._"
             fi
           } > /tmp/fork-opus-comment.md
           existing="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
@@ -510,7 +510,7 @@ jobs:
             gh pr comment "$PR" --body-file /tmp/fork-opus-comment.md || true
           fi
 
-      # Fail-CLOSED finalize of the required "Opus 5 Review" check-run, keyed to
+      # Fail-CLOSED finalize of the required "Opus 4.8 Review" check-run, keyed to
       # head_sha; posts a failing check-run if the job died before opening one.
       # Opus is a REQUIRED gating check, so it never resolves neutral.
       - name: Finalize check-run (fail closed)
@@ -533,12 +533,12 @@ jobs:
           if [ -n "${CHECK_ID:-}" ]; then
             gh api --method PATCH "repos/$REPO/check-runs/$CHECK_ID" \
               -f status="completed" -f conclusion="$conclusion" \
-              -f "output[title]=Opus 5 Review — $title" \
+              -f "output[title]=Opus 4.8 Review — $title" \
               -f "output[summary]=Fork AI review for $HEAD. See the PR comment for details." >/dev/null || true
           elif [ -n "${HEAD:-}" ]; then
             gh api --method POST "repos/$REPO/check-runs" \
-              -f name="Opus 5 Review" -f head_sha="$HEAD" \
+              -f name="Opus 4.8 Review" -f head_sha="$HEAD" \
               -f status="completed" -f conclusion="failure" \
-              -f "output[title]=Opus 5 Review — could not run" \
+              -f "output[title]=Opus 4.8 Review — could not run" \
               -f "output[summary]=The fork Opus review job failed before producing a verdict; re-run it." >/dev/null || true
           fi

--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -21,7 +21,7 @@ on:
       - CI
       - Build
       - Code Review
-      - Opus 5 Review
+      - Opus 4.8 Review
       - GPT 5.6 Review
       - Design Review
       - UX Review
@@ -30,13 +30,13 @@ on:
       # `workflow_run` (on CI's completion), so their own completion must
       # re-trigger this job to publish the fork PR's real verdict once the
       # reviews land -- otherwise the fork verdict freezes at `checking`.
-      - Fork Opus 5 Review
+      - Fork Opus 4.8 Review
       - Fork GPT 5.6 Review
       - Fork Design Review
       - Fork UX Review
     # `completed` publishes the real verdict. `requested`/`in_progress` exist so
     # a monitored workflow flipping BACK to running -- most commonly a re-run of
-    # a reviewer (e.g. Opus 5 re-run after a human override) -- re-triggers this
+    # a reviewer (e.g. Opus 4.8 re-run after a human override) -- re-triggers this
     # job WHILE it runs, instead of leaving the label frozen at the previous
     # commit's verdict until the re-run completes. On re-evaluation that workflow
     # is queried live as `in_progress`, buckets into `pending`, and the label
@@ -310,13 +310,13 @@ jobs:
             # CodeQL, so that lane stays ineligible. The AI code reviews DO run
             # on forks: the privileged Stage-2 fork-*-review.yml pipeline fires
             # on CI completion from the default branch and posts a check-run
-            # named exactly like the same-repo lane ("Opus 5 Review", etc.).
+            # named exactly like the same-repo lane ("Opus 4.8 Review", etc.).
             # Read those results from the head SHA's check-runs (checkrun:
             # specs) so a fully-reviewed green fork can reach "passed" instead
             # of being forced to a maintainer-review verdict.
             skipped+=("CodeQL (fork PR)")
             workflow_specs+=(
-              "checkrun:Opus 5 Review|Opus 5 Review"
+              "checkrun:Opus 4.8 Review|Opus 4.8 Review"
               "checkrun:GPT 5.6 Review|GPT 5.6 Review"
               "checkrun:Design Review|Design Review"
               "checkrun:UX Review|UX Review"
@@ -328,7 +328,7 @@ jobs:
               workflow_specs+=("dynamic/github-code-scanning/codeql|CodeQL")
             fi
             workflow_specs+=(
-              "claude-review.yml|Opus 5 Review"
+              "claude-review.yml|Opus 4.8 Review"
               "codex-review.yml|GPT 5.6 Review"
               "design-review.yml|Design Review"
               "ux-review.yml|UX Review"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -451,7 +451,7 @@ depends on *where your branch lives*:
 
 | Check | Fork PR | Branch pushed to `kirodotdev/KiroCrew` |
 | --- | --- | --- |
-| **Opus 5 Review** | Skipped (neutral — not a failure) | Runs |
+| **Opus 4.8 Review** | Skipped (neutral — not a failure) | Runs |
 | **GPT 5.6 Review** | Skipped | Runs |
 | **Design Review** | Skipped | Runs |
 | Tests, lint, typecheck, CodeQL, coverage, build | Run normally | Run normally |

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -24,7 +24,7 @@ pull_request
   |-- code-review.yml   "Code Review"  grep rules, woke, Semgrep, PR hygiene, dep audit
   |-- dependency-review.yml            license allowlist
   |-- docker-smoke.yml                 container contract (paths-filtered)
-  |-- claude-review.yml "Opus 5 Review"     line-level, code-only, blocking
+  |-- claude-review.yml "Opus 4.8 Review"     line-level, code-only, blocking
   |-- codex-review.yml  "GPT 5.6 Review"    line-level + PR intent, blocking
   |-- design-review.yml "Design Review"     design shape, advisory
   |-- ux-review.yml     "UX Review"         rendered experience, advisory
@@ -207,12 +207,12 @@ design axis is **what each is allowed to read** (its prompt-injection surface) a
 
 | Reviewer | Check name | Harness | Reads | Question | Blocks? |
 |---|---|---|---|---|---|
-| Opus 5 | `Opus 5 Review` | Agentic, `--max-turns 120`, one pass with two internal phases | **Code only**: `Read`, `Grep`, `Glob`, `Bash(gh pr diff:*)` | Line-level correctness, security, AUTOSDE | Yes, fail-closed |
+| Opus 4.8 | `Opus 4.8 Review` | Agentic, `--max-turns 120`, one pass with two internal phases | **Code only**: `Read`, `Grep`, `Glob`, `Bash(gh pr diff:*)` | Line-level correctness, security, AUTOSDE | Yes, fail-closed |
 | GPT 5.6 | `GPT 5.6 Review` | Non-agentic, **two** invocations (discovery, then authoritative falsification), `reasoning_effort: medium` | Code plus PR title and body as nonce-wrapped **UNTRUSTED** context | Line-level second perspective, plus description-versus-diff consistency (advisory) | Yes, fail-closed |
 | Design Review | `Design Review` | Agentic Fable 5, with an Opus fallback model | Code plus `gh pr view` (it must judge intent) | Should we build this, and is it the right *shape*? | Advisory; red only on a genuine `BLOCK` |
 | UX Review | `UX Review` | Agentic Fable 5, with the same fallback | Code plus committed screenshot PNGs, read directly | Does the shipped experience read correctly? | Advisory; red only on a genuine `BLOCK` |
 
-### Why Opus 5 is code-only
+### Why Opus 4.8 is code-only
 
 It is the agentic reviewer, so pulling attacker-controllable PR prose into its
 context is a prompt-injection surface. `gh pr view` and `gh api` are disallowed, and
@@ -240,7 +240,7 @@ says "No findings." is the expected output for a typical PR.
 
 ### Asymmetric multi-pass is intentional
 
-The agentic Opus 5 reviewer runs ONE pass with two internal phases: discover
+The agentic Opus 4.8 reviewer runs ONE pass with two internal phases: discover
 (generous candidate collection), then falsify (kill each candidate against code it
 opened, with extra falsification effort only where the diff touches
 security or data-integrity paths). The lean single-shot GPT 5.6 reviewer runs
@@ -256,7 +256,7 @@ and therefore cannot contradict itself across rounds.
 
 The markers are the **only** gate:
 
-- Opus 5 emits `[OPUS-REVIEWED] <sha>` always, and `[BLOCK-MERGE] <sha>` only when a
+- Opus 4.8 emits `[OPUS-REVIEWED] <sha>` always, and `[BLOCK-MERGE] <sha>` only when a
   blocking finding exists. Both are parsed out of the action's `execution_file`
   transcript rather than a `--json-schema` structured output, because the harness's
   internal structured-output tool is unreliable when other tools are enabled:
@@ -353,7 +353,7 @@ queries the latest run per monitored workflow, and publishes **one `PR Readiness
 commit status plus one `readiness:` label**.
 
 - **Always required:** CI, Build, Code Review.
-- **Additionally required on a same-repo PR:** CodeQL, Opus 5 Review, GPT 5.6
+- **Additionally required on a same-repo PR:** CodeQL, Opus 4.8 Review, GPT 5.6
   Review, and completion of Design Review and UX Review.
 - **Design Review and UX Review are completion-required but advisory:** once
   complete they score as `"(advisory)"` whatever their conclusion, so neither their
@@ -421,7 +421,7 @@ protection remain separate gates.
 `fork-ux-review.yml` each trigger on the **completion of CI** (stage 1) and run
 privileged from the default branch (stage 2), gated on
 `workflow_run.head_repository.full_name != github.repository`. Each posts a check-run
-named exactly like its same-repo twin (`Opus 5 Review`, `GPT 5.6 Review`,
+named exactly like its same-repo twin (`Opus 4.8 Review`, `GPT 5.6 Review`,
 `Design Review`, `UX Review`), so branch protection is satisfied on either path, and
 it opens that check-run as early as possible keyed to `head_sha` so a job that dies
 still leaves a fail-closed result.
@@ -466,7 +466,7 @@ resists this:
   code, it is out of scope for the bot and the finding is dropped. **The absence of a
   mechanism is never a finding.** This makes "add mechanism X" structurally
   un-reportable: the demand fails the bar before it can become a finding. A scope cap
-  complements it: Opus 5 stays within the evident scope of the diff (it is code-only),
+  complements it: Opus 4.8 stays within the evident scope of the diff (it is code-only),
   and GPT 5.6 stays within the PR's stated purpose, flagging a
   description-versus-diff mismatch as an **advisory** finding rather than a block.
 - **The WHAT BLOCKS list is closed:** exhaustive, never extended, never reasoned about

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -356,7 +356,7 @@ Making `PR Readiness` a required status remains an explicit branch-protection
 or ruleset setting outside the workflow.
 
 The aggregate covers the latest PR run for CI, Build,
-Code Review, Opus 5 Review, GPT 5.6 Review (the reconciled result of its three
+Code Review, Opus 4.8 Review, GPT 5.6 Review (the reconciled result of its three
 calls), and Design Review, plus the managed dynamic CodeQL workflow conclusion.
 Grading the CodeQL
 workflow conclusion, rather than its neutral summary check, preserves failures

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -97,7 +97,7 @@ class TestLineReviewHumanOverrides:
         assert '.user.login == "github-actions[bot]"' in workflow
         assert "steps.human_override.outputs.active != 'true'" in workflow
         assert "✅ human override accepted" in workflow
-        assert "Human judgment by $OVERRIDE_ACTOR overrides Opus 5" in workflow
+        assert "Human judgment by $OVERRIDE_ACTOR overrides Opus 4.8" in workflow
         assert "/ai-review override fable $HEAD:" in workflow
 
     def test_gpt_has_clear_verdict_banner_and_human_override(self) -> None:
@@ -257,7 +257,7 @@ class TestPrReadiness:
             "build.yml|Build",
             "code-review.yml|Code Review",
             "dynamic/github-code-scanning/codeql|CodeQL",
-            "claude-review.yml|Opus 5 Review",
+            "claude-review.yml|Opus 4.8 Review",
             "codex-review.yml|GPT 5.6 Review",
             "design-review.yml|Design Review",
         ):
@@ -278,7 +278,7 @@ class TestPrReadiness:
         # CodeQL stays the only ineligible fork lane.
         assert '"CodeQL (fork PR)"' in workflow
         # AI reviews are now monitored on forks via check-run specs.
-        assert '"checkrun:Opus 5 Review|Opus 5 Review"' in workflow
+        assert '"checkrun:Opus 4.8 Review|Opus 4.8 Review"' in workflow
         assert '"checkrun:GPT 5.6 Review|GPT 5.6 Review"' in workflow
         assert '"checkrun:Design Review|Design Review"' in workflow
         assert '"checkrun:UX Review|UX Review"' in workflow
@@ -289,7 +289,7 @@ class TestPrReadiness:
         assert "AI reviews could not run" not in workflow
         # Stage-2 fork reviewers re-trigger readiness on completion so the
         # green verdict actually lands.
-        assert "Fork Opus 5 Review" in workflow
+        assert "Fork Opus 4.8 Review" in workflow
         assert "Fork GPT 5.6 Review" in workflow
         assert "github.event.workflow_run.event == 'workflow_run'" in workflow
 


### PR DESCRIPTION
## Problem

PR #2339 switched the Opus reviewer's model to `us.anthropic.claude-opus-4-8`, but the check is still named **`Opus 5 Review`**. This repo names reviewers by model (`Opus 5 Review`, `GPT 5.6 Review`) rather than by vendor/harness, so the displayed name now misrepresents what actually runs.

## Why it matters

A contributor reading a red `Opus 5 Review` check has no way to know the finding came from 4.8. The name is the only model signal on the PR surface, and a wrong one sends people to the wrong model card and the wrong prompt when triaging a finding.

## Fix

**Symptom**: check says "Opus 5", model is 4.8.
**Root cause**: #2339 changed the model but deliberately deferred the rename to keep that PR to 4 lines.
**Change**: rename the lane to `Opus 4.8 Review` everywhere the name is the *live check identity*.

**Why this is safe — no admin change, no fail-closed window.** Branch protection does not require this check directly. The `protected-branches` ruleset requires only the aggregate **`PR Readiness`** status (classic branch-protection `contexts` is empty), and readiness resolves the individual lane internally. So renaming the reviewer cannot orphan a required check.

Renamed:
- `claude-review.yml` — workflow/job/step names, gate + summary messages
- `fork-opus-review.yml` — workflow/job names **and the posted check-run name**, which must stay byte-identical to the same-repo job name or readiness stops matching fork PRs
- `pr-readiness.yml` — `workflow_run.workflows` entries plus both mapping specs (`claude-review.yml|...` and `checkrun:...`)
- `code-review.yml`, `codex-review.yml` — stale cross-references
- `docs/ci/ci-and-reviews.md`, `docs/system-specs/modules/security.md`, `CONTRIBUTING.md`
- `test/test_ai_review_workflows.py` — 4 assertions pinning these strings

**Deliberately NOT renamed** (this is the trap a repo-wide `sed` would fall into): ~20 `# Raised by the Opus 5 review` provenance comments under `src/kiro_crew/apps/builtins/auto_improvement/**` and the auto-improvement docs. Those record which model actually found a past bug — rewriting them would falsify the record. `ship-report.yml`'s `Opus 5 -> Opus 4.8` comment also stays, since it describes that workflow's own model fallback chain rather than this check.

## Tests

`test/test_ai_review_workflows.py` — 4 assertions updated to the new names; the suite already pins the readiness mapping specs and the fork check-run name, so it fails if any of the three coupled spellings drift apart. **33/33 pass.**

## Manual verification

- `gh api repos/kirodotdev/KiroCrew/rulesets` → only `protected-branches` carries a `required_status_checks` rule, and its sole context is `PR Readiness`; classic `branches/main/protection` returns `contexts: []`. Confirms no GitHub-side update is required.
- `grep -rn "Opus 5" .github/workflows/` → only the intentional `ship-report.yml` fallback comment remains.
- `git diff --stat` → exactly 9 files, +54/-54, no `auto_improvement/**` files touched.

**Transition note:** `pr-readiness.yml` matches lanes by workflow name, so a PR already in flight when this merges will show this lane as missing until its next push or re-run. Self-healing; no action needed.
