### PR TITLE
fix(i18n): match ko sort_largest spacing to the catalog convention

### DIFF
--- a/website/src/i18n/locales/ko.json
+++ b/website/src/i18n/locales/ko.json
@@ -9128,7 +9128,7 @@
       "restore": "복원",
       "resumable": "재개 가능",
       "search_placeholder": "세션 검색",
-      "sort_largest": "큰 순",
+      "sort_largest": "큰순",
       "sort_name": "이름",
       "sort_oldest": "오래된순",
       "subheading": "세션 {{sessions}}개 · 디스크 사용량 {{total}} · {{reclaimable}} 회수 가능",


### PR DESCRIPTION
The Storage sort dropdown spells the same 순 suffix two ways: sort_largest was 큰 순 (spaced) beside the fixed sort_oldest 오래된순 (unspaced), which pages.chatSidebar.sort_oldest already established. One control, two spellings.

Close the space. 큰 순 is arguably the stricter orthography — 순 is a 의존명사 after the 관형형 큰 — but 오래된순 is the same 관형형+의존명사 shape and the catalog already writes it closed, so the spaced form is the odd one out rather than the correct one. Consistency inside a single dropdown is worth more here than the spacing rule.

Not 크기순: that is unspaced and lexicalised, but it says "by size" and drops the "largest FIRST" direction the sibling options state.

Raised by the UX Review on #2306 after it merged.

<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

<!-- Bug fix: the concrete symptom — what is broken or missing, ideally what the
     user observes.
     New feature / enhancement: the gap, use case, or opportunity this addresses
     — what a user cannot do (or does awkwardly) today. -->

## Why it matters

<!-- Impact if this is left undone: for a fix, who is hit by the bug and how
     badly; for a feature, the user/business value it unlocks. -->

## What changed (motivation → approach → change)

<!-- A short chain of thought so the reader sees *why this is the right change*,
     not just what changed:
     - Bug fix: observed symptom → underlying root cause → the specific change
       that addresses that cause.
     - New feature / enhancement: goal → the approach/design you chose (and why,
       over the alternatives you considered) → what you actually built. -->

## Tests

<!-- Automated tests added/updated and the behavior each one locks in. -->

## Manual verification

<!-- Manual steps performed or still required where unit tests fall short
     (integration paths, UI, external services). State "N/A — unit coverage
     sufficient" only when genuinely true, with a one-line why. -->

## Screenshots / video

<!-- MANDATORY for any user-visible UI change (new/changed panels, components,
     layouts, themes); delete this section otherwise.

     - Show each affected surface in its meaningful variants (e.g. desktop vs
       browser, empty vs populated, light vs dark).
     - Prefer a short video/GIF when the change involves motion or a multi-step
       flow (animations, transitions, interactions) — a still image cannot
       prove those.
     - Commit media to the PR branch under a top-level, ephemeral, never-packaged
       dir `temp-screenshots/<feature>/` (never under docs/ or src/kiro_crew/**)
       and embed with commit-SHA-pinned URLs so they survive branch deletion on
       merge and periodic cleanup:
       ![alt](https://github.com/<owner>/<repo>/raw/<sha>/temp-screenshots/<feature>/<name>.png)
     - Put the two or three most telling shots inline; fold full-page context
       into a <details> block. -->

## Related Issues

<!-- Link to relevant issues, e.g. Fixes #123 -->

## Checklist

- [ ] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [ ] Existing tests pass and new tests added for new functionality
- [ ] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
