### PR TITLE
docs: document four shipped apps the notes never mentioned, and the rc.7 delta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ weeks in the open.
   you and recovers on its own — enabling it never errors out — and the agent can
   also serve browser work from the native embedded view.
 
-### Four new built-in apps
+### Eight new built-in apps
 
 - **Spec Builder** — a spec-driven development surface: shape requirements into
   a spec, then hand it to the agent to implement.
@@ -26,6 +26,18 @@ weeks in the open.
 - **Crew Companion** — a desk companion that reflects what your agent is doing.
 - **Auto-Improvement** — measurement-first self-improvement that proposes,
   lands, and verifies its own changes GitHub-natively.
+- **Meetings** — transcribes a live meeting, keeps structured notes and diagrams
+  as it goes, and extracts action items you can review afterwards. Recordings
+  and notes can now be deleted from the app.
+- **Papyrus** — a LaTeX paper editor with a split-pane view, live PDF preview,
+  and an AI co-author.
+- **Mochi** — a desktop companion that lives on your screen in its own panel,
+  watches pages and feeds for you, and plans its day around your schedule.
+- **PPTX Maker** — describe the deck you want in chat and get a real `.pptx`
+  back, by way of an agent that interviews you and writes a brief, an outline,
+  and an art direction first.
+- Every one of these is **opt-in**: install it from the App Store and enable it
+  before it does anything.
 - Installed apps are searchable and launchable from the command palette, and
   third-party apps now run under **per-app trust grants**, with a denial that
   tells you exactly what to do about it.
@@ -34,6 +46,9 @@ weeks in the open.
 - **Connections** gained a provider registry, so an integration declares what it
   is asking for and its consent URL is validated before you are sent to it.
 - Code Review Sage works against **GitHub Enterprise Server** hosts.
+- An MCP server that authenticates with OAuth now receives the scope list and
+  client id in the fields kiro-cli actually reads, so those connections
+  authorize instead of silently failing.
 
 ### Windows, properly
 
@@ -70,6 +85,8 @@ weeks in the open.
   relevance order, and the chat action footer grows to 40px targets on touch
   devices.
 - Bold, italic, and strikethrough now render correctly in **CJK prose**.
+- While the agent is waiting on something, the wait shows a **live countdown**
+  with a button to end it early instead of leaving you guessing.
 
 ### Channels, and setup that no longer assumes Slack
 


### PR DESCRIPTION
## Problem

Two things, found while preparing to cut `v0.2.0-rc.7`.

**1. Four built-in apps ship today and appear in no release's notes at all.** `BUILTIN_NAMES` lists eleven apps. Grepping the entire changelog for each one, these four are never mentioned in any version:

| App | Added | PR |
|---|---|---|
| Papyrus | 2026-08-02 | #1077 |
| Meetings | 2026-08-02 | #1080 |
| PPTX Maker | 2026-08-03 | #1079 |
| Mochi | 2026-08-04 | #1258 |

All four landed in the window between `v0.1.2` (tagged 2026-08-04 00:58) and now. `0.1.2`'s list named a different six (Auto Research, Code Review Sage, Issue Radar, Workflows, File Explorer, Dev Fleet), and `0.2.0`'s heading claimed **"Four new built-in apps"** while eight had in fact arrived.

This is not a lagging-notes problem. A user can install and enable any of these from the App Store right now, so the notes were **hiding shipped functionality**.

**2. Cutting rc.7 from `main` moves the target #2412 aimed at.** #2412 scoped the 0.2.0 section to `5fe4bd5af..ab20b4e68`, which is what rc.6 ships. `main` now carries three user-visible commits beyond rc.6, so tagging rc.7 without this PR would reintroduce exactly the drift #2412 just removed:

- `feat: add meeting deletion (#2268)`
- `feat(chat): live countdown and early-end button for the wait tool (#2331)`
- `fix(mcp): emit oauthScopes and oauth.clientId that kiro-cli actually reads`

## Why it matters

`v0.2.0` will be promoted from an RC's exact bytes, and `CHANGELOG.md` is baked into the artifact (`MANIFEST.in` → `include CHANGELOG.md`; the dashboard's Releases tab reads the bundled copy on wheel installs). Whatever text is in the promoted RC is what every stable user reads, permanently. `0.1.2`'s notes are already published and immutable, so 0.2.0 is the only place the four apps can ever surface.

## Fix

- Heading corrected: **Four → Eight** new built-in apps, with an entry for each of Meetings, Papyrus, Mochi, and PPTX Maker written from each app's own manifest description rather than guessed.
- Added the line that all of them are **opt-in** (every one has `defaultEnabled: false`), so the notes do not imply they are running.
- Documented the three post-rc.6 user-visible changes, so the section matches what rc.7 ships.

Prose only. No code, no behavior change.

## Tests

- `test/test_changelog_handler.py` — **7 passed**.
- Section re-parsed after the edit: **8 subsections, 43 top-level bullets**.
- No `## [Unreleased]` section introduced.
- The one line over 80 characters in the section is pre-existing and untouched.

## Manual verification

N/A for behavior. Every app description was taken from that app's `app.json`, and every `defaultEnabled: false` was read from the manifest rather than assumed. The first-appearance date of each app directory was established with `git log --diff-filter=A` against its `app.json`, and compared against the `v0.1.2` tag date, rather than inferred from the PR number.

## Screenshots

N/A — no UI change.

## A structural note for the maintainers

This is the **second** reconciliation pass in an hour, and it will drift again the moment another user-visible PR merges. Sweeping the changelog before each release cannot converge, because the sweep itself advances `main`. The durable fix is requiring a changelog line in the PR that introduces a user-visible change. Worth its own issue if there is appetite.
