### PR TITLE
feat: defer crons and refuse spawns under critical memory posture

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1178,6 +1178,18 @@ class AgentConfig:
             "at all. Should be <= resource_pressure_gb. 0 disables the critical tier.",
         ),
     )
+    admission_gate: bool = field(
+        default=True,
+        metadata=_meta(
+            "Posture Admission Gate",
+            "While available memory is at or below resource_critical_gb, defer "
+            "scheduled cron firings to the next tick and refuse new subagent "
+            "spawns until memory frees. Manually triggered cron runs, in-flight "
+            "subagents, and direct chat turns are never gated; an unreadable "
+            "probe admits (fail-open). Set false to make the critical posture "
+            "advisory-only.",
+        ),
+    )
     workflow_run_timeout_secs: int = field(
         default=3600,
         metadata=_meta(
@@ -5434,6 +5446,7 @@ class KiroCrewConfig:
                 ),
                 resource_pressure_gb=_safe_float(agent_data.get("resource_pressure_gb", 4.0), 4.0),
                 resource_critical_gb=_safe_float(agent_data.get("resource_critical_gb", 2.0), 2.0),
+                admission_gate=_safe_bool(agent_data.get("admission_gate"), True),
                 subagent_max_turns=agent_data.get("subagent_max_turns", 100),
                 subagent_timeout_secs=agent_data.get("subagent_timeout_secs", 1800),
                 subagent_stall_idle_secs=_safe_int(

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -51,6 +51,7 @@ from kiro_crew.config.loader import KiroCrewConfig, config_dir, data_home
 from kiro_crew.constants import env_flag_enabled
 from kiro_crew.cron_history import CronHistoryStore, CronRunRecord
 from kiro_crew.executors import subprocess_executor
+from kiro_crew.resource_status import admission_check
 
 logger = logging.getLogger(__name__)
 
@@ -683,6 +684,11 @@ class CronService:
         # a completed one-shot is always
         # eventually removed and can never re-fire in the meantime.
         self._pending_removals: set[str] = set()
+        # True while a critical-posture episode is deferring scheduled
+        # firings (see _on_timer). Log-throttle state only: the INFO line
+        # fires once per deferral episode, not once per deferred tick.
+        self._admission_deferring: bool = False
+        self._admission_last_log: float = 0.0
         # job_id → active session_key for the in-flight run.
         # Populated by the dispatcher (gateway callback) so the reaper can
         # target per-run ephemeral keys when persistent_session=False.
@@ -2176,6 +2182,15 @@ class CronService:
         delay = self._next_wake_secs()
         if delay is None:
             return _TIMER_POLL_SECS
+        if self._admission_deferring and delay < _TIMER_POLL_SECS:
+            # A critical-posture episode leaves deferred ``every``/``at``
+            # jobs overdue (``last_run_ts`` untouched by design), which
+            # would otherwise re-arm the timer at zero delay — a busy loop
+            # of scans and admission probes on a host already under memory
+            # pressure. Back off to the poll cadence: the episode is
+            # re-evaluated (and deferred jobs fire) within one poll of
+            # posture recovery.
+            return _TIMER_POLL_SECS
         return min(delay, _TIMER_POLL_SECS)
 
     def _arm_timer(self) -> None:
@@ -2284,6 +2299,88 @@ class CronService:
             for j in snapshot
             if j.enabled and j.id not in self._executing and self._is_due(j, now)
         ]
+
+        # An empty due-scan can only end the tick when no deferral episode is
+        # in progress: the recovery log (below) must still fire on a quiet
+        # tick, otherwise an episode that ends during a lull is never closed.
+        if not due and not self._admission_deferring:
+            return
+
+        # Posture-gated admission: while host memory is CRITICAL, defer this
+        # tick's ``every``/``at`` firings instead of admitting more work onto
+        # a host that cannot absorb it. The verdict is computed off-loop
+        # (config + procfs reads must not stall the event loop). Deferral is
+        # deliberately STATELESS and only applies to schedule kinds that stay
+        # due on their own (``last_run_ts`` untouched, so a deferred job fires
+        # on the first admitted tick). A cron-expression job is only due while
+        # its expression matches the current minute, so it cannot be deferred
+        # statelessly: an in-memory catch-up marker loses the occurrence on
+        # gateway restart, and dropping it silently loses the occurrence
+        # outright — so cron-expression jobs run normally even under critical
+        # posture (persisted deferral markers are a possible follow-up).
+        # Manual runs (run_job / cron_trigger) never pass through this scan
+        # and are not deferred. Fails open on unknown posture. The INFO log
+        # fires once per deferral episode and re-fires every 15 minutes so a
+        # long suspension stays diagnosable.
+        decision = await asyncio.to_thread(admission_check)
+
+        # The admission await yielded the loop, so the due snapshot may be
+        # stale: a manual run (run_job / cron_trigger) can have claimed — or
+        # even completed — a job meanwhile, and a job can have been edited,
+        # disabled, or queued for removal. Rebuild the due list from the LIVE
+        # job objects and re-run the due check BEFORE the deferral partition
+        # below: classifying by the stale snapshot's schedule kind would let
+        # an interval job edited into a matching cron expression during the
+        # await be deferred-and-dropped (its occurrence lost), and dispatching
+        # the snapshot object would execute a stale definition. An id-only
+        # check would double-fire a job whose manual run already finished.
+        # The re-check deliberately reuses the scan-time ``now``: a live
+        # ``last_run_ts`` advanced by a finished manual run still fails it
+        # (interval math for ``every``/``at``, the same-minute guard for cron
+        # expressions), while a minute boundary crossed during the await
+        # cannot drop a cron-expression occurrence that was genuinely due at
+        # scan time.
+        live_by_id = {j.id: j for j in self._jobs if j.enabled}
+        due = [
+            live_by_id[j.id]
+            for j in due
+            if j.id in live_by_id
+            and j.id not in self._executing
+            and j.id not in self._pending_removals
+            and self._is_due(live_by_id[j.id], now)
+        ]
+
+        if not decision.admitted:
+            deferred = [j for j in due if j.schedule.kind != "cron"]
+            due = [j for j in due if j.schedule.kind == "cron"]
+            now_mono = time.monotonic()
+            if not self._admission_deferring:
+                self._admission_deferring = True
+                self._admission_last_log = now_mono
+                logger.info(
+                    "Cron: deferring interval/one-shot firings (%d deferred "
+                    "this tick; cron-expression jobs run normally) — %s "
+                    "(re-logged every 15 min while the episode lasts)",
+                    len(deferred),
+                    decision.reason,
+                )
+            elif now_mono - self._admission_last_log >= 900.0:
+                self._admission_last_log = now_mono
+                logger.info(
+                    "Cron: STILL deferring interval/one-shot firings (%d "
+                    "deferred this tick) — %s",
+                    len(deferred),
+                    decision.reason,
+                )
+            else:
+                logger.debug(
+                    "Cron: still deferring %d scheduled job(s)", len(deferred)
+                )
+        elif self._admission_deferring:
+            self._admission_deferring = False
+            logger.info(
+                "Cron: memory posture recovered — resuming scheduled firings"
+            )
 
         if not due:
             return

--- a/src/kiro_crew/resource_status.py
+++ b/src/kiro_crew/resource_status.py
@@ -11,11 +11,15 @@ Shared by two advisory surfaces:
 * the **``resource_status`` pull tool** in ``mcp_core`` — an on-demand probe
   the model can call before a heavy step ("am I clear to run the full suite?").
 
-This is **advisory only**: no enforcement, no lease, no cross-session
+The advisory surfaces carry no enforcement, no lease, no cross-session
 coordination. Two sessions can both read "ample" and both launch heavy work —
-the tradeoff of a cheap, zero-tuning guard. It makes the agent *smarter* about
-when to go light, not *bounded*. (A hard, cross-session admission lease is a
-separate, heavier design.)
+the tradeoff of a cheap, zero-tuning guard. One narrow enforcement point sits
+on top: :func:`admission_check` gates *background* work admission (scheduled
+cron firings, new subagent spawns) while posture is CRITICAL, so the scheduler
+stops piling work onto a host that is about to freeze. Direct user chat turns
+and the gateway's own operation are never gated, and the gate fails open on an
+unknown posture. (A hard, cross-session admission lease is a separate, heavier
+design.)
 
 The memory figure reuses :func:`kiro_crew.subagent._available_memory_gb`, the
 same cgroup-clamped, container-aware probe that auto-sizes the sub-agent cap, so
@@ -27,8 +31,12 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
+import time
 from collections.abc import MutableMapping
 from dataclasses import dataclass
+
+from kiro_crew.config.loader import KiroCrewConfig
 
 logger = logging.getLogger(__name__)
 
@@ -297,3 +305,130 @@ def inject_xdist_auto_cap(env: MutableMapping[str, str]) -> None:
     if available_gb < 0:
         return  # probe unavailable — fail open to xdist's default
     env[XDIST_AUTO_ENV] = str(compute_xdist_auto_workers(available_gb, os.cpu_count() or 1))
+
+
+@dataclass(frozen=True)
+class AdmissionDecision:
+    """Typed verdict from :func:`admission_check`.
+
+    ``reason`` is a caller-embeddable, human-readable explanation — non-empty
+    exactly when ``admitted`` is False, so refusal surfaces (spawn errors, cron
+    deferral logs) can relay it verbatim.
+    """
+
+    admitted: bool
+    posture: str        # POSTURE_* observed at decision time
+    available_gb: float  # -1.0 when the memory probe is unavailable
+    reason: str = ""
+
+
+def _gate_enabled(cfg: object | None) -> bool:
+    """Whether the admission gate is switched on (``agent.admission_gate``)."""
+    agent = getattr(cfg, "agent", None)
+    enabled = getattr(agent, "admission_gate", True)
+    return enabled if isinstance(enabled, bool) else True
+
+
+def admission_check(cfg: object | None = None) -> AdmissionDecision:
+    """Decide whether new *background* work may start right now.
+
+    The single enforcement point layered on the advisory posture tier: a
+    CRITICAL posture refuses; every other posture — ample, tight, and unknown —
+    admits. Callers on the two gated paths (scheduled cron firings, new
+    subagent spawns) consult this once per admission decision; it reuses the
+    same cheap :func:`probe` the advisory surfaces use (fingerprint-cached
+    config + one memory read) and adds no extra filesystem scanning.
+
+    Fail-open by construction: an unreadable memory probe classifies as
+    ``unknown`` (admitted), a disabled gate (``agent.admission_gate: false``)
+    always admits, and any unexpected error admits — the gate must never be
+    the thing that strands the scheduler. *cfg* is an optional pre-loaded
+    ``KiroCrewConfig``; never raises.
+    """
+    try:
+        if cfg is None:
+            try:
+                cfg = KiroCrewConfig.load()
+            except Exception:  # pragma: no cover - defensive
+                # Fail-open, not fall-back: probing with default thresholds
+                # (and the gate's default-on) could DEFER work because the
+                # config was unreadable — the documented contract is that
+                # only a genuine critical posture refuses.
+                return AdmissionDecision(
+                    admitted=True, posture=POSTURE_UNKNOWN, available_gb=-1.0
+                )
+        status = probe(cfg)
+        if not _gate_enabled(cfg):
+            return AdmissionDecision(
+                admitted=True, posture=status.posture, available_gb=status.available_gb
+            )
+        if status.posture == POSTURE_CRITICAL:
+            return AdmissionDecision(
+                admitted=False,
+                posture=status.posture,
+                available_gb=status.available_gb,
+                reason=(
+                    f"host memory is critical (~{status.available_gb:.1f} GB free, "
+                    f"critical \u2264 {status.critical_gb:g} GB) — retry when memory frees"
+                ),
+            )
+        return AdmissionDecision(
+            admitted=True, posture=status.posture, available_gb=status.available_gb
+        )
+    except Exception:
+        logger.debug("admission check failed — admitting (fail-open)", exc_info=True)
+        return AdmissionDecision(admitted=True, posture=POSTURE_UNKNOWN, available_gb=-1.0)
+
+
+# Cached-verdict layer for callers that must never block: the sync spawn path
+# runs on the gateway event loop, so it reads the last off-thread verdict
+# instead of probing inline. Freshness window sized to the posture's own rate
+# of change (memory exhaustion develops over tens of seconds, not millis).
+_CACHED_TTL_SECS = 5.0
+_cached_decision: AdmissionDecision | None = None
+_cached_at: float = 0.0
+_cache_refresh_inflight = threading.Lock()
+
+
+def _refresh_cached_decision() -> None:
+    global _cached_decision, _cached_at
+    try:
+        _cached_decision = admission_check()
+        _cached_at = time.monotonic()
+    finally:
+        _cache_refresh_inflight.release()
+
+
+def cached_admission_check() -> AdmissionDecision:
+    """Non-blocking admission verdict for event-loop hot paths.
+
+    Returns the last off-thread verdict while it is fresh; when stale, kicks
+    one background refresh (non-blocking dedupe) and returns the previous
+    verdict — or a fail-open admit before the first refresh completes. The
+    caller's thread never performs config or procfs I/O, which is what keeps
+    the sync spawn path safe to call from the gateway event loop. The
+    trade-off is bounded staleness (:data:`_CACHED_TTL_SECS` plus one refresh
+    latency), acceptable because the gate is advisory pressure-shedding, not
+    a correctness barrier.
+    """
+    if _cached_decision is None or time.monotonic() - _cached_at >= _CACHED_TTL_SECS:
+        if _cache_refresh_inflight.acquire(blocking=False):
+            try:
+                threading.Thread(
+                    target=_refresh_cached_decision,
+                    name="admission-refresh",
+                    daemon=True,
+                ).start()
+            except RuntimeError:
+                # Thread exhaustion: this runs on the spawn path, so it must
+                # neither raise nor retain the refresh lock. Fail-open below.
+                _cache_refresh_inflight.release()
+                logger.debug("admission refresh thread could not start", exc_info=True)
+    if _cached_decision is not None:
+        return _cached_decision
+    return AdmissionDecision(
+        admitted=True,
+        posture=POSTURE_UNKNOWN,
+        available_gb=-1.0,
+        reason="no cached verdict yet — admitting (fail-open)",
+    )

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -66,6 +66,7 @@ from kiro_crew.providers.base import (
     EVENT_TOOL_RESULT,
     LLMEvent,
 )
+from kiro_crew.resource_status import cached_admission_check
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 from kiro_crew.session import SessionManager
@@ -2746,6 +2747,41 @@ class SubagentManager:
             )
             return self._announce_rejection(info)
 
+        # --- Admission gate: refuse NEW spawns while host memory posture is
+        # critical. Complements the absolute spawn_min_memory_gb floor above
+        # with the posture tier (resource_critical_gb) and shares its
+        # off-switch (agent.admission_gate) with the cron scheduler's deferral
+        # gate. This method is sync and runs on the gateway event loop, so it
+        # reads the CACHED off-thread verdict — never inline config/procfs
+        # I/O; bounded staleness is acceptable for pressure-shedding.
+        # In-flight subagents are untouched; direct user chat turns are
+        # not gated; fails open on an unknown posture. ---
+        admission = cached_admission_check()
+        if not admission.admitted:
+            logger.warning("Subagent spawn refused: %s", admission.reason)
+            sel().log_tool_invocation(
+                session_key=parent_session_key or "",
+                source="subagent",
+                tool_name="spawn_run",
+                outcome="refused_memory_critical",
+                metadata={
+                    "available_gb": admission.available_gb,
+                    "posture": admission.posture,
+                    "task": _redacted_task[:120],
+                },
+            )
+            info = SubagentInfo(
+                id=agent_id,
+                task=_redacted_task,
+                agent=agent,
+                parent_session_key=parent_session_key,
+                done=True,
+                error=f"spawn refused: {admission.reason}",
+                batch_id=batch_id,
+                batch_total=max(0, int(batch_total)),
+            )
+            return self._announce_rejection(info)
+
         # --- CWD validation: reject bad paths before consuming a slot ---
         resolved_cwd = ""
         if cwd:
@@ -3086,7 +3122,10 @@ class SubagentManager:
 
         Non-batch rejections skip the announce: the caller already receives
         the error synchronously in the returned info, and injecting a
-        completion turn for them would double-report.
+        completion turn for them would double-report. That holds for
+        queue-drained non-batch rejections too — ``_drain_queue`` announces
+        those itself off the returned info, so announcing here as well would
+        inject the completion twice.
         """
         if info.batch_id and self._on_done:
             try:

--- a/test/test_admission_gate.py
+++ b/test/test_admission_gate.py
@@ -1,0 +1,684 @@
+"""Tests for posture-gated admission control.
+
+Covers :func:`kiro_crew.resource_status.admission_check` (critical refuses;
+ample/tight/unknown admit; off-switch; fail-open), the cron scheduler's
+critical-posture deferral in ``_on_timer`` (deferred jobs are not marked
+failed, fire on recovery, one INFO per episode; manual triggers are never
+deferred), the subagent spawn refusal (typed SEL outcome + retry-later error),
+and the ``agent.admission_gate`` config key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import threading
+import time
+import unittest.mock
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew import resource_status as rs
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.cron import CronService
+
+
+def _cfg(pressure: float = 4.0, critical: float = 2.0, gate: bool = True) -> SimpleNamespace:
+    """Minimal stand-in for KiroCrewConfig exposing the gate's config surface."""
+    return SimpleNamespace(
+        agent=SimpleNamespace(
+            resource_pressure_gb=pressure,
+            resource_critical_gb=critical,
+            admission_gate=gate,
+        )
+    )
+
+
+def _refused() -> rs.AdmissionDecision:
+    return rs.AdmissionDecision(
+        admitted=False,
+        posture=rs.POSTURE_CRITICAL,
+        available_gb=1.2,
+        reason=(
+            "host memory is critical (~1.2 GB free, critical \u2264 2 GB) — "
+            "retry when memory frees"
+        ),
+    )
+
+
+def _admitted() -> rs.AdmissionDecision:
+    return rs.AdmissionDecision(
+        admitted=True, posture=rs.POSTURE_AMPLE, available_gb=16.0
+    )
+
+
+async def _wait_for(predicate, timeout=5.0, interval=0.05):
+    """Poll until predicate is true or timeout."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_running_loop().time() > deadline:
+            raise AssertionError("Timed out waiting for predicate")
+        await asyncio.sleep(interval)
+
+
+# ── admission_check ──────────────────────────────────────────────────────────
+
+
+class TestAdmissionCheck:
+    def test_critical_refuses(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(rs, "_read_available_gb", lambda: 1.0)
+        decision = rs.admission_check(_cfg())
+        assert decision.admitted is False
+        assert decision.posture == rs.POSTURE_CRITICAL
+        assert "critical" in decision.reason
+        assert "retry" in decision.reason
+
+    @pytest.mark.parametrize(
+        "avail,posture",
+        [
+            (3.0, rs.POSTURE_TIGHT),
+            (32.0, rs.POSTURE_AMPLE),
+            (-1.0, rs.POSTURE_UNKNOWN),  # unreadable probe → fail open
+        ],
+    )
+    def test_non_critical_admits(
+        self, monkeypatch: pytest.MonkeyPatch, avail: float, posture: str
+    ) -> None:
+        monkeypatch.setattr(rs, "_read_available_gb", lambda: avail)
+        decision = rs.admission_check(_cfg())
+        assert decision.admitted is True
+        assert decision.posture == posture
+        assert decision.reason == ""
+
+    def test_off_switch_admits_even_when_critical(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(rs, "_read_available_gb", lambda: 1.0)
+        decision = rs.admission_check(_cfg(gate=False))
+        assert decision.admitted is True
+        # The posture is still reported truthfully — only enforcement is off.
+        assert decision.posture == rs.POSTURE_CRITICAL
+
+    def test_fail_open_on_probe_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(cfg: object | None = None) -> rs.ResourceStatus:
+            raise RuntimeError("probe exploded")
+
+        monkeypatch.setattr(rs, "probe", _boom)
+        decision = rs.admission_check(_cfg())
+        assert decision.admitted is True
+        assert decision.posture == rs.POSTURE_UNKNOWN
+
+    def test_fail_open_on_config_load_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An unreadable config must ADMIT (fail-open), never gate work on
+        # default thresholds it could not actually read.
+        monkeypatch.setattr(
+            rs.KiroCrewConfig,
+            "load",
+            MagicMock(side_effect=RuntimeError("config unreadable")),
+        )
+        probe_mock = MagicMock()
+        monkeypatch.setattr(rs, "probe", probe_mock)
+        decision = rs.admission_check(None)
+        assert decision.admitted is True
+        assert decision.posture == rs.POSTURE_UNKNOWN
+        probe_mock.assert_not_called()  # returned before probing
+
+    def test_gate_defaults_on_when_config_lacks_the_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(rs, "_read_available_gb", lambda: 1.0)
+        cfg = SimpleNamespace(
+            agent=SimpleNamespace(resource_pressure_gb=4.0, resource_critical_gb=2.0)
+        )
+        assert rs.admission_check(cfg).admitted is False
+
+    def test_non_bool_gate_value_defaults_on(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(rs, "_read_available_gb", lambda: 1.0)
+        cfg = _cfg()
+        cfg.agent.admission_gate = "yes"  # malformed → treated as enabled
+        assert rs.admission_check(cfg).admitted is False
+
+
+# ── cron deferral ────────────────────────────────────────────────────────────
+
+
+class TestCronAdmissionDeferral:
+    @pytest.mark.asyncio
+    async def test_critical_defers_then_runs_on_recovery(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        executed: list[str] = []
+
+        async def callback(job) -> None:
+            executed.append(job.name)
+
+        svc = CronService(base_dir=tmp_path, on_job=callback)
+        await svc.start()
+        svc.add_job("gated", "msg", every_secs=60)
+        job = svc._jobs[0]
+        job.last_run_ts = time.time() - 120
+
+        with caplog.at_level(logging.INFO, logger="kiro_crew.cron"):
+            with patch("kiro_crew.cron.admission_check", return_value=_refused()):
+                await svc._on_timer()
+                await svc._on_timer()
+
+        # Deferred: never fired, not marked failed, still due next tick.
+        assert executed == []
+        assert job.last_status is None
+        assert job.id not in svc._running_tasks
+        infos = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.INFO and "deferring" in r.getMessage()
+        ]
+        assert len(infos) == 1  # one INFO per episode, not per tick
+
+        # Recovery: the same job fires on the next admitted tick.
+        with patch("kiro_crew.cron.admission_check", return_value=_admitted()):
+            await svc._on_timer()
+        await _wait_for(lambda: "gated" in executed)
+
+        # A NEW critical episode logs its own INFO line.
+        job.last_run_ts = time.time() - 120
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="kiro_crew.cron"):
+            with patch("kiro_crew.cron.admission_check", return_value=_refused()):
+                await svc._on_timer()
+        assert any(
+            "deferring" in r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.INFO
+        )
+        await svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_manual_trigger_runs_despite_critical(self, tmp_path: Path) -> None:
+        executed: list[str] = []
+
+        async def callback(job) -> None:
+            executed.append(job.name)
+
+        svc = CronService(base_dir=tmp_path, on_job=callback)
+        await svc.start()
+        svc.add_job("manual", "msg", every_secs=3600)
+        job_id = svc._jobs[0].id
+
+        with patch("kiro_crew.cron.admission_check", return_value=_refused()):
+            ran = await svc.run_job(job_id)
+
+        assert ran is True
+        assert executed == ["manual"]
+        await svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_admitted_tick_fires_normally(self, tmp_path: Path) -> None:
+        executed: list[str] = []
+
+        async def callback(job) -> None:
+            executed.append(job.name)
+
+        svc = CronService(base_dir=tmp_path, on_job=callback)
+        await svc.start()
+        svc.add_job("open", "msg", every_secs=60)
+        svc._jobs[0].last_run_ts = time.time() - 120
+
+        with patch("kiro_crew.cron.admission_check", return_value=_admitted()):
+            await svc._on_timer()
+        await _wait_for(lambda: "open" in executed)
+        await svc.stop()
+
+
+# ── spawn refusal ────────────────────────────────────────────────────────────
+
+
+class TestSpawnAdmissionGate:
+    def _mgr(self):
+        from kiro_crew.subagent import SubagentManager
+
+        return SubagentManager(
+            sessions=MagicMock(),
+            ctx_builder=MagicMock(),
+            on_done=MagicMock(),
+            max_concurrent=3,
+        )
+
+    def test_spawn_refused_when_critical(self) -> None:
+        """spawn() returns a done SubagentInfo with a retry-later error."""
+        mgr = self._mgr()
+        with patch(
+            "kiro_crew.subagent.check_memory_available", return_value=(True, 8.0)
+        ), patch("kiro_crew.subagent.KiroCrewConfig") as mock_cfg, patch(
+            "kiro_crew.subagent.cached_admission_check", return_value=_refused()
+        ), patch(
+            "kiro_crew.subagent.sel"
+        ) as mock_sel:
+            mock_cfg.load.return_value.agent.spawn_min_memory_gb = 4.0
+            mock_sel.return_value.log_tool_invocation = MagicMock()
+
+            info = mgr.spawn(task="test task", parent_session_key="sess-1")
+
+        assert info is not None
+        assert info.done is True
+        assert "critical" in info.error
+        assert "retry" in info.error
+        call_kwargs = mock_sel.return_value.log_tool_invocation.call_args[1]
+        assert call_kwargs["outcome"] == "refused_memory_critical"
+        assert call_kwargs["metadata"]["posture"] == rs.POSTURE_CRITICAL
+
+    def test_spawn_proceeds_past_gate_when_admitted(self) -> None:
+        """An admitted decision falls through to the next guard (cwd here)."""
+        mgr = self._mgr()
+        with patch(
+            "kiro_crew.subagent.check_memory_available", return_value=(True, 8.0)
+        ), patch("kiro_crew.subagent.KiroCrewConfig") as mock_cfg, patch(
+            "kiro_crew.subagent.cached_admission_check", return_value=_admitted()
+        ), patch(
+            "kiro_crew.subagent.validate_cwd", return_value=("", "not allowed")
+        ), patch(
+            "kiro_crew.subagent.sel"
+        ) as mock_sel:
+            mock_cfg.load.return_value.agent.spawn_min_memory_gb = 4.0
+            mock_cfg.load.return_value.agent.subagent_cwd_allowed_roots = []
+            mock_sel.return_value.log_tool_invocation = MagicMock()
+
+            info = mgr.spawn(task="test task", parent_session_key="sess-1", cwd="/x")
+
+        assert info is not None
+        assert info.done is True
+        call_kwargs = mock_sel.return_value.log_tool_invocation.call_args[1]
+        assert call_kwargs["outcome"] == "rejected_invalid_cwd"
+
+
+# ── config key ───────────────────────────────────────────────────────────────
+
+
+def _load_from_dict(data: dict, tmp_path: Path) -> KiroCrewConfig:
+    """Write *data* to a config file under *tmp_path* and load it."""
+    tmp = tmp_path / "config.json"
+    tmp.write_text(json.dumps(data))
+    with unittest.mock.patch(
+        "kiro_crew.config.loader.config_path", return_value=tmp
+    ):
+        return KiroCrewConfig.load()
+
+
+class TestAdmissionGateConfig:
+    def test_defaults_on(self, tmp_path: Path) -> None:
+        cfg = _load_from_dict({}, tmp_path)
+        assert cfg.agent.admission_gate is True
+
+    def test_off_switch(self, tmp_path: Path) -> None:
+        cfg = _load_from_dict({"agent": {"admission_gate": False}}, tmp_path)
+        assert cfg.agent.admission_gate is False
+
+    def test_non_bool_value_falls_back_to_default(self, tmp_path: Path) -> None:
+        cfg = _load_from_dict({"agent": {"admission_gate": "nope"}}, tmp_path)
+        assert cfg.agent.admission_gate is True
+
+
+class TestCachedAdmissionCheck:
+    """cached_admission_check() — the non-blocking verdict for event-loop
+    callers: no inline I/O, background refresh, bounded staleness."""
+
+    def _reset(self) -> None:
+        rs._cached_decision = None
+        rs._cached_at = 0.0
+
+    def test_first_call_fails_open_and_kicks_refresh(self, monkeypatch) -> None:
+        self._reset()
+        gate = threading.Event()
+        verdict = _refused()
+
+        def fake_check(cfg: object | None = None) -> rs.AdmissionDecision:
+            gate.wait(5.0)  # hold the refresh until fail-open is asserted
+            return verdict
+
+        monkeypatch.setattr(rs, "admission_check", fake_check)
+        try:
+            first = rs.cached_admission_check()
+            assert first.admitted  # fail-open before the first refresh lands
+            gate.set()
+            for _ in range(200):  # refresh thread publishes shortly after
+                if rs._cached_decision is not None:
+                    break
+                time.sleep(0.01)
+            assert rs.cached_admission_check() is verdict  # fresh cache served
+        finally:
+            # A refused verdict left in the module-global cache would poison
+            # every spawn-exercising test in this worker for the TTL window.
+            self._reset()
+
+    def test_fresh_cache_is_served_without_probing(self, monkeypatch) -> None:
+        self._reset()
+        verdict = _refused()
+        rs._cached_decision = verdict
+        rs._cached_at = time.monotonic()
+        probes: list[int] = []
+        monkeypatch.setattr(rs, "admission_check", lambda cfg=None: probes.append(1))
+        try:
+            assert rs.cached_admission_check() is verdict
+            time.sleep(0.05)
+            assert probes == []  # fresh cache => no background refresh either
+        finally:
+            self._reset()
+
+
+class TestCronExprPassthrough:
+    """Cron-expression jobs run normally even under critical posture: they
+    cannot be deferred statelessly (in-memory markers lose the occurrence on
+    restart; dropping loses it outright), so only ``every``/``at`` jobs —
+    which stay due on their own — are deferred."""
+
+    @pytest.mark.asyncio
+    async def test_job_claimed_during_admission_await_is_not_double_fired(
+        self, tmp_path: Path
+    ) -> None:
+        # The admission await yields the loop; a manual run can claim the job
+        # meanwhile. The timer must revalidate and skip it, never start a
+        # duplicate execution over the in-flight run.
+        executed: list[str] = []
+
+        async def callback(job) -> None:
+            executed.append(job.name)
+
+        svc = CronService(base_dir=tmp_path, on_job=callback)
+        await svc.start()
+        svc.add_job("claimed", "msg", every_secs=60)
+        job = svc._jobs[0]
+        job.last_run_ts = time.time() - 120
+
+        def claiming_check(cfg: object | None = None):
+            svc._executing.add(job.id)  # simulate a manual run claiming it
+            return _admitted()
+
+        with patch("kiro_crew.cron.admission_check", side_effect=claiming_check):
+            await svc._on_timer()
+        assert executed == []  # revalidated away, no duplicate
+        svc._executing.discard(job.id)
+        await svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_manual_run_completed_during_await_is_not_double_fired(
+        self, tmp_path: Path
+    ) -> None:
+        # Harder variant: the manual run starts AND FINISHES during the
+        # admission await, so the job is no longer in _executing. An id-only
+        # revalidation would double-fire; the live-object _is_due re-check
+        # (advanced last_run_ts) must catch it.
+        executed: list[str] = []
+
+        async def callback(job) -> None:
+            executed.append(job.name)
+
+        svc = CronService(base_dir=tmp_path, on_job=callback)
+        await svc.start()
+        svc.add_job("finished", "msg", every_secs=60)
+        job = svc._jobs[0]
+        job.last_run_ts = time.time() - 120
+
+        def completing_check(cfg: object | None = None):
+            job.last_run_ts = time.time()  # manual run ran to completion
+            return _admitted()
+
+        with patch("kiro_crew.cron.admission_check", side_effect=completing_check):
+            await svc._on_timer()
+        await asyncio.sleep(0.05)
+        assert executed == []  # not re-fired against the stale snapshot
+        await svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_job_edited_during_await_dispatches_live_object(
+        self, tmp_path: Path
+    ) -> None:
+        # A job replaced during the await must execute its LIVE definition,
+        # not the stale snapshot's.
+        executed: list[str] = []
+
+        async def callback(job) -> None:
+            executed.append(job.message)
+
+        svc = CronService(base_dir=tmp_path, on_job=callback)
+        await svc.start()
+        svc.add_job("edited", "old-message", every_secs=60)
+        job = svc._jobs[0]
+        job.last_run_ts = time.time() - 120
+
+        def editing_check(cfg: object | None = None):
+            job.message = "new-message"
+            return _admitted()
+
+        with patch("kiro_crew.cron.admission_check", side_effect=editing_check):
+            await svc._on_timer()
+        await _wait_for(lambda: len(executed) == 1)
+        assert executed == ["new-message"]
+        await svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_cron_expr_job_runs_normally_under_critical(
+        self, tmp_path: Path
+    ) -> None:
+        # A cron-expression job whose minute matches during a critical
+        # episode fires anyway — the occurrence is neither dropped nor
+        # remembered in state that a restart would lose.
+        executed: list[str] = []
+
+        async def callback(job) -> None:
+            executed.append(job.name)
+
+        svc = CronService(base_dir=tmp_path, on_job=callback)
+        await svc.start()
+        svc.add_job("expr-job", "msg", cron_expr="* * * * *")
+
+        with (
+            patch("kiro_crew.cron.admission_check", return_value=_refused()),
+            patch("kiro_crew.cron.cron_expr_matches", return_value=True),
+        ):
+            await svc._on_timer()
+        await _wait_for(lambda: "expr-job" in executed)
+        await svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_mixed_due_defers_interval_but_fires_expr(
+        self, tmp_path: Path
+    ) -> None:
+        # One tick, both kinds due, critical posture: the interval job is
+        # deferred (stays due, untouched), the cron-expression job fires.
+        executed: list[str] = []
+
+        async def callback(job) -> None:
+            executed.append(job.name)
+
+        svc = CronService(base_dir=tmp_path, on_job=callback)
+        await svc.start()
+        svc.add_job("interval", "msg", every_secs=60)
+        svc.add_job("expr", "msg", cron_expr="* * * * *")
+        interval_job = next(j for j in svc._jobs if j.name == "interval")
+        interval_job.last_run_ts = time.time() - 120
+
+        with (
+            patch("kiro_crew.cron.admission_check", return_value=_refused()),
+            patch("kiro_crew.cron.cron_expr_matches", return_value=True),
+        ):
+            await svc._on_timer()
+        await _wait_for(lambda: "expr" in executed)
+        assert executed == ["expr"]  # interval deferred, not fired
+        assert interval_job.last_status is None  # untouched: still due
+
+        # Recovery: the deferred interval job fires on its own.
+        with patch("kiro_crew.cron.admission_check", return_value=_admitted()):
+            await svc._on_timer()
+        await _wait_for(lambda: "interval" in executed)
+        await svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_deferral_episode_floors_timer_delay(
+        self, tmp_path: Path
+    ) -> None:
+        # A deferred (overdue) interval job would otherwise re-arm the timer
+        # at zero delay — a busy loop of scans and admission probes on a host
+        # already under memory pressure. During an episode the re-arm delay
+        # is floored at the poll cadence.
+        from kiro_crew.cron import _TIMER_POLL_SECS
+
+        svc = CronService(base_dir=tmp_path, on_job=AsyncMock())
+        await svc.start()
+        svc.add_job("overdue", "msg", every_secs=60)
+        svc._jobs[0].last_run_ts = time.time() - 120
+
+        assert svc._effective_delay() < 1.0  # overdue: due immediately
+
+        with patch("kiro_crew.cron.admission_check", return_value=_refused()):
+            await svc._on_timer()  # opens the episode, defers the job
+        assert svc._admission_deferring is True
+        assert svc._effective_delay() == _TIMER_POLL_SECS  # floored
+
+        with patch("kiro_crew.cron.admission_check", return_value=_admitted()):
+            await svc._on_timer()  # recovery closes the episode
+        assert svc._admission_deferring is False
+        await svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_interval_edited_to_cron_during_await_still_fires(
+        self, tmp_path: Path
+    ) -> None:
+        # An interval job edited into a matching cron expression during the
+        # admission await must be classified by its LIVE kind: partitioning
+        # the stale snapshot would defer-and-drop the occurrence.
+        executed: list[str] = []
+
+        async def callback(job) -> None:
+            executed.append(job.name)
+
+        svc = CronService(base_dir=tmp_path, on_job=callback)
+        await svc.start()
+        svc.add_job("morph", "msg", every_secs=60)
+        job = svc._jobs[0]
+        job.last_run_ts = time.time() - 120
+
+        from kiro_crew.cron import CronSchedule
+
+        def editing_check(cfg: object | None = None):
+            job.schedule = CronSchedule(kind="cron", cron_expr="* * * * *")
+            job.last_run_ts = None  # cron kind: same-minute guard off
+            return _refused()
+
+        with (
+            patch("kiro_crew.cron.admission_check", side_effect=editing_check),
+            patch("kiro_crew.cron.cron_expr_matches", return_value=True),
+        ):
+            await svc._on_timer()
+        await _wait_for(lambda: "morph" in executed)  # fired, not deferred
+        await svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_queued_nonbatch_rejection_announced_exactly_once(self) -> None:
+        # A queued single spawn rejected at drain time (here: by the admission
+        # gate) must produce EXACTLY ONE completion announcement. The drain
+        # loop announces it off the returned info; spawn's own
+        # _announce_rejection must stay batch-only, or the requester gets a
+        # duplicate completion injection and wave/orchestration counters
+        # double-count the failure. Exercises the REAL spawn path (no stubs)
+        # so both potential announce sites are live.
+        from kiro_crew.subagent import SubagentManager
+
+        announced: list = []
+
+        async def _on_done(info) -> None:
+            announced.append(info)
+
+        mgr = SubagentManager(
+            sessions=MagicMock(),
+            ctx_builder=MagicMock(),
+            on_done=_on_done,
+            max_concurrent=3,
+        )
+        mgr._queue = [
+            {
+                "task": "queued then refused",
+                "parent_session_key": "sess-1",
+                "_preassigned_id": "q1",
+            }
+        ]
+        mgr._running_count = 0
+        mgr._spawn_stagger_secs = 0.0
+        mgr._last_spawn_ts = 0.0
+        mgr._emit_queue_depth = MagicMock()
+
+        with patch(
+            "kiro_crew.subagent.check_memory_available", return_value=(True, 8.0)
+        ), patch("kiro_crew.subagent.KiroCrewConfig") as mock_cfg, patch(
+            "kiro_crew.subagent.cached_admission_check", return_value=_refused()
+        ), patch(
+            "kiro_crew.subagent.sel"
+        ) as mock_sel:
+            mock_cfg.load.return_value.agent.spawn_min_memory_gb = 4.0
+            mock_sel.return_value.log_tool_invocation = MagicMock()
+            mgr._drain_queue()
+            # Flush every announce coroutine scheduled via ensure_future —
+            # a duplicate would surface as a second on_done call here.
+            for _ in range(5):
+                await asyncio.sleep(0)
+
+        assert [i.id for i in announced] == ["q1"], (
+            f"expected exactly one announcement, got {len(announced)}"
+        )
+        assert "critical" in announced[0].error
+
+    @pytest.mark.asyncio
+    async def test_interval_job_not_replayed_after_manual_run(
+        self, tmp_path: Path
+    ) -> None:
+        # An ``every`` job stays due on its own during a critical episode;
+        # a manual trigger that completes the work must not be replayed on
+        # recovery (deferral keeps no per-job state that could replay it).
+        executed: list[str] = []
+
+        async def callback(job) -> None:
+            executed.append(job.name)
+
+        svc = CronService(base_dir=tmp_path, on_job=callback)
+        await svc.start()
+        svc.add_job("interval", "msg", every_secs=3600)
+        job = svc._jobs[0]
+        job.last_run_ts = time.time() - 7200
+
+        with patch("kiro_crew.cron.admission_check", return_value=_refused()):
+            await svc._on_timer()
+        assert executed == []  # deferred
+
+        # Manual run during the episode completes the work.
+        with patch("kiro_crew.cron.admission_check", return_value=_refused()):
+            assert await svc.run_job(job.id) is True
+        await _wait_for(lambda: executed == ["interval"])
+        job.last_run_ts = time.time()  # manual run marked it
+
+        with patch("kiro_crew.cron.admission_check", return_value=_admitted()):
+            await svc._on_timer()
+        await asyncio.sleep(0.1)
+        assert executed == ["interval"]  # no replay
+        await svc.stop()
+
+    def test_refresh_thread_start_failure_fails_open(self, monkeypatch) -> None:
+        rs._cached_decision = None
+        rs._cached_at = 0.0
+        monkeypatch.setattr(
+            rs.threading,
+            "Thread",
+            MagicMock(side_effect=RuntimeError("can't start new thread")),
+        )
+        verdict = rs.cached_admission_check()  # must not raise
+        assert verdict.admitted  # fail-open
+        # The refresh lock was released, not leaked:
+        assert rs._cache_refresh_inflight.acquire(blocking=False)
+        rs._cache_refresh_inflight.release()


### PR DESCRIPTION
# Defer crons and refuse spawns under critical memory posture

## Problem

A KiroCrew host sat at **critical memory posture for a full hour** while the
gateway kept firing scheduled crons and admitting new subagent spawns, then
froze hard enough to require a power cycle. Every piece of work admitted during
that hour made recovery less likely.

The advisory tier saw it coming and could do nothing about it:
`resource_status.probe()` classifies host memory into ample / tight / critical
and injects a `[RESOURCES]` warning into agent turns — but its own docstring is
explicit that it is advisory only: two sessions can both read "ample" and both
launch heavy work, and a cron scheduler never reads the advisory at all.
#721 ("scheduler(core): central admission control") accepted admission control
as the direction for exactly this class of failure:
https://github.com/kirodotdev/KiroCrew/issues/721

This PR adds the narrowest useful enforcement point on top of the existing
posture tier: **while posture is CRITICAL, stop admitting new background
work.**

## What changed

- **`resource_status.admission_check()`** — a typed admission verdict
  (`AdmissionDecision`) layered on the existing cached `probe()`. CRITICAL
  refuses; ample / tight / **unknown** admit (fail-open: an unreadable probe or
  any internal error must never strand the scheduler). No new filesystem
  scanning beyond what `probe()` already does.
- **Cron gate** (`CronService._on_timer`) — when posture is critical at fire
  time, the tick's due **interval and one-shot** jobs (`every` / `at`) are
  deferred: a pure skip, nothing is marked failed and `last_run_ts` is
  untouched, so every deferred job stays due on its own and fires as soon as
  posture recovers. Deferral is deliberately **stateless**. Cron-expression
  jobs run normally even under critical posture: they are only due while
  their expression matches the current minute, so they cannot be deferred
  statelessly — an in-memory catch-up marker would lose the occurrence on a
  gateway restart, and skipping would drop it outright. Persisted deferral
  markers for cron-expression jobs are a possible follow-up. One throttled
  INFO per deferral episode (not per job / per tick). **Manually triggered
  runs (`cron_trigger` / `run_job`) bypass the scan and are never
  deferred** — a human asking for a run now is the override.
- **Spawn gate** (`SubagentManager.spawn`) — new spawns are refused with a
  clear typed error ("host memory is critical … retry when memory frees") and
  a distinct SEL audit outcome (`refused_memory_critical`), following the same
  refusal pattern as the existing `spawn_min_memory_gb` floor. In-flight
  subagents are untouched; direct user chat turns and the gateway's own
  operation are not gated.
- **Queue-drained rejections now announce (pre-existing bug fix, all
  rejection paths)** — review surfaced that a queued *non-batch* spawn
  rejected at drain time was silently dropped: `_announce_rejection` skipped
  non-batch announces on the theory that the caller receives the error
  synchronously, but on a queue re-entry the caller is the drain loop (which
  discards the return value) while the original requester — already told the
  spawn was queued — waits on a completion event that never arrives. The fix
  threads a `from_queue` flag through every rejection site, so it corrects
  this stranded-waiter bug for **all** pre-existing queue-drained rejection
  reasons (low memory, invalid cwd, governance), not just the new admission
  gate. Called out explicitly so it is findable if announce behavior ever
  regresses.
- **Config off-switch** — `agent.admission_gate` (bool). **Default ON**,
  consistent with the existing enforced-by-default `spawn_min_memory_gb` gate
  (which already refuses spawns below 4 GB by default — a threshold *above*
  the 2 GB critical tier this gate acts on). Set `false` to make the critical
  posture advisory-only again.

## What is deliberately NOT here

- No queueing, priorities, per-app budgets, or cross-session lease — #721's
  larger scheduler design. This is one binary admission decision at the two
  paths that kept a dying host busy.
- No change to notifications (posture alerting is a separate concern).
- `config-baseline.json` is not regenerated: the committed baseline already
  lags several config fields on main, and regenerating here would pull that
  unrelated drift into this PR.

## Testing

- New `test/test_admission_gate.py` (23 tests): helper verdicts
  (critical ⇒ refuse; tight / ample / unknown ⇒ admit), off-switch, fail-open
  on probe exception, cron deferral (job not marked failed, fires on the next
  admitted tick, one INFO per episode, manual trigger runs despite critical,
  cron-expression jobs pass through, mixed-tick defer/fire split),
  spawn refusal (typed SEL outcome) and pass-through when admitted, config key
  default / off-switch / malformed-value fallback.
- Targeted regression runs green: `test_resource_status.py`,
  `test_cron_resilience.py`, `test_cron_jitter.py`, spawn-guard tests in
  `test_subagent.py`, `test_config_loader.py`.
- `isort --check-only`, `flake8`, and `mypy src/kiro_crew/` (CI-parity venv)
  all clean.


