### PR TITLE
fix(setup): warn when --slack is ignored under --agent-only

### DIFF
--- a/src/kiro_crew/cli_setup.py
+++ b/src/kiro_crew/cli_setup.py
@@ -344,6 +344,13 @@ def _setup_impl(
     _setup_sandbox_consent()
 
     if agent_only:
+        # --agent-only returns before the channel steps below, so an explicit
+        # --slack has nothing to act on. Say so instead of dropping it silently.
+        if slack:
+            print(
+                "\n  ⚠️  --slack is ignored with --agent-only. Run "
+                "'kirocrew setup --slack' for the guided Slack setup."
+            )
         print("\n👻 Done! Try: kirocrew gateway")
         return
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3794,6 +3794,25 @@ class TestSetupChannelGating:
         calls = self._run_setup(monkeypatch, tmp_path, slack=True)
         assert calls == ["slack_tokens", "slash_command"]
 
+    def test_agent_only_with_slack_warns_and_skips_slack_steps(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """--agent-only --slack: no Slack steps run, but a notice explains why."""
+        calls = self._run_setup(monkeypatch, tmp_path, agent_only=True, slack=True)
+        assert calls == []
+        out = capsys.readouterr().out
+        assert "--slack is ignored with --agent-only" in out
+        assert "setup --slack" in out
+
+    def test_agent_only_without_slack_prints_no_notice(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """--agent-only alone: the guided-setup pointer is not printed."""
+        calls = self._run_setup(monkeypatch, tmp_path, agent_only=True)
+        assert calls == []
+        out = capsys.readouterr().out
+        assert "--slack is ignored" not in out
+
 
 class TestSpawnCliAuth:
     """``kirocrew spawn`` attaches X-Internal-Secret on every gateway call.


### PR DESCRIPTION
## Problem / Motivation

`kirocrew setup --agent-only --slack` runs the agent-only path and silently drops the explicitly requested Slack steps. The `--agent-only` early return happens before the messaging-channel block, so `--slack` has nothing to act on. The precedence is documented only in the flag's `--help` string, so from the command line it looks like nothing happened.

## Why it matters

A user who types `--agent-only --slack` asked for two things and got one, with no feedback that the second was ignored. A single line at the point of the drop turns a silent no-op into an explainable one and points them at the right command.

## What changed (motivation to approach to change)

On the `--agent-only` early-return path in `_setup_impl`, when `slack=True`, print one notice explaining that `--slack` is ignored here and pointing at `kirocrew setup --slack` for the guided flow. No other behavior changes; the Slack steps still do not run under `--agent-only` (that precedence is unchanged), the user is just told why.

## Tests

Two cases added to `TestSetupChannelGating` in `test/test_cli.py`:

- `--agent-only --slack` prints the notice and still runs no Slack steps.
- `--agent-only` alone stays silent (no false notice).

Confirmed the first test fails on the pre-fix code and passes with the change.

## Manual verification

N/A, unit coverage exercises the exact branch; the change is a single `print` on an already-tested code path.

## Related Issues

Closes #2350

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable), N/A: the `--help` text already documents the precedence
- [x] No secrets, credentials, or internal references in the diff
