### PR TITLE
fix(browser): re-attach CDP control after the embedded view is rebuilt

### DIFF
--- a/website/electron/browser-control.js
+++ b/website/electron/browser-control.js
@@ -157,6 +157,12 @@ function createControlPlane(deps) {
 
   let owner = OWNER.NONE;
   let attached = false;
+  // The exact webContents LIGHT's debugger is attached to. Tracked so a stale
+  // attachment can be told apart from a live one: the embedded view can be torn
+  // down and rebuilt under us (panel reopened, session re-keyed), leaving the
+  // owner recorded as LIGHT while `getWebContents()` returns a fresh target the
+  // debugger was never attached to. Compared by identity, never dereferenced.
+  let attachedWc = null;
 
   const audit = (event, detail) => {
     try {
@@ -175,6 +181,7 @@ function createControlPlane(deps) {
   function detachLight() {
     const dbg = debuggerFor();
     attached = false;
+    attachedWc = null;
     if (!dbg) return;
     try {
       if (typeof dbg.isAttached === "function" ? dbg.isAttached() : true) {
@@ -187,16 +194,34 @@ function createControlPlane(deps) {
   }
 
   function attachLight() {
-    const dbg = debuggerFor();
+    const wc = getWebContents();
+    const dbg = wc && wc.debugger ? wc.debugger : null;
     if (!dbg) throw new Error("no browser view to control");
     // Idempotent: re-attaching when we already hold it would throw, and a
     // transition must be safe to re-run.
     if (typeof dbg.isAttached === "function" && dbg.isAttached()) {
       attached = true;
+      attachedWc = wc;
       return;
     }
     dbg.attach(CDP_VERSION);
     attached = true;
+    attachedWc = wc;
+  }
+
+  // True when LIGHT's in-process debugger is still attached to the CURRENT
+  // embedded view. Goes false when the WebContentsView is rebuilt underneath us:
+  // the owner is still recorded as LIGHT, but `getWebContents()` now returns a
+  // different, un-attached target. This is what lets a re-request of LIGHT know
+  // it must re-attach rather than short-circuit as a no-op.
+  function lightAttachmentLive() {
+    if (owner !== OWNER.LIGHT || !attached) return false;
+    const wc = getWebContents();
+    if (!wc || !wc.debugger) return false;
+    if (attachedWc && wc !== attachedWc) return false;
+    const dbg = wc.debugger;
+    if (typeof dbg.isAttached === "function" && !dbg.isAttached()) return false;
+    return true;
   }
 
   async function send(method, params) {
@@ -235,7 +260,28 @@ function createControlPlane(deps) {
           return { owner, changed: false, refused: verdict.reason };
         }
       }
-      if (plan.noop) return { owner, changed: false };
+      if (plan.noop) {
+        // Re-requesting the owner already held is normally a no-op. The one
+        // exception: LIGHT whose attachment went stale because the embedded view
+        // was rebuilt under us. The owner is still LIGHT, but the debugger is now
+        // attached to nothing (or to a target that no longer exists), so the next
+        // CDP send would hit a detached target — the bug that forced users to
+        // fully close the browser before a second agent op. Re-attach to the
+        // current view instead of short-circuiting.
+        if (requested === OWNER.LIGHT && !lightAttachmentLive()) {
+          detachLight();
+          try {
+            attachLight();
+          } catch (err) {
+            owner = OWNER.NONE;
+            audit("browser-control-failed", { requested, error: String(err && err.message) });
+            throw err;
+          }
+          audit("browser-control-reattach", { owner });
+          return { owner, changed: false, reattached: true };
+        }
+        return { owner, changed: false };
+      }
 
       // Order matters: release before acquire, so the two owner classes never
       // overlap even though Chromium would permit it.

--- a/website/electron/test/browser-control.test.js
+++ b/website/electron/test/browser-control.test.js
@@ -323,3 +323,62 @@ test("plane: a throwing audit sink never breaks a transition", async () => {
   const res = await plane.setOwner(OWNER.LIGHT, ALLOW);
   assert.strictEqual(res.changed, true);
 });
+
+// ── reuse across a view rebuild (the "close before a second op" bug) ──
+
+// A WebContents fake that models Chromium's debugger faithfully: `sendCommand`
+// THROWS unless the debugger is currently attached to THIS target, and each
+// target owns its own attach state. The shared `fakeWc()` above never checks
+// attach state on send, so it cannot surface a stale-attachment bug — this one
+// can. `id` is only for readability in failures.
+function realisticWc(id) {
+  let isAttached = false;
+  return {
+    id,
+    debugger: {
+      isAttached: () => isAttached,
+      attach() {
+        if (isAttached) throw new Error("Debugger is already attached to the target");
+        isAttached = true;
+      },
+      detach() {
+        isAttached = false;
+      },
+      async sendCommand(method) {
+        if (!isAttached) throw new Error("Debugger is not attached to the target");
+        return method === "Runtime.evaluate" ? { result: { value: 7 } } : {};
+      },
+    },
+  };
+}
+
+test("plane: reuse after the embedded view is rebuilt re-attaches instead of hitting a detached target", async () => {
+  // Reproduces the "must close the browser before a second operation" symptom.
+  // The embedded WebContentsView can be torn down and rebuilt under the control
+  // plane (panel reopened, session re-keyed, view recreated). The recorded owner
+  // stays LIGHT, but the debugger that was attached to the OLD view is gone with
+  // it. A second agent op re-requests LIGHT — a planTransition(LIGHT,LIGHT)
+  // no-op — so without re-validating the attachment the next CDP send lands on
+  // the NEW view's detached debugger and throws. Fully closing the panel is what
+  // "fixed" it for users, because that path resets the owner to NONE.
+  let current = realisticWc("A");
+  const plane = createControlPlane({ getWebContents: () => current });
+
+  await plane.setOwner(OWNER.LIGHT, ALLOW);
+  assert.strictEqual(await plane.evaluate("1+1"), 7, "first op drives view A");
+
+  // View A is destroyed; a fresh view B is mounted (new WebContents whose
+  // debugger is NOT attached). The control plane still records owner = LIGHT.
+  current = realisticWc("B");
+
+  // The next agent op re-requests LIGHT, exactly as main.js dispatch does.
+  const again = await plane.setOwner(OWNER.LIGHT, ALLOW);
+  assert.strictEqual(again.changed, false, "same logical owner");
+
+  // Must transparently reuse view B — not require the user to close first.
+  assert.strictEqual(
+    await plane.evaluate("1+1"),
+    7,
+    "second op must reuse the rebuilt view, not hit a detached target",
+  );
+});


### PR DESCRIPTION
## Problem
In the native browser panel, the agent's `browser_*` operations reuse a single long-lived `WebContentsView`. But if that view is torn down and rebuilt underneath the control plane (panel reopened, session re-keyed, view recreated), a **second** agent operation fails — the browser appears stuck, and the only workaround is to fully close it before acting again.

## Why it matters
Reuse is the intended design (the view is deliberately hidden-not-destroyed on tab switches to preserve page state). The failure forces a manual close between operations, breaking multi-step agent browsing and the "let the agent act" flow.

## Fix (symptom → root cause → change)
- **Symptom:** the second op throws `Debugger is not attached to the target`.
- **Root cause:** the control plane (`website/electron/browser-control.js`) tracked CDP attachment as a bare `attached` boolean. After a view rebuild the recorded owner stays `LIGHT`, but the debugger attached to the *old* `webContents` is gone. The next op re-requests `LIGHT`, which is a `planTransition(LIGHT, LIGHT)` **no-op**, so `attachLight()` never runs against the new view — and the subsequent CDP `send()` lands on a detached target. Fully closing the panel "fixed" it only because that path resets the owner to `NONE`.
- **Change:** track *which* `webContents` `LIGHT` is attached to (`attachedWc`) and add `lightAttachmentLive()`. On a re-request of `LIGHT`, if the attachment is stale (the current view differs from the attached one, or the debugger reports not-attached), re-attach to the current view instead of short-circuiting the no-op. Reuse now self-heals across a view rebuild regardless of which teardown path ran, preserving the single-owner invariant.

## Tests
- New regression test in `website/electron/test/browser-control.test.js` using a Chromium-faithful `webContents` fake whose `sendCommand` throws on a detached target (the shared `fakeWc()` cannot surface this). It drives `open → rebuild view → reuse` and asserts the second op transparently re-attaches.
- Full Electron `node:test` suite green: **845 passed, 0 failed**.

## Manual verification
N/A for automated coverage — the defect is pure control-plane state, reproduced deterministically by the new unit test without Electron. End-to-end confirmation on the packaged desktop build (native `WebContentsView`) is a follow-up that needs a human at the desktop app, since a headless pod does not run the Electron shell where this code lives.

## Screenshots
N/A — no user-visible UI change (control-plane logic only).
