### PR TITLE
fix: guard claim-push against PID reuse with process start tokens (#1018)

### DIFF
--- a/docs/architecture/design-notes/mcp-gateway-claim-push.md
+++ b/docs/architecture/design-notes/mcp-gateway-claim-push.md
@@ -56,12 +56,23 @@ Push (new): gateway rekey() ─────────────────�
 3. **The gateway pushes a claim on rekey** (`claim.py`, hooked into
    `AcpClient.rekey` and `SessionHandle.rekey`): a one-shot connection to the
    gatewayd socket sends
-   `{"type": "claim", "pid": P, "caller": {...}}` and reads one ack frame.
+   `{"type": "claim", "pid": P, "pid_start_id": T, "caller": {...}}` and
+   reads one ack frame. `pid_start_id` is the claimed runtime's process start
+   token (`platform_compat.get_process_start_id`; `None` where unavailable).
    Fire-and-forget (`schedule_claim`), bounded at 5 s, no-ops cleanly when
    preconditions are missing.
 4. **gatewayd applies the claim** (`_apply_claim`): every indexed connection
    under P gets the new caller, each change SEL-audited
    (`mcp-gateway.caller-claim`). Idempotent re-claims (same key) are silent.
+   Because `_CONN_INDEX` is keyed on the raw int PID, a bucket can mix a
+   stale connection (register-time owner of P exited, stub transport still
+   open) with a live one after the OS recycles P. gatewayd therefore records
+   `get_process_start_id` for every indexed PID at register time
+   (`_StubConn.pid_start_ids`) and skips a connection on a DEFINITE token
+   mismatch — both tokens known and unequal — auditing the skip as denied
+   and reporting it in the ack (`skipped`). `None` on either side means
+   "identity unknown" (Windows, unreadable /proc, legacy frames) and counts
+   as a match, so platforms without a token keep the pre-guard behavior.
 
 ## Trust model
 
@@ -74,6 +85,10 @@ Push (new): gateway rekey() ─────────────────�
   the caller always tracks the *current* owning session.
 - Malformed claims (non-int pid, pid ≤ 1, empty/missing session key) update
   nothing and are audited as denied.
+- A claim naming a **recycled PID** never lands on the pre-recycle
+  connection: the per-connection start-token check above is the guard. This
+  is a correctness/attribution boundary, not a uid boundary — the socket's
+  0700 gate already limits claims to the same user.
 
 ## Fallback
 

--- a/src/kiro_crew/mcp_gateway/claim.py
+++ b/src/kiro_crew/mcp_gateway/claim.py
@@ -26,10 +26,12 @@ but claim-push is the primary, event-driven path.
 
 Import-light on purpose: imported from ``acp/client.py`` and
 ``acp/session_provider.py`` (hot paths) and must not pull in config loading.
-The only non-stdlib import is ``mcp_gateway.transport``, whose whole chain
-is ``transport -> platform_compat -> executors`` and reaches no config
-loader; it is needed because the endpoint is a unix socket on POSIX and a
-named pipe on Windows, and this module must not know which.
+The only non-stdlib imports are ``platform_compat`` (process start tokens for
+the PID-recycle guard), ``executors`` (offloads the /proc token read from the
+event loop), and ``mcp_gateway.transport`` — all already in the
+``transport -> platform_compat -> executors`` chain, which reaches no config
+loader; transport is needed because the endpoint is a unix socket on POSIX
+and a named pipe on Windows, and this module must not know which.
 """
 
 from __future__ import annotations
@@ -40,6 +42,8 @@ import logging
 import os
 from typing import Optional
 
+from kiro_crew import platform_compat
+from kiro_crew.executors import subprocess_executor
 from kiro_crew.mcp_gateway import transport
 
 logger = logging.getLogger(__name__)
@@ -64,10 +68,19 @@ def classify_session_type(session_key: str) -> str:
 
 
 def build_claim_frame(pid: int, session_key: str, channel_id: Optional[str]) -> dict:
-    """Assemble the one-shot claim frame sent to gatewayd."""
+    """Assemble the one-shot claim frame sent to gatewayd.
+
+    ``pid_start_id`` is the claimed runtime's process start token
+    (``platform_compat.get_process_start_id``) — gatewayd compares it against
+    the token it recorded at register time so a claim can never land on a
+    connection whose PID was recycled to a different process. ``None`` means
+    "identity unknown" (Windows, unreadable /proc) and is treated by gatewayd
+    as a match, preserving legacy behavior.
+    """
     return {
         "type": "claim",
         "pid": pid,
+        "pid_start_id": platform_compat.get_process_start_id(pid),
         "caller": {
             "session_key": session_key,
             "session_type": classify_session_type(session_key),
@@ -86,7 +99,13 @@ async def _send_claim_inner(
     channel_id: Optional[str],
 ) -> bool:
     """Unbounded socket round-trip; ``send_claim`` enforces the time budget."""
-    frame = build_claim_frame(pid, session_key, channel_id)
+    # build_claim_frame resolves the runtime's start token from /proc; a
+    # /proc read can wedge on a D-state target, so keep it off the event
+    # loop (a leaked worker thread on a wedge is survivable; a frozen loop
+    # is not). send_claim's aggregate wait_for still bounds this await.
+    frame = await asyncio.get_running_loop().run_in_executor(
+        subprocess_executor(), build_claim_frame, pid, session_key, channel_id
+    )
     reader, writer = await transport.connect(socket_path)
     try:
         writer.write(json.dumps(frame).encode("utf-8") + b"\n")

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -75,6 +75,7 @@ from kiro_crew.mcp_gateway.shutdown_budget import DRAIN_SECS, POOL_SHUTDOWN_SECS
 from kiro_crew.mcp_gateway.spill import cleanup_old_spill_files
 from kiro_crew.metrics.provider import get_recorder
 from kiro_crew.peer_resolve import resolve_peer_identity
+from kiro_crew.platform_compat import get_process_start_id as _get_process_start_id
 from kiro_crew.sandbox import warm_backend
 from kiro_crew.sel import SecurityEventLog
 
@@ -1219,9 +1220,16 @@ class _StubConn:
     warm-pool stubs) and is replaced by ``recaller`` frames (stub-initiated,
     deny-by-default) or ``claim`` frames (gateway-initiated, replace-allowed).
     Single event loop — no locking needed.
+
+    ``pid_start_ids`` maps each indexed PID to its register-time process
+    start token (``platform_compat.get_process_start_id``), the PID-recycle
+    guard: a later ``claim`` naming a PID whose token no longer matches is
+    targeting a DIFFERENT process that recycled the number, and must not
+    retarget this connection. ``None`` means "identity unknown" (Windows,
+    unreadable /proc) and never counts as a mismatch.
     """
 
-    __slots__ = ("stub_uuid", "ancestor_pids", "pool_label", "caller")
+    __slots__ = ("stub_uuid", "ancestor_pids", "pool_label", "caller", "pid_start_ids")
 
     def __init__(
         self,
@@ -1229,11 +1237,13 @@ class _StubConn:
         ancestor_pids: list[int],
         pool_label: str,
         caller: Optional[CallerContext],
+        pid_start_ids: Optional[dict[int, Optional[str]]] = None,
     ) -> None:
         self.stub_uuid = stub_uuid
         self.ancestor_pids = ancestor_pids
         self.pool_label = pool_label
         self.caller = caller
+        self.pid_start_ids = pid_start_ids if pid_start_ids is not None else {}
 
 
 #: Live stub connections indexed by every ancestor PID of the kiro-cli
@@ -1474,7 +1484,11 @@ def _apply_claim(frame: dict[str, Any]) -> dict[str, Any]:
     Returns the ack frame. Validation is deny-by-default: a non-integer or
     out-of-range pid, or an empty/malformed caller, updates nothing and is
     audited as denied. A valid claim REPLACES existing identities (gateway-
-    trusted; this is what keeps callers correct across warm-pool re-claims).
+    trusted; this is what keeps callers correct across warm-pool re-claims) —
+    except on a connection whose register-time start token for the PID
+    definitively differs from the frame's ``pid_start_id`` (the PID was
+    recycled to a different process); those are skipped and audited as
+    denied rather than silently misattributed.
     """
     raw_pid = frame.get("pid")
     pid = raw_pid if isinstance(raw_pid, int) and not isinstance(raw_pid, bool) else 0
@@ -1506,7 +1520,34 @@ def _apply_claim(frame: dict[str, Any]) -> dict[str, Any]:
         )
         return {"type": "claim-noop", "updated": 0, "connections": 0}
     updated = 0
+    skipped = 0
+    # PID-recycle guard: the frame's token identifies the process the gateway
+    # actually claimed; the recorded token identifies the process that owned
+    # the PID at register time. Skip a connection only on a DEFINITE mismatch
+    # (both tokens known and unequal) — ``None`` on either side means
+    # "identity unknown" (Windows, unreadable /proc, legacy claim frames) and
+    # MUST count as a match, otherwise every claim on those platforms would
+    # be rejected.
+    raw_token = frame.get("pid_start_id")
+    claim_token = raw_token if isinstance(raw_token, str) else None
     for conn in conns:
+        recorded_token = conn.pid_start_ids.get(pid)
+        if claim_token is not None and recorded_token is not None and claim_token != recorded_token:
+            skipped += 1
+            reason = (
+                f"pid {pid} recycled: claim start-token {claim_token} != "
+                f"register-time token {recorded_token} — refusing to retarget "
+                f"stub {conn.stub_uuid}"
+            )
+            logger.warning("claim skipped stale connection: %s", reason)
+            _audit_caller_claimed(
+                conn.caller.session_key if conn.caller is not None else "",
+                updated_caller.session_key,
+                conn.pool_label,
+                "denied",
+                reason,
+            )
+            continue
         old_key = conn.caller.session_key if conn.caller is not None else ""
         if old_key == updated_caller.session_key:
             continue  # already correct — idempotent re-claim
@@ -1520,7 +1561,7 @@ def _apply_claim(frame: dict[str, Any]) -> dict[str, Any]:
             updated_caller.session_type,
             old_key or "<none>",
         )
-    return {"type": "claimed", "updated": updated, "connections": len(conns)}
+    return {"type": "claimed", "updated": updated, "connections": len(conns), "skipped": skipped}
 
 
 def _audit_abort_applied(
@@ -1911,7 +1952,24 @@ async def _handle_connection(
     stub_pids = _register_pids(register)
     indexed_pids = stub_pids + [p for p in peer_host_pids if p not in stub_pids]
 
-    conn = _StubConn(stub_uuid, indexed_pids, pool_key.human_readable(), caller)
+    # PID-recycle guard: snapshot each indexed PID's start token NOW, while
+    # the register-time process tree is still alive. A later claim carries
+    # the claimed runtime's own token; a definite mismatch means the OS
+    # recycled the PID to a different process and the claim must not land
+    # here. Computed server-side so old stubs are covered with no wire
+    # change. subprocess_executor: a /proc read can wedge on a D-state
+    # target, so keep it off the event loop, matching the
+    # _resolve_peer_identity walk above.
+    try:
+        pid_start_ids: dict[int, Optional[str]] = await asyncio.get_running_loop().run_in_executor(
+            subprocess_executor(),
+            lambda: {p: _get_process_start_id(p) for p in indexed_pids},
+        )
+    except Exception:  # graceful degradation: unknown tokens never deny claims
+        logger.exception("pid start-id snapshot failed for stub %s", stub_uuid)
+        pid_start_ids = {}
+
+    conn = _StubConn(stub_uuid, indexed_pids, pool_key.human_readable(), caller, pid_start_ids)
     _conn_index_add(conn)
 
     # Register this connection for the keepalive probe. Scoped to the handler's

--- a/test/test_mcp_gateway_claim.py
+++ b/test/test_mcp_gateway_claim.py
@@ -501,6 +501,187 @@ async def test_claim_first_frame_connection_acked(monkeypatch: pytest.MonkeyPatc
     assert writer.frames[0]["updated"] == 0  # nothing registered under _PID
 
 
+# --- PID-recycle guard (claim start-token verification) ----------------------
+
+
+def _fake_sel(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    sel_calls: list[dict[str, Any]] = []
+
+    class _FakeSEL:
+        def log_api_access(self, **kwargs: Any) -> None:
+            sel_calls.append(kwargs)
+
+    monkeypatch.setattr(gw, "SecurityEventLog", _FakeSEL)
+    return sel_calls
+
+
+def _indexed_conn(pid: int, token: Optional[str], session_key: str = "") -> gw._StubConn:
+    """Register-shaped connection: indexed under ``pid`` with a recorded
+    start token, carrying an optional existing caller identity."""
+    caller = None
+    if session_key:
+        caller = gw._caller_from_register(_claim(pid, session_key))
+    conn = gw._StubConn("rt-stub", [pid], "rt-pool", caller, {pid: token})
+    gw._conn_index_add(conn)
+    return conn
+
+
+def _claim_with_token(pid: int, session_key: str, token: Optional[str]) -> dict[str, Any]:
+    frame = _claim(pid, session_key)
+    frame["pid_start_id"] = token
+    return frame
+
+
+def test_claim_skips_recycled_pid(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The core defect scenario: the register-time owner of PID P exited, the
+    OS recycled P to a different session's runtime, and the claim for the NEW
+    process must not retarget the STALE connection — previously it silently
+    re-attributed every call (issue #1018). Definite token mismatch → skip,
+    WARN, denied audit."""
+    sel = _fake_sel(monkeypatch)
+    conn = _indexed_conn(_PID, "111", "dashboard:original-owner")
+    with caplog.at_level("WARNING", logger="kiro_crew.mcp_gateway.gatewayd"):
+        ack = gw._apply_claim(_claim_with_token(_PID, "dashboard:new-owner", "222"))
+    assert ack == {"type": "claimed", "updated": 0, "connections": 1, "skipped": 1}
+    assert conn.caller is not None
+    assert conn.caller.session_key == "dashboard:original-owner"  # unchanged
+    assert any("recycled" in r.message for r in caplog.records)
+    denied = [e for e in _claim_events(sel) if e["outcome"] == "denied"]
+    assert len(denied) == 1
+    assert "recycled" in denied[0]["error"]
+
+
+def test_claim_applies_on_matching_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same token on both sides — the register-time process is still alive —
+    keeps the existing replace behavior."""
+    sel = _fake_sel(monkeypatch)
+    conn = _indexed_conn(_PID, "111", "dashboard:old-session")
+    ack = gw._apply_claim(_claim_with_token(_PID, "dashboard:new-session", "111"))
+    assert ack == {"type": "claimed", "updated": 1, "connections": 1, "skipped": 0}
+    assert conn.caller is not None and conn.caller.session_key == "dashboard:new-session"
+    events = _claim_events(sel)
+    assert len(events) == 1 and events[0]["outcome"] == "allowed"
+
+
+@pytest.mark.parametrize(
+    ("frame_token", "recorded_token"),
+    [
+        (None, None),  # neither side knows — Windows both ends / legacy frame
+        (None, "111"),  # legacy claim frame without the field
+        ("111", None),  # register-time token unreadable (Windows, /proc denied)
+        ("111", "111"),  # both known and equal
+    ],
+)
+def test_claim_unknown_token_is_match(
+    monkeypatch: pytest.MonkeyPatch,
+    frame_token: Optional[str],
+    recorded_token: Optional[str],
+) -> None:
+    """``None`` on either side means "identity unknown" and MUST be treated
+    as a match — otherwise Windows (where get_process_start_id is always
+    None) and legacy claim frames would reject every claim."""
+    _fake_sel(monkeypatch)
+    conn = _indexed_conn(_PID, recorded_token)
+    ack = gw._apply_claim(_claim_with_token(_PID, "dashboard:chat-TOK-1", frame_token))
+    assert ack["updated"] == 1 and ack["skipped"] == 0
+    assert conn.caller is not None
+    assert conn.caller.session_key == "dashboard:chat-TOK-1"
+
+
+def test_claim_mixed_bucket_retargets_only_matching_conn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Index buckets stay keyed on the raw int PID, so a bucket may mix a
+    stale (pre-recycle) connection with a live one — the per-connection token
+    check is what disambiguates: only the matching conn is retargeted."""
+    sel = _fake_sel(monkeypatch)
+    stale = _indexed_conn(_PID, "111", "dashboard:original-owner")
+    live = _indexed_conn(_PID, "222")
+    ack = gw._apply_claim(_claim_with_token(_PID, "dashboard:new-owner", "222"))
+    assert ack == {"type": "claimed", "updated": 1, "connections": 2, "skipped": 1}
+    assert stale.caller is not None
+    assert stale.caller.session_key == "dashboard:original-owner"
+    assert live.caller is not None and live.caller.session_key == "dashboard:new-owner"
+    outcomes = sorted(e["outcome"] for e in _claim_events(sel))
+    assert outcomes == ["allowed", "denied"]
+
+
+def test_claim_non_string_token_treated_as_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A garbage (non-string) ``pid_start_id`` never becomes a mismatch: it is
+    normalized to "unknown" so a malformed field cannot deny valid claims."""
+    _fake_sel(monkeypatch)
+    conn = _indexed_conn(_PID, "111")
+    frame = _claim(_PID, "dashboard:chat-G-1")
+    frame["pid_start_id"] = 12345  # wrong type
+    ack = gw._apply_claim(frame)
+    assert ack["updated"] == 1 and ack["skipped"] == 0
+    assert conn.caller is not None and conn.caller.session_key == "dashboard:chat-G-1"
+
+
+def test_stubconn_legacy_constructor_defaults_to_empty_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pre-guard constructor shape (no ``pid_start_ids``) keeps working:
+    the mapping defaults to empty, every lookup is "unknown", and claims
+    still apply."""
+    _fake_sel(monkeypatch)
+    conn = gw._StubConn("legacy-stub", [_PID], "legacy-pool", None)
+    assert conn.pid_start_ids == {}
+    gw._conn_index_add(conn)
+    ack = gw._apply_claim(_claim_with_token(_PID, "dashboard:chat-L-1", "999"))
+    assert ack["updated"] == 1 and ack["skipped"] == 0
+    assert conn.caller is not None and conn.caller.session_key == "dashboard:chat-L-1"
+
+
+@pytest.mark.asyncio
+async def test_register_records_start_tokens_and_claim_verifies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Full wiring through the register handler: tokens are snapshotted for
+    every indexed PID at register time, and a later claim carrying a
+    different token for that PID is skipped."""
+    fb, sel = _patch_env(monkeypatch)
+    monkeypatch.setattr(gw, "_get_process_start_id", lambda _pid: "111")
+    reader = _QueueReader()
+    reader.feed(_register(""))
+    reader.feed(_CALL)
+    task = asyncio.create_task(_handle(reader, _RecordingWriter()))
+    await asyncio.wait_for(fb.forwarded.wait(), timeout=5.0)
+    (conn,) = gw._CONN_INDEX[_PID]
+    assert conn.pid_start_ids == {p: "111" for p in _ANCESTORS}
+
+    ack = gw._apply_claim(_claim_with_token(_PID, "dashboard:chat-W-1", "222"))
+    assert ack["updated"] == 0 and ack["skipped"] == 1
+
+    fb.forwarded.clear()
+    reader.feed(_CALL)
+    await asyncio.wait_for(fb.forwarded.wait(), timeout=5.0)
+    reader.feed({"type": "unregister"})
+    await task
+    assert fb.callers == [None, None]  # identity never misattributed
+    denied = [e for e in _claim_events(sel) if e["outcome"] == "denied"]
+    assert len(denied) == 1
+
+
+def test_build_claim_frame_includes_pid_start_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sender resolves the claimed runtime's start token and puts it on
+    the frame verbatim (including None passthrough on platforms without a
+    token)."""
+    monkeypatch.setattr(pc, "get_process_start_id", lambda pid: f"tok-{pid}")
+    frame = claim_mod.build_claim_frame(777, "dashboard:chat-F-1", None)
+    assert frame["pid_start_id"] == "tok-777"
+
+    monkeypatch.setattr(pc, "get_process_start_id", lambda _pid: None)
+    frame = claim_mod.build_claim_frame(777, "dashboard:chat-F-1", None)
+    assert frame["pid_start_id"] is None
+
+
 @pytest.mark.asyncio
 async def test_conn_index_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
     """Register indexes the connection under EVERY ancestor PID; teardown


### PR DESCRIPTION
## Problem

gatewayd's claim-push index (`_CONN_INDEX`) is keyed on raw PIDs only. `_apply_claim` re-binds the caller identity of every connection under the claimed PID with no check that the PID still refers to the process that was indexed at register time. If a kiro-cli ancestor exits while its stub connection stays open (wedged stub, SIGKILLed runtime), the OS can recycle that PID to a *different* session's runtime — the next claim for that PID then also lands on the stale connection and silently re-attributes its tool calls (`learn_add`, cron management, subagent completion delivery) to the wrong session.

## Why it matters

Silent cross-session caller misattribution: lessons and memory writes land in the wrong session, completion events wake the wrong agent, and the SEL audit trail records the wrong actor — with zero signal that it happened. Materially likelier on macOS (pid_max 99999) than Linux. Not a cross-uid escalation (the socket is uid-gated 0700), but a correctness/attribution defect on a security-relevant path.

## Fix (symptoms → root cause → change)

Root cause: the claim path is the one consumer of PIDs in the codebase not using the existing PID-recycle primitive (`platform_compat.get_process_start_id`, already used by `session_pid._pid_start_token`).

- **Register (gatewayd):** snapshot `get_process_start_id(pid)` for every indexed PID at register time, stored on the connection (`_StubConn.pid_start_ids`; legacy constructor shape defaults to `{}`). Computed server-side, so old stubs are covered with **no wire change**. The snapshot runs in `subprocess_executor()` — a `/proc` read can wedge on a D-state target, matching the existing `_resolve_peer_identity` offload.
- **Claim (gateway):** `build_claim_frame` sends the claimed runtime's own token as `pid_start_id` (built inside the executor via `_send_claim_inner`, still bounded by the aggregate 5s claim budget).
- **Verify (`_apply_claim`):** a connection is skipped only on a **definite** mismatch — both tokens non-None and unequal. `None` on either side means "identity unknown" (Windows, unreadable /proc, legacy frames) and counts as a match, so no platform regresses. Skips log at WARNING and emit a denied `mcp-gateway.caller-claim` SEL audit; the ack keeps its shape and gains a `skipped` count.

Scope discipline per the issue: `_CONN_INDEX` keying, cleanup, the abort path, and the recaller path are untouched — buckets may mix identities and the per-connection token check at claim time disambiguates.

## Tests

`test/test_mcp_gateway_claim.py` (+8, red-checked — the recycle test fails on unfixed code):
- recycled PID → caller unchanged, 0 updated, WARN + denied audit
- matching token → replace behavior preserved
- unknown-is-match, parametrized over all None/known combinations (Windows/legacy safety)
- mixed bucket under one PID → only the matching connection retargeted
- non-string `pid_start_id` normalized to unknown (malformed field cannot deny valid claims)
- legacy 4-arg `_StubConn` constructor still works, claims still apply
- full register-handler wiring: tokens snapshotted per indexed PID, mismatched claim skipped end-to-end
- `build_claim_frame` token passthrough incl. None

Docs: `docs/architecture/design-notes/mcp-gateway-claim-push.md` updated in the same commit.

## Manual verification

N/A — unit coverage exercises the real `_handle_connection` loop and `_apply_claim` directly; the recycle scenario cannot be reproduced deterministically on a live host without controlling kernel PID assignment.

## Screenshots

N/A — backend-only change.

Closes #1018
