### PR TITLE
feat: pin tunnel sessions to daemon-verified tailnet peer (#1762)

### DIFF
--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -292,6 +292,38 @@ the same and the difference is the whole security story:
   Tailscale is absent, stopped, or MagicDNS is off it contributes nothing and the
   dashboard starts exactly as before. It does not widen the network bind and does
   not change authentication — every request still needs a dashboard session.
+
+  Optionally, opt in to **identity-pinned sessions** so the session pin binds to
+  your device's daemon-verified tailnet identity instead of the tunnel's shared
+  loopback address (and the audit trail names your login instead of
+  `127.0.0.1`):
+  ```json
+  {
+    "dashboard": {
+      "tailscale": {
+        "enabled": true,
+        "trust_identity": true,
+        "allowed_logins": ["you@example.com"],
+        "pin_scope": "node"
+      }
+    }
+  }
+  ```
+  `allowed_logins` is mandatory — `trust_identity` with an empty list is refused
+  at startup, and a verified peer whose login is not listed is denied. The
+  identity is resolved from the local `tailscale whois` daemon, never from a
+  header. When identity cannot be resolved (daemon stopped, Tailscale absent,
+  Windows — where resolution is not yet verified), a NEW login falls back to
+  the ordinary token path, while a session already pinned to a tailnet
+  identity is refused ("tailnet identity unverified") until the daemon
+  answers again — an unverified proxied request can never satisfy an
+  identity pin. `pin_scope: "node"` (the default) means a leaked session cookie is
+  usable only from the original device; `"login"` relaxes that to any device
+  carrying your Tailscale identity. An ACL-tagged node is always pinned at node
+  scope regardless of `pin_scope`, because every tagged device shares the
+  literal `tagged-devices` login. Identity trust does **not** unlock the
+  config-write or secret-reveal surfaces: a tailnet request is still a proxied
+  request and those stay read-only.
 - [Tailscale Funnel](https://tailscale.com/kb/1223/funnel) does the opposite: it
   puts the service **on the public internet**, like cloudflared and ngrok. Use it
   only if you actually want public ingress.
@@ -332,7 +364,10 @@ service installer such as `cloudflared service install`).
 > indefinitely if the browser keeps rotating its refresh cookie. For the same
 > reason the audit trail records the caller as `127.0.0.1` rather than a client
 > address. Security Posture → Dashboard token auth reports which of the two states
-> you are actually in.
+> you are actually in. The one exception is `tailscale serve` **with
+> `trust_identity` configured** (see above): there the pin binds to the
+> daemon-verified peer identity and is per-client again. For cloudflared, ngrok,
+> and Funnel the pin is always shared.
 >
 > So the real control for a tunnelled dashboard is the provider's own auth layer
 > (Cloudflare Access, or `tailscale serve`, which keeps the service inside your

--- a/docs/request-for-change/rfc-tailnet-dashboard-access.md
+++ b/docs/request-for-change/rfc-tailnet-dashboard-access.md
@@ -16,8 +16,16 @@ superseded-by: []
 - Status: partial — **Phase 1 landed** as PR #1761 (merged commit `f8afcff7`):
   `is_proxied_request()`, the per-binding `proxied` flag, the tri-state Security
   Posture row, and the guide correction across all three tunnel providers.
-  Phases 2–4 have no implementation. Phase 1 reports the pin's real scope; it
-  does **not** repair the pin, which is Phase 3 and is tracked as issue #1762.
+  **Phase 3 landed** (issue #1762): `resolve_forwarded_peer()` in
+  `dashboard/tailnet.py`, the peer-keyed session pin and login allowlist in
+  `dashboard/token_auth.py`, and audit attribution to the resolved login —
+  POSIX-only per OQ4 (Windows resolution is unverified and degrades to the
+  token path). One shape divergence from §3: the implemented peer keys are
+  `ts:node:<login>|<node>` / `ts:login:<login>` — the scope tag and the `|`
+  separator (forbidden inside either component) exist because logins are
+  emails and contain `@`, so the bare shapes in §3 are ambiguous. Phase 2's explicit half
+  (`dashboard.tailscale.enabled` origin derivation) is implemented; its
+  inferred signal (§4 signal 2) and Phase 4 are not.
   Pin scope was settled after review: configurable, defaulting to `node` (§3.1).
 - Author: zezhexu
 - Created: 2026-08-06

--- a/docs/system-specs/features/dashboard-token-auth.md
+++ b/docs/system-specs/features/dashboard-token-auth.md
@@ -113,8 +113,21 @@ def validate_token(token: str, *, use_session_exp: bool = False) -> tuple[bool, 
     # use_session_exp=True for cookie-based access (validates against session_exp)
     # use_session_exp=False for URL click (validates against exp / link window)
 
+def bind_token_peer(token: str, peer_key: str) -> None: ...
+def check_token_peer(token: str, peer_key: str) -> tuple[bool, str]: ...
+    # The session pin is keyed by a PEER KEY: "ip:<addr>" (the default address
+    # pin, byte-for-byte the pre-peer behaviour) or "ts:node:<login>|<node>" / "ts:login:<login>" for a
+    # daemon-verified tailnet peer (rfc-tailnet-dashboard-access §3). check
+    # returns (ok, mismatch_reason); the reason names what the STORED pin was
+    # bound to — "IP mismatch" for an ip: pin, "device identity mismatch" for a
+    # node-scoped ts: pin, "peer identity mismatch" for a login-scoped one. In
+    # the middleware, a ts:-pinned session checked by a request on which NO
+    # peer resolved is reported as "tailnet identity unverified" instead —
+    # this request could not establish who is behind the proxy, which is not
+    # evidence the device changed.
 def bind_token_ip(token: str, ip: str) -> None: ...
 def check_token_ip(token: str, ip: str) -> bool: ...
+    # Thin compat wrappers over the peer functions for plain address pins.
 
 def mark_consumed(token: str) -> None: ...
 def is_consumed(token: str) -> bool: ...
@@ -475,7 +488,7 @@ HTML 403 page includes instructions to run `!dashboard` in Slack. The middleware
 
 1. Per-process HMAC secret (`os.urandom(32)`) — process restart invalidates all tokens
 2. Dual expiry: 5-minute link click window + configurable session TTL (max 20h)
-3. IP pinning on first use — prevents token theft across networks
+3. Peer-keyed session pinning on first use — prevents token theft across networks. The pin binds to the client address (`ip:<addr>`), or — when the operator opted into `dashboard.tailscale.trust_identity` and the local daemon verified the forwarded peer — to the tailnet identity (`ts:node:<login>|<node>` or `ts:login:<login>` per `pin_scope`, ACL-tagged nodes always node-scoped). A verified login outside `allowed_logins` is denied outright. Resolution failure is fail-closed on identity and fail-open on availability for NEW sessions: they degrade to the address pin. A session already pinned to a tailnet identity is denied ("tailnet identity unverified") while the daemon cannot answer — never satisfiable by an unverified proxied request — and transient daemon failures (spawn error, timeout) are cached only ~2s so a startup blip clears quickly. Behind a non-Tailscale tunnel the pin binds to the tunnel's loopback address and is therefore shared (reported by Security Posture)
 4. Single-use URL consumption — re-click from different client rejected; same client redirected to strip token
 5. Dashboard link sent via DM only — never posted in channels
 6. Loopback always trusted — local processes (mcp-core, doctor, SSH tunnels) never need tokens

--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -854,7 +854,7 @@ new module/class names.
     deny-by-default, a `PlatformCompositionError` is re-raised. The public
     Default cannot raise, so standalone never reaches the fallback.
   - `DashboardContributor.on_token_consumed(user_id, channel, session_exp,
-    thread_ts)` — fired in `dashboard/token_auth.py` after `bind_token_ip` on the
+    thread_ts)` — fired in `dashboard/token_auth.py` after `bind_token_peer` on the
     first (non-cookie) exchange, with `channel`/`thread_ts` read from the token's
     signed `extra` payload. OBSERVER only; the anchor a challenge auth-window
     opens on. Default no-op. `safe_context_call(fallback=None)` re-raises

--- a/src/kiro_crew/cli_config.py
+++ b/src/kiro_crew/cli_config.py
@@ -109,7 +109,10 @@ def _config_cmd(args: argparse.Namespace) -> None:
             # takes precedence over the base file) cannot become the one way to
             # store `true` on a pinned host. Only the enable direction is refused
             # (tightest-wins), matching the PATCH 403 and the startup gate.
-            if key == "dashboard.tailscale.enabled" and parsed is True:
+            if (
+                key in ("dashboard.tailscale.enabled", "dashboard.tailscale.trust_identity")
+                and parsed is True
+            ):
                 from kiro_crew.dashboard import tailnet
 
                 if tailnet.is_governance_pinned_off(audit_tool="config_set_cli_tailnet"):

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1870,6 +1870,86 @@ class TailscaleConfig:
             "still needs a dashboard session.",
         ),
     )
+    trust_identity: bool = field(
+        default=False,
+        metadata=_meta(
+            "Trust Tailnet Identity",
+            "Pin dashboard sessions arriving via `tailscale serve` to the "
+            "daemon-verified tailnet peer instead of the tunnel's shared "
+            "loopback address, and record that identity in the audit trail. "
+            "Explicit opt-in, never inferred, and requires a non-empty "
+            "allowed_logins — enabling it with an empty allowlist is refused at "
+            "load. Every failure to verify a peer falls back to the ordinary "
+            "token path. POSIX only. Takes effect on the next gateway "
+            "start (the trust settings are read once at startup).",
+        ),
+    )
+    allowed_logins: list[str] = field(
+        default_factory=list,
+        metadata=_meta(
+            "Allowed Tailnet Logins",
+            "Tailscale logins permitted when trust_identity is on. Mandatory: "
+            "a shared tailnet can have hundreds of members, so identity trust "
+            "without an allowlist would hand each of them the dashboard. A "
+            "verified peer whose login is not listed is denied.",
+        ),
+    )
+    pin_scope: str = field(
+        default="node",
+        metadata=_meta(
+            "Pin Scope",
+            "What an identity-pinned session binds to: 'node' (default — a "
+            "leaked cookie is usable only from the original device) or 'login' "
+            "(usable from any device carrying that Tailscale identity). An "
+            "unrecognised value falls back to 'node'. An ACL-tagged node is "
+            "always pinned at node scope regardless of this setting. Takes "
+            "effect on the next gateway start.",
+        ),
+    )
+
+
+def _tailscale_config_from(raw: object) -> TailscaleConfig:
+    """Build the validated :class:`TailscaleConfig` (RFC §3/§3.1 load rules).
+
+    Two rules, both narrowing-only so a typo can never widen access:
+
+    * ``trust_identity: true`` with an empty ``allowed_logins`` is a
+      configuration error — refused with a logged reason, identity trust stays
+      OFF. Never a silently-permissive default: "any tailnet member" on a
+      shared corporate tailnet would hand the dashboard to all of them.
+    * An unrecognised ``pin_scope`` falls back to ``"node"`` (the narrower
+      scope) with a logged warning — never to ``"login"``.
+    """
+    data = _safe_dict(raw)
+    enabled = _safe_bool(data.get("enabled"), False)
+    trust_identity = _safe_bool(data.get("trust_identity"), False)
+    raw_logins = data.get("allowed_logins")
+    allowed_logins = [
+        entry.strip()
+        for entry in (raw_logins if isinstance(raw_logins, list) else [])
+        if isinstance(entry, str) and entry.strip()
+    ]
+    pin_scope = str(data.get("pin_scope") or "node").strip().lower()
+    if pin_scope not in ("node", "login"):
+        logger.warning(
+            "dashboard.tailscale.pin_scope %r is not recognised; falling back to "
+            "'node' (the narrower scope)",
+            pin_scope,
+        )
+        pin_scope = "node"
+    if trust_identity and not allowed_logins:
+        logger.error(
+            "dashboard.tailscale.trust_identity is on but allowed_logins is "
+            "empty — identity trust requires an explicit login allowlist and "
+            "stays OFF. Add the Tailscale logins you want to admit."
+        )
+        trust_identity = False
+    return TailscaleConfig(
+        enabled=enabled,
+        trust_identity=trust_identity,
+        allowed_logins=allowed_logins,
+        pin_scope=pin_scope,
+    )
 
 
 @dataclass
@@ -5208,11 +5288,7 @@ class KiroCrewConfig:
             ),
             dashboard=DashboardConfig(
                 url=dashboard_data.get("url", ""),
-                tailscale=TailscaleConfig(
-                    enabled=_safe_bool(
-                        _safe_dict(dashboard_data.get("tailscale")).get("enabled"), False
-                    ),
-                ),
+                tailscale=_tailscale_config_from(dashboard_data.get("tailscale")),
                 restore_sessions=dashboard_data.get("restore_sessions", False),
                 restore_window_minutes=dashboard_data.get("restore_window_minutes", 30),
                 surface_channel_sessions=dashboard_data.get("surface_channel_sessions", True),

--- a/src/kiro_crew/dashboard/handlers/auth_refresh.py
+++ b/src/kiro_crew/dashboard/handlers/auth_refresh.py
@@ -31,9 +31,11 @@ from kiro_crew.dashboard.refresh_tokens import (
     refresh_cookie_name,
     validate_refresh_token,
 )
+from kiro_crew.dashboard.tailnet import TailnetTrust, peer_pin_key, resolve_forwarded_peer
 from kiro_crew.dashboard.token_auth import (
     MAX_SESSION_TTL_SECS,
     _cookie_port_from_host,
+    bind_token_peer,
     extract_numeric_claim,
     generate_token,
     revoke_access_cookie,
@@ -498,12 +500,40 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
         replacement=json.dumps(grace_payload, separators=(",", ":")),
     )
 
+    await _rebind_rotated_token_to_peer(request, new_access_token, new_session_exp)
+
     resp = web.json_response(public_payload)
     _set_access_cookie(resp, request, new_access_token, new_session_exp)
     _set_refresh_cookie(resp, request, new_refresh_token, new_refresh_exp)
     _expire_foreign_port_cookies(resp, request)
     _audit(user_id, "refresh_token_use", "ok")
     return resp
+
+
+async def _rebind_rotated_token_to_peer(
+    request: web.Request, access_token: str, session_exp: float
+) -> None:
+    """Carry the tailnet identity pin across an access-token rotation (RFC §3).
+
+    This endpoint is bypassed by the auth middleware, so without this the
+    replacement access token would be UNBOUND — one rotation would launder a
+    node-scoped identity pin into an any-peer token. When the refresh request
+    itself resolves a verified peer, the fresh token is pinned to that peer's
+    key; when no peer resolves (non-tailnet setups, daemon down, Windows) the
+    token stays unbound, which is byte-for-byte the pre-identity behaviour.
+    The middleware's early allowlist deny already covers this route (it runs
+    before the bypass list), so a verified-but-unallowlisted peer never
+    reaches this mint in the first place.
+    """
+    trust = request.app.get("tailnet_trust")
+    if not isinstance(trust, TailnetTrust) or not trust.trust_identity:
+        return
+    if not trust.allowed_logins:
+        return
+    peer = await resolve_forwarded_peer(request, trust)
+    if peer is None:
+        return
+    bind_token_peer(access_token, peer_pin_key(peer, trust.pin_scope), session_exp)
 
 
 async def api_auth_logout(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -1469,6 +1469,15 @@ _EDITABLE_CONFIG: dict[str, dict] = {
     # enterprise ceiling can refuse the enabling write outright — see the
     # ``capabilities.tailnet_origin`` gate below.
     "dashboard.tailscale.enabled": {"type": "bool"},
+    # Identity trust for tailnet peers (RFC §2–§3.1). Only the boolean opt-in
+    # and the pin scope are editable here; ``allowed_logins`` is a list and is
+    # deliberately config-file-only — the write surface below has no list type,
+    # and the allowlist is the control that decides who gets in, so it should
+    # be an explicit file edit rather than an API-reachable value. Loader-side
+    # validation keeps every bad combination narrowing-only (trust with an
+    # empty allowlist stays off; an unrecognised pin_scope falls back to node).
+    "dashboard.tailscale.trust_identity": {"type": "bool"},
+    "dashboard.tailscale.pin_scope": {"type": "str", "max_len": 8},
     # SSO login flags for an edition that supplies a real sso_login_handler.
     # Bounded to a short string here; the companion login handler re-validates
     # each token against its own flag allowlist before spawning the login PTY
@@ -1680,7 +1689,10 @@ async def api_kirocrew_config_patch(request: web.Request) -> web.Response:
     # does nothing — `resolve_tailnet_host` already refuses to derive, so without
     # this the config file and the card would both claim "on" while no origin is
     # ever added.
-    if path_key == "dashboard.tailscale.enabled" and value is True:
+    if (
+        path_key in ("dashboard.tailscale.enabled", "dashboard.tailscale.trust_identity")
+        and value is True
+    ):
         pinned = await asyncio.to_thread(_tailnet_governance_pinned_off)
         if pinned:
             return _deny(

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -3019,8 +3019,13 @@ async def start_dashboard(
     # Off by default; resolved in a thread so the daemon call cannot stall the
     # loop; "" whenever Tailscale is absent, stopped, or produced nothing that
     # validated.
-    _tailnet_host = await tailnet.resolve_tailnet_host(
-        KiroCrewConfig.load().dashboard.tailscale.enabled
+    _ts_cfg = KiroCrewConfig.load().dashboard.tailscale
+    _tailnet_host = await tailnet.resolve_tailnet_host(_ts_cfg.enabled)
+    # Identity trust (RFC §2–§3.1): validated at config load, governance
+    # ceiling applied inside the shared helper — ONE code path for both
+    # startup surfaces, so they cannot drift.
+    _tailnet_trust = await tailnet.governed_tailnet_trust(
+        _ts_cfg.trust_identity, tuple(_ts_cfg.allowed_logins), _ts_cfg.pin_scope
     )
     if _tailnet_host:
         logger.info(
@@ -3037,6 +3042,10 @@ async def start_dashboard(
     # already shipped a bug from touching one startup site and not the other.
     app["tailnet_host"] = _tailnet_host
     app["tailnet_resolved_at"] = int(time.time()) if _tailnet_host else 0
+    # The governance-filtered identity-trust value the middleware was built
+    # with, for handlers the middleware bypasses (POST /api/auth/refresh must
+    # re-bind a rotated access token to the same verified peer identity).
+    app["tailnet_trust"] = _tailnet_trust
     app["allowed_origins"] = build_allowed_origins(
         port, local_only, configured_host, tailnet_host=_tailnet_host
     )
@@ -3112,6 +3121,7 @@ async def start_dashboard(
             port=port,
             local_only=local_only,
             spa_shell_handler=handlers.index,
+            tailnet_trust=_tailnet_trust,
         ),
         sel_audit_middleware,
         spa_fallback,
@@ -3572,8 +3582,12 @@ async def start_api_server(
     # The MCP route surface is identical to the dashboard's, so the middleware
     # chain must be too. Host-allowlist source of truth is shared with the CSRF
     # Origin check via build_allowed_origins/build_allowed_hosts (see origin.py).
-    _tailnet_host = await tailnet.resolve_tailnet_host(
-        KiroCrewConfig.load().dashboard.tailscale.enabled
+    _ts_cfg = KiroCrewConfig.load().dashboard.tailscale
+    _tailnet_host = await tailnet.resolve_tailnet_host(_ts_cfg.enabled)
+    # Same identity-trust value as start_dashboard, via the same shared helper
+    # — the auth surface is identical, so the middleware inputs must be too.
+    _tailnet_trust = await tailnet.governed_tailnet_trust(
+        _ts_cfg.trust_identity, tuple(_ts_cfg.allowed_logins), _ts_cfg.pin_scope
     )
     app["allowed_origins"] = build_allowed_origins(
         port,
@@ -3588,6 +3602,10 @@ async def start_api_server(
     # surface later would silently read "" as "nothing was trusted".
     app["tailnet_host"] = _tailnet_host
     app["tailnet_resolved_at"] = int(time.time()) if _tailnet_host else 0
+    # The governance-filtered identity-trust value the middleware was built
+    # with, for handlers the middleware bypasses (POST /api/auth/refresh must
+    # re-bind a rotated access token to the same verified peer identity).
+    app["tailnet_trust"] = _tailnet_trust
     app["local_only"] = local_only
 
     # Per-session internal secret for machine-to-machine (mcp-core, cron) auth.
@@ -3686,6 +3704,7 @@ async def start_api_server(
             # No SPA shell in headless mode: a no-token request must be denied
             # outright, never served an HTML shell (there is no UI to boot).
             spa_shell_handler=None,
+            tailnet_trust=_tailnet_trust,
         ),
         sel_audit_middleware,
     ]

--- a/src/kiro_crew/dashboard/tailnet.py
+++ b/src/kiro_crew/dashboard/tailnet.py
@@ -25,19 +25,30 @@ as tailnet-specific (its own example is ``userfoo.tailscale.net``, not
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import json
 import logging
 import os
 import re
 import subprocess
-from typing import Any
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
+from kiro_crew.dashboard.urls import is_loopback
+from kiro_crew.executors import subprocess_executor
 from kiro_crew.platform.governance_profiles import (
     GOVERNANCE_ERROR_REASON,
     governance_permits,
     vet_and_audit,
 )
+from kiro_crew.platform_compat import IS_POSIX
 from kiro_crew.sandbox import scrub_env
+
+if TYPE_CHECKING:
+    from aiohttp import web
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +63,10 @@ _CLI_TIMEOUT_SECS = 3.0
 #: a normal dev box) could plant a ``tailscale`` executable, and the next gateway
 #: start with this feature enabled would execute it. The arguments were never
 #: agent-influenced, but the *binary* was — so resolution is pinned to the
-#: locations the official packages install into, all of which need root to write:
+#: locations the official packages install into. Most need root to write, but
+#: not all (Homebrew chowns its prefix to the console user), so
+#: :func:`_cli_path` additionally refuses any candidate the gateway user can
+#: write:
 #:
 #: * ``/usr/bin`` — Linux distro packages
 #: * ``/usr/local/bin`` — Linux tarball, macOS Homebrew on Intel
@@ -82,11 +96,60 @@ def _cli_path() -> str | None:
     """Locate the ``tailscale`` CLI, or ``None`` if it is not installed.
 
     Deliberately does **not** consult ``PATH`` — see ``_CLI_CANDIDATE_PATHS``.
+
+    A candidate is additionally refused when the binary or its directory is
+    writable by the gateway user (checked on POSIX; the Windows entry needs
+    elevation to write). The pinned list mostly needs root, but two entries do
+    not everywhere: Homebrew chowns ``/opt/homebrew/bin`` (and sometimes
+    ``/usr/local/bin``) to the console user, and identity resolution makes
+    this a request-triggered execution on the auth path — an agent that can
+    write there must not be able to plant a ``tailscale`` the next
+    credential-bearing request executes. A refused Homebrew install degrades
+    exactly like a missing binary: the feature contributes nothing and the
+    documented ``dashboard.url`` fallback still works.
     """
+    # getattr: os.geteuid does not exist on Windows, and tests exercise this
+    # path with IS_POSIX patched True on every platform.
     for candidate in _CLI_CANDIDATE_PATHS:
-        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-            return candidate
+        if not (os.path.isfile(candidate) and os.access(candidate, os.X_OK)):
+            continue
+        if IS_POSIX and not _posix_candidate_trusted(candidate):
+            logger.debug(
+                "tailscale CLI at %s is in a location this deployment cannot "
+                "trust; refusing to execute it (planted-binary defence). Use "
+                "an explicit dashboard.url instead.",
+                candidate,
+            )
+            continue
+        return candidate
     return None
+
+
+def _posix_candidate_trusted(candidate: str) -> bool:
+    """Whether *candidate* is safe to execute (POSIX planted-binary defence).
+
+    Refused when the binary or its directory is group/world-writable, when the
+    gateway user can write either (a file the executing user owns is always
+    effectively writable), or — when running as root, for whom every path is
+    writable so the access check says nothing — when either is not root-owned.
+    A root gateway therefore accepts only distro-style root-owned installs;
+    everything refused degrades like a missing binary.
+    """
+    directory = os.path.dirname(candidate)
+    try:
+        st_file = os.stat(candidate)
+        st_dir = os.stat(directory)
+    except OSError:
+        return False
+    group_world_write = 0o022
+    if (st_file.st_mode | st_dir.st_mode) & group_world_write:
+        return False
+    # getattr: os.geteuid does not exist on Windows, and tests exercise this
+    # path with IS_POSIX patched True on every platform.
+    euid = getattr(os, "geteuid", lambda: -1)()
+    if euid == 0:
+        return st_file.st_uid == 0 and st_dir.st_uid == 0
+    return not (os.access(candidate, os.W_OK) or os.access(directory, os.W_OK))
 
 
 def _run_json(args: list[str]) -> Any | None:
@@ -97,10 +160,24 @@ def _run_json(args: list[str]) -> Any | None:
     output) means the same thing to it. Failures are logged at debug so a host
     without Tailscale does not emit noise on every start.
     """
+    return _run_json_detail(args)[0]
+
+
+def _run_json_detail(args: list[str]) -> tuple[Any | None, bool]:
+    """Run the CLI and parse stdout as JSON. ``(parsed, transient)``.
+
+    ``transient`` is ``True`` only when the CLI could not be run or did not
+    answer in time (spawn failure, timeout) — the "daemon still starting up"
+    class, expected to clear within seconds. A completed run (any exit code,
+    any output) and a missing binary are definitive for this host right now.
+    The whois cache uses the flag to keep a transient failure on a much
+    shorter TTL, so one startup blip does not hold an identity-pinned session
+    denied for a full cache window.
+    """
     cli = _cli_path()
     if not cli:
         logger.debug("tailscale CLI not found; skipping tailnet origin derivation")
-        return None
+        return None, False
     try:
         proc = subprocess.run(  # noqa: S603 - vetted absolute binary, fixed argv, no shell
             [cli, *args],
@@ -117,7 +194,7 @@ def _run_json(args: list[str]) -> Any | None:
         )
     except (OSError, subprocess.SubprocessError) as exc:
         logger.debug("tailscale %s failed to run: %s", " ".join(args), exc)
-        return None
+        return None, True
     if proc.returncode != 0:
         logger.debug(
             "tailscale %s exited %d: %s",
@@ -125,12 +202,12 @@ def _run_json(args: list[str]) -> Any | None:
             proc.returncode,
             (proc.stderr or "").strip()[:200],
         )
-        return None
+        return None, False
     try:
-        return json.loads(proc.stdout or "")
+        return json.loads(proc.stdout or ""), False
     except (json.JSONDecodeError, ValueError) as exc:
         logger.debug("tailscale %s produced non-JSON output: %s", " ".join(args), exc)
-        return None
+        return None, False
 
 
 def _valid_magicdns_name(raw: object, magic_dns_suffix: object) -> str | None:
@@ -362,3 +439,313 @@ async def resolve_tailnet_host(enabled: bool) -> str:
         )
         return ""
     return name
+
+
+# ---------------------------------------------------------------------------
+# Forwarded-peer resolution (RFC §2–§3.1) — daemon-verified identity behind
+# `tailscale serve`, so the session pin can bind to a person's device instead
+# of the tunnel's loopback address.
+#
+# The organizing rule (RFC §1): the immediate peer decides whether a forwarded
+# header may be read at all; the local daemon, not the header, decides who the
+# peer is; the header is only corroboration.
+# ---------------------------------------------------------------------------
+
+#: The address ranges a tailnet peer can legitimately arrive from. Anything
+#: outside these is not a tailnet address and is never sent to the daemon.
+_TAILNET_RANGES = (
+    ipaddress.ip_network("100.64.0.0/10"),
+    ipaddress.ip_network("fd7a:115c:a1e0::/48"),
+)
+
+#: The login `tailscale whois` reports for EVERY ACL-tagged node
+#: (tailscale/tailscale#4605). Under ``pin_scope: "login"`` that single value
+#: would collapse the pin across the entire tagged fleet, so a resolved login
+#: equal to this is ALWAYS pinned at node scope — a hard override, not a
+#: preference.
+TAGGED_DEVICES_LOGIN = "tagged-devices"
+
+PIN_SCOPE_NODE = "node"
+PIN_SCOPE_LOGIN = "login"
+PIN_SCOPES = (PIN_SCOPE_NODE, PIN_SCOPE_LOGIN)
+
+_FORWARDED_FOR_HEADER = "X-Forwarded-For"
+#: Only this module may read this header, and only to corroborate — the daemon
+#: decides identity. A header is not a credential.
+_USER_LOGIN_HEADER = "Tailscale-User-Login"
+
+#: whois results are cached by address so a request storm cannot fork a daemon
+#: call per request. Short TTL: peer identity is stable over seconds, and a
+#: short window bounds how long a stale daemon answer can outlive reality.
+_WHOIS_CACHE_TTL_SECS = 30.0
+#: A TRANSIENT failure (spawn error, timeout — the daemon-still-starting class)
+#: is cached far shorter, so a single blip does not hold an identity-pinned
+#: session denied for a full cache window. Definitive answers — including a
+#: definitive "no such peer" — keep the full TTL.
+_WHOIS_TRANSIENT_TTL_SECS = 2.0
+
+#: Bounded entry count — a flood of distinct spoofed source addresses must not
+#: grow the cache without limit.
+_WHOIS_CACHE_MAX_ENTRIES = 256
+
+
+@dataclass(frozen=True)
+class ForwardedPeer:
+    """A daemon-verified tailnet peer behind the local `tailscale serve` proxy."""
+
+    login: str
+    node: str
+    address: str
+
+
+@dataclass(frozen=True)
+class TailnetTrust:
+    """The operator's identity-trust opt-in, as validated at config load.
+
+    Carried as a plain value object (not read from config here) so this module
+    stays free of a config import — the same rule :func:`resolve_tailnet_host`
+    follows for ``enabled``.
+    """
+
+    trust_identity: bool = False
+    allowed_logins: tuple[str, ...] = ()
+    pin_scope: str = PIN_SCOPE_NODE
+
+
+_whois_lock = threading.Lock()
+#: address → (monotonic expiry, resolved (login, node) or None). Negative
+#: results are cached too: a stopped daemon must not be re-probed per request.
+_whois_cache: OrderedDict[str, tuple[float, tuple[str, str] | None]] = OrderedDict()
+
+
+#: Charset allowlist for identity components (login, node name) accepted from
+#: the daemon. An allowlist, not a denylist, mirroring ``_valid_magicdns_name``:
+#: the destinations are the session pin key and the SEL ``caller`` field, so the
+#: question is "is this provably a plain identity token". Covers email-shaped
+#: and provider-handle logins, DNS node names, and the literal
+#: ``tagged-devices``. Deliberately EXCLUDES ``|`` (the pin-key separator) and
+#: ``:`` (the pin-key namespace delimiter), which is what makes the composed
+#: key unambiguous.
+_IDENTITY_RE = re.compile(r"^[A-Za-z0-9@._%+-]{1,253}$")
+
+
+def _valid_identity(raw: object) -> str | None:
+    """Return *raw* as a usable identity component, or ``None``.
+
+    The value arrives from a subprocess and its destinations are the session
+    pin key and the SEL audit ``caller`` field — strict allowlist, see
+    ``_IDENTITY_RE``.
+    """
+    if not isinstance(raw, str):
+        return None
+    s = raw.strip()
+    if not _IDENTITY_RE.match(s):
+        return None
+    return s
+
+
+def _whois_node(addr: str) -> tuple[tuple[str, str] | None, bool]:
+    """Ask the local daemon who *addr* is. ``((login, node) | None, transient)``.
+
+    Every failure (no binary, daemon down, timeout, non-zero exit, malformed
+    JSON, unexpected schema) is ``None`` — the module's "nothing here raises"
+    invariant. The second element reports whether the failure was TRANSIENT
+    (could not run / timed out) so the cache can retry it sooner.
+    """
+    data, transient = _run_json_detail(["whois", "--json", addr])
+    if not isinstance(data, dict):
+        return None, transient
+    profile = data.get("UserProfile")
+    node = data.get("Node")
+    login = _valid_identity(profile.get("LoginName") if isinstance(profile, dict) else None)
+    name_raw: object = None
+    if isinstance(node, dict):
+        name_raw = node.get("Name") or node.get("ComputedName")
+    name = _valid_identity(name_raw)
+    if login is None or name is None:
+        logger.debug("tailscale whois for %s returned no usable identity", addr)
+        return None, False
+    return (login, name.rstrip(".")), False
+
+
+def _whois_cached(addr: str) -> tuple[str, str] | None:
+    """Cache wrapper around :func:`_whois_node`, TTL'd and bounded.
+
+    Runs in a worker thread (the daemon call blocks). The lock is held across
+    the miss path deliberately: under a request storm every concurrent miss for
+    the same address waits for the ONE in-flight daemon call and then reads the
+    fresh cache entry, instead of each forking its own subprocess.
+    """
+    with _whois_lock:
+        now = time.monotonic()
+        hit = _whois_cache.get(addr)
+        if hit is not None and hit[0] > now:
+            _whois_cache.move_to_end(addr)
+            return hit[1]
+        result, transient = _whois_node(addr)
+        ttl = _WHOIS_TRANSIENT_TTL_SECS if transient else _WHOIS_CACHE_TTL_SECS
+        _whois_cache[addr] = (now + ttl, result)
+        _whois_cache.move_to_end(addr)
+        while len(_whois_cache) > _WHOIS_CACHE_MAX_ENTRIES:
+            _whois_cache.popitem(last=False)
+        return result
+
+
+def _forwarded_peer_candidate(request: web.Request, trust: TailnetTrust) -> str | None:
+    """The cheap, synchronous gate: RFC §2 conditions (a)–(d), fail-closed.
+
+    Returns the single forwarded tailnet address worth asking the daemon
+    about, or ``None``. No I/O — safe to run inline on the event loop.
+    """
+    # Windows daemon/CLI behaviour is unverified (RFC OQ4): resolution is
+    # POSIX-only and everything degrades to the token+IP path there.
+    if not IS_POSIX:
+        logger.debug("tailnet peer resolution is POSIX-only; skipping on this platform")
+        return None
+    # (b) explicit opt-in AND a non-empty allowlist. Identity trust is never
+    # inferred, and an empty allowlist means trust was refused at config load.
+    if not trust.trust_identity or not trust.allowed_logins:
+        return None
+    # (a) the immediate peer must be the local proxy. A remote peer's forwarded
+    # header is an unverifiable claim and is never read.
+    if not is_loopback(request.remote or ""):
+        return None
+    # (c) EXACTLY one forwarded address. Two or more — whether as repeated
+    # headers or one comma-joined value — is a proxy chain this design cannot
+    # attribute; reject rather than trust the first or the last.
+    values = request.headers.getall(_FORWARDED_FOR_HEADER, [])
+    if len(values) != 1:
+        return None
+    raw = values[0].strip()
+    if not raw or "," in raw:
+        return None
+    # (d) the address must parse and sit inside the tailnet ranges.
+    try:
+        candidate = ipaddress.ip_address(raw)
+    except ValueError:
+        return None
+    if not any(candidate in net for net in _TAILNET_RANGES):
+        return None
+    return str(candidate)
+
+
+async def resolve_forwarded_peer(request: web.Request, trust: TailnetTrust) -> ForwardedPeer | None:
+    """Resolve the daemon-verified peer behind a local proxy, or ``None``.
+
+    ``None`` covers every unresolvable case — trust off, non-loopback peer,
+    zero/multiple forwarded addresses, non-tailnet address, daemon absent or
+    down, timeout, malformed output, or a corroborating header that disagrees
+    with the daemon. The caller falls through to the existing token+IP path:
+    fail-closed on identity, fail-open on availability.
+
+    The blocking daemon call is offloaded to a worker thread so it never runs
+    on the event loop; the WebSocket path resolves once here at upgrade, never
+    per frame.
+    """
+    addr = _forwarded_peer_candidate(request, trust)
+    if addr is None:
+        return None
+    # (e) the daemon decides identity. Offloaded onto the DEDICATED subprocess
+    # executor, not asyncio.to_thread's shared default pool: waiters can hold a
+    # worker for up to the daemon timeout behind _whois_lock, and starving the
+    # process-wide default pool with header-driven work would stall unrelated
+    # gateway offloads (the cross-starvation subprocess_executor exists to stop).
+    resolved = await asyncio.get_running_loop().run_in_executor(
+        subprocess_executor(), _whois_cached, addr
+    )
+    if resolved is None:
+        return None
+    login, node = resolved
+    # (f) the header is only corroboration. Absent costs nothing; a
+    # disagreement is a rejection, not a warning — a proxy relaying an
+    # attacker-chosen header must not win over the daemon.
+    header_login = (request.headers.get(_USER_LOGIN_HEADER) or "").strip()
+    if header_login and header_login.lower() != login.lower():
+        logger.warning(
+            "tailnet peer %s: %s header (%r) disagrees with whois login; rejecting identity",
+            addr,
+            _USER_LOGIN_HEADER,
+            header_login[:64],
+        )
+        return None
+    return ForwardedPeer(login=login, node=node, address=addr)
+
+
+def peer_pin_key(peer: ForwardedPeer, pin_scope: str) -> str:
+    """The session pin key for a resolved peer, per RFC §3.1.
+
+    ``node`` scope (the default, and anything unrecognised — a typo may only
+    ever narrow): ``ts:node:<login>|<node>``. ``login`` scope:
+    ``ts:login:<login>``. Two shape rules keep the key namespace unambiguous:
+    the scope tag in the prefix (logins are emails and contain ``@``, so the
+    RFC's bare shapes cannot be told apart when classifying a mismatch), and a
+    ``|`` separator that ``_IDENTITY_RE`` forbids inside either component, so
+    ``login="a@b", node="c"`` can never collide with ``login="a",
+    node="b@c"``. Keys are only ever compared for full-string equality, never
+    parsed.
+
+    Hard override: an ACL-tagged node reports the literal ``tagged-devices``
+    login for EVERY tagged device, so login scope would make one leaked
+    CI-runner session replayable from the whole tagged fleet. A tagged node is
+    therefore always pinned at node scope, and the override is logged.
+    """
+    if peer.login == TAGGED_DEVICES_LOGIN:
+        if pin_scope == PIN_SCOPE_LOGIN:
+            logger.warning(
+                "tailnet peer %s is an ACL-tagged node (login %r); pin_scope "
+                "'login' is overridden to node scope for it",
+                peer.node,
+                TAGGED_DEVICES_LOGIN,
+            )
+        return f"ts:node:{peer.login}|{peer.node}"
+    if pin_scope == PIN_SCOPE_LOGIN:
+        return f"ts:login:{peer.login}"
+    return f"ts:node:{peer.login}|{peer.node}"
+
+
+def login_allowed(login: str, allowed_logins: tuple[str, ...]) -> bool:
+    """Whether *login* is on the operator's allowlist. Case-insensitive.
+
+    Deny-by-default: an empty allowlist allows no one (and also disables
+    resolution upstream — see :func:`_forwarded_peer_candidate`).
+    """
+    candidate = login.strip().lower()
+    if not candidate:
+        return False
+    return any(candidate == entry.strip().lower() for entry in allowed_logins if entry.strip())
+
+
+async def governed_tailnet_trust(
+    trust_identity: bool, allowed_logins: tuple[str, ...], pin_scope: str
+) -> TailnetTrust:
+    """Build the identity-trust value object, with the governance ceiling applied.
+
+    ONE code path for both server startup surfaces (dashboard and headless API)
+    — a prior round of the tailnet feature shipped a bug from exactly this
+    dual-site drift, so the trust construction lives here rather than being
+    duplicated at each call site. Takes plain values rather than a config
+    object to keep this module free of a config import.
+
+    An enterprise ceiling pinning ``capabilities.tailnet_origin`` off disables
+    identity trust too: the config-set surfaces refuse the enabling WRITE, but
+    a value already stored must not keep request-time whois calls and identity
+    pinning alive under a policy that forbids the tailnet integration. The
+    probe runs in a thread (it reads the trust-root policy from disk) and is
+    audited as a governance decision.
+    """
+    trust = TailnetTrust(
+        trust_identity=trust_identity,
+        allowed_logins=allowed_logins,
+        pin_scope=pin_scope,
+    )
+    if trust.trust_identity and await asyncio.to_thread(
+        is_governance_pinned_off, audit_tool="tailnet_trust_startup"
+    ):
+        logger.warning(
+            "dashboard.tailscale.trust_identity is on, but capabilities."
+            "tailnet_origin is pinned OFF by your administrator's security "
+            "policy — tailnet identity trust stays disabled and sessions keep "
+            "the ordinary token+IP pin."
+        )
+        return TailnetTrust()
+    return trust

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -37,6 +37,13 @@ from kiro_crew.dashboard.refresh_tokens import (
     generate_refresh_token,
     refresh_cookie_name,
 )
+from kiro_crew.dashboard.tailnet import (
+    ForwardedPeer,
+    TailnetTrust,
+    login_allowed,
+    peer_pin_key,
+    resolve_forwarded_peer,
+)
 
 # Canonical HMAC-secret definitions live in token_secret to break the import
 # cycle between token_auth and refresh_tokens. Re-exported here for backwards
@@ -251,8 +258,11 @@ class TokenStateManager:
         # OrderedDict maintains insertion order for O(1) oldest eviction
         self._nonces: OrderedDict[str, float] = OrderedDict()
         # Observation latches for the Security Posture surface only — never read
-        # by an auth decision. See bind_ip() / proxied_pin_observed().
-        self._ip_bindings: dict[str, tuple[str, float, bool]] = {}  # token → (ip, exp, proxied)
+        # by an auth decision. See bind_peer() / proxied_pin_observed().
+        # token → (peer key, exp, proxied). The peer key is "ip:<addr>" for the
+        # default address pin and "ts:node:<login>@<node>" / "ts:login:<login>" for a
+        # daemon-verified tailnet peer (RFC §3) — in-memory only, regenerated on restart.
+        self._peer_bindings: dict[str, tuple[str, float, bool]] = {}
         self._consumed: dict[str, float] = {}  # token → exp
 
     def register_nonce(self, nonce: str, expiry: float) -> str | None:
@@ -280,17 +290,21 @@ class TokenStateManager:
             self._nonces.move_to_end(nonce)
             return True, ""
 
-    def bind_ip(self, token: str, ip: str, session_exp: float, proxied: bool = False) -> None:
-        """Bind a token to a client IP address.
+    def bind_peer(
+        self, token: str, peer_key: str, session_exp: float, proxied: bool = False
+    ) -> None:
+        """Bind a token to a peer key (``ip:<addr>`` or a ``ts:``-prefixed identity).
 
-        ``proxied`` records that *ip* came from a same-host proxy rather than
-        from the client itself, which means this binding pins the token to the
-        proxy and is therefore shared by every client behind it. It is an
-        observation for the Security Posture surface only — it does not change
-        the binding or how :meth:`check_ip` compares it.
+        ``proxied`` records that the pin is a same-host proxy's address rather
+        than a client identity, which means this binding pins the token to the
+        proxy and is therefore shared by every client behind it. A session
+        pinned to a daemon-verified tailnet peer key is per-client, NOT shared
+        — callers pass ``proxied=False`` for it. It is an observation for the
+        Security Posture surface only — it does not change the binding or how
+        :meth:`check_peer` compares it.
         """
         with self._lock:
-            self._ip_bindings[token] = (ip, session_exp, proxied)
+            self._peer_bindings[token] = (peer_key, session_exp, proxied)
 
     def proxied_pin_observed(self, now: float) -> bool | None:
         """Report the pin scope of the sessions that are LIVE at *now*.
@@ -299,7 +313,8 @@ class TokenStateManager:
         report — which is NOT the same as "pins are effective" and must not be
         rendered as if it were. ``True`` = at least one live session is pinned to
         a same-host proxy's address and is therefore shared by every client
-        behind it. ``False`` = live sessions are pinned to client addresses.
+        behind it. ``False`` = live sessions are pinned per client (to a client
+        address, or to a daemon-verified tailnet identity).
 
         Derived from the bindings rather than from a latch, deliberately. A latch
         would outlive the sessions it describes: one tunnelled login would report
@@ -311,16 +326,35 @@ class TokenStateManager:
         run, so the answer never depends on when eviction last happened.
         """
         with self._lock:
-            live_proxied = [p for _, exp, p in self._ip_bindings.values() if exp > now]
+            live_proxied = [p for _, exp, p in self._peer_bindings.values() if exp > now]
             if not live_proxied:
                 return None
             return any(live_proxied)
 
-    def check_ip(self, token: str, ip: str) -> bool:
-        """Check if token is bound to the given IP (or unbound)."""
+    def check_peer(self, token: str, peer_key: str) -> tuple[bool, str]:
+        """Check *token* against its bound peer key (or unbound).
+
+        Returns ``(ok, mismatch_reason)``. The reason names what the STORED pin
+        was bound to, because that is what the user must fix: a node-scoped
+        tailnet pin that stops matching means the device's identity changed
+        (Tailscale re-enroll), and reporting it as "IP mismatch" would send
+        them chasing the wrong thing.
+        """
         with self._lock:
-            entry = self._ip_bindings.get(token)
-            return entry is None or entry[0] == ip
+            entry = self._peer_bindings.get(token)
+        if entry is None or entry[0] == peer_key:
+            return True, ""
+        stored = entry[0]
+        if stored.startswith("ts:node:"):
+            return False, "device identity mismatch"
+        if stored.startswith("ts:"):
+            return False, "peer identity mismatch"
+        return False, "IP mismatch"
+
+    def has_binding(self, token: str) -> bool:
+        """Whether *token* currently has a peer binding (live or not)."""
+        with self._lock:
+            return token in self._peer_bindings
 
     def mark_consumed(self, token: str, session_exp: float) -> None:
         """Mark a token as consumed (used for one-time token patterns)."""
@@ -346,10 +380,10 @@ class TokenStateManager:
     def evict_expired(self, now: float) -> None:
         """Remove all expired entries from all state stores."""
         with self._lock:
-            # Evict expired IP bindings
-            expired_tokens = [t for t, (_, exp, _p) in self._ip_bindings.items() if exp < now]
+            # Evict expired peer bindings
+            expired_tokens = [t for t, (_, exp, _p) in self._peer_bindings.items() if exp < now]
             for t in expired_tokens:
-                self._ip_bindings.pop(t, None)
+                self._peer_bindings.pop(t, None)
             # Evict consumed tokens independently using their own expiry
             expired_consumed = [t for t, exp in self._consumed.items() if exp < now]
             for t in expired_consumed:
@@ -360,10 +394,10 @@ class TokenStateManager:
                 self._nonces.pop(n, None)
 
     def clear_all(self) -> None:
-        """Clear all token state (nonces, IP bindings, consumed tokens)."""
+        """Clear all token state (nonces, peer bindings, consumed tokens)."""
         with self._lock:
             self._nonces.clear()
-            self._ip_bindings.clear()
+            self._peer_bindings.clear()
             self._consumed.clear()
 
 
@@ -989,17 +1023,24 @@ def _evict_expired() -> None:
     _state.evict_expired(time.time())
 
 
-def bind_token_ip(
-    token: str, ip: str, session_exp: float = 0.0, proxied: bool = False
+def bind_token_peer(
+    token: str, peer_key: str, session_exp: float = 0.0, proxied: bool = False
 ) -> None:
-    """Bind a token to a client IP for session validation.
+    """Bind a token to a peer key for session validation (RFC §3).
 
-    ``proxied`` is an observation only (see ``_TokenState.bind_ip``): it records
-    that *ip* is a same-host proxy's address rather than the client's, so the
-    Security Posture surface can report that the pin is shared. It never changes
-    the binding or the comparison.
+    *peer_key* is ``ip:<addr>`` for the default address pin — byte-for-byte
+    today's behaviour for every non-Tailscale path — or ``ts:node:<login>@<node>`` / ``ts:login:<login>``
+    for a daemon-verified tailnet peer. ``proxied`` is an observation only (see
+    ``TokenStateManager.bind_peer``): it records that the pin is a same-host
+    proxy's address and therefore shared, so the Security Posture surface can
+    report it. It never changes the binding or the comparison.
     """
-    _state.bind_ip(token, ip, session_exp or time.time() + MAX_SESSION_TTL_SECS, proxied)
+    _state.bind_peer(token, peer_key, session_exp or time.time() + MAX_SESSION_TTL_SECS, proxied)
+
+
+def bind_token_ip(token: str, ip: str, session_exp: float = 0.0, proxied: bool = False) -> None:
+    """Thin compat wrapper over :func:`bind_token_peer` for address pins."""
+    bind_token_peer(token, f"ip:{ip}", session_exp, proxied)
 
 
 def proxied_pin_observed() -> bool | None:
@@ -1008,15 +1049,21 @@ def proxied_pin_observed() -> bool | None:
     ``None`` = nothing is currently pinned (no scope to report), ``True`` = at
     least one live session is pinned to a same-host proxy address and is
     therefore shared by every client behind it, ``False`` = live sessions are
-    pinned to client addresses. Recovers on its own once proxied sessions
-    expire — no gateway restart needed.
+    pinned per client (client address or daemon-verified tailnet identity).
+    Recovers on its own once proxied sessions expire — no gateway restart
+    needed.
     """
     return _state.proxied_pin_observed(time.time())
 
 
+def check_token_peer(token: str, peer_key: str) -> tuple[bool, str]:
+    """Check *token* against its bound peer key. ``(ok, mismatch_reason)``."""
+    return _state.check_peer(token, peer_key)
+
+
 def check_token_ip(token: str, ip: str) -> bool:
-    """Check if token is bound to the given IP (or unbound)."""
-    return _state.check_ip(token, ip)
+    """Thin compat wrapper over :func:`check_token_peer` for address pins."""
+    return _state.check_peer(token, f"ip:{ip}")[0]
 
 
 def mark_consumed(token: str, session_exp: float = 0.0) -> None:
@@ -1279,6 +1326,7 @@ def token_auth_middleware(
     port: int = 5476,
     local_only: bool = True,
     spa_shell_handler: Callable[..., Any] | None = None,
+    tailnet_trust: TailnetTrust | None = None,
 ) -> Callable[..., Any]:
     """Factory returning aiohttp middleware for token-based dashboard auth.
 
@@ -1298,6 +1346,13 @@ def token_auth_middleware(
     (e.g. ``/api/spawn`` every 5s) don't trigger false session-expired
     banners.  Use this for any internal-path that the browser polls.
 
+    *tailnet_trust* is the operator's identity-trust opt-in (RFC §2–§3.1,
+    validated at config load). When set and enabled, a request arriving from
+    the local ``tailscale serve`` proxy is attributed to the daemon-verified
+    tailnet peer: the session pin binds to a ``ts:``-prefixed peer key instead of
+    the proxy's loopback address, the allowlist is enforced, and audit records
+    name the login. When ``None`` (the default, and every failure mode of the
+    resolution) behaviour is byte-for-byte the existing token+IP path.
     """
 
     # NOTE: the signing-secret and revoked-nonce singletons are NOT warmed
@@ -1310,23 +1365,121 @@ def token_auth_middleware(
     # constructing this middleware chain, so the first auth op still hits the
     # already-built singletons without any blocking I/O landing on the loop.
 
-    def _extract_and_validate_token(request: web.Request, _port: int) -> tuple[bool, str, str, str]:
+    def _extract_and_validate_token(
+        request: web.Request, _port: int
+    ) -> tuple[bool, str, str, str, str]:
         """Extract token from query param or cookie and validate it.
 
-        Returns ``(valid, user_id, reason, app_name)``. Used by internal-path
-        browser/app auth (no secret header). The main auth flow has its own
-        extraction with IP-binding and from_cookie tracking that this helper
-        intentionally does not replicate.
+        Returns ``(valid, user_id, reason, app_name, token)``. Used by
+        internal-path browser/app auth (no secret header). The main auth flow
+        has its own extraction with peer-binding and from_cookie tracking that
+        this helper intentionally does not replicate — but its callers still
+        run the peer-pin check on the returned token, so an internal path never
+        accepts a session pin the main flow would refuse.
         """
         cookie_name = f"mc_token_{_cookie_port_from_host(request, _port)}"
         token = request.query.get("token") or request.cookies.get(cookie_name, "")
         if not token:
-            return False, "", "no token", ""
-        return validate_token_with_app(token, use_session_exp=True)
+            return False, "", "no token", "", ""
+        valid, uid, reason, app = validate_token_with_app(token, use_session_exp=True)
+        return valid, uid, reason, app, token
 
     @web.middleware
     async def middleware(request: web.Request, handler: object) -> web.StreamResponse:
         path = request.path
+
+        # Forwarded-peer resolution (RFC §2), once per request — the WebSocket
+        # path therefore resolves once at upgrade, never per frame. ``None`` on
+        # every unresolvable or failure case, in which case everything below is
+        # byte-for-byte the existing token+IP behaviour.
+        #
+        # Gated on the request PRESENTING A CREDENTIAL (query token, an access
+        # or refresh cookie), not on where in the middleware it would be
+        # consumed: a credential-less request (static assets, probes) can never
+        # bind or satisfy a pin, so resolving identity for it would only hand
+        # an unauthenticated local caller a header-driven daemon spawn. The
+        # gate is credential-PRESENCE rather than validity so the allowlist
+        # deny below still covers the /api/auth/refresh bypass.
+        peer: ForwardedPeer | None = None
+        if (
+            tailnet_trust is not None
+            and tailnet_trust.trust_identity
+            and tailnet_trust.allowed_logins
+            and (
+                bool(request.query.get("token"))
+                or any(c.startswith(("mc_token_", "mc_refresh_")) for c in request.cookies)
+            )
+        ):
+            peer = await resolve_forwarded_peer(request, tailnet_trust)
+            if peer is not None and not login_allowed(peer.login, tailnet_trust.allowed_logins):
+                # The allowlist is mandatory (RFC §3): a daemon-verified login
+                # that the operator did not allowlist is denied outright — a
+                # positive identity outside the allowlist must never fall
+                # through to a path it could satisfy with a leaked token.
+                _sel = _sel_fn()
+                _sel.log_api_access(
+                    caller=peer.login,
+                    operation="tailnet_peer_auth",
+                    outcome="denied",
+                    source="token_auth",
+                    resources=path,
+                    error="login not in allowed_logins",
+                )
+                _log_auth(request, peer.login, "denied", "tailnet login not allowed")
+                return _deny(request, "tailnet login not allowed")
+        # Audit attribution (RFC §3): when a peer resolved, the trail names a
+        # person; otherwise it stays the immediate peer address as today.
+        _caller = peer.login if peer is not None else (request.remote or "")
+
+        def _audit_uid(user_id: str) -> str:
+            """The identity ``_log_auth`` should record as the caller.
+
+            The daemon-verified login when a peer resolved (the RFC's audit
+            requirement — the trail names a person, not the proxy or a bare
+            token subject); the token identity otherwise.
+            """
+            return peer.login if peer is not None else user_id
+
+        def _peer_key_for_request() -> str:
+            """The pin key this request must satisfy (RFC §3)."""
+            if peer is not None and tailnet_trust is not None:
+                return peer_pin_key(peer, tailnet_trust.pin_scope)
+            return f"ip:{request.remote or 'unknown'}"
+
+        def _check_pin(token: str) -> tuple[bool, str]:
+            """Peer-pin check with an honest failure reason.
+
+            When the stored pin is a tailnet identity but NO peer resolved on
+            this request, the mismatch is reported as the identity being
+            UNVERIFIED rather than a device mismatch: this request could not
+            establish who is behind the proxy (daemon blip, header stripped,
+            or a genuinely different client), and "device identity mismatch"
+            would send the user chasing a re-enrolled device that never
+            changed. Fail-closed either way — an identity-pinned session is
+            never satisfiable by an unverified proxied request.
+            """
+            ok, mismatch = check_token_peer(token, _peer_key_for_request())
+            if not ok and peer is None and mismatch != "IP mismatch":
+                mismatch = "tailnet identity unverified"
+            if ok and peer is not None and not _state.has_binding(token):
+                # First-use re-pin after a restart, at the shared check so the
+                # internal cookie-auth branches get it too. The binding map is
+                # in-memory by design (RFC: regenerated on restart), so a
+                # surviving cookie is unbound until the first VERIFIED peer
+                # claims it; every other device is denied from then on, and
+                # the SEL row names who claimed it. Scoped to resolved peers —
+                # re-pinning ip: keys would change app-token and multi-hop
+                # semantics that predate identity pinning.
+                repin_key = _peer_key_for_request()
+                bind_token_peer(token, repin_key)
+                _sel_fn().log_api_access(
+                    caller=peer.login,
+                    operation="tailnet_peer_bind",
+                    outcome="granted",
+                    source="token_auth",
+                    resources=f"{repin_key} (first-use re-pin)",
+                )
+            return ok, mismatch
 
         # Internal API paths: loopback + secret grants immediate access.
         # If the secret is missing (browser request), fall through to
@@ -1352,7 +1505,7 @@ def token_auth_middleware(
                 if not internal_secret:
                     _sel = _sel_fn()
                     _sel.log_api_access(
-                        caller=request.remote or "",
+                        caller=_caller,
                         operation="internal_auth",
                         outcome="denied",
                         source="token_auth",
@@ -1364,7 +1517,7 @@ def token_auth_middleware(
                 if hmac.compare_digest(internal_secret, _provided_secret):
                     _sel = _sel_fn()
                     _sel.log_api_access(
-                        caller=request.remote or "",
+                        caller=_caller,
                         operation="internal_auth",
                         outcome="granted",
                         source="token_auth",
@@ -1382,7 +1535,7 @@ def token_auth_middleware(
                 # Wrong secret → deny (don't fall through)
                 _sel = _sel_fn()
                 _sel.log_api_access(
-                    caller=request.remote or "",
+                    caller=_caller,
                     operation="internal_auth",
                     outcome="denied",
                     source="token_auth",
@@ -1396,11 +1549,11 @@ def token_auth_middleware(
             # at the decision point rather than deferring to downstream.
             # NOTE: uses _extract_and_validate_token helper (defined above)
             # for cookie/query-param validation.
-            _valid, _uid, _reason, _app = _extract_and_validate_token(request, port)
+            _valid, _uid, _reason, _app, _tok = _extract_and_validate_token(request, port)
             if not _valid:
                 _sel = _sel_fn()
                 _sel.log_api_access(
-                    caller=request.remote or "",
+                    caller=_caller,
                     operation="internal_auth",
                     outcome="denied",
                     source="token_auth",
@@ -1409,6 +1562,14 @@ def token_auth_middleware(
                 )
                 _log_auth(request, "internal", "denied", f"cookie auth failed: {_reason}")
                 return _deny(request, "Forbidden")
+            # Session-pin enforcement (RFC §3). Internal paths validated the
+            # cookie but historically skipped the pin, which would let a
+            # peer-pinned session be replayed against /api/chat, /api/spawn
+            # and friends from a client the pin excludes.
+            _pin_ok, _pin_mismatch = _check_pin(_tok)
+            if not _pin_ok:
+                _log_auth(request, _audit_uid(_uid), "denied", _pin_mismatch)
+                return _deny(request, _pin_mismatch)
             # Expose identity so downstream handlers (and app-scope) see it.
             request["user"] = _uid
             request["app"] = _app
@@ -1421,7 +1582,7 @@ def token_auth_middleware(
                 return _scope_deny
             _sel = _sel_fn()
             _sel.log_api_access(
-                caller=request.remote or "",
+                caller=_caller,
                 operation="internal_auth",
                 outcome="granted",
                 source="token_auth",
@@ -1445,7 +1606,7 @@ def token_auth_middleware(
                     ):
                         _sel = _sel_fn()
                         _sel.log_api_access(
-                            caller=request.remote or "",
+                            caller=_caller,
                             operation="internal_auth",
                             outcome="denied",
                             source="token_auth",
@@ -1456,11 +1617,11 @@ def token_auth_middleware(
                             request, "internal", "denied", "wrong secret (non-loopback mixed)"
                         )
                         return _deny(request, "Forbidden")
-                _valid, _uid, _reason, _app = _extract_and_validate_token(request, port)
+                _valid, _uid, _reason, _app, _tok = _extract_and_validate_token(request, port)
                 if not _valid:
                     _sel = _sel_fn()
                     _sel.log_api_access(
-                        caller=request.remote or "",
+                        caller=_caller,
                         operation="internal_auth",
                         outcome="denied",
                         source="token_auth",
@@ -1474,6 +1635,12 @@ def token_auth_middleware(
                         f"mixed non-loopback cookie auth failed: {_reason}",
                     )
                     return _deny(request, "Forbidden")
+                # Session-pin enforcement (RFC §3) — same rationale as the
+                # loopback branch above.
+                _pin_ok, _pin_mismatch = _check_pin(_tok)
+                if not _pin_ok:
+                    _log_auth(request, _audit_uid(_uid), "denied", _pin_mismatch)
+                    return _deny(request, _pin_mismatch)
                 # Expose identity + confine app tokens to their declared scope
                 # (same rationale as the loopback branch above).
                 request["user"] = _uid
@@ -1483,7 +1650,7 @@ def token_auth_middleware(
                     return _scope_deny
                 _sel = _sel_fn()
                 _sel.log_api_access(
-                    caller=request.remote or "",
+                    caller=_caller,
                     operation="internal_auth",
                     outcome="granted",
                     source="token_auth",
@@ -1502,7 +1669,7 @@ def token_auth_middleware(
                 # isolation that the internal-secret design provides.
                 _sel = _sel_fn()
                 _sel.log_api_access(
-                    caller=request.remote or "",
+                    caller=_caller,
                     operation="internal_auth",
                     outcome="denied",
                     source="token_auth",
@@ -1597,11 +1764,14 @@ def token_auth_middleware(
             _log_auth(request, "", "denied", reason)
             return _deny(request, reason)
 
-        client_ip = request.remote or "unknown"
+        # The session pin key (RFC §3): the daemon-verified peer identity when
+        # one resolved, else the immediate address — byte-for-byte today's pin.
+        peer_key = _peer_key_for_request()
 
-        if not check_token_ip(token, client_ip):
-            _log_auth(request, user_id, "denied", "IP mismatch")
-            return _deny(request, "IP mismatch")
+        _pin_ok, _pin_mismatch = _check_pin(token)
+        if not _pin_ok:
+            _log_auth(request, _audit_uid(user_id), "denied", _pin_mismatch)
+            return _deny(request, _pin_mismatch)
 
         # Extract session_exp for cookie and IP binding on first query-param use
         session_exp = 0.0
@@ -1673,17 +1843,31 @@ def token_auth_middleware(
                 # offload so it never blocks the event loop. is_revoked above is
                 # an in-memory check and is cheap enough to run inline.
                 await asyncio.to_thread(_get_revoked_store().revoke, _link_nonce, session_exp)
-            # Bind the SESSION token (what becomes the cookie) to the client IP,
+            # Bind the SESSION token (what becomes the cookie) to the peer key,
             # not the consumed URL token. ``proxied`` is recorded so Security
             # Posture can tell the user whether that pin is per-client or shared
             # with everyone behind a same-host tunnel — it does not affect the
-            # binding itself.
-            bind_token_ip(
+            # binding itself. A session pinned to a daemon-verified tailnet peer
+            # is per-client even though the request is proxied, so the flag is
+            # only set when NO peer resolved.
+            bind_token_peer(
                 session_token,
-                client_ip,
+                peer_key,
                 session_exp,
-                is_proxied_request(request),
+                proxied=is_proxied_request(request) and peer is None,
             )
+            if peer is not None:
+                # The one permission decision that changes state: this session
+                # is now pinned to a verified identity and the audit trail
+                # re-attributes to a login. One SEL row per session, at bind —
+                # not per request, which would only add volume.
+                _sel_fn().log_api_access(
+                    caller=peer.login,
+                    operation="tailnet_peer_bind",
+                    outcome="granted",
+                    source="token_auth",
+                    resources=peer_key,
+                )
 
             # Token-consumption anchor seam (Default: no-op, OSS-identical). A
             # Slack challenge-redirect link, once opened on a verified device,
@@ -1803,7 +1987,7 @@ def token_auth_middleware(
                     _refresh_err,
                 )
 
-        _log_auth(request, user_id, "ok", "")
+        _log_auth(request, _audit_uid(user_id), "ok", "")
         return resp  # type: ignore[return-value]
 
     middleware._is_token_auth = True  # type: ignore[attr-defined]  # sentinel for server.py security gate

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1160,7 +1160,10 @@ def _token_auth_items() -> list[PostureItem]:
             "transport that preserves the client address, for the pin to identify one client"
         )
     else:
-        _pin_detail = "A session is bound to the client address that first used it"
+        _pin_detail = (
+            "Per-client: a session is bound to the client address — or the "
+            "daemon-verified tailnet identity — that first used it"
+        )
 
     return [
         PostureItem(

--- a/test/test_security_posture.py
+++ b/test/test_security_posture.py
@@ -639,7 +639,7 @@ class TestOmissionDetection:
         src = inspect.getsource(token_auth)
         for marker in (
             "hmac.new",  # HMAC-SHA256 signature
-            "bind_ip",  # IP pinning
+            "bind_peer",  # session pinning (peer-keyed: ip:<addr> / ts:… identity)
             "try_consume",  # single-use link nonce
             "MAX_SESSION_TTL_SECS",  # bounded session lifetime
             "revocation_gen",  # revocation generation

--- a/test/test_session_pin_scope.py
+++ b/test/test_session_pin_scope.py
@@ -77,11 +77,11 @@ def _reset_pin_bindings():
     from kiro_crew.dashboard import token_auth
 
     state = token_auth._state
-    before = dict(state._ip_bindings)
-    state._ip_bindings.clear()
+    before = dict(state._peer_bindings)
+    state._peer_bindings.clear()
     yield
-    state._ip_bindings.clear()
-    state._ip_bindings.update(before)
+    state._peer_bindings.clear()
+    state._peer_bindings.update(before)
 
 
 def _live() -> float:
@@ -98,14 +98,14 @@ class TestPostureReportsEffectivePinScope:
         detail = _pin_detail()
         assert "not known yet" in detail
         # Must not claim the per-client property it has not observed.
-        assert "client address that first used it" not in detail
+        assert "Per-client" not in detail
 
     def test_direct_bind_reports_per_client(self) -> None:
         from kiro_crew.dashboard.token_auth import bind_token_ip, proxied_pin_observed
 
         bind_token_ip("t-direct", "203.0.113.7", _live(), False)
         assert proxied_pin_observed() is False
-        assert "client address that first used it" in _pin_detail()
+        assert "Per-client" in _pin_detail()
 
     def test_proxied_bind_reports_shared_pin(self) -> None:
         """The state the guide used to advertise as a mitigation."""
@@ -138,7 +138,7 @@ class TestPostureReportsEffectivePinScope:
         bind_token_ip("t-proxied", "127.0.0.1", time.time() - 1, True)  # already expired
         bind_token_ip("t-direct", "203.0.113.7", _live(), False)
         assert proxied_pin_observed() is False
-        assert "client address that first used it" in _pin_detail()
+        assert "Per-client" in _pin_detail()
 
     def test_all_sessions_expired_reports_not_known_rather_than_stale(self) -> None:
         from kiro_crew.dashboard.token_auth import bind_token_ip, proxied_pin_observed

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -171,8 +171,10 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # version into versions.txt. The binary name is a module constant; a
         # resource ceiling / sandbox adds nothing to a `--version` call.
         "diagnostics.py::_kiro_cli_version",
-        # Tailnet origin derivation (RFC: rfc-tailnet-dashboard-access): one
-        # fixed argv, ``["<tailscale>", "status", "--json"]``, with a 3s timeout,
+        # Tailnet origin derivation + forwarded-peer whois (RFC:
+        # rfc-tailnet-dashboard-access): one fixed argv — ``["<tailscale>",
+        # "status", "--json"]`` or ``["<tailscale>", "whois", "--json",
+        # <validated tailnet address>]`` — with a 3s timeout,
         # no shell and no cwd. The binary is resolved from a vetted absolute
         # allowlist (``_CLI_CANDIDATE_PATHS``) and NOT from ``PATH`` — a ``PATH``
         # lookup made the executable itself agent-selectable even though the
@@ -184,7 +186,7 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # is that *nothing raises* so the gateway still boots on a host with no
         # Tailscale. Routing it would make dashboard startup depend on sandbox
         # availability, which is exactly the failure that property rules out.
-        "dashboard/tailnet.py::_run_json",
+        "dashboard/tailnet.py::_run_json_detail",
         "apps/backend.py::_proc_start_time",
         "apps/backend.py::_resolve_nvm_path",
         "apps/backend.py::stop_app_backend",

--- a/test/test_tailnet_peer.py
+++ b/test/test_tailnet_peer.py
@@ -1,0 +1,566 @@
+"""Forwarded-peer resolution and identity-pinned sessions (RFC Phase 3).
+
+The attack matrix from the RFC's adversarial-review list, pinned as tests:
+X-Forwarded-For injection, multi-value XFF, header/whois disagreement,
+daemon-absent fallback, timeout fail-closed, tagged-node login-scope collapse,
+and allowlist enforcement. Whois is always mocked at the ``_run_json`` /
+subprocess seam — no test invokes a real ``tailscale`` binary.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from multidict import CIMultiDict
+
+import kiro_crew.config.loader as loader
+from kiro_crew.config.loader import _tailscale_config_from
+from kiro_crew.dashboard import tailnet
+from kiro_crew.dashboard.tailnet import (
+    PIN_SCOPE_LOGIN,
+    PIN_SCOPE_NODE,
+    TAGGED_DEVICES_LOGIN,
+    ForwardedPeer,
+    TailnetTrust,
+    login_allowed,
+    peer_pin_key,
+    resolve_forwarded_peer,
+)
+
+TRUST = TailnetTrust(
+    trust_identity=True,
+    allowed_logins=("you@example.com",),
+    pin_scope=PIN_SCOPE_NODE,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_whois_cache(monkeypatch):
+    """Isolate the process-global whois cache, and pin IS_POSIX=True so the
+    resolution matrix is exercised identically on the Windows CI shard (the
+    explicit Windows-degrade test overrides it back to False itself)."""
+    monkeypatch.setattr(tailnet, "IS_POSIX", True)
+    tailnet._whois_cache.clear()
+    yield
+    tailnet._whois_cache.clear()
+
+
+def _req(remote: str, headers: dict[str, str] | None = None) -> Any:
+    """Request double: resolution reads only ``.remote`` and ``.headers``."""
+    return SimpleNamespace(remote=remote, headers=CIMultiDict(headers or {}))
+
+
+def _whois_json(login: str = "you@example.com", node: str = "phone.tail.ts.net.") -> dict:
+    return {"Node": {"Name": node}, "UserProfile": {"LoginName": login}}
+
+
+def _patch_whois(monkeypatch, result: dict | None) -> MagicMock:
+    """Mock the CLI at the ``_run_json_detail`` seam (result, transient=False)."""
+    mock = MagicMock(return_value=(result, False))
+    monkeypatch.setattr(tailnet, "_run_json_detail", mock)
+    return mock
+
+
+# ── RFC §2 conditions (a)–(f), each individually fail-closed ──
+
+
+class TestResolutionMatrix:
+    @pytest.mark.asyncio
+    async def test_happy_path_resolves_the_daemon_verified_peer(self, monkeypatch) -> None:
+        _patch_whois(monkeypatch, _whois_json())
+        peer = await resolve_forwarded_peer(
+            _req("127.0.0.1", {"X-Forwarded-For": "100.64.0.5"}), TRUST
+        )
+        assert peer == ForwardedPeer(
+            login="you@example.com", node="phone.tail.ts.net", address="100.64.0.5"
+        )
+
+    @pytest.mark.asyncio
+    async def test_xff_injection_from_non_loopback_peer_is_never_read(self, monkeypatch) -> None:
+        """(a) A remote peer's forwarded header is an unverifiable claim."""
+        whois = _patch_whois(monkeypatch, _whois_json())
+        peer = await resolve_forwarded_peer(
+            _req("203.0.113.7", {"X-Forwarded-For": "100.64.0.5"}), TRUST
+        )
+        assert peer is None
+        whois.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_trust_disabled_never_resolves(self, monkeypatch) -> None:
+        whois = _patch_whois(monkeypatch, _whois_json())
+        trust_off = TailnetTrust(trust_identity=False, allowed_logins=("you@example.com",))
+        peer = await resolve_forwarded_peer(
+            _req("127.0.0.1", {"X-Forwarded-For": "100.64.0.5"}), trust_off
+        )
+        assert peer is None
+        whois.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_allowlist_never_resolves(self, monkeypatch) -> None:
+        """(b) empty allowlist means trust was refused at load — belt and braces."""
+        whois = _patch_whois(monkeypatch, _whois_json())
+        trust = TailnetTrust(trust_identity=True, allowed_logins=())
+        peer = await resolve_forwarded_peer(
+            _req("127.0.0.1", {"X-Forwarded-For": "100.64.0.5"}), trust
+        )
+        assert peer is None
+        whois.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_comma_joined_xff_is_rejected_not_first_or_last(self, monkeypatch) -> None:
+        """(c) two addresses in one header value = unattributable proxy chain."""
+        whois = _patch_whois(monkeypatch, _whois_json())
+        peer = await resolve_forwarded_peer(
+            _req("127.0.0.1", {"X-Forwarded-For": "100.64.0.5, 100.64.0.6"}), TRUST
+        )
+        assert peer is None
+        whois.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_repeated_xff_headers_are_rejected(self, monkeypatch) -> None:
+        """(c) two header instances are just as unattributable as a comma."""
+        whois = _patch_whois(monkeypatch, _whois_json())
+        headers = CIMultiDict()
+        headers.add("X-Forwarded-For", "100.64.0.5")
+        headers.add("X-Forwarded-For", "100.64.0.6")
+        peer = await resolve_forwarded_peer(
+            SimpleNamespace(remote="127.0.0.1", headers=headers), TRUST
+        )
+        assert peer is None
+        whois.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_xff_resolves_nothing(self, monkeypatch) -> None:
+        whois = _patch_whois(monkeypatch, _whois_json())
+        assert await resolve_forwarded_peer(_req("127.0.0.1"), TRUST) is None
+        whois.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("addr", ["203.0.113.7", "10.0.0.5", "not-an-ip", ""])
+    async def test_address_outside_tailnet_ranges_is_rejected(self, monkeypatch, addr) -> None:
+        """(d) only CGNAT 100.64/10 and the tailnet ULA reach the daemon."""
+        whois = _patch_whois(monkeypatch, _whois_json())
+        peer = await resolve_forwarded_peer(_req("127.0.0.1", {"X-Forwarded-For": addr}), TRUST)
+        assert peer is None
+        whois.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_tailnet_ula_ipv6_address_is_accepted(self, monkeypatch) -> None:
+        _patch_whois(monkeypatch, _whois_json())
+        peer = await resolve_forwarded_peer(
+            _req("::1", {"X-Forwarded-For": "fd7a:115c:a1e0::1"}), TRUST
+        )
+        assert peer is not None
+        assert peer.address == "fd7a:115c:a1e0::1"
+
+    @pytest.mark.asyncio
+    async def test_header_whois_login_disagreement_is_a_rejection(self, monkeypatch) -> None:
+        """(f) the daemon decides identity; a disagreeing header is a rejection."""
+        _patch_whois(monkeypatch, _whois_json(login="you@example.com"))
+        peer = await resolve_forwarded_peer(
+            _req(
+                "127.0.0.1",
+                {
+                    "X-Forwarded-For": "100.64.0.5",
+                    "Tailscale-User-Login": "someone-else@example.com",
+                },
+            ),
+            TRUST,
+        )
+        assert peer is None
+
+    @pytest.mark.asyncio
+    async def test_absent_login_header_costs_nothing(self, monkeypatch) -> None:
+        """The header is only corroboration — absence is not a failure."""
+        _patch_whois(monkeypatch, _whois_json())
+        peer = await resolve_forwarded_peer(
+            _req("127.0.0.1", {"X-Forwarded-For": "100.64.0.5"}), TRUST
+        )
+        assert peer is not None
+
+    @pytest.mark.asyncio
+    async def test_agreeing_login_header_passes(self, monkeypatch) -> None:
+        _patch_whois(monkeypatch, _whois_json())
+        peer = await resolve_forwarded_peer(
+            _req(
+                "127.0.0.1",
+                {
+                    "X-Forwarded-For": "100.64.0.5",
+                    "Tailscale-User-Login": "You@Example.com",  # case-insensitive
+                },
+            ),
+            TRUST,
+        )
+        assert peer is not None
+
+    @pytest.mark.asyncio
+    async def test_windows_degrades_to_none(self, monkeypatch) -> None:
+        """RFC OQ4: resolution is POSIX-only; Windows falls to the token path."""
+        whois = _patch_whois(monkeypatch, _whois_json())
+        monkeypatch.setattr(tailnet, "IS_POSIX", False)
+        peer = await resolve_forwarded_peer(
+            _req("127.0.0.1", {"X-Forwarded-For": "100.64.0.5"}), TRUST
+        )
+        assert peer is None
+        whois.assert_not_called()
+
+
+class TestDaemonFailureModes:
+    """(e) fail-closed on identity, fail-open on availability — every daemon
+    failure is ``None``, exercised at the subprocess seam."""
+
+    @pytest.fixture(autouse=True)
+    def _fake_cli(self, monkeypatch):
+        monkeypatch.setattr(tailnet, "_cli_path", lambda: "/usr/bin/tailscale")
+
+    @pytest.mark.asyncio
+    async def test_daemon_absent_is_none(self, monkeypatch) -> None:
+        monkeypatch.setattr(tailnet, "_cli_path", lambda: None)
+        assert (
+            await resolve_forwarded_peer(
+                _req("127.0.0.1", {"X-Forwarded-For": "100.64.0.5"}), TRUST
+            )
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_zero_exit_is_none(self, monkeypatch) -> None:
+        proc = SimpleNamespace(returncode=1, stdout="", stderr="no such peer")
+        monkeypatch.setattr(tailnet.subprocess, "run", lambda *a, **k: proc)
+        assert (
+            await resolve_forwarded_peer(
+                _req("127.0.0.1", {"X-Forwarded-For": "100.64.0.5"}), TRUST
+            )
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_is_none(self, monkeypatch) -> None:
+        proc = SimpleNamespace(returncode=0, stdout="not json{", stderr="")
+        monkeypatch.setattr(tailnet.subprocess, "run", lambda *a, **k: proc)
+        assert (
+            await resolve_forwarded_peer(
+                _req("127.0.0.1", {"X-Forwarded-For": "100.64.0.5"}), TRUST
+            )
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_timeout_is_none(self, monkeypatch) -> None:
+        def _boom(*a: Any, **k: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd="tailscale", timeout=3.0)
+
+        monkeypatch.setattr(tailnet.subprocess, "run", _boom)
+        assert (
+            await resolve_forwarded_peer(
+                _req("127.0.0.1", {"X-Forwarded-For": "100.64.0.5"}), TRUST
+            )
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_whois_missing_identity_fields_is_none(self, monkeypatch) -> None:
+        proc = SimpleNamespace(returncode=0, stdout=json.dumps({"Node": {}}), stderr="")
+        monkeypatch.setattr(tailnet.subprocess, "run", lambda *a, **k: proc)
+        assert (
+            await resolve_forwarded_peer(
+                _req("127.0.0.1", {"X-Forwarded-For": "100.64.0.5"}), TRUST
+            )
+            is None
+        )
+
+
+class TestWhoisCache:
+    def test_results_are_cached_by_address(self, monkeypatch) -> None:
+        whois = _patch_whois(monkeypatch, _whois_json())
+        assert tailnet._whois_cached("100.64.0.5") == tailnet._whois_cached("100.64.0.5")
+        assert whois.call_count == 1
+
+    def test_negative_results_are_cached_too(self, monkeypatch) -> None:
+        whois = _patch_whois(monkeypatch, None)
+        assert tailnet._whois_cached("100.64.0.9") is None
+        assert tailnet._whois_cached("100.64.0.9") is None
+        assert whois.call_count == 1
+
+    def test_entry_count_is_bounded(self, monkeypatch) -> None:
+        _patch_whois(monkeypatch, None)
+        for i in range(tailnet._WHOIS_CACHE_MAX_ENTRIES + 50):
+            tailnet._whois_cached(f"100.64.{i // 256}.{i % 256}")
+        assert len(tailnet._whois_cache) <= tailnet._WHOIS_CACHE_MAX_ENTRIES
+
+
+# ── RFC §3.1 pin keys ──
+
+
+class TestPeerPinKey:
+    PEER = ForwardedPeer(login="you@example.com", node="phone.tail.ts.net", address="100.64.0.5")
+
+    def test_node_scope_key_shape(self) -> None:
+        assert (
+            peer_pin_key(self.PEER, PIN_SCOPE_NODE) == "ts:node:you@example.com|phone.tail.ts.net"
+        )
+
+    def test_login_scope_key_shape(self) -> None:
+        assert peer_pin_key(self.PEER, PIN_SCOPE_LOGIN) == "ts:login:you@example.com"
+
+    def test_unrecognised_scope_narrows_to_node(self) -> None:
+        assert peer_pin_key(self.PEER, "everyone") == "ts:node:you@example.com|phone.tail.ts.net"
+
+    def test_tagged_node_is_forced_to_node_scope_and_logged(self, caplog) -> None:
+        """An ACL tag replaces the user identity, so login scope would collapse
+        the pin across the entire tagged fleet (tailscale/tailscale#4605)."""
+        tagged = ForwardedPeer(
+            login=TAGGED_DEVICES_LOGIN, node="ci.tail.ts.net", address="100.64.0.6"
+        )
+        with caplog.at_level("WARNING", logger="kiro_crew.dashboard.tailnet"):
+            key = peer_pin_key(tagged, PIN_SCOPE_LOGIN)
+        assert key == f"ts:node:{TAGGED_DEVICES_LOGIN}|ci.tail.ts.net"
+        assert any("overridden" in r.message for r in caplog.records)
+
+    def test_two_tagged_nodes_get_distinct_keys_even_under_login_scope(self) -> None:
+        """The 'tagged-devices in allowed_logins' hazard: node identity stays
+        unique, so one tagged node's session is not replayable from another."""
+        a = ForwardedPeer(login=TAGGED_DEVICES_LOGIN, node="ci-a.ts.net", address="100.64.0.6")
+        b = ForwardedPeer(login=TAGGED_DEVICES_LOGIN, node="ci-b.ts.net", address="100.64.0.7")
+        assert peer_pin_key(a, PIN_SCOPE_LOGIN) != peer_pin_key(b, PIN_SCOPE_LOGIN)
+
+
+class TestLoginAllowlist:
+    def test_membership_is_case_insensitive(self) -> None:
+        assert login_allowed("You@Example.com", ("you@example.com",)) is True
+
+    def test_non_member_is_denied(self) -> None:
+        assert login_allowed("mallory@example.com", ("you@example.com",)) is False
+
+    def test_empty_allowlist_allows_no_one(self) -> None:
+        assert login_allowed("you@example.com", ()) is False
+
+    def test_blank_entries_never_match(self) -> None:
+        assert login_allowed("", ("", " ")) is False
+
+
+# ── Config load validation (RFC §3/§3.1) ──
+
+
+class TestConfigLoadValidation:
+    def test_trust_with_empty_allowlist_is_refused_at_load(self, caplog) -> None:
+        with caplog.at_level("ERROR", logger="kiro_crew.config.loader"):
+            cfg = _tailscale_config_from({"enabled": True, "trust_identity": True})
+        assert cfg.trust_identity is False
+        assert any("allowed_logins" in r.message for r in caplog.records)
+
+    def test_unrecognised_pin_scope_narrows_to_node_with_warning(self, caplog) -> None:
+        with caplog.at_level("WARNING", logger="kiro_crew.config.loader"):
+            cfg = _tailscale_config_from(
+                {"trust_identity": True, "allowed_logins": ["a@b.c"], "pin_scope": "everyone"}
+            )
+        assert cfg.pin_scope == "node"
+        assert cfg.trust_identity is True
+        assert any("pin_scope" in r.message for r in caplog.records)
+
+    def test_valid_config_passes_through(self) -> None:
+        cfg = _tailscale_config_from(
+            {
+                "enabled": True,
+                "trust_identity": True,
+                "allowed_logins": ["you@example.com", "  ", 42],
+                "pin_scope": "login",
+            }
+        )
+        assert cfg.enabled is True
+        assert cfg.trust_identity is True
+        assert cfg.allowed_logins == ["you@example.com"]  # blanks/non-strings dropped
+        assert cfg.pin_scope == "login"
+
+    def test_defaults_are_all_off(self) -> None:
+        cfg = _tailscale_config_from(None)
+        assert cfg.enabled is False
+        assert cfg.trust_identity is False
+        assert cfg.allowed_logins == []
+        assert cfg.pin_scope == "node"
+
+    def test_non_list_allowed_logins_is_treated_as_empty(self, caplog) -> None:
+        with caplog.at_level("ERROR", logger="kiro_crew.config.loader"):
+            cfg = _tailscale_config_from({"trust_identity": True, "allowed_logins": "a@b.c"})
+        assert cfg.trust_identity is False
+
+
+# ── RFC §5: what stays closed ──
+
+
+class TestVerifiedPeerStaysReadOnly:
+    def test_verified_peer_request_is_not_direct_local(self) -> None:
+        """A verified tailnet peer still sends X-Forwarded-For, so the
+        config-write / secret-reveal predicate stays False for it."""
+        from kiro_crew.dashboard.origin import is_direct_local_request
+
+        req = SimpleNamespace(
+            remote="127.0.0.1",
+            headers={"X-Forwarded-For": "100.64.0.5", "Tailscale-User-Login": "you@example.com"},
+        )
+        assert is_direct_local_request(req) is False
+
+    def test_messaging_config_surface_reports_read_only_for_verified_peer(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """RFC §5 regression: a whois-verified tailnet peer receives
+        ``read_only: true`` on the handlers/messaging.py config surfaces —
+        identity trust must not unlock the config-write surfaces."""
+        import kiro_crew.dashboard.handlers.messaging as messaging
+
+        monkeypatch.setattr(loader, "env_path", lambda: tmp_path / ".env")
+        monkeypatch.setattr(loader, "config_path", lambda: tmp_path / "config.json")
+
+        class _PeerReq:
+            remote = "127.0.0.1"
+            headers = {
+                "X-Forwarded-For": "100.64.0.5",
+                "Tailscale-User-Login": "you@example.com",
+            }
+
+            def __init__(self, state: Any) -> None:
+                self.app = {"state": state}
+
+        state = MagicMock()
+        state.teams_connected = False
+        state.teams_connect_error = ""
+        import asyncio
+
+        resp = asyncio.run(messaging.api_teams_config_get(_PeerReq(state)))
+        body = resp.body
+        assert isinstance(body, (bytes, bytearray))
+        assert json.loads(body)["read_only"] is True
+
+
+# ── Review-round hardening (adversarial fleet findings) ──
+
+
+class TestTransientFailureCaching:
+    def test_timeout_is_cached_on_the_short_transient_ttl(self, monkeypatch) -> None:
+        """A daemon-still-starting blip (timeout/spawn error) must not hold an
+        identity-pinned session denied for the full cache window."""
+        monkeypatch.setattr(tailnet, "_cli_path", lambda: "/usr/bin/tailscale")
+
+        def _boom(*a: Any, **k: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd="tailscale", timeout=3.0)
+
+        monkeypatch.setattr(tailnet.subprocess, "run", _boom)
+        assert tailnet._whois_cached("100.64.0.5") is None
+        expiry, value = tailnet._whois_cache["100.64.0.5"]
+        assert value is None
+        import time as _time
+
+        assert expiry - _time.monotonic() <= tailnet._WHOIS_TRANSIENT_TTL_SECS + 0.5
+
+    def test_definitive_negative_keeps_the_full_ttl(self, monkeypatch) -> None:
+        """The daemon answered 'no such peer' — that is worth the full TTL."""
+        monkeypatch.setattr(tailnet, "_cli_path", lambda: "/usr/bin/tailscale")
+        proc = SimpleNamespace(returncode=1, stdout="", stderr="no such peer")
+        monkeypatch.setattr(tailnet.subprocess, "run", lambda *a, **k: proc)
+        assert tailnet._whois_cached("100.64.0.6") is None
+        expiry, _value = tailnet._whois_cache["100.64.0.6"]
+        import time as _time
+
+        assert expiry - _time.monotonic() > tailnet._WHOIS_TRANSIENT_TTL_SECS + 1
+
+
+class TestIdentityCharset:
+    """The pin-key namespace stays unambiguous because ``_IDENTITY_RE`` forbids
+    the ``|`` separator and the ``:`` delimiter inside either component."""
+
+    @pytest.mark.parametrize(
+        "good", ["you@example.com", "tagged-devices", "phone.tail.ts.net", "User_1%2B"]
+    )
+    def test_accepts_plain_identity_tokens(self, good: str) -> None:
+        assert tailnet._valid_identity(good) == good
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["a|b", "a:b", "a b", "a\tb", "", "  ", "a\x00b", "x" * 254, 42, None],
+    )
+    def test_rejects_separator_delimiter_and_junk(self, bad: object) -> None:
+        assert tailnet._valid_identity(bad) is None
+
+    def test_pin_keys_cannot_collide_across_login_node_split(self) -> None:
+        """login='a@b', node='c' vs login='a', node='b@c' — the RFC's bare key
+        shape collides on these; the '|' separator cannot."""
+        a = ForwardedPeer(login="a@b", node="c", address="100.64.0.1")
+        b = ForwardedPeer(login="a", node="b@c", address="100.64.0.2")
+        assert peer_pin_key(a, PIN_SCOPE_NODE) != peer_pin_key(b, PIN_SCOPE_NODE)
+
+
+class TestRefreshRotationRebind:
+    """A rotated access token must not launder the identity pin (the refresh
+    endpoint is bypassed by the middleware, so it re-binds explicitly)."""
+
+    @pytest.mark.asyncio
+    async def test_rotation_rebinds_when_a_peer_resolves(self, monkeypatch) -> None:
+        from kiro_crew.dashboard import token_auth as _ta
+        from kiro_crew.dashboard.handlers.auth_refresh import _rebind_rotated_token_to_peer
+
+        _ta._state.clear_all()
+        _patch_whois(monkeypatch, _whois_json())
+        req = SimpleNamespace(
+            remote="127.0.0.1",
+            headers=CIMultiDict({"X-Forwarded-For": "100.64.0.5"}),
+            app={"tailnet_trust": TRUST},
+        )
+        await _rebind_rotated_token_to_peer(req, "new-token", 9999999999.0)
+        key, _exp, proxied = _ta._state._peer_bindings["new-token"]
+        assert key == "ts:node:you@example.com|phone.tail.ts.net"
+        assert proxied is False
+        _ta._state.clear_all()
+
+    @pytest.mark.asyncio
+    async def test_rotation_stays_unbound_without_a_peer(self, monkeypatch) -> None:
+        """No peer (trust off / daemon down / non-tailnet): byte-for-byte the
+        pre-identity refresh behaviour — the token stays unbound."""
+        from kiro_crew.dashboard import token_auth as _ta
+        from kiro_crew.dashboard.handlers.auth_refresh import _rebind_rotated_token_to_peer
+
+        _ta._state.clear_all()
+        _patch_whois(monkeypatch, None)
+        req = SimpleNamespace(
+            remote="127.0.0.1",
+            headers=CIMultiDict({"X-Forwarded-For": "100.64.0.5"}),
+            app={"tailnet_trust": TRUST},
+        )
+        await _rebind_rotated_token_to_peer(req, "new-token", 9999999999.0)
+        assert "new-token" not in _ta._state._peer_bindings
+        req2 = SimpleNamespace(remote="127.0.0.1", headers=CIMultiDict(), app={})
+        await _rebind_rotated_token_to_peer(req2, "other-token", 9999999999.0)
+        assert "other-token" not in _ta._state._peer_bindings
+
+
+class TestCliPathTrust:
+    """A candidate the gateway user can write is refused — planted-binary
+    defence for Homebrew-style user-owned prefixes on the request-triggered
+    whois path."""
+
+    def test_user_writable_binary_is_refused(self, monkeypatch, tmp_path) -> None:
+        import os
+
+        fake = tmp_path / "tailscale"
+        fake.write_text("#!/bin/sh\n")
+        fake.chmod(0o755)  # user-writable by construction (tmp_path is ours)
+        monkeypatch.setattr(tailnet, "_CLI_CANDIDATE_PATHS", (str(fake),))
+        monkeypatch.setattr(tailnet, "IS_POSIX", True)
+        if getattr(os, "geteuid", lambda: 1)() == 0:
+            pytest.skip("writability gate is bypassed for root")
+        assert tailnet._cli_path() is None
+
+    def test_group_writable_binary_is_refused_even_for_root(self, monkeypatch, tmp_path) -> None:
+        """The mode check does not depend on who runs the gateway."""
+        fake = tmp_path / "tailscale"
+        fake.write_text("#!/bin/sh\n")
+        fake.chmod(0o775)  # group-writable
+        assert tailnet._posix_candidate_trusted(str(fake)) is False
+
+    def test_missing_binary_is_none(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.setattr(tailnet, "_CLI_CANDIDATE_PATHS", (str(tmp_path / "absent"),))
+        assert tailnet._cli_path() is None

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -1369,7 +1369,7 @@ def test_evict_expired_removes_old_entries() -> None:
 
     # Verify expired entries were removed
     with _state._lock:
-        assert token not in _state._ip_bindings, "expired IP binding should be evicted"
+        assert token not in _state._peer_bindings, "expired IP binding should be evicted"
         assert token not in _state._consumed, "expired consumed token should be evicted"
         assert "expired_nonce" not in _state._nonces, "expired nonce should be evicted"
 
@@ -2657,3 +2657,388 @@ def test_app_window_entries_register_route_and_exclusion(tmp_path) -> None:
         assert "/app-windows/someapp/other.html" not in ta._APP_WINDOW_EXCLUDED_PATHS
     finally:
         ta._APP_WINDOW_EXCLUDED_PATHS = prior
+
+
+# -- Identity-pinned sessions (RFC Phase 3, issue #1762) --
+#
+# Middleware-level behaviour of the peer-keyed pin: the tailnet branch is new,
+# the ip: branch must be byte-for-byte the pre-peer behaviour. Whois is mocked
+# at the tailnet._run_json seam — no test invokes a real tailscale binary.
+
+
+def _tailnet_trust(**kw):
+    from kiro_crew.dashboard.tailnet import TailnetTrust
+
+    defaults = dict(trust_identity=True, allowed_logins=("you@example.com",), pin_scope="node")
+    defaults.update(kw)
+    return TailnetTrust(**defaults)
+
+
+def _whois_payload(login: str = "you@example.com", node: str = "phone.tail.ts.net"):
+    return {"Node": {"Name": node}, "UserProfile": {"LoginName": login}}
+
+
+@pytest.fixture()
+def _tailnet_env(monkeypatch):
+    """Clear the whois cache and hand back a patch hook for its result."""
+    from kiro_crew.dashboard import tailnet
+
+    monkeypatch.setattr(tailnet, "IS_POSIX", True)
+    tailnet._whois_cache.clear()
+
+    def set_whois(result):
+        mock = MagicMock(return_value=(result, False))
+        monkeypatch.setattr(tailnet, "_run_json_detail", mock)
+        return mock
+
+    yield set_whois
+    tailnet._whois_cache.clear()
+
+
+def _peer_request(
+    remote: str = "127.0.0.1",
+    forwarded: str | None = "100.64.0.5",
+    query: dict | None = None,
+    cookies: dict | None = None,
+):
+    from multidict import CIMultiDict
+
+    headers = CIMultiDict()
+    if forwarded is not None:
+        headers.add("X-Forwarded-For", forwarded)
+    return _make_request(query=query, cookies=cookies, remote=remote, headers=headers)
+
+
+@pytest.mark.asyncio
+async def test_verified_peer_session_pins_to_identity_key(_tailnet_env) -> None:
+    """A verified tailnet peer's session binds ts:node:<login>|<node>, not the
+    tunnel's loopback address — and it is per-client, so posture must not
+    report SHARED for it."""
+    from kiro_crew.dashboard import token_auth as _ta
+
+    _tailnet_env(_whois_payload())
+    mw = token_auth_middleware(tailnet_trust=_tailnet_trust())
+    token = generate_token("tsuser", ttl_seconds=300)
+    resp = await mw(_peer_request(query={"token": token}), _ok_handler)
+    assert resp.status == 200
+    cookie = resp.cookies.get("mc_token_5476")
+    assert cookie is not None
+    key, _exp, proxied = _ta._state._peer_bindings[cookie.value]
+    assert key == "ts:node:you@example.com|phone.tail.ts.net"
+    assert proxied is False
+    from kiro_crew.dashboard.token_auth import proxied_pin_observed
+
+    assert proxied_pin_observed() is False
+
+
+@pytest.mark.asyncio
+async def test_node_scope_replay_from_another_node_denied_with_device_reason(
+    _tailnet_env,
+) -> None:
+    """A node-pinned session replayed from a different node in the same tailnet
+    is rejected, and the reason names DEVICE identity — a phone re-enrolling
+    Tailscale must not surface as an unexplained 'IP mismatch'."""
+    from kiro_crew.dashboard.token_auth import bind_token_peer
+
+    _tailnet_env(_whois_payload(node="other-node.tail.ts.net"))
+    mw = token_auth_middleware(tailnet_trust=_tailnet_trust())
+    token = generate_token("tsuser", ttl_seconds=300)
+    bind_token_peer(token, "ts:node:you@example.com|phone.tail.ts.net")
+    mark_consumed(token)
+    resp = await mw(_peer_request(cookies={"mc_token_5476": token}), _ok_handler)
+    assert resp.status == 403
+    assert b"device identity mismatch" in resp.body
+    assert b"IP mismatch" not in resp.body
+
+
+@pytest.mark.asyncio
+async def test_login_scope_replay_from_another_node_is_accepted(_tailnet_env) -> None:
+    """Under pin_scope login the same replay is accepted — the two scopes are
+    separately pinned, so neither silently becomes the other."""
+    from kiro_crew.dashboard.token_auth import bind_token_peer
+
+    _tailnet_env(_whois_payload(node="other-node.tail.ts.net"))
+    mw = token_auth_middleware(tailnet_trust=_tailnet_trust(pin_scope="login"))
+    token = generate_token("tsuser", ttl_seconds=300)
+    bind_token_peer(token, "ts:login:you@example.com")
+    mark_consumed(token)
+    resp = await mw(_peer_request(cookies={"mc_token_5476": token}), _ok_handler)
+    assert resp.status == 200
+
+
+@pytest.mark.asyncio
+async def test_login_scope_replay_with_different_login_is_denied(_tailnet_env) -> None:
+    from kiro_crew.dashboard.token_auth import bind_token_peer
+
+    _tailnet_env(_whois_payload(login="other@example.com"))
+    mw = token_auth_middleware(
+        tailnet_trust=_tailnet_trust(
+            allowed_logins=("you@example.com", "other@example.com"), pin_scope="login"
+        )
+    )
+    token = generate_token("tsuser", ttl_seconds=300)
+    bind_token_peer(token, "ts:login:you@example.com")
+    mark_consumed(token)
+    resp = await mw(_peer_request(cookies={"mc_token_5476": token}), _ok_handler)
+    assert resp.status == 403
+    assert b"peer identity mismatch" in resp.body
+
+
+@pytest.mark.asyncio
+async def test_verified_login_outside_allowlist_is_denied(_tailnet_env) -> None:
+    """The allowlist is mandatory: a daemon-verified login the operator did not
+    list is denied outright, valid token or not."""
+    _tailnet_env(_whois_payload(login="mallory@example.com"))
+    mw = token_auth_middleware(tailnet_trust=_tailnet_trust())
+    token = generate_token("tsuser", ttl_seconds=300)
+    resp = await mw(_peer_request(query={"token": token}), _ok_handler)
+    assert resp.status == 403
+    assert b"tailnet login not allowed" in resp.body
+
+
+@pytest.mark.asyncio
+async def test_tagged_node_session_not_replayable_from_second_tagged_node(
+    _tailnet_env,
+) -> None:
+    """allowed_logins containing 'tagged-devices' under pin_scope login must not
+    let one tagged node replay another's session: the pin is forced to node
+    scope for tagged nodes."""
+    from kiro_crew.dashboard.token_auth import bind_token_peer
+
+    _tailnet_env(_whois_payload(login="tagged-devices", node="ci-b.tail.ts.net"))
+    mw = token_auth_middleware(
+        tailnet_trust=_tailnet_trust(allowed_logins=("tagged-devices",), pin_scope="login")
+    )
+    token = generate_token("ci", ttl_seconds=300)
+    # Session originally bound on tagged node A (forced node scope).
+    bind_token_peer(token, "ts:node:tagged-devices|ci-a.tail.ts.net")
+    mark_consumed(token)
+    resp = await mw(_peer_request(cookies={"mc_token_5476": token}), _ok_handler)
+    assert resp.status == 403
+    assert b"device identity mismatch" in resp.body
+
+
+@pytest.mark.asyncio
+async def test_xff_injection_from_non_loopback_peer_gets_ip_pin(_tailnet_env) -> None:
+    """A remote client spraying X-Forwarded-For never resolves a peer: the
+    session pins to its real address and the daemon is never consulted."""
+    from kiro_crew.dashboard import token_auth as _ta
+
+    whois = _tailnet_env(_whois_payload())
+    mw = token_auth_middleware(tailnet_trust=_tailnet_trust())
+    token = generate_token("attacker", ttl_seconds=300)
+    resp = await mw(_peer_request(remote="203.0.113.7", query={"token": token}), _ok_handler)
+    assert resp.status == 200
+    cookie = resp.cookies.get("mc_token_5476")
+    assert _ta._state._peer_bindings[cookie.value][0] == "ip:203.0.113.7"
+    whois.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_daemon_failure_degrades_to_token_ip_path(_tailnet_env) -> None:
+    """Daemon absent/down/timeout → request proceeds on today's token+IP path:
+    fail-closed on identity, fail-open on availability."""
+    from kiro_crew.dashboard import token_auth as _ta
+
+    _tailnet_env(None)  # every whois outcome collapses to None at this seam
+    mw = token_auth_middleware(tailnet_trust=_tailnet_trust())
+    token = generate_token("tsuser", ttl_seconds=300)
+    resp = await mw(_peer_request(query={"token": token}), _ok_handler)
+    assert resp.status == 200
+    cookie = resp.cookies.get("mc_token_5476")
+    key, _exp, proxied = _ta._state._peer_bindings[cookie.value]
+    assert key == "ip:127.0.0.1"
+    assert proxied is True  # same-host proxy pin — posture reports SHARED
+
+
+@pytest.mark.asyncio
+async def test_non_tailscale_tunnel_behaviour_is_unchanged(_tailnet_env) -> None:
+    """Loopback peer + XFF with identity trust OFF: byte-for-byte today's
+    behaviour — pin ip:127.0.0.1, posture SHARED, no daemon call."""
+    from kiro_crew.dashboard import token_auth as _ta
+    from kiro_crew.dashboard.token_auth import proxied_pin_observed
+
+    whois = _tailnet_env(_whois_payload())
+    mw = token_auth_middleware()  # tailnet_trust=None: every non-Tailscale setup
+    token = generate_token("tunneluser", ttl_seconds=300)
+    resp = await mw(_peer_request(query={"token": token}), _ok_handler)
+    assert resp.status == 200
+    cookie = resp.cookies.get("mc_token_5476")
+    key, _exp, proxied = _ta._state._peer_bindings[cookie.value]
+    assert key == "ip:127.0.0.1"
+    assert proxied is True
+    assert proxied_pin_observed() is True
+    whois.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_plain_ip_mismatch_reason_is_preserved(_tailnet_env) -> None:
+    """The address-pin denial keeps its historical reason string."""
+    mw = token_auth_middleware()
+    token = generate_token("user", ttl_seconds=300)
+    bind_token_ip(token, "10.0.0.1")
+    mark_consumed(token)
+    req = _make_request(cookies={"mc_token_5476": token}, remote="192.168.1.9")
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 403
+    assert b"IP mismatch" in resp.body
+
+
+# -- Review-round hardening (adversarial fleet findings) --
+
+
+@pytest.mark.asyncio
+async def test_credential_less_request_never_reaches_the_daemon(_tailnet_env) -> None:
+    """An unauthenticated local caller spraying X-Forwarded-For on a static
+    path must not be able to force whois spawns: resolution is gated on the
+    request presenting a credential (query token or mc_* cookie)."""
+    whois = _tailnet_env(_whois_payload())
+    mw = token_auth_middleware(tailnet_trust=_tailnet_trust())
+    resp = await mw(_peer_request(query={}, cookies={}), _ok_handler)
+    assert resp.status == 403  # no token — denied as today
+    whois.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_cookie_alone_still_reaches_the_allowlist_deny(_tailnet_env) -> None:
+    """The credential gate keys on PRESENCE (including the refresh cookie), so
+    the allowlist deny still covers the /api/auth/refresh middleware bypass."""
+    _tailnet_env(_whois_payload(login="mallory@example.com"))
+    mw = token_auth_middleware(tailnet_trust=_tailnet_trust())
+    req = _peer_request(cookies={"mc_refresh_5476": "whatever"})
+    req.path = "/api/auth/refresh"
+    req.method = "POST"
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 403
+    assert b"tailnet login not allowed" in resp.body
+
+
+@pytest.mark.asyncio
+async def test_internal_mixed_path_enforces_the_peer_pin(_tailnet_env) -> None:
+    """A node-pinned session replayed from another node against a mixed
+    internal path (/api/spawn-style cookie auth) is denied — the internal
+    branches must not skip the pin the main flow enforces."""
+    from kiro_crew.dashboard.token_auth import bind_token_peer
+
+    _tailnet_env(_whois_payload(node="other-node.tail.ts.net"))
+    mw = token_auth_middleware(
+        mixed_internal_paths=frozenset({"/api/spawn"}),
+        tailnet_trust=_tailnet_trust(),
+    )
+    token = generate_token("tsuser", ttl_seconds=300)
+    bind_token_peer(token, "ts:node:you@example.com|phone.tail.ts.net")
+    mark_consumed(token)
+    req = _peer_request(cookies={"mc_token_5476": token})
+    req.path = "/api/spawn"
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 403
+    assert b"device identity mismatch" in resp.body
+
+
+@pytest.mark.asyncio
+async def test_internal_mixed_path_accepts_the_matching_peer(_tailnet_env) -> None:
+    from kiro_crew.dashboard.token_auth import bind_token_peer
+
+    _tailnet_env(_whois_payload())
+    mw = token_auth_middleware(
+        mixed_internal_paths=frozenset({"/api/spawn"}),
+        tailnet_trust=_tailnet_trust(),
+    )
+    token = generate_token("tsuser", ttl_seconds=300)
+    bind_token_peer(token, "ts:node:you@example.com|phone.tail.ts.net")
+    mark_consumed(token)
+    req = _peer_request(cookies={"mc_token_5476": token})
+    req.path = "/api/spawn"
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 200
+
+
+@pytest.mark.asyncio
+async def test_identity_pinned_session_with_daemon_down_names_unavailability(
+    _tailnet_env,
+) -> None:
+    """A ts:-pinned session checked while NO peer resolves is denied with a
+    reason naming the unverified identity — not 'device identity mismatch',
+    which would tell the user their device changed when the daemon blipped."""
+    from kiro_crew.dashboard.token_auth import bind_token_peer
+
+    _tailnet_env(None)  # daemon unreachable
+    mw = token_auth_middleware(tailnet_trust=_tailnet_trust())
+    token = generate_token("tsuser", ttl_seconds=300)
+    bind_token_peer(token, "ts:node:you@example.com|phone.tail.ts.net")
+    mark_consumed(token)
+    resp = await mw(_peer_request(cookies={"mc_token_5476": token}), _ok_handler)
+    assert resp.status == 403
+    assert b"tailnet identity unverified" in resp.body
+    assert b"device identity mismatch" not in resp.body
+
+
+@pytest.mark.asyncio
+async def test_restart_first_use_repins_verified_peer_cookie(_tailnet_env) -> None:
+    """After a gateway restart the in-memory binding map is empty, so a
+    surviving cookie is unbound. The first request carrying a VERIFIED peer
+    identity re-claims the pin; a replay from another node is denied again."""
+    from kiro_crew.dashboard import token_auth as _ta
+
+    set_whois = _tailnet_env
+    set_whois(_whois_payload())
+    mw = token_auth_middleware(tailnet_trust=_tailnet_trust())
+    token = generate_token("tsuser", ttl_seconds=300)
+    mark_consumed(token)
+    # No bind_token_peer call: simulates the post-restart unbound state.
+    resp = await mw(_peer_request(cookies={"mc_token_5476": token}), _ok_handler)
+    assert resp.status == 200
+    key, _exp, _proxied = _ta._state._peer_bindings[token]
+    assert key == "ts:node:you@example.com|phone.tail.ts.net"
+    # Same cookie replayed from a different node (different tailnet address,
+    # so the whois cache cannot serve the first node's answer) is rejected.
+    set_whois(_whois_payload(node="other-node.tail.ts.net"))
+    resp2 = await mw(
+        _peer_request(forwarded="100.64.0.6", cookies={"mc_token_5476": token}), _ok_handler
+    )
+    assert resp2.status == 403
+    assert b"device identity mismatch" in resp2.body
+
+
+@pytest.mark.asyncio
+async def test_restart_repin_covers_internal_mixed_paths(_tailnet_env) -> None:
+    """The first-use re-pin lives in the shared check, so an unbound cookie
+    presented on a mixed internal route also claims the pin — a later replay
+    from another node is denied there too."""
+    from kiro_crew.dashboard import token_auth as _ta
+
+    set_whois = _tailnet_env
+    set_whois(_whois_payload())
+    mw = token_auth_middleware(
+        mixed_internal_paths=frozenset({"/api/spawn"}), tailnet_trust=_tailnet_trust()
+    )
+    token = generate_token("tsuser", ttl_seconds=300)
+    mark_consumed(token)
+    req = _peer_request(cookies={"mc_token_5476": token})
+    req.path = "/api/spawn"
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 200
+    assert _ta._state._peer_bindings[token][0] == "ts:node:you@example.com|phone.tail.ts.net"
+    set_whois(_whois_payload(node="other-node.tail.ts.net"))
+    req2 = _peer_request(forwarded="100.64.0.6", cookies={"mc_token_5476": token})
+    req2.path = "/api/spawn"
+    resp2 = await mw(req2, _ok_handler)
+    assert resp2.status == 403
+    assert b"device identity mismatch" in resp2.body
+
+
+@pytest.mark.asyncio
+async def test_restart_unbound_cookie_without_peer_keeps_todays_semantics(
+    _tailnet_env,
+) -> None:
+    """No verified peer (trust off): an unbound cookie stays unbound — the
+    pre-identity restart behaviour is byte-for-byte preserved."""
+    from kiro_crew.dashboard import token_auth as _ta
+
+    _tailnet_env(_whois_payload())
+    mw = token_auth_middleware()  # trust off
+    token = generate_token("user", ttl_seconds=300)
+    mark_consumed(token)
+    resp = await mw(_make_request(cookies={"mc_token_5476": token}), _ok_handler)
+    assert resp.status == 200
+    assert token not in _ta._state._peer_bindings


### PR DESCRIPTION
## Summary

Implements RFC `rfc-tailnet-dashboard-access` **Phase 3** (§2–§3.1). Behind every documented tunnel (cloudflared, ngrok, `tailscale serve`) the session IP pin binds from `request.remote`, which is the tunnel's loopback address — so one pin is satisfied by anyone behind the same tunnel for up to the 20h session TTL, and the SEL audit trail records `127.0.0.1` as the caller. Phase 1 (PR #1761) made that state visible; this PR repairs it for the one provider whose local daemon can verify a peer.

### What changes

- **`dashboard/tailnet.py` — `resolve_forwarded_peer()`** (RFC §2, all conditions fail-closed): peer resolves only when the immediate peer is loopback, `trust_identity` is on with a non-empty `allowed_logins`, `X-Forwarded-For` carries exactly one address (multi-value = reject, never first/last) inside the tailnet ranges, and `tailscale whois --json` (vetted absolute CLI paths, hard timeout, bounded TTL cache, dedicated subprocess executor) resolves it. `Tailscale-User-Login` is corroboration only — a disagreement is a rejection. Transient daemon failures (spawn error/timeout) cache ~2s so a startup blip clears fast; definitive answers keep the 30s TTL. POSIX-only per RFC OQ4 — Windows degrades to the token path.
- **`dashboard/token_auth.py` — peer-keyed session pin** (RFC §3/§3.1): `ip:<addr>` byte-for-byte today's behaviour for every non-Tailscale path; `ts:node:<login>|<node>` (default) / `ts:login:<login>` for a verified peer. The `|` separator is forbidden inside components (identity charset allowlist), so keys cannot collide. An ACL-tagged node (`tagged-devices` login) is **always** node-scoped — login scope would collapse the pin across the whole tagged fleet. `allowed_logins` is enforced at the auth decision (the early deny also covers the `/api/auth/refresh` middleware bypass), the pin check also runs on the internal cookie-auth branches, and mismatch denials name device identity / unverified identity rather than a misleading "IP mismatch". Resolution is gated on the request presenting a credential, so an unauthenticated local caller can never drive daemon spawns with headers. SEL: caller attribution to the resolved login + one `tailnet_peer_bind` row per session.
- **`handlers/auth_refresh.py`**: a rotated access token re-binds to the verified peer key, so rotation cannot launder a node pin into an unbound token.
- **`server.py`**: an enterprise ceiling pinning `capabilities.tailnet_origin` off also forces identity trust off at startup (audited governance decision) — a stored `trust_identity: true` cannot keep whois calls alive under a policy that forbids the integration.
- **`config/loader.py`**: `trust_identity` / `allowed_logins` / `pin_scope` with narrowing-only load validation: trust with an empty allowlist is refused (never silently permissive); an unrecognised `pin_scope` falls back to `node`.
- **What stays closed (RFC §5)**: `is_direct_local_request()` unchanged — a verified peer still receives `read_only: true` on the messaging config surfaces (regression-tested).
- **Docs**: guide gains the opt-in config snippet and honest per-provider pin semantics; RFC status updated; token-auth spec updated.

### Adversarial review (pre-push)

The issue required adversarial review before landing. A dual model-pinned reviewer fleet (GPT + Opus lanes mirroring the repo's CI reviewers) ran against the working tree with the explicit attack list (XFF injection, multi-value XFF, header/whois disagreement, daemon-absent fallback, timeout fail-closed, tagged-node login-scope collapse, allowlist bypass). All blocking findings were fixed before this PR: internal-path pin bypass, refresh-rotation pin laundering, governance force-off gap, shared-executor starvation + unauthenticated daemon spawn, 30s negative-cache lockout with misattributed reason — plus advisories (key-separator ambiguity, identity charset allowlist, SEL bind row, `_log_auth` attribution).

### Tested

- `test/test_tailnet_peer.py` (new): full RFC §2 resolution matrix, daemon failure modes at the subprocess seam, cache TTL/boundedness, pin-key shapes + tagged override + collision-resistance, config load validation, RFC §5 read-only regression, refresh re-bind.
- `test/test_token_auth.py`: middleware integration — identity bind, node/login-scope replay semantics, allowlist deny, credential gate, internal mixed-path pin enforcement, unverified-identity denial reason, byte-for-byte non-Tailscale behaviour (whois never called, posture SHARED preserved).
- Local gates green: isort, flake8, mypy (856 files), targeted pytest (1,800+ tests across all touched surfaces), docs-lint, brand gate.

Closes #1762
