### PR TITLE
test: make hanging beacon test deterministic

### DIFF
--- a/test/test_beacon.py
+++ b/test/test_beacon.py
@@ -14,7 +14,6 @@ import ssl
 import subprocess
 import tempfile
 import threading
-import time
 import urllib.error
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -779,7 +778,7 @@ class TestFailOpen:
         """The gateway starts the beacon on a thread and never joins it.
 
         Pins the boot-path contract: even a beacon that hangs far past its own
-        timeout costs the caller only the thread spawn.
+        timeout leaves the caller waiting only for the thread to start.
 
         The hang is RELEASED at the end rather than left running. ``beacon.send``
         resolves state through the module-global ``config_dir``, which
@@ -799,7 +798,6 @@ class TestFailOpen:
             raise OSError("released")
 
         monkeypatch.setattr(beacon.urllib.request, "urlopen", hang)
-        start = time.monotonic()
         thread = threading.Thread(
             target=beacon.send,
             args=("https://e.invalid", "1.2.3"),
@@ -807,8 +805,7 @@ class TestFailOpen:
             daemon=True,
         )
         thread.start()
-        elapsed = time.monotonic() - start
-        assert elapsed < 1.0, f"spawning the beacon cost {elapsed:.2f}s"
+        assert thread.is_alive(), "the caller waited for the blocked beacon"
         assert thread.daemon, "must not pin interpreter exit"
         released.set()
         thread.join(timeout=10)


### PR DESCRIPTION
## Problem

`test_a_hanging_beacon_does_not_delay_the_caller` treats a
`Thread.start()` call that takes at least one second as a failure. Under a
loaded CI scheduler, that wall-clock budget can be exceeded even though the
beacon is correctly detached from the caller, making the backend suite flaky.

Closes #2294.

## Why it matters

The false failure makes healthy changes look broken and consumes contributor
and CI time without detecting a regression in beacon behavior.

## Fix (symptoms → root cause → change)

The test needs to prove that the caller returns while the beacon remains
blocked. The one-second assertion measured host scheduling latency instead of
that contract. Assert that the beacon thread is still alive immediately after
`start()` returns, while preserving the daemon and cleanup assertions.

## Tests

- `python -m pytest test/test_beacon.py -n0 -q` (`150 passed`)
- `isort --check-only src/kiro_crew test`
- `flake8 src/kiro_crew test`
- `npm --prefix website run build`
- Two read-only local reviews against the GPT and Opus/AUTOSDE contracts
  reported no findings.

The broader local gates still expose unrelated `main`/host baseline failures:
the macOS Xcode toolchain trust test, resource-banner context injection, three
`os.*xattr` mypy stubs, and the frontend unit-literal ratchet. This PR does not
touch those paths; GitHub CI remains the authoritative clean-environment run.

## Manual verification

N/A — this changes only a deterministic test assertion, and the complete beacon
test module covers the behavior.
