### PR TITLE
feat: session control -- open, stop and read another chat session

### DIFF
--- a/docs/system-specs/modules/README.md
+++ b/docs/system-specs/modules/README.md
@@ -21,6 +21,7 @@ agent loads only the one it needs.
 | [session-summary.md](session-summary.md) | Intent-level session summaries: the sidecar cache, extraction, and the turn-end pass. |
 | [file-search.md](file-search.md) | The `@`-mention file/folder search: index, ranking, `kinds` filter, and the sensitive-path symmetry. |
 | [session-storage.md](session-storage.md) | What sessions cost on disk, and the user-initiated trash that reclaims it. |
+| [session-control.md](session-control.md) | One chat session opening, stopping, and reading another. |
 | [config.md](config.md) | The config schema, defaults, loading, and live reload. |
 | [cli.md](cli.md) | Every CLI command, the gateway flags, and the test harness. |
 | [heartbeat.md](heartbeat.md) | The liveness heartbeat and its restricted tool allowlist. |

--- a/docs/system-specs/modules/session-control.md
+++ b/docs/system-specs/modules/session-control.md
@@ -1,0 +1,200 @@
+# Session Control Module
+
+## Overview
+
+Session control lets one of the user's chat sessions observe and interrupt
+another: open a new session, stop an in-flight turn, and read a transcript tail.
+It exists because a session cannot see what its peers are doing. A session that
+has spent an hour on a PR cannot tell whether the session watching the build has
+finished, and today the only way to find out is for the human to switch tabs and
+look. Session control lets the session ask directly.
+
+Three MCP tools on `kirocrew-dashboard`, three strict-internal routes, one config
+switch. Every route is on `_STRICT_INTERNAL_API_PATHS`; an unlisted one is
+unreachable in production because the caller's `X-Internal-Secret` is ignored.
+
+| Tool | Route | What it does |
+|------|-------|--------------|
+| `session_create` | `POST /api/session-control/create` | Open a new, empty session in the caller's workspace |
+| `session_stop` | `POST /api/session-control/stop` | Stop another session's in-flight turn |
+| `session_read_message` | `GET /api/session-control/read` | Read another session's transcript tail + liveness |
+
+**Nothing here writes into another session's conversation.** Reading returns a
+transcript tail, stopping cancels a turn the way the Stop button does, and
+creating opens an empty session the person types the first message into. Every
+verb is authorized at the moment it acts, so there is no delivery that can be
+delayed past its own authorization.
+
+`session_create` earns its place on its own, not as the front half of a delivery
+design: an agent that has just worked out that a job needs its own session can
+open it pre-named and bound to the right agent, in the caller's workspace, and
+hand the person a key they can read and stop. Without it the person does that by
+hand -- new tab, retype the title, pick the agent -- and the two observation verbs
+have nothing to point at that the agent itself put there. It deliberately does
+NOT seed a first message: that would be delivery.
+
+`kirocrew-dashboard` rather than `kirocrew-core`, because these tools are not a
+capability every session should carry. That server is an **assignable set**: it
+is absent from the default agent's spec and loads only for an agent whose own
+spec references it, so an ordinary session spends no context on tools it will
+never call. The set already holds the chat-folder tools, and the two classes are
+granted together on purpose — an agent given the job of organizing sessions is
+the same agent that should be able to see what they are doing. A test pins that
+bundling so neither half can leave the set unnoticed.
+
+Discovery is not new: `list_sessions` already enumerates the caller's sessions,
+and its keys are what `target` accepts.
+
+## Authorization
+
+Deny-by-default, and checked in **one** place — `authorize_target` — for the two
+verbs that take a target, so a guard cannot be present on `stop` and missing on
+`read`. (`session_create` has no target to authorize; it checks the caller's own
+eligibility with the same refusals.) Every refusal is recorded in the SEL as
+`session_control.<op>` with `outcome=denied`, so an attempt to reach a session
+that is out of bounds is visible after the fact even though nothing happened.
+
+| Refusal | Status | Why |
+|---------|--------|-----|
+| Config switch off (`agent.session_control`) | 403 | Operator opted out |
+| Caller session cannot be identified | 403 | An unidentifiable caller makes the self-target guard blind |
+| Caller is an unattended session (`cron-*`, `workflow-*`) | 403 | A scheduled job acting on live conversations is not a handoff |
+| Caller is itself incognito, temporary, or app-scoped | 403 | Caller-side isolation — the direction the target-side checks cannot see |
+| Caller is channel-linked (`linked_session_key` set) | 403 | The exfiltration direction: a linked caller's conversation IS a channel thread, so a read would hand a private dashboard transcript to that channel's readers. `CHANNEL_AGENT_BLOCKED_TOOLS` keys on the agent identity; a linked slot is a second route to the same surface |
+| Caller's own session is no longer open | 403 | Nothing to attribute the operation to |
+| Caller changed workspace while a creation was in flight | 403 | Creation resolves the workspace's project directory off-loop, so it suspends between authorizing the caller and allocating the slot. Both decisions that read the caller's workspace -- the memory boundary the child inherits, and whether the answering agent is bound to that workspace -- are invalidated by a move, and re-deciding the binding here is not available: it needs a config load, which must not run on the event loop |
+| Named agent does not resolve to a configured one | 403 | The resolver falls back to the default agent, which passes the workspace check because it is the caller's own default -- so no boundary is crossed, but the created session would store and advertise a name that is not what answers. `ResolvedBindings.requested_resolved` states that contract for callers that store the requested name. Refused rather than rewritten to the effective agent: nothing exists yet, so a corrected name costs one retry, whereas an existing slot keeps its stored name verbatim so a momentarily stale resolution cannot permanently rebind it |
+| Target is the caller | 403 | A session controlling itself has no exit |
+| Target is unattended (`cron-*`, `workflow-*`) | 403 | A `workflow-<run_id>` slot is display-only and a cron's turns are driven by a schedule |
+| Target is incognito or temporary | 403 | Never addressable, matching `list_sessions` |
+| Target is app-scoped | 403 | App sessions are the app's, not a peer's |
+| Target is channel-linked (`linked_session_key` set) | 403 | Its conversation is mirrored to Slack/Telegram, so reaching it crosses a surface boundary both ways — and its stop cannot be honoured, because the stop path addresses `dashboard:<slot>` while a linked slot's turns run under its linked key |
+| Target or caller has an outbound channel mirror (`get_mirror_link`) | 403 | The same boundary reached by the other mechanism. `linked_session_key` marks a channel-BORN slot; a dashboard-born slot given a mirror link republishes its turns to a channel just as surely, and the link lives in the session store rather than on the slot, so the slot-side check reads empty on exactly the session that mirrors |
+| Target is a crew-mode session (`mode == "crew"`) | 403 | A crew session's turn lifecycle is not the dashboard's: `/api/chat` routes its input to `state.crew.ingest`, which makes a durable queue entry and fans it out to topic sub-sessions. Refused rather than emulated — a target whose lifecycle differs needs its own handling, not a second copy of the orchestrator's rules |
+| Target is in another workspace | 403 | Workspaces are the memory boundary |
+| Target names no open session | 404 | A mistake, not an authorization failure |
+| Title matches more than one session | 409 | Guessing means acting on the wrong conversation |
+
+Two notes on scope:
+
+- **Only sessions the dashboard currently holds are addressable.** A closed tab
+  is out of reach on purpose — waking one would resurrect a conversation the
+  user put away. This is narrower than `list_sessions`, which also lists history.
+- **All three tools are on `CHANNEL_AGENT_BLOCKED_TOOLS`, including the read.** A
+  channel agent is contained to channel posts, and session control crosses that
+  boundary in both directions: a stop reaches the user through one of their
+  dashboard transcripts, and `session_read_message` pulls a private dashboard
+  conversation into a channel other humans can see. Containment is about what
+  crosses the boundary, not about who writes, so the read is blocked alongside
+  the rest. `session_create` earns its place for a different reason: it writes
+  nothing into an existing conversation, but it puts a persistent,
+  sidebar-visible session outside that containment.
+
+All three tools additionally require a **signed** caller identity
+(`_resolve_session_key_strict`), not the lenient `/proc` ancestor walk. A
+subagent spawned by `spawn_run` lives under its parent slot's process tree, so
+the walk resolves it to the parent — and since authorization here is entirely
+"what may this session reach", that would let a subagent read or stop the
+parent's sibling sessions. A caller the gateway issued no key to is refused with
+an explanation rather than silently borrowing one.
+
+The routes are **strict-internal** (`_STRICT_INTERNAL_API_PATHS`): loopback plus
+`X-Internal-Secret`, with no cookie fall-through. No browser calls them, and they
+are the entry point to opening, stopping, and reading another live conversation —
+a cookie path there would be a new authorization surface rather than a
+convenience. The MCP process holds the secret; an agent's own sandbox does not
+(`KIROCREW_INTERNAL_SECRET` is stripped from agent env), which is why these are
+tools rather than something an agent can curl.
+
+Each handler **re-asserts** `request["internal_auth"] is True` rather than
+trusting the path classification. Strict is not self-enforcing at the handler:
+with the header absent the middleware falls through to cookie auth, and a
+`local_only=False` deployment reclassifies strict paths as mixed. Because these
+routes authorize on the `X-Session-Key` the caller supplies, a same-origin page
+holding only a dashboard cookie could otherwise act **as** any of the user's
+sessions. `internal_auth` is set only after a constant-time secret match, so one
+check closes the cookie path, the app-token path, and the non-loopback
+reclassification together. The same reasoning is why
+`/api/computer-use/frame` re-asserts it.
+
+The config read fails **closed**: `KiroCrewConfig.load()` raising resolves to
+disabled, which is also the field's own default, so neither a malformed unrelated
+section nor a missing setting can produce cross-session reach.
+
+## The wait → read poll loop
+
+`session_read_message` is the observation half, and polling is the supported
+shape:
+
+1. `session_read_message(target)` — record `next_since`.
+2. `wait(seconds=…)`.
+3. `session_read_message(target, since=<previous next_since>)` — returns only what
+   arrived since, so a loop does not re-read the same messages.
+
+`total` is an **absolute position** in the session, not the length of the live
+window. A slot retains only its most recent messages in memory and credits each
+trimmed row to a frozen-prefix counter, so a length-derived cursor would freeze
+at the retention cap — and a poller on a long session would silently stop seeing
+replies, on exactly the sessions that need it most. A `since` read on a session
+whose rows have aged out is refused with `cursor_unavailable` (409) rather than
+fast-forwarded onto newer rows as if they were the ones asked for: the position
+is no longer exact, so answering it would be a guess dressed as an answer. The
+caller falls back to a tail read, which is why `next_since` is omitted in that
+case — its absence IS the signal that cursors are not available.
+
+`running` is what makes the loop terminable: `running: false` with an empty
+window means the target finished and went idle, which is different from "nothing
+new yet". `queue_depth` reports how much the target still owes.
+
+The cursor deliberately stops **before the streaming tail**. `chat_runner`
+appends a `chunk` row per token burst and `_flush_segment` then deletes that
+trailing run, replacing it with one durable assistant message — so chunk rows are
+always a suffix, never interleaved. Counting them would inflate `total`, the
+flush would shrink the list back under it, and the next `since=next_since` read would
+skip the finished reply permanently. A read taken mid-reply therefore reports
+`streaming: true`, so an empty window while the target is composing is
+distinguishable from an empty window because nothing is happening.
+
+A stale cursor is refused, not clamped. A compacted or rewound transcript shrinks,
+so a `since` past the end answers 409 `cursor_unavailable` and the caller falls
+back to a tail read. Clamping it to the end would look friendlier and lose data:
+the rows below the clamp are what replaced the old tail, a cursor never moves
+backwards, so they would be skipped permanently while the response read as
+"nothing new". A cursor exactly AT the end is not stale and still returns an empty
+window.
+
+## Configuration
+
+`agent.session_control` (bool, default **false**). Off makes all three tools
+refuse with a message naming the switch, so an agent that has not been granted it
+reports why rather than failing silently.
+
+Default-off is the deliberate part. The three tools ride on the existing
+assignable `kirocrew-dashboard` server rather than a new one, so an operator who
+had already assigned that server to an agent for folder organization would
+otherwise find that agent able to read peer transcripts and stop peer turns purely
+by upgrading. Every target is still one of the user's own sessions on their own
+machine, reached over loopback with an audited internal secret -- the objection is
+not that the capability is dangerous but that it would arrive without anyone
+granting it. Making it an explicit switch costs one setting and buys a grant that
+matches what the operator actually chose.
+
+Both absent and malformed values resolve to disabled. `_safe_bool(..., False)`
+handles the malformed case -- `bool("false")` is `True`, so a user who wrote the
+value in an editor that quotes it would otherwise get the opposite of what they
+read -- and the lookup now supplies `False` for the absent case, so nothing has to
+infer a grant from silence.
+
+## What is deliberately not here
+
+- **No message delivery.** No verb writes into another session's conversation.
+  Delivering a message to a peer has two authorization moments — acceptance and
+  the drain that can be minutes later — and the target's agent, workspace and
+  channel binding can all change in between. That is a different design from the
+  three verbs here, which are each authorized at the moment they act, so it is
+  scoped to its own change rather than carried along.
+- **No cross-workspace or cross-machine reach.** The boundary is one gateway's
+  live sessions in one workspace.
+- **No waking closed sessions.** See above.
+- **No writes on the read path.** `session_read_message` never changes the
+  target's state, so a poll loop cannot perturb what it is measuring.

--- a/src/kiro_crew/channel.py
+++ b/src/kiro_crew/channel.py
@@ -38,10 +38,26 @@ _INBOX_POLL_SECS = 1.0
 # agents communicate exclusively through channel posts.  send_notification
 # reaches the user like send_message does (notification feed publish, badge,
 # and sound), so both sit
-# behind the same containment boundary.  Matched against the rendered
+# behind the same containment boundary.  All THREE session-control tools sit
+# behind it, in both directions: stopping one of the user's dashboard sessions
+# reaches the user through that session's transcript, and READING one pulls a
+# private dashboard conversation into a channel other humans can see.  The read
+# tool mutates nothing, but containment here is about what crosses the boundary,
+# not about who writes — so the exfiltration direction is blocked alongside the
+# control one.  CREATE is blocked for a different reason than the other two: it
+# writes nothing into an existing conversation, but a session it opened would be
+# one the channel agent then owns and may act on, which is exactly the
+# containment this list exists to hold.
+# Matched against the rendered
 # permission-request text/title via _blocked_tool_named() (boundary-aware,
 # not naive substring — "Editing send_notification.py" must NOT match).
-CHANNEL_AGENT_BLOCKED_TOOLS: tuple[str, ...] = ("send_message", "send_notification")
+CHANNEL_AGENT_BLOCKED_TOOLS: tuple[str, ...] = (
+    "send_message",
+    "send_notification",
+    "session_stop",
+    "session_read_message",
+    "session_create",
+)
 
 # Boundary-aware matcher: the tool name must stand alone in the rendered
 # title — not embedded in a filename/path/identifier ("send_notification.py",

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1600,6 +1600,21 @@ class AgentConfig:
             "and additionally to 60s below the turn ceiling at load time.",
         ),
     )
+    session_control: bool = field(
+        default=False,
+        metadata=_meta(
+            "Session Control",
+            "Let one chat session open a new session, and stop or read another "
+            "session of yours. No session writes into another session's "
+            "conversation: reading returns a transcript tail, stopping cancels an "
+            "in-flight turn, and a created session starts empty for you to type "
+            "into. Off by default: the three tools ride on a server you may "
+            "already have assigned for other work, so reaching another session "
+            "waits for you to grant it here rather than arriving with an upgrade. "
+            "Sessions can only reach peers in the same workspace; incognito, "
+            "app-scoped and scheduled sessions are never addressable.",
+        ),
+    )
     subagent_cost_gb: float = field(
         default=0.5,
         metadata=_meta(
@@ -6255,6 +6270,14 @@ class KiroCrewConfig:
                     TOOL_APPROVAL_TIMEOUT_MIN,
                     TOOL_APPROVAL_TIMEOUT_MAX,
                 ),
+                # Absent means OFF, and a malformed value falls to False too. This
+                # switch grants one session reach into another, and the three tools
+                # ride on the `kirocrew-dashboard` server an operator may already
+                # have assigned for folder work -- so an upgrade must not hand an
+                # existing assignment stop-and-read over peer sessions that nobody
+                # granted. Both directions fail closed: `{"session_control":
+                # "false"}` is a truthy string and must not load as enabled either.
+                session_control=_safe_bool(agent_data.get("session_control", False), False),
                 subagent_cost_gb=_safe_float(agent_data.get("subagent_cost_gb", 0.5), 0.5),
                 subagent_cpu_cost_cores=_safe_float(
                     agent_data.get("subagent_cpu_cost_cores", 1.0), 1.0

--- a/src/kiro_crew/dashboard/chat_delivery.py
+++ b/src/kiro_crew/dashboard/chat_delivery.py
@@ -1,0 +1,333 @@
+"""Delivery of a user message into a chat slot, independent of the caller.
+
+The interesting cases are all in the bookkeeping: a mid-turn steer has to be
+registered before the RPC suspends, the transcript segment has to be cut at the
+steer boundary, and a steer the live client refuses must fall through to the
+queue rather than vanish. Held here rather than inside the route handler so the
+bookkeeping can be tested against a slot directly, without an HTTP request, and
+so a second delivery caller inherits it rather than growing a second copy that
+drifts until a message is silently dropped.
+
+The helpers own that bookkeeping and nothing else — no HTTP, no request parsing,
+no response shaping — so a caller layers its own authorization and response
+format on top.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from kiro_crew.dashboard.chat_utils import _redact_for_display
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+logger = logging.getLogger(__name__)
+
+# Outcomes of :func:`steer_into_running_turn`.
+#
+# The two middle values split the case where the optimistic registration
+# vanished during the steer RPC. Both mean "do NOT queue it again", but they are
+# opposite answers to "did the message survive": the turn's teardown REQUEUED it
+# (it is in the slot's queue and will run). A hard stop clears both the queue and
+# the pending-steer list, so a discarded message has no outcome to report -- the
+# refusals that cover that case raise directly rather than returning a code.
+STEER_STEERED = "steered"
+STEER_REQUEUED = "requeued"
+STEER_UNAVAILABLE = "unavailable"
+
+
+def sanitize_outbound(text: str) -> str:
+    """Return *text* with credentials and exfiltration URLs stripped.
+
+    The single sanitization chain every delivery path uses before a message is
+    persisted or broadcast: raw content must never reach an external surface.
+    """
+    sanitized, _ = redact_exfiltration_urls(text)
+    sanitized, _ = redact_credentials(sanitized)
+    return sanitized
+
+
+def _row_has_delivery_id(slot: Any, delivery_id: str) -> bool:
+    """Whether a durable row already carries *delivery_id* in its meta.
+
+    The drain unions every consumed queue entry's meta onto the row it appends, so
+    this is true exactly when the requeue-then-drain path already persisted this
+    delivery — including when the row merged several queued messages together, where
+    no content comparison would match.
+    """
+    for m in reversed(slot.messages):
+        meta = m.get("meta")
+        if not isinstance(meta, dict):
+            continue
+        if meta.get("steer_delivery_id") == delivery_id:
+            return True
+        # A merged row names every delivery it stands for, so membership — not
+        # equality — is the question once the drain has folded messages together.
+        many = meta.get("steer_delivery_ids")
+        if isinstance(many, list) and delivery_id in many:
+            return True
+    return False
+
+
+def _queue_has_delivery_id(slot: Any, delivery_id: str) -> bool:
+    """Whether a QUEUE entry carries *delivery_id* in its meta.
+
+    True exactly when the turn's teardown requeued THIS steer: the requeue moves
+    the id out of `_steer_delivery_ids` and into the new queue entry's meta.
+
+    Identity rather than content, because a content count cannot tell this steer's
+    requeue apart from an unrelated client queueing the same text in the same
+    window -- and reading that as "mine was requeued" drops the transcript row for
+    a steer the turn actually consumed.
+    """
+    for item in slot._queue:
+        meta = item.get("meta")
+        if isinstance(meta, dict) and meta.get("steer_delivery_id") == delivery_id:
+            return True
+    return False
+
+
+def _log_stop_race(slot: Any, stop_gen: int, *, preserved: bool) -> None:
+    """Record a steer that raced a stop, and which way it resolved."""
+    logger.info(
+        "steer for slot %s raced a stop (generation %d -> %d); message %s",
+        slot.key,
+        stop_gen,
+        int(getattr(slot, "_stop_generation", 0) or 0),
+        "preserved" if preserved else "discarded",
+    )
+
+
+async def steer_into_running_turn(
+    state: "DashboardState",
+    slot: "_ChatSlot",
+    message: str,
+) -> str:
+    """Inject *message* into the slot's RUNNING turn; return a ``STEER_*`` outcome.
+
+    Requires a live, steer-capable inner ACP client that the turn published on
+    the slot. Fire-and-forget by design: the inline steer card materializes when
+    kiro-cli echoes ``steering_consumed``.
+    """
+    client = getattr(slot, "_acp_client", None)
+    if client is None or not getattr(client, "supports_steer", False):
+        return STEER_UNAVAILABLE
+
+    # Register as pending BEFORE the await: ``steer()`` suspends on
+    # ``stdin.drain()``, and if the turn's finally runs during that suspension
+    # it must already see this steer to requeue it (an append after the await
+    # would land on an idle slot and orphan the message). The force-stop
+    # ``clear()`` races correctly for the same reason: a hard kill during the
+    # await discards the entry, so a late write cannot resurrect it.
+    # Captured BEFORE the await. ``_stop_generation`` counts stop INITIATIONS and
+    # is never reset by turn teardown, so it detects a Stop that fired AND
+    # resolved while ``steer()`` was suspended — re-reading ``_stop_state`` after
+    # the await would miss exactly that window.
+    stop_gen = int(getattr(slot, "_stop_generation", 0) or 0)
+
+    # AT MOST ONE pending steer per distinct text, enforced here at entry.
+    #
+    # `_pending_steers` holds plain strings and every consumer of it matches by
+    # CONTENT — the turn teardown requeues by content, the queue comparison below
+    # matches by content. So with two identical entries in flight, no amount of
+    # counting downstream can say WHOSE entry survived: if another caller's copy is
+    # consumed while ours is refused, the count falls back exactly as it would if
+    # ours had gone, and we would persist a refused message as delivered and then
+    # let the teardown requeue it — the same text twice.
+    #
+    # Rather than try to resolve an ambiguous signal, remove the ambiguity: refuse
+    # the second identical steer. Nothing is lost, because `STEER_UNAVAILABLE`
+    # sends the caller down the queue path. And since a concurrent caller hits this
+    # same guard, once our entry is appended no further identical entry can appear,
+    # which is what makes every check after the await unambiguously about ours.
+    # "In flight" is BOTH markers, not just the pending list. A steer whose pending
+    # entry has already been consumed by the running turn is still in flight: it is
+    # still awaiting and still owns an entry in `_steer_delivery_ids`. Consulting
+    # only `_pending_steers` therefore lets a second identical steer through at
+    # exactly that moment, and its `_steer_delivery_ids[message] = ...` overwrites
+    # the first caller's live id -- after which reconciliation removes the second's
+    # id and the first's row can persist twice. The dict is keyed by message
+    # precisely because this guard promises one in-flight steer per text, so the
+    # guard has to read it or the uniqueness it promises is not enforced.
+    if slot._pending_steers.count(message) or message in slot._steer_delivery_ids:
+        logger.info("identical steer already pending for slot %s; queueing instead", slot.key)
+        return STEER_UNAVAILABLE
+
+    # A real identity, not a content match. Every earlier attempt here compared
+    # text, and text cannot survive the transitions: consumed, requeued, drained,
+    # or merged into a larger row all look alike afterwards. The id is keyed by the
+    # message only because the one-per-text guard above makes that key unique, and
+    # it is handed to the requeue, which puts it on the queue entry; the drain then
+    # unions entry meta onto the row it appends, so the id reaches the row even
+    # through a merge.
+    delivery_id = uuid.uuid4().hex
+    slot._steer_delivery_ids[message] = delivery_id
+    slot._pending_steers.append(message)
+    try:
+        steered = await client.steer(message)
+    except Exception as exc:  # best-effort — the caller falls back to the queue
+        logger.warning("steer failed for slot %s: %s", slot.key, exc)
+        steered = False
+
+    # ONE reconciliation for every path. The outcome turns on WHERE the text is
+    # now, not on `steered`: the RPC returning True only means the client
+    # accepted the write, and the turn it was written into may already have ended
+    # during the await. A natural teardown is the case a `steered`-gated check
+    # misses entirely — it requeues the pending steer without touching
+    # `_stop_generation`, so reporting STEERED would let the caller persist a row
+    # that the queue drain then appends a second time.
+    # Our entry is the only possible match (see the one-per-text guard), so a
+    # surviving match is unambiguously ours.
+    if _row_has_delivery_id(slot, delivery_id):
+        # The whole requeue-then-drain sequence completed while we were suspended,
+        # so the row is already written and the only thing left to get wrong is
+        # writing a second one. Checked first: it is the one signal that survives
+        # every intermediate transition, including a merged row.
+        slot._steer_delivery_ids.pop(message, None)
+        logger.info(
+            "steer for slot %s was requeued and drained during the RPC; row already " "persisted",
+            slot.key,
+        )
+        return STEER_REQUEUED
+
+    still_registered = bool(slot._pending_steers.count(message))
+    queued = _queue_has_delivery_id(slot, delivery_id)
+    stopped = int(getattr(slot, "_stop_generation", 0) or 0) != stop_gen
+
+    if still_registered:
+        if not steered:
+            # Unwind the optimistic registration so a queue fallback cannot
+            # double-deliver. Unambiguous by construction: the one-per-text guard
+            # above means this is the only matching entry, which is why this is a
+            # plain remove and not an index dance over possible duplicates.
+            slot._pending_steers.remove(message)
+            slot._steer_delivery_ids.pop(message, None)
+            return STEER_UNAVAILABLE
+        if stopped:
+            # Still registered means the teardown has not run yet and will
+            # requeue it, so the text still runs — the caller must NOT resend.
+            _log_stop_race(slot, stop_gen, preserved=True)
+            return STEER_REQUEUED
+        # Delivered and live: fall through to cut the segment and persist the row.
+
+    # Ours vanished during the await, so some consumer took it. Which one decides
+    # whether the message still runs, and only the queue can tell them apart.
+    if queued:
+        # The turn's teardown moved it — a natural end or a soft stop. Either
+        # way it gets its own queue card and the drain appends it, so persisting
+        # a row here would duplicate it.
+        if stopped:
+            _log_stop_race(slot, stop_gen, preserved=True)
+        return STEER_REQUEUED
+    # Absence alone does not say WHICH consumer took the registration. THREE
+    # things remove one: the running turn CONSUMING the steer, the hard-kill
+    # clear, and a teardown requeue whose queue card the user then cancelled
+    # before we resumed. Only the first means the text ran, and they are told
+    # apart by the delivery id, because a consume leaves `_steer_delivery_ids`
+    # populated while the hard kill and `_requeue_unconsumed_steers` both drop it
+    # (the requeue moves it into the queue entry's meta, which the `queued` check
+    # above already answered -- reaching here means that entry is gone too).
+    #
+    # Checked regardless of `stopped`: a natural stage end requeues without ever
+    # touching `_stop_generation`, so the cancelled-card case arrives with
+    # `stopped` false and would otherwise fall through to the persisting tail.
+    if message not in slot._steer_delivery_ids:
+        # It did not run -- either a hard kill discarded the turn it was written
+        # into, or it was requeued and the user cancelled its card. Persisting
+        # here would write a transcript row for text that never executed and
+        # tell the caller it landed. Resending is safe precisely because neither
+        # path ran it.
+        if stopped:
+            _log_stop_race(slot, stop_gen, preserved=False)
+        return STEER_UNAVAILABLE
+    if stopped:
+        # Consumed, then stopped: the text is already delivered and its side
+        # effects may be complete, so this must never tell the caller to resend.
+        # A duplicate execution is worse than a transcript row for a turn that was
+        # killed, and worse still for an unattended caller that retries on its own.
+        _log_stop_race(slot, stop_gen, preserved=True)
+    if not steered:
+        # NOT discarded. The entry is gone and nothing queued it, and the thing
+        # that removes a registration in that state is the running turn CONSUMING
+        # it. `steer()` writing successfully and then raising on `stdin.drain()`
+        # lands exactly here, so trusting the exception over the evidence would
+        # answer 409 for a message the target already has: the caller resends and
+        # the target runs it twice.
+        #
+        # The asymmetry is deliberate. Telling a caller to RESEND is the one
+        # answer that can cause a duplicate execution, so nothing reports it on
+        # evidence that cannot tell delivery from loss. Every path here is
+        # accounted for by somebody, and a duplicate is worse than a stale error.
+        logger.info(
+            "steer RPC for slot %s failed but its registration was consumed; "
+            "treating as delivered",
+            slot.key,
+        )
+    # The entry is gone because the RUNNING turn consumed it — the
+    # `steering_consumed` settle path removes it exactly as a requeue would, which
+    # is why absence alone can never be read as loss. A real delivery, so it takes
+    # the same persisting tail as the live case.
+
+    # Terminal for this delivery: the row is persisted below rather than by a
+    # later drain, so nothing downstream will ever read this id again. The map is
+    # keyed by the message TEXT, so leaving it would hold one full message string
+    # per successful steer for the slot's whole lifetime -- the requeue paths above
+    # deliberately keep theirs because `chat_runner`'s drain still has to match it,
+    # and that entry is bounded by the queue.
+    slot._steer_delivery_ids.pop(message, None)
+
+    ts = datetime.now(timezone.utc).isoformat()
+    # Cut the in-flight text segment at the steer boundary BEFORE persisting the
+    # user message, so the transcript reads [assistant(pre-steer), user(steer),
+    # …] — the order the client rendered live. Without this the whole segment
+    # lands BELOW the steer bubble at end-of-turn and the refresh visibly
+    # reorders the reply. Best-effort: a cut failure must never lose the steer.
+    cut = getattr(slot, "_steer_segment_cut", None)
+    if cut is not None:
+        try:
+            cut()
+        except Exception:
+            logger.warning("steer segment cut failed for slot %s", slot.key, exc_info=True)
+
+    sanitized = sanitize_outbound(message)
+    meta: dict[str, Any] = {"steer": True}
+    # Store the sanitized form — raw content must never reach an external
+    # surface — so the steer survives a page reload via the dirty-flush cycle.
+    slot.append("user", sanitized, "msg msg-u", ts=ts, meta=meta)
+    state.broadcast_ws(
+        "steer_push",
+        {
+            "slot": slot.key,
+            "content": _redact_for_display(sanitized),
+            "ts": ts,
+        },
+    )
+    return STEER_STEERED
+
+
+def queue_for_next_turn(
+    state: "DashboardState",
+    slot: "_ChatSlot",
+    message: str,
+) -> str:
+    """Append *message* to the slot's queue and announce it; return the queue id.
+
+    The running turn's teardown drains the queue, so this is how a message
+    reaches a busy slot when steering is unavailable or not asked for.
+    """
+    qid = slot.queue_append(message)
+    state.broadcast_ws(
+        "queue_push",
+        {
+            "slot": slot.key,
+            "content": _redact_for_display(sanitize_outbound(message)),
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "queue_id": qid,
+        },
+    )
+    return qid

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -31,6 +31,12 @@ from kiro_crew.config.loader import (
 )
 from kiro_crew.dashboard.channel_slots import channel_slot_name, note_slot_closed
 from kiro_crew.dashboard.chat_auto_tag import maybe_auto_tag
+from kiro_crew.dashboard.chat_delivery import (
+    STEER_REQUEUED,
+    STEER_STEERED,
+    queue_for_next_turn,
+    steer_into_running_turn,
+)
 from kiro_crew.dashboard.chat_folders import _unhide_folder
 from kiro_crew.dashboard.chat_orchestrator import _stage_loop
 from kiro_crew.dashboard.chat_persistence import (
@@ -314,96 +320,20 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         # path (steer is unavailable between stages, so it falls through to the
         # queue below and is held until the plan ends).
         if body.get("steer") and message:
-            _client = slot._acp_client
-            if _client is not None and getattr(_client, "supports_steer", False):
-                # Register as pending BEFORE the await: _client.steer() suspends
-                # on stdin.drain(), and if the turn's finally runs during that
-                # suspension it must already see this steer to requeue it
-                # (append-after-await would land on an idle slot and orphan the
-                # message). The force-stop
-                # clear() likewise races correctly: a hard kill during the
-                # await discards the entry, so a late write can't resurrect it.
-                slot._pending_steers.append(message)
-                try:
-                    steered = await _client.steer(message)
-                except Exception as exc:  # best-effort — fall through to queue
-                    logger.warning("steer failed for slot %s: %s", slot.key, exc)
-                    steered = False
-                if not steered:
-                    # Unwind the optimistic registration so the queue fallback
-                    # below doesn't double-deliver. If the entry is already
-                    # gone, the turn's finally requeued it (or a hard kill
-                    # discarded it) during the await — either way the message
-                    # is accounted for, so skip the fallback.
-                    try:
-                        slot._pending_steers.remove(message)
-                    except ValueError:
-                        return web.json_response({"ok": True, "queued": True})
-                if steered:
-                    _ts = datetime.now(timezone.utc).isoformat()
-                    # Cut the in-flight text segment at the steer boundary
-                    # BEFORE persisting the user message, so the transcript
-                    # reads [assistant(pre-steer), user(steer), …] — the same
-                    # order the client rendered live. Without this the whole
-                    # segment lands BELOW the steer bubble at end-of-turn and
-                    # the chat_done refresh visibly reorders the reply (and the
-                    # pre-steer chunk entries are stranded in slot.messages —
-                    # _flush_segment's trailing-run walk stops at this user
-                    # message). Best-effort: a cut failure must never lose the
-                    # steer itself.
-                    _cut = slot._steer_segment_cut
-                    if _cut is not None:
-                        try:
-                            _cut()
-                        except Exception:
-                            logger.warning(
-                                "steer segment cut failed for slot %s",
-                                slot.key,
-                                exc_info=True,
-                            )
-                    # Sanitize: same chain as the queue path.
-                    _sanitized, _ = redact_exfiltration_urls(message)
-                    _sanitized, _ = redact_credentials(_sanitized)
-                    _redacted = _redact_for_display(_sanitized)
-                    # Persist the steered message so it survives page reload
-                    # (dirty-flush picks it up on next save cycle). Store the
-                    # sanitized form — raw content must never reach an external
-                    # surface (security-controls).
-                    slot.append(
-                        "user",
-                        _sanitized,
-                        "msg msg-u",
-                        ts=_ts,
-                        meta={"steer": True},
-                    )
-                    state.broadcast_ws(
-                        "steer_push",
-                        {
-                            "slot": slot.key,
-                            "content": _redacted,
-                            "ts": _ts,
-                        },
-                    )
-                    return web.json_response({"ok": True, "steered": True})
-            # steer requested but unavailable → fall through to queue below.
-        # Queue the message — return JSON immediately (no SSE needed).
+            outcome = await steer_into_running_turn(state, slot, message)
+            if outcome == STEER_STEERED:
+                return web.json_response({"ok": True, "steered": True})
+            if outcome == STEER_REQUEUED:
+                # The turn's teardown moved it into the queue while the steer RPC
+                # was suspended — queueing again would deliver the same text twice.
+                return web.json_response({"ok": True, "queued": True})
+            # steer requested but unavailable -> fall through to queue below.
+        # Queue the message - return JSON immediately (no SSE needed).
         # The existing SSE reader will pick up queued messages as _run_chat
         # processes the queue in its finally block. The message is non-empty
         # here (hoisted guard above the busy branch), so `queued: true`
         # always reports a real enqueue.
-        qid = slot.queue_append(message)
-        _c, _ = redact_exfiltration_urls(message)
-        _c, _ = redact_credentials(_c)
-        _redacted = _redact_for_display(_c)
-        state.broadcast_ws(
-            "queue_push",
-            {
-                "slot": slot.key,
-                "content": _redacted,
-                "ts": datetime.now(timezone.utc).isoformat(),
-                "queue_id": qid,
-            },
-        )
+        queue_for_next_turn(state, slot, message)
         return web.json_response({"ok": True, "queued": True})
 
     # ── Crew Mode dispatch (RFC orchestrator-chat-sessions) ─────────
@@ -2330,33 +2260,35 @@ def _app_cancel_denied(
     return _slot_not_found()
 
 
-async def api_chat_slot_stop(request: web.Request) -> web.Response:
-    """POST /api/chat/slots/{slot}/stop — cooperative stop with kill fallback.
+async def stop_slot_turn(
+    state: "DashboardState",
+    slot: "_ChatSlot",
+    *,
+    force: bool = False,
+    source: str = "dashboard",
+    cancel_key: str = "",
+) -> dict[str, Any]:
+    """Stop the slot's turn: cooperative cancel, hard kill on a second call.
 
-    First press: soft cancel (cooperative). Second press (?force=true):
-    hard kill. Inserts a stop_event message into the slot transcript.
+    First call: soft cancel. A second call while the first is still pending
+    escalates to a hard kill, regardless of *force* — the caller's view of the
+    stop state can lag the backend's, so the backend's own ``_stop_state`` is
+    what decides.
+
+    Inserts a ``stop_event`` card into the slot transcript so whoever is
+    watching the session sees the stop, and returns the JSON body the route
+    would have sent. *source* labels the SEL audit line with who asked.
+
+    *cancel_key* is the session the stop must land on, resolved ONCE by the
+    caller. A caller that authorizes the stop has to pass the very key it
+    authorized: re-deriving it here could name a different session if a rebind
+    lands between the check and the cancel, which is the whole reason the route
+    resolves it up front. Omitted only by callers with nothing to authorize
+    against, which fall back to the slot's own routing.
     """
-    state: DashboardState = request.app["state"]
-    name = request.match_info["slot"]
-    slot = state._slots.get(name)
-    if not slot:
-        return _slot_not_found()
-    denied = _deny_cross_app_slot_access(request, slot, name, "slot_stop")
-    if denied is not None:
-        return denied
-    # Before ANY side effect — the escalation branch below clears the queue and
-    # drops pending steers before it reaches stop_turn, so a guard placed later
-    # would still let a foreign caller mutate the slot.
-    # One target, resolved once: the session the in-flight turn actually runs
-    # on. Authorization and every stop_turn below are handed this same value, so
-    # they cannot disagree — neither across the request-body await in
-    # /interrupt, nor across two presses of Stop while a rebind lands between
-    # them.
-    cancel_key = _cancel_target(slot)
-    denied = _app_cancel_denied(request, slot, "chat_stop", cancel_key)
-    if denied is not None:
-        return denied
-    force = request.query.get("force", "").lower() == "true"
+    name = slot.key
+    cancel_key = cancel_key or _cancel_target(slot)
+
     # Escalation path: a second stop press while a cooperative cancel is
     # already pending hard-kills. We escalate on ANY second press — not only
     # when the client computed force=true — because the client derives force
@@ -2374,6 +2306,16 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
         # Hard kill = "discard everything": drop unconsumed steers too, so the
         # end-of-turn requeue (chat_runner finally) has nothing to resurrect.
         # Mirrors the queue clear above; a soft stop preserves both.
+        #
+        # Their delivery ids go with them, and that is load-bearing rather than
+        # tidiness: `steer_into_running_turn` reconciles an in-flight steer by
+        # asking what removed its registration, and a CONSUMED steer leaves its
+        # `_steer_delivery_ids` entry in place. Dropping the entry here is
+        # therefore what tells the two apart -- absence means this hard kill
+        # discarded the text, so the caller is told it was not delivered instead
+        # of having a row persisted for a message that never ran.
+        for _discarded in slot._pending_steers:
+            slot._steer_delivery_ids.pop(_discarded, None)
         slot._pending_steers.clear()
         state.push_slots_update()
         logger.info("Stop (force): hard-killing session for slot %s", name)
@@ -2400,9 +2342,9 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
             outcome="hard",
             # Record what the client requested (force flag) vs. the escalation
             # the backend actually performed (always a hard kill here).
-            metadata={"slot": name, "force": force, "escalated": True},
+            metadata={"slot": name, "via": source, "force": force, "escalated": True},
         )
-        return web.json_response({"ok": True})
+        return {"ok": True}
 
     # Already stopping or not running — no-op (idempotent repeat press guard)
     if slot._stop_state != "idle" or not slot.running:
@@ -2418,9 +2360,9 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
             tool_name="dashboard_stop",
             tool_kind="command",
             outcome="noop",
-            metadata={"slot": name, "reason": _info},
+            metadata={"slot": name, "via": source, "reason": _info},
         )
-        return web.json_response({"ok": True, "info": _info})
+        return {"ok": True, "info": _info}
 
     # First press: soft stop
     slot._stop_state = "soft_pending"
@@ -2493,9 +2435,41 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
         tool_name="dashboard_stop",
         tool_kind="command",
         outcome=outcome,
-        metadata={"slot": name, "force": False},
+        metadata={"slot": name, "via": source, "force": False},
     )
-    return web.json_response({"ok": True})
+    return {"ok": True}
+
+
+async def api_chat_slot_stop(request: web.Request) -> web.Response:
+    """POST /api/chat/slots/{slot}/stop — cooperative stop with kill fallback.
+
+    The route is where authorization lives, because it is the only layer holding
+    the ``request`` an app token rides on. ``stop_slot_turn`` is the mechanism
+    and takes a slot, so every caller that reaches it by another path (session
+    control) has to establish its own authority — the guard cannot be inherited
+    by accident.
+    """
+    state: DashboardState = request.app["state"]
+    name = request.match_info["slot"]
+    slot = state._slots.get(name)
+    if not slot:
+        return _slot_not_found()
+    denied = _deny_cross_app_slot_access(request, slot, name, "slot_stop")
+    if denied is not None:
+        return denied
+    # Before ANY side effect — the escalation branch inside stop_slot_turn clears
+    # the queue and drops pending steers, so a guard placed later would still let
+    # a foreign caller mutate the slot. One target, resolved once: the session the
+    # in-flight turn actually runs on, so authorization and the stop cannot
+    # disagree across a mid-turn rebind.
+    cancel_key = _cancel_target(slot)
+    denied = _app_cancel_denied(request, slot, "chat_stop", cancel_key)
+    if denied is not None:
+        return denied
+    force = request.query.get("force", "").lower() == "true"
+    return web.json_response(
+        await stop_slot_turn(state, slot, force=force, cancel_key=cancel_key)
+    )
 
 
 async def api_chat_slot_continue(request: web.Request) -> web.Response:

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -3632,7 +3632,17 @@ def _requeue_unconsumed_steers(state: "DashboardState", slot: "_ChatSlot") -> No
         # apply _redact_for_display, and every queue_* broadcast (including the
         # queue_push below) sanitizes. Sanitizing at insert would corrupt the
         # delivered message relative to the normal queue path.
-        qid = slot.queue_insert(0, steer_msg)
+        #
+        # Carry the delivery id the steer registered under. The drain unions every
+        # consumed entry's meta onto the row it writes, so this reaches the row even
+        # when several queued items are merged into one — which is the only way the
+        # steer's caller can tell "already persisted by the drain" from "consumed by
+        # the turn" after both bookkeeping lists have emptied.
+        _meta: dict | None = None
+        _did = getattr(slot, "_steer_delivery_ids", {}).pop(steer_msg, "")
+        if _did:
+            _meta = {"steer_delivery_id": _did}
+        qid = slot.queue_insert(0, steer_msg, meta=_meta)
         try:
             content, _ = redact_exfiltration_urls(steer_msg)
             content, _ = redact_credentials(content)
@@ -3839,19 +3849,6 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
     cron_label = match.group(1) if match else "cron"
     cron_label, _ = redact_exfiltration_urls(cron_label)
     cron_label, _ = redact_credentials(cron_label)
-    # Structured completion facts stamped at enqueue time (gateway _subagent_done)
-    # ride through to the row so the card reads them instead of re-parsing the
-    # header prose. Only a single, un-merged system injection carries
-    # them: a merge concatenates several entries under one synthetic header, for
-    # which per-entry facts are meaningless — subagent completions never merge
-    # (they drain one at a time and break any user-message merge), so this only
-    # fires on the shape it was computed for.
-    _row_meta = consumed[0].get("meta") if (is_subagent and len(consumed) == 1) else None
-    # When synthesis is pending, mark the completion so the frontend can collapse
-    # the per-completion assistant response that follows (it will be restated by
-    # the synthesis turn).
-    if is_subagent and slot._pending_synthesis and isinstance(_row_meta, dict):
-        _row_meta = {**_row_meta, "synthesisPending": True}
     if is_subagent:
         row_role = "subagent"
     elif is_cron or is_recovery:
@@ -3866,6 +3863,38 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
         row_cls = "msg msg-inject"
     else:
         row_cls = "msg msg-u"
+    # Provenance a producer attached to the queue entry belongs on the row the
+    # drain writes, not only on the entry that is about to disappear.
+    _drained_meta: dict = {}
+    # Delivery ids ACCUMULATE; everything else is last-writer-wins. A merge folds
+    # several queued messages into one row, and each may carry its own steer's id —
+    # a plain `update` would keep only the last, and every other caller would see
+    # no row for its delivery and append a duplicate. The row stands for all of
+    # them, so it has to name all of them.
+    #
+    # Accumulating generally does not undo the narrow rule above: per-entry
+    # subagent facts would be meaningless on a merged row, but a subagent
+    # completion never merges (it drains alone and breaks any user-message
+    # merge), so a merged row cannot carry them in the first place.
+    _drained_ids: list[str] = []
+    for item in consumed:
+        _item_meta = item.get("meta")
+        if isinstance(_item_meta, dict):
+            _one = _item_meta.get("steer_delivery_id")
+            if isinstance(_one, str) and _one:
+                _drained_ids.append(_one)
+            _many = _item_meta.get("steer_delivery_ids")
+            if isinstance(_many, list):
+                _drained_ids.extend(x for x in _many if isinstance(x, str) and x)
+            _drained_meta.update(_item_meta)
+    if _drained_ids:
+        _drained_meta.pop("steer_delivery_id", None)
+        _drained_meta["steer_delivery_ids"] = _drained_ids
+    # When synthesis is pending, mark the completion so the frontend can collapse
+    # the per-completion assistant response that follows (it will be restated by
+    # the synthesis turn).
+    if is_subagent and slot._pending_synthesis and _drained_meta:
+        _drained_meta["synthesisPending"] = True
     # Durable provenance for every `inject` row. `cls` is NOT persisted for this
     # role (chat_persistence only keeps it for `role == "system"`), and the
     # frontend's `meta.cronLabel` exists on the wire only because parse_cls_meta
@@ -3877,6 +3906,12 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
     # message verbatim when the turn emitted nothing, and that row must keep
     # rendering as speech. `synthetic_payload` is the existing answer to exactly
     # that question, so reuse it rather than inventing a second signal.
+    #
+    # Folded into the drained meta rather than a separate `_row_meta`: this drain
+    # now unions the meta of EVERY consumed entry (a merged row names all of its
+    # steer delivery ids), so the drained mapping is the one the row write reads.
+    # An `inject` row and a `subagent` row are mutually exclusive by `row_role`,
+    # so these two provenance blocks can never both fire on one row.
     if row_role == "inject":
         if is_cron:
             _inject_kind = "cron"
@@ -3887,12 +3922,12 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
         _inject_meta: dict = {"injectKind": _inject_kind}
         if is_cron:
             _inject_meta["cronLabel"] = cron_label
-        _row_meta = {**_row_meta, **_inject_meta} if isinstance(_row_meta, dict) else _inject_meta
+        _drained_meta.update(_inject_meta)
     slot.append(
         row_role,
         next_msg,
         row_cls,
-        meta=_row_meta if isinstance(_row_meta, dict) else None,
+        meta=_drained_meta or None,
     )
 
     # Per-turn consumption cell for a drained sub-agent completion (see

--- a/src/kiro_crew/dashboard/handlers/session_control.py
+++ b/src/kiro_crew/dashboard/handlers/session_control.py
@@ -1,0 +1,185 @@
+"""Routes behind the session-control MCP tools.
+
+Strict-internal (loopback + ``X-Internal-Secret``): no browser calls these, and
+they are the entry point to acting on another live conversation, so a cookie
+fall-through would be a genuinely new path rather than a convenience.
+
+The handlers do parsing and status mapping only — resolution, authorization and
+the operations themselves live in ``dashboard/session_control.py`` so the verbs
+that take a target share one guard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from aiohttp import web
+
+from kiro_crew.dashboard import session_control as sc
+from kiro_crew.dashboard.handlers._shared import _read_session_key
+from kiro_crew.dashboard.state import DashboardState
+from kiro_crew.sel import sel
+
+logger = logging.getLogger(__name__)
+
+
+async def _require_internal(request: web.Request) -> web.Response | None:
+    """Refuse anything that did not present ``X-Internal-Secret``.
+
+    These paths are on ``_STRICT_INTERNAL_API_PATHS``, but strict is not
+    self-enforcing at the handler: with the header ABSENT the middleware falls
+    through to cookie auth, and a ``local_only=False`` deployment reclassifies
+    every strict path as "mixed". Either way a same-origin page holding only a
+    dashboard cookie could reach here and — by choosing ``X-Session-Key`` —
+    message, stop, or read any of the user's sessions AS one of them. The
+    session key is an identity claim these routes authorize on, so it has to be
+    backed by the secret rather than by whatever a browser sends.
+
+    ``internal_auth`` is set only after a constant-time secret match, so
+    requiring it closes the cookie path, the app-token path, and the
+    non-loopback reclassification in one check. Returns the refusal, or ``None``
+    when the caller is authentic.
+    """
+    if request.get("internal_auth") is True:
+        return None
+    # Off the loop AND best-effort, the two properties `_audit_denied` exists to
+    # carry for exactly this shape of site: a refusal logged BEFORE the audit
+    # middleware has run. `log_api_access` only enqueues, but the FIRST `sel()` of
+    # a process constructs the log -- trust-dir creation, key validation, and on
+    # Windows an `icacls` subprocess -- so a fresh gateway whose first
+    # session-control request is unauthenticated would run that synchronously on
+    # the event loop. And construction can raise (a trust root too short to sign
+    # the chain), which unguarded would turn this 403 into a 500: losing the
+    # denial in order to report it.
+    try:
+        await asyncio.to_thread(
+            lambda: sel().log_api_access(
+                caller="unknown",
+                operation=f"session_control.{request.path.rsplit('/', 1)[-1]}",
+                outcome="denied",
+                source="dashboard",
+                resources=request.path,
+                error="internal secret required",
+            )
+        )
+    except Exception:
+        logger.warning("Failed to log a session-control denial to SEL", exc_info=True)
+    return web.json_response({"error": "forbidden", "code": "internal_secret_required"}, status=403)
+
+
+def _refusal(exc: sc.SessionControlError) -> web.Response:
+    """Render a :class:`SessionControlError` as its HTTP response.
+
+    Written as an explicit branch per status rather than
+    ``status=exc.status`` so the route can only ever answer with a status from
+    this closed set: an unmapped value degrades to 400 instead of forwarding
+    whatever integer reached it. ``code`` is the field callers match on;
+    ``message`` is advisory prose.
+    """
+    if exc.status == 403:
+        return web.json_response({"error": exc.message, "code": exc.code}, status=403)
+    if exc.status == 404:
+        return web.json_response({"error": exc.message, "code": exc.code}, status=404)
+    if exc.status == 409:
+        return web.json_response({"error": exc.message, "code": exc.code}, status=409)
+    if exc.status == 429:
+        return web.json_response({"error": exc.message, "code": exc.code}, status=429)
+    return web.json_response({"error": exc.message, "code": exc.code}, status=400)
+
+
+async def _body(request: web.Request) -> dict:
+    try:
+        body = await request.json()
+    except Exception:
+        raise sc.SessionControlError("invalid JSON", code="invalid_json")
+    if not isinstance(body, dict):
+        raise sc.SessionControlError("body must be a JSON object", code="invalid_body")
+    return body
+
+
+def _target(body: dict) -> str:
+    target = body.get("target")
+    if not isinstance(target, str) or not target.strip():
+        raise sc.SessionControlError("target is required", code="target_required")
+    return target.strip()
+
+
+async def api_session_control_create(request: web.Request) -> web.Response:
+    """POST /api/session-control/create — open a session this caller will own."""
+    refused = await _require_internal(request)
+    if refused is not None:
+        return refused
+    state: DashboardState = request.app["state"]
+    try:
+        body = await _body(request)
+        # Warmed AFTER the body read, which suspends: a config edit landing in that
+        # window would change the fingerprint and leave `create_session`'s own
+        # synchronous gate re-reading the file on the loop. Nothing suspends between
+        # here and that gate, which is the first thing `create_session` does.
+        await sc.prewarm_enabled_check()
+        result = await sc.create_session(
+            state,
+            caller_session_key=_read_session_key(request),
+            title=str(body.get("title") or ""),
+            agent=str(body.get("agent") or ""),
+        )
+    except sc.SessionControlError as exc:
+        return _refusal(exc)
+    return web.json_response(result)
+
+
+async def api_session_control_stop(request: web.Request) -> web.Response:
+    """POST /api/session-control/stop — stop another session's in-flight turn."""
+    refused = await _require_internal(request)
+    if refused is not None:
+        return refused
+    # No prewarm here: `stop_target` warms the config after its own SEL prewarm,
+    # which is the last suspension before the gate. Warming here as well would be
+    # dead work -- the body read and that SEL await both sit in between.
+    state: DashboardState = request.app["state"]
+    try:
+        body = await _body(request)
+        result = await sc.stop_target(
+            state,
+            caller_session_key=_read_session_key(request),
+            target=_target(body),
+        )
+    except sc.SessionControlError as exc:
+        return _refusal(exc)
+    return web.json_response(result)
+
+
+async def api_session_control_read(request: web.Request) -> web.Response:
+    """GET /api/session-control/read — read another session's transcript tail."""
+    refused = await _require_internal(request)
+    if refused is not None:
+        return refused
+    # Stays at the top for read alone: everything between here and the gate is
+    # synchronous query parsing (`request.query` is already available and
+    # `read_messages` does not await), so there is no suspension to invalidate it.
+    await sc.prewarm_enabled_check()
+    state: DashboardState = request.app["state"]
+    try:
+        target = (request.query.get("target") or "").strip()
+        if not target:
+            raise sc.SessionControlError("target is required", code="target_required")
+        limit_raw = request.query.get("limit")
+        since_raw = request.query.get("since")
+        try:
+            limit = int(limit_raw) if limit_raw else sc.DEFAULT_READ_MESSAGES
+            since = int(since_raw) if since_raw else None
+        except ValueError:
+            raise sc.SessionControlError(
+                "limit and since must be integers", code="invalid_pagination"
+            )
+        result = sc.read_messages(
+            state,
+            caller_session_key=_read_session_key(request),
+            target=target,
+            limit=limit,
+            since=since,
+        )
+    except sc.SessionControlError as exc:
+        return _refusal(exc)
+    return web.json_response(result)

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -319,6 +319,21 @@ _STRICT_INTERNAL_API_PATHS = frozenset(
         # wiring class as "/api/notifications/agent" above.
         "/api/knowledge/agent-document",
         "/api/mcp/servers",
+        # Session control -- the three routes behind the session_create /
+        # session_stop / session_read_message MCP tools.
+        # STRICT, not mixed: no browser calls them, and they are the entry point
+        # to opening, stopping, and reading ANOTHER live conversation. A cookie
+        # fall-through there would be a new authorization path, not a
+        # convenience.
+        #
+        # Every route registered under /api/session-control MUST appear here.
+        # An unlisted path falls through to the general branch, which honors only
+        # cookie/query tokens, so the MCP caller's X-Internal-Secret is ignored
+        # and the handler's own internal_auth re-assert then refuses it -- the
+        # tool is unreachable in production while handler-level tests still pass.
+        "/api/session-control/create",
+        "/api/session-control/stop",
+        "/api/session-control/read",
     }
 )
 
@@ -968,6 +983,27 @@ def _precompute_telemetry(state: "DashboardState") -> None:
         _log.debug("telemetry.record_event(gateway_start) failed", exc_info=True)
 
 
+def _deferred_session_control(handler_name: str) -> Callable:
+    """Bind a session-control route without importing the subsystem at boot.
+
+    Session control is feature-flagged (``agent.session_control``), and the
+    enabled check lives inside the handler -- so a module-level import would be
+    an eager import of an optional subsystem whose gate runs after it, which the
+    boot-path rule names explicitly. Route registration itself is allowed at
+    boot; only the import moves to first request, so an operator who disabled the
+    feature never pays for loading it.
+    """
+
+    async def _route(request: web.Request) -> web.StreamResponse:
+        from kiro_crew.dashboard.handlers import session_control
+
+        handler = getattr(session_control, handler_name)
+        return await handler(request)
+
+    _route.__name__ = handler_name
+    return _route
+
+
 def _register_mcp_routes(app: web.Application) -> None:
     """Register API routes used by MCP tools (spawn, lessons, crons, etc.)."""
     app.router.add_post("/api/spawn", handlers.api_spawn)
@@ -1013,6 +1049,19 @@ def _register_mcp_routes(app: web.Application) -> None:
     # here (not the dashboard-only block) so headless --slack-only mode
     # serves it too; it is on _STRICT_INTERNAL_API_PATHS like send-message.
     app.router.add_post("/api/notifications/agent", handlers.api_notification_agent_push)
+    # Session control. Registered here so the headless --slack-only server
+    # serves the same MCP surface as the dashboard; all three are on
+    # _STRICT_INTERNAL_API_PATHS, which test_session_control_routes_are_strict
+    # pins by deriving the route set from the router rather than a hand-copied list.
+    app.router.add_post(
+        "/api/session-control/create", _deferred_session_control("api_session_control_create")
+    )
+    app.router.add_post(
+        "/api/session-control/stop", _deferred_session_control("api_session_control_stop")
+    )
+    app.router.add_get(
+        "/api/session-control/read", _deferred_session_control("api_session_control_read")
+    )
     app.router.add_get("/api/browser/install", handlers.api_browser_install_get)
     app.router.add_put("/api/browser/token", handlers.api_browser_token_put)
     app.router.add_post("/api/browser/install", handlers.api_browser_install_start)

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -1,0 +1,1016 @@
+"""Session control: letting one chat session observe and interrupt another.
+
+Three operations — create a session, stop its turn, read its transcript — plus the
+authorization that decides whether a caller may address a target at all. The
+operations are deliberately thin: they reuse the same creation, stop and history
+paths the dashboard itself uses, so a controlled session behaves exactly like one
+a human is typing into.
+
+**Nothing here writes into another session's conversation.** Reading returns a
+transcript tail; stopping cancels an in-flight turn the way the Stop button does;
+creating opens an empty session in the user's sidebar. Every verb is therefore
+resolved and authorized at the moment it acts, with no delivery that can be
+delayed past its own authorization.
+
+Authorization is deny-by-default and checked in one place
+(:func:`authorize_target`) for the two operations that take a target, so a guard
+cannot be present on one verb and missing on another. ``session_create`` has no
+target; it checks the caller's own eligibility with the same refusals.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from kiro_crew.config.loader import (
+    KiroCrewConfig,
+    _workspace_name_for_dir,
+    default_project_dir,
+    resolve_agent_bindings,
+)
+from kiro_crew.dashboard.chat_delivery import sanitize_outbound
+from kiro_crew.dashboard.chat_persistence import _TRANSIENT_ROLES as _PERSISTENCE_TRANSIENT_ROLES
+from kiro_crew.dashboard.chat_utils import slot_history_key
+from kiro_crew.dashboard.state import SlotOrigin
+from kiro_crew.history import metadata_now_iso, transcript_stem
+from kiro_crew.security import redact, redact_and_truncate
+from kiro_crew.sel import sel
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from kiro_crew.dashboard.state import DashboardState, _ChatSlot
+
+logger = logging.getLogger(__name__)
+
+#: Live-slot ceiling for `session_create`, matching `_MAX_SLOTS_FOR_FORK` and
+#: `_MAX_SLOTS_FOR_IMPORT`. Every path that allocates a slot enforces the same
+#: number; a creator that skipped it would make the cap advisory, since nothing
+#: else bounds how many sessions one caller may open.
+_MAX_SLOTS_FOR_CREATE = 500
+
+# Reads are cheap but not free — each one walks the target's in-memory window.
+MAX_READ_MESSAGES = 100
+DEFAULT_READ_MESSAGES = 20
+
+# Per-message content cap for reads, so pulling a transcript tail cannot return
+# a multi-megabyte tool payload verbatim.
+MAX_READ_CONTENT_CHARS = 4000
+
+# Slot-key prefixes for sessions no human is watching: a cron run's own slot
+# (``cron-<job_id>``) and a background workflow's result slot
+# (``workflow-<run_id>``, created by ``workflow_inject`` only when the
+# originating tab is gone). They are refused as BOTH source and target. As a
+# target, a message would start a fresh agent turn in a display-only slot nobody
+# reads; as a source, a scheduled job would be able to type into the user's live
+# conversations unattended. Notifications are the supported path for those
+# (``send_message``), not session control.
+UNATTENDED_SLOT_PREFIXES = ("cron-", "workflow-")
+
+# Roles a read must not count, taken from the persistence layer's own list rather
+# than restated here: those are exactly the rows rehydration DROPS, so any cursor
+# that counted them would name a different position after a restart than before
+# it. ``chunk`` runs are deleted when a segment flushes and ``done`` markers never
+# persist at all, so counting either inflates ``total``, the list shrinks back
+# under it, and the next ``since=next_since`` read skips the finished reply for good.
+TRANSIENT_ROLES = _PERSISTENCE_TRANSIENT_ROLES
+
+
+class SessionControlError(Exception):
+    """A refusal carrying the HTTP status AND the machine-readable reason.
+
+    ``code`` is the contract the dashboard and the MCP tools match on; ``message``
+    is advisory English prose (RFC 9457 3.1.3). Prose alone would be
+    untranslatable by construction, since callers render it verbatim.
+    """
+
+    def __init__(
+        self, message: str, status: int = 400, code: str = "session_control_error"
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status = status
+        self.code = code
+
+
+def session_control_enabled() -> bool:
+    """Whether the session-control surface is switched on in config.
+
+    A config read that RAISES resolves to disabled, not to the field's default.
+    ``load()`` can fail on a malformed section that has nothing to do with this
+    feature, and treating that as "enabled" would let unrelated corruption
+    silently undo an explicit ``session_control: false`` — the one switch
+    standing between two of the user's sessions. Failing closed costs a
+    refusal the user can diagnose from the log line; failing open costs the
+    opt-out.
+    """
+    try:
+        return bool(KiroCrewConfig.load().agent.session_control)
+    except Exception:
+        logger.warning(
+            "session_control: config read failed — refusing until config loads", exc_info=True
+        )
+        return False
+
+
+async def prewarm_enabled_check() -> None:
+    """Warm the config cache in a thread so the sync gate reads the cached path.
+
+    :func:`session_control_enabled` cannot await -- ``authorize_target`` is
+    synchronous, and ``read_messages`` is synchronous with it -- but its
+    ``KiroCrewConfig.load()`` re-reads and validates the file on the FIRST call
+    after a config edit, and doing that inline blocks the loop for every other
+    session.
+
+    Must be called with NOTHING that suspends between it and the gate. An
+    ``await`` in that gap reopens exactly the hole this closes: a config edit
+    landing in the window changes the fingerprint, so the gate's own read misses
+    the cache and does the synchronous read anyway. That is why this is not done
+    once at the top of each handler -- reading a request body suspends, and so
+    does the SEL prewarm inside ``stop_target``.
+
+    Lives here rather than in the handlers so the three call sites share one
+    implementation, and so ``stop_target`` can warm it after its own prewarm
+    without the handler layer reaching back into it.
+
+    Best-effort: a failure is the gate's business, and the gate fails closed on
+    its own.
+    """
+    try:
+        await asyncio.to_thread(session_control_enabled)
+    except Exception:  # pragma: no cover - the gate re-reads and decides
+        logger.debug("session-control config prewarm failed; the gate will read it inline")
+
+
+def caller_slot_key(state: "DashboardState", session_key: str) -> str:
+    """Map a caller's session key to its slot key, or ``""`` when unknown.
+
+    The MCP process authenticates as a session key (the history key), while
+    every operation here is slot-keyed. Resolution walks the live slots and
+    matches on the key each slot actually writes, which is the same identity
+    ``list_sessions`` reports — so "who am I" cannot disagree between the two.
+
+    An unresolvable caller is not fatal: it only means the self-target guard has
+    nothing to compare against, which :func:`authorize_target` treats as a
+    refusal rather than a pass.
+    """
+    if not session_key:
+        return ""
+    for slot in list(state._slots.values()):
+        try:
+            history_key = slot_history_key(slot)
+            if session_key in (history_key, slot.key, transcript_stem(history_key)):
+                return slot.key
+        except Exception:
+            continue
+    return ""
+
+
+def _has_channel_mirror(state: "DashboardState", slot: "_ChatSlot") -> bool:
+    """Whether *slot*'s conversation is mirrored out to a channel.
+
+    `linked_session_key` catches a channel-BORN slot. It does not catch a
+    dashboard-born slot that was later given an OUTBOUND mirror link, which
+    reaches a channel just as surely: the link lives in the session store, not
+    on the slot, so a slot with an empty `linked_session_key` can still be
+    republishing every turn to Slack or Telegram.
+
+    Read on the EFFECTIVE session key, because that is the key the mirror is
+    registered under -- the slot key would miss a mirror on a session whose turns
+    run under a different identity.
+
+    Best-effort by design: a store that cannot answer is treated as mirrored, so
+    an unreadable link fails closed rather than opening the boundary.
+    """
+    sessions = getattr(state, "sessions", None)
+    getter = getattr(sessions, "get_mirror_link", None)
+    if getter is None:
+        return False
+    try:
+        return bool(getter(slot_history_key(slot)))
+    except Exception:
+        logger.debug("mirror-link probe failed; treating as mirrored", exc_info=True)
+        return True
+
+
+def _refuse_ineligible_creator(state: "DashboardState", caller_slot: "_ChatSlot") -> None:
+    """Refuse a caller that may not manufacture a session.
+
+    A caller that may not CONTROL a peer may not manufacture one either --
+    otherwise a channel-bound session creates a session and then drives it,
+    reaching the same place the caller-side refusals exist to prevent. This set
+    therefore mirrors `authorize_target`'s caller half exactly; a refusal present
+    there and missing here is a hole.
+
+    Extracted so it can be applied TWICE: once on entry, so an ineligible caller
+    is refused before any work is done and with the refusal precedence a caller
+    can rely on, and again immediately before the slot is allocated. Two of these
+    answers are not stable -- `_has_channel_mirror` reads the live session store,
+    and a dashboard-born session can be given an outbound mirror link at any
+    moment -- so an eligibility decided before a suspension point says nothing
+    about eligibility at the moment of allocation.
+    """
+    if getattr(caller_slot, "_app", ""):
+        # An app-scoped session is confined to its own app's slots. Creating a
+        # plain user-origin slot would put a persistent, sidebar-visible session
+        # outside that confinement, owned by the app.
+        raise SessionControlError(
+            "app-scoped sessions cannot create sessions", code="app_scoped_caller"
+        )
+    if getattr(caller_slot, "memory_mode", "persistent") != "persistent":
+        # An incognito/temporary caller is defined by leaving nothing behind.
+        # A persistent child it owns would outlive it, carrying its work into
+        # storage the caller was promised would not retain anything.
+        raise SessionControlError(
+            "incognito and temporary sessions cannot create sessions",
+            code="ephemeral_caller",
+        )
+    if getattr(caller_slot, "linked_session_key", ""):
+        raise SessionControlError(
+            "channel-linked sessions cannot create sessions",
+            code="linked_session_caller",
+        )
+    if _has_channel_mirror(state, caller_slot):
+        raise SessionControlError(
+            "sessions mirrored to a channel cannot create sessions",
+            code="mirrored_caller",
+        )
+
+
+def _resolve_slot(state: "DashboardState", target: str) -> "_ChatSlot | None":
+    """Find the live slot *target* names: by slot key, transcript stem, or title.
+
+    All three forms are things a caller actually holds. ``list_sessions`` reports
+    FILENAME STEMS (``dashboard_chat-7``), not slot keys (``chat-7``), and the
+    tool description tells callers to pass what it returned — so matching only
+    ``slot.key`` refused the documented happy path with ``target_not_found``.
+    Title matching covers what the caller sees on screen; it is exact and
+    case-insensitive.
+
+    Every form is resolved before anything is returned, and a string that matches
+    two DIFFERENT slots across forms is refused as ambiguous. Returning on the
+    first key hit would silently prefer it over a title the caller was reading off
+    the screen, and picking the wrong conversation is exactly the outcome this
+    function must never produce — ``session_stop`` discards a live turn's work.
+    The doctrine is already the module's own for title-vs-title collisions; it
+    applies no less when the collision crosses forms.
+    """
+    found: list[_ChatSlot] = []
+
+    def _add(candidate: "_ChatSlot") -> None:
+        if not any(c is candidate for c in found):
+            found.append(candidate)
+
+    slot = state.get_slot(target)
+    if slot is not None:
+        _add(slot)
+    for candidate in list(state._slots.values()):
+        try:
+            if transcript_stem(slot_history_key(candidate)) == target:
+                _add(candidate)
+        except Exception:
+            continue
+    wanted = target.strip().casefold()
+    if wanted:
+        for candidate in list(state._slots.values()):
+            if (candidate.display_title or "").strip().casefold() == wanted:
+                _add(candidate)
+
+    if len(found) > 1:
+        raise SessionControlError(
+            f"{len(found)} sessions match {target!r} (as a session key, transcript "
+            "name, or title) — address it by its session key instead",
+            status=409,
+            code="ambiguous_target",
+        )
+    return found[0] if found else None
+
+
+async def create_session(
+    state: "DashboardState",
+    *,
+    caller_session_key: str,
+    title: str = "",
+    agent: str = "",
+) -> dict[str, Any]:
+    """Open a new session in the caller's workspace, persisted at birth.
+
+    The new slot is an ordinary dashboard session -- it appears in the sidebar, the
+    user can read it, type into it and close it -- so this gives a workstream a home
+    of its own rather than a private channel the user cannot see. It starts empty:
+    the person is the one who types the first message into it.
+
+    The caller's own eligibility is checked against the SAME caller-side refusal
+    set `authorize_target` applies (`authorize_target` cannot be reused here:
+    there is no target yet), and the child inherits the caller's workspace. Both
+    matter because a caller refusal missing here, or a workspace not inherited,
+    would hand back a session outside the boundary the other verbs enforce.
+    """
+    if not session_control_enabled():
+        raise SessionControlError(
+            "session control is disabled in config (agent.session_control)",
+            code="session_control_disabled",
+        )
+    caller_key = caller_slot_key(state, caller_session_key)
+    if not caller_key:
+        raise SessionControlError(
+            "caller session could not be identified", code="caller_unidentified"
+        )
+    if caller_key.startswith(UNATTENDED_SLOT_PREFIXES):
+        raise SessionControlError(
+            "unattended sessions (scheduled runs) cannot create sessions",
+            code="unattended_caller",
+        )
+    caller_slot = state.get_slot(caller_key)
+    if caller_slot is None:
+        raise SessionControlError("caller session is not open", code="caller_not_open", status=404)
+    _refuse_ineligible_creator(state, caller_slot)
+
+    # The child is created in the CALLER'S workspace, not the default one.
+    # Workspace is the memory boundary and `authorize_target` refuses a
+    # cross-workspace target, so a child left in "default" would be a boundary
+    # crossing its own creator could not then read or stop.
+    workspace = getattr(caller_slot, "workspace", "default") or "default"
+    # An unnamed agent inherits the CALLER'S, not the global default: the caller is
+    # already running in this workspace, so its agent is the one bound here, and
+    # falling to the global default would put the child on another workspace's
+    # memory store the moment the default is bound elsewhere. It also matches what
+    # creating a session to hand work to means -- the same kind of session.
+    # Sanitized like `title` below, and for the same reason: this value arrives
+    # from the calling model, is persisted verbatim to the metadata line, and is
+    # pushed to every dashboard client. The schema caps its LENGTH; sanitizing is
+    # what keeps a credential-shaped string out of storage and out of the sidebar.
+    # An inherited caller agent is already internal, but running both through the
+    # same call keeps the guard on the field rather than on one of its sources.
+    agent_name = sanitize_outbound(agent.strip() or (getattr(caller_slot, "agent", "") or ""))
+
+    log = state.conversation_log
+    if log is None:
+        # No durable store means the session cannot be persisted at birth, so it
+        # would vanish on the next restart. Refusing is the honest answer;
+        # returning a key would hand back a session that is dead on arrival.
+        raise SessionControlError(
+            "session history is unavailable, so the session cannot be persisted",
+            code="history_unavailable",
+        )
+
+    # Resolved BEFORE the slot exists, because `get_or_create_slot` publishes into
+    # the slot table and `await` is a suspension point: a slot that is visible
+    # while its agent and project are still unset can be addressed in that window,
+    # and `/api/chat` would then resolve bindings from a blank agent -- running the
+    # turn against the DEFAULT workspace's memory store rather than this one.
+    # `default_project_dir` needs only the workspace name, so nothing forces it to
+    # run after construction.
+    #
+    # Offloaded: it resolves a realpath, stats the directory and screens it against
+    # the sensitive-path list, so it is filesystem work the loop should not wait on.
+    # The rule's own tiebreaker applies -- a leaked worker thread is survivable, a
+    # frozen loop is not.
+    project_dir = await asyncio.to_thread(default_project_dir, workspace)
+
+    # ONE invariant covers every branch of agent resolution: the agent that will
+    # actually ANSWER must be bound to the caller's workspace. Authorization reads
+    # `slot.workspace` while execution follows the agent's own binding, so any
+    # branch where those disagree carries another workspace's memory store into
+    # the child. Enumerating the branches instead of stating the invariant is how
+    # the empty-agent case was missed:
+    #
+    #   agent given, binding matches   -> allowed, dispatches that agent
+    #   agent given, binding differs   -> refused (agent_workspace_mismatch)
+    #   agent given, name unresolvable -> refused (agent_unresolved), because the
+    #                                     default would answer under the requested
+    #                                     name
+    #   agent omitted                  -> `resolve_agent_bindings` falls to
+    #                                     config.default_agent, so the SAME check
+    #                                     applies to whatever would answer; an
+    #                                     omitted agent is not an unchecked one
+    #   config unreadable              -> refused (agent_unverifiable), because
+    #                                     "cannot verify" must not read as "fine"
+    #
+    # Resolved with the child's own `project_dir`: a materialized kiro agent is
+    # declared per project directory rather than registered in `config.agents`, so
+    # resolving without it reports an app's agent as unresolvable and would refuse
+    # a name that does resolve for the session being created.
+    try:
+        # Offloaded: a cache miss reads and validates the config file, so leaving it
+        # on the loop stalls every other gateway task, not just this request. It is
+        # awaited HERE, still ahead of the caller re-resolve below, so the decisions
+        # that authorize the allocation are all made after the last suspension.
+        cfg = await asyncio.to_thread(KiroCrewConfig.load)
+    except Exception:
+        raise SessionControlError(
+            "cannot verify the effective agent's workspace binding",
+            code="agent_unverifiable",
+        ) from None
+    bindings = resolve_agent_bindings(cfg, agent_name, project_dir)
+    agent_workspace = _workspace_name_for_dir(cfg, bindings.workspace_dir)
+    if agent_workspace != workspace:
+        who = repr(agent_name) if agent_name else "the default agent"
+        raise SessionControlError(
+            f"{who} is bound to workspace {agent_workspace!r}, not the caller's " f"{workspace!r}",
+            code="agent_workspace_mismatch",
+        )
+    if not bindings.requested_resolved:
+        # The workspace check above passed for whatever ANSWERS -- the default
+        # agent -- so no memory boundary is crossed. What would be wrong is the
+        # record: `slot.agent` stores this name, and `ResolvedBindings` states the
+        # contract for exactly this caller class, that a caller storing the
+        # requested name must not advertise it when the request was not honored.
+        # A session that names one agent while another answers misleads every later
+        # reader of the sidebar and of `list_sessions`.
+        #
+        # Refused rather than silently rewritten to the effective agent, because
+        # the caller asked for a specific one and nothing is lost by refusing: no
+        # session exists yet, and a corrected name is one retry away. (An existing
+        # slot is the opposite case -- there the stored name is the user's own
+        # intent and is kept verbatim, since a momentarily stale resolution must
+        # not permanently rebind it.)
+        raise SessionControlError(
+            f"{agent_name!r} does not resolve to a configured agent",
+            code="agent_unresolved",
+        )
+
+    # SlotOrigin.USER, not SYSTEM: the visibility semantics must match an
+    # ordinary session, because the point of creating it here is that the user
+    # can see and take over the work. SYSTEM-origin slots fall outside the
+    # `slots:user` WS scope, which would hide it from the sidebar.
+
+    # Re-resolved and re-gated HERE, adjacent to the allocation, because every
+    # decision above was made before this coroutine suspended -- twice, for the
+    # project directory and the config load -- and the inputs to those decisions are
+    # live state that can flip inside either window.
+    #
+    # Re-reading the slot TABLE is the part that matters most: closing the caller's
+    # tab removes its slot, and a Python reference to the removed object stays
+    # perfectly usable, so re-running the gate on the object resolved earlier would
+    # authorize against a caller whose authority has already ended. Identity is
+    # compared rather than mere presence, because the key can be re-minted onto a
+    # different session inside the same window. `_has_channel_mirror` reads the
+    # session store, so an outbound mirror link registered while this waited would
+    # otherwise leave a now-channel-backed caller publishing a persistent session
+    # outside its containment; `live_slot_count` reads the slot table, so two
+    # concurrent creations could each pass the ceiling and then both land over it.
+    #
+    # Nothing suspends between this point and the fully-configured slot below, so
+    # the gate and the act it authorizes stay adjacent -- the same discipline
+    # `stop_target` keeps by prewarming its SEL logger ABOVE its gate rather than
+    # between gate and act.
+    live_caller = state.get_slot(caller_key)
+    if live_caller is None or live_caller is not caller_slot:
+        raise SessionControlError("caller session is not open", code="caller_not_open", status=404)
+    # A slot that survived but MOVED workspaces has invalidated both decisions that
+    # read it: the memory boundary the child inherits, and the agent-binding check
+    # above, whose whole question was whether the answering agent is bound to THIS
+    # workspace. Re-running that check here is not an option -- it needs
+    # `KiroCrewConfig.load()`, which is filesystem work that must not run on the
+    # event loop -- so a moved caller is refused instead of re-authorized.
+    if (getattr(live_caller, "workspace", "default") or "default") != workspace:
+        raise SessionControlError(
+            "caller session changed workspace while the session was being created",
+            code="caller_workspace_changed",
+        )
+    _refuse_ineligible_creator(state, live_caller)
+    if state.live_slot_count() >= _MAX_SLOTS_FOR_CREATE:
+        raise SessionControlError(
+            f"slot cap reached ({_MAX_SLOTS_FOR_CREATE})",
+            code="slot_cap_reached",
+            status=429,
+        )
+
+    # The agent rides in the constructor rather than being assigned afterwards, for
+    # the same reason: it decides which workspace actually EXECUTES the turn, so it
+    # must never be observable as empty. Everything after this point is synchronous
+    # until the slot is fully configured.
+    slot = state.get_or_create_slot(
+        None, agent=agent_name, workspace=workspace, origin=SlotOrigin.USER
+    )
+    # cwd must follow the workspace too, or file search and project-scoped agents
+    # resolve against a directory the slot does not claim -- the same
+    # authorization-vs-execution split as the agent binding, one layer down.
+    if not slot.project:
+        slot.project = project_dir
+    if title.strip():
+        slot.title = sanitize_outbound(title.strip())[:200]
+        slot._titled = True
+    # Persist at birth. `save_slot_off_loop` cannot do this: the save it wraps
+    # returns early on an empty message window -- before its `force` check -- so a
+    # freshly created session, which has no messages by definition, would write
+    # nothing at all. The tool would then hand back a session that does not survive
+    # a restart.
+    #
+    # Awaited, and a failure RETRACTS the slot rather than merely propagating: an
+    # unpersisted slot stays in the table, usable in memory and addressable by its
+    # creator, then vanishes on restart. Reporting the failure while leaving that
+    # behind is the worse of the two outcomes, because the caller sees an error and
+    # the session exists anyway. Same retraction the fork path uses on a failed
+    # build.
+    try:
+        await asyncio.to_thread(
+            log.update_metadata,
+            slot_history_key(slot),
+            {
+                "_type": "metadata",
+                # The slot's OWN durable identity, and its origin, both of which
+                # the normal save path writes -- but a slot created here may never
+                # reach that path: `_save_slot_to_history` returns early on an
+                # empty message window, so for a session that is created and then
+                # sits idle THIS dict is the only record on disk. Omitting `origin`
+                # is silently destructive on the next restart: rehydrate falls back
+                # to the fail-closed empty sentinel, so a session opened as USER
+                # comes back unattributed and `slots:user` subscribers stop seeing
+                # it. Checked field-by-field against the save path; these are the
+                # only fields a slot carries at birth that it does not already
+                # write.
+                "tab_id": slot._tab_id,
+                "origin": slot._origin,
+                "created_at": metadata_now_iso(),
+                "workspace": slot.workspace,
+                "agent": slot.agent or "",
+                "project": slot.project or "",
+                "title": slot.title or "",
+                "memory_mode": getattr(slot, "memory_mode", "persistent"),
+            },
+        )
+    except Exception:
+        # Retract, but never at the cost of work already in flight. The slot is
+        # addressable from the moment `get_or_create_slot` publishes it, which is
+        # before this await, so a turn can have started on it while the write was
+        # in the worker thread. Popping the slot then would leave that turn running
+        # with nothing pointing at it -- unreachable, unstoppable, and invisible to
+        # the stop verb. A phantom session that vanishes on the next restart is the
+        # lesser harm, so liveness wins over tidiness and the slot stays.
+        if not slot.running and not slot.messages:
+            state._slots.pop(slot.key, None)
+        state.push_slots_update()
+        raise
+    state.push_slots_update()
+    _audit(
+        caller_session_key=caller_key,
+        operation="create",
+        slot_key=slot.key,
+        outcome="allowed",
+        detail={"agent": slot.agent or ""},
+    )
+    return {"ok": True, "target": slot.key, "title": slot.title or slot.key}
+
+
+def authorize_target(
+    state: "DashboardState",
+    *,
+    caller_session_key: str,
+    target: str,
+    operation: str,
+) -> "_ChatSlot":
+    """Resolve *target* and decide whether *caller* may act on it.
+
+    Deny-by-default: every refusal raises :class:`SessionControlError` and is
+    recorded in the SEL, so an attempt to reach a session that is out of bounds
+    is visible after the fact even though nothing happened.
+    """
+
+    def deny(reason: str, code: str, status: int = 403) -> SessionControlError:
+        # Off the loop for the same reason `_audit` is: this can be the process's
+        # FIRST `sel()`, which constructs the log. A denial is the likeliest
+        # first-ever session-control call on a fresh gateway -- the feature refuses
+        # before it ever allows -- so this path is not the rare one.
+        #
+        # Redacted BEFORE the write, because the audit sink is durable and served
+        # back: `sel.py` documents that on-disk records are not redacted by the
+        # writer, and `/api/sel/events` returns `recent()` rows verbatim to the
+        # dashboard. `target` is raw MCP input, and `target_not_found` interpolates
+        # it into `reason`, so both carry caller text. Redacting at this chokepoint
+        # rather than at the one interpolating call site keeps a future `deny`
+        # caller from reopening it. `redact` is what `sel._forward_event` already
+        # applies to events on the forward path; this closes the same gap on the
+        # path the dashboard reads.
+        #
+        # Only the audit copy is redacted: the returned message goes to the caller
+        # that supplied the string, so it keeps naming the target it was given.
+        _audit_target = redact(target)
+        _audit_reason = redact(reason)
+        _sel_off_loop(
+            lambda: sel().log_api_access(
+                caller=f"session:{caller_session_key or 'unknown'}",
+                operation=f"session_control.{operation}",
+                outcome="denied",
+                source="mcp",
+                resources=f"target={_audit_target}:{code}",
+                error=_audit_reason,
+            ),
+            "session-control denial audit",
+        )
+        return SessionControlError(reason, status=status, code=code)
+
+    if not session_control_enabled():
+        raise deny(
+            "session control is disabled in config (agent.session_control)",
+            "session_control_disabled",
+        )
+
+    caller_key = caller_slot_key(state, caller_session_key)
+    if not caller_key:
+        # Without a resolved caller the self-target guard is blind, and a session
+        # that can reach every peer while being unidentifiable is exactly the
+        # shape this surface must not have.
+        raise deny("caller session could not be identified", "caller_unidentified")
+    if caller_key.startswith(UNATTENDED_SLOT_PREFIXES):
+        raise deny(
+            "unattended sessions (scheduled runs) cannot control other sessions",
+            "unattended_caller",
+        )
+
+    try:
+        slot = _resolve_slot(state, target)
+    except SessionControlError as exc:
+        raise deny(exc.message, exc.code, status=exc.status) from exc
+    if slot is None:
+        # 404 rather than 403: naming a session that is not open is a mistake,
+        # not an authorization failure. Only sessions the dashboard currently
+        # holds are addressable — a closed tab is out of scope, because waking
+        # one would resurrect a conversation the user put away.
+        raise deny(f"no open session matches {target!r}", "target_not_found", status=404)
+
+    if slot.key == caller_key:
+        raise deny("a session cannot control itself", "self_target")
+    if slot.key.startswith(UNATTENDED_SLOT_PREFIXES):
+        raise deny("unattended sessions (scheduled runs) cannot be controlled", "unattended_target")
+    if getattr(slot, "memory_mode", "persistent") != "persistent":
+        raise deny("incognito and temporary sessions are not addressable", "ephemeral_target")
+    if getattr(slot, "_app", ""):
+        raise deny("app-scoped sessions are not addressable", "app_scoped_target")
+    if getattr(slot, "linked_session_key", ""):
+        # A channel-linked session's conversation is mirrored to Slack/Telegram,
+        # so reaching it crosses a surface boundary in both directions: a message
+        # would surface to whoever reads that thread, and a read would pull the
+        # channel's content back. That alone is reason enough to keep it out.
+        #
+        # It is also the one target whose STOP cannot be honoured: the stop path
+        # addresses the session as ``dashboard:<slot>`` while a linked slot's turns
+        # actually run under its ``linked_session_key``, so the cancel would miss
+        # and the target would keep executing after a reported success. Refusing
+        # is the honest answer until the stop path resolves the effective key.
+        raise deny("channel-linked sessions are not addressable", "linked_session_target")
+    if _has_channel_mirror(state, slot):
+        # Same boundary, reached by the other mechanism: an outbound mirror
+        # republishes this session's turns to a channel, so a read would pull
+        # that channel's content back and a stop would act on a conversation
+        # other people are party to.
+        raise deny("sessions mirrored to a channel are not addressable", "mirrored_target")
+    if getattr(slot, "mode", "") == "crew":
+        # A crew session's ingress is NOT a turn. `/api/chat` routes it to
+        # `state.crew.ingest`, which makes the message a durable queue entry and
+        # fans it out to topic sub-sessions; the orchestrator acks instantly and
+        # the message is only shown once the entry is durable. Delivering here as
+        # a turn instead would run generic work that is neither queued nor routed
+        # -- accepted, apparently fine, and silently outside the mode.
+        #
+        # Refused rather than emulated, for the same reason a channel-linked
+        # target is: a target whose turn lifecycle differs needs its own
+        # handling rather than a second, drifting copy of the orchestrator's
+        # rules.
+        raise deny("crew-mode sessions are not addressable", "crew_mode_target")
+
+    # The caller's own isolation gates it too, and for the same reasons the
+    # target's does: an incognito or temporary session is one the user asked to
+    # leave no trace, and an app-scoped session belongs to its app. Either one
+    # reaching a persistent peer would launder content across the boundary it
+    # was created to have — in the direction the target-side checks cannot see.
+    caller_slot = state.get_slot(caller_key)
+    if caller_slot is None:
+        raise deny("caller session is no longer open", "caller_gone")
+    if getattr(caller_slot, "_app", ""):
+        raise deny("app-scoped sessions cannot control other sessions", "app_scoped_caller")
+    if getattr(caller_slot, "memory_mode", "persistent") != "persistent":
+        raise deny(
+            "incognito and temporary sessions cannot control other sessions",
+            "ephemeral_caller",
+        )
+    if getattr(caller_slot, "linked_session_key", ""):
+        # The exfiltration direction, and the reason this is not merely the
+        # mirror of the target-side check: a linked caller's own conversation is
+        # a channel thread, so anything it reads lands in front of whoever is in
+        # that channel. `session_read_message` would hand a private dashboard
+        # transcript to Slack/Discord readers who were never party to it.
+        #
+        # `CHANNEL_AGENT_BLOCKED_TOOLS` already blocks these tools for channel
+        # AGENTS, but that guard keys on the agent identity; a linked SLOT is a
+        # second route to the same surface and has to be closed on its own.
+        raise deny(
+            "channel-linked sessions cannot control other sessions",
+            "linked_session_caller",
+        )
+    if _has_channel_mirror(state, caller_slot):
+        # The exfiltration direction again, via the outbound mechanism: a mirrored
+        # caller republishes its own turns to a channel, so a peer's transcript it
+        # reads lands in front of that channel's audience.
+        raise deny(
+            "sessions mirrored to a channel cannot control other sessions",
+            "mirrored_caller",
+        )
+
+    if getattr(slot, "workspace", "default") != getattr(caller_slot, "workspace", "default"):
+        # Workspaces are the memory boundary; reaching across one would let a
+        # session act on work it cannot see.
+        raise deny("target session belongs to a different workspace", "workspace_mismatch")
+
+    return slot
+
+
+def _audit(
+    *,
+    caller_session_key: str,
+    operation: str,
+    slot_key: str,
+    outcome: str,
+    detail: dict[str, Any] | None = None,
+) -> None:
+    """Record one completed session-control operation in the SEL.
+
+    Logged as a tool invocation rather than an API access because that is what
+    it is from the caller's side, and because it carries the per-call detail
+    (how the message landed, whether a stop escalated) that makes the audit
+    line answer "what actually happened to the other session".
+
+    Dispatched OFF the loop when one is running, mirroring
+    ``update_metadata_off_loop``. ``log_tool_invocation`` only enqueues, but the
+    FIRST ``sel()`` of a process CONSTRUCTS the log -- trust-dir creation, key
+    validation, and on Windows an ``icacls`` subprocess -- and this can genuinely
+    be that first call: ``sel_audit_middleware`` logs AFTER ``await handler(...)``,
+    so on a fresh gateway the first authenticated request constructs the log
+    inside whatever handler runs first. Offloading here covers every call site
+    without adding a step to the boot path -- which the boot-path rule forbids and
+    a background prewarm would only race rather than close.
+    """
+
+    def _do() -> None:
+        sel().log_tool_invocation(
+            session_key=caller_session_key,
+            agent="",
+            source="mcp",
+            tool_name=f"session_{operation}",
+            tool_kind="command",
+            outcome=outcome,
+            resources=f"target={slot_key}",
+            metadata=dict(detail or {}, target=slot_key),
+        )
+
+    _sel_off_loop(_do, "session-control audit")
+
+
+def _sel_off_loop(write: "Callable[[], None]", what: str) -> None:
+    """Run one SEL write off the event loop, best-effort.
+
+    Shared by every session-control SEL write so the property holds in one place
+    instead of per call site -- the denial audit was the THIRD site of this class
+    to be found separately, having been missed while the other two were fixed.
+
+    Two failure modes, both handled: a loop-blocking construct (a ``sel()`` that
+    creates the trust dir, validates keys, and on Windows shells out to
+    ``icacls``), and a construct that RAISES, which unguarded turns a 403 into a
+    500 -- losing the refusal in order to report it. An audit that cannot be
+    written must never change what the caller is told.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    if loop is None:
+        try:
+            write()
+        except Exception:  # noqa: BLE001 - an audit failure must not fail the op
+            logger.warning("%s failed inline", what, exc_info=True)
+        return
+
+    def _report(fut: "asyncio.Future[None]") -> None:
+        exc = fut.exception()
+        if exc is not None:
+            logger.warning("%s failed off-loop: %r", what, exc)
+
+    loop.run_in_executor(None, write).add_done_callback(_report)
+
+
+async def stop_target(
+    state: "DashboardState",
+    *,
+    caller_session_key: str,
+    target: str,
+) -> dict[str, Any]:
+    """Stop *target*'s in-flight turn, via the same path as the Stop button.
+
+    A first call cancels cooperatively; calling again while that is pending
+    escalates to a hard kill. The escalation is decided by the target's own stop
+    state, not by anything the caller can ask for -- which is why there is no
+    force flag: `stop_slot_turn` escalates on a second press regardless of one,
+    so advertising it would promise a hard kill a first call cannot deliver.
+    """
+    # Prewarmed BEFORE `authorize_target`, and that ordering is load-bearing.
+    # `stop_slot_turn`'s IDLE branch logs to the SEL with no await before it, so on
+    # a fresh gateway a first `session_stop` against an idle slot would CONSTRUCT
+    # the log on the loop -- trust-dir creation, key validation, and on Windows an
+    # `icacls` subprocess. Constructing it off-loop first makes that call a cheap
+    # cache hit. Per-request, not a boot step: prewarming at startup is what
+    # `no-new-work-on-gateway-boot-path` forbids, and a background task would only
+    # narrow the race rather than close it.
+    #
+    # It must sit ABOVE the gate because `await` is a suspension point: between
+    # `authorize_target` and `stop_slot_turn` the loop must not yield, or a user
+    # action landing in that window (linking the target to a channel) makes the
+    # decision stale and the `mirrored_target` refusal is bypassed -- the turn gets
+    # cancelled on a session that became channel-backed after the check passed.
+    # Nothing may suspend between this gate and the act it authorizes.
+    #
+    # Best-effort on purpose: construction can raise (a trust root too short to
+    # sign the chain), and this is a latency guard, not an authorization one --
+    # failing it must not turn a stop into a 500.
+    try:
+        await asyncio.to_thread(sel)
+    except Exception:  # noqa: BLE001 - a prewarm failure must not fail the stop
+        logger.warning("session-control SEL prewarm failed", exc_info=True)
+
+    # The config warm goes HERE, not in the handler: the SEL prewarm above is an
+    # `await`, and so is reading the request body, so a warm done before either of
+    # them can be invalidated by a config edit landing in the gap -- leaving
+    # `authorize_target`'s synchronous `session_control_enabled` to re-read and
+    # validate the file on the loop, which is the whole thing the warm exists to
+    # avoid. This is the last suspension before the gate.
+    await prewarm_enabled_check()
+
+    slot = authorize_target(
+        state,
+        caller_session_key=caller_session_key,
+        target=target,
+        operation="stop",
+    )
+    # Deferred: ``chat_handlers`` imports ``dashboard.chat`` transitively, which
+    # reaches back into the gateway at import time — a module-scope import here
+    # closes that cycle through ``handlers.session_control`` -> ``server``.
+    from kiro_crew.dashboard.chat_handlers import stop_slot_turn
+
+    result = await stop_slot_turn(state, slot, source="session_control")
+    _audit(
+        caller_session_key=caller_session_key,
+        operation="stop",
+        slot_key=slot.key,
+        outcome="allowed",
+        detail={"result": result.get("info", "stopping")},
+    )
+    return {"ok": True, "target": slot.key, **result}
+
+
+def read_messages(
+    state: "DashboardState",
+    *,
+    caller_session_key: str,
+    target: str,
+    limit: int = DEFAULT_READ_MESSAGES,
+    since: int | None = None,
+) -> dict[str, Any]:
+    """Read *target*'s transcript tail plus enough state to poll it.
+
+    ``next_since`` is the cursor to poll with; passing it back as ``since`` on the
+    next call returns only what arrived in between, which is the whole
+    wait → read poll loop. ``running`` says whether the target is still
+    working, so a caller knows the difference between "nothing new yet" and
+    "finished and idle".
+    """
+    if limit < 1 or limit > MAX_READ_MESSAGES:
+        raise SessionControlError(
+            f"limit must be between 1 and {MAX_READ_MESSAGES}", code="invalid_limit"
+        )
+    slot = authorize_target(
+        state,
+        caller_session_key=caller_session_key,
+        target=target,
+        operation="read",
+    )
+
+    # Indexes are ABSOLUTE positions in the session, not offsets into the live
+    # window. A slot keeps only the most recent ``_MAX_SLOT_MESSAGES`` in memory
+    # and credits each trimmed row to ``_disk_older_count``, so window length
+    # stops growing once trimming starts. A cursor derived from that length
+    # would freeze at the cap and never see another reply; adding the
+    # frozen-prefix count makes it monotonic for the session's whole life.
+    raw_window = list(slot.messages)
+    base = int(getattr(slot, "_disk_older_count", 0) or 0)
+    # Stop the cursor before the streaming tail (see ``TRANSIENT_ROLES``): those
+    # rows are deleted when the segment flushes, so a cursor past them would sit
+    # beyond the list that replaces them and never return the finished reply.
+    messages = [m for m in raw_window if m.get("role") not in TRANSIENT_ROLES]
+    durable_end = len(messages)
+    total = base + durable_end
+    if since is not None:
+        if since < 0:
+            raise SessionControlError("since must be >= 0", code="invalid_since")
+        if base:
+            # ``_disk_older_count`` counts every trimmed row, transient ones
+            # included (persistence writes them and only skips them when reading
+            # back), while the positions above are built over DURABLE rows only.
+            # The two agree until a transient row is trimmed into the frozen
+            # prefix — then `base` advances with no durable row behind it, every
+            # position shifts, and a `since` read serves a durable message the
+            # caller already had.
+            #
+            # An exact cursor needs a durable-only prefix count, which does not
+            # exist yet and cannot be added from here: ``_disk_older_count`` has a
+            # contract with the save model (it is the frozen prefix saves must not
+            # rewrite) and is read by backfill, rewind and channel slots. So this
+            # refuses loudly instead of quietly duplicating. Tail reads (no
+            # ``since``) still work, and the window is 10,000 rows, so only a very
+            # long-lived session reaches this at all. Tracked for the real fix.
+            raise SessionControlError(
+                "this session is long enough that older messages have been "
+                "trimmed, and cursor positions are no longer exact — read without "
+                "`since` to get the latest messages",
+                status=409,
+                code="cursor_unavailable",
+            )
+        # `base` is 0 from here on — the guard above refused every trimmed
+        # session — so the absolute position and the window offset coincide.
+        #
+        # A cursor PAST the end is the remaining inexact case, and it is not the
+        # same as a stale one: rewind and regenerate shrink a transcript, so
+        # `total` can move backwards under a caller that is still holding the old
+        # position. Clamping it to `total` would start the read at the end and
+        # silently skip every replacement row written below the old cursor, with
+        # nothing in the response saying so. That is the failure the trimmed-session
+        # guard above refuses loudly rather than answer approximately, so this
+        # refuses the same way. Reads without `since` are unaffected.
+        if since > total:
+            raise SessionControlError(
+                "this session is shorter than your cursor — it was rewound or "
+                "regenerated, so earlier positions no longer line up — read "
+                "without `since` to get the latest messages",
+                status=409,
+                code="cursor_unavailable",
+            )
+        start = since
+        offset = start
+    else:
+        # A tail read is still served on a trimmed session (only `since` reads are
+        # refused), so the two spaces come apart here: slice the in-memory window
+        # by OFFSET, but report the index in ABSOLUTE terms so the number still
+        # means "position in the session". Conflating them returned an empty
+        # window, because `total` counts the frozen prefix the list does not hold.
+        offset = max(0, durable_end - limit)
+        start = base + offset
+    window = messages[offset:][:limit]
+
+    out: list[dict[str, Any]] = []
+    for offset, msg in enumerate(window):
+        content = str(msg.get("content", "") or "")
+        # ``redact_and_truncate`` scans the COMPLETE text before slicing. Cutting
+        # first would split a credential straddling the boundary into a prefix
+        # that no longer matches the scanner, so the fragment would ship.
+        emitted = redact_and_truncate(content, MAX_READ_CONTENT_CHARS)
+        row: dict[str, Any] = {
+            "index": start + offset,
+            "role": str(msg.get("role", "") or ""),
+            "content": emitted,
+            "ts": str(msg.get("ts", "") or ""),
+        }
+        if len(content) > MAX_READ_CONTENT_CHARS:
+            row["truncated"] = True
+        out.append(row)
+
+    _audit(
+        caller_session_key=caller_session_key,
+        operation="read",
+        slot_key=slot.key,
+        outcome="allowed",
+        detail={"returned": len(out)},
+    )
+    return {
+        "ok": True,
+        "target": slot.key,
+        "title": sanitize_outbound(slot.display_title),
+        # Busy means "more output is coming", which is exactly what a poller needs
+        # to decide whether to wait. `slot.running` alone is not that: during a
+        # multi-stage plan each stage's `_run_chat` closes its own turn, so it
+        # briefly reads False BETWEEN stages and a poller would conclude the work
+        # had finished and stop before the later stages produced anything.
+        "running": bool(slot.running or getattr(slot, "_in_stage_execution", False)),
+        # True when the target is mid-reply: rows exist that the cursor
+        # deliberately does not cover yet, so "nothing new" here does not mean
+        # "nothing happening".
+        **({"streaming": True} if durable_end < len(raw_window) else {}),
+        "queue_depth": len(slot._queue),
+        "total": total,
+        # The cursor to poll with next. This is NOT `total`: when more than
+        # `limit` rows are new, the window stops short of the end, and a caller
+        # that polled `since=total` would jump the gap and never see the rows in
+        # between. `next_since` is the absolute position just past the last row
+        # actually returned, so consecutive polls cover every row exactly once.
+        # `total` stays in the response as the backlog depth — the difference
+        # from `next_since` is how far behind the caller still is.
+        #
+        # Omitted once rows have been trimmed, because positions stop being exact
+        # there (see the `cursor_unavailable` refusal above). Handing back a
+        # cursor that the next call would reject is worse than saying it is gone,
+        # so its ABSENCE is the signal: a caller with no `next_since` falls back
+        # to tail reads. No separate flag says the same thing -- two encodings of
+        # one fact can disagree, and the reader already has to handle the absent
+        # key.
+        **({"next_since": start + len(out)} if not base else {}),
+        "messages": out,
+    }

--- a/src/kiro_crew/dashboard/session_pulse_counter.py
+++ b/src/kiro_crew/dashboard/session_pulse_counter.py
@@ -20,10 +20,12 @@ a new-ish install gated shut rather than surfacing the survey on bad data).
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
 import tempfile
+import threading
 from pathlib import Path
 
 from kiro_crew.config.loader import config_dir
@@ -32,6 +34,11 @@ logger = logging.getLogger(__name__)
 
 _FILE = "session_pulse_sessions.json"
 _KEY = "user_sessions"
+
+# Serializes the counter's read-modify-write. Needed because the increment is
+# scheduled into an executor (see `increment_user_session_count_off_loop`), so it
+# is no longer serialized by the event loop the way an inline call was.
+_WRITE_LOCK = threading.Lock()
 
 # Minimum genuine user-initiated chats before the survey may appear. A person
 # below this is treated as a new user and never surveyed -- their rating would
@@ -67,21 +74,62 @@ def increment_user_session_count() -> int:
     Atomic write (temp file + ``os.replace``) so a crash mid-write cannot
     corrupt the file. On write failure this logs and returns the pre-increment
     value rather than raising into the session-creation path.
+
+    The read-modify-write is held under ``_WRITE_LOCK``. Inline on the event loop
+    that was free -- births are serialized by the loop -- but
+    :func:`increment_user_session_count_off_loop` runs this in an executor, where
+    two births could otherwise interleave their read and write and drop a count.
+    Cross-PROCESS interleaving (two gateways sharing a home) is unchanged and
+    still only guaranteed not to corrupt the file, not to be exact.
     """
-    current = get_user_session_count()
-    new_val = current + 1
-    path = _path()
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{_FILE}.", suffix=".tmp")
+    with _WRITE_LOCK:
+        current = get_user_session_count()
+        new_val = current + 1
+        path = _path()
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                json.dump({_KEY: new_val}, fh)
-            os.replace(tmp, path)
-        finally:
-            if os.path.exists(tmp):
-                os.unlink(tmp)
-    except Exception:
-        logger.warning("failed to persist session-pulse session count", exc_info=True)
-        return current
-    return new_val
+            path.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{_FILE}.", suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    json.dump({_KEY: new_val}, fh)
+                os.replace(tmp, path)
+            finally:
+                if os.path.exists(tmp):
+                    os.unlink(tmp)
+        except Exception:
+            logger.warning("failed to persist session-pulse session count", exc_info=True)
+            return current
+        return new_val
+
+
+def increment_user_session_count_off_loop() -> None:
+    """Count one user session without doing its disk I/O on the event loop.
+
+    ``get_or_create_slot`` is synchronous and runs on the gateway loop for every
+    request-layer slot birth -- a new chat tab, a fork, and the session-control
+    create verb all reach it -- so doing this module's read, ``mkdir``, tempfile
+    write and ``os.replace`` inline stalls the whole loop on slow or contended
+    storage.
+
+    Nothing reads the count until the survey's own eligibility check, and the
+    increment is already best-effort (it swallows its own I/O errors and returns
+    the pre-increment value), so a slot birth has no reason to wait for it.
+
+    Deliberately fixed HERE rather than by making the caller async: the
+    allocation inside ``get_or_create_slot`` must not suspend part-way, because
+    callers depend on the slot being fully configured before anything else can
+    observe it. Offloading the allocation would reintroduce exactly that window;
+    offloading the I/O does not.
+
+    Fire-and-forget by design: the future is not awaited, which is safe only
+    because the callee cannot raise. A count lost to shutdown racing the executor
+    is acceptable for a survey timing gate and matches the best-effort contract
+    the module already documents.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No loop: a test, a CLI, or a background thread. Nothing to protect.
+        increment_user_session_count()
+        return
+    loop.run_in_executor(None, increment_user_session_count)

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -32,7 +32,7 @@ from kiro_crew.constants import (
     SUBAGENT_COMPLETION_PREFIX,
 )
 from kiro_crew.dashboard.chat_compaction_notice import deliver_channel_compaction_notice
-from kiro_crew.dashboard.session_pulse_counter import increment_user_session_count
+from kiro_crew.dashboard.session_pulse_counter import increment_user_session_count_off_loop
 from kiro_crew.dashboard.side_state import SideState
 from kiro_crew.dashboard.system_notices import is_system_notice
 from kiro_crew.history import latest_transcript_ts, monotonic_transcript_ts
@@ -1487,6 +1487,7 @@ class _ChatSlot:
         "_native_subagent_tracker",
         "_native_subagent_output",
         "_pending_steers",
+        "_steer_delivery_ids",
         "_wait_state",
         "_end_wait_request",
         "_wait_last_ping",
@@ -1942,6 +1943,13 @@ class _ChatSlot:
         # STOP, error). Without this, a steer swallowed by a dying turn
         # vanished with no trace (see the requeue site).
         self._pending_steers: list[str] = []
+        # Opaque id per in-flight steer, keyed by its text (the one-per-text
+        # rule in chat_delivery makes that key unique). The requeue moves the id
+        # onto the queue entry and the drain unions entry meta onto the row it
+        # writes, which is how a caller can tell a delivery the drain already
+        # persisted from one the running turn consumed — a distinction the bare
+        # text cannot make.
+        self._steer_delivery_ids: dict[str, str] = {}
         # In-flight `wait` tool sleep, as reported by the tool's own keepalive
         # ping: {"wait_id": str, "seconds": int, "deadline_ts": float}. The
         # deadline is on the dashboard's clock (see api_session_keepalive) so
@@ -2483,7 +2491,14 @@ class _ChatSlot:
         """
         self._last_enqueue_ts = datetime.now(timezone.utc).isoformat()
 
-    def queue_insert(self, index: int, content: str, kind: str = "", payload: str = "") -> str:
+    def queue_insert(
+        self,
+        index: int,
+        content: str,
+        kind: str = "",
+        payload: str = "",
+        meta: dict | None = None,
+    ) -> str:
         """Insert a message at a specific queue position. Returns the queue ID.
 
         See :meth:`queue_append` for the ``kind`` structural origin tag. ``payload``
@@ -2492,7 +2507,10 @@ class _ChatSlot:
         message shares the recovery kind but is not machine speech.
         """
         qid = uuid.uuid4().hex[:12]
-        self._queue.insert(index, {"id": qid, "content": content, "kind": kind, "payload": payload})
+        entry: dict[str, Any] = {"id": qid, "content": content, "kind": kind, "payload": payload}
+        if meta:
+            entry["meta"] = dict(meta)
+        self._queue.insert(index, entry)
         self._note_enqueue()
         return qid
 
@@ -5143,7 +5161,14 @@ class DashboardState:
             # only the request layer ever supplies origin=USER. Best-effort:
             # the helper swallows its own I/O errors and never raises into
             # slot creation.
-            increment_user_session_count()
+            #
+            # Off the loop, because this method is synchronous and every
+            # request-layer birth runs it on the gateway loop -- the counter's
+            # read + mkdir + tempfile write + replace would stall it on slow
+            # storage. The offload is the counter's, not this allocation's: this
+            # block must not become a suspension point, or callers could observe
+            # a half-configured slot.
+            increment_user_session_count_off_loop()
         if memory_mode and memory_mode != "persistent":
             self._restricted_keys.add(f"dashboard:{name}")
         if ephemeral:

--- a/src/kiro_crew/mcp_dashboard.py
+++ b/src/kiro_crew/mcp_dashboard.py
@@ -80,6 +80,9 @@ from kiro_crew.validation import (
     CHAT_FOLDER_MOVE_SESSION_SCHEMA,
     CHAT_FOLDER_TREE_SCHEMA,
     MCP_DASHBOARD_SCHEMAS,
+    SESSION_CREATE_SCHEMA,
+    SESSION_READ_MESSAGE_SCHEMA,
+    SESSION_STOP_SCHEMA,
     validate_tool_args,
 )
 
@@ -87,6 +90,18 @@ logger = logging.getLogger(__name__)
 
 SERVER_NAME = "kirocrew-dashboard"
 SERVER_VERSION = "1.0.0"
+
+#: The session-control half of this server's tool set, in one place because three
+#: separate things must agree on it: the caller-identity gate in
+#: ``_call_tool_inner``, the channel-agent containment list
+#: (``CHANNEL_AGENT_BLOCKED_TOOLS``), and the pinned advertised set in the
+#: registration tests. Spelling it out per site is how ``session_create`` came to
+#: be gated for identity but reachable from a channel agent.
+SESSION_CONTROL_TOOLS: tuple[str, ...] = (
+    "session_create",
+    "session_stop",
+    "session_read_message",
+)
 
 # The folder endpoints store ``name[:100]``. Mirroring the number here is what
 # lets this server refuse an overlong name instead of writing one it cannot
@@ -193,6 +208,95 @@ def _tool_definitions() -> list[dict[str, Any]]:
                     },
                 },
                 "required": ["session"],
+            },
+        },
+        {
+            "name": "session_create",
+            "description": (
+                "Open a NEW chat session, pre-named and bound to the agent you pick, so a "
+                "separate workstream has a home of its own. The new session appears in "
+                "the user's sidebar like any other — they can read it, take it over and "
+                "close it — so use it to stand up a workstream alongside this one (watch a "
+                "build, grind a long refactor) rather than to hide work. It starts empty: "
+                "the person is the one who types the first message into it. Returns its "
+                "key; pass that as `target` to the other session tools."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": (
+                            "Short name for the session, shown in the sidebar. Say what the "
+                            "session is FOR so the user can tell your sessions apart."
+                        ),
+                    },
+                    "agent": {
+                        "type": "string",
+                        "description": (
+                            "Agent to bind the session to. Omit to use the default agent."
+                        ),
+                    },
+                },
+                "required": [],
+            },
+        },
+        {
+            "name": "session_stop",
+            "description": (
+                "Stop another session's in-flight turn — the same thing as pressing Stop "
+                "in that tab. Use it when a peer session is working on something you now "
+                "know is wrong or already done, and letting it finish would waste the run "
+                "or make a conflicting change. The first call cancels cooperatively; "
+                "calling again while that is still pending escalates to a hard kill. "
+                "A stop card appears in the "
+                "target's transcript so the person reading it sees what happened. Stopping "
+                "discards the turn's work, so read the session first when you are not sure "
+                "what it is doing."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Session key from list_sessions, or its exact title.",
+                    },
+                },
+                "required": ["target"],
+            },
+        },
+        {
+            "name": "session_read_message",
+            "description": (
+                "Read the tail of another session's transcript, plus whether it is still "
+                "working. Use it to watch a peer session's progress: `wait`, then read — "
+                "pass the ``next_since`` from the previous read back as ``since`` "
+                "and you get only what arrived in between, so a poll loop does not re-read "
+                "the same messages. ``running: false`` with nothing new means the target "
+                "finished and is idle, which is the difference between 'not done yet' and "
+                "'done'. READ-only: it never sends anything or changes the target's state."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "Session key from list_sessions, or its exact title.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max messages to return (default 20, max 100).",
+                        "default": 20,
+                    },
+                    "since": {
+                        "type": "integer",
+                        "description": (
+                            "Return messages from this index onward — pass the ``next_since`` from "
+                            "your previous read to get only new ones. Omit for the newest tail."
+                        ),
+                    },
+                },
+                "required": ["target"],
             },
         },
     ]
@@ -687,6 +791,114 @@ def _refuse_tree_shaping_if_unverifiable(verb: str) -> tuple[str, str | None]:
 
 def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
     """Dispatch one validated tool call."""
+    caller_key = ""
+    if name in SESSION_CONTROL_TOOLS:
+        # Authorization for all four is the CALLER'S IDENTITY: the route decides
+        # what a session may reach from the key sent here. The lenient resolver
+        # walks /proc ancestors, and a spawned subagent lives under its parent
+        # slot's process tree — so the walk would hand a subagent its parent's
+        # identity and let it read, message, or stop the parent's sibling
+        # sessions. Only the signed sources count.
+        #
+        # The verified key is KEPT and handed to the request helper below. Gating
+        # on the strict resolver and then letting the helper resolve again would
+        # authorize the check and the action as potentially different sessions:
+        # the lenient walk reads mutable process state, so what it answers at
+        # request time need not be what the gate approved.
+        caller_key = _resolve_session_key_strict()
+        if not caller_key:
+            return (
+                "Error: this session cannot be identified well enough to control another "
+                "session. Session control authorizes on the calling session's identity, and "
+                "only a gateway-issued key counts — a spawned subagent has none of its own."
+            )
+
+    if name == "session_create":
+        args = validate_tool_args(args, SESSION_CREATE_SCHEMA)
+        resp = _post(
+            "/api/session-control/create",
+            {"title": args.get("title", ""), "agent": args.get("agent", "")},
+            session_key=caller_key,
+        )
+        if resp.get("error"):
+            return f"Error: could not create a session: {resp['error']}"
+        return (
+            f"\U0001f195 Opened `{resp.get('target')}` ({resp.get('title')}). "
+            "It is empty and waiting in the user's sidebar; watch it with "
+            "session_read_message."
+        )
+
+    if name == "session_stop":
+        args = validate_tool_args(args, SESSION_STOP_SCHEMA)
+        resp = _post(
+            "/api/session-control/stop",
+            {"target": args["target"]},
+            session_key=caller_key,
+        )
+        if resp.get("error"):
+            return f"Error: could not stop that session: {resp['error']}"
+        target = resp.get("target", args["target"])
+        info = resp.get("info")
+        if info:
+            # The target was not running (or a stop was already in flight) — say
+            # so rather than implying a turn was cancelled.
+            return f"\u2139\ufe0f `{target}`: {info} — nothing to stop."
+        return f"\U0001f6d1 Stop sent to `{target}`. Its transcript now shows the stop card."
+
+    if name == "session_read_message":
+        args = validate_tool_args(args, SESSION_READ_MESSAGE_SCHEMA)
+        query = f"target={quote(str(args['target']))}&limit={args.get('limit', 20)}"
+        if args.get("since") is not None:
+            query += f"&since={int(args['since'])}"
+        resp = _get(f"/api/session-control/read?{query}", caller_key)
+        if resp.get("error"):
+            return f"Error: could not read that session: {resp['error']}"
+        msg_rows = resp.get("messages") or []
+        state_line = "still working" if resp.get("running") else "idle"
+        queued = resp.get("queue_depth", 0)
+        if queued:
+            state_line += f", {queued} message(s) queued"
+        head_line = (
+            f"\U0001f4d6 `{resp.get('target', '')}` — {resp.get('title', '')} "
+            f"({state_line}; total={resp.get('total', 0)})"
+        )
+        if not msg_rows:
+            # The cursor rides along even with nothing to show. A poll loop's most
+            # common answer is an empty window, and a caller left without a
+            # position either re-reads without `since` -- taking the tail, which
+            # silently skips everything older than the last `limit` rows once the
+            # target answers in a burst -- or keeps reusing a cursor from before,
+            # re-reading rows it has already seen. `next_since` is absent only when
+            # rows have been trimmed and positions stopped being exact, which is
+            # the one case a cursor must not be invented for.
+            empty_lines = [head_line, "No messages in that window yet."]
+            if "next_since" in resp:
+                empty_lines.append(
+                    f"Pass since={resp['next_since']} on your next read to resume from here."
+                )
+            return "\n".join(empty_lines)
+        read_lines = [head_line]
+        for row in msg_rows:
+            text_body = str(row.get("content", ""))
+            if row.get("truncated"):
+                text_body += " …[truncated]"
+            read_lines.append(f"[{row.get('index')}] {row.get('role')}: {text_body}")
+        read_lines.append(
+            (
+                f"Pass since={resp['next_since']} on your next read to see only what "
+                f"is new. (total={resp.get('total', 0)} is the backlog depth — when it "
+                f"exceeds next_since there are older rows this window did not reach, so "
+                f"read again immediately rather than waiting.)"
+            )
+            if "next_since" in resp
+            else (
+                "This session is long enough that older messages have been trimmed, so "
+                "cursor positions are no longer exact and `since` reads are refused. "
+                "Read again without `since` to get the latest messages."
+            )
+        )
+        return "\n".join(read_lines)
+
     if name == "chat_folder_tree":
         validate_tool_args(args, CHAT_FOLDER_TREE_SCHEMA)
         chat_folders, folders_err = _get_rows("/api/chat/folders")

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -127,6 +127,24 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "the sidecar is durable and read straight back to the panel.",
     ),
     (
+        "Cross-session turn delivery",
+        "dashboard/chat_delivery.py",
+        "The text a steer or a queued message carries into a turn, on the path "
+        "`POST /api/chat` uses. Two boundaries in one call: the text is persisted "
+        "into the slot's transcript and broadcast to every connected browser as a "
+        "`steer_push` / `queue_push` card, so the scan happens here, before either "
+        "boundary.",
+    ),
+    (
+        "Session control read",
+        "dashboard/session_control.py",
+        "Another session's transcript tail, served by "
+        "`GET /api/session-control/read` to the calling agent. Conversation "
+        "content read off a live slot, so it can carry a credential a tool "
+        "printed — the same output-boundary reason as the session-storage inventory "
+        "below, with the reader being an LLM rather than the browser.",
+    ),
+    (
         "Session storage inventory",
         "dashboard/handlers/session_storage.py",
         "A session's title and its first message, served by "

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -2513,6 +2513,30 @@ LIST_SESSIONS_SCHEMA = ToolSchema(
     ],
 )
 
+SESSION_CREATE_SCHEMA = ToolSchema(
+    tool_name="session_create",
+    fields=[
+        FieldSpec("title", str, required=False, default="", max_len=200),
+        FieldSpec("agent", str, required=False, default="", max_len=MAX_SHORT_STRING),
+    ],
+)
+
+SESSION_STOP_SCHEMA = ToolSchema(
+    tool_name="session_stop",
+    fields=[
+        FieldSpec("target", str, required=True, max_len=MAX_SHORT_STRING),
+    ],
+)
+
+SESSION_READ_MESSAGE_SCHEMA = ToolSchema(
+    tool_name="session_read_message",
+    fields=[
+        FieldSpec("target", str, required=True, max_len=MAX_SHORT_STRING),
+        FieldSpec("limit", int, required=False, min_val=1, max_val=100, default=20),
+        FieldSpec("since", int, required=False, min_val=0),
+    ],
+)
+
 # ── Schema Registry ──
 
 MCP_CORE_SCHEMAS: dict[str, ToolSchema] = {
@@ -2723,6 +2747,9 @@ def _cu_coord_field(name: str, *, required: bool = False) -> FieldSpec:
 # routes validation through it, and a tool absent from its server's registry has
 # its args passed through raw.
 MCP_DASHBOARD_SCHEMAS: dict[str, ToolSchema] = {
+    "session_create": SESSION_CREATE_SCHEMA,
+    "session_stop": SESSION_STOP_SCHEMA,
+    "session_read_message": SESSION_READ_MESSAGE_SCHEMA,
     "chat_folder_tree": CHAT_FOLDER_TREE_SCHEMA,
     "chat_folder_create": CHAT_FOLDER_CREATE_SCHEMA,
     "chat_folder_move": CHAT_FOLDER_MOVE_SCHEMA,

--- a/test/chat_test_helpers.py
+++ b/test/chat_test_helpers.py
@@ -123,6 +123,30 @@ def _make_state(tmp_path, **kwargs):
     sessions.set_slack_link = MagicMock(side_effect=_set_slack_link)
     sessions.get_slack_link = MagicMock(side_effect=_get_slack_link)
     sessions.clear_slack_link = MagicMock(side_effect=_clear_slack_link)
+
+    # Real in-memory mirror-link store, for the same reason as the Slack one and
+    # with a sharper failure mode: callers branch on whether a mirror is PRESENT,
+    # and a bare MagicMock is unconditionally truthy, so every session reads as
+    # mirrored to a channel. A guard that refuses mirrored sessions then refuses
+    # ALL of them, which looks like a broken guard rather than a missing double.
+    # Parity with SessionStore: absent -> None.
+    _mirror_links: dict[str, tuple[str, str]] = {}
+
+    def _set_mirror_link(key, channel_id, thread_ts):
+        if channel_id or thread_ts:
+            _mirror_links[key] = (channel_id, thread_ts)
+        else:
+            _mirror_links.pop(key, None)
+
+    def _get_mirror_link(key):
+        return _mirror_links.get(key)
+
+    def _clear_mirror_link(key):
+        return _mirror_links.pop(key, None) is not None
+
+    sessions.set_mirror_link = MagicMock(side_effect=_set_mirror_link)
+    sessions.get_mirror_link = MagicMock(side_effect=_get_mirror_link)
+    sessions.clear_mirror_link = MagicMock(side_effect=_clear_mirror_link)
     state = DashboardState(
         sessions=sessions,
         crons=MagicMock(list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})),

--- a/test/test_channel_blocked_tools.py
+++ b/test/test_channel_blocked_tools.py
@@ -101,3 +101,21 @@ def test_blocked_tool_matcher_precision(rendered, expected):
     from kiro_crew.channel import _blocked_tool_named
 
     assert _blocked_tool_named(rendered) is expected
+
+
+def test_every_session_control_tool_is_contained():
+    """The whole session-control surface sits behind this boundary, not part of it.
+
+    Pinned against the advertised tool set rather than a hand-written list, so a
+    fourth verb fails here instead of shipping reachable from a channel agent. The
+    omission this guards against is not hypothetical: `session_create` was added
+    to the surface and missed here, and nothing else in the suite noticed.
+
+    Create earns its place for a different reason than the other two. It writes
+    nothing into an existing conversation, but it puts a persistent,
+    sidebar-visible session outside the containment this list holds.
+    """
+    from kiro_crew.mcp_dashboard import SESSION_CONTROL_TOOLS
+
+    missing = sorted(set(SESSION_CONTROL_TOOLS) - set(CHANNEL_AGENT_BLOCKED_TOOLS))
+    assert not missing, f"session-control tools reachable from a channel agent: {missing}"

--- a/test/test_mcp_dashboard_folders.py
+++ b/test/test_mcp_dashboard_folders.py
@@ -1375,6 +1375,91 @@ class TestPrivateSessionsAreInvisible:
         mock_patch.assert_not_called()
 
 
+class TestTheVerifiedCallerKeyReachesTheRequest:
+    """The gate resolves the caller strictly; the request must SEND that key.
+
+    Gating on `_resolve_session_key_strict` and then letting the request helper
+    resolve again authorizes the check and the action as potentially different
+    sessions: the lenient walk reads mutable process state, so what it answers
+    at request time need not be what the gate approved. The endpoint authorizes
+    on the key it receives, which makes the sent key the security-relevant one.
+    """
+
+    VERIFIED = "dashboard:chat-verified"
+
+    def test_create_carries_the_verified_key(self):
+        with patch(
+            "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
+        ), patch(
+            "kiro_crew.mcp_dashboard._post", return_value={"target": "chat-2", "title": "w"}
+        ) as post:
+            _call_tool_inner("session_create", {"title": "worker"})
+        assert post.call_args.kwargs["session_key"] == self.VERIFIED
+
+    def test_stop_carries_the_verified_key(self):
+        with patch(
+            "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
+        ), patch("kiro_crew.mcp_dashboard._post", return_value={"ok": True}) as post:
+            _call_tool_inner("session_stop", {"target": "peer"})
+        assert post.call_args.kwargs["session_key"] == self.VERIFIED
+
+    def test_read_carries_the_verified_key(self):
+        with patch(
+            "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
+        ), patch(
+            "kiro_crew.mcp_dashboard._get", return_value={"messages": [], "total": 0}
+        ) as get:
+            _call_tool_inner("session_read_message", {"target": "peer"})
+        # `_get` takes the key positionally, matching its signature.
+        assert get.call_args.args[1] == self.VERIFIED
+
+    def test_an_empty_window_still_hands_back_the_cursor(self):
+        """A poll loop's commonest answer is empty, and it must not lose its place.
+
+        Without the cursor the caller either re-reads with no `since` -- taking the
+        tail, which skips everything older than the last `limit` rows once the
+        target answers in a burst -- or reuses a stale position and re-reads rows it
+        has already seen.
+
+        Mutation guard: returning only the head line and "No messages" fails here.
+        """
+        with patch(
+            "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
+        ), patch(
+            "kiro_crew.mcp_dashboard._get",
+            return_value={"messages": [], "total": 7, "next_since": 7},
+        ):
+            out = _call_tool_inner("session_read_message", {"target": "peer"})
+        assert "since=7" in out, "an empty window must still carry next_since"
+
+    def test_a_trimmed_transcript_invents_no_cursor_on_an_empty_window(self):
+        """`next_since` is absent exactly when positions stopped being exact."""
+        with patch(
+            "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
+        ), patch(
+            "kiro_crew.mcp_dashboard._get", return_value={"messages": [], "total": 7}
+        ):
+            out = _call_tool_inner("session_read_message", {"target": "peer"})
+        assert "since=" not in out, "no cursor may be invented once rows are trimmed"
+
+    def test_an_unverifiable_caller_never_reaches_the_request(self):
+        """The refusal must precede the call, not merely alter its key."""
+        with patch(
+            "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=""
+        ), patch("kiro_crew.mcp_dashboard._post") as post, patch(
+            "kiro_crew.mcp_dashboard._get"
+        ) as get:
+            for tool, args in (
+                ("session_create", {"title": "worker"}),
+                ("session_stop", {"target": "peer"}),
+                ("session_read_message", {"target": "peer"}),
+            ):
+                out = _call_tool_inner(tool, args)
+                assert "cannot be identified" in out
+        post.assert_not_called()
+        get.assert_not_called()
+
+
 class TestAdvertisedSet:
     """Reaching this server means an agent spec referenced it.
 
@@ -1389,4 +1474,7 @@ class TestAdvertisedSet:
             "chat_folder_create",
             "chat_folder_move",
             "chat_folder_move_session",
+            "session_create",
+            "session_stop",
+            "session_read_message",
         }

--- a/test/test_mcp_dashboard_registration.py
+++ b/test/test_mcp_dashboard_registration.py
@@ -336,25 +336,51 @@ class TestWhatThisSetGrants:
         "chat_folder_move",
         "chat_folder_move_session",
     }
+    #: The session-control half. Granted by the SAME assignment as the folder
+    #: half — see ``test_session_driving_tools_ship_with_the_folder_tools`` for
+    #: why the two classes ride together rather than in two servers.
+    SESSION_TOOLS = {
+        "session_create",
+        "session_stop",
+        "session_read_message",
+    }
+    GRANTED_TOOLS = FOLDER_TOOLS | SESSION_TOOLS
 
     def test_the_set_is_exactly_the_folder_tools(self) -> None:
         from kiro_crew import mcp_dashboard
 
-        assert {t["name"] for t in mcp_dashboard._tool_definitions()} == self.FOLDER_TOOLS
+        assert {t["name"] for t in mcp_dashboard._tool_definitions()} == self.GRANTED_TOOLS
 
     def test_the_advertised_list_is_the_set(self) -> None:
         """Reaching the process means the set was assigned; nothing is hidden."""
         from kiro_crew import mcp_dashboard
 
-        assert {t["name"] for t in mcp_dashboard._list_tools()} == self.FOLDER_TOOLS
+        assert {t["name"] for t in mcp_dashboard._list_tools()} == self.GRANTED_TOOLS
 
-    def test_no_session_driving_tool_joins_this_set(self) -> None:
-        """A tool that messages/stops another session needs its own server."""
+    def test_session_driving_tools_ship_with_the_folder_tools(self) -> None:
+        """This set deliberately bundles two capability classes.
+
+        The earlier ratchet here asserted the OPPOSITE — that nothing which
+        messages or stops another session may join the folder set. That guard
+        existed for the window before session control landed, to stop such a tool
+        arriving as an unnoticed side effect of a folder change. Bundling them is
+        now the decided design: one assignable set, granted as a whole, so an
+        agent told to organize sessions can also hand work between them.
+
+        The ratchet is inverted rather than deleted, because the property worth
+        protecting did not go away: what the set contains must be a decision, not
+        an accident. If either class disappears from the server, this fails and
+        whoever changed it has to say which half they meant to drop.
+        """
         from kiro_crew import mcp_dashboard
 
         names = {t["name"] for t in mcp_dashboard._tool_definitions()}
-        forbidden = {n for n in names if "message" in n or "stop" in n or "steer" in n}
-        assert not forbidden, (
-            f"{sorted(forbidden)} drive another session but would be granted by "
-            "assigning the folder-organization set — give that class its own server"
+        folder = {n for n in names if n.startswith("chat_folder_")}
+        session = {n for n in names if n.startswith("session_")}
+        assert folder, "the folder-organization tools left this set"
+        assert session, "the session-control tools left this set"
+        # Nothing else rides along unannounced.
+        assert names == folder | session, (
+            f"{sorted(names - folder - session)} is neither folder organization nor "
+            "session control — name the class it belongs to before adding it here"
         )

--- a/test/test_session_control.py
+++ b/test/test_session_control.py
@@ -1,0 +1,2225 @@
+"""Session control: one chat session sending to, stopping, and reading another.
+
+The suite is organized around the two things that can go wrong here. First,
+authorization: every refusal is asserted against the REAL slot objects, because
+the guards read ``memory_mode`` / ``workspace`` / ``_app`` off the production
+class and a permissive test double would let a dead guard look alive. Second,
+delivery: a message must land exactly once — the interesting failures are the
+double-delivery and silent-drop paths around a steer that the live client
+refuses mid-flight.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from chat_test_helpers import _make_state
+
+from kiro_crew.config import loader
+from kiro_crew.dashboard import chat_delivery as cd
+from kiro_crew.dashboard import session_control as sc
+from kiro_crew.dashboard.chat_utils import slot_history_key
+from kiro_crew.dashboard.handlers import session_control as handlers_sc
+
+# The autouse fixture below replaces ``sc.session_control_enabled`` so every
+# other test runs in the shipped (enabled) state without reading config. Keep a
+# handle on the real function so the tests that are ABOUT that function can call
+# it — it still resolves ``KiroCrewConfig`` through module globals, so patching
+# the config class continues to work through this reference.
+_REAL_ENABLED = sc.session_control_enabled
+
+
+@pytest.fixture(autouse=True)
+def _enabled(monkeypatch):
+    """Default every test to the shipped state (enabled) without reading config."""
+    monkeypatch.setattr(sc, "session_control_enabled", lambda: True)
+
+
+def _slot(state, name: str, **kwargs):
+    return state.get_or_create_slot(name, **kwargs)
+
+
+def _key(slot) -> str:
+    """The session key the MCP process would present for *slot*."""
+    return slot_history_key(slot)
+
+
+def _peer_target(state, name: str, caller, **kwargs):
+    """A peer session in the caller's workspace, addressable by the other verbs."""
+    return state.get_or_create_slot(name, **kwargs)
+
+
+def _busy(slot):
+    """Make *slot* look like a turn is in flight.
+
+    ``running`` is derived (``task is not None and not task.done()``), so a busy
+    slot is expressed by its task — assigning ``running`` would raise.
+    """
+    task = MagicMock()
+    task.done.return_value = False
+    slot.task = task
+    return slot
+
+
+def _steerable(accepted: bool = True) -> MagicMock:
+    client = MagicMock()
+    client.supports_steer = True
+    client.steer = AsyncMock(return_value=accepted)
+    return client
+
+
+# ── Target resolution ────────────────────────────────────────────────────────
+
+
+def test_resolves_target_by_slot_key(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    resolved = sc.authorize_target(
+        state, caller_session_key=_key(caller), target="chat-2", operation="read"
+    )
+    assert resolved is target
+
+
+def test_resolves_target_by_exact_title(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    target.title = "Rebase the watchdog PR"
+    resolved = sc.authorize_target(
+        state,
+        caller_session_key=_key(caller),
+        target="rebase the watchdog pr",
+        operation="read",
+    )
+    assert resolved is target
+
+
+def test_resolves_target_by_the_key_list_sessions_reports(tmp_path):
+    """``list_sessions`` hands out FILENAME STEMS, and the tools say to pass them.
+
+    Mutation guard: matching only ``slot.key`` refuses the documented happy path
+    with ``target_not_found`` — the caller does the thing the description tells
+    it to do and the tool says the session does not exist.
+    """
+    from kiro_crew.history import transcript_stem
+
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    stem = transcript_stem(slot_history_key(target))
+    assert stem != target.key, "fixture must exercise the differing-form case"
+
+    resolved = sc.authorize_target(
+        state, caller_session_key=_key(caller), target=stem, operation="read"
+    )
+    assert resolved is target
+
+
+def test_the_caller_is_also_resolvable_by_its_stem(tmp_path):
+    """Symmetry: the MCP process may present either form as the caller identity."""
+    from kiro_crew.history import transcript_stem
+
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    stem = transcript_stem(slot_history_key(caller))
+    assert sc.caller_slot_key(state, stem) == caller.key
+
+
+def test_ambiguous_title_is_refused_not_guessed(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    for name in ("chat-2", "chat-3"):
+        _slot(state, name).title = "Shared Title"
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.authorize_target(
+            state, caller_session_key=_key(caller), target="Shared Title", operation="read"
+        )
+    assert exc.value.status == 409
+    # The refusal covers a collision in ANY addressing form, not titles alone,
+    # so it names the forms rather than saying "share the title".
+    assert exc.value.code == "ambiguous_target"
+    assert "sessions match" in exc.value.message
+
+
+def test_unknown_target_is_404(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.authorize_target(
+            state, caller_session_key=_key(caller), target="chat-nope", operation="read"
+        )
+    assert exc.value.status == 404
+
+
+def test_caller_is_resolved_from_its_history_key(tmp_path):
+    """The caller presents a HISTORY key, which is not always the slot key.
+
+    Mutation guard: resolving on ``slot.key`` alone would fail to identify the
+    caller here, and an unidentifiable caller is refused outright — so the
+    self-send guard would stop protecting anything.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    history_key = _key(caller)
+    assert history_key != caller.key, "fixture must exercise the differing-key case"
+    assert sc.caller_slot_key(state, history_key) == caller.key
+
+
+# ── Authorization refusals ───────────────────────────────────────────────────
+
+
+def test_a_session_cannot_control_itself(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.authorize_target(
+            state, caller_session_key=_key(caller), target="chat-1", operation="read"
+        )
+    assert "cannot control itself" in exc.value.message
+
+
+def test_unidentifiable_caller_is_refused(tmp_path):
+    state = _make_state(tmp_path)
+    _slot(state, "chat-2")
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.authorize_target(
+            state, caller_session_key="who:knows", target="chat-2", operation="read"
+        )
+    assert "could not be identified" in exc.value.message
+
+
+def test_incognito_target_is_not_addressable(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _slot(state, "chat-secret", memory_mode="incognito")
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.authorize_target(
+            state, caller_session_key=_key(caller), target="chat-secret", operation="read"
+        )
+    assert "incognito" in exc.value.message
+
+
+def test_temporary_target_is_not_addressable(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _slot(state, "chat-temp", memory_mode="temporary")
+    with pytest.raises(sc.SessionControlError):
+        sc.authorize_target(
+            state, caller_session_key=_key(caller), target="chat-temp", operation="read"
+        )
+
+
+def test_app_scoped_target_is_not_addressable(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _slot(state, "chat-app", app="issue-radar")
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.authorize_target(
+            state, caller_session_key=_key(caller), target="chat-app", operation="read"
+        )
+    assert "app-scoped" in exc.value.message
+
+
+def test_between_plan_stages_the_target_still_reports_running(tmp_path):
+    """An orchestrator between stages is busy, and `read` must say so.
+
+    `slot.running` is derived from the task, and each stage's `_run_chat` closes
+    its own turn — so between stages it reads False while the plan is very much
+    alive. A poller following the documented "send, then read until not running"
+    loop would stop here and miss every later stage.
+
+    Mutation guard: reporting `slot.running` alone returns False.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    target.messages.append({"role": "assistant", "content": "stage one done"})
+    # Between stages: no task in flight, but the plan is still orchestrating.
+    target.task = None
+    target._in_stage_execution = True
+
+    out = sc.read_messages(state, caller_session_key=_key(caller), target="chat-2")
+
+    assert out["running"] is True, "a mid-plan target must not look idle"
+
+
+@pytest.mark.asyncio
+async def test_an_identical_queue_entry_does_not_masquerade_as_our_requeue(tmp_path):
+    """A pre-existing identical queue entry must not be read as OUR requeue.
+
+    The turn consumes our steer (so it leaves `_pending_steers`) while an unrelated
+    queue entry happens to carry the same text. Testing the queue for mere
+    PRESENCE reports REQUEUED and skips the transcript row, losing the bubble for
+    a message that really was delivered.
+
+    Mutation guard: comparing presence instead of a rising count fails this.
+    """
+    state = _make_state(tmp_path)
+    slot = _busy(_slot(state, "chat-1"))
+    # Someone queued the same words earlier; nothing to do with our steer.
+    slot._queue.append({"id": "q-old", "content": "same words"})
+
+    async def _steer(msg):
+        # The running turn consumes our registration, as the settle path does.
+        slot._pending_steers.remove(msg)
+        return True
+
+    client = MagicMock()
+    client.supports_steer = True
+    client.steer = AsyncMock(side_effect=_steer)
+    slot._acp_client = client
+
+    outcome = await cd.steer_into_running_turn(state, slot, "same words")
+
+    assert outcome == cd.STEER_STEERED
+    # The delivery is real, so it must leave exactly one row.
+    assert len([m for m in slot.messages if m.get("content") == "same words"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_consumed_steer_is_not_discarded_when_the_rpc_raises(tmp_path):
+    """`steer()` writing and THEN raising must not be reported as discarded.
+
+    `stdin.drain()` can raise after the bytes already reached the child, so the
+    exception says nothing about delivery. The evidence does: the registration is
+    gone, nothing queued it, and no stop ran — and only the running turn consuming
+    it produces that state. Answering 409 here makes the caller resend a message
+    the target already has, and it runs twice.
+
+    Mutation guard: trusting the exception over the evidence returns DISCARDED.
+    """
+    state = _make_state(tmp_path)
+    slot = _busy(_slot(state, "chat-1"))
+
+    async def _consume_then_raise(msg):
+        slot._pending_steers.remove(msg)  # the turn took it
+        raise ConnectionResetError("drain failed after the write landed")
+
+    client = MagicMock()
+    client.supports_steer = True
+    client.steer = AsyncMock(side_effect=_consume_then_raise)
+    slot._acp_client = client
+
+    outcome = await cd.steer_into_running_turn(state, slot, "do the thing")
+
+    assert outcome == cd.STEER_STEERED
+    # Delivered, so exactly one row — the same persisting tail as a clean steer.
+    assert len([m for m in slot.messages if m.get("content") == "do the thing"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_merged_row_satisfies_every_delivery_it_stands_for(tmp_path):
+    """When the drain merges two steers into one row, BOTH ids must be on it.
+
+    The drain unions each consumed entry's meta, and a plain dict update keeps only
+    the last `steer_delivery_id` — so the other caller would find no row for its
+    delivery and append a duplicate. The row stands for both messages, so it names
+    both ids and each caller recognises it.
+
+    Mutation guard: overwriting instead of accumulating makes the earlier caller
+    miss its row.
+    """
+    state = _make_state(tmp_path)
+    slot = _busy(_slot(state, "chat-1"))
+
+    # Another caller's steer is already pending with its own id.
+    other_id = "other-delivery-id"
+    slot._pending_steers.append("other text")
+    slot._steer_delivery_ids["other text"] = other_id
+
+    async def _merge_both(msg):
+        mine = slot._steer_delivery_ids.get(msg, "")
+        slot._pending_steers.clear()
+        # One row for both messages, naming both deliveries.
+        slot.append(
+            "user",
+            f"other text\n\n{msg}",
+            "msg msg-u",
+            meta={"steer_delivery_ids": [other_id, mine]},
+        )
+        return True
+
+    client = MagicMock()
+    client.supports_steer = True
+    client.steer = AsyncMock(side_effect=_merge_both)
+    slot._acp_client = client
+
+    outcome = await cd.steer_into_running_turn(state, slot, "my text")
+
+    assert outcome == cd.STEER_REQUEUED
+    # Only the merged row exists — no standalone duplicate was appended.
+    assert len(slot.messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_requeued_and_drained_message_is_not_persisted_twice(tmp_path):
+    """The whole requeue-then-drain sequence can complete during the await.
+
+    Teardown moves the pending steer into the queue and the NEXT turn drains it,
+    appending the row — all while this call is suspended in `steer()`. By then the
+    entry is in neither list, which is indistinguishable from the running turn
+    having consumed it, so a reconciliation that reads only those lists appends a
+    second row for the same message.
+
+    What makes it decidable is the delivery id: the requeue moves it onto the queue
+    entry and the drain unions entry meta onto the row it writes, so a row carrying
+    the id proves the delivery is already persisted. The simulation below carries
+    the id exactly as `_requeue_unconsumed_steers` and the drain do — without that,
+    the test would be asserting against a drain that does not exist.
+
+    Mutation guard: dropping the id check appends a second row.
+    """
+    state = _make_state(tmp_path)
+    slot = _busy(_slot(state, "chat-1"))
+
+    async def _teardown_then_drain(msg):
+        # Teardown requeues, carrying the delivery id onto the entry...
+        did = slot._steer_delivery_ids.get(msg, "")
+        slot._pending_steers.remove(msg)
+        slot._queue.append({"id": "q1", "content": msg, "meta": {"steer_delivery_id": did}})
+        # ...and the next turn drains it, unioning entry meta onto the row.
+        entry = slot._queue.pop(0)
+        slot.append("user", msg, "msg msg-u", meta=entry["meta"])
+        return True
+
+    client = MagicMock()
+    client.supports_steer = True
+    client.steer = AsyncMock(side_effect=_teardown_then_drain)
+    slot._acp_client = client
+
+    outcome = await cd.steer_into_running_turn(state, slot, "one message only")
+
+    assert outcome == cd.STEER_REQUEUED
+    # Exactly one row: the drain's. A second would be the duplicate.
+    assert len([m for m in slot.messages if m.get("content") == "one message only"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_natural_teardown_during_the_steer_reports_requeued(tmp_path):
+    """The turn ends normally mid-RPC: the teardown requeues, so we must not persist.
+
+    This is the case a `steered`-gated reconciliation cannot see. A natural end
+    touches neither `_stop_generation` nor `_stop_state`, so the old code returned
+    STEERED and appended a transcript row while the queue drain appended the same
+    text again — one message, two bubbles.
+
+    Mutation guard: gating the queue check on `stopped` or on `not steered` makes
+    this return STEERED.
+    """
+    state = _make_state(tmp_path)
+    slot = _busy(_slot(state, "chat-1"))
+
+    async def _steer(msg):
+        # The turn's teardown runs while the RPC is in flight: it moves the
+        # pending steer into the queue. No stop is involved. The entry carries the
+        # delivery id, because that is what `_requeue_unconsumed_steers` writes --
+        # and it is how reconciliation tells OUR requeue from an unrelated client
+        # queueing the same words.
+        did = slot._steer_delivery_ids.pop(msg, "")
+        slot._pending_steers.remove(msg)
+        slot._queue.append({"id": "q1", "content": msg, "meta": {"steer_delivery_id": did}})
+        return True
+
+    client = MagicMock()
+    client.supports_steer = True
+    client.steer = AsyncMock(side_effect=_steer)
+    slot._acp_client = client
+
+    outcome = await cd.steer_into_running_turn(state, slot, "hello there")
+
+    assert outcome == cd.STEER_REQUEUED
+    # The drain owns the append now; a row here would be the duplicate.
+    assert not [m for m in slot.messages if m.get("content") == "hello there"]
+
+
+@pytest.mark.asyncio
+async def test_a_second_identical_steer_is_refused_rather_than_registered(tmp_path):
+    """Two overlapping identical steers: the second must not register at all.
+
+    `_pending_steers` holds plain strings and every consumer matches by content, so
+    with two identical entries in flight nothing downstream can say whose survived.
+    The failing case: the FIRST is consumed while the SECOND is refused — the count
+    falls back exactly as it would if the second's own entry had gone, so the second
+    got persisted as delivered and then requeued by the teardown. One message, two
+    bubbles.
+
+    The guard removes the ambiguity instead of resolving it downstream: the second
+    steer is refused up front and its caller queues it, so nothing is lost.
+
+    Mutation guard: dropping the guard lets the second register, and with the first
+    consumed during the await it is persisted as delivered.
+    """
+    state = _make_state(tmp_path)
+    slot = _busy(_slot(state, "chat-1"))
+    # A first caller's identical steer is already in flight.
+    slot._pending_steers = ["same text"]
+    slot._acp_client = _steerable(accepted=False)
+
+    outcome = await cd.steer_into_running_turn(state, slot, "same text")
+
+    assert outcome == cd.STEER_UNAVAILABLE
+    # It never registered, so the first caller's entry is untouched...
+    assert slot._pending_steers == ["same text"]
+    # ...and nothing was persisted as delivered.
+    assert not [m for m in slot.messages if m.get("content") == "same text"]
+    # The RPC was never attempted — refusing before the await is the point.
+    slot._acp_client.steer.assert_not_awaited()
+
+
+def test_the_cursor_does_not_skip_rows_beyond_the_limit(tmp_path):
+    """A window capped by `limit` must advance the cursor by what it RETURNED.
+
+        Mutation guard: polling with `total` jumps to the end, so every row between
+        the window's end and `total` is skipped permanently — the documented
+    @pytest.mark.parametrize(
+        "send, then poll" loop would silently lose the middle of a long reply.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    for i in range(10):
+        target.messages.append({"role": "assistant", "content": f"row-{i}"})
+
+    first = sc.read_messages(
+        state, caller_session_key=_key(caller), target="chat-2", limit=4, since=0
+    )
+    assert [m["content"] for m in first["messages"]] == ["row-0", "row-1", "row-2", "row-3"]
+    assert first["total"] == 10
+    # The cursor trails the backlog — that difference is the caller's signal to
+    # read again rather than wait.
+    assert first["next_since"] == 4
+
+    second = sc.read_messages(
+        state,
+        caller_session_key=_key(caller),
+        target="chat-2",
+        limit=4,
+        since=first["next_since"],
+    )
+    assert [m["content"] for m in second["messages"]] == ["row-4", "row-5", "row-6", "row-7"]
+    assert second["next_since"] == 8
+
+    third = sc.read_messages(
+        state,
+        caller_session_key=_key(caller),
+        target="chat-2",
+        limit=4,
+        since=second["next_since"],
+    )
+    # Every row seen exactly once, nothing skipped.
+    assert [m["content"] for m in third["messages"]] == ["row-8", "row-9"]
+    assert third["next_since"] == 10 == third["total"]
+
+
+def test_a_channel_linked_caller_is_refused(tmp_path):
+    """The exfiltration direction: a linked caller's reads land in a channel.
+
+    Mutation guard: without this, `session_read_message` from a Slack/Discord-linked
+    slot hands a private dashboard transcript to whoever reads that thread.
+    `CHANNEL_AGENT_BLOCKED_TOOLS` does not cover it — that keys on the agent
+    identity, and a linked slot is a second route to the same surface.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-linked-caller")
+    caller.linked_session_key = "slack:1786300000.000200"
+    _slot(state, "chat-victim")
+
+    for op in ("send", "stop", "read"):
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc.authorize_target(
+                state,
+                caller_session_key=_key(caller),
+                target="chat-victim",
+                operation=op,
+            )
+        assert exc.value.code == "linked_session_caller", op
+
+
+def test_a_channel_linked_target_is_refused(tmp_path):
+    """A linked session is mirrored to Slack/Telegram AND cannot be stopped correctly.
+
+    Mutation guard: allowing it lets a relay surface into a channel other humans
+    read, and `session_stop` would report success while the target keeps running —
+    the stop path addresses `dashboard:<slot>` but a linked slot's turns run under
+    its `linked_session_key`.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    linked = _slot(state, "chat-linked")
+    linked.linked_session_key = "slack:1786300000.000100"
+
+    for op in ("send", "stop", "read"):
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc.authorize_target(
+                state, caller_session_key=_key(caller), target="chat-linked", operation=op
+            )
+        assert exc.value.code == "linked_session_target", op
+
+
+def test_target_in_another_workspace_is_refused(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1", workspace="default")
+    _slot(state, "chat-other", workspace="research")
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.authorize_target(
+            state, caller_session_key=_key(caller), target="chat-other", operation="read"
+        )
+    assert "different workspace" in exc.value.message
+
+
+def test_scheduled_target_is_refused(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _slot(state, "cron-abc123")
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.authorize_target(
+            state, caller_session_key=_key(caller), target="cron-abc123", operation="read"
+        )
+    assert "unattended" in exc.value.message
+
+
+def test_scheduled_caller_cannot_control_anyone(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "cron-abc123")
+    _slot(state, "chat-2")
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.authorize_target(
+            state, caller_session_key=_key(caller), target="chat-2", operation="read"
+        )
+    assert "cannot control other sessions" in exc.value.message
+
+
+def test_an_incognito_caller_cannot_reach_a_persistent_peer(tmp_path):
+    """Caller-side isolation, which the target-side checks cannot see.
+
+    Mutation guard: without this the incognito session the user asked to leave
+    no trace can launder a persistent peer's content in either direction.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-secret", memory_mode="incognito")
+    _slot(state, "chat-2")
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.authorize_target(
+            state, caller_session_key=_key(caller), target="chat-2", operation="read"
+        )
+    assert exc.value.code == "ephemeral_caller"
+
+
+def test_an_app_scoped_caller_cannot_reach_a_dashboard_peer(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-app", app="issue-radar")
+    _slot(state, "chat-2")
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.authorize_target(
+            state, caller_session_key=_key(caller), target="chat-2", operation="read"
+        )
+    assert exc.value.code == "app_scoped_caller"
+
+
+def test_a_workflow_result_slot_is_unattended(tmp_path):
+    """``workflow-<run_id>`` is the real prefix workflow_inject creates.
+
+    Mutation guard: the guard listed ``wf-`` and was dead for this whole class,
+    so a peer could start a fresh agent turn in a display-only slot.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _slot(state, "workflow-abc123")
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.authorize_target(
+            state, caller_session_key=_key(caller), target="workflow-abc123", operation="read"
+        )
+    assert exc.value.code == "unattended_target"
+
+
+def test_a_workflow_result_slot_cannot_control_anyone(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "workflow-abc123")
+    _slot(state, "chat-2")
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.authorize_target(
+            state, caller_session_key=_key(caller), target="chat-2", operation="read"
+        )
+    assert exc.value.code == "unattended_caller"
+
+
+def test_config_switch_off_refuses_everything(tmp_path, monkeypatch):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _slot(state, "chat-2")
+    monkeypatch.setattr(sc, "session_control_enabled", lambda: False)
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.authorize_target(
+            state, caller_session_key=_key(caller), target="chat-2", operation="read"
+        )
+    assert "disabled" in exc.value.message
+
+
+# ── Route authentication ─────────────────────────────────────────────────────
+
+
+class TestTheRoutesRequireTheInternalSecret:
+    """Strict-internal is not self-enforcing at the handler.
+
+    With ``X-Internal-Secret`` ABSENT the middleware falls through to cookie
+    auth, and a ``local_only=False`` deployment reclassifies strict paths as
+    mixed. Since these routes authorize on the ``X-Session-Key`` the caller
+    sends, a browser holding only a dashboard cookie could otherwise act AS any
+    of the user's sessions. Mutation guard: dropping the ``internal_auth`` check
+    makes every case below reach the operation.
+    """
+
+    def _request(self, tmp_path, *, internal: bool, path: str, method: str = "POST"):
+        from unittest.mock import MagicMock
+
+        state = _make_state(tmp_path)
+        caller = _slot(state, "chat-1")
+        _slot(state, "chat-2")
+        request = MagicMock()
+        request.app = {"state": state}
+        request.path = path
+        request.method = method
+        request.headers = {"X-Session-Key": _key(caller)}
+        request.query = {"target": "chat-2"}
+        request.get = lambda key, default=None: (
+            True if (key == "internal_auth" and internal) else default
+        )
+
+        async def _json():
+            return {"target": "chat-2", "message": "hi"}
+
+        request.json = _json
+        return request
+
+    def _body(self, response):
+        import json
+
+        return json.loads(response.body.decode())
+
+    def test_create_without_the_secret_is_forbidden(self, tmp_path):
+        req = self._request(tmp_path, internal=False, path="/api/session-control/create")
+        resp = asyncio.run(handlers_sc.api_session_control_create(req))
+        assert resp.status == 403
+        assert self._body(resp)["code"] == "internal_secret_required"
+
+    def test_create_returns_a_session_it_actually_opened(self, tmp_path):
+        """The create ROUTE needs its own test: a handler-only defect ships it dead.
+
+        An earlier round proved that once -- the route was missing from the strict
+        internal path list, so every call refused while the handler-level tests
+        still passed.
+        """
+        req = self._request(tmp_path, internal=True, path="/api/session-control/create")
+
+        async def _json():
+            return {"title": "worker"}
+
+        req.json = _json
+        resp = asyncio.run(handlers_sc.api_session_control_create(req))
+
+        assert resp.status == 200
+        payload = self._body(resp)
+        assert payload["ok"] is True
+        state = req.app["state"]
+        created = state.get_slot(payload["target"])
+        assert created is not None, "the route reported a target it did not create"
+        assert created.title == "worker"
+
+    def test_create_renders_a_refusal_as_its_status_not_a_500(self, tmp_path, monkeypatch):
+        """A SessionControlError from create must come back as its own refusal."""
+        req = self._request(tmp_path, internal=True, path="/api/session-control/create")
+
+        async def _boom(*_a, **_kw):
+            raise sc.SessionControlError("nope", status=429, code="slot_cap_reached")
+
+        monkeypatch.setattr(sc, "create_session", _boom)
+        resp = asyncio.run(handlers_sc.api_session_control_create(req))
+
+        assert resp.status == 429
+        assert self._body(resp)["code"] == "slot_cap_reached"
+
+    def test_stop_without_the_secret_is_forbidden(self, tmp_path):
+        req = self._request(tmp_path, internal=False, path="/api/session-control/stop")
+        resp = asyncio.run(handlers_sc.api_session_control_stop(req))
+        assert resp.status == 403
+
+    def test_a_failing_audit_still_refuses_rather_than_erroring(self, tmp_path, monkeypatch):
+        """Auditing the refusal must not be able to turn it into a 500.
+
+        The first `sel()` of a process CONSTRUCTS the log, and construction can
+        raise (a trust root too short to sign the chain). An unguarded write would
+        lose the denial in order to report it -- the caller would see a server
+        error where it should see a clean 403.
+        """
+
+        def _boom():
+            raise RuntimeError("trust root too short")
+
+        monkeypatch.setattr(handlers_sc, "sel", _boom)
+        req = self._request(tmp_path, internal=False, path="/api/session-control/stop")
+        resp = asyncio.run(handlers_sc.api_session_control_stop(req))
+        assert resp.status == 403, "a broken audit must not escalate a refusal to 500"
+        assert self._body(resp)["code"] == "internal_secret_required"
+
+    def test_read_without_the_secret_is_forbidden(self, tmp_path):
+        req = self._request(
+            tmp_path, internal=False, path="/api/session-control/read", method="GET"
+        )
+        resp = asyncio.run(handlers_sc.api_session_control_read(req))
+        assert resp.status == 403
+
+    def test_read_with_the_secret_reaches_the_operation(self, tmp_path):
+        """The guard must not refuse an authentic caller."""
+        req = self._request(tmp_path, internal=True, path="/api/session-control/read", method="GET")
+        resp = asyncio.run(handlers_sc.api_session_control_read(req))
+        assert resp.status == 200
+        assert self._body(resp)["target"] == "chat-2"
+
+
+# ── The config switch ────────────────────────────────────────────────────────
+
+
+def test_the_trust_switch_needs_a_positive_grant():
+    """``agent.session_control`` must not enable itself from absence OR from junk.
+
+    Two independent ways this switch could grant cross-session reach without
+    anyone asking for it, and both are pinned here:
+
+    * **Absent.** The three tools ride on the existing assignable
+      `kirocrew-dashboard` server, so an operator who assigned that server for
+      folder work would gain peer stop-and-read purely by upgrading. Both the
+      ``.get`` default and the dataclass field default must therefore be
+      ``False`` -- a grant has to be written down.
+    * **Malformed.** ``bool("false")`` is ``True``, so a plain coercion loads a
+      quoted opt-out as ENABLED and a user who wrote it in an editor that quotes
+      values would keep cross-session control on while believing it off.
+      ``_safe_bool`` accepts only a real bool and falls back to ``False``.
+
+    Asserted on the source rather than through ``KiroCrewConfig.load()``:
+    ``load()`` merges the real data home's ``config.local.json`` and serves a
+    fingerprint-cached dict, so a per-field assertion through it depends on the
+    developer's own config rather than on the payload under test. The parse is
+    one inline expression with no seam to call directly, so the wiring itself is
+    what gets pinned.
+    """
+    src = Path(loader.__file__).read_text(encoding="utf-8")
+    parse = re.search(r"^\s*session_control=(.+)$", src, re.MULTILINE)
+    assert parse is not None, "the session_control parse line is gone"
+    wiring = parse.group(1).strip().rstrip(",")
+    assert wiring.startswith(
+        "_safe_bool("
+    ), f"session_control must be parsed through _safe_bool, got: {wiring}"
+    assert wiring.endswith(
+        "False)"
+    ), f"the fallback must be False so a malformed value fails closed, got: {wiring}"
+    assert '"session_control", False' in wiring, (
+        "an absent setting must read as DISABLED -- otherwise an existing "
+        f"kirocrew-dashboard assignment gains peer stop/read on upgrade, got: {wiring}"
+    )
+    # The field default is the second absent path: it is what a config object
+    # built without going through the loader resolves to.
+    assert loader.AgentConfig().session_control is False, (
+        "the dataclass default must also be False, or a config built outside the "
+        "loader grants cross-session reach with nothing written down"
+    )
+
+
+def test_a_config_read_that_raises_disables_the_feature(monkeypatch):
+    """Unrelated config corruption must not undo an explicit opt-out.
+
+    Mutation guard: returning True here means a malformed section elsewhere in
+    config.json silently re-enables cross-session control.
+    """
+
+    class _Exploding:
+        @staticmethod
+        def load():
+            raise ValueError("malformed knowledge.auto_ingest_artifact_kinds")
+
+    monkeypatch.setattr(sc, "KiroCrewConfig", _Exploding)
+    assert _REAL_ENABLED() is False
+
+
+def test_safe_bool_rejects_every_non_bool():
+    """The helper the wiring above depends on: only a real bool survives."""
+    for bad in ("false", "true", "yes", 1, 0, [], {}, None):
+        assert loader._safe_bool(bad, False) is False, bad
+    assert loader._safe_bool(True, False) is True
+    assert loader._safe_bool(False, True) is False
+
+
+# ── Reading: cursor semantics ────────────────────────────────────────────────
+
+
+def test_completion_markers_never_advance_the_cursor(tmp_path):
+    """``done`` rows are appended but never persisted, so counting them drifts.
+
+    Mutation guard: a cursor that counts them names a position rehydration
+    cannot reproduce, so ``since=total`` skips real messages after a restart.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    target.append("assistant", "the answer", "msg msg-a")
+    target.append("done", "", "done")
+
+    out = sc.read_messages(state, caller_session_key=_key(caller), target="chat-2")
+
+    assert out["total"] == 1, "a done marker must not count toward the cursor"
+    assert [m["role"] for m in out["messages"]] == ["assistant"]
+
+
+def test_a_cursor_past_the_end_is_refused_rather_than_clamped(tmp_path):
+    """A shrunk transcript must not silently drop the rows that replaced the old tail.
+
+    Rewind and regenerate move ``total`` backwards under a caller still holding the
+    old position. Clamping that cursor to ``total`` starts the read at the end, so
+    every replacement row below it is skipped permanently and nothing in the
+    response says so -- the same silent-mis-window failure the trimmed-session
+    guard already refuses loudly.
+
+    Mutation guard: restoring `min(since, total)` returns rows instead of raising.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    for n in range(4):
+        target.append("user", f"m{n}", "msg msg-u")
+
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.read_messages(state, caller_session_key=_key(caller), target="chat-2", since=99)
+
+    assert exc.value.code == "cursor_unavailable"
+    assert exc.value.status == 409
+
+
+def test_a_credential_at_the_truncation_boundary_is_still_redacted(tmp_path):
+    """Redaction runs over the whole message, then the slice happens.
+
+    Mutation guard: truncating first cuts the secret into a prefix the scanner
+    no longer matches, and that fragment ships to the caller.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    secret = "ghp_" + "B" * 36
+    # Straddle the boundary: only the first 10 chars of the secret survive a
+    # naive slice, and a 10-char fragment no longer matches the credential
+    # scanner — so it is exactly what leaks when the order is wrong.
+    filler = "x" * (sc.MAX_READ_CONTENT_CHARS - 10)
+    surviving_fragment = secret[:10]
+    target.append("assistant", filler + secret, "msg msg-a")
+
+    row = sc.read_messages(state, caller_session_key=_key(caller), target="chat-2")["messages"][0]
+
+    assert (
+        surviving_fragment not in row["content"]
+    ), "a truncated credential prefix escaped redaction"
+    assert row["truncated"] is True
+
+
+def test_the_cursor_stops_before_the_streaming_tail(tmp_path):
+    """Chunk rows are deleted when the segment flushes, so the cursor skips them.
+
+    Mutation guard: counting them inflates ``total``; the flush shrinks the list
+    back under it, and the next ``since=total`` read misses the finished reply
+    permanently.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    target.append("user", "go", "msg msg-u")
+    for piece in ("par", "tial", " reply"):
+        target.append("chunk", piece, "")
+
+    mid = sc.read_messages(state, caller_session_key=_key(caller), target="chat-2")
+
+    assert mid["total"] == 1, "streaming chunks must not advance the cursor"
+    assert [m["role"] for m in mid["messages"]] == ["user"]
+    assert mid["streaming"] is True
+
+    # Stand in for _flush_segment: drop the trailing chunk run, append the real
+    # assistant message in its place.
+    del target.messages[1:]
+    target.append("assistant", "partial reply", "msg msg-a")
+
+    after = sc.read_messages(
+        state, caller_session_key=_key(caller), target="chat-2", since=mid["total"]
+    )
+
+    assert [m["content"] for m in after["messages"]] == ["partial reply"]
+    assert "streaming" not in after
+
+
+# ── Reading ──────────────────────────────────────────────────────────────────
+
+
+def test_read_returns_the_tail_with_a_total_to_poll_from(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    for i in range(5):
+        target.append("assistant", f"line {i}", "msg msg-a")
+
+    out = sc.read_messages(state, caller_session_key=_key(caller), target="chat-2", limit=2)
+
+    assert out["total"] == 5
+    assert [m["content"] for m in out["messages"]] == ["line 3", "line 4"]
+    assert [m["index"] for m in out["messages"]] == [3, 4]
+    assert out["running"] is False
+
+
+def test_read_since_returns_only_what_arrived_after(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    for i in range(3):
+        target.append("assistant", f"old {i}", "msg msg-a")
+    first = sc.read_messages(state, caller_session_key=_key(caller), target="chat-2")
+    target.append("assistant", "brand new", "msg msg-a")
+
+    second = sc.read_messages(
+        state, caller_session_key=_key(caller), target="chat-2", since=first["total"]
+    )
+
+    assert [m["content"] for m in second["messages"]] == ["brand new"]
+
+
+def test_a_stale_cursor_after_a_shrink_is_recoverable(tmp_path):
+    """A compacted transcript shrinks; the poller must be able to SEE what replaced it.
+
+    Clamping the stale cursor to ``total`` looks friendlier -- it answers
+    ``messages: []`` and hands back a plausible cursor -- but the rows below the
+    clamp are the replacement content, and a cursor never moves backwards, so they
+    are skipped permanently while the response reads as "nothing new". Refusing
+    sends the caller to a tail read, which actually returns that content, so the
+    loud answer is the recoverable one.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    target.append("assistant", "what replaced the old tail", "msg msg-a")
+
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.read_messages(state, caller_session_key=_key(caller), target="chat-2", since=999)
+    assert exc.value.code == "cursor_unavailable"
+
+    # The refusal names the fallback, and the fallback shows the replacement row.
+    recovered = sc.read_messages(state, caller_session_key=_key(caller), target="chat-2")
+    assert [m["content"] for m in recovered["messages"]] == ["what replaced the old tail"]
+
+    # A cursor exactly AT the end is not stale -- it is an up-to-date poller.
+    caught_up = sc.read_messages(
+        state, caller_session_key=_key(caller), target="chat-2", since=recovered["total"]
+    )
+    assert caught_up["messages"] == []
+
+
+def test_read_truncates_a_huge_message_and_says_so(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    target.append("assistant", "y" * (sc.MAX_READ_CONTENT_CHARS + 500), "msg msg-a")
+
+    row = sc.read_messages(state, caller_session_key=_key(caller), target="chat-2")["messages"][0]
+
+    assert row["truncated"] is True
+    assert len(row["content"]) <= sc.MAX_READ_CONTENT_CHARS
+
+
+def test_read_rejects_an_out_of_range_limit(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _slot(state, "chat-2")
+    with pytest.raises(sc.SessionControlError):
+        sc.read_messages(
+            state,
+            caller_session_key=_key(caller),
+            target="chat-2",
+            limit=sc.MAX_READ_MESSAGES + 1,
+        )
+
+
+def test_the_read_cursor_is_absolute_across_a_trimmed_window(tmp_path):
+    """Window length freezes at the retention cap; `total` and the indexes must not.
+
+    Mutation guard: deriving `total` from `len(slot.messages)` makes it freeze at
+    the cap, so a caller can no longer tell how much history exists.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    for i in range(3):
+        target.append("assistant", f"live {i}", "msg msg-a")
+    # Stand in for the trim: 5,000 rows already aged into the frozen prefix.
+    target._disk_older_count = 5000
+
+    out = sc.read_messages(state, caller_session_key=_key(caller), target="chat-2")
+
+    assert out["total"] == 5003, "total must count the frozen prefix, not just the window"
+    assert [m["index"] for m in out["messages"]] == [5000, 5001, 5002]
+    # No cursor is offered once trimming has started, because positions built on
+    # `_disk_older_count` (which counts transient rows) cannot line up with
+    # durable-only indexes. Handing back a cursor the next call would reject is
+    # worse than admitting it is gone, and the ABSENCE of `next_since` is the
+    # whole signal -- no separate flag restates it.
+    assert "next_since" not in out
+    assert "cursor_exact" not in out, "absence of next_since is the only signal"
+
+
+def test_cursor_pagination_is_refused_once_rows_have_been_trimmed(tmp_path):
+    """A `since` read on a trimmed session must fail loudly, not duplicate a row.
+
+    `_disk_older_count` counts every trimmed row including transient ones, while
+    positions here are durable-only. Once a transient row is trimmed into the
+    frozen prefix the two disagree, every position shifts, and a `since` read
+    serves a durable message the caller already had.
+
+    Mutation guard: dropping the refusal silently returns the shifted window.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    for i in range(3):
+        target.append("assistant", f"live {i}", "msg msg-a")
+    target._disk_older_count = 5000
+
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.read_messages(state, caller_session_key=_key(caller), target="chat-2", since=5000)
+    assert exc.value.code == "cursor_unavailable"
+    assert exc.value.status == 409
+
+    # The tail read is the documented fallback and still works.
+    tail = sc.read_messages(state, caller_session_key=_key(caller), target="chat-2")
+    assert [m["content"] for m in tail["messages"]] == ["live 0", "live 1", "live 2"]
+
+
+def test_an_untrimmed_session_still_reports_a_gap_free_cursor(tmp_path):
+    """With nothing trimmed the cursor is exact, which is the common case.
+
+    The old version of this test asserted a `trimmed` gap report on a session
+    whose rows HAD aged out — that path is now refused outright (see
+    `cursor_unavailable`), because the gap count was derived from the same mixed
+    counter that made the positions wrong.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    for i in range(4):
+        target.append("assistant", f"row {i}", "msg msg-a")
+
+    out = sc.read_messages(state, caller_session_key=_key(caller), target="chat-2", since=2)
+
+    assert [m["content"] for m in out["messages"]] == ["row 2", "row 3"]
+    assert out["next_since"] == 4 == out["total"]
+    assert "trimmed" not in out
+    assert "cursor_exact" not in out, "an exact cursor needs no caveat"
+
+
+def test_read_reports_the_targets_queue_depth(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    target.queue_append("waiting")
+
+    out = sc.read_messages(state, caller_session_key=_key(caller), target="chat-2")
+
+    assert out["queue_depth"] == 1
+
+
+# ── Stopping ─────────────────────────────────────────────────────────────────
+
+
+def test_birth_metadata_carries_the_slots_own_identity_and_origin(tmp_path, monkeypatch):
+    """A created-then-idle session's only disk record is this metadata line.
+
+    `_save_slot_to_history` returns early on an empty message window, so a session
+    that is created and never messaged never reaches the normal save path. Omitting
+    `tab_id` makes rehydrate mint a fresh one -- which breaks the ownership match
+    this design depends on -- and omitting `origin` makes it come back
+    unattributed, dropping it out of `slots:user`.
+
+    Mutation guard: removing either key from the dict fails here.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    monkeypatch.setattr(sc, "_workspace_name_for_dir", lambda cfg, ws_dir: caller.workspace)
+
+    result = asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+    created = state.get_slot(result["target"])
+    written = state.conversation_log.get_metadata(sc.slot_history_key(created))
+
+    assert written.get("tab_id") == created._tab_id, (
+        "tab_id must reach the birth metadata -- without it a restart remints the "
+        "slot's identity and ownership stops matching"
+    )
+    assert written.get("origin") == created._origin, (
+        "origin must reach the birth metadata -- without it the session comes back "
+        "unattributed and leaves slots:user"
+    )
+
+
+def test_nothing_suspends_between_the_stop_gate_and_the_stop(tmp_path, monkeypatch):
+    """The SEL prewarm must run BEFORE authorization, not between it and the act.
+
+    `await` is a suspension point. With the prewarm sitting between
+    `authorize_target` and `stop_slot_turn`, a user action landing in that window
+    -- linking the target to a channel -- makes the decision stale, and a turn gets
+    cancelled on a session that became channel-backed after `mirrored_target`
+    already passed. `send_message` documents the same rule for its cooldown claim.
+
+    Mutation guard: moving the prewarm back below the gate flips this order.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    order: list[str] = []
+
+    def _sel():
+        order.append("sel")
+        return MagicMock()
+
+    real_authorize = sc.authorize_target
+
+    def _authorize(*a, **kw):
+        order.append("authorize")
+        return real_authorize(*a, **kw)
+
+    async def _fake_stop(_state, slot, *, source):
+        order.append("stop")
+        return {"ok": True}
+
+    monkeypatch.setattr(sc, "sel", _sel)
+    monkeypatch.setattr(sc, "authorize_target", _authorize)
+    monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.stop_slot_turn", _fake_stop)
+
+    asyncio.run(sc.stop_target(state, caller_session_key=_key(caller), target=target.key))
+
+    assert order[:1] == ["sel"], f"the prewarm must precede authorization; got {order}"
+    assert order.index("authorize") < order.index("stop")
+    # The decisive assertion: authorization and the act must be ADJACENT, so no
+    # await can separate them.
+    assert (
+        order.index("stop") - order.index("authorize") == 1
+    ), f"something ran between the gate and the act it authorizes: {order}"
+
+
+def test_the_config_warm_is_the_last_suspension_before_the_stop_gate(tmp_path, monkeypatch):
+    """A warm with an `await` after it is no warm at all.
+
+    `session_control_enabled` is synchronous and its `KiroCrewConfig.load()`
+    re-reads and validates the file on the first call after a config edit. The warm
+    exists so the gate's own read is a cache hit -- but a config edit landing in any
+    suspension BETWEEN the warm and the gate changes the fingerprint, so the gate
+    misses the cache and does that read on the loop regardless.
+
+    `stop_target` has its own SEL prewarm await, so warming in the handler (before
+    the body read AND before that prewarm) left two suspensions in the gap. The warm
+    therefore belongs immediately after the SEL prewarm.
+
+    Mutation guard: moving the warm back above the SEL prewarm, or into the handler,
+    puts `sel` between it and `authorize`.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    order: list[str] = []
+
+    def _sel():
+        order.append("sel")
+        return MagicMock()
+
+    real_authorize = sc.authorize_target
+
+    def _authorize(*a, **kw):
+        order.append("authorize")
+        return real_authorize(*a, **kw)
+
+    def _enabled():
+        order.append("warm")
+        return True
+
+    async def _fake_stop(_state, slot, *, source):
+        order.append("stop")
+        return {"ok": True}
+
+    monkeypatch.setattr(sc, "sel", _sel)
+    monkeypatch.setattr(sc, "authorize_target", _authorize)
+    monkeypatch.setattr(sc, "session_control_enabled", _enabled)
+    monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.stop_slot_turn", _fake_stop)
+
+    asyncio.run(sc.stop_target(state, caller_session_key=_key(caller), target=target.key))
+
+    assert "warm" in order, "the config was never warmed"
+    # The warm runs off-loop via to_thread, so it is a suspension; nothing that
+    # suspends may follow it before the gate reads config.
+    assert order.index("sel") < order.index("warm"), (
+        "the config warm must come AFTER the SEL prewarm -- that prewarm is an "
+        f"await, and it would otherwise invalidate the warm: {order}"
+    )
+    assert order.index("warm") < order.index("authorize"), f"warm must precede the gate: {order}"
+
+
+def test_create_warms_the_config_after_reading_the_body():
+    """The body read suspends, so a warm above it can be stale by the gate.
+
+    `create_session`'s first statement is the synchronous enabled check, so the warm
+    has to sit below `_body` -- which awaits `request.json()` -- and above the call.
+    Asserted on source order because the suspension being guarded against is the
+    handler's own `await`, which a runtime probe cannot observe without racing it.
+
+    Mutation guard: moving the warm back above `_body` flips these positions.
+    """
+    src = Path(handlers_sc.__file__).read_text(encoding="utf-8")
+    create = src[src.index("async def api_session_control_create") :]
+    create = create[: create.index("async def api_session_control_stop")]
+    body_at = create.index("await _body(request)")
+    warm_at = create.index("await sc.prewarm_enabled_check()")
+    call_at = create.index("await sc.create_session(")
+    assert body_at < warm_at < call_at, (
+        "the config warm must sit between the body read and create_session, so no "
+        "await separates it from create_session's own synchronous gate"
+    )
+
+
+def test_stop_constructs_the_sel_off_loop_before_stopping(tmp_path, monkeypatch):
+    """`stop_slot_turn`'s idle branch logs with no await before it.
+
+    So a first `session_stop` on a fresh gateway would construct the log on the
+    loop. Mutation guard: dropping the prewarm runs `sel()` on the loop thread.
+    """
+    import threading
+
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    seen: dict[str, int] = {}
+
+    def _sel():
+        seen.setdefault("thread", threading.get_ident())
+        return MagicMock()
+
+    monkeypatch.setattr(sc, "sel", _sel)
+
+    async def _fake_stop(_state, slot, *, source):
+        return {"ok": True}
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.stop_slot_turn", _fake_stop)
+
+    async def _drive() -> int:
+        await sc.stop_target(state, caller_session_key=_key(caller), target=target.key)
+        return threading.get_ident()
+
+    loop_thread = asyncio.run(_drive())
+
+    assert "thread" in seen, "the SEL was never constructed"
+    assert (
+        seen["thread"] != loop_thread
+    ), "the SEL must be constructed off the loop thread before the stop"
+
+
+def test_stop_goes_through_the_same_path_as_the_stop_button(tmp_path, monkeypatch):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    target = _peer_target(state, "chat-2", caller)
+    _busy(target)
+
+    seen: dict[str, object] = {}
+
+    async def _fake_stop(_state, slot, *, source):
+        seen["slot"] = slot.key
+        seen["source"] = source
+        return {"ok": True}
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.stop_slot_turn", _fake_stop)
+
+    out = asyncio.run(sc.stop_target(state, caller_session_key=_key(caller), target="chat-2"))
+
+    assert out["target"] == "chat-2"
+    # No `force`: `stop_slot_turn` escalates on a second press regardless of one,
+    # so the tool does not advertise a flag a first call cannot honour.
+    assert seen == {"slot": "chat-2", "source": "session_control"}
+
+
+def test_stop_is_refused_for_a_session_out_of_bounds(tmp_path):
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    _slot(state, "chat-hidden", memory_mode="incognito")
+    with pytest.raises(sc.SessionControlError):
+        asyncio.run(sc.stop_target(state, caller_session_key=_key(caller), target="chat-hidden"))
+
+
+def test_session_control_routes_are_strict_internal():
+    """Every registered session-control route must sit in the strict bucket.
+
+    The route table and `_STRICT_INTERNAL_API_PATHS` are two hand-maintained
+    lists, and nothing else pairs them. An unlisted path falls through
+    `token_auth`'s general branch, which honors only cookie/query tokens, so the
+    MCP caller's `X-Internal-Secret` is ignored and the handler's own
+    `internal_auth` re-assert refuses the call -- the tool is unreachable in
+    production. The handler-level suites cannot catch that: they stub
+    `request["internal_auth"]` and call handlers directly, bypassing the
+    middleware entirely, so they stay green while the route is dead.
+
+    Derived from the router rather than a literal list, so a fifth route fails
+    here instead of shipping unreachable.
+    """
+    from aiohttp import web
+
+    from kiro_crew.dashboard.server import _STRICT_INTERNAL_API_PATHS, _register_mcp_routes
+
+    app = web.Application()
+    _register_mcp_routes(app)
+
+    registered = {
+        resource.canonical
+        for resource in app.router.resources()
+        if str(getattr(resource, "canonical", "")).startswith("/api/session-control/")
+    }
+    assert registered, "no session-control routes found -- the derivation broke, not the wiring"
+
+    missing = sorted(registered - set(_STRICT_INTERNAL_API_PATHS))
+    assert not missing, (
+        "session-control routes registered but absent from _STRICT_INTERNAL_API_PATHS "
+        f"(unreachable in production, X-Internal-Secret ignored): {missing}"
+    )
+
+
+def test_create_refuses_the_caller_classes_authorize_target_refuses(tmp_path):
+    """`create_session` must apply the SAME caller refusals as the other verbs.
+
+    An owned child is sendable by construction, so a caller class refused a
+    target but allowed to CREATE one gets there anyway: create, then send to
+    what it just made. Mutation guard: dropping either check below lets an
+    app-scoped or incognito session manufacture a persistent peer it owns.
+    """
+    state = _make_state(tmp_path)
+
+    app_caller = _slot(state, "chat-app")
+    app_caller._app = "some-app"
+    with pytest.raises(sc.SessionControlError) as exc:
+        asyncio.run(sc.create_session(state, caller_session_key=_key(app_caller)))
+    assert exc.value.code == "app_scoped_caller"
+
+    ghost = _slot(state, "chat-ghost")
+    ghost.memory_mode = "incognito"
+    with pytest.raises(sc.SessionControlError) as exc:
+        asyncio.run(sc.create_session(state, caller_session_key=_key(ghost)))
+    assert exc.value.code == "ephemeral_caller"
+
+    linked = _slot(state, "chat-linked")
+    linked.linked_session_key = "channel:1786300000.000100"
+    with pytest.raises(sc.SessionControlError) as exc:
+        asyncio.run(sc.create_session(state, caller_session_key=_key(linked)))
+    assert exc.value.code == "linked_session_caller"
+
+
+def test_created_session_inherits_the_callers_workspace(tmp_path, monkeypatch):
+    """The child lands in the caller's workspace, not the `default` one.
+
+    Two consequences ride on this, and the second is why a plausible-looking
+    default is not harmless: workspace is the memory boundary, AND
+    `authorize_target` refuses a cross-workspace target -- so a child left in
+    `default` is both a boundary crossing and unsendable by its own creator,
+    which would make `session_create` useless outside the default workspace.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    caller.workspace = "research"
+    # The caller's own agent is bound to its workspace by construction, and the
+    # child inherits it -- so the binding check passes without naming an agent.
+    caller.agent = "researcher"
+    _agent_resolves(monkeypatch, "research")
+
+    created = asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+    child = state.get_slot(created["target"])
+    assert child is not None
+    assert child.workspace == "research", "the child must not fall back to 'default'"
+    assert child.agent == "researcher", "an unnamed agent inherits the caller's"
+
+    # And the creator can actually address it -- the property the default breaks.
+    assert (
+        sc.authorize_target(
+            state,
+            caller_session_key=_key(caller),
+            target=created["target"],
+            operation="read",
+        ).key
+        == created["target"]
+    )
+
+
+def test_create_checks_the_workspace_binding_even_when_no_agent_is_named(tmp_path, monkeypatch):
+    """An omitted agent is not an unchecked agent.
+
+    `resolve_agent_bindings` falls through to `config.default_agent` when no name
+    is given, so the agent that ANSWERS may be bound to another workspace even
+    though the caller named nothing. Authorization reads `slot.workspace` while
+    execution follows that binding, so the same check has to cover this branch --
+    which is exactly the branch the first version of this guard skipped.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    caller.workspace = "research"
+
+    # The effective default resolves to a DIFFERENT workspace than the caller's.
+    monkeypatch.setattr(sc, "_workspace_name_for_dir", lambda cfg, ws_dir: "default")
+
+    with pytest.raises(sc.SessionControlError) as exc:
+        asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+
+    assert exc.value.code == "agent_workspace_mismatch"
+    assert "default agent" in str(exc.value), "the message should name what would answer"
+
+
+def test_created_session_gets_its_workspace_project_dir(tmp_path):
+    """cwd follows the workspace, or project-scoped resolution uses the wrong tree."""
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+
+    created = asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+    child = state.get_slot(created["target"])
+    assert child is not None
+    assert child.project == loader.default_project_dir(child.workspace)
+
+
+def test_every_session_control_refusal_is_audited_as_failed():
+    """A refused tool call must not be recorded as a completed one.
+
+    `call_tool_with_logging` classifies by prefix -- `outcome="failed"` only when
+    the result starts with "Error:". A refusal without it lands in the audit as a
+    successful invocation, which inverts the record for exactly the calls a
+    reviewer would go looking for. Derived from the source so a new refusal that
+    forgets the prefix fails here.
+    """
+    import re
+    from pathlib import Path
+
+    src = Path(sc.__file__).parent.parent / "mcp_dashboard.py"
+    body = src.read_text(encoding="utf-8")
+
+    # The dispatch's own refusal returns: a return whose string opens with the
+    # cross mark is a refusal that will be audited as completed.
+    bare = re.findall(r"return[^\n]*\\u274c[^\n]*", body)
+    assert not bare, f"session-control refusals not prefixed with 'Error:': {bare}"
+
+
+def _agent_resolves(monkeypatch, workspace: str) -> None:
+    """Make the effective agent resolve and be bound to *workspace*.
+
+    Tests whose subject is not agent resolution still have to get past the binding
+    check, which refuses a name nothing would dispatch. Forcing the honored flag
+    keeps those tests focused without weakening the check -- the refusal itself is
+    covered by `test_an_agent_name_that_does_not_resolve_is_refused`.
+    """
+    real = sc.resolve_agent_bindings
+    monkeypatch.setattr(sc, "_workspace_name_for_dir", lambda cfg, ws_dir: workspace)
+    monkeypatch.setattr(
+        sc,
+        "resolve_agent_bindings",
+        lambda cfg, agent_name=None, project_dir=None: dataclasses.replace(
+            real(cfg, None, project_dir), requested_resolved=True
+        ),
+    )
+
+
+def test_an_agent_name_that_does_not_resolve_is_refused(tmp_path, monkeypatch):
+    """A session must not advertise an agent that is not the one answering.
+
+    An unknown name falls back to the default agent's bindings, which pass the
+    workspace check because they ARE the caller's default -- so no memory boundary
+    is crossed, but `slot.agent` would store a name that nothing dispatches.
+    `ResolvedBindings.requested_resolved` states exactly that contract for callers
+    which store the requested name.
+
+    Mutation guard: without the check the session is created and reports the
+    unresolved name as its agent.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    before = set(state._slots)
+
+    real = sc.resolve_agent_bindings
+
+    def _unresolved(cfg, agent_name=None, project_dir=None):
+        bindings = real(cfg, None, project_dir)
+        return dataclasses.replace(bindings, requested_resolved=False)
+
+    monkeypatch.setattr(sc, "resolve_agent_bindings", _unresolved)
+
+    with pytest.raises(sc.SessionControlError) as err:
+        asyncio.run(
+            sc.create_session(state, caller_session_key=_key(caller), agent="no-such-agent")
+        )
+
+    assert err.value.code == "agent_unresolved"
+    assert set(state._slots) == before, "a refused creation leaves no slot behind"
+
+
+def test_the_binding_is_resolved_with_the_childs_project_dir(tmp_path, monkeypatch):
+    """A materialized kiro agent is declared per project directory, not in config.
+
+    Resolving without the project directory reports an app's own agent as
+    unresolvable, so the refusal above would reject a name that does resolve for
+    the session being created.
+
+    Mutation guard: dropping the argument passes None and the assertion fails.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    seen: dict[str, object] = {}
+
+    real = sc.resolve_agent_bindings
+
+    def _record(cfg, agent_name=None, project_dir=None):
+        seen["project_dir"] = project_dir
+        return dataclasses.replace(real(cfg, None, project_dir), requested_resolved=True)
+
+    monkeypatch.setattr(sc, "resolve_agent_bindings", _record)
+
+    asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+
+    # Asserted as identity-against-None plus equality rather than truthiness: a
+    # workspace with no configured project directory resolves to "", which is a
+    # correct value to pass on. Dropping the argument yields None, which fails both
+    # halves in every environment.
+    assert seen["project_dir"] is not None, "the project dir must be passed, not omitted"
+    assert seen["project_dir"] == loader.default_project_dir(caller.workspace)
+
+
+def test_a_caller_that_closes_during_the_await_cannot_still_create(tmp_path, monkeypatch):
+    """A removed slot stays usable as an object, so presence must be re-read.
+
+    Closing the caller's tab removes its slot from the table, but the reference
+    resolved before the await keeps working -- every attribute still answers. Gating
+    on that object would authorize against a caller whose authority already ended
+    and publish a persistent session behind it.
+
+    Mutation guard: gating the stale object instead of re-resolving publishes the
+    session.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    before = set(state._slots)
+
+    def _resolve_then_close(_workspace):
+        # The caller's tab closes while the project directory is being resolved.
+        state._slots.pop(caller.key, None)
+        return str(tmp_path)
+
+    monkeypatch.setattr(sc, "default_project_dir", _resolve_then_close)
+
+    with pytest.raises(sc.SessionControlError) as err:
+        asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+
+    assert err.value.code == "caller_not_open"
+    assert set(state._slots) - before == set(), "no session may outlive its creator's authority"
+
+
+def test_a_caller_that_moves_workspace_during_the_await_is_refused(tmp_path, monkeypatch):
+    """The workspace fed the agent-binding decision, so a move invalidates it.
+
+    Mutation guard: carrying the pre-await workspace forward puts the child on a
+    boundary its creator no longer sits behind.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+
+    def _resolve_then_move(_workspace):
+        caller.workspace = "somewhere-else"
+        return str(tmp_path)
+
+    monkeypatch.setattr(sc, "default_project_dir", _resolve_then_move)
+
+    with pytest.raises(sc.SessionControlError) as err:
+        asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+
+    assert err.value.code == "caller_workspace_changed"
+
+
+def test_a_mirror_link_landing_during_the_await_still_refuses(tmp_path, monkeypatch):
+    """Eligibility decided before a suspension point says nothing at allocation time.
+
+    The project directory is resolved in a worker thread, so the coroutine suspends
+    between the caller gate and the allocation. `_has_channel_mirror` reads the live
+    session store, and a dashboard-born session can be given an outbound mirror link
+    at any moment -- so a link registered inside that window would otherwise let a
+    now-channel-backed caller publish a persistent session outside its containment.
+
+    Mutation guard: without the re-assert next to the allocation, the slot is
+    created and the refusal never fires.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    before = set(state._slots)
+    mirrored = {"now": False}
+
+    monkeypatch.setattr(sc, "_has_channel_mirror", lambda _state, _slot: mirrored["now"])
+
+    def _resolve_then_mirror(_workspace):
+        # Stand in for the interleaving: the mirror link lands while the project
+        # directory is still being resolved off-loop.
+        mirrored["now"] = True
+        return str(tmp_path)
+
+    monkeypatch.setattr(sc, "default_project_dir", _resolve_then_mirror)
+
+    with pytest.raises(sc.SessionControlError) as err:
+        asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+
+    assert err.value.code == "mirrored_caller"
+    assert set(state._slots) == before, "no slot may be published for a refused caller"
+
+
+def test_the_slot_cap_is_re_checked_after_the_await(tmp_path, monkeypatch):
+    """The ceiling is read from live state, so it can fill inside the window too.
+
+    Mutation guard: checking the cap only before the await lets two concurrent
+    creations land over the ceiling.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+
+    def _resolve_then_fill(_workspace):
+        for i in range(sc._MAX_SLOTS_FOR_CREATE):
+            _slot(state, f"filler-{i}")
+        return str(tmp_path)
+
+    monkeypatch.setattr(sc, "default_project_dir", _resolve_then_fill)
+
+    with pytest.raises(sc.SessionControlError) as err:
+        asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+
+    assert err.value.code == "slot_cap_reached"
+
+
+def test_creation_never_loads_the_config_on_the_event_loop():
+    """A cache miss reads and validates the config file, stalling every task.
+
+    `KiroCrewConfig.load()` is synchronous filesystem work. Called directly from a
+    coroutine it blocks the whole gateway, not just this request -- the loop cannot
+    run anything else while it reads. Offloading it is also what the repository's
+    no-blocking-call-on-event-loop rule requires.
+
+    Comments are stripped before the check, so the prose explaining WHY the call is
+    offloaded cannot satisfy or break the assertion about the call itself.
+
+    Mutation guard: calling it directly fails the first assertion.
+    """
+    import inspect
+
+    src = inspect.getsource(sc.create_session)
+    code = "\n".join(line.split("#", 1)[0] for line in src.splitlines())
+    assert "KiroCrewConfig.load()" not in code, "the config load must not run inline on the loop"
+    assert (
+        "await asyncio.to_thread(KiroCrewConfig.load)" in code
+    ), "the config load must be offloaded to a worker thread"
+
+
+def test_nothing_suspends_while_the_created_slot_is_half_configured():
+    """`get_or_create_slot` publishes, so the agent must not be set after an await.
+
+    The slot is in the table the moment it is constructed. `await` is a suspension
+    point, so a slot published with no agent can be addressed in that window, and
+    `/api/chat` would resolve bindings from a blank agent -- running the turn
+    against the DEFAULT workspace's memory store instead of this one. The agent
+    therefore rides in the constructor, and the project directory is resolved
+    BEFORE the slot exists.
+
+    Asserted on ORDER rather than on the finished slot: every field is correct by
+    the time `create_session` returns either way, so a state assertion passes under
+    the very interleaving this pins.
+    """
+    import inspect
+
+    src = inspect.getsource(sc.create_session)
+    publish = src.index("get_or_create_slot(")
+    assert "await asyncio.to_thread(default_project_dir" in src
+    resolve = src.index("await asyncio.to_thread(default_project_dir")
+    assert resolve < publish, "the project directory must be resolved before the slot is published"
+    # The agent is a constructor argument, not a later assignment.
+    assert "agent=agent_name" in src, "the agent must be set at construction"
+    assert (
+        "slot.agent = " not in src
+    ), "assigning the agent after construction reopens the half-configured window"
+    # Nothing may suspend between publishing the slot and the last field it needs.
+    configured = src.index("slot._titled = True")
+    assert "await" not in src[publish:configured], (
+        "an await between publishing the slot and configuring it makes a "
+        "half-built session addressable"
+    )
+    # The eligibility gate must be the last thing before the allocation, with no
+    # suspension between them, or its answer is stale by the time it is acted on.
+    gate = src.rindex("_refuse_ineligible_creator(")
+    assert (
+        resolve < gate < publish
+    ), "the caller gate must be re-asserted after the await and before the slot"
+    assert "await" not in src[gate:publish], (
+        "an await between the eligibility gate and the allocation lets a caller "
+        "that has since become ineligible publish a session"
+    )
+    # The re-check must read the slot TABLE again, not the object resolved before
+    # the await: a closed tab's slot is removed while the reference keeps working.
+    reresolve = src.index("live_caller = state.get_slot(caller_key)")
+    assert resolve < reresolve < gate, "the caller must be re-resolved from its key after the await"
+    assert (
+        "_refuse_ineligible_creator(state, live_caller)" in src
+    ), "the gate must run on the re-resolved slot, not the pre-await object"
+    # Nothing may suspend from the re-resolve onward: this span re-reads every input
+    # the allocation rests on, so an await inside it puts the decisions back out of
+    # date. Asserted from the re-resolve rather than the gate because more than one
+    # await precedes it, and the property is about the LAST one.
+    assert "await" not in src[reresolve:publish], (
+        "an await between re-resolving the caller and allocating the slot makes "
+        "every re-read decision stale again"
+    )
+
+
+def test_create_refuses_at_the_same_slot_cap_as_fork_and_import(tmp_path, monkeypatch):
+    """A third creation path must not make the shared ceiling advisory.
+
+    `chat_fork` and `session_transfer` both refuse at 500 live slots. Nothing else
+    bounds how many sessions one caller may open, so a creator that skipped the cap
+    would let a looping agent exhaust slots and transcript files.
+
+    Mutation guard: dropping the check lets this create succeed.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    monkeypatch.setattr(type(state), "live_slot_count", lambda self: 500)
+
+    with pytest.raises(sc.SessionControlError) as exc:
+        asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+
+    assert exc.value.code == "slot_cap_reached"
+    assert exc.value.status == 429
+
+
+def test_a_failed_persist_retracts_the_slot(tmp_path, monkeypatch):
+    """A session whose ownership did not reach disk must not be left behind.
+
+    Reporting the failure while leaving the slot in the table is the worst outcome:
+    the caller sees an error and the session exists anyway -- usable in memory,
+    addressable by its creator, and gone on the next restart.
+
+    Mutation guard: without the retraction the slot survives the raise.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    before = set(state._slots)
+
+    def _boom(*_a, **_kw):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(state.conversation_log, "update_metadata", _boom)
+
+    with pytest.raises(OSError):
+        asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+
+    assert set(state._slots) == before, "the unpersisted slot must not survive"
+
+
+def test_retraction_spares_a_slot_a_turn_already_started_on(tmp_path, monkeypatch):
+    """Retraction must not detach work that began inside the persist window.
+
+    `get_or_create_slot` publishes, and the birth write is awaited, so a turn can
+    start on the slot while that write is in a worker thread. Popping the slot then
+    leaves the turn running with nothing pointing at it -- unreachable by the read
+    verb and unstoppable by the stop verb, because both resolve through the slot
+    table. A phantom session that vanishes on the next restart is the lesser harm.
+
+    Mutation guard: an unconditional pop removes the slot and loses the turn.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    before = set(state._slots)
+
+    def _boom(*_a, **_kw):
+        # Stand in for the interleaving: the turn lands on the freshly published
+        # slot while the birth write is still in flight, and only then does the
+        # write fail.
+        born = [k for k in state._slots if k not in before]
+        assert born, "the slot is published before the birth write, so it exists here"
+        state._slots[born[0]].append("user", "work that must not be orphaned", "msg msg-u")
+        raise OSError("disk full")
+
+    monkeypatch.setattr(state.conversation_log, "update_metadata", _boom)
+
+    with pytest.raises(OSError):
+        asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+
+    survivors = set(state._slots) - before
+    assert len(survivors) == 1, "a slot carrying a started turn must not be retracted"
+    assert state._slots[survivors.pop()].messages, "the turn's work is still reachable"
+
+
+def test_an_identical_steer_is_refused_while_the_first_is_still_in_flight(tmp_path):
+    """In flight means either marker, not just the pending list.
+
+    A steer whose pending entry the running turn has already consumed is still
+    awaiting and still owns its `_steer_delivery_ids` entry. Admitting a second
+    identical steer at that moment overwrites the first caller's live id, and
+    reconciliation then removes the second's -- letting the first's row persist
+    twice.
+
+    Mutation guard: checking only `_pending_steers` admits the second steer.
+    """
+    from kiro_crew.dashboard import chat_delivery
+
+    state = _make_state(tmp_path)
+    slot = _busy(_slot(state, "chat-2"))
+    text = "run the deploy"
+    # A steerable client is required or the function returns STEER_UNAVAILABLE from
+    # its top guard and never reaches the one under test -- which is how the first
+    # version of this test passed against the unfixed code.
+    slot._acp_client = _steerable(accepted=True)
+
+    # The first steer is mid-flight with its pending entry already consumed.
+    slot._pending_steers = []
+    slot._steer_delivery_ids[text] = "id-of-the-first-caller"
+
+    result = asyncio.run(chat_delivery.steer_into_running_turn(state, slot, text))
+
+    assert (
+        result == chat_delivery.STEER_UNAVAILABLE
+    ), "the second identical steer must be refused down the queue path"
+    assert (
+        slot._steer_delivery_ids[text] == "id-of-the-first-caller"
+    ), "the first caller's delivery id must not be overwritten"
+    slot._acp_client.steer.assert_not_awaited()
+
+
+def test_an_unrelated_identical_queue_item_is_not_read_as_our_requeue(tmp_path):
+    """Requeue detection is by delivery id, so identical text cannot impersonate it.
+
+    Counting queue entries that match the TEXT cannot tell this steer's requeue
+    apart from another client queueing the same words in the same window. Reading
+    that as "mine was requeued" makes the caller skip persisting, and the steer the
+    turn actually consumed loses its transcript row.
+
+    Mutation guard: a content count sees the queue grow and returns the requeued
+    outcome, so nothing persists.
+    """
+    from kiro_crew.dashboard import chat_delivery
+
+    state = _make_state(tmp_path)
+    slot = _busy(_slot(state, "chat-2"))
+    text = "run the deploy"
+    slot._acp_client = _steerable(accepted=True)
+
+    def _consume_and_let_someone_else_queue(*_a, **_kw):
+        # The running turn consumes our registration, and an unrelated client
+        # queues the very same words while the RPC is still suspended. That entry
+        # carries no delivery id, so it is not ours.
+        slot._pending_steers.clear()
+        slot.queue_append(text)
+        return True
+
+    slot._acp_client.steer = AsyncMock(side_effect=_consume_and_let_someone_else_queue)
+
+    result = asyncio.run(chat_delivery.steer_into_running_turn(state, slot, text))
+
+    assert (
+        result == chat_delivery.STEER_STEERED
+    ), "an identical queue entry without our delivery id must not read as our requeue"
+
+
+def test_our_own_requeue_is_still_detected_by_its_delivery_id(tmp_path):
+    """The other side: a real requeue carries the id and must report requeued.
+
+    Mutation guard: dropping the id probe reports this as delivered and the drain
+    then appends the row a second time.
+    """
+    from kiro_crew.dashboard import chat_delivery
+
+    state = _make_state(tmp_path)
+    slot = _busy(_slot(state, "chat-2"))
+    text = "run the deploy"
+    slot._acp_client = _steerable(accepted=True)
+
+    def _requeue_like_the_teardown(*_a, **_kw):
+        # The teardown moves the pending steer into the queue, carrying the id it
+        # was registered under -- exactly what `_requeue_unconsumed_steers` does.
+        did = slot._steer_delivery_ids.get(text, "")
+        slot._pending_steers.clear()
+        slot.queue_insert(0, text, meta={"steer_delivery_id": did})
+        return True
+
+    slot._acp_client.steer = AsyncMock(side_effect=_requeue_like_the_teardown)
+
+    result = asyncio.run(chat_delivery.steer_into_running_turn(state, slot, text))
+
+    assert result == chat_delivery.STEER_REQUEUED, "our own requeue must be recognised"
+
+
+def test_a_steer_a_hard_kill_discarded_is_not_reported_as_delivered(tmp_path):
+    """A hard kill discards the text, so no row may claim it was delivered.
+
+    A hard kill clears `_pending_steers` AND drops the matching
+    `_steer_delivery_ids` entry, while the running turn CONSUMING a steer leaves
+    that entry in place. The delivery id is therefore what tells the two apart --
+    without it, absence alone is ambiguous and the reconciliation has to guess.
+
+    Reporting delivery for a discarded steer persists a transcript row for text
+    that never ran and answers the caller `steered: true`. `STEER_UNAVAILABLE`
+    instead falls through to the queue, so the message becomes a visible,
+    cancellable card; resending cannot duplicate anything, because the killed turn
+    did not run it.
+
+    Mutation guard: without the delivery-id check this returns the delivered path.
+    """
+    from kiro_crew.dashboard import chat_delivery
+
+    state = _make_state(tmp_path)
+    slot = _busy(_slot(state, "chat-2"))
+    text = "change the plan"
+    slot._acp_client = _steerable(accepted=True)
+
+    # The hard kill ran while the steer RPC was suspended: pending entry cleared,
+    # delivery id dropped with it, stop generation advanced.
+    def _clear_like_a_hard_kill(*_a, **_kw):
+        slot._pending_steers.clear()
+        slot._steer_delivery_ids.clear()
+        slot._stop_generation = int(getattr(slot, "_stop_generation", 0) or 0) + 1
+        return True
+
+    slot._acp_client.steer = AsyncMock(side_effect=_clear_like_a_hard_kill)
+
+    result = asyncio.run(chat_delivery.steer_into_running_turn(state, slot, text))
+
+    assert (
+        result == chat_delivery.STEER_UNAVAILABLE
+    ), "a discarded steer must not be reported as delivered"
+
+
+def test_a_steer_consumed_before_a_stop_is_still_reported_as_delivered(tmp_path):
+    """The other side of the same discrimination -- and the more dangerous one.
+
+    A consume leaves the delivery id in place. Telling that caller to resend is
+    the one answer that can run the text twice, so a surviving id keeps the
+    delivered path even though the turn was stopped afterwards.
+
+    Mutation guard: reading absence as discard would send this down the queue path
+    and risk a duplicate execution.
+    """
+    from kiro_crew.dashboard import chat_delivery
+
+    state = _make_state(tmp_path)
+    slot = _busy(_slot(state, "chat-2"))
+    text = "change the plan"
+    slot._acp_client = _steerable(accepted=True)
+
+    def _consume_then_stop(*_a, **_kw):
+        # The running turn consumed the registration; the delivery id survives.
+        slot._pending_steers.clear()
+        slot._stop_generation = int(getattr(slot, "_stop_generation", 0) or 0) + 1
+        return True
+
+    slot._acp_client.steer = AsyncMock(side_effect=_consume_then_stop)
+
+    result = asyncio.run(chat_delivery.steer_into_running_turn(state, slot, text))
+
+    assert (
+        result != chat_delivery.STEER_UNAVAILABLE
+    ), "a consumed steer must never be answered with 'resend'"
+
+
+def test_session_control_is_not_imported_on_the_gateway_boot_path():
+    """A feature-flagged subsystem must not be eagerly imported by `server.py`.
+
+    The enabled check (`session_control_enabled`) lives inside the handlers, so a
+    module-level import in `server.py` is an import whose gate runs after it --
+    an operator who set `agent.session_control=false` would still pay to load the
+    subsystem on every launch. Route registration stays at boot; only the import
+    is deferred to first request.
+
+    Mutation guard: restoring the module-level import fails this.
+    """
+    from pathlib import Path
+
+    from kiro_crew.dashboard import server as dashboard_server
+
+    src = Path(dashboard_server.__file__).read_text(encoding="utf-8")
+    for line in src.splitlines():
+        if line.startswith("from kiro_crew.dashboard.handlers import"):
+            assert "session_control" not in line, (
+                "session_control must not be imported at server module level -- " f"found: {line!r}"
+            )
+
+
+def test_the_created_agent_name_is_sanitized_before_storage(tmp_path, monkeypatch):
+    """The caller-supplied agent goes through the same outbound guard as the title.
+
+    It arrives from the calling model, is persisted verbatim to the metadata line
+    and pushed to every dashboard client, so the schema's length cap is not
+    enough -- a credential-shaped string would otherwise be stored and displayed.
+
+    Mutation guard: dropping the `sanitize_outbound` call leaves the raw value.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    monkeypatch.setattr(sc, "sanitize_outbound", lambda s: f"SANITIZED:{s}")
+    # Keep the binding check satisfied so the test reaches the storage under test.
+    _agent_resolves(monkeypatch, caller.workspace)
+
+    created = asyncio.run(
+        sc.create_session(state, caller_session_key=_key(caller), agent="secret-looking")
+    )
+    child = state.get_slot(created["target"])
+    assert child is not None
+    assert child.agent.startswith(
+        "SANITIZED:"
+    ), "the agent value must pass through the outbound guard before storage"
+
+
+def test_the_audit_write_does_not_run_on_the_event_loop(tmp_path, monkeypatch):
+    """Constructing the SEL must not happen on the loop.
+
+    `log_tool_invocation` only enqueues, but the FIRST `sel()` of a process
+    constructs the log -- trust-dir creation, key validation, and on Windows an
+    `icacls` subprocess. This can genuinely be that first call, because
+    `sel_audit_middleware` logs AFTER `await handler(...)`: on a fresh gateway the
+    first authenticated request constructs the log inside whatever handler runs
+    first.
+
+    Mutation guard: calling `sel()` inline runs it on the calling thread.
+    """
+    import threading
+    import time
+
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    seen: dict[str, int] = {}
+
+    class _Recorder:
+        def log_tool_invocation(self, **_kw):
+            seen["thread"] = threading.get_ident()
+
+    monkeypatch.setattr(sc, "sel", lambda: _Recorder())
+    monkeypatch.setattr(sc, "_workspace_name_for_dir", lambda cfg, ws_dir: caller.workspace)
+
+    async def _drive() -> int:
+        await sc.create_session(state, caller_session_key=_key(caller))
+        return threading.get_ident()
+
+    loop_thread = asyncio.run(_drive())
+
+    # The offload is fire-and-forget, so wait for it rather than racing it.
+    deadline = time.monotonic() + 5
+    while "thread" not in seen and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert "thread" in seen, "the audit never ran"
+    assert (
+        seen["thread"] != loop_thread
+    ), "the audit must be dispatched off the loop's thread, not called inline"
+
+
+def test_the_denial_audit_does_not_run_on_the_event_loop(tmp_path, monkeypatch):
+    """The same property for the DENIAL path, which is the likelier first `sel()`.
+
+    A fresh gateway refuses before it ever allows -- a disabled feature, an
+    unidentified caller -- so the denial audit is the more probable site of the
+    first-ever `sel()` construction, not the rarer one.
+
+    Mutation guard: calling `sel()` inline in `deny` runs it on the loop thread.
+    """
+    import threading
+    import time
+
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    seen: dict[str, int] = {}
+
+    class _Recorder:
+        def log_api_access(self, **_kw):
+            seen["thread"] = threading.get_ident()
+
+    monkeypatch.setattr(sc, "sel", lambda: _Recorder())
+
+    async def _drive() -> int:
+        with pytest.raises(sc.SessionControlError):
+            sc.authorize_target(
+                state,
+                caller_session_key=_key(caller),
+                target="does-not-exist",
+                operation="read",
+            )
+        return threading.get_ident()
+
+    loop_thread = asyncio.run(_drive())
+
+    deadline = time.monotonic() + 5
+    while "thread" not in seen and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert "thread" in seen, "the denial was never audited"
+    assert (
+        seen["thread"] != loop_thread
+    ), "the denial audit must be dispatched off the loop's thread"
+
+
+def test_the_denial_audit_does_not_persist_caller_supplied_credentials(tmp_path, monkeypatch):
+    """A credential passed as `target` must not survive into the audit sink.
+
+    `target` is raw MCP input. The audit is durable AND served back: the SEL
+    writer does not redact on-disk records (`sel.py` says so outright) and
+    `/api/sel/events` returns `recent()` rows verbatim to the dashboard, so an
+    unredacted write is readable long after the refusal.
+
+    Both fields are asserted because both carry caller text: `resources`
+    interpolates `target` directly, and the `target_not_found` refusal
+    interpolates it into `reason`, which becomes `error`. A fix that redacted
+    only one of them would leave the other serving the secret.
+
+    Mutation guard: dropping either `redact` call in `deny` fails this.
+    """
+    import time
+
+    # Assembled rather than written literally: a real-looking token in source
+    # trips secret scanners for no benefit. `redact_credentials` matches the
+    # `ghp_` + 36 shape.
+    noisy_target = "ghp_" + ("a" * 36)
+
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    captured: dict[str, str] = {}
+
+    class _Recorder:
+        def log_api_access(self, **kw):
+            captured.update({k: str(v) for k, v in kw.items()})
+
+    monkeypatch.setattr(sc, "sel", lambda: _Recorder())
+
+    async def _drive() -> None:
+        with pytest.raises(sc.SessionControlError):
+            sc.authorize_target(
+                state,
+                caller_session_key=_key(caller),
+                target=noisy_target,
+                operation="read",
+            )
+
+    asyncio.run(_drive())
+
+    deadline = time.monotonic() + 5
+    while "resources" not in captured and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert "resources" in captured, "the denial was never audited"
+    assert noisy_target not in captured["resources"], (
+        "the raw target reached the audit's `resources`; /api/sel/events would "
+        "serve the credential back to the dashboard"
+    )
+    assert noisy_target not in captured.get("error", ""), (
+        "the target_not_found reason interpolates the target, so `error` carried "
+        "the credential even though `resources` was redacted"
+    )
+    # The refusal must still be diagnosable: the code survives redaction.
+    assert "target_not_found" in captured["resources"]

--- a/test/test_session_control_boundaries.py
+++ b/test/test_session_control_boundaries.py
@@ -1,0 +1,316 @@
+"""Session control: the channel-mirror boundary and the HTTP route layer.
+
+Two surfaces the main suite did not reach.
+
+The mirror checks exist because `linked_session_key` only marks a channel-BORN
+slot. A dashboard-born slot given an OUTBOUND mirror link reaches a channel just
+as surely, and the link lives in the session store rather than on the slot, so
+the original checks read empty on exactly the session that republishes.
+
+The route tests cover `handlers/session_control.py`, whose `_require_internal`
+is the gate that stops a same-origin page with only a dashboard cookie from
+messaging, stopping, or reading any session AS one of them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard import session_control as sc
+from kiro_crew.dashboard.chat_utils import slot_history_key
+from kiro_crew.dashboard.handlers import session_control as handlers_sc
+
+
+@pytest.fixture(autouse=True)
+def _enabled(monkeypatch):
+    monkeypatch.setattr(sc, "session_control_enabled", lambda: True)
+
+
+def _slot(state, name: str, **kwargs):
+    return state.get_or_create_slot(name, **kwargs)
+
+
+def _mirror(state, *keys: str) -> None:
+    """Register an outbound mirror link for each of *keys*.
+
+    Goes through the store's own setter so the test exercises the same shape
+    production reads, rather than replacing the accessor.
+    """
+    for key in keys:
+        state.sessions.set_mirror_link(key, "C123", "1777.0")
+
+
+# -- the outbound-mirror boundary --------------------------------------------
+
+
+class TestMirroredSessionsAreOutOfBounds:
+    def _pair(self, tmp_path):
+        state = _make_state(tmp_path)
+        caller = _slot(state, "caller")
+        target = _slot(state, "peer")
+        return state, caller, target
+
+    def test_a_mirrored_target_is_refused(self, tmp_path):
+        state, caller, target = self._pair(tmp_path)
+        _mirror(state, slot_history_key(target))
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc.authorize_target(
+                state,
+                caller_session_key=slot_history_key(caller),
+                target=target.key,
+                operation="read",
+            )
+        assert exc.value.code == "mirrored_target"
+
+    def test_a_mirrored_caller_cannot_control_a_peer(self, tmp_path):
+        state, caller, target = self._pair(tmp_path)
+        _mirror(state, slot_history_key(caller))
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc.authorize_target(
+                state,
+                caller_session_key=slot_history_key(caller),
+                target=target.key,
+                operation="read",
+            )
+        assert exc.value.code == "mirrored_caller"
+
+    def test_an_unmirrored_pair_is_still_allowed(self, tmp_path):
+        """The guard must not swallow the ordinary case."""
+        state, caller, target = self._pair(tmp_path)
+        _mirror(state)  # store answers None for every key
+        assert (
+            sc.authorize_target(
+                state,
+                caller_session_key=slot_history_key(caller),
+                target=target.key,
+                operation="read",
+            )
+            is target
+        )
+
+    def test_an_unreadable_mirror_store_fails_closed(self, tmp_path):
+        """A store that raises must not be read as 'not mirrored'."""
+        state, caller, target = self._pair(tmp_path)
+
+        def _boom(key: str):
+            raise RuntimeError("store unavailable")
+
+        state.sessions.get_mirror_link = _boom
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc.authorize_target(
+                state,
+                caller_session_key=slot_history_key(caller),
+                target=target.key,
+                operation="read",
+            )
+        assert exc.value.code in {"mirrored_target", "mirrored_caller"}
+
+    def test_a_store_without_the_accessor_is_not_treated_as_mirrored(self, tmp_path):
+        """An older store lacking the method must not refuse everything.
+
+        Absence of the feature is not evidence of a mirror, so it reads False --
+        unlike a store that HAS the accessor and raises, which fails closed.
+        """
+        state, _caller, target = self._pair(tmp_path)
+        state.sessions = object()  # no get_mirror_link at all
+        assert sc._has_channel_mirror(state, target) is False
+
+
+class TestCrewModeTargetsAreOutOfBounds:
+    """A crew session's ingress is a durable queue entry, not a turn.
+
+    `/api/chat` routes `mode == "crew"` to `state.crew.ingest` before anything
+    else, which queues the message durably and fans it out to topic
+    sub-sessions. Delivering it here as a turn would run generic work that is
+    neither queued nor routed -- and would report success for it.
+    """
+
+    def _pair(self, tmp_path):
+        state = _make_state(tmp_path)
+        caller = _slot(state, "caller")
+        target = _slot(state, "peer")
+        return state, caller, target
+
+    def test_a_crew_target_is_refused(self, tmp_path):
+        state, caller, target = self._pair(tmp_path)
+        target.mode = "crew"
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc.authorize_target(
+                state,
+                caller_session_key=slot_history_key(caller),
+                target=target.key,
+                operation="read",
+            )
+        assert exc.value.code == "crew_mode_target"
+
+    def test_an_ordinary_target_is_unaffected(self, tmp_path):
+        state, caller, target = self._pair(tmp_path)
+        assert getattr(target, "mode", "") != "crew"
+        assert (
+            sc.authorize_target(
+                state,
+                caller_session_key=slot_history_key(caller),
+                target=target.key,
+                operation="read",
+            )
+            is target
+        )
+
+    def test_a_crew_CALLER_may_still_control_a_peer(self, tmp_path):
+        """The defect is in delivery semantics, not the caller's standing.
+
+        A crew session is still the person's own; only its own INGRESS differs.
+        Refusing it as a caller would narrow the surface for no stated reason.
+        """
+        state, caller, target = self._pair(tmp_path)
+        caller.mode = "crew"
+        assert (
+            sc.authorize_target(
+                state,
+                caller_session_key=slot_history_key(caller),
+                target=target.key,
+                operation="read",
+            )
+            is target
+        )
+
+
+# -- cross-form target ambiguity ---------------------------------------------
+
+
+class TestCrossFormAmbiguity:
+    def test_a_title_matching_another_slots_key_is_refused(self, tmp_path):
+        """Returning the key match would stop a session the caller never named.
+
+        The caller reads titles off the screen. If one session's TITLE equals
+        another's KEY, preferring the key silently addresses the wrong
+        conversation -- and `session_stop` discards a live turn's work.
+        """
+        state = _make_state(tmp_path)
+        _slot(state, "caller")
+        keyed = _slot(state, "chat-donor")
+        titled = _slot(state, "other")
+        titled.title = keyed.key
+
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc._resolve_slot(state, keyed.key)
+        assert exc.value.code == "ambiguous_target"
+        assert exc.value.status == 409
+
+    def test_a_unique_key_still_resolves(self, tmp_path):
+        state = _make_state(tmp_path)
+        target = _slot(state, "peer")
+        assert sc._resolve_slot(state, target.key) is target
+
+    def test_a_unique_title_still_resolves(self, tmp_path):
+        state = _make_state(tmp_path)
+        target = _slot(state, "peer")
+        target.title = "Release checklist"
+        assert sc._resolve_slot(state, "release checklist") is target
+
+    def test_two_slots_sharing_a_title_are_still_refused(self, tmp_path):
+        state = _make_state(tmp_path)
+        a = _slot(state, "a")
+        b = _slot(state, "b")
+        a.title = b.title = "Same"
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc._resolve_slot(state, "Same")
+        assert exc.value.code == "ambiguous_target"
+
+    def test_one_slot_matching_two_forms_is_not_ambiguous(self, tmp_path):
+        """A single slot answering by both key and title is one match, not two."""
+        state = _make_state(tmp_path)
+        target = _slot(state, "peer")
+        target.title = target.key
+        assert sc._resolve_slot(state, target.key) is target
+
+
+# -- the HTTP route layer ----------------------------------------------------
+
+
+def _request(path: str, *, internal: bool, body: object = None, app_state=None):
+    """A request double carrying only what these handlers read."""
+    req = MagicMock()
+    req.path = path
+    req.app = {"state": app_state}
+    store = {"internal_auth": True} if internal else {}
+    req.get = store.get
+    req.headers = {}
+    req.query = {}
+
+    async def _json():
+        if isinstance(body, Exception):
+            raise body
+        return body
+
+    req.json = _json
+    return req
+
+
+class TestTheRoutesRequireTheInternalSecret:
+    @pytest.mark.parametrize(
+        "handler,path",
+        [
+            (handlers_sc.api_session_control_stop, "/api/session-control/stop"),
+            (handlers_sc.api_session_control_read, "/api/session-control/read"),
+        ],
+    )
+    def test_a_cookie_only_caller_is_refused(self, handler, path):
+        """Strict paths are not self-enforcing: with the header absent the
+        middleware falls through to cookie auth, so the handler re-asserts."""
+        resp = asyncio.run(handler(_request(path, internal=False)))
+        assert resp.status == 403
+
+
+class TestRouteBodyValidation:
+    def test_a_missing_target_is_400(self, tmp_path):
+        state = _make_state(tmp_path)
+        resp = asyncio.run(
+            handlers_sc.api_session_control_stop(
+                _request(
+                    "/api/session-control/stop",
+                    internal=True,
+                    body={"force": True},
+                    app_state=state,
+                )
+            )
+        )
+        assert resp.status == 400
+        assert b"target_required" in resp.body
+
+    def test_a_blank_target_is_rejected_like_a_missing_one(self, tmp_path):
+        state = _make_state(tmp_path)
+        resp = asyncio.run(
+            handlers_sc.api_session_control_stop(
+                _request(
+                    "/api/session-control/stop",
+                    internal=True,
+                    body={"target": "   "},
+                    app_state=state,
+                )
+            )
+        )
+        assert resp.status == 400
+        assert b"target_required" in resp.body
+
+
+class TestRefusalStatusMapping:
+    """The renderer answers only from a closed set of statuses."""
+
+    @pytest.mark.parametrize("status", [403, 404, 409, 429])
+    def test_a_mapped_status_is_forwarded(self, status):
+        exc = sc.SessionControlError("no", status=status, code="c")
+        assert handlers_sc._refusal(exc).status == status
+
+    def test_an_unmapped_status_degrades_to_400(self):
+        """A status outside the set must not be forwarded verbatim."""
+        exc = sc.SessionControlError("no", status=500, code="c")
+        assert handlers_sc._refusal(exc).status == 400
+
+    def test_the_code_is_always_present(self):
+        exc = sc.SessionControlError("no", status=404, code="target_not_found")
+        assert b"target_not_found" in handlers_sc._refusal(exc).body

--- a/test/test_session_pulse_counter.py
+++ b/test/test_session_pulse_counter.py
@@ -39,6 +39,60 @@ def test_sequential_increments_are_monotonic() -> None:
     assert spc.get_user_session_count() == 3
 
 
+class TestOffLoopIncrement:
+    """The slot-birth path must not do this module's disk I/O on the event loop.
+
+    `get_or_create_slot` is synchronous and every request-layer birth -- a new
+    chat tab, a fork, the session-control create verb -- runs it on the gateway
+    loop, so an inline read + mkdir + tempfile write + replace stalls the loop on
+    slow storage. The offload belongs to the counter rather than the allocation:
+    suspending inside `get_or_create_slot` would let callers observe a
+    half-configured slot.
+    """
+
+    def test_without_a_running_loop_it_increments_inline(_self, _isolated_home) -> None:
+        # A CLI, a test, or a background thread has no loop to protect, so the
+        # count must still land rather than being silently dropped.
+        spc.increment_user_session_count_off_loop()
+        assert spc.get_user_session_count() == 1
+
+    @pytest.mark.asyncio
+    async def test_with_a_running_loop_the_io_leaves_the_loop_thread(_self, _isolated_home) -> None:
+        import asyncio
+        import threading
+
+        loop_thread = threading.get_ident()
+        seen: list[int] = []
+        real = spc.increment_user_session_count
+
+        def _recording() -> int:
+            # Recorded AFTER the write returns, not before: the poll below exits as
+            # soon as `seen` is non-empty, so appending first would let the test --
+            # and `tmp_path` teardown -- run while this worker is still writing.
+            # The ident is the same either way, since the whole wrapper runs on the
+            # worker thread.
+            result = real()
+            seen.append(threading.get_ident())
+            return result
+
+        spc.increment_user_session_count = _recording  # type: ignore[assignment]
+        try:
+            spc.increment_user_session_count_off_loop()
+            # Fire-and-forget: give the executor a moment to pick the job up.
+            for _ in range(200):
+                if seen:
+                    break
+                await asyncio.sleep(0.01)
+        finally:
+            spc.increment_user_session_count = real  # type: ignore[assignment]
+
+        assert seen, "the increment never ran"
+        assert seen[0] != loop_thread, (
+            "the counter's read-modify-write ran on the event loop thread; a slow "
+            "or contended disk would stall every session in the gateway"
+        )
+
+
 def test_corrupt_file_is_treated_as_zero(_isolated_home) -> None:
     (_isolated_home / "session_pulse_sessions.json").write_text("{not json", encoding="utf-8")
     assert spc.get_user_session_count() == 0

--- a/test/test_steer_requeue.py
+++ b/test/test_steer_requeue.py
@@ -40,6 +40,81 @@ def _running_slot(state, key="test"):
     return slot
 
 
+class TestDeliveryIdLifecycle:
+    """The delivery-id map must not outlive the delivery it identifies.
+
+    It is keyed by the message TEXT, so an entry left behind holds a full
+    message string for the slot's whole lifetime. The requeue paths keep theirs
+    on purpose -- the drain in `chat_runner` still has to match the id, and that
+    entry is bounded by the queue -- but a delivery that persists its own row is
+    terminal here and nothing downstream will read it again.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_successful_steer_leaves_no_entry(self, tmp_path, monkeypatch, _patch_sel):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = AsyncMock(return_value=True)
+        slot._acp_client = client_mock
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat", json={"slot": "test", "message": "fix sw.js", "steer": True}
+            )
+            assert resp.status == 200
+
+        assert slot._steer_delivery_ids == {}, (
+            "a delivered steer that persisted its own row is terminal; its id has "
+            "no later reader, so keeping it holds the message text for the slot's life"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_refused_steer_leaves_no_entry(self, tmp_path, monkeypatch, _patch_sel):
+        """The unwind path must clear it too, or a queue fallback leaks instead."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = AsyncMock(return_value=False)
+        slot._acp_client = client_mock
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            await client.post(
+                "/api/chat", json={"slot": "test", "message": "fix sw.js", "steer": True}
+            )
+
+        assert slot._steer_delivery_ids == {}
+
+    @pytest.mark.asyncio
+    async def test_many_successful_steers_do_not_accumulate(
+        self, tmp_path, monkeypatch, _patch_sel
+    ):
+        """The growth shape is what makes this a leak rather than one stale key."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = AsyncMock(return_value=True)
+        slot._acp_client = client_mock
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            for n in range(5):
+                await client.post(
+                    "/api/chat",
+                    json={"slot": "test", "message": f"unique message {n}", "steer": True},
+                )
+
+        assert slot._steer_delivery_ids == {}
+
+
 class TestSteerPendingTracking:
     """The steer handler records successful steers on the slot."""
 
@@ -319,6 +394,25 @@ class TestProductionWiring:
             "the queue drain so a requeued steer is delivered on the very next turn"
         )
 
+    def test_inject_provenance_folds_into_the_mapping_the_row_write_reads(self):
+        """One mapping carries BOTH provenance kinds to the row.
+
+        `_start_next_queued_turn` builds row meta from two independent producers:
+        the drain's union over every consumed entry (which is what carries a merged
+        row's steer delivery ids) and the `inject` block's `injectKind`/`cronLabel`.
+        They must fold into the SAME mapping, because only one of them is passed to
+        `slot.append`. A second local would silently drop whichever producer the row
+        write does not read -- and no drain-level test covers `injectKind`, so that
+        loss would not otherwise surface.
+        """
+        src = self._runner_source()
+        fold_at = src.index("_drained_meta.update(_inject_meta)")
+        write_at = src.index("meta=_drained_meta or None", fold_at)
+        assert fold_at < write_at, (
+            "the inject provenance fold must target _drained_meta -- the same "
+            "mapping slot.append receives -- and must precede the row write"
+        )
+
     def test_event_loop_wires_steer_consumed_to_settle(self):
         src = self._runner_source()
         assert "elif event.kind == EVENT_STEER_CONSUMED:" in src
@@ -330,11 +424,11 @@ class TestProductionWiring:
     def test_steer_handler_registers_before_await(self):
         from pathlib import Path
 
-        import kiro_crew.dashboard.chat_handlers as ch
+        import kiro_crew.dashboard.chat_delivery as cd
 
-        src = Path(ch.__file__).read_text(encoding="utf-8")
+        src = Path(cd.__file__).read_text(encoding="utf-8")
         register_at = src.index("slot._pending_steers.append(message)")
-        await_at = src.index("await _client.steer(message)")
+        await_at = src.index("await client.steer(message)")
         assert register_at < await_at, (
             "pending registration must precede the steer RPC await so a turn "
             "dying mid-write still requeues the steer"
@@ -401,6 +495,64 @@ class TestSteerRequeueOnTurnDeath:
         # message is in the queue even though the broadcast failed
         assert [i["content"] for i in slot._queue] == ["important"]
         assert slot._pending_steers == []
+
+
+class TestRequeuedThenCancelledSteer:
+    """A requeued steer whose card the user cancels never ran, so no row.
+
+    The teardown requeue MOVES the delivery id out of `_steer_delivery_ids` and
+    into the new queue entry's meta. If the user then cancels that card before the
+    steer RPC resumes, the id is in neither place and no row was ever written --
+    which looks exactly like the running turn having consumed the steer.
+
+    A natural stage end requeues without touching `_stop_generation`, so this
+    arrives with `stopped` false. Before the fix the not-stopped path never
+    consulted the delivery-id map and fell through to the persisting tail,
+    writing a transcript row for text the user had explicitly cancelled.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cancelled_requeue_is_not_persisted_as_delivered(
+        self, tmp_path, monkeypatch, _patch_sel
+    ):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+        text = "fix sw.js"
+
+        async def _requeue_then_cancel(*_a, **_k):
+            # Mirror `_requeue_unconsumed_steers`: it pops BOTH the pending entry
+            # and the delivery id, carrying the id into the queue entry's meta.
+            did = slot._steer_delivery_ids.get(text, "")
+            slot._pending_steers.clear()
+            slot._steer_delivery_ids.clear()
+            qid = slot.queue_insert(0, text, meta={"steer_delivery_id": did})
+            # The user dismisses that card before this RPC returns.
+            slot.queue_remove_by_id(qid)
+            return True
+
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = AsyncMock(side_effect=_requeue_then_cancel)
+        slot._acp_client = client_mock
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            await client.post("/api/chat", json={"slot": "test", "message": text, "steer": True})
+
+        persisted = [m for m in slot.messages if text in str(m.get("content", ""))]
+        assert persisted == [], (
+            "the steer was requeued and its card cancelled, so the text never ran; "
+            "persisting a row claims a delivery the user explicitly discarded"
+        )
+        # Not lost either: STEER_UNAVAILABLE means "did not land, safe to resend",
+        # so `/api/chat` falls back to `queue_for_next_turn` and the message comes
+        # back as its own cancellable card. That fallback is the pre-existing
+        # contract of this return value (the hard-kill path shares it) -- what the
+        # fix changes is only that no row claims the steer was delivered.
+        assert [q["content"] for q in slot._queue] == [
+            text
+        ], "an undeliverable steer must fall back to the queue rather than vanish"
 
 
 class TestHardKillDiscardsSteers:


### PR DESCRIPTION
## Problem / Motivation

A chat session cannot see what its peers are doing. A session watching a build,
grinding a refactor, or waiting on CI is opaque to every other session the user
has open: there is no way to ask whether it has finished, read what it concluded,
or stop it when its work is already known to be wrong. The only path today is for
the person to switch tabs and look, then retype what they saw into the session
that needed it.

## Why it matters to the user

The user is the transport. Every cross-session question costs them a tab switch
and a retype, and the cost lands exactly where sessions are most useful -- long
runs they started so they would not have to watch. A session that could ask
"is the build session done, and what did it say" would let one conversation
coordinate several, instead of the person doing it by hand. And when a peer
session is working on something the user already knows is wrong, there is no way
to stop it from another session; the run finishes and wastes its budget, or makes
a conflicting change.

## What changed

Three MCP tools on the assignable `kirocrew-dashboard` server, three
strict-internal routes, one config switch:

- `session_create` -- open a new, empty session in the caller's workspace,
  pre-named and bound to a chosen agent. It appears in the sidebar like any other
  session and the person types the first message into it.
- `session_stop` -- stop another session's in-flight turn, the same mechanism as
  pressing Stop in that tab. First call cancels cooperatively; calling again while
  that is pending escalates.
- `session_read_message` -- read a transcript tail plus liveness, with a cursor
  (`since` / `next_since`) so a poll loop does not re-read what it already has.

The chain from symptom to fix:

- The symptom is that cross-session state is unreadable, so the fix is a READ
  verb with a cursor rather than a notification. `total` is an absolute position
  rather than a window length, because a slot retains only its recent messages and
  a length-derived cursor would freeze at the retention cap -- silently stalling a
  poller on exactly the long sessions this exists for. A cursor past the end is
  refused with `cursor_unavailable` rather than clamped, because the rows below a
  clamp are what replaced the old tail and clamping would skip them permanently
  while reporting "nothing new".
- The read stops before the streaming tail. `chat_runner` appends a `chunk` row
  per token burst and the segment flush deletes that trailing run, so counting
  chunks would inflate `total`, the flush would shrink the list back under it, and
  the next read would skip the finished reply. A mid-reply read reports
  `streaming: true` instead.
- Authorization is deny-by-default in one place (`authorize_target`) for the two
  verbs that take a target, so a guard cannot be present on `stop` and missing on
  `read`. Both sides are gated: an incognito, temporary, app-scoped,
  channel-linked or channel-mirrored session is refused as target AND as caller.
  The caller-side half is not the mirror of the target-side one -- it closes the
  exfiltration direction, where a linked or mirrored CALLER would land a peer's
  private transcript in front of a channel's audience.
- All three tools require a signed caller identity, not the lenient process-tree
  walk. A subagent lives under its parent slot's process tree, so the walk would
  resolve it to the parent and let it read or stop the parent's siblings.
- The routes are strict-internal (loopback + `X-Internal-Secret`, no cookie
  fall-through) and each handler re-asserts `internal_auth` rather than trusting
  the path classification, because these routes authorize on a caller-supplied
  session key -- a same-origin page holding only a dashboard cookie could
  otherwise act as any of the user's sessions.
- The config read fails closed: a raising `KiroCrewConfig.load()` resolves to
  disabled, so malformed config in an unrelated section cannot silently undo an
  explicit `session_control: false`.

`dashboard/chat_delivery.py` holds the steer, queue and stop helpers that
`/api/chat` had inline. Only `stop_slot_turn` is reused by a verb here; the steer
and queue helpers still have exactly one consumer, `/api/chat` itself, and are
moved so the delivery verb tracked in #4333 does not have to reach into a
handler module for them. That module is registered as a redaction sink, and the
security-posture ratchet pins it.

Two behaviour changes on the `/api/chat` steer path ride along, because both are
bugs reachable today rather than new surface. A steer is now reconciled by an
opaque delivery id instead of by matching message text, so an unrelated client
queueing identical words can no longer be mistaken for this steer's requeue and
drop its transcript row; and a hard kill drops the delivery ids it discards, so a
steer the kill threw away is no longer reported as delivered. As a consequence a
second IDENTICAL steer, sent while the first is still in flight, is refused down
the queue path rather than attempted -- previously it could overwrite the first
caller's live id.

These three verbs land on the EXISTING assignable `kirocrew-dashboard` server
rather than a new one, so an operator may already have assigned that server to an
agent for folder organization. `agent.session_control` therefore defaults **off**:
without it the three tools refuse with a message naming the switch, and an upgrade
cannot hand an existing assignment the ability to read peer transcripts or stop peer
turns. The bundling itself is deliberate -- an agent given the job of organizing
sessions is the one that should be able to see what they are doing -- but the grant
is the operator's to make rather than something that arrives with a version bump.

Turning it on is one setting. Reverting to default-on is a one-line change if the
maintainer prefers that, in which case the widening belongs in the release notes as
an explicit acknowledgment.

Message delivery between sessions is deliberately NOT in this change. Delivering
to a peer has two authorization moments -- acceptance, and a drain that can be
minutes later -- and the target's agent, workspace and channel binding can all
change in between. That is a different design from the three verbs here, each of
which is authorized at the moment it acts, so it is scoped to its own change
rather than carried along. Follow-up issue: #4333.

## Tests

- `test/test_session_control.py` -- the verbs and their refusals: the resolver's
  three target forms and its ambiguity refusal, the cursor semantics
  (absolute `total`, `streaming`, the 409 on a cursor whose rows aged out), the stop
  escalation and its race handling, and the create route.
- `test/test_session_control_boundaries.py` -- the channel-linked, mirrored,
  crew-mode and cross-workspace boundaries in both directions (target and
  caller), plus the strict-internal route assertions derived from the router
  rather than a hand-copied list.
- `test/test_chat_runner_coverage.py`, `test/test_steer_requeue.py` -- the
  extracted delivery helpers on the `/api/chat` path they came from, including
  the requeue-on-turn-death behaviour and the delivery-id carry that keeps a
  steer from being persisted twice.
- `test/test_channel_blocked_tools.py` -- every advertised session-control tool
  is contained for a channel agent, pinned against the advertised set so a new
  verb fails here instead of shipping reachable.
- `test/test_mcp_dashboard_registration.py`, `test/test_mcp_dashboard_folders.py`
  -- the advertised tool set, and that the verified caller key is what reaches
  the request rather than a re-resolved one.
- `test/test_security_posture.py` -- the redaction-sink registry, whose
  omission-detection ratchet fails if a module that calls a redactor is not
  registered.

Manual verification: N/A -- no user-visible UI change; the surface is MCP tools
and loopback routes, covered above.

<!-- no-visual-delta -->
**Why no screenshot:** backend and MCP-tool only; nothing renders differently.