### PR TITLE
fix(dev-fleet): refuse the sync when pip cannot reinstall into the live venv

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -2886,6 +2886,49 @@ def _venv_python(repo: str) -> Path | None:
     return None
 
 
+def _write_locked_console_scripts(venv_python: Path) -> list[str]:
+    """The venv's ``kirocrew`` console scripts that cannot currently be rewritten.
+
+    Windows holds a mandatory lock on a running executable's image, so when the
+    gateway is served BY the very venv pip is about to reinstall into — the
+    ordinary single-checkout setup — pip cannot replace
+    ``Scripts\\kirocrew.exe``, and the reinstall can never succeed.
+
+    That matters well beyond one failed step. pip's uninstall is not atomic: by
+    the time it reaches the locked script it has already renamed the dist-info
+    aside and deleted the editable ``.pth`` that puts ``src`` on ``sys.path``,
+    and it rolls back neither. The venv is left unable to import the package at
+    all, which also kills the console script the gateway is restarted through.
+    The running process survives on already-imported modules, so the damage
+    stays invisible until the next restart fails.
+
+    Probing with an ``r+b`` open is non-destructive and discriminates correctly:
+    a running executable refuses it while every other script in the same
+    directory opens fine. It does not model every way a delete can fail — an
+    opener that permits writes but denies deletes would pass this probe — so a
+    clean result means "no known blocker", not a guarantee. A miss simply leaves
+    the previous behaviour, which is why this is worth doing even though it
+    cannot be exhaustive.
+
+    POSIX returns nothing: an executing binary can be unlinked there, which is
+    why pip has always been able to replace it.
+    """
+    if not platform_compat.IS_WINDOWS:
+        return []
+    locked: list[str] = []
+    for exe in sorted(Path(venv_python).parent.glob("kirocrew*.exe")):
+        try:
+            with exe.open("r+b"):
+                pass
+        except PermissionError:
+            locked.append(str(exe))
+        except OSError:
+            # Unreadable for some other reason. Let pip be the judge rather than
+            # skipping a step that might well have succeeded.
+            continue
+    return locked
+
+
 async def _sync_start_locked() -> dict:
     """Start the sync run. Caller holds _SYNC_LOCK."""
     global _SYNC_RID  # noqa: F824 (assigned below after await)
@@ -2914,12 +2957,17 @@ async def _sync_start_locked() -> dict:
         )}
     # Both binary lookups stat the filesystem (`_trusted_bin` walks the trusted
     # dirs; `_toolchain_bin` adds a `shutil.which` over the node bin dirs, which
-    # may be NFS-backed). Resolve them together on the executor so /api/sync
-    # cannot stall the gateway's requests and liveness behind a directory scan.
+    # may be NFS-backed). The console-script probe opens files in the target
+    # venv. Resolve them together on the executor so /api/sync cannot stall the
+    # gateway's requests and liveness behind a directory scan.
     loop = asyncio.get_running_loop()
-    git_bin, npm_bin = await loop.run_in_executor(
+    git_bin, npm_bin, locked_scripts = await loop.run_in_executor(
         subprocess_executor(),
-        lambda: (_trusted_bin("git"), _toolchain_bin("npm")),
+        lambda: (
+            _trusted_bin("git"),
+            _toolchain_bin("npm"),
+            _write_locked_console_scripts(target_py),
+        ),
     )
     if git_bin is None:
         return {"ok": False, "error": (
@@ -2944,6 +2992,45 @@ async def _sync_start_locked() -> dict:
             "KIROCREW_NODE_BIN_DIR=/abs/path/to/node/bin in the gateway's "
             "service environment; that one does need a restart, because a "
             "running process cannot see a new environment variable."
+        )}
+    if locked_scripts:
+        # Refuse the WHOLE sync rather than omitting just the reinstall.
+        #
+        # pip cannot replace a running executable on Windows, and its uninstall
+        # is not atomic: it renames the dist-info aside and deletes the editable
+        # `.pth` before it reaches the locked script, rolling back neither. That
+        # alone argues for not starting pip.
+        #
+        # But merging without installing is not a safe consolation prize. A
+        # revision that adds a dependency would land on disk with that dependency
+        # absent, the run would exit 0, and the UI would offer "restart gateway
+        # to apply" — so the next restart imports the new code, fails on the
+        # missing import, and the gateway does not come back. Any newly spawned
+        # subprocess hits the same gap even without a restart. That is the same
+        # unstartable-gateway outcome this guard exists to prevent, just later
+        # and with a success report in front of it.
+        #
+        # The checkout is therefore left at a revision whose dependencies are
+        # satisfied, and the remedy names itself.
+        return {"ok": False, "error": (
+            "refusing to sync: cannot reinstall into the venv this gateway runs "
+            f"from. {', '.join(locked_scripts)} is locked by a running process, so "
+            "a reinstall cannot replace it — and pip's uninstall is not "
+            "atomic, so attempting it would strip the editable install on the way "
+            "out and leave the venv unable to import the package at all. Pulling "
+            "without installing is refused too: a revision whose new dependencies "
+            "are missing crashes the gateway on its next restart. Stop the gateway "
+            "and sync from a terminal instead: "
+            # Every path is absolute and quoted. `-e .` would resolve against the
+            # terminal's cwd, and this project's normal working state is several
+            # worktrees side by side — so a command copied out of a feature
+            # worktree would install THAT checkout into the primary venv and
+            # repoint its editable install at the wrong tree. `git -C` already
+            # pins the pull, which makes an unpinned `.` actively misleading:
+            # the line reads as if it were cwd-independent. Quoting covers the
+            # spaces that are normal in a Windows home directory.
+            f'git -C "{MAIN_REPO}" pull --ff-only '
+            f'&& "{target_py}" -m pip install -e "{MAIN_REPO}"'
         )}
     raw_steps: list[tuple[list[str], str, dict, str]] = [
         ([git_bin, "fetch", remote, BASE_BRANCH], "standard",
@@ -3013,11 +3100,30 @@ async def _sync_start_locked() -> dict:
         wrapped_steps.append({"argv": w_argv, "env": w_env, "label": label})
     script = (
         "import subprocess, sys, json\n"
+        # Align the writer with the reader. `_start_run` decodes this stream as
+        # UTF-8 (`line.decode(errors="replace")`), but a piped stdout on Windows
+        # encodes with the process locale codepage — so any non-ASCII that ever
+        # reaches a print here would be mangled at best and raise
+        # UnicodeEncodeError at worst, killing the runner before its first step.
+        # errors="replace" additionally guarantees no print can be fatal.
+        "sys.stdout.reconfigure(encoding='utf-8', errors='replace')\n"
         f"steps = json.loads({json.dumps(json.dumps(wrapped_steps))})\n"
         f"cwd = {json.dumps(MAIN_REPO)}\n"
         "for i, st in enumerate(steps):\n"
         "    print(f'::step::{i}::{st[\"label\"]}', flush=True)\n"
-        "    r = subprocess.run(st['argv'], cwd=cwd, env=st['env'])\n"
+        # reconfigure() above rebinds only THIS process's stdout object. Each
+        # step is a separate process that inherits the same pipe and re-derives
+        # its own encoding from the locale, so the Python steps — pip, and the
+        # build-and-stage child — would still encode a non-ASCII checkout path
+        # with the codepage and die on it. Set it in the environment, which is
+        # the only channel that reaches a child, so the whole pipe is UTF-8 from
+        # every writer the reader has to decode. Non-Python steps (git, npm)
+        # ignore the variable and are unaffected. Assigned rather than
+        # defaulted: the reader's encoding is fixed, so a divergent inherited
+        # value would be the defect, not a preference to preserve.
+        "    env = dict(st['env'])\n"
+        "    env['PYTHONIOENCODING'] = 'utf-8:replace'\n"
+        "    r = subprocess.run(st['argv'], cwd=cwd, env=env)\n"
         "    if r.returncode != 0:\n"
         "        sys.exit(r.returncode)\n"
     )

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -324,6 +324,280 @@ async def test_sync_script_emits_step_markers():
     mod._UPSTREAM_REMOTE = None
 
 
+# --- Windows: a write-locked console script must not be handed to pip ---
+def _make_scripts(tmp_path, *names):
+    """A fake venv Scripts/ dir, returning the interpreter path inside it."""
+    scripts = tmp_path / ".venv" / "Scripts"
+    scripts.mkdir(parents=True)
+    for name in names:
+        (scripts / name).write_bytes(b"MZ")
+    return scripts / "python.exe"
+
+
+def _raise_on(monkeypatch, name, exc):
+    """Make Path.open raise *exc* for the file called *name* only."""
+    real_open = Path.open
+
+    def fake_open(self, *args, **kwargs):
+        if self.name == name:
+            raise exc
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", fake_open)
+
+
+def test_write_locked_console_scripts_is_a_posix_noop(tmp_path, monkeypatch):
+    """POSIX can unlink an executing binary, so there is nothing to detect."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    py = _make_scripts(tmp_path, "kirocrew.exe")
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", False)
+    _raise_on(monkeypatch, "kirocrew.exe", PermissionError(13, "in use"))
+
+    assert mod._write_locked_console_scripts(py) == []
+
+
+def test_write_locked_console_scripts_flags_a_locked_script(tmp_path, monkeypatch):
+    """The real failure: the exe the gateway is executing cannot be replaced."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    py = _make_scripts(tmp_path, "kirocrew.exe")
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    _raise_on(monkeypatch, "kirocrew.exe", PermissionError(13, "in use"))
+
+    locked = mod._write_locked_console_scripts(py)
+    assert len(locked) == 1
+    assert locked[0].endswith("kirocrew.exe")
+
+
+def test_write_locked_console_scripts_passes_a_writable_script(tmp_path, monkeypatch):
+    """A venv the gateway is NOT running from must still get its reinstall."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    py = _make_scripts(tmp_path, "kirocrew.exe")
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+
+    assert mod._write_locked_console_scripts(py) == []
+
+
+def test_write_locked_console_scripts_ignores_unrelated_executables(tmp_path, monkeypatch):
+    """Only the scripts pip would rewrite matter.
+
+    Some other locked exe sharing the Scripts dir must not suppress the
+    reinstall — that would turn an unrelated process into a silent skip.
+    """
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    py = _make_scripts(tmp_path, "kirocrew.exe", "unrelated.exe")
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    _raise_on(monkeypatch, "unrelated.exe", PermissionError(13, "in use"))
+
+    assert mod._write_locked_console_scripts(py) == []
+
+
+def test_write_locked_console_scripts_lets_pip_judge_other_errors(tmp_path, monkeypatch):
+    """An unreadable-for-other-reasons script is not evidence of a lock.
+
+    Skipping on any OSError would suppress installs that would have worked.
+    """
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    py = _make_scripts(tmp_path, "kirocrew.exe")
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+    _raise_on(monkeypatch, "kirocrew.exe", OSError(5, "I/O error"))
+
+    assert mod._write_locked_console_scripts(py) == []
+
+
+def _steps_from_script(script):
+    """Pull the structured step list back out of the generated script.
+
+    Asserting on the raw script text is a trap: the steps are embedded
+    double-JSON-encoded, so a label reads as ``\\"Pull\\"`` and a naive
+    ``'"pip install"' in script`` check can never match — it passes whether or
+    not the step is there. Parse it instead so the assertions actually bite.
+    """
+    import json as _json
+    import re
+
+    m = re.search(r"steps = json\.loads\((.*?)\)\n", script, re.S)
+    assert m, "steps assignment not found — the script shape changed"
+    return [s["label"] for s in _json.loads(_json.loads(m.group(1)))]
+
+
+async def _run_sync(mod, locked):
+    """Drive _sync_start_locked with the probe stubbed; return its result dict
+    plus the generated script (None when the sync refused)."""
+    mod._UPSTREAM_REMOTE = "origin"
+    mod._SYNC_RID = None
+    with patch.object(mod, "_git", new_callable=AsyncMock, return_value="main"), \
+         patch.object(mod, "_venv_python", return_value=Path("/fake/.venv/bin/python")), \
+         patch.object(mod, "_trusted_bin", side_effect=lambda n: f"/usr/bin/{n}"), \
+         patch.object(mod, "_write_locked_console_scripts", return_value=locked), \
+         patch("kiro_crew.apps.builtins.dev_fleet.server.sandboxed_spawn_argv",
+               side_effect=lambda cmd, mode, env=None: (cmd, env or {}, None)), \
+         patch.object(mod, "_start_run", new_callable=AsyncMock, return_value="run-123") as mock_start:
+        async with mod._SYNC_LOCK:
+            result = await mod._sync_start_locked()
+    mod._UPSTREAM_REMOTE = None
+    script = mock_start.call_args[0][1][2] if mock_start.call_args else None
+    return result, script
+
+
+@pytest.mark.asyncio
+async def test_sync_refuses_entirely_when_a_console_script_is_locked():
+    """Nothing may run — not even fetch/merge.
+
+    pip cannot replace the locked binary, and merging anyway is not a safe
+    consolation prize: a revision that adds a dependency would land with that
+    dependency absent, the run would report success, and the next restart would
+    fail to import it. Leaving the checkout on a revision whose dependencies are
+    satisfied is the only outcome that cannot brick the gateway.
+    """
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    result, script = await _run_sync(mod, [r"C:\repo\.venv\Scripts\kirocrew.exe"])
+
+    assert result["ok"] is False
+    # No run was started at all, so fetch/merge never happened.
+    assert script is None
+    err = result["error"]
+    assert "kirocrew.exe" in err          # names the blocker
+    assert "pip install -e" in err        # and the remedy
+    assert "Stop the gateway" in err
+
+
+@pytest.mark.asyncio
+async def test_refusal_remedy_is_cwd_independent_and_quoted():
+    """The suggested command must not depend on where it is pasted.
+
+    `-e .` resolves against the terminal's cwd, and this project is normally
+    checked out as several worktrees at once — so the same line copied from a
+    feature worktree would install THAT tree into the primary venv and repoint
+    its editable install away from the primary checkout. Both paths are also
+    quoted, because a Windows home directory routinely contains a space.
+    """
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    result, _ = await _run_sync(mod, [r"C:\repo\.venv\Scripts\kirocrew.exe"])
+    err = result["error"]
+
+    # The install target is named explicitly, never left to the shell's cwd —
+    # including in the prose, so the message never shows the misleading form.
+    assert "pip install -e ." not in err
+    assert f'pip install -e "{mod.MAIN_REPO}"' in err
+    assert f'git -C "{mod.MAIN_REPO}"' in err
+
+
+@pytest.mark.asyncio
+async def test_every_step_gets_a_utf8_pin_in_its_environment():
+    """The runner's own reconfigure() does not reach its children.
+
+    Each step is a separate process that inherits the pipe but re-derives its
+    encoding from the locale, so the Python steps (pip, and the build-and-stage
+    child) would still encode a non-ASCII checkout path with the codepage and
+    die on it. The environment is the only channel that reaches a child.
+    """
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    _, script = await _run_sync(mod, [])
+
+    assert "env['PYTHONIOENCODING'] = 'utf-8:replace'" in script
+    # Applied to the env actually handed to subprocess.run, not a stale copy.
+    assert "subprocess.run(st['argv'], cwd=cwd, env=env)" in script
+    assert "env=st['env']" not in script
+    # Set before the step is spawned, not after.
+    assert script.index("PYTHONIOENCODING") < script.index("subprocess.run(")
+
+
+@pytest.mark.asyncio
+async def test_sync_runs_every_step_when_nothing_is_locked():
+    """Control: an unlocked venv gets the full sync, reinstall included."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    result, script = await _run_sync(mod, [])
+
+    assert result["ok"] is True, result
+    labels = _steps_from_script(script)
+    assert "pip install" in labels
+    assert "Pull" in labels
+
+
+@pytest.mark.asyncio
+async def test_sync_runner_pins_utf8_stdout_before_its_first_print():
+    """Align the writing side with the reader.
+
+    `_start_run` decodes the stream as UTF-8, while a piped stdout on Windows
+    encodes with the process locale codepage — a mismatch that mangles or kills
+    any non-ASCII print. Pinned before the step loop so no print predates it.
+    """
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    _, script = await _run_sync(mod, [])
+
+    assert "reconfigure(encoding='utf-8'" in script
+    assert script.index("reconfigure(") < script.index("print(f'::step::")
+
+
+def test_utf8_reconfigure_survives_a_legacy_codepage_pipe():
+    """Prove the mechanism, not just its presence in the source.
+
+    Forcing a legacy codepage on the child's stdout is what the Windows
+    mismatch looks like; the reconfigure call is what keeps the print
+    non-fatal, and the reader side decodes UTF-8.
+    """
+    import subprocess
+    import sys as _sys
+
+    text = "\u9648\u660e\u4f2a"
+    body = (
+        "import sys\n"
+        "sys.stdout.reconfigure(encoding='utf-8', errors='replace')\n"
+        f"print({text!r}, flush=True)\n"
+    )
+    env = {**os.environ, "PYTHONIOENCODING": "cp1252"}
+    proc = subprocess.run(
+        [_sys.executable, "-c", body], capture_output=True, env=env, timeout=60
+    )
+
+    assert proc.returncode == 0, proc.stderr.decode(errors="replace")
+    # Matches how the run reader decodes the stream.
+    assert text in proc.stdout.decode(errors="replace")
+
+
+def test_pythonioencoding_saves_a_step_child_that_prints_a_non_ascii_path():
+    """The child half of the same mismatch, proven end to end.
+
+    A step child cannot call the runner's reconfigure() for itself, so this is
+    the case the environment variable has to carry: the SAME print that dies
+    under a legacy codepage survives once the pin is in the env, which is what
+    a pip or build step does when it echoes a non-ASCII checkout path.
+    """
+    import subprocess
+    import sys as _sys
+
+    path = "C:\\Users\\\u9648\u660e\u4f2a\\KiroCrew"
+    body = f"print({path!r}, flush=True)\n"
+    codepage = {**os.environ, "PYTHONIOENCODING": "cp1252"}
+
+    # Without the pin the child dies on the encode — the defect being fixed.
+    unpinned = subprocess.run(
+        [_sys.executable, "-c", body], capture_output=True, env=codepage, timeout=60
+    )
+    assert unpinned.returncode != 0
+    assert b"UnicodeEncodeError" in unpinned.stderr
+
+    # With it, the child survives and the reader gets the real path back.
+    pinned = subprocess.run(
+        [_sys.executable, "-c", body],
+        capture_output=True,
+        env={**codepage, "PYTHONIOENCODING": "utf-8:replace"},
+        timeout=60,
+    )
+    assert pinned.returncode == 0, pinned.stderr.decode(errors="replace")
+    assert path in pinned.stdout.decode(errors="replace")
+
+
 # --- repo owner/name parsing ---
 @pytest.mark.asyncio
 async def test_repo_owner_name_ssh():


### PR DESCRIPTION
Fixes #2297.

## Problem

On Windows, Dev Fleet's **Pull + Build** dies at the `pip install` step, and the failure leaves the venv broken rather than merely un-upgraded.

```
Installing collected packages: defusedxml, kirocrew
  Attempting uninstall: kirocrew
    Found existing installation: kirocrew 0.1.2
    Uninstalling kirocrew-0.1.2:
ERROR: Could not install packages due to an OSError: [WinError 32] The process cannot
access the file because it is being used by another process:
'c:\\users\\...\\.venv\\scripts\\kirocrew.exe'
```

`_sync_start_locked()` runs pip with the main checkout's own venv interpreter, deliberately — the existing comment explains it must not re-point a worktree venv's editable install at `MAIN_REPO`. That reasoning is right, but in the ordinary single-checkout setup that venv **is** the one running the gateway. Windows holds a mandatory lock on a running executable's image, so pip cannot rewrite `Scripts\kirocrew.exe`, and the step can never succeed. It is deterministic, not a race.

## Why it matters

The failed step is the smaller half. pip's uninstall is not atomic — by the time it reaches the locked script it has already:

1. renamed `kirocrew-<ver>.dist-info` to its `~irocrew-<ver>.dist-info` backup, and
2. deleted `__editable__.kirocrew-<ver>.pth`, the file that puts `src` on `sys.path`

and it rolls back neither. Observed aftermath on a real install:

| check | result |
|---|---|
| `pip show kirocrew` | `Package(s) not found: kirocrew` |
| `python -c "import kiro_crew"` | `ModuleNotFoundError` |
| any pip command | `WARNING: Ignoring invalid distribution ~irocrew` |

The running gateway survives on already-imported modules, so nothing surfaces at the time. But the `kirocrew` CLI is dead (its entry point can't import), which means `kirocrew stop` / `restart` no longer work, new subprocesses that import `kiro_crew` fail, and **the gateway does not come back from its next restart**. One click takes a working install to one that is fine right up until it is stopped.

## Fix (symptom → root cause → change)

**1. Probe before doing anything.** Check the console scripts pip would have to rewrite, and refuse when one is locked. pip is never started, so it cannot begin an uninstall it can't finish.

The probe is an `r+b` open — non-destructive, and it discriminates correctly. Validated against a genuinely locked exe:

| file | probe |
|---|---|
| `kirocrew.exe` (running) | `PermissionError` |
| `pip.exe`, `idna.exe`, `f2py.exe`, … (same dir) | writable |
| `os.remove("kirocrew.exe")` | `winerror=32` — exactly pip's error |

It runs on `subprocess_executor()` alongside the existing `git`/`npm` resolution, so it costs no extra round-trip and never blocks the event loop.

**Deliberately bounded:** the probe does not model every way a delete can fail — an opener that permits writes but denies deletes would pass it. A clean result therefore means "no known blocker", not a guarantee, and a miss just leaves the pre-fix behaviour. It is worth doing anyway because it removes the failure that actually occurs.

**2. Refuse the whole sync, not just the reinstall.** An earlier revision of this PR ran fetch/merge and omitted only the pip step. GPT 5.6 Review showed that is unsafe, and it was right — [disposition](https://github.com/kirodotdev/KiroCrew/pull/2445#issuecomment-5234958684). Merging without installing lands a revision on disk whose new dependencies are absent, the run exits **0**, and the UI then offers *"restart gateway to apply"* (`build_pending`) — so the next restart imports the new code, fails on the missing import, and the gateway does not come back. Newly spawned subprocesses hit the same gap with no restart at all. That is the same unstartable-gateway outcome this guard exists to prevent, reached later and with a green run in front of it.

So the sync now refuses early, alongside the function's existing guards (wrong branch, no venv, no git, no npm), leaving the checkout on a revision whose dependencies are satisfied. The error names the blocking file and the exact remedy:

```
refusing to sync: cannot reinstall into the venv this gateway runs from.
...\Scripts\kirocrew.exe is locked by a running process, so a reinstall
cannot replace it — and pip's uninstall is not atomic, so attempting it would
strip the editable install on the way out and leave the venv unable to import
the package at all. Pulling without installing is refused too: a revision whose
new dependencies are missing crashes the gateway on its next restart. Stop the
gateway and sync from a terminal instead:
git -C "<repo>" pull --ff-only && "<venv-python>" -m pip install -e "<repo>"
```

Keeping fetch/merge and merely reporting failure was considered and rejected: the hazard is the merged-but-uninstalled revision itself, so a non-zero exit would not remove it.

That remedy line names an **absolute, quoted** repository path rather than `-e .`, which GPT 5.6 also flagged. Handing the user a recovery command is the refusal's entire purpose, so the line must not depend on where it is pasted: this project is normally checked out as several worktrees at once, and `-e .` copied into a feature worktree's terminal would install *that* tree into the primary venv and repoint its editable install away from the primary checkout -- the same wrong-tree-in-the-venv outcome the refusal exists to avoid. `git -C` already pinned the pull, which made an unpinned `.` actively misleading, since the line read as though it were cwd-independent. The surrounding prose no longer shows the bare `-e .` form either, so the message cannot teach the wrong command anywhere.

**Consequence, stated plainly:** on Windows, Pull + Build now **refuses** while the gateway runs from that venv, rather than half-working. That is the honest state of the configuration until a deeper fix exists (an out-of-process or restart-time installer, tracked in #2297) — a refusal that explains itself beats a success that breaks the next restart.

**3. Pin the whole pipe to UTF-8.** `_start_run` decodes that stream as UTF-8 (`line.decode(errors="replace")`), while a piped stdout on Windows encodes with the process locale codepage. That writer/reader mismatch is pre-existing: it mangles any non-ASCII output and can raise `UnicodeEncodeError` before the first step. `errors="replace"` additionally guarantees no print can be fatal.

Reconfiguring the runner's own stdout fixes only one of the two writers, which GPT 5.6 caught on the rebased revision and was right about again -- [disposition](https://github.com/kirodotdev/KiroCrew/pull/2445#issuecomment-5235482170). Each step is a separate process that inherits the same pipe and re-derives its encoding from the locale, and two steps are Python -- `pip install -e`, and the `build_and_stage` child -- so a non-ASCII checkout path would still be encoded with the codepage and die there, one process further down. The environment is the only channel that reaches a child, so every step is now spawned with `PYTHONIOENCODING=utf-8:replace`; non-Python steps (`git`, `npm`) ignore it and are unaffected. (Raised by GPT 5.6 on the first revision — [disposition](https://github.com/kirodotdev/KiroCrew/pull/2445#issuecomment-5234888786).)

POSIX is untouched — an executing binary can be unlinked there, which is why pip has always been able to replace it. The helper returns immediately on non-Windows.

## Tests

- `test_write_locked_console_scripts_is_a_posix_noop` — the platform gate.
- `test_write_locked_console_scripts_flags_a_locked_script` — the real failure is detected.
- `test_write_locked_console_scripts_passes_a_writable_script` — a venv the gateway is *not* running from still syncs normally.
- `test_write_locked_console_scripts_ignores_unrelated_executables` — an unrelated locked exe in the same `Scripts/` must not block the sync; that would turn any other process into a silent refusal.
- `test_write_locked_console_scripts_lets_pip_judge_other_errors` — a non-lock `OSError` is not evidence of a lock; refusing on any error would block syncs that would have worked.
- `test_sync_refuses_entirely_when_a_console_script_is_locked` — **no run is started at all**, asserted via `_start_run` never being called, so fetch/merge provably did not happen; and the message names both blocker and remedy.
- `test_sync_runs_every_step_when_nothing_is_locked` — control: the full step list including `pip install`.
- `test_sync_runner_pins_utf8_stdout_before_its_first_print` — ordering asserted, not just presence.
- `test_utf8_reconfigure_survives_a_legacy_codepage_pipe` — runs the mechanism in a real subprocess with `PYTHONIOENCODING=cp1252`, asserting exit 0 and a clean UTF-8 round-trip, so the test proves the fix rather than only proving the line exists.

The step assertions parse the generated script's **structured step list** rather than substring-matching its text. Worth calling out: an early draft asserted `'"pip install"' not in script`, which is vacuous — the steps are embedded double-JSON-encoded, so a label reads as `\"pip install\"` and the quoted check passes whether or not the step is present. The parsed form fails if the gate is removed.

## Manual verification

Local gates: `isort` clean, `flake8` clean, `mypy` reports **0 errors in the changed file**.

`test_dev_fleet_app.py` on this branch: **39 failed, 260 passed, 6 skipped**. Clean `origin/main` in the same worktree: **39 failed, 251 passed, 6 skipped** — the identical 39 pre-existing failures (Windows-host `make_live` / service-pointer / module-entry tests), plus the 9 new tests passing. None of the new test names appear in the failure list. (`mypy` run locally on Windows also reports 157 pre-existing errors across 34 untouched files for POSIX-only stubs — `fcntl`, `resource`, `os.fork`; CI's `backend-lint` runs on `ubuntu-latest`, where those resolve.)

## Screenshots

N/A — no user-visible UI change; this is one backend module and its test.
