### PR TITLE
feat: eagerly create chat-slot sessions on intent signals

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1250,6 +1250,16 @@ class SessionConfig:
             "Max age in seconds for pooled processes. Stale processes are discarded at claim time. 0 disables.",
         ),
     )
+    eager_spawn: bool = field(
+        default=True,
+        metadata=_meta(
+            "Eager Session Spawn",
+            "Speculatively create a chat slot's session when the slot is created, "
+            "its agent is switched, or its project directory changes, instead of "
+            "on first message. Hides the multi-second session handshake behind "
+            "user think-time.",
+        ),
+    )
     archive_retention_days: int = field(
         default=30,
         metadata=_meta(
@@ -4861,6 +4871,7 @@ class KiroCrewConfig:
                 pool_size=_safe_int(session_data.get("pool_size", 2), 2),
                 pool_agent=str(session_data.get("pool_agent", "")),
                 pool_ttl_secs=_safe_int(session_data.get("pool_ttl_secs", 1800), 1800),
+                eager_spawn=bool(session_data.get("eager_spawn", True)),
                 archive_retention_days=_archive_retention_days(session_data),
                 watchdog_rss_max_mb=_safe_int(session_data.get("watchdog_rss_max_mb", 0), 0),
             ),

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -43,6 +43,7 @@ from kiro_crew.dashboard.chat_runner import (
     _context_usage_payload,
     _run_chat,
     _start_next_queued_turn,
+    schedule_eager_spawn,
 )
 from kiro_crew.dashboard.chat_title import _maybe_auto_title
 from kiro_crew.dashboard.chat_utils import (
@@ -1022,6 +1023,9 @@ async def api_chat_slot_create(request: web.Request) -> web.Response:
     # origin and the background refresh may rewrite the pin.
     if folder_id or title:
         await save_slot_off_loop(state, slot, force=True)
+    # Speculative session creation: overlap the ACP handshake with the user's
+    # think-time before their first message. No-op unless session.eager_spawn.
+    schedule_eager_spawn(state, slot)
     return web.json_response(state.serialize_slot(slot))
 
 
@@ -1925,6 +1929,13 @@ async def api_chat_slot_delete(request: web.Request) -> web.Response:
     # ask_question holds an MCP worker on a blocked HTTP request, and the slot
     # is going away, so nobody will ever answer its card.
     _unblock_pending_waits(state, slot)
+    # Cancel any pending speculative session creation. Without this, an
+    # eager task mid-debounce or mid-handshake outlives the slot; combined
+    # with the task's own post-create liveness re-check this closes both
+    # halves of the delete/recreate race.
+    _eager = getattr(slot, "_eager_spawn_task", None)
+    if _eager is not None and not _eager.done():
+        _eager.cancel()
     if slot.running and slot.task is not None:
         slot.task.cancel()
         try:
@@ -2126,6 +2137,10 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
     # Reset session so next message uses the new agent
     logger.info("Slot %s agent switched to %r, resetting session", name, agent_name or "kirocrew")
     await _reset_slot_session(state, slot, _history_key_for(name))
+    # The reset destroyed any eagerly created session; picking an agent is
+    # itself a strong first-message intent signal (it also resets the
+    # project), so re-arm the speculative spawn for the new bindings.
+    schedule_eager_spawn(state, slot)
     # Persist the new agent so the session resumes under the correct agent
     # after a gateway restart.  Written after reset succeeds so we never
     # advertise an agent we couldn't actually switch to.
@@ -2622,6 +2637,11 @@ async def api_chat_slot_project(request: web.Request) -> web.Response:
     # inline reset would killpg() the caller. Consumed in chat_runner.
     if project != old_project:
         slot._pending_reset_history_key = _history_key_for(name)
+        # Speculatively re-create the session rooted at the new project so the
+        # cwd change is paid during think-time. The eager task consumes the
+        # deferred reset itself, but only when no turn is running — the
+        # same killpg constraint that deferred the reset applies to it.
+        schedule_eager_spawn(state, slot)
     state.push_slots_update()
     return web.json_response({"ok": True, "project": project})
 

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -180,7 +180,7 @@ from kiro_crew.security import (
     redact_exfiltration_urls,
 )
 from kiro_crew.sel import sel
-from kiro_crew.session import SessionClosingError
+from kiro_crew.session import SessionClosingError, SpeculativeResumeRefused
 from kiro_crew.slack.handler import post_linked_approval, resolve_linked_approval
 from kiro_crew.slack.outbound import PostedOptions
 from kiro_crew.validation import ValidationError, infer_use_case, validate_ask_user_question
@@ -2140,6 +2140,165 @@ async def _consume_pending_reset(state: DashboardState, slot: _ChatSlot) -> None
         )
 
 
+# Debounce before a speculative spawn. Absorbs rapid consecutive signals
+# (slot create immediately followed by a project set, or a user re-picking
+# the project) so only the settled state spawns a session.
+_EAGER_SPAWN_DEBOUNCE_SECS = 1.5
+
+# Global cap on concurrent speculative spawns. Bounds the process/RSS burst
+# when many slots fire signals at once (bulk restore, slot surfing); a spawn
+# that cannot get a permit simply skips — the first message cold-starts as
+# it does today, so the cap only ever degrades back to current behavior.
+_EAGER_SPAWN_MAX_CONCURRENT = 2
+_eager_spawn_sem = asyncio.Semaphore(_EAGER_SPAWN_MAX_CONCURRENT)
+
+
+def schedule_eager_spawn(state: "DashboardState", slot: "_ChatSlot") -> None:
+    """Speculatively create *slot*'s session ahead of its first message.
+
+    Fire-and-forget: called from the slot-create and project-set handlers so
+    the multi-second ACP handshake (spawn + session/new, or session/load for
+    a resumable slot) overlaps with the user's think-time instead of being
+    paid on the first send. No-op unless ``session.eager_spawn`` is enabled.
+
+    At most one pending task per slot: a newer signal cancels the older task,
+    so the spawn always reflects the slot's settled agent/model/project.
+    """
+    try:
+        cfg = KiroCrewConfig.load()
+        if not cfg.session.eager_spawn:
+            return
+    except Exception:
+        return
+    prev = getattr(slot, "_eager_spawn_task", None)
+    if prev is not None and not prev.done():
+        prev.cancel()
+    slot._eager_spawn_task = asyncio.create_task(_eager_spawn(state, slot))
+
+
+async def _eager_spawn(state: "DashboardState", slot: "_ChatSlot") -> None:
+    """Debounce, re-validate, then create the slot's session and release it.
+
+    Ordering is load-bearing:
+
+    1. The turn-in-flight bail (``slot.running``) MUST precede the pending-
+       reset consume. The project-set endpoint is reachable from inside the
+       kiro-cli process group via the ``set_project`` MCP tool, and consuming
+       the reset kills that session's process group — mid-turn that would
+       kill the caller, which is exactly what the deferred-reset design
+       exists to prevent. When a turn is running, its own end-of-turn path
+       consumes the reset instead.
+    2. ``get_or_create`` acquires the per-session semaphore; it is released
+       immediately below because no turn follows. A first message arriving
+       mid-handshake blocks on that same semaphore and then reuses the
+       created session — the per-key serialization in ``get_or_create`` is
+       what makes the eager call and the real call converge on one session.
+    """
+    try:
+        await asyncio.sleep(_EAGER_SPAWN_DEBOUNCE_SECS)
+        sessions = getattr(state, "sessions", None)
+        if sessions is None:
+            return
+        if state.get_slot(slot.key) is not slot:
+            return  # slot deleted or replaced while debouncing
+        if slot.running:
+            return  # a real turn owns session creation (and the pending reset)
+        if _eager_spawn_sem.locked():
+            logger.info("Eager spawn: concurrency cap reached, skipping slot %s", slot.key)
+            return
+        async with _eager_spawn_sem:
+            await _consume_pending_reset(state, slot)
+            session_key = effective_session_key(slot)
+            # Snapshot the bindings the handshake is about to bake in. A
+            # switch handler (workspace, model, reasoning effort) that fires
+            # mid-handshake resets the session key — but the reset no-ops
+            # because nothing is registered yet, so without this check the
+            # eager task would register a session carrying the OLD bindings
+            # and the first real turn would silently reuse it (e.g. run tools
+            # in the wrong workspace). Agent/project changes re-arm through
+            # schedule_eager_spawn and cancel this task, but the other
+            # switches don't — the snapshot covers them all uniformly.
+            _bound = (slot.agent, slot.model, slot.project, slot.reasoning_effort)
+            kiro_agent: str | None = None
+            agent_model = ""
+            try:
+                cfg = KiroCrewConfig.load()
+                bindings = resolve_agent_bindings(cfg, slot.agent or None)
+                kiro_agent = bindings.kiro_agent
+                agent_model = normalize_agent_model(bindings.model)
+            except Exception:
+                logger.warning(
+                    "Eager spawn: failed to resolve agent bindings for slot %s",
+                    slot.key,
+                    exc_info=True,
+                )
+            _t0 = time.monotonic()
+            try:
+                # speculative=True keeps the one-shot first-turn flag armed for
+                # the real first message (atomically, at registration) and
+                # refuses resumable keys — the real turn must be the one that
+                # observes resumed=True. See get_or_create's docstring.
+                _, is_new, resumed = await sessions.get_or_create(
+                    session_key,
+                    agent=kiro_agent or slot.agent or None,
+                    model=slot.model or agent_model or None,
+                    cwd=slot.project or None,
+                    speculative=True,
+                    reasoning_effort_override=slot.reasoning_effort or None,
+                )
+            except SpeculativeResumeRefused:
+                logger.info("Eager spawn: %s is resumable, leaving to first turn", session_key)
+                return
+            sessions.release(session_key)
+            # The cleanup below may only tear down a session THIS task created.
+            # is_new=False means another creator won the same-key race (or the
+            # claim attached to an already-registered session): a real turn
+            # owns that runtime, may have finished its turn already, and may
+            # have background work (subagents) still attached — removing it
+            # here would terminate the winner's session out from under it. The
+            # winner registered with its own current bindings, so the stale-
+            # bindings hazard these guards exist for does not apply to it.
+            if not is_new:
+                logger.info(
+                    "Eager spawn: another creator won %s, leaving session alone", session_key
+                )
+                return
+            # The slot can be deleted while the handshake ran; the delete
+            # handler's sessions.remove() may have executed before this task
+            # registered the session, which would leave an orphan that a
+            # recreated slot with the same key would silently reuse with THIS
+            # slot's (now stale) agent/cwd bindings. Tear it down.
+            if state.get_slot(slot.key) is not slot:
+                logger.info(
+                    "Eager spawn: slot %s vanished mid-handshake, removing session", slot.key
+                )
+                await sessions.remove(session_key)
+                return
+            # Same shape for a binding change: a switch handler's reset ran
+            # before registration and found nothing, so the session we just
+            # registered carries stale bindings. Remove it — the first real
+            # message cold-starts with the current bindings, exactly as if
+            # eager spawn never ran.
+            if (slot.agent, slot.model, slot.project, slot.reasoning_effort) != _bound:
+                logger.info(
+                    "Eager spawn: slot %s bindings changed mid-handshake, removing session",
+                    slot.key,
+                )
+                await sessions.remove(session_key)
+                return
+            logger.info(
+                "Eager spawn: session ready for %s in %.0fms (new=%s resumed=%s)",
+                session_key,
+                (time.monotonic() - _t0) * 1000.0,
+                is_new,
+                resumed,
+            )
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.warning("Eager spawn failed for slot %s", slot.key, exc_info=True)
+
+
 async def _handle_goal_command(state: "DashboardState", slot: "_ChatSlot", message: str) -> None:
     """Handle the ``/goal`` slash command (v0 self-verdict loop).
 
@@ -2501,6 +2660,34 @@ def _finish_queue_cycle(state: DashboardState, slot: _ChatSlot) -> None:
         refresh_task.add_done_callback(state._background_tasks.discard)
 
 
+def _emit_ttft_metric(t0: float, session_key: str, *, is_new: bool, resumed: bool) -> None:
+    """Emit the user-message → first-visible-token latency histogram.
+
+    Best-effort, one point per top-level user prompt. ``first_turn`` splits the
+    cold-path population eager spawn targets (the slot's first message) from
+    steady-state turns, and ``resumed`` separates ``session/load`` costs — the
+    same attribution axes as the startup metric, so the two histograms can be
+    read side by side.
+    """
+    try:
+        # circular import: metrics.provider -> config.loader -> ... (same
+        # reason _emit_kiro_startup_metric imports lazily).
+        from kiro_crew.metrics.provider import get_recorder
+
+        get_recorder().histogram(
+            "kirocrew.chat.first_token.duration",
+            (time.monotonic() - t0) * 1000.0,
+            unit="ms",
+            attrs={
+                "channel": telemetry_channel_of(session_key),
+                "first_turn": bool(is_new),
+                "resumed": bool(resumed),
+            },
+        )
+    except Exception:
+        logger.debug("TTFT metric emission failed", exc_info=True)
+
+
 async def _run_chat(
     state: DashboardState,
     slot: _ChatSlot,
@@ -2514,6 +2701,15 @@ async def _run_chat(
 
     session_key = effective_session_key(slot)
     sessions = getattr(state, "sessions", None)
+
+    # Time-to-first-token clock: starts when the user's message reaches the
+    # runner, stops at the first visible model output (text OR thinking chunk).
+    # This is the end-to-end latency eager spawn / warm pooling exist to cut —
+    # startup.duration only covers the handshake slice, so without this the
+    # user-perceived win is not measurable. Top-level user prompts only:
+    # synthetic payloads and nested prompts are runner-authored, and mixing
+    # them in would skew the distribution the feature is judged by.
+    _ttft_t0 = time.monotonic() if (_prompt_depth == 0 and not _synthetic_payload) else None
 
     # Inherit Slack link: if this dashboard session mirrors a Slack thread,
     # copy the link so every exit path, including an auth failure, can reply on
@@ -2614,9 +2810,8 @@ async def _run_chat(
     # execution turn driven by _stage_loop. Only planning turns detect/arm a
     # plan; stage-execution turns must never re-arm (that corrupted the stage
     # total). `_in_stage_execution` is set by _stage_loop around its _run_chat.
-    _orch_planning = (
-        getattr(slot, "mode", "") == "orchestrator"
-        and not getattr(slot, "_in_stage_execution", False)
+    _orch_planning = getattr(slot, "mode", "") == "orchestrator" and not getattr(
+        slot, "_in_stage_execution", False
     )
     # Rolling-buffer redactor for the live chat_chunk wire stream. Per-chunk
     # redaction misses a credential split across streaming boundaries;
@@ -3027,9 +3222,7 @@ async def _run_chat(
         withheld_pin = False
         if not slot.model:
             slot.model = _backfill_canonical_model(client, provider_name) or slot.model
-        elif (is_new or resumed) and _pinned_model_withheld(
-            client, slot.model, provider_name
-        ):
+        elif (is_new or resumed) and _pinned_model_withheld(client, slot.model, provider_name):
             withheld_pin = True
             # The session just advertised what this account can run, and the pin
             # is not on the list — the spawn withheld it, so this session runs on
@@ -3530,9 +3723,11 @@ async def _run_chat(
                 {
                     "slot": slot.key,
                     "kind": "context",
-                    "text": f"Injected {ctx_len:,} chars of context ({_named})"
-                    if _named
-                    else f"Injected {ctx_len:,} chars of context",
+                    "text": (
+                        f"Injected {ctx_len:,} chars of context ({_named})"
+                        if _named
+                        else f"Injected {ctx_len:,} chars of context"
+                    ),
                 },
             )
 
@@ -3615,6 +3810,11 @@ async def _run_chat(
             if time.time() - last_heartbeat > 5:
                 state.broadcast_ws("heartbeat", {"slot": slot.key, "ts": time.time()})
                 last_heartbeat = time.time()
+
+            # First visible model output for this user prompt — emit TTFT once.
+            if _ttft_t0 is not None and event.kind in (EVENT_TEXT_CHUNK, EVENT_THINKING_CHUNK):
+                _emit_ttft_metric(_ttft_t0, session_key, is_new=is_new, resumed=resumed)
+                _ttft_t0 = None
 
             # Security: tool_call_id originates from LLM — redact before any use
             if hasattr(event, "tool_call_id") and event.tool_call_id:
@@ -3737,7 +3937,9 @@ async def _run_chat(
                     "tool_call",
                     _tool_payload,
                 )
-                slot.append("tool", f"🔧 {_tool_payload['tool']}", "msg msg-tool", meta=_tool_meta(event))
+                slot.append(
+                    "tool", f"🔧 {_tool_payload['tool']}", "msg msg-tool", meta=_tool_meta(event)
+                )
                 sel().log_tool_invocation(
                     session_key=session_key,
                     agent=slot.agent or "kirocrew",
@@ -5251,9 +5453,7 @@ async def _run_chat(
                 # frontend drops its stale counts and the meter self-corrects on
                 # the next turn. On failure/timeout `used` is unchanged and still
                 # valid, so the same call re-sends the real counts as-is.
-                state.broadcast_context_usage(
-                    slot.key, _context_usage_payload(slot.key, client)
-                )
+                state.broadcast_context_usage(slot.key, _context_usage_payload(slot.key, client))
 
         if assistant_text:
             # ── Plan format validation (planning turn only) ─────
@@ -5592,8 +5792,7 @@ async def _run_chat(
                     )
                     if _mirror_ts:
                         _owner = (
-                            state.sessions.get_session_for_thread(_mirror_thread)
-                            or session_key
+                            state.sessions.get_session_for_thread(_mirror_thread) or session_key
                             if getattr(state, "sessions", None)
                             else session_key
                         )
@@ -5816,9 +6015,7 @@ async def _run_chat(
                     # which of the two happened, so the continuation must
                     # agree with it rather than pick one.
                     cause=(
-                        ResetCause.CONNECTION_LOST
-                        if _is_pipe_death
-                        else ResetCause.SESSION_BUSY
+                        ResetCause.CONNECTION_LOST if _is_pipe_death else ResetCause.SESSION_BUSY
                     ),
                     message_is_synthetic=_is_synthetic,
                 )
@@ -6028,9 +6225,7 @@ async def _run_chat(
             # conversation" and "backend-wide outage/throttle" is done by the
             # CANARY PROBE below, not by classifying the error.
             _prestream_exhausted = (
-                not _turn_emitted
-                and not _turn_thought
-                and acp_error_is_transient(exc)
+                not _turn_emitted and not _turn_thought and acp_error_is_transient(exc)
             )
             if _prestream_exhausted:
                 slot._prestream_exhausted_cycles += 1
@@ -6081,9 +6276,7 @@ async def _run_chat(
                 # or rejection raises instead of degrading). No readable
                 # model ⇒ the probe cannot be trusted ⇒ inconclusive ⇒ no
                 # discard.
-                _session_model = str(
-                    getattr(client, "served_model", "") or ""
-                ).strip()
+                _session_model = str(getattr(client, "served_model", "") or "").strip()
                 if _session_model:
                     try:
                         _canary_text = await run_bg_oneliner(
@@ -6302,7 +6495,14 @@ async def _run_chat(
         # here would skip the steer requeue and queue drain below, silently
         # stranding queued work at the end of an otherwise successful turn.
         try:
+            _had_pending_reset = bool(slot._pending_reset_history_key)
             await _consume_pending_reset(state, slot)
+            # The consume tore down the session for a mid-turn project change;
+            # without a respawn the NEXT message pays the full cold start the
+            # eager path exists to hide. Only when a reset was actually
+            # consumed — an ordinary turn end must not spawn anything.
+            if _had_pending_reset:
+                schedule_eager_spawn(state, slot)
         except Exception:
             logger.debug("_consume_pending_reset failed", exc_info=True)
         # ── Requeue unconsumed steers ──

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -843,6 +843,7 @@ class _ChatSlot:
         "_stop_event_id",
         "_stop_escalated_card_id",
         "_pending_reset_history_key",
+        "_eager_spawn_task",
         "_dirty_flag",
         "_dirty_gen",
         "_orch_tracker",
@@ -1014,6 +1015,10 @@ class _ChatSlot:
         # inline because the endpoint can be reached from inside the kiro-cli
         # process group via the set_project MCP tool.
         self._pending_reset_history_key: str | None = None
+        # Debounced speculative session-creation task (session.eager_spawn).
+        # At most one per slot: scheduling a new one cancels the previous, so
+        # rapid signals (create + project set) collapse into a single spawn.
+        self._eager_spawn_task: asyncio.Task[None] | None = None
         self._dirty_flag: bool = False  # True when messages changed since last flush
         # Bumped by the _dirty setter on every True. Lets the periodic flush tell
         # "the True I started this save under" from "a NEW True set during it".

--- a/src/kiro_crew/metrics/provider.py
+++ b/src/kiro_crew/metrics/provider.py
@@ -195,6 +195,10 @@ _HISTOGRAM_BUCKETS_MS: dict[str, list[float]] = {
     # 0.5ms..60s, which covers both without flooring the tail percentiles.
     "kirocrew.telegram.api.duration": _FAST_BUCKETS_MS,
     "kirocrew.session.startup.duration": _STARTUP_BUCKETS_MS,
+    # User message → first visible token. Warm turns land at 1-5s (model
+    # latency), a cold first message adds the 5-25s spawn/handshake — the same
+    # shape and range as startup, whose family is densest exactly there.
+    "kirocrew.chat.first_token.duration": _STARTUP_BUCKETS_MS,
     "kirocrew.mcp.lazy_load.duration": _STARTUP_BUCKETS_MS,
     "kirocrew.gateway.boot.duration": _STARTUP_BUCKETS_MS,
     "kirocrew.turn.duration": _TURN_BUCKETS_MS,

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -460,6 +460,18 @@ class SessionClosingError(RuntimeError):
     """
 
 
+class SpeculativeResumeRefused(RuntimeError):
+    """Raised by ``get_or_create(speculative=True)`` on a resumable key.
+
+    A speculative caller must never be the one that resumes a persisted
+    session: the real first turn needs to observe ``resumed=True`` to make its
+    history-injection decision, and existing-session reuse reports
+    ``resumed=False``. Raised on the same session-map read that would drive
+    the resume, so there is no window for a mapping to appear between a
+    caller-side check and the create.
+    """
+
+
 def _provider_has_active_turn(provider: LLMProvider) -> bool:
     """True only if ``provider`` reports a real in-flight turn.
 
@@ -1014,9 +1026,7 @@ class SessionManager:
             return
         async with self._lock:
             if BACKGROUND_KEY not in self._sessions:
-                sess = _Session(
-                    provider=provider, is_new=False, agent=BACKGROUND_AGENT
-                )
+                sess = _Session(provider=provider, is_new=False, agent=BACKGROUND_AGENT)
                 self._sessions[BACKGROUND_KEY] = sess
                 logger.info("Background session created")
             else:
@@ -1992,11 +2002,7 @@ class SessionManager:
                 # cannot be displayed as an age directly, so project it back
                 # onto the wall clock the consumer subtracts from.
                 spawn = getattr(runtime, "_spawn_monotonic", None)
-                created = (
-                    now_wall - (now_mono - spawn)
-                    if isinstance(spawn, (int, float))
-                    else None
-                )
+                created = now_wall - (now_mono - spawn) if isinstance(spawn, (int, float)) else None
                 rows.append(
                     {
                         "key": label,
@@ -2260,6 +2266,7 @@ class SessionManager:
         model: str | None = None,
         cwd: str | None = None,
         extra_env: dict[str, str] | None = None,
+        speculative: bool = False,
         _won_race_retries: int = 0,
         **extra_factory_kwargs: Any,
     ) -> tuple[LLMProvider, bool, bool]:
@@ -2283,6 +2290,17 @@ class SessionManager:
                 value like ``"auto"``, in which case it stays ``None`` to let
                 the backend resolve from the agent's own JSON config.  Flows
                 through to the provider factory as the ``model_override`` kwarg.
+            speculative: The caller is pre-creating the session ahead of a real
+                first turn (eager spawn) rather than running one.  Three atomic
+                consequences, all inside this method so no caller-side
+                check-then-act window exists: the one-shot first-turn flag is
+                never consumed (a speculative creator registers the session
+                with it still armed; a speculative claimant leaves it as-is);
+                a key with a resume mapping raises
+                :class:`SpeculativeResumeRefused` instead of resuming, because
+                the real first turn must be the one that observes
+                ``resumed=True``; and the returned ``is_new`` reflects the
+                flag's state without consuming it.
         """
         # Fast path: existing session — hold lock only briefly
         # Fold bare/canonical Slack key aliases FIRST: the SessionMap thread
@@ -2292,7 +2310,7 @@ class SessionManager:
         # cold-starts a context-free duplicate (thread split).
         key = self._fold_key(key)
         stale_provider = None
-        _claimed: "tuple[_Session, bool] | None" = None
+        _claimed: "_Session | None" = None
         try:
             async with self._lock:
                 # Refuse to start OR resume any turn once teardown has begun.
@@ -2356,8 +2374,13 @@ class SessionManager:
                         # per spawn so a key collision with a different agent
                         # cannot happen in practice.
                         sess.last_used = time.monotonic()
-                        was_new = sess.is_new
-                        sess.is_new = False
+                        # The one-shot first-turn flag is NOT touched here: it
+                        # is read and consumed below, only after this caller
+                        # actually acquires the session semaphore. Consuming at
+                        # claim time destroys the flag when the claimant is
+                        # cancelled while waiting, or when a queued won-race
+                        # caller acquires first — ownership of the flag must
+                        # follow semaphore acquisition order.
                         # Lazy-save CC session_id: init event fires after
                         # registration, so the first get_or_create that finds
                         # a live session with a populated session_id persists it.
@@ -2379,7 +2402,7 @@ class SessionManager:
                         # _bg ACP process) would otherwise pin self._lock and
                         # freeze get_or_create for EVERY session. Acquire below,
                         # after the lock is released, then re-validate.
-                        _claimed = (sess, was_new)
+                        _claimed = sess
 
                 if _claimed is None:
                     if not self._provider_factory:
@@ -2400,8 +2423,17 @@ class SessionManager:
         # acquiring: another coroutine may have recycled/removed this session
         # while we waited on the semaphore — if so, fall through to cold-start.
         if _claimed is not None:
-            sess, was_new = _claimed
+            sess = _claimed
             if await self._reacquire_and_validate(key, sess):
+                # Consume the one-shot first-turn flag HERE, as the semaphore
+                # owner — not at claim time under self._lock. A claimant
+                # cancelled while waiting must not destroy the flag, and when
+                # several callers queue on an armed (speculatively created)
+                # session, the flag belongs to whichever real caller acquires
+                # first. A speculative claimant reads without consuming.
+                was_new = sess.is_new
+                if not speculative:
+                    sess.is_new = False
                 return sess.provider, was_new, False
             # Stale between claim and acquire — the semaphore has already been
             # released by the re-validate. If the entry is still ours but the
@@ -2450,6 +2482,13 @@ class SessionManager:
         ) and not self._is_continuable_key(key)
         if not is_stateless:
             resume_sid = self._session_map.get(key)
+        # A speculative caller must never be the one that resumes: the real
+        # first turn needs to observe resumed=True to make its history-injection
+        # decision, and the existing-session fast path reports resumed=False.
+        # Checked HERE, on the same map read that would drive the resume, so no
+        # check-then-act window exists for a mapping to appear in between.
+        if speculative and resume_sid:
+            raise SpeculativeResumeRefused(key)
 
         # Try warm pool first (no resume — pooled processes have no prior session)
         logger.info(
@@ -2529,7 +2568,9 @@ class SessionManager:
                         else:
                             _switch_model = model_registry.to_acp_id(model)
                             _cmp_pool = (
-                                model_registry.to_acp_id(_pool_model) if _pool_model else _pool_model
+                                model_registry.to_acp_id(_pool_model)
+                                if _pool_model
+                                else _pool_model
                             )
                         if _pool_model and _switch_model != _cmp_pool:
                             # This is an INHERITED value (the slot's persisted
@@ -2553,9 +2594,7 @@ class SessionManager:
                                 )
                             else:
                                 await provider.client.set_model(_switch_model)
-                                logger.info(
-                                    "Pool post-claim: switched model to %s", _switch_model
-                                )
+                                logger.info("Pool post-claim: switched model to %s", _switch_model)
                 logger.info(
                     "Claimed warm-pool process for %s (agent=%s)", key, agent or self._pool_agent
                 )
@@ -2651,6 +2690,20 @@ class SessionManager:
                 resumed = provider.client.resumed
 
             async with self._lock:
+                # Re-check _closing: the entry gate ran BEFORE the multi-second
+                # provider.start(), so close_all() can begin (and finish its
+                # drain + kill snapshot) while the handshake is in flight. A
+                # session registered here after that snapshot is invisible to
+                # the shutdown loop — the kiro-cli process would outlive the
+                # gateway holding the persisted session lock, breaking the
+                # next startup's session/load. Raising sends us to the
+                # except-BaseException below, which kills the provider.
+                if self._closing:
+                    raise SessionClosingError(
+                        "SessionManager began closing during provider startup; "
+                        "refusing to register a session behind the shutdown "
+                        "snapshot"
+                    )
                 # Re-check: another coroutine may have created this key while we
                 # were starting the provider (race on same key). In-place
                 # compaction (kiro-cli and claude) leaves the existing entry
@@ -2683,7 +2736,14 @@ class SessionManager:
                 else:
                     sess = _Session(
                         provider=provider,
-                        is_new=False,
+                        # A real creator consumes the first-turn flag itself
+                        # (is_new=True goes back to it in `result`); a
+                        # speculative creator leaves it ARMED for the first
+                        # real turn, which claims it via the fast path or the
+                        # won-race path. Set atomically at registration, under
+                        # self._lock — this is what replaces the racy
+                        # rearm-after-release design.
+                        is_new=bool(speculative),
                         approval_policy=approval_policy,
                         agent=agent or "",
                     )
@@ -2753,7 +2813,18 @@ class SessionManager:
                         "Failed to shut down duplicate provider for %s", key, exc_info=True
                     )
             if await self._reacquire_and_validate(key, _won_race_sess):
-                return _won_race_sess.provider, False, False
+                # Mirror the fast path's flag handling: when the race winner
+                # was a SPECULATIVE creator it registered the session with the
+                # first-turn flag still armed, and this loser may be the first
+                # real turn — hardcoding False here would strand the flag and
+                # skip first-turn context injection (then fire it, late, on a
+                # later message). Both-real races are unchanged: the real
+                # winner consumed its own flag at registration, so was_new
+                # reads False exactly as before.
+                was_new = _won_race_sess.is_new
+                if not speculative:
+                    _won_race_sess.is_new = False
+                return _won_race_sess.provider, was_new, False
             # Stale winner: the semaphore has already been released by the
             # re-validate; retry from the top (cold-starts cleanly). Bounded so
             # a pathological recycle race can't recurse without limit.
@@ -2771,6 +2842,7 @@ class SessionManager:
                 model=model,
                 cwd=cwd,
                 extra_env=extra_env,
+                speculative=speculative,
                 _won_race_retries=_won_race_retries + 1,
                 **extra_factory_kwargs,
             )
@@ -3190,9 +3262,7 @@ class SessionManager:
                     # of a fixed slice, so a compaction that outlives the
                     # prompt turn is not abandoned with budget left unused.
                     result_wait_used = _compact_result_wait_secs(time.monotonic() - started)
-                    result = await session.provider.wait_for_compaction(
-                        timeout=result_wait_used
-                    )
+                    result = await session.provider.wait_for_compaction(timeout=result_wait_used)
                     status = result.get("type") if isinstance(result, dict) else None
                 if status != "completed":
                     raise RuntimeError(f"compaction reported {status or 'no result'}")
@@ -3402,19 +3472,13 @@ class SessionManager:
                     try:
                         await waiter(timeout=timeout)
                     except asyncio.TimeoutError:
-                        logger.debug(
-                            "drain_active_turns: post-cancel wait_turn_done timed out"
-                        )
+                        logger.debug("drain_active_turns: post-cancel wait_turn_done timed out")
                     except Exception:
-                        logger.debug(
-                            "drain_active_turns: wait_turn_done failed", exc_info=True
-                        )
+                        logger.debug("drain_active_turns: wait_turn_done failed", exc_info=True)
 
         try:
             await asyncio.wait_for(
-                asyncio.gather(
-                    *[_drain_one(p) for p in unfinished], return_exceptions=True
-                ),
+                asyncio.gather(*[_drain_one(p) for p in unfinished], return_exceptions=True),
                 # A hair above the per-session budget so an internally-bounded
                 # cancel resolves as its own timeout rather than the gather being
                 # cancelled out from under it.
@@ -3753,11 +3817,7 @@ class SessionManager:
         key = self._fold_key(key)
         session = self._sessions.get(key)
         if session:
-            if (
-                cleanup
-                and key.startswith(_SUBAGENT_PREFIX)
-                and not self._is_continuable_key(key)
-            ):
+            if cleanup and key.startswith(_SUBAGENT_PREFIX) and not self._is_continuable_key(key):
                 try:
                     session_id = session.provider.session_id
                     if session_id:
@@ -4018,9 +4078,7 @@ class SessionManager:
         accepts_inbound: bool = False,
     ) -> list[str]:
         """Sessions that must stop *key* from binding *link*, or [] if it is free."""
-        return self._session_map.mirror_claim_blockers(
-            key, link, accepts_inbound=accepts_inbound
-        )
+        return self._session_map.mirror_claim_blockers(key, link, accepts_inbound=accepts_inbound)
 
     def clear_mirror_link(self, key: str) -> bool:
         """Remove a session's outbound mirror binding. Returns True iff present."""

--- a/test/test_eager_spawn.py
+++ b/test/test_eager_spawn.py
@@ -1,0 +1,559 @@
+"""Tests for speculative session creation (session.eager_spawn).
+
+Covers the schedule/debounce contract in ``chat_runner.schedule_eager_spawn``
+and the re-validation ordering in ``_eager_spawn``: config gate, task
+supersession, slot-liveness bail, the turn-in-flight bail that protects the
+deferred project-reset killpg constraint, semaphore release after creation,
+and the handler wiring on project set.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.dashboard import chat_runner
+from kiro_crew.dashboard.chat_runner import _eager_spawn, schedule_eager_spawn
+from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+
+def _mock_state(slot: _ChatSlot) -> DashboardState:
+    state = MagicMock(spec=DashboardState)
+    state.get_slot = MagicMock(return_value=slot)
+    state.sessions = MagicMock()
+    state.sessions.get_or_create = AsyncMock(return_value=(MagicMock(), True, False))
+    state.sessions.release = MagicMock()
+    state.sessions.reset = AsyncMock()
+    state.sessions.remove = AsyncMock()
+    return state
+
+
+def _cfg(enabled: bool) -> MagicMock:
+    cfg = MagicMock()
+    cfg.session.eager_spawn = enabled
+    bindings = MagicMock()
+    bindings.kiro_agent = "kirocrew"
+    bindings.model = ""
+    cfg_loader = MagicMock(return_value=cfg)
+    return cfg_loader
+
+
+class TestScheduleEagerSpawn:
+    def test_config_loader_parses_eager_spawn(self, tmp_path):
+        """The loader's explicit SessionConfig construction must carry the flag.
+
+        The dataclass field alone is not enough: KiroCrewConfig.load() builds
+        SessionConfig with per-field parsing, and a field missing there is
+        silently dropped on load — then the boot-time migration write-back
+        saves the dataclass default over the user's setting. Caught live.
+        With the default now True, the falsifying direction is an explicit
+        FALSE surviving the round-trip; the empty config pins the default.
+        """
+        import json
+        import unittest.mock
+
+        def _load(data: dict, name: str):
+            tmp = tmp_path / name
+            tmp.write_text(json.dumps(data))
+            with unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=tmp):
+                return chat_runner.KiroCrewConfig.load()
+
+        assert _load({"session": {"eager_spawn": False}}, "off.json").session.eager_spawn is False
+        assert _load({}, "empty.json").session.eager_spawn is True  # default on
+
+    @pytest.mark.asyncio
+    async def test_noop_when_flag_disabled(self):
+        slot = _ChatSlot("t1")
+        state = _mock_state(slot)
+        with patch.object(chat_runner.KiroCrewConfig, "load", _cfg(False)):
+            schedule_eager_spawn(state, slot)
+        assert slot._eager_spawn_task is None
+
+    @pytest.mark.asyncio
+    async def test_noop_when_config_unreadable(self):
+        slot = _ChatSlot("t1")
+        state = _mock_state(slot)
+        with patch.object(
+            chat_runner.KiroCrewConfig, "load", MagicMock(side_effect=OSError("boom"))
+        ):
+            schedule_eager_spawn(state, slot)
+        assert slot._eager_spawn_task is None
+
+    @pytest.mark.asyncio
+    async def test_newer_signal_cancels_older_task(self):
+        slot = _ChatSlot("t1")
+        state = _mock_state(slot)
+        with patch.object(chat_runner.KiroCrewConfig, "load", _cfg(True)):
+            schedule_eager_spawn(state, slot)
+            first = slot._eager_spawn_task
+            assert first is not None
+            schedule_eager_spawn(state, slot)
+            second = slot._eager_spawn_task
+        assert second is not first
+        # The older task must be cancelled — it holds the stale slot state.
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        second.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await second
+
+
+class TestEagerSpawn:
+    """_eager_spawn body, with debounce zeroed for test speed."""
+
+    @pytest.fixture(autouse=True)
+    def _no_debounce(self, monkeypatch):
+        monkeypatch.setattr(chat_runner, "_EAGER_SPAWN_DEBOUNCE_SECS", 0)
+
+    @pytest.mark.asyncio
+    async def test_creates_session_with_slot_bindings_and_releases(self, tmp_path):
+        slot = _ChatSlot("t1")
+        slot.agent = "wfe-oncall"
+        slot.project = str(tmp_path)
+        state = _mock_state(slot)
+        bindings = MagicMock()
+        bindings.kiro_agent = "wfe-oncall"
+        bindings.model = ""
+        with (
+            patch.object(chat_runner.KiroCrewConfig, "load", _cfg(True)),
+            patch.object(chat_runner, "resolve_agent_bindings", return_value=bindings),
+        ):
+            await _eager_spawn(state, slot)
+        state.sessions.get_or_create.assert_awaited_once()
+        kwargs = state.sessions.get_or_create.await_args.kwargs
+        assert kwargs["agent"] == "wfe-oncall"
+        assert kwargs["cwd"] == str(tmp_path)
+        # The per-session semaphore acquired by get_or_create MUST be released
+        # here: no turn follows, and a held semaphore would deadlock the first
+        # real message.
+        key = state.sessions.get_or_create.await_args.args[0]
+        state.sessions.release.assert_called_once_with(key)
+
+    @pytest.mark.asyncio
+    async def test_bails_when_slot_replaced(self):
+        slot = _ChatSlot("t1")
+        state = _mock_state(slot)
+        state.get_slot = MagicMock(return_value=_ChatSlot("t1"))  # different object
+        with patch.object(chat_runner.KiroCrewConfig, "load", _cfg(True)):
+            await _eager_spawn(state, slot)
+        state.sessions.get_or_create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bails_when_turn_running_without_consuming_reset(self, tmp_path):
+        """The turn-in-flight bail must precede the pending-reset consume.
+
+        Consuming the reset kills the session's process group; when the
+        project-set call originated from the set_project MCP tool inside that
+        session, a mid-turn consume would kill the caller.
+        """
+        slot = _ChatSlot("t1")
+        # slot.running derives from slot.task being a live task.
+        _turn = asyncio.get_running_loop().create_future()
+        _task = asyncio.ensure_future(_turn)
+        slot.task = _task
+        slot._pending_reset_history_key = "dashboard:t1"
+        state = _mock_state(slot)
+        try:
+            with patch.object(chat_runner.KiroCrewConfig, "load", _cfg(True)):
+                await _eager_spawn(state, slot)
+        finally:
+            _turn.set_result(None)
+            await _task
+        state.sessions.get_or_create.assert_not_awaited()
+        state.sessions.reset.assert_not_awaited()
+        assert slot._pending_reset_history_key == "dashboard:t1"
+
+    @pytest.mark.asyncio
+    async def test_consumes_pending_reset_when_idle(self, tmp_path):
+        slot = _ChatSlot("t1")
+        slot.project = str(tmp_path)
+        slot._pending_reset_history_key = "dashboard:t1"
+        state = _mock_state(slot)
+        with patch.object(chat_runner.KiroCrewConfig, "load", _cfg(True)):
+            await _eager_spawn(state, slot)
+        state.sessions.reset.assert_awaited_once_with("dashboard:t1")
+        assert slot._pending_reset_history_key is None
+        state.sessions.get_or_create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_get_or_create_failure_is_swallowed(self):
+        slot = _ChatSlot("t1")
+        state = _mock_state(slot)
+        state.sessions.get_or_create = AsyncMock(side_effect=RuntimeError("spawn failed"))
+        with patch.object(chat_runner.KiroCrewConfig, "load", _cfg(True)):
+            await _eager_spawn(state, slot)  # must not raise
+        state.sessions.release.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_passes_speculative_flag(self):
+        """The eager path must create speculatively: the flag is what keeps
+        the one-shot first-turn context injection armed for the real message
+        (atomically, inside get_or_create — both local reviewers flagged the
+        earlier rearm-after-release design as racy)."""
+        slot = _ChatSlot("t1")
+        state = _mock_state(slot)
+        with patch.object(chat_runner.KiroCrewConfig, "load", _cfg(True)):
+            await _eager_spawn(state, slot)
+        assert state.sessions.get_or_create.await_args.kwargs["speculative"] is True
+
+    @pytest.mark.asyncio
+    async def test_resumable_key_refusal_is_clean(self):
+        """SpeculativeResumeRefused is an expected outcome, not an error: the
+        real first turn must be the one that resumes."""
+        from kiro_crew.session import SpeculativeResumeRefused
+
+        slot = _ChatSlot("t1")
+        state = _mock_state(slot)
+        state.sessions.get_or_create = AsyncMock(
+            side_effect=SpeculativeResumeRefused("dashboard:t1")
+        )
+        with patch.object(chat_runner.KiroCrewConfig, "load", _cfg(True)):
+            await _eager_spawn(state, slot)  # must not raise
+        state.sessions.release.assert_not_called()
+        state.sessions.remove.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_removes_session_when_slot_deleted_mid_handshake(self):
+        """A slot deleted during the handshake must not leave an orphan
+        session that a recreated slot with the same key would reuse with
+        stale agent/cwd bindings."""
+        slot = _ChatSlot("t1")
+        state = _mock_state(slot)
+        state.sessions.remove = AsyncMock()
+
+        # Simulate deletion landing while get_or_create is in flight: after the
+        # handshake completes, get_slot no longer returns this slot object.
+        async def _create_then_delete(*a, **kw):
+            state.get_slot = MagicMock(return_value=None)
+            return (MagicMock(), True, False)
+
+        state.sessions.get_or_create = AsyncMock(side_effect=_create_then_delete)
+        with patch.object(chat_runner.KiroCrewConfig, "load", _cfg(True)):
+            await _eager_spawn(state, slot)
+        key = state.sessions.get_or_create.await_args.args[0]
+        state.sessions.remove.assert_awaited_once_with(key)
+        # Semaphore still released before teardown.
+        state.sessions.release.assert_called_once_with(key)
+
+    @pytest.mark.asyncio
+    async def test_removes_session_when_bindings_change_mid_handshake(self, tmp_path):
+        """GPT BLOCKING — stale-workspace session. A switch handler (workspace,
+        model, reasoning effort) firing mid-handshake resets a key that has
+        nothing registered yet, so the reset no-ops; without the bindings
+        snapshot the eager task would then register a session with the OLD cwd
+        and the first real turn would run tools in the wrong workspace."""
+        slot = _ChatSlot("t1")
+        slot.project = str(tmp_path / "a")
+        state = _mock_state(slot)
+        state.sessions.remove = AsyncMock()
+
+        # The workspace switch lands while get_or_create is in flight.
+        async def _create_then_switch(*a, **kw):
+            slot.project = str(tmp_path / "b")
+            return (MagicMock(), True, False)
+
+        state.sessions.get_or_create = AsyncMock(side_effect=_create_then_switch)
+        with patch.object(chat_runner.KiroCrewConfig, "load", _cfg(True)):
+            await _eager_spawn(state, slot)
+        key = state.sessions.get_or_create.await_args.args[0]
+        state.sessions.remove.assert_awaited_once_with(key)
+        # Semaphore still released before teardown.
+        state.sessions.release.assert_called_once_with(key)
+
+    @pytest.mark.asyncio
+    async def test_unchanged_bindings_keep_the_session(self, tmp_path):
+        """The bindings guard must not tear down the common case."""
+        slot = _ChatSlot("t1")
+        slot.project = str(tmp_path)
+        state = _mock_state(slot)
+        state.sessions.remove = AsyncMock()
+        with patch.object(chat_runner.KiroCrewConfig, "load", _cfg(True)):
+            await _eager_spawn(state, slot)
+        state.sessions.remove.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_lost_race_never_removes_the_winning_session(self, tmp_path):
+        """GPT BLOCKING — stale eager cleanup destroying the real turn's session.
+
+        is_new=False from get_or_create means another creator won the same-key
+        race: a real turn owns that runtime and may have unfinished background
+        work attached. Even when a cleanup trigger fires (bindings changed
+        mid-handshake here; slot-vanish is the same gate), the eager loser must
+        leave the winner's session alone — removing it would terminate the
+        winner mid-flight. The winner registered with its own current bindings,
+        so no stale-bindings hazard exists on its session.
+        """
+        slot = _ChatSlot("t1")
+        slot.project = str(tmp_path / "a")
+        state = _mock_state(slot)
+        state.sessions.remove = AsyncMock()
+
+        # A real turn wins registration while our handshake runs (is_new=False),
+        # AND a workspace switch lands — the pre-fix code removed the session.
+        async def _lose_race_and_switch(*a, **kw):
+            slot.project = str(tmp_path / "b")
+            return (MagicMock(), False, False)
+
+        state.sessions.get_or_create = AsyncMock(side_effect=_lose_race_and_switch)
+        with patch.object(chat_runner.KiroCrewConfig, "load", _cfg(True)):
+            await _eager_spawn(state, slot)
+        state.sessions.remove.assert_not_awaited()
+        # Semaphore still released so the winner's next turn isn't blocked.
+        key = state.sessions.get_or_create.await_args.args[0]
+        state.sessions.release.assert_called_once_with(key)
+
+
+class TestTtftMetric:
+    """kirocrew.chat.first_token.duration — user message → first visible token."""
+
+    def test_emits_histogram_with_attribution_attrs(self):
+        rec = MagicMock()
+        with patch("kiro_crew.metrics.provider.get_recorder", return_value=rec):
+            chat_runner._emit_ttft_metric(0.0, "dashboard:chat-1-x", is_new=True, resumed=False)
+        assert rec.histogram.call_count == 1
+        name = rec.histogram.call_args.args[0]
+        attrs = rec.histogram.call_args.kwargs["attrs"]
+        assert name == "kirocrew.chat.first_token.duration"
+        assert attrs["first_turn"] is True
+        assert attrs["resumed"] is False
+        assert rec.histogram.call_args.kwargs["unit"] == "ms"
+
+    def test_recorder_failure_is_swallowed(self):
+        """Best-effort: a metrics outage must never break the chat stream."""
+        with patch("kiro_crew.metrics.provider.get_recorder", side_effect=RuntimeError("boom")):
+            chat_runner._emit_ttft_metric(0.0, "dashboard:chat-1-x", is_new=False, resumed=True)
+
+
+def _stub_factory():
+    def factory(session_key=None, agent=None, channel_id=None, **kwargs):
+        m = AsyncMock()
+        m.start = AsyncMock()
+        m.shutdown = AsyncMock()
+        m.context_usage_pct = lambda: 0.0
+        m.is_alive.return_value = True
+        m.is_process_alive = lambda: True
+        return m
+
+    return factory
+
+
+class TestSpeculativeGetOrCreate:
+    """SessionManager-level semantics of the speculative flag, on the real
+    get_or_create paths (no mocks around the flag mechanics)."""
+
+    @pytest.fixture
+    def cfg(self):
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        c = KiroCrewConfig()
+        c.agent.provider = "acp"
+        c.session.pool_size = 0
+        return c
+
+    @pytest.mark.asyncio
+    async def test_speculative_create_leaves_first_turn_armed(self, cfg):
+        """A speculative creator registers is_new=True; the next real
+        get_or_create claims it (was_new=True) and consumes it. This is the
+        end-to-end invariant that keeps first-turn context injection alive."""
+        from kiro_crew.session import SessionManager
+
+        mgr = SessionManager(cfg, provider_factory=_stub_factory())
+        key = "dashboard:eager-x"
+        _, is_new, resumed = await mgr.get_or_create(key, speculative=True)
+        mgr.release(key)
+        assert mgr._sessions[key].is_new is True  # still armed
+        # Real first turn claims via the fast path and consumes.
+        _, was_new, _ = await mgr.get_or_create(key)
+        mgr.release(key)
+        assert was_new is True
+        assert mgr._sessions[key].is_new is False
+        # A second real turn is not new.
+        _, was_new2, _ = await mgr.get_or_create(key)
+        mgr.release(key)
+        assert was_new2 is False
+
+    @pytest.mark.asyncio
+    async def test_speculative_claim_does_not_consume(self, cfg):
+        """A speculative call landing on an already-armed live session must
+        read the flag without consuming it (repeat eager signals)."""
+        from kiro_crew.session import SessionManager
+
+        mgr = SessionManager(cfg, provider_factory=_stub_factory())
+        key = "dashboard:eager-y"
+        await mgr.get_or_create(key, speculative=True)
+        mgr.release(key)
+        await mgr.get_or_create(key, speculative=True)  # fast path, speculative
+        mgr.release(key)
+        assert mgr._sessions[key].is_new is True
+
+    @pytest.mark.asyncio
+    async def test_speculative_refuses_resumable_key(self, cfg, tmp_path, monkeypatch):
+        """A key with a session-map entry raises instead of resuming, on the
+        same map read that would drive the resume (no TOCTOU window).
+
+        SessionMap.get self-prunes entries whose kiro transcript files are
+        missing, so the mapping must be backed by a real .json + a >=10-byte
+        .jsonl in the (patched, isolated) kiro sessions dir or the guard is
+        never exercised.
+        """
+        from kiro_crew.session import SessionManager, SpeculativeResumeRefused
+
+        sessions_dir = tmp_path / "kiro-sessions"
+        sessions_dir.mkdir()
+        monkeypatch.setattr("kiro_crew.session_map._kiro_sessions_dir", lambda: sessions_dir)
+        sid = "prior-sid-1234"
+        (sessions_dir / f"{sid}.json").write_text("{}")
+        (sessions_dir / f"{sid}.jsonl").write_text("x" * 32)
+
+        mgr = SessionManager(cfg, provider_factory=_stub_factory())
+        key = "dashboard:eager-z"
+        mgr._session_map.set(key, sid)
+        with pytest.raises(SpeculativeResumeRefused):
+            await mgr.get_or_create(key, speculative=True)
+        assert key not in mgr._sessions
+
+    @pytest.mark.asyncio
+    async def test_real_turn_losing_race_to_speculative_winner_gets_the_flag(self, cfg):
+        """Verifier race: eager and the first real turn cold-start
+        concurrently and the eager call wins registration. The loser takes
+        the won-race path and must receive was_new=True (the armed flag),
+        not a hardcoded False."""
+        import asyncio
+
+        from kiro_crew.session import SessionManager
+
+        mgr = SessionManager(cfg, provider_factory=_stub_factory())
+        key = "dashboard:eager-race"
+
+        results: dict[str, tuple] = {}
+
+        async def eager():
+            results["eager"] = await mgr.get_or_create(key, speculative=True)
+            mgr.release(key)
+
+        async def real():
+            results["real"] = await mgr.get_or_create(key)
+            mgr.release(key)
+
+        await asyncio.gather(eager(), real())
+        # Exactly one registration; whoever lost the race went through the
+        # won-race (or fast) path. The REAL caller must end with the flag.
+        _, real_is_new, _ = results["real"]
+        assert real_is_new is True
+        assert mgr._sessions[key].is_new is False  # consumed by the real turn
+
+    @pytest.mark.asyncio
+    async def test_cancelled_waiting_claimant_does_not_destroy_the_flag(self, cfg):
+        """Verifier race: a real claimant that is CANCELLED while waiting on
+        the session semaphore must not consume the first-turn flag. Ownership
+        of the flag follows semaphore acquisition, so the next real claimant
+        still receives was_new=True."""
+        import asyncio
+
+        from kiro_crew.session import SessionManager
+
+        mgr = SessionManager(cfg, provider_factory=_stub_factory())
+        key = "dashboard:eager-cancel"
+        await mgr.get_or_create(key, speculative=True)
+        # Speculative creator still holds the semaphore (release() not called
+        # yet) — an arriving real claimant will block on acquire.
+        waiter = asyncio.ensure_future(mgr.get_or_create(key))
+        for _ in range(50):
+            if mgr._sessions[key].semaphore.locked():
+                break
+            await asyncio.sleep(0.01)
+        await asyncio.sleep(0.02)  # let the waiter park inside acquire()
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+        mgr.release(key)  # eager creator finishes
+        # The cancelled waiter must not have consumed the flag.
+        assert mgr._sessions[key].is_new is True
+        _, was_new, _ = await mgr.get_or_create(key)
+        mgr.release(key)
+        assert was_new is True
+
+
+class TestProjectSetWiring:
+    @pytest.mark.asyncio
+    async def test_agent_switch_schedules_eager_spawn(self):
+        """The agent-switch reset destroys any eager session; the handler must
+        re-arm the spawn for the new bindings (Design Review coverage gap)."""
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        from kiro_crew.dashboard.chat import api_chat_slot_agent
+
+        slot = _ChatSlot("t1")
+        state = MagicMock(spec=DashboardState)
+        state._slots = {slot.key: slot}
+        state.push_slots_update = MagicMock()
+        state.conversation_log = None  # instance attr; spec= does not provide it
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/agent", api_chat_slot_agent)
+        with (
+            patch(
+                "kiro_crew.dashboard.chat_handlers._reset_slot_session",
+                new=AsyncMock(),
+            ),
+            patch("kiro_crew.dashboard.chat_handlers.save_slot_off_loop", new=AsyncMock()),
+            patch("kiro_crew.dashboard.chat_handlers.schedule_eager_spawn") as sched,
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post("/api/chat/slots/t1/agent", json={"agent": "kirocrew"})
+                assert resp.status == 200
+            sched.assert_called_once_with(state, slot)
+
+    @pytest.mark.asyncio
+    async def test_project_change_schedules_eager_spawn(self, tmp_path):
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        from kiro_crew.dashboard.chat import api_chat_slot_project
+
+        slot = _ChatSlot("t1")
+        state = MagicMock(spec=DashboardState)
+        state._slots = {slot.key: slot}
+        state.push_slots_update = MagicMock()
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/project", api_chat_slot_project)
+        with (
+            patch("kiro_crew.dashboard.chat_handlers._save_recent_project"),
+            patch("kiro_crew.dashboard.chat_handlers.schedule_eager_spawn") as sched,
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/chat/slots/t1/project", json={"project": str(tmp_path)}
+                )
+                assert resp.status == 200
+            sched.assert_called_once_with(state, slot)
+
+    @pytest.mark.asyncio
+    async def test_noop_project_set_does_not_schedule(self, tmp_path):
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+
+        from kiro_crew.dashboard.chat import api_chat_slot_project
+
+        slot = _ChatSlot("t1")
+        slot.project = str(tmp_path)
+        state = MagicMock(spec=DashboardState)
+        state._slots = {slot.key: slot}
+        state.push_slots_update = MagicMock()
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post("/api/chat/slots/{slot}/project", api_chat_slot_project)
+        with (
+            patch("kiro_crew.dashboard.chat_handlers._save_recent_project"),
+            patch("kiro_crew.dashboard.chat_handlers.schedule_eager_spawn") as sched,
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/api/chat/slots/t1/project", json={"project": str(tmp_path)}
+                )
+                assert resp.status == 200
+            sched.assert_not_called()

--- a/test/test_session_drain.py
+++ b/test/test_session_drain.py
@@ -285,9 +285,9 @@ async def test_drain_waits_on_already_cancelled_but_unfinished_turn(cfg):
 
     n = await mgr.drain_active_turns(timeout=1.0)
 
-    assert n == 1                            # selected despite has_active_turn False
-    assert p.cancel_calls == [1.0]           # graceful cancel still attempted
-    assert p.wait_turn_done_calls == [1.0]   # and we waited for the pending ack
+    assert n == 1  # selected despite has_active_turn False
+    assert p.cancel_calls == [1.0]  # graceful cancel still attempted
+    assert p.wait_turn_done_calls == [1.0]  # and we waited for the pending ack
     assert p.has_unfinished_turn() is False  # ack arrived -> turn finished
 
 
@@ -321,10 +321,10 @@ async def test_close_all_drain_plus_kill_fit_tight_deadline(cfg):
     await asyncio.wait_for(mgr.close_all(drain_timeout=0.2), timeout=1.0)
     elapsed = time.monotonic() - t0
 
-    assert p.cancel_calls == [0.2]      # drain used the passed budget
-    assert p.shutdown_called is True    # kill path ran
+    assert p.cancel_calls == [0.2]  # drain used the passed budget
+    assert p.shutdown_called is True  # kill path ran
     assert mgr.count == 0
-    assert elapsed < 1.0                # fit inside the tight deadline
+    assert elapsed < 1.0  # fit inside the tight deadline
 
 
 @pytest.mark.asyncio
@@ -349,8 +349,8 @@ async def test_close_all_propagates_outer_cancel_to_keep_deadline_honest(cfg):
         await asyncio.wait_for(mgr.close_all(drain_timeout=5.0), timeout=0.3)
     elapsed = time.monotonic() - t0
 
-    assert p.cancel_calls              # drain was attempted before the cancel
-    assert elapsed < 1.0               # the 0.3s deadline was honored, not ~6s
+    assert p.cancel_calls  # drain was attempted before the cancel
+    assert elapsed < 1.0  # the 0.3s deadline was honored, not ~6s
     # The cancel propagated instead of being swallowed: close_all did not run the
     # in-line kill to completion on this path (that is the reaper's job).
     assert p.shutdown_called is False
@@ -376,6 +376,36 @@ async def test_close_all_sets_closing_state(cfg):
     assert mgr._closing is False
     await mgr.close_all()
     assert mgr._closing is True
+
+
+@pytest.mark.asyncio
+async def test_registration_refused_when_closing_began_during_startup(cfg):
+    """GPT BLOCKING — late-registration leak. The entry gate runs BEFORE the
+    multi-second provider.start(); if close_all() begins during the handshake,
+    the registration lock must re-check _closing and refuse — a session
+    registered behind the shutdown snapshot is invisible to the kill loop and
+    its kiro-cli would outlive the gateway holding the persisted session lock.
+    Eager spawn widens this window: its handshakes run with no turn in flight,
+    which is exactly when the drain completes instantly."""
+    started = asyncio.Event()
+    resume = asyncio.Event()
+
+    class _SlowStartProvider(_FakeProvider):
+        async def start(self) -> None:
+            started.set()
+            await resume.wait()
+
+    provider = _SlowStartProvider()
+    mgr = SessionManager(cfg, provider_factory=lambda *a, **k: provider)
+
+    task = asyncio.create_task(mgr.get_or_create("s-late"))
+    await asyncio.wait_for(started.wait(), timeout=2)
+    mgr._closing = True  # close_all()'s first act, mid-handshake
+    resume.set()
+    with pytest.raises(SessionClosingError):
+        await asyncio.wait_for(task, timeout=2)
+    # Nothing registered behind the snapshot.
+    assert "s-late" not in mgr._sessions
 
 
 # ── begin_turn: lease-dispatch race (Codex HIGH) ──


### PR DESCRIPTION
## Problem

Sending the first message in a dashboard chat slot pays a 4–8 s pause before anything streams: the gateway spawns kiro-cli and runs the full ACP handshake only when the message arrives. Local OTLP metrics over 4 days: fresh-session startup averages 5419 ms (of which `session_new` is 4538 ms / 84%), and only 16% of dashboard sessions hit the warm pool — 30% are bypassed because the slot's project directory differs from the pool cwd (`bypass_cwd`), which the pool structurally cannot serve since ACP session cwd is immutable after setup.

## Why it matters

The first-message stall is the single most felt latency in the dashboard, and the warm pool cannot address the project-scoped majority of it: a pooled process is permanently bound to the cwd baked in at fill time (ACP spec v1 mandates cwd immutability; verified against the spec, a live kiro-cli 2.14.2 probe, and other implementations). Closes #2330. Resume prefetch — the other half of the latency story — is deliberately out of scope here and tracked in #2346.

## Fix (symptom → root cause → change)

Symptom: first message stalls. Root cause: the expensive, context-free part of session startup (process spawn + `session/new`) is serialized behind the user's send, even though everything it needs — agent, model, cwd — is already known from the slot's intent signals. Change: create the session speculatively on those signals, overlapping the handshake with user think-time.

- `session.eager_spawn` config flag (default **on**; set `false` to opt out), parsed in the loader's explicit `SessionConfig` construction (the dataclass field alone is silently dropped on load and then overwritten by the boot migration write-back — caught in live testing).
- `schedule_eager_spawn` (chat_runner): debounced 1.5 s fire-and-forget task, one per slot (newer signal cancels older), global cap of 2 concurrent spawns. Wired into **four** session-invalidating intent signals: slot create, project set, agent switch (whose reset destroys any eager session and is itself the strongest first-message signal), and the end-of-turn deferred-reset consume for a mid-turn project change (re-arms only when a reset was actually consumed). The eager task bails when a turn is running — the pending project-reset consume kills the session process group, and the project-set endpoint is reachable from inside that group via the `set_project` MCP tool.
- `get_or_create(speculative=True)` (session.py): the atomic core, replacing a caller-side rearm design that three review rounds showed racy. A speculative creator registers the session with the one-shot first-turn flag still **armed** (under the manager lock); a speculative claimant reads without consuming; a resumable key raises `SpeculativeResumeRefused` on the same session-map read that would drive the resume (no TOCTOU); the flag is consumed only by the caller that actually **acquires the session semaphore**, on both the fast path and the won-race path, so a claimant cancelled while queued cannot destroy it.
- Slot delete cancels the pending eager task, and the eager task re-checks slot liveness after the handshake and tears down its session if the slot vanished — closing both halves of the delete/recreate stale-bindings race.

Behavior for existing (non-speculative) callers is unchanged: a real creator still consumes its own flag at registration, so the won-race path's `was_new` can only read `True` when the winner was speculative.

## Tests

`test/test_eager_spawn.py` (19 tests, all revert-verified or falsifying by construction):
- Schedule contract: config gate off/unreadable, newer-signal-cancels-older.
- Eager task: speculative flag passed, slot-replaced bail, turn-in-flight bail preserving the deferred reset (the killpg constraint), idle reset consume, failure swallow, clean `SpeculativeResumeRefused` handling, mid-handshake slot-delete teardown with semaphore release.
- SessionManager semantics on the real `get_or_create` paths: speculative create leaves the flag armed and the next real turn claims+consumes it; repeat speculative claims don't consume; resumable key refusal (backed by real transcript files, since `SessionMap.get` self-prunes unbacked entries); concurrent cold-start race where the real loser receives the armed flag via the won-race path; cancelled-while-waiting claimant does not destroy the flag (fails on pre-fix code, verified by path-limited revert).
- Config loader round-trip regression: explicit `false` survives the round-trip and the empty config pins the default-on.
- Handler wiring: project change schedules, no-op project set does not, agent switch schedules after its reset.

## Manual verification

Verified live on an isolated `dev-backend.sh` instance (systemd user pods unavailable on this host): slot created with `agent=kirocrew`, project set to a second repo; kiro-cli spawned ~1 s after the debounce and the session file appeared with the slot's exact project cwd ~85 s before any message; the first message then streamed with **no new session created** — the pre-created session's transcript grew at send time, proving convergence. Model-flip-after-spawn needs no new code (`_try_live_model_switch` applies `session/set_model` live).

## Screenshots

N/A — backend-only; no UI change. The flag is on by default; opt out via `kirocrew config set session.eager_spawn false`.


### Review-round additions (`5208580b0`)

- **TTFT metric**: `kirocrew.chat.first_token.duration` histogram (user message -> first visible token, attrs `channel`/`first_turn`/`resumed`) - the end-to-end latency this feature targets, readable alongside `kirocrew.session.startup.duration`.
- **Shutdown-race hardening**: `get_or_create` re-checks `_closing` under the registration lock so a handshake that outlives `close_all()` cannot register a leaked session.
- **Stale-bindings guard**: `_eager_spawn` snapshots slot bindings pre-handshake and tears down the session if a workspace/model/effort switch landed mid-handshake.
