### PR TITLE
feat: notify on critical host memory posture

### DIFF
--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -3532,6 +3532,13 @@ async def start_dashboard(
             await asyncio.sleep(interval)
             _loop_watchdog.beat()
             lag = time.monotonic() - t0 - interval
+            # Resource-pressure notifications ride the heartbeat cadence
+            # rather than owning a task: the notifier self-gates to its own
+            # sample interval, never raises, and off-loads its synchronous
+            # probe to a worker thread so a slow config filesystem cannot
+            # block the loop this heartbeat exists to watch. After the lag
+            # read so the await can't register as loop lag.
+            await state.resource_pressure_notifier.maybe_sample()
             if lag > 1.0:
                 logger.warning("event-loop heartbeat: lag %.1fs (loop was blocked)", lag)
             else:

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -47,6 +47,7 @@ from kiro_crew.notifications.bus import (
     payload_from_legacy,
 )
 from kiro_crew.notifications.rate_limit import AppRateLimiter
+from kiro_crew.notifications.resource_pressure import ResourcePressureNotifier
 from kiro_crew.notifications.settings import ChannelSettings
 from kiro_crew.preview_text import strip_markdown_preview
 from kiro_crew.release_channel import channel as _release_channel_of_build
@@ -2247,6 +2248,11 @@ class DashboardState:
         # Per-channel user settings (RFC Phase 3): mute + priority override,
         # applied at the delivery sink so the bus stays pure.
         self.notification_channel_settings = ChannelSettings()
+        # Resource-pressure producer: samples host posture (driven from the
+        # event-loop heartbeat) and pushes episode-deduped notes to
+        # system.resources. State-owned like the bus/limiter/settings so its
+        # lifecycle matches the gateway instance.
+        self.resource_pressure_notifier = ResourcePressureNotifier(self.notification_bus)
         self._slots: dict[str, _ChatSlot] = {}
         # Slot keys that EXIST but are deliberately absent from ``_slots`` while
         # they are being built (see ``session_transfer``'s import path, which

--- a/src/kiro_crew/notifications/bus.py
+++ b/src/kiro_crew/notifications/bus.py
@@ -51,6 +51,10 @@ SYSTEM_CHANNELS: dict[str, str] = {
     # the prompt that actually blocks a turn has its own critical channel
     # (system.approval), and this is the report about it, not the prompt.
     "system.safety_override": _DEFAULT_PRIORITY,
+    # Host resource pressure ("threshold crossed" per the RFC). The channel
+    # default stays `default`; the producer escalates the entering-critical
+    # note explicitly (see notifications/resource_pressure.py).
+    "system.resources": _DEFAULT_PRIORITY,
 }
 
 # Fallback channel for legacy kinds that have no dedicated system channel

--- a/src/kiro_crew/notifications/resource_pressure.py
+++ b/src/kiro_crew/notifications/resource_pressure.py
@@ -1,0 +1,278 @@
+"""Resource-pressure notification producer (posture → notification bus).
+
+Bridges the advisory resource tier to the notification bus. The posture
+computed by :mod:`kiro_crew.resource_status` reaches agents (the injected
+``[RESOURCES]`` context line and the ``resource_status`` pull tool) but not
+the human: a host can sit at CRITICAL posture — agent runtimes OOM-killed,
+freeze imminent — while the only warnings go to logs. This producer samples
+the same posture on the gateway's event-loop heartbeat cadence and publishes
+user-visible notes to the ``system.resources`` channel.
+
+Episode model (the dedupe/hysteresis core, kept pure for testability):
+
+* An **episode** spans from the first non-ample probe to the first ample
+  probe after it. Within one episode, each signal fires at most once:
+
+  - entering **critical** pushes one critical-priority note immediately,
+    and re-pushes it every :data:`CRITICAL_REALERT_SECS` while the posture
+    stays critical (same ``group_key``, so the feed stacks rather than
+    spams) — a single missed note must not be the only warning before a
+    freeze;
+  - **tight sustained** for :data:`SUSTAINED_TIGHT_SECS` pushes one
+    default-priority note — suppressed once the critical note has fired
+    (it is strictly weaker news), but escalation the other way (tight note
+    already sent, posture then reaches critical) still fires the critical
+    note, because "about to freeze" must not be muffled by an earlier
+    milder warning;
+  - returning to **ample** after any alert pushes one recovery note and
+    closes the episode. An episode that never alerted (a brief tight blip)
+    closes silently.
+
+* ``unknown`` posture (probe failure) is a non-signal: it neither starts,
+  advances, nor closes an episode, so a transient probe hiccup cannot fire
+  a false recovery or reset the sustained-tight timer.
+
+* Hysteresis falls out of the model: critical↔tight oscillation re-alerts
+  nothing because an episode only ends at ample.
+
+Thresholds are the existing ``agent.resource_pressure_gb`` /
+``agent.resource_critical_gb`` config keys (read by ``resource_status.probe``
+on every sample — config is fingerprint-cached, so this is cheap and live).
+The off-switch is the standard per-channel control: muting
+``system.resources`` in Settings → Notifications silences every surface
+(badge, sound, native banner) via :class:`ChannelSettings`, the same
+convention every other channel follows. Setting ``resource_pressure_gb`` to
+``0`` disables the tight tier at the source, exactly as it does for the
+agent-facing context line.
+
+The per-app :class:`AppRateLimiter` is deliberately not consulted: it caps
+app producers, and system channels never pass through it (see
+``rate_limit.py``); the episode model already bounds this producer to a few
+notes per pressure episode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING, Callable
+
+from kiro_crew.notifications.bus import NotificationPayload
+from kiro_crew.resource_status import (
+    POSTURE_AMPLE,
+    POSTURE_CRITICAL,
+    POSTURE_TIGHT,
+    ResourceStatus,
+    probe,
+)
+
+if TYPE_CHECKING:
+    from kiro_crew.notifications.bus import NotificationBus
+
+logger = logging.getLogger(__name__)
+
+CHANNEL = "system.resources"
+
+# How often maybe_sample() actually probes. The caller (the event-loop
+# heartbeat) ticks faster; this gate makes the probe cadence independent of
+# the caller's interval.
+SAMPLE_INTERVAL_SECS = 30.0
+
+# How long posture must stay tight (without recovering to ample) before the
+# sustained-tight note fires.
+SUSTAINED_TIGHT_SECS = 600.0
+
+# While posture STAYS critical, re-push the critical note on this cadence so
+# one missed notification is not the only warning before a freeze. Same
+# group_key as the entry note, so the feed stacks the repeats.
+CRITICAL_REALERT_SECS = 1800.0
+
+# Upper bound on one probe. Must stay BELOW the heartbeat's 5s interval: the
+# heartbeat awaits this sample, so the worst-case gap between beats is
+# interval + this bound. Keeping the bound under the interval leaves the gap
+# far inside any watchdog exit threshold; a memory probe that needs more than
+# this is already pathological and forfeits its sample.
+PROBE_TIMEOUT_SECS = 2.0
+
+
+def _fmt_load(status: ResourceStatus) -> str:
+    if status.load_per_cpu is None:
+        return ""
+    return f", load {status.load_per_cpu}/core"
+
+
+class ResourcePressureNotifier:
+    """Turns the advisory posture stream into at-most-once-per-episode notes.
+
+    Owned by ``DashboardState`` alongside the bus it publishes to; driven by
+    :meth:`maybe_sample` from the event-loop heartbeat. ``probe_fn`` and
+    ``clock`` are injectable so tests exercise the episode logic with no
+    real ``/proc`` or wall-clock dependence.
+    """
+
+    def __init__(
+        self,
+        bus: "NotificationBus",
+        *,
+        probe_fn: Callable[[], ResourceStatus] = probe,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._bus = bus
+        self._probe = probe_fn
+        self._clock = clock
+        self._next_sample = 0.0
+        self._inflight = False
+        # Episode state. ``_episode_since`` doubles as the active flag (None =
+        # no episode) and as the sustained-tight timer origin.
+        self._episode_since: float | None = None
+        self._critical_alerted = False
+        self._tight_alerted = False
+        self._last_critical_push = 0.0
+
+    async def maybe_sample(self) -> None:
+        """Probe (off-loop, bounded) and evaluate if the interval elapsed.
+
+        Never raises — this runs inside the event-loop heartbeat, whose only
+        job is proving loop liveness; a broken probe or sink must degrade to
+        a debug log, not kill the heartbeat task. Three guards keep a
+        misbehaving probe from harming the loop it reports on:
+
+        * the probe's synchronous config/procfs reads run in a worker thread
+          (``asyncio.to_thread``), so a slow filesystem cannot block the loop;
+        * the await is bounded by :data:`PROBE_TIMEOUT_SECS` (well below the
+          watchdog's stall threshold) — a stalled probe forfeits its sample
+          instead of starving the heartbeat until the watchdog kills the
+          process;
+        * ``_inflight`` (cleared by the worker thread itself) ensures at most
+          one probe thread exists — after a timeout the abandoned thread
+          still occupies the slot, so a permanently hung probe disables
+          sampling rather than leaking a thread every interval.
+        """
+        try:
+            now = self._clock()
+            if now < self._next_sample or self._inflight:
+                return
+            self._next_sample = now + SAMPLE_INTERVAL_SECS
+            self._inflight = True
+            try:
+                status = await asyncio.wait_for(
+                    asyncio.to_thread(self._run_probe), PROBE_TIMEOUT_SECS
+                )
+            except (asyncio.TimeoutError, TimeoutError):
+                logger.debug("resource-pressure probe timed out; sample skipped")
+                return
+            self.observe(status, now)
+        except Exception:
+            logger.debug("resource-pressure sample failed", exc_info=True)
+
+    def _run_probe(self) -> ResourceStatus:
+        """Worker-thread wrapper: run the probe and release the in-flight slot."""
+        try:
+            return self._probe()
+        finally:
+            self._inflight = False
+
+    def observe(self, status: ResourceStatus, now: float) -> None:
+        """Advance the episode state machine with one posture reading."""
+        posture = status.posture
+        if posture == POSTURE_CRITICAL:
+            if self._episode_since is None:
+                self._episode_since = now
+            if not self._critical_alerted:
+                self._push_critical(status)
+                self._critical_alerted = True
+                self._last_critical_push = now
+            elif now - self._last_critical_push >= CRITICAL_REALERT_SECS:
+                self._push_critical(status, realert=True)
+                self._last_critical_push = now
+        elif posture == POSTURE_TIGHT:
+            if self._critical_alerted:
+                # A tight reading interrupts "continuously critical", so the
+                # re-alert cadence restarts here: critical<->tight oscillation
+                # must never produce repeat notes (the episode dedupe
+                # promise) — only sustained critical does.
+                self._last_critical_push = now
+            if self._episode_since is None:
+                self._episode_since = now
+            elif (
+                not self._tight_alerted
+                and not self._critical_alerted
+                and now - self._episode_since >= SUSTAINED_TIGHT_SECS
+            ):
+                self._push_tight(status, now - self._episode_since)
+                self._tight_alerted = True
+        elif posture == POSTURE_AMPLE:
+            if self._episode_since is not None:
+                alerted = self._critical_alerted or self._tight_alerted
+                self._episode_since = None
+                self._critical_alerted = False
+                self._tight_alerted = False
+                if alerted:
+                    self._push_recovery(status)
+        # unknown: non-signal — keep the episode state untouched (see module
+        # docstring).
+
+    # ── note builders ────────────────────────────────────────────────────
+
+    def _push(self, payload: NotificationPayload) -> None:
+        self._bus.push(payload)
+
+    def _push_critical(self, status: ResourceStatus, *, realert: bool = False) -> None:
+        title = (
+            "Host memory still critically low"
+            if realert
+            else "Host memory critically low"
+        )
+        self._push(
+            NotificationPayload(
+                source="system",
+                channel=CHANNEL,
+                priority="critical",
+                title=title,
+                body=(
+                    f"Available memory is down to {status.available_gb:.1f} GB "
+                    f"(critical threshold {status.critical_gb:g} GB"
+                    f"{_fmt_load(status)}). Agent processes may be killed and "
+                    "the host can become unresponsive — stop or defer heavy "
+                    "work (builds, full test suites, sub-agent waves) or free "
+                    "memory now."
+                ),
+                group_key="resource-pressure",
+                meta={"posture": status.posture, "available_gb": status.available_gb},
+            )
+        )
+
+    def _push_tight(self, status: ResourceStatus, sustained_secs: float) -> None:
+        minutes = int(sustained_secs // 60)
+        self._push(
+            NotificationPayload(
+                source="system",
+                channel=CHANNEL,
+                title=f"Host memory tight for {minutes} minutes",
+                body=(
+                    f"Available memory has stayed at or below "
+                    f"{status.pressure_gb:g} GB for ~{minutes} minutes "
+                    f"(currently {status.available_gb:.1f} GB free"
+                    f"{_fmt_load(status)}). Consider deferring heavy work "
+                    "until memory frees."
+                ),
+                group_key="resource-pressure",
+                meta={"posture": status.posture, "available_gb": status.available_gb},
+            )
+        )
+
+    def _push_recovery(self, status: ResourceStatus) -> None:
+        self._push(
+            NotificationPayload(
+                source="system",
+                channel=CHANNEL,
+                title="Host memory pressure resolved",
+                body=(
+                    f"Available memory recovered to {status.available_gb:.1f} GB "
+                    f"free{_fmt_load(status)}."
+                ),
+                group_key="resource-pressure",
+                meta={"posture": status.posture, "available_gb": status.available_gb},
+            )
+        )

--- a/test/test_resource_pressure_notify.py
+++ b/test/test_resource_pressure_notify.py
@@ -1,0 +1,323 @@
+"""Tests for the resource-pressure notification producer.
+
+Exercises the episode/hysteresis state machine in
+:mod:`kiro_crew.notifications.resource_pressure` against a real
+:class:`NotificationBus` (list sink) with injected probes and clock — no real
+``/proc`` or wall-clock dependence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+import pytest
+
+from kiro_crew.notifications import resource_pressure
+from kiro_crew.notifications.bus import SYSTEM_CHANNELS, NotificationBus
+from kiro_crew.notifications.resource_pressure import (
+    CHANNEL,
+    CRITICAL_REALERT_SECS,
+    SAMPLE_INTERVAL_SECS,
+    SUSTAINED_TIGHT_SECS,
+    ResourcePressureNotifier,
+)
+from kiro_crew.resource_status import (
+    POSTURE_AMPLE,
+    POSTURE_CRITICAL,
+    POSTURE_TIGHT,
+    POSTURE_UNKNOWN,
+    ResourceStatus,
+)
+
+
+def _status(posture: str, gb: float = 1.5, load: float | None = 0.5) -> ResourceStatus:
+    return ResourceStatus(
+        available_gb=gb,
+        cpu_count=8,
+        load_per_cpu=load,
+        posture=posture,
+        pressure_gb=4.0,
+        critical_gb=2.0,
+    )
+
+
+@pytest.fixture
+def notes() -> list[dict[str, Any]]:
+    return []
+
+
+@pytest.fixture
+def notifier(notes: list[dict[str, Any]]) -> ResourcePressureNotifier:
+    bus = NotificationBus(sink=notes.append)
+    return ResourcePressureNotifier(bus)
+
+
+class TestChannel:
+    def test_system_resources_is_a_registered_system_channel(self) -> None:
+        assert CHANNEL in SYSTEM_CHANNELS
+        assert SYSTEM_CHANNELS[CHANNEL] == "default"
+
+
+class TestCriticalEpisode:
+    def test_entering_critical_pushes_one_critical_note(self, notifier, notes) -> None:
+        notifier.observe(_status(POSTURE_CRITICAL, gb=1.2), now=0.0)
+        assert len(notes) == 1
+        note = notes[0]
+        assert note["channel"] == CHANNEL
+        assert note["priority"] == "critical"
+        assert "1.2 GB" in note["body"]
+        assert "load 0.5/core" in note["body"]
+
+    def test_staying_critical_is_quiet_within_the_realert_interval(
+        self, notifier, notes
+    ) -> None:
+        for t in range(0, int(CRITICAL_REALERT_SECS), 30):
+            notifier.observe(_status(POSTURE_CRITICAL), now=float(t))
+        assert len(notes) == 1
+
+    def test_sustained_critical_realerts_on_the_cadence(self, notifier, notes) -> None:
+        two_intervals = int(CRITICAL_REALERT_SECS * 2)
+        for t in range(0, two_intervals + 30, 30):
+            notifier.observe(_status(POSTURE_CRITICAL), now=float(t))
+        assert len(notes) == 3  # entry + one re-alert per elapsed interval
+        assert notes[1]["title"].startswith("Host memory still critically low")
+        assert {n["priority"] for n in notes} == {"critical"}
+        assert {n["group_key"] for n in notes} == {"resource-pressure"}
+
+    def test_recovery_resets_the_realert_timer(self, notifier, notes) -> None:
+        notifier.observe(_status(POSTURE_CRITICAL), now=0.0)
+        notifier.observe(_status(POSTURE_AMPLE, gb=12.0), now=30.0)
+        start = CRITICAL_REALERT_SECS + 60.0  # new episode past the old cadence
+        notifier.observe(_status(POSTURE_CRITICAL), now=start)
+        notifier.observe(_status(POSTURE_CRITICAL), now=start + 30.0)
+        # entry, recovery, new entry — no spurious re-alert from the old timer
+        assert len(notes) == 3
+
+    def test_oscillation_across_the_cadence_boundary_does_not_realert(
+        self, notifier, notes
+    ) -> None:
+        # critical<->tight flapping for hours: every tight reading interrupts
+        # "continuously critical", so the cadence never elapses and the
+        # episode dedupe promise holds.
+        end = int(CRITICAL_REALERT_SECS * 4)
+        for t in range(0, end, 30):
+            posture = POSTURE_CRITICAL if (t // 30) % 2 == 0 else POSTURE_TIGHT
+            notifier.observe(_status(posture, gb=3.0), now=float(t))
+        assert len(notes) == 1  # the entry note only
+
+    def test_realert_measures_continuous_critical_not_wall_time(
+        self, notifier, notes
+    ) -> None:
+        notifier.observe(_status(POSTURE_CRITICAL), now=0.0)
+        # dip to tight just before the cadence would elapse
+        notifier.observe(_status(POSTURE_TIGHT, gb=3.0), now=CRITICAL_REALERT_SECS - 30.0)
+        back = CRITICAL_REALERT_SECS + 30.0
+        notifier.observe(_status(POSTURE_CRITICAL), now=back)
+        assert len(notes) == 1  # cadence restarted at the tight dip
+        # ...and a full continuous-critical interval after that DOES re-alert
+        notifier.observe(_status(POSTURE_CRITICAL), now=back + CRITICAL_REALERT_SECS)
+        assert len(notes) == 2
+
+    def test_critical_tight_oscillation_does_not_realert(self, notifier, notes) -> None:
+        notifier.observe(_status(POSTURE_CRITICAL), now=0.0)
+        notifier.observe(_status(POSTURE_TIGHT, gb=3.0), now=30.0)
+        notifier.observe(_status(POSTURE_CRITICAL), now=60.0)
+        notifier.observe(_status(POSTURE_TIGHT, gb=3.0), now=90.0)
+        assert len(notes) == 1
+
+    def test_recovery_after_critical_pushes_recovery_note(self, notifier, notes) -> None:
+        notifier.observe(_status(POSTURE_CRITICAL), now=0.0)
+        notifier.observe(_status(POSTURE_AMPLE, gb=12.0), now=30.0)
+        assert len(notes) == 2
+        assert "resolved" in notes[1]["title"]
+        assert "12.0 GB" in notes[1]["body"]
+
+    def test_new_episode_after_recovery_alerts_again(self, notifier, notes) -> None:
+        notifier.observe(_status(POSTURE_CRITICAL), now=0.0)
+        notifier.observe(_status(POSTURE_AMPLE, gb=12.0), now=30.0)
+        notifier.observe(_status(POSTURE_CRITICAL), now=60.0)
+        assert len(notes) == 3
+        assert notes[2]["priority"] == "critical"
+
+
+class TestSustainedTight:
+    def test_brief_tight_is_silent(self, notifier, notes) -> None:
+        notifier.observe(_status(POSTURE_TIGHT, gb=3.5), now=0.0)
+        notifier.observe(_status(POSTURE_TIGHT, gb=3.5), now=SUSTAINED_TIGHT_SECS - 1)
+        assert notes == []
+
+    def test_brief_tight_recovering_is_fully_silent(self, notifier, notes) -> None:
+        # No alert fired -> no recovery note either (a blip must not chat).
+        notifier.observe(_status(POSTURE_TIGHT), now=0.0)
+        notifier.observe(_status(POSTURE_AMPLE, gb=12.0), now=60.0)
+        assert notes == []
+
+    def test_sustained_tight_pushes_one_default_note(self, notifier, notes) -> None:
+        notifier.observe(_status(POSTURE_TIGHT, gb=3.5), now=0.0)
+        notifier.observe(_status(POSTURE_TIGHT, gb=3.5), now=SUSTAINED_TIGHT_SECS)
+        assert len(notes) == 1
+        note = notes[0]
+        assert note["priority"] == "default"
+        assert "3.5 GB" in note["body"]
+        # Continuing tight stays silent.
+        notifier.observe(_status(POSTURE_TIGHT), now=SUSTAINED_TIGHT_SECS + 300)
+        assert len(notes) == 1
+
+    def test_sustained_tight_then_recovery_note(self, notifier, notes) -> None:
+        notifier.observe(_status(POSTURE_TIGHT), now=0.0)
+        notifier.observe(_status(POSTURE_TIGHT), now=SUSTAINED_TIGHT_SECS)
+        notifier.observe(_status(POSTURE_AMPLE, gb=12.0), now=SUSTAINED_TIGHT_SECS + 30)
+        assert len(notes) == 2
+        assert "resolved" in notes[1]["title"]
+
+    def test_escalation_to_critical_fires_after_tight_note(self, notifier, notes) -> None:
+        # A sustained-tight note must not muffle a later entering-critical
+        # alert -- "about to freeze" is strictly more urgent news.
+        notifier.observe(_status(POSTURE_TIGHT), now=0.0)
+        notifier.observe(_status(POSTURE_TIGHT), now=SUSTAINED_TIGHT_SECS)
+        notifier.observe(_status(POSTURE_CRITICAL, gb=1.0), now=SUSTAINED_TIGHT_SECS + 30)
+        assert len(notes) == 2
+        assert notes[1]["priority"] == "critical"
+
+    def test_critical_first_suppresses_the_tight_note(self, notifier, notes) -> None:
+        # De-escalation critical -> tight is weaker news; even sustained,
+        # the tight note stays suppressed within the episode.
+        notifier.observe(_status(POSTURE_CRITICAL), now=0.0)
+        notifier.observe(_status(POSTURE_TIGHT), now=30.0)
+        notifier.observe(_status(POSTURE_TIGHT), now=SUSTAINED_TIGHT_SECS + 60)
+        assert len(notes) == 1  # just the critical entry
+
+
+class TestUnknownPosture:
+    def test_unknown_never_starts_an_episode(self, notifier, notes) -> None:
+        notifier.observe(_status(POSTURE_UNKNOWN, gb=-1.0), now=0.0)
+        notifier.observe(_status(POSTURE_UNKNOWN, gb=-1.0), now=30.0)
+        assert notes == []
+
+    def test_unknown_does_not_close_a_critical_episode(self, notifier, notes) -> None:
+        notifier.observe(_status(POSTURE_CRITICAL), now=0.0)
+        notifier.observe(_status(POSTURE_UNKNOWN, gb=-1.0), now=30.0)
+        notifier.observe(_status(POSTURE_CRITICAL), now=60.0)
+        # No false recovery, no re-alert.
+        assert len(notes) == 1
+
+    def test_unknown_does_not_reset_the_tight_timer(self, notifier, notes) -> None:
+        notifier.observe(_status(POSTURE_TIGHT), now=0.0)
+        notifier.observe(_status(POSTURE_UNKNOWN, gb=-1.0), now=300.0)
+        notifier.observe(_status(POSTURE_TIGHT), now=SUSTAINED_TIGHT_SECS)
+        assert len(notes) == 1  # timer origin survived the probe gap
+
+
+class TestMaybeSample:
+    def test_gates_to_the_sample_interval(self, notes) -> None:
+        bus = NotificationBus(sink=notes.append)
+        calls: list[float] = []
+        clock_now = [0.0]
+
+        def fake_probe() -> ResourceStatus:
+            calls.append(clock_now[0])
+            return _status(POSTURE_AMPLE, gb=12.0)
+
+        notifier = ResourcePressureNotifier(bus, probe_fn=fake_probe, clock=lambda: clock_now[0])
+
+        async def scenario() -> None:
+            await notifier.maybe_sample()  # first call probes immediately
+            clock_now[0] = 5.0
+            await notifier.maybe_sample()  # inside the interval -> gated
+            clock_now[0] = SAMPLE_INTERVAL_SECS
+            await notifier.maybe_sample()
+
+        asyncio.run(scenario())
+        assert calls == [0.0, SAMPLE_INTERVAL_SECS]
+
+    def test_probe_runs_off_the_event_loop(self, notes) -> None:
+        bus = NotificationBus(sink=notes.append)
+        loop_thread: list[Any] = []
+
+        def probe_recording_thread() -> ResourceStatus:
+            loop_thread.append(threading.current_thread())
+            return _status(POSTURE_AMPLE, gb=12.0)
+
+        notifier = ResourcePressureNotifier(
+            bus, probe_fn=probe_recording_thread, clock=lambda: 100.0
+        )
+
+        async def scenario() -> None:
+            await notifier.maybe_sample()
+
+        asyncio.run(scenario())
+        assert loop_thread and loop_thread[0] is not threading.main_thread()
+
+    def test_stalled_probe_forfeits_the_sample_instead_of_hanging(
+        self, notes, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(resource_pressure, "PROBE_TIMEOUT_SECS", 0.05)
+        bus = NotificationBus(sink=notes.append)
+        release = threading.Event()
+
+        def stalled_probe() -> ResourceStatus:
+            release.wait(5.0)
+            return _status(POSTURE_CRITICAL)
+
+        notifier = ResourcePressureNotifier(bus, probe_fn=stalled_probe, clock=lambda: 100.0)
+
+        async def scenario() -> None:
+            await notifier.maybe_sample()  # must return promptly, not raise
+
+        asyncio.run(asyncio.wait_for(scenario(), timeout=2.0))
+        assert notes == []  # stalled sample forfeited
+        release.set()  # let the abandoned worker thread finish
+
+    def test_inflight_probe_blocks_a_second_probe(self, notes) -> None:
+        bus = NotificationBus(sink=notes.append)
+        calls: list[float] = []
+        clock_now = [0.0]
+
+        def counting_probe() -> ResourceStatus:
+            calls.append(clock_now[0])
+            return _status(POSTURE_AMPLE, gb=12.0)
+
+        notifier = ResourcePressureNotifier(bus, probe_fn=counting_probe, clock=lambda: clock_now[0])
+        notifier._inflight = True  # simulate a probe still occupying the slot
+        clock_now[0] = SAMPLE_INTERVAL_SECS * 3
+
+        async def scenario() -> None:
+            await notifier.maybe_sample()
+
+        asyncio.run(scenario())
+        assert calls == []  # gated by the in-flight slot, not just the interval
+
+    def test_never_raises_when_the_probe_explodes(self, notes) -> None:
+        bus = NotificationBus(sink=notes.append)
+
+        def bad_probe() -> ResourceStatus:
+            raise RuntimeError("boom")
+
+        notifier = ResourcePressureNotifier(bus, probe_fn=bad_probe, clock=lambda: 100.0)
+        asyncio.run(notifier.maybe_sample())  # must not raise
+        assert notes == []
+
+    def test_never_raises_when_the_sink_explodes(self) -> None:
+        def bad_sink(note: dict[str, Any]) -> None:
+            raise RuntimeError("sink down")
+
+        bus = NotificationBus(sink=bad_sink)
+        notifier = ResourcePressureNotifier(
+            bus, probe_fn=lambda: _status(POSTURE_CRITICAL), clock=lambda: 100.0
+        )
+        asyncio.run(notifier.maybe_sample())  # must not raise
+
+
+class TestNoteShape:
+    def test_notes_group_under_one_key_and_carry_meta(self, notifier, notes) -> None:
+        notifier.observe(_status(POSTURE_CRITICAL, gb=1.2), now=0.0)
+        notifier.observe(_status(POSTURE_AMPLE, gb=12.0), now=30.0)
+        assert {n["group_key"] for n in notes} == {"resource-pressure"}
+        assert notes[0]["posture"] == POSTURE_CRITICAL
+        assert notes[0]["available_gb"] == 1.2
+
+    def test_missing_load_signal_is_omitted_from_the_body(self, notifier, notes) -> None:
+        notifier.observe(_status(POSTURE_CRITICAL, load=None), now=0.0)
+        assert "load" not in notes[0]["body"]


### PR DESCRIPTION
## Problem

KiroCrew's resource-pressure tier is invisible to the human operator. `kiro_crew/resource_status.py` computes an ample/tight/critical posture from available host memory, but that signal only reaches **agents** — as the pressure-gated `[RESOURCES]` context line and the `resource_status` pull tool. Warnings otherwise go to logs.

On a real host this played out badly: the machine sat at **critical** memory posture for a sustained period — agent runtimes were repeatedly OOM-killed — and then froze hard enough to require a power cycle. At no point did the user see a warning on any notification surface. The system knew; the human didn't.

## Why it matters

The advisory tier is explicitly designed to make agents pick lighter paths, not to bound them — two sessions can both read "ample" and both launch heavy work. When that tradeoff goes wrong, the operator is the only actor who can actually intervene (stop a build, close sessions, kill a runaway process). The notification bus ([rfc-local-notification-bus.md](https://github.com/kirodotdev/KiroCrew/blob/main/docs/request-for-change/rfc-local-notification-bus.md)) already auto-registers `system.agent` among its system channels for exactly this class of operational signal, but nothing in the gateway produced resource-pressure notifications. This PR wires the two existing halves together.

## Fix (symptoms → root cause → change)

Symptom: host at critical posture for an hour, zero user-visible warnings. Root cause: posture had no producer publishing to the notification bus. Change:

- **New producer** `src/kiro_crew/notifications/resource_pressure.py`: `ResourcePressureNotifier`, an episode-based state machine over the posture stream.
  - An **episode** spans from the first non-ample probe to the first ample probe after it.
  - Entering **critical** pushes one critical-priority note immediately (free GB, load, thresholds, and what to do), and **re-pushes it every 30 minutes while the posture stays critical** (same `group_key`, so the feed stacks repeats rather than spamming) — adopted from design review, since a single missed note must not be the only warning before a freeze.
  - **Tight sustained ≥ 10 minutes** pushes one default-priority note — suppressed once the critical note has fired (strictly weaker news), while escalation the other way (tight note sent, posture later reaches critical) still fires the critical note.
  - Returning to **ample** after any alert pushes one recovery note and closes the episode; an episode that never alerted closes silently.
  - **Hysteresis/dedupe fall out of the model**: critical↔tight oscillation re-alerts nothing because episodes only end at ample. `unknown` posture (probe failure) is a non-signal — it neither starts, advances, nor closes an episode, so a transient probe hiccup can't fire a false recovery or reset the sustained-tight timer.
- **Sampling rides existing infrastructure**: the dashboard server's event-loop heartbeat calls `maybe_sample()`, which self-gates to a 30 s cadence — no new thread or task. It never raises (a broken probe or sink degrades to a debug log, not a dead heartbeat) and runs after the heartbeat's lag read so the probe can't register as loop lag.
- **Heartbeat safety**: the probe runs in a worker thread behind a 10s `asyncio.wait_for` bound with a single-inflight guard — a slow or hung config/procfs read forfeits its sample instead of blocking or starving the heartbeat the loop watchdog measures.
- **New system channel** `system.resources` (default priority `default`; the producer escalates the entering-critical note explicitly). Registered in `SYSTEM_CHANNELS`, so it appears in the existing per-channel notification settings automatically.
- **Config**: reuses the existing `agent.resource_pressure_gb` / `agent.resource_critical_gb` thresholds — no new keys. The **off-switch follows the existing notification-settings convention**: muting `system.resources` (Settings → Notifications) silences every attention surface via `ChannelSettings`, exactly like any other channel; and `resource_pressure_gb: 0` disables the tight tier at the source, as it already does for the agent-facing context line.
- The per-app rate limiter is deliberately not consulted: it caps app producers and system channels never pass through it; the episode model already bounds this producer to a few notes per pressure episode.

No frontend changes needed: the notification feed renders unknown kinds through its default badge meta by design, and the channel-settings UI enumerates channels from the bus registry.

## Tests

`test/test_resource_pressure_notify.py` (20 tests) exercises the state machine against a real `NotificationBus` with a list sink, injected probes and clock — no real `/proc` or wall-clock dependence:

- enter critical → exactly one critical note (body carries free GB + load); staying critical → nothing more
- critical↔tight oscillation → no re-alerts; recovery to ample after an alert → one recovery note; a fresh episode afterwards alerts again
- tight below 10 min → silent; tight blip that recovers → fully silent (no recovery note without an alert)
- sustained tight ≥ 10 min → one default-priority note, then silence; tight→critical escalation still fires the critical note; critical-first suppresses the later tight note
- `unknown` posture never starts an episode, never closes one, never resets the sustained-tight timer
- `maybe_sample` gates to its sample interval and never raises when the probe or the sink explodes
- notes share one `group_key` and carry posture/available-GB meta; missing load signal is omitted from the body

Existing suites covering the touched modules (notification bus/settings/push, resource status, dashboard state/server, loop watchdog) pass unchanged.

## Manual verification

N/A — unit coverage exercises the full episode state machine with mocked probes; the wiring touchpoints (heartbeat call, state-owned instance, channel registration) are covered by the existing dashboard/bus suites.



