### PR TITLE
fix: sweep orphaned agent-spawned test runs (pytest, xdist workers)

### DIFF
--- a/src/kiro_crew/session_pid.py
+++ b/src/kiro_crew/session_pid.py
@@ -184,9 +184,17 @@ def _pid_file_lock():  # type: ignore[no-untyped-def]
             yield
 
 
+# Basenames of agent runtimes whose lifecycle Kiro Crew manages through PID-file
+# tracking (kiro_pids.txt / kiro_session_pids.txt). Used to re-validate tracked
+# PIDs before a kill, and as a NEGATIVE gate in the work-orphan sweep: these
+# runtimes are reclaimed by their own tracked-PID sweep, never by the
+# marker-based work sweep (see _is_sweepable_orphan_work).
+_MANAGED_AGENT_MARKERS: tuple[str, ...] = ("kiro-cli", "claude")
+
+
 def _is_managed_agent_process(pid: int) -> bool:
     """Check if a PID belongs to an agent process managed by KiroCrew (guards against PID recycling)."""
-    return platform_compat.process_matches(pid, ("kiro-cli", "claude"))
+    return platform_compat.process_matches(pid, _MANAGED_AGENT_MARKERS)
 
 
 def _pid_gone_or_unmanaged(pid: int) -> bool:
@@ -975,6 +983,52 @@ def _protected_pids() -> set[int]:
 _ORPHAN_SWEEP_MAX_KILLS = 30
 _ORPHAN_MIN_AGE_SECONDS = 120  # Never reap processes younger than this
 
+# Dedicated, more conservative age floor for the WORK-process orphan class
+# (agent-spawned pytest/build/shim subtrees identified purely by the
+# KIROCREW_SPAWNED environ marker — see _is_sweepable_orphan_work). Work
+# processes get a much more generous grace than the 120s MCP floor: a
+# long-running legitimate build or test run whose agent briefly detaches must
+# not be raced, and the floor also guarantees a just-detached spawn is never
+# swept before its agent could have re-attached tracking.
+_ORPHAN_WORK_MIN_AGE_SECONDS = 600
+
+# Execnet's popen-worker bootstrap: the single ``-c`` payload pytest-xdist
+# workers run under (verified empirically against pytest-xdist 3.x). Matched
+# as an EXACT argv element, never as a substring.
+_XDIST_BOOTSTRAP = b"import sys;exec(eval(sys.stdin.readline()))"
+
+
+def _work_sweep_cmdline_is_test_runner(cmdline: bytes) -> bool:
+    """Structural test-runner match on parsed argv — never substring.
+
+    A test runner is never a legitimate long-lived daemon, unlike other
+    marked-but-detached processes an agent may deliberately leave running
+    (a preview server, for instance) — so this is the positive shape gate for
+    the work-orphan sweep. Matching is structural to avoid path-fragment
+    false positives (``node /work/pytest-dashboard/server.js`` must NOT
+    match). Exactly three shapes qualify:
+
+    * argv0 basename is exactly ``pytest`` (a venv console script), or
+    * an adjacent ``-m pytest`` argument pair (``python -m pytest ...``), or
+    * a ``-c`` argument whose payload is exactly execnet's worker bootstrap
+      (:data:`_XDIST_BOOTSTRAP`).
+    """
+    args = [a for a in cmdline.split(b"\x00") if a]
+    if len(args) <= 1:
+        # Space-joined fallback (ps output); NUL-split is canonical on Linux.
+        args = [a for a in cmdline.split(b" ") if a]
+    if not args:
+        return False
+    if args[0].rsplit(b"/", 1)[-1] == b"pytest":
+        return True
+    for i in range(len(args) - 1):
+        if args[i] == b"-m" and args[i + 1] == b"pytest":
+            return True
+        if args[i] == b"-c" and args[i + 1] == _XDIST_BOOTSTRAP:
+            return True
+    return False
+
+
 # A candidate PID can exit between the /proc (or ps) snapshot and the per-PID
 # probe. Linux surfaces that as FileNotFoundError/ProcessLookupError reading
 # /proc/<pid>/cmdline; macOS as a non-zero `ps -p <pid>` exit. All three mean
@@ -1164,6 +1218,98 @@ def _is_sweepable_orphan_mcp(pid: int, cmdline: bytes) -> bool:
     return _is_marked_mcp_launcher(cmdline) and _env_has_kirocrew_marker(pid)
 
 
+def _work_orphan_basename(cmdline: bytes) -> bytes:
+    """argv0 basename from a raw cmdline (NUL-separated Linux, space macOS)."""
+    args = cmdline.split(b"\x00")
+    if len(args) == 1:
+        args = cmdline.split(b" ")
+    return args[0].rsplit(b"/", 1)[-1]
+
+
+def _is_sweepable_orphan_work(pid: int, cmdline: bytes, age_seconds: float) -> bool:
+    """Third positive-identity path: agent-spawned TEST-RUNNER process
+    (pytest coordinator or pytest-xdist/execnet worker) that outlived its
+    agent session.
+
+    The positive identity is the conjunction of:
+
+    1. A structural test-runner argv match
+       (:func:`_work_sweep_cmdline_is_test_runner`). Test runners
+       are never legitimate long-lived daemons, unlike other marked-but-
+       detached processes an agent may deliberately leave running (a preview
+       server started with ``start_new_session=True``, for instance) — those
+       are intentional survivors and MUST NOT be swept, so a marker alone is
+       not sufficient identity.
+    2. The ``KIROCREW_SPAWNED`` environ marker (:func:`_env_has_kirocrew_marker`,
+       Linux-only, fail-closed elsewhere). The marker is only ever injected
+       into environments Kiro Crew itself spawns (sandbox wrapper, ACP client
+       and runtime, MCP gateway backend) and is inherited by every descendant,
+       so it can never identify a user-launched process.
+    3. Reparenting to init/systemd --user — guaranteed by the caller, which
+       only iterates :func:`_our_orphan_pids` — AND the owning session's
+       LEADER being gone (:func:`_work_orphan_session_leader_alive`). Kiro
+       Crew starts every agent runtime with ``start_new_session=True``, so
+       the runtime is a session leader and every descendant inherits its SID
+       — including through ``nohup`` and reparenting. A work process whose
+       session leader still exists belongs to a LIVE agent session that may
+       be polling its output (a backgrounded test run, for instance) and is
+       never swept; only when the leader is gone has the owning session
+       positively ended, making the run unreachable by any agent.
+    4. Age above :data:`_ORPHAN_WORK_MIN_AGE_SECONDS` — deliberately much
+       higher than the 120s MCP floor so a just-detached spawn is never raced
+       and a slow-but-legitimate long test run gets generous grace.
+
+    Two NEGATIVE gates keep the blast radius tight: managed agent runtimes
+    (:data:`_MANAGED_AGENT_MARKERS`) stay owned by their own tracked-PID
+    lifecycle, and gateway/CLI entrypoints (:data:`_GATEWAY_MARKERS`) are
+    excluded so agent-launched peer gateways (e.g. dev pods) are never swept.
+    """
+    if age_seconds < _ORPHAN_WORK_MIN_AGE_SECONDS:
+        return False
+    if not cmdline:
+        return False  # kernel thread / zombie — nothing meaningful to kill
+    normalized = cmdline.replace(b"\x00", b" ")
+    if any(marker in normalized for marker in _GATEWAY_MARKERS):
+        return False
+    if not _work_sweep_cmdline_is_test_runner(cmdline):
+        return False
+    basename = _work_orphan_basename(cmdline)
+    if any(marker.encode() in basename for marker in _MANAGED_AGENT_MARKERS):
+        return False
+    if _work_orphan_session_leader_alive(pid):
+        return False  # owning agent session still live — a backgrounded run
+    return _env_has_kirocrew_marker(pid)
+
+
+def _work_orphan_session_leader_alive(pid: int) -> bool:
+    """True when *pid*'s session LEADER still exists as a session leader.
+
+    The SID of an agent-spawned work process is the PID of the kiro-cli
+    runtime that (transitively) spawned it — the runtime is started with
+    ``start_new_session=True`` and neither ``nohup`` nor reparenting to init
+    changes a process's SID. A live leader means the owning agent session may
+    still be driving or polling the work process, so the sweep must leave it
+    alone. PID-recycling is handled by requiring the leader candidate to
+    itself be a session leader (a leader's SID equals its own PID); a
+    recycled PID that is not a leader does not resurrect ownership.
+
+    FAIL-CLOSED for the sweep: any read failure returns True ("assume
+    alive"), so the work path never kills without positively verifying the
+    owning session ended.
+    """
+    sid = _linux_pid_sid(pid)
+    if sid <= 0:
+        return True  # unreadable — assume the owner is alive, do not sweep
+    if sid == pid:
+        # The work process became its own session leader (setsid'd daemon):
+        # SID carries no ownership information. Assume alive — the shape gate
+        # already restricts this path to test runners, and a coordinator that
+        # setsid'd itself is not distinguishable from an owned one.
+        return True
+    leader_sid = _linux_pid_sid(sid)
+    return leader_sid == sid  # alive AND still a session leader
+
+
 def find_orphan_mcp_candidates(active_pids: set[int]) -> list[int]:
     """Scan process table for orphaned MCP processes not in any active set.
 
@@ -1212,11 +1358,32 @@ def find_orphan_mcp_candidates(active_pids: set[int]) -> list[int]:
             continue
         if pid_age < _ORPHAN_MIN_AGE_SECONDS:
             continue
-        if not _is_sweepable_orphan_mcp(pid, cmdline):
+        if not (
+            _is_sweepable_orphan_mcp(pid, cmdline)
+            or _is_sweepable_orphan_work(pid, cmdline, pid_age)
+        ):
             continue
         candidates.append(pid)
 
     return candidates
+
+
+def _linux_pid_sid(pid: int) -> int:
+    """Session id (SID) from /proc/pid/stat (field 6, index 3 after state).
+
+    The SID of an agent-spawned work process points at the kiro-cli session
+    leader that (transitively) spawned it — kiro-cli is started with
+    ``start_new_session=True``, so every descendant inherits its SID even
+    after the direct parent dies and the process reparents to init. Returns
+    -1 when unreadable (caller must fail closed).
+    """
+    try:
+        stat_data = Path(f"/proc/{pid}/stat").read_text()
+        close_paren = stat_data.rfind(")")
+        fields = stat_data[close_paren + 2 :].split()
+        return int(fields[3])  # field 6 (session) = index 3 after state
+    except (OSError, ValueError, IndexError):
+        return -1
 
 
 def _linux_pid_age(pid: int, now: float) -> float:
@@ -1284,25 +1451,33 @@ def kill_orphan_mcps(pids: list[int]) -> int:
                     stderr=subprocess.DEVNULL,
                     timeout=2,
                 )
-            if not _is_sweepable_orphan_mcp(pid, cmdline):
+            if _is_sweepable_orphan_mcp(pid, cmdline):
+                pgid = os.getpgid(pid)
+                if pgid == pid and pgid != my_pgid and pgid > 1:
+                    os.killpg(pgid, signal.SIGKILL)
+                    killed += 1
+                    _sel_orphan_kill(pid, pgid, cmdline, "killpg")
+                else:
+                    # Candidate already passed UID + orphan-ppid + positive MCP
+                    # marker + two-phase active-PID re-verify + cmdline re-check.
+                    # Direct os.kill of the confirmed-orphan PID only — NOT a tree
+                    # walk. _kill_pid_tree is gated by kiro-cli/claude markers that
+                    # MCP processes don't carry. If this orphan shares a pgid (not
+                    # its own group leader) and has children, those children that
+                    # carry an MCP marker are reclaimed on a subsequent sweep; any
+                    # without a marker were never sweep candidates to begin with.
+                    os.kill(pid, signal.SIGKILL)
+                    killed += 1
+                    _sel_orphan_kill(pid, pgid, cmdline, "kill")
                 continue
-            pgid = os.getpgid(pid)
-            if pgid == pid and pgid != my_pgid and pgid > 1:
-                os.killpg(pgid, signal.SIGKILL)
-                killed += 1
-                _sel_orphan_kill(pid, pgid, cmdline, "killpg")
-            else:
-                # Candidate already passed UID + orphan-ppid + positive MCP
-                # marker + two-phase active-PID re-verify + cmdline re-check.
-                # Direct os.kill of the confirmed-orphan PID only — NOT a tree
-                # walk. _kill_pid_tree is gated by kiro-cli/claude markers that
-                # MCP processes don't carry. If this orphan shares a pgid (not
-                # its own group leader) and has children, those children that
-                # carry an MCP marker are reclaimed on a subsequent sweep; any
-                # without a marker were never sweep candidates to begin with.
-                os.kill(pid, signal.SIGKILL)
-                killed += 1
-                _sel_orphan_kill(pid, pgid, cmdline, "kill")
+            # Work-class orphan (KIROCREW_SPAWNED marker, no launcher shape).
+            # Re-verify the full identity — including the age floor — right
+            # before the kill; _is_sweepable_orphan_work fails closed off Linux.
+            work_age = _linux_pid_age(pid, time.time()) if sys.platform == "linux" else 0.0
+            if _is_sweepable_orphan_work(pid, cmdline, work_age):
+                killed += _kill_orphan_work_tree(
+                    pid, cmdline, work_age, budget=_ORPHAN_SWEEP_MAX_KILLS - killed
+                )
         except (
             ProcessLookupError,
             PermissionError,
@@ -1351,6 +1526,93 @@ def _sel_orphan_kill(pid: int, pgid: int, cmdline: bytes, method: str) -> None:
         )
     except Exception:
         logger.debug("SEL orphan-kill audit failed", exc_info=True)
+
+
+def _kill_orphan_work_tree(pid: int, cmdline: bytes, age_seconds: float, budget: int) -> int:
+    """SIGKILL a confirmed work-class orphan and its WHOLE subtree, leaf-first.
+
+    Deliberately NOT :func:`_kill_pid_tree`: that helper only reaps
+    descendants that are themselves managed agent runtimes (kiro-cli/claude),
+    which is correct for tracked agent PIDs but wrong here — every descendant
+    of a marked work orphan inherited the ``KIROCREW_SPAWNED`` environment
+    and is sweepable (an orphaned pytest's own python/shim children are
+    exactly the processes that pile up).
+
+    Descendants are enumerated once (preorder) and killed in reverse, so
+    every process dies before its parent — no child is re-parented away
+    mid-kill and the enumeration stays valid. The root goes last. *budget*
+    bounds the total SIGKILLs so the caller's global
+    :data:`_ORPHAN_SWEEP_MAX_KILLS` cap covers subtree members too; if the
+    budget runs out mid-subtree the survivors are re-reaped next sweep cycle.
+
+    Returns the number of processes killed.
+    """
+    if budget <= 0:
+        return 0
+    descendants: list[int] = []
+    try:
+        # circular import: session_pid → acp.client → session → session_pid
+        from kiro_crew.acp.client import _get_child_pids
+
+        descendants = _get_child_pids(pid)
+    except Exception:
+        logger.debug("Error enumerating descendants of work orphan %s", pid, exc_info=True)
+    my_pid = os.getpid()
+    basename = _work_orphan_basename(cmdline).decode("utf-8", errors="replace")
+    killed = 0
+    for target in [*reversed(descendants), pid]:
+        if killed >= budget:
+            break  # global kill cap exhausted; next sweep cycle finishes the job
+        if target <= 0 or target == my_pid:
+            continue
+        try:
+            platform_compat.kill_pid(target, platform_compat.SIGKILL)
+            killed += 1
+            if target == pid:
+                logger.info(
+                    "Orphan work sweep: SIGKILL pid=%d basename=%s age=%ds "
+                    "reason=KIROCREW_SPAWNED work orphan (reparented to init)",
+                    target,
+                    basename,
+                    int(age_seconds),
+                )
+            else:
+                logger.info(
+                    "Orphan work sweep: SIGKILL pid=%d reason=descendant of work orphan %d",
+                    target,
+                    pid,
+                )
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+    if killed:
+        _sel_orphan_work_kill(pid, basename, age_seconds, cmdline, killed)
+    return killed
+
+
+def _sel_orphan_work_kill(
+    pid: int, basename: str, age_seconds: float, cmdline: bytes, killed: int
+) -> None:
+    """Emit SEL audit event for a work-orphan subtree kill."""
+    try:
+        # Lazy import to avoid a circular import (see kill_orphan_mcps).
+        from kiro_crew.sel import sel
+
+        sel().log_tool_invocation(
+            session_key="gateway",
+            agent="kirocrew",
+            source="background",
+            tool_name="orphan_work_sweep",
+            tool_kind="process_kill",
+            outcome="completed",
+            resources=f"pid={pid} basename={basename} age={int(age_seconds)}s method=work_tree",
+            metadata={
+                "cmdline": cmdline[:200].decode("utf-8", errors="replace"),
+                "killed_in_tree": killed,
+                "reason": "KIROCREW_SPAWNED orphan work process",
+            },
+        )
+    except Exception:
+        logger.debug("SEL orphan-work-kill audit failed", exc_info=True)
 
 
 _PAGE_SIZE = os.sysconf("SC_PAGE_SIZE") if hasattr(os, "sysconf") else 4096

--- a/test/test_pid_lifecycle.py
+++ b/test/test_pid_lifecycle.py
@@ -1275,6 +1275,10 @@ class TestMarkedLauncherSweepIntegration:
             patch("os.getpid", return_value=1),
             patch("kiro_crew.session_pid._linux_pid_age", return_value=300.0),
             patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            patch(
+                "kiro_crew.session_pid._work_orphan_session_leader_alive",
+                return_value=False,
+            ),
         ):
             mock_sys.platform = "linux"
             result = find_orphan_mcp_candidates(active_pids=set())
@@ -1309,6 +1313,10 @@ class TestMarkedLauncherSweepIntegration:
             patch("kiro_crew.session_pid.sys") as mock_sys,
             patch.object(Path, "read_bytes", return_value=b"npx\x00@playwright/mcp\x00--headless"),
             patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            patch(
+                "kiro_crew.session_pid._work_orphan_session_leader_alive",
+                return_value=False,
+            ),
         ):
             mock_sys.platform = "linux"
             killed = kill_orphan_mcps([720])
@@ -1335,6 +1343,381 @@ class TestMarkedLauncherSweepIntegration:
         assert killed == 0
         mock_killpg.assert_not_called()
         mock_kill.assert_not_called()
+
+
+# ── Work-process orphan sweep tests ───────────
+
+
+class TestIsSweepableOrphanWork:
+    """Unit tests for the work-class positive-identity predicate."""
+
+    _PYTEST_CMDLINE = b"/usr/bin/python3\x00-m\x00pytest\x00test/\x00-x\x00-q"
+
+    def test_marked_orphaned_old_work_process_is_sweepable(self) -> None:
+        from kiro_crew.session_pid import _is_sweepable_orphan_work
+
+        with (
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            patch(
+                "kiro_crew.session_pid._work_orphan_session_leader_alive",
+                return_value=False,
+            ),
+            patch(
+                "kiro_crew.session_pid._work_orphan_session_leader_alive",
+                return_value=False,
+            ),
+        ):
+            assert _is_sweepable_orphan_work(1234, self._PYTEST_CMDLINE, 700.0) is True
+
+    def test_xdist_execnet_worker_is_sweepable(self) -> None:
+        """pytest-xdist popen workers run under execnet's bootstrap cmdline."""
+        from kiro_crew.session_pid import _is_sweepable_orphan_work
+
+        worker = (
+            b"/repo/.venv/bin/python\x00-u\x00-c"
+            b"\x00import sys;exec(eval(sys.stdin.readline()))"
+        )
+        with (
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            patch(
+                "kiro_crew.session_pid._work_orphan_session_leader_alive",
+                return_value=False,
+            ),
+            patch(
+                "kiro_crew.session_pid._work_orphan_session_leader_alive",
+                return_value=False,
+            ),
+        ):
+            assert _is_sweepable_orphan_work(1234, worker, 700.0) is True
+
+    def test_live_session_leader_blocks_sweep(self) -> None:
+        """A backgrounded run whose kiro-cli session leader is ALIVE is kept.
+
+        ``nohup pytest &`` reparents to init while the owning agent session
+        still polls its log — SID still points at the live leader, so the
+        sweep must leave the run alone. The environ is never read.
+        """
+        from kiro_crew.session_pid import _is_sweepable_orphan_work
+
+        with (
+            patch(
+                "kiro_crew.session_pid._work_orphan_session_leader_alive",
+                return_value=True,
+            ),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker") as mock_env,
+        ):
+            assert _is_sweepable_orphan_work(1234, self._PYTEST_CMDLINE, 700.0) is False
+        mock_env.assert_not_called()
+
+    def test_unreadable_sid_fails_closed(self) -> None:
+        """SID read failure -> assume the owner is alive -> never sweep."""
+        from kiro_crew.session_pid import _work_orphan_session_leader_alive
+
+        with patch("kiro_crew.session_pid._linux_pid_sid", return_value=-1):
+            assert _work_orphan_session_leader_alive(1234) is True
+
+    def test_self_session_leader_fails_closed(self) -> None:
+        """A setsid'd coordinator (own leader) carries no ownership info -> kept."""
+        from kiro_crew.session_pid import _work_orphan_session_leader_alive
+
+        with patch("kiro_crew.session_pid._linux_pid_sid", return_value=1234):
+            assert _work_orphan_session_leader_alive(1234) is True
+
+    def test_dead_leader_means_session_ended(self) -> None:
+        """Leader gone (or PID recycled into a non-leader) -> session ended."""
+        from kiro_crew.session_pid import _work_orphan_session_leader_alive
+
+        def fake_sid(pid: int) -> int:
+            return 500 if pid == 1234 else -1  # leader 500 unreadable = gone
+
+        with patch("kiro_crew.session_pid._linux_pid_sid", side_effect=fake_sid):
+            assert _work_orphan_session_leader_alive(1234) is False
+
+    def test_marked_detached_daemon_is_not_sweepable(self) -> None:
+        """A marked process WITHOUT a test-runner shape is never swept.
+
+        Agents deliberately leave some marked processes running past turn end
+        (e.g. a preview server detached with ``start_new_session=True``).
+        Those are intentional survivors — the shape gate excludes them, and
+        their environ is never even read.
+        """
+        from kiro_crew.session_pid import _is_sweepable_orphan_work
+
+        daemon = b"/usr/bin/node\x00/opt/serve-sim/cli.js\x00--udid\x00ABC123"
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker") as mock_env:
+            assert _is_sweepable_orphan_work(1234, daemon, 7000.0) is False
+        mock_env.assert_not_called()
+
+    def test_pytest_path_fragment_daemon_is_not_sweepable(self) -> None:
+        """'pytest' inside a path ARGUMENT must not match (structural, not
+        substring): ``nohup node /work/pytest-dashboard/server.js`` is a
+        daemon, not a test run."""
+        from kiro_crew.session_pid import _is_sweepable_orphan_work
+
+        daemon = b"/usr/bin/node\x00/work/pytest-dashboard/server.js"
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker") as mock_env:
+            assert _is_sweepable_orphan_work(1234, daemon, 7000.0) is False
+        mock_env.assert_not_called()
+
+    def test_venv_pytest_console_script_is_sweepable(self) -> None:
+        """argv0 basename exactly ``pytest`` (venv console script) matches."""
+        from kiro_crew.session_pid import _is_sweepable_orphan_work
+
+        console = b"/repo/.venv/bin/pytest\x00test/\x00-q"
+        with (
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            patch(
+                "kiro_crew.session_pid._work_orphan_session_leader_alive",
+                return_value=False,
+            ),
+        ):
+            assert _is_sweepable_orphan_work(1234, console, 700.0) is True
+
+    def test_bootstrap_payload_as_free_arg_is_not_sweepable(self) -> None:
+        """The execnet payload only matches as the argument OF ``-c`` — the
+        same bytes appearing as any other argv element do not qualify."""
+        from kiro_crew.session_pid import _work_sweep_cmdline_is_test_runner
+
+        free = b"/usr/bin/grep\x00import sys;exec(eval(sys.stdin.readline()))\x00log"
+        assert _work_sweep_cmdline_is_test_runner(free) is False
+
+    def test_young_work_process_is_not_sweepable(self) -> None:
+        """Below the dedicated work floor (600s) — even marked, left alone.
+
+        Age is checked FIRST so a young process never even has its environ
+        read; the env-marker mock asserts it stays uncalled.
+        """
+        from kiro_crew.session_pid import _is_sweepable_orphan_work
+
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker") as mock_env:
+            assert _is_sweepable_orphan_work(1234, self._PYTEST_CMDLINE, 599.0) is False
+        mock_env.assert_not_called()
+
+    def test_mcp_floor_is_not_enough_for_work_class(self) -> None:
+        """The 120s MCP floor must NOT admit work processes (dedicated floor)."""
+        from kiro_crew.session_pid import (
+            _ORPHAN_MIN_AGE_SECONDS,
+            _ORPHAN_WORK_MIN_AGE_SECONDS,
+            _is_sweepable_orphan_work,
+        )
+
+        assert _ORPHAN_WORK_MIN_AGE_SECONDS > _ORPHAN_MIN_AGE_SECONDS
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True):
+            assert (
+                _is_sweepable_orphan_work(
+                    1234, self._PYTEST_CMDLINE, _ORPHAN_MIN_AGE_SECONDS + 1
+                )
+                is False
+            )
+
+    def test_unmarked_work_process_is_not_sweepable(self) -> None:
+        """No KIROCREW_SPAWNED environ marker — a user's own pytest is safe."""
+        from kiro_crew.session_pid import _is_sweepable_orphan_work
+
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=False):
+            assert _is_sweepable_orphan_work(1234, self._PYTEST_CMDLINE, 700.0) is False
+
+    def test_managed_agent_basename_is_not_sweepable(self) -> None:
+        """kiro-cli/claude runtimes stay owned by their tracked-PID lifecycle."""
+        from kiro_crew.session_pid import _is_sweepable_orphan_work
+
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True):
+            assert (
+                _is_sweepable_orphan_work(
+                    1234, b"/usr/local/bin/kiro-cli\x00chat\x00--acp", 700.0
+                )
+                is False
+            )
+            assert _is_sweepable_orphan_work(1234, b"claude\x00--print", 700.0) is False
+
+    def test_gateway_entrypoint_is_not_sweepable(self) -> None:
+        """Agent-launched peer gateways (e.g. dev pods) are never swept."""
+        from kiro_crew.session_pid import _is_sweepable_orphan_work
+
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True):
+            assert (
+                _is_sweepable_orphan_work(
+                    1234, b"python3\x00-m\x00kiro_crew.mcp_gateway.gatewayd", 700.0
+                )
+                is False
+            )
+
+    def test_empty_cmdline_is_not_sweepable(self) -> None:
+        """Kernel threads / zombies (empty cmdline) are never candidates."""
+        from kiro_crew.session_pid import _is_sweepable_orphan_work
+
+        with patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True):
+            assert _is_sweepable_orphan_work(1234, b"", 700.0) is False
+
+
+class TestWorkOrphanSweepIntegration:
+    """find + kill phases honor the work-process positive-ID path."""
+
+    _PYTEST_CMDLINE = b"/usr/bin/python3\x00-m\x00pytest\x00test/\x00-x\x00-q"
+
+    def test_find_includes_marked_old_work_orphan(self) -> None:
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[900]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=self._PYTEST_CMDLINE),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=700.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            patch(
+                "kiro_crew.session_pid._work_orphan_session_leader_alive",
+                return_value=False,
+            ),
+        ):
+            mock_sys.platform = "linux"
+            result = find_orphan_mcp_candidates(active_pids=set())
+
+        assert result == [900]
+
+    def test_find_excludes_young_marked_work_orphan(self) -> None:
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[901]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=self._PYTEST_CMDLINE),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=300.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            patch(
+                "kiro_crew.session_pid._work_orphan_session_leader_alive",
+                return_value=False,
+            ),
+        ):
+            mock_sys.platform = "linux"
+            result = find_orphan_mcp_candidates(active_pids=set())
+
+        assert result == []
+
+    def test_find_excludes_unmarked_work_orphan(self) -> None:
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[902]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=self._PYTEST_CMDLINE),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=700.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=False),
+        ):
+            mock_sys.platform = "linux"
+            result = find_orphan_mcp_candidates(active_pids=set())
+
+        assert result == []
+
+    def test_find_excludes_marked_kiro_cli_orphan(self) -> None:
+        """Managed agent runtime carrying the marker still isn't work-swept."""
+        from kiro_crew.session_pid import find_orphan_mcp_candidates
+
+        with (
+            patch("kiro_crew.session_pid._our_orphan_pids", return_value=[903]),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(
+                Path, "read_bytes", return_value=b"/usr/local/bin/kiro-cli\x00chat\x00--acp"
+            ),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=700.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            patch(
+                "kiro_crew.session_pid._work_orphan_session_leader_alive",
+                return_value=False,
+            ),
+        ):
+            mock_sys.platform = "linux"
+            result = find_orphan_mcp_candidates(active_pids=set())
+
+        assert result == []
+
+    def test_kill_sweeps_whole_subtree_leaf_first(self) -> None:
+        """Descendants (incl. grandchildren) die before parents; root last."""
+        from kiro_crew.session_pid import kill_orphan_mcps
+
+        kill_order: list[int] = []
+
+        with (
+            patch("os.getpgrp", return_value=1000),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=self._PYTEST_CMDLINE),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=700.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            patch(
+                "kiro_crew.session_pid._work_orphan_session_leader_alive",
+                return_value=False,
+            ),
+            # Preorder: 910 -> [911, 912(-> 913)]; 913 is a grandchild.
+            patch("kiro_crew.acp.client._get_child_pids", return_value=[911, 912, 913]),
+            patch(
+                "kiro_crew.session_pid.platform_compat.kill_pid",
+                side_effect=lambda p, _sig: kill_order.append(p),
+            ),
+        ):
+            mock_sys.platform = "linux"
+            killed = kill_orphan_mcps([910])
+
+        assert killed == 4
+        # Reversed preorder guarantees each process dies before its parent.
+        assert kill_order == [913, 912, 911, 910]
+
+    def test_kill_reverify_skips_now_young_or_unmarked(self) -> None:
+        """Kill-phase re-verify fails closed when the marker is gone (TOCTOU)."""
+        from kiro_crew.session_pid import kill_orphan_mcps
+
+        with (
+            patch("os.getpgrp", return_value=1000),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=self._PYTEST_CMDLINE),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=700.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=False),
+            patch("kiro_crew.session_pid.platform_compat.kill_pid") as mock_kill,
+        ):
+            mock_sys.platform = "linux"
+            killed = kill_orphan_mcps([920])
+
+        assert killed == 0
+        mock_kill.assert_not_called()
+
+    def test_subtree_kill_respects_global_cap(self) -> None:
+        """The _ORPHAN_SWEEP_MAX_KILLS cap bounds subtree members too."""
+        from kiro_crew.session_pid import kill_orphan_mcps
+
+        kill_order: list[int] = []
+
+        with (
+            patch("kiro_crew.session_pid._ORPHAN_SWEEP_MAX_KILLS", 3),
+            patch("os.getpgrp", return_value=1000),
+            patch("os.getpid", return_value=1),
+            patch("kiro_crew.session_pid.sys") as mock_sys,
+            patch.object(Path, "read_bytes", return_value=self._PYTEST_CMDLINE),
+            patch("kiro_crew.session_pid._linux_pid_age", return_value=700.0),
+            patch("kiro_crew.session_pid._env_has_kirocrew_marker", return_value=True),
+            patch(
+                "kiro_crew.session_pid._work_orphan_session_leader_alive",
+                return_value=False,
+            ),
+            patch(
+                "kiro_crew.acp.client._get_child_pids",
+                return_value=[931, 932, 933, 934, 935],
+            ),
+            patch(
+                "kiro_crew.session_pid.platform_compat.kill_pid",
+                side_effect=lambda p, _sig: kill_order.append(p),
+            ),
+        ):
+            mock_sys.platform = "linux"
+            killed = kill_orphan_mcps([930])
+
+        assert killed == 3
+        # Deepest three descendants reaped; root survives to the next cycle.
+        assert kill_order == [935, 934, 933]
+        assert 930 not in kill_order
 
 
 class TestSpawnedMarkerInjection:


### PR DESCRIPTION
## Problem

The gateway's periodic orphan sweep (the `orphan_mcp` cleanup hook, every ~5 minutes) reclaims escaped **MCP** subtrees, but never reclaims orphaned **test runs** that an agent spawned and whose session is gone.

Observed on a real Linux host on 2026-08-09: pytest processes still running **11+ hours** after the agent session that started them had ended, at roughly 0.75–1.0 GB per xdist worker — dead weight on an unswapped 61 GB host that suffered two memory-pressure near-freezes the same day.

Why the sweep misses them: `_is_sweepable_orphan_mcp` only positively identifies

1. cmdlines carrying a KiroCrew MCP entrypoint fingerprint (`kirocrew_sandbox_*`, `kiro_crew.mcp_gateway.stub`), or
2. fingerprint-less MCP **launcher shapes** (`npx @playwright/mcp`, `mcp start-server`) paired with the `KIROCREW_SPAWNED` environ marker.

An orphaned `pytest` **does** carry the `KIROCREW_SPAWNED` marker (it is injected at every spawn-env build site: the sandbox wrapper, the ACP client and runtime, and the MCP gateway backend, and is inherited by descendants) — but it matches no launcher shape, so it is never swept and lives until reboot.

## Fix

Add a third positive-identity path, `_is_sweepable_orphan_work`, wired into both the find phase (`find_orphan_mcp_candidates`) and the pre-kill re-verify (`kill_orphan_mcps`). A process is a sweepable orphaned test run only when **all** of the following hold:

1. **Test-runner cmdline shape** (`_WORK_SWEEP_SHAPES`): a pytest coordinator (`-m pytest` / `pytest` argv0) or a pytest-xdist worker (execnet's `import sys;exec(eval(sys.stdin.readline()))` bootstrap, verified empirically against xdist 3.x popen workers). Test runners are never legitimate long-lived daemons — unlike other marked-but-detached processes an agent may deliberately leave running (a preview server started with `start_new_session=True`, for instance), which a marker-only rule would wrongly kill.
2. **`KIROCREW_SPAWNED` environ marker present** (`/proc/<pid>/environ`; Linux-only and fail-closed — any read failure or non-Linux platform means "not sweepable"). The marker is only ever injected into environments Kiro Crew itself spawns, so it can never identify a user-launched process.
3. **Owning session positively ended**: the process is reparented to init / `systemd --user` (guaranteed by the caller, which only iterates `_our_orphan_pids()`) **and** its session leader is gone (`_work_orphan_session_leader_alive`). Every agent runtime is started with `start_new_session=True`, so it is a session leader and every descendant keeps its SID — through `nohup` and reparenting alike. A backgrounded run (`nohup pytest … &`) under a live agent session therefore still resolves to its living leader and is never swept; only when the leader is gone has the owning session ended. Fail-closed: an unreadable SID, or a run that made itself a session leader, is assumed owned and left alone.
4. **Age above a dedicated 600s floor** (`_ORPHAN_WORK_MIN_AGE_SECONDS`) — deliberately much more conservative than the 120s MCP floor, so a just-detached spawn is never raced and a long-running legitimate suite gets generous grace.

Two negative gates keep the blast radius tight:

- **Managed agent runtimes** (`kiro-cli`, `claude` basenames) are excluded — they stay owned by their own tracked-PID lifecycle.
- **Gateway/CLI entrypoints** (`_GATEWAY_MARKERS`) are excluded, so agent-launched peer gateways (e.g. dev pods) are never swept.

Scope note: this PR deliberately covers **test runs only**. Other orphaned work classes (version-probe shim spinners, build tools) were observed on the same host but are CPU rather than memory weight; they can be added later with their own vetted argv shapes behind the same marker + leader-gone + age gates.

### Kill semantics

A confirmed orphaned test run is killed with its **whole subtree, leaf-first** (`_kill_orphan_work_tree`): descendants are enumerated preorder and killed in reverse, root last, so every process dies before its parent. This deliberately does **not** reuse `_kill_pid_tree`, which skips descendants that are not themselves managed agent runtimes — correct for tracked agent PIDs, wrong here, because every descendant of a marked test run inherited the `KIROCREW_SPAWNED` environment and is exactly what piles up (an orphaned pytest coordinator's own worker children).

The existing global blast-radius bound `_ORPHAN_SWEEP_MAX_KILLS = 30` now covers subtree members too (a per-call budget is threaded into the tree kill; survivors are re-reaped next cycle). Every kill is logged with pid, basename, age, and reason, and each swept tree emits a SEL audit event (`orphan_work_sweep`), consistent with the existing sweep's auditing.

## Testing

- New unit tests for the predicate: marked+orphaned+old pytest coordinator and xdist execnet worker are sweepable (leader gone); a marked run whose session leader is **alive** is kept and its environ never read; a marked **non-test daemon** (e.g. a detached preview server) is never swept; marked-but-young is not swept; the 120s MCP floor does not admit test runs; unmarked orphan is not sweepable; `kiro-cli`/`claude` basenames and gateway entrypoints are not sweepable; empty cmdline (kernel thread/zombie) is not sweepable.
- Leader-liveness unit tests: unreadable SID fails closed; a self-leader (setsid'd) run fails closed; a dead or PID-recycled-into-non-leader leader means the session ended.
- Find/kill integration tests: find phase includes a marked old orphaned test run and excludes young/unmarked/managed-runtime ones; kill phase sweeps the whole subtree leaf-first including grandchildren (kill order verified); kill-phase re-verify fails closed when the marker is gone; the global kill cap bounds subtree kills (root survives to the next cycle when the budget runs out).
- Full `test/test_pid_lifecycle.py` (120 passed) and the other sweep-adjacent modules `test/test_session.py` + `test/test_spawn_audit.py` (246 passed); `isort --check`, `flake8`, and `mypy` clean on touched files.
