### PR TITLE
feat: verify internal-API session claims via unix-socket peer creds (#302)

### DIFF
--- a/docs/system-specs/features/dashboard-token-auth.md
+++ b/docs/system-specs/features/dashboard-token-auth.md
@@ -376,6 +376,69 @@ same token-auth chain; otherwise every state-changing MCP route (`/api/spawn`,
 `/api/taskrunner`) is reachable unauthenticated on loopback (port forwarders and
 browser CSRF reach `127.0.0.1`).
 
+#### Unix-socket transport: kernel-attested `X-Session-Key` (POSIX)
+
+TCP loopback + `X-Internal-Secret` authenticates the *installation* (any
+same-uid process can read `.local_secret`), but the session identity in
+`X-Session-Key` is entirely client-declared — a same-uid process could claim
+any session's key. To close that gap, both server entrypoints additionally
+bind a `web.UnixSite` on the **same** `AppRunner` at
+`dashboard_socket_path(port)` (`~/.kiro/crew/dashboard-<port>.sock`,
+port-suffixed so multi-instance homes don't collide; see
+`server._start_unix_site`). Windows and any bind failure degrade to TCP-only
+— today's behavior — after one log line. The socket file is unlinked
+best-effort at shutdown and self-heals from stale files at startup.
+
+For an internal/mixed-internal request arriving on that socket **and carrying
+`X-Session-Key`**, `token_auth_middleware` kernel-verifies the claim before
+either auth flavor can grant (see `_verify_unix_peer`):
+
+1. `socketsec.check_peer_is_self` — anything but a positive `MATCH` (foreign
+   uid, or credentials unreadable) → deny, mirroring gatewayd's
+   deny-by-default register policy. On supported POSIX platforms an accepted
+   `AF_UNIX` connection always yields peer credentials, so `UNVERIFIABLE`
+   means the attestation mechanism itself failed.
+2. `socketsec.get_peer_pid` (`SO_PEERCRED` / `LOCAL_PEERPID`) → peer pid.
+3. `peer_resolve.resolve_peer_identity(..., signed_only=True)` (the same
+   host-namespace /proc ancestry walk gatewayd uses for stub registration,
+   offloaded to the subprocess executor) → the session key of the nearest
+   ancestor whose `session_pid_<pid>.txt` **HMAC sidecar verifies**. The bare
+   `.txt` is same-uid agent-writable and MUST NOT authorize: an unsigned
+   mapping counts as unresolvable, so a planted
+   `session_pid_<own_pid>.txt` cannot mint a verified identity (the sidecar
+   is keyed by the agent-unreadable SEL trust root with the pid bound into
+   the MAC).
+4. Resolved key **differs** from the declared header → **403** + SEL
+   `dashboard.peer-identity-mismatch` (outcome=denied, peer pid recorded).
+   Resolved and equal → proceed with `request["peer_verified"] = True`.
+   Unresolvable (warm-pool runtime before claim, cron scripts, pooled MCP
+   backends — no pidfile in the ancestry; or a mapping published unsigned) →
+   proceed under today's semantics.
+
+CSRF interplay: `check_origin`'s no-Origin branch trusts the unix transport
+(`origin.request_is_unix_socket`) exactly as it trusts loopback TCP — a
+browser cannot connect to the unix socket, so the cookie-attaching
+cross-origin threat the CSRF check exists for cannot arrive on it. Without
+this, every mutating internal call on the socket would 403 at the CSRF layer
+before token auth ran.
+
+The posture is deliberately **verify-when-resolvable / deny-on-mismatch**:
+never weaker than the TCP-era check, kernel-verified whenever the gateway's
+own registry can attest the peer. Strict fail-closed denial of unresolvable
+peers is explicitly out of scope (it would break warm-pool and cron callers).
+TCP requests never engage the branch — browser cookies, Windows, and remote
+`local_only=False` deployments are untouched.
+
+Client side, `loopback_http.loopback_urlopen` accepts a `unix_socket_path`
+and `mcp_core` prefers the socket for every `_API` request when the file
+exists (`_api_urlopen`), falling back to TCP **only** when nothing answered
+at connect time (`FileNotFoundError` / `ConnectionRefusedError` — cases that
+provably never delivered the request, so the retry cannot double-send). HTTP
+error statuses and read timeouts propagate unchanged, keeping every caller's
+error shape identical. The Playwright proxy stays on TCP: it sends no
+session-mutating claims and deliberately avoids the config import the socket
+path requires.
+
 ### 6. `gateway.py` Integration
 
 `_init_dashboard()` resolves config and passes to `start_dashboard()`:

--- a/src/kiro_crew/dashboard/origin.py
+++ b/src/kiro_crew/dashboard/origin.py
@@ -45,6 +45,7 @@ from kiro_crew.dashboard.urls import (  # noqa: F401
     build_allowed_origins,
     build_dashboard_url,
     dashboard_origin,
+    dashboard_socket_path,
     devspaces_proxy_url,
     format_dashboard_urls,
     is_local_only,
@@ -184,6 +185,35 @@ def is_https_request(request: web.Request) -> bool:
 # ---------------------------------------------------------------------------
 
 
+# ``socket.AF_UNIX`` does not exist on Windows CPython; resolved once so the
+# per-request discriminator below can never raise AttributeError there.
+_AF_UNIX = getattr(socket, "AF_UNIX", None)
+
+
+def request_is_unix_socket(request: web.Request) -> bool:
+    """True iff *request* arrived on an ``AF_UNIX`` transport.
+
+    Requests on the dashboard's unix socket (``server._start_unix_site``) have
+    no loopback peer IP (``request.remote`` is empty), yet are same-machine by
+    a strictly STRONGER guarantee than loopback TCP: connecting requires
+    traversing the 0700 data home, and the kernel reports the peer's
+    credentials (consumed by ``token_auth``'s peer verification). Used by the
+    no-Origin CSRF branch and the token-auth internal branch as the
+    loopback-equivalent discriminator. Never raises — returns ``False`` for
+    TCP requests, mocked/absent transports, and platforms without AF_UNIX.
+    """
+    if _AF_UNIX is None:
+        return False
+    transport = getattr(request, "transport", None)
+    if transport is None:
+        return False
+    try:
+        sock = transport.get_extra_info("socket")
+    except Exception:
+        return False
+    return sock is not None and getattr(sock, "family", None) == _AF_UNIX
+
+
 def check_origin(
     request: web.Request,
     *,
@@ -202,8 +232,12 @@ def check_origin(
     if not origin and fallback_header:
         origin = request.headers.get(fallback_header, "")
     if not origin:
-        # No Origin header: trust loopback (local processes), reject others
-        if is_loopback(request.remote or ""):
+        # No Origin header: trust loopback and the dashboard's own unix
+        # socket (local processes like mcp-core and doctor send no Origin;
+        # a browser cannot connect to the unix socket at all, so the CSRF
+        # threat model — cookie-attaching cross-origin pages — does not
+        # exist on that transport). Reject others.
+        if is_loopback(request.remote or "") or request_is_unix_socket(request):
             return True
         return not require
     origin_base = "/".join(origin.split("/")[:3]) if "://" in origin else ""

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -8,6 +8,7 @@ import faulthandler
 import importlib
 import logging
 import os
+import stat
 import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -148,6 +149,7 @@ from kiro_crew.dashboard.origin import (
     build_allowed_origins,
     check_host,
     check_origin,
+    dashboard_socket_path,
     resolve_dashboard_host,
     should_canonicalize_host,
 )
@@ -173,6 +175,7 @@ from kiro_crew.executors import subprocess_executor
 from kiro_crew.hooks import ScriptHookStore, set_global_hook_store
 from kiro_crew.instances.registry import InstancesRegistry
 from kiro_crew.instances.ssh_tunnel_manager import SshTunnelManager, TunnelState
+from kiro_crew.mcp_gateway.socketsec import chmod_socket_0600
 from kiro_crew.metrics.http_metrics import (
     make_route_latency_middleware,
     record_boot_to_ready,
@@ -1228,6 +1231,95 @@ async def _start_site(
         retries * delay,
     )
     raise SystemExit(1) from last_exc
+
+
+def _remove_stale_unix_socket(path: Path) -> None:
+    """Best-effort unlink of a leftover unix-socket file before rebind.
+
+    Only a socket inode is removed — anything else at the path is left in
+    place (and the subsequent bind fails, degrading to TCP-only). Safe against
+    a live sibling instance: the socket name is port-suffixed and the TCP port
+    bind (a singleton per port) has already succeeded by the time this runs,
+    so an existing file with our port's name can only be stale.
+    """
+    try:
+        st = os.stat(path)
+    except OSError:
+        return
+    if not stat.S_ISSOCK(st.st_mode):
+        logger.warning(
+            "path %s exists and is not a socket (mode=%o); leaving in place", path, st.st_mode
+        )
+        return
+    try:
+        path.unlink()
+    except OSError as exc:
+        logger.warning("could not remove stale dashboard socket %s: %s", path, exc)
+
+
+async def _start_unix_site(runner: web.AppRunner, port: int) -> Path | None:
+    """Additionally serve the internal API on a unix socket (POSIX only).
+
+    Binds ``dashboard_socket_path(port)`` on the same :class:`web.AppRunner`
+    as the TCP site, so both transports serve the identical app + middleware
+    chain. The unix transport exists so ``token_auth_middleware`` can
+    kernel-verify (``SO_PEERCRED`` + /proc ancestry) the session identity an
+    internal caller declares in ``X-Session-Key`` — TCP loopback carries no
+    peer credentials.
+
+    Strictly additive: skipped entirely on Windows, and ANY failure (bind
+    error, permission problem) logs once and degrades to TCP-only, which is
+    exactly today's behavior. The socket file inherits the data home's 0700
+    directory gate (created here if missing) and is itself tightened to 0600,
+    mirroring ``mcp_gateway/transport`` conventions. Returns the bound path,
+    or ``None`` when the transport is unavailable.
+    """
+    if platform_compat.IS_WINDOWS:
+        return None
+    try:
+        path = dashboard_socket_path(port)
+        # Offloaded: directory creation, the stale-socket stat/unlink, and the
+        # post-bind chmod are blocking fs I/O (no-blocking-call-on-event-loop).
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            subprocess_executor(), platform_compat.make_owner_only_dir, path.parent
+        )
+        await loop.run_in_executor(subprocess_executor(), _remove_stale_unix_socket, path)
+        unix_site = web.UnixSite(runner, str(path))
+        await unix_site.start()
+        await loop.run_in_executor(subprocess_executor(), chmod_socket_0600, path)
+        logger.info("dashboard internal API also listening on unix socket %s", path)
+        return path
+    except Exception as exc:
+        logger.warning(
+            "dashboard unix socket unavailable (%s); internal API stays TCP-only", exc
+        )
+        return None
+
+
+def _register_unix_socket_cleanup(app: web.Application, holder: dict[str, Path | None]) -> None:
+    """Register best-effort removal of the unix socket file at shutdown.
+
+    Registered BEFORE ``runner.setup()`` freezes the app's signal lists; the
+    socket path only becomes known after the site starts, so it is read from
+    *holder* lazily. aiohttp does not unlink a ``UnixSite``'s socket file on
+    stop, and while startup self-heals a stale file, a clean shutdown should
+    not leave one for clients to trip over (each stale connect costs the
+    client a refused-connect before its TCP fallback).
+    """
+
+    async def _unlink_unix_socket(app_: web.Application) -> None:
+        path = holder.get("path")
+        if path is None:
+            return
+        try:
+            await asyncio.get_running_loop().run_in_executor(
+                subprocess_executor(), _remove_stale_unix_socket, path
+            )
+        except Exception:  # pragma: no cover — cleanup must never break shutdown
+            logger.debug("dashboard unix socket cleanup failed", exc_info=True)
+
+    app.on_cleanup.append(_unlink_unix_socket)
 
 
 def _write_secret_file(secret_path: Path, secret: str) -> None:
@@ -3167,6 +3259,12 @@ async def start_dashboard(
     # ``_register_instances_hooks`` for why ordering matters.
     _register_instances_hooks(app, state, port)
 
+    # Unix-socket cleanup hook — registered before runner.setup freezes the
+    # signal lists; the path itself only becomes known after the site starts
+    # (below), hence the holder indirection.
+    _unix_socket_holder: dict[str, Path | None] = {"path": None}
+    _register_unix_socket_cleanup(app, _unix_socket_holder)
+
     # Hardened runner: bounds the request-line/header read time (slowloris /
     # CWE-400) and reaps idle keep-alive connections. See dashboard.slowloris.
     # max_field_size is raised from aiohttp's 8190 default so the accumulated
@@ -3176,6 +3274,9 @@ async def start_dashboard(
     await runner.setup()
     site = web.TCPSite(runner, bind_address_for(local_only), port)
     await _start_site(site, port)
+    # Additional kernel-verifiable transport for the internal API (POSIX only;
+    # degrades to TCP-only on any failure — see _start_unix_site).
+    _unix_socket_holder["path"] = await _start_unix_site(runner, port)
 
     # Port bind succeeded — now safe to write the secret file. Offloaded:
     # _write_secret_file does blocking fs I/O (os.open/os.close and, on Windows,
@@ -3714,6 +3815,11 @@ async def start_api_server(
     # Slack task, identically to the full dashboard.
     _register_prevent_sleep_shutdown(app, state)
 
+    # Unix-socket cleanup hook — same holder pattern as start_dashboard,
+    # registered before runner.setup freezes the signal lists.
+    _unix_socket_holder: dict[str, Path | None] = {"path": None}
+    _register_unix_socket_cleanup(app, _unix_socket_holder)
+
     # Hardened runner: same slowloris / CWE-400 mitigation as start_dashboard,
     # plus the raised max_field_size (see start_dashboard for the cookie-jar
     # rationale).
@@ -3727,6 +3833,9 @@ async def start_api_server(
     bind_addr = bind_address_for(local_only)
     site = web.TCPSite(runner, bind_addr, port)
     await _start_site(site, port)
+    # Additional kernel-verifiable transport for the internal API (parity with
+    # start_dashboard; POSIX only, degrades to TCP-only on any failure).
+    _unix_socket_holder["path"] = await _start_unix_site(runner, port)
 
     # Port bind succeeded — now safe to persist the secret file (parity with
     # start_dashboard: write deferred so a failed bind can't poison it).

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -18,6 +18,7 @@ import threading
 import time
 from collections import OrderedDict
 from collections.abc import Callable, Iterable
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +29,7 @@ from kiro_crew.dashboard.origin import (
     is_https_request,
     is_loopback,
     is_proxied_request,
+    request_is_unix_socket,
 )
 from kiro_crew.dashboard.refresh_tokens import (
     MAX_REFRESH_TTL_SECS,
@@ -51,6 +53,9 @@ from kiro_crew.dashboard.token_secret import (  # noqa: F401  # re-exports
     _get_secret,
     _load_or_create_secret,
 )
+from kiro_crew.executors import subprocess_executor
+from kiro_crew.mcp_gateway.socketsec import PeerCredResult, check_peer_is_self, get_peer_pid
+from kiro_crew.peer_resolve import resolve_peer_identity
 from kiro_crew.sel import sel as _sel_fn
 
 logger = logging.getLogger(__name__)
@@ -1271,6 +1276,126 @@ async def warm_auth_singletons() -> None:
     await asyncio.to_thread(_get_revoked_store)
 
 
+def _unix_request_socket(request: web.Request) -> Any:
+    """Return the request's underlying socket iff it is ``AF_UNIX``.
+
+    Thin socket-returning wrapper over the shared
+    :func:`~kiro_crew.dashboard.origin.request_is_unix_socket` discriminator
+    (one definition of "arrived on the dashboard's unix socket" for the CSRF
+    and token-auth layers). The peer-verification branch needs the SOCKET (to
+    read kernel peer credentials), not just the boolean. Returns ``None`` for
+    TCP requests, mocked/absent transports, platforms without ``AF_UNIX``,
+    and any error — never raises.
+    """
+    if not request_is_unix_socket(request):
+        return None
+    transport = getattr(request, "transport", None)
+    if transport is None:  # pragma: no cover — excluded by the check above
+        return None
+    try:
+        return transport.get_extra_info("socket")
+    except Exception:
+        return None
+
+
+async def _verify_unix_peer(
+    request: web.Request, sock: Any, path: str
+) -> web.StreamResponse | None:
+    """Kernel-verify the declared ``X-Session-Key`` of an AF_UNIX peer.
+
+    Verify-when-resolvable, deny-on-mismatch, degrade-to-status-quo when
+    unresolvable — strictly monotonic hardening over the TCP-era behavior
+    (where the header was accepted entirely on the caller's word):
+
+    * peer uid positively ≠ ours (``MISMATCH``) → deny. Cannot normally
+      happen (the socket sits in the 0700 data home), so a hit means the
+      directory gate failed — exactly when denying matters most.
+    * peer resolved to a session key that DIFFERS from the declared header →
+      deny 403 + SEL ``dashboard.peer-identity-mismatch`` (the impersonation
+      this check exists to close: a same-uid process declaring another
+      session's identity).
+    * peer resolved to the SAME key → proceed with
+      ``request["peer_verified"] = True``.
+    * anything unresolvable (no peer pid mechanism, no ``session_pid_<pid>``
+      file in the ancestry — warm-pool runtimes before claim, cron scripts,
+      pooled MCP backends) → proceed under today's semantics: no new denial.
+
+    Returns a deny response, or ``None`` to proceed. The /proc ancestry walk
+    is blocking I/O and runs on the subprocess executor (mirroring gatewayd's
+    register-path offload).
+    """
+    declared = request.headers.get("X-Session-Key", "")
+    if not declared:
+        # Nothing session-scoped is being claimed — nothing to verify.
+        return None
+    verdict = check_peer_is_self(sock)
+    if verdict is not PeerCredResult.MATCH:
+        # Deny-by-default, mirroring gatewayd's register-path policy: a peer
+        # whose principal cannot be POSITIVELY confirmed as ours is refused.
+        # On the supported POSIX platforms (Linux SO_PEERCRED, macOS
+        # LOCAL_PEERCRED) an accepted AF_UNIX connection always yields peer
+        # credentials, so UNVERIFIABLE here means the mechanism itself failed
+        # — exactly when trusting the claim is least justified. TCP callers
+        # are unaffected (this branch is AF_UNIX-only) and the client falls
+        # back to TCP transparently if the socket ever refuses connects.
+        _reason = (
+            "unix peer uid differs from server uid"
+            if verdict is PeerCredResult.MISMATCH
+            else "unix peer credentials unverifiable"
+        )
+        _sel_fn().log_api_access(
+            caller="unknown",
+            operation="dashboard.peer-identity-mismatch",
+            outcome="denied",
+            source="token_auth",
+            resources=path,
+            error=_reason,
+        )
+        _log_auth(request, "internal", "denied", _reason)
+        return _deny(request, "Forbidden")
+    peer_pid = get_peer_pid(sock)
+    if peer_pid is None:
+        return None
+    try:
+        # signed_only: authorization decisions must not trust the bare
+        # same-uid-writable .txt mapping — require the HMAC sidecar (pid
+        # bound into the MAC, keyed by the agent-unreadable SEL trust root),
+        # or the walk yields "" and this check degrades to status quo.
+        peer_key, _chain = await asyncio.get_running_loop().run_in_executor(
+            subprocess_executor(),
+            partial(resolve_peer_identity, peer_pid, signed_only=True),
+        )
+    except Exception:
+        # Resolution machinery failing is an "unresolvable" outcome, not a
+        # denial — the change must never be weaker OR stricter than intended.
+        logger.debug("unix peer identity resolution failed", exc_info=True)
+        return None
+    if not peer_key:
+        return None
+    if peer_key != declared:
+        _sel_fn().log_api_access(
+            caller=declared,
+            operation="dashboard.peer-identity-mismatch",
+            outcome="denied",
+            source="token_auth",
+            resources=path,
+            error=f"peer_pid={peer_pid} resolved session differs from declared X-Session-Key",
+        )
+        _log_auth(
+            request,
+            "internal",
+            "denied",
+            f"peer identity mismatch (peer_pid={peer_pid})",
+        )
+        return _deny(request, "Forbidden")
+    # Positive kernel attestation. Debug-level on purpose — this fires on
+    # every internal call from a claimed session; the SEL trail records the
+    # deny arm, which is the permission decision that changes anything.
+    logger.debug("unix peer identity verified for %s (peer_pid=%d)", path, peer_pid)
+    request["peer_verified"] = True
+    return None
+
+
 def token_auth_middleware(
     *,
     internal_paths: frozenset[str] = frozenset(),
@@ -1344,7 +1469,24 @@ def token_auth_middleware(
             _matches_mixed = True
             _matches_strict = False
         _matches_internal = _matches_strict or _matches_mixed
-        if _matches_internal and is_loopback(request.remote or ""):
+        # A request on the dashboard's unix socket is same-machine by
+        # construction (the socket lives in the 0700 data home), so it
+        # qualifies as "local" for the internal branch even though it has no
+        # loopback peer IP (request.remote is empty for AF_UNIX transports).
+        _unix_sock = _unix_request_socket(request) if _matches_internal else None
+        if _matches_internal and (
+            _unix_sock is not None or is_loopback(request.remote or "")
+        ):
+            # Kernel-attested peer verification (AF_UNIX only): deny a caller
+            # whose /proc ancestry resolves to a DIFFERENT session than the
+            # one its X-Session-Key header declares. Runs before either auth
+            # flavor grants — a mismatched peer is denied no matter what
+            # credentials it carries. TCP loopback is untouched (no peer
+            # credentials to check).
+            if _unix_sock is not None:
+                _peer_deny = await _verify_unix_peer(request, _unix_sock, path)
+                if _peer_deny is not None:
+                    return _peer_deny
             _has_secret_header = "X-Internal-Secret" in request.headers
             if _has_secret_header:
                 _provided_secret = request.headers["X-Internal-Secret"]

--- a/src/kiro_crew/dashboard/urls.py
+++ b/src/kiro_crew/dashboard/urls.py
@@ -20,6 +20,7 @@ import ipaddress
 import logging
 import os
 import socket
+from pathlib import Path
 from urllib.parse import parse_qs, quote, urlparse
 
 logger = logging.getLogger(__name__)
@@ -61,6 +62,27 @@ def is_loopback(host: str) -> bool:
         return ipaddress.ip_address(host).is_loopback
     except ValueError:
         return False
+
+
+def dashboard_socket_path(port: int) -> Path:
+    """Path of the dashboard internal-API unix socket for *port*.
+
+    Both the server (``dashboard/server`` binds a ``web.UnixSite`` here) and
+    the client (``mcp_core`` prefers this transport when the file exists) must
+    agree on the path, so it is computed in exactly one place. The name is
+    port-suffixed because the data home can be shared by multiple gateway
+    instances on different ports (the instances feature): each instance binds
+    its own socket, and a client resolving its port from ``dashboard.url``
+    reaches the same logical endpoint it would have reached over TCP.
+
+    The ``config`` import is deliberately lazy: this module is a stdlib-only
+    leaf on the hot CLI / MCP-stdio import path (see the module docstring),
+    and only callers that actually use the unix transport should pay for
+    config resolution.
+    """
+    from kiro_crew.config.loader import config_dir
+
+    return config_dir() / f"dashboard-{int(port)}.sock"
 
 
 # ---------------------------------------------------------------------------

--- a/src/kiro_crew/loopback_http.py
+++ b/src/kiro_crew/loopback_http.py
@@ -23,15 +23,20 @@ Redirects are refused for the same reason the external bearer-token path in
 ``dashboard/handlers/kiro_usage_api.py`` refuses them -- a 3xx from the gateway
 would replay the secret to whatever host ``Location`` names.
 
-This module is a **stdlib-only leaf** and must stay one: it imports
-``urllib.request`` and nothing else. That is what lets the cheapest callers use
-it -- ``cron_trigger`` imports nothing from ``kiro_crew`` at all, and the MCP
-stdio proxies deliberately avoid importing the gateway, since reaching
-``parse_dashboard_url`` through ``dashboard.origin`` costs ~605 ms and 1124
-modules (see the ``dashboard/urls.py`` docstring). Adding an import here that
-pulls aiohttp in behind it would defeat the point.
+This module is a **stdlib-only leaf** and must stay one: it imports only
+standard-library modules (``urllib.request``, ``http.client``, ``os``,
+``socket``) and nothing from ``kiro_crew``. That is what lets the cheapest
+callers use it -- ``cron_trigger`` imports nothing from ``kiro_crew`` at all,
+and the MCP stdio proxies deliberately avoid importing the gateway, since
+reaching ``parse_dashboard_url`` through ``dashboard.origin`` costs ~605 ms and
+1124 modules (see the ``dashboard/urls.py`` docstring). Adding an import here
+that pulls aiohttp in behind it would defeat the point.
 """
 
+import http.client
+import os
+import socket
+import urllib.error
 import urllib.request
 
 __all__ = ["build_loopback_opener", "loopback_urlopen"]
@@ -61,7 +66,64 @@ def build_loopback_opener() -> urllib.request.OpenerDirector:
     return urllib.request.build_opener(urllib.request.ProxyHandler({}), _NoRedirect())
 
 
-def loopback_urlopen(req: urllib.request.Request | str, timeout: float):
+class _UnixHTTPConnection(http.client.HTTPConnection):
+    """``HTTPConnection`` whose transport is an ``AF_UNIX`` stream socket.
+
+    The ``host`` from the request URL is kept (so the ``Host`` header the
+    gateway's host-validation middleware sees is identical to the TCP path);
+    only ``connect()`` is rerouted onto the unix socket.
+    """
+
+    def __init__(self, socket_path: str, host: str, timeout=None) -> None:
+        if timeout is None:
+            super().__init__(host)
+        else:
+            super().__init__(host, timeout=timeout)
+        self._socket_path = socket_path
+
+    def connect(self) -> None:  # noqa: D102 -- contract inherited
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        if self.timeout is not None:
+            sock.settimeout(self.timeout)
+        try:
+            sock.connect(self._socket_path)
+        except OSError:
+            sock.close()
+            raise
+        self.sock = sock
+
+
+class _UnixHTTPHandler(urllib.request.HTTPHandler):
+    """Route ``http://`` requests over a fixed ``AF_UNIX`` socket path.
+
+    Subclasses ``HTTPHandler`` so ``build_opener`` displaces the default TCP
+    handler (same displacement rule ``build_loopback_opener`` documents).
+    """
+
+    def __init__(self, socket_path: str) -> None:
+        super().__init__()
+        self._socket_path = socket_path
+
+    def http_open(self, req):  # noqa: D102 -- contract inherited
+        def _factory(host, timeout=None, **_kwargs):
+            return _UnixHTTPConnection(self._socket_path, host, timeout=timeout)
+
+        return self.do_open(_factory, req)
+
+
+def _build_unix_opener(socket_path: str) -> urllib.request.OpenerDirector:
+    """Opener twin of :func:`build_loopback_opener` bound to a unix socket."""
+    return urllib.request.build_opener(
+        urllib.request.ProxyHandler({}), _NoRedirect(), _UnixHTTPHandler(socket_path)
+    )
+
+
+def loopback_urlopen(
+    req: urllib.request.Request | str,
+    timeout: float,
+    *,
+    unix_socket_path: "str | os.PathLike[str] | None" = None,
+):
     """Open ``req`` against the local gateway, ignoring any configured proxy.
 
     Drop-in for ``urllib.request.urlopen`` at loopback call sites, with one
@@ -69,6 +131,17 @@ def loopback_urlopen(req: urllib.request.Request | str, timeout: float):
     gateway that can hang forever is never what a call site wants, and making
     it explicit costs nothing -- every existing loopback site already passes
     one.
+
+    When *unix_socket_path* is given and the file exists, the request is sent
+    over that ``AF_UNIX`` socket instead of TCP (the URL -- and therefore the
+    ``Host`` header -- is unchanged). This lets the gateway kernel-verify the
+    caller's identity via ``SO_PEERCRED``; see ``dashboard/token_auth``. The
+    TCP fallback triggers ONLY when nobody answers on the socket at connect
+    time (``FileNotFoundError`` / ``ConnectionRefusedError``, i.e. a stale
+    file left by a dead gateway): those cases provably never delivered the
+    request, so retrying over TCP cannot double-send. Any later failure --
+    an HTTP error status, a read timeout, a reset mid-response -- propagates
+    exactly as it would on TCP, keeping every caller's error shape unchanged.
 
     The opener is rebuilt per call rather than cached at module scope. Both
     handlers are stateless, so a cache would be safe for the FIXED code -- but
@@ -83,4 +156,19 @@ def loopback_urlopen(req: urllib.request.Request | str, timeout: float):
     default opener, because they genuinely need the corporate proxy to leave
     the host.
     """
+    if unix_socket_path is not None and hasattr(socket, "AF_UNIX"):
+        sock_path = os.fspath(unix_socket_path)
+        if os.path.exists(sock_path):
+            try:
+                return _build_unix_opener(sock_path).open(req, timeout=timeout)
+            except urllib.error.HTTPError:
+                # The gateway answered (4xx/5xx) -- a real response, never a
+                # transport failure. HTTPError subclasses URLError, so this
+                # re-raise must precede the URLError arm below.
+                raise
+            except urllib.error.URLError as exc:
+                if not isinstance(exc.reason, (FileNotFoundError, ConnectionRefusedError)):
+                    raise
+                # Stale socket file (gateway died / restarted TCP-only):
+                # connect never delivered anything, so TCP retry is safe.
     return build_loopback_opener().open(req, timeout=timeout)

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -48,7 +48,7 @@ from kiro_crew.config.loader import (
     resolve_agent_bindings,
 )
 from kiro_crew.context_management import COMPLETION_KEEP_DEFAULT_CHARS, summarize_result
-from kiro_crew.dashboard.origin import parse_dashboard_url
+from kiro_crew.dashboard.origin import dashboard_socket_path, parse_dashboard_url
 from kiro_crew.history import _SEARCH_SCAN_WINDOW as SEARCH_SCAN_WINDOW
 from kiro_crew.history import INCOGNITO_MEMORY_MODES, ConversationLog
 from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes
@@ -145,6 +145,34 @@ def _resolve_api_base() -> str:
 
 
 _API = _resolve_api_base()
+
+
+def _resolve_api_unix_socket() -> str:
+    """Path of the gateway's internal-API unix socket (may not exist yet).
+
+    Preferred transport for every ``_API`` request: connecting through it lets
+    the gateway kernel-verify (``SO_PEERCRED`` + /proc ancestry) that this
+    process actually belongs to the session its ``X-Session-Key`` header
+    declares, instead of taking the header on faith. ``loopback_urlopen``
+    checks existence per call and falls back to TCP when the file is absent
+    (Windows, older gateway, bind failure) or nobody answers on it, so
+    resolving the path once at import — mirroring ``_API`` — is safe.
+    """
+    try:
+        cfg = KiroCrewConfig.load()
+        _host, port = parse_dashboard_url(cfg.dashboard.url)
+        return str(dashboard_socket_path(port))
+    except Exception:
+        return ""
+
+
+_API_UNIX_SOCKET = _resolve_api_unix_socket()
+
+
+def _api_urlopen(req: urllib.request.Request | str, timeout: float):
+    """``loopback_urlopen`` against ``_API`` with the unix-socket preference."""
+    return loopback_urlopen(req, timeout=timeout, unix_socket_path=_API_UNIX_SOCKET or None)
+
 
 # How often a sleeping `wait` polls /api/session-keepalive.
 #
@@ -2969,7 +2997,7 @@ def _post(path: str, body: dict | None = None, *, timeout: float = 30) -> dict:
     )
     try:
         # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected -- URL is the loopback gateway (_API from dashboard.url config) + a fixed internal path; never user-controlled  # noqa: E501
-        with loopback_urlopen(req, timeout=timeout) as resp:
+        with _api_urlopen(req, timeout=timeout) as resp:
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:
         # urlopen raises HTTPError on 4xx/5xx; str(e) is only "HTTP Error 400:
@@ -3044,7 +3072,7 @@ def _get(path: str) -> dict:
         headers=headers,
     )
     try:
-        with loopback_urlopen(req, timeout=10) as resp:
+        with _api_urlopen(req, timeout=10) as resp:
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:
         return _http_error_body(e)
@@ -3070,7 +3098,7 @@ def _patch(path: str, body: dict | None = None) -> dict:
     try:
         # _API is the hardcoded loopback dashboard base and `path` is a code
         # literal — never attacker-controlled, so no file:// scheme risk.
-        with loopback_urlopen(req, timeout=30) as resp:  # nosemgrep  # noqa: E501
+        with _api_urlopen(req, timeout=30) as resp:  # nosemgrep  # noqa: E501
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:
         return _http_error_body(e)
@@ -3102,7 +3130,7 @@ def _put(path: str, body: dict | None = None) -> dict:
     try:
         # _API is the hardcoded loopback dashboard base and `path` is a code
         # literal — never attacker-controlled, so no file:// scheme risk.
-        with loopback_urlopen(req, timeout=30) as resp:  # nosemgrep  # noqa: E501
+        with _api_urlopen(req, timeout=30) as resp:  # nosemgrep  # noqa: E501
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:
         return _http_error_body(e)
@@ -3128,7 +3156,7 @@ def _delete(path: str, body: dict | None = None) -> dict:
         method="DELETE",
     )
     try:
-        with loopback_urlopen(req, timeout=10) as resp:
+        with _api_urlopen(req, timeout=10) as resp:
             return json.loads(resp.read())
     except urllib.error.HTTPError as e:
         return _http_error_body(e)
@@ -5265,7 +5293,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             f"{_API}/api/artifacts/{slug}", data=data, headers=headers, method="PATCH"
         )
         try:
-            with loopback_urlopen(req, timeout=30) as http_resp:
+            with _api_urlopen(req, timeout=30) as http_resp:
                 d = json.loads(http_resp.read())
         except urllib.error.HTTPError as exc:
             try:
@@ -5327,7 +5355,7 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             f"{_API}/api/artifacts/{slug}", data=data, headers=headers, method="PATCH"
         )
         try:
-            with loopback_urlopen(req, timeout=30) as http_resp:
+            with _api_urlopen(req, timeout=30) as http_resp:
                 d = json.loads(http_resp.read())
         except urllib.error.HTTPError as exc:
             try:

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -74,9 +74,9 @@ from kiro_crew.mcp_gateway.rewriter import (
 from kiro_crew.mcp_gateway.shutdown_budget import DRAIN_SECS, POOL_SHUTDOWN_SECS
 from kiro_crew.mcp_gateway.spill import cleanup_old_spill_files
 from kiro_crew.metrics.provider import get_recorder
+from kiro_crew.peer_resolve import resolve_peer_identity
 from kiro_crew.sandbox import warm_backend
 from kiro_crew.sel import SecurityEventLog
-from kiro_crew.session_pid_sig import read_session_pid_txt
 
 logger = logging.getLogger(__name__)
 
@@ -1419,51 +1419,19 @@ def _audit_caller_claimed(
 def _resolve_peer_identity(peer_pid: int) -> tuple[str, list[int]]:
     """Walk the peer's real-PID ancestry (server-side): session key + host chain.
 
-    Runs in gatewayd's own PID namespace (real pids), so it works regardless
-    of how the stub sees the world. A single /proc walk returns both:
-
-    * the session_key from the first ancestor with a ``session_pid_<pid>.txt``
-      file (``""`` when none matches — normal at register time for a runtime
-      that has not been claimed yet), and
-    * the full HOST ancestor PID chain (peer first). The register handler
-      indexes the stub connection under this chain so a later ``claim`` frame
-      — which always carries the runtime's HOST pid — matches even when the
-      stub's self-reported ``ancestor_pids`` are namespace-local (sandbox
-      PID-namespace topology). Without the host chain in ``_CONN_INDEX`` the
-      claim-push silently updates zero connections and the stub stays
-      identity-less for life: orphan subagents with empty ``parent_session``
-      and undeliverable completion events.
-
-    The walk continues past a session-key match so the chain is complete for
-    claim matching at any ancestry level.
+    Delegates to the shared :func:`kiro_crew.peer_resolve.resolve_peer_identity`
+    walk (also consumed by the dashboard's unix-socket peer verification) with
+    gatewayd's module-level ``_config_dir`` / ``_ppid_fn`` seams, which tests
+    monkeypatch. The register handler indexes the stub connection under the
+    returned host chain so a later ``claim`` frame — which always carries the
+    runtime's HOST pid — matches even when the stub's self-reported
+    ``ancestor_pids`` are namespace-local (sandbox PID-namespace topology).
+    Without the host chain in ``_CONN_INDEX`` the claim-push silently updates
+    zero connections and the stub stays identity-less for life: orphan
+    subagents with empty ``parent_session`` and undeliverable completion
+    events.
     """
-    session_key = ""
-    chain: list[int] = []
-    try:
-        cfg_dir = _config_dir()
-    except Exception:
-        return "", []
-
-    pid = peer_pid
-    seen: set[int] = set()
-    while pid > 1 and pid not in seen:
-        seen.add(pid)
-        chain.append(pid)
-        if not session_key:
-            # Hardened read (symlink refusal, regular-file check, size
-            # bound) — gatewayd is a trusted process reading a predictable,
-            # agent-writable path, the exact symlink-planting surface
-            # session_pid_sig's reader exists to close.
-            try:
-                session_key = read_session_pid_txt(pid, cfg_dir)
-            except OSError:
-                pass
-        try:
-            pid = _ppid_fn(pid)
-        except (OSError, ValueError):
-            # Target exited mid-walk (/proc/<pid>/stat gone or malformed).
-            break
-    return session_key, chain
+    return resolve_peer_identity(peer_pid, config_dir_fn=_config_dir, ppid_fn=_ppid_fn)
 
 
 def _audit_peer_identity_resolved(caller: str, peer_pid: int, stub_uuid: str) -> None:

--- a/src/kiro_crew/peer_resolve.py
+++ b/src/kiro_crew/peer_resolve.py
@@ -1,0 +1,113 @@
+"""Kernel-attested peer identity resolution shared by gatewayd and the dashboard.
+
+A local peer that connected over an ``AF_UNIX`` socket has a kernel-reported
+PID (``SO_PEERCRED`` on Linux, ``LOCAL_PEERPID`` on macOS — see
+:mod:`kiro_crew.mcp_gateway.socketsec`). Walking that PID's */proc* ancestry
+and looking for the gateway-published ``session_pid_<pid>.txt`` mapping yields
+a session identity the CALLER cannot forge: the pidfile is written by the
+gateway on session claim, and the walk runs in the SERVER's PID namespace, so
+a same-uid process cannot substitute an attacker-chosen ancestry the way it
+can substitute an env var or an HTTP header.
+
+Two consumers share this single walk:
+
+* ``mcp_gateway.gatewayd`` resolves identities for key-less MCP stub
+  registrations (and indexes the returned host chain for claim frames).
+* ``dashboard.token_auth`` cross-checks the client-declared ``X-Session-Key``
+  header on internal-API requests arriving over the dashboard's unix socket.
+
+Both need identical semantics — one hardened read discipline, one ancestry
+walk — which is why the walk lives here rather than being duplicated.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable
+
+from kiro_crew.config.loader import config_dir as _default_config_dir
+from kiro_crew.mcp_caller import _parent_pid as _default_ppid
+from kiro_crew.session_pid_sig import read_session_pid_txt, verify_session_pid
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_peer_identity(
+    peer_pid: int,
+    *,
+    config_dir_fn: Callable[[], Path] | None = None,
+    ppid_fn: Callable[[int], int] | None = None,
+    signed_only: bool = False,
+) -> tuple[str, list[int]]:
+    """Walk the peer's real-PID ancestry (server-side): session key + host chain.
+
+    Runs in the calling server's own PID namespace (real pids), so it works
+    regardless of how the peer sees the world. A single /proc walk returns
+    both:
+
+    * the session_key from the first ancestor with a ``session_pid_<pid>.txt``
+      file (``""`` when none matches — normal for warm-pool runtimes before
+      claim, cron scripts, and pooled MCP backends), and
+    * the full HOST ancestor PID chain (peer first). gatewayd indexes stub
+      connections under this chain so a later ``claim`` frame — which always
+      carries the runtime's HOST pid — matches even when the stub's
+      self-reported ``ancestor_pids`` are namespace-local (sandbox
+      PID-namespace topology).
+
+    The walk continues past a session-key match so the chain is complete for
+    claim matching at any ancestry level.
+
+    ``config_dir_fn`` / ``ppid_fn`` are injection seams for the callers'
+    existing test surfaces; they default to the shared production
+    implementations. Reads go through :func:`~kiro_crew.session_pid_sig.
+    read_session_pid_txt` (symlink refusal, regular-file check, size bound) —
+    the caller is a trusted process reading a predictable, agent-writable
+    path, the exact symlink-planting surface that hardened reader closes.
+
+    ``signed_only=True`` additionally requires each mapping's HMAC sidecar to
+    verify (:func:`~kiro_crew.session_pid_sig.verify_session_pid`, pid bound
+    into the MAC, keyed by the agent-unreadable SEL trust root). REQUIRED for
+    any AUTHORIZATION use of the result: the bare ``.txt`` is same-uid
+    agent-writable, so an unsigned mapping proves only what a local process
+    chose to write — an attacker planting ``session_pid_<own_pid>.txt`` with
+    a victim's key would otherwise turn kernel peer attestation into a
+    self-serve identity oracle. gatewayd's stub-registration walk stays
+    lenient (``False``): there the result only ATTRIBUTES a stub for
+    claim-indexing, and warm-pool mappings may legitimately predate the SEL
+    key.
+
+    Blocking /proc + filesystem I/O — async callers MUST offload this to an
+    executor (both consumers do).
+    """
+    if config_dir_fn is None:
+        config_dir_fn = _default_config_dir
+    if ppid_fn is None:
+        ppid_fn = _default_ppid
+
+    session_key = ""
+    chain: list[int] = []
+    try:
+        cfg_dir = config_dir_fn()
+    except Exception:
+        return "", []
+
+    pid = peer_pid
+    seen: set[int] = set()
+    while pid > 1 and pid not in seen:
+        seen.add(pid)
+        chain.append(pid)
+        if not session_key:
+            try:
+                if signed_only:
+                    session_key = verify_session_pid(pid, cfg_dir)
+                else:
+                    session_key = read_session_pid_txt(pid, cfg_dir)
+            except OSError:
+                pass
+        try:
+            pid = ppid_fn(pid)
+        except (OSError, ValueError):
+            # Target exited mid-walk (/proc/<pid>/stat gone or malformed).
+            break
+    return session_key, chain

--- a/src/kiro_crew/session_pid_sig.py
+++ b/src/kiro_crew/session_pid_sig.py
@@ -282,14 +282,18 @@ def read_session_pid_txt(pid: int | str, cfg: Path | None = None) -> str:
     return txt.strip() if txt is not None else ""
 
 
-def verify_session_pid(pid: int | str) -> str:
+def verify_session_pid(pid: int | str, cfg: Path | None = None) -> str:
     """Return the session key for *pid* iff its HMAC sidecar verifies.
 
     Fails closed to ``""`` on: missing ``.txt``, missing ``.sig``, a symlink
     or non-regular file at either path (see :func:`_read_regular_nofollow`),
     missing or short SEL key, or signature mismatch. Never raises.
+
+    *cfg* overrides the mapping directory (mirrors
+    :func:`read_session_pid_txt`); defaults to :func:`config_dir`.
     """
-    cfg = config_dir()
+    if cfg is None:
+        cfg = config_dir()
     txt = _read_regular_nofollow(_txt_path(pid, cfg))
     sig_raw = _read_regular_nofollow(_sig_path(pid, cfg))
     if txt is None or sig_raw is None:

--- a/test/test_dashboard_peer_auth.py
+++ b/test/test_dashboard_peer_auth.py
@@ -1,0 +1,722 @@
+"""Tests for kernel-attested peer verification of internal-API session claims.
+
+Covers the four layers of the unix-socket peer-identity feature:
+
+* :mod:`kiro_crew.peer_resolve` — the shared /proc ancestry walk (extracted
+  from gatewayd; its original tests in ``test_mcp_gateway_claim.py`` keep
+  covering the gatewayd wrapper seams).
+* ``dashboard.token_auth`` — the middleware branch: deny-on-mismatch,
+  allow-on-match (with ``peer_verified`` set), status-quo on unresolvable,
+  and the guarantee that TCP requests never engage the branch.
+* ``dashboard.server._start_unix_site`` — POSIX-only bind with 0700 dir,
+  Windows skip, degrade-to-TCP-only on bind failure.
+* ``loopback_http`` — the stdlib unix-socket client transport and its
+  fall-back-only-when-nothing-answered semantics.
+
+The end-to-end test uses a real ``web.UnixSite`` + ``AF_UNIX`` connection so
+the kernel populates real peer credentials (Linux ``SO_PEERCRED`` / macOS
+``LOCAL_PEERPID``); pure-unit tests fake the socketsec seams instead so they
+run identically on every platform.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import urllib.error
+import urllib.request
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+
+import kiro_crew.dashboard.token_auth as ta
+from kiro_crew import platform_compat
+from kiro_crew.loopback_http import loopback_urlopen
+from kiro_crew.mcp_gateway.socketsec import PeerCredResult
+from kiro_crew.peer_resolve import resolve_peer_identity
+
+SECRET = "test-internal-secret"
+INTERNAL = frozenset({"/api/spawn"})
+
+
+# ---------------------------------------------------------------------------
+# peer_resolve — the shared ancestry walk
+# ---------------------------------------------------------------------------
+
+
+def _ppid_map(mapping: dict[int, int]):
+    def _fn(pid: int) -> int:
+        return mapping.get(pid, 0)
+
+    return _fn
+
+
+def test_resolve_peer_identity_finds_key_and_chain(tmp_path: Path) -> None:
+    (tmp_path / "session_pid_50.txt").write_text("dashboard:chat-1-abc", encoding="utf-8")
+    key, chain = resolve_peer_identity(
+        100,
+        config_dir_fn=lambda: tmp_path,
+        ppid_fn=_ppid_map({100: 50, 50: 20, 20: 1}),
+    )
+    assert key == "dashboard:chat-1-abc"
+    assert chain == [100, 50, 20]
+
+
+def test_resolve_peer_identity_no_pidfile_returns_empty_key(tmp_path: Path) -> None:
+    key, chain = resolve_peer_identity(
+        300, config_dir_fn=lambda: tmp_path, ppid_fn=_ppid_map({300: 1})
+    )
+    assert key == ""
+    assert chain == [300]
+
+
+def test_resolve_peer_identity_config_dir_error_degrades(tmp_path: Path) -> None:
+    def _boom() -> Path:
+        raise RuntimeError("boom")
+
+    assert resolve_peer_identity(999, config_dir_fn=_boom, ppid_fn=_ppid_map({})) == ("", [])
+
+
+def test_resolve_peer_identity_cycle_terminates(tmp_path: Path) -> None:
+    """A pid cycle (possible with pid reuse mid-walk) must not loop forever."""
+    key, chain = resolve_peer_identity(
+        10, config_dir_fn=lambda: tmp_path, ppid_fn=_ppid_map({10: 20, 20: 10})
+    )
+    assert key == ""
+    assert chain == [10, 20]
+
+
+def test_signed_only_refuses_forged_unsigned_mapping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """REGRESSION (review finding): the bare .txt is same-uid agent-writable,
+    so an attacker planting session_pid_<own_pid>.txt with a victim's key
+    must NOT satisfy the authorization walk — signed_only requires the HMAC
+    sidecar the attacker cannot produce."""
+    from kiro_crew import session_pid_sig as sps
+
+    monkeypatch.setattr(sps, "_load_hmac_key", lambda: b"K" * 32)
+    (tmp_path / "session_pid_50.txt").write_text("dashboard:chat-victim", encoding="utf-8")
+    key, chain = resolve_peer_identity(
+        50, config_dir_fn=lambda: tmp_path, ppid_fn=_ppid_map({50: 1}), signed_only=True
+    )
+    assert key == ""  # unsigned mapping refused
+    assert chain == [50]
+    # ...and a forged sidecar (wrong MAC) is refused too.
+    (tmp_path / "session_pid_50.sig").write_text("0" * 64, encoding="utf-8")
+    key, _ = resolve_peer_identity(
+        50, config_dir_fn=lambda: tmp_path, ppid_fn=_ppid_map({50: 1}), signed_only=True
+    )
+    assert key == ""
+
+
+def test_signed_only_accepts_gateway_signed_mapping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from kiro_crew import session_pid_sig as sps
+
+    _hmac_key = b"K" * 32
+    monkeypatch.setattr(sps, "_load_hmac_key", lambda: _hmac_key)
+    (tmp_path / "session_pid_50.txt").write_text("dashboard:chat-1", encoding="utf-8")
+    (tmp_path / "session_pid_50.sig").write_text(
+        sps._compute_sig(_hmac_key, 50, "dashboard:chat-1"), encoding="utf-8"
+    )
+    key, chain = resolve_peer_identity(
+        100,
+        config_dir_fn=lambda: tmp_path,
+        ppid_fn=_ppid_map({100: 50, 50: 1}),
+        signed_only=True,
+    )
+    assert key == "dashboard:chat-1"
+    assert chain == [100, 50]
+
+
+# ---------------------------------------------------------------------------
+# token_auth middleware — unit tests with faked socketsec seams
+# ---------------------------------------------------------------------------
+
+
+class _FakeUnixSock:
+    # getattr guard: socket.AF_UNIX does not exist on Windows CPython; module
+    # collection must still succeed there (unit tests fake the family value —
+    # the middleware compares against the same getattr-resolved constant).
+    family = getattr(socket, "AF_UNIX", None)
+
+
+def _make_request(
+    path: str = "/api/spawn",
+    headers: dict | None = None,
+    remote: str | None = None,
+    unix: bool = False,
+) -> tuple[MagicMock, dict]:
+    """Mock request + the dict backing its item assignment (``store``)."""
+    req = MagicMock(spec=web.Request)
+    req.path = path
+    req.query = {}
+    req.cookies = {}
+    req.remote = remote if remote is not None else ("" if unix else "127.0.0.1")
+    req.headers = headers or {}
+    req.method = "POST"
+    store: dict = {}
+    req.__setitem__.side_effect = store.__setitem__
+    req.__getitem__.side_effect = store.__getitem__
+    transport = MagicMock()
+    transport.get_extra_info = (
+        (lambda name: _FakeUnixSock() if name == "socket" else None)
+        if unix
+        else (lambda name: None)
+    )
+    req.transport = transport
+    return req, store
+
+
+async def _ok_handler(request: web.Request) -> web.Response:
+    return web.Response(text="ok")
+
+
+# The middleware deliberately never engages on Windows (AF_UNIX resolves to
+# None and the server binds no UnixSite), so a faked unix-transport request —
+# an impossible shape there — is treated as plain non-loopback and denied by
+# the ordinary internal-path rules. Every test that fakes a unix transport is
+# therefore POSIX-only, engagement and pass-through alike.
+_posix_only = pytest.mark.skipif(
+    platform_compat.IS_WINDOWS, reason="AF_UNIX transport is POSIX-only"
+)
+
+
+def _wire_peer(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    verdict: PeerCredResult = PeerCredResult.MATCH,
+    peer_pid: int | None = 4242,
+    resolved: str = "",
+) -> list[dict]:
+    """Fake socketsec + resolver seams; return the captured SEL calls."""
+    calls: list[dict] = []
+
+    class _FakeSel:
+        def log_api_access(self, **kw):
+            calls.append(kw)
+
+    monkeypatch.setattr(ta, "_sel_fn", lambda: _FakeSel())
+    monkeypatch.setattr(ta, "check_peer_is_self", lambda sock: verdict)
+    monkeypatch.setattr(ta, "get_peer_pid", lambda sock: peer_pid)
+    monkeypatch.setattr(ta, "resolve_peer_identity", lambda pid, **kw: (resolved, [pid]))
+    return calls
+
+
+@_posix_only
+@pytest.mark.asyncio
+async def test_unix_peer_match_allowed_and_marked(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire_peer(monkeypatch, resolved="dashboard:chat-1-abc")
+    mw = ta.token_auth_middleware(internal_paths=INTERNAL, internal_secret=SECRET)
+    req, store = _make_request(
+        headers={"X-Internal-Secret": SECRET, "X-Session-Key": "dashboard:chat-1-abc"},
+        unix=True,
+    )
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 200
+    assert store.get("peer_verified") is True
+
+
+@_posix_only
+@pytest.mark.asyncio
+async def test_unix_peer_mismatch_denied_with_sel(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _wire_peer(monkeypatch, resolved="dashboard:chat-1-abc")
+    mw = ta.token_auth_middleware(internal_paths=INTERNAL, internal_secret=SECRET)
+    req, store = _make_request(
+        headers={"X-Internal-Secret": SECRET, "X-Session-Key": "dashboard:chat-9-EVIL"},
+        unix=True,
+    )
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 403
+    mismatches = [c for c in calls if c.get("operation") == "dashboard.peer-identity-mismatch"]
+    assert len(mismatches) == 1
+    assert mismatches[0]["outcome"] == "denied"
+    assert "peer_pid=4242" in mismatches[0]["error"]
+
+
+@_posix_only
+@pytest.mark.asyncio
+async def test_unix_peer_mismatch_denied_even_with_wrong_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The peer check runs before either auth flavor — impersonation is denied
+    regardless of what credentials the caller carries."""
+    _wire_peer(monkeypatch, resolved="dashboard:chat-1-abc")
+    mw = ta.token_auth_middleware(internal_paths=INTERNAL, internal_secret=SECRET)
+    req, store = _make_request(
+        headers={"X-Internal-Secret": "wrong", "X-Session-Key": "dashboard:chat-9-EVIL"},
+        unix=True,
+    )
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 403
+
+
+@_posix_only
+@pytest.mark.asyncio
+async def test_unix_peer_unresolvable_proceeds_status_quo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty resolved key (warm pool before claim, cron, pooled backend) must
+    keep today's semantics: valid secret grants."""
+    _wire_peer(monkeypatch, resolved="")
+    mw = ta.token_auth_middleware(internal_paths=INTERNAL, internal_secret=SECRET)
+    req, store = _make_request(
+        headers={"X-Internal-Secret": SECRET, "X-Session-Key": "dashboard:chat-1-abc"},
+        unix=True,
+    )
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 200
+    assert "peer_verified" not in store
+
+
+@_posix_only
+@pytest.mark.asyncio
+async def test_unix_peer_no_pid_proceeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire_peer(monkeypatch, peer_pid=None, resolved="never-consulted")
+    mw = ta.token_auth_middleware(internal_paths=INTERNAL, internal_secret=SECRET)
+    req, store = _make_request(
+        headers={"X-Internal-Secret": SECRET, "X-Session-Key": "dashboard:chat-1-abc"},
+        unix=True,
+    )
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 200
+
+
+@_posix_only
+@pytest.mark.asyncio
+async def test_unix_peer_uid_mismatch_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _wire_peer(monkeypatch, verdict=PeerCredResult.MISMATCH)
+    mw = ta.token_auth_middleware(internal_paths=INTERNAL, internal_secret=SECRET)
+    req, store = _make_request(
+        headers={"X-Internal-Secret": SECRET, "X-Session-Key": "dashboard:chat-1-abc"},
+        unix=True,
+    )
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 403
+    assert any(c.get("outcome") == "denied" for c in calls)
+
+
+@_posix_only
+@pytest.mark.asyncio
+async def test_unix_peer_uid_unverifiable_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    """UNVERIFIABLE peer principal is DENIED (deny-by-default, mirroring
+    gatewayd's register-path policy): on supported POSIX platforms an
+    accepted AF_UNIX connection always yields peer credentials, so a failed
+    read means the attestation mechanism itself broke."""
+    calls = _wire_peer(monkeypatch, verdict=PeerCredResult.UNVERIFIABLE, resolved="")
+    mw = ta.token_auth_middleware(internal_paths=INTERNAL, internal_secret=SECRET)
+    req, store = _make_request(
+        headers={"X-Internal-Secret": SECRET, "X-Session-Key": "dashboard:chat-1-abc"},
+        unix=True,
+    )
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 403
+    assert any("unverifiable" in c.get("error", "") for c in calls)
+
+
+@_posix_only
+@pytest.mark.asyncio
+async def test_unix_no_session_key_skips_verification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No X-Session-Key → nothing session-scoped claimed → no walk at all."""
+
+    def _explode(pid, **kw):  # pragma: no cover — the assertion IS that it never runs
+        raise AssertionError("resolver must not run without a session claim")
+
+    _wire_peer(monkeypatch)
+    monkeypatch.setattr(ta, "resolve_peer_identity", _explode)
+    mw = ta.token_auth_middleware(internal_paths=INTERNAL, internal_secret=SECRET)
+    req, store = _make_request(headers={"X-Internal-Secret": SECRET}, unix=True)
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 200
+
+
+@pytest.mark.asyncio
+async def test_tcp_request_never_engages_peer_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _explode(sock):  # pragma: no cover — the assertion IS that it never runs
+        raise AssertionError("peer check must not run for TCP requests")
+
+    monkeypatch.setattr(ta, "check_peer_is_self", _explode)
+    mw = ta.token_auth_middleware(internal_paths=INTERNAL, internal_secret=SECRET)
+    req, store = _make_request(
+        headers={"X-Internal-Secret": SECRET, "X-Session-Key": "dashboard:chat-1-abc"},
+        unix=False,
+    )
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 200
+
+
+@_posix_only
+@pytest.mark.asyncio
+async def test_resolver_exception_degrades_to_status_quo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire_peer(monkeypatch)
+
+    def _boom(pid, **kw):
+        raise RuntimeError("proc walk exploded")
+
+    monkeypatch.setattr(ta, "resolve_peer_identity", _boom)
+    mw = ta.token_auth_middleware(internal_paths=INTERNAL, internal_secret=SECRET)
+    req, store = _make_request(
+        headers={"X-Internal-Secret": SECRET, "X-Session-Key": "dashboard:chat-1-abc"},
+        unix=True,
+    )
+    resp = await mw(req, _ok_handler)
+    assert resp.status == 200
+
+
+# ---------------------------------------------------------------------------
+# End-to-end over a real UnixSite (POSIX): kernel-populated peer credentials
+# ---------------------------------------------------------------------------
+
+
+def _unix_http_request(
+    sock_path: str, path: str, headers: dict[str, str], timeout: float = 5.0
+) -> tuple[int, bytes]:
+    """Minimal raw-HTTP client over AF_UNIX (independent of loopback_http)."""
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(timeout)
+    s.connect(sock_path)
+    try:
+        lines = [f"GET {path} HTTP/1.1", "Host: localhost:5476", "Connection: close"]
+        lines += [f"{k}: {v}" for k, v in headers.items()]
+        s.sendall(("\r\n".join(lines) + "\r\n\r\n").encode())
+        buf = b""
+        while True:
+            chunk = s.recv(65536)
+            if not chunk:
+                break
+            buf += chunk
+        status = int(buf.split(b" ", 2)[1])
+        return status, buf
+    finally:
+        s.close()
+
+
+@pytest.mark.skipif(platform_compat.IS_WINDOWS, reason="AF_UNIX transport is POSIX-only")
+@pytest.mark.asyncio
+async def test_unix_site_end_to_end_peer_verification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Real UnixSite + real AF_UNIX connect: the kernel reports OUR pid/uid,
+    so with a session_pid file for an ancestor of this test process the
+    middleware must deny a foreign declared key and allow the matching one."""
+    import os
+
+    from kiro_crew import session_pid_sig as sps
+
+    # Publish a SIGNED pidfile for THIS process so the ancestry walk (starting
+    # at the kernel-reported peer pid == our pid) resolves immediately under
+    # the middleware's signed_only=True discipline. The HMAC trust root is
+    # pinned so the sidecar can be computed against the tmp config dir.
+    _hmac_key = b"K" * 32
+    monkeypatch.setattr(sps, "_load_hmac_key", lambda: _hmac_key)
+    pid = os.getpid()
+    (tmp_path / f"session_pid_{pid}.txt").write_text("dashboard:chat-e2e", encoding="utf-8")
+    (tmp_path / f"session_pid_{pid}.sig").write_text(
+        sps._compute_sig(_hmac_key, pid, "dashboard:chat-e2e"), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        ta,
+        "resolve_peer_identity",
+        lambda p, **kw: resolve_peer_identity(p, config_dir_fn=lambda: tmp_path, **kw),
+    )
+
+    app = web.Application()
+    app.middlewares.append(
+        ta.token_auth_middleware(internal_paths=INTERNAL, internal_secret=SECRET)
+    )
+
+    async def handler(request: web.Request) -> web.Response:
+        return web.json_response({"peer_verified": bool(request.get("peer_verified"))})
+
+    app.router.add_get("/api/spawn", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    sock_path = str(tmp_path / "dash-test.sock")
+    site = web.UnixSite(runner, sock_path)
+    await site.start()
+    try:
+        loop = asyncio.get_running_loop()
+        status_ok, body_ok = await loop.run_in_executor(
+            None,
+            _unix_http_request,
+            sock_path,
+            "/api/spawn",
+            {"X-Internal-Secret": SECRET, "X-Session-Key": "dashboard:chat-e2e"},
+        )
+        assert status_ok == 200
+        assert b'"peer_verified": true' in body_ok
+        status_evil, _ = await loop.run_in_executor(
+            None,
+            _unix_http_request,
+            sock_path,
+            "/api/spawn",
+            {"X-Internal-Secret": SECRET, "X-Session-Key": "dashboard:chat-OTHER"},
+        )
+        assert status_evil == 403
+    finally:
+        await runner.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# CSRF: the no-Origin branch trusts the unix transport
+# ---------------------------------------------------------------------------
+
+
+@_posix_only
+def test_check_origin_trusts_unix_transport_without_origin() -> None:
+    """An AF_UNIX request has no loopback request.remote; without this trust
+    the CSRF middleware would 403 every mutating internal call on the socket
+    before token auth ever ran (review finding)."""
+    from kiro_crew.dashboard.origin import check_origin
+
+    req, _store = _make_request(unix=True)
+    req.app = {"allowed_origins": set()}
+    assert check_origin(req, require=True) is True
+
+
+def test_check_origin_still_rejects_plain_remote_without_origin() -> None:
+    from kiro_crew.dashboard.origin import check_origin
+
+    req, _store = _make_request(remote="10.0.0.1", unix=False)
+    req.app = {"allowed_origins": set()}
+    assert check_origin(req, require=True) is False
+
+
+# ---------------------------------------------------------------------------
+# server startup — _start_unix_site
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(platform_compat.IS_WINDOWS, reason="AF_UNIX transport is POSIX-only")
+@pytest.mark.asyncio
+async def test_start_unix_site_binds_and_removes_stale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from kiro_crew.dashboard import server as srv
+
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.server.dashboard_socket_path",
+        lambda port: tmp_path / f"dashboard-{port}.sock",
+    )
+    # Plant a stale socket file (bound then abandoned) to prove self-healing.
+    stale = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    stale.bind(str(tmp_path / "dashboard-5999.sock"))
+    stale.close()
+
+    app = web.Application()
+    runner = web.AppRunner(app)
+    await runner.setup()
+    try:
+        path = await srv._start_unix_site(runner, 5999)
+        assert path is not None
+        assert path.exists()
+        import stat as _stat
+
+        assert _stat.S_ISSOCK(path.stat().st_mode)
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_start_unix_site_skipped_on_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    from kiro_crew.dashboard import server as srv
+
+    monkeypatch.setattr(srv.platform_compat, "IS_WINDOWS", True)
+    assert await srv._start_unix_site(MagicMock(), 5999) is None
+
+
+@pytest.mark.skipif(platform_compat.IS_WINDOWS, reason="AF_UNIX transport is POSIX-only")
+@pytest.mark.asyncio
+async def test_start_unix_site_bind_failure_degrades(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-socket file squatting the path makes the bind fail; startup must
+    degrade to TCP-only (return None), never raise."""
+    from kiro_crew.dashboard import server as srv
+
+    squatter = tmp_path / "dashboard-6001.sock"
+    squatter.write_text("not a socket", encoding="utf-8")
+    monkeypatch.setattr("kiro_crew.dashboard.server.dashboard_socket_path", lambda port: squatter)
+    app = web.Application()
+    runner = web.AppRunner(app)
+    await runner.setup()
+    try:
+        assert await srv._start_unix_site(runner, 6001) is None
+        assert squatter.read_text(encoding="utf-8") == "not a socket"  # left in place
+    finally:
+        await runner.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# loopback_http client — unix transport preference + fallback semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def unix_http_server(tmp_path: Path):
+    """A minimal threaded HTTP server on an AF_UNIX socket."""
+    import http.server
+    import socketserver
+    import threading
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 — stdlib contract
+            body = json.dumps({"via": "unix"}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *a):  # silence
+            pass
+
+    class _UnixServer(socketserver.ThreadingUnixStreamServer):
+        daemon_threads = True
+
+        # BaseHTTPRequestHandler derives client_address[0]; unix sockets
+        # provide '' — normalize so the handler does not crash.
+        def get_request(self):
+            request, _ = super().get_request()
+            return request, ("unix", 0)
+
+    sock_path = str(tmp_path / "client-test.sock")
+    server = _UnixServer(sock_path, _Handler)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    yield sock_path
+    server.shutdown()
+    server.server_close()
+
+
+@pytest.mark.skipif(platform_compat.IS_WINDOWS, reason="AF_UNIX transport is POSIX-only")
+def test_loopback_urlopen_uses_unix_socket(unix_http_server: str) -> None:
+    req = urllib.request.Request("http://localhost:59999/api/anything")
+    with loopback_urlopen(req, timeout=5, unix_socket_path=unix_http_server) as resp:
+        assert json.loads(resp.read()) == {"via": "unix"}
+
+
+def test_loopback_urlopen_absent_socket_falls_back_to_tcp(tmp_path: Path) -> None:
+    """Socket file missing → straight to TCP (refused on a dead port)."""
+    req = urllib.request.Request("http://127.0.0.1:1/api/x")
+    with pytest.raises(urllib.error.URLError):
+        loopback_urlopen(req, timeout=2, unix_socket_path=str(tmp_path / "nope.sock"))
+
+
+@pytest.mark.skipif(platform_compat.IS_WINDOWS, reason="AF_UNIX transport is POSIX-only")
+def test_loopback_urlopen_stale_socket_falls_back_to_tcp(tmp_path: Path) -> None:
+    """Socket file exists but nobody listens → connect refused → TCP fallback.
+
+    The TCP side serves a real response, proving the fallback actually runs
+    the request rather than re-raising."""
+    import http.server
+    import threading
+
+    stale_path = tmp_path / "stale.sock"
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.bind(str(stale_path))
+    s.close()  # bound but never listened/accepting → ECONNREFUSED
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 — stdlib contract
+            body = b'{"via": "tcp"}'
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *a):
+            pass
+
+    tcp = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    port = tcp.server_address[1]
+    t = threading.Thread(target=tcp.serve_forever, daemon=True)
+    t.start()
+    try:
+        req = urllib.request.Request(f"http://127.0.0.1:{port}/api/x")
+        with loopback_urlopen(req, timeout=5, unix_socket_path=str(stale_path)) as resp:
+            assert json.loads(resp.read()) == {"via": "tcp"}
+    finally:
+        tcp.shutdown()
+        tcp.server_close()
+
+
+@pytest.mark.skipif(platform_compat.IS_WINDOWS, reason="AF_UNIX transport is POSIX-only")
+def test_loopback_urlopen_http_error_propagates_no_fallback(tmp_path: Path) -> None:
+    """A 4xx over the unix socket is a REAL response — it must propagate as
+    HTTPError, never trigger a duplicate TCP send."""
+    import http.server
+    import socketserver
+    import threading
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 — stdlib contract
+            self.send_response(403)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, *a):
+            pass
+
+    class _UnixServer(socketserver.ThreadingUnixStreamServer):
+        daemon_threads = True
+
+        def get_request(self):
+            request, _ = super().get_request()
+            return request, ("unix", 0)
+
+    sock_path = str(tmp_path / "err.sock")
+    server = _UnixServer(sock_path, _Handler)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    try:
+        req = urllib.request.Request("http://127.0.0.1:1/api/x")
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            loopback_urlopen(req, timeout=5, unix_socket_path=sock_path)
+        assert exc_info.value.code == 403
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+# ---------------------------------------------------------------------------
+# mcp_core client — socket preference wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(platform_compat.IS_WINDOWS, reason="AF_UNIX transport is POSIX-only")
+def test_mcp_core_post_prefers_unix_socket(
+    unix_http_server: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import kiro_crew.mcp_core as mcp_core
+
+    monkeypatch.setattr(mcp_core, "_API_UNIX_SOCKET", unix_http_server)
+    monkeypatch.setattr(mcp_core, "_API", "http://127.0.0.1:1")  # TCP would refuse
+    monkeypatch.setattr(mcp_core, "_internal_secret", lambda: "s")
+    monkeypatch.setattr(mcp_core, "_resolve_session_key", lambda: "dashboard:chat-1")
+    assert mcp_core._get("/api/anything") == {"via": "unix"}
+
+
+def test_mcp_core_post_falls_back_to_tcp_when_socket_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Error shape of _get is unchanged when neither transport answers."""
+    import kiro_crew.mcp_core as mcp_core
+
+    monkeypatch.setattr(mcp_core, "_API_UNIX_SOCKET", str(tmp_path / "absent.sock"))
+    monkeypatch.setattr(mcp_core, "_API", "http://127.0.0.1:1")
+    monkeypatch.setattr(mcp_core, "_internal_secret", lambda: "s")
+    monkeypatch.setattr(mcp_core, "_resolve_session_key", lambda: "dashboard:chat-1")
+    out = mcp_core._get("/api/anything")
+    assert "error" in out

--- a/test/test_identity_topology.py
+++ b/test/test_identity_topology.py
@@ -475,11 +475,24 @@ _REGISTERED_CALL_SITES: dict[str, str] = {
         "ancestry and calling session_pid_sig.verify_session_pid (HMAC-verified) "
         "on each ancestor — HOST-pid-keyed, no unsigned .txt read"
     ),
-    "mcp_gateway/gatewayd.py": (
-        "(_resolve_peer_identity) — runs in gatewayd's own (host) pid namespace, "
-        "so it is immune to client-side namespace divergence; also indexes the "
-        "host ancestor chain for claim-push matching; .txt reads via "
-        "session_pid_sig.read_session_pid_txt (hardened, unsigned)"
+    "peer_resolve.py": (
+        "reader: the SERVER-side /proc ancestry walk (extracted from "
+        "mcp_gateway/gatewayd._resolve_peer_identity, which now delegates "
+        "here) — runs in the server's own (host) pid namespace, so it is "
+        "immune to client-side namespace divergence; returns the session key "
+        "plus the host ancestor chain (gatewayd indexes the chain for "
+        "claim-push matching); .txt reads via "
+        "session_pid_sig.read_session_pid_txt (hardened, unsigned). Consumed "
+        "by gatewayd (stub register) and dashboard/token_auth (unix-socket "
+        "peer verification)"
+    ),
+    "dashboard/token_auth.py": (
+        "reader (via peer_resolve.resolve_peer_identity, no inline walk): "
+        "kernel-attests internal-API requests arriving on the dashboard's "
+        "AF_UNIX socket — SO_PEERCRED peer pid → host-namespace ancestry walk "
+        "→ session_pid_<pid>.txt; denies when the resolved key differs from "
+        "the client-declared X-Session-Key header, degrades to status quo "
+        "when unresolvable"
     ),
     "sandbox.py": (
         "writer-adjacent: launcher exports KIROCREW_HOST_PID (its own HOST pid — "


### PR DESCRIPTION
Closes #302

## Summary

Follow-up from #300. The dashboard internal HTTP API authenticated callers with loopback TCP + `X-Internal-Secret` (a same-uid-readable file) and took the session identity from the fully client-declared `X-Session-Key` header — so a same-uid process could impersonate any session on every session-scoped internal route. This PR closes the gap with kernel-attested peer identity, reusing the exact mechanism gatewayd already trusts for MCP stub registration (`SO_PEERCRED` + /proc ancestry over `socketsec`).

**Posture: verify-when-resolvable, deny-on-mismatch, degrade-to-status-quo when unresolvable.** The change is strictly monotonic — never weaker than today's auth, kernel-verified whenever the gateway's own registry can attest the peer.

## Changes

- **`peer_resolve.py` (new)** — gatewayd's `_resolve_peer_identity` ancestry walk extracted into a shared module; gatewayd delegates through its existing `_config_dir`/`_ppid_fn` test seams (behavior-preserving: all existing gatewayd/claim tests pass unmodified).
- **`dashboard/server.py`** — both start paths (`start_dashboard`, `start_api_server`) additionally bind a `web.UnixSite` on the same `AppRunner` at `~/.kiro/crew/dashboard-<port>.sock`. POSIX only; any failure logs once and degrades to TCP-only (today's behavior). 0700 dir gate + 0600 socket, stale-socket self-heal at startup, best-effort unlink at shutdown. Port-suffixed name so multi-instance data homes don't collide, and a client resolving its port from `dashboard.url` reaches the same logical endpoint as its TCP fallback.
- **`dashboard/token_auth.py`** — for internal/mixed-internal paths arriving on `AF_UNIX` and carrying `X-Session-Key`: confirm peer uid (deny on positive mismatch), resolve the peer's session via the shared ancestry walk (offloaded to the subprocess executor), **deny 403 + SEL `dashboard.peer-identity-mismatch`** when the resolved key differs from the declared header, set `request["peer_verified"] = True` on match, and proceed under today's semantics when unresolvable (warm-pool runtimes before claim, cron scripts, pooled MCP backends). The check runs before either auth flavor grants. TCP requests never engage the branch — browser cookies, Windows, and remote `local_only=False` deployments are untouched.
- **`loopback_http.py`** — stdlib-only `AF_UNIX` transport (`_UnixHTTPConnection` + handler); `loopback_urlopen(unix_socket_path=...)` prefers the socket when the file exists and falls back to TCP **only** on connect-level `FileNotFoundError`/`ConnectionRefusedError` (cases that provably never delivered the request — cannot double-send). HTTP error statuses and read timeouts propagate unchanged; every caller's error shape is identical.
- **`mcp_core.py`** — `_API_UNIX_SOCKET` resolved at import next to `_API`; all 7 `_API` call sites route through `_api_urlopen`.
- **Docs** — `docs/system-specs/features/dashboard-token-auth.md` gains the transport + verification contract.
- **Tests** — new `test/test_dashboard_peer_auth.py` (28 tests): shared-walk units, middleware deny/allow/status-quo/TCP-never-engages (faked socketsec seams), a real-`UnixSite` end-to-end with kernel-populated peer credentials, server-startup bind/degrade/Windows-skip, client transport preference + fallback + no-double-send, and mcp_core wiring. `test_identity_topology.py` call-site registry updated for the relocated walk.

## Deliberately out of scope (per issue #302 spec)

- Strict fail-closed denial of unresolvable unix-socket peers (product decision — would break warm-pool/cron flows).
- Browser/cookie path changes; Windows named-pipe transport.
- Migrating the four session-directive tools off `_resolve_session_key_strict` (their directive leg is already session-bound).
- Playwright proxy transport (sends no session-mutating claims; deliberately avoids the config import).

## Notes for reviewers

- **Deviation from the issue sketch:** socket named `dashboard-<port>.sock` (issue sketched `dashboard.sock`) so multiple gateway instances sharing a data home cannot collide, and client/server port resolution stays symmetric.
- **Topology safety (verified in-repo):** subagent kiro-cli processes receive their own `KIROCREW_SESSION_KEY` via `acp/client.py` and are not descendants of a claimed slot's kiro-cli, so their ancestry resolves to `""` → status quo, never a false deny. Pooled MCP backends are children of gatewayd → same. A keepalive from a dead session's process tree after pid recycling could in principle resolve to a different live session and be denied — that denial is the correct outcome.
- **Pre-push review:** spawn-based dual-model review was refused by governance in this run; a contract-driven self-review against both reviewer charters was performed instead (caught and fixed a Windows `socket.AF_UNIX` `AttributeError` that would have broken the middleware chain on Windows, plus test-collection guards). The in-CI GPT + Opus review gates apply as normal.

## Testing

- `isort` / `flake8` / `mypy` clean (857 files).
- Full `pytest`: 39,689 passed; 90 failures verified **pre-existing environment issues** (sandbox backend unavailable on this host, root-owned-binary checks, `KIROCREW_PORT` env pollution) — identical failure set reproduced on pristine `origin/main` with the same subset.
- New suite: 28/28. Adjacent suites (token_auth 200+, gatewayd claim, socketsec, identity topology, mcp_core 287, dashboard server coverage): all pass.
