### PR TITLE
fix: per-root hardlink-scan budgets with loud truncation (#646)

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -1471,6 +1471,16 @@ def main():
         # ── Step 7: Pre-exec hardlink scan ──
         # Scan the agent workspace + /tmp for hardlinks (nlink > 1) whose
         # inode matches a protected credential file. If found, refuse to exec.
+        # Only credential inodes with st_nlink > 1 enter the match set: an
+        # inode with a single link has no alias anywhere on the filesystem, so
+        # when every credential has nlink == 1 the walk is skipped entirely
+        # and the common healthy-host spawn pays nothing. When a walk does
+        # run, each root gets its OWN scan budget so a large workspace cannot
+        # starve the /tmp scan (the world-writable root this check exists
+        # for). On budget exhaustion the scan deliberately degrades OPEN with
+        # a stderr warning rather than failing closed: /tmp on a busy host can
+        # exceed any fixed budget from ordinary telemetry/cache churn, and
+        # exiting here would break every sandbox spawn on such hosts.
         _protected_inodes = set()
         for _pd in SENSITIVE_DIRS:
             if os.path.isdir(_pd):
@@ -1478,25 +1488,29 @@ def main():
                     for _fname in _files_scan:
                         try:
                             _st = os.stat(os.path.join(_root, _fname))
-                            _protected_inodes.add((_st.st_dev, _st.st_ino))
+                            if _st.st_nlink > 1:
+                                _protected_inodes.add((_st.st_dev, _st.st_ino))
                         except OSError:
                             pass
                     break  # depth=1 for credential dirs
         for _pf in SENSITIVE_FILES:
             try:
                 _st = os.stat(_pf)
-                _protected_inodes.add((_st.st_dev, _st.st_ino))
+                if _st.st_nlink > 1:
+                    _protected_inodes.add((_st.st_dev, _st.st_ino))
             except OSError:
                 pass
 
         if _protected_inodes:
-            _scan_count = 0
-            _MAX_SCAN = 10000
+            _MAX_SCAN_PER_ROOT = 100000
             _dangerous_links = []
+            _truncated_roots = []
             _cwd = os.getcwd()
             for _scan_root in (_cwd, "/tmp"):
                 if not os.path.isdir(_scan_root):
                     continue
+                _root_scanned = 0
+                _root_truncated = False
                 for _root2, _dirs2, _files2 in os.walk(_scan_root):
                     # Depth limit: max 5 levels
                     _depth = _root2[len(_scan_root):].count(os.sep)
@@ -1504,9 +1518,10 @@ def main():
                         _dirs2.clear()
                         continue
                     for _fn2 in _files2:
-                        _scan_count += 1
-                        if _scan_count > _MAX_SCAN:
+                        if _root_scanned >= _MAX_SCAN_PER_ROOT:
+                            _root_truncated = True
                             break
+                        _root_scanned += 1
                         _fp2 = os.path.join(_root2, _fn2)
                         try:
                             _st2 = os.lstat(_fp2)
@@ -1515,8 +1530,17 @@ def main():
                                     _dangerous_links.append(_fp2)
                         except OSError:
                             pass
-                    if _scan_count > _MAX_SCAN:
+                    if _root_truncated:
                         break
+                if _root_truncated:
+                    _truncated_roots.append((_scan_root, _root_scanned))
+            for _t_root, _t_count in _truncated_roots:
+                print(
+                    "sandbox: WARNING — pre-exec hardlink scan truncated at "
+                    "%d files in %s; scan incomplete (control degrades open)"
+                    % (_t_count, _t_root),
+                    file=sys.stderr,
+                )
             if _dangerous_links:
                 sys.exit(
                     f"sandbox: BLOCKED — found hardlink(s) to protected credential "

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -470,6 +470,101 @@ class TestBuildLauncherScript:
             ), f"{level}: launcher references un-importable module(s) {forbidden}"
 
 
+class TestHardlinkScanBudget:
+    """Step-7 pre-exec hardlink scan: per-root budgets + loud truncation.
+
+    The launcher needs ``unshare`` so it cannot run end-to-end in CI; these
+    are text/compile assertions on the generated script, the same pattern as
+    the other launcher-script tests above. A single budget shared across the
+    CWD and /tmp walks let a large worktree consume the whole budget before
+    /tmp (the world-writable root the check exists for) was scanned at all,
+    and an exhausted budget fell through to exec silently — a truncated scan
+    was indistinguishable from a clean one.
+    """
+
+    def test_shared_budget_counter_is_gone(self):
+        script = _build_launcher_script("strict")
+        assert "_scan_count > _MAX_SCAN" not in script
+        assert "_scan_count" not in script
+
+    def test_only_aliased_credential_inodes_arm_the_walk(self):
+        # An inode with st_nlink == 1 has no alias anywhere on the
+        # filesystem, so it must not enter the match set: when every
+        # credential has nlink == 1 the CWD + /tmp walk is skipped and the
+        # common healthy-host spawn pays nothing (and emits no truncation
+        # warning). Both collection loops (SENSITIVE_DIRS and
+        # SENSITIVE_FILES) carry the gate.
+        script = _build_launcher_script("strict")
+        assert script.count("if _st.st_nlink > 1:") == 2
+
+    def test_per_root_budget_covers_a_busy_tmp(self):
+        # The budget only applies once a credential inode is actually
+        # aliased (see the nlink gate above), so it can afford to be
+        # generous: 100k covers the busiest observed /tmp (~11.8k files)
+        # with an order of magnitude to spare, making truncation genuinely
+        # exceptional rather than a steady-state warning.
+        script = _build_launcher_script("strict")
+        assert "_MAX_SCAN_PER_ROOT = 100000" in script
+
+    def test_per_root_budget_with_counter_reset_inside_root_loop(self):
+        script = _build_launcher_script("strict")
+        assert "_MAX_SCAN_PER_ROOT" in script
+        # The counter reset must be a DIRECT child of the per-root loop body:
+        # each root gets exactly one fresh budget, so a large CWD cannot
+        # starve the /tmp scan. AST-based, because a byte-offset check cannot
+        # tell this apart from a reset nested inside the os.walk loop (which
+        # would reset per-directory and make the scan effectively unbounded).
+        root_loops = [
+            node
+            for node in ast.walk(ast.parse(script))
+            if isinstance(node, ast.For)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "_scan_root"
+        ]
+        assert len(root_loops) == 1
+        direct_assigns = [
+            stmt
+            for stmt in root_loops[0].body
+            if isinstance(stmt, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "_root_scanned"
+                for t in stmt.targets
+            )
+        ]
+        assert len(direct_assigns) == 1, (
+            "_root_scanned reset must sit directly in the per-root loop body"
+        )
+
+    def test_truncation_warns_on_stderr_without_exiting(self):
+        script = _build_launcher_script("strict")
+        assert "hardlink scan truncated" in script
+        assert "scan incomplete" in script
+        # The diagnostic goes to stderr, which the parent already captures.
+        warn_idx = script.index("hardlink scan truncated")
+        stderr_idx = script.index("file=sys.stderr", warn_idx)
+        # Deliberate fail-open: the truncation path warns, it never exits.
+        assert "sys.exit" not in script[warn_idx:stderr_idx]
+
+    def test_blocked_exit_path_for_found_hardlinks_still_present(self):
+        script = _build_launcher_script("strict")
+        assert "sandbox: BLOCKED — found hardlink" in script
+
+    def test_no_directory_pruning_in_the_scan(self):
+        # /tmp is world-writable and the sandboxed agent shares the uid, so
+        # any name- or prefix-based prune list is a deterministic bypass: the
+        # attacker just names their directory to match. The scan must visit
+        # every directory the depth limit allows; noisy trees are handled by
+        # the per-root budget + truncation warning, never by skipping.
+        script = _build_launcher_script("strict")
+        assert "_SKIP_TMP_DIR_PREFIXES" not in script
+
+    def test_generated_script_compiles_at_every_level(self):
+        # Proves the f-string brace escaping in the template produced
+        # syntactically valid Python for every sandbox level.
+        for level in ("strict", "standard", "cc"):
+            compile(_build_launcher_script(level), "<launcher>", "exec")
+
+
 class TestLauncherStdlibShadowing:
     """End-to-end: a sibling /tmp/struct.py must NOT crash the launcher.
 


### PR DESCRIPTION
## Problem
The Linux namespace sandbox's pre-exec hardlink scan (Step 7 of the launcher script generated by `_build_launcher_script`) walks the agent CWD and `/tmp` looking for hardlinks (`st_nlink > 1`) aliasing protected credential inodes. The walk was capped by a single counter (`_MAX_SCAN = 10000`) shared across BOTH roots, and on exhaustion the loops broke silently and fell through to `os.execvp` exactly as if the scan had passed clean.

## Why it matters
Two failure modes, both live in normal operation (issue evidence: `/tmp` alone held ~11.8k files from routine telemetry/cache churn — no attacker action needed):
1. A truncated scan was indistinguishable from a clean one — no stderr line, no audit signal.
2. The CWD is walked first and consumed the shared budget, so a large worktree starved `/tmp` — the world-writable root the check exists for — of any scanning at all.

## Fix (symptoms → root cause → change)
Silent degradation → one shared budget with a silent `break`, spent unconditionally on every spawn → three changes confined to the Step-7 scan block of the f-string launcher template in `src/kiro_crew/sandbox.py`:
1. **Arm the walk only when an alias can exist** — credential inodes enter the match set only when `st_nlink > 1`. A single-link inode has no alias anywhere on the filesystem, so on healthy hosts the whole CWD+`/tmp` walk is skipped and the spawn pays nothing. `st_nlink` is an inode property (any hardlink raises it on the shared inode), so the gate cannot miss a pre-existing alias; the BLOCKED-exit input set is unchanged for any filesystem state stable across the scan (the walk side already required `st_nlink > 1` to match).
2. **Independent per-root budgets, sized for the suspicious case** — `_MAX_SCAN_PER_ROOT = 100000` with `_root_scanned` reset per `_scan_root`, so a large CWD can never zero out the `/tmp` scan, and the budget (only ever paid when a credential is actually aliased) covers the busiest observed `/tmp` with an order of magnitude to spare. Worst case ≤200k `lstat`s in the child pre-exec, off the gateway loop.
3. **Loud, observable truncation** — one stderr diagnostic per truncated root (`sandbox: WARNING — pre-exec hardlink scan truncated at N files in <root>; scan incomplete (control degrades open)`), captured by the parent's stderr drain. Deliberately fail-OPEN: exiting would break sandbox spawns on any host whose `/tmp` outgrows the budget; rationale documented in the block comment.

Deliberately **not** included: pruning "known-noise" `/tmp` subtrees by name prefix. `/tmp` is world-writable and the sandboxed agent shares the uid, so any name-based skip list is a deterministic bypass (plant the hardlink under `/tmp/node-compile-cache-evil/`). Both pre-push reviewers flagged this independently; a regression test pins the absence of any prune list.

## Tests
`test/test_sandbox_argv.py::TestHardlinkScanBudget` (8 tests, same generated-script text/compile-assertion pattern as the other launcher tests — the launcher needs `unshare` and cannot run end-to-end in CI). Red-checked against unfixed code.
- shared `_scan_count`/`_MAX_SCAN` counter is gone
- both collection loops carry the `st_nlink > 1` gate (exactly 2 occurrences)
- `_MAX_SCAN_PER_ROOT = 100000` present
- AST assertion that the `_root_scanned = 0` reset is a DIRECT child of the `for _scan_root` loop body (a byte-offset check could not distinguish a per-root reset from a per-directory one nested in the `os.walk` loop)
- truncation warning literal present, routed to stderr, with no `sys.exit` on that path
- regression guard: `sandbox: BLOCKED — found hardlink` exit path unchanged
- no directory pruning: `_SKIP_TMP_DIR_PREFIXES` absent from the generated script
- `compile(script, "<launcher>", "exec")` at all three sandbox levels proves the f-string brace escaping produced valid Python

## Manual verification
N/A — unit coverage sufficient: the changed logic is fully exercised through the generated-script assertions plus `compile()`; the walk itself runs in the sandbox child pre-`execvp` and needs `unshare`, which CI lacks. Full backend gates (isort/flake8/mypy/pytest) green locally; pytest failures on the dev host are identical to a clean `origin/main` baseline (pre-existing environment failures, zero overlap with this change).

## Screenshots
N/A — no UI change.

## Out of scope (per issue)
Per-session private `/tmp` namespace; periodic `/tmp` junk sweep in session maintenance.

Closes #646
