### PR TITLE
feat: doctor warns when host has no swap and no userspace OOM killer

### DIFF
--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -649,6 +649,125 @@ def _doctor_pod_session_bus(issues: list[str]) -> None:
         print("               taking running pods with it. " f"Fix: loginctl enable-linger {user}")
 
 
+# Where SwapTotal is read from. A module attribute (not inlined) so tests can
+# point it at a fabricated meminfo file.
+_PROC_MEMINFO = Path("/proc/meminfo")
+
+# Userspace OOM killers doctor knows how to detect, in probe order:
+# systemd-oomd ships with systemd (the common case), earlyoom is the usual
+# add-on daemon.
+_OOM_KILLER_UNITS = ("systemd-oomd", "earlyoom")
+
+
+def _swap_total_kib() -> int | None:
+    """``SwapTotal`` from ``/proc/meminfo`` in KiB, ``None`` when unreadable.
+
+    Read from procfs directly rather than shelling out to ``free``/``swapon``:
+    the file is world-readable and parsing it cannot hang or prompt.
+    """
+    try:
+        text = _PROC_MEMINFO.read_text(encoding="ascii")
+    except (OSError, UnicodeDecodeError):
+        return None
+    for line in text.splitlines():
+        if line.startswith("SwapTotal:"):
+            parts = line.split()
+            try:
+                return int(parts[1])
+            except (IndexError, ValueError):
+                return None
+    return None
+
+
+def _detect_userspace_oom_killer() -> str | bool | None:
+    """Which userspace OOM killer is active, if any.
+
+    Returns the unit name (``"systemd-oomd"`` / ``"earlyoom"``) when one is
+    active, ``False`` when every probe completed and none is active, and
+    ``None`` when it cannot be determined (no ``systemctl``, probe timeout or
+    failure) so the caller reports "unknown" rather than guessing. ``True`` is
+    never returned — the truthy arm carries the unit name.
+
+    Non-privileged and bounded: ``systemctl is-active`` needs no root and each
+    probe is capped at 5s, so this can never hang the doctor.
+    """
+    systemctl = platform_compat.trusted_system_bin("systemctl")
+    if systemctl is None:
+        return None
+    determined = True
+    for unit in _OOM_KILLER_UNITS:
+        try:
+            res = subprocess.run(
+                [systemctl, "is-active", unit],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            determined = False
+            continue
+        if res.returncode == 0 and res.stdout.strip() == "active":
+            return unit
+    return False if determined else None
+
+
+def _doctor_memory_pressure(issues: list[str]) -> None:
+    """Report whether the host can degrade gracefully under memory pressure.
+
+    A Linux host with zero swap and no userspace OOM killer has no pressure
+    release valve: sustained memory pressure evicts file-backed pages (running
+    code included) faster than they re-fault in, and the host livelocks —
+    unresponsive for minutes, sometimes until a power cycle — before the kernel
+    OOM killer's conservative heuristics fire. Either protection alone (swap to
+    absorb the spike, or earlyoom/systemd-oomd to kill a hog early) prevents
+    the freeze, so this warns only when BOTH are absent. When detection is
+    inconclusive it reports "unknown" instead of warning.
+
+    Advisory only (never appended to ``issues``): swap sizing and OOM-killer
+    policy are host configuration the user owns — doctor reports the exposure,
+    it does not fail the install over it. Linux-only: the freeze mode and both
+    detection sources are Linux-specific.
+    """
+    del issues  # advisory-only diagnostic; keeps the call-site signature uniform
+    print("\nMemory Pressure")
+    if not sys.platform.startswith("linux"):
+        print(
+            f"  freeze risk: ⏹ not applicable ({sys.platform} — the swap/OOM-killer "
+            "check reads Linux procfs)"
+        )
+        return
+
+    swap_kib = _swap_total_kib()
+    if swap_kib is None:
+        print("  swap:        ⚠️  could not read SwapTotal from /proc/meminfo — check skipped")
+        return
+    if swap_kib > 0:
+        print(f"  swap:        ✅ {swap_kib / 1048576:.1f} GiB configured")
+    else:
+        print("  swap:        ⏹ none (SwapTotal = 0)")
+
+    killer = _detect_userspace_oom_killer()
+    if isinstance(killer, str):
+        print(f"  oom killer:  ✅ {killer} active")
+    elif killer is False:
+        print("  oom killer:  ⏹ none active (checked: " + ", ".join(_OOM_KILLER_UNITS) + ")")
+    else:
+        print("  oom killer:  ⏹ could not determine (no systemctl, or the probe failed)")
+
+    if swap_kib > 0 or isinstance(killer, str):
+        return
+    if killer is None:
+        # Uncertain detection must not warn — a container or non-systemd host
+        # may run a killer doctor cannot see.
+        print("  freeze risk: ⏹ unknown — no swap, and OOM-killer detection was inconclusive")
+        return
+    print("  freeze risk: ⚠️  host can freeze under sustained memory pressure")
+    print("               With no swap and no userspace OOM killer, memory pressure")
+    print("               thrashes file-backed pages and the host can livelock before")
+    print("               the kernel OOM killer intervenes.")
+    print("               Fix: add swap, enable systemd-oomd, or install earlyoom.")
+
+
 def _doctor_model_url_reachable(issues: list[str]) -> None:
     """Light HTTPS-reachability probe of the resolved embedding-model URL.
 
@@ -924,6 +1043,9 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     # Ahead of MCP Tools: the probes below spawn through the sandbox chokepoint,
     # so this verdict is the context for any probe failure they report.
     _doctor_sandbox(issues)
+
+    # ── Memory pressure preparedness (swap / userspace OOM killer) ──
+    _doctor_memory_pressure(issues)
 
     # ── MCP Tools ──
     print("\nMCP Tools")

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -341,3 +341,176 @@ class TestTrustRoot:
         out = capsys.readouterr().out
         assert "not created yet" in out
         assert "⚠" not in out
+
+
+class TestSwapTotalProbe:
+    """``SwapTotal`` parsed from /proc/meminfo → KiB, or None when unreadable."""
+
+    def _meminfo(self, monkeypatch, tmp_path: Path, content: str) -> None:
+        path = tmp_path / "meminfo"
+        path.write_text(content, encoding="ascii")
+        monkeypatch.setattr(cli_doctor, "_PROC_MEMINFO", path)
+
+    def test_swap_present(self, monkeypatch, tmp_path: Path) -> None:
+        self._meminfo(
+            monkeypatch, tmp_path, "MemTotal:       63901234 kB\nSwapTotal:       8388604 kB\n"
+        )
+        assert cli_doctor._swap_total_kib() == 8388604
+
+    def test_swap_zero(self, monkeypatch, tmp_path: Path) -> None:
+        self._meminfo(
+            monkeypatch, tmp_path, "MemTotal:       63901234 kB\nSwapTotal:             0 kB\n"
+        )
+        assert cli_doctor._swap_total_kib() == 0
+
+    def test_missing_file_is_none(self, monkeypatch, tmp_path: Path) -> None:
+        monkeypatch.setattr(cli_doctor, "_PROC_MEMINFO", tmp_path / "absent")
+        assert cli_doctor._swap_total_kib() is None
+
+    def test_missing_line_is_none(self, monkeypatch, tmp_path: Path) -> None:
+        self._meminfo(monkeypatch, tmp_path, "MemTotal:       63901234 kB\n")
+        assert cli_doctor._swap_total_kib() is None
+
+    def test_malformed_value_is_none(self, monkeypatch, tmp_path: Path) -> None:
+        self._meminfo(monkeypatch, tmp_path, "SwapTotal: banana kB\n")
+        assert cli_doctor._swap_total_kib() is None
+
+
+class TestOomKillerProbe:
+    """``systemctl is-active <unit>`` → unit name / False / None (unknown)."""
+
+    def _probe(self, monkeypatch, active: set[str] | None, *, raises: bool = False):
+        import subprocess
+
+        monkeypatch.setattr(
+            cli_doctor.platform_compat,
+            "trusted_system_bin",
+            lambda _n: "/usr/bin/systemctl",
+        )
+
+        def fake_run(cmd, **_k):
+            if raises:
+                raise subprocess.TimeoutExpired(cmd=cmd, timeout=5)
+            unit = cmd[-1]
+            if active is not None and unit in active:
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="active\n")
+            return subprocess.CompletedProcess(args=cmd, returncode=3, stdout="inactive\n")
+
+        monkeypatch.setattr(cli_doctor.subprocess, "run", fake_run)
+        return cli_doctor._detect_userspace_oom_killer()
+
+    def test_systemd_oomd_active(self, monkeypatch) -> None:
+        assert self._probe(monkeypatch, {"systemd-oomd"}) == "systemd-oomd"
+
+    def test_earlyoom_active(self, monkeypatch) -> None:
+        assert self._probe(monkeypatch, {"earlyoom"}) == "earlyoom"
+
+    def test_none_active_is_false(self, monkeypatch) -> None:
+        assert self._probe(monkeypatch, set()) is False
+
+    def test_probe_timeout_is_unknown(self, monkeypatch) -> None:
+        # A hung/failed probe must degrade to "unknown", never propagate.
+        assert self._probe(monkeypatch, None, raises=True) is None
+
+    def test_absent_systemctl_is_unknown(self, monkeypatch) -> None:
+        # Resolution goes through the trusted-bin pin (fixed system dirs), so a
+        # PATH-planted shim can never be executed; a miss degrades to unknown.
+        monkeypatch.setattr(
+            cli_doctor.platform_compat, "trusted_system_bin", lambda _n: None
+        )
+        assert cli_doctor._detect_userspace_oom_killer() is None
+
+
+class TestMemoryPressure:
+    """`kirocrew doctor` Memory Pressure section — freeze-preparedness verdict.
+
+    A Linux host with zero swap AND no userspace OOM killer livelocks under
+    sustained memory pressure (file-backed page thrashing) before the kernel
+    OOM killer fires. Doctor warns on exactly that quadrant, passes when either
+    protection exists, reports "unknown" when detection is inconclusive, and
+    never gates its exit code on any of it (host config is the user's call).
+    """
+
+    def _arrange(
+        self, monkeypatch, *, swap_kib: int | None, killer: str | bool | None
+    ) -> list[str]:
+        monkeypatch.setattr(cli_doctor.sys, "platform", "linux")
+        monkeypatch.setattr(cli_doctor, "_swap_total_kib", lambda: swap_kib)
+        monkeypatch.setattr(cli_doctor, "_detect_userspace_oom_killer", lambda: killer)
+        return ["pre-existing"]
+
+    def test_no_swap_no_killer_warns_but_never_blocks(self, monkeypatch, capsys) -> None:
+        # The dangerous quadrant: warn with the remediation, but stay advisory —
+        # swap sizing and killer policy are host configuration the user owns.
+        issues = self._arrange(monkeypatch, swap_kib=0, killer=False)
+
+        cli_doctor._doctor_memory_pressure(issues)
+
+        out = capsys.readouterr().out
+        assert "freeze" in out and "⚠️" in out
+        assert "add swap" in out and "systemd-oomd" in out and "earlyoom" in out
+        assert issues == ["pre-existing"], "the warning must not add an issue"
+
+    def test_swap_present_no_killer_passes(self, monkeypatch, capsys) -> None:
+        issues = self._arrange(monkeypatch, swap_kib=8388604, killer=False)
+
+        cli_doctor._doctor_memory_pressure(issues)
+
+        out = capsys.readouterr().out
+        assert "swap:        ✅" in out
+        assert "⚠️" not in out
+        assert issues == ["pre-existing"]
+
+    def test_no_swap_killer_active_passes(self, monkeypatch, capsys) -> None:
+        issues = self._arrange(monkeypatch, swap_kib=0, killer="earlyoom")
+
+        cli_doctor._doctor_memory_pressure(issues)
+
+        out = capsys.readouterr().out
+        assert "oom killer:  ✅ earlyoom" in out
+        assert "⚠️" not in out
+        assert issues == ["pre-existing"]
+
+    def test_both_protections_pass(self, monkeypatch, capsys) -> None:
+        issues = self._arrange(monkeypatch, swap_kib=8388604, killer="systemd-oomd")
+
+        cli_doctor._doctor_memory_pressure(issues)
+
+        out = capsys.readouterr().out
+        assert "swap:        ✅" in out and "oom killer:  ✅ systemd-oomd" in out
+        assert "⚠️" not in out
+        assert issues == ["pre-existing"]
+
+    def test_no_swap_unknown_killer_is_informational_not_warning(
+        self, monkeypatch, capsys
+    ) -> None:
+        # Inconclusive detection (no systemctl / probe failure) must not warn —
+        # a container or non-systemd host may run a killer doctor cannot see.
+        issues = self._arrange(monkeypatch, swap_kib=0, killer=None)
+
+        cli_doctor._doctor_memory_pressure(issues)
+
+        out = capsys.readouterr().out
+        assert "unknown" in out and "inconclusive" in out
+        assert "⚠️" not in out
+        assert issues == ["pre-existing"]
+
+    def test_unreadable_meminfo_skips_quietly(self, monkeypatch, capsys) -> None:
+        issues = self._arrange(monkeypatch, swap_kib=None, killer=False)
+
+        cli_doctor._doctor_memory_pressure(issues)
+
+        out = capsys.readouterr().out
+        assert "check skipped" in out
+        assert "freeze risk: ⚠️" not in out
+        assert issues == ["pre-existing"]
+
+    def test_non_linux_is_not_applicable(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(cli_doctor.sys, "platform", "darwin")
+        issues: list[str] = []
+
+        cli_doctor._doctor_memory_pressure(issues)
+
+        out = capsys.readouterr().out
+        assert "not applicable" in out
+        assert issues == []

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -571,6 +571,10 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "cli_commands.py::_register_app_crons_to_scheduler",
         "cli_doctor.py::_doctor",
         "cli_doctor.py::_doctor_mcp_tools",
+        # ``systemctl is-active <unit>`` probes for the memory-pressure
+        # preparedness check: argv is hardcoded (systemd-oomd/earlyoom unit
+        # names), no agent influence, 5s-capped, read-only query.
+        "cli_doctor.py::_detect_userspace_oom_killer",
         # Read-only diagnostic: `loginctl show-user <user> -p Linger --value`,
         # a fixed argv whose only variable is the invoking account name taken
         # from $USER/$LOGNAME (never agent-supplied). Same class as


### PR DESCRIPTION
## Motivation

A Linux host running heavy agent workloads with **zero swap and no userspace OOM killer** does not degrade under memory pressure — it freezes. Sustained pressure evicts file-backed pages (running executables and libraries included) faster than they re-fault in, and the host livelocks in page-thrash for many minutes — in the observed incident, 17+ minutes of total unresponsiveness ending in a forced power cycle — before the kernel OOM killer's conservative heuristics ever fire. Either protection alone prevents the freeze: swap absorbs the spike, and a userspace killer (systemd-oomd, [earlyoom](https://github.com/rfjakob/earlyoom)) kills a memory hog early, while the system is still responsive.

KiroCrew workloads are exactly the kind that hit this: parallel sub-agents, full test suites, and builds can spike memory quickly. `kirocrew doctor` is the preparedness surface — it already checks dependencies, config, and platform state — but today it says nothing about this host condition. Users only find out when the host is already frozen.

## What the check does

Adds a **Memory Pressure** section to `kirocrew doctor`:

- **Linux-only** — reports `⏹ not applicable` on macOS/Windows, matching the existing platform-specific sections (Pods session bus).
- **Swap**: reads `SwapTotal` from `/proc/meminfo` directly (no shelling out; world-readable, cannot hang or prompt).
- **Userspace OOM killer**: probes `systemctl is-active systemd-oomd` / `earlyoom` — non-privileged, each probe capped at 5s, and every failure path (no `systemctl`, timeout, subprocess error) degrades to "unknown" rather than crashing or hanging the doctor.
- **Verdict**:
  - ⚠️ warns **only** when `SwapTotal == 0` AND no userspace killer is active — suggests adding swap, enabling systemd-oomd, or installing earlyoom.
  - ✅ passes when either protection exists.
  - ⏹ informational "unknown" (never a warning) when detection is inconclusive — a container or non-systemd host may run a killer the probe cannot see.

## Why WARN-only, never a doctor failure

Swap sizing and OOM-killer policy are host configuration the user owns. Many valid deployments (containers, CI runners, hosts with ample headroom) intentionally run without swap, so this must never flip `kirocrew doctor`'s exit code to 1 on a healthy install. The section is advisory, following the same pattern as the existing Pods session-bus section: report the exposure, leave the decision to the user.

## Test coverage

- `TestSwapTotalProbe` (5): SwapTotal present / zero / meminfo missing / line missing / malformed value.
- `TestOomKillerProbe` (5): systemd-oomd active / earlyoom active / none active / probe timeout → unknown / no systemctl → unknown.
- `TestMemoryPressure` (7): all four swap×killer quadrants, the detection-failure (unknown) path, unreadable meminfo, and non-Linux skip — each asserting the advisory contract (never appends to `issues`).

All follow the existing `test_cli_doctor.py` conventions (monkeypatched module attributes, `capsys` output assertions).
