### PR TITLE
fix: route subagent completion replies to non-Slack channel parents (#2319)

### DIFF
--- a/docs/system-specs/modules/slack-gateway.md
+++ b/docs/system-specs/modules/slack-gateway.md
@@ -386,6 +386,8 @@ Bidirectional sync: Slack ack → resolves dashboard approval future + broadcast
 
 When a subagent with a Slack parent session completes, the synthesized LLM response is posted to the owner's DM thread. Long replies are split into multiple messages using `_split_message()` from `handler.py` (3900 chars per chunk, split on newline boundaries), matching the behavior of final chat messages.
 
+A parent session born on any other channel (Telegram, Discord, `unified:` DM buckets, …) delivers the same synthesized reply through the governed cross-surface transport ladder instead (`_deliver_channel_reply` in `gateway.py`): the conversation is resolved via origin link (recorded by Discord's inbound dispatch) → non-Slack mirror link (e.g. a Telegram `/link` binding) → for direct (1:1) sessions only, the stored `"{namespace}:{user_id}"` channel value resolved through `transport.resolve_configured_target`; the target is vetted by `_resolve_channel_target` (SEL-audited, fail-closed, capability-gated on `supports_proactive_send`), then redacted and chunked to the transport's `max_message_chars`. Delivery is best-effort and fail-closed on ambiguity — group/forum sessions without an origin or mirror link, dispatchers that record neither, and denied egress all degrade to the dashboard notification (never a cross-conversation send), and the injected ACP turn still keeps the parent session aware of the result.
+
 ## Tool Approval via Slack
 
 Background task approvals (subagent/cron/taskrunner) post approval buttons to Slack DM via `_interactive_approval()`, racing with dashboard approval:

--- a/docs/system-specs/modules/subagent.md
+++ b/docs/system-specs/modules/subagent.md
@@ -241,6 +241,7 @@ Native kiro-cli subagents run inside the parent ACP turn and are owned by the pa
 |---|---|---|---|
 | Dashboard (`dashboard:*`) | Append as user message + broadcast via WS | TUI/web re-injects via `sendMessage` → LLM round-trip | LLM's response summarizing the result |
 | Slack (thread ts) | Post to Slack channel thread + dashboard notification | _(none — raw result posted directly)_ | Raw subagent result text |
+| Non-Slack channel (`telegram:*`, `discord:*`, `unified:*`, …) | Inject into the parent ACP session, then send the synthesized reply through the governed cross-surface transport ladder (`_deliver_channel_reply` → `_resolve_channel_target` → `MessagingTransport.send_message`) + dashboard notification. Target resolution: origin link (recorded by Discord's inbound dispatch) → non-Slack mirror link (e.g. Telegram `/link`) → for **direct (1:1) sessions only**, the stored `"{namespace}:{user_id}"` channel value, resolved to a postable conversation via `transport.resolve_configured_target`. Group/forum sessions without an origin/mirror link, channels whose dispatcher records neither, and denied/unsupported egress all degrade to notification-only — never a cross-conversation send. | _(none)_ | LLM's synthesized reply in the channel conversation |
 | Cron/no parent | Dashboard notification only | _(none)_ | Notification panel entry |
 
 ### Post-fan-out Synthesis Turn

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -83,7 +83,7 @@ from kiro_crew.cron import CronJob, CronService, CronStoreBusy, build_cron_sessi
 from kiro_crew.cron_script import resolve_script_path, run_command_sandboxed, run_script_sandboxed
 from kiro_crew.dashboard import start_dashboard
 from kiro_crew.dashboard.chat_persistence import rehydrate_slot_from_history_async
-from kiro_crew.dashboard.chat_runner import _run_chat
+from kiro_crew.dashboard.chat_runner import _resolve_channel_target, _run_chat
 from kiro_crew.dashboard.chat_utils import (
     dashboard_slot_key,
     remember_slack_options,
@@ -161,11 +161,22 @@ from kiro_crew.mcp_gateway.rewriter import (
 from kiro_crew.memory import MemoryStore
 from kiro_crew.messaging import registry
 from kiro_crew.messaging.identity import publish_turn_identity
+from kiro_crew.messaging.link import (
+    CHANNEL_SESSION_NAMESPACES,
+    CHAT_TYPE_DIRECT,
+    DM_SCOPE_UNIFIED,
+    SLACK_NAMESPACE,
+    ChannelLink,
+    channel_namespace_of,
+    parse_session_key,
+)
+from kiro_crew.messaging.renderer import chunk_text
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.platform import boot_platform
 from kiro_crew.platform.context import (
     PlatformCompositionError,
     current_context,
+    redact_via_context,
     safe_context_call,
 )
 from kiro_crew.platform.governance_profiles import (
@@ -1720,6 +1731,159 @@ class GatewayOrchestrator:
                 )
             except Exception:
                 logger.debug("Cron %s: failed to post OPTIONS blocks", parent_key, exc_info=True)
+        return True
+
+    def _channel_reply_link(self, parent_key: str) -> tuple[ChannelLink, bool] | None:
+        """Resolve the non-Slack channel conversation behind *parent_key*.
+
+        Returns ``(link, needs_dm_resolution)``, or None when no safe target
+        exists. Resolution ladder, most explicit first:
+
+        1. the session's **origin link** — the conversation's real send target,
+           recorded by a transport's inbound dispatch (e.g. Discord);
+        2. a non-Slack **mirror link** (e.g. a Telegram ``/link`` binding),
+           which also carries a forum Topic thread id;
+        3. the session's stored channel value — a *session-attribution* id,
+           not a postable conversation, so it is accepted ONLY when it names a
+           direct (1:1) peer: for a canonical channel key the stored
+           ``"{namespace}:{user_id}"`` must match the key's own namespace and
+           the key's chat_type must be direct; for a ``unified:`` DM bucket
+           (direct-only by construction — forum routes never collapse into it)
+           the stored namespace must be a registered non-Slack channel. The id
+           is the peer's USER id, so the caller must resolve the postable
+           conversation through ``transport.resolve_configured_target``
+           (``needs_dm_resolution=True``). Group/forum sessions never take
+           this rung: their stored value carries the sender's user id, and
+           sending there would leak the conversation into a private DM.
+
+        Returns None for Slack, dashboard, and unrecognized keys so callers
+        keep their existing delivery for those.
+        """
+        namespace = channel_namespace_of(parent_key)
+        if not namespace or namespace == SLACK_NAMESPACE or self.sessions is None:
+            return None
+        for getter in (self.sessions.get_origin_link, self.sessions.get_mirror_link):
+            try:
+                link = getter(parent_key)
+            except Exception:
+                link = None
+            if link is not None and link.channel_id and link.channel_type != SLACK_NAMESPACE:
+                return link, False
+        try:
+            stored = self.sessions.get_channel(parent_key)
+        except Exception:
+            stored = None
+        if not stored:
+            return None
+        channel_type, sep, peer_id = stored.partition(":")
+        if not (sep and channel_type and peer_id) or channel_type == SLACK_NAMESPACE:
+            return None
+        if namespace == DM_SCOPE_UNIFIED:
+            # A unified bucket carries no chat_type of its own; validate the
+            # stored namespace against the registered channel set instead.
+            if channel_type not in CHANNEL_SESSION_NAMESPACES or channel_type == DM_SCOPE_UNIFIED:
+                return None
+        else:
+            parsed = parse_session_key(parent_key)
+            if parsed is None or parsed.chat_type != CHAT_TYPE_DIRECT or channel_type != namespace:
+                return None
+        return ChannelLink(channel_type, channel_id=peer_id), True
+
+    async def _deliver_channel_reply(
+        self,
+        parent_key: str,
+        text: str,
+        *,
+        resolved_link: tuple[ChannelLink, bool] | None = None,
+    ) -> bool:
+        """Deliver a subagent-completion reply to a non-Slack channel conversation.
+
+        The transport leg of completion routing: resolves the conversation
+        behind *parent_key*, vets the egress through the shared governed
+        cross-surface ladder (``_resolve_channel_target`` — SEL-audited,
+        fail-closed, capability-gated on ``supports_proactive_send``), then
+        redacts, chunks, and sends via the registered ``MessagingTransport``.
+        A link derived from the stored channel value carries the peer's USER
+        id, so the postable conversation is resolved through
+        ``transport.resolve_configured_target`` first.
+
+        ``resolved_link`` lets the caller pass a target snapshotted BEFORE an
+        injection retry loop — a timeout-path ``sessions.reset()`` evicts the
+        in-memory origin link, so resolving only here would lose it.
+
+        Returns True when the reply reached the channel; False degrades the
+        caller to dashboard-notification-only. Never raises: a delivery
+        failure must not break completion handling for the other paths.
+        """
+        if not text.strip() or self.dashboard_state is None:
+            return False
+        if resolved_link is None:
+            resolved_link = self._channel_reply_link(parent_key)
+        if resolved_link is None:
+            return False
+        link, needs_dm_resolution = resolved_link
+        try:
+            # Off-loop: the ladder's governance gate walks the profile
+            # directory (iterdir + stat, with a possible reload), which is
+            # unbounded on slow or networked storage.
+            target = await asyncio.to_thread(
+                _resolve_channel_target, self.dashboard_state, parent_key, link
+            )
+        except Exception:
+            logger.exception("Subagent reply: channel target resolution failed for %s", parent_key)
+            return False
+        if target is None:
+            return False
+        resolved, transport = target
+        try:
+            conversation_id = resolved.channel_id
+            if needs_dm_resolution:
+                # The stored value is the direct peer's user id, not a postable
+                # conversation. resolve_configured_target("user:<id>") is the
+                # transport contract for exactly this: it enforces the
+                # transport's allow-list and returns the real send target
+                # (learned conversation on Teams, DM-channel creation on
+                # Discord, identity on Telegram) — or None when the peer has
+                # no reachable conversation, which fails closed here.
+                dm_target = await transport.resolve_configured_target(
+                    f"user:{resolved.channel_id}"
+                )
+                # Audit the allow-list decision (allowed/denied) BEFORE
+                # branching, matching chat_mirror's configured-target resolve:
+                # a peer the resolver rejects is an authorization outcome and
+                # must land in the SEL trail, not just degrade silently.
+                sel().log_api_access(
+                    caller="subagent",
+                    operation="subagent.reply_target_resolve",
+                    outcome="allowed" if dm_target else "denied",
+                    source="gateway",
+                    resources=f"{parent_key} -> {link.channel_type}:user:{resolved.channel_id}",
+                )
+                if not dm_target or not dm_target[0]:
+                    return False
+                conversation_id = dm_target[0]
+            # Redact through the canonical egress shim so a loaded companion's
+            # extra credential/token regexes apply, then split on the
+            # channel's max message length, mirroring the cross-surface
+            # mirror leg.
+            safe_text = redact_via_context(text)
+            parts = chunk_text(safe_text, transport.capabilities.max_message_chars)
+            for part in parts:
+                await transport.send_message(conversation_id, part, thread_id=resolved.thread_id)
+        except Exception:
+            logger.warning(
+                "Subagent reply: %s delivery failed for %s",
+                link.channel_type,
+                parent_key,
+                exc_info=True,
+            )
+            return False
+        logger.info(
+            "Subagent reply → %s:%s (%d part(s))",
+            link.channel_type,
+            conversation_id,
+            len(parts),
+        )
         return True
 
     def _cron_job_is_silent(self, parent_key: str) -> bool:
@@ -4491,11 +4655,25 @@ class GatewayOrchestrator:
                 return
 
             if parent_key and not parent_key.startswith(("cron:", "subagent:")):
-                # Slack session — inject silently into ACP session (no visible Slack message).
-                # Retry up to _MAX_INJECT_ATTEMPTS times on timeout.
+                # Channel session — inject silently into the parent's ACP
+                # session, then deliver only the synthesized reply to the
+                # conversation. Retry up to _MAX_INJECT_ATTEMPTS times on
+                # timeout. Slack keeps its dedicated rich posting; every other
+                # channel namespace (Telegram, Discord, …) delivers through
+                # the governed transport ladder — its stored channel value is
+                # not a Slack channel id, so posting it through the Slack
+                # client can never reach the user.
                 assert self.sessions is not None
+                _namespace = channel_namespace_of(parent_key)
+                _via_transport = bool(_namespace) and _namespace != SLACK_NAMESPACE
+                _inject_label = _namespace if _via_transport else "Slack"
+                # Snapshot the delivery target BEFORE the injection retry
+                # loop: the timeout path's sessions.reset() evicts the
+                # session's in-memory origin link, so resolving after a retry
+                # would lose a Discord thread/forum target and drop the reply.
+                _reply_link = self._channel_reply_link(parent_key) if _via_transport else None
                 _injected = False
-                _slack_failure_reasons: list[str] = []
+                _inject_failure_reasons: list[str] = []
                 _sleep_before_retry = False
                 for _attempt in range(1, _MAX_INJECT_ATTEMPTS + 1):
                     if _sleep_before_retry:
@@ -4505,8 +4683,9 @@ class GatewayOrchestrator:
                     _footer_client = None
                     try:
                         logger.debug(
-                            "Subagent %s: Slack injection attempt %d/%d into %s",
+                            "Subagent %s: %s injection attempt %d/%d into %s",
                             info.id,
+                            _inject_label,
                             _attempt,
                             _MAX_INJECT_ATTEMPTS,
                             parent_key,
@@ -4526,14 +4705,22 @@ class GatewayOrchestrator:
                         else:
                             msg = announce
                         response = await asyncio.wait_for(
-                            _inject_with_retry(client, msg, parent_key, "Slack"),
+                            _inject_with_retry(client, msg, parent_key, _inject_label),
                             timeout=INJECTION_TIMEOUT,
                         )
-                        _injected = True  # LLM processed result; Slack posting is best-effort
+                        _injected = True  # LLM processed result; channel posting is best-effort
 
+                        # Deliver only the LLM's synthesized response to the
+                        # parent's own conversation. Non-Slack channels go
+                        # through the governed transport ladder; on failure
+                        # the dashboard notification below still fires.
+                        if _via_transport and response:
+                            await self._deliver_channel_reply(
+                                parent_key, response, resolved_link=_reply_link
+                            )
                         # Post only the LLM's synthesized response to Slack
                         try:
-                            if response and self.slack and self._owner_id:
+                            if response and not _via_transport and self.slack and self._owner_id:
                                 channel = (
                                     self.sessions.get_channel(parent_key) if self.sessions else None
                                 ) or await self.slack.open_dm(self._owner_id)
@@ -4618,15 +4805,18 @@ class GatewayOrchestrator:
                                     exc_info=True,
                                 )
 
-                        logger.info("Subagent %s → Slack session %s", info.id, parent_key)
+                        logger.info(
+                            "Subagent %s → %s session %s", info.id, _inject_label, parent_key
+                        )
                         break
                     except asyncio.TimeoutError:
-                        _slack_failure_reasons.append(
+                        _inject_failure_reasons.append(
                             f"attempt {_attempt} timed out after {int(INJECTION_TIMEOUT)}s"
                         )
                         logger.warning(
-                            "Subagent %s: Slack injection attempt %d/%d timed out after %.0fs",
+                            "Subagent %s: %s injection attempt %d/%d timed out after %.0fs",
                             info.id,
+                            _inject_label,
                             _attempt,
                             _MAX_INJECT_ATTEMPTS,
                             INJECTION_TIMEOUT,
@@ -4636,15 +4826,15 @@ class GatewayOrchestrator:
                                 await self.sessions.reset(parent_key)
                             except Exception:
                                 logger.debug(
-                                    "Failed to reset %s after Slack injection timeout",
+                                    "Failed to reset %s after channel injection timeout",
                                     parent_key,
                                     exc_info=True,
                                 )
                         if _attempt < _MAX_INJECT_ATTEMPTS:
                             _sleep_before_retry = True
                     except Exception as exc:
-                        _slack_failure_reasons.append(f"attempt {_attempt} failed: {exc}")
-                        logger.exception("Subagent %s Slack injection failed", info.id)
+                        _inject_failure_reasons.append(f"attempt {_attempt} failed: {exc}")
+                        logger.exception("Subagent %s %s injection failed", info.id, _inject_label)
                         break
                     finally:
                         if _acquired:
@@ -4662,13 +4852,14 @@ class GatewayOrchestrator:
                                 logger.exception("Failed to release session %s", parent_key)
 
                 if not _injected:
-                    _last_failure_reason = "; ".join(_slack_failure_reasons)
+                    _last_failure_reason = "; ".join(_inject_failure_reasons)
                     _last_failure_reason, _ = redact_exfiltration_urls(_last_failure_reason)
                     _last_failure_reason, _ = redact_credentials(_last_failure_reason)
                     logger.error(
-                        "Subagent %s: all %d Slack injection attempts failed: %s",
+                        "Subagent %s: all %d %s injection attempts failed: %s",
                         info.id,
                         _MAX_INJECT_ATTEMPTS,
+                        _inject_label,
                         _last_failure_reason,
                     )
                     if self.subagent_mgr:

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -4808,6 +4808,412 @@ class TestSlackSubagentCompletionPersistence:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+# Tests: subagent completion delivery to non-Slack channel parents
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestSubagentChannelTransportDelivery:
+    """Completion replies for channel-born parents reach the channel transport.
+
+    A parent session started on Telegram/Discord has no dashboard tab and no
+    Slack conversation, so its synthesized reply must go through the governed
+    cross-surface transport ladder; a missing transport degrades to the
+    dashboard notification without raising.
+    """
+
+    def _setup(self, *, parent_channel=None, transport=None):
+        orch = _make_orchestrator(slack_enabled=True, owner_id="U1")
+        orch.sessions = _mock_sessions()
+        # MagicMock attribute lookups return truthy mocks; the link ladder
+        # treats those as real links, so pin the optional sources to None.
+        orch.sessions.get_origin_link = MagicMock(return_value=None)
+        orch.sessions.get_mirror_link = MagicMock(return_value=None)
+        orch.sessions.get_channel = MagicMock(return_value=parent_channel)
+        orch.ctx_builder = MagicMock()
+        orch.ctx_builder.hooks = MagicMock()
+        orch.ctx_builder.build_message = MagicMock(return_value=("msg", None))
+        orch.dashboard_state = _mock_dashboard_state()
+        orch.dashboard_state.get_channel_transport = MagicMock(return_value=transport)
+        orch.slack = MagicMock()
+        orch.slack.open_dm = AsyncMock(return_value="D_U1")
+        orch.slack.post_message = AsyncMock()
+        orch.slack.post_blocks = AsyncMock(return_value="ts")
+        with patch("kiro_crew.slack.handler.is_yolo_mode", return_value=False):
+            with patch("kiro_crew.slack.gateway.SubagentManager") as mock_sm:
+                mock_sm_inst = MagicMock()
+                mock_sm_inst.start_reaper = MagicMock()
+                mock_sm_inst.running = []
+                mock_sm_inst.queued_count_for = MagicMock(return_value=0)
+                mock_sm_inst.has_pending_work_for = MagicMock(return_value=False)
+                mock_sm_inst.running_agents_for = MagicMock(return_value=[])
+                mock_sm_inst.get = MagicMock(return_value=None)
+                mock_sm_inst.notify_injection_failed = MagicMock()
+                mock_sm.return_value = mock_sm_inst
+                orch._init_subagents()
+        return orch, mock_sm
+
+    @staticmethod
+    def _fake_transport(channel_type="telegram", proactive=True, max_chars=4096):
+        async def _identity_target(target_id):
+            # Mirror the Telegram transport: "user:<id>" -> (<id>, None).
+            kind, _, value = target_id.partition(":")
+            return (value, None) if kind == "user" and value else None
+
+        return SimpleNamespace(
+            channel_type=channel_type,
+            capabilities=SimpleNamespace(
+                supports_proactive_send=proactive, max_message_chars=max_chars
+            ),
+            send_message=AsyncMock(return_value="mid-1"),
+            resolve_configured_target=AsyncMock(side_effect=_identity_target),
+        )
+
+    def _make_info(self, parent_key):
+        info = MagicMock()
+        info.id = "agent-channel"
+        info.parent_session_key = parent_key
+        info.error = None
+        info.result = "channel result"
+        info.result_path = ""
+        info.task = "analyze code"
+        info.agent = "kirocrew"
+        info.silent = False
+        info.elapsed = 5.0
+        info.started = time.time() - 5.0
+        return info
+
+    @staticmethod
+    def _permit_governance():
+        return patch(
+            "kiro_crew.platform.governance_profiles.vet_and_audit",
+            return_value=SimpleNamespace(permitted=True),
+        )
+
+    @pytest.mark.asyncio
+    async def test_telegram_parent_reply_reaches_registered_transport(self):
+        """A telegram:-born parent's synthesized reply is sent via the transport,
+        addressed to the session's own conversation id, never through Slack."""
+        transport = self._fake_transport("telegram")
+        orch, mock_sm = self._setup(parent_channel="telegram:12345", transport=transport)
+        on_done = mock_sm.call_args[1]["on_done"]
+        info = self._make_info("telegram:kirocrew:direct:12345")
+
+        with patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            new_callable=AsyncMock,
+            return_value="synthesized reply",
+        ), self._permit_governance():
+            await on_done(info)
+
+        transport.send_message.assert_awaited_once_with(
+            "12345", "synthesized reply", thread_id=None
+        )
+        orch.slack.post_message.assert_not_awaited()
+        orch.slack.open_dm.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_origin_link_wins_over_stored_channel(self):
+        """A recorded origin link (the conversation's real send target) takes
+        precedence over the stored channel value."""
+        transport = self._fake_transport("discord")
+        orch, mock_sm = self._setup(parent_channel="discord:U999", transport=transport)
+        from kiro_crew.messaging.link import ChannelLink
+
+        orch.sessions.get_origin_link = MagicMock(
+            return_value=ChannelLink("discord", channel_id="C777")
+        )
+        on_done = mock_sm.call_args[1]["on_done"]
+        info = self._make_info("discord:kirocrew:direct:U999")
+
+        with patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            new_callable=AsyncMock,
+            return_value="reply",
+        ), self._permit_governance():
+            await on_done(info)
+
+        transport.send_message.assert_awaited_once_with("C777", "reply", thread_id=None)
+
+    @pytest.mark.asyncio
+    async def test_slack_parent_still_posts_through_slack_client(self):
+        """Regression: a Slack-born parent keeps the dedicated Slack posting."""
+        orch, mock_sm = self._setup(parent_channel="C123")
+        on_done = mock_sm.call_args[1]["on_done"]
+        info = self._make_info("slack:1234567890.123456")
+
+        with patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            new_callable=AsyncMock,
+            return_value="slack reply",
+        ):
+            await on_done(info)
+
+        orch.slack.post_message.assert_awaited()
+        posted_channel = orch.slack.post_message.await_args_list[0][0][0]
+        assert posted_channel == "C123"
+        orch.dashboard_state.get_channel_transport.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_transport_degrades_to_notification_only(self):
+        """No registered transport: no crash, no Slack misdelivery, and the
+        dashboard notification still fires."""
+        orch, mock_sm = self._setup(parent_channel="telegram:12345", transport=None)
+        on_done = mock_sm.call_args[1]["on_done"]
+        info = self._make_info("telegram:kirocrew:direct:12345")
+
+        with patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            new_callable=AsyncMock,
+            return_value="synthesized reply",
+        ), self._permit_governance():
+            await on_done(info)
+
+        orch.slack.post_message.assert_not_awaited()
+        orch.dashboard_state.notify.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_transport_send_failure_never_raises(self):
+        """A transport that fails to send must not break completion handling."""
+        transport = self._fake_transport("telegram")
+        transport.send_message = AsyncMock(side_effect=RuntimeError("network down"))
+        orch, mock_sm = self._setup(parent_channel="telegram:12345", transport=transport)
+        on_done = mock_sm.call_args[1]["on_done"]
+        info = self._make_info("telegram:kirocrew:direct:12345")
+
+        with patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            new_callable=AsyncMock,
+            return_value="synthesized reply",
+        ), self._permit_governance():
+            await on_done(info)  # must not raise
+
+        orch.dashboard_state.notify.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_target_snapshotted_before_injection_survives_session_reset(self):
+        """A timeout-path sessions.reset() evicts the in-memory origin link;
+        the delivery target is snapshotted before injection, so a retry that
+        then succeeds still delivers to the original conversation."""
+        transport = self._fake_transport("discord")
+        orch, mock_sm = self._setup(parent_channel=None, transport=transport)
+        from kiro_crew.messaging.link import ChannelLink
+
+        # Origin link present at entry, gone after the first (timed-out)
+        # injection attempt — exactly what reset() does to a live session.
+        orch.sessions.get_origin_link = MagicMock(
+            side_effect=[ChannelLink("discord", channel_id="C777", thread_id="T1")]
+            + [None] * 8
+        )
+        on_done = mock_sm.call_args[1]["on_done"]
+        info = self._make_info("discord:kirocrew:direct:U999")
+
+        with patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            new_callable=AsyncMock,
+            side_effect=[asyncio.TimeoutError, "reply after retry"],
+        ), patch("asyncio.sleep", new_callable=AsyncMock), self._permit_governance():
+            await on_done(info)
+
+        transport.send_message.assert_awaited_once_with(
+            "C777", "reply after retry", thread_id="T1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_peer_resolution_outcome_is_sel_audited(self):
+        """The configured-target allow-list decision lands in the SEL trail
+        (allowed and denied alike), matching the chat_mirror precedent."""
+        for resolved_target, expected in ((("12345", None), "allowed"), (None, "denied")):
+            transport = self._fake_transport("telegram")
+            transport.resolve_configured_target = AsyncMock(return_value=resolved_target)
+            orch, mock_sm = self._setup(parent_channel="telegram:12345", transport=transport)
+            on_done = mock_sm.call_args[1]["on_done"]
+            info = self._make_info("telegram:kirocrew:direct:12345")
+
+            with patch(
+                "kiro_crew.slack.gateway.stream_and_collect",
+                new_callable=AsyncMock,
+                return_value="reply",
+            ), self._permit_governance(), patch("kiro_crew.slack.gateway.sel") as mock_sel:
+                mock_sel.return_value.log_api_access = MagicMock()
+                await on_done(info)
+
+            audit_calls = [
+                c
+                for c in mock_sel.return_value.log_api_access.call_args_list
+                if c.kwargs.get("operation") == "subagent.reply_target_resolve"
+            ]
+            assert len(audit_calls) == 1
+            assert audit_calls[0].kwargs["outcome"] == expected
+
+    @pytest.mark.asyncio
+    async def test_reply_is_redacted_before_send(self):
+        """Fresh LLM output is redacted at the channel egress."""
+        transport = self._fake_transport("telegram")
+        orch, mock_sm = self._setup(parent_channel="telegram:12345", transport=transport)
+        on_done = mock_sm.call_args[1]["on_done"]
+        info = self._make_info("telegram:kirocrew:direct:12345")
+        leaked = "result aws_secret_access_key=AKIAIOSFODNN7EXAMPLE done"
+
+        with patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            new_callable=AsyncMock,
+            return_value=leaked,
+        ), self._permit_governance():
+            await on_done(info)
+
+        transport.send_message.assert_awaited_once()
+        sent_text = transport.send_message.await_args[0][1]
+        assert "AKIAIOSFODNN7EXAMPLE" not in sent_text
+
+    @pytest.mark.asyncio
+    async def test_forum_parent_without_links_degrades_to_notification(self):
+        """A forum-born parent's stored channel value carries the SENDER's user
+        id; without an origin/mirror link the reply must NOT be sent (a send
+        would leak group conversation content into a private DM)."""
+        transport = self._fake_transport("telegram")
+        orch, mock_sm = self._setup(parent_channel="telegram:12345", transport=transport)
+        on_done = mock_sm.call_args[1]["on_done"]
+        info = self._make_info("telegram:kirocrew:forum:987:5")
+
+        with patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            new_callable=AsyncMock,
+            return_value="synthesized reply",
+        ), self._permit_governance():
+            await on_done(info)
+
+        transport.send_message.assert_not_awaited()
+        orch.dashboard_state.notify.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_mirror_link_delivers_into_forum_topic(self):
+        """A Telegram /link mirror binding wins over the stored value and
+        carries the forum Topic thread id."""
+        transport = self._fake_transport("telegram")
+        orch, mock_sm = self._setup(parent_channel="telegram:12345", transport=transport)
+        from kiro_crew.messaging.link import ChannelLink
+
+        orch.sessions.get_mirror_link = MagicMock(
+            return_value=ChannelLink("telegram", channel_id="987", thread_id="5")
+        )
+        on_done = mock_sm.call_args[1]["on_done"]
+        info = self._make_info("telegram:kirocrew:forum:987:5")
+
+        with patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            new_callable=AsyncMock,
+            return_value="reply",
+        ), self._permit_governance():
+            await on_done(info)
+
+        transport.send_message.assert_awaited_once_with("987", "reply", thread_id="5")
+        # A link recorded by the transport is already a postable conversation.
+        transport.resolve_configured_target.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unified_parent_uses_stored_channel_value(self):
+        """A unified: DM bucket (direct-only by construction) resolves the
+        stored channel value even though its namespace differs from the key's."""
+        transport = self._fake_transport("telegram")
+        orch, mock_sm = self._setup(parent_channel="telegram:12345", transport=transport)
+        on_done = mock_sm.call_args[1]["on_done"]
+        info = self._make_info("unified:kirocrew")
+
+        with patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            new_callable=AsyncMock,
+            return_value="reply",
+        ), self._permit_governance():
+            await on_done(info)
+
+        transport.send_message.assert_awaited_once_with("12345", "reply", thread_id=None)
+
+    @pytest.mark.asyncio
+    async def test_stored_peer_id_is_resolved_to_a_postable_conversation(self):
+        """The stored value is the peer's USER id; the transport resolves the
+        postable conversation (e.g. Discord DM-channel creation, Teams'
+        learned conversation) via resolve_configured_target."""
+        transport = self._fake_transport("discord")
+        transport.resolve_configured_target = AsyncMock(return_value=("DM123", None))
+        orch, mock_sm = self._setup(parent_channel="discord:U999", transport=transport)
+        on_done = mock_sm.call_args[1]["on_done"]
+        info = self._make_info("discord:kirocrew:direct:U999")
+
+        with patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            new_callable=AsyncMock,
+            return_value="reply",
+        ), self._permit_governance():
+            await on_done(info)
+
+        transport.resolve_configured_target.assert_awaited_once_with("user:U999")
+        transport.send_message.assert_awaited_once_with("DM123", "reply", thread_id=None)
+
+    @pytest.mark.asyncio
+    async def test_unreachable_peer_fails_closed(self):
+        """A peer the transport cannot reach (e.g. Teams with no learned
+        conversation/serviceUrl) degrades to notification-only, no send."""
+        transport = self._fake_transport("teams")
+        transport.resolve_configured_target = AsyncMock(return_value=None)
+        orch, mock_sm = self._setup(
+            parent_channel="teams:user@example.com", transport=transport
+        )
+        on_done = mock_sm.call_args[1]["on_done"]
+        info = self._make_info("teams:kirocrew:direct:user@example.com")
+
+        with patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            new_callable=AsyncMock,
+            return_value="reply",
+        ), self._permit_governance():
+            await on_done(info)
+
+        transport.send_message.assert_not_awaited()
+        orch.dashboard_state.notify.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_governance_denial_blocks_the_send(self):
+        """A non-permitting governance decision must block the egress."""
+        transport = self._fake_transport("telegram")
+        orch, mock_sm = self._setup(parent_channel="telegram:12345", transport=transport)
+        on_done = mock_sm.call_args[1]["on_done"]
+        info = self._make_info("telegram:kirocrew:direct:12345")
+
+        with patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            new_callable=AsyncMock,
+            return_value="reply",
+        ), patch(
+            "kiro_crew.platform.governance_profiles.vet_and_audit",
+            return_value=SimpleNamespace(permitted=False),
+        ):
+            await on_done(info)
+
+        transport.send_message.assert_not_awaited()
+        orch.dashboard_state.notify.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_long_reply_is_chunked_to_the_transport_limit(self):
+        """A reply longer than max_message_chars arrives as multiple sends."""
+        transport = self._fake_transport("telegram", max_chars=20)
+        orch, mock_sm = self._setup(parent_channel="telegram:12345", transport=transport)
+        on_done = mock_sm.call_args[1]["on_done"]
+        info = self._make_info("telegram:kirocrew:direct:12345")
+        long_reply = "\n".join(f"line {i} of the reply" for i in range(6))
+
+        with patch(
+            "kiro_crew.slack.gateway.stream_and_collect",
+            new_callable=AsyncMock,
+            return_value=long_reply,
+        ), self._permit_governance():
+            await on_done(info)
+
+        assert transport.send_message.await_count > 1
+        reassembled = "".join(c.args[1] for c in transport.send_message.await_args_list)
+        assert "line 5 of the reply" in reassembled
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 # Tests: _connect_slack resilience (Slack connect must never crash the gateway)
 # ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Problem

When a session started from Telegram spawns subagents via `spawn_run`, the completion result never reaches the user in Telegram. They see only a dashboard notification; on their next inbound message the agent behaves as if it already knows the result (the injection worked — only the outbound reply was lost). Discord and every other non-Slack channel share the gap.

## Why it matters

Subagent delegation is effectively broken for channel users: the work completes, the parent session knows the outcome, but the person who asked never hears back unless they happen to check the dashboard. This silently defeats the core "spawn and get notified" contract on every channel except Slack.

## Fix (symptom → root cause → change)

- **Symptom:** completion replies vanish for `telegram:`/`discord:`/`unified:` parents.
- **Root cause:** `_subagent_done`'s no-tab fallback branch is written for Slack only — the synthesized reply is posted exclusively through `self.slack.post_message(...)`. For a non-Slack parent either `self.slack` is `None`, or `sessions.get_channel()` returns `"telegram:<id>"`, which is not a Slack channel. The transport infrastructure needed (`register_channel_transport`, `get_channel_transport`, the governed `_resolve_channel_target` ladder) already exists but was never consulted on this branch.
- **Change:** the branch now routes by `channel_namespace_of(parent_key)`. Slack keeps its dedicated rich posting; every other namespace delivers through a new `_deliver_channel_reply`, which resolves the conversation via a fail-closed ladder — origin link → non-Slack mirror link → (direct 1:1 sessions only) the stored `"{namespace}:{user_id}"` value resolved to a postable conversation through `transport.resolve_conversation` — then vets the egress through the shared governed `_resolve_channel_target` (SEL-audited, fail-closed, capability-gated on `supports_proactive_send`), redacts through `redact_via_context`, and chunks to the transport's `max_message_chars`. Group/forum sessions without an origin/mirror link, unregistered transports, and denied egress all degrade to the existing dashboard notification — never a cross-conversation send (the stored value carries the *sender's* user id, so sending there from a forum would leak group content into a private DM). Delivery is best-effort and can never raise out of the completion handler.

Pre-push review (dual model-pinned reviewers + focused verifier) drove the fail-closed gating: rung 3 requires `chat_type == direct` and stored-namespace == key-namespace (`unified:` buckets are accepted because only direct DMs ever collapse into them), which also guarantees every `channel_type` reaching `vet_and_audit` comes from the registered channel set. One reviewer suggested failing closed for `unified:` parents outright; rebutted: unified is an explicit opt-in that collapses all direct DMs into one cross-surface conversation, both candidate targets belong to the same authorized owner, and the compaction notice already delivers unattended output the same way — failing closed would keep the reported bug for unified users.

## Tests

`TestSubagentChannelTransportDelivery` (12 tests, red-check verified — the telegram delivery test fails on unfixed code):
- telegram DM parent → reply reaches the registered transport, addressed to the session's own conversation, Slack client untouched
- origin link wins over the stored value (Discord)
- Slack parent regression: still posts through the Slack client, transport registry untouched
- missing transport / transport send failure → degrade to notification, never raise
- reply redacted at the egress (credential token stripped)
- forum parent without links → fail closed (no DM leak), notification fires
- mirror link delivers into the forum Topic (`thread_id` carried, no DM resolution)
- `unified:` parent delivers via the stored value
- stored peer id resolved to a postable conversation via `transport.resolve_conversation`
- governance denial blocks the send
- long reply chunked to `max_message_chars` across multiple sends

Spec docs updated in the same commit (`docs/system-specs/modules/subagent.md` routing table, `docs/system-specs/modules/slack-gateway.md`).

## Manual verification

N/A — unit coverage exercises the real ladder (`_resolve_channel_target`, `chunk_text`, `redact_via_context` all run un-mocked; only the governance decision and the transport are test doubles). Full local gates green: pytest (39k tests; the 19 failures present are identical on `origin/main` — pre-existing host/sandbox environment issues), isort, flake8, mypy.

## Screenshots

N/A — backend-only change, no UI surface.

Closes #2319
