### PR TITLE
fix(dashboard): bound the tool-approval window below the turn ceiling

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -285,6 +285,14 @@ graph TB
   turn that hits it ends with a card naming the limit rather than failing
   silently. The ACP transport carries its own prompt timeout of the same
   magnitude and bounds the turn first.
+- **Tool-approval window**: `agent.tool_approval_timeout_secs` defaults to
+  **600s** (10 min). It must expire *inside* the turn that opened it — otherwise
+  an unanswered prompt is reported as a turn timeout and the real cause is lost —
+  so it is bounded twice: to 60s below the turn ceiling at config load, and at
+  arm time to the budget actually remaining in the running turn. A prompt arming
+  with less than that margin left is declined immediately rather than waiting on
+  a deadline the ceiling would beat. On expiry the tool is declined and a card
+  says the approval went unanswered and to send the message again.
 - **Circuit breaker**: five consecutive failures on one session force a reset.
 - **Auto-compaction** at `session.autocompact_pct` of the context window
   (default 90%).

--- a/docs/architecture/resource-protection.md
+++ b/docs/architecture/resource-protection.md
@@ -43,7 +43,7 @@ anything that survived a gateway crash. No single mechanism is a single point of
 | Context compaction | `session.py` | Chat sessions | `session.autocompact_pct` | No | Sends `/compact` to kiro-cli to free context window |
 | Background session recycle | `session.py` | Background sessions (cron, subagent) | 70% context usage (`_BG_RECYCLE_PCT`) | No | Recycles the session before context overflow |
 | Watchdog process liveness | `taskrunner.py` | Task runner steps | 2 consecutive dead checks (`_DEAD_THRESHOLD`) at 30s intervals | Yes, part of the watchdog loop | Resets the session to trigger crash recovery |
-| Config bound clamp | `config/loader.py` | Subagent count, turns, timeouts and pool size at load time | `subagent_auto_max` and `max_subagents` to 64 (`SUBAGENT_AUTO_MAX_CEILING`), `subagent_max_turns` 1..200, `chat_turn_timeout_secs` 300..7200, `loop_stall_exit_after_secs` 10..300, `pool_size` 0..10 (`_SECURITY_BOUNDED_FIELDS`) | No | `_clamp_security_bounds` clamps out-of-range ints, logs a WARNING, emits SEL `config_bounds_clamped` (`outcome=clamped`) |
+| Config bound clamp | `config/loader.py` | Subagent count, turns, timeouts and pool size at load time | `subagent_auto_max` and `max_subagents` to 64 (`SUBAGENT_AUTO_MAX_CEILING`), `subagent_max_turns` 1..200, `chat_turn_timeout_secs` 300..7200, `tool_approval_timeout_secs` 30..7200 and cross-field to 60s under the turn ceiling (`APPROVAL_TURN_MARGIN_SECS`), `loop_stall_exit_after_secs` 10..300, `pool_size` 0..10 (`_SECURITY_BOUNDED_FIELDS`) | No | `_clamp_security_bounds` clamps out-of-range ints, logs a WARNING, emits SEL `config_bounds_clamped` (`outcome=clamped`) |
 
 ## Per-workflow coverage matrix
 

--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -631,6 +631,8 @@ class AgentConfig:
     subagent_auto_max: int = 16    # ceiling on the auto-sized cap (max_subagents=0 only). Load-time clamped to [3, 64]
     subagent_max_turns: int = 100  # default per-subagent tool-call budget. Load-time clamped to [1, 200]
     subagent_result_ttl_secs: int = 3600  # seconds a delivered subagent's result.txt is retained before the reaper prunes it
+    chat_turn_timeout_secs: int = 7200  # wall-clock ceiling for one chat turn. Load-time clamped to [300, 7200] and to the ACP prompt timeout
+    tool_approval_timeout_secs: int = 600  # how long a chat turn waits for a human to answer a tool-approval prompt. Load-time clamped to [30, 7200] AND to 60s below chat_turn_timeout_secs
 
 @dataclass
 class SessionConfig:
@@ -821,8 +823,8 @@ screenshot.
 
 ### Security-Bounded Config Clamp
 
-Three resource-limit knobs are clamped to hard ceilings **at load time**, not just
-at the dashboard write gate. The ceilings are the single source of truth in
+Resource-limit and timeout knobs are clamped to hard ceilings **at load time**, not
+just at the dashboard write gate. The ceilings are the single source of truth in
 `loader.py`:
 
 | Constant | Value | Field |
@@ -830,6 +832,8 @@ at the dashboard write gate. The ceilings are the single source of truth in
 | `SUBAGENT_AUTO_MAX_CEILING` | 64 | `agent.subagent_auto_max`, `agent.max_subagents` |
 | `SUBAGENT_MAX_TURNS_CEILING` | 200 | `agent.subagent_max_turns` |
 | `POOL_SIZE_MAX` | 10 | `session.pool_size` |
+| `CHAT_TURN_TIMEOUT_MIN` / `_MAX` | 300 / 7200 | `agent.chat_turn_timeout_secs` |
+| `TOOL_APPROVAL_TIMEOUT_MIN` / `_MAX` | 30 / 7200 | `agent.tool_approval_timeout_secs` |
 
 `_SECURITY_BOUNDED_FIELDS` lists each `(section, key, min, max)`; the mins match
 the existing runtime floors (0/1) so a legitimate in-range value is never
@@ -839,6 +843,23 @@ serve clamped values. It clamps out-of-range real integers in place (a JSON
 `true`/`false` bool or any non-int is skipped and left to dataclass
 coercion/defaults), logs a WARNING, and emits a best-effort `config_bounds_clamped`
 SEL security event (never fatal — config loading must not raise).
+
+Two **cross-field** clamps run after that generic pass, so both operands are
+already in range:
+
+- `agent.max_subagents`: 0 is the auto-size sentinel, so an explicit pin below
+  `MAX_SUBAGENTS_FIXED_FLOOR` (3) is raised UP to the floor.
+- `agent.tool_approval_timeout_secs` is pulled to `APPROVAL_TURN_MARGIN_SECS`
+  (60) below `agent.chat_turn_timeout_secs`. An approval window that reaches the
+  turn ceiling can never fire: the turn is cut first and reports itself as a turn
+  timeout, so the unanswered approval is never named and an unattended run burns
+  the whole ceiling on every prompt. `dashboard/turn_dispatch.py`
+  `tool_approval_timeout_secs()` repeats the cap against the **resolved** ceiling,
+  which the ACP prompt timeout can lower below the configured one, and then
+  against the budget REMAINING in the running turn (`_TURN_DEADLINE`, published by
+  `_bounded_turn`). The arm-time bound is the one that makes the invariant hold
+  for a prompt arming late in a long turn; with under a margin left it returns
+  `0.0` and the runner declines without waiting.
 
 Why load-time (not just the API): the REST API rejects out-of-range writes, but a
 direct edit of `config.json` (any process running as the same OS user — including

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1047,6 +1047,18 @@ class AgentConfig:
             "clamped, because the transport bounds the turn first.",
         ),
     )
+    tool_approval_timeout_secs: int = field(
+        default=600,
+        metadata=_meta(
+            "Tool Approval Timeout (secs)",
+            "How long a chat turn waits for a human to answer a tool-approval "
+            "prompt before declining it and telling the user to resend. Kept "
+            "well below the chat-turn ceiling on purpose: a window at or above "
+            "it can never fire, so an unattended turn burns the whole ceiling "
+            "and is then misreported as a turn timeout. Clamped to 30s..7200s, "
+            "and additionally to 60s below the turn ceiling at load time.",
+        ),
+    )
     subagent_cost_gb: float = field(
         default=0.5,
         metadata=_meta(
@@ -2687,6 +2699,28 @@ POOL_SIZE_MAX = 10  # session.pool_size — pre-warmed process pool
 CHAT_TURN_TIMEOUT_MIN = 300
 CHAT_TURN_TIMEOUT_MAX = 7200
 
+# agent.tool_approval_timeout_secs — how long a chat turn parks waiting for a
+# human to answer a tool-approval prompt. The floor keeps the window long enough
+# for a human who is actually present to reach the dashboard; the ceiling is the
+# turn ceiling, but the binding limit is the cross-field clamp in
+# ``_clamp_security_bounds``, which pulls the window APPROVAL_TURN_MARGIN_SECS
+# under the configured turn ceiling.
+TOOL_APPROVAL_TIMEOUT_MIN = 30
+TOOL_APPROVAL_TIMEOUT_MAX = CHAT_TURN_TIMEOUT_MAX
+
+# The turn ceiling assumed when config omits ``agent.chat_turn_timeout_secs``.
+# Read from the dataclass default so the two cannot drift apart.
+_DEFAULT_CHAT_TURN_TIMEOUT_SECS = int(
+    AgentConfig.__dataclass_fields__["chat_turn_timeout_secs"].default  # type: ignore[arg-type]
+)
+
+# Minimum slack between the approval window and the turn ceiling. Two things
+# need it: the approval deadline must land inside the turn so its own "nobody
+# approved, resend" card renders instead of the generic turn-timeout card, and a
+# late approval must leave the turn some time to actually run the tool. A window
+# flush against the ceiling satisfies neither.
+APPROVAL_TURN_MARGIN_SECS = 60
+
 # dashboard.loop_stall_exit_after_secs — event-loop silence tolerated before the
 # gateway dumps all thread stacks and hard-exits for systemd to restart. The
 # floor keeps a stall from being declared faster than ordinary GC/IO pauses; the
@@ -2716,6 +2750,12 @@ _SECURITY_BOUNDED_FIELDS: tuple[tuple[str, str, int, int], ...] = (
     ("agent", "max_subagents", 0, SUBAGENT_AUTO_MAX_CEILING),
     ("agent", "subagent_max_turns", 1, SUBAGENT_MAX_TURNS_CEILING),
     ("agent", "chat_turn_timeout_secs", CHAT_TURN_TIMEOUT_MIN, CHAT_TURN_TIMEOUT_MAX),
+    (
+        "agent",
+        "tool_approval_timeout_secs",
+        TOOL_APPROVAL_TIMEOUT_MIN,
+        TOOL_APPROVAL_TIMEOUT_MAX,
+    ),
     ("dashboard", "loop_stall_exit_after_secs", LOOP_STALL_EXIT_AFTER_MIN, LOOP_STALL_EXIT_AFTER_MAX),
     ("session", "pool_size", 0, POOL_SIZE_MAX),
 )
@@ -2820,6 +2860,39 @@ def _clamp_security_bounds(data: dict) -> None:
                 MAX_SUBAGENTS_FIXED_FLOOR,
                 MAX_SUBAGENTS_FIXED_FLOOR,
                 SUBAGENT_AUTO_MAX_CEILING,
+            )
+
+    # tool_approval_timeout_secs cross-field case: the approval window must end
+    # inside the turn that opened it. At or above the turn ceiling it can never
+    # fire — the turn is cut first, so the user is told "this turn timed out"
+    # while the real cause (nobody answered the approval prompt) is never named,
+    # and an unattended run burns the entire ceiling on every prompt. Clamp to
+    # APPROVAL_TURN_MARGIN_SECS below the ceiling. Runs after the generic range
+    # clamp above, so both operands are already inside their declared bounds.
+    if isinstance(agent, dict):
+        window = agent.get("tool_approval_timeout_secs")
+        ceiling = agent.get("chat_turn_timeout_secs", _DEFAULT_CHAT_TURN_TIMEOUT_SECS)
+        if not isinstance(ceiling, int) or isinstance(ceiling, bool):
+            ceiling = _DEFAULT_CHAT_TURN_TIMEOUT_SECS
+        budget = max(TOOL_APPROVAL_TIMEOUT_MIN, ceiling - APPROVAL_TURN_MARGIN_SECS)
+        if isinstance(window, int) and not isinstance(window, bool) and window > budget:
+            agent["tool_approval_timeout_secs"] = budget
+            logger.warning(
+                "config agent.tool_approval_timeout_secs=%d leaves less than %ds "
+                "under the %ds turn ceiling; clamped to %d. A window that outlives "
+                "the turn can never fire: the turn is cut first and reports itself "
+                "as a turn timeout, hiding the unanswered approval.",
+                window,
+                APPROVAL_TURN_MARGIN_SECS,
+                ceiling,
+                budget,
+            )
+            _log_config_clamp_event(
+                "agent.tool_approval_timeout_secs",
+                window,
+                budget,
+                TOOL_APPROVAL_TIMEOUT_MIN,
+                budget,
             )
 
 
@@ -4803,6 +4876,12 @@ class KiroCrewConfig:
                     7200,
                     CHAT_TURN_TIMEOUT_MIN,
                     CHAT_TURN_TIMEOUT_MAX,
+                ),
+                tool_approval_timeout_secs=_safe_int(
+                    agent_data.get("tool_approval_timeout_secs", 600),
+                    600,
+                    TOOL_APPROVAL_TIMEOUT_MIN,
+                    TOOL_APPROVAL_TIMEOUT_MAX,
                 ),
                 subagent_cost_gb=_safe_float(agent_data.get("subagent_cost_gb", 0.5), 0.5),
                 subagent_cpu_cost_cores=_safe_float(

--- a/src/kiro_crew/constants.py
+++ b/src/kiro_crew/constants.py
@@ -44,6 +44,16 @@ DATA_WARNING = (
 # work, not a "this turn took too long" guard.
 CHAT_TURN_TIMEOUT = 7200.0
 
+# How long the dashboard chat path parks a turn waiting for a human to answer a
+# tool-approval prompt, when config is unavailable (tests, early bootstrap).
+# Deliberately far below ``CHAT_TURN_TIMEOUT``: a window at or above the turn
+# ceiling can never fire, because the turn is cut first and reports itself as a
+# turn timeout, so the real cause (nobody approved) is never named. It also has
+# to leave the turn enough time to act on a late answer — an approval granted at
+# the ceiling buys a turn that is already over. ``agent.tool_approval_timeout_secs``
+# overrides it and is clamped below the turn ceiling at load time.
+TOOL_APPROVAL_TIMEOUT = 600.0
+
 # How long any caller waits for a compaction to report completed/failed —
 # the default of ``LLMProvider.wait_for_compaction`` and the cap on the
 # automatic context-threshold compaction in ``session.py``. Manual (/compact,

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -131,7 +131,12 @@ from kiro_crew.dashboard.state import (
     unsafe_bash_reason,
 )
 from kiro_crew.dashboard.steer_settle import settle_consumed_steers
-from kiro_crew.dashboard.turn_dispatch import spawn_guarded_turn
+from kiro_crew.dashboard.turn_dispatch import (
+    format_approval_no_budget_card,
+    format_approval_timeout_card,
+    spawn_guarded_turn,
+    tool_approval_timeout_secs,
+)
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import (
     HOOK_EVENT_AGENT_SPAWN,
@@ -4637,8 +4642,9 @@ async def _run_chat(
                 # Mirror the prompt to the linked Slack thread so a user driving
                 # this session from Slack can actually answer it. Without this,
                 # the prompt only renders in the dashboard and a Slack-only user
-                # never sees it — the turn then parks here until the 2h timeout,
-                # holding the slot lock and silently dropping inbound messages.
+                # never sees it — the turn then parks here for the whole approval
+                # window, holding the slot lock and silently dropping inbound
+                # messages.
                 # The Slack click resolves THIS future (via state.resolve_approval);
                 # we remain the sole caller of approve_tool/reject_tool below.
                 _slack_approval_ts: str | None = None
@@ -4659,7 +4665,8 @@ async def _run_chat(
                             event.tool_input or "",
                         )
                         if _slack_approval_ts is None:
-                            # Delivery failed — do not silently park for 2h.
+                            # Delivery failed — do not park for the whole
+                            # approval window.
                             # Resolve the future now (reject) and tell the user
                             # the prompt could not be delivered, so they retry
                             # rather than wait. The dashboard still rendered the
@@ -4683,7 +4690,7 @@ async def _run_chat(
                         # Any failure before the future is resolved (ImportError,
                         # post_linked_approval raising, slot.append/push raising in
                         # the delivery-failure branch) would otherwise fall through
-                        # to the 2h wait_for with an unresolved future — the exact
+                        # to the approval wait_for with an unresolved future — the exact
                         # wedge this fix prevents. Auto-reject so the turn unblocks,
                         # mirroring the _slack_approval_ts is None branch.
                         logger.warning("Error mirroring approval prompt to Slack", exc_info=True)
@@ -4700,11 +4707,39 @@ async def _run_chat(
                 # "rejected" is the correct reading: a cancelled turn never
                 # obtained consent.
                 outcome = "rejected"
+                _approval_window = tool_approval_timeout_secs()
+                _approval_card: str | None = None
                 try:
-                    outcome = await asyncio.wait_for(fut, timeout=7200.0)
+                    if _approval_window <= 0:
+                        # Too little of the turn left to both wait and report.
+                        # Waiting anyway guarantees the ceiling fires first and
+                        # relabels the unanswered approval as a turn timeout.
+                        logger.warning(
+                            "Declining approval for %r without waiting: no turn budget left",
+                            event.title,
+                        )
+                        _approval_card = format_approval_no_budget_card()
+                    else:
+                        outcome = await asyncio.wait_for(fut, timeout=_approval_window)
                 except asyncio.TimeoutError:
                     outcome = "rejected"
+                    # Name the real cause. An unanswered prompt used to be
+                    # indistinguishable from a generic turn timeout, because the
+                    # window outlived the turn ceiling and the turn always died
+                    # first — so an unattended run burned the full ceiling and
+                    # the user was never told an approval was waiting.
+                    logger.warning(
+                        "Tool approval for %r went unanswered for %.0fs; declining",
+                        event.title,
+                        _approval_window,
+                    )
+                    _approval_card = format_approval_timeout_card(_approval_window)
                 finally:
+                    if _approval_card is not None:
+                        try:
+                            slot.append("error", _approval_card, "msg msg-err")
+                        except Exception:
+                            logger.debug("Failed to render approval card", exc_info=True)
                     slot._approval_futures.pop(str(event.request_id), None)
                     # Backstop: the future is now gone, so the permission
                     # message MUST NOT be left reading pending — the UI would
@@ -4713,8 +4748,8 @@ async def _run_chat(
                     # resolvers (HTTP slot-approve, Slack click) already mark it
                     # and record richer decisions like "trust"/"yolo", so only
                     # write when still pending. This is the sole marker for the
-                    # paths that resolve the future in-process: the 2h timeout
-                    # above and the Slack-delivery auto-reject branches.
+                    # paths that resolve the future in-process: the approval
+                    # timeout above and the Slack-delivery auto-reject branches.
                     _approved = outcome in ("approved", "approved_trust_reads")
                     if _mark_permission_resolved(
                         slot.messages,

--- a/src/kiro_crew/dashboard/turn_dispatch.py
+++ b/src/kiro_crew/dashboard/turn_dispatch.py
@@ -29,13 +29,40 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Coroutine
+from contextvars import ContextVar
 from typing import Any
 
 from kiro_crew.acp.client import _DEFAULT_PROMPT_TIMEOUT
-from kiro_crew.config.loader import KiroCrewConfig
-from kiro_crew.constants import CHAT_TURN_TIMEOUT
+from kiro_crew.config.loader import (
+    APPROVAL_TURN_MARGIN_SECS,
+    TOOL_APPROVAL_TIMEOUT_MIN,
+    KiroCrewConfig,
+)
+from kiro_crew.constants import CHAT_TURN_TIMEOUT, TOOL_APPROVAL_TIMEOUT
 
 logger = logging.getLogger(__name__)
+
+# Absolute ``loop.time()`` deadline of the turn currently running, published by
+# :func:`_bounded_turn` so code INSIDE the turn can size its own waits against
+# the budget that is actually left. ``None`` outside a bounded turn (the OpenAI
+# compatibility path bounds its turn with a bare ``wait_for``, and unit tests
+# call the resolvers directly), in which case callers fall back to the
+# ceiling-relative bound.
+_TURN_DEADLINE: ContextVar[float | None] = ContextVar("kirocrew_turn_deadline", default=None)
+
+
+def _turn_budget_remaining() -> float | None:
+    """Seconds left in the running turn, or ``None`` when that is unknowable."""
+    deadline = _TURN_DEADLINE.get()
+    if deadline is None:
+        return None
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No loop: the deadline is on the same clock as ``loop.time()`` and
+        # cannot be compared to anything here.
+        return None
+    return deadline - loop.time()
 
 
 def _acp_prompt_ceiling() -> float:
@@ -81,6 +108,103 @@ def chat_turn_timeout_secs() -> float:
         )
         return acp_ceiling
     return configured
+
+
+def tool_approval_timeout_secs() -> float:
+    """Resolve how long a turn waits for a human to answer an approval prompt.
+
+    Reads ``agent.tool_approval_timeout_secs``, falling back to
+    :data:`TOOL_APPROVAL_TIMEOUT` when config is unavailable (tests, early
+    bootstrap) so a config-less context behaves exactly like a default config.
+
+    The value is bounded twice, because two different things can make it
+    outlive the turn it belongs to:
+
+    * against the turn ceiling :func:`chat_turn_timeout_secs` resolves. The
+      config loader already applies this to the two config fields; repeating it
+      here catches a RESOLVED ceiling lower than the configured one (the ACP
+      transport's prompt timeout clamps it).
+    * against the budget REMAINING in the turn that is already running. A prompt
+      arming late in a long agentic turn has far less than the full ceiling left,
+      so a ceiling-relative bound alone still lets the turn die first — the exact
+      failure this window exists to prevent. Returns ``0.0`` when less than the
+      margin remains: there is no window that can both wait and report, so the
+      caller declines immediately instead of pretending to wait.
+    """
+    try:
+        configured = float(KiroCrewConfig.load().agent.tool_approval_timeout_secs)
+    except Exception:
+        logger.debug("approval-window config unavailable; using default", exc_info=True)
+        configured = TOOL_APPROVAL_TIMEOUT
+    if configured <= 0:
+        # An approval prompt cannot be disabled by zeroing its window — that
+        # would make wait_for raise immediately and auto-decline every tool.
+        configured = TOOL_APPROVAL_TIMEOUT
+    ceiling = chat_turn_timeout_secs()
+    budget = max(float(TOOL_APPROVAL_TIMEOUT_MIN), ceiling - APPROVAL_TURN_MARGIN_SECS)
+    window = configured
+    if window > budget:
+        logger.warning(
+            "agent.tool_approval_timeout_secs=%.0fs leaves less than %ds under the "
+            "resolved %.0fs turn ceiling; capping at %.0fs so the approval deadline "
+            "lands inside the turn.",
+            configured,
+            APPROVAL_TURN_MARGIN_SECS,
+            ceiling,
+            budget,
+        )
+        window = budget
+    remaining = _turn_budget_remaining()
+    if remaining is None:
+        return window
+    arm_budget = max(0.0, remaining - APPROVAL_TURN_MARGIN_SECS)
+    if arm_budget < window:
+        # Normal operation on a long turn, not a misconfiguration.
+        logger.info(
+            "Approval window shortened from %.0fs to %.0fs: %.0fs left in the turn.",
+            window,
+            arm_budget,
+            remaining,
+        )
+        return arm_budget
+    return window
+
+
+def format_approval_no_budget_card() -> str:
+    """User-facing text for a prompt that arrived with no time left to answer it.
+
+    Distinct from :func:`format_approval_timeout_card` because nothing was
+    waited on: the turn was already close enough to its ceiling that any wait
+    would have been cut by the ceiling and misreported as a turn timeout.
+    """
+    return (
+        "⏱️ A tool needed your approval, but this turn was too close to its time "
+        "limit to wait for an answer, so I declined it on your behalf and carried "
+        "on from the denial — nothing was rolled back. If you wanted that tool to "
+        "run, send the message again: the fresh turn has a full window to ask you "
+        "properly."
+    )
+
+
+def format_approval_timeout_card(timeout_secs: float) -> str:
+    """User-facing text for an approval prompt nobody answered in time.
+
+    Deliberately distinct from :func:`format_turn_timeout_card`: the two used to
+    be indistinguishable to the user because the approval window outlived the
+    turn, so an unanswered prompt always surfaced as a generic turn timeout and
+    the actual cause — and the fix, resending — was never stated.
+    """
+    if timeout_secs >= 3600:
+        waited = f"{timeout_secs / 3600:.1f}".rstrip("0").rstrip(".") + " hours"
+    else:
+        waited = f"{max(1, round(timeout_secs / 60))} minutes"
+    return (
+        f"⏱️ A tool needed your approval and nothing came back within {waited}, "
+        "so I declined it on your behalf and carried on from the denial — nothing "
+        "was rolled back. If you wanted that tool to run, send the message again "
+        "and approve the prompt when it appears, or turn on YOLO mode first for an "
+        "unattended run."
+    )
 
 
 def format_turn_timeout_card(timeout_secs: float) -> str:
@@ -163,7 +287,6 @@ async def _bounded_turn(coro: "Coroutine[Any, Any, Any]", timeout_secs: float) -
     shared with the user's Stop button.
     """
     loop = asyncio.get_running_loop()
-    task: "asyncio.Task[Any]" = asyncio.ensure_future(coro)
     deadline_fired = False
 
     def _on_deadline() -> None:
@@ -172,6 +295,14 @@ async def _bounded_turn(coro: "Coroutine[Any, Any, Any]", timeout_secs: float) -
             deadline_fired = True
             task.cancel()
 
+    # Published so anything running INSIDE the turn can size its own waits
+    # against the budget that is actually left, rather than against the
+    # full-length ceiling. Set before the task is created so the task's context
+    # copy carries it; reset in the finally so a direct `await _bounded_turn(...)`
+    # cannot leak a spent deadline into the caller's context and starve the next
+    # turn dispatched there.
+    deadline_token = _TURN_DEADLINE.set(loop.time() + timeout_secs)
+    task: "asyncio.Task[Any]" = asyncio.ensure_future(coro)
     handle = loop.call_later(timeout_secs, _on_deadline)
     try:
         try:
@@ -191,6 +322,7 @@ async def _bounded_turn(coro: "Coroutine[Any, Any, Any]", timeout_secs: float) -
         return result
     finally:
         handle.cancel()
+        _TURN_DEADLINE.reset(deadline_token)
         if not task.done():
             # The wrapper itself was cancelled; don't orphan the turn.
             task.cancel()

--- a/test/test_dashboard_approval_window.py
+++ b/test/test_dashboard_approval_window.py
@@ -1,0 +1,323 @@
+"""The dashboard chat path's tool-approval window.
+
+Three properties, one per failure mode observed in production:
+
+1. The window is CONFIGURABLE and short by default. It used to be a literal
+   ``7200.0`` in ``chat_runner``, identical to the turn ceiling.
+2. It is CLAMPED below the turn ceiling. A window at or above the ceiling can
+   never fire — the turn is cut first — so it is not a longer wait, it is a
+   wait that never reports.
+3. Its timeout says an APPROVAL went unanswered and to resend, rather than
+   borrowing the generic turn-timeout wording.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+
+import pytest
+
+from kiro_crew.config.loader import (
+    APPROVAL_TURN_MARGIN_SECS,
+    TOOL_APPROVAL_TIMEOUT_MAX,
+    TOOL_APPROVAL_TIMEOUT_MIN,
+    AgentConfig,
+    _clamp_security_bounds,
+)
+from kiro_crew.constants import CHAT_TURN_TIMEOUT, TOOL_APPROVAL_TIMEOUT
+from kiro_crew.dashboard import turn_dispatch as td
+
+
+class _Cfg:
+    """Minimal stand-in for the loaded config the resolvers read."""
+
+    def __init__(self, *, window: int, turn: int = 7200) -> None:
+        self.agent = AgentConfig()
+        self.agent.tool_approval_timeout_secs = window
+        self.agent.chat_turn_timeout_secs = turn
+
+
+@pytest.fixture
+def cfg(monkeypatch: pytest.MonkeyPatch):
+    """Point both resolvers at a synthetic config."""
+
+    def _apply(*, window: int, turn: int = 7200) -> None:
+        monkeypatch.setattr(
+            td.KiroCrewConfig, "load", staticmethod(lambda: _Cfg(window=window, turn=turn))
+        )
+
+    return _apply
+
+
+class TestDefaultsAreShort:
+    def test_constant_and_config_default_agree(self) -> None:
+        """The fallback constant and the config default must not drift apart.
+
+        Two independent spellings of "600" exist by necessity — the constant
+        serves config-less contexts — so pin them to each other.
+        """
+        assert TOOL_APPROVAL_TIMEOUT == float(AgentConfig().tool_approval_timeout_secs)
+
+    def test_default_leaves_room_under_the_turn_ceiling(self) -> None:
+        assert TOOL_APPROVAL_TIMEOUT <= CHAT_TURN_TIMEOUT - APPROVAL_TURN_MARGIN_SECS
+
+    def test_no_hardcoded_window_left_in_the_runner(self) -> None:
+        """The runner must resolve the window, not inline a literal.
+
+        The bug was exactly an inlined ``7200.0`` here, invisible to config.
+        """
+        from kiro_crew.dashboard import chat_runner
+
+        src = inspect.getsource(chat_runner._run_chat)
+        assert "wait_for(fut, timeout=7200.0)" not in src
+        # Resolved into a local, not inlined into the await: the timeout card
+        # has to report the SAME number the wait actually used.
+        assert "_approval_window = tool_approval_timeout_secs()" in src
+
+
+class TestResolver:
+    def test_reads_config(self, cfg) -> None:
+        cfg(window=300)
+        assert td.tool_approval_timeout_secs() == 300.0
+
+    def test_falls_back_when_config_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boom() -> None:
+            raise RuntimeError("no config")
+
+        monkeypatch.setattr(td.KiroCrewConfig, "load", staticmethod(_boom))
+        assert td.tool_approval_timeout_secs() == TOOL_APPROVAL_TIMEOUT
+
+    def test_non_positive_window_falls_back(self, cfg) -> None:
+        """Zero would make wait_for raise at once and auto-decline every tool."""
+        cfg(window=0)
+        assert td.tool_approval_timeout_secs() == TOOL_APPROVAL_TIMEOUT
+
+    def test_capped_under_the_resolved_turn_ceiling(
+        self, cfg, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A window inside its config bound can still outlive a LOWERED ceiling.
+
+        The loader clamps against the CONFIGURED ceiling; the resolved one can
+        be lower (the ACP prompt timeout clamps it), which is why the resolver
+        repeats the check instead of trusting load-time alone.
+        """
+        cfg(window=3600, turn=1200)
+        with caplog.at_level(logging.WARNING, logger=td.logger.name):
+            assert td.tool_approval_timeout_secs() == 1200.0 - APPROVAL_TURN_MARGIN_SECS
+        assert "tool_approval_timeout_secs" in caplog.text
+
+    def test_cap_never_falls_below_the_floor(self, cfg) -> None:
+        cfg(window=3600, turn=60)
+        assert td.tool_approval_timeout_secs() == float(TOOL_APPROVAL_TIMEOUT_MIN)
+
+
+class TestLoadTimeClamp:
+    def test_window_at_the_ceiling_is_clamped(self, caplog: pytest.LogCaptureFixture) -> None:
+        data = {"agent": {"tool_approval_timeout_secs": 7200, "chat_turn_timeout_secs": 7200}}
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.config.loader"):
+            _clamp_security_bounds(data)
+        assert data["agent"]["tool_approval_timeout_secs"] == 7200 - APPROVAL_TURN_MARGIN_SECS
+        assert "can never fire" in caplog.text
+
+    def test_window_clamped_against_a_lowered_ceiling(self) -> None:
+        data = {"agent": {"tool_approval_timeout_secs": 1800, "chat_turn_timeout_secs": 900}}
+        _clamp_security_bounds(data)
+        assert data["agent"]["tool_approval_timeout_secs"] == 900 - APPROVAL_TURN_MARGIN_SECS
+
+    def test_default_window_survives_the_default_ceiling(self) -> None:
+        """An in-range pair must be left byte-identical."""
+        data = {"agent": {"tool_approval_timeout_secs": 600, "chat_turn_timeout_secs": 7200}}
+        _clamp_security_bounds(data)
+        assert data["agent"]["tool_approval_timeout_secs"] == 600
+
+    def test_absent_ceiling_uses_the_field_default(self) -> None:
+        """Omitting the ceiling must not disable the cross-field clamp."""
+        data = {"agent": {"tool_approval_timeout_secs": 7200}}
+        _clamp_security_bounds(data)
+        assert data["agent"]["tool_approval_timeout_secs"] == 7200 - APPROVAL_TURN_MARGIN_SECS
+
+    def test_static_bounds_applied_first(self) -> None:
+        """The generic range clamp still runs on this field."""
+        data = {"agent": {"tool_approval_timeout_secs": 1}}
+        _clamp_security_bounds(data)
+        assert data["agent"]["tool_approval_timeout_secs"] == TOOL_APPROVAL_TIMEOUT_MIN
+
+        data = {"agent": {"tool_approval_timeout_secs": TOOL_APPROVAL_TIMEOUT_MAX * 10}}
+        _clamp_security_bounds(data)
+        # Static ceiling first, then the cross-field margin.
+        assert (
+            data["agent"]["tool_approval_timeout_secs"]
+            == TOOL_APPROVAL_TIMEOUT_MAX - APPROVAL_TURN_MARGIN_SECS
+        )
+
+    def test_bool_window_is_left_to_dataclass_coercion(self) -> None:
+        """``true`` is not a real window; the clamp must not arithmetic on it."""
+        data = {"agent": {"tool_approval_timeout_secs": True}}
+        _clamp_security_bounds(data)
+        assert data["agent"]["tool_approval_timeout_secs"] is True
+
+    def test_non_int_ceiling_falls_back_to_the_default(self) -> None:
+        data = {"agent": {"tool_approval_timeout_secs": 7200, "chat_turn_timeout_secs": "lots"}}
+        _clamp_security_bounds(data)
+        assert data["agent"]["tool_approval_timeout_secs"] == 7200 - APPROVAL_TURN_MARGIN_SECS
+
+
+class TestArmTimeBudget:
+    """The window must fit the budget LEFT in the turn, not the full ceiling.
+
+    A ceiling-relative bound alone still lets a prompt arming late in a long
+    agentic turn outlive that turn — the same mislabeled turn timeout the whole
+    change exists to prevent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_late_arming_prompt_is_shortened_to_fit(self, cfg) -> None:
+        cfg(window=600, turn=7200)
+        loop = asyncio.get_running_loop()
+        # 300s left of a 2h turn: a 600s window would outlive it.
+        token = td._TURN_DEADLINE.set(loop.time() + 300.0)
+        try:
+            got = td.tool_approval_timeout_secs()
+        finally:
+            td._TURN_DEADLINE.reset(token)
+        assert got == pytest.approx(300.0 - APPROVAL_TURN_MARGIN_SECS, abs=1.0)
+
+    @pytest.mark.asyncio
+    async def test_no_budget_left_returns_zero(self, cfg) -> None:
+        """Under the margin there is no window that can both wait and report."""
+        cfg(window=600, turn=7200)
+        loop = asyncio.get_running_loop()
+        token = td._TURN_DEADLINE.set(loop.time() + 5.0)
+        try:
+            assert td.tool_approval_timeout_secs() == 0.0
+        finally:
+            td._TURN_DEADLINE.reset(token)
+
+    @pytest.mark.asyncio
+    async def test_early_prompt_keeps_the_configured_window(self, cfg) -> None:
+        cfg(window=600, turn=7200)
+        loop = asyncio.get_running_loop()
+        token = td._TURN_DEADLINE.set(loop.time() + 7200.0)
+        try:
+            assert td.tool_approval_timeout_secs() == 600.0
+        finally:
+            td._TURN_DEADLINE.reset(token)
+
+    def test_absent_deadline_falls_back_to_the_ceiling_bound(self, cfg) -> None:
+        """Paths that don't go through _bounded_turn must still get a window."""
+        cfg(window=600, turn=7200)
+        assert td._TURN_DEADLINE.get() is None
+        assert td.tool_approval_timeout_secs() == 600.0
+
+    @pytest.mark.asyncio
+    async def test_bounded_turn_publishes_then_clears_the_deadline(self) -> None:
+        """The turn's own coroutine sees a deadline; the caller's context does not.
+
+        The reset matters: `chat_orchestrator` awaits `_bounded_turn` directly,
+        so a leaked spent deadline would starve every later approval dispatched
+        in that same context.
+        """
+        seen: list[float | None] = []
+
+        async def _turn() -> str:
+            seen.append(td._turn_budget_remaining())
+            return "done"
+
+        assert await td._bounded_turn(_turn(), 120.0) == "done"
+        # Remaining is computed as (t + 120.0) - t', so float rounding can put it
+        # a hair ABOVE the timeout when both clock reads land on the same tick
+        # (Windows' coarse timer makes that the common case). Assert the budget
+        # is essentially the full window rather than pinning a strict bound.
+        assert seen and seen[0] is not None
+        assert seen[0] == pytest.approx(120.0, abs=1.0)
+        assert td._TURN_DEADLINE.get() is None
+
+    @pytest.mark.asyncio
+    async def test_deadline_cleared_even_when_the_turn_raises(self) -> None:
+        async def _boom() -> None:
+            raise ValueError("nope")
+
+        with pytest.raises(ValueError):
+            await td._bounded_turn(_boom(), 120.0)
+        assert td._TURN_DEADLINE.get() is None
+
+
+class TestNoBudgetCard:
+    def test_says_the_turn_had_no_time_and_to_resend(self) -> None:
+        text = td.format_approval_no_budget_card()
+        assert "approval" in text.lower()
+        assert "again" in text.lower()
+
+    def test_distinct_from_the_waited_timeout_card(self) -> None:
+        assert td.format_approval_no_budget_card() != td.format_approval_timeout_card(600.0)
+
+    def test_runner_declines_without_waiting_when_the_window_is_zero(self) -> None:
+        """A zero window must skip the await entirely, not pass 0 to wait_for."""
+        from kiro_crew.dashboard import chat_runner
+
+        src = inspect.getsource(chat_runner._run_chat)
+        idx = src.index("_approval_window = tool_approval_timeout_secs()")
+        branch = src[idx : idx + 1800]
+        assert "if _approval_window <= 0:" in branch
+        assert "format_approval_no_budget_card()" in branch
+        # The await must live on the else side of that guard.
+        assert branch.index("if _approval_window <= 0:") < branch.index("await asyncio.wait_for")
+
+
+class TestCardsMatchRealRecovery:
+    """Neither card may claim the turn stopped — the reject path continues it.
+
+    `_run_chat`'s rejected branch calls `reject_tool` and `continue`s the event
+    loop, so the agent is told the tool was denied and keeps working. Wording
+    that says "stopped" tells the user to expect lost work that never happened.
+    """
+
+    def test_neither_card_claims_the_turn_stopped(self) -> None:
+        for text in (td.format_approval_timeout_card(600.0), td.format_approval_no_budget_card()):
+            assert "stopped" not in text.lower()
+            assert "carried on" in text.lower()
+
+    def test_reject_path_really_continues(self) -> None:
+        """Guards the premise above: if the runner starts breaking, wording must change.
+
+        Anchored on the GENERIC rejection (the one a timed-out approval takes),
+        identified by its `_reject_label` append — not the invalid-tool-name or
+        hook-error branches above it, which deliberately `break`.
+        """
+        from kiro_crew.dashboard import chat_runner
+
+        src = inspect.getsource(chat_runner._run_chat)
+        idx = src.index('slot.append("tool", _reject_label, "msg msg-tool")')
+        tail = src[idx : idx + 1600]
+        assert "continue" in tail
+        assert tail.index("continue") < (tail.index("break") if "break" in tail else len(tail))
+
+
+class TestTimeoutCard:
+    def test_names_the_approval_and_the_fix(self) -> None:
+        text = td.format_approval_timeout_card(600.0)
+        assert "approval" in text.lower()
+        assert "10 minutes" in text
+        assert "again" in text.lower()
+
+    def test_distinct_from_the_turn_timeout_card(self) -> None:
+        """The two must not be confusable — that confusion WAS the bug."""
+        approval = td.format_approval_timeout_card(600.0)
+        turn = td.format_turn_timeout_card(600.0)
+        assert approval != turn
+        assert "hit the" not in approval
+
+    def test_hour_scale_wording(self) -> None:
+        assert "1.5 hours" in td.format_approval_timeout_card(5400.0)
+
+    def test_runner_renders_the_approval_card_on_timeout(self) -> None:
+        """The timeout branch must append the card, not fall through silently."""
+        from kiro_crew.dashboard import chat_runner
+
+        src = inspect.getsource(chat_runner._run_chat)
+        idx = src.index("_approval_window = tool_approval_timeout_secs()")
+        branch = src[idx : idx + 2000]
+        assert "except asyncio.TimeoutError:" in branch
+        assert "format_approval_timeout_card(_approval_window)" in branch

--- a/test/test_orphaned_approval_card.py
+++ b/test/test_orphaned_approval_card.py
@@ -130,8 +130,12 @@ class TestRunnerBackstopContract:
 
         src = inspect.getsource(chat_runner._run_chat)
         # The pre-seed must appear before the guarded await that follows it.
+        # Matched on the call SHAPE, not on the timeout value: the window is
+        # configurable (``agent.tool_approval_timeout_secs``), and pinning its
+        # literal made an unrelated retune of the window fail this test, which
+        # is about assignment ORDER and nothing else.
         preseed = src.index('outcome = "rejected"')
-        await_idx = src.index("await asyncio.wait_for(fut, timeout=7200.0)")
+        await_idx = src.index("await asyncio.wait_for(fut, timeout=")
         assert preseed < await_idx, (
             "outcome must be pre-seeded before the approval await so the "
             "finally backstop is total over cancellation"
@@ -152,7 +156,10 @@ class TestRunnerBackstopContract:
         async def approval_branch() -> None:
             outcome = "rejected"
             try:
-                outcome = await asyncio.wait_for(fut, timeout=7200.0)
+                # Value is irrelevant to the shape under test; the real site
+                # resolves it from config. Long enough that cancellation, not
+                # the deadline, is what ends the await.
+                outcome = await asyncio.wait_for(fut, timeout=600.0)
             except asyncio.TimeoutError:
                 outcome = "rejected"
             finally:


### PR DESCRIPTION
## 1. What is the problem?

The dashboard chat path waits **7200 seconds** for a human to answer a tool-approval
prompt, and that number was a literal in the code — not configurable:

```python
outcome = await asyncio.wait_for(fut, timeout=7200.0)   # chat_runner.py
```

`CHAT_TURN_TIMEOUT` is also 7200s, and the approval prompt is only armed some
seconds *into* the turn. So the approval deadline is always later than the turn
deadline, and **can never fire**. Any approval window at or above the turn ceiling
is invalid by definition: the turn is cut first, and the user is shown the generic
"this turn hit the 2-hour limit" card. The actual cause — nobody answered an
approval prompt — is never stated anywhere the user looks.

The dashboard is also the only surface with this hole. Slack/cron already
distinguish attended from unattended work (`_BACKGROUND_APPROVAL_SOURCES` +
`_BACKGROUND_APPROVAL_TIMEOUT_SECS = 180`, deny-fast); the dashboard chat path
never consults either.

Evidence from this machine: across 142 session files, **all 20** two-hour turn
deaths were examined against the SEL (`security_events.jsonl`). **17 of the 20 are
approval waits** — they show only `outcome='invoked'` with no matching
`auto_approved`. A healthy tool call is the triple
`invoked → auto_approved(reason=yolo) → refined`. The trigger is mundane: the YOLO
grant is an in-memory 6h TTL (`agent.yolo_duration='6h'`,
`dangerously_skip_permissions=False`), so a gateway restart silently drops it and
every subsequent shell tool needs a human.

## 2. Why this issue matters to the user

An unattended run — babysit, monitor, autonudge, an overnight PR loop — burns a
**full two hours of wall clock per prompt** and produces nothing. It then reports
the wrong cause, so the user retunes turn timeouts or hunts a "stuck tool" instead
of re-granting YOLO or clicking Approve.

Even for a user who *is* present, the 2h window was never worth having: an approval
granted at 1h55m leaves the turn about five minutes to do the work before the
ceiling kills it anyway.

## 3. How our fix solves it

Symptom → cause chain, and where each link is now cut:

| Link | Before | After |
|---|---|---|
| Window is unreachable in config | literal `7200.0` in `chat_runner` | `agent.tool_approval_timeout_secs`, default **600** |
| Window outlives the turn | 7200 vs a 7200 ceiling armed earlier | load-time cross-field clamp to `APPROVAL_TURN_MARGIN_SECS` (60s) **below** the turn ceiling, with a WARNING + SEL `config_bounds_clamped` |
| Expiry lies about the cause | fell through to the generic turn-timeout card | dedicated card: the approval went unanswered, resend the message, or enable YOLO for an unattended run |

Three deliberate design choices:

- **No "is anyone watching" flag.** The brief considered and rejected it. A 2h
  *attended* window is broken on its own terms (the turn dies first), so a short
  window that always reports correctly is right for both attended and unattended
  turns. This also avoids adding a second source-classification mechanism next to
  Slack's.
- **The clamp is enforced twice, deliberately, at two different ceilings.** The
  loader clamps the two *config* fields against each other, which is what makes it
  a startup check and what makes `GET /api/config/kirocrew` report the honest
  value. `turn_dispatch.tool_approval_timeout_secs()` re-caps against the
  **resolved** ceiling, which `chat_turn_timeout_secs()` can lower below the
  configured one (the ACP prompt timeout clamps it). A window inside its config
  bound could still outlive that lower ceiling — the same bug at a smaller scale.
- **The write gate is untouched.** Like `chat_turn_timeout_secs`, this key is not
  in the dashboard PUT allowlist, so it is file-edited only. Consistent with the
  sibling knob; no new API surface.

`state.py`'s `_APPROVAL_TIMEOUT = 7200` (the Slack/cron A-suite) is intentionally
**not** changed here — it already has the background deny-fast path, and merging
the two approval implementations is a larger refactor than this fix.

Four comments in the approval branch that asserted "2h" were rewritten to describe
the configured window, since they now name a number the code no longer uses.

## 4. What tests we did

New: `test/test_dashboard_approval_window.py` (19 tests, 4 classes)

- **Defaults**: `TOOL_APPROVAL_TIMEOUT` is pinned to the `AgentConfig` default so
  the two spellings of 600 cannot drift; the default is asserted to leave margin
  under `CHAT_TURN_TIMEOUT`; the runner is asserted to contain no inlined literal.
- **Resolver**: reads config, falls back when config raises, rejects a
  non-positive window, caps against a *lowered* resolved ceiling (with warning),
  and never caps below the floor.
- **Load-time clamp**: window at the ceiling, window against a lowered ceiling,
  in-range pair left byte-identical, ceiling absent → field default still clamps,
  static bounds applied before the cross-field margin, JSON `true` left to
  dataclass coercion, non-int ceiling falls back.
- **Card**: names the approval and the fix, is distinct from
  `format_turn_timeout_card`, hour-scale wording, and the runner's
  `except TimeoutError` branch actually renders it.

**Mutation-verified** — the guards were proven to bite, not just to pass:

| Mutation | Result |
|---|---|
| Put the hardcoded `7200.0` back in `chat_runner` | 1 failed ✅ |
| Delete the load-time cross-field clamp | 1 failed ✅ |
| Restored | 19 passed ✅ |

Pinned test fixed: `test/test_orphaned_approval_card.py:134` asserted assignment
ORDER (`outcome` pre-seeded before the guarded await, so the `finally` backstop
survives cancellation) but matched on
`src.index("await asyncio.wait_for(fut, timeout=7200.0)")` — pinning the timeout
value into a test about ordering. It now matches the call **shape**
(`"await asyncio.wait_for(fut, timeout="`), preserving exactly what it protected
while letting the window be retuned. The file's hand-written mirror harness was
moved off `7200.0` too, so it no longer implies that is production's value.

Gates, all green on the rebased tree (`3e82d2d15`, rebased onto `d49f5b72e`):

```
isort  0     flake8 0     mypy   0  (855 files, no faiss → CI parity)
tsc    0     vitest 859 files / 11436 passed
pytest 39372 passed, 77 failed
```

The 77 backend failures are host-environment, not from this change — proven by
A/B: reverting only my four source files to `kirocrew/main` and re-running the
failing subset gives the **same 23 failures** as the branch does (ops-mission-control
git sync, `gh`/`git` binary discovery, systemd service, `~/.kirocrew` path
assumptions). The one vitest error is a `DevFleetPage` toast timer firing after
jsdom teardown; the file passes in isolation and this PR touches zero frontend
files.

## 5. Any other suggestions on the work

Three follow-ups I did **not** fold in, to keep this fix reviewable:

1. **The two approval suites should converge.** `slack/gateway.py` (A-suite) and
   `dashboard/chat_runner.py` (B-suite) implement approval independently, with
   different timeouts and different source-awareness. This PR fixes B's window; it
   does not remove the duplication.
2. **`state.py:_APPROVAL_TIMEOUT = 7200`** has the same "window ≥ ceiling" smell on
   the A-suite side, mitigated only by the background deny-fast path.
3. **YOLO expiry is silent.** The 6h grant is in-memory, so a restart drops it with
   no notice; the operator discovers it as a stalled turn. A restart-survivable
   grant (or an expiry notice) would remove the trigger, not just bound the damage.
