### PR TITLE
fix: include artifact library and uploads in snapshot/restore

### DIFF
--- a/src/kiro_crew/portability.py
+++ b/src/kiro_crew/portability.py
@@ -308,7 +308,15 @@ def apply_import_zip(zip_path: Path, mode: str = "merge") -> dict:
             auto_dir = snap / "skills" / "auto"
             if auto_dir.is_dir():
                 shutil.rmtree(str(auto_dir))
-            _do_replace(snap, mc, None)
+            # Artifacts and uploads are CLI-restore-only: a dashboard import
+            # zip must not write into the artifact library or uploads store,
+            # so pass the explicit pre-existing component surface instead of
+            # None (= everything).
+            _do_replace(
+                snap,
+                mc,
+                ["memory", "crons", "config", "notifications", "security", "workspace", "skills"],
+            )
             summary["items"].append("full replace")
         else:
             # Merge mode

--- a/src/kiro_crew/snapshot.py
+++ b/src/kiro_crew/snapshot.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import hashlib
 import json
 import os
 import re
 import shutil
 import socket
+import stat as _stat
 import tarfile
 import tempfile
 from datetime import datetime, timezone
@@ -26,7 +28,17 @@ try:
 except Exception:  # pragma: no cover - optional during early/standalone import
     _DASHBOARD_PORT = int(os.environ.get("KIROCREW_PORT", 5476))
 
-VALID_COMPONENTS = ("memory", "crons", "config", "skills", "workspace", "notifications", "security")
+VALID_COMPONENTS = (
+    "memory",
+    "crons",
+    "config",
+    "skills",
+    "workspace",
+    "notifications",
+    "security",
+    "artifacts",
+    "uploads",
+)
 
 # Files that must always have 0o600 permissions in snapshots and on restore.
 SECURITY_SENSITIVE_FILES: frozenset = frozenset({"sel_hmac.key", "telemetry_salt"})
@@ -139,6 +151,13 @@ def _audit(event_type: str, resources: str) -> None:
         logging.getLogger(__name__).warning("SEL audit event '%s' failed: %s", event_type, e)
 
 
+def _refusal_reason(e: BaseException) -> str:
+    """Audit tag for a refusal at the snapshot/restore CLI boundary:
+    RuntimeError = a deliberate safety refusal (hardlinked user file);
+    OSError = a filesystem failure (unreadable source, full destination)."""
+    return "hardlink_refused" if isinstance(e, RuntimeError) else "io_error"
+
+
 CORE_FILES: dict[str, tuple[str, ...]] = {
     "memory": ("memory.db", "memory_index.db"),
     "crons": ("crons.json",),
@@ -155,6 +174,8 @@ COMPONENT_HELP = {
     "workspace": "workspace/, plan_memory/ directories",
     "notifications": "notifications.jsonl (notification history)",
     "security": "telemetry_salt (sel_hmac.key excluded — regenerated on restore)",
+    "artifacts": "artifacts/ directory (versioned artifact library; additive-only on restore — existing slugs are never overwritten)",
+    "uploads": "uploads/ directory (user-uploaded files; additive-only on restore — existing filenames are never overwritten)",
 }
 
 
@@ -186,17 +207,136 @@ def _list_components() -> None:
     print("\nCombine with commas: --components memory,crons,skills")
 
 
-def _copytree_safe(src: Path, dst: Path, **kwargs) -> None:
-    """copytree that skips symlinks to prevent sensitive file leakage."""
+def _pinned_copy_file(s: str, d: str, *, on_hardlink: str = "abort") -> None:
+    """Copy one file's bytes from a descriptor pinned to a validated inode.
+
+    The staging walks copy user-writable trees, so the copy itself must not
+    trust the path name: the listing-time link/hardlink screen checks an
+    entry by name, and a ``shutil.copy2`` that then reopens the same NAME
+    dereferences whatever the entry points at NOW — an agent that swaps a
+    checked artifact or upload for a hardlink/symlink to a credential (e.g.
+    ``~/.aws/credentials``) between the check and the copy gets the
+    credential bytes staged as innocent-looking regular content that the tar
+    pass's hardlink rejection (``_data_filter``) never sees. Open first, then
+    validate the DESCRIPTOR: ``O_NOFOLLOW`` where the platform has it, then
+    ``fstat`` the open fd — the inode that is validated is exactly the inode
+    whose bytes are copied, so no check-to-use window remains. Mode and
+    timestamps are applied from the same ``fstat`` result rather than a
+    fresh by-name stat.
+
+    This is the same invariant as ``_pinned_copy_file`` in the sessions
+    snapshot path (PR: include agent session transcripts in snapshots) —
+    keep the two implementations aligned so the PRs merge-compose cleanly.
+
+    A symlink swapped in after the listing screen surfaces as ``ELOOP`` and
+    is skipped with a warning (the screen would have skipped it the same
+    way). A hardlinked or non-regular source follows ``on_hardlink``:
+    ``"abort"`` raises the module's standard refusal (snapshot creation of
+    user trees must not silently omit data), ``"skip"`` drops it with a
+    warning. ``FileNotFoundError`` propagates for the callers' vanish
+    tolerance; every other ``OSError`` propagates so real failures abort.
+    """
+    # O_NONBLOCK: an O_RDONLY open on a FIFO planted in the tree would block
+    # until a writer appears; nonblocking open succeeds immediately and the
+    # fstat below then refuses the non-regular file. Regular-file reads are
+    # unaffected by the flag.
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_BINARY", 0)
+    )
+    try:
+        fd = os.open(s, flags)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            print(f"⚠️  Skipping symlink in source tree: {s}")
+            return
+        raise
+    try:
+        st = os.fstat(fd)
+        if not _stat.S_ISREG(st.st_mode) or st.st_nlink > 1:
+            if on_hardlink == "abort":
+                raise RuntimeError(
+                    f"Refusing snapshot: {s} is hardlinked (link count > 1) "
+                    "or not a regular file. Copying would either silently "
+                    "omit it or bypass the tar hardlink rejection. Replace "
+                    "the hardlink with a regular copy and retry."
+                )
+            print(f"⚠️  Skipping hardlinked or non-regular file during snapshot copy: {s}")
+            return
+        with os.fdopen(fd, "rb") as fsrc:
+            fd = -1  # ownership passed to the file object
+            with open(d, "wb") as fdst:
+                shutil.copyfileobj(fsrc, fdst)
+        os.chmod(d, _stat.S_IMODE(st.st_mode))
+        os.utime(d, ns=(st.st_atime_ns, st.st_mtime_ns))
+    finally:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _copytree_safe(src: Path, dst: Path, *, on_hardlink: str = "skip", **kwargs) -> None:
+    """copytree that skips symlinks, junctions AND hardlinked files.
+
+    Links are skipped to prevent sensitive-file leakage. Hardlinks need the
+    same treatment at COPY time: ``shutil`` dereferences them into ordinary
+    files, so the tar pass's hardlink rejection (``_data_filter``) never sees
+    a link to reject — a hardlink to a credential would otherwise enter the
+    snapshot as innocent-looking regular bytes.
+
+    ``on_hardlink="abort"`` raises instead of skipping: snapshot CREATION of
+    user trees must not report success while silently omitting a legitimate
+    hardlinked file — the user discovers the loss only when a restore
+    permanently lacks it. Skip remains the default for the paths where a
+    hardlink is impossible (post-tar-filter snapshot content) or already
+    pre-screened (``_refuse_hardlinked_files``).
+    """
     outer_ignore = kwargs.pop("ignore", None)
 
+    def _entry_unsafe(directory: str, name: str) -> bool:
+        full = os.path.join(directory, name)
+        if platform_compat.is_link_or_junction(full):
+            return True
+        try:
+            st = os.lstat(full)
+        except OSError:
+            return True  # unstatable: cannot vouch for it, skip
+        if _stat.S_ISREG(st.st_mode) and st.st_nlink > 1:
+            if on_hardlink == "abort":
+                raise RuntimeError(
+                    f"Refusing snapshot: {full} is hardlinked (link count > 1). "
+                    "Copying would either silently omit it or bypass the tar "
+                    "hardlink rejection. Replace the hardlink with a regular "
+                    "copy and retry."
+                )
+            return True
+        return False
+
     def _ignore_symlinks(directory, contents):
-        skipped = {name for name in contents if os.path.islink(os.path.join(directory, name))}
+        skipped = {name for name in contents if _entry_unsafe(directory, name)}
         for name in skipped:
             print(f"⚠️  Skipping symlink in source tree: {os.path.join(directory, name)}")
         if outer_ignore:
             skipped |= set(outer_ignore(directory, contents))
         return skipped
+
+    if on_hardlink == "abort":
+        # Staging of user-writable trees: the ignore-callback screen above
+        # checks entries by NAME, so it alone leaves a check-to-use window.
+        # Copy every file through the descriptor-pinned gate so the inode
+        # that was screened is the inode whose bytes ride the snapshot.
+
+        def _pinned(s, d):
+            _pinned_copy_file(s, d, on_hardlink=on_hardlink)
+
+        shutil.copytree(
+            str(src), str(dst), ignore=_ignore_symlinks, copy_function=_pinned, **kwargs
+        )
+        return
 
     shutil.copytree(str(src), str(dst), ignore=_ignore_symlinks, **kwargs)
 
@@ -211,6 +351,705 @@ def _copy_tree_no_overwrite(src: Path, dst: Path) -> None:
         elif item.is_file() and not target.exists():
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(str(item), str(target))
+
+
+_GUARDED_DIR_FD_OK = (
+    os.open in os.supports_dir_fd
+    and os.mkdir in os.supports_dir_fd
+    and os.unlink in os.supports_dir_fd
+)
+
+
+def _copy_tree_no_overwrite_guarded(src: Path, dst: Path) -> None:
+    """Additive copy that additionally never writes through a linked target.
+
+    ``_copy_tree_no_overwrite`` guards the SOURCE against symlinks but trusts
+    the destination. Restoring user files cannot: a symlink or junction at
+    any destination component would redirect restored files outside the data
+    home. Validating the destination path by name and then re-traversing it
+    by name for the write leaves a check-to-use window — an agent that swaps
+    a destination ancestor (``uploads/`` itself, or any subdirectory) for a
+    link between the check and the ``os.open`` gets the restored bytes
+    written through the replaced component. So where the platform supports
+    ``dir_fd``, every destination component is opened ``O_NOFOLLOW`` relative
+    to its PARENT's descriptor and files are created exclusively via
+    ``dir_fd``: the directory that was validated is exactly the directory
+    written into, with no by-name re-traversal. Platforms without ``dir_fd``
+    (Windows) fall back to the by-name link screen in
+    ``_copy_tree_no_overwrite_guarded_by_name``.
+    """
+    if not _GUARDED_DIR_FD_OK:  # pragma: no cover - Windows fallback
+        _copy_tree_no_overwrite_guarded_by_name(src, dst)
+        return
+
+    o_dir = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+
+    def _open_dir_pinned(parent_fd: int, name: str, rel: Path) -> int | None:
+        """Open (creating if absent) directory ``name`` relative to
+        ``parent_fd``. ``None`` = skip the subtree: a link swapped in at this
+        component (ELOOP) or a local FILE squatting on the name (ENOTDIR) —
+        the local side owns the name, restore stays additive."""
+        for _attempt in range(2):
+            try:
+                return os.open(name, o_dir, dir_fd=parent_fd)
+            except FileNotFoundError:
+                try:
+                    # 0o700: the restored directory is the effective
+                    # permission boundary (the tar data filter normalizes
+                    # file modes), matching ``_make_restore_dir_owner_only``.
+                    os.mkdir(name, 0o700, dir_fd=parent_fd)
+                except FileExistsError:
+                    pass  # raced with another writer: retry the open
+                continue
+            except OSError as exc:
+                if exc.errno == errno.ELOOP:
+                    print(f"  ⚠️  skipping {rel} (linked restore destination)")
+                    return None
+                if exc.errno == errno.ENOTDIR:
+                    break
+                raise
+        print(f"  ⚠️  skipping {rel} (path type conflict)")
+        return None
+
+    try:
+        root_fd = os.open(str(dst), o_dir)
+    except OSError as exc:
+        if exc.errno in (errno.ELOOP, errno.ENOTDIR, errno.ENOENT):
+            print(f"  ⚠️  skipping restore into {dst} (linked restore destination)")
+            return
+        raise
+    try:
+        for item in sorted(src.rglob("*")):
+            if item.is_symlink():
+                continue
+            rel = item.relative_to(src)
+            parts = rel.parts
+            fds: list[int] = []
+            try:
+                parent_fd = root_fd
+                skip = False
+                for depth, comp in enumerate(parts[:-1]):
+                    fd = _open_dir_pinned(parent_fd, comp, Path(*parts[: depth + 1]))
+                    if fd is None:
+                        skip = True
+                        break
+                    fds.append(fd)
+                    parent_fd = fd
+                if skip:
+                    continue
+                if item.is_dir():
+                    fd = _open_dir_pinned(parent_fd, parts[-1], rel)
+                    if fd is not None:
+                        os.close(fd)
+                    continue
+                if not item.is_file():
+                    continue
+                # Exclusive create closes the exists()-then-copy race: any
+                # entry already at the name (a concurrently restored file, a
+                # dangling symlink planted at the incoming filename) raises
+                # FileExistsError — someone else owns it, restore is
+                # additive. O_BINARY (Windows CRT) keeps the descriptor
+                # byte-exact: without it a text-mode fd expands 0x0A to
+                # 0x0D 0x0A, corrupting every restored binary upload
+                # (mirrors ``_read_meta_bounded``).
+                try:
+                    fdesc = os.open(
+                        parts[-1],
+                        os.O_CREAT
+                        | os.O_EXCL
+                        | os.O_WRONLY
+                        | getattr(os, "O_NOFOLLOW", 0)
+                        | getattr(os, "O_BINARY", 0),
+                        0o600,
+                        dir_fd=parent_fd,
+                    )
+                except FileExistsError:
+                    continue
+                try:
+                    # Copy and apply metadata THROUGH the exclusively created
+                    # descriptor — a by-name copystat here would reopen the
+                    # very window the pinned traversal just closed.
+                    with open(item, "rb") as src_f, os.fdopen(fdesc, "wb") as dst_f:
+                        shutil.copyfileobj(src_f, dst_f)
+                        st = os.stat(item)
+                        os.fchmod(dst_f.fileno(), _stat.S_IMODE(st.st_mode))
+                        os.utime(dst_f.fileno(), ns=(st.st_atime_ns, st.st_mtime_ns))
+                except BaseException:
+                    try:
+                        os.unlink(parts[-1], dir_fd=parent_fd)
+                    except OSError:
+                        pass
+                    raise
+            finally:
+                for fd in fds:
+                    os.close(fd)
+    finally:
+        os.close(root_fd)
+
+
+def _copy_tree_no_overwrite_guarded_by_name(src: Path, dst: Path) -> None:
+    """By-name fallback for platforms without ``dir_fd`` (Windows).
+
+    Screens every destination component for links/junctions before writing
+    and creates files exclusively. Unlike the pinned variant this leaves a
+    check-to-use window between the screen and the write; junction detection
+    lives in ``platform_compat``.
+    """
+
+    def _path_is_linked(p: Path) -> bool:
+        while True:
+            if platform_compat.is_link_or_junction(p):
+                return True
+            if p == dst:
+                return False
+            parent = p.parent
+            if parent == p:  # filesystem root — out of scope, refuse
+                return True
+            p = parent
+
+    for item in sorted(src.rglob("*")):
+        if item.is_symlink():
+            continue
+        target = dst / item.relative_to(src)
+        if _path_is_linked(target):
+            print(f"  ⚠️  skipping {item.relative_to(src)} (linked restore destination)")
+            continue
+        if item.is_dir():
+            try:
+                target.mkdir(parents=True, exist_ok=True)
+            except (FileExistsError, NotADirectoryError):
+                # A FILE already occupies this directory path locally: the
+                # local side owns the name — skip the subtree additively
+                # instead of aborting a restore that already changed earlier
+                # components.
+                print(f"  ⚠️  skipping {item.relative_to(src)} (path type conflict)")
+                continue
+        elif item.is_file():
+            try:
+                target.parent.mkdir(parents=True, exist_ok=True)
+            except (FileExistsError, NotADirectoryError):
+                print(f"  ⚠️  skipping {item.relative_to(src)} (path type conflict)")
+                continue
+            try:
+                fdesc = os.open(
+                    str(target),
+                    os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_BINARY", 0),
+                )
+            except FileExistsError:
+                continue
+            try:
+                with open(item, "rb") as src_f, os.fdopen(fdesc, "wb") as dst_f:
+                    shutil.copyfileobj(src_f, dst_f)
+                shutil.copystat(str(item), str(target))
+            except BaseException:
+                target.unlink(missing_ok=True)
+                raise
+
+
+_META_MAX_BYTES = 1 << 20  # generous cap; a real meta.json is a few KB
+_FOLDERS_MAX_BYTES = 1 << 20  # generous cap; a real artifact_folders.json is a few KB
+_FOLDERS_MAX_RECORDS = 10_000  # far beyond any real folder tree
+
+
+def _read_meta_bounded(slug_dir: Path) -> bytes | None:
+    """Descriptor-pinned, bounded read of a slug's ``meta.json``.
+
+    A bare ``read_bytes()`` follows a symlink planted at ``meta.json`` — a
+    link to an endless source (a device node, a FIFO) turns the stability
+    probe into an unbounded read that hangs or OOMs the snapshot. Open with
+    ``O_NOFOLLOW`` (plus a link pre-check for platforms where the flag
+    degrades to 0), verify ON THE OPENED DESCRIPTOR (``fstat``) that the
+    target is a regular, non-hardlinked file within the size cap, and read
+    through that same descriptor so the verified inode is the one whose
+    bytes are returned. ``None`` for a link, non-regular, or oversized
+    meta.json, and for one that DISAPPEARED (slug mid-create/mid-delete) —
+    the slug's stability check then fails and the slug is skipped; the raw
+    bytes are never read. Any other read failure (EACCES, EIO, ...)
+    propagates so snapshot creation fails instead of silently omitting the
+    slug.
+    """
+    meta = slug_dir / "meta.json"
+    if platform_compat.is_link_or_junction(meta):
+        return None
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
+    try:
+        fd = os.open(str(meta), flags)
+    except OSError as exc:
+        # Only DISAPPEARANCE (slug mid-create/mid-delete) and a link swapped
+        # in after the screen keep the skip semantics. Anything else (EACCES,
+        # EIO, ...) propagates so snapshot creation FAILS: treating an
+        # unreadable meta.json as transient would silently omit the whole
+        # slug from a backup that then reports success.
+        if exc.errno in (errno.ENOENT, errno.ENOTDIR, errno.ELOOP):
+            return None
+        raise
+    try:
+        st = os.fstat(fd)
+        if not _stat.S_ISREG(st.st_mode) or st.st_nlink > 1 or st.st_size > _META_MAX_BYTES:
+            return None
+        chunks: list[bytes] = []
+        remaining = _META_MAX_BYTES + 1  # one past the cap: detects mid-read growth
+        while remaining > 0:
+            chunk = os.read(fd, min(65536, remaining))
+            if not chunk:
+                return b"".join(chunks)
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return None  # grew past the cap while being read
+    finally:
+        os.close(fd)
+
+
+def _slug_state(slug_dir: Path) -> tuple | None:
+    """Point-in-time fingerprint of a slug directory's FULL file state.
+
+    ``meta.json`` bytes alone cannot prove a copy coherent: an updater that
+    writes content/version files after (or without) touching ``meta.json``
+    produces a torn copy whose meta-only probe still passes. Fingerprint
+    every entry instead — (relpath, kind, size, mtime_ns) via ``lstat`` so
+    links fingerprint as themselves — mirroring the (size, mtime_ns)
+    stability check ``_stage_uploads_stable`` already applies per file.
+    ``*.tmp`` atomic-write staging files are excluded: they never ride the
+    copy, and a slow in-flight writer holding one open would otherwise defeat
+    the bounded retries even when the real files are stable. ``None`` when
+    the tree cannot be walked (slug vanishing mid-probe).
+    """
+    entries: list[tuple[str, str, int, int]] = []
+    try:
+        for dirpath, dirnames, filenames in os.walk(slug_dir):
+            dirnames[:] = [
+                d
+                for d in dirnames
+                if not platform_compat.is_link_or_junction(os.path.join(dirpath, d))
+            ]
+            rel_base = os.path.relpath(dirpath, str(slug_dir))
+            for d in dirnames:
+                entries.append((os.path.join(rel_base, d), "d", 0, 0))
+            for name in filenames:
+                if name.endswith(".tmp"):
+                    continue
+                try:
+                    st = os.lstat(os.path.join(dirpath, name))
+                except OSError:
+                    return None
+                entries.append(
+                    (os.path.join(rel_base, name), "f", st.st_size, st.st_mtime_ns)
+                )
+    except OSError:
+        return None
+    # A same-size rewrite can land within one mtime_ns tick on coarse-clock
+    # filesystems, making the stat fingerprint blind to it. meta.json is the
+    # store's version record and small by contract — include its BYTES so a
+    # version bump is always caught (this is exactly the sensitivity the
+    # previous meta-only probe had).
+    return (tuple(sorted(entries)), _read_meta_bounded(slug_dir))
+
+
+def _stage_artifact_slugs(src: Path, dst: Path) -> None:
+    """Stage the artifact library slug-by-slug with metadata stability checks.
+
+    A whole-tree copy racing a live ``ArtifactStore.update`` can capture a
+    slug whose ``meta.json`` and version files come from different writes. A
+    slug is the store's unit of consistency, so each is copied individually:
+    the slug's FULL file state (every entry's path, size, mtime) is
+    fingerprinted before and after the copy, and the slug is re-copied
+    (bounded retries) when they differ. If the state is still moving after the
+    retries, the slug is OMITTED from this generation and the skip is reported
+    to the operator: a retry-exhausted copy is by construction one whose
+    consistency probe failed on every attempt, and silently shipping an
+    unproven copy would be worse than deferring the slug to the next scheduled
+    snapshot. ``*.tmp`` atomic-write staging files never ride.
+    """
+    dst.mkdir(parents=True, exist_ok=True)
+    tmp_ignore = shutil.ignore_patterns("*.tmp")
+
+    for entry in sorted(src.iterdir()):
+        if platform_compat.is_link_or_junction(entry):
+            continue
+        target = dst / entry.name
+        if entry.is_file():
+            if not entry.name.endswith(".tmp"):
+                # Descriptor-pinned copy in abort mode: refuses — not
+                # silently thins out — a hardlinked user file, and closes the
+                # window between the listing screen and the copy (mirrors the
+                # workspace/skills components' contract).
+                _pinned_copy_file(str(entry), str(target), on_hardlink="abort")
+            continue
+        if not entry.is_dir():
+            continue
+        staged_ok = False
+        for _attempt in range(3):
+            if _read_meta_bounded(entry) is None:
+                # A slug with unreadable/absent metadata is either mid-create
+                # or mid-delete — it cannot be verified consistent, so it
+                # never rides this snapshot generation.
+                break
+            before = _slug_state(entry)
+            if before is None:
+                break
+            if target.exists():
+                shutil.rmtree(str(target))
+            try:
+                _copytree_safe(entry, target, on_hardlink="abort", ignore=tmp_ignore)
+            except (FileNotFoundError, NotADirectoryError):
+                # Source vanished mid-copy (live deletion): drop the partial
+                # stage copy and move on rather than aborting the snapshot.
+                # Only disappearance is tolerated — any other copy failure
+                # (EACCES, ENOSPC, ...) re-raises below so the snapshot fails
+                # loudly instead of reporting success minus an artifact.
+                break
+            if _slug_state(entry) == before:
+                staged_ok = True
+                break
+        if not staged_ok:
+            if target.exists():
+                shutil.rmtree(str(target), ignore_errors=True)
+            print(f"⚠️  artifact changing during snapshot; skipped this generation: {entry.name}")
+
+
+def _stage_uploads_stable(src: Path, dst: Path) -> None:
+    """Stage uploads/ with per-file stability checks.
+
+    The upload handler streams multipart bodies directly to their final path
+    (no atomic rename), so a snapshot racing an in-flight upload could capture
+    a truncated file that then looks valid forever. Each file's (size,
+    mtime_ns) is compared before and after its copy; on mismatch the copy is
+    retried, and a file still moving after the retries is dropped from THIS
+    snapshot generation with a warning — the next scheduled snapshot picks up
+    the completed upload.
+    """
+    dst.mkdir(parents=True, exist_ok=True)
+    # Top-down walk with explicit pruning: rglob would TRAVERSE a linked
+    # directory before any per-item check could reject it, so a nested
+    # junction's target files would already be in the iteration. os.walk with
+    # in-place dirnames filtering never descends into pruned entries.
+    for dirpath, dirnames, filenames in os.walk(src):
+        dirnames[:] = [
+            d for d in dirnames if not platform_compat.is_link_or_junction(Path(dirpath) / d)
+        ]
+        rel = Path(dirpath).relative_to(src)
+        (dst / rel).mkdir(parents=True, exist_ok=True)
+        for fname in sorted(filenames):
+            item = Path(dirpath) / fname
+            if platform_compat.is_link_or_junction(item):
+                continue
+            target = dst / rel / fname
+            stable = False
+            for _attempt in range(3):
+                try:
+                    st1 = item.stat()
+                    # Descriptor-pinned copy in abort mode: refuses — not
+                    # silently thins out — a hardlinked user file (mirroring
+                    # the workspace/skills components), and closes the window
+                    # between the link screen above and the copy.
+                    _pinned_copy_file(str(item), str(target), on_hardlink="abort")
+                    st2 = item.stat()
+                except (FileNotFoundError, NotADirectoryError):
+                    # Vanished mid-copy (e.g. rejected upload cleanup). Only
+                    # disappearance is tolerated — any other copy failure
+                    # (EACCES, ENOSPC, ...) re-raises so the snapshot fails
+                    # loudly instead of reporting success minus an upload.
+                    break
+                if (st1.st_size, st1.st_mtime_ns) == (st2.st_size, st2.st_mtime_ns):
+                    stable = True
+                    break
+            if not stable:
+                target.unlink(missing_ok=True)
+                print(f"⚠️  upload still being written; skipped this snapshot: {fname}")
+
+
+def _copy_artifacts_no_overwrite(src: Path, dst: Path) -> tuple[int, int]:
+    """Copy artifact entries from ``src`` into ``dst``, whole slug at a time.
+
+    A slug directory is the unit of consistency — its ``meta.json`` indexes the
+    version files beside it — so a slug is copied in full when absent on the
+    target and skipped entirely when it already exists. Mixing snapshot version
+    files into a live slug could desync ``meta.json`` from the versions it
+    describes, and an existing slug may hold newer work than the snapshot.
+    Returns ``(imported, skipped)`` counts.
+    """
+    imported = skipped = 0
+    for entry in sorted(src.iterdir()):
+        if entry.is_symlink():
+            continue
+        target = dst / entry.name
+        if target.exists():
+            skipped += 1
+            continue
+        # Atomically reserve ownership of the destination before copying:
+        # FileExistsError here means another writer created the entry after
+        # the exists() probe (e.g. two --force restores racing), and that
+        # entry is THEIRS — treat it as existing and never touch it. The
+        # cleanup below may only ever delete a destination this loop created.
+        if entry.is_dir():
+            try:
+                target.mkdir()
+            except FileExistsError:
+                skipped += 1
+                continue
+            try:
+                _copytree_safe(entry, target, dirs_exist_ok=True)
+            except BaseException:
+                # A partial slug copy must not survive: a later retry would
+                # see the target as existing, skip it, and strand the artifact
+                # in a half-copied state forever. BaseException so Ctrl-C /
+                # SystemExit mid-copy also cleans up. Owned by us — see above.
+                shutil.rmtree(str(target), ignore_errors=True)
+                raise
+        elif entry.is_file():
+            try:
+                fd = os.open(str(target), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            except FileExistsError:
+                skipped += 1
+                continue
+            os.close(fd)
+            try:
+                shutil.copy2(str(entry), str(target))
+            except BaseException:
+                # Same contract as the directory branch: an interrupt must not
+                # strand a zero-byte/partial file that later restores skip.
+                target.unlink(missing_ok=True)
+                raise
+        else:
+            continue
+        imported += 1
+    return imported, skipped
+
+
+def _merge_artifact_folders(src_path: Path, dst_path: Path) -> None:
+    """Merge the artifact folder tree by folder id; target records win.
+
+    Folder ids are opaque hex handles, so an id present on both sides is the
+    same folder (shared lineage) and the target's copy is kept unchanged; ids
+    only in the snapshot are appended. A ``parent_id`` whose folder was not
+    imported is tolerated: ``ArtifactFolderStore`` treats a dangling parent as
+    root, so a partial import degrades to flat folders rather than data loss.
+    Written atomically (tmp + rename), mirroring the store's own persistence.
+    """
+    try:
+        # Bounded like ``_read_meta_bounded``: a snapshot produced elsewhere
+        # can carry a pathological artifact_folders.json, and an unbounded
+        # read-plus-parse would balloon restore memory before any record
+        # validation runs. Reject past the caps instead of parsing.
+        if src_path.stat().st_size > _FOLDERS_MAX_BYTES:
+            print("  ⚠️  Snapshot artifact_folders.json exceeds size cap; skipping folder merge")
+            return
+        snap_raw = json.loads(src_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, RecursionError):
+        print("  ⚠️  Could not read snapshot artifact_folders.json; skipping folder merge")
+        return
+    if not isinstance(snap_raw, list):
+        return
+    if len(snap_raw) > _FOLDERS_MAX_RECORDS:
+        print("  ⚠️  Snapshot artifact_folders.json exceeds record cap; skipping folder merge")
+        return
+    existing: list = []
+    if dst_path.exists():
+        try:
+            raw = json.loads(dst_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, RecursionError):
+            print("  ⚠️  Could not read target artifact_folders.json; keeping target as-is")
+            return
+        if not isinstance(raw, list):
+            # Valid JSON but not the store's shape: treating it as empty would
+            # atomically replace (and so discard) the target's contents below,
+            # violating target-wins. Fail closed like the unreadable case.
+            print("  ⚠️  Target artifact_folders.json is not a list; keeping target as-is")
+            return
+        existing = raw
+    have = {
+        f["id"]
+        for f in existing
+        if isinstance(f, dict) and isinstance(f.get("id"), str) and f["id"]
+    }
+    added = 0
+    for rec in snap_raw:
+        # Records are sanitized to the store's exact shape, never appended
+        # verbatim: a snapshot produced elsewhere can carry malformed fields
+        # (an unhashable id crashes the set lookup here; a non-numeric
+        # ``order`` persists and then crashes the folder listing's int()
+        # coercion server-side). Only validated ids merge; every other field
+        # is coerced or defaulted to a value the store is known to handle.
+        if not (isinstance(rec, dict) and isinstance(rec.get("id"), str) and rec["id"]):
+            continue
+        if rec["id"] in have:
+            continue
+        clean: dict = {
+            "id": rec["id"],
+            "name": str(rec.get("name") or "")[:100],
+            "order": rec["order"] if isinstance(rec.get("order"), int) else len(existing),
+            "parent_id": rec["parent_id"] if isinstance(rec.get("parent_id"), str) else "",
+        }
+        if isinstance(rec.get("icon"), str):
+            clean["icon"] = rec["icon"]
+        if isinstance(rec.get("color"), str):
+            clean["color"] = rec["color"]
+        existing.append(clean)
+        have.add(clean["id"])
+        added += 1
+    if added:
+        try:
+            payload = json.dumps(existing, indent=2, sort_keys=True).encode()
+        except (RecursionError, ValueError):
+            # A snapshot record that survived id-validation can still be a
+            # deeply nested structure json can't serialize without blowing
+            # the stack — skip the merge rather than abort the restore.
+            print("  ⚠️  Could not serialize merged artifact_folders.json; skipping folder merge")
+            return
+        fd, tmp = tempfile.mkstemp(dir=str(dst_path.parent), suffix=".tmp")
+        try:
+            try:
+                # os.write may write fewer bytes than given (e.g. a nearly
+                # full filesystem) — a single unchecked call could atomically
+                # replace valid folder metadata with truncated JSON. Loop
+                # until every byte lands; a zero-byte write is an error.
+                view = memoryview(payload)
+                while view:
+                    written = os.write(fd, view)
+                    if written <= 0:
+                        raise OSError("short write while persisting artifact_folders.json")
+                    view = view[written:]
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+            os.replace(tmp, str(dst_path))
+        except OSError:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    print(f"  Artifact folders imported: {added}")
+
+
+def _make_restore_dir_owner_only(dd: Path) -> bool:
+    """Create *dd* owner-only for a restore; True when the lockdown held.
+
+    ``platform_compat.make_owner_only_dir`` is deliberately best-effort (it
+    warns and continues), which is the wrong contract here: restored artifacts
+    and uploads are private user content, so if the directory cannot be locked
+    down the restore of that component must not proceed under inherited
+    readable permissions. The link check runs FIRST — the lockdown helper
+    follows links, so calling it on a linked root would chmod/re-DACL an
+    unrelated directory before the refusal. POSIX verifies the resulting
+    mode; Windows re-runs the fail-loud DACL restriction directly.
+    """
+    if platform_compat.is_link_or_junction(dd):
+        # A linked local destination root would both redirect restored files
+        # outside the data home AND get its TARGET's permissions rewritten by
+        # the lockdown below. Refuse before touching anything.
+        return False
+    try:
+        # A REGULAR FILE squatting on the component name would make the
+        # mkdir inside the lockdown helper raise and abort the whole restore
+        # mid-way; treat it as a refusal for this component instead.
+        platform_compat.make_owner_only_dir(dd)
+        if not dd.is_dir():
+            return False
+        if platform_compat.IS_WINDOWS:
+            platform_compat.restrict_to_owner(dd)
+        elif dd.stat().st_mode & 0o077:
+            return False
+    except (OSError, FileExistsError):
+        return False
+    return True
+
+
+def _acquire_gateway_lock(mc: Path) -> int | None:
+    """Acquire and HOLD the exclusive ``gateway.lock`` flock; fd or ``None``.
+
+    Port-probing ``_is_gateway_running`` misses a gateway serving on a
+    non-default port (``dashboard.url``); the lock file is port-independent —
+    the gateway holds an exclusive flock on it for its whole lifetime. A
+    probe-then-release check is not enough: a gateway starting AFTER the
+    probe loads the pre-merge folder list and its next mutation rewrites the
+    file wholesale, silently erasing the merged records. So the lock is
+    ACQUIRED here (non-blocking) and held by the caller across the merge —
+    while held, no gateway can start. ``None`` means the lock is held
+    elsewhere or unusable: positive evidence the merge must be skipped. The
+    caller must ``os.close()`` the returned fd, which releases the lock.
+    """
+    lock_path = mc / "gateway.lock"
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(str(lock_path), flags, 0o600)
+    except OSError:
+        # Fail closed: a lock file that cannot be opened gives no evidence
+        # the gateway is absent — merging anyway would let a live gateway's
+        # next folder save erase the merged records.
+        return None
+    try:
+        if platform_compat.try_acquire_lock(fd, exclusive=True):
+            return fd
+    except OSError:
+        pass
+    os.close(fd)
+    return None
+
+
+def _restore_artifacts(snap: Path, mc: Path) -> None:
+    """Restore the artifact library; never overwrites an existing slug.
+
+    Used by both replace and merge modes: the artifact library is versioned
+    user work keyed by slug, so restore is additive-only in either mode — a
+    slug already on the target wins over the snapshot copy unconditionally.
+    The folder tree (``artifact_folders.json``) is merged by folder id so
+    restored artifacts keep resolving their ``folder_id`` references.
+    """
+    sd = snap / "artifacts"
+    if sd.is_dir():
+        dd = mc / "artifacts"
+        # Owner-only, fail closed: restored artifacts are user content and
+        # must not be copied into a group/world-traversable directory.
+        if not _make_restore_dir_owner_only(dd):
+            print("  ⚠️  artifacts not restored (could not restrict artifacts/ to owner-only)")
+            return
+        imported, skipped = _copy_artifacts_no_overwrite(sd, dd)
+        print(f"  Artifacts imported: {imported} (skipped {skipped} existing)")
+    sf = snap / "artifact_folders.json"
+    if sf.is_file():
+        # The gateway's folder store keeps the WHOLE folder list in memory
+        # and rewrites the file wholesale on its next mutation — unlike
+        # per-slug artifact files, an on-disk merge under a live gateway is
+        # guaranteed to be silently erased by that next save. This applies
+        # even under --force. Ownership is decided by the port-independent,
+        # data-home-scoped ``gateway.lock`` flock alone: a port probe would
+        # conflate an UNRELATED listener on the default port (another data
+        # home's gateway, any other process) with a gateway owning THIS home,
+        # skipping the merge for no reason. The flock is acquired and HELD
+        # across the merge, so a gateway starting mid-merge cannot slip past.
+        lock_fd = _acquire_gateway_lock(mc)
+        if lock_fd is None:
+            print(
+                "  ⚠️  artifact folder tree not merged (gateway running; "
+                "rerun with the gateway stopped to import folders)"
+            )
+        else:
+            try:
+                _merge_artifact_folders(sf, mc / "artifact_folders.json")
+            finally:
+                os.close(lock_fd)
+    print("  ✅ artifacts")
+
+
+def _restore_uploads(snap: Path, mc: Path) -> None:
+    """Restore user uploads; never overwrites an existing filename.
+
+    Used by both replace and merge modes: uploads are referenced by transcripts
+    on the target host, so restore is additive-only in either mode — an
+    existing filename wins over the snapshot copy unconditionally.
+    """
+    sd = snap / "uploads"
+    if sd.is_dir():
+        dd = mc / "uploads"
+        # Owner-only, fail closed: the tar data filter normalizes file modes
+        # on extraction, so the directory is the effective permission boundary
+        # for a restored private upload.
+        if not _make_restore_dir_owner_only(dd):
+            print("  ⚠️  uploads not restored (could not restrict uploads/ to owner-only)")
+            return
+        _copy_tree_no_overwrite_guarded(sd, dd)
+    print("  ✅ uploads")
 
 
 # ── Snapshot ──────────────────────────────────────────────────────────────────
@@ -277,7 +1116,7 @@ def snapshot_main(
 
     with tempfile.TemporaryDirectory() as work:
         stage = Path(work) / name
-        for d in ("workspace", "skills", "plan_memory"):
+        for d in ("workspace", "skills", "plan_memory", "artifacts", "uploads"):
             (stage / d).mkdir(parents=True, exist_ok=True)
 
         # Core files
@@ -299,27 +1138,87 @@ def snapshot_main(
                     else:
                         shutil.copy2(str(src), str(stage / f))
 
-        # Workspace (exclude hygiene_data, insert_facts*.py)
-        if (mc / "workspace").is_dir():
-            _copytree_safe(
-                mc / "workspace",
-                stage / "workspace",
-                dirs_exist_ok=True,
-                ignore=shutil.ignore_patterns("hygiene_data", "insert_facts*.py"),
-            )
+        # Workspace (exclude hygiene_data, insert_facts*.py), plan memory and
+        # skills: abort — not silently thin out — the snapshot on a hardlinked
+        # user file. TemporaryDirectory cleans up the partial stage.
+        try:
+            if (mc / "workspace").is_dir():
+                _copytree_safe(
+                    mc / "workspace",
+                    stage / "workspace",
+                    on_hardlink="abort",
+                    dirs_exist_ok=True,
+                    ignore=shutil.ignore_patterns("hygiene_data", "insert_facts*.py"),
+                )
+            if (mc / "plan_memory").is_dir():
+                _copytree_safe(
+                    mc / "plan_memory",
+                    stage / "plan_memory",
+                    on_hardlink="abort",
+                    dirs_exist_ok=True,
+                )
+            if (mc / "skills").is_dir():
+                _copytree_safe(
+                    mc / "skills", stage / "skills", on_hardlink="abort", dirs_exist_ok=True
+                )
+        except (RuntimeError, OSError) as e:
+            # OSError: staging hit a filesystem failure (unreadable source,
+            # full destination) — report it like any other refusal instead
+            # of letting a traceback escape the CLI.
+            print(f"❌ {e}")
+            _audit("snapshot_rejected", f"reason={_refusal_reason(e)}")
+            return 1
 
-        # Plan memory
-        if (mc / "plan_memory").is_dir():
-            _copytree_safe(mc / "plan_memory", stage / "plan_memory", dirs_exist_ok=True)
+        # Artifacts (versioned artifact library, one directory per slug), plus
+        # the folder-tree metadata that artifact ``folder_id`` fields point at —
+        # without it a restored library loses its folder organization.
+        # Linked component roots are refused outright (a symlinked/junctioned
+        # artifacts/ or uploads/ would re-target the walk to an arbitrary
+        # tree, e.g. a credentials directory). ``*.tmp`` is the store's
+        # atomic-write staging suffix (tmp + rename in ``_write_text``):
+        # excluding it means a snapshot taken mid-write can never capture a
+        # torn temp file, only the previous complete rename.
+        art_root = mc / "artifacts"
+        up_root = mc / "uploads"
+        try:
+            if art_root.is_dir():
+                if platform_compat.is_link_or_junction(art_root):
+                    print("⚠️  artifacts not snapshotted (artifacts/ is a link or junction)")
+                else:
+                    _stage_artifact_slugs(art_root, stage / "artifacts")
+            folders_src = mc / "artifact_folders.json"
+            if folders_src.is_file() and not os.path.islink(folders_src):
+                # Abort — never silently omit — on a hardlinked folder file:
+                # a fresh restore would otherwise lose the library's folder
+                # organization with no signal at snapshot time. The copy goes
+                # through the descriptor-pinned gate so the inode that is
+                # checked is the inode staged.
+                _pinned_copy_file(
+                    str(folders_src),
+                    str(stage / "artifact_folders.json"),
+                    on_hardlink="abort",
+                )
 
-        # Skills
-        if (mc / "skills").is_dir():
-            _copytree_safe(mc / "skills", stage / "skills", dirs_exist_ok=True)
+            # Uploads (user files referenced by chat transcripts)
+            if up_root.is_dir():
+                if platform_compat.is_link_or_junction(up_root):
+                    print("⚠️  uploads not snapshotted (uploads/ is a link or junction)")
+                else:
+                    _stage_uploads_stable(up_root, stage / "uploads")
+        except (RuntimeError, OSError) as e:
+            # OSError: staging hit a filesystem failure (unreadable source,
+            # full destination) — report it like any other refusal instead
+            # of letting a traceback escape the CLI.
+            print(f"❌ {e}")
+            _audit("snapshot_rejected", f"reason={_refusal_reason(e)}")
+            return 1
 
         # Manifest
         ws_files = sum(1 for _ in (stage / "workspace").rglob("*") if _.is_file())
         pm_files = sum(1 for _ in (stage / "plan_memory").rglob("*") if _.is_file())
         sk_count = sum(1 for _ in (stage / "skills").iterdir() if _.is_dir())
+        art_count = sum(1 for _ in (stage / "artifacts").iterdir() if _.is_dir())
+        up_files = sum(1 for _ in (stage / "uploads").rglob("*") if _.is_file())
         manifest = {
             "version": 2,
             "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -335,6 +1234,8 @@ def snapshot_main(
                 "workspace_files": ws_files,
                 "plan_memory_files": pm_files,
                 "skill_count": sk_count,
+                "artifact_count": art_count,
+                "upload_files": up_files,
             },
         }
         (stage / "MANIFEST.json").write_text(json.dumps(manifest, indent=2))
@@ -403,6 +1304,12 @@ def _print_manifest(snap: Path) -> None:
         print(f"  Skills: {c.get('skill_count', 0)}")
         print(f"  Notifications: {c.get('notifications_jsonl', 0) // 1024} KB")
         print(f"  Plan memory files: {c.get('plan_memory_files', 0)}")
+        # Only present in snapshots created after these components were added;
+        # omit the lines (rather than printing 0) for older snapshots.
+        if "artifact_count" in c:
+            print(f"  Artifacts: {c['artifact_count']}")
+        if "upload_files" in c:
+            print(f"  Upload files: {c['upload_files']}")
     except Exception as e:
         print(f"  (Could not read manifest: {e})")
 
@@ -560,7 +1467,41 @@ def _backup_and_copy(mc: Path, backup: Path, snap: Path, component: str) -> None
                     raise
 
 
+def _refuse_hardlinked_files(mc: Path, components: list[str] | None) -> None:
+    """Abort replace-mode restore if a tree slated for wholesale replacement
+    contains a hardlinked regular file.
+
+    ``_copytree_safe`` deliberately skips hardlinks (they must never enter a
+    portable snapshot), but the pre-restore BACKUP reuses it: a hardlinked
+    file would be silently absent from the backup and then deleted by the
+    ``rmtree`` that follows — unrecoverable data loss. Refuse up front,
+    before any mutation, so the user can materialize the file first.
+    """
+    dirnames: list[str] = []
+    if _want(components, "workspace"):
+        dirnames += ["workspace", "plan_memory"]
+    if _want(components, "skills"):
+        dirnames.append("skills")
+    for dirname in dirnames:
+        d = mc / dirname
+        if not d.is_dir():
+            continue
+        for path in d.rglob("*"):
+            try:
+                st = path.lstat()
+            except OSError:
+                continue
+            if _stat.S_ISREG(st.st_mode) and st.st_nlink > 1:
+                raise RuntimeError(
+                    f"Refusing replace-mode restore: {path} is hardlinked "
+                    "(link count > 1). The pre-restore backup skips hardlinks, "
+                    "so replacing this tree would lose the file. Replace the "
+                    "hardlink with a regular copy and retry."
+                )
+
+
 def _do_replace(snap: Path, mc: Path, components: list[str] | None) -> None:
+    _refuse_hardlinked_files(mc, components)
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     backup = mc / f"pre-restore-{ts}"
     backup.mkdir(exist_ok=True)
@@ -593,6 +1534,17 @@ def _do_replace(snap: Path, mc: Path, components: list[str] | None) -> None:
                 shutil.rmtree(str(sk))
             _copytree_safe(snap_sk, sk)
         print("  ✅ skills")
+
+    # Artifacts and uploads are deliberately additive-only even in replace
+    # mode (no backup + wholesale-replace like workspace/skills): both hold
+    # user data keyed by stable names (artifact slugs, upload filenames), so an
+    # entry already on the target may be newer than the snapshot copy and is
+    # never overwritten or deleted.
+    if _want(components, "artifacts"):
+        _restore_artifacts(snap, mc)
+
+    if _want(components, "uploads"):
+        _restore_uploads(snap, mc)
 
     try:
         backup.rmdir()
@@ -675,6 +1627,12 @@ def _do_merge(snap: Path, mc: Path, components: list[str] | None) -> None:
             (mc / "skills").mkdir(parents=True, exist_ok=True)
             _copy_tree_no_overwrite(snap / "skills", mc / "skills")
         print("  ✅ skills")
+
+    if _want(components, "artifacts"):
+        _restore_artifacts(snap, mc)
+
+    if _want(components, "uploads"):
+        _restore_uploads(snap, mc)
 
     print("✅ Merge complete.")
 
@@ -775,10 +1733,21 @@ def restore_main(argv: list[str] | None = None, *, parsed: argparse.Namespace | 
             return 0
 
         mc.mkdir(parents=True, exist_ok=True)
-        if mode == "replace":
-            _do_replace(snap, mc, components)
-        else:
-            _do_merge(snap, mc, components)
+        try:
+            if mode == "replace":
+                _do_replace(snap, mc, components)
+            else:
+                _do_merge(snap, mc, components)
+        except (RuntimeError, OSError) as e:
+            # OSError: a filesystem failure mid-restore (unreadable snapshot
+            # content, full destination) — report and return failure instead
+            # of letting a traceback escape after a partial restoration.
+            print(f"❌ {e}")
+            _audit(
+                "state_restore_rejected",
+                f"reason={_refusal_reason(e)} from={snap_path.name}",
+            )
+            return 1
 
     # Integrity check
     if _want(components, "memory") and (mc / "memory.db").is_file():

--- a/test/test_portability.py
+++ b/test/test_portability.py
@@ -499,6 +499,30 @@ class TestImportReplace:
         finally:
             os.unlink(str(zip_path))
 
+    def test_import_replace_never_writes_artifacts_or_uploads(self, patched_config_dir, tmp_path):
+        """Artifacts/uploads are CLI-restore-only: a crafted import zip
+        carrying artifacts/ or uploads/ trees must not populate the target's
+        artifact library or uploads store."""
+        zip_path = self._make_export(patched_config_dir)
+        try:
+            # Inject artifact/upload payloads into the export zip.
+            import zipfile as _zf
+            with _zf.ZipFile(str(zip_path), "a") as zf:
+                root = zf.namelist()[0].split("/")[0]
+                zf.writestr(f"{root}/artifacts/evil-slug/artifact.json", "{}")
+                zf.writestr(f"{root}/uploads/evil.bin", "payload")
+
+            target = tmp_path / "target_mc"
+            target.mkdir()
+            with patch("kiro_crew.portability.config_dir", return_value=target):
+                with patch.dict(os.environ, {"KIROCREW_HOME": str(target)}):
+                    apply_import_zip(zip_path, mode="replace")
+
+            assert not (target / "artifacts").exists()
+            assert not (target / "uploads").exists()
+        finally:
+            os.unlink(str(zip_path))
+
 
 # ── Exclusion Logic Tests ──
 

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import os
+import shutil
 import sqlite3
 import tarfile
 from pathlib import Path
@@ -33,13 +35,15 @@ def _setup_fake_kirocrew(d: Path) -> None:
         "workspace/hygiene_data",
         "skills/my-skill",
         "plan_memory",
+        "artifacts/my-widget/versions",
+        "artifacts/other-widget",
+        "uploads",
     ):
         (d / sub).mkdir(parents=True, exist_ok=True)
 
     # memory.db with all tables
     conn = sqlite3.connect(str(d / "memory.db"))
-    conn.executescript(
-        """
+    conn.executescript("""
         CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
         CREATE TABLE semantic_memory (key TEXT PRIMARY KEY, value_json TEXT NOT NULL,
             confidence REAL DEFAULT 0.5, source TEXT NOT NULL, created_at TEXT NOT NULL,
@@ -71,8 +75,7 @@ def _setup_fake_kirocrew(d: Path) -> None:
             VALUES ('user', 'prefers', 'dark_mode', 'ep1', '2026-01-01');
         INSERT INTO knowledge_edges (source_key, target_key, relation, weight, created_at)
             VALUES ('user', 'dark_mode', 'prefers', 1.0, '2026-01-01');
-    """
-    )
+    """)
     conn.close()
 
     (d / "crons.json").write_text(
@@ -103,6 +106,21 @@ def _setup_fake_kirocrew(d: Path) -> None:
     (d / "workspace/hygiene_data/week1.json").write_text("big data")
     (d / "plan_memory/plan1.json").write_text("plan data")
     (d / "skills/my-skill/SKILL.md").write_text("# My Skill")
+    (d / "artifacts/my-widget/meta.json").write_text('{"slug": "my-widget", "version": 2}')
+    (d / "artifacts/my-widget/current.html").write_text("<p>v2</p>")
+    (d / "artifacts/my-widget/versions/v1.html").write_text("<p>v1</p>")
+    (d / "artifacts/other-widget/meta.json").write_text('{"slug": "other-widget", "version": 1}')
+    (d / "artifacts/other-widget/current.html").write_text("<p>other</p>")
+    (d / "artifact_folders.json").write_text(
+        json.dumps(
+            [
+                {"id": "aaaaaaaaaaaa", "name": "Reports", "order": 0, "parent_id": ""},
+                {"id": "bbbbbbbbbbbb", "name": "Drafts", "order": 1, "parent_id": "aaaaaaaaaaaa"},
+            ]
+        )
+    )
+    (d / "uploads/aaa_doc.txt").write_text("uploaded doc")
+    (d / "uploads/bbb_photo.png").write_bytes(b"\x89PNG fake image bytes")
 
 
 def _make_snapshot(src: Path, out: Path, extra_args: list[str] | None = None) -> Path:
@@ -281,6 +299,39 @@ class TestRestoreReplace:
         ]
         assert backups
         assert (backups[0] / "workspace/local_only.md").is_file()
+
+    def test_replace_refuses_hardlinked_workspace_file(self, env, monkeypatch, capsys):
+        """A hardlinked file would be skipped by the backup then rmtree'd —
+        the restore must refuse up front instead of losing it."""
+        _, _, tarball, tmp_path = env
+        existing = tmp_path / "existing_hl"
+        _setup_fake_kirocrew(existing)
+        original = existing / "workspace" / "precious.md"
+        original.write_text("irreplaceable")
+        os.link(str(original), str(existing / "workspace" / "precious-link.md"))
+        monkeypatch.setenv("KIROCREW_HOME", str(existing))
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 1
+        assert "hardlink" in capsys.readouterr().out.lower()
+        # Nothing was mutated: the file survives and no backup dir was left behind.
+        assert original.read_text() == "irreplaceable"
+        assert (existing / "workspace" / "precious-link.md").is_file()
+        assert not [d for d in existing.iterdir() if d.name.startswith("pre-restore-")]
+
+    def test_snapshot_refuses_hardlinked_workspace_file(self, tmp_path, monkeypatch, capsys):
+        """Snapshot CREATION aborts (exit 1) on a hardlinked user file instead
+        of reporting success while silently omitting it."""
+        src = tmp_path / "src_hl_create"
+        _setup_fake_kirocrew(src)
+        original = src / "workspace" / "keeper.md"
+        original.write_text("must not be silently dropped")
+        os.link(str(original), str(src / "workspace" / "keeper-link.md"))
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        out_dir = tmp_path / "out_hl_create"
+        ret = snapshot_main([str(out_dir)])
+        assert ret == 1
+        assert "hardlink" in capsys.readouterr().out.lower()
+        assert not list(out_dir.glob("*.tar.gz")) if out_dir.is_dir() else True
 
 
 class TestRestoreMerge:
@@ -476,7 +527,17 @@ class TestComponents:
         """TEST 18"""
         restore_main(["--list-components"])
         out = capsys.readouterr().out
-        for c in ("memory", "crons", "config", "skills", "workspace", "notifications", "security"):
+        for c in (
+            "memory",
+            "crons",
+            "config",
+            "skills",
+            "workspace",
+            "notifications",
+            "security",
+            "artifacts",
+            "uploads",
+        ):
             assert c in out
 
     def test_memory_only(self, env, monkeypatch):
@@ -724,7 +785,1086 @@ class TestParsedNamespace:
         assert (fresh / "memory.db").is_file()
 
 
+class TestArtifactsUploads:
+    def test_snapshot_includes_artifacts_and_uploads(self, env):
+        """Artifact slug dirs and upload files ride the snapshot; manifest counts them."""
+        _, _, tarball, tmp_path = env
+        extract = tmp_path / "extract_art"
+        extract.mkdir()
+        with tarfile.open(str(tarball)) as tar:
+            tar.extractall(extract, filter=lambda t, _d="": t)
+        snap = next(d for d in extract.iterdir() if d.name.startswith("kirocrew-snapshot-"))
+        assert (snap / "artifacts/my-widget/meta.json").is_file()
+        assert (snap / "artifacts/my-widget/current.html").is_file()
+        assert (snap / "artifacts/my-widget/versions/v1.html").is_file()
+        assert (snap / "artifacts/other-widget/current.html").is_file()
+        assert (snap / "uploads/aaa_doc.txt").is_file()
+        assert (snap / "uploads/bbb_photo.png").is_file()
+        m = json.loads((snap / "MANIFEST.json").read_text(encoding="utf-8"))
+        assert m["contents"]["artifact_count"] == 2
+        assert m["contents"]["upload_files"] == 2
+
+    def test_restore_fresh_copies_artifacts_and_uploads(self, env, monkeypatch):
+        """Replace mode onto a fresh dir restores the full artifact library and uploads."""
+        _, _, tarball, tmp_path = env
+        fresh = tmp_path / "fresh_art"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 0
+        assert (fresh / "artifacts/my-widget/versions/v1.html").is_file()
+        assert (fresh / "artifacts/other-widget/meta.json").is_file()
+        assert (fresh / "uploads/aaa_doc.txt").read_text(encoding="utf-8") == "uploaded doc"
+        assert (fresh / "uploads/bbb_photo.png").is_file()
+
+    def test_replace_skips_existing_artifact_slug(self, env, capsys, monkeypatch):
+        """An existing slug is never overwritten, even in replace mode; absent slugs import."""
+        _, _, tarball, tmp_path = env
+        dst = tmp_path / "dst_art_skip"
+        _setup_fake_kirocrew(dst)
+        (dst / "artifacts/my-widget/current.html").write_text("<p>local v3</p>")
+        shutil.rmtree(str(dst / "artifacts/other-widget"))
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 0
+        # Local slug untouched — no file-level merge into an existing slug.
+        html = (dst / "artifacts/my-widget/current.html").read_text(encoding="utf-8")
+        assert html == "<p>local v3</p>"
+        # Absent slug imported whole.
+        assert (dst / "artifacts/other-widget/current.html").is_file()
+        assert "Artifacts imported: 1 (skipped 1 existing)" in capsys.readouterr().out
+
+    def test_merge_skips_existing_upload_filename(self, env, monkeypatch):
+        """An existing upload filename wins over the snapshot copy; absent ones import."""
+        _, _, tarball, tmp_path = env
+        dst = tmp_path / "dst_up_skip"
+        _setup_fake_kirocrew(dst)
+        (dst / "uploads/aaa_doc.txt").write_text("local edit")
+        (dst / "uploads/bbb_photo.png").unlink()
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        assert ret == 0
+        assert (dst / "uploads/aaa_doc.txt").read_text(encoding="utf-8") == "local edit"
+        assert (dst / "uploads/bbb_photo.png").is_file()
+
+    def test_components_artifacts_only(self, env, monkeypatch):
+        """--components artifacts restores only the artifact library."""
+        _, _, tarball, tmp_path = env
+        fresh = tmp_path / "fresh_art_only"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        restore_main([str(tarball), "--mode", "replace", "--components", "artifacts", "--force"])
+        assert (fresh / "artifacts/my-widget/meta.json").is_file()
+        assert not (fresh / "memory.db").exists()
+        assert not (fresh / "uploads").exists()
+        assert not (fresh / "skills").exists()
+
+    def test_old_snapshot_without_artifacts_restores(self, env, monkeypatch):
+        """A snapshot created before these components existed restores unchanged."""
+        _, _, tarball, tmp_path = env
+        extract = tmp_path / "extract_old"
+        extract.mkdir()
+        with tarfile.open(str(tarball)) as tar:
+            tar.extractall(extract, filter=lambda t, _d="": t)
+        snap = next(d for d in extract.iterdir() if d.name.startswith("kirocrew-snapshot-"))
+        shutil.rmtree(str(snap / "artifacts"))
+        shutil.rmtree(str(snap / "uploads"))
+        (snap / "artifact_folders.json").unlink()
+        m = json.loads((snap / "MANIFEST.json").read_text(encoding="utf-8"))
+        del m["contents"]["artifact_count"]
+        del m["contents"]["upload_files"]
+        (snap / "MANIFEST.json").write_text(json.dumps(m))
+        old_tar = tmp_path / "old_format.tar.gz"
+        with tarfile.open(str(old_tar), "w:gz") as tar:
+            tar.add(str(snap), arcname=snap.name)
+        fresh = tmp_path / "fresh_old"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main([str(old_tar), "--mode", "replace", "--force"])
+        assert ret == 0
+        assert (fresh / "memory.db").is_file()
+        assert not (fresh / "artifacts").exists()
+        assert not (fresh / "uploads").exists()
+
+    def test_snapshot_includes_artifact_folders_file(self, env):
+        """The folder-tree metadata rides the snapshot beside the artifacts dir."""
+        _, _, tarball, tmp_path = env
+        extract = tmp_path / "extract_folders"
+        extract.mkdir()
+        with tarfile.open(str(tarball)) as tar:
+            tar.extractall(extract, filter=lambda t, _d="": t)
+        snap = next(d for d in extract.iterdir() if d.name.startswith("kirocrew-snapshot-"))
+        raw = json.loads((snap / "artifact_folders.json").read_text(encoding="utf-8"))
+        assert {f["id"] for f in raw} == {"aaaaaaaaaaaa", "bbbbbbbbbbbb"}
+
+    def test_restore_merges_artifact_folders_target_wins(self, env, capsys, monkeypatch):
+        """Folder records merge by id: target copies win, snapshot-only ids append."""
+        _, _, tarball, tmp_path = env
+        dst = tmp_path / "dst_folders"
+        _setup_fake_kirocrew(dst)
+        (dst / "artifact_folders.json").write_text(
+            json.dumps(
+                [
+                    # Same id as the snapshot's "Reports" but renamed locally.
+                    {"id": "aaaaaaaaaaaa", "name": "Renamed", "order": 0, "parent_id": ""},
+                    {"id": "cccccccccccc", "name": "Local only", "order": 2, "parent_id": ""},
+                ]
+            )
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        assert ret == 0
+        raw = json.loads((dst / "artifact_folders.json").read_text(encoding="utf-8"))
+        by_id = {f["id"]: f for f in raw}
+        # Target's record for the shared id is untouched.
+        assert by_id["aaaaaaaaaaaa"]["name"] == "Renamed"
+        # Local-only folder survives; snapshot-only folder is appended.
+        assert by_id["cccccccccccc"]["name"] == "Local only"
+        assert by_id["bbbbbbbbbbbb"]["name"] == "Drafts"
+        assert "Artifact folders imported: 1" in capsys.readouterr().out
+
+    def test_restore_folders_onto_fresh_host(self, env, monkeypatch):
+        """A fresh host gets the whole folder tree so folder_id refs resolve."""
+        _, _, tarball, tmp_path = env
+        fresh = tmp_path / "fresh_folders"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 0
+        raw = json.loads((fresh / "artifact_folders.json").read_text(encoding="utf-8"))
+        assert {f["id"] for f in raw} == {"aaaaaaaaaaaa", "bbbbbbbbbbbb"}
+
+    def test_folder_merge_fails_closed_on_non_list_target(self, env, monkeypatch):
+        """A target folders file with valid-but-non-list JSON is never replaced."""
+        _, _, tarball, tmp_path = env
+        dst = tmp_path / "dst_folders_nonlist"
+        _setup_fake_kirocrew(dst)
+        (dst / "artifact_folders.json").write_text('{"not": "a list"}')
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        assert ret == 0
+        raw = (dst / "artifact_folders.json").read_text(encoding="utf-8")
+        assert raw == '{"not": "a list"}'
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+    def test_restore_created_dirs_are_owner_only(self, env, monkeypatch):
+        """Restore-created artifacts/ and uploads/ deny traversal to other users."""
+        _, _, tarball, tmp_path = env
+        fresh = tmp_path / "fresh_modes"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 0
+        assert (fresh / "artifacts").stat().st_mode & 0o777 == 0o700
+        assert (fresh / "uploads").stat().st_mode & 0o777 == 0o700
+
+    def test_partial_slug_copy_removed_on_failure(self, tmp_path, monkeypatch):
+        """An interrupted slug copy never strands a half-copied artifact.
+
+        A stranded partial slug would be skipped as 'existing' by every later
+        retry, freezing the corruption permanently.
+        """
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_partial"
+        dst = tmp_path / "dst_partial"
+        (src / "my-widget" / "versions").mkdir(parents=True)
+        (src / "my-widget" / "meta.json").write_text("{}")
+        (src / "my-widget" / "versions" / "v1.html").write_text("<p>v1</p>")
+        dst.mkdir()
+
+        def _boom(s, d, **k):
+            # Leave a genuinely partial copy behind before failing.
+            Path(d).mkdir(exist_ok=True)
+            (Path(d) / "half.html").write_text("partial")
+            raise OSError("disk full")
+
+        monkeypatch.setattr(snapshot_mod, "_copytree_safe", _boom)
+        with pytest.raises(OSError):
+            snapshot_mod._copy_artifacts_no_overwrite(src, dst)
+        assert not (dst / "my-widget").exists()
+
+    def test_interrupted_slug_copy_removed_on_keyboard_interrupt(self, tmp_path, monkeypatch):
+        """Ctrl-C mid-slug-copy cleans the partial slug before propagating.
+
+        Cleanup gated on ``except OSError`` would let a KeyboardInterrupt
+        strand the half-copied slug, which every later additive restore then
+        skips as 'existing' — freezing the corruption permanently.
+        """
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_intr_slug"
+        dst = tmp_path / "dst_intr_slug"
+        (src / "my-widget" / "versions").mkdir(parents=True)
+        (src / "my-widget" / "meta.json").write_text("{}")
+        dst.mkdir()
+
+        def _interrupt(s, d, **k):
+            Path(d).mkdir(exist_ok=True)
+            (Path(d) / "half.html").write_text("partial")
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(snapshot_mod, "_copytree_safe", _interrupt)
+        with pytest.raises(KeyboardInterrupt):
+            snapshot_mod._copy_artifacts_no_overwrite(src, dst)
+        assert not (dst / "my-widget").exists()
+
+    def test_interrupted_file_copy_removed_on_keyboard_interrupt(self, tmp_path, monkeypatch):
+        """Ctrl-C during a top-level artifact file copy never strands the
+        zero-byte placeholder created by the exclusive open."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_intr_file"
+        dst = tmp_path / "dst_intr_file"
+        src.mkdir()
+        dst.mkdir()
+        (src / "stray.json").write_text("{}")
+
+        def _interrupt(s, d, **k):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(snapshot_mod.shutil, "copy2", _interrupt)
+        with pytest.raises(KeyboardInterrupt):
+            snapshot_mod._copy_artifacts_no_overwrite(src, dst)
+        monkeypatch.undo()
+        assert not (dst / "stray.json").exists()
+
+    def test_raced_slug_is_skipped_not_deleted(self, tmp_path, monkeypatch):
+        """A slug created by a concurrent writer after the exists() probe is
+        treated as existing — never copied over and never cleaned up."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_race"
+        dst = tmp_path / "dst_race"
+        (src / "my-widget").mkdir(parents=True)
+        (src / "my-widget" / "meta.json").write_text("{}")
+        dst.mkdir()
+        (dst / "my-widget").mkdir()
+        (dst / "my-widget" / "meta.json").write_text('{"local": "wins"}')
+
+        # Simulate the exists() probe losing the race: it reports absent while
+        # the directory is really there, so the atomic mkdir reservation is
+        # what must catch the conflict.
+        monkeypatch.setattr(Path, "exists", lambda self: False)
+        imported, skipped = snapshot_mod._copy_artifacts_no_overwrite(src, dst)
+        monkeypatch.undo()
+        assert imported == 0
+        assert skipped == 1
+        assert (dst / "my-widget" / "meta.json").read_text(encoding="utf-8") == '{"local": "wins"}'
+
+    def test_restore_skipped_when_owner_only_lockdown_fails(self, env, capsys, monkeypatch):
+        """If the destination cannot be made owner-only, nothing is copied."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        _, _, tarball, tmp_path = env
+        fresh = tmp_path / "fresh_lockdown"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        monkeypatch.setattr(
+            snapshot_mod,
+            "_make_restore_dir_owner_only",
+            lambda dd: (dd.mkdir(parents=True, exist_ok=True), False)[1],
+        )
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 0
+        out = capsys.readouterr().out
+        assert "artifacts not restored" in out
+        assert "uploads not restored" in out
+        assert not (fresh / "artifacts" / "my-widget").exists()
+        assert not (fresh / "uploads" / "aaa_doc.txt").exists()
+
+    def test_folder_merge_ignores_malformed_ids(self, env, monkeypatch):
+        """Non-string / empty folder ids never crash the restore merge."""
+        _, _, tarball, tmp_path = env
+        dst = tmp_path / "dst_bad_ids"
+        _setup_fake_kirocrew(dst)
+        (dst / "artifact_folders.json").write_text(
+            json.dumps(
+                [
+                    {"id": ["not", "hashable"], "name": "Broken"},
+                    {"id": "", "name": "Empty"},
+                    {"id": "cccccccccccc", "name": "Local only"},
+                ]
+            )
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        assert ret == 0
+        raw = json.loads((dst / "artifact_folders.json").read_text(encoding="utf-8"))
+        names = {f["name"] for f in raw}
+        # Merge completed (snapshot folders imported), malformed records kept
+        # untouched, no TypeError.
+        assert {"Broken", "Empty", "Local only", "Reports", "Drafts"} <= names
+
+    def test_oversized_folder_metadata_skipped(self, tmp_path, monkeypatch, capsys):
+        """A snapshot artifact_folders.json past the byte cap is rejected
+        before parsing; the target is left untouched."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        monkeypatch.setattr(snapshot_mod, "_FOLDERS_MAX_BYTES", 64)
+        src_f = tmp_path / "snap_folders.json"
+        dst_f = tmp_path / "live_folders.json"
+        src_f.write_text(json.dumps([{"id": "a" * 200, "name": "Bloated"}]))
+        dst_f.write_text(
+            json.dumps([{"id": "keep00000000", "name": "Local", "order": 0, "parent_id": ""}])
+        )
+        snapshot_mod._merge_artifact_folders(src_f, dst_f)
+        assert "size cap" in capsys.readouterr().out
+        raw = json.loads(dst_f.read_text(encoding="utf-8"))
+        assert [f["id"] for f in raw] == ["keep00000000"]
+
+    def test_folder_metadata_record_cap(self, tmp_path, monkeypatch, capsys):
+        """A snapshot folder list past the record cap is rejected wholesale;
+        the target is left untouched."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        monkeypatch.setattr(snapshot_mod, "_FOLDERS_MAX_RECORDS", 2)
+        src_f = tmp_path / "snap_folders_many.json"
+        dst_f = tmp_path / "live_folders_many.json"
+        src_f.write_text(
+            json.dumps(
+                [{"id": f"id{i:010d}", "name": f"F{i}", "order": i, "parent_id": ""} for i in range(3)]
+            )
+        )
+        dst_f.write_text(
+            json.dumps([{"id": "keep00000000", "name": "Local", "order": 0, "parent_id": ""}])
+        )
+        snapshot_mod._merge_artifact_folders(src_f, dst_f)
+        assert "record cap" in capsys.readouterr().out
+        raw = json.loads(dst_f.read_text(encoding="utf-8"))
+        assert [f["id"] for f in raw] == ["keep00000000"]
+
+    def test_store_tmp_files_not_staged(self, tmp_path, monkeypatch):
+        """The artifact store's atomic-write *.tmp staging files never ride."""
+        src = tmp_path / "src_tmpfiles"
+        _setup_fake_kirocrew(src)
+        (src / "artifacts" / "my-widget" / "meta.json.tmp").write_text("{torn")
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        out = tmp_path / "out_tmpfiles"
+        tarball = _make_snapshot(src, out)
+        extract = tmp_path / "extract_tmpfiles"
+        extract.mkdir()
+        with tarfile.open(str(tarball)) as tar:
+            tar.extractall(extract, filter=lambda t, _d="": t)
+        snap = next(d for d in extract.iterdir() if d.name.startswith("kirocrew-snapshot-"))
+        assert not (snap / "artifacts" / "my-widget" / "meta.json.tmp").exists()
+        assert (snap / "artifacts" / "my-widget" / "meta.json").is_file()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+    def test_linked_component_roots_not_staged(self, tmp_path, monkeypatch):
+        """Symlinked artifacts/ or uploads/ roots stage nothing."""
+        src = tmp_path / "src_linked_roots"
+        _setup_fake_kirocrew(src)
+        shutil.rmtree(str(src / "artifacts"))
+        shutil.rmtree(str(src / "uploads"))
+        outside = tmp_path / "outside_roots"
+        (outside / "secrets").mkdir(parents=True)
+        (outside / "secrets" / "id_key").write_text("credential material")
+        (src / "artifacts").symlink_to(outside)
+        (src / "uploads").symlink_to(outside)
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        out = tmp_path / "out_linked_roots"
+        tarball = _make_snapshot(src, out)
+        extract = tmp_path / "extract_linked_roots"
+        extract.mkdir()
+        with tarfile.open(str(tarball)) as tar:
+            tar.extractall(extract, filter=lambda t, _d="": t)
+        snap = next(d for d in extract.iterdir() if d.name.startswith("kirocrew-snapshot-"))
+        assert not (snap / "artifacts" / "secrets").exists()
+        assert not (snap / "uploads" / "secrets").exists()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+    def test_linked_restore_root_not_mutated(self, env, tmp_path, monkeypatch):
+        """A linked destination root is refused BEFORE any permission change."""
+        _, _, tarball, _ = env
+        dst = tmp_path / "dst_linked_restore"
+        _setup_fake_kirocrew(dst)
+        shutil.rmtree(str(dst / "uploads"))
+        outside = tmp_path / "outside_perm_target"
+        outside.mkdir()
+        outside.chmod(0o755)
+        (dst / "uploads").symlink_to(outside)
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        assert ret == 0
+        # The link's target kept its permissions AND received no files.
+        assert outside.stat().st_mode & 0o777 == 0o755
+        assert not any(outside.iterdir())
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+    def test_linked_destination_component_in_uploads_skipped(self, tmp_path, monkeypatch, env):
+        """Restore never writes through an existing linked uploads subpath."""
+        _, _, tarball, _ = env
+        dst = tmp_path / "dst_linked_subpath"
+        _setup_fake_kirocrew(dst)
+        outside = tmp_path / "outside_subpath"
+        outside.mkdir()
+        # A dangling link named exactly like an incoming upload: exists() says
+        # False, so the naive copy would write THROUGH it to the link target.
+        (dst / "uploads" / "aaa_doc.txt").unlink()
+        (dst / "uploads" / "aaa_doc.txt").symlink_to(outside / "gone.txt")
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        assert ret == 0
+        assert not (outside / "gone.txt").exists()
+
+    def test_slug_vanishing_mid_copy_skipped_not_fatal(self, tmp_path, monkeypatch):
+        """A slug deleted while being staged is dropped, not a snapshot abort."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_vanish"
+        dst = tmp_path / "dst_vanish"
+        (src / "doomed" / "versions").mkdir(parents=True)
+        (src / "doomed" / "meta.json").write_text('{"version": 1}')
+        (src / "keeper").mkdir()
+        (src / "keeper" / "meta.json").write_text('{"version": 1}')
+        dst.mkdir()
+
+        real_copy = snapshot_mod._copytree_safe
+
+        def _vanish_copy(s, d, **k):
+            if Path(s).name == "doomed":
+                shutil.rmtree(str(Path(s)))
+                raise FileNotFoundError("source vanished")
+            real_copy(s, d, **k)
+
+        monkeypatch.setattr(snapshot_mod, "_copytree_safe", _vanish_copy)
+        snapshot_mod._stage_artifact_slugs(src, dst)
+        monkeypatch.undo()
+        assert not (dst / "doomed").exists()
+        assert (dst / "keeper" / "meta.json").is_file()
+
+    def test_metaless_slug_never_staged(self, tmp_path):
+        """A slug without readable meta.json (mid-create/delete) never rides."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_metaless"
+        dst = tmp_path / "dst_metaless"
+        (src / "half-created").mkdir(parents=True)
+        (src / "half-created" / "current.html").write_text("<p>no meta yet</p>")
+        dst.mkdir()
+        snapshot_mod._stage_artifact_slugs(src, dst)
+        assert not (dst / "half-created").exists()
+
+    def test_folder_merge_proceeds_despite_unrelated_port_listener(self, env, capsys, monkeypatch):
+        """An unrelated listener on the default port must NOT block the folder
+        merge: ownership of THIS data home is decided by the mc-scoped
+        ``gateway.lock`` flock alone (a gateway owning the home holds it and
+        is covered by the flock test below)."""
+        _, _, tarball, tmp_path = env
+        fresh = tmp_path / "fresh_gateway_folders"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        monkeypatch.setenv("KIROCREW_ASSUME_GATEWAY_RUNNING", "1")
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 0
+        out = capsys.readouterr().out
+        assert "folder tree not merged" not in out
+        assert (fresh / "artifacts" / "my-widget" / "meta.json").is_file()
+        assert (fresh / "artifact_folders.json").is_file()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX flock")
+    def test_folder_merge_skipped_when_gateway_lock_held(self, env, capsys, monkeypatch):
+        """A gateway on a custom port is still detected via gateway.lock."""
+        import fcntl
+
+        _, _, tarball, tmp_path = env
+        fresh = tmp_path / "fresh_lock_folders"
+        fresh.mkdir()
+        # Simulate a live gateway on a non-default port: no port probe hit,
+        # but an exclusive flock held on gateway.lock.
+        lock_path = fresh / "gateway.lock"
+        lock_path.write_text("1")
+        holder = os.open(str(lock_path), os.O_RDWR)
+        fcntl.flock(holder, fcntl.LOCK_EX)
+        try:
+            monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+            monkeypatch.setenv("KIROCREW_ASSUME_GATEWAY_RUNNING", "0")
+            ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+            assert ret == 0
+            assert "folder tree not merged" in capsys.readouterr().out
+            assert not (fresh / "artifact_folders.json").exists()
+        finally:
+            os.close(holder)
+
+    def test_file_squatting_on_component_name_skips_component(self, env, capsys, monkeypatch):
+        """A regular FILE named uploads/ must not abort the whole restore."""
+        _, _, tarball, tmp_path = env
+        dst = tmp_path / "dst_squat"
+        _setup_fake_kirocrew(dst)
+        shutil.rmtree(str(dst / "uploads"))
+        (dst / "uploads").write_text("I am a file, not a directory")
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        assert ret == 0
+        assert "uploads not restored" in capsys.readouterr().out
+        # The squatting file survives untouched; other components restored.
+        assert (dst / "uploads").is_file()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX hardlinks")
+    def test_snapshot_refuses_hardlinked_upload(self, tmp_path, monkeypatch, capsys):
+        """Snapshot CREATION aborts (exit 1) on a hardlinked upload instead of
+        reporting success while silently omitting it — mirroring the
+        workspace/skills components."""
+        src = tmp_path / "src_hl_upload"
+        _setup_fake_kirocrew(src)
+        original = src / "uploads" / "aaa_doc.txt"
+        os.link(str(original), str(src / "uploads" / "doc-link.txt"))
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        out_dir = tmp_path / "out_hl_upload"
+        ret = snapshot_main([str(out_dir)])
+        assert ret == 1
+        assert "hardlink" in capsys.readouterr().out.lower()
+        assert not list(out_dir.glob("*.tar.gz")) if out_dir.is_dir() else True
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX hardlinks")
+    def test_snapshot_refuses_hardlinked_artifact_file(self, tmp_path, monkeypatch, capsys):
+        """Snapshot CREATION aborts (exit 1) on a hardlinked file inside an
+        artifact slug instead of shipping a snapshot that silently lacks it."""
+        src = tmp_path / "src_hl_artifact"
+        _setup_fake_kirocrew(src)
+        original = src / "artifacts" / "my-widget" / "current.html"
+        os.link(str(original), str(src / "artifacts" / "my-widget" / "linked.html"))
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        out_dir = tmp_path / "out_hl_artifact"
+        ret = snapshot_main([str(out_dir)])
+        assert ret == 1
+        assert "hardlink" in capsys.readouterr().out.lower()
+        assert not list(out_dir.glob("*.tar.gz")) if out_dir.is_dir() else True
+
+    def test_unstable_upload_skipped_from_snapshot(self, tmp_path, monkeypatch):
+        """A file whose (size, mtime) moves during every copy attempt is
+        dropped from this snapshot generation rather than shipped truncated."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_unstable"
+        dst = tmp_path / "dst_unstable"
+        src.mkdir()
+        (src / "steady.txt").write_text("complete upload")
+        moving = src / "inflight.bin"
+        moving.write_text("chunk-0")
+
+        real_pinned = snapshot_mod._pinned_copy_file
+        counter = {"n": 0}
+
+        def _copy_and_grow(s, d, **k):
+            real_pinned(s, d, **k)
+            if Path(s).name == "inflight.bin":
+                # Simulate the upload handler appending after our copy.
+                counter["n"] += 1
+                with open(s, "a", encoding="utf-8") as f:
+                    f.write(f"chunk-{counter['n']}")
+
+        monkeypatch.setattr(snapshot_mod, "_pinned_copy_file", _copy_and_grow)
+        snapshot_mod._stage_uploads_stable(src, dst)
+        monkeypatch.undo()
+        assert (dst / "steady.txt").read_text(encoding="utf-8") == "complete upload"
+        assert not (dst / "inflight.bin").exists()
+
+    def test_concurrent_restore_never_overwrites_restored_upload(self, tmp_path, monkeypatch):
+        """The guarded copy creates files exclusively — a file that appears
+        between the walk and the write is owned by someone else and skipped."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_excl"
+        dst = tmp_path / "dst_excl"
+        src.mkdir()
+        dst.mkdir()
+        (src / "doc.txt").write_text("from snapshot")
+        (dst / "doc.txt").write_text("from concurrent restore")
+        # exists() lies (simulating the race window); O_EXCL must catch it.
+        monkeypatch.setattr(Path, "exists", lambda self: False)
+        snapshot_mod._copy_tree_no_overwrite_guarded(src, dst)
+        monkeypatch.undo()
+        assert (dst / "doc.txt").read_text(encoding="utf-8") == "from concurrent restore"
+
+    def test_guarded_copy_opens_destination_binary(self, tmp_path, monkeypatch):
+        """The exclusive-create descriptor carries O_BINARY where it exists.
+
+        Writing through a Windows CRT text-mode fd expands 0x0A to 0x0D 0x0A,
+        permanently corrupting every restored binary upload — the same hazard
+        ``_read_meta_bounded`` already guards on its read path.
+        """
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_obinary"
+        dst = tmp_path / "dst_obinary"
+        src.mkdir()
+        dst.mkdir()
+        payload = b"\x89PNG\r\n\x1a\n\x0adata"
+        (src / "img.png").write_bytes(payload)
+        fake_flag = 0x40000000  # stands in for os.O_BINARY on POSIX
+        monkeypatch.setattr(os, "O_BINARY", fake_flag, raising=False)
+        seen: dict[str, int] = {}
+        real_open = os.open
+
+        def _capture(path, flags, *a, **k):
+            seen[str(path)] = flags
+            return real_open(path, flags & ~fake_flag, *a, **k)
+
+        monkeypatch.setattr(snapshot_mod.os, "open", _capture)
+        snapshot_mod._copy_tree_no_overwrite_guarded(src, dst)
+        monkeypatch.undo()
+        # dir_fd-pinned creation opens by bare name relative to the parent
+        # descriptor, so match on the basename rather than the full path.
+        file_opens = [f for p, f in seen.items() if Path(p).name == "img.png"]
+        assert file_opens and all(f & fake_flag for f in file_opens)
+        assert (dst / "img.png").read_bytes() == payload
+
+    def test_upload_path_type_conflict_skipped(self, env, capsys, monkeypatch, tmp_path):
+        """A local FILE occupying a snapshot DIRECTORY path skips additively."""
+        _, _, tarball, _ = env
+        # Build a snapshot whose uploads/ contains a subdirectory.
+        extract = tmp_path / "extract_typeconf"
+        extract.mkdir()
+        with tarfile.open(str(tarball)) as tar:
+            tar.extractall(extract, filter=lambda t, _d="": t)
+        snap = next(d for d in extract.iterdir() if d.name.startswith("kirocrew-snapshot-"))
+        (snap / "uploads" / "subdir").mkdir()
+        (snap / "uploads" / "subdir" / "nested.txt").write_text("nested upload")
+        conf_tar = tmp_path / "typeconf.tar.gz"
+        with tarfile.open(str(conf_tar), "w:gz") as tar:
+            tar.add(str(snap), arcname=snap.name)
+        dst = tmp_path / "dst_typeconf"
+        _setup_fake_kirocrew(dst)
+        # Local FILE squats on the directory name the snapshot wants.
+        (dst / "uploads" / "subdir").write_text("I am a file")
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+        ret = restore_main([str(conf_tar), "--mode", "merge", "--force"])
+        assert ret == 0
+        assert "path type conflict" in capsys.readouterr().out
+        # Local file untouched; sibling uploads still restored.
+        assert (dst / "uploads" / "subdir").is_file()
+        assert (dst / "uploads" / "bbb_photo.png").is_file()
+
+    def test_folder_merge_survives_deeply_nested_json(self, env, monkeypatch, tmp_path, capsys):
+        """A pathologically nested folders file skips the merge, not the restore."""
+        _, _, tarball, _ = env
+        extract = tmp_path / "extract_nested"
+        extract.mkdir()
+        with tarfile.open(str(tarball)) as tar:
+            tar.extractall(extract, filter=lambda t, _d="": t)
+        snap = next(d for d in extract.iterdir() if d.name.startswith("kirocrew-snapshot-"))
+        (snap / "artifact_folders.json").write_text("[" * 40000 + "]" * 40000)
+        nested_tar = tmp_path / "nested.tar.gz"
+        with tarfile.open(str(nested_tar), "w:gz") as tar:
+            tar.add(str(snap), arcname=snap.name)
+        fresh = tmp_path / "fresh_nested"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main([str(nested_tar), "--mode", "replace", "--force"])
+        assert ret == 0
+        # Artifacts restored despite the poisoned folders file.
+        assert (fresh / "artifacts" / "my-widget" / "meta.json").is_file()
+
+    def test_slug_recopied_when_meta_changes_mid_copy(self, tmp_path, monkeypatch):
+        """A slug whose meta.json moves during the copy is re-copied whole."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_metarace"
+        dst = tmp_path / "dst_metarace"
+        (src / "my-widget").mkdir(parents=True)
+        (src / "my-widget" / "meta.json").write_text('{"version": 1}')
+        (src / "my-widget" / "current.html").write_text("<p>v1</p>")
+
+        real_copy = snapshot_mod._copytree_safe
+        bumped = {"done": False}
+
+        def _racy_copy(s, d, **k):
+            real_copy(s, d, **k)
+            if not bumped["done"]:
+                # Simulate a live update landing mid-copy: meta and content
+                # advance AFTER this copy completed.
+                bumped["done"] = True
+                (src / "my-widget" / "meta.json").write_text('{"version": 2}')
+                (src / "my-widget" / "current.html").write_text("<p>v2</p>")
+
+        monkeypatch.setattr(snapshot_mod, "_copytree_safe", _racy_copy)
+        snapshot_mod._stage_artifact_slugs(src, dst)
+        # The retry captured the post-update state coherently.
+        assert (dst / "my-widget" / "meta.json").read_text(encoding="utf-8") == '{"version": 2}'
+        assert (dst / "my-widget" / "current.html").read_text(encoding="utf-8") == "<p>v2</p>"
+
+    def test_slug_recopied_when_content_changes_but_meta_does_not(self, tmp_path, monkeypatch):
+        """A mid-copy update that touches content/version files WITHOUT
+        rewriting meta.json must still fail the stability probe — a meta-only
+        check would ship the torn copy."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_torn"
+        dst = tmp_path / "dst_torn"
+        (src / "my-widget").mkdir(parents=True)
+        (src / "my-widget" / "meta.json").write_text('{"version": 1}')
+        (src / "my-widget" / "current.html").write_text("<p>v1</p>")
+
+        real_copy = snapshot_mod._copytree_safe
+        bumped = {"done": False}
+
+        def _racy_copy(s, d, **k):
+            real_copy(s, d, **k)
+            if not bumped["done"]:
+                # Content advances mid-copy; meta.json is left untouched
+                # (updater writes meta last — or not at all for history files).
+                bumped["done"] = True
+                content = src / "my-widget" / "current.html"
+                content.write_text("<p>v2</p>")
+                os.utime(content, ns=(1, 1))  # force a distinct mtime_ns
+
+        monkeypatch.setattr(snapshot_mod, "_copytree_safe", _racy_copy)
+        snapshot_mod._stage_artifact_slugs(src, dst)
+        # The retry re-copied and captured the post-update content.
+        assert (dst / "my-widget" / "current.html").read_text(encoding="utf-8") == "<p>v2</p>"
+
+    def test_folder_merge_sanitizes_malformed_fields(self, env, monkeypatch, tmp_path):
+        """Imported folder records are coerced to the store's exact shape.
+
+        A non-numeric ``order`` from a foreign snapshot would otherwise
+        persist and crash the folder listing's int() coercion server-side.
+        """
+        _, _, tarball, _ = env
+        # Build a snapshot whose folders file carries malformed fields.
+        extract = tmp_path / "extract_sanitize"
+        extract.mkdir()
+        with tarfile.open(str(tarball)) as tar:
+            tar.extractall(extract, filter=lambda t, _d="": t)
+        snap = next(d for d in extract.iterdir() if d.name.startswith("kirocrew-snapshot-"))
+        (snap / "artifact_folders.json").write_text(
+            json.dumps(
+                [
+                    {"id": "dddddddddddd", "name": 42, "order": "NaN", "parent_id": None},
+                ]
+            )
+        )
+        bad_tar = tmp_path / "sanitize.tar.gz"
+        with tarfile.open(str(bad_tar), "w:gz") as tar:
+            tar.add(str(snap), arcname=snap.name)
+        fresh = tmp_path / "fresh_sanitize"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main([str(bad_tar), "--mode", "replace", "--force"])
+        assert ret == 0
+        raw = json.loads((fresh / "artifact_folders.json").read_text(encoding="utf-8"))
+        rec = next(f for f in raw if f["id"] == "dddddddddddd")
+        assert isinstance(rec["order"], int)
+        assert isinstance(rec["name"], str)
+        assert rec["parent_id"] == ""
+        # The store's own listing path must survive the imported record.
+        from kiro_crew.artifacts import ArtifactFolderStore
+
+        store = ArtifactFolderStore(path=fresh / "artifact_folders.json")
+        assert any(f["id"] == "dddddddddddd" for f in store.list())
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlink")
+    def test_symlinked_meta_json_marks_slug_unstable(self, tmp_path, capsys):
+        """A meta.json that is a symlink is never raw-read; the slug skips.
+
+        A link to an endless source (device node, FIFO) would turn the bare
+        read into an unbounded hang/OOM; the bounded reader refuses the link
+        at open, so the stability check fails and the slug never rides.
+        """
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_linkmeta"
+        dst = tmp_path / "dst_linkmeta"
+        (src / "linked").mkdir(parents=True)
+        real = tmp_path / "outside.json"
+        real.write_text('{"version": 1}')
+        (src / "linked" / "meta.json").symlink_to(real)
+        (src / "ok-slug").mkdir()
+        (src / "ok-slug" / "meta.json").write_text('{"version": 1}')
+        dst.mkdir()
+        snapshot_mod._stage_artifact_slugs(src, dst)
+        assert not (dst / "linked").exists()
+        assert (dst / "ok-slug" / "meta.json").is_file()
+        assert "skipped this generation" in capsys.readouterr().out
+
+    def test_oversized_meta_json_marks_slug_unstable(self, tmp_path, monkeypatch):
+        """A meta.json past the size cap fails the stability check (skip)."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        monkeypatch.setattr(snapshot_mod, "_META_MAX_BYTES", 16)
+        src = tmp_path / "src_bigmeta"
+        dst = tmp_path / "dst_bigmeta"
+        (src / "bloated").mkdir(parents=True)
+        (src / "bloated" / "meta.json").write_text("x" * 64)
+        (src / "small").mkdir()
+        (src / "small" / "meta.json").write_text('{"v": 1}')
+        dst.mkdir()
+        snapshot_mod._stage_artifact_slugs(src, dst)
+        assert not (dst / "bloated").exists()
+        assert (dst / "small" / "meta.json").is_file()
+
+    def test_slug_copy_permission_error_fails_loudly(self, tmp_path, monkeypatch):
+        """A non-disappearance copy failure aborts the snapshot stage.
+
+        Suppressing EACCES/ENOSPC would report a successful snapshot that is
+        silently missing artifacts; only a vanished source may be skipped.
+        """
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_eacces"
+        dst = tmp_path / "dst_eacces"
+        (src / "denied").mkdir(parents=True)
+        (src / "denied" / "meta.json").write_text('{"version": 1}')
+        dst.mkdir()
+
+        def _denied_copy(s, d, **k):
+            raise PermissionError("copy denied")
+
+        monkeypatch.setattr(snapshot_mod, "_copytree_safe", _denied_copy)
+        with pytest.raises(PermissionError):
+            snapshot_mod._stage_artifact_slugs(src, dst)
+
+    def test_upload_copy_permission_error_fails_loudly(self, tmp_path, monkeypatch):
+        """Upload staging re-raises non-disappearance copy failures."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_up_eacces"
+        dst = tmp_path / "dst_up_eacces"
+        src.mkdir()
+        (src / "doc.txt").write_text("payload")
+        dst.mkdir()
+
+        def _denied_copy(s, d, **k):
+            raise PermissionError("copy denied")
+
+        monkeypatch.setattr(snapshot_mod, "_pinned_copy_file", _denied_copy)
+        with pytest.raises(PermissionError):
+            snapshot_mod._stage_uploads_stable(src, dst)
+
+    def test_vanished_upload_skipped_not_fatal(self, tmp_path, monkeypatch):
+        """A source file vanishing mid-copy is dropped, not a snapshot abort."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_up_vanish"
+        dst = tmp_path / "dst_up_vanish"
+        src.mkdir()
+        (src / "gone.txt").write_text("rejected upload")
+        (src / "kept.txt").write_text("complete upload")
+        dst.mkdir()
+        real_pinned = snapshot_mod._pinned_copy_file
+
+        def _vanish_copy(s, d, **k):
+            if Path(s).name == "gone.txt":
+                raise FileNotFoundError("vanished")
+            real_pinned(s, d, **k)
+
+        monkeypatch.setattr(snapshot_mod, "_pinned_copy_file", _vanish_copy)
+        snapshot_mod._stage_uploads_stable(src, dst)
+        monkeypatch.undo()
+        assert not (dst / "gone.txt").exists()
+        assert (dst / "kept.txt").read_text(encoding="utf-8") == "complete upload"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX flock")
+    def test_folder_merge_holds_gateway_lock_across_merge(self, env, monkeypatch, tmp_path):
+        """The gateway.lock flock is HELD during the merge, then released.
+
+        A probe-then-release check leaves a window: a gateway starting after
+        the probe loads the pre-merge folder list and its next save erases
+        the merged records. While the merge runs, an independent exclusive
+        acquire must fail; after the restore it must succeed again.
+        """
+        import fcntl
+
+        from kiro_crew import snapshot as snapshot_mod
+
+        _, _, tarball, _ = env
+        fresh = tmp_path / "fresh_lock_held"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        real_merge = snapshot_mod._merge_artifact_folders
+        seen = {"locked_during_merge": None}
+
+        def _probing_merge(src_path, dst_path):
+            probe = os.open(str(fresh / "gateway.lock"), os.O_RDWR)
+            try:
+                fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                seen["locked_during_merge"] = False
+                fcntl.flock(probe, fcntl.LOCK_UN)
+            except OSError:
+                seen["locked_during_merge"] = True
+            finally:
+                os.close(probe)
+            real_merge(src_path, dst_path)
+
+        monkeypatch.setattr(snapshot_mod, "_merge_artifact_folders", _probing_merge)
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        monkeypatch.undo()
+        assert ret == 0
+        assert seen["locked_during_merge"] is True
+        assert (fresh / "artifact_folders.json").is_file()
+        # Released after the merge: a fresh exclusive acquire succeeds.
+        fd = os.open(str(fresh / "gateway.lock"), os.O_RDWR)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
 # ── Comment 8: New edge-case tests ───────────────────────────────────────────
+
+
+class TestDescriptorPinnedStaging:
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX hardlinks")
+    def test_pinned_copy_refuses_hardlink_at_descriptor(self, tmp_path):
+        """The staged-read gate validates the inode on the OPEN DESCRIPTOR, so
+        a hardlink that slipped past a by-name screen is still refused at
+        copy time — credential bytes never enter the stage."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        secret = tmp_path / "credential"
+        secret.write_text("AKIA-secret")
+        link = tmp_path / "innocent.html"
+        os.link(str(secret), str(link))
+        dstf = tmp_path / "staged.html"
+        with pytest.raises(RuntimeError, match="hardlink"):
+            snapshot_mod._pinned_copy_file(str(link), str(dstf), on_hardlink="abort")
+        assert not dstf.exists()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+    def test_pinned_copy_skips_symlink_without_dereference(self, tmp_path, capsys):
+        """A symlink swapped in after the listing screen surfaces as ELOOP on
+        the O_NOFOLLOW open and is skipped — never dereferenced."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        secret = tmp_path / "credential"
+        secret.write_text("AKIA-secret")
+        link = tmp_path / "swapped.html"
+        link.symlink_to(secret)
+        dstf = tmp_path / "staged.html"
+        snapshot_mod._pinned_copy_file(str(link), str(dstf), on_hardlink="abort")
+        assert not dstf.exists()
+        assert "Skipping symlink" in capsys.readouterr().out
+
+    def test_slug_staging_copies_through_pinned_gate(self, tmp_path, monkeypatch):
+        """Abort-mode tree staging routes every file copy through the
+        descriptor-pinned gate — no bare by-name copy remains."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_gate"
+        dst = tmp_path / "dst_gate"
+        (src / "sub").mkdir(parents=True)
+        (src / "a.txt").write_text("a")
+        (src / "sub" / "b.txt").write_text("b")
+        seen: list[str] = []
+        real_pinned = snapshot_mod._pinned_copy_file
+
+        def _record(s, d, **k):
+            seen.append(Path(s).name)
+            real_pinned(s, d, **k)
+
+        monkeypatch.setattr(snapshot_mod, "_pinned_copy_file", _record)
+        snapshot_mod._copytree_safe(src, dst, on_hardlink="abort")
+        assert sorted(seen) == ["a.txt", "b.txt"]
+        assert (dst / "sub" / "b.txt").read_text(encoding="utf-8") == "b"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX hardlinks")
+    def test_snapshot_refuses_hardlinked_folder_metadata(self, tmp_path, monkeypatch, capsys):
+        """Snapshot CREATION aborts (exit 1) on a hardlinked
+        artifact_folders.json instead of shipping a snapshot whose fresh
+        restore silently loses the folder organization."""
+        src = tmp_path / "src_hl_folders"
+        _setup_fake_kirocrew(src)
+        os.link(str(src / "artifact_folders.json"), str(src / "folders-link.json"))
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        out_dir = tmp_path / "out_hl_folders"
+        ret = snapshot_main([str(out_dir)])
+        assert ret == 1
+        assert "hardlink" in capsys.readouterr().out.lower()
+
+    def test_snapshot_staging_oserror_reported_not_traceback(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A filesystem failure during staging (ENOSPC, EACCES) exits 1 with
+        the module's error message instead of escaping as a traceback."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_oserr"
+        _setup_fake_kirocrew(src)
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+
+        def _no_space(*a, **k):
+            raise OSError(errno.ENOSPC, "No space left on device")
+
+        monkeypatch.setattr(snapshot_mod, "_stage_uploads_stable", _no_space)
+        ret = snapshot_main([str(tmp_path / "out_oserr")])
+        assert ret == 1
+        assert "No space left" in capsys.readouterr().out
+
+    def test_restore_oserror_reported_not_traceback(self, env, monkeypatch, capsys):
+        """A filesystem failure mid-restore exits 1 with the module's error
+        message instead of a traceback after partial restoration."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        _, _, tarball, tmp_path = env
+        fresh = tmp_path / "fresh_oserr"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+
+        def _disk_full(*a, **k):
+            raise OSError(errno.ENOSPC, "No space left on device")
+
+        monkeypatch.setattr(snapshot_mod, "_do_replace", _disk_full)
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 1
+        assert "No space left" in capsys.readouterr().out
+
+    @pytest.mark.skipif(
+        os.name == "nt" or getattr(os, "geteuid", lambda: 1)() == 0,
+        reason="POSIX permissions, non-root",
+    )
+    def test_unreadable_meta_fails_snapshot_not_skips(self, tmp_path):
+        """An EACCES meta.json FAILS the stage instead of silently omitting
+        the whole slug from a backup that then reports success (an absent
+        meta.json still skips — covered by test_metaless_slug_never_staged).
+        """
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_meta_eacces"
+        dst = tmp_path / "dst_meta_eacces"
+        (src / "locked").mkdir(parents=True)
+        meta = src / "locked" / "meta.json"
+        meta.write_text('{"version": 1}')
+        dst.mkdir()
+        meta.chmod(0o000)
+        try:
+            with pytest.raises(PermissionError):
+                snapshot_mod._stage_artifact_slugs(src, dst)
+        finally:
+            meta.chmod(0o600)
+        assert not (dst / "locked").exists()
+
+    def test_guarded_copy_pins_destination_traversal(self, tmp_path, monkeypatch):
+        """Every destination component is opened relative to its parent's
+        descriptor (dir_fd + bare name): no by-name re-traversal remains
+        between the link validation and the write, so an ancestor swapped
+        for a symlink after validation cannot redirect the restore."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        if not snapshot_mod._GUARDED_DIR_FD_OK:
+            pytest.skip("dir_fd not supported on this platform")
+        src = tmp_path / "src_pin"
+        dst = tmp_path / "dst_pin"
+        (src / "nested" / "deep").mkdir(parents=True)
+        (src / "nested" / "deep" / "f.txt").write_text("payload")
+        dst.mkdir()
+        calls: list[tuple[str, bool]] = []
+        real_open = os.open
+
+        def _capture(path, flags, *a, **k):
+            calls.append((str(path), k.get("dir_fd") is not None))
+            return real_open(path, flags, *a, **k)
+
+        monkeypatch.setattr(snapshot_mod.os, "open", _capture)
+        snapshot_mod._copy_tree_no_overwrite_guarded(src, dst)
+        monkeypatch.undo()
+        assert (dst / "nested" / "deep" / "f.txt").read_text(encoding="utf-8") == "payload"
+        # The destination root is opened by full path; every component below
+        # it by bare name relative to a directory descriptor.
+        non_root = [c for c in calls if c[0] != str(dst)]
+        assert non_root and all(pinned for _path, pinned in non_root)
+        assert all(os.sep not in path for path, _pinned in non_root)
 
 
 class TestSchemaIncompatibleMerge:


### PR DESCRIPTION
<!-- Fill in each section below. -->

## Problem / Motivation

`kirocrew snapshot` silently drops the artifact library (`~/.kiro/crew/artifacts/`) and user uploads (`~/.kiro/crew/uploads/`): staging copies only the core file list plus the `workspace/`, `plan_memory/`, and `skills/` directories, so neither directory ever enters the tarball and neither survives a restore. I found this while planning disaster recovery for my own install — on my machine the artifact library holds versioned documents and dashboards the product explicitly promotes as "durable, named work that outlives the chat scrollback", and `uploads/` holds files my chat transcripts reference by server-side path, so a restore onto a fresh machine would lose the artifacts entirely and leave transcripts pointing at files that no longer exist.

## Why it matters

Snapshot/restore is the product's stated portability and backup story, and these two directories are exactly the kind of irreplaceable user data a backup exists to protect: artifacts are user-curated work with version history that exists nowhere else, and uploads are one-of-a-kind user files. Losing them on restore is silent — the restore reports success and the user only discovers the gap when they open the artifact library on the new machine.

## What changed (motivation → approach → change)

The snapshot module already has a clean per-component shape (`VALID_COMPONENTS`, `COMPONENT_HELP`, staged directories, manifest counts, per-mode restore), so I added `artifacts` and `uploads` as two first-class components rather than folding them into an existing one — they are distinct user-facing stores and selective restore (`--components artifacts`) reads naturally. Staging copies both directories through the existing `_copytree_safe` (symlink-skipping) helper, and the manifest gains `artifact_count` (slug directories, mirroring `skill_count`) and `upload_files` counts. Restore is deliberately additive-only in **both** replace and merge modes: an artifact slug directory is copied whole when absent and skipped entirely when it already exists (a slug's `meta.json` indexes the version files beside it, so file-level merging into a live slug could desync the metadata, and an existing slug may hold newer versions than the snapshot), and an existing upload filename likewise always wins over the snapshot copy. This deviates from the backup-then-wholesale-replace pattern replace mode uses for `workspace/` and `skills/`, and the code comments say why: both stores hold user data keyed by stable names, so a restore should never overwrite or delete a newer local entry with an older snapshot copy. Rolling back a specific bad local entry to the snapshot copy stays available compositionally — delete the unwanted slug (or upload) locally, then restore with `--components artifacts` (or `uploads`) — keeping destructive intent explicit at the CLI, and `--list-components` states the additive-only contract inline so the behavior is discoverable where components are chosen. The artifact store is pure filesystem (no SQLite), so no backup-API handling is needed, and `NEVER_SNAPSHOT_FILES` is untouched — the existing `_data_filter` runs over the whole tar including the new trees, with its symlink/hardlink/path-traversal rejection applying unchanged.

Old snapshots (created before these components existed) restore unchanged: the restore helpers no-op when the snapshot lacks the directories, and the manifest printer only shows the new count lines when the keys are present. The separate dashboard zip export (`portability.py`) deliberately excludes `uploads/` today; I left that surface untouched to keep this PR scoped to the CLI snapshot path. Chat session transcripts (`sessions/`) have the same coverage gap and are addressed in a separate PR to keep each change single-purpose.

Two additions from review: the artifact **folder tree** rides along with the library — `artifact_folders.json` (the config-dir file that artifact `folder_id` fields point at) is staged with the artifacts component and merged on restore by folder id with target-wins semantics (a new `_merge_artifact_folders` helper with an atomic tmp+rename write that fails closed when the target file is unreadable or not the store's list shape), so restored artifacts keep their folder organization instead of dangling `folder_id` references; and restore now creates the `artifacts/` and `uploads/` destinations via `platform_compat.make_owner_only_dir` (POSIX `0700`, Windows DACL restriction) instead of plain `mkdir`, so restored private user files are not readable by other OS users through a group/world-traversable directory (the tar data filter normalizes file modes on extraction, making the directory the effective permission boundary).

Later review rounds hardened the same surfaces further: the artifact library is staged **slug-by-slug** (`_stage_artifact_slugs`) with a metadata-stability check — each slug's `meta.json` is read before and after its copy and the slug is re-copied when a live update landed mid-copy (bounded retries, last complete copy kept since the store tolerant-loads version skew) — so a scheduled snapshot racing an artifact update can no longer capture a torn slug; linked component roots are refused in both directions (staging skips a symlinked/junctioned `artifacts/` or `uploads/`, restore refuses a linked destination root BEFORE the permission lockdown so a link target is never chmod'd, and uploads restore never writes through a linked destination component, dangling links included); the shared `_copytree_safe` filter now recognizes Windows junctions, not just POSIX symlinks; owner-only restore fails closed (component skipped when the lockdown cannot be verified); and imported folder records are sanitized to the store's exact field shapes so a malformed snapshot can never persist a record that crashes the folder listing.

## Tests

Extended `test/test_snapshot.py` (the fake data-dir fixture now includes two artifact slugs — one with a `versions/` history — two uploads, and a two-folder tree, which also exercises every pre-existing snapshot/restore test against the new content): `test_snapshot_includes_artifacts_and_uploads` locks in staging plus the manifest counts; `test_restore_fresh_copies_artifacts_and_uploads` locks in the disaster-recovery path onto a fresh directory; `test_replace_skips_existing_artifact_slug` locks in that an existing slug is never overwritten even in replace mode (no file-level merge) while an absent slug imports whole, including the reported import/skip counts; `test_merge_skips_existing_upload_filename` locks in the same never-overwrite rule for uploads; `test_components_artifacts_only` locks in selective restore; `test_old_snapshot_without_artifacts_restores` locks in backward compatibility with pre-change snapshots (directories, folders file, and manifest keys absent); `test_snapshot_includes_artifact_folders_file`, `test_restore_merges_artifact_folders_target_wins`, `test_restore_folders_onto_fresh_host`, and `test_folder_merge_fails_closed_on_non_list_target` lock in the folder-tree staging, id-based target-wins merge, fresh-host restore, and the fail-closed guard against replacing a malformed target file; `test_restore_created_dirs_are_owner_only` (POSIX) locks in the `0700` restore directories; `test_partial_slug_copy_removed_on_failure` locks in that an interrupted slug copy is fully removed instead of stranding a half-copy a retry would skip forever; `test_raced_slug_is_skipped_not_deleted` locks in that a slug created by a concurrent writer between the existence probe and the copy is treated as existing (atomic mkdir/O_EXCL reservation) and never deleted by the failure-cleanup path; `test_folder_merge_ignores_malformed_ids` locks in that non-string or empty folder ids from a foreign snapshot are skipped instead of crashing the merge; `test_restore_skipped_when_owner_only_lockdown_fails` locks in the fail-closed path (nothing is copied when the destination cannot be restricted to owner-only); `test_store_tmp_files_not_staged` locks in that the store's atomic-write `*.tmp` staging files never ride a snapshot. The existing `--list-components` test now asserts the new names.

## Manual verification

Ran `kirocrew snapshot` semantics end-to-end via the test harness (snapshot → extract → restore in both modes, fresh and populated targets). The full backend suite passes locally except 23 failures that reproduce identically with this diff stashed (local-environment failures in unrelated modules: auto_improvement app tests, spec_builder route redaction, subprocess sandbox tests).

## Related Issues

None filed — found during a backup-coverage audit of `snapshot.py`.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no doc enumerates the component list; `docs/system-specs/modules/cli.md` documents `--components` generically and stays accurate
- [x] No secrets, credentials, or internal references in the diff




