### PR TITLE
fix(i18n): drop shebangs that break test collection on Windows

### DIFF
--- a/website/scripts/check-i18n-strings.mjs
+++ b/website/scripts/check-i18n-strings.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Untranslated-string gate. Two checks with different jobs:
  *

--- a/website/scripts/i18n-translate.mjs
+++ b/website/scripts/i18n-translate.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Translation driver: renders the committed prompt per (locale, shard), validates
  * filled shards, and drives `i18n-shard.mjs join` across every shipped locale.

--- a/website/src/test/scriptsShebang.test.ts
+++ b/website/src/test/scriptsShebang.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Guard: a script imported from `src/` must not open with a shebang.
+ *
+ * WHY THIS EXISTS. `scripts/check-i18n-strings.mjs` and `scripts/i18n-translate.mjs`
+ * began with `#!/usr/bin/env node`, and four i18n tests import them. On Windows,
+ * Vite's CJS interop prepends its generated requires to line 1, which pushes the
+ * shebang *after* executable code:
+ *
+ *   const fileURLToPath = __vite__cjsImport3_node_url["fileURLToPath"];#!/usr/bin/env node
+ *
+ * Rolldown then fails the parse with `Invalid Character '!'`. The failure mode is
+ * the bad kind: the importing file collects ZERO tests and reports "no tests"
+ * rather than a red assertion, so `unitLiterals`, `localeFormatting`,
+ * `untranslatedRatchet` and `translateDriver` silently stop gating anything.
+ * On Linux the transform leaves the shebang on its own line, so CI — which runs
+ * Linux only — cannot see it. That is precisely why this needs to be a test and
+ * not a convention.
+ *
+ * The shebangs were decorative. Every one of these files is mode 100644 (not
+ * executable) and is invoked as `node scripts/<name>.mjs` from package.json, so
+ * nothing was relying on them.
+ *
+ * `scripts/lib/*.mjs` — the modules this repo already extracted so gates could be
+ * shared with tests — carry no shebang. This test pins that pattern for the
+ * top-level scripts that tests reach into directly.
+ */
+
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+import { describe, it, expect } from 'vitest'
+
+const SRC = resolve(__dirname, '..')
+const WEBSITE = resolve(SRC, '..')
+
+/** Every `.ts`/`.tsx` under `src/`, which is the only place that imports scripts. */
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules') continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else if (/\.tsx?$/.test(entry)) out.push(full)
+  }
+  return out
+}
+
+/**
+ * Matches `from '../../scripts/x.mjs'` at any depth. Deliberately only `scripts/`:
+ * a shebang anywhere else is nobody's business, and a script NOT imported by the
+ * bundler is free to keep one.
+ */
+const IMPORT_RE = /from\s+['"](?:\.\.\/)+scripts\/([^'"]+)['"]/g
+
+describe('scripts imported from src (windows transform safety)', () => {
+  const imported = new Set<string>()
+  for (const file of walk(SRC)) {
+    const source = readFileSync(file, 'utf-8')
+    for (const m of source.matchAll(IMPORT_RE)) imported.add(m[1])
+  }
+
+  it('finds the script imports it is meant to guard', () => {
+    // A refactor that moves every import behind `scripts/lib/` would empty this
+    // set and make the assertion below vacuously true. Fail loudly instead.
+    expect(imported.size).toBeGreaterThan(0)
+  })
+
+  it('never imports a script that opens with a shebang', () => {
+    const offenders: string[] = []
+    for (const rel of [...imported].sort()) {
+      const full = join(WEBSITE, 'scripts', rel)
+      if (!existsSync(full)) continue // a bare specifier resolved elsewhere
+      const firstLine = readFileSync(full, 'utf-8').split('\n', 1)[0]
+      if (firstLine.startsWith('#!')) offenders.push(`scripts/${rel}: ${firstLine.trim()}`)
+    }
+    expect(
+      offenders,
+      'A shebang on an imported script breaks collection on Windows — Vite prepends its '
+      + 'CJS requires to line 1 and Rolldown fails on the "!". Drop the shebang (these '
+      + 'files are not executable and run as `node scripts/<name>.mjs`), or move the '
+      + 'imported exports into scripts/lib/ the way qa-checks.mjs did.\n  '
+      + offenders.join('\n  '),
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

`scripts/check-i18n-strings.mjs` and `scripts/i18n-translate.mjs` open with
`#!/usr/bin/env node`. Four i18n tests import them. On Windows, Vite's CJS interop
prepends its generated requires to line 1, which leaves the shebang sitting after
executable code:
const fileURLToPath = __vite__cjsImport3_node_url["fileURLToPath"];#!/usr/bin/env node
^ Invalid Character !

Rolldown fails the parse, and the importing file collects **zero tests**, reporting
`no tests` rather than a red assertion.
## Why it matters
Four gates stop gating on Windows, silently:
- `unitLiterals`, the number+unit literal ceiling
- `localeFormatting`
- `untranslatedRatchet`
- `translateDriver`
A green local run on Windows means nothing for those four, and the failure announces
itself as `no tests` rather than as an error. CI is Linux-only, where the transform
leaves the shebang on its own line, so nothing catches it there either. Given #2297
and #2301, Windows contributors are a real constituency.
## What changed (motivation → approach → change)
**Root cause:** a shebang is only legal on line 1, and the CJS transform takes line 1.
**Change:** delete both shebangs. They were decorative. Both files are mode `100644`
(not executable) and every invocation goes through `node scripts/<name>.mjs` from
`package.json`, so nothing could have executed them directly. The modules already
extracted so gates can be shared with tests, `scripts/lib/*.mjs`, carry none, which is
the pattern this follows.
**Guard:** `src/test/scriptsShebang.test.ts` asserts that no script under `scripts/`
imported from `src/` opens with `#!`. A Linux-only CI cannot see this class of bug, so
a convention would not survive it.
Considered and not done: moving the imported exports into `scripts/lib/` the way
`qa-checks.mjs` did. That is arguably the better end state, but it touches four test
files and two scripts to fix a two-line defect. Happy to follow up if preferred.
## Tests
`src/test/scriptsShebang.test.ts`, two assertions:
- no imported script opens with a shebang. **Mutation-checked:** restoring either
  shebang fails it and names the file.
- the discovered import set is non-empty, so a future move behind `scripts/lib/`
  cannot make the guard vacuously green.
## Manual verification
| Check | Windows | Linux |
|---|---|---|
| 4 affected suites + guard | **0 collected → 119 passed** | 119 passed |
| Full `src/i18n/` suite | | 597 passed |
| `npm run check` | | 864 files passed |
| `npm run lint:i18n` | | normal report, exit 0 |
| `node scripts/i18n-translate.mjs` | | prints usage, exits clean |
The last two matter most. Removing a shebang from a file that gets run is how you break
a build, so both scripts were exercised the way `package.json` and the docs invoke them.
One unrelated failure in the full run: `unitLiterals` timed out at 19.7 s under
`--coverage` on a 16-core box. It passes in isolation and is untouched by this diff.
Same pre-existing flake reported in #2023, #1810 and #2159.
## Screenshots / video
N/A. No UI change.
## Related Issues
None open for this. Adjacent Windows issues: #2297, #2301.
## Checklist
- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable): N/A
- [x] No secrets, credentials, or internal references in the diff