### PR TITLE
feat: cap pytest -n auto workers by available memory at agent spawn

### DIFF
--- a/docs/architecture/resource-protection.md
+++ b/docs/architecture/resource-protection.md
@@ -235,6 +235,26 @@ resolved from an absolute path, never a caller-influenced `PATH`, and when no `e
 exists the layer **fails closed**: the locators are not forwarded at all, so the wrapper
 fails loudly rather than handing the child a reachable bus.
 
+## Memory-aware cap for pytest-xdist `-n auto`
+
+pytest-xdist resolves `-n auto` to the CPU count and never looks at memory, so on a
+many-core host a full-suite run inside an agent turn spawns one worker per core at roughly
+1 GB each — and two agent sessions doing it concurrently can exhaust an unswapped host
+before the cgroup scope's per-tree ceiling helps (the scopes are per-spawn-tree, not an
+aggregate). xdist honors the
+[`PYTEST_XDIST_AUTO_NUM_WORKERS`](https://pytest-xdist.readthedocs.io/en/stable/distribution.html)
+environment variable when resolving `auto`, so both agent spawn boundaries
+(`acp/client.py` and `acp/runtime.py`) seed it via
+`resource_status.inject_xdist_auto_cap()`:
+`min(cpu_count, floor(available_gb * 0.5 / 1.0))`, floored at 1, computed from the same
+cgroup-clamped memory probe the advisory `resource_status` tool uses. Half of the
+*currently available* memory, so two sessions sizing themselves at the same instant cannot
+jointly commit more than what was free. This shapes **only** `auto`/`logical` resolution:
+explicit `-n N`, non-xdist runs, and venvs without xdist installed are untouched, and a
+value already present in the environment is never overridden. Configured via
+`resource_limits.xdist_auto_cap`: `-1` (default) auto-computes, `0` disables the injection
+entirely, `N > 0` pins a fixed worker cap.
+
 ## Known gaps
 
 1. **The subagent timeout is not configurable.** `_TIMEOUT_SECS` (30 min) is hardcoded, and
@@ -250,6 +270,15 @@ fails loudly rather than handing the child a reachable bus.
    several spawn trees, and enforcement depends on cgroup v2 delegation being present. The
    load-time config clamp bounds process *counts* (subagent count, turn budget, pool size),
    not memory or CPU.
+
+4. **The xdist auto-cap is snapshotted at session spawn, not at test-run time.** Agent
+   sessions are long-lived: a session spawned while memory was ample carries its generous
+   `PYTEST_XDIST_AUTO_NUM_WORKERS` for its whole lifetime, so a suite launched hours later
+   under pressure still gets the stale cap — and conversely, a session spawned under
+   transient pressure stays throttled after the pressure clears. The "two sessions cannot
+   jointly over-commit" property holds at *spawn* instant only. Refreshing the value at
+   command-execution time (a pre-tool-use boundary rather than process birth) is the
+   planned follow-up.
 
 ## Interaction notes
 

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -114,6 +114,7 @@ from kiro_crew.hooks import (
 from kiro_crew.kiro_cli import resolve_kiro_cli
 from kiro_crew.mcp_gateway.claim import schedule_claim
 from kiro_crew.mcp_gateway.session_servers import pooled_session_servers
+from kiro_crew.resource_status import inject_xdist_auto_cap
 from kiro_crew.sandbox import (
     RLIMIT_PROFILE_SESSION_HOST,
     cgroup_scope_argv,
@@ -2402,6 +2403,14 @@ class AcpClient:
         # server it spawns inherit this, so escaped launcher trees (``npx
         # @playwright/mcp`` -> node) are identifiable as ours.
         env[KIROCREW_SPAWNED_ENV] = KIROCREW_SPAWNED_VALUE
+        # Memory-aware cap for pytest-xdist's ``-n auto``: xdist sizes auto to
+        # the CPU count, ignoring memory, so a full-suite run in an agent turn
+        # can spawn cpu_count workers x ~1 GB each and exhaust the host. xdist
+        # honors PYTEST_XDIST_AUTO_NUM_WORKERS when resolving auto, so seeding
+        # it here bounds ONLY auto resolution — explicit ``-n N``, non-xdist
+        # runs, and venvs without xdist are unaffected. Respects a value
+        # already present in the env; see resource_status.inject_xdist_auto_cap.
+        inject_xdist_auto_cap(env)
 
         # Process-group isolation for clean tree-kill. Pass both flags explicitly
         # (NOT via **dict unpack — that breaks mypy's Popen overload resolution on

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -62,6 +62,7 @@ from kiro_crew.constants import KIROCREW_SPAWNED_ENV, KIROCREW_SPAWNED_VALUE
 from kiro_crew.env import augmented_path, resolve_krb5_ccname
 from kiro_crew.executors import subprocess_executor
 from kiro_crew.mcp_gateway.session_servers import pooled_session_servers
+from kiro_crew.resource_status import inject_xdist_auto_cap
 from kiro_crew.sandbox import (
     RLIMIT_PROFILE_SESSION_HOST,
     cgroup_scope_argv,
@@ -703,6 +704,11 @@ class AcpRuntime:
         # server it spawns inherit this, so escaped launcher trees (``npx
         # @playwright/mcp`` -> node) are identifiable as ours.
         env[KIROCREW_SPAWNED_ENV] = KIROCREW_SPAWNED_VALUE
+        # Memory-aware cap for pytest-xdist's ``-n auto`` (subagent spawn path —
+        # mirrors acp/client.py): xdist sizes auto to the CPU count, ignoring
+        # memory; PYTEST_XDIST_AUTO_NUM_WORKERS bounds ONLY auto resolution.
+        # Respects a pre-set value; see resource_status.inject_xdist_auto_cap.
+        inject_xdist_auto_cap(env)
 
         self._process = await create_subprocess_limited(
             *argv,

--- a/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/profile.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/profile.py
@@ -382,6 +382,13 @@ _MEASURE_ENV_PASSTHROUGH = (
     "TERM",  # some suites probe it; absent TERM makes output differ between arms
     "SYSTEMROOT",  # Windows: CPython needs it to initialize
     "COMSPEC",  # Windows
+    # Memory-aware cap for xdist's ``-n auto`` (_XDIST_ARGV below adds it
+    # unconditionally when xdist is importable). Seeded at the agent spawn
+    # boundary (see resource_status.inject_xdist_auto_cap); without this
+    # passthrough the allowlist would strip it and the suite would size to the
+    # CPU count regardless of memory. Same value for both A/B arms, so arm
+    # fairness is preserved. Not credential-shaped.
+    "PYTEST_XDIST_AUTO_NUM_WORKERS",
 )
 
 

--- a/src/kiro_crew/resource_status.py
+++ b/src/kiro_crew/resource_status.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import MutableMapping
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -206,3 +207,93 @@ def probe(cfg: object | None = None) -> ResourceStatus:
         pressure_gb=pressure_gb,
         critical_gb=critical_gb,
     )
+
+
+# ── pytest-xdist auto-worker cap ─────────────────────────────────────────────
+#
+# The one place resource awareness SHAPES agent work instead of only advising
+# on it. pytest-xdist resolves ``-n auto`` / ``-n logical`` to the CPU count,
+# ignoring memory entirely — on a many-core host each worker's interpreter +
+# fixtures cost ~1 GB, so one full-suite run claims 12-16 GB and two concurrent
+# agent runs can exhaust an unswapped host. xdist honors the
+# ``PYTEST_XDIST_AUTO_NUM_WORKERS`` environment variable when resolving *auto*
+# (https://pytest-xdist.readthedocs.io/en/stable/distribution.html), so seeding
+# it into every agent child env caps ONLY auto resolution: explicit ``-n N``,
+# non-xdist runs, and venvs without xdist are untouched.
+
+#: Env var pytest-xdist consults when resolving ``-n auto`` / ``-n logical``.
+XDIST_AUTO_ENV = "PYTEST_XDIST_AUTO_NUM_WORKERS"
+
+#: Assumed steady-state memory of one xdist worker (GB). Deliberately a
+#: constant, not a config key — ``xdist_auto_cap`` is the single operator knob.
+_XDIST_PER_WORKER_GB = 1.0
+
+#: Fraction of *currently available* memory one test run may claim. Half, so
+#: two concurrent agent sessions sizing themselves at the same instant cannot
+#: jointly commit more than what was free.
+_XDIST_MEMORY_SHARE = 0.5
+
+
+def compute_xdist_auto_workers(
+    available_gb: float,
+    cpu_count: int,
+    *,
+    per_worker_gb: float = _XDIST_PER_WORKER_GB,
+    share: float = _XDIST_MEMORY_SHARE,
+) -> int:
+    """Memory-aware worker count for ``-n auto``: never more than the CPUs,
+    never more than ``available_gb * share / per_worker_gb``, never below 1.
+
+    The floor of 1 keeps a low-memory host running the suite serially rather
+    than failing the run; the CPU ceiling means this can only tighten xdist's
+    own default, never exceed it.
+    """
+    cpus = max(1, cpu_count)
+    by_memory = int(max(0.0, available_gb) * share / per_worker_gb)
+    return max(1, min(cpus, by_memory))
+
+
+def _xdist_cap_config() -> int:
+    """Resolve ``resource_limits.xdist_auto_cap`` from the raw config.
+
+    Semantics: ``-1`` (default) = auto-compute from available memory;
+    ``0`` = disabled, inject nothing (passthrough to xdist's own default);
+    ``N > 0`` = fixed cap. Junk values fall back to the default. Reads the
+    same raw ``resource_limits`` block as :func:`security.apply_resource_limits`
+    and ``sandbox._cgroup_limits_from_config``; the import is function-level
+    for the same reason theirs is (no import cycle through the config loader).
+    """
+    try:
+        from kiro_crew.config.loader import _raw_config
+
+        rl = _raw_config().get("resource_limits")
+        if isinstance(rl, dict):
+            v = rl.get("xdist_auto_cap")
+            if isinstance(v, (int, float)) and not isinstance(v, bool) and int(v) >= -1:
+                return int(v)
+    except Exception:  # pragma: no cover - defensive; config must never break a spawn
+        logger.debug("xdist auto cap: config unavailable, using default", exc_info=True)
+    return -1
+
+
+def inject_xdist_auto_cap(env: MutableMapping[str, str]) -> None:
+    """Seed ``PYTEST_XDIST_AUTO_NUM_WORKERS`` into an agent child environment.
+
+    Called at the agent spawn boundary (``acp/client.py`` / ``acp/runtime.py``)
+    after the child env has been assembled. Only affects how pytest-xdist
+    resolves ``-n auto`` — see the section comment above. Never overrides a
+    value already present (operator/user wins), never raises, and injects
+    nothing when disabled via config or when the memory probe is unavailable.
+    """
+    if env.get(XDIST_AUTO_ENV):
+        return  # already set by the operator/user — respect it
+    cap = _xdist_cap_config()
+    if cap == 0:
+        return  # disabled: leave xdist's own auto resolution untouched
+    if cap > 0:
+        env[XDIST_AUTO_ENV] = str(cap)
+        return
+    available_gb = _read_available_gb()
+    if available_gb < 0:
+        return  # probe unavailable — fail open to xdist's default
+    env[XDIST_AUTO_ENV] = str(compute_xdist_auto_workers(available_gb, os.cpu_count() or 1))

--- a/test/test_xdist_auto_cap.py
+++ b/test/test_xdist_auto_cap.py
@@ -1,0 +1,193 @@
+"""Tests for the memory-aware pytest-xdist ``-n auto`` cap.
+
+Covers :func:`kiro_crew.resource_status.compute_xdist_auto_workers` (clamping),
+:func:`kiro_crew.resource_status.inject_xdist_auto_cap` (config modes,
+respect-existing-env, fail-open on an unreadable probe), and the presence of
+the injection in the environment built by the ACP client spawn path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew import resource_status as rs
+
+# ── compute_xdist_auto_workers ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "available_gb,cpu_count,expected",
+    [
+        # CPU-bound: plenty of memory → the CPU count is the ceiling.
+        (64.0, 8, 8),
+        # Memory-bound: 16 CPUs but 8 GB free → floor(8 * 0.5 / 1.0) = 4.
+        (8.0, 16, 4),
+        # The observed incident shape: 16 CPUs, ~12 GB free → 6, not 16.
+        (12.0, 16, 6),
+        # Low-memory floor: never below 1, even with (near-)zero memory.
+        (0.5, 16, 1),
+        (0.0, 16, 1),
+        # Fractional result truncates down (floor): 5 GB * 0.5 = 2.5 → 2.
+        (5.0, 16, 2),
+        # Degenerate CPU counts clamp to at least 1.
+        (64.0, 0, 1),
+        (64.0, -3, 1),
+    ],
+)
+def test_compute_clamping(available_gb: float, cpu_count: int, expected: int) -> None:
+    assert rs.compute_xdist_auto_workers(available_gb, cpu_count) == expected
+
+
+def test_compute_respects_overrides() -> None:
+    # 2 GB per worker halves the memory-bound count relative to the default.
+    assert rs.compute_xdist_auto_workers(8.0, 16, per_worker_gb=2.0) == 2
+    # A full share doubles it.
+    assert rs.compute_xdist_auto_workers(8.0, 16, share=1.0) == 8
+
+
+# ── _xdist_cap_config ────────────────────────────────────────────────────────
+
+
+def _with_raw_config(raw: dict):
+    return patch("kiro_crew.config.loader._raw_config", return_value=raw)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ({}, -1),  # unset → auto
+        ({"resource_limits": {}}, -1),
+        ({"resource_limits": {"xdist_auto_cap": -1}}, -1),
+        ({"resource_limits": {"xdist_auto_cap": 0}}, 0),  # disabled
+        ({"resource_limits": {"xdist_auto_cap": 6}}, 6),  # fixed
+        ({"resource_limits": {"xdist_auto_cap": -5}}, -1),  # junk → default
+        ({"resource_limits": {"xdist_auto_cap": True}}, -1),  # bool is junk
+        ({"resource_limits": {"xdist_auto_cap": "8"}}, -1),  # str is junk
+        ({"resource_limits": "nope"}, -1),  # non-dict block
+    ],
+)
+def test_cap_config_modes(raw: dict, expected: int) -> None:
+    with _with_raw_config(raw):
+        assert rs._xdist_cap_config() == expected
+
+
+# ── inject_xdist_auto_cap ────────────────────────────────────────────────────
+
+
+def test_inject_respects_existing_env() -> None:
+    env = {rs.XDIST_AUTO_ENV: "3"}
+    with _with_raw_config({"resource_limits": {"xdist_auto_cap": 9}}):
+        rs.inject_xdist_auto_cap(env)
+    assert env[rs.XDIST_AUTO_ENV] == "3"  # operator/user value wins
+
+
+def test_inject_disabled_injects_nothing() -> None:
+    env: dict[str, str] = {}
+    with _with_raw_config({"resource_limits": {"xdist_auto_cap": 0}}):
+        rs.inject_xdist_auto_cap(env)
+    assert rs.XDIST_AUTO_ENV not in env
+
+
+def test_inject_fixed_cap() -> None:
+    env: dict[str, str] = {}
+    with _with_raw_config({"resource_limits": {"xdist_auto_cap": 6}}):
+        rs.inject_xdist_auto_cap(env)
+    assert env[rs.XDIST_AUTO_ENV] == "6"
+
+
+def test_inject_auto_computes_from_probe() -> None:
+    env: dict[str, str] = {}
+    with (
+        _with_raw_config({}),
+        patch.object(rs, "_read_available_gb", return_value=8.0),
+        patch("os.cpu_count", return_value=16),
+    ):
+        rs.inject_xdist_auto_cap(env)
+    assert env[rs.XDIST_AUTO_ENV] == "4"  # floor(8 * 0.5 / 1.0)
+
+
+def test_inject_auto_fails_open_when_probe_unavailable() -> None:
+    env: dict[str, str] = {}
+    with (
+        _with_raw_config({}),
+        patch.object(rs, "_read_available_gb", return_value=-1.0),
+    ):
+        rs.inject_xdist_auto_cap(env)
+    assert rs.XDIST_AUTO_ENV not in env  # leave xdist's own default
+
+
+def test_inject_auto_low_memory_floors_at_one_worker() -> None:
+    env: dict[str, str] = {}
+    with (
+        _with_raw_config({}),
+        patch.object(rs, "_read_available_gb", return_value=0.2),
+        patch("os.cpu_count", return_value=16),
+    ):
+        rs.inject_xdist_auto_cap(env)
+    assert env[rs.XDIST_AUTO_ENV] == "1"
+
+
+# ── injection presence in the built spawn env (ACP client path) ─────────────
+
+
+@pytest.mark.asyncio
+async def test_spawn_env_carries_xdist_cap(tmp_path) -> None:
+    """The env handed to the agent subprocess carries the computed cap."""
+    from kiro_crew.acp.client import AcpClient
+
+    client = AcpClient(work_dir=tmp_path, session_key="k")
+    with (
+        patch("kiro_crew.acp.client._resolve_kiro_bin", return_value="/usr/bin/kiro-cli"),
+        patch(
+            "kiro_crew.acp.client.wrap_argv", return_value=(["/usr/bin/kiro-cli", "acp"], None)
+        ),
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+        patch("kiro_crew.session._track_pid"),
+        patch("kiro_crew.session._track_session_pid"),
+        _with_raw_config({}),
+        patch.object(rs, "_read_available_gb", return_value=8.0),
+        patch("os.cpu_count", return_value=16),
+    ):
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.returncode = None
+        mock_exec.return_value = mock_proc
+
+        await client._spawn()
+
+        call_kwargs = mock_exec.call_args
+        env = call_kwargs.kwargs.get("env") or call_kwargs[1].get("env")
+        assert env is not None
+        assert env[rs.XDIST_AUTO_ENV] == "4"
+
+
+@pytest.mark.asyncio
+async def test_spawn_env_leaves_preset_xdist_cap_alone(tmp_path, monkeypatch) -> None:
+    """A value inherited from the gateway environment is never overridden."""
+    from kiro_crew.acp.client import AcpClient
+
+    monkeypatch.setenv(rs.XDIST_AUTO_ENV, "2")
+    client = AcpClient(work_dir=tmp_path, session_key="k")
+    with (
+        patch("kiro_crew.acp.client._resolve_kiro_bin", return_value="/usr/bin/kiro-cli"),
+        patch(
+            "kiro_crew.acp.client.wrap_argv", return_value=(["/usr/bin/kiro-cli", "acp"], None)
+        ),
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec,
+        patch("kiro_crew.session._track_pid"),
+        patch("kiro_crew.session._track_session_pid"),
+        _with_raw_config({"resource_limits": {"xdist_auto_cap": 9}}),
+    ):
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.returncode = None
+        mock_exec.return_value = mock_proc
+
+        await client._spawn()
+
+        call_kwargs = mock_exec.call_args
+        env = call_kwargs.kwargs.get("env") or call_kwargs[1].get("env")
+        assert env is not None
+        assert env[rs.XDIST_AUTO_ENV] == "2"


### PR DESCRIPTION
## Problem

`pytest-xdist` resolves `-n auto` (and `-n logical`) to the CPU count and never looks at memory. On a many-core host, a full-suite run launched from an agent turn spawns one worker per core at roughly 0.75-1.0 GB each — on a 16-core, 61 GB, no-swap host that is 12-16 GB **per run**. Observed on 2026-08-09: two concurrent agent-driven full-suite runs drove the 1-minute load to 46 and contributed to a memory-exhaustion near-freeze (the two session cgroup scopes peaked at 17.7 GB and 13.7 GB).

Kiro Crew currently shapes nothing here: the `resource_status` probe is advisory-only, and no environment variable at the agent spawn boundary bounds xdist. The per-spawn-tree cgroup `MemoryMax` ceiling does not help either — it is per scope, not an aggregate across concurrent sessions, so N sessions can each stay under their own ceiling while jointly exhausting the host. This repo's own `setup.cfg` `addopts` uses `-n auto`, so every agent that runs the suite hits exactly this.

## Fix

xdist honors the [`PYTEST_XDIST_AUTO_NUM_WORKERS`](https://pytest-xdist.readthedocs.io/en/stable/distribution.html) environment variable when resolving `auto`. Both agent spawn boundaries (`acp/client.py` and the shared runtime spawn path in `acp/runtime.py`) now seed it via a new `resource_status.inject_xdist_auto_cap()` helper:

```
workers = clamp(min(cpu_count, floor(available_gb * 0.5 / 1.0)), 1, cpu_count)
```

- **Available memory** comes from the same cgroup-clamped, container-aware probe the `resource_status` advisory already uses, taken at spawn time.
- **Half of available memory** per run, so two sessions sizing themselves at the same instant cannot jointly commit more than what was free.
- **~1 GB per worker** is the observed steady-state worker cost; deliberately a constant, not a second knob.
- **Floor of 1**: a low-memory host runs the suite serially instead of failing.

This shapes **only** `auto`/`logical` resolution — explicit `-n N`, non-xdist runs, and venvs without xdist installed are untouched — and a value already present in the environment is never overridden (operator/user wins). If the memory probe is unavailable, nothing is injected (fail-open to xdist's own default).

## Config

New key in the existing `resource_limits` block:

| `resource_limits.xdist_auto_cap` | behavior |
|---|---|
| `-1` (default) | auto-compute from available memory at spawn time |
| `0` | disabled — inject nothing, xdist's own auto resolution applies |
| `N > 0` | fixed worker cap |

## Also covered

The auto-improvement profile's measurement environment is a strict allowlist and adds `-n auto` unconditionally when xdist is importable; without a passthrough it would strip the variable and size to CPUs regardless of memory. `PYTEST_XDIST_AUTO_NUM_WORKERS` is now on that allowlist (same value for both A/B arms, so arm fairness is preserved; not credential-shaped). Documented in `docs/architecture/resource-protection.md`.

## Tested

- New `test/test_xdist_auto_cap.py`: computation clamping (CPU-bound, memory-bound, low-memory floor of 1, degenerate CPU counts), config modes (`-1`/`0`/`N`/junk), respect-existing-env, fail-open on unreadable probe, and injection presence in the env built by the ACP client spawn path (49 passed together with `test_resource_status.py`).
- `test/test_acp_client.py` + `test_github_profile.py`: 559 passed; `test/test_acp_runtime.py`: 190 passed.
- `isort --check`, `flake8`, `mypy` clean on all touched files.
