### PR TITLE
ci: add PR quality gates and make Design Review actually block

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -1,0 +1,128 @@
+name: Cross-Platform Portability
+
+# Catches POSIX-only assumptions in Python that ships to macOS, Linux AND
+# Windows. The Windows pytest shards already catch breakage that a test
+# exercises -- this gate exists for the code paths tests do not reach, where a
+# hardcoded `bash`, a `/tmp` literal, or an os-specific signal only fails on a
+# real user's Windows box.
+#
+# Deterministic, ADDED-LINES ONLY, no model. Every rule below is a pattern the
+# repo has actually been burned by, not a speculative portability opinion.
+#
+# Scope: `src/kiro_crew/**/*.py`, excluding the vendored tree (not ours to fix),
+# tests (they may legitimately assert POSIX behaviour behind a skip marker),
+# and `platform_compat.py` itself -- that module's whole job is to name the
+# os-specific primitives everything else routes through.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-platform-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  cross-platform:
+    name: Cross-Platform Portability
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Scan added lines for non-portable patterns
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Escape hatch for a deliberate, reviewed POSIX-only path (e.g. the
+          # pod runner, which is Linux-only by design and says so).
+          EXEMPT: ${{ contains(github.event.pull_request.labels.*.name, 'posix-only-approved') }}
+        run: |
+          set -uo pipefail
+
+          # ADDED lines only ('^+', excluding the '+++' file header). A
+          # pre-existing violation elsewhere in a touched file is not this PR's
+          # problem and must not block it.
+          added="$(git diff --unified=0 "$BASE_SHA...$HEAD_SHA" -- \
+            'src/kiro_crew/**/*.py' \
+            ':(exclude)src/kiro_crew/_vendor/**' \
+            ':(exclude)src/kiro_crew/platform_compat.py' \
+            2>/dev/null | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+
+          if [ -z "$added" ]; then
+            echo "No added Python lines under src/kiro_crew/ to scan."
+            exit 0
+          fi
+
+          # Drop lines that are PROSE, not code: whole-line comments, and any
+          # line quoting a pattern in reST double-backticks (a docstring that
+          # merely NAMES `shell=True` to explain why it is avoided must not be
+          # flagged -- validated against commit 1d78b24e3, which did exactly
+          # that). Without this filter the gate fires on its own documentation.
+          added="$(printf '%s\n' "$added" | grep -vE '^\+[[:space:]]*#' | grep -vF '``' || true)"
+
+          if [ -z "$added" ]; then
+            echo "Added Python lines are comments/prose only -- nothing to scan."
+            exit 0
+          fi
+
+          findings=0
+          report() {
+            findings=$((findings + 1))
+            echo "::error::$1"
+            echo "- **$1**" >> "$GITHUB_STEP_SUMMARY"
+            printf '%s\n' "$2" | sed 's/^/    /' >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          echo "### Cross-platform portability findings" >> "$GITHUB_STEP_SUMMARY"
+
+          # 1. Hardcoded shell. Windows has no /bin/bash and no `sh`; a spawned
+          #    shell is also how shell-injection surfaces get introduced.
+          hits="$(printf '%s' "$added" | grep -nE '(subprocess\.(run|Popen|call|check_output)\([^)]*\[?["'"'"']((/bin/)?(ba)?sh)["'"'"']|shell[[:space:]]*=[[:space:]]*True|os\.system\()' || true)"
+          [ -n "$hits" ] && report "Hardcoded shell or shell=True -- not available on Windows. Use a plain argv list, or platform_compat's helpers." "$hits"
+
+          # 2. POSIX path literals. Windows has no /tmp, /etc, /usr, /var.
+          hits="$(printf '%s' "$added" | grep -nE '["'"'"']/(tmp|etc|usr|var|opt)/' || true)"
+          [ -n "$hits" ] && report "Absolute POSIX path literal -- no such path on Windows. Use tempfile.gettempdir() / pathlib / platformdirs." "$hits"
+
+          # 3. POSIX-only signals and process primitives.
+          hits="$(printf '%s' "$added" | grep -nE '\b(os\.(fork|kill|getuid|geteuid|setsid|getpgid|killpg)|signal\.(SIGKILL|SIGHUP|SIGUSR[12]|SIGCHLD))\b' || true)"
+          [ -n "$hits" ] && report "POSIX-only process/signal primitive -- absent or different on Windows. Gate on sys.platform or route through platform_compat." "$hits"
+
+          # 4. Hardcoded path separator in a joined path. Backslash-vs-slash is
+          #    the classic silent Windows break.
+          hits="$(printf '%s' "$added" | grep -nE '\.(split|join|rsplit)\(["'"'"']/["'"'"']\)|\+[[:space:]]*["'"'"']/["'"'"'][[:space:]]*\+' || true)"
+          [ -n "$hits" ] && report "Manual '/' path assembly -- use pathlib or os.path.join so Windows separators work." "$hits"
+
+          # NOTE -- deliberately NO "missing encoding=" rule. It cannot be done
+          # reliably with a line regex: a nested call
+          # (`write_text(json.dumps(x), encoding="utf-8")`) truncates any
+          # `[^)]*` lookahead at the inner paren, and a multi-line call puts
+          # `encoding=` on a line the unified=0 diff hands over separately.
+          # Both produce FALSE failures on correct code -- verified against
+          # commit 1d78b24e3. The Windows pytest shards remain the real guard
+          # for cp1252 decode breakage.
+
+          if [ "$findings" -eq 0 ]; then
+            echo "No non-portable patterns in added lines." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo
+            echo "Each finding is on a line THIS PR adds. Fix the line, or -- if this"
+            echo "code path is intentionally POSIX-only and documented as such -- add the"
+            echo "\`posix-only-approved\` label and re-run."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$EXEMPT" = "true" ]; then
+            echo "::warning::'posix-only-approved' label present -- $findings portability finding(s) reported but not blocking."
+            exit 0
+          fi
+          exit 1

--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -210,11 +210,21 @@ jobs:
             - BLOCK: the design itself is wrong — no real problem, the change does
               not actually solve the stated problem, a clearly better alternative
               was ignored, or an unsafe one-way door with no migration/compat
-              story. (Advisory: BLOCK does NOT block the merge; it flags for a
-              human.)
+              story. BLOCK **FAILS this check and blocks PR readiness** -- a
+              contributor cannot merge past it without fixing the design or
+              getting an explicit human override. Treat it accordingly.
             Tie-breaker: when torn between BLOCK and CONCERNS, choose CONCERNS.
             Only reach for BLOCK when the DESIGN is wrong — never merely because
             the change is large or far-reaching.
+            FALSIFY BEFORE YOU BLOCK (mandatory, because BLOCK now blocks): for
+            each BLOCK candidate, actively try to KILL it -- name the specific
+            requirement the design fails, the concrete alternative that is
+            better, and the consequence of shipping as-is. A candidate survives
+            ONLY if you can state all three from the diff and the code you
+            opened. If any is "might", "unclear", or a matter of taste, it is a
+            CONCERNS at most -- never a BLOCK. Budget: at most 1 BLOCK per
+            review; if you have two, you are almost certainly describing one
+            root design problem, so merge them.
 
             FINAL OUTPUT (authoritative — this is your LAST message; the workflow
             captures it verbatim from the run transcript, so do NOT call any tool
@@ -313,7 +323,7 @@ jobs:
           case "$verdict" in
             PASS) badge="✅ PASS" ;;
             CONCERNS) badge="🟡 CONCERNS" ;;
-            BLOCK) badge="🔴 BLOCK (advisory)" ;;
+            BLOCK) badge="🔴 BLOCK (blocking)" ;;
             *) badge="" ;;
           esac
           if [ -n "$badge" ]; then
@@ -368,10 +378,13 @@ jobs:
       # Dependabot skip, and — critically — any run that DID NOT COMPLETE
       # (Bedrock overload / throttle / 403 / action error → UNKNOWN or empty
       # verdict). An errored or overloaded review must NEVER fail this gate; only
-      # a genuine BLOCK does. NOTE: failing here only turns the "Design Review"
-      # check red — it gates MERGE only if the check is added to the base
-      # branch's REQUIRED status checks (a repo branch-protection setting, out of
-      # scope of this workflow). Do NOT widen the failing branch beyond BLOCK.
+      # a genuine BLOCK does. This check DOES gate merge: pr-readiness.yml
+      # aggregates "Design Review" into the `PR Readiness` status, which is the
+      # branch ruleset's required check, and a `failure` here is counted as a
+      # readiness blocker. That wiring is only safe BECAUSE the failing branch
+      # below is exactly BLOCK -- an errored or overloaded review exits 0, so
+      # infrastructure noise can never block a merge. Do NOT widen the failing
+      # branch beyond BLOCK.
       - name: Design review status (gates on BLOCK)
         if: always()
         env:

--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -318,11 +318,21 @@ jobs:
             - BLOCK: the design itself is wrong — no real problem, the change does
               not actually solve the stated problem, a clearly better alternative
               was ignored, or an unsafe one-way door with no migration/compat
-              story. (Advisory: BLOCK does NOT block the merge; it flags for a
-              human.)
+              story. BLOCK **FAILS this check and blocks PR readiness** -- a
+              contributor cannot merge past it without fixing the design or
+              getting an explicit human override. Treat it accordingly.
             Tie-breaker: when torn between BLOCK and CONCERNS, choose CONCERNS.
             Only reach for BLOCK when the DESIGN is wrong — never merely because
             the change is large or far-reaching.
+            FALSIFY BEFORE YOU BLOCK (mandatory, because BLOCK now blocks): for
+            each BLOCK candidate, actively try to KILL it -- name the specific
+            requirement the design fails, the concrete alternative that is
+            better, and the consequence of shipping as-is. A candidate survives
+            ONLY if you can state all three from the diff and the code you
+            opened. If any is "might", "unclear", or a matter of taste, it is a
+            CONCERNS at most -- never a BLOCK. Budget: at most 1 BLOCK per
+            review; if you have two, you are almost certainly describing one
+            root design problem, so merge them.
 
             FINAL OUTPUT (authoritative — this is your LAST message; the workflow
             captures it verbatim from the run transcript, so do NOT call any tool
@@ -427,7 +437,7 @@ jobs:
           case "${VERDICT:-UNKNOWN}" in
             PASS) badge="✅ PASS" ;;
             CONCERNS) badge="🟡 CONCERNS" ;;
-            BLOCK) badge="🔴 BLOCK (advisory)" ;;
+            BLOCK) badge="🔴 BLOCK (blocking)" ;;
             *) badge="" ;;
           esac
           if [ -n "$badge" ] && [ -s "$f" ]; then

--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -368,11 +368,25 @@ jobs:
                     and (.conclusion | IN("success","neutral")))] | length' <<<"$cruns")"
               if [ "$total" -eq 0 ] || [ "$incomplete" -gt 0 ]; then
                 pending+=("$label (not started)")
-              elif [ "$label" = "Design Review" ] || [ "$label" = "UX Review" ]; then
-                # Advisory: once the real review posts any decisive result it
-                # never blocks; only-skipped means it has not posted yet.
+              elif [ "$label" = "UX Review" ]; then
+                # UX stays advisory: once the real review posts any decisive
+                # result it never blocks; only-skipped means it has not posted yet.
                 if [ "$fail" -gt 0 ] || [ "$pass" -gt 0 ]; then
                   passed+=("$label (advisory)")
+                else
+                  pending+=("$label (not started)")
+                fi
+              elif [ "$label" = "Design Review" ]; then
+                # Design Review BLOCKS on a real BLOCK verdict, so a contributor
+                # cannot merge past a design judged wrong. Safe to treat a
+                # failure as a blocker because fork-design-review.yml fails the
+                # check ONLY on BLOCK -- an errored, throttled or verdict-less
+                # run resolves NEUTRAL and exits 0 -- so `failure` here can only
+                # mean a judged-wrong design, never infrastructure noise.
+                if [ "$fail" -gt 0 ]; then
+                  failed+=("$label (BLOCK)")
+                elif [ "$pass" -gt 0 ]; then
+                  passed+=("$label")
                 else
                   pending+=("$label (not started)")
                 fi
@@ -425,11 +439,21 @@ jobs:
                   success|skipped) passed+=("$label") ;;
                   *) failed+=("$label ($conclusion)") ;;
                 esac
-              elif [ "$label" = "Design Review" ] || [ "$label" = "UX Review" ]; then
-                # Design and UX are advisory: their opinions and infrastructure
-                # failures do not become an independent readiness blocker, but
-                # completion is still required so the verdict is not premature.
+              elif [ "$label" = "UX Review" ]; then
+                # UX is advisory: its opinions and infrastructure failures do not
+                # become an independent readiness blocker, but completion is
+                # still required so the verdict is not premature.
                 passed+=("$label (advisory)")
+              elif [ "$label" = "Design Review" ]; then
+                # Design Review BLOCKS on a real BLOCK verdict. design-review.yml
+                # fails the check ONLY on BLOCK (PASS/CONCERNS, the Dependabot
+                # skip, and any errored/overloaded/verdict-less run all exit 0),
+                # so a `failure` conclusion is a judged-wrong design rather than
+                # infrastructure noise and is safe to treat as a blocker.
+                case "$conclusion" in
+                  success|neutral|skipped) passed+=("$label") ;;
+                  *) failed+=("$label (BLOCK)") ;;
+                esac
               else
                 case "$conclusion" in
                   success|neutral|skipped) passed+=("$label") ;;

--- a/.github/workflows/pr-scope.yml
+++ b/.github/workflows/pr-scope.yml
@@ -1,0 +1,110 @@
+name: PR Scope
+
+# ADVISORY signal that a PR may not be self-contained -- i.e. it bundles changes
+# to several unrelated areas that would review better as separate PRs.
+#
+# This check NEVER fails the build, and that is a deliberate design decision:
+# "are these changes related?" is a judgment call, and a hard threshold on it
+# would block legitimate work (a cross-cutting refactor, a rename that touches
+# every transport) while being trivially gamed by splitting one logical change
+# across two PRs. A warning that a human reads is the honest strength of the
+# signal available deterministically.
+#
+# The semantic half of this question is already owned by the GPT reviewer, which
+# compares the diff against the PR's stated purpose and flags undeclared scope.
+# This gate covers only what a model cannot see cheaply: raw breadth.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-scope-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-scope:
+    name: PR Scope
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Measure diff breadth
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # A PR must exceed BOTH thresholds to be flagged. Breadth alone is
+          # fine (a one-line rename across 6 transports is self-contained); size
+          # alone is fine (a big change to one module is self-contained). It is
+          # the COMBINATION -- large and scattered -- that reviews badly.
+          MAX_AREAS: "4"
+          MAX_LINES: "400"
+        run: |
+          set -uo pipefail
+
+          # Vendored code and review screenshots are excluded: they inflate both
+          # metrics without adding anything a reviewer must reason about.
+          files="$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- . \
+            ':(exclude)src/kiro_crew/_vendor/**' \
+            ':(exclude)temp-screenshots/**' \
+            2>/dev/null || true)"
+          lines="$(git diff --numstat "$BASE_SHA...$HEAD_SHA" -- . \
+            ':(exclude)src/kiro_crew/_vendor/**' \
+            ':(exclude)temp-screenshots/**' \
+            2>/dev/null | awk '{a+=$1; d+=$2} END {print a+d+0}')"
+
+          if [ -z "$files" ]; then
+            echo "No reviewable files changed."
+            exit 0
+          fi
+
+          # An "area" is the unit a reviewer holds in their head. For the backend
+          # and the SPA that is the module/feature directory (2 levels deep), not
+          # the repo-wide bucket -- otherwise every backend PR looks like one area.
+          areas="$(printf '%s\n' "$files" | awk -F/ '
+            /^src\/kiro_crew\// { print (NF>=3 ? $1"/"$2"/"$3 : $1"/"$2); next }
+            /^website\/src\//   { print (NF>=3 ? $1"/"$2"/"$3 : $1"/"$2); next }
+            { print $1 }
+          ' | sort -u)"
+          area_count="$(printf '%s\n' "$areas" | grep -c . || true)"
+
+          echo "reviewable changed lines: $lines"
+          echo "distinct areas: $area_count"
+          printf '%s\n' "$areas" | sed 's/^/  - /'
+
+          {
+            echo "### PR scope"
+            echo
+            echo "| metric | value | threshold |"
+            echo "|---|---|---|"
+            echo "| reviewable changed lines | $lines | $MAX_LINES |"
+            echo "| distinct areas | $area_count | $MAX_AREAS |"
+            echo
+            echo "**Areas touched**"
+            printf '%s\n' "$areas" | sed 's/^/- `/; s/$/`/'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$area_count" -gt "$MAX_AREAS" ] && [ "${lines:-0}" -gt "$MAX_LINES" ]; then
+            echo "::warning::This PR changes $lines lines across $area_count areas. If these changes are independent, splitting them into separate PRs gets each one reviewed properly and keeps them individually revertable."
+            {
+              echo
+              echo "> **Consider splitting.** $lines lines across $area_count areas is wide"
+              echo "> enough that a reviewer cannot hold the whole change at once, and a"
+              echo "> revert takes unrelated work with it."
+              echo ">"
+              echo "> This is advisory only -- it never fails the build. A genuinely"
+              echo "> cross-cutting change (a rename, a shared-helper migration) is"
+              echo "> expected to be wide, and that is fine; say so in the description."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Scope looks self-contained."
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Scope looks self-contained." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/screenshot-evidence.yml
+++ b/.github/workflows/screenshot-evidence.yml
@@ -1,0 +1,123 @@
+name: Screenshot Evidence
+
+# Requires visual evidence in the PR body when the diff touches a USER-VISIBLE
+# frontend surface. Rationale: a reviewer cannot judge a layout, theme, or
+# component change from a diff -- the repo's PR description contract already
+# mandates screenshots for UI changes, but nothing enforced it, so the
+# requirement was routinely missed.
+#
+# Deterministic on purpose: no model, no network beyond the PR read. It answers
+# exactly one question -- "does the body carry an image for a visual change?"
+#
+# Scope is deliberately NARROWER than "website/** changed". Test files, i18n
+# locale catalogues, and type-only declarations change constantly without any
+# visual delta; gating on those would train contributors to paste a meaningless
+# screenshot to get green, which is worse than no gate.
+
+on:
+  pull_request:
+    # `edited` matters: adding the screenshots to the body must be able to turn
+    # this check green WITHOUT forcing a no-op code push.
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: screenshot-evidence-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  screenshot-evidence:
+    name: Screenshot Evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Visual surfaces only. Mirrors the `frontend` bucket in ci.yml but
+      # subtracts the paths that change without a visual delta.
+      - name: Detect user-visible frontend changes
+        id: visual
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+          changed="$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- \
+            'website/src/components/**' \
+            'website/src/pages/**' \
+            'website/src/apps/**' \
+            'website/src/**/*.css' \
+            'website/index.html' \
+            ':(exclude)website/src/**/*.test.ts' \
+            ':(exclude)website/src/**/*.test.tsx' \
+            ':(exclude)website/src/test/**' \
+            ':(exclude)website/src/**/*.d.ts' \
+            2>/dev/null || true)"
+          if [ -n "$changed" ]; then
+            echo "visual=true" >> "$GITHUB_OUTPUT"
+            echo "Visual surfaces touched:"
+            printf '%s\n' "$changed"
+          else
+            echo "visual=false" >> "$GITHUB_OUTPUT"
+            echo "No user-visible frontend surface touched."
+          fi
+
+      # The body is UNTRUSTED author input. It is only ever regex-matched here --
+      # never executed, never echoed into a shell as code.
+      - name: Require visual evidence in the PR body
+        if: steps.visual.outputs.visual == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          # Escape hatch for a genuinely non-visual change to a visual file
+          # (a pure rename, a comment, an a11y attribute with no rendered delta).
+          # Labelled PRs pass with a warning rather than silently.
+          EXEMPT: ${{ contains(github.event.pull_request.labels.*.name, 'no-screenshots') }}
+        run: |
+          set -uo pipefail
+          if [ "$EXEMPT" = "true" ]; then
+            echo "::warning::'no-screenshots' label present -- visual-evidence requirement waived for this PR."
+            exit 0
+          fi
+
+          body="$(gh api "repos/$REPO/pulls/$PR" --jq '.body // ""' 2>/dev/null || true)"
+
+          # Accept any form that actually renders as an image/video for a
+          # reviewer: markdown image, HTML img/video, a committed
+          # temp-screenshots path, or a GitHub user-attachment URL.
+          if printf '%s' "$body" | grep -qiE '!\[[^]]*\]\([^)]+\)|<img[[:space:]]|<video[[:space:]]|temp-screenshots/|user-attachments/'; then
+            echo "Visual evidence found in the PR description."
+            exit 0
+          fi
+
+          echo "::error::This PR changes a user-visible frontend surface but its description carries no screenshot or recording."
+          {
+            echo "### Screenshot evidence required"
+            echo
+            echo "This PR touches a user-visible surface under \`website/src/\`, so the PR"
+            echo "description must show the change. A diff cannot demonstrate a layout,"
+            echo "theme, or component result."
+            echo
+            echo "**What to attach**"
+            echo "- Static layout / styling / a component at rest -> screenshots"
+            echo "- Animation, transition, hover or focus state -> a recording (video or GIF)"
+            echo "- A multi-step flow (wizard, modal, drag) -> a recording of the whole sequence"
+            echo
+            echo "**How to attach it** (see the \`web-verify\` and \`frontend-design-workflow\` skills)"
+            echo "1. Capture the surface yourself from a running dev server or pod."
+            echo "2. Commit the images under \`temp-screenshots/<feature>/\` -- never under"
+            echo "   \`docs/\` or \`src/kiro_crew/**\`, which ship in the wheel and the DMG."
+            echo "3. Embed with a commit-SHA-pinned URL so it survives branch deletion:"
+            echo "   \`![alt](https://github.com/$REPO/raw/<sha>/temp-screenshots/<feature>/<name>.png)\`"
+            echo
+            echo "**If the change genuinely has no visual delta** (pure rename, comment-only,"
+            echo "or a non-rendering attribute), add the \`no-screenshots\` label and re-run."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/test/test_pr_quality_gates.py
+++ b/test/test_pr_quality_gates.py
@@ -1,0 +1,162 @@
+"""Regression tests for the PR quality gates.
+
+These pin the behaviours that are easy to break silently by editing YAML:
+the triggers a gate needs to be fixable without a code push, the
+added-lines-only scoping that keeps a gate from blaming a PR for
+pre-existing code, the advisory-vs-blocking contract of each lane, and --
+most importantly -- that `pr-readiness.yml` no longer force-passes a failing
+Design Review.
+"""
+
+from pathlib import Path
+
+import pytest
+
+WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+
+def _read(name: str) -> str:
+    return (WORKFLOWS / name).read_text(encoding="utf-8")
+
+
+class TestScreenshotEvidence:
+    """The gate must be satisfiable by editing the PR body alone."""
+
+    def test_reruns_on_body_edit_and_label_change(self):
+        # Without `edited`, a contributor who adds the screenshots to the
+        # description cannot turn the check green without a no-op push.
+        # Without `labeled`, the escape hatch has the same problem.
+        wf = _read("screenshot-evidence.yml")
+        types_line = next(ln for ln in wf.splitlines() if "types:" in ln)
+        for needed in ("edited", "labeled", "unlabeled"):
+            assert needed in types_line, f"missing '{needed}' trigger"
+
+    def test_has_escape_hatch_label(self):
+        # A gate with no exemption path forces contributors to paste a
+        # meaningless screenshot to get green, which defeats the purpose.
+        assert "no-screenshots" in _read("screenshot-evidence.yml")
+
+    def test_excludes_non_visual_frontend_paths(self):
+        # Tests, type declarations and locale catalogues change constantly
+        # with no visual delta; gating on them trains bad habits.
+        wf = _read("screenshot-evidence.yml")
+        for excluded in (
+            ":(exclude)website/src/**/*.test.tsx",
+            ":(exclude)website/src/test/**",
+            ":(exclude)website/src/**/*.d.ts",
+        ):
+            assert excluded in wf, f"should exclude {excluded}"
+
+    def test_body_is_only_pattern_matched(self):
+        # The PR body is untrusted author input. It must never be eval'd or
+        # interpolated into a shell command.
+        wf = _read("screenshot-evidence.yml")
+        assert 'body="$(gh api' in wf
+        assert "eval" not in wf
+
+
+class TestCrossPlatform:
+    """Findings must be confined to lines the PR actually adds."""
+
+    def test_scans_added_lines_only(self):
+        wf = _read("cross-platform.yml")
+        assert "grep -E '^\\+'" in wf
+        assert "grep -vE '^\\+\\+\\+'" in wf
+
+    def test_filters_prose_before_matching(self):
+        # Verified against commit 1d78b24e3: a docstring quoting ``shell=True``
+        # to explain why it is avoided must not fail the gate.
+        wf = _read("cross-platform.yml")
+        assert "grep -vE '^\\+[[:space:]]*#'" in wf
+        assert "grep -vF '``'" in wf
+
+    def test_no_encoding_rule(self):
+        # A line regex cannot decide this: nested calls truncate the lookahead
+        # and multi-line calls split `encoding=` onto another line. Both give
+        # FALSE failures on correct code (verified against commit 1d78b24e3),
+        # so the rule is deliberately absent and its absence is documented.
+        wf = _read("cross-platform.yml")
+        assert "deliberately NO" in wf, "the absence must stay documented"
+        # No rule may actually grep for the encoding kwarg.
+        rule_lines = [
+            ln for ln in wf.splitlines()
+            if ln.lstrip().startswith("hits=")
+        ]
+        assert rule_lines, "expected at least one scan rule"
+        for ln in rule_lines:
+            assert "encoding" not in ln, f"encoding rule reintroduced: {ln.strip()[:80]}"
+
+    def test_excludes_vendor_and_compat_module(self):
+        wf = _read("cross-platform.yml")
+        assert ":(exclude)src/kiro_crew/_vendor/**" in wf
+        assert ":(exclude)src/kiro_crew/platform_compat.py" in wf
+
+    def test_has_escape_hatch_label(self):
+        assert "posix-only-approved" in _read("cross-platform.yml")
+
+
+class TestPrScope:
+    """Scope breadth is advisory: it must never fail the build."""
+
+    def test_never_exits_nonzero(self):
+        wf = _read("pr-scope.yml")
+        assert "exit 1" not in wf, "PR Scope must stay advisory"
+
+    def test_requires_both_thresholds(self):
+        # Breadth alone or size alone is legitimately self-contained; only the
+        # combination reviews badly.
+        wf = _read("pr-scope.yml")
+        assert '-gt "$MAX_AREAS" ] && [' in wf
+        assert 'MAX_LINES' in wf
+
+    def test_excludes_vendor_and_screenshots(self):
+        wf = _read("pr-scope.yml")
+        assert ":(exclude)src/kiro_crew/_vendor/**" in wf
+        assert ":(exclude)temp-screenshots/**" in wf
+
+
+class TestDesignReviewBlocks:
+    """A BLOCK verdict must reach the required `PR Readiness` status."""
+
+    def test_readiness_no_longer_force_passes_design_review(self):
+        # This is the whole point of the change: previously BOTH lanes did
+        # `passed+=("$label (advisory)")` for Design Review, so a red Design
+        # Review check still produced a green PR Readiness.
+        wf = _read("pr-readiness.yml")
+        assert '"$label" = "Design Review" ] || [ "$label" = "UX Review"' not in wf, (
+            "Design Review must no longer share the UX advisory branch"
+        )
+        assert 'failed+=("$label (BLOCK)")' in wf
+
+    def test_ux_review_stays_advisory(self):
+        # Only Design Review was promoted; UX keeps its advisory contract.
+        wf = _read("pr-readiness.yml")
+        assert 'passed+=("$label (advisory)")' in wf
+        assert '[ "$label" = "UX Review" ]' in wf
+
+    @pytest.mark.parametrize("name", ["design-review.yml", "fork-design-review.yml"])
+    def test_prompt_no_longer_claims_block_is_advisory(self, name):
+        # The prompt used to tell the model "BLOCK does NOT block the merge",
+        # which taught it to under-use the verdict that now actually gates.
+        wf = _read(name)
+        assert "does NOT block the merge" not in wf
+        assert "BLOCK (advisory)" not in wf
+        assert "blocks PR readiness" in wf
+
+    @pytest.mark.parametrize("name", ["design-review.yml", "fork-design-review.yml"])
+    def test_falsification_step_and_block_budget(self, name):
+        # Raising the stakes of BLOCK requires a matching precision bar.
+        wf = _read(name)
+        assert "FALSIFY BEFORE YOU BLOCK" in wf
+        assert "at most 1 BLOCK per" in wf
+
+    def test_same_repo_gate_fails_only_on_block(self):
+        # The readiness wiring is only safe because every non-BLOCK outcome --
+        # including an errored or throttled run -- exits 0.
+        wf = _read("design-review.yml")
+        gate = wf.split("Design review status (gates on BLOCK)")[1]
+        assert "PASS|CONCERNS)" in gate
+        assert "exit 1 ;;" in gate
+        # The wildcard (errored / no verdict) branch must not fail.
+        tail = gate.split("BLOCK)")[1]
+        assert "exit 0" in tail, "an incomplete review must never block"


### PR DESCRIPTION
## Problem

Four review gaps that contributors were routinely slipping past:

1. The PR description contract mandates screenshots for UI changes, but **nothing enforced it** — so visual changes landed with no evidence a reviewer could judge.
2. Nothing catches POSIX-only assumptions before they ship. The Windows pytest shards only catch what a test happens to exercise; a hardcoded `bash` or `/tmp` on an untested path fails on a real user's Windows box.
3. Large, scattered PRs get reviewed shallowly and can't be reverted independently, with no signal flagging it.
4. **Design Review couldn't actually stop anything.** `design-review.yml` already failed its check on a `BLOCK` verdict — but `pr-readiness.yml` force-passed the lane on *both* paths (`passed+=("$label (advisory)")`), so a red Design Review still produced a green `PR Readiness`, which is the only required check. A contributor could merge straight past a design judged wrong.

## Why it matters

Gap 4 is the serious one: the repo had a design gate that looked like it worked and didn't. The other three each cost reviewer time or ship latent cross-platform bugs.

## Fix

### 1. Screenshot Evidence (new, blocking)
Requires an image/recording in the PR body when the diff touches a user-visible surface under `website/src/`.

Scope is deliberately **narrower** than "`website/**` changed" — tests, `*.d.ts` and locale catalogues are excluded, because gating on churn with no visual delta trains contributors to paste a meaningless screenshot to get green, which is worse than no gate. `edited`/`labeled` triggers are included so the gate is satisfiable **by editing the body**, with no no-op push. Escape hatch: `no-screenshots`.

### 2. Cross-Platform Portability (new, blocking)
Scans **added lines only** for: hardcoded `bash` / `shell=True` / `os.system`, `/tmp|/etc|/usr|/var|/opt` literals, POSIX-only signal/process primitives, and manual `'/'` path assembly.

Validated against the last **12 merged commits: zero false positives**, plus a positive control confirming every rule fires on a real violation. Two omissions, both forced by that validation:
- **Prose is filtered out** (whole-line comments and ``` `` ```-quoted text) — commit `1d78b24e3`'s docstring *names* `shell=True` to explain why it's avoided, and the gate was flagging its own documentation.
- **No "missing `encoding=`" rule.** A line regex cannot decide it: a nested call (`write_text(json.dumps(x), encoding="utf-8")`) truncates any `[^)]*` lookahead at the inner paren, and a multi-line call puts `encoding=` on a separately-diffed line. Both produce **false failures on correct code**. The Windows shards stay the guard.

Escape hatch: `posix-only-approved`.

### 3. PR Scope (new, ADVISORY — never fails)
Warns when a PR is both wide and large (>4 areas **and** >400 reviewable lines).

Advisory on purpose, and I'd push back on making it blocking: "are these changes related?" is a judgment call, a hard threshold blocks legitimate cross-cutting refactors, and it's trivially gamed by splitting one logical change across two PRs. The semantic half is already owned by the GPT reviewer's scope-coherence check; this covers only raw breadth. Calibration on real commits — the 2513-line/7-area Agent Templates redesign warns, focused PRs don't.

### 4. Design Review now genuinely blocks
`pr-readiness.yml` now counts a Design Review failure as a readiness blocker, on both the same-repo and fork paths.

**This is safe precisely because the gate fails ONLY on `BLOCK`**: `PASS`, `CONCERNS`, the Dependabot skip, and any errored / throttled / verdict-less run all `exit 0`. So infrastructure noise can never block a merge — only a design judged wrong.

Also fixed the contradiction that undercut the verdict: the prompt told the model *"BLOCK does NOT block the merge"* and the badge read *"BLOCK (advisory)"*, which taught it to under-use the verdict that now gates. Corrected in both lanes, with a mandatory **FALSIFY BEFORE YOU BLOCK** step and a **1-BLOCK budget** as the precision bar the higher stakes require.

**UX Review keeps its advisory contract** — only Design Review was promoted.

## Tests

`test/test_pr_quality_gates.py` — 19 tests pinning the triggers, added-lines-only scoping, the documented absence of the encoding rule, each lane's advisory-vs-blocking contract, and the readiness change.

**Positive control:** reverting the readiness force-pass makes `test_readiness_no_longer_force_passes_design_review` **fail**; restoring it passes. The test is not vacuous.

`52/52` pass across the new file and `test_ai_review_workflows.py`. flake8 + isort clean. All 6 workflows YAML-validated.

## Manual verification

- Portability rules run against 12 merged commits via a standalone harness → all clean after the prose filter; before it, `1d78b24e3` false-positived twice.
- Positive control on synthetic violations → all 4 rules fire; `tempfile.gettempdir()` and `sys.executable` correctly stay clean.
- Scope thresholds run against 4 real commits → only the 2513-line/7-area one crosses both.
- Confirmed the design gate's non-BLOCK branches all `exit 0` before wiring readiness to its failure.

## Screenshots

N/A — CI-only change, no user-visible surface.

---

**Note on splitting:** gates 1–3 are additive and independently revertable, but **gate 4 changes merge behaviour for every PR**. If you'd rather land that separately for revertability, say so and I'll split it out — the readiness edit plus the two design lanes is a clean seam.
