### PR TITLE
fix: make revocation generation cover refresh tokens (#2028)

### DIFF
--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -342,15 +342,16 @@ service installer such as `cloudflared service install`).
 > tunnelled browser that keeps rotating stays authenticated for as long as it
 > keeps being used.
 >
-> **`kirocrew logout` does not end that.** It revokes access sessions, but it does
-> not revoke refresh chains, so a browser still holding a valid refresh cookie can
-> obtain a fresh access cookie afterwards. Restarting the gateway does not end them
-> either: a refresh cookie is self-contained and signed with the persistent
-> `token_signing.key`. Only the dashboard's own sign-out
-> (`POST /api/auth/logout`) revokes a chain, and only the chain belonging to the
-> browser that calls it. **To cut off remote access, revoke at the provider's auth
-> layer or tear the tunnel down.** This is a known gap rather than intended
-> behaviour, so check the current release notes before relying on it.
+> **`kirocrew logout` ends those sessions.** It bumps a persisted revocation
+> generation that both access and refresh tokens embed, so established access
+> cookies and refresh chains alike are rejected on their next request. The
+> dashboard's own sign-out (`POST /api/auth/logout`) is the narrower control:
+> it revokes only the chain belonging to the browser that calls it. Restarting
+> the gateway ends nothing: cookies are self-contained, signed with the
+> persistent `token_signing.key`, and the revocation generation is reloaded
+> unchanged. **To cut off remote access entirely, also revoke at the provider's
+> auth layer or tear the tunnel down** — logout ends Kiro Crew's sessions, not
+> the tunnel itself.
 > Note also that config-write and secret-reveal endpoints refuse tunnelled requests:
 > `is_direct_local_request()` treats any request carrying `Forwarded` /
 > `X-Forwarded-*` / `X-Real-IP` as remote, and every standard tunnel and reverse
@@ -405,13 +406,15 @@ an error. `kirocrew token` defaults straight to `20h`. The 5-minute click window
 is not the session length: it only means a link left sitting in a DM overnight is
 dead and you need a fresh one.
 
-**When you do need a fresh link.** Three things end a refresh chain:
+**When you do need a fresh link.** Four things end a refresh chain:
 
 - **30 days idle** — nothing opened the dashboard inside the window.
 - **Signing out in the dashboard** (`POST /api/auth/logout`) — revokes that
-  browser's chain and denylists its access cookie. `kirocrew logout` is **not**
-  equivalent: it ends access sessions globally but leaves refresh chains live, so
-  a browser still holding one mints a fresh access cookie on its next refresh.
+  browser's chain and denylists its access cookie, leaving other browsers'
+  sessions alive.
+- **`kirocrew logout`** — ends **all** sessions globally, refresh chains
+  included: it bumps a persisted revocation generation that every access and
+  refresh token embeds, so tokens minted before the logout are rejected.
 - **Reuse detection** — a consumed refresh token replayed outside a 60-second
   same-IP grace window (`REFRESH_GRACE_SECS`) auto-revokes the entire chain
   (RFC 6819 §5.2.2.3). The frontend reports `refresh_chain_revoked` and stops

--- a/docs/guides/slack-setup.md
+++ b/docs/guides/slack-setup.md
@@ -461,19 +461,19 @@ Dashboard tokens grant full session access, so treat them like passwords.
 | ✅ Do | ❌ Don't |
 |-------|----------|
 | Keep the dashboard behind your own tunnel or reverse proxy | Share dashboard URLs, which carry the token in `?token=` |
-| If a token is exposed, revoke at your tunnel or reverse-proxy auth layer — `kirocrew logout` alone does not end refresh sessions | Paste tokens in Slack channels, shared docs, or wikis |
+| If a token is exposed, run `kirocrew logout` (ends all sessions, refresh chains included) and revoke at your tunnel or reverse-proxy auth layer | Paste tokens in Slack channels, shared docs, or wikis |
 | Avoid showing the browser URL bar during screen shares | Leave dashboard links in screen-share recordings |
 | Leave the built-in `kirocrew token` deny rules enabled | Trust an AI agent that asks to run `kirocrew token` |
 
-`kirocrew logout` revokes every issued **access** cookie, not just in-memory
-state: it bumps a persisted revocation generation, so access cookies handed out
-before the logout are rejected on their next request. It does **not** revoke
-refresh chains, and neither does restarting the gateway, so a browser still
-holding a valid `mc_refresh_<port>` cookie can obtain a fresh access cookie
-afterwards — see
-[remote-and-mobile.md](remote-and-mobile.md#session-duration). To cut off an
-exposed dashboard, revoke at your tunnel or reverse-proxy auth layer, or sign out
-in that browser (`POST /api/auth/logout`), which does revoke its chain.
+`kirocrew logout` ends every issued session, not just in-memory state: it bumps
+a persisted revocation generation that both access cookies and
+`mc_refresh_<port>` refresh tokens embed, so cookies handed out before the
+logout — refresh chains included — are rejected on their next request. See
+[remote-and-mobile.md](remote-and-mobile.md#session-duration). Restarting the
+gateway ends nothing (the generation reloads unchanged). To cut off an exposed
+dashboard completely, also revoke at your tunnel or reverse-proxy auth layer;
+to end just one browser's session, sign out in that browser
+(`POST /api/auth/logout`), which revokes its chain alone.
 
 > ⚠️ **Prompt injection risk**: an attacker can hide instructions in a webpage or
 > document that trick your agent into running `kirocrew token` and exfiltrating

--- a/docs/system-specs/features/dashboard-token-auth.md
+++ b/docs/system-specs/features/dashboard-token-auth.md
@@ -4,7 +4,7 @@
 
 Token authentication for the Kiro Crew dashboard. The owner mints a time-limited, HMAC-SHA256 signed URL from the CLI (`kirocrew token`) or via the `!dashboard` Slack command (currently the only chat channel that mints links). An aiohttp middleware validates the token on every request (query param or cookie fallback), sets a session cookie on first use, and pins the token to the client's IP. Static assets bypass checks. Loopback access (127.0.0.1) is always trusted regardless of mode — this ensures local processes (mcp-core, doctor, SSH tunnels) work without tokens. All generation and validation events are logged to SEL.
 
-Up to `MAX_CONCURRENT_NONCES` (50) link nonces can be valid concurrently (FIFO eviction via `OrderedDict` when the limit is exceeded), allowing multiple browser tabs and CLI sessions without invalidating each other. All in-memory link-session state is managed by a thread-safe `TokenStateManager`. Auth is **not** purely in-memory: the HMAC signing key is the **persistent** `token_signing.key` (mode `0600`) and revoked access-cookie nonces persist to `token_revoked_nonces.json` (mode `0600`), so signed cookies and per-session logouts both survive a gateway restart. Users can revoke a single session — access cookie **and** its refresh chain — via `POST /api/auth/logout`, or all **access** sessions via `kirocrew logout`. Note that `kirocrew logout` does not revoke refresh chains, so a browser holding a valid refresh cookie can still mint a new access cookie.
+Up to `MAX_CONCURRENT_NONCES` (50) link nonces can be valid concurrently (FIFO eviction via `OrderedDict` when the limit is exceeded), allowing multiple browser tabs and CLI sessions without invalidating each other. All in-memory link-session state is managed by a thread-safe `TokenStateManager`. Auth is **not** purely in-memory: the HMAC signing key is the **persistent** `token_signing.key` (mode `0600`) and revoked access-cookie nonces persist to `token_revoked_nonces.json` (mode `0600`), so signed cookies and per-session logouts both survive a gateway restart. Users can revoke a single session — access cookie **and** its refresh chain — via `POST /api/auth/logout`, or **all** sessions via `kirocrew logout`: the persisted revocation generation (`revocation_gen.py`) is embedded in both access and refresh tokens, and validation of either kind rejects a stale generation, so `kirocrew logout` ends established browser sessions and their refresh chains alike.
 
 The dashboard also issues a paired **refresh cookie** (`mc_refresh_{port}`, HttpOnly, path-restricted to `/api/auth`, up to 30-day TTL) alongside the access cookie on initial token-URL use. The SPA calls `POST /api/auth/refresh` shortly before the access cookie expires to silently rotate both cookies (rotation-on-use), so users only re-run `!dashboard` / `kirocrew token` roughly once per 30 idle days instead of every ~20h. Refresh tokens are HMAC-signed with the same persistent `token_signing.key` and enforce RFC 6819 §5.2.2.3 reuse detection: a consumed `jti` replayed outside a 60s same-IP multi-tab grace window auto-revokes the entire chain.
 
@@ -123,10 +123,11 @@ def try_consume(token: str) -> bool: ...
 
 def revoke_all_sessions() -> None: ...
     # Clears all nonces, IP bindings, and consumed tokens AND bumps the
-    # persisted revocation-generation counter, so every outstanding ACCESS
-    # cookie (for all users) is rejected. Used by `kirocrew logout`. Note this
-    # does NOT revoke refresh chains: validate_refresh_token() never consults
-    # the revocation generation, so a live refresh cookie survives it.
+    # persisted revocation-generation counter, so every outstanding cookie
+    # (for all users) is rejected. Used by `kirocrew logout`. The counter is
+    # authoritative over BOTH cookie types: validate_token() AND
+    # validate_refresh_token() reject a token whose embedded gen is stale, so
+    # the bump ends established access cookies and refresh chains alike.
 
 def revoke_access_cookie(token: str) -> bool: ...
     # Per-session revocation (CWE-613). Validates the token, then adds ITS nonce
@@ -255,7 +256,7 @@ class TokenStateManager:
 
 Up to `MAX_CONCURRENT_NONCES` (**50**) link nonces are valid simultaneously. When the limit is exceeded, the oldest nonce is evicted via `OrderedDict.popitem(last=False)` (O(1)); a successful nonce check also refreshes a nonce's eviction position so an actively-used session isn't evicted by newer grants. The limit was **raised from 5 to 50** specifically so pending Slack link nonces aren't evicted by other token-minting activity (crons, dashboard links, etc.). This allows multiple browser tabs and `kirocrew token` invocations without invalidating prior sessions.
 
-The in-memory `TokenStateManager` (link nonces, IP bindings, consumed set) is cleared on restart, but this does **not** log users out: an established session cookie is validated on the cookie path (`use_session_exp=True`), which needs only a valid HMAC signature (persistent key) + unexpired `session_exp` + a nonce not on the persisted denylist — it never consults the in-memory link-nonce set. Revoked-session state is durable: `RevokedNonceStore` persists to `token_revoked_nonces.json` (mode `0600`), so a logged-out cookie stays dead across restarts. Users can revoke a single session via `POST /api/auth/logout` (`revoke_access_cookie()`) or all in-memory sessions via `kirocrew logout` (`revoke_all_sessions()`).
+The in-memory `TokenStateManager` (link nonces, IP bindings, consumed set) is cleared on restart, but this does **not** log users out: an established session cookie is validated on the cookie path (`use_session_exp=True`), which needs only a valid HMAC signature (persistent key) + unexpired `session_exp` + a current revocation generation + a nonce not on the persisted denylist — it never consults the in-memory link-nonce set. Revoked-session state is durable: `RevokedNonceStore` persists to `token_revoked_nonces.json` (mode `0600`) and the revocation generation persists to `token_revocation.gen`, so a logged-out cookie stays dead across restarts while a restart alone (generation reloaded unchanged) logs nobody out. Users can revoke a single session via `POST /api/auth/logout` (`revoke_access_cookie()`) or all sessions — access cookies and refresh chains — via `kirocrew logout` (`revoke_all_sessions()`, which bumps the generation both token kinds embed and check).
 
 #### App-token scope confinement (CWE-269)
 
@@ -482,6 +483,6 @@ HTML 403 page includes instructions to run `!dashboard` in Slack. The middleware
 7. CSRF middleware also trusts loopback — local POST requests (mcp-core API calls) bypass origin checks
 8. Static assets bypass auth — error pages render correctly
 9. Bounded concurrent nonces (max 50; raised from 5 so pending Slack link nonces aren't evicted by other token-minting activity) — prevents unbounded memory growth, limits exposure window; an active session refreshes its eviction position on each check
-10. Explicit revocation via `kirocrew logout` — clears all nonces, IP bindings, and consumed tokens
+10. Explicit revocation via `kirocrew logout` — clears all nonces, IP bindings, and consumed tokens, and bumps the persisted revocation generation, ending every outstanding access cookie and refresh chain
 11. App-token scope confinement (CWE-269) — an `app`-claim token is confined deny-by-default to its own namespace (`/apps/<name>`, `/api/apps/<name>`) + its manifest `permissions.api` allowlist, enforced at every grant point; no-op for dashboard-user tokens
 12. Headless (`--slack-only`) auth parity — `start_api_server()` serves the same MCP route surface as the dashboard and mounts the same `host_validation → csrf → token_auth → sel_audit` chain against the shared `_STRICT_INTERNAL_API_PATHS`/`_MIXED_INTERNAL_API_PATHS` sets. Internal MCP routes require loopback **plus** `X-Internal-Secret` (loopback alone is not sufficient for these paths — port forwarders can spoof `127.0.0.1`); `sel_audit_middleware` alone only logs and is never a substitute for the token-auth chain

--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -83,7 +83,7 @@ This allows `kirocrew` to find project-level agent config and skills from any di
 | `kirocrew learn add/list/remove` | Manage learned corrections |
 | `kirocrew run TASK.md` | Run an autonomous task from a spec file |
 | `kirocrew token` | Print a dashboard access URL with auth token |
-| `kirocrew logout` | Revoke all active dashboard access sessions (does not revoke refresh chains) |
+| `kirocrew logout` | Revoke all active dashboard sessions, refresh chains included |
 | `kirocrew manifest` | Generate Slack manifest with user alias auto-populated |
 | `kirocrew update` | Update to latest version (git pull + rebuild) |
 | `kirocrew status` | Show runtime stats from running gateway |

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -1986,7 +1986,29 @@ async def api_logout(request: web.Request) -> web.Response:
         )
         return web.json_response({"error": "invalid secret"}, status=403)
 
-    revoke_all_sessions()
+    # Fail-closed: bump_revocation_gen raises when the persisted counter
+    # cannot be read (bumping from an assumed base could persist a LOWER
+    # counter, resurrecting revoked sessions after restart) or when the write
+    # fails (the counter is left unchanged, so the revocation did not take
+    # effect). Report the failure instead of a false success.
+    try:
+        revoke_all_sessions()
+    except OSError:
+        logger.warning("logout failed: could not persist session revocation", exc_info=True)
+        _sel().log_api_access(
+            caller=request.remote or "unknown",
+            operation="logout",
+            outcome="error",
+            source="cli",
+            resources="revocation-persist-failed",
+        )
+        return web.json_response(
+            {
+                "error": "could not persist session revocation; logout not completed",
+                "code": "revocation_persist_failed",
+            },
+            status=500,
+        )
     _sel().log_api_access(
         caller=request.remote or "unknown",
         operation="logout",

--- a/src/kiro_crew/dashboard/refresh_tokens.py
+++ b/src/kiro_crew/dashboard/refresh_tokens.py
@@ -33,6 +33,10 @@ from typing import TYPE_CHECKING, Iterable, Mapping
 
 from kiro_crew import platform_compat
 from kiro_crew.config.loader import config_dir
+from kiro_crew.dashboard.revocation_gen import (
+    current_revocation_gen,
+    current_revocation_gen_or_none,
+)
 from kiro_crew.dashboard.token_secret import _get_secret
 
 if TYPE_CHECKING:
@@ -267,7 +271,7 @@ class RefreshStateManager:
                     self._grace_replacements.pop(chain_id, None)
 
     def clear_all(self) -> None:
-        """Wipe all state. Used by tests and ``kirocrew logout``."""
+        """Wipe all rotation/revocation state (test-isolation helper)."""
         with self._lock:
             self._consumed_jtis.clear()
             self._revoked_chains.clear()
@@ -432,6 +436,10 @@ def generate_refresh_token(
         "jti": jti,
         "iat": now,
         "session_exp": now + session_ttl,
+        # Revocation generation: validate_refresh_token rejects a token whose
+        # gen is below the current persisted value, so revoke_all_sessions()
+        # (kirocrew logout) ends refresh chains, not just access cookies.
+        "gen": current_revocation_gen(),
     }
     payload = json.dumps(payload_dict, separators=(",", ":")).encode()
     encoded_payload = _b64url_encode(payload)
@@ -442,10 +450,12 @@ def generate_refresh_token(
 def validate_refresh_token(token: str) -> tuple[bool, str, str, str, str, float]:
     """Return ``(valid, user_id, reason, chain_id, jti, session_exp)``.
 
-    Validates HMAC, ``kind=refresh``, ``session_exp``, and that the chain
-    has not been revoked. Does NOT consult the consumed-jti map — callers
-    decide whether to apply consumption semantics (the refresh endpoint
-    does, the ``/auth/me`` peek does not).
+    Validates HMAC, ``kind=refresh``, ``session_exp``, that the chain has not
+    been revoked, and that the token's revocation generation is current (a
+    ``revoke_all_sessions()`` bump rejects it with reason ``"session
+    revoked"``). Does NOT consult the consumed-jti map — callers decide whether
+    to apply consumption semantics (the refresh endpoint does, the ``/auth/me``
+    peek does not).
     """
     parts = token.split(".", 1)
     if len(parts) != 2:
@@ -476,6 +486,21 @@ def validate_refresh_token(token: str) -> tuple[bool, str, str, str, str, float]
     state = _get_state()
     if state.is_chain_revoked(chain_id):
         return False, user_id, "chain revoked", chain_id, jti, session_exp
+    # Revocation generation: mirrors the access-cookie semantics in
+    # validate_token(), making the persisted counter authoritative over BOTH
+    # cookie types — revoke_all_sessions() (kirocrew logout) bumps it once and
+    # every outstanding refresh token is rejected, with no chain enumeration.
+    # Tokens minted before this claim existed default to gen 0, so they are
+    # rejected once any logout has ever bumped the counter (deliberate
+    # fail-closed posture); on installs that never ran a logout, gen is 0 and
+    # legacy tokens keep validating. Fail-closed on I/O too: when the persisted
+    # counter cannot be read, the token cannot be proven un-revoked, so it is
+    # rejected (the next validation retries the read).
+    current_gen = current_revocation_gen_or_none()
+    if current_gen is None:
+        return False, user_id, "revocation state unavailable", chain_id, jti, session_exp
+    if int(payload.get("gen", 0)) < current_gen:
+        return False, user_id, "session revoked", chain_id, jti, session_exp
     return True, user_id, "", chain_id, jti, session_exp
 
 

--- a/src/kiro_crew/dashboard/revocation_gen.py
+++ b/src/kiro_crew/dashboard/revocation_gen.py
@@ -1,0 +1,158 @@
+"""Persisted token-revocation generation counter shared by both cookie types.
+
+Lives outside ``token_auth`` so ``refresh_tokens`` can consult the counter
+without a ``token_auth`` <-> ``refresh_tokens`` import cycle (the same seam
+``token_secret.py`` provides for the HMAC secret).
+
+Every minted access token AND refresh token embeds the current ``gen`` claim;
+validation rejects a token whose ``gen`` is below the current value. Bumping
+the counter (``revoke_all_sessions()``, i.e. ``kirocrew logout``) therefore
+ends ALL outstanding sessions — established access cookies and refresh chains
+alike. Persisting the counter is what lets it survive a gateway restart
+WITHOUT logging users out: the gen is reloaded unchanged, so previously-issued
+cookies still match.
+
+Loading is LAZY and memoized: merely importing this module must not touch the
+filesystem (the CLI imports the dashboard auth modules transitively for every
+``kirocrew`` subcommand). Both validators read the LIVE value through
+:func:`current_revocation_gen` — never an import-time copy — so a bump is
+visible to every subsequent validation in-process.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+
+logger = logging.getLogger(__name__)
+
+_REVOCATION_FILE = "token_revocation.gen"
+
+# Memoized counter. ``None`` = not yet loaded from disk. Guarded by the lock so
+# concurrent first reads / bumps agree on one value.
+_gen: int | None = None
+_gen_lock = threading.Lock()
+
+
+def _load_revocation_gen_or_none() -> int | None:
+    """Read the persisted revocation counter from disk.
+
+    Returns the counter (0 when the file has never been written — a definitive
+    answer) or ``None`` when the state is unreadable, so callers can
+    distinguish "gen is 0" from "could not read": treating a failed read as 0
+    would silently undo a prior revocation. An EXISTING but empty file is
+    unreadable, not 0 — it is evidence of an interrupted write, and the atomic
+    replace in :func:`bump_revocation_gen` means a healthy file always carries
+    a complete value.
+    """
+    # circular import: config.loader pulls in modules that import token_auth
+    # (which re-exports this module's names), so a top-level import here risks
+    # a cycle. Matches the config_dir() call sites in token_secret.py.
+    from kiro_crew.config.loader import config_dir
+
+    try:
+        p = config_dir() / _REVOCATION_FILE
+        try:
+            text = p.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return 0
+        stripped = text.strip()
+        if not stripped:
+            # Logs the counter file PATH only, never any token or secret value;
+            # the Semgrep rule fires on the credential-adjacent wording in the
+            # static message string.
+            logger.warning(  # nosemgrep: python-logger-credential-disclosure
+                "token revocation counter file %s is empty (interrupted write?); "
+                "treating as unreadable",
+                p,
+            )
+            return None
+        return int(stripped)
+    except (OSError, ValueError):
+        logger.warning("could not read token revocation counter", exc_info=True)
+        return None
+
+
+def _load_revocation_gen() -> int:
+    """Read the persisted revocation counter from disk (0 if unset/unreadable)."""
+    loaded = _load_revocation_gen_or_none()
+    return 0 if loaded is None else loaded
+
+
+def current_revocation_gen_or_none() -> int | None:
+    """Return the LIVE revocation generation, or ``None`` when unreadable.
+
+    Called on every token validation, so after the first disk read this is an
+    in-memory lookup under a lock. ``warm_auth_singletons()`` primes it off the
+    event loop before the server accepts connections. A FAILED disk read is not
+    memoized — this call returns ``None`` and the next call retries. Validators
+    MUST treat ``None`` as fail-closed (reject): revocation state that cannot
+    be read must not silently authenticate a session the operator revoked.
+    """
+    global _gen
+    with _gen_lock:
+        if _gen is None:
+            _gen = _load_revocation_gen_or_none()
+        return _gen
+
+
+def current_revocation_gen() -> int:
+    """Return the LIVE revocation generation, degrading to 0 when unreadable.
+
+    For MINT paths (embedding the claim in a new token). Validation paths must
+    use :func:`current_revocation_gen_or_none` instead and reject on ``None``
+    — degrading a validator to 0 would accept revoked sessions.
+    """
+    loaded = current_revocation_gen_or_none()
+    return 0 if loaded is None else loaded
+
+
+def bump_revocation_gen() -> int:
+    """Increment and persist the revocation counter. Returns the new value.
+
+    Fail-closed on I/O errors, in both directions:
+
+    * If the persisted base cannot be READ, raises ``OSError`` without writing:
+      bumping from an assumed 0 would persist a LOWER counter than on disk,
+      resurrecting previously revoked sessions after a restart.
+    * If the WRITE fails, raises ``OSError`` with the counter UNCHANGED in
+      memory and on disk. The in-memory value is published only after the
+      atomic replace succeeds, so a token can never be minted with a
+      generation that is not durable — an unpersisted generation would be
+      reloaded lower after restart, letting that token outlive a later
+      successful logout. The caller reports the failed logout instead of a
+      false success.
+
+    The lock is held through persistence so a concurrent reader never observes
+    a generation that might still fail to land; the write is a few bytes and
+    callers already run off the event loop for this path.
+    """
+    global _gen
+    # circular import: see _load_revocation_gen_or_none.
+    from kiro_crew.config.loader import config_dir
+
+    with _gen_lock:
+        base = _gen if _gen is not None else _load_revocation_gen_or_none()
+        if base is None:
+            raise OSError(
+                "cannot read persisted token revocation counter; refusing to "
+                "bump from an assumed base"
+            )
+        new_gen = base + 1
+        try:
+            p = config_dir() / _REVOCATION_FILE
+            p.parent.mkdir(parents=True, exist_ok=True)
+            # Atomic replace via a same-directory temporary file: a truncate-
+            # then-write torn by process termination would leave an empty file
+            # that a later boot must treat as unreadable — with the atomic
+            # rename, the file on disk always carries either the old or the
+            # new complete value.
+            tmp = p.with_suffix(p.suffix + ".tmp")
+            tmp.write_text(str(new_gen), encoding="utf-8")
+            os.replace(tmp, p)
+        except OSError:
+            logger.warning("could not persist token revocation counter", exc_info=True)
+            raise
+        _gen = new_gen
+        return new_gen

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -38,6 +38,20 @@ from kiro_crew.dashboard.refresh_tokens import (
     refresh_cookie_name,
 )
 
+# Canonical revocation-generation definitions live in revocation_gen so the
+# refresh-token module can consult the counter without recreating the
+# token_auth <-> refresh_tokens import cycle (same pattern as token_secret
+# below). Re-exported here for backwards compatibility. Both validators read
+# the LIVE value via current_revocation_gen() — never an import-time copy —
+# so a bump is visible to every subsequent validation in-process.
+from kiro_crew.dashboard.revocation_gen import (  # noqa: F401  # re-exports
+    _REVOCATION_FILE,
+    _load_revocation_gen,
+    bump_revocation_gen,
+    current_revocation_gen,
+    current_revocation_gen_or_none,
+)
+
 # Canonical HMAC-secret definitions live in token_secret to break the import
 # cycle between token_auth and refresh_tokens. Re-exported here for backwards
 # compatibility — callers elsewhere import these names from token_auth. The
@@ -55,52 +69,9 @@ from kiro_crew.sel import sel as _sel_fn
 
 logger = logging.getLogger(__name__)
 
-
-_REVOCATION_FILE = "token_revocation.gen"
-
-
-def _load_revocation_gen() -> int:
-    """Return the persisted revocation generation counter (0 if unset).
-
-    Every minted token embeds the current ``gen``; cookie validation rejects a
-    token whose ``gen`` is below the current value. ``revoke_all_sessions()``
-    bumps and persists it, so an operator ``kirocrew logout`` invalidates ALL
-    outstanding tokens/cookies — including established browser cookies, which
-    the nonce store (per-process, cleared on restart) could not. Persisting the
-    counter is what lets it survive a gateway restart WITHOUT logging users out:
-    the gen is reloaded unchanged, so previously-issued cookies still match.
-    """
-    from kiro_crew.config.loader import config_dir
-
-    try:
-        p = config_dir() / _REVOCATION_FILE
-        if p.exists():
-            return int(p.read_text(encoding="utf-8").strip() or "0")
-    except (OSError, ValueError):
-        logger.warning("could not read token revocation counter; assuming 0", exc_info=True)
-    return 0
-
-
-def _bump_revocation_gen() -> int:
-    """Increment and persist the revocation counter. Returns the new value.
-
-    Falls back to an in-memory bump if the file is unwritable (revocation still
-    holds for the life of this process, the pre-existing best-effort behaviour).
-    """
-    global _REVOCATION_GEN
-    _REVOCATION_GEN += 1
-    from kiro_crew.config.loader import config_dir
-
-    try:
-        p = config_dir() / _REVOCATION_FILE
-        p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(str(_REVOCATION_GEN), encoding="utf-8")
-    except OSError:
-        logger.warning("could not persist token revocation counter", exc_info=True)
-    return _REVOCATION_GEN
-
-
-_REVOCATION_GEN = _load_revocation_gen()
+# Alias of bump_revocation_gen: callers elsewhere import the private name
+# from this module.
+_bump_revocation_gen = bump_revocation_gen
 
 
 # -- Per-session access-cookie revocation -------------------------------------
@@ -698,7 +669,7 @@ def generate_token(
         # Revocation generation: validate_token rejects a token whose gen is
         # below the current persisted value, so revoke_all_sessions() kills
         # established cookies (not just the per-process nonce store).
-        "gen": _REVOCATION_GEN,
+        "gen": current_revocation_gen(),
     }
     if app:
         payload_dict["app"] = app
@@ -744,9 +715,16 @@ def validate_token(token: str, *, use_session_exp: bool = False) -> tuple[bool, 
     # cookie — carries a lower gen and is rejected. This is the ONLY check that
     # invalidates an established cookie (the nonce store is per-process and
     # restart-cleared; the HMAC secret is persisted, not rotated), so it is what
-    # makes "revoke all sessions" actually revoke cookie sessions. Tokens minted
-    # before this field existed default to gen 0, matching the initial counter.
-    if int(data.get("gen", 0)) < _REVOCATION_GEN:
+    # makes "revoke all sessions" actually revoke cookie sessions. Refresh-token
+    # validation applies the same check, so the counter is authoritative over
+    # BOTH cookie types. Tokens minted before this field existed default to
+    # gen 0, matching the initial counter. Fail-closed: when the persisted
+    # counter cannot be read, the token cannot be proven un-revoked, so it is
+    # rejected (the next validation retries the read).
+    current_gen = current_revocation_gen_or_none()
+    if current_gen is None:
+        return False, "", "revocation state unavailable"
+    if int(data.get("gen", 0)) < current_gen:
         return False, "", "session revoked"
     # Nonce is a single-use guard for the one-time LINK click only. For an
     # established session cookie (use_session_exp=True), a valid HMAC signature
@@ -1074,6 +1052,11 @@ def revoke_all_sessions() -> None:
     """Revoke all active dashboard sessions (also used for test isolation).
 
     Emits a SEL audit event before clearing state so the revocation is recorded.
+    Raises ``OSError`` (fail-closed) when the persisted revocation counter
+    cannot be read or the bumped value cannot be written — see
+    ``bump_revocation_gen``. On failure the generation is unchanged (in memory
+    and on disk) so no token is ever minted with an unpersisted generation;
+    the in-memory link/IP/consumed state has still been cleared.
     """
     _sel_fn().log_api_access(
         caller="system",
@@ -1085,8 +1068,9 @@ def revoke_all_sessions() -> None:
     _state.clear_all()
     # Bump the persisted revocation generation so already-issued cookies (which
     # the cleared per-process nonce store cannot touch) are rejected on their
-    # next request. This is what makes logout actually end cookie sessions.
-    _bump_revocation_gen()
+    # next request. Both access-cookie and refresh-token validation check the
+    # gen, so this ends established browser sessions AND their refresh chains.
+    bump_revocation_gen()
 
 
 def parse_duration(s: str) -> int | None:
@@ -1269,6 +1253,9 @@ async def warm_auth_singletons() -> None:
     """
     await asyncio.to_thread(_get_secret)
     await asyncio.to_thread(_get_revoked_store)
+    # The revocation generation is lazy-loaded from disk on first use; prime it
+    # here too so the first token validation never does file I/O on the loop.
+    await asyncio.to_thread(current_revocation_gen)
 
 
 def token_auth_middleware(

--- a/test/test_refresh_tokens.py
+++ b/test/test_refresh_tokens.py
@@ -1067,6 +1067,7 @@ def test_tr_u_27_logout_revokes_access_cookie(tmp_path, monkeypatch):
 
     from aiohttp import web
 
+    import kiro_crew.dashboard.revocation_gen as rg
     import kiro_crew.dashboard.token_auth as ta
     from kiro_crew.dashboard.handlers import auth_refresh as ar
     from kiro_crew.dashboard.token_auth import generate_token, validate_token
@@ -1074,7 +1075,7 @@ def test_tr_u_27_logout_revokes_access_cookie(tmp_path, monkeypatch):
     # Isolate BOTH the refresh store and the token_auth revoked-nonce store to
     # tmp dirs so nothing touches the real ~/.kirocrew.
     monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
-    monkeypatch.setattr(ta, "_REVOCATION_GEN", 0)
+    monkeypatch.setattr(rg, "_gen", 0)
     monkeypatch.setattr(ta, "_revoked_store_singleton", None)
     refresh_state = RefreshStateManager(state_path=tmp_path / "refresh_chains.json")
 
@@ -1207,3 +1208,275 @@ def test_refresh_leaves_small_jar_untouched(
     # The other live gateway's cookies were not touched (no expiry Set-Cookie).
     assert "mc_token_6821" not in resp.cookies
     assert "mc_refresh_6821" not in resp.cookies
+
+
+# -- Global revocation generation (TR-U-28..31) --------------------------------
+#
+# `kirocrew logout` (revoke_all_sessions) bumps the persisted revocation
+# generation; refresh-token validation rejects any token carrying a lower gen,
+# mirroring the access-cookie semantics — the counter is authoritative over
+# BOTH cookie types.
+
+
+@pytest.fixture()
+def isolated_gen(tmp_path: Path, monkeypatch):
+    """Pin the revocation generation to 0 and isolate its persistence file.
+
+    Yields the revocation_gen module so tests can bump/inspect the counter.
+    """
+    import kiro_crew.dashboard.revocation_gen as rg
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+    monkeypatch.setattr(rg, "_gen", 0)
+    yield rg
+
+
+def test_tr_u_28_revoke_all_sessions_kills_refresh_token(
+    isolated_gen, isolated_state: RefreshStateManager, monkeypatch
+):
+    """A refresh token minted before `kirocrew logout` must be rejected.
+
+    revoke_all_sessions() bumps the persisted revocation generation; the
+    pre-logout refresh token carries the old gen and validation rejects it
+    with reason "session revoked" — the same semantics as the access cookie.
+    """
+    import kiro_crew.dashboard.token_auth as ta
+    from kiro_crew.dashboard.token_auth import revoke_all_sessions
+
+    # Fresh revoked-nonce store bound to this test's tmp config_dir.
+    monkeypatch.setattr(ta, "_revoked_store_singleton", None)
+
+    token, chain_id, _jti, exp = generate_refresh_token("alice")
+    valid_before, _, _, _, _, _ = validate_refresh_token(token)
+    assert valid_before is True
+
+    revoke_all_sessions()  # operator `kirocrew logout`
+
+    valid, user, reason, decoded_chain, _jti2, decoded_exp = validate_refresh_token(token)
+    assert valid is False
+    assert reason == "session revoked"
+    # Identity/claims still surfaced for audit, mirroring the other deny paths.
+    assert user == "alice"
+    assert decoded_chain == chain_id
+    assert decoded_exp == exp
+
+
+def test_tr_u_29_refresh_token_minted_after_bump_validates(
+    isolated_gen, isolated_state: RefreshStateManager, monkeypatch
+):
+    """A refresh token minted AFTER the bump embeds the new gen and validates."""
+    import kiro_crew.dashboard.token_auth as ta
+    from kiro_crew.dashboard.token_auth import revoke_all_sessions
+
+    monkeypatch.setattr(ta, "_revoked_store_singleton", None)
+
+    revoke_all_sessions()
+    token, _chain_id, _jti, _exp = generate_refresh_token("alice")
+    valid, user, reason, _cid, _j, _e = validate_refresh_token(token)
+    assert valid is True
+    assert user == "alice"
+    assert reason == ""
+
+
+def test_tr_u_30_legacy_payload_without_gen_fails_closed(
+    isolated_gen, isolated_state: RefreshStateManager
+):
+    """A pre-gen-claim refresh token is valid at gen 0, rejected once gen > 0.
+
+    Tokens minted before the gen claim existed default to gen 0, so they are
+    rejected once any logout has ever bumped the counter — the deliberate
+    fail-closed posture. On installs that never ran a logout (gen still 0),
+    legacy tokens keep validating.
+    """
+    import kiro_crew.dashboard.refresh_tokens as rt
+
+    now = time.time()
+    legacy_payload = {
+        "sub": "alice",
+        "kind": "refresh",
+        "chain_id": "abc123def456",
+        "jti": "a" * 24,
+        "iat": now,
+        "session_exp": now + 3600,
+        # no "gen" claim — pre-upgrade token
+    }
+    raw = json.dumps(legacy_payload, separators=(",", ":")).encode()
+    token = f"{rt._b64url_encode(raw)}.{rt._sign(raw)}"
+
+    valid_at_zero, _, reason_zero, _, _, _ = validate_refresh_token(token)
+    assert valid_at_zero is True, f"legacy token should validate at gen 0: {reason_zero}"
+
+    isolated_gen.bump_revocation_gen()
+
+    valid_after, _, reason_after, _, _, _ = validate_refresh_token(token)
+    assert valid_after is False
+    assert reason_after == "session revoked"
+
+
+def test_tr_u_31_refresh_endpoint_rejects_pre_logout_cookie(
+    isolated_gen, isolated_state: RefreshStateManager, monkeypatch
+):
+    """POST /api/auth/refresh with a pre-logout refresh cookie must 401.
+
+    End-to-end at the handler level: after revoke_all_sessions() the browser's
+    saved `mc_refresh_<port>` cookie can no longer mint a fresh access cookie.
+    """
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from aiohttp import web
+
+    import kiro_crew.dashboard.token_auth as ta
+    from kiro_crew.dashboard.handlers import auth_refresh as ar
+    from kiro_crew.dashboard.token_auth import revoke_all_sessions
+
+    monkeypatch.setattr(ta, "_revoked_store_singleton", None)
+
+    token, _chain_id, _jti, _exp = generate_refresh_token("alice")
+    revoke_all_sessions()
+
+    request = MagicMock(spec=web.Request)
+    request.app = {"port": 7777, "allowed_origins": set()}
+    request.cookies = {refresh_cookie_name(7777): token}
+    request.headers = {"Origin": "http://localhost:7777", "Host": "localhost:7777"}
+    request.scheme = "http"
+    request.host = "localhost:7777"
+    request.remote = "127.0.0.1"
+
+    with patch(
+        "kiro_crew.dashboard.handlers.auth_refresh.check_origin", return_value=True
+    ), patch(
+        "kiro_crew.dashboard.handlers.auth_refresh._rate_limited", return_value=False
+    ):
+        resp = asyncio.run(ar.api_auth_refresh(request))
+
+    assert resp.status == 401
+
+
+def test_tr_u_32_failed_gen_load_is_not_memoized(monkeypatch):
+    """A transient counter read failure must not permanently un-revoke sessions.
+
+    If the first disk read fails, current_revocation_gen() answers 0 for that
+    call but leaves the memo unset, so the next call retries and picks up the
+    real persisted counter — a startup read glitch on a host whose counter is
+    above 0 cannot pin the process at gen 0 for its lifetime.
+    """
+    import kiro_crew.dashboard.revocation_gen as rg
+
+    monkeypatch.setattr(rg, "_gen", None)
+    loads = iter([None, 7])  # first read fails, retry succeeds
+    monkeypatch.setattr(rg, "_load_revocation_gen_or_none", lambda: next(loads))
+
+    assert rg.current_revocation_gen() == 0  # failure degrades to 0 for this call
+    assert rg.current_revocation_gen() == 7  # retried — the failure was not memoized
+    assert rg.current_revocation_gen() == 7  # success IS memoized (iterator not consumed)
+
+
+def test_tr_u_33_validator_fails_closed_when_counter_unreadable(
+    isolated_gen, isolated_state: RefreshStateManager, monkeypatch
+):
+    """An unreadable revocation counter must REJECT, never accept.
+
+    If the persisted counter cannot be read, a token cannot be proven
+    un-revoked — degrading to gen 0 would authenticate sessions the operator
+    revoked. Both the refresh and access validators reject with
+    "revocation state unavailable"; the next validation retries the read.
+    """
+    from kiro_crew.dashboard.token_auth import generate_token, validate_token
+
+    refresh_token, _cid, _jti, _exp = generate_refresh_token("alice")  # minted at gen 0
+    access_token = generate_token("alice", ttl_seconds=3600)
+
+    import kiro_crew.dashboard.revocation_gen as rg
+
+    monkeypatch.setattr(rg, "_gen", None)
+    monkeypatch.setattr(rg, "_load_revocation_gen_or_none", lambda: None)
+
+    valid_r, _, reason_r, _, _, _ = validate_refresh_token(refresh_token)
+    assert valid_r is False
+    assert reason_r == "revocation state unavailable"
+
+    valid_a, _, reason_a = validate_token(access_token, use_session_exp=True)
+    assert valid_a is False
+    assert reason_a == "revocation state unavailable"
+
+
+def test_tr_u_34_bump_refuses_unreadable_base(monkeypatch):
+    """bump_revocation_gen must not bump from an assumed base.
+
+    Reading the persisted counter failed: bumping from 0 could persist a LOWER
+    value than on disk (e.g. 5 -> 1), resurrecting revoked sessions after a
+    restart. The bump refuses with OSError instead.
+    """
+    import kiro_crew.dashboard.revocation_gen as rg
+
+    monkeypatch.setattr(rg, "_gen", None)
+    monkeypatch.setattr(rg, "_load_revocation_gen_or_none", lambda: None)
+
+    with pytest.raises(OSError):
+        rg.bump_revocation_gen()
+
+
+def test_tr_u_35_bump_persist_failure_leaves_counter_unchanged(
+    tmp_path: Path, monkeypatch
+):
+    """A failed counter WRITE raises and leaves the generation UNCHANGED.
+
+    The in-memory value is published only after the atomic replace succeeds:
+    a token minted with an unpersisted generation would be reloaded lower
+    after restart and outlive a later successful logout, so a failed persist
+    must not advance what mints observe.
+    """
+    import kiro_crew.dashboard.revocation_gen as rg
+
+    # Point config_dir at a FILE so the mkdir(parents=True) in the persist
+    # path raises — a deterministic write failure confined to tmp_path.
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("x", encoding="utf-8")
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: blocker)
+    monkeypatch.setattr(rg, "_gen", 3)
+
+    with pytest.raises(OSError):
+        rg.bump_revocation_gen()
+
+    # Counter unchanged — no mint can observe a generation that is not durable.
+    assert rg.current_revocation_gen() == 3
+
+
+def test_tr_u_36_empty_counter_file_fails_closed(tmp_path: Path, monkeypatch):
+    """An existing-but-empty counter file is unreadable, not gen 0.
+
+    A write torn by process termination leaves an empty file; interpreting it
+    as 0 would resurrect every revoked session on the next boot. The loader
+    reports it unreadable and validators reject until the state is repaired
+    (or the next successful bump atomically replaces it).
+    """
+    import kiro_crew.dashboard.revocation_gen as rg
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+    (tmp_path / rg._REVOCATION_FILE).write_text("", encoding="utf-8")
+    monkeypatch.setattr(rg, "_gen", None)
+
+    assert rg._load_revocation_gen_or_none() is None
+
+    token, _cid, _jti, _exp = generate_refresh_token("alice")  # mint degrades to gen 0
+    valid, _, reason, _, _, _ = validate_refresh_token(token)
+    assert valid is False
+    assert reason == "revocation state unavailable"
+
+
+def test_tr_u_37_bump_persists_atomically(tmp_path: Path, monkeypatch):
+    """The bump lands via same-directory tmp + os.replace: the on-disk file
+    always carries a complete value and no tmp residue is left behind."""
+    import kiro_crew.dashboard.revocation_gen as rg
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+    monkeypatch.setattr(rg, "_gen", None)
+
+    assert rg.bump_revocation_gen() == 1
+    assert rg.bump_revocation_gen() == 2
+
+    p = tmp_path / rg._REVOCATION_FILE
+    assert p.read_text(encoding="utf-8") == "2"
+    leftovers = [f.name for f in tmp_path.iterdir() if f.name != rg._REVOCATION_FILE]
+    assert leftovers == []

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -659,8 +659,9 @@ class TestRedactCredentials:
         claims = json.loads(
             base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
         )
-        # `gen` is normalised alongside `sub` because it mirrors the process-global
-        # `_REVOCATION_GEN`, which is LOADED FROM DISK at import. Left ambient, the
+        # `gen` is normalised alongside `sub` because it mirrors the persisted
+        # counter behind `revocation_gen.current_revocation_gen()`, LOADED FROM
+        # DISK on first use. Left ambient, the
         # derived floor would depend on how many times this machine has revoked:
         # the repr widens at 10, moving the floor 145 -> 147, so the pin below would
         # fail on a clean checkout with no code change.

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -45,10 +45,13 @@ def clear_nonces(tmp_path, monkeypatch):
     clears the nonce store. Uses _state.clear_all() (not revoke_all_sessions)
     so the gen isn't bumped between unrelated tests.
     """
+    import kiro_crew.dashboard.revocation_gen as _rg
     import kiro_crew.dashboard.token_auth as _ta
 
     monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
-    monkeypatch.setattr(_ta, "_REVOCATION_GEN", 0)
+    # Pin the memoized revocation generation to 0 (skips the lazy disk load)
+    # so no persisted counter from a prior test or the real home leaks in.
+    monkeypatch.setattr(_rg, "_gen", 0)
     # Reset the per-session revoked-nonce store so each test gets a fresh store
     # bound to its own tmp_path config_dir (the singleton would otherwise pin
     # the first test's path and leak revocations across tests).
@@ -56,7 +59,7 @@ def clear_nonces(tmp_path, monkeypatch):
     _ta._state.clear_all()
     _ta._app_perms_cache.clear()
     yield
-    monkeypatch.setattr(_ta, "_REVOCATION_GEN", 0)
+    monkeypatch.setattr(_rg, "_gen", 0)
     monkeypatch.setattr(_ta, "_revoked_store_singleton", None)
     _ta._state.clear_all()
     _ta._app_perms_cache.clear()


### PR DESCRIPTION
## Problem

`kirocrew logout` (CLI → `POST /api/logout` → `revoke_all_sessions()`) ends access sessions but not refresh chains: `validate_refresh_token()` checks HMAC, `kind`, `session_exp`, and per-chain revocation, but never consults the revocation generation, and `generate_refresh_token()` embeds no `gen` claim. A browser still holding a valid `mc_refresh_<port>` cookie can call `POST /api/auth/refresh` after logout and mint a fresh access cookie carrying the new generation. There is also no global refresh-chain revocation path — `revoke_chain` is per-chain and only reachable from the target browser's own cookie.

## Why it matters

An operator running `kirocrew logout` reasonably expects every outstanding session to end. Sessions that silently survive the documented "revoke all sessions" control are a behavior/consistency gap (documented as a known limitation in the docs; this PR removes the gap the docs describe).

## Fix (symptom → root cause → change)

Symptom: sessions survive `kirocrew logout` via the refresh path. Root cause: the persisted revocation-generation counter is embedded and checked only in access tokens. Change: make the counter authoritative over BOTH cookie types — the issue's preferred option, reusing the already-persisted counter with no chain enumeration.

- **New `src/kiro_crew/dashboard/revocation_gen.py`** — the counter's canonical home (`current_revocation_gen()` / `bump_revocation_gen()`), extracted from `token_auth.py` so `refresh_tokens.py` can consult it without recreating the known `token_auth` ↔ `refresh_tokens` import cycle (same seam as `token_secret.py`). Loading is lazy + lock-guarded; both validators read the LIVE value through the accessor. A **failed** disk read is not memoized (answers 0 for that call, retries next call), so a transient startup read error cannot permanently un-revoke sessions. `warm_auth_singletons()` primes it off the event loop for both server entry points.
- **`token_auth.py`** — re-exports the old names (`_REVOCATION_FILE`, `_load_revocation_gen`, `_bump_revocation_gen`) for backwards compatibility; `generate_token` / `validate_token` now go through the accessor.
- **`refresh_tokens.py`** — `generate_refresh_token()` embeds `"gen": current_revocation_gen()`; `validate_refresh_token()` rejects `gen < current` with reason `"session revoked"`, mirroring the access-cookie semantics. Also corrects the stale `RefreshStateManager.clear_all()` docstring (logout never calls it — and must not, since it would clear `_revoked_chains`).
- **Docs** — `dashboard-token-auth.md`, `remote-and-mobile.md`, `slack-setup.md`, `cli.md` updated in the same commit: the generation counter is authoritative over both cookie types; restart semantics unchanged (counter reloads unchanged, logs nobody out); `POST /api/auth/logout` remains the narrower per-browser control.

**Upgrade consequence (deliberate fail-closed posture):** refresh tokens minted before this claim existed default to `gen 0`, so on installs where the operator has ever run `kirocrew logout`, existing refresh chains are rejected once and users re-mint via the `kirocrew token` URL. Installs that never ran a logout (gen still 0) are unaffected. Access-cookie behavior is unchanged.

## Tests

Extends `test/test_refresh_tokens.py` (TR-U-28..32):
- Refresh token minted, then `revoke_all_sessions()` → invalid with reason `"session revoked"` (identity/claims still surfaced for audit).
- Refresh token minted after the bump validates.
- Legacy payload with no `gen` claim: valid while gen==0, rejected once gen>0 (fail-closed).
- Handler-level: `POST /api/auth/refresh` with a pre-logout refresh cookie → 401.
- A failed counter read is not memoized (retry restores the persisted gen).

Existing chain-revocation, reuse-detection, and access-cookie gen tests pass; fixtures in `test_token_auth.py` / `test_refresh_tokens.py` updated to pin the moved counter.

## Manual verification

N/A — unit coverage sufficient: the change is confined to token mint/validate paths exercised end-to-end by the handler-level test.

Closes #2028
