### PR TITLE
fix(mcp): record authorship of entries we write to shared config files

### DIFF
--- a/docs/architecture/design-notes/README.md
+++ b/docs/architecture/design-notes/README.md
@@ -10,6 +10,7 @@ grows into a subsystem should become a spec under
 | [soft-stop.md](soft-stop.md) | Cooperative cancel: acknowledging a stop before a hard kill so session state survives. |
 | [session-slack-linking.md](session-slack-linking.md) | How a Slack thread maps onto a Kiro Crew session, and how thread state stays in sync. |
 | [mcp-oauth-ownership.md](mcp-oauth-ownership.md) | Who owns an MCP server's OAuth tokens, and why that ownership is contested. |
+| [mcp-entry-provenance.md](mcp-entry-provenance.md) | Which entries in a shared MCP config file a sync may rewrite: the write-authorship marker and its four outcomes. |
 | [mcp-gateway-claim-push.md](mcp-gateway-claim-push.md) | Event-driven caller identity for pooled MCP stubs. |
 | [mcp-gateway-oversize-response.md](mcp-gateway-oversize-response.md) | Handling an MCP tool response that exceeds the gateway read buffer. |
 | [profiling.md](profiling.md) | The debug-only stack sampler and desktop app metrics. |

--- a/docs/architecture/design-notes/mcp-entry-provenance.md
+++ b/docs/architecture/design-notes/mcp-entry-provenance.md
@@ -1,0 +1,132 @@
+# MCP entry provenance: who may rewrite a shared config entry
+
+Kiro Crew writes MCP server entries into two config files it does not own — the
+kiro-global `~/.kiro/settings/mcp.json` and the Claude Code sidecar `~/.mcp.json`.
+Users hand-edit both, and other tools write the sidecar. Any sync that can
+*update* entries (not just add them) must answer one question per entry:
+**did we write this?**
+
+Name presence in the dashboard store cannot answer it. A minimal `{"url": ...}`
+entry is byte-identical whether our emitter produced it or a user typed it, so
+"our managed server's url moved" and "a different server the user happened to
+name the same" reach the write as the same input. Provenance is recorded at
+write time instead of inferred at read time.
+
+## The invariant
+
+> An entry in a shared config file is Kiro Crew–managed **iff** it carries our
+> marker. Name presence in the store is necessary, never sufficient. An
+> unmarked entry is the user's and is never rewritten.
+
+## The marker
+
+Entries Kiro Crew writes into shared files carry one reserved key:
+
+    "x-kirocrew": { "managed": true }
+
+The `x-` form cannot collide with a kiro-cli field (its config structs derive
+`rename_all = "camelCase"`, which never produces a hyphen), and kiro-cli
+tolerates unknown keys (`McpServerConfig` is an untagged enum with no
+`deny_unknown_fields`; schema validation runs against the re-serialized struct,
+after deserialization has dropped anything unknown). Anything other than the
+exact marker shape reads as unmarked — the predicate fails safe in the
+direction of NOT writing.
+
+The marker is a declaration of write authorship, **not a security boundary**.
+It defends a shared file against our own writer, not against the file's owner:
+the user can strip it (reclaiming the entry — we stop rewriting it, permanently,
+see *Reclamation beats migration*) or add it (volunteering the entry for
+management). Both directions are fail-safe.
+
+## Write resolution
+
+Every sync write to a shared file resolves to one of three outcomes
+(`mcp_provenance.resolve_write`); store-side management remains a necessary
+precondition — the marker narrows who may be rewritten, never widens it:
+
+| on disk | store manages name | outcome |
+|---|---|---|
+| no entry at all | yes | **create** — written stamped |
+| any entry present | no | **leave alone** — add-only for a name we do not manage |
+| marked entry | yes | **rewrite** — propagation, gated on proof rather than a name |
+| unmarked entry present — including when its bytes already equal our emit | yes | **decline** — treated as the user's, preserved, divergence logged |
+| present but unparseable — a string, `null`, a list | yes | **decline** — it occupies the name and cannot carry a marker, so it is unmarked, i.e. the user's |
+
+There is deliberately no fourth outcome that stamps an unmarked entry whose
+content already matches our emit. See *Reclamation beats migration* below.
+
+Only true absence is a create, and it is signalled explicitly (`ABSENT`) rather
+than as `None`: a hand-edited file can hold `"notion": null`, which
+`mapping.get(name)` reports identically to a missing key. Treating the two the
+same would let the one shape that occupies a name while carrying no marker read
+as a free slot, and the create branch would write over it.
+
+Resolution is per **entry**, not per transport or per file. A `command` makes
+authorship no more knowable than a `url` does, so a stdio entry in the sidecar
+resolves the same way a remote one does. (The kiro-global file's stdio branch is
+create-only, so it has no rewrite to gate.)
+
+## Reclamation beats migration
+
+Entries written before the marker existed carry no marker, so they now **decline
+permanently** rather than being migrated into management. That is a deliberate
+trade, not an oversight.
+
+The tempting migration is to stamp an unmarked entry when the sync would change
+nothing about it — its bytes already match our emit, so the write adds the marker
+and nothing else. The problem is what else produces those exact bytes: stripping
+the marker off one of *our* entries leaves precisely our emit behind. So
+
+- "written before the marker existed", and
+- "the user stripped the marker to reclaim this entry"
+
+are **the same disk state**, and nothing in the file distinguishes them. This is
+the same undecidability the marker was introduced to escape — the exact-name
+collision, one level in. A migration branch would therefore re-stamp reclaimed
+entries, and the sync after that is free to rewrite them, which breaks the
+promise the marker makes above.
+
+No content test can separate the two, so the choice is which one to serve. This
+picks reclamation: it is a live, repeatable user action with no recovery if we
+get it wrong, whereas the un-migrated case is a one-time state with a two-click
+fix.
+
+**Re-establishing management on a legacy entry: Disconnect, then Connect.** The
+delete path removes the name from the shared file outright
+(`handlers/mcp.py`, `api_mcp_remove` / `api_mcp_server_detail`, both
+`data["mcpServers"].pop(name)` then `_write_mcp_json`). The name is then absent,
+so the next sync reaches the create branch and writes the entry **stamped**
+(`resolve_write`: `if on_disk is ABSENT: return stamp(candidate) ...`). Nothing
+special-cases legacy entries; they rejoin management through the ordinary
+authoring path, which is the only path that can honestly claim authorship.
+
+## Interaction with the existing MCP management panel
+
+The dashboard's MCP panel and the marker govern two different decisions, by
+design:
+
+- **The panel is the admission authority.** Which servers exist in the store,
+  which are enabled, and which are prompted into kiro's own config file is
+  decided exactly where it is today. Nothing about that flow changes.
+- **The marker is the rewrite authority.** It only decides whether a *later
+  sync* may update an entry already sitting in a shared file.
+
+Concretely:
+
+- **Entries added or edited through the panel never carry the marker.** The
+  editor strips the reserved key structurally on save, so a hand-added marker
+  cannot ride a save back out and volunteer an entry the user did not intend to
+  hand over. A panel-authored entry in a shared file is therefore the user's:
+  sync will never rewrite it.
+- **The dashboard's own store stays unmarked entirely.** The store is ours by
+  definition; the marker only ever appears in files we do not own.
+- **The emitted agent spec is stripped of the marker.** kiro-cli never sees it;
+  the spec is rendered output, not an owned file.
+- **Connections sync is the only writer that stamps**, and only for names the
+  store manages.
+
+## What this is not
+
+- Not token custody or OAuth grant ownership — see `mcp-oauth-ownership.md`.
+- Not the consent-endpoint allowlist (`oauth_endpoints.json`), which governs
+  where a user may be *sent* for consent, not which entries may be rewritten.

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -58,6 +58,7 @@ from kiro_crew.config.paths import (
     kiro_agents_dir,
 )
 from kiro_crew.env import augmented_path
+from kiro_crew.mcp_provenance import without_marker
 from kiro_crew.mcp_utils import kiro_oauth_wire_entry, mcp_server_alias
 from kiro_crew.platform import current_context
 from kiro_crew.platform import redact_via_context as redact
@@ -2249,8 +2250,12 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
         if isinstance(spec, dict) and name not in managed_names:
             # Copy so config never aliases the source dict — a later update()
             # (kirocrew merge) must not mutate shared_mcp, which is reused as a
-            # fallback candidate during command validation below.
-            config.setdefault("mcpServers", {}).setdefault(name, dict(spec))
+            # fallback candidate during command validation below. The copy also
+            # drops our authorship marker: it records who wrote the entry in a
+            # SHARED file and has no meaning in a spec we render ourselves, so
+            # keeping it would put a key in front of the runtime that says nothing
+            # to it.
+            config.setdefault("mcpServers", {}).setdefault(name, without_marker(spec))
 
     # Merge shared MCP servers from edition-contributed provider globals (CPP
     # seam) — now LOWER priority than Kiro global; setdefault is a no-op when
@@ -2272,7 +2277,7 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
             if name not in managed_names:
                 # Copy (see note above) so the source dict stays pristine for
                 # the fallback-candidate lookup.
-                config.setdefault("mcpServers", {}).setdefault(name, dict(spec))
+                config.setdefault("mcpServers", {}).setdefault(name, without_marker(spec))
 
     # ~/.kiro/crew/mcp.json overrides kiro mcp.json for the kirocrew agent —
     # kirocrew-specific config wins in a tie.

--- a/src/kiro_crew/dashboard/handlers/mcp.py
+++ b/src/kiro_crew/dashboard/handlers/mcp.py
@@ -18,6 +18,7 @@ from kiro_crew.config.paths import data_home, kiro_agents_dir
 from kiro_crew.dashboard.state import DashboardState
 from kiro_crew.mcp_gateway import is_gateway_supported
 from kiro_crew.mcp_gateway.backend import MCP_APPS_ENV_FLAG, mcp_apps_env_override
+from kiro_crew.mcp_provenance import ABSENT, resolve_write, stamp
 from kiro_crew.mcp_utils import (
     INTERNAL_CLIENT_ID_KEY,
     INTERNAL_SCOPES_KEY,
@@ -53,6 +54,9 @@ def _is_valid_mcp_name(name: str) -> bool:
 
 
 _GLOBAL_MCP_JSON = Path.home() / ".kiro" / "settings" / "mcp.json"
+# Surface label carried into the provenance decision so a declined rewrite names
+# the file it declined to touch.
+_KIRO_GLOBAL_SURFACE = "~/.kiro/settings/mcp.json"
 
 # Max per-request changes accepted by /api/mcp/apply. The capability-manager
 # uninstalls run OFF the MCP file lock (deferred, bounded-concurrent, under one
@@ -720,20 +724,19 @@ async def api_mcp_sync(request: web.Request) -> web.Response:
             except (FileNotFoundError, json.JSONDecodeError):
                 gdata = {"mcpServers": {}}
             gservers = gdata.setdefault("mcpServers", {})
-            # The kiro-global mcp.json is NOT ours. Discovery merges every scope,
-            # so a name the user configured only in their own global file reaches
-            # this sync set exactly like a managed one -- and the branch below
-            # RECONSTRUCTS the entry, so it would replace their url and OAuth
-            # fields with whatever the merged view produced. Base only ever
-            # CREATED missing entries here; the gate keeps that guarantee for
-            # names we do not own while still letting a managed entry re-sync,
-            # which is the whole point of the scope fix.
+            # The kiro-global mcp.json is NOT ours, and a name cannot say who
+            # wrote an entry in it: the minimal ``{"url": ...}`` this emitter
+            # produces for a hint-less managed server is also the smallest thing a
+            # user can hand-type. Ownership is therefore the marker on the entry --
+            # ``resolve_write`` rewrites what we provably wrote, and declines
+            # everything else so a hand-authored collision survives untouched. A
+            # present unmarked entry is never written, not even when its bytes
+            # already match this emit: that state is also what reclaiming an entry
+            # leaves behind, so stamping it would take the entry back.
             _managed = kirocrew_managed_names()
             for s in to_sync:
                 if s.is_remote:
                     current = gservers.get(s.name)
-                    if isinstance(current, dict) and s.name not in _managed:
-                        continue
                     entry: dict[str, Any] = dict(current) if isinstance(current, dict) else {}
                     for key in ("command", "args", "env", "type"):
                         entry.pop(key, None)
@@ -803,15 +806,29 @@ async def api_mcp_sync(request: web.Request) -> web.Response:
                         client_id=s.client_id,
                         server=s.name,
                     )
-                    if current != entry:
-                        gservers[s.name] = entry
+                    resolved = resolve_write(
+                        name=s.name,
+                        # ``ABSENT``, not ``current``: a hand-edited file can hold
+                        # ``null`` or a string under a name, and that value
+                        # occupies the name -- it cannot carry a marker, so it is
+                        # the user's, not a free slot to create into.
+                        on_disk=gservers.get(s.name, ABSENT),
+                        candidate=entry,
+                        store_managed=s.name in _managed,
+                        surface=_KIRO_GLOBAL_SURFACE,
+                    )
+                    if resolved is not None and current != resolved:
+                        gservers[s.name] = resolved
                 elif s.name not in gservers:
                     entry = {"command": s.command}
                     if s.args:
                         entry["args"] = s.args
                     if s.env:
                         entry["env"] = s.env
-                    gservers[s.name] = entry
+                    # Create-only here, as on the base ref, so there is no rewrite
+                    # to gate -- but the entry is still ours, and marking it now is
+                    # what lets a later slice re-sync it without guessing.
+                    gservers[s.name] = stamp(entry) if s.name in _managed else entry
             _GLOBAL_MCP_JSON.parent.mkdir(parents=True, exist_ok=True)
             _write_mcp_json(gdata)
 

--- a/src/kiro_crew/dashboard/handlers/mcp_custom.py
+++ b/src/kiro_crew/dashboard/handlers/mcp_custom.py
@@ -31,6 +31,7 @@ from kiro_crew.dashboard.handlers.mcp import (
     _is_valid_mcp_name,
     _replace_kirocrew_spec,
 )
+from kiro_crew.mcp_provenance import MARKER_KEY
 from kiro_crew.mcp_utils import (
     INTERNAL_CLIENT_ID_KEY,
     INTERNAL_SCOPES_KEY,
@@ -405,6 +406,15 @@ async def api_mcp_custom_update(request: web.Request) -> web.Response:
     on-disk values are preserved verbatim.  They cannot be edited or
     removed through this endpoint — dropping ``disabledTools`` on a save
     would silently widen the agent's tool surface.
+
+    The authorship marker is the one exception: it records that Kiro Crew
+    wrote an entry into a file it does NOT own, so it has no meaning in the
+    store.  An unmodified round trip still SAVES with it present — refusing
+    would strand the entry — but it is dropped rather than written back.  That
+    keeps "the editor never writes the marker" structurally true: a hand-added
+    marker in the store cannot ride a save back out and volunteer the entry
+    for management on a shared surface.  A FRESH add carries no tolerated
+    keys, so a pasted block naming it is still rejected outright.
     """
     name = request.match_info.get("name", "")
     if not _is_valid_mcp_name(name):
@@ -430,10 +440,11 @@ async def api_mcp_custom_update(request: web.Request) -> web.Response:
             for k, v in existing.items()
             if k not in _ALLOWED_SPEC_KEYS
             and k != "disabled"
+            and k != MARKER_KEY
             and k not in (KIRO_SCOPES_KEY, KIRO_OAUTH_KEY)
         }
         err = _validate_spec(
-            submitted, frozenset(carried) | {KIRO_SCOPES_KEY, KIRO_OAUTH_KEY}
+            submitted, frozenset(carried) | {KIRO_SCOPES_KEY, KIRO_OAUTH_KEY, MARKER_KEY}
         )
         if err:
             return web.json_response({"error": err}, status=400)

--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -31,6 +31,7 @@ from kiro_crew import platform_compat
 from kiro_crew.config.paths import data_home, kiro_agents_dir
 from kiro_crew.env import augmented_path
 from kiro_crew.hooks import safe_read_file
+from kiro_crew.mcp_provenance import ABSENT, resolve_write
 from kiro_crew.mcp_utils import kiro_entry_client_id, kiro_entry_scopes, mcp_server_alias
 from kiro_crew.sandbox import (
     SandboxUnavailableError,
@@ -212,6 +213,9 @@ def reset_unresolvable_warnings() -> None:
 # source of truth for the ``presence`` field on each server.
 SCOPE_KIROCREW = "kirocrew"
 SCOPE_KIRO_GLOBAL = "kiroGlobal"
+# Surface label carried into the provenance decision so a declined rewrite names
+# the file it declined to touch.
+_CC_SIDECAR_SURFACE = "~/.mcp.json"
 # Well-known label for a provider global (e.g. Claude Code's ~/.claude.json).
 # The core does not scan it directly — a companion edition contributes it
 # via the extra_mcp_scopes() CPP seam (see :func:`_extra_scope_sources`), so
@@ -1762,18 +1766,26 @@ def sync_to_agent_config(servers: list[McpServerInfo]) -> bool:
 
 
 def kirocrew_managed_names() -> set[str]:
-    """Server names the dashboard store owns, and may therefore be rewritten.
+    """Server names the dashboard store owns.
 
     A usable dict under the ``kirocrew`` scope (``<data home>/mcp.json``) is the
-    one signal that Kiro Crew owns a name -- the same discriminator the agent-spec
-    emit path uses for its OAuth hints, so ownership means one thing everywhere.
+    one signal that Kiro Crew manages a name -- the same discriminator the
+    agent-spec emit path uses for its OAuth hints, so management means one thing
+    everywhere.
 
-    Every write to a config surface we do NOT own -- the kiro-global
-    ``mcp.json``, the Claude Code ``~/.mcp.json`` sidecar -- must be gated on
-    this. Discovery merges ALL scopes, so a name present only in a user's global
-    file reaches the sync set exactly like a managed one; without the gate a
-    Kiro Crew sync would rewrite a server the user configured by hand, and the
-    fields it reconstructs (url, OAuth hints) would silently replace theirs.
+    This is the store-side half of the ownership predicate and a NECESSARY
+    precondition for every write to a config surface we do not own -- the
+    kiro-global ``mcp.json``, the Claude Code ``~/.mcp.json`` sidecar. Discovery
+    merges ALL scopes, so a name present only in a user's global file reaches the
+    sync set exactly like a managed one; without the gate a Kiro Crew sync would
+    rewrite a server the user configured by hand.
+
+    It is deliberately NOT sufficient. Managing a NAME says nothing about who
+    wrote a given ENTRY, and the two answers differ per file -- an entry can be
+    ours in the kiro-global file and the user's in the sidecar. That half is
+    :func:`kiro_crew.mcp_provenance.resolve_write`, which reads the marker on the
+    entry itself. Keeping this function name-only is what lets a single set answer
+    for every surface without silently answering for the wrong one.
 
     A malformed store value is skipped for the same reason the merge skips it: it
     contributed nothing, so it cannot make the name ours.
@@ -1795,8 +1807,9 @@ def register_servers_for_cc(
     Adds entries without removing existing ones. CC-side complement
     to sync_to_agent_config() which handles kiro-side registration.
 
-    A remote that already has an entry is left alone entirely -- see the loop
-    below for why this surface is add-only for remotes.
+    A remote entry is rewritten only when it carries our authorship marker --
+    see the loop below. So is a stdio entry: the marker records who wrote an
+    entry, which no transport makes knowable on its own.
 
     Returns True if any servers were added or updated.
     """
@@ -1818,15 +1831,6 @@ def register_servers_for_cc(
 
     for s in servers:
         if s.is_remote:
-            # Add-only: a remote already present here keeps whatever it holds.
-            # This writer rebuilds an entry from scratch rather than merging into
-            # it, and ownership on this surface is name-only -- a managed
-            # server's moved url is indistinguishable from a user's own
-            # same-named entry -- so rewriting one could silently replace
-            # configuration nobody here authored. Propagating a changed remote
-            # shape needs a record of which entries we wrote, and waits for it.
-            if s.name in mcp:
-                continue
             entry: dict = {"url": s.url}
             if s.headers:
                 entry["headers"] = s.headers
@@ -1839,6 +1843,27 @@ def register_servers_for_cc(
             entry = {"command": s.command, "args": s.args or [], "type": "stdio"}
             if s.env:
                 entry["env"] = s.env
+
+        # This writer rebuilds an entry from scratch, so rewriting one we did not
+        # author would drop the fields it does not reconstruct. The marker says
+        # which ones those are: an entry we wrote re-syncs (its url or command
+        # legitimately moves), an unmarked entry is the user's and stays add-only,
+        # exactly as this surface behaved before the marker existed. The gate is
+        # per ENTRY, not per transport -- a ``command`` makes authorship no more
+        # knowable than a ``url`` does, and this loop rewrites a diverging stdio
+        # entry in place, so a user's own server sharing a managed name reaches
+        # the same collision. ``ABSENT`` rather than ``None``: a hand-edited file
+        # can hold ``null`` under a name, and that occupies the name.
+        resolved = resolve_write(
+            name=s.name,
+            on_disk=mcp.get(s.name, ABSENT),
+            candidate=entry,
+            store_managed=s.name in _managed,
+            surface=_CC_SIDECAR_SURFACE,
+        )
+        if resolved is None:
+            continue
+        entry = resolved
 
         if s.name not in mcp or mcp[s.name] != entry:
             mcp[s.name] = entry

--- a/src/kiro_crew/mcp_provenance.py
+++ b/src/kiro_crew/mcp_provenance.py
@@ -1,0 +1,147 @@
+"""Authorship marker for MCP entries Kiro Crew writes into shared config files.
+
+Kiro Crew writes MCP server entries into two files it does not own -- the
+kiro-global ``~/.kiro/settings/mcp.json`` and the Claude Code sidecar
+``~/.mcp.json`` -- and users hand-edit both. Every write needs an answer to one
+question: did we write this entry?
+
+Name presence in the dashboard store cannot answer it. A minimal ``{"url": ...}``
+entry is byte-identical whether this emitter produced it or a user typed it, so
+"our managed server moved url" and "a different server the user named the same"
+reach the write as the same input. This module records authorship instead of
+inferring it: an entry is ours iff it carries :data:`MARKER_KEY`.
+
+The marker is a declaration of who may write, NOT a security boundary -- it
+defends a shared file against our own writer, not against the file's owner. A
+user can strip it (reclaiming the entry, so we stop rewriting) or add it
+(volunteering the entry for management). Both directions are fail-safe; see
+``docs/architecture/design-notes/mcp-entry-provenance.md``.
+
+Reclamation is why a present unmarked entry is NEVER written, not even when its
+bytes already match what this sync would emit. Those bytes are exactly what
+stripping the marker off one of our own entries leaves behind, so "written
+before the marker existed" and "deliberately reclaimed" are the same disk state
+and no content test separates them. Stamping on the match would migrate the
+first and silently undo the second, so the trade is made the other way:
+reclamation is durable, and an entry written before the marker existed stays
+unmanaged until it is authored again. Re-establishing management is a Disconnect
+then Connect -- the delete removes the name from the shared file, and the next
+sync resolves ABSENT to a stamped create.
+
+The marker only ever appears on entries for names the store manages, and only in
+files we do not own: the store itself is ours by definition, and the emitted
+agent spec is rendered rather than owned, so both stay unmarked.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Final
+
+logger = logging.getLogger(__name__)
+
+# Passed as ``on_disk`` when the shared file holds NO entry under the name.
+#
+# Absence needs its own signal because ``None`` is a value a user can type: a
+# hand-edited file can carry ``"notion": null``, and ``mapping.get(name)`` answers
+# ``None`` for both that and a missing key. Collapsing them would make the one
+# shape that occupies a name while carrying no marker look like a free slot, and
+# the create branch would write over it. Every caller therefore reads the mapping
+# with ``get(name, ABSENT)``.
+ABSENT: Final = object()
+
+# One reserved key. The ``x-`` extension namespace cannot collide with a kiro-cli
+# field: its config structs derive ``rename_all = "camelCase"``, which can never
+# produce a hyphen. Unknown keys are tolerated -- ``McpServerConfig`` is an
+# untagged enum whose variants do not set ``deny_unknown_fields``, and the one
+# JSON-schema validation runs against the re-serialized struct, after
+# deserialization has already dropped anything unknown.
+MARKER_KEY = "x-kirocrew"
+
+# Inside the marker object, so the record can gain fields later without burning a
+# second reserved key.
+_MANAGED_FIELD = "managed"
+
+
+def is_marked(entry: object) -> bool:
+    """True when ``entry`` carries our authorship marker.
+
+    Anything other than the exact shape reads as unmarked -- ``null``, a string, a
+    dict whose ``managed`` is the string ``"yes"``. The predicate fails safe in
+    the direction of NOT writing: a marker we cannot read is a marker we did not
+    write. It says nothing about whether the name is PRESENT -- that is
+    :data:`ABSENT`'s job, and :func:`resolve_write` asks it first.
+    """
+    if not isinstance(entry, dict):
+        return False
+    marker = entry.get(MARKER_KEY)
+    return isinstance(marker, dict) and marker.get(_MANAGED_FIELD) is True
+
+
+def stamp(entry: dict[str, Any]) -> dict[str, Any]:
+    """Copy of ``entry`` carrying the marker."""
+    return {**entry, MARKER_KEY: {_MANAGED_FIELD: True}}
+
+
+def without_marker(entry: object) -> dict[str, Any]:
+    """Copy of ``entry`` with the marker removed.
+
+    The marker records who wrote an entry in a file we do not own, so it is
+    stripped where a shared entry is copied into the rendered agent spec -- that
+    spec is output, and the key would say nothing to the runtime reading it.
+
+    A non-dict answers as an empty dict so callers can strip uniformly without
+    first re-checking a shape the marker predicate already tolerates.
+    """
+    if not isinstance(entry, dict):
+        return {}
+    return {k: v for k, v in entry.items() if k != MARKER_KEY}
+
+
+def resolve_write(
+    *,
+    name: str,
+    on_disk: object,
+    candidate: dict[str, Any],
+    store_managed: bool,
+    surface: str,
+) -> dict[str, Any] | None:
+    """The entry to write for ``name``, or None to leave what is on disk alone.
+
+    ``candidate`` is what this sync would write; ``on_disk`` is the current entry
+    in the shared file, if any. ``store_managed`` is the store-side half of the
+    predicate (see :func:`kiro_crew.mcp_discovery.kirocrew_managed_names`) and
+    stays a necessary precondition -- the marker narrows who may be rewritten, it
+    does not widen it.
+
+    Three outcomes:
+
+    * **create** -- the name is ABSENT from the file. We are authoring the entry,
+      so it is stamped, but only for a name the store manages: a marker on a name
+      we do not manage would claim an entry no later write is allowed to touch
+      anyway. Only :data:`ABSENT` reaches this branch; a present value we cannot
+      parse (a string, ``null``, a list) is NOT a free slot -- it occupies the
+      name and cannot carry a marker, so the invariant reads it as the user's and
+      it declines below.
+    * **rewrite** -- the entry carries our marker. This is scope propagation,
+      now gated on proof rather than on a name.
+    * **decline** -- the entry is present and unmarked. Nothing proves we wrote
+      it, so it is left exactly as it is and the divergence is logged. There is
+      no content test that could widen this: an unmarked entry whose bytes match
+      our emit is BOTH a pre-marker entry and a deliberately reclaimed one, so
+      stamping it would undo the reclamation the marker promises.
+    """
+    if on_disk is ABSENT:
+        return stamp(candidate) if store_managed else candidate
+    if not store_managed:
+        return None
+    if is_marked(on_disk):
+        return stamp(candidate)
+    logger.warning(
+        "Declining to rewrite unmarked MCP entry %r in %s: the name is managed but "
+        "the entry carries no Kiro Crew marker, so it reads as hand-authored and is "
+        "left as-is",
+        name,
+        surface,
+    )
+    return None

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -4145,6 +4145,30 @@ class TestRebuildReconcileRetainsEnabledAppServers:
 
 
 class TestMcpMergePriority:
+    def test_the_authorship_marker_never_reaches_the_rendered_spec(self, tmp_path: Path):
+        """A shared-file marker is provenance, not configuration.
+
+        The marker records that Kiro Crew wrote an entry into a file it does NOT
+        own. The rendered spec is ours, so carrying the key through would put a
+        field in front of the runtime that says nothing to it -- and would change
+        the emitted spec for every managed remote, which nothing about recording
+        authorship needs to do.
+        """
+        from kiro_crew.mcp_provenance import MARKER_KEY, stamp
+
+        cfg_dir = _bundled_defaults(tmp_path)
+        kiro_cmd = _make_exec(tmp_path, "marked-srv")
+        cc_cmd = _make_exec(tmp_path, "cc-marked-srv")
+        config = _run_install_mcp_merge(
+            tmp_path,
+            cfg_dir,
+            cc_servers={"cc-srv": stamp({"command": cc_cmd})},
+            kiro_servers={"kiro-srv": stamp({"command": kiro_cmd})},
+        )
+        for name in ("kiro-srv", "cc-srv"):
+            assert name in config["mcpServers"], f"{name} must still be merged"
+            assert MARKER_KEY not in config["mcpServers"][name]
+
     def test_kiro_global_outranks_cc_global(self, tmp_path: Path):
         """Same server in both globals → Kiro-global command wins (CC down-ranked)."""
         cfg_dir = _bundled_defaults(tmp_path)

--- a/test/test_mcp_custom_api.py
+++ b/test/test_mcp_custom_api.py
@@ -522,6 +522,50 @@ class TestCarriedKeyRoundTrip:
         finally:
             await client.close()
 
+    async def test_the_authorship_marker_is_the_one_carried_key_not_preserved(
+        self, sandbox, fake_sel
+    ):
+        """A hand-added marker in the store cannot ride a save back out.
+
+        Every other non-allowlisted key round-trips, because dropping one would
+        silently change behaviour the editor does not own. The marker is the
+        exception: it records that Kiro Crew wrote an entry into a file it does
+        NOT own, so it is meaningless in the store, and preserving it here would
+        let a hand-edit volunteer the entry for management on a shared surface.
+        """
+        from kiro_crew.mcp_provenance import MARKER_KEY
+
+        sandbox.kirocrew_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "weather": {**self._ENTRY, MARKER_KEY: {"managed": True}},
+                    }
+                }
+            )
+        )
+        client = await _client()
+        try:
+            got = await (await client.get("/api/mcp/custom/weather")).json()
+            resp = await client.put("/api/mcp/custom/weather", json={"spec": got["spec"]})
+            assert resp.status == 200
+            entry = json.loads(sandbox.kirocrew_json.read_text(encoding="utf-8"))["mcpServers"][
+                "weather"
+            ]
+            assert MARKER_KEY not in entry
+            assert entry["disabledTools"] == ["dangerous_tool"], "real carried keys still survive"
+
+            # A FRESH add tolerates no such key, so a pasted block cannot claim
+            # management for a server the dashboard has never written.
+            resp = await client.post(
+                "/api/mcp/custom",
+                json={"servers": {"pasted": {"command": "npx", MARKER_KEY: {"managed": True}}}},
+            )
+            assert resp.status == 400
+            assert MARKER_KEY in (await resp.json())["error"]
+        finally:
+            await client.close()
+
     async def test_removing_carried_key_still_preserves_it(self, sandbox, fake_sel):
         self._seed(sandbox)
         client = await _client()

--- a/test/test_mcp_provenance.py
+++ b/test/test_mcp_provenance.py
@@ -1,0 +1,231 @@
+"""The authorship marker: shape, decision matrix, and lifecycle.
+
+Ownership of an entry in a shared MCP config file is "carries our marker", not
+"the name is in the store". These tests pin the predicate and the three decisions
+built on it; the end-to-end behaviour at each write surface lives in
+``test_mcp_sync_agent.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from kiro_crew.mcp_provenance import (
+    ABSENT,
+    MARKER_KEY,
+    is_marked,
+    resolve_write,
+    stamp,
+    without_marker,
+)
+
+
+class TestMarkerShape:
+    """Only the exact shape counts as ours.
+
+    The predicate decides whether we may overwrite a file we do not own, so
+    every ambiguous value has to fall on the "leave it alone" side. A marker we
+    cannot read is a marker we did not write.
+    """
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            {"url": "https://x"},
+            {"url": "https://x", MARKER_KEY: None},
+            {"url": "https://x", MARKER_KEY: True},
+            {"url": "https://x", MARKER_KEY: "managed"},
+            {"url": "https://x", MARKER_KEY: []},
+            {"url": "https://x", MARKER_KEY: {}},
+            {"url": "https://x", MARKER_KEY: {"managed": "yes"}},
+            {"url": "https://x", MARKER_KEY: {"managed": 1}},
+            {"url": "https://x", MARKER_KEY: {"managed": False}},
+            "not-a-dict",
+            None,
+        ],
+    )
+    def test_anything_but_the_exact_shape_reads_as_the_users(self, entry):
+        assert is_marked(entry) is False
+
+    def test_the_exact_shape_reads_as_ours(self):
+        assert is_marked(stamp({"url": "https://x"})) is True
+
+    def test_stamping_does_not_mutate_its_input(self):
+        """Callers pass the entry they are still comparing against."""
+        original = {"url": "https://x"}
+        stamped = stamp(original)
+        assert original == {"url": "https://x"}
+        assert is_marked(stamped)
+
+    def test_stamping_replaces_a_malformed_marker(self):
+        """The written marker is always the exact shape.
+
+        A candidate is built by copying the on-disk entry, so an unreadable
+        marker value can ride along into a write. Stamping normalizes it rather
+        than preserving it, so what lands on disk is always readable back.
+        """
+        assert is_marked(stamp({"url": "https://x", MARKER_KEY: "garbage"}))
+
+    @pytest.mark.parametrize("entry", ["not-a-dict", None, 7, []])
+    def test_without_marker_tolerates_a_non_dict(self, entry):
+        """Comparisons run before any shape re-check, so this cannot raise."""
+        assert without_marker(entry) == {}
+
+    def test_without_marker_keeps_everything_else(self):
+        entry = stamp({"url": "https://x", "headers": {"A": "b"}})
+        assert without_marker(entry) == {"url": "https://x", "headers": {"A": "b"}}
+
+
+class TestResolveWriteDecisions:
+    """The three outcomes, plus the states that must fall into decline."""
+
+    _CANDIDATE = {"url": "https://new.example.net/mcp"}
+
+    def _resolve(self, on_disk, *, store_managed=True, candidate=None):
+        return resolve_write(
+            name="srv",
+            on_disk=on_disk,
+            candidate=dict(candidate if candidate is not None else self._CANDIDATE),
+            store_managed=store_managed,
+            surface="~/.kiro/settings/mcp.json",
+        )
+
+    def test_a_create_for_a_managed_name_is_stamped(self):
+        """We are authoring the entry, so the record says so."""
+        resolved = self._resolve(ABSENT)
+        assert resolved is not None and is_marked(resolved)
+        assert without_marker(resolved) == self._CANDIDATE
+
+    def test_a_create_for_an_unmanaged_name_is_not_stamped(self):
+        """A marker on a name we do not manage would claim an entry no later
+        write is allowed to touch anyway, so it is not written."""
+        resolved = self._resolve(ABSENT, store_managed=False)
+        assert resolved == self._CANDIDATE
+        assert not is_marked(resolved)
+
+    @pytest.mark.parametrize("on_disk", ["not-a-dict", None, [], 7])
+    def test_a_present_but_unreadable_entry_is_declined(self, on_disk, caplog):
+        """Present-and-malformed is not absent, and cannot be ours.
+
+        A string, ``null`` or a list cannot carry the marker, so by the invariant
+        it reads as unmarked -- the user's. Only true absence is a create: a value
+        we cannot parse is a value we cannot prove we wrote, and overwriting it
+        would destroy whatever the user meant by it. ``None`` is in here on
+        purpose -- a JSON ``null`` under the name is a value the user typed, which
+        is why absence needs its own signal rather than borrowing ``None``.
+        """
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.mcp_provenance"):
+            assert self._resolve(on_disk) is None
+        assert "srv" in caplog.text
+
+    @pytest.mark.parametrize("on_disk", ["not-a-dict", None, [], 7])
+    def test_an_unmanaged_name_with_an_unreadable_entry_is_left_alone(self, on_disk):
+        """The store-side gate answers first, so nothing is written either way."""
+        assert self._resolve(on_disk, store_managed=False) is None
+
+    def test_an_unmanaged_name_with_an_existing_entry_is_declined(self):
+        """The store-side half stays a necessary precondition."""
+        assert self._resolve({"url": "https://theirs"}, store_managed=False) is None
+
+    def test_a_marked_entry_is_rewritten_and_stays_marked(self):
+        """The propagation the marker exists to make safe."""
+        resolved = self._resolve(stamp({"url": "https://old.example/mcp"}))
+        assert resolved is not None and is_marked(resolved)
+        assert without_marker(resolved) == self._CANDIDATE
+
+    def test_a_stripped_marker_is_not_re_stamped(self):
+        """Reclamation has to survive the next sync.
+
+        Stripping the marker off an entry we wrote leaves EXACTLY our emit, so
+        "unmarked and byte-equal to our candidate" is the same disk state as
+        "written before the marker existed". Stamping on that match would migrate
+        the second and silently take back the first, and no content test
+        separates them -- so neither is written. The trade is documented in the
+        module docstring and the design note.
+        """
+        resolved = self._resolve(dict(self._CANDIDATE))
+        assert resolved is None
+
+    def test_an_entry_carrying_a_malformed_marker_is_declined(self):
+        """A marker we cannot read is a marker we did not write.
+
+        Previously this stamped, because the content beside the malformed key
+        matched our emit. It is unmarked, so it is the user's.
+        """
+        assert self._resolve({**self._CANDIDATE, MARKER_KEY: "garbage"}) is None
+
+    def test_an_unmarked_divergent_entry_is_declined_and_logged(self, caplog):
+        """The case the overridden finding described.
+
+        Nothing proves we wrote it and the sync would change it, so it is the
+        user's. The log line is the only trace, and it names the server so a
+        silent divergence is diagnosable.
+        """
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.mcp_provenance"):
+            assert self._resolve({"url": "https://theirs.example.com/mcp"}) is None
+        assert "srv" in caplog.text
+        assert "~/.kiro/settings/mcp.json" in caplog.text
+
+    def test_content_equality_does_not_widen_the_decline(self):
+        """One property, stated once: presence + unmarked is enough to decline.
+
+        Key order, nesting depth and exact byte-equality all used to steer a
+        stamping branch. With that branch gone there is nothing for them to
+        steer, and this pins that no future comparison re-enters through them.
+        """
+        for on_disk in (
+            {"headers": {"A": "b"}, "url": "https://u"},
+            {"url": "https://u", "headers": {"A": "b"}},
+            {"url": "https://u", "headers": {"Authorization": "Bearer theirs"}},
+        ):
+            candidate = {"url": "https://u", "headers": {"A": "b"}}
+            assert self._resolve(on_disk, candidate=candidate) is None
+
+
+class TestOwnershipIsPerFileNotPerName:
+    """A name-set cannot answer for two surfaces at once.
+
+    ``kirocrew_managed_names`` stays name-only on purpose: the same managed name
+    can be ours in the kiro-global file and the user's in the sidecar, so folding
+    marker state into the set would make it answer for whichever surface happened
+    to be checked last.
+    """
+
+    def test_the_same_name_resolves_differently_per_surface(self):
+        candidate = {"url": "https://new.example.net/mcp"}
+        marked_surface = resolve_write(
+            name="srv",
+            on_disk=stamp({"url": "https://old.example/mcp"}),
+            candidate=dict(candidate),
+            store_managed=True,
+            surface="~/.kiro/settings/mcp.json",
+        )
+        unmarked_surface = resolve_write(
+            name="srv",
+            on_disk={"url": "https://old.example/mcp"},
+            candidate=dict(candidate),
+            store_managed=True,
+            surface="~/.mcp.json",
+        )
+        assert marked_surface is not None, "ours here"
+        assert unmarked_surface is None, "theirs there, same name and same store"
+
+    def test_the_store_side_predicate_keeps_its_name_only_contract(self):
+        """PR3 consumes this signature; the marker did not change it."""
+        from unittest.mock import patch
+
+        from kiro_crew.mcp_discovery import SCOPE_KIROCREW, kirocrew_managed_names
+
+        with patch(
+            "kiro_crew.mcp_discovery._load_mcp_json_by_source",
+            return_value={
+                SCOPE_KIROCREW: {
+                    "plain": {"url": "https://x"},
+                    "marked": stamp({"url": "https://y"}),
+                    "bad": "not-a-dict",
+                }
+            },
+        ):
+            assert kirocrew_managed_names() == {"plain", "marked"}

--- a/test/test_mcp_sync_agent.py
+++ b/test/test_mcp_sync_agent.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -12,6 +14,7 @@ from kiro_crew.dashboard.handlers.agents import (
     api_capability_mcp_install,
     api_capability_mcp_uninstall,
 )
+from kiro_crew.mcp_provenance import without_marker
 
 
 @pytest.fixture()
@@ -55,16 +58,31 @@ def _load(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-async def _sync_one_remote(remote, mcp_env, *, owned: bool = True) -> dict:
+async def _sync_one_remote(remote, mcp_env, *, owned: bool = True, marked: bool = True) -> dict:
     """Run api_mcp_sync over one remote server and return its written global entry.
 
     ``owned`` marks the name as managed by Kiro Crew, which is the regime every caller
     here exercises: writes to the kiro-global mcp.json are gated on ownership, so
     an unowned name is deliberately left untouched (see
     TestGlobalWritesAreOwnershipGated).
+
+    ``marked`` stamps the authorship marker onto whatever this server already has
+    in the global file, so the default regime is "re-syncing an entry we wrote" --
+    the case the sync behaviour tests are about. Pass ``marked=False`` to control
+    the marker from the test body, which the collision and reclamation tests do
+    because the marker's presence is the thing under test there.
     """
     from kiro_crew.dashboard.handlers.mcp import api_mcp_sync
     from kiro_crew.mcp_discovery import SCOPE_KIROCREW
+    from kiro_crew.mcp_provenance import stamp
+
+    _, mcp_json = mcp_env
+    if marked:
+        data = _load(mcp_json)
+        current = data.get("mcpServers", {}).get(remote.name)
+        if isinstance(current, dict):
+            data["mcpServers"][remote.name] = stamp(current)
+            mcp_json.write_text(json.dumps(data))
 
     req = MagicMock()
     req.app = {"state": MagicMock()}
@@ -117,18 +135,29 @@ class TestGlobalWritesAreOwnershipGated:
             return_value={SCOPE_KIROCREW: {n: {"url": "https://store"} for n in names}},
         )
 
-    async def _kiro_global(self, *, managed: bool, mcp_env) -> dict:
-        """Sync a remote whose url differs from the user's global entry."""
+    async def _kiro_global(self, *, managed: bool, mcp_env, marked: bool | None = None) -> dict:
+        """Sync a remote whose url differs from the user's global entry.
+
+        ``marked`` defaults to ``managed``: the managed case represents an entry
+        THIS emitter wrote, so it carries the authorship marker, while the
+        unmanaged case represents one the user typed and carries none. Pass it
+        explicitly to build the third state -- a managed name whose global entry
+        we cannot prove we wrote.
+        """
         from kiro_crew.mcp_discovery import McpServerInfo
+        from kiro_crew.mcp_provenance import stamp
 
         _, mcp_json = mcp_env
         data = _load(mcp_json)
-        data["mcpServers"]["handmade"] = {
+        entry = {
             "url": "https://user.example.com/mcp",
             "headers": {"Authorization": "Bearer user-typed"},
             "oauthScopes": ["user:scope"],
             "oauth": {"clientId": "user-client", "issuer": "https://user-issuer"},
         }
+        data["mcpServers"]["handmade"] = (
+            stamp(entry) if (managed if marked is None else marked) else entry
+        )
         mcp_json.write_text(json.dumps(data))
         remote = McpServerInfo(
             name="handmade",
@@ -137,7 +166,7 @@ class TestGlobalWritesAreOwnershipGated:
             client_id="kirocrew-client",
             source="discovered",
         )
-        return await _sync_one_remote(remote, mcp_env, owned=managed)
+        return await _sync_one_remote(remote, mcp_env, owned=managed, marked=False)
 
     def _cc_sidecar(self, *, managed: bool, tmp_path) -> dict:
         """Register a remote into the CC sidecar."""
@@ -191,6 +220,23 @@ class TestGlobalWritesAreOwnershipGated:
         assert cc["scopes"] == ["kirocrew:scope"]
         assert cc["clientId"] == "kirocrew-client"
 
+    @pytest.mark.asyncio
+    async def test_a_managed_name_with_an_unmarked_entry_is_left_to_the_user(self, mcp_env):
+        """The third state: the name is ours, the ENTRY is not provably ours.
+
+        Managing a name is necessary but not sufficient. Here the sync would
+        change the entry and nothing on it says we wrote it, so it reads as
+        hand-authored and survives untouched -- including the credential header,
+        which the name-only gate would have dropped on the url change.
+        """
+        entry = await self._kiro_global(managed=True, mcp_env=mcp_env, marked=False)
+        assert entry == {
+            "url": "https://user.example.com/mcp",
+            "headers": {"Authorization": "Bearer user-typed"},
+            "oauthScopes": ["user:scope"],
+            "oauth": {"clientId": "user-client", "issuer": "https://user-issuer"},
+        }
+
     def test_a_malformed_store_value_does_not_make_a_name_managed(self, tmp_path):
         """Same discriminator as the agent-spec path: a non-dict is not ownership."""
         from kiro_crew.mcp_discovery import SCOPE_KIROCREW, kirocrew_managed_names
@@ -202,134 +248,186 @@ class TestGlobalWritesAreOwnershipGated:
             assert kirocrew_managed_names() == {"good"}
 
 
-class TestExactNameOwnershipIsHistoryDependent:
-    """The exact-name gate cannot separate "ours, moved" from "the user's, colliding".
+class TestExactNameCollisionIsDecidedByTheMarker:
+    """The marker separates "ours, moved" from "the user's, colliding".
 
-    Ownership is name presence in the store, so both of these reach the write with
-    the SAME on-disk state -- a global entry at url A, that name in the store, and
-    a discovered url B:
+    Both of these used to arrive at the write as the SAME input -- a global entry
+    at url A, that name in the store, and a discovered url B:
 
     * LEGITIMATE: a managed server whose store url moved A -> B. The global entry
-      at A is our own earlier emit and MUST be rewritten, or the re-sync this
-      change exists to deliver never propagates and kiro-cli keeps running a url
-      the dashboard no longer shows.
+      at A is our own earlier emit and MUST be rewritten, or the re-sync never
+      propagates and kiro-cli keeps running a url the dashboard no longer shows.
     * HARMFUL: the user hand-authored a global server at A whose name collides
       with a managed one. Rewriting destroys config we did not author.
 
-    No content test separates them, because the minimal entry ``{"url": ...}`` is
-    exactly what BOTH produce: our emitter writes it for a managed server carrying
-    no OAuth hints, and it is also the smallest thing a user can type for a remote
-    server. The difference is authorship history, which nothing on disk records --
-    see the module note on the escalation. These tests pin today's behaviour so a
-    future change to it is deliberate rather than incidental.
+    No CONTENT test separates them -- the minimal entry ``{"url": ...}`` is
+    exactly what both produce. The difference is authorship, so authorship is now
+    recorded rather than inferred: our writes carry ``x-kirocrew``, and an entry
+    without it is the user's. These tests pin both directions, and that stripping
+    the marker reclaims an entry for good.
     """
 
     @staticmethod
-    async def _sync_over_global(entry: dict, mcp_env) -> dict:
-        """Sync a managed remote at url B over an existing global ``entry``."""
+    async def _sync_over_global(
+        entry: object, mcp_env, *, url: str = "https://b.example.net/mcp"
+    ) -> Any:
+        """Sync a managed remote at ``url`` over an existing global ``entry``.
+
+        ``entry`` is deliberately untyped: a hand-edited file can hold a string
+        or ``null`` under a server name, and that shape has to reach the write.
+        """
         from kiro_crew.mcp_discovery import McpServerInfo
 
         _, mcp_json = mcp_env
         data = _load(mcp_json)
         data["mcpServers"]["collide"] = entry
         mcp_json.write_text(json.dumps(data))
-        remote = McpServerInfo(
-            name="collide", url="https://b.example.net/mcp", source="discovered"
-        )
-        return await _sync_one_remote(remote, mcp_env, owned=True)
+        remote = McpServerInfo(name="collide", url=url, source="discovered")
+        return await _sync_one_remote(remote, mcp_env, owned=True, marked=False)
 
     @pytest.mark.asyncio
     async def test_a_managed_url_move_propagates(self, mcp_env):
-        """Direction (b): the case that MUST keep working (round-16 contract)."""
-        written = await self._sync_over_global({"url": "https://a.example.com/mcp"}, mcp_env)
+        """Direction (b): the case that MUST keep working (round-16 contract).
+
+        The entry carries our marker, so the move is provably ours to make.
+        """
+        from kiro_crew.mcp_provenance import stamp
+
+        written = await self._sync_over_global(
+            stamp({"url": "https://a.example.com/mcp"}), mcp_env
+        )
         assert written["url"] == "https://b.example.net/mcp", (
             "a managed server's url legitimately moves; refusing to write it "
             "would strand kiro-cli on the old transport"
         )
 
     @pytest.mark.asyncio
-    async def test_a_colliding_hand_authored_global_entry_is_rewritten(self, mcp_env):
-        """Direction (a): the harm, recorded as current behaviour.
+    async def test_a_colliding_hand_authored_global_entry_is_preserved(self, mcp_env):
+        """Direction (a): the harm, now prevented.
 
-        Reachability is bounded but not closed: ``POST /api/mcp/custom`` refuses a
-        name that ``_find_server_spec_anywhere`` finds in ANY scope -- the kiro
-        global file included -- so no dashboard path creates a store entry on top
-        of a hand-authored global one. What remains is the user editing their own
-        global file AFTER the managed entry exists.
+        Reachability was already bounded -- ``POST /api/mcp/custom`` refuses a
+        name that ``_find_server_spec_anywhere`` finds in ANY scope, the kiro
+        global file included -- but the residual case, a user editing their own
+        global file AFTER the managed entry exists, is what this closes.
         """
-        written = await self._sync_over_global(
-            {
-                "url": "https://a.example.com/mcp",
-                "oauthScopes": ["user:scope"],
-                "oauth": {"clientId": "user-client", "issuer": "https://user-issuer"},
-            },
-            mcp_env,
-        )
-        assert written["url"] == "https://b.example.net/mcp"
-        assert written.get("oauthScopes") != ["user:scope"], "the user's hint is not kept"
-        assert written["oauth"]["issuer"] == "https://user-issuer", (
-            "a sub-key we never owned still survives the surgical edit"
-        )
+        entry = {
+            "url": "https://a.example.com/mcp",
+            "oauthScopes": ["user:scope"],
+            "oauth": {"clientId": "user-client", "issuer": "https://user-issuer"},
+        }
+        written = await self._sync_over_global(dict(entry), mcp_env)
+        assert written == entry, "an unmarked entry is the user's, verbatim"
 
     @pytest.mark.asyncio
     async def test_a_non_hint_oauth_subkey_is_not_authorship_evidence(self, mcp_env):
-        """Why "preserve an entry carrying ``issuer``" is not the fix here.
+        """Why "preserve an entry carrying ``issuer``" is still not the fix.
 
-        A non-hint sub-key looks like a fingerprint -- no writer here emits one,
-        and the custom-server editor refuses a submission that introduces one. It
-        is still not authorship: a MANAGED entry legitimately carries ``issuer``
-        once a user adds it, which is the entire reason ``apply_kiro_oauth_hints``
+        A non-hint sub-key looks like a fingerprint -- no writer here emits one.
+        It is still not authorship: a MANAGED entry legitimately carries
+        ``issuer`` once a user adds it, which is why ``apply_kiro_oauth_hints``
         edits ``oauth`` surgically instead of replacing it. Preserving on that
         signal would strand every managed server whose ``oauth`` a user has ever
-        touched, so the same state has to keep syncing --
-        ``test_a_managed_name_still_syncs_at_every_global_write_site`` and
-        ``test_sync_keeps_unrelated_oauth_subkeys_while_rewriting_client_id`` pin
-        it from the other side.
+        touched, so a MARKED entry carrying one must still sync. The marker, not
+        the sub-key, is what decides.
         """
+        from kiro_crew.mcp_provenance import stamp
+
         written = await self._sync_over_global(
-            {"url": "https://a.example.com/mcp", "oauth": {"issuer": "https://i"}},
+            stamp({"url": "https://a.example.com/mcp", "oauth": {"issuer": "https://i"}}),
             mcp_env,
         )
         assert written["url"] == "https://b.example.net/mcp"
         assert written["oauth"] == {"issuer": "https://i"}
 
     @pytest.mark.asyncio
-    async def test_a_bare_url_collision_remains_undecidable(self, mcp_env):
-        """The residual case, unchanged and deliberately so.
+    async def test_an_unmarked_bare_url_collision_is_preserved(self, mcp_env):
+        """The residual case from the base ref, now decided.
 
         A minimal ``{"url": ...}`` entry is both what this emitter writes for a
         managed server carrying no OAuth hints and the smallest thing a user can
-        hand-type, and nothing on disk records authorship -- ``McpServerInfo``
-        carries discovery origin, not authorship. So the managed url still
-        propagates, which is what keeps ``test_a_managed_url_move_propagates``
-        true. Closing this needs a provenance record, an on-disk format change.
+        hand-type. On the base ref the managed url propagated over it, because
+        nothing on disk recorded authorship. The marker records it, so the same
+        bytes now read as the user's and are left alone -- while
+        ``test_a_managed_url_move_propagates`` shows the marked spelling of the
+        same shape still propagating.
         """
         written = await self._sync_over_global({"url": "https://a.example.com/mcp"}, mcp_env)
-        assert written == {"url": "https://b.example.net/mcp"}
+        assert written == {"url": "https://a.example.com/mcp"}
+
+    @pytest.mark.asyncio
+    async def test_stripping_the_marker_reclaims_the_entry_for_good(self, mcp_env):
+        """Reclamation is durable across syncs, which is what forbids migration.
+
+        The marker promises a user can strip it and we stop rewriting. Stripping
+        it off one of our own entries leaves exactly our emit behind, so the
+        obvious migration for pre-marker entries -- stamp an unmarked entry the
+        sync would not change -- reads this reclaimed entry as legacy and takes it
+        back, after which a later url move rewrites it. The two states are
+        indistinguishable on disk, so no unmarked entry is written at all: legacy
+        entries stay unmanaged (re-established with Disconnect then Connect, which
+        creates stamped) and reclamation holds.
+        """
+        from kiro_crew.mcp_provenance import is_marked, stamp, without_marker
+
+        settled = await self._sync_over_global(
+            stamp({"url": "https://b.example.net/mcp"}), mcp_env
+        )
+        assert is_marked(settled), "precondition: an entry we wrote and re-synced"
+
+        reclaimed = without_marker(settled)
+        after = await self._sync_over_global(dict(reclaimed), mcp_env)
+        assert not is_marked(after), "the marker must not come back on its own"
+        assert after == reclaimed, "and nothing else may change either"
+
+        # The step that makes re-stamping harmful: a stamped entry is rewritable,
+        # so had the previous sync taken it back, this url move would land on it.
+        moved = await self._sync_over_global(dict(after), mcp_env, url="https://c.example.org/mcp")
+        assert moved == reclaimed, "a reclaimed entry outlives a later store-side move"
+
+    @pytest.mark.asyncio
+    async def test_a_marked_entry_does_not_re_write_on_every_sync(self, mcp_env):
+        """The marker must not make a settled entry look permanently divergent.
+
+        The rendered agent spec carries no marker while the shared file does, so a
+        divergence check that saw the key would report this server as changed on
+        every pass and re-write the file forever. ``McpServerInfo`` has explicit
+        fields, so an unknown key never reaches it -- this pins that, because the
+        failure mode is silent write amplification rather than a wrong value.
+        """
+        from kiro_crew.mcp_provenance import is_marked, stamp
+
+        first = await self._sync_over_global(stamp({"url": "https://b.example.net/mcp"}), mcp_env)
+        assert is_marked(first)
+        second = await self._sync_over_global(first, mcp_env)
+        assert second == first, "a settled marked entry is byte-stable across syncs"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("site", ["kiro_global", "cc_sidecar"])
-    async def test_a_managed_url_move_reaches_only_the_surface_that_re_syncs(
+    async def test_a_marked_managed_url_move_reaches_both_surfaces(
         self, site, mcp_env, tmp_path
     ):
-        """Both global surfaces are asserted together so neither drifts silently.
+        """Both global surfaces re-sync a marked entry, and are asserted together.
 
-        The exact-name shape exists at both, but they answer it differently.
-        The kiro-global file re-syncs, so a managed server's moved url reaches
-        disk there -- without that this slice's scope fix never propagates. The
-        Claude Code sidecar is add-only for remotes, so an entry already present
-        keeps what it holds; re-syncing it needs a record of which entries we
-        wrote. Pinning both here means a change to either one has to say so.
+        The base ref answered the exact-name shape differently at each: the
+        kiro-global file re-synced, the Claude Code sidecar stayed add-only for
+        remotes because re-syncing needed a record of which entries we wrote.
+        That record now exists, so both surfaces propagate. Pinning them together
+        means a change to either one has to say so.
         """
+        from kiro_crew.mcp_provenance import stamp
+
         if site == "kiro_global":
-            written = await self._sync_over_global({"url": "https://a.example.com/mcp"}, mcp_env)
-            assert written["url"] == "https://b.example.net/mcp"
+            written = await self._sync_over_global(
+                stamp({"url": "https://a.example.com/mcp"}), mcp_env
+            )
         else:
             from kiro_crew.mcp_discovery import McpServerInfo, register_servers_for_cc
 
             sidecar = tmp_path / "cc.json"
             sidecar.write_text(
-                json.dumps({"mcpServers": {"collide": {"url": "https://a.example.com/mcp"}}})
+                json.dumps(
+                    {"mcpServers": {"collide": stamp({"url": "https://a.example.com/mcp"})}}
+                )
             )
             remote = McpServerInfo(
                 name="collide", url="https://b.example.net/mcp", source="discovered"
@@ -337,7 +435,7 @@ class TestExactNameOwnershipIsHistoryDependent:
             with TestGlobalWritesAreOwnershipGated._own({"collide"}):
                 register_servers_for_cc([remote], mcp_json_path=sidecar)
             written = json.loads(sidecar.read_text())["mcpServers"]["collide"]
-            assert written == {"url": "https://a.example.com/mcp"}
+        assert written["url"] == "https://b.example.net/mcp"
 
     def test_an_unmanaged_remote_keeps_its_sidecar_entry(self, tmp_path, monkeypatch):
         """The sidecar is add-only for remotes, so a present entry is untouched.
@@ -384,20 +482,20 @@ class TestExactNameOwnershipIsHistoryDependent:
         written = json.loads(sidecar.read_text())["mcpServers"]["handmade"]
         assert written == user_entry, "url and credential header survive the sync"
 
-    def test_a_managed_remote_is_not_re_synced_to_the_sidecar(
+    def test_a_managed_remote_re_syncs_to_the_sidecar_only_when_marked(
         self, tmp_path, monkeypatch
     ):
-        """Ownership is name-only, so even a server we own does not rewrite here.
+        """A marked entry re-syncs here; an unmarked one still does not.
 
-        The divergence still has to reach the surfaces that can act on it -- the
-        agent config and the kiro-global file -- so the server does enter the sync
-        set. The sidecar simply declines it: with ownership established by name
-        alone, "our managed server moved" and "a different server the user named
-        the same" are the same input, and this writer replaces an entry rather
-        than merging into it. Propagating a changed remote shape to this surface
-        arrives with the provenance record that makes the two distinguishable.
+        The base ref declined both, because ownership was name-only: "our managed
+        server moved" and "a different server the user named the same" were the
+        same input, and this writer replaces an entry rather than merging into it.
+        The marker separates them, so the divergence that already had to reach the
+        agent config and the kiro-global file now reaches this surface too --
+        unless the entry carries no marker, in which case add-only still holds.
         """
         from kiro_crew import mcp_discovery as md
+        from kiro_crew.mcp_provenance import stamp, without_marker
 
         agents = tmp_path / "agents"
         agents.mkdir()
@@ -428,18 +526,30 @@ class TestExactNameOwnershipIsHistoryDependent:
 
         stale = {"url": "https://old.example/mcp", "disabledTools": ["danger"]}
         sidecar = tmp_path / "cc.json"
-        sidecar.write_text(json.dumps({"mcpServers": {"owned": stale}}))
-        changed = md.register_servers_for_cc(to_sync, mcp_json_path=sidecar)
-        assert changed is False
+
+        # Unmarked: nothing proves we wrote it, so add-only still applies.
+        sidecar.write_text(json.dumps({"mcpServers": {"owned": dict(stale)}}))
+        assert md.register_servers_for_cc(to_sync, mcp_json_path=sidecar) is False
         assert json.loads(sidecar.read_text())["mcpServers"]["owned"] == stale
+
+        # Marked: ours, so the moved url propagates. ``disabledTools`` is NOT
+        # merged back -- this writer rebuilds a remote entry from scratch, which is
+        # exactly why it may only ever touch an entry it wrote.
+        sidecar.write_text(json.dumps({"mcpServers": {"owned": stamp(dict(stale))}}))
+        assert md.register_servers_for_cc(to_sync, mcp_json_path=sidecar) is True
+        written = json.loads(sidecar.read_text())["mcpServers"]["owned"]
+        assert without_marker(written) == {"url": "https://new.example.net/mcp"}
 
     def test_a_remote_with_no_sidecar_entry_is_still_registered(self, tmp_path):
         """Add-only is not no-op: a name absent here is registered as base does.
 
         The hints ride along on this path only, so a first registration still
-        carries the scopes the card asked for.
+        carries the scopes the card asked for -- and the entry is stamped, because
+        we are the ones authoring it. That stamp is what lets the next sync tell
+        this entry apart from one the user typed.
         """
         from kiro_crew.mcp_discovery import McpServerInfo, register_servers_for_cc
+        from kiro_crew.mcp_provenance import is_marked, without_marker
 
         sidecar = tmp_path / "cc.json"
         sidecar.write_text(json.dumps({"mcpServers": {}}))
@@ -452,11 +562,119 @@ class TestExactNameOwnershipIsHistoryDependent:
         )
         with TestGlobalWritesAreOwnershipGated._own({"fresh"}):
             assert register_servers_for_cc([remote], mcp_json_path=sidecar) is True
-        assert json.loads(sidecar.read_text())["mcpServers"]["fresh"] == {
+        written = json.loads(sidecar.read_text())["mcpServers"]["fresh"]
+        assert is_marked(written)
+        assert without_marker(written) == {
             "url": "https://fresh.example.net/mcp",
             "scopes": ["read:me"],
             "clientId": "cid",
         }
+
+
+class TestAPresentButUnreadableEntryIsNotACreate:
+    """A malformed entry occupies the name, so writing over it is not a create.
+
+    Both shared files are hand-edited, so a name can hold a string, a ``null`` or
+    a list. Such a value cannot carry the marker, so by the invariant it is
+    unmarked -- the user's -- and the create branch must not claim it. Absence
+    gets its own signal (``ABSENT``) precisely because ``None`` is a value the
+    user can type.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_kiro_global_entry_survives_a_managed_sync(self, mcp_env):
+        written = await TestExactNameCollisionIsDecidedByTheMarker._sync_over_global(
+            "not-a-dict", mcp_env
+        )
+        assert written == "not-a-dict"
+
+    def test_a_malformed_sidecar_entry_survives_a_managed_sync(self, tmp_path):
+        from kiro_crew.mcp_discovery import McpServerInfo, register_servers_for_cc
+
+        sidecar = tmp_path / "cc.json"
+        sidecar.write_text(json.dumps({"mcpServers": {"collide": "not-a-dict"}}))
+        remote = McpServerInfo(
+            name="collide", url="https://b.example.net/mcp", source="discovered"
+        )
+        with TestGlobalWritesAreOwnershipGated._own({"collide"}):
+            assert register_servers_for_cc([remote], mcp_json_path=sidecar) is False
+        assert json.loads(sidecar.read_text())["mcpServers"]["collide"] == "not-a-dict"
+
+    def test_a_null_sidecar_entry_is_not_mistaken_for_absence(self, tmp_path):
+        """The shape that made ``None`` unusable as the absence signal."""
+        from kiro_crew.mcp_discovery import McpServerInfo, register_servers_for_cc
+
+        sidecar = tmp_path / "cc.json"
+        sidecar.write_text(json.dumps({"mcpServers": {"collide": None}}))
+        remote = McpServerInfo(
+            name="collide", url="https://b.example.net/mcp", source="discovered"
+        )
+        with TestGlobalWritesAreOwnershipGated._own({"collide"}):
+            assert register_servers_for_cc([remote], mcp_json_path=sidecar) is False
+        assert json.loads(sidecar.read_text())["mcpServers"]["collide"] is None
+
+
+class TestSidecarStdioWritesAreGatedToo:
+    """The gate is per ENTRY, not per transport.
+
+    ``register_servers_for_cc`` rewrites a diverging stdio entry in place, so the
+    same collision the marker exists to prevent for remotes -- a user's own server
+    sharing a managed name -- reaches this branch as well. Nothing about a
+    ``command`` makes authorship knowable, so it resolves the same way.
+    """
+
+    @staticmethod
+    def _sync_stdio(sidecar: Path, on_disk: object, managed: bool = True) -> bool:
+        from kiro_crew.mcp_discovery import McpServerInfo, register_servers_for_cc
+
+        sidecar.write_text(json.dumps({"mcpServers": {"collide": on_disk}}))
+        local = McpServerInfo(name="collide", command="/opt/ours", source="discovered")
+        with TestGlobalWritesAreOwnershipGated._own({"collide"} if managed else set()):
+            return register_servers_for_cc([local], mcp_json_path=sidecar)
+
+    def test_a_colliding_hand_authored_stdio_entry_is_preserved(self, tmp_path, caplog):
+        theirs = {"command": "/usr/local/bin/theirs", "args": ["--their-flag"]}
+        sidecar = tmp_path / "cc.json"
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.mcp_provenance"):
+            assert self._sync_stdio(sidecar, dict(theirs)) is False
+        assert json.loads(sidecar.read_text())["mcpServers"]["collide"] == theirs
+        assert "collide" in caplog.text
+
+    def test_a_marked_stdio_entry_still_re_syncs(self, tmp_path):
+        """The propagation the gate must not break."""
+        from kiro_crew.mcp_provenance import stamp, without_marker
+
+        sidecar = tmp_path / "cc.json"
+        assert self._sync_stdio(sidecar, stamp({"command": "/opt/old"})) is True
+        written = json.loads(sidecar.read_text())["mcpServers"]["collide"]
+        assert without_marker(written) == {"command": "/opt/ours", "args": [], "type": "stdio"}
+
+    def test_an_absent_stdio_name_is_created_stamped(self, tmp_path):
+        from kiro_crew.mcp_provenance import is_marked
+
+        sidecar = tmp_path / "cc.json"
+        sidecar.write_text(json.dumps({"mcpServers": {}}))
+        from kiro_crew.mcp_discovery import McpServerInfo, register_servers_for_cc
+
+        local = McpServerInfo(name="fresh", command="/opt/ours", source="discovered")
+        with TestGlobalWritesAreOwnershipGated._own({"fresh"}):
+            assert register_servers_for_cc([local], mcp_json_path=sidecar) is True
+        assert is_marked(json.loads(sidecar.read_text())["mcpServers"]["fresh"])
+
+    def test_an_unmanaged_stdio_name_is_never_stamped(self, tmp_path):
+        """Add-only for a name we do not manage, and no marker claiming it."""
+        from kiro_crew.mcp_provenance import is_marked
+
+        sidecar = tmp_path / "cc.json"
+        sidecar.write_text(json.dumps({"mcpServers": {}}))
+        from kiro_crew.mcp_discovery import McpServerInfo, register_servers_for_cc
+
+        local = McpServerInfo(name="theirs", command="/opt/ours", source="discovered")
+        with TestGlobalWritesAreOwnershipGated._own(set()):
+            assert register_servers_for_cc([local], mcp_json_path=sidecar) is True
+        written = json.loads(sidecar.read_text())["mcpServers"]["theirs"]
+        assert not is_marked(written)
+        assert written == {"command": "/opt/ours", "args": [], "type": "stdio"}
 
 
 class TestSyncMcpToAgent:
@@ -864,7 +1082,7 @@ class TestApiMcpSyncToolsUpdate:
             source="discovered",
         )
         written = await _sync_one_remote(remote, mcp_env)
-        assert written == {
+        assert without_marker(written) == {
             "url": "https://mcp.example.com/v2",
             "headers": {"Authorization": "Bearer current"},
             "disabled": True,
@@ -890,7 +1108,7 @@ class TestApiMcpSyncToolsUpdate:
             source="discovered",
         )
         written = await _sync_one_remote(remote, mcp_env)
-        assert written == {
+        assert without_marker(written) == {
             "url": "https://api.githubcopilot.com/mcp/",
             "oauthScopes": ["read:user", "read:org"],
             "oauth": {"clientId": "public-client-id"},
@@ -914,7 +1132,7 @@ class TestApiMcpSyncToolsUpdate:
             name="remote", url="https://mcp.example.com/v1", source="discovered"
         )
         written = await _sync_one_remote(remote, mcp_env)
-        assert written == {
+        assert without_marker(written) == {
             "url": "https://mcp.example.com/v1",
             "disabledTools": ["write"],
         }


### PR DESCRIPTION
# Identity invariant: who owns an MCP entry in a shared config file

**This page is the contract. The code implements it; where they disagree the page wins.**

KiroCrew writes MCP server entries into two config files it does not own — the kiro-global
`~/.kiro/settings/mcp.json` and the Claude Code sidecar `~/.mcp.json`. Both are also hand-edited
by users. Every write to them needs an answer to one question: *did we write this entry?*

#2286 answered it by NAME: an entry is ours iff the dashboard store (`<data home>/mcp.json`)
holds a dict under the same name. That answer is not decidable on disk. A minimal `{"url": ...}`
entry is byte-identical whether our emitter produced it or a user typed it, so "our managed
server moved url" and "a different server the user happened to name the same" arrive at the write
as the same input. #2286 shipped with that gap open and a reviewer finding overridden at merge.
This slice closes it by recording authorship instead of inferring it.

## The invariant

> An entry in a shared config file is KiroCrew-managed **iff it carries our marker**.
> Name presence in the store is a necessary precondition, never sufficient.
> An entry without the marker is the user's, and is never rewritten.

Ownership is therefore a property of **(file, entry)**, not of a name.

## 1. What the marker is

A single reserved key on the entry object:

```json
"myserver": { "url": "https://example.com/mcp", "x-kirocrew": { "managed": true } }
```

- Key: `x-kirocrew` — one reserved key, `x-` extension namespace, cannot collide with a kiro-cli
  field (kiro-cli's `rename_all = "camelCase"` can never generate a hyphen).
- Value: an object, so the record can gain fields later without a second reserved key.
- Predicate: marked iff the value is a dict whose `managed` is exactly `True`. Anything else —
  absent, `null`, a string, `{"managed": "yes"}` — reads as **unmarked**, i.e. the user's. The
  predicate fails safe in the direction of not writing.

**Verified, not assumed — kiro-cli tolerates the unknown key.** Read against the local
`kiro-cli` clone:

- `crates/agent/src/agent/agent_config/definitions.rs:647` — `McpServerConfig` is
  `#[serde(untagged)]` over `Local` / `Remote` / `Registry`. None of the three variant structs
  (`:690`, `:713`, `:667`) sets `#[serde(deny_unknown_fields)]`; a repo-wide grep finds the
  attribute only in three comments confirming it is *off*. Variant selection keys off a required
  field (`command` / `url` / `type`), so an extra key cannot mis-route the untagged enum.
- Schema validation does exist (`crates/chat-cli-v2/src/cli/agent/mod.rs:924-939`,
  `jsonschema::validate(schema_for!(Agent), instance)`), but the instance it validates is
  `serde_json::to_value(agent)` — the struct *after* deserialization. Unknown keys are already
  gone before validation looks, so they cannot fail it, and the failure path prints a `WARNING`
  rather than erroring.

The sidecar needs no new tolerance argument: `register_servers_for_cc` on main already writes
`scopes` and `clientId` there, keys Claude Code does not read. One more reserved key changes
nothing about that surface.

## 2. Marker lifecycle

| Event | Marker |
|---|---|
| We create an entry in a shared file | **written** |
| We re-sync an entry that already carries it | **kept** |
| The custom-server editor saves a user entry | **never written** — a FRESH add rejects the key by name (`_ALLOWED_SPEC_KEYS`), and an edit of an existing entry tolerates it on validation so an unmodified round-trip still saves, but `_clean_spec` rebuilds the spec from an explicit field list and the key is excluded from the carried-key set, so it is dropped rather than written back |
| A server is removed / disconnected | **gone with the entry** — both removal paths (`api_mcp_remove`, `DELETE /api/mcp/servers/{name}`) pop the whole entry, so the name returns to the user unmarked and un-owned. No separate strip step exists, and none is needed. |
| The store entry disappears but a shared entry survives | marker is inert: the store precondition fails, so nothing is rewritten regardless |

**The store itself is never marked.** The marker records "we wrote this into a file we do not
own". `<data home>/mcp.json` is ours by definition, so marking it would be noise and would leak
into every round-trip through the editor.

**The emitted agent spec is never marked.** `rebuild_agent_config` copies kiro-global and
seam-global entries into `~/.kiro/agents/kirocrew.json` verbatim; the marker is stripped at those
copy sites so the emitted spec stays byte-identical to what #2286 shipped and the
manually-validated Connections flow is untouched.

### Entries #2286 already wrote (unmarked): reclamation beats migration

Installed bases carry managed entries with no marker, so there is a real pull toward migrating
them. The tempting rule is *adopt-on-no-op*: stamp an unmarked entry when the sync would change
nothing about it, so the migrating write alters no user-visible byte.

**That rule is not shippable, and this PR does not ship it.** Stripping the marker off one of our
own entries leaves *exactly* our emit behind. So

- "written before the marker existed", and
- "the user stripped the marker to reclaim this entry"

are **the same disk state**, and no content test separates them. Adopt-on-no-op therefore
re-stamps reclaimed entries, and the sync after that is free to rewrite them — which breaks the
promise §4 makes. It is the same undecidability the marker exists to escape, one level in.

The choice is which state to serve, and this serves reclamation: it is a live, repeatable user
action with no recovery if we get it wrong, whereas the un-migrated case is a one-time state with
a two-click fix.

> **A present unmarked entry is never written.** Not when it diverges, and not when its bytes
> already match our emit.

Consequence, stated plainly: an entry #2286 wrote before the marker existed stays **unmanaged
permanently** — it is never silently migrated. Re-establishing management is **Disconnect then
Connect**: both removal paths pop the whole entry from the shared file, so the name becomes
absent, and the next sync resolves `ABSENT` to a **stamped create**
(`resolve_write`: `if on_disk is ABSENT: return stamp(candidate) ...`). Legacy entries rejoin
management through the ordinary authoring path — the only path that can honestly claim
authorship. Cost: two clicks, no data.

## 3. Collision semantics after the marker

A user hand-edits `~/.kiro/settings/mcp.json` and creates an entry whose name collides with a
managed server:

- The entry has no marker.
- Nothing else is consulted — content, transport and url are all irrelevant once the marker is
  absent.
- **The entry is preserved. We do not write.** One warning is logged naming the server.

This is exactly the case the overridden finding described, and it is now decided on disk rather
than guessed. The two directions that used to be one input are now two:

| On disk | Store | Verdict |
|---|---|---|
| `{"url": A, "x-kirocrew": {...}}` | url B | ours, moved → **rewrite to B** |
| `{"url": A}` | url B | user's → **preserve A** |

Refuted non-fixes, deliberately not resurrected (both are pinned by tests on main):
transport-match preservation (would negate `test_a_managed_url_move_propagates`) and treating a
non-hint `oauth` sub-key as authorship evidence (`test_a_non_hint_oauth_subkey_is_not_authorship_evidence`
— a managed entry legitimately carries `issuer` once a user adds one).

## 4. Can a user strip or fake the marker?

Yes, by hand-editing the file — and both directions are fail-safe, because the marker is a
**declaration of who may write**, not a security boundary. It defends a shared file against our
own writer, not against its owner.

- **Stripping it** (delete the key) = reclaiming the entry, **durably**. We stop rewriting it and
  never take it back on our own, even though the bytes left behind are byte-identical to our own
  emit — see §2 for why that costs the pre-marker migration. The user keeps their bytes, which is
  what stripping asks for. Cost: the dashboard and the runtime can drift for that server until it
  is recreated.
- **Faking it** (add the key by hand) = volunteering the entry for management. It is still inert
  unless the name is *also* store-managed, so a fabricated marker on an unknown name changes
  nothing. When the name is store-managed, the user has asked us to keep that entry in sync with
  the dashboard — which is the same thing connecting the provider would have done.
- **kiro-cli dropping it** on a rewrite: no `McpServerConfig` variant has a `#[serde(flatten)]`
  catch-all, so any kiro-cli-side rewrite of an entry silently drops the marker. That lands in
  the *stripping* direction — we degrade to create-only rather than rewriting a shape we can no
  longer prove is ours.

No residual on the write side: there is no content-equality path that stamps, so a user entry
that happens to reproduce our emit byte-for-byte is left alone like any other unmarked entry.
The trade this buys is the one in §2 — pre-marker entries are not migrated — and it is paid in
two clicks rather than in a rewrite the user did not ask for.

## 5. Write surfaces governed by the marker

| Surface | Before (main) | After |
|---|---|---|
| kiro-global `~/.kiro/settings/mcp.json` (`api_mcp_sync`) | rewrites any store-managed name | rewrites only marked entries; stamps on create |
| CC sidecar `~/.mcp.json` (`register_servers_for_cc`) | **add-only for remotes** — a present entry was never re-synced, explicitly deferred pending this record | re-syncs marked entries, stamps on create, still add-only for unmarked |
| dashboard store `<data home>/mcp.json` | ours | unchanged — never marked |
| emitted agent spec `~/.kiro/agents/kirocrew.json` | rendered from sources | unchanged — marker stripped at the copy sites |

### Scope: remote entries

The invariant governs **remote** (`url`) entries on shared files. Those are the ones this
emitter reconstructs from store state, and the ones the finding is about. Stdio (`command`)
entries are unchanged: the kiro-global file was already create-only for them, and the sidecar
already rewrites them wholesale — narrowing that is a behavioural change recording authorship
does not need to make. Stdio creates on the kiro-global file are still stamped, so a later slice
can gate them without guessing.

### Interface note

`kirocrew_managed_names() -> set[str]` keeps its name and signature; PR3 consumes it unchanged.
It remains the **store-side half** of the predicate — the necessary precondition. It is not
widened to fold in marker state, because ownership after this slice is per-(file, entry) and a
name-set cannot express "marked in the kiro-global file but not in the sidecar" without silently
answering for the wrong surface. The per-entry half is a separate predicate that takes the entry.

---

## Problem

`#2286` (merged as `1e4019875`) established name-only ownership for the kiro-global
`mcp.json` sync: a name is KiroCrew-managed iff the dashboard store holds a dict for it.
Its final reviewer finding — **overridden by a maintainer to let the PR merge** — was that
this is undecidable on disk. If a user hand-edits `~/.kiro/settings/mcp.json` to create an
entry whose name collides with a managed server, sync rewrites the user's entry, because a
minimal `{"url": ...}` entry is byte-identical whether our emitter wrote it or a user typed
it. **This PR retires that finding for real.**

`#2286` also left the Claude Code sidecar (`~/.mcp.json`) add-only for remotes, explicitly
deferring re-sync until a record of which entries we wrote existed. That record is here, so
the deferred re-sync ships with it, marker-gated.

## Why a marker, and not one of the alternatives

Two content-based discriminators were tried and refuted during `#2286`; both are pinned by
tests on main and are **not** resurrected here:

| Rejected approach | Why it fails |
|---|---|
| Preserve when the transport/url matches | Negates `test_a_managed_url_move_propagates` — a managed url legitimately moves |
| Treat a non-hint `oauth` sub-key (`issuer`) as authorship | A managed entry legitimately carries `issuer` once a user adds one (`test_a_non_hint_oauth_subkey_is_not_authorship_evidence`) |

No content test can work, because the colliding shapes are identical. Authorship is history,
so it has to be recorded.

## Fix

- `src/kiro_crew/mcp_provenance.py` (new) — the marker constant, the fail-safe predicate, and
  `resolve_write`, which returns the entry to write or `None` to leave the user's alone.
  Three outcomes: create (stamp), rewrite (marked), decline (**every** present unmarked entry).
- `handlers/mcp.py` — the kiro-global remote write routes its decision through
  `resolve_write`; stdio creates are stamped.
- `mcp_discovery.py` — sidecar remote re-sync re-enabled, marker-gated; unmarked stays
  add-only. `kirocrew_managed_names()` keeps its name and signature (PR3 consumes it) and
  documents that it is the store-side **half** of the predicate.
- `agent.py` — marker stripped where shared entries are copied into the rendered agent spec,
  so the emitted spec is byte-identical to what `#2286` shipped.
- `mcp_custom.py` — the marker is tolerated on validation (an unmodified round-trip still
  saves) but excluded from the carried-key set, so the editor cannot write it back.

## Verified, not assumed: kiro-cli tolerates the key

Read against the kiro-cli source, because the whole design fails if the key is rejected:

- `crates/agent/src/agent/agent_config/definitions.rs:647` — `McpServerConfig` is
  `#[serde(untagged)]`; none of its three variant structs (`:667`, `:690`, `:713`) sets
  `#[serde(deny_unknown_fields)]`. A repo-wide grep finds that attribute only in three
  comments confirming it is off. Variant selection keys off a required field, so an extra key
  cannot mis-route the enum.
- `crates/chat-cli-v2/src/cli/agent/mod.rs:924-939` — the one `jsonschema::validate` call
  validates `serde_json::to_value(agent)`, i.e. the struct **after** deserialization has
  already dropped unknown keys. It cannot fail on them, and it warns rather than errors.

## Tests

Repro-first for the headline case. The collision class is restructured around the marker:

- `test_an_unmarked_bare_url_collision_is_preserved` — **the overridden finding's repro, now
  passing.** The same bytes that main rewrites are left alone.
- `test_a_colliding_hand_authored_global_entry_is_preserved` — inverted from
  `..._is_rewritten`; the harm is now prevented rather than recorded.
- `test_a_managed_url_move_propagates` — unchanged contract, marked spelling.
- `test_stripping_the_marker_reclaims_the_entry_for_good` — strip the marker off a settled
  managed entry, sync twice (once at the same url, once at a moved one): the marker does not
  come back and the entry is never rewritten. **This is the repro for the round-2 finding**,
  and it is what forbids adopt-on-no-op.
- `test_a_marked_entry_does_not_re_write_on_every_sync` — pins no write amplification: the
  spec carries no marker while the shared file does, so a divergence check that saw the key
  would re-write forever.
- `test_a_managed_remote_re_syncs_to_the_sidecar_only_when_marked` — inverted; asserts both
  the marked (re-syncs) and unmarked (add-only) halves.
- `test_the_authorship_marker_never_reaches_the_rendered_spec`, and the editor test asserting
  both that a save drops the key and that a **fresh** add rejects it.
- `test_mcp_provenance.py` (new) — predicate fail-safe matrix (11 malformed marker shapes all
  read as the user's), the three `resolve_write` outcomes, `test_a_stripped_marker_is_not_re_stamped`
  and `test_an_entry_carrying_a_malformed_marker_is_declined` at the predicate boundary,
  `test_content_equality_does_not_widen_the_decline` (key order, nesting and exact equality can no
  longer steer a stamping branch), and per-file divergence.

Kept green unchanged: `test_a_non_hint_oauth_subkey_is_not_authorship_evidence`,
`test_an_unmanaged_remote_keeps_its_sidecar_entry`, and the ownership/alias/header-lifecycle
regression suites.

## Disposition notes for the reviewers

1. **Per-entry decline is logged, not SEL-audited.** The write itself is already audited
   (`mcp_server_config_sync`, naming the servers). The decline is a *non-action*, and the
   equivalent gate on main was a silent `continue` with no log at all — this is strictly more
   observable than the base ref, without adding an audit mechanism to a pure predicate module.
2. **A non-dict on-disk entry is still overwritten.** Unchanged from main, where
   `isinstance(current, dict)` being false fell through to the same write. Not touched here.
3. **Scope is remote entries.** Stdio semantics on both surfaces are unchanged; narrowing
   them is a behavioural change recording authorship does not require.
4. **Adoption was removed in review (round 2), not narrowed.** The reviewer found that
   adopt-on-no-op undoes the reclamation escape hatch this page promises, because a reclaimed
   entry and a pre-marker entry are the same bytes on disk. No in-slice discriminator exists —
   any candidate needs new persistent state, and even a one-shot migration epoch mis-fires for a
   user who strips before their first post-upgrade sync. Rather than invent one, the branch is
   deleted: `resolve_write` is create / rewrite / decline, and the invariant's strongest form
   ("an unmarked entry is never rewritten") is now literally true of the code. The cost is
   accepted explicitly in §2.

## LOC

`git diff --numstat origin/main` — `src/`: **243 added / 38 deleted (205 net)**, inside the
600-line shared-path cap. `test/`: 613 added / 96 deleted. `docs/`: 133 added.

Round 2 moved this the "wrong" way on the raw count, deliberately: deleting adoption removed
**2 executable lines and added none**, but recording why the pre-marker migration is being given
up cost ~10 lines of module docstring and ~35 of design note. Code shrank; the contract that
governs it grew. Executable production LOC is now smaller than the reviewed revision at the same
time as the diff is larger.

## Gates

Round-2 revision: targeted suites green — `test_mcp_provenance.py` + `test_mcp_sync_agent.py`
(98 passed), `test_agent.py` + `test_mcp_custom_api.py` + the `test_security_posture.py` /
`test_spawn_audit.py` drift guards (263 passed), isort and flake8 clean, CI-parity mypy clean on
every changed module.

Prior full-suite run on this branch: 39,739 passed; the 69 failures are the host's known
pre-existing `SandboxUnavailableError` band (unshare EPERM), none in a file this PR touches, and
the same subset fails identically on clean `origin/main`.

