### PR TITLE
feat: cap aggregate agent memory via MemoryHigh on the agent slice

### DIFF
--- a/docs/architecture/resource-protection.md
+++ b/docs/architecture/resource-protection.md
@@ -30,6 +30,7 @@ anything that survived a gateway crash. No single mechanism is a single point of
 | Per-process resource limits | `security.py` (`apply_resource_limits`), delivered **after `exec`** by `_spawn_exec_shim.py` via `sandbox.py` (`create_subprocess_limited` / `spawn_shim_argv`) | Every agent-influenced spawn (see the profile list below) | Kernel-enforced `RLIMIT_NOFILE=1024` default-on; `RLIMIT_NPROC` / `RLIMIT_CPU` / `RLIMIT_AS` opt-in (default off) | Yes, the kernel enforces at fork/alloc/open time, no sweep needed | Kernel refuses `open()` past the FD cap (EMFILE); on opt-in NPROC/CPU/AS: EAGAIN, SIGXCPU, ENOMEM |
 | cgroup v2 scope (fork bomb + memory) | `sandbox.py` (`cgroup_scope_argv`) | Every agent-influenced spawn tree (root agent plus all its MCP servers and subagents as one scope; each cron, app-backend, hook, git or tool spawn gets its own) | `pids.max=8192` (`TasksMax`) plus `memory.max=65% of host RAM` (`MemoryMax`, `MemorySwapMax=0`) per transient `systemd-run --user --scope` under `kirocrew-agents.slice`, default-on where cgroup v2 delegation exists | Yes, the kernel enforces at `fork()`/alloc time; OOM-kills the scope on a memory breach, `fork()` fails EAGAIN past `pids.max` — **per scope**: the aggregate across concurrent scopes is bounded by the slice row below | Fork bomb bounded to `pids.max`; memory balloon OOM-killed at `memory.max`. Unavailable (no delegation, macOS): no-op plus one loud SECURITY warning, `RLIMIT_NOFILE` still applies |
 | cgroup v2 slice (aggregate across concurrent spawns) | `sandbox.py` (`ensure_agents_slice_limits`), applied at gateway startup | ALL concurrent agent scopes together (they are siblings under `kirocrew-agents.slice`) | `memory.max=80% of host RAM` (`MemoryMax`, `MemorySwapMax=0`) plus `pids.max=32768` (`TasksMax`) on the slice, via `systemctl --user set-property --runtime`; overridable via `resource_limits.max_total_memory_mb` / `max_total_processes` | Yes — cgroup v2 bounds a descendant by the **minimum** effective limit of itself and all ancestors, so N scopes at 65% each can no longer jointly exceed the slice ceiling | Kernel OOM-kills some scope inside the slice on an aggregate breach; the resource-pressure sampler logs new kills with victim scopes, slice `memory.current`, and whether the slice ceiling (vs a scope's own) engaged. Same availability gate and single SECURITY warning as the scope row |
+| Aggregate agent-slice soft ceiling (throttle) | `sandbox.py` (`_ensure_agent_slice_memory_high`) | The SUM of all concurrent agent scopes (`kirocrew-agents.slice` as one subtree); never the gateway, which runs outside the slice | `memory.high=75% of host RAM` on the slice (`systemctl --user set-property --runtime`); deliberately NOT config-driven — the slice is UID-global and shared by every gateway instance (live, dev, pods), so no single instance may lift the others' ceiling; default-on where cgroup v2 delegation exists | Yes, the kernel throttles-and-reclaims the whole subtree past `memory.high` | Concurrent agent trees that together cross 75% get throttled BEFORE the slice's hard 80% `MemoryMax` (row above) OOM-kills a scope; the reconcile worker also watches the slice's `memory.events` `high` counter and logs once per climbing episode so "agents mysteriously slow" is diagnosable as ceiling throttling. Unavailable or `systemctl` fails: no-op plus one loud SECURITY warning, the slice and per-scope `MemoryMax` still apply |
 | Bounded restart shutdown | `dashboard/handlers/sessions.py` | Dashboard Apply & Restart | 10s (`_SHUTDOWN_TIMEOUT_SECS`) | No | `asyncio.wait_for` on `provider.shutdown()`; `_sync_kill_provider` fallback on timeout |
 | Subagent injection outer cap | `subagent.py` `_run()` | Per-subagent completion | 1200s (`_ON_DONE_TIMEOUT`) | No | Covers semaphore wait plus injection; on timeout kills the stuck kiro-cli via `sessions.reset()` and queues a failure event for the parent to drain |
 | Subagent injection inner cap | `slack/gateway.py` | Per `stream_and_collect` | 900s (`INJECTION_TIMEOUT`, from `_DEFAULT_INJECTION_TIMEOUT`; override with `KIROCREW_INJECTION_TIMEOUT`, clamped down to `_ON_DONE_TIMEOUT`) | No | `_inject_with_retry` up to 3 attempts with backoff, bounded by the outer 1200s cap |
@@ -200,6 +201,46 @@ its descendants), biasing the kernel OOM killer toward tool subprocesses so a
 memory-ballooning command is killed *before* `memory.max` takes out the entire agent scope.
 It is requested explicitly (`--oom-bias`) by the `tool` and `build` profiles only
 (`_PROFILE_OOM_BIAS`).
+
+### The aggregate slice ceiling (`memory.high` on `kirocrew-agents.slice`)
+
+`MemoryMax` is a **per-scope** cap, and scopes are created per spawn — so several
+concurrent agent trees, each legitimately under its own 65% ceiling, can still **sum past
+physical RAM** and livelock a swapless host: nothing individually breaches, everything
+collectively starves. The containment for that failure mode is one level up, on the slice
+every agent scope is parented under. `sandbox._ensure_agent_slice_memory_high()` sets
+**`MemoryHigh`** on `kirocrew-agents.slice`, always **75% of physical RAM**
+(`_SLICE_MEMORY_HIGH_FRACTION`, with a `_SLICE_FALLBACK_MEMORY_HIGH_MB` = 12288 MB fallback
+when RAM cannot be read). The ceiling is deliberately **not config-driven**: the slice is
+UID-global — every gateway instance under the user (live, dev-backend, pods where delegation
+applies) parents scopes into the same slice — so a per-instance config key would let one
+permissively-configured instance lift or lower the ceiling that protects the others.
+Past `memory.high` the kernel **throttles and reclaims** the whole subtree
+instead of OOM-killing it — agents slow down, the host stays interactive, and each scope's
+`memory.max` still hard-kills an individual runaway. The gateway itself never runs inside
+the slice, so slice pressure degrades agents, never the control plane.
+
+The mechanism is deliberately root-free and stateless on disk: `systemctl --user
+set-property --runtime kirocrew-agents.slice MemoryHigh=<N>M`, run by the unprivileged user
+manager that owns the slice. `--runtime` keeps the drop-in under `$XDG_RUNTIME_DIR` (it
+vanishes with the login session), so no persistent unit files accumulate and a stale ceiling
+never outlives the login session. Reconciliation before each scope wrap is a no-op string
+compare in steady state. It shares the scope
+wrapper's availability gate (`_probe_cgroup_scope`: Linux, cgroup v2, `memory` controller
+delegated, systemd user session); where that gate fails, or `systemctl` itself fails, the
+ceiling degrades to a no-op with **one loud SECURITY warning** and agent spawns proceed
+uncontained at the slice level — per-scope `MemoryMax` still applies.
+
+Throttling past `memory.high` is otherwise **silent**: agents just slow down, nothing kills,
+and nothing alerts (per-scope `MemoryMax` never fired). To keep "agents mysteriously slow"
+diagnosable as ceiling throttling rather than a hang, each reconcile also reads the slice
+cgroup's `memory.events` and logs **one warning per climbing episode** of its `high` counter
+(the kernel's count of subtree throttle-and-reclaim passes for the ceiling): the first
+observed increase logs, further increases stay silent until the counter is seen stable, and
+a counter that went *down* is a recreated slice cgroup and only re-baselines. The read is a
+plain file read of the systemd user manager's cgroup subtree, shares the reconciler's
+per-spawn cadence and kill switch, and degrades to a silent no-op wherever the file does not
+exist (macOS/Windows, no cgroup v2, slice not materialized).
 
 The kernel enforces both ceilings at `fork()` and allocation time, so there is no reaper
 race. `--scope` execs into the target rather than forking a wrapper, so the gateway's PID

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -3817,6 +3817,238 @@ def _cgroup_limits_from_config() -> tuple[int, int, int, int]:
     return max_procs, max_mem_mb, cpu_weight, max_cpu_percent
 
 
+# ── aggregate agent-slice soft ceiling (memory.high on kirocrew-agents.slice) ──
+# Per-scope MemoryMax bounds ONE runaway spawn tree, but scopes are created per
+# spawn: several concurrent agent trees, each legitimately under its own 65%
+# cap, can still sum past physical RAM and livelock a swapless host. memory.high
+# on the slice all agent scopes share throttles-and-reclaims the whole subtree
+# once the SUM of agent memory crosses it, keeping the kernel and the gateway
+# (which lives outside the slice) responsive — a soft layer BELOW the slice's
+# hard aggregate memory.max (ensure_agents_slice_limits), which OOM-kills a
+# scope only when throttling was not enough, while each scope's own memory.max
+# still hard-kills an individual runaway. Same trust model as the scope
+# ceilings: unprivileged, enforced by the user manager, requires the memory
+# controller delegated to the user slice (the existing _probe_cgroup_scope
+# check).
+
+# Fraction of physical RAM used for the default slice memory.high. Higher than
+# the per-scope 65% because it bounds the SUM of all agent scopes, and below
+# the slice's hard 80% memory.max so throttling engages before the kernel
+# OOM-kills, with OS + gateway headroom preserved even while the whole fleet
+# is being throttled.
+_SLICE_MEMORY_HIGH_FRACTION = 0.75
+# Fallback slice memory.high (MB) used only when physical RAM can't be read.
+# The slice path is Linux-only, where SC_PHYS_PAGES exists, so this is a
+# belt-and-suspenders default, not the normal path.
+_SLICE_FALLBACK_MEMORY_HIGH_MB = 12288
+
+# Last MemoryHigh value applied to the slice by THIS process ("24576M" /
+# "infinity"), or None before the first reconcile. The desired value is
+# host-derived and constant for the process's life (no config input), so
+# after the first successful apply every later reconcile reduces to a
+# string compare and no-ops. Kept as a reconcile (rather than a one-shot)
+# so an apply that failed transiently is retried on the next spawn.
+_SLICE_MEMHIGH_APPLIED: str | None = None
+# Process-level kill switch: set after a failed apply so a broken systemctl is
+# warned about ONCE and never hammered on every subsequent spawn.
+_SLICE_MEMHIGH_DISABLED = False
+
+
+def _default_slice_memory_high_mb() -> int:
+    """Return the default slice ``memory.high`` in MB: a fixed fraction
+    (:data:`_SLICE_MEMORY_HIGH_FRACTION`) of physical RAM, falling back to
+    :data:`_SLICE_FALLBACK_MEMORY_HIGH_MB` if host RAM can't be determined.
+    """
+    try:
+        total_bytes = os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
+        mb = int(total_bytes * _SLICE_MEMORY_HIGH_FRACTION) // (1024 * 1024)
+        if mb > 0:
+            return mb
+    except (ValueError, OSError, AttributeError):
+        pass
+    return _SLICE_FALLBACK_MEMORY_HIGH_MB
+
+
+def _ensure_agent_slice_memory_high() -> None:
+    """Reconcile ``MemoryHigh`` on :data:`_CGROUP_AGENTS_SLICE` with the host default.
+
+    The slice is UID-GLOBAL: every gateway instance under this user (live,
+    dev-backend, pods with delegation) parents scopes into the same slice, so
+    the ceiling is deliberately NOT config-driven — a per-instance config key
+    would let one instance (e.g. a dev gateway configured permissively) lift
+    or lower the ceiling that protects the others. The value is always the
+    host-derived default (:func:`_default_slice_memory_high_mb`).
+
+    Runs ``systemctl --user set-property --runtime`` — unprivileged: the user
+    manager owns the slice, and the memory controller is delegated wherever the
+    caller's probe passed. ``--runtime`` is deliberate: the drop-in lives under
+    ``$XDG_RUNTIME_DIR`` and vanishes with the login session, so no persistent
+    unit files accumulate under ``~/.config`` and a stale ceiling can never
+    outlive the login session that set it.
+
+    Never raises: agent spawns must not fail because the ceiling could not be
+    applied. On failure it logs one loud warning and disarms for the rest of
+    the process.
+    """
+    global _SLICE_MEMHIGH_APPLIED, _SLICE_MEMHIGH_DISABLED
+    if _SLICE_MEMHIGH_DISABLED:
+        return
+    desired = f"{_default_slice_memory_high_mb()}M"
+    if desired == _SLICE_MEMHIGH_APPLIED:
+        return
+    try:
+        systemctl = platform_compat.trusted_system_bin("systemctl")
+        if systemctl is None:
+            raise FileNotFoundError("systemctl not found in trusted system dirs")
+        proc = subprocess.run(
+            [
+                systemctl,
+                "--user",
+                "set-property",
+                "--runtime",
+                _CGROUP_AGENTS_SLICE,
+                f"MemoryHigh={desired}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError((proc.stderr or proc.stdout or "").strip() or "non-zero exit")
+    except Exception as exc:
+        _SLICE_MEMHIGH_DISABLED = True
+        logger.warning(
+            "SECURITY: could not apply MemoryHigh=%s to %s (%s); the AGGREGATE "
+            "agent memory ceiling is NOT enforced on this host — per-scope "
+            "MemoryMax still applies. See "
+            "docs/architecture/resource-protection.md.",
+            desired,
+            _CGROUP_AGENTS_SLICE,
+            exc,
+        )
+        return
+    _SLICE_MEMHIGH_APPLIED = desired
+    logger.info("agent slice %s: MemoryHigh=%s applied", _CGROUP_AGENTS_SLICE, desired)
+
+
+# Last observed value of the slice's memory.events `high` counter, or None
+# before the first successful read. The first read only baselines — the
+# counter is monotonic for the slice cgroup's lifetime, so a nonzero value
+# may predate this process — and climbs are judged against it.
+_SLICE_MEMHIGH_EVENTS_SEEN: int | None = None
+# True while inside a climbing episode that has already been warned about, so
+# sustained throttling logs once per episode instead of on every spawn. Reset
+# when an observation finds the counter stable (episode over) or lower (slice
+# cgroup recreated).
+_SLICE_MEMHIGH_CLIMB_WARNED = False
+
+
+def _slice_memory_events_high() -> int | None:
+    """Return the ``high`` counter from the slice cgroup's ``memory.events``.
+
+    The slice directory comes from :func:`_agents_slice_cgroup_dir`, which
+    understands systemd's dash-hierarchy (``kirocrew-agents.slice`` nests
+    under ``kirocrew.slice`` in the user manager's subtree). ``None`` when it
+    cannot be read: not Linux, no cgroup v2, the slice cgroup not currently
+    materialized (systemd releases an empty slice), or unparseable content.
+    """
+    slice_dir = _agents_slice_cgroup_dir()
+    if slice_dir is None:
+        return None
+    return _read_cgroup_counters(slice_dir / "memory.events").get("high")
+
+
+def _check_slice_memory_pressure() -> None:
+    """Warn when the slice's ``memory.events`` ``high`` counter climbs.
+
+    Past ``memory.high`` the kernel throttles-and-reclaims the subtree
+    SILENTLY — agents just slow down; nothing kills and nothing alerts, since
+    per-scope ``MemoryMax`` never fired. The ``high`` counter climbing is the
+    kernel's only signal that the aggregate ceiling is throttling, and
+    surfacing it makes "agents mysteriously slow" diagnosable from the
+    gateway log as ceiling throttling rather than a hang.
+
+    Warned once per climbing episode: the first observed increase logs, later
+    increases stay silent until an observation finds the counter stable,
+    which closes the episode. A DECREASE means the slice cgroup was recreated
+    (an empty slice is released and its counters reset) — re-baseline
+    silently, never warn.
+    """
+    global _SLICE_MEMHIGH_EVENTS_SEEN, _SLICE_MEMHIGH_CLIMB_WARNED
+    current = _slice_memory_events_high()
+    if current is None:
+        return
+    previous = _SLICE_MEMHIGH_EVENTS_SEEN
+    _SLICE_MEMHIGH_EVENTS_SEEN = current
+    if previous is None or current <= previous:
+        # First read, counter stable, or slice cgroup recreated: (re)baseline
+        # and close any open episode.
+        _SLICE_MEMHIGH_CLIMB_WARNED = False
+        return
+    if _SLICE_MEMHIGH_CLIMB_WARNED:
+        return
+    _SLICE_MEMHIGH_CLIMB_WARNED = True
+    logger.warning(
+        "agent slice %s: memory.events high counter climbed %d -> %d — "
+        "aggregate agent memory crossed the slice MemoryHigh ceiling and the "
+        "kernel is throttling the whole agent subtree; agents run slowly "
+        "(not hung) until aggregate memory drops. See "
+        "docs/architecture/resource-protection.md.",
+        _CGROUP_AGENTS_SLICE,
+        previous,
+        current,
+    )
+
+
+# Serializes reconciliation workers. Deliberately a plain blocking mutex held
+# for the whole reconcile body: every schedule spawns its own short-lived
+# worker and workers queue on the mutex, so concurrent spawns never interleave
+# systemctl calls and a failed apply is retried by the next spawn's worker.
+# The desired value is host-derived and process-constant (no config input) —
+# the mutex guards the apply/retry handoff, not value freshness. Redundant
+# workers are near-free (the applied-value check reduces them to a string
+# compare), and thread count is bounded by concurrent agent spawns.
+_SLICE_MEMHIGH_MUTEX = threading.Lock()
+
+
+def _reconcile_slice_memory_high_off_thread() -> None:
+    """Reconcile ``MemoryHigh`` and check slice throttling in a daemon thread.
+
+    The reconciliation reads config and shells out to ``systemctl`` (up to
+    10s), and its caller sits on the agent-spawn path, which runs on the
+    gateway event loop — so it must never execute inline. Fire-and-forget is
+    semantically safe: ``MemoryHigh`` set on a slice applies to members that
+    are already running, so a reconciliation that lands moments after the
+    spawn still bounds it, and every later spawn re-reconciles. The worker
+    also runs :func:`_check_slice_memory_pressure`, so throttle visibility
+    shares the reconcile cadence (per spawn) and its kill switch.
+    """
+    global _SLICE_MEMHIGH_DISABLED
+    if _SLICE_MEMHIGH_DISABLED:
+        return
+
+    def _worker() -> None:
+        with _SLICE_MEMHIGH_MUTEX:
+            _ensure_agent_slice_memory_high()
+            _check_slice_memory_pressure()
+
+    try:
+        threading.Thread(
+            target=_worker, name="agent-slice-memhigh", daemon=True
+        ).start()
+    except RuntimeError as exc:
+        # Thread exhaustion. This sits on the agent-spawn path, so it must
+        # never abort the spawn. Disarm like any other reconciliation
+        # failure: per-scope MemoryMax still applies.
+        _SLICE_MEMHIGH_DISABLED = True
+        logger.warning(
+            "SECURITY: could not start the MemoryHigh reconciliation thread "
+            "(%s); the AGGREGATE agent memory ceiling is NOT enforced on this "
+            "host — per-scope MemoryMax still applies.",
+            exc,
+        )
+
+
 def cgroup_scope_argv(argv: list[str]) -> list[str]:
     """Wrap *argv* in a transient systemd --user --scope with cgroup v2 limits.
 
@@ -3833,6 +4065,13 @@ def cgroup_scope_argv(argv: list[str]) -> list[str]:
     the returned argv's eventual PID is the real child — parent PID tracking,
     ``killpg``, and descendant scans are unaffected.
 
+    Every scope is parented under :data:`_CGROUP_AGENTS_SLICE`, and the
+    slice-level soft ceiling (``MemoryHigh``, see
+    :func:`_ensure_agent_slice_memory_high`) — a host-derived constant (75%
+    of RAM) — is ensured before each wrap, throttling the SUM of all
+    concurrent agent trees before the slice's hard ``MemoryMax``
+    (:func:`ensure_agents_slice_limits`) OOM-kills a scope.
+
     Layers OUTSIDE the OS-level sandbox: callers pass the already-``wrap_argv``-ed
     argv here so the child is filesystem-isolated AND cgroup-bounded.
 
@@ -3845,6 +4084,11 @@ def cgroup_scope_argv(argv: list[str]) -> list[str]:
     if not available:
         _warn_cgroup_unavailable(reason)
         return argv
+    # Reconcile the slice-level aggregate ceiling off-thread: this call site
+    # runs on the gateway event loop during agent spawn, and reconciliation
+    # does config reads + a systemctl subprocess. MemoryHigh on a slice
+    # applies to already-running members, so the spawn need not wait for it.
+    _reconcile_slice_memory_high_off_thread()
     max_procs, max_mem_mb, cpu_weight, max_cpu_percent = _cgroup_limits_from_config()
     props = [
         "-p",
@@ -4036,6 +4280,13 @@ def ensure_agents_slice_limits() -> bool:
     return True
 
 
+# cgroup v2 directory of the systemd user manager's subtree (transient
+# --user units always live under user@<uid>.service on the unified
+# hierarchy); ``{uid}`` is filled at resolve time. Module-level so tests can
+# point the resolver at a fabricated tree.
+_USER_MANAGER_CGROUP_BASE = "/sys/fs/cgroup/user.slice/user-{uid}.slice/user@{uid}.service"
+
+
 def _agents_slice_cgroup_dir() -> Path | None:
     """Resolve the agents slice's cgroup directory, or None when absent.
 
@@ -4048,8 +4299,7 @@ def _agents_slice_cgroup_dir() -> Path | None:
     """
     if sys.platform != "linux":
         return None
-    uid = os.getuid()
-    base = Path(f"/sys/fs/cgroup/user.slice/user-{uid}.slice/user@{uid}.service")
+    base = Path(_USER_MANAGER_CGROUP_BASE.format(uid=os.getuid()))
     direct = base / "kirocrew.slice" / _CGROUP_AGENTS_SLICE
     if direct.is_dir():
         return direct

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -631,6 +631,37 @@ def _isolate_message_entry_cache():
 
 
 @pytest.fixture(autouse=True)
+def _disarm_agent_slice_memory_high():
+    """Disarm the agent-slice ``MemoryHigh`` reconcile for every test.
+
+    ``cgroup_scope_argv`` reconciles ``MemoryHigh`` on the shared agent slice
+    via a real ``systemctl --user set-property`` before wrapping a spawn. On a
+    Linux host WITH cgroup delegation the probe passes for real, so any test
+    that reaches ``cgroup_scope_argv`` (spawn-audit, the real pids.max
+    enforcement test, integration paths) would mutate the developer's live
+    user manager — exactly the class of side effect the root conftest's
+    host-service guard refuses (``set-property`` is a mutating verb), turning
+    those tests into guard failures. Pre-disarm via the module's own kill
+    switch and restore all four state globals after, so tests of the
+    reconciler itself can re-arm explicitly in their own body.
+    """
+    import kiro_crew.sandbox as _sb
+
+    saved_disabled = _sb._SLICE_MEMHIGH_DISABLED
+    saved_applied = _sb._SLICE_MEMHIGH_APPLIED
+    saved_events_seen = _sb._SLICE_MEMHIGH_EVENTS_SEEN
+    saved_climb_warned = _sb._SLICE_MEMHIGH_CLIMB_WARNED
+    _sb._SLICE_MEMHIGH_DISABLED = True
+    try:
+        yield
+    finally:
+        _sb._SLICE_MEMHIGH_DISABLED = saved_disabled
+        _sb._SLICE_MEMHIGH_APPLIED = saved_applied
+        _sb._SLICE_MEMHIGH_EVENTS_SEEN = saved_events_seen
+        _sb._SLICE_MEMHIGH_CLIMB_WARNED = saved_climb_warned
+
+
+@pytest.fixture(autouse=True)
 def _reset_options_control_state():
     """Clear the per-message OPTIONS registries between tests.
 

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -8,6 +8,8 @@ import os
 import re
 import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -2254,3 +2256,401 @@ class TestMacOsNestingDetection:
             assert sandbox_mod._macos_sandbox_state() is None
         finally:
             sandbox_mod._macos_sandbox_state.cache_clear()
+
+
+class TestAgentSliceMemoryHigh:
+    """_ensure_agent_slice_memory_high() reconciles the AGGREGATE MemoryHigh
+    ceiling on kirocrew-agents.slice — bounding the SUM of all concurrent agent
+    scopes, which the per-scope MemoryMax cannot (N scopes each under their own
+    65% cap can still livelock a swapless host together)."""
+
+    def test_spawn_path_schedules_reconciliation_off_thread(self):
+        # cgroup_scope_argv runs on the gateway event loop, so the
+        # reconciliation (config read + systemctl subprocess) must happen in
+        # a worker thread, never inline on the caller's thread.
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        calling_thread: list = []
+        done = threading.Event()
+
+        def record_thread() -> None:
+            calling_thread.append(threading.current_thread())
+            done.set()
+
+        try:
+            with patch(
+                "kiro_crew.sandbox._ensure_agent_slice_memory_high",
+                side_effect=record_thread,
+            ):
+                sb._reconcile_slice_memory_high_off_thread()
+                assert done.wait(5.0), "reconciliation thread never ran"
+            assert calling_thread[0] is not threading.current_thread()
+        finally:
+            self._restore()
+
+    def test_schedule_during_reconciliation_queues_and_applies(self):
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        first_started = threading.Event()
+        release = threading.Event()
+        calls: list = []
+
+        def slow_reconcile() -> None:
+            calls.append(1)
+            if len(calls) == 1:
+                first_started.set()
+                release.wait(5.0)
+
+        try:
+            with patch(
+                "kiro_crew.sandbox._ensure_agent_slice_memory_high",
+                side_effect=slow_reconcile,
+            ):
+                sb._reconcile_slice_memory_high_off_thread()
+                assert first_started.wait(5.0)
+                # A schedule landing mid-reconciliation is NOT dropped: the
+                # second worker queues on the mutex and re-reconciles from
+                # live config after the first releases it.
+                sb._reconcile_slice_memory_high_off_thread()
+                release.set()
+                for _ in range(200):
+                    if len(calls) == 2:
+                        break
+                    time.sleep(0.01)
+            assert len(calls) == 2
+        finally:
+            self._restore()
+
+    def test_thread_start_failure_disarms_without_aborting_the_spawn(self) -> None:
+        # Thread exhaustion on the spawn path must not raise (aborting the
+        # agent spawn) nor retain the in-flight slot forever.
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            with patch(
+                "kiro_crew.sandbox.threading.Thread",
+                side_effect=RuntimeError("can't start new thread"),
+            ):
+                sb._reconcile_slice_memory_high_off_thread()  # must not raise
+            assert sb._SLICE_MEMHIGH_DISABLED is True
+            # The serialization mutex is untouched by the failure path:
+            assert sb._SLICE_MEMHIGH_MUTEX.acquire(blocking=False)
+            sb._SLICE_MEMHIGH_MUTEX.release()
+        finally:
+            self._restore()
+
+    def _reset(self):
+        import kiro_crew.sandbox as sb
+
+        sb._SLICE_MEMHIGH_APPLIED = None
+        sb._SLICE_MEMHIGH_DISABLED = False
+        sb._SLICE_MEMHIGH_EVENTS_SEEN = None
+        sb._SLICE_MEMHIGH_CLIMB_WARNED = False
+
+    def _restore(self):
+        # Leave the module disarmed, matching the autouse conftest fixture's
+        # in-test state (it restores its own snapshot afterwards).
+        import kiro_crew.sandbox as sb
+
+        sb._SLICE_MEMHIGH_APPLIED = None
+        sb._SLICE_MEMHIGH_DISABLED = True
+        sb._SLICE_MEMHIGH_EVENTS_SEEN = None
+        sb._SLICE_MEMHIGH_CLIMB_WARNED = False
+
+    def test_applies_host_default_via_systemctl_runtime(self):
+        # The slice is UID-global (shared by live/dev/pod gateways), so the
+        # ceiling is deliberately NOT config-driven: always the host-derived
+        # default, so no single instance can lift the others' protection.
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            with (
+                patch("kiro_crew.sandbox._default_slice_memory_high_mb", return_value=2048),
+                patch("kiro_crew.sandbox.platform_compat.trusted_system_bin", return_value="/usr/bin/systemctl"),
+                patch("kiro_crew.sandbox.subprocess.run") as run,
+            ):
+                run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+                sb._ensure_agent_slice_memory_high()
+            assert run.call_count == 1
+            argv = run.call_args[0][0]
+            assert argv == [
+                "/usr/bin/systemctl",
+                "--user",
+                "set-property",
+                "--runtime",
+                "kirocrew-agents.slice",
+                "MemoryHigh=2048M",
+            ]
+            assert sb._SLICE_MEMHIGH_APPLIED == "2048M"
+        finally:
+            self._restore()
+
+    def test_steady_state_is_a_noop(self):
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            with (
+                patch(
+                    "kiro_crew.sandbox._default_slice_memory_high_mb",
+                    return_value=2048,
+                ),
+                patch("kiro_crew.sandbox.platform_compat.trusted_system_bin", return_value="/usr/bin/systemctl"),
+                patch("kiro_crew.sandbox.subprocess.run") as run,
+            ):
+                run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+                sb._ensure_agent_slice_memory_high()
+                sb._ensure_agent_slice_memory_high()  # same value -> no spawn
+                assert run.call_count == 1
+            assert sb._SLICE_MEMHIGH_APPLIED == "2048M"
+        finally:
+            self._restore()
+
+    def test_failure_warns_once_and_disarms(self, caplog):
+        import logging
+
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            with (
+                patch("kiro_crew.sandbox._default_slice_memory_high_mb", return_value=2048),
+                patch("kiro_crew.sandbox.platform_compat.trusted_system_bin", return_value="/usr/bin/systemctl"),
+                patch("kiro_crew.sandbox.subprocess.run") as run,
+            ):
+                run.return_value = MagicMock(returncode=1, stderr="Failed to set", stdout="")
+                with caplog.at_level(logging.WARNING):
+                    sb._ensure_agent_slice_memory_high()
+                    sb._ensure_agent_slice_memory_high()  # disarmed -> no retry
+                assert run.call_count == 1
+            sec = [r for r in caplog.records if "SECURITY" in r.getMessage()]
+            assert len(sec) == 1
+            assert "MemoryHigh" in sec[0].getMessage()
+            assert sb._SLICE_MEMHIGH_DISABLED is True
+            assert sb._SLICE_MEMHIGH_APPLIED is None
+        finally:
+            self._restore()
+
+    def test_missing_systemctl_warns_and_disarms_without_raising(self, caplog):
+        import logging
+
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            with (
+                patch("kiro_crew.sandbox._default_slice_memory_high_mb", return_value=2048),
+                patch("kiro_crew.sandbox.platform_compat.trusted_system_bin", return_value=None),
+            ):
+                with caplog.at_level(logging.WARNING):
+                    sb._ensure_agent_slice_memory_high()
+            assert sb._SLICE_MEMHIGH_DISABLED is True
+            assert any("SECURITY" in r.getMessage() for r in caplog.records)
+        finally:
+            self._restore()
+
+    def test_cgroup_scope_argv_reconciles_when_available(self):
+        import kiro_crew.sandbox as sb
+
+        sb._CGROUP_SCOPE_PROBE = None
+        try:
+            with (
+                patch("kiro_crew.sandbox._probe_cgroup_scope", return_value=(True, "ok")),
+                patch(
+                    "kiro_crew.sandbox._cgroup_limits_from_config",
+                    return_value=(8192, 8192, 50, 0),
+                ),
+                patch("kiro_crew.sandbox._cpu_controller_delegated", return_value=False),
+                patch(
+                    "kiro_crew.sandbox._reconcile_slice_memory_high_off_thread"
+                ) as ensure,
+            ):
+                out = sb.cgroup_scope_argv(["kiro-cli", "chat"])
+            ensure.assert_called_once_with()
+            assert "--slice=kirocrew-agents.slice" in out
+        finally:
+            sb._CGROUP_SCOPE_PROBE = None
+
+    def test_cgroup_scope_argv_skips_reconcile_when_unavailable(self):
+        """No delegation -> passthrough argv AND no systemctl side effect (the
+        non-Linux / no-delegation degradation path)."""
+        import kiro_crew.sandbox as sb
+
+        sb._CGROUP_SCOPE_PROBE = None
+        sb._CGROUP_WARNED = False
+        try:
+            with (
+                patch(
+                    "kiro_crew.sandbox._probe_cgroup_scope",
+                    return_value=(False, "not Linux"),
+                ),
+                patch("kiro_crew.sandbox._ensure_agent_slice_memory_high") as ensure,
+            ):
+                out = sb.cgroup_scope_argv(["git", "status"])
+            ensure.assert_not_called()
+            assert out == ["git", "status"]
+        finally:
+            sb._CGROUP_SCOPE_PROBE = None
+            sb._CGROUP_WARNED = False
+
+    def test_default_is_host_proportional_with_fallback(self):
+        import kiro_crew.sandbox as sb
+
+        sixteen_g = 16 * 1024**3
+        with patch("os.sysconf", side_effect=lambda n: sixteen_g // 4096 if "PHYS" in n else 4096):
+            mb = sb._default_slice_memory_high_mb()
+        assert mb == int(sixteen_g * sb._SLICE_MEMORY_HIGH_FRACTION) // (1024 * 1024)
+        with patch("os.sysconf", side_effect=OSError("no sysconf")):
+            assert sb._default_slice_memory_high_mb() == sb._SLICE_FALLBACK_MEMORY_HIGH_MB
+        with patch("os.sysconf", return_value=0):
+            assert sb._default_slice_memory_high_mb() == sb._SLICE_FALLBACK_MEMORY_HIGH_MB
+
+    def test_worker_checks_pressure_after_reconcile(self):
+        # Throttle visibility rides the reconcile worker: every scheduled
+        # reconcile also reads memory.events, including the steady state
+        # where the MemoryHigh apply itself is a no-op string compare.
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        done = threading.Event()
+        try:
+            with (
+                patch("kiro_crew.sandbox._ensure_agent_slice_memory_high") as ensure,
+                patch(
+                    "kiro_crew.sandbox._check_slice_memory_pressure",
+                    side_effect=lambda: done.set(),
+                ) as check,
+            ):
+                sb._reconcile_slice_memory_high_off_thread()
+                assert done.wait(5.0), "pressure check never ran"
+            ensure.assert_called_once_with()
+            check.assert_called_once_with()
+        finally:
+            self._restore()
+
+    def test_pressure_warns_once_per_climbing_episode(self, caplog):
+        # A sustained throttling episode logs ONCE (at the first observed
+        # increase), stays silent while the counter keeps climbing, and
+        # re-arms only after an observation finds the counter stable.
+        import logging
+
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            readings = iter([0, 3, 5, 5, 7])
+            with patch(
+                "kiro_crew.sandbox._slice_memory_events_high",
+                side_effect=lambda: next(readings),
+            ):
+                with caplog.at_level(logging.WARNING):
+                    sb._check_slice_memory_pressure()  # 0: baseline, silent
+                    sb._check_slice_memory_pressure()  # 0 -> 3: warns
+                    sb._check_slice_memory_pressure()  # 3 -> 5: same episode
+                    sb._check_slice_memory_pressure()  # 5 == 5: episode ends
+                    sb._check_slice_memory_pressure()  # 5 -> 7: warns again
+            warns = [r for r in caplog.records if "memory.events" in r.getMessage()]
+            assert len(warns) == 2
+            assert "0 -> 3" in warns[0].getMessage()
+            assert "5 -> 7" in warns[1].getMessage()
+        finally:
+            self._restore()
+
+    def test_pressure_first_read_baselines_without_warning(self, caplog):
+        # The counter is monotonic for the slice cgroup's lifetime, so a
+        # nonzero FIRST read may predate this process — never warn on it.
+        import logging
+
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        try:
+            with patch("kiro_crew.sandbox._slice_memory_events_high", return_value=42):
+                with caplog.at_level(logging.WARNING):
+                    sb._check_slice_memory_pressure()
+            assert not [r for r in caplog.records if "memory.events" in r.getMessage()]
+            assert sb._SLICE_MEMHIGH_EVENTS_SEEN == 42
+        finally:
+            self._restore()
+
+    def test_pressure_counter_reset_rebaselines_silently(self, caplog):
+        # systemd releases an empty slice; recreation resets memory.events to
+        # zero. A DECREASE is that reset, not a climb: re-baseline, close any
+        # open episode, and warn again only on a genuine later increase.
+        import logging
+
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        sb._SLICE_MEMHIGH_EVENTS_SEEN = 5
+        sb._SLICE_MEMHIGH_CLIMB_WARNED = True
+        try:
+            with caplog.at_level(logging.WARNING):
+                with patch("kiro_crew.sandbox._slice_memory_events_high", return_value=2):
+                    sb._check_slice_memory_pressure()
+                assert sb._SLICE_MEMHIGH_EVENTS_SEEN == 2
+                assert sb._SLICE_MEMHIGH_CLIMB_WARNED is False
+                with patch("kiro_crew.sandbox._slice_memory_events_high", return_value=4):
+                    sb._check_slice_memory_pressure()
+            warns = [r for r in caplog.records if "memory.events" in r.getMessage()]
+            assert len(warns) == 1
+            assert "2 -> 4" in warns[0].getMessage()
+        finally:
+            self._restore()
+
+    def test_pressure_unreadable_is_silent_and_keeps_state(self, caplog):
+        # An unreadable memory.events (slice not materialized, no cgroup v2,
+        # macOS/Windows) must neither warn nor clobber the baseline.
+        import logging
+
+        import kiro_crew.sandbox as sb
+
+        self._reset()
+        sb._SLICE_MEMHIGH_EVENTS_SEEN = 5
+        try:
+            with patch("kiro_crew.sandbox._slice_memory_events_high", return_value=None):
+                with caplog.at_level(logging.WARNING):
+                    sb._check_slice_memory_pressure()
+            assert not [r for r in caplog.records if "memory.events" in r.getMessage()]
+            assert sb._SLICE_MEMHIGH_EVENTS_SEEN == 5
+        finally:
+            self._restore()
+
+    def test_slice_memory_events_high_reads_counter(self, tmp_path):
+        import kiro_crew.sandbox as sb
+
+        evt = tmp_path / "memory.events"
+        evt.write_text("low 0\nhigh 42\nmax 1\noom 0\noom_kill 0\n", encoding="utf-8")
+        with patch("kiro_crew.sandbox._agents_slice_cgroup_dir", return_value=tmp_path):
+            assert sb._slice_memory_events_high() == 42
+        with patch("kiro_crew.sandbox._agents_slice_cgroup_dir", return_value=None):
+            assert sb._slice_memory_events_high() is None
+        empty = tmp_path / "no-events"
+        empty.mkdir()
+        with patch("kiro_crew.sandbox._agents_slice_cgroup_dir", return_value=empty):
+            assert sb._slice_memory_events_high() is None
+        evt.write_text("low 0\nhigh notanumber\n", encoding="utf-8")
+        with patch("kiro_crew.sandbox._agents_slice_cgroup_dir", return_value=tmp_path):
+            assert sb._slice_memory_events_high() is None
+
+    @pytest.mark.skipif(sys.platform != "linux", reason="the resolver is Linux-only")
+    def test_slice_memory_events_high_resolves_dash_hierarchy(self, tmp_path):
+        """Regression: on the standard systemd layout the agents slice nests
+        under kirocrew.slice (dash-hierarchy), NOT directly under
+        user@<uid>.service. The reader must find memory.events through the
+        real resolver on that layout — a hardcoded flat path used to miss it,
+        silently disabling the throttle warning."""
+        import kiro_crew.sandbox as sb
+
+        nested = tmp_path / "kirocrew.slice" / sb._CGROUP_AGENTS_SLICE
+        nested.mkdir(parents=True)
+        (nested / "memory.events").write_text(
+            "low 0\nhigh 7\nmax 0\noom 0\noom_kill 0\n", encoding="utf-8"
+        )
+        with patch.object(sb, "_USER_MANAGER_CGROUP_BASE", str(tmp_path)):
+            assert sb._agents_slice_cgroup_dir() == nested
+            assert sb._slice_memory_events_high() == 7

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -767,6 +767,13 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         # would be circular: it constructs the cgroup boundary agent spawns
         # are confined by.
         "sandbox.py::ensure_agents_slice_limits",
+        # The agent-slice MemoryHigh reconciler. Fixed argv: `systemctl --user
+        # set-property --runtime kirocrew-agents.slice MemoryHigh=<value>`, where
+        # the binary is resolved with shutil.which (never a caller-supplied PATH)
+        # and <value> is derived from host RAM, never from agent input.
+        # Sandboxing it would also be circular: it CONFIGURES the cgroup
+        # containment that agent spawns are wrapped in.
+        "sandbox.py::_ensure_agent_slice_memory_high",
         # The chokepoint wrapper itself. It spawns whatever argv it is handed, so
         # it cannot route on its own behalf — its CALLERS are the ones this audit
         # holds to sandboxed_spawn_argv / wrap_argv, and they still appear here


### PR DESCRIPTION
## Problem

A host running heavy agent workloads froze hard under memory pressure: sustained allocation across concurrent agent process trees livelocked the machine for ~17 minutes until a power cycle. On a barebones, swapless host nothing recovers on its own — the kernel thrashes on reclaim, the gateway can't act, and the operator can't even get a shell.

The aggregate is already **capped**: every agent-influenced spawn is wrapped in a transient `systemd-run --user --scope` under `kirocrew-agents.slice` with a per-scope `MemoryMax` (65% of RAM), and `ensure_agents_slice_limits` puts a hard `MemoryMax=80%` + `MemorySwapMax=0` on the slice itself at gateway startup, so concurrent trees can no longer sum past physical RAM. What remains is the **failure semantics at that ceiling**: `memory.max` is a kill boundary — when the fleet's sum reaches 80%, the kernel OOM-kills a victim scope of its choosing, destroying that agent's in-flight work with no graceful degradation before it. There is no layer at which the fleet slows down instead of a random member dying.

## Fix

Add a **soft layer below the hard ceiling**, on the slice all agent scopes already share. `sandbox._ensure_agent_slice_memory_high()` reconciles `MemoryHigh` on `kirocrew-agents.slice` before each scope wrap:

- **Always 75% of physical RAM** (12288 MB fallback when RAM can't be read). The ceiling is deliberately **not config-driven**: the slice is UID-global — every gateway instance under the user (live, dev-backend, pods with delegation) parents scopes into the same slice — so a per-instance config key would let one permissively-configured instance lift the ceiling protecting the others.
- **`memory.high`, not `memory.max`**: past the ceiling the kernel throttles-and-reclaims the whole subtree instead of OOM-killing it. Agents slow down, the host stays interactive, and each scope's existing `MemoryMax` still hard-kills an individual runaway. The gateway never runs inside the slice, so slice pressure degrades agents — never the control plane.
- **No root, no external tooling, stateless on disk**: `systemctl --user set-property --runtime kirocrew-agents.slice MemoryHigh=<N>M`, executed by the unprivileged user manager that owns the slice. `--runtime` keeps the drop-in under `$XDG_RUNTIME_DIR` so it vanishes with the login session — no persistent unit files accumulate, and a stale ceiling never outlives the login session. Steady state costs one string compare per spawn.

### Degradation ladder

1. Linux + cgroup v2 + `memory` controller delegated + systemd user session (the existing `_probe_cgroup_scope` gate): ceiling enforced.
2. Probe fails (no delegation, no user session, macOS): no-op — the scope wrapper's existing one-time loud SECURITY warning already covers this.
3. Probe passes but `systemctl` is missing or the property call fails: one loud SECURITY warning, then disarmed for the process — agent spawns proceed uncontained at the slice level, per-scope `MemoryMax` still applies. Spawns never fail because containment couldn't be applied.

### Config

None. The ceiling is intentionally not configurable: the slice is UID-global and shared by every gateway instance under the user, so a per-instance key would let one instance change the ceiling that protects the others. The value is always host-derived (75% of physical RAM).
## Tests

- `test_sandbox_argv.py::TestAgentSliceMemoryHigh` (9 tests): exact `systemctl` argv, steady-state no-op, failure warns once and disarms, missing `systemctl` never raises, `cgroup_scope_argv` reconciles when delegation is available and skips when not, host-proportional default with fallback.
- Autouse fixture in `test/conftest.py` disarms the reconciler suite-wide so tests on delegation-capable hosts can't mutate the developer's real user manager (the root conftest's host-service guard refuses `set-property` for exactly this reason); the reconciler's own tests re-arm explicitly.
- Spawn-audit allowlist entry for the reconciler: fixed argv, `shutil.which`-resolved binary, host-derived value — not agent-influenced, and sandboxing it would be circular (it configures the containment agent spawns are wrapped in).

`docs/architecture/resource-protection.md` gains a summary-table row and a section documenting the mechanism, the UID-global-slice rationale, and the degradation ladder.


