### PR TITLE
docs: reconcile the 0.2.0 changelog with what rc.6 actually ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to KiroCrew are documented in this file.
 
 The first feature release after launch: a real browser for the agent, four new
 built-in apps, a native Windows desktop build, Korean and Japanese interfaces,
-and several hundred fixes from the first weeks in the open.
+setup that no longer assumes Slack, and several hundred fixes from the first
+weeks in the open.
 
 ### The agent gets a browser
 
@@ -28,6 +29,11 @@ and several hundred fixes from the first weeks in the open.
 - Installed apps are searchable and launchable from the command palette, and
   third-party apps now run under **per-app trust grants**, with a denial that
   tells you exactly what to do about it.
+- **MCP Apps has its own switch** instead of riding the connection-pooling
+  toggle, and the shared MCP gateway follows it.
+- **Connections** gained a provider registry, so an integration declares what it
+  is asking for and its consent URL is validated before you are sent to it.
+- Code Review Sage works against **GitHub Enterprise Server** hosts.
 
 ### Windows, properly
 
@@ -42,8 +48,9 @@ and several hundred fixes from the first weeks in the open.
   **Storage** screen that reports what sessions cost on disk and reclaims space
   to a trash, with an inventory that no longer calls idle sessions "in use".
 - **Releases tab** — this changelog, rendered per version in Settings.
-- **Webhooks surface** — named tokens, HMAC signing, and a kill switch for
-  inbound automation, managed from Settings.
+- **Webhooks** — named tokens, HMAC signing, and a kill switch for inbound
+  automation. The page is still being finished, so it now sits behind a
+  per-device **Preview pages** toggle under Developer and is hidden by default.
 - Redesigned sidebar folders, drag a session into an open chat to reference it,
   suggested folders for new sessions, consistent empty states with a next step,
   and a notification sound when an approval prompt needs you.
@@ -52,6 +59,30 @@ and several hundred fixes from the first weeks in the open.
   failed restores. Queued messages can be reordered before they send.
 - The terminal panel pops out into its own window, completes subcommands and
   flags (not just paths), and takes a configurable font.
+- **Agent Templates became a two-pane inspector**, and agents defined in the
+  project you are working in are discovered alongside your user-level ones.
+- **Send a copy of a session to another instance** — hand a conversation, with
+  its context, to a different Kiro Crew you run.
+- Jira issue URLs and setting references render as **link chips** you can click
+  straight through.
+- Stale auto-titles refresh in the background, the command palette tells a
+  failed scoped search apart from an empty one, sidebar search keeps its
+  relevance order, and the chat action footer grows to 40px targets on touch
+  devices.
+- Bold, italic, and strikethrough now render correctly in **CJK prose**.
+
+### Channels, and setup that no longer assumes Slack
+
+- **`kirocrew setup` stops asking for Slack tokens.** The wizard finishes on the
+  dashboard and points at the full set of chat channels; walk through the Slack
+  credentials only when you ask for them with `kirocrew setup --slack`. Docs and
+  in-app copy describe Kiro Crew as multi-channel rather than Slack-first.
+- **Telegram** takes **multiple bot accounts per gateway** and accepts inbound
+  attachments — images for vision, documents, and audio that is transcribed on
+  arrival.
+- A sub-agent's completion now reports back into **non-Slack** parent sessions,
+  Discord continues the connected session when a reply arrives, and Slack
+  renders an `OPTIONS` prompt as a real control everywhere it appears.
 
 ### Voice, language, and models
 
@@ -80,9 +111,16 @@ and several hundred fixes from the first weeks in the open.
   paths and credential redaction got faster without getting looser.
 - The ACP runtime survives oversize output frames, worker sessions are no longer
   reaped as orphans, and `kirocrew update` works for wheel and `cli.sh` installs.
+- A refusal from one of **your own** deny patterns can carry your note
+  explaining it, and the seven always-on git-publish rules now render locked in
+  Settings instead of offering a toggle that never took effect.
+- The gateway **refuses to boot when its data home cannot persist state**,
+  rather than running and losing your work silently.
+- The tool-approval window and the watchdog's stall windows are both bounded by
+  the turn ceiling, so neither outlives the turn it belongs to.
 
-Plus roughly 240 further fixes across the dashboard, chat, Slack, ACP transport,
-history consolidation, packaging, and CI.
+Plus roughly 280 further fixes across the dashboard, chat, the chat channels,
+ACP transport, history consolidation, packaging, and CI.
 
 ## [0.1.3] — 2026-08-07
 


### PR DESCRIPTION
## Problem

The `## [0.2.0]` changelog section was authored in #2305 — the commit that became `v0.2.0-rc.4` — and never revisited. **71 commits have landed on `main` since, 19 of them `feat:`.** The section is stale in two directions:

- It **omits** shipped features (Telegram multi-account, Agent Templates redesign, cross-instance session copy, the Connections provider registry, the MCP Apps switch, Jira link chips, opt-in Slack setup, and more).
- It **describes one feature that no longer exists as written**, which is the part that actually misleads a reader:

  > **Webhooks surface** — named tokens, HMAC signing, and a kill switch for inbound automation, managed from Settings.

  #2343 moved that page behind a per-device **Preview pages** toggle under Developer and hides it by default. That commit landed *after* rc.4, so the bullet was accurate when written and is wrong now.

## Why it matters

The dashboard renders this file per version in the **Releases** tab (`KIROCREW_PROJECT_DIR/CHANGELOG.md` for source installs, the bundled copy for wheel installs), so it is not a repo-internal document — it is the in-app artifact users read to understand what changed. A 0.2.0 user who follows the current notes goes to Settings looking for a Webhooks page that is not there, and gets no explanation for why `kirocrew setup` stopped asking for Slack credentials.

`v0.2.0` will be promoted from `ab20b4e68`, so this text ships to everyone on the stable channel unless it is fixed first.

## Fix

Symptom (notes disagree with the build) → root cause (section written at rc.4, 71 commits ago, with no mechanism to keep it current) → change (reconcile the section against exactly the range the RC ships).

- Corrected the Webhooks bullet to state the preview-flag reality.
- Added the missing user-visible work into the existing thematic sections.
- Added one new section, **"Channels, and setup that no longer assumes Slack"**, because the channel work (#2340, #2203, #2201, #2352, #2326, #1467) is a coherent theme with no existing home.
- Updated the intro clause and the trailing unlisted-fix count (240 → 280).

Prose only. No code, no behavior change.

### Scope discipline

The range described is exactly **`5fe4bd5af..ab20b4e68`** — what `v0.2.0-rc.6` ships. `main` carries three commits beyond rc.6, including `feat: add meeting deletion (#2268)`; those belong to the next release and are deliberately **not** described here. Writing them into 0.2.0 would claim features the 0.2.0 artifact does not contain.

## Tests

No new tests: this is a prose change to a data file, and the existing gate already covers it.

- `test/test_changelog_handler.py` — **7 passed**. Covers the path resolution and parsing the dashboard relies on.
- Verified the section still parses into its subsections after the edit: **8 subsections, 36 top-level bullets**.
- Confirmed no `## [Unreleased]` section was introduced (the repo forbids one).
- The single line over 80 characters in the section is pre-existing and untouched.

## Manual verification

N/A for behavior — nothing executable changed. The rendered result was verified structurally by re-parsing the section with the same heading/bullet shape the Releases tab consumes, and every added claim was checked against a specific commit in the range rather than written from memory.

## Screenshots

N/A — no UI change. The Releases tab renders this file unchanged; only its text content differs.
