### PR TITLE
fix(followup): hide OPTIONS chips immediately on Quick Send when slot is busy

### DIFF
--- a/website/src/test/deriveFollowUpOptions.test.ts
+++ b/website/src/test/deriveFollowUpOptions.test.ts
@@ -54,4 +54,18 @@ describe('deriveFollowUpOptions', () => {
   it('returns no options when there is no assistant turn', () => {
     expect(deriveFollowUpOptions([user('hi')], false).followUpOptions).toEqual([])
   })
+
+  // Regression: Quick Send while the slot is busy appends a 'queued' bubble
+  // instead of an optimistic 'user' bubble. Options must still vanish.
+  it('clears options when a queued message follows the options turn', () => {
+    const queued: ChatMessage = { role: 'queued', content: 'Alpha', cls: 'msg msg-queued', meta: { queueId: 'q1' } }
+    const msgs = [user('go'), assistant(OPTIONS_MSG), queued]
+    expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+  })
+
+  it('clears options when a queued message follows a compaction notice after options', () => {
+    const queued: ChatMessage = { role: 'queued', content: 'Beta', cls: 'msg msg-queued', meta: { queueId: 'q2' } }
+    const msgs = [user('go'), assistant(OPTIONS_MSG), compactionLive(), queued]
+    expect(deriveFollowUpOptions(msgs, false).followUpOptions).toEqual([])
+  })
 })

--- a/website/src/utils/deriveFollowUpOptions.ts
+++ b/website/src/utils/deriveFollowUpOptions.ts
@@ -10,9 +10,13 @@ export interface FollowUpDerivation {
  * Derive the follow-up `[OPTIONS:]` buttons for the current chat by scanning
  * backward for the most recent real assistant turn.
  *
- * Two messages short-circuit the scan:
+ * Three messages short-circuit the scan:
  *  - a `user` message ends the previous turn, so its options no longer apply →
  *    return none.
+ *  - a `queued` message means the user already acted (Quick Send while the
+ *    slot was busy). The optimistic user bubble was suppressed, but the intent
+ *    is identical — hide options immediately so they don't linger until the
+ *    queue drains.
  *  - a `compaction` notice is skipped. Auto-compaction appends a
  *    "✅ Conversation compacted" message with the `assistant` role but tagged
  *    `kind="compaction"` (see `chat_utils._broadcast_compaction_result`). It
@@ -28,7 +32,7 @@ export function deriveFollowUpOptions(
   if (isStreaming) return { followUpOptions: [], followUpIsPlan: false }
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i]
-    if (m.role === 'user') return { followUpOptions: [], followUpIsPlan: false }
+    if (m.role === 'user' || m.role === 'queued') return { followUpOptions: [], followUpIsPlan: false }
     if ((m.kind ?? (m.meta?.kind as string | undefined)) === 'compaction') continue
     if (m.role === 'assistant' && m.content) {
       const { options, isPlan } = parseOptions(m.content)


### PR DESCRIPTION
## Summary

Fixes #2409

When Quick Send (⚡) fires while `selectComposerBusy` is true (stale `orchestrating` or `subagents_running` on the dashboard slot), the optimistic `{role: "user"}` bubble is suppressed and a `{role: "queued"}` message appears via WebSocket instead. `deriveFollowUpOptions()` did not recognize `queued` as a terminal signal — it scanned past it and found the assistant's OPTIONS message, keeping chips visible for 1-3 seconds until the queue drained or streaming began.

## Root Cause

```
tryQuickSend gates on: slotRunning (allows the send)
send() gates optimistic bubble on: selectComposerBusy (broader — includes orchestrating, subagents_running)
```

When busy: send fires ✓, but no optimistic `user` bubble is appended. Server echoes `queued`. The backward scan in `deriveFollowUpOptions` did not stop on `queued`, so options persisted.

## Fix

One-line change: treat `role === 'queued'` the same as `role === 'user'` in `deriveFollowUpOptions()`. Both mean the user has acted on the presented options.

```diff
-    if (m.role === 'user') return { followUpOptions: [], followUpIsPlan: false }
+    if (m.role === 'user' || m.role === 'queued') return { followUpOptions: [], followUpIsPlan: false }
```

## Testing

- 2 new test cases covering the `queued` role scenario (direct + after compaction notice)
- All 173 existing tests pass (deriveFollowUpOptions, QuickSend, FollowUpBar, ChatInput)
- All 207 chatSlice tests pass
- TypeScript clean

## Files Changed

- `website/src/utils/deriveFollowUpOptions.ts` — logic fix
- `website/src/test/deriveFollowUpOptions.test.ts` — regression tests