### PR TITLE
fix: include chat sessions in snapshots so restores are internally consistent

### DIFF
--- a/src/kiro_crew/snapshot.py
+++ b/src/kiro_crew/snapshot.py
@@ -3,18 +3,32 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import hashlib
 import json
 import os
 import re
 import shutil
 import socket
+import stat as _stat
 import tarfile
 import tempfile
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.paths import kiro_sessions_dir
+from kiro_crew.gateway_lock import GatewayLock, GatewayLockError
+from kiro_crew.history import (
+    ARCHIVE_DIR_NAME,
+    ARCHIVE_SEGMENT_DELIMITER,
+    INCOGNITO_MEMORY_MODES,
+    transcript_stem,
+    transcript_stems,
+)
+from kiro_crew.messaging.link import canonical_key, is_legacy_slack_key
 
 try:
     import pysqlite3 as sqlite3
@@ -26,7 +40,16 @@ try:
 except Exception:  # pragma: no cover - optional during early/standalone import
     _DASHBOARD_PORT = int(os.environ.get("KIROCREW_PORT", 5476))
 
-VALID_COMPONENTS = ("memory", "crons", "config", "skills", "workspace", "notifications", "security")
+VALID_COMPONENTS = (
+    "memory",
+    "crons",
+    "config",
+    "skills",
+    "workspace",
+    "notifications",
+    "security",
+    "sessions",
+)
 
 # Files that must always have 0o600 permissions in snapshots and on restore.
 SECURITY_SENSITIVE_FILES: frozenset = frozenset({"sel_hmac.key", "telemetry_salt"})
@@ -35,14 +58,14 @@ SECURITY_SENSITIVE_FILES: frozenset = frozenset({"sel_hmac.key", "telemetry_salt
 # so audit-log HMACs stay bound to the host that wrote them.
 #
 # This set is matched by BASENAME inside `_data_filter`, which runs over the
-# ENTIRE tar — including the staged workspace/, plan_memory/ and skills/ trees.
-# So any name added here also silently drops a USER file that happens to share
-# it. Keep the set minimal for that reason.
+# ENTIRE tar — including the staged workspace/, plan_memory/, skills/ and
+# sessions/ trees. So any name added here also silently drops a USER file that
+# happens to share it. Keep the set minimal for that reason.
 #
 # The beacon's per-install identity (beacon_install_id / beacon_last_sent) is
 # deliberately NOT here: snapshot staging copies an explicit per-component file
-# list (CORE_FILES) plus those three directories, and no component lists a beacon
-# file, so a root beacon file is never staged in the first place. The
+# list (CORE_FILES) plus a fixed set of directories, and no component lists a
+# beacon file, so a root beacon file is never staged in the first place. The
 # id-cloning hazard is closed by that non-selection, not by a basename filter.
 NEVER_SNAPSHOT_FILES: frozenset = frozenset({"sel_hmac.key"})
 
@@ -155,6 +178,7 @@ COMPONENT_HELP = {
     "workspace": "workspace/, plan_memory/ directories",
     "notifications": "notifications.jsonl (notification history)",
     "security": "telemetry_salt (sel_hmac.key excluded — regenerated on restore)",
+    "sessions": "sessions/ (chat transcripts + archives; incognito/temporary sessions excluded)",
 }
 
 
@@ -186,8 +210,78 @@ def _list_components() -> None:
     print("\nCombine with commas: --components memory,crons,skills")
 
 
-def _copytree_safe(src: Path, dst: Path, **kwargs) -> None:
-    """copytree that skips symlinks to prevent sensitive file leakage."""
+def _pinned_copy_file(
+    s: str, d: str, *, dir_fd: int | None = None, name: str | None = None
+) -> None:
+    """Copy one file's bytes from a descriptor pinned to a validated inode.
+
+    The session-staging walk copies user-writable trees, so the copy itself
+    must not trust the path name: ``shutil.copy2`` dereferences a hardlink
+    into innocent-looking regular bytes, and the tar pass's hardlink
+    rejection (``_data_filter``) never sees a link to reject — a hardlink to
+    a credential (e.g. ``~/.aws/credentials``) planted inside an allowlisted
+    session workspace would ride the snapshot as plain content. Same
+    open-first discipline as ``hooks.safe_read_file_bytes_nolink`` (and the
+    ``on_hardlink`` refusal in the artifacts staging path): open with
+    ``O_NOFOLLOW`` where the platform has it, then ``fstat`` the DESCRIPTOR —
+    the inode that is validated is exactly the inode whose bytes are copied,
+    so no check-to-use window remains. Anything not a regular file with
+    ``st_nlink == 1`` is skipped with a warning, matching this module's
+    existing skip conventions. Mode and timestamps are applied from the same
+    ``fstat`` result rather than a fresh by-name stat.
+
+    When ``dir_fd``/``name`` are given, the source is opened relative to the
+    caller's pinned parent-directory descriptor (``_stage_tree_pinned``), so
+    the ``O_NOFOLLOW`` here protects the final component of a path whose
+    every ancestor was itself opened ``O_NOFOLLOW`` against its parent — no
+    by-name re-traversal anywhere. ``s`` remains the by-name path, used only
+    for messages.
+
+    ``FileNotFoundError`` propagates for the caller's vanish tolerance; every
+    other ``OSError`` propagates so real failures still abort the snapshot.
+    """
+    try:
+        if dir_fd is not None and name is not None:
+            fd = os.open(name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0), dir_fd=dir_fd)
+        else:
+            fd = os.open(s, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            # A symlink final component that appeared after the listing-time
+            # link screen — refuse it the same way the screen would have.
+            print(f"⚠️  Skipping symlink in source tree: {s}")
+            return
+        raise
+    try:
+        st = os.fstat(fd)
+        if not _stat.S_ISREG(st.st_mode) or st.st_nlink != 1:
+            print(f"⚠️  Skipping hardlinked or non-regular file during snapshot copy: {s}")
+            return
+        with os.fdopen(fd, "rb") as fsrc:
+            fd = -1  # ownership passed to the file object
+            with open(d, "wb") as fdst:
+                shutil.copyfileobj(fsrc, fdst)
+        os.chmod(d, _stat.S_IMODE(st.st_mode))
+        os.utime(d, ns=(st.st_atime_ns, st.st_mtime_ns))
+    finally:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _copytree_safe(src: Path, dst: Path, *, tolerate_vanished: bool = False, **kwargs) -> None:
+    """copytree that skips symlinks to prevent sensitive file leakage.
+
+    ``tolerate_vanished=True`` additionally ignores entries that DISAPPEAR
+    between the directory listing and their copy (a live session being
+    deleted while the snapshot walks the tree) — and ONLY those: every other
+    error (EACCES, ENOSPC, ...) still aborts, so a snapshot never silently
+    ships with files it failed to read. On this path every file is copied
+    through :func:`_pinned_copy_file`, which additionally refuses hardlinked
+    and non-regular sources at copy time.
+    """
     outer_ignore = kwargs.pop("ignore", None)
 
     def _ignore_symlinks(directory, contents):
@@ -198,7 +292,124 @@ def _copytree_safe(src: Path, dst: Path, **kwargs) -> None:
             skipped |= set(outer_ignore(directory, contents))
         return skipped
 
-    shutil.copytree(str(src), str(dst), ignore=_ignore_symlinks, **kwargs)
+    if not tolerate_vanished:
+        shutil.copytree(str(src), str(dst), ignore=_ignore_symlinks, **kwargs)
+        return
+
+    def _copy2_tolerant(s, d, **kw):
+        try:
+            _pinned_copy_file(s, d)
+        except FileNotFoundError:
+            print(f"⚠️  Skipping vanished file during snapshot copy: {s}")
+
+    try:
+        shutil.copytree(
+            str(src), str(dst), ignore=_ignore_symlinks, copy_function=_copy2_tolerant, **kwargs
+        )
+    except shutil.Error as err:
+        # A subdirectory vanishing mid-walk surfaces here as an aggregated
+        # (src, dst, why) entry rather than through copy_function. Filter the
+        # vanished ones by errno marker; anything else re-raises untouched.
+        remaining = [
+            e
+            for e in err.args[0]
+            if not any(m in str(e[2]) for m in ("[Errno 2]", "[WinError 2]", "[WinError 3]"))
+        ]
+        if remaining:
+            raise shutil.Error(remaining) from err
+        for e in err.args[0]:
+            print(f"⚠️  Skipping vanished entry during snapshot copy: {e[0]}")
+
+
+# Staging pins the SOURCE traversal to directory descriptors where the
+# platform supports it (POSIX); Windows keeps the by-name walk.
+_STAGE_DIR_FD_OK = os.open in os.supports_dir_fd and os.listdir in os.supports_fd
+
+
+def _stage_tree_pinned(
+    src: Path, dst: Path, ignore: Callable[[str, list[str]], set[str]] | None = None
+) -> None:
+    """Source-pinned staging copy: no by-name re-traversal of any component.
+
+    ``_copytree_safe``'s walk re-resolves source paths BY NAME for every
+    entry, so its link screens protect only the final component: an agent
+    that swaps an allowlisted ancestor DIRECTORY for a credential-directory
+    link mid-walk redirects every deeper by-name open through the link, and
+    ``_pinned_copy_file``'s ``O_NOFOLLOW`` never fires — the final component
+    inside the replaced tree is a plain regular file. Here every directory
+    is opened ``O_NOFOLLOW|O_DIRECTORY`` relative to its PARENT's descriptor
+    and every file is opened ``O_NOFOLLOW`` relative to its pinned parent:
+    the directory that was validated is exactly the directory descended
+    into. Shares the containment invariant with the destination-side
+    ``_copy_tree_no_overwrite_guarded`` in the artifacts restore path — both
+    refuse any component that stops being a plain directory between
+    validation and use.
+
+    Otherwise matches ``_copytree_safe(tolerate_vanished=True)`` semantics:
+    symlinks and non-regular files are skipped with a warning, entries that
+    vanish mid-walk are skipped, ``ignore`` sees ``(directory, contents)``
+    by name, and every other error aborts the snapshot. Platforms without
+    ``dir_fd`` support (Windows) fall back to the by-name walk at the call
+    site — junction refusal there lives in the ``ignore`` screens.
+    """
+    o_dir = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+
+    def _walk(dir_fd: int, by_name: str, cur_dst: Path) -> None:
+        names = os.listdir(dir_fd)
+        skipped = set(ignore(by_name, names)) if ignore else set()
+        for entry in sorted(names):
+            if entry in skipped:
+                continue
+            path = os.path.join(by_name, entry)
+            try:
+                st = os.lstat(entry, dir_fd=dir_fd)
+            except FileNotFoundError:
+                print(f"⚠️  Skipping vanished entry during snapshot copy: {path}")
+                continue
+            if _stat.S_ISLNK(st.st_mode):
+                print(f"⚠️  Skipping symlink in source tree: {path}")
+            elif _stat.S_ISDIR(st.st_mode):
+                try:
+                    child_fd = os.open(entry, o_dir, dir_fd=dir_fd)
+                except FileNotFoundError:
+                    print(f"⚠️  Skipping vanished entry during snapshot copy: {path}")
+                    continue
+                except OSError as exc:
+                    if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+                        # Swapped for a link (or replaced by a file) between
+                        # the lstat above and this pinned open — refuse it,
+                        # exactly as the listing-time screen would have.
+                        print(f"⚠️  Skipping symlink in source tree: {path}")
+                        continue
+                    raise
+                try:
+                    child_dst = cur_dst / entry
+                    child_dst.mkdir(exist_ok=True)
+                    _walk(child_fd, path, child_dst)
+                finally:
+                    os.close(child_fd)
+            elif _stat.S_ISREG(st.st_mode):
+                try:
+                    _pinned_copy_file(path, str(cur_dst / entry), dir_fd=dir_fd, name=entry)
+                except FileNotFoundError:
+                    print(f"⚠️  Skipping vanished file during snapshot copy: {path}")
+            else:
+                print(f"⚠️  Skipping hardlinked or non-regular file during snapshot copy: {path}")
+
+    try:
+        root_fd = os.open(str(src), o_dir)
+    except OSError as exc:
+        if exc.errno in (errno.ELOOP, errno.ENOTDIR, errno.ENOENT):
+            # The root itself was swapped or removed after the caller's
+            # listing-time screen.
+            print(f"⚠️  Skipping symlink in source tree: {src}")
+            return
+        raise
+    try:
+        dst.mkdir(parents=True, exist_ok=True)
+        _walk(root_fd, str(src), dst)
+    finally:
+        os.close(root_fd)
 
 
 def _copy_tree_no_overwrite(src: Path, dst: Path) -> None:
@@ -211,6 +422,586 @@ def _copy_tree_no_overwrite(src: Path, dst: Path) -> None:
         elif item.is_file() and not target.exists():
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(str(item), str(target))
+
+
+# ── Sessions component ────────────────────────────────────────────────────────
+
+_TRANSCRIPT_SUFFIX = ".jsonl"
+# How many head lines to scan for the transcript's metadata record. Mirrors the
+# head-read in ``history.ConversationLog.recent_from_source``, which reads the
+# same marker for the same purpose (skipping private sessions).
+_TRANSCRIPT_HEAD_LINES = 5
+# kiro-cli session ids are UUID-shaped; the id is joined onto a directory path
+# below, so its shape is enforced rather than trusted (it arrives from a
+# snapshot produced elsewhere).
+_SAFE_SID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+#: Sentinel for "memory_mode key absent from the metadata record" — distinct
+#: from every JSON-representable value, including null.
+_MODE_ABSENT = object()
+
+
+def _transcript_candidates(sessions_root: Path) -> list[Path]:
+    """Live transcript files eligible for staging decisions.
+
+    Link/junction entries are excluded at the source: a linked transcript is
+    never copied (the copy-time guard skips it), so it must not be able to
+    vouch for anything either — a stem in the staging allowlist authorizes
+    that session's archive segments and workspace directory, and a link is
+    not evidence the session's data actually lives here.
+    """
+    return [
+        p
+        for p in sessions_root.glob(f"*{_TRANSCRIPT_SUFFIX}")
+        if not platform_compat.is_link_or_junction(p)
+    ]
+
+
+def _restricted_session_stems(
+    transcript_paths: list[Path], restricted_modes: frozenset
+) -> set[str]:
+    """Filename stems of transcripts NOT positively classified as persistent.
+
+    The privacy marker is the ``memory_mode`` field of the metadata record at
+    the head of each transcript. Classification fails closed: a transcript is
+    restricted unless a metadata record is found whose ``memory_mode`` is a
+    recognized persistent value — an unreadable head, a head with no metadata
+    record, and an unrecognized or restricted mode all keep the transcript
+    out of the snapshot. An ABSENT ``memory_mode`` field is persistent by the
+    store's own contract (``ConversationLog`` defaults it to ``"persistent"``
+    on read), so legacy transcripts written before the field existed still
+    ride.
+    """
+    restricted: set[str] = set()
+    for path in transcript_paths:
+        stem = path.name[: -len(_TRANSCRIPT_SUFFIX)]
+        persistent = False
+        try:
+            with open(path, encoding="utf-8") as f:
+                for _, line in zip(range(_TRANSCRIPT_HEAD_LINES), f):
+                    try:
+                        d = json.loads(line.strip())
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+                    if isinstance(d, dict) and d.get("_type") == "metadata":
+                        # Sentinel distinguishes a genuinely ABSENT field
+                        # (persistent by the store's setdefault contract) from
+                        # a present-but-malformed value: null, "", false, 0,
+                        # [] and {} are all present, unclassifiable, and must
+                        # fail closed rather than collapse to "".
+                        raw = d.get("memory_mode", _MODE_ABSENT)
+                        if raw is _MODE_ABSENT:
+                            persistent = True
+                        elif isinstance(raw, str):
+                            mode = raw.lower()
+                            persistent = mode not in restricted_modes and mode == "persistent"
+                        break  # the first metadata record decides
+        except (OSError, UnicodeError):
+            # Unreadable OR undecodable head: cannot classify, fail closed.
+            persistent = False
+        if not persistent:
+            restricted.add(stem)
+    return restricted
+
+
+def _flag_restricted_stems(mc: Path) -> set[str] | None:
+    """Stems restricted via session-map privacy flags, canonical + legacy.
+
+    Channel sessions (e.g. Slack ``!incognito``) persist privacy as a boolean
+    flag on the ``session_map.json`` entry rather than in the transcript's
+    metadata head, so the head-based classifier alone would export them.
+    Returns ``None`` when the map exists but cannot be parsed — the caller
+    must fail closed (stage no sessions), since flags cannot be ruled out.
+    """
+    map_path = mc / "session_map.json"
+    if not map_path.is_file():
+        return set()
+    try:
+        raw = json.loads(map_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, UnicodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    out: set[str] = set()
+    for key, entry in raw.items():
+        if not isinstance(entry, dict):
+            continue
+        flags = entry.get("flags")
+        if isinstance(flags, dict) and any(flags.get(f) for f in INCOGNITO_MEMORY_MODES):
+            out |= set(transcript_stems(str(key)))
+    return out
+
+
+def _stage_sessions(mc: Path, stage: Path) -> None:
+    """Stage the sessions/ tree (chat transcripts, archives, session workspaces).
+
+    Excluded from staging:
+
+    * Incognito/temporary transcripts — private by contract everywhere else
+      (never searched, listed, or summarized), so they must not leave the host
+      inside a snapshot either. Their archive segments and per-session
+      workspace directories are excluded with them.
+    * ``.lock`` files — per-process runtime artifacts with no meaning on
+      another host.
+    """
+    src = mc / "sessions"
+    if not src.is_dir():
+        return
+    if platform_compat.is_link_or_junction(src):
+        # A linked sessions root re-targets the walk to an arbitrary tree
+        # (e.g. a credentials directory), which would then ride the portable
+        # snapshot. POSIX symlinks AND Windows junctions must both be refused;
+        # the plain copytree symlink guard does not see junctions.
+        print("⚠️  sessions not snapshotted (sessions/ is a link or junction)")
+        return
+
+    candidates = _transcript_candidates(src)
+    flag_restricted = _flag_restricted_stems(mc)
+    if flag_restricted is None:
+        # The session map exists but cannot be read: privacy flags cannot be
+        # ruled out for any session, so nothing is staged (fail closed).
+        print("⚠️  sessions not snapshotted (session_map.json unreadable; privacy flags unknown)")
+        return
+    restricted = _restricted_session_stems(candidates, INCOGNITO_MEMORY_MODES) | flag_restricted
+    # Archive segments are allowlisted by their owning live transcript rather
+    # than denylisted by the restricted set: a rotated segment has no reliable
+    # privacy marker of its own, so a segment whose live transcript is absent
+    # (or restricted) cannot be classified and must not ride the snapshot.
+    staged_stems = {p.name[: -len(_TRANSCRIPT_SUFFIX)] for p in candidates} - restricted
+    # A pre-migration Slack session keeps its live transcript under the bare
+    # thread_ts filename, while its archive segments and workspace directory
+    # are always named by the canonical ``slack:`` key (_archive_lines derives
+    # its stem from the session key, not the transcript path). Allowlist the
+    # canonical spelling too — unless that canonical transcript itself exists
+    # and is restricted, in which case privacy wins over the alias.
+    owner_stems = set(staged_stems)
+    for stem in staged_stems:
+        if is_legacy_slack_key(stem):
+            alias = transcript_stem(canonical_key(stem))
+            if alias not in restricted:
+                owner_stems.add(alias)
+    root = src.resolve()
+    archive_rel = Path(ARCHIVE_DIR_NAME)
+
+    def _dir_is_staged(name: str) -> bool:
+        # A per-session workspace directory is named by the session key its
+        # subagent results belong to. Its transcript stem is either the
+        # sanitized key itself (channel sessions) or carries the ``dashboard_``
+        # prefix (dashboard slot keys — see chat_utils._normalize_slot_key's
+        # documented invariant). Allowlisted against staged live transcripts —
+        # like archive segments, a workspace whose transcript is absent (e.g.
+        # a deleted incognito session with retained results) cannot be
+        # classified and must not ride the snapshot.
+        stem_channel = transcript_stem(name)
+        stem_dashboard = transcript_stem(f"dashboard:{name}")
+        # The name maps to TWO possible owning sessions; when EITHER
+        # interpretation is restricted the directory may hold that restricted
+        # session's results, so privacy wins over the staged sibling (an
+        # incognito ``slack:<ts>`` must not leak through a persistent
+        # ``dashboard:slack_<ts>`` sharing the sanitized name).
+        if stem_channel in restricted or stem_dashboard in restricted:
+            return False
+        return stem_channel in owner_stems or stem_dashboard in owner_stems
+
+    def _archive_owner_is_staged(stem: str) -> bool:
+        # Exact owner match only: the segment name is <owner><DELIM><stamp>,
+        # and the owner itself may contain the delimiter, so the owner is
+        # everything before the LAST delimiter. A prefix test would leak a
+        # restricted sibling whose stem merely extends a staged stem
+        # (owner__private__stamp startswith owner__).
+        if ARCHIVE_SEGMENT_DELIMITER not in stem:
+            return False
+        return stem.rsplit(ARCHIVE_SEGMENT_DELIMITER, 1)[0] in owner_stems
+
+    def _ignore(directory: str, contents: list[str]) -> set[str]:
+        try:
+            rel = Path(directory).resolve().relative_to(root)
+        except (OSError, ValueError):
+            return set()
+        skipped: set[str] = set()
+        for name in contents:
+            child = Path(directory) / name
+            if platform_compat.is_link_or_junction(child):
+                # Windows junctions pass the plain symlink check inside
+                # _copytree_safe; refuse them here so a junctioned child
+                # cannot pull an external tree into the snapshot.
+                skipped.add(name)
+            elif name.endswith((".lock", ".tmp")):
+                # ``.tmp``: atomic_write stages full transcript bodies in
+                # mkstemp files beside the target; one caught mid-replace
+                # would ride the snapshot with NO stem classification, so an
+                # incognito transcript could leak through the privacy filter.
+                skipped.add(name)
+            elif rel == Path(".") and name.endswith(_TRANSCRIPT_SUFFIX):
+                # Allowlist against the scanned candidates, not a denylist
+                # against the restricted set: a transcript created after the
+                # candidate scan (e.g. a new incognito session starting while
+                # the copy walk runs) has no classification and must not ride.
+                if name[: -len(_TRANSCRIPT_SUFFIX)] not in staged_stems:
+                    skipped.add(name)
+            elif rel == Path(".") and name != ARCHIVE_DIR_NAME:
+                if child.is_dir() and not _dir_is_staged(name):
+                    skipped.add(name)
+            elif rel == archive_rel and name.endswith(_TRANSCRIPT_SUFFIX):
+                stem = name[: -len(_TRANSCRIPT_SUFFIX)]
+                if not _archive_owner_is_staged(stem):
+                    skipped.add(name)
+        return skipped
+
+    dst = stage / "sessions"
+    if _STAGE_DIR_FD_OK:
+        _stage_tree_pinned(src, dst, _ignore)
+    else:  # pragma: no cover - Windows fallback (by-name walk + link screens)
+        _copytree_safe(src, dst, tolerate_vanished=True, ignore=_ignore)
+
+    # Post-copy privacy sweep: classification above ran BEFORE the copy walk,
+    # so a session flagged restricted while the walk was running (a Slack
+    # ``!incognito`` landing on the map, or a transcript head rewritten to a
+    # restricted mode) was copied under a stale persistent verdict. Re-read
+    # the map and re-scan the STAGED transcript heads (the post-copy state),
+    # recompute the allowlist, and evict anything no longer authorized. The
+    # stage is private scratch, so deleting from it cannot race the gateway.
+    post_flag_restricted = _flag_restricted_stems(mc)
+    if post_flag_restricted is None:
+        # The map became unreadable after the pre-copy read: privacy flags can
+        # no longer be ruled out for anything already staged (fail closed).
+        shutil.rmtree(dst, ignore_errors=True)
+        print("⚠️  sessions not snapshotted (session_map.json unreadable; privacy flags unknown)")
+        return
+    post_candidates = _transcript_candidates(dst)
+    post_restricted = (
+        _restricted_session_stems(post_candidates, INCOGNITO_MEMORY_MODES) | post_flag_restricted
+    )
+    post_staged = {p.name[: -len(_TRANSCRIPT_SUFFIX)] for p in post_candidates} - post_restricted
+    post_owners = set(post_staged)
+    for stem in post_staged:
+        if is_legacy_slack_key(stem):
+            alias = transcript_stem(canonical_key(stem))
+            if alias not in post_restricted:
+                post_owners.add(alias)
+    for p in post_candidates:
+        if p.name[: -len(_TRANSCRIPT_SUFFIX)] not in post_staged:
+            p.unlink(missing_ok=True)
+    arch_dir = dst / ARCHIVE_DIR_NAME
+    if arch_dir.is_dir():
+        for p in arch_dir.glob(f"*{_TRANSCRIPT_SUFFIX}"):
+            stem = p.name[: -len(_TRANSCRIPT_SUFFIX)]
+            if (
+                ARCHIVE_SEGMENT_DELIMITER not in stem
+                or stem.rsplit(ARCHIVE_SEGMENT_DELIMITER, 1)[0] not in post_owners
+            ):
+                p.unlink(missing_ok=True)
+    for child in dst.iterdir():
+        if child.name == ARCHIVE_DIR_NAME or not child.is_dir():
+            continue
+        sweep_channel = transcript_stem(child.name)
+        sweep_dashboard = transcript_stem(f"dashboard:{child.name}")
+        # Same ambiguity rule as _dir_is_staged: a name whose EITHER
+        # interpretation is restricted may hold that restricted session's
+        # results — privacy wins over the staged sibling.
+        if (
+            sweep_channel in post_restricted
+            or sweep_dashboard in post_restricted
+            or (sweep_channel not in post_owners and sweep_dashboard not in post_owners)
+        ):
+            shutil.rmtree(child, ignore_errors=True)
+
+
+def _sessions_privacy_filter(
+    mc: Path, arcname: str
+) -> Callable[[tarfile.TarInfo], "tarfile.TarInfo | None"]:
+    """Tar filter that re-enforces session privacy FLAGS at archive time.
+
+    ``_stage_sessions`` classifies before its copy walk and sweeps after it,
+    but the tarball is written later still: a privacy flag landing on
+    ``session_map.json`` between the post-copy sweep and ``tar.add`` (a
+    Slack ``!incognito`` on a just-staged thread) would ship the
+    already-staged transcript under a stale persistent verdict. The tar
+    filter runs per entry at the moment that entry is added, so consulting a
+    fresh read of the flag map here makes the privacy verdict atomic with
+    archive creation. The map is re-parsed only when its stat identity
+    changes; an unreadable map fails closed for every sessions entry, the
+    same rule as the staging-time reads. Staged transcript HEADS are not
+    re-read: the stage is private scratch whose bytes were fixed at copy
+    time — after the post-copy sweep only the live flag map keeps moving.
+
+    Wraps :func:`_data_filter`, which keeps handling traversal/link/mode
+    hygiene for the whole tar.
+    """
+    prefix = f"{arcname}/sessions/"
+    cached_sig: object = object()  # never equal to a real signature
+    cached: set[str] | None = None
+
+    def _restricted_now() -> set[str] | None:
+        nonlocal cached_sig, cached
+        map_path = mc / "session_map.json"
+        try:
+            st = map_path.stat()
+            sig: object = (st.st_ino, st.st_mtime_ns, st.st_size)
+        except OSError:
+            sig = None
+        if sig != cached_sig:
+            cached = _flag_restricted_stems(mc)
+            cached_sig = sig
+        return cached
+
+    def _filter(info: tarfile.TarInfo, dest: str = "") -> "tarfile.TarInfo | None":
+        out = _data_filter(info, dest)
+        if out is None or not out.name.startswith(prefix):
+            return out
+        parts = PurePosixPath(out.name[len(prefix) :]).parts
+        if not parts:
+            return out
+        restricted = _restricted_now()
+        if restricted is None:
+            print(f"⚠️  Dropping sessions entry (session_map.json unreadable): {out.name}")
+            return None
+        first = parts[0]
+        if first == ARCHIVE_DIR_NAME:
+            if len(parts) < 2 or not parts[1].endswith(_TRANSCRIPT_SUFFIX):
+                return out
+            stem = parts[1][: -len(_TRANSCRIPT_SUFFIX)]
+            if ARCHIVE_SEGMENT_DELIMITER not in stem:
+                return out
+            if stem.rsplit(ARCHIVE_SEGMENT_DELIMITER, 1)[0] in restricted:
+                print(f"⚠️  Dropping freshly flag-restricted sessions entry: {out.name}")
+                return None
+            return out
+        if len(parts) == 1 and first.endswith(_TRANSCRIPT_SUFFIX):
+            if first[: -len(_TRANSCRIPT_SUFFIX)] in restricted:
+                print(f"⚠️  Dropping freshly flag-restricted sessions entry: {out.name}")
+                return None
+            return out
+        # Per-session workspace directory (or a file inside one). The name
+        # maps to TWO possible owning sessions — same ambiguity rule as
+        # ``_dir_is_staged``: privacy wins over either interpretation.
+        if transcript_stem(first) in restricted or transcript_stem(f"dashboard:{first}") in (
+            restricted
+        ):
+            print(f"⚠️  Dropping freshly flag-restricted sessions entry: {out.name}")
+            return None
+        return out
+
+    return _filter
+
+
+def _copy_sessions_no_overwrite(sd: Path, dd: Path) -> None:
+    """Sessions-specific additive copy; never writes through a linked target.
+
+    ``_copy_tree_no_overwrite`` guards the SOURCE against symlinks but trusts
+    the destination. Sessions restore cannot: an existing local symlink or
+    junction at any destination component (including a dangling one, which
+    ``exists()`` reports False for) would redirect restored files outside the
+    sessions tree. Every write is refused when any path component from the
+    sessions root down to the target is a link.
+    """
+
+    def _path_is_linked(p: Path) -> bool:
+        while True:
+            if platform_compat.is_link_or_junction(p):
+                return True
+            if p == dd:
+                return False
+            parent = p.parent
+            if parent == p:  # filesystem root — out of scope, refuse
+                return True
+            p = parent
+
+    for item in sorted(sd.rglob("*")):
+        if item.is_symlink():
+            continue
+        target = dd / item.relative_to(sd)
+        if _path_is_linked(target):
+            print(f"  ⚠️  skipping {item.relative_to(sd)} (linked restore destination)")
+            continue
+        if item.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+        elif item.is_file():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            # Exclusive create closes the exists()-then-copy race: a --force
+            # restore under a live gateway could otherwise truncate a
+            # transcript the gateway created between the probe and the copy.
+            # FileExistsError = the local side owns that file; keep it.
+            try:
+                fdesc = os.open(
+                    str(target),
+                    os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_BINARY", 0),
+                )
+            except FileExistsError:
+                continue
+            try:
+                # Copy THROUGH the exclusively created descriptor: closing it
+                # and letting copy2 reopen by name would truncate anything a
+                # live gateway appended to the path in between.
+                with open(item, "rb") as src_f, os.fdopen(fdesc, "wb") as dst_f:
+                    shutil.copyfileobj(src_f, dst_f)
+                shutil.copystat(str(item), str(target))
+            except BaseException:
+                # BaseException, not OSError: a Ctrl-C mid-copy would
+                # otherwise leave a partial transcript that every later
+                # restore skips as existing. We reserved the target above,
+                # so removing it on ANY failure is safe.
+                target.unlink(missing_ok=True)
+                raise
+
+
+def _restore_sessions(snap: Path, mc: Path, components: list[str] | None) -> bool:
+    """Additively restore sessions/; True only when restoration actually ran.
+
+    Transcripts are irreplaceable conversation history, so unlike other
+    components the sessions tree has no replace semantics and no backup step:
+    files missing locally are copied in, files already present locally are kept
+    as-is, in both restore modes. A snapshot created before the sessions
+    component existed has no sessions/ directory and restores as a no-op.
+    The return value gates session-map reconciliation — reconciling after a
+    REFUSED restore (e.g. a linked local sessions root) would drop restored
+    mappings whose transcripts were never copied in.
+    """
+    sd = snap / "sessions"
+    if not sd.is_dir():
+        if components is not None and "sessions" in components:
+            print("  sessions: not present in snapshot (created before sessions were included)")
+        return False
+    dd = mc / "sessions"
+    if platform_compat.is_link_or_junction(dd):
+        # A linked local sessions root would redirect every restored transcript
+        # outside the data home. Refuse rather than follow.
+        print("  ⚠️  sessions not restored (local sessions/ is a link or junction)")
+        return False
+    dd.mkdir(parents=True, exist_ok=True)
+    _copy_sessions_no_overwrite(sd, dd)
+    print("  ✅ sessions (existing local files kept)")
+    return True
+
+
+def _reconcile_session_map(mc: Path) -> None:
+    """Drop restored session-map entries whose session exists nowhere on this host.
+
+    A restored ``session_map.json`` can reference sessions the restoring host
+    does not have — most commonly entries whose transcript predates the
+    sessions component, or whose incognito transcript was deliberately not
+    shipped. Such an entry maps a key to a conversation that can never be
+    resumed here.
+
+    Conservative by construction: an entry is removed only when it names a
+    kiro-cli session id AND neither its Kiro Crew transcript nor its kiro-cli
+    session file exists locally. Linkage-only entries (no sid) and
+    externally-stored providers are kept, mirroring ``SessionMap.prune``.
+
+    An entry whose sid is unusable here but which is backed by something
+    durable — a local transcript, privacy flags (e.g. Slack ``!incognito``),
+    or thread linkage — is kept with the sid CLEARED rather than left stale:
+    ``SessionMap.prune`` deletes any stale-sid entry that lacks a durable
+    flag (only ``mirror_opt_out``) at gateway startup — thread linkage,
+    mirrors, and session-scoped flags do NOT save it — so a kept-but-stale
+    sid would take the whole entry (flags and linkage included) down on the
+    first start. A cleared sid survives that prune when the entry carries
+    thread linkage or a mirror (prune keeps linkage-shaped SIDLESS entries);
+    for the rest, clearing still strictly beats a stale sid — the transcript
+    file itself is never at stake either way.
+
+    The pass runs under the gateway's own single-writer lock
+    (``gateway.lock``): reconciliation is a read-modify-write of the whole
+    map, so a live gateway writing an entry between this pass's read and its
+    write would see that entry deleted by the stale rewrite. Holding the
+    lock makes the pass atomic against gateway map writes in both
+    directions — a gateway starting mid-pass is refused by its own startup
+    acquire. When a live gateway already holds the lock (a ``--force``
+    restore), the pass is skipped rather than raced: no cross-process map
+    write can stick under a live gateway anyway — its next whole-map save
+    from in-memory state overwrites the restored file, so the entries this
+    pass would preserve are lost to that save with or without it. That is
+    NOT because ``SessionMap.prune`` is an equivalent substitute: prune
+    DELETES a stale-sid entry outright unless it carries a durable flag
+    (``_DURABLE_FLAGS`` is ``mirror_opt_out`` only) — thread linkage and
+    mirrors included. Clearing such sids so linkage-bearing entries survive
+    prune's startup pass is exactly what this reconciliation exists to do.
+    """
+    try:
+        lock = GatewayLock(mc).acquire()
+    except GatewayLockError:
+        print(
+            "  ⚠️  session_map reconciliation skipped (a running gateway owns "
+            "the map; restored entries cannot outlive its next in-memory save)"
+        )
+        return
+    try:
+        _reconcile_session_map_locked(mc)
+    finally:
+        lock.release()
+
+
+def _reconcile_session_map_locked(mc: Path) -> None:
+    """The reconciliation pass itself. Caller holds ``gateway.lock``."""
+    map_path = mc / "session_map.json"
+    if not map_path.is_file():
+        return
+    try:
+        raw = json.loads(map_path.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as e:
+        print(f"⚠️  session_map reconciliation skipped (unreadable map: {e})")
+        return
+    if not isinstance(raw, dict):
+        return
+    sessions_root = mc / "sessions"
+    cli_dir = kiro_sessions_dir()
+    dropped: list = []
+    cleared: list = []
+    for key, val in raw.items():
+        entry = {"sid": val} if isinstance(val, str) else val
+        if not isinstance(entry, dict):
+            continue
+        sid = entry.get("sid")
+        if not sid or entry.get("provider") == "claude_code":
+            continue
+
+        def _transcript_exists(stem: str) -> bool:
+            # A key of filesystem-component length (corrupt or hostile map)
+            # makes ``is_file`` raise ENAMETOOLONG — one bad entry must not
+            # crash reconciliation mid-restore. Unprobeable = absent.
+            try:
+                return (sessions_root / f"{stem}{_TRANSCRIPT_SUFFIX}").is_file()
+            except OSError:
+                return False
+
+        has_transcript = any(_transcript_exists(stem) for stem in transcript_stems(key))
+        has_cli_session = (
+            isinstance(sid, str)
+            and bool(_SAFE_SID_RE.match(sid))
+            and (cli_dir / f"{sid}.json").is_file()
+        )
+        if has_cli_session:
+            continue
+        # The sid is unusable on this host: unsafe shape, or no matching
+        # kiro-cli session file. Leaving it in place is worse than clearing
+        # it — the gateway's ``SessionMap.prune`` deletes any entry whose sid
+        # lacks a local session file, taking the durable per-conversation
+        # state (privacy flags, thread linkage) and the transcript mapping
+        # down with it. Clear just the sid when anything durable backs the
+        # entry (a local transcript, flags, linkage); drop bare entries.
+        flags = entry.get("flags")
+        has_state = bool(flags) or entry.get("slack_thread_ts") or entry.get("mirror")
+        if has_transcript or has_state:
+            cleared.append(key)
+        else:
+            dropped.append(key)
+    if not dropped and not cleared:
+        return
+    for k in dropped:
+        del raw[k]
+    for k in cleared:
+        entry = raw[k]
+        if isinstance(entry, dict):
+            entry["sid"] = ""
+        else:
+            raw[k] = {"sid": ""}
+    # atomic_write, not a bare tmp+replace: it retries the rename on the
+    # transient PermissionError a Windows antivirus/indexer hold produces,
+    # so reconciliation cannot abort a restore after partially applying state.
+    atomic_write(map_path, json.dumps(raw, indent=2))
+    print(
+        f"  Session map: dropped {len(dropped)} bare entries, cleared unusable "
+        f"sids on {len(cleared)} entries with a local transcript or durable state"
+    )
 
 
 # ── Snapshot ──────────────────────────────────────────────────────────────────
@@ -316,10 +1107,20 @@ def snapshot_main(
         if (mc / "skills").is_dir():
             _copytree_safe(mc / "skills", stage / "skills", dirs_exist_ok=True)
 
+        # Sessions (chat transcripts; incognito/temporary excluded)
+        _stage_sessions(mc, stage)
+
         # Manifest
         ws_files = sum(1 for _ in (stage / "workspace").rglob("*") if _.is_file())
         pm_files = sum(1 for _ in (stage / "plan_memory").rglob("*") if _.is_file())
         sk_count = sum(1 for _ in (stage / "skills").iterdir() if _.is_dir())
+        sess_stage = stage / "sessions"
+        session_transcripts = (
+            sum(1 for _ in sess_stage.glob(f"*{_TRANSCRIPT_SUFFIX}")) if sess_stage.is_dir() else 0
+        )
+        session_files = (
+            sum(1 for _ in sess_stage.rglob("*") if _.is_file()) if sess_stage.is_dir() else 0
+        )
         manifest = {
             "version": 2,
             "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -335,6 +1136,8 @@ def snapshot_main(
                 "workspace_files": ws_files,
                 "plan_memory_files": pm_files,
                 "skill_count": sk_count,
+                "session_transcripts": session_transcripts,
+                "session_files": session_files,
             },
         }
         (stage / "MANIFEST.json").write_text(json.dumps(manifest, indent=2))
@@ -345,7 +1148,7 @@ def snapshot_main(
         tmp_tar = outfile.with_suffix(".tar.gz.tmp")
         try:
             with tarfile.open(str(tmp_tar), "w:gz") as tar:
-                tar.add(str(stage), arcname=name, filter=_data_filter)
+                tar.add(str(stage), arcname=name, filter=_sessions_privacy_filter(mc, name))
             tmp_tar.rename(outfile)
         except BaseException:
             tmp_tar.unlink(missing_ok=True)
@@ -403,6 +1206,8 @@ def _print_manifest(snap: Path) -> None:
         print(f"  Skills: {c.get('skill_count', 0)}")
         print(f"  Notifications: {c.get('notifications_jsonl', 0) // 1024} KB")
         print(f"  Plan memory files: {c.get('plan_memory_files', 0)}")
+        if "session_transcripts" in c:
+            print(f"  Session transcripts: {c.get('session_transcripts', 0)}")
     except Exception as e:
         print(f"  (Could not read manifest: {e})")
 
@@ -775,10 +1580,34 @@ def restore_main(argv: list[str] | None = None, *, parsed: argparse.Namespace | 
             return 0
 
         mc.mkdir(parents=True, exist_ok=True)
+        # Whether session_map.json can arrive from the snapshot this run:
+        # replace mode overwrites it; merge mode copies it only when missing.
+        # Reconciliation additionally requires the snapshot to actually carry
+        # a sessions tree — a pre-sessions snapshot ships a map but no
+        # transcripts, and reconciling against that would delete every
+        # restored mapping instead of leaving history intact.
+        map_from_snapshot = _want(components, "config") and (
+            mode == "replace" or not (mc / "session_map.json").is_file()
+        )
         if mode == "replace":
             _do_replace(snap, mc, components)
         else:
             _do_merge(snap, mc, components)
+        # Sessions restore is invoked ONLY from this CLI entrypoint, never
+        # from the shared _do_replace/_do_merge helpers: portability's
+        # dashboard ZIP import reuses those helpers, and its documented
+        # exclusion of conversation data must hold even for a ZIP that
+        # happens to contain a sessions/ directory.
+        sessions_restored = False
+        if _want(components, "sessions"):
+            sessions_restored = _restore_sessions(snap, mc, components)
+        # Reconciliation additionally requires sessions to have ACTUALLY been
+        # restored this run: with --components config the transcripts
+        # deliberately do not arrive, and a refused restore (e.g. linked local
+        # sessions root) never copied them — reconciling against either gap
+        # would permanently drop valid mappings.
+        if map_from_snapshot and sessions_restored:
+            _reconcile_session_map(mc)
 
     # Integrity check
     if _want(components, "memory") and (mc / "memory.db").is_file():

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import sqlite3
 import tarfile
 from pathlib import Path
 
 import pytest
 
+from kiro_crew.gateway_lock import GatewayLock, GatewayLockError
 from kiro_crew.snapshot import restore_main, snapshot_main
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -38,8 +40,7 @@ def _setup_fake_kirocrew(d: Path) -> None:
 
     # memory.db with all tables
     conn = sqlite3.connect(str(d / "memory.db"))
-    conn.executescript(
-        """
+    conn.executescript("""
         CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
         CREATE TABLE semantic_memory (key TEXT PRIMARY KEY, value_json TEXT NOT NULL,
             confidence REAL DEFAULT 0.5, source TEXT NOT NULL, created_at TEXT NOT NULL,
@@ -71,8 +72,7 @@ def _setup_fake_kirocrew(d: Path) -> None:
             VALUES ('user', 'prefers', 'dark_mode', 'ep1', '2026-01-01');
         INSERT INTO knowledge_edges (source_key, target_key, relation, weight, created_at)
             VALUES ('user', 'dark_mode', 'prefers', 1.0, '2026-01-01');
-    """
-    )
+    """)
     conn.close()
 
     (d / "crons.json").write_text(
@@ -825,3 +825,1165 @@ class TestConcurrentSnapshot:
         tarballs = list(out.glob("kirocrew-snapshot-*.tar.gz"))
         assert len(tarballs) == 2
         assert tarballs[0].name != tarballs[1].name
+
+
+# ── Sessions component ────────────────────────────────────────────────────────
+
+
+def _meta_line(memory_mode: str) -> str:
+    return (
+        json.dumps({"_type": "metadata", "created_at": "2026-01-01", "memory_mode": memory_mode})
+        + "\n"
+    )
+
+
+def _msg_line(content: str) -> str:
+    return json.dumps({"role": "user", "content": content, "ts": "2026-01-01"}) + "\n"
+
+
+def _add_fake_sessions(d: Path) -> None:
+    """Populate a fake sessions/ tree: transcripts, archives, locks, workspaces."""
+    s = d / "sessions"
+    (s / "archive").mkdir(parents=True, exist_ok=True)
+    # Persistent dashboard transcript + its archive segment + workspace dir
+    (s / "dashboard_chat-1-111.jsonl").write_text(_meta_line("persistent") + _msg_line("hello"))
+    (s / "dashboard_chat-1-111.jsonl.lock").write_text("")
+    (s / "archive" / "dashboard_chat-1-111__20260101T000000Z.jsonl").write_text(
+        _msg_line("older rotated line")
+    )
+    (s / "chat-1-111").mkdir(exist_ok=True)
+    (s / "chat-1-111" / "agent-abc.md").write_text("subagent result")
+    # Incognito dashboard transcript + its archive segment + workspace dir
+    (s / "dashboard_chat-2-222.jsonl").write_text(_meta_line("incognito") + _msg_line("private"))
+    (s / "archive" / "dashboard_chat-2-222__20260101T000000Z.jsonl").write_text(
+        _msg_line("private rotated")
+    )
+    (s / "chat-2-222").mkdir(exist_ok=True)
+    (s / "chat-2-222" / "agent-def.md").write_text("private subagent result")
+    # Temporary channel transcript (sanitized slack key stem)
+    (s / "slack_123.456.jsonl").write_text(_meta_line("temporary") + _msg_line("guest"))
+    # Atomic-write staging file caught mid-replace: carries a full transcript
+    # body (here an incognito one) under an unclassifiable mkstemp name.
+    (s / "tmpa1b2c3.tmp").write_text(_meta_line("incognito") + _msg_line("mid-write private"))
+
+
+@pytest.fixture
+def sessions_env(tmp_path, monkeypatch):
+    """Fake data home with a populated sessions/ tree, snapshotted."""
+    src = tmp_path / "src"
+    out = tmp_path / "out"
+    _setup_fake_kirocrew(src)
+    _add_fake_sessions(src)
+    monkeypatch.setenv("KIROCREW_HOME", str(src))
+    # Keep the kiro-cli session store hermetic (session-map reconciliation
+    # probes it for native session files).
+    monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home"))
+    tarball = _make_snapshot(src, out)
+    return src, out, tarball, tmp_path
+
+
+def _extract(tarball: Path, dest: Path) -> Path:
+    dest.mkdir(exist_ok=True)
+    with tarfile.open(str(tarball)) as tar:
+        tar.extractall(dest, filter=lambda t, _d="": t)
+    return next(d for d in dest.iterdir() if d.name.startswith("kirocrew-snapshot-"))
+
+
+class TestSessionsStaging:
+    def test_persistent_sessions_staged(self, sessions_env, tmp_path):
+        _, _, tarball, _ = sessions_env
+        snap = _extract(tarball, tmp_path / "extract_sess")
+        assert (snap / "sessions/dashboard_chat-1-111.jsonl").is_file()
+        assert (snap / "sessions/archive/dashboard_chat-1-111__20260101T000000Z.jsonl").is_file()
+        assert (snap / "sessions/chat-1-111/agent-abc.md").is_file()
+
+    def test_incognito_and_temporary_excluded(self, sessions_env, tmp_path):
+        _, _, tarball, _ = sessions_env
+        snap = _extract(tarball, tmp_path / "extract_priv")
+        # Incognito transcript, its archive segment, and its workspace dir
+        assert not (snap / "sessions/dashboard_chat-2-222.jsonl").exists()
+        assert not (snap / "sessions/archive/dashboard_chat-2-222__20260101T000000Z.jsonl").exists()
+        assert not (snap / "sessions/chat-2-222").exists()
+        # Temporary channel transcript
+        assert not (snap / "sessions/slack_123.456.jsonl").exists()
+
+    def test_lock_files_excluded(self, sessions_env, tmp_path):
+        _, _, tarball, _ = sessions_env
+        snap = _extract(tarball, tmp_path / "extract_lock")
+        assert not any(p.name.endswith(".lock") for p in (snap / "sessions").rglob("*"))
+
+    def test_atomic_write_tmp_files_excluded(self, sessions_env, tmp_path):
+        """A transcript-bearing mkstemp ``.tmp`` caught mid-replace must not ride."""
+        _, _, tarball, _ = sessions_env
+        snap = _extract(tarball, tmp_path / "extract_tmp")
+        assert not any(p.name.endswith(".tmp") for p in (snap / "sessions").rglob("*"))
+
+    def test_session_vanishing_mid_copy_does_not_abort_snapshot(self, tmp_path, monkeypatch):
+        """A session deleted while the copy walks the tree must be skipped,
+        not abort the whole snapshot."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_vanish"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        doomed = src / "sessions" / "dashboard_chat-1-111.jsonl"
+
+        real_copy = snapshot_mod._pinned_copy_file
+        state = {"deleted": False}
+
+        def _racy_copy(s, d, **kw):
+            # Delete the transcript just before ITS OWN copy — models a live
+            # dashboard deletion landing between listdir and the copy.
+            if not state["deleted"] and str(s).endswith("dashboard_chat-1-111.jsonl"):
+                state["deleted"] = True
+                doomed.unlink()
+            real_copy(s, d, **kw)
+
+        monkeypatch.setattr(snapshot_mod, "_pinned_copy_file", _racy_copy)
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_vanish"))
+        out = tmp_path / "out_vanish"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_vanish")
+        # Snapshot completed; the vanished transcript is simply absent.
+        assert (snap / "sessions").is_dir()
+        assert not (snap / "sessions" / "dashboard_chat-1-111.jsonl").exists()
+
+    def test_non_vanish_copy_error_still_aborts_sessions_staging(self, tmp_path, monkeypatch):
+        """Vanish tolerance must not swallow real copy failures (EACCES)."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_eacces_sess"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+
+        def _denied_copy(s, d, **kw):
+            raise PermissionError(f"copy denied: {s}")
+
+        monkeypatch.setattr(snapshot_mod, "_pinned_copy_file", _denied_copy)
+        # The pinned walk propagates the error directly; the by-name fallback
+        # (non-dir_fd platforms) aggregates it into shutil.Error.
+        with pytest.raises((shutil.Error, PermissionError)):
+            snapshot_mod._stage_sessions(src, tmp_path / "stage_eacces_sess")
+
+    def test_hardlinked_file_in_session_workspace_not_staged(self, tmp_path, monkeypatch, capsys):
+        """A hardlink to a credential planted inside a staged session workspace
+        must not have its bytes copied into the snapshot — the copy is pinned
+        to a descriptor whose fstat must show a regular file with nlink == 1."""
+        src = tmp_path / "src_hardlink_sess"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        secret = tmp_path / "aws_credentials"
+        secret.write_text("[default]\naws_secret_access_key = HUNTER2\n")
+        planted = src / "sessions" / "chat-1-111" / "creds"
+        os.link(str(secret), str(planted))
+
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_hardlink"))
+        out = tmp_path / "out_hardlink"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_hardlink")
+        # Snapshot completed; the sibling regular file rode, the hardlink did not.
+        assert (snap / "sessions" / "chat-1-111" / "agent-abc.md").is_file()
+        assert not (snap / "sessions" / "chat-1-111" / "creds").exists()
+        assert "Skipping hardlinked or non-regular file" in capsys.readouterr().out
+
+    def test_orphaned_archive_segment_excluded(self, tmp_path, monkeypatch):
+        """An archive segment with no live transcript cannot be classified — not staged."""
+        src = tmp_path / "src_orphan"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        (src / "sessions/archive/gone-session__20260101T000000Z.jsonl").write_text(
+            _msg_line("segment of a deleted session")
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        out = tmp_path / "out_orphan"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_orphan")
+        assert not (snap / "sessions/archive/gone-session__20260101T000000Z.jsonl").exists()
+        assert (snap / "sessions/archive/dashboard_chat-1-111__20260101T000000Z.jsonl").is_file()
+
+    def test_workspace_shared_with_restricted_session_excluded(self, tmp_path, monkeypatch):
+        """A workspace dir whose name maps to BOTH a restricted channel session
+        and a staged dashboard session must not ride — privacy wins over the
+        staged sibling (the OR-authorization leak)."""
+        src = tmp_path / "src_ambig"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        s = src / "sessions"
+        # Incognito CHANNEL session: slack:999.888 -> stem slack_999.888
+        (s / "slack_999.888.jsonl").write_text(_meta_line("incognito") + _msg_line("private"))
+        # Persistent DASHBOARD session whose stem is dashboard_slack_999.888
+        (s / "dashboard_slack_999.888.jsonl").write_text(
+            _meta_line("persistent") + _msg_line("public")
+        )
+        # The shared sanitized workspace dir name both sessions map to
+        (s / "slack_999.888").mkdir()
+        (s / "slack_999.888" / "agent-xyz.md").write_text("possibly-private subagent result")
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        out = tmp_path / "out_ambig"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_ambig")
+        # The persistent dashboard transcript rides; the incognito one and the
+        # ambiguous workspace dir do not.
+        assert (snap / "sessions/dashboard_slack_999.888.jsonl").is_file()
+        assert not (snap / "sessions/slack_999.888.jsonl").exists()
+        assert not (snap / "sessions/slack_999.888").exists()
+
+    def test_ancestor_dir_swapped_for_link_mid_walk_not_followed(self, tmp_path, monkeypatch):
+        """An allowlisted ancestor DIRECTORY swapped for a credential-directory
+        link between the listing screen and the descend must not be followed.
+
+        The final-component O_NOFOLLOW in ``_pinned_copy_file`` alone would
+        miss this: files inside the swapped-in tree are plain regular files.
+        The staging walk opens every directory component O_NOFOLLOW relative
+        to its parent's pinned descriptor, so the swap is refused at the
+        component that changed."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        if not snapshot_mod._STAGE_DIR_FD_OK:
+            pytest.skip("dir_fd traversal unsupported on this platform")
+        src = tmp_path / "src_swap"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        secret_dir = tmp_path / "aws"
+        secret_dir.mkdir()
+        (secret_dir / "credentials").write_text("aws_secret_access_key = HUNTER2\n")
+        workspace = src / "sessions" / "chat-1-111"
+
+        real_pinned = snapshot_mod._stage_tree_pinned
+        real_safe = snapshot_mod._copytree_safe
+        state = {"swapped": False}
+
+        def _swap_after_root_screen(inner):
+            # Fires inside the ignore callback for the sessions ROOT: the
+            # listing-time link screens have already run against the real
+            # directory, and no entry has been processed yet — the exact
+            # check-to-use window the finding describes.
+            def wrapped(directory, contents):
+                result = set(inner(directory, contents)) if inner else set()
+                if not state["swapped"] and Path(directory) == src / "sessions":
+                    state["swapped"] = True
+                    shutil.rmtree(workspace)
+                    os.symlink(str(secret_dir), str(workspace))
+                return result
+
+            return wrapped
+
+        def _pinned_hooked(s, d, ignore=None):
+            real_pinned(s, d, _swap_after_root_screen(ignore))
+
+        def _safe_hooked(s, d, **kw):
+            kw["ignore"] = _swap_after_root_screen(kw.get("ignore"))
+            real_safe(s, d, **kw)
+
+        monkeypatch.setattr(snapshot_mod, "_stage_tree_pinned", _pinned_hooked)
+        monkeypatch.setattr(snapshot_mod, "_copytree_safe", _safe_hooked)
+        stage = tmp_path / "stage_swap"
+        snapshot_mod._stage_sessions(src, stage)
+        assert state["swapped"], "swap hook never fired — test wiring broke"
+        staged = stage / "sessions"
+        # The swapped component was refused, not traversed: no credential
+        # bytes anywhere in the stage.
+        assert not (staged / "chat-1-111" / "credentials").exists()
+        staged_bodies = "".join(p.read_text() for p in staged.rglob("*") if p.is_file())
+        assert "HUNTER2" not in staged_bodies
+
+    def test_manifest_counts_sessions(self, sessions_env, tmp_path):
+        _, _, tarball, _ = sessions_env
+        snap = _extract(tarball, tmp_path / "extract_manifest")
+        m = json.loads((snap / "MANIFEST.json").read_text(encoding="utf-8"))
+        assert m["contents"]["session_transcripts"] == 1
+        assert m["contents"]["session_files"] >= 3  # transcript + archive + workspace file
+
+
+class TestSessionsRestore:
+    def test_restore_fresh(self, sessions_env, tmp_path, monkeypatch):
+        _, _, tarball, _ = sessions_env
+        fresh = tmp_path / "fresh_sess"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 0
+        assert (fresh / "sessions/dashboard_chat-1-111.jsonl").is_file()
+        assert (fresh / "sessions/chat-1-111/agent-abc.md").is_file()
+
+    def test_restore_never_overwrites_local_transcript(self, sessions_env, tmp_path, monkeypatch):
+        _, _, tarball, _ = sessions_env
+        dst = tmp_path / "dst_sess"
+        _setup_fake_kirocrew(dst)
+        (dst / "sessions").mkdir()
+        (dst / "sessions/dashboard_chat-1-111.jsonl").write_text("local transcript content")
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+        for mode in ("replace", "merge"):
+            ret = restore_main([str(tarball), "--mode", mode, "--force"])
+            assert ret == 0
+            local = (dst / "sessions/dashboard_chat-1-111.jsonl").read_text(encoding="utf-8")
+            assert local == "local transcript content"
+        # Files missing locally are still copied in
+        assert (dst / "sessions/chat-1-111/agent-abc.md").is_file()
+
+    def test_component_selection_excludes_sessions(self, sessions_env, tmp_path, monkeypatch):
+        _, _, tarball, _ = sessions_env
+        fresh = tmp_path / "fresh_sel"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        restore_main([str(tarball), "--mode", "replace", "--components", "memory", "--force"])
+        assert not (fresh / "sessions").exists()
+
+    def test_sessions_component_only(self, sessions_env, tmp_path, monkeypatch):
+        _, _, tarball, _ = sessions_env
+        fresh = tmp_path / "fresh_only"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        restore_main([str(tarball), "--mode", "replace", "--components", "sessions", "--force"])
+        assert (fresh / "sessions/dashboard_chat-1-111.jsonl").is_file()
+        assert not (fresh / "memory.db").exists()
+
+    def test_old_snapshot_without_sessions_restores_unchanged(self, env, capsys, monkeypatch):
+        """A snapshot with no sessions/ (pre-sessions layout) restores as before."""
+        _, _, tarball, tmp_path = env
+        fresh = tmp_path / "fresh_old"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 0
+        assert (fresh / "memory.db").is_file()
+        assert not (fresh / "sessions").exists()
+
+    def test_old_snapshot_explicit_sessions_component_notes_absence(self, env, capsys, monkeypatch):
+        _, _, tarball, tmp_path = env
+        fresh = tmp_path / "fresh_old_note"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main(
+            [str(tarball), "--mode", "replace", "--components", "sessions", "--force"]
+        )
+        assert ret == 0
+        assert "not present in snapshot" in capsys.readouterr().out
+
+
+class TestSessionMapReconciliation:
+    def test_dangling_entries_dropped(self, tmp_path, monkeypatch):
+        src = tmp_path / "src_map"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        (src / "session_map.json").write_text(
+            json.dumps(
+                {
+                    # Transcript staged in the snapshot → kept, unusable sid cleared
+                    "dashboard:chat-1-111": {"sid": "aaaa-1111"},
+                    # No transcript anywhere → dropped
+                    "dashboard:chat-9-999": {"sid": "bbbb-9999"},
+                    # Incognito transcript is excluded from the snapshot → dropped
+                    "dashboard:chat-2-222": {"sid": "cccc-2222"},
+                    # No sid (linkage-only) → kept
+                    "slack:777.888": {"sid": None, "slack_thread_ts": "777.888"},
+                    # Externally-stored provider → kept
+                    "dashboard:chat-8-888": {"sid": "dddd-8888", "provider": "claude_code"},
+                    # Dangling sid BUT durable privacy flag → kept, sid cleared
+                    "slack:333.444": {"sid": "eeee-3333", "flags": {"incognito": True}},
+                }
+            )
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_map"))
+        out = tmp_path / "out_map"
+        tarball = _make_snapshot(src, out)
+
+        fresh = tmp_path / "fresh_map"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 0
+        restored = json.loads((fresh / "session_map.json").read_text(encoding="utf-8"))
+        assert set(restored) == {
+            "dashboard:chat-1-111",
+            "slack:777.888",
+            "dashboard:chat-8-888",
+            "slack:333.444",
+        }
+        # The flagged entry survives with its privacy state intact and the
+        # unusable sid cleared.
+        assert restored["slack:333.444"]["flags"] == {"incognito": True}
+        assert restored["slack:333.444"]["sid"] == ""
+        # The transcript-backed entry survives, but its sid is unusable on
+        # this host and is cleared — a stale sid left in place would get the
+        # whole entry deleted by SessionMap.prune() at first gateway start.
+        assert restored["dashboard:chat-1-111"]["sid"] == ""
+
+    def test_transcript_backed_unusable_sid_cleared_not_kept_stale(self, tmp_path, monkeypatch):
+        """A transcript-backed entry never keeps a sid that is unusable here.
+
+        SessionMap.prune() deletes ANY entry whose sid lacks a local kiro-cli
+        session file — privacy flags and thread linkage included. Keeping the
+        stale sid would therefore lose the durable state on the first gateway
+        start; clearing just the sid keeps the entry prune-safe.
+        """
+        src = tmp_path / "src_stale_sid"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        (src / "session_map.json").write_text(
+            json.dumps(
+                {
+                    # Transcript staged + durable flags, sid unusable → sid
+                    # cleared, flags kept.
+                    "dashboard:chat-1-111": {
+                        "sid": "gggg-1111",
+                        "flags": {"incognito": False},
+                        "slack_thread_ts": "111.222",
+                    },
+                }
+            )
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_stale_sid"))
+        out = tmp_path / "out_stale_sid"
+        tarball = _make_snapshot(src, out)
+
+        fresh = tmp_path / "fresh_stale_sid"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 0
+        restored = json.loads((fresh / "session_map.json").read_text(encoding="utf-8"))
+        entry = restored["dashboard:chat-1-111"]
+        assert entry["sid"] == ""
+        assert entry["flags"] == {"incognito": False}
+        assert entry["slack_thread_ts"] == "111.222"
+
+    def test_unsafe_sid_shape_cleared_on_transcript_backed_entry(self, tmp_path, monkeypatch):
+        """A sid that fails the safe-shape check is unusable and gets cleared."""
+        src = tmp_path / "src_unsafe_sid"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        (src / "session_map.json").write_text(
+            json.dumps({"dashboard:chat-1-111": {"sid": "../evil/../../sid"}})
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_unsafe_sid"))
+        out = tmp_path / "out_unsafe_sid"
+        tarball = _make_snapshot(src, out)
+
+        fresh = tmp_path / "fresh_unsafe_sid"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 0
+        restored = json.loads((fresh / "session_map.json").read_text(encoding="utf-8"))
+        assert restored["dashboard:chat-1-111"]["sid"] == ""
+
+    def test_entry_kept_when_cli_session_exists(self, tmp_path, monkeypatch):
+        src = tmp_path / "src_cli"
+        _setup_fake_kirocrew(src)
+        (src / "session_map.json").write_text(
+            json.dumps({"dashboard:chat-9-999": {"sid": "eeee-9999"}})
+        )
+        kiro_home = tmp_path / "kiro_home_cli"
+        (kiro_home / "sessions" / "cli").mkdir(parents=True)
+        (kiro_home / "sessions" / "cli" / "eeee-9999.json").write_text("{}")
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(kiro_home))
+        out = tmp_path / "out_cli"
+        tarball = _make_snapshot(src, out)
+
+        fresh = tmp_path / "fresh_cli"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 0
+        restored = json.loads((fresh / "session_map.json").read_text(encoding="utf-8"))
+        assert "dashboard:chat-9-999" in restored
+
+    def test_merge_with_local_map_untouched(self, sessions_env, tmp_path, monkeypatch):
+        """Merge mode never reconciles a pre-existing local map."""
+        _, _, tarball, _ = sessions_env
+        dst = tmp_path / "dst_local_map"
+        _setup_fake_kirocrew(dst)
+        local_map = {"dashboard:chat-77-777": {"sid": "ffff-7777"}}
+        (dst / "session_map.json").write_text(json.dumps(local_map))
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        assert ret == 0
+        after = json.loads((dst / "session_map.json").read_text(encoding="utf-8"))
+        assert after == local_map
+
+    def test_overlong_map_key_does_not_crash_reconciliation(self, tmp_path, monkeypatch):
+        """A session-map key of filesystem-component length raises
+        ENAMETOOLONG from the transcript probe — one corrupt entry must not
+        crash reconciliation and leave a partially applied restore."""
+        src = tmp_path / "src_longkey"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        (src / "session_map.json").write_text(
+            json.dumps({"dashboard:" + "x" * 4096: {"sid": "aaaa-1111"}})
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_longkey"))
+        out = tmp_path / "out_longkey"
+        tarball = _make_snapshot(src, out)
+
+        fresh = tmp_path / "fresh_longkey"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 0
+        # Reconciliation completed: the map exists and the entry was treated
+        # as transcript-absent (dropped/cleared), not crashed on.
+        assert (fresh / "session_map.json").is_file()
+
+    def test_config_only_restore_never_reconciles(self, tmp_path, monkeypatch):
+        """--components config restores the map but not transcripts — the map
+        must survive untouched rather than being reconciled against the
+        deliberately-absent sessions."""
+        src = tmp_path / "src_config_only"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        (src / "session_map.json").write_text(
+            json.dumps({"dashboard:chat-1-111": {"sid": "aaaa-1111"}})
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_config_only"))
+        out = tmp_path / "out_config_only"
+        tarball = _make_snapshot(src, out)
+
+        fresh = tmp_path / "fresh_config_only"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main([str(tarball), "--mode", "replace", "--components", "config", "--force"])
+        assert ret == 0
+        restored = json.loads((fresh / "session_map.json").read_text(encoding="utf-8"))
+        # The entry's transcript was NOT restored (sessions excluded) and no
+        # kiro-cli file exists — reconciliation would have dropped it.
+        assert "dashboard:chat-1-111" in restored
+        assert not (fresh / "sessions").exists()
+
+    def test_pre_sessions_snapshot_map_not_reconciled(self, tmp_path, monkeypatch):
+        """A snapshot without a sessions/ tree never triggers map reconciliation.
+
+        A pre-sessions snapshot ships session_map.json but no transcripts;
+        reconciling against that would delete every restored mapping.
+        """
+        src = tmp_path / "src_pre"
+        _setup_fake_kirocrew(src)
+        (src / "session_map.json").write_text(
+            json.dumps({"dashboard:chat-9-999": {"sid": "aaaa-9999"}})
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_pre"))
+        out = tmp_path / "out_pre"
+        tarball = _make_snapshot(src, out)
+        # The fixture has no sessions/ tree, so the tarball matches the
+        # pre-sessions layout as-is: a session map with no transcripts.
+        snap = _extract(tarball, tmp_path / "extract_pre")
+        assert not (snap / "sessions").exists()
+
+        fresh = tmp_path / "fresh_pre"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 0
+        restored = json.loads((fresh / "session_map.json").read_text(encoding="utf-8"))
+        # Entry survives despite no transcript existing anywhere locally.
+        assert "dashboard:chat-9-999" in restored
+
+    def test_reconciliation_deferred_while_gateway_holds_lock(self, tmp_path, monkeypatch, capsys):
+        """A --force restore under a live gateway never rewrites the map.
+
+        The race being pinned: the gateway writes a new mapping after
+        reconciliation reads the map, and reconciliation's stale whole-map
+        write deletes it. The pass is gated on ``gateway.lock``, so while a
+        live gateway holds it the map is left alone — the gateway's next
+        in-memory save overwrites the restored file regardless, so skipping
+        loses nothing the save would not already discard.
+        """
+        src = tmp_path / "src_gwlock"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        (src / "session_map.json").write_text(
+            # No transcript, no durable state → reconciliation would drop it.
+            json.dumps({"dashboard:chat-9-999": {"sid": "bbbb-9999"}})
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_gwlock"))
+        out = tmp_path / "out_gwlock"
+        tarball = _make_snapshot(src, out)
+
+        fresh = tmp_path / "fresh_gwlock"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        with GatewayLock(fresh):  # simulate the live gateway owning this home
+            ret = restore_main([str(tarball), "--mode", "replace", "--force"])
+        assert ret == 0
+        restored = json.loads((fresh / "session_map.json").read_text(encoding="utf-8"))
+        # Reconciliation would have dropped this entry; the gated pass left
+        # the map untouched instead of racing the (simulated) live gateway.
+        assert "dashboard:chat-9-999" in restored
+        assert "reconciliation skipped" in capsys.readouterr().out
+
+    def test_reconciliation_pass_holds_gateway_lock(self, tmp_path, monkeypatch):
+        """The map read-modify-write runs entirely under ``gateway.lock``.
+
+        Probes at the write step: a second acquire of the same home's lock
+        must be refused while the pass is writing, proving a concurrent
+        gateway map write could not have interleaved with the pass.
+        """
+        import kiro_crew.snapshot as snapshot_mod
+
+        mc = tmp_path / "mc_lock_probe"
+        (mc / "sessions").mkdir(parents=True)
+        (mc / "session_map.json").write_text(
+            json.dumps({"dashboard:chat-9-999": {"sid": "bbbb-9999"}})
+        )
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_probe"))
+
+        held_at_write: dict[str, bool] = {}
+        real_atomic_write = snapshot_mod.atomic_write
+
+        def probe(path, content):
+            try:
+                GatewayLock(mc).acquire().release()
+                held_at_write["value"] = False
+            except GatewayLockError:
+                held_at_write["value"] = True
+            real_atomic_write(path, content)
+
+        monkeypatch.setattr(snapshot_mod, "atomic_write", probe)
+        snapshot_mod._reconcile_session_map(mc)
+
+        # The write landed, and it happened while the pass held the lock.
+        assert held_at_write == {"value": True}
+        restored = json.loads((mc / "session_map.json").read_text(encoding="utf-8"))
+        assert "dashboard:chat-9-999" not in restored
+
+
+class TestPrivacyMarkerContract:
+    """Locks the shared incognito-marker contract between history and snapshot.
+
+    ``_restricted_session_stems`` reads the same metadata head-line marker that
+    ``history.recent_from_source`` uses to skip private sessions. This test
+    goes through the REAL producer (``ConversationLog.update_metadata``) so a
+    change to how history persists ``memory_mode`` breaks here loudly instead
+    of snapshots silently shipping incognito transcripts off-host.
+    """
+
+    def test_real_writer_transcript_classified_restricted(self, tmp_path, monkeypatch):
+        from kiro_crew.history import INCOGNITO_MEMORY_MODES, ConversationLog
+
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+        sessions = tmp_path / "home" / "sessions"
+        log = ConversationLog(base_dir=sessions)
+        log.append("dashboard:chat-3-333", "user", "hello")
+        log.append("dashboard:chat-4-444", "user", "hello private")
+        log.update_metadata("dashboard:chat-4-444", {"memory_mode": "incognito"})
+
+        from kiro_crew.snapshot import _restricted_session_stems, _transcript_candidates
+
+        restricted = _restricted_session_stems(
+            _transcript_candidates(sessions), INCOGNITO_MEMORY_MODES
+        )
+        assert "dashboard_chat-4-444" in restricted
+        assert "dashboard_chat-3-333" not in restricted
+
+    def test_unclassifiable_transcripts_fail_closed(self, tmp_path, monkeypatch):
+        """Malformed heads and unrecognized memory_mode values never ride.
+
+        Classification is positive: only a metadata record whose memory_mode
+        is absent (the store's persistent default) or "persistent" stages the
+        transcript. Everything else — an unknown mode, a head with no metadata
+        record — is unclassifiable and stays out of the snapshot.
+        """
+        src = tmp_path / "src_failclosed"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        s = src / "sessions"
+        # Unrecognized mode string.
+        (s / "dashboard_chat-6-666.jsonl").write_text(_meta_line("shadow") + _msg_line("x"))
+        # No metadata record anywhere in the head.
+        (s / "dashboard_chat-7-777.jsonl").write_text(_msg_line("no metadata at all"))
+        # Absent memory_mode field == persistent (legacy transcripts).
+        legacy_meta = json.dumps({"_type": "metadata", "created_at": "2026-01-01"}) + "\n"
+        (s / "dashboard_chat-8-888.jsonl").write_text(legacy_meta + _msg_line("legacy ok"))
+        # Present-but-malformed falsy values must NOT collapse to persistent.
+        null_meta = json.dumps({"_type": "metadata", "memory_mode": None}) + "\n"
+        (s / "dashboard_chat-10-010.jsonl").write_text(null_meta + _msg_line("null mode"))
+        empty_meta = json.dumps({"_type": "metadata", "memory_mode": ""}) + "\n"
+        (s / "dashboard_chat-11-011.jsonl").write_text(empty_meta + _msg_line("empty mode"))
+        list_meta = json.dumps({"_type": "metadata", "memory_mode": []}) + "\n"
+        (s / "dashboard_chat-12-012.jsonl").write_text(list_meta + _msg_line("list mode"))
+        # Undecodable head: cannot classify, fails closed.
+        (s / "dashboard_chat-13-013.jsonl").write_bytes(b"\xff\xfe garbage \xff" + b"\n")
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_failclosed"))
+        out = tmp_path / "out_failclosed"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_failclosed")
+        assert not (snap / "sessions" / "dashboard_chat-6-666.jsonl").exists()
+        assert not (snap / "sessions" / "dashboard_chat-7-777.jsonl").exists()
+        assert (snap / "sessions" / "dashboard_chat-8-888.jsonl").is_file()
+        assert not (snap / "sessions" / "dashboard_chat-10-010.jsonl").exists()
+        assert not (snap / "sessions" / "dashboard_chat-11-011.jsonl").exists()
+        assert not (snap / "sessions" / "dashboard_chat-12-012.jsonl").exists()
+        assert not (snap / "sessions" / "dashboard_chat-13-013.jsonl").exists()
+
+    def test_session_map_flagged_session_excluded(self, tmp_path, monkeypatch):
+        """A session flagged incognito/temporary in session_map.json never rides.
+
+        Channel sessions (Slack ``!incognito``) persist privacy as a flag on
+        the map entry, not in the transcript's metadata head — the head-based
+        classifier alone would export them.
+        """
+        src = tmp_path / "src_map_flag"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        s = src / "sessions"
+        # Transcript head says persistent; the map flag says incognito.
+        (s / "slack_555.777.jsonl").write_text(_meta_line("persistent") + _msg_line("flagged"))
+        (s / "archive" / "slack_555.777__20260101T000000Z.jsonl").write_text(
+            _msg_line("flagged rotated")
+        )
+        (src / "session_map.json").write_text(
+            json.dumps(
+                {
+                    "slack:555.777": {"sid": "ffff-5555", "flags": {"incognito": True}},
+                    "dashboard:chat-1-111": {"sid": "aaaa-1111"},
+                }
+            )
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_map_flag"))
+        out = tmp_path / "out_map_flag"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_map_flag")
+        assert not (snap / "sessions" / "slack_555.777.jsonl").exists()
+        assert not (
+            snap / "sessions" / "archive" / "slack_555.777__20260101T000000Z.jsonl"
+        ).exists()
+        # Unflagged sessions still ride.
+        assert (snap / "sessions" / "dashboard_chat-1-111.jsonl").is_file()
+
+    def test_flag_arriving_after_sweep_enforced_at_archive_time(self, tmp_path, monkeypatch):
+        """A ``!incognito`` landing between the post-copy sweep and tar.add
+        still excludes the session: the tar filter consults a fresh flag-map
+        read per entry, so the privacy verdict is atomic with archive
+        creation rather than fixed at staging time."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_late_flag"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        (src / "session_map.json").write_text(
+            json.dumps({"dashboard:chat-1-111": {"sid": "aaaa-1111"}})
+        )
+
+        real_stage = snapshot_mod._stage_sessions
+
+        def _stage_then_flag(mc, stage):
+            real_stage(mc, stage)
+            # The flag lands AFTER staging and the post-copy sweep have both
+            # completed, BEFORE the tarball is written.
+            (src / "session_map.json").write_text(
+                json.dumps(
+                    {
+                        "dashboard:chat-1-111": {
+                            "sid": "aaaa-1111",
+                            "flags": {"incognito": True},
+                        }
+                    }
+                )
+            )
+
+        monkeypatch.setattr(snapshot_mod, "_stage_sessions", _stage_then_flag)
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_late_flag"))
+        out = tmp_path / "out_late_flag"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_late_flag")
+        # The freshly flagged session was dropped at archive time: transcript,
+        # archive segment, and workspace dir all excluded.
+        assert not (snap / "sessions" / "dashboard_chat-1-111.jsonl").exists()
+        assert not (
+            snap / "sessions" / "archive" / "dashboard_chat-1-111__20260101T000000Z.jsonl"
+        ).exists()
+        assert not (snap / "sessions" / "chat-1-111").exists()
+        # Unrelated snapshot content still rides.
+        assert (snap / "MANIFEST.json").is_file()
+
+    def test_unreadable_session_map_fails_closed(self, tmp_path, monkeypatch):
+        """An unparseable session_map.json stages no sessions at all."""
+        src = tmp_path / "src_bad_map"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        (src / "session_map.json").write_text("{not json")
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_bad_map"))
+        out = tmp_path / "out_bad_map"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_bad_map")
+        assert not any((snap / "sessions").rglob("*.jsonl"))
+
+    def test_transcript_appearing_after_scan_is_not_staged(self, tmp_path, monkeypatch):
+        """A transcript the candidate scan never saw is skipped by the copy walk.
+
+        Covers an incognito session starting between classification and the
+        copy: the walk allowlists root transcripts against the scanned set
+        instead of denylisting against the restricted set.
+        """
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_postscan"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        late = src / "sessions" / "dashboard_chat-9-999.jsonl"
+        late.write_text(_meta_line("incognito") + _msg_line("started mid-snapshot"))
+
+        real_candidates = snapshot_mod._transcript_candidates
+
+        def _scan_missing_late(root):
+            return [p for p in real_candidates(root) if p.name != late.name]
+
+        monkeypatch.setattr(snapshot_mod, "_transcript_candidates", _scan_missing_late)
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_postscan"))
+        out = tmp_path / "out_postscan"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_postscan")
+        assert not (snap / "sessions" / "dashboard_chat-9-999.jsonl").exists()
+        assert (snap / "sessions" / "dashboard_chat-1-111.jsonl").is_file()
+
+    def test_flag_landing_during_copy_is_evicted_from_stage(self, tmp_path, monkeypatch):
+        """A session flagged !incognito between classification and the copy
+        walk must not ride: the post-copy sweep re-reads the map and evicts
+        the staged transcript, archive segment, and workspace directory."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_flag_race"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        s = src / "sessions"
+        (s / "slack_555.777.jsonl").write_text(_meta_line("persistent") + _msg_line("racy"))
+        (s / "archive" / "slack_555.777__20260101T000000Z.jsonl").write_text(
+            _msg_line("racy rotated")
+        )
+        (s / "slack_555.777").mkdir()
+        (s / "slack_555.777" / "agent-racy.md").write_text("racy result")
+
+        real_flag = snapshot_mod._flag_restricted_stems
+        state = {"calls": 0}
+
+        def _flag_with_race(mc):
+            state["calls"] += 1
+            out = real_flag(mc)
+            if state["calls"] == 1:
+                # After the pre-copy classification read, a channel session
+                # is flagged !incognito while the copy walk runs.
+                m = json.loads((mc / "session_map.json").read_text(encoding="utf-8"))
+                m["slack:555.777"] = {"sid": "ffff-5555", "flags": {"incognito": True}}
+                (mc / "session_map.json").write_text(json.dumps(m))
+            return out
+
+        monkeypatch.setattr(snapshot_mod, "_flag_restricted_stems", _flag_with_race)
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_flag_race"))
+        out = tmp_path / "out_flag_race"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_flag_race")
+        assert state["calls"] >= 2  # the post-copy re-read actually ran
+        assert not (snap / "sessions" / "slack_555.777.jsonl").exists()
+        assert not (
+            snap / "sessions" / "archive" / "slack_555.777__20260101T000000Z.jsonl"
+        ).exists()
+        assert not (snap / "sessions" / "slack_555.777").exists()
+        # Unaffected sessions still ride, workspace dirs included.
+        assert (snap / "sessions" / "dashboard_chat-1-111.jsonl").is_file()
+        assert (snap / "sessions" / "chat-1-111" / "agent-abc.md").is_file()
+
+    def test_head_flipping_restricted_during_copy_is_evicted(self, tmp_path, monkeypatch):
+        """A transcript whose head turns restricted after classification but
+        before the copy is caught by the post-copy re-scan of STAGED heads."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_head_race"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        s = src / "sessions"
+        flipping = s / "dashboard_chat-5-555.jsonl"
+        flipping.write_text(_meta_line("persistent") + _msg_line("about to go private"))
+
+        real_restricted = snapshot_mod._restricted_session_stems
+        state = {"calls": 0}
+
+        def _restricted_with_race(paths, modes):
+            state["calls"] += 1
+            out = real_restricted(paths, modes)
+            if state["calls"] == 1:
+                # The session flips to incognito after classification; the
+                # copy walk then stages the already-private head.
+                flipping.write_text(_meta_line("incognito") + _msg_line("now private"))
+            return out
+
+        monkeypatch.setattr(snapshot_mod, "_restricted_session_stems", _restricted_with_race)
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_head_race"))
+        out = tmp_path / "out_head_race"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_head_race")
+        assert state["calls"] >= 2
+        assert not (snap / "sessions" / "dashboard_chat-5-555.jsonl").exists()
+        assert (snap / "sessions" / "dashboard_chat-1-111.jsonl").is_file()
+
+    def test_map_unreadable_after_copy_fails_closed(self, tmp_path, monkeypatch):
+        """If the post-copy map re-read fails, the entire staged sessions tree
+        is discarded: privacy flags can no longer be ruled out for anything."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        src = tmp_path / "src_postcopy_bad_map"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+
+        real_flag = snapshot_mod._flag_restricted_stems
+        state = {"calls": 0}
+
+        def _flag_then_corrupt(mc):
+            state["calls"] += 1
+            out = real_flag(mc)
+            if state["calls"] == 1:
+                (mc / "session_map.json").write_text("{not json")
+            return out
+
+        monkeypatch.setattr(snapshot_mod, "_flag_restricted_stems", _flag_then_corrupt)
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_postcopy_bad_map"))
+        out = tmp_path / "out_postcopy_bad_map"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_postcopy_bad_map")
+        assert state["calls"] >= 2
+        assert not (snap / "sessions").exists()
+
+
+class TestSessionsRestoreDestinationGuards:
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+    def test_linked_local_sessions_root_refused(self, sessions_env, tmp_path, monkeypatch, capsys):
+        _, _, tarball, _ = sessions_env
+        dst = tmp_path / "dst_linked_root"
+        _setup_fake_kirocrew(dst)
+        outside = tmp_path / "outside_restore_root"
+        outside.mkdir()
+        (dst / "sessions").symlink_to(outside)
+        # A map entry whose transcript is only in the snapshot: if refusal
+        # wrongly triggered reconciliation, this entry would be dropped.
+        (dst / "session_map.json").write_text(
+            json.dumps({"dashboard:chat-1-111": {"sid": "aaaa-1111"}})
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_linked_root"))
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        assert ret == 0
+        assert "sessions not restored" in capsys.readouterr().out
+        assert not (outside / "dashboard_chat-1-111.jsonl").exists()
+        # Refused restore must NOT reconcile: the mapping survives.
+        after = json.loads((dst / "session_map.json").read_text(encoding="utf-8"))
+        assert "dashboard:chat-1-111" in after
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+    def test_restore_never_truncates_raced_transcript(self, sessions_env, tmp_path, monkeypatch):
+        """A transcript created between the exists() probe and the copy is
+        owned by the live gateway and never truncated (exclusive create)."""
+        from kiro_crew import snapshot as snapshot_mod
+
+        _, _, tarball, _ = sessions_env
+        snap = _extract(tarball, tmp_path / "extract_race_tr")
+        dd = tmp_path / "dd_race_tr"
+        dd.mkdir()
+        (dd / "dashboard_chat-1-111.jsonl").write_text("live gateway wrote this")
+        # Simulate the race: exists() lies while the file is really there.
+        monkeypatch.setattr(Path, "exists", lambda self: False)
+        snapshot_mod._copy_sessions_no_overwrite(snap / "sessions", dd)
+        monkeypatch.undo()
+        content = (dd / "dashboard_chat-1-111.jsonl").read_text(encoding="utf-8")
+        assert content == "live gateway wrote this"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+    def test_linked_destination_component_skipped(self, sessions_env, tmp_path, monkeypatch):
+        """Restore never writes through an existing linked subdirectory."""
+        _, _, tarball, _ = sessions_env
+        dst = tmp_path / "dst_linked_archive"
+        _setup_fake_kirocrew(dst)
+        (dst / "sessions").mkdir()
+        outside = tmp_path / "outside_archive"
+        outside.mkdir()
+        (dst / "sessions" / "archive").symlink_to(outside)
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"])
+        assert ret == 0
+        # Nothing escaped through the link; the transcript beside it landed.
+        assert not any(outside.iterdir())
+        assert (dst / "sessions" / "dashboard_chat-1-111.jsonl").is_file()
+
+    def test_do_replace_never_restores_sessions(self, sessions_env, tmp_path, monkeypatch):
+        """The shared _do_replace helper must not restore sessions.
+
+        Portability's dashboard ZIP import calls _do_replace directly and
+        documents that conversation data is excluded — a manifest-valid ZIP
+        carrying a sessions/ directory must not smuggle transcripts in.
+        Sessions restore belongs to restore_main only.
+        """
+        from kiro_crew import snapshot as snapshot_mod
+
+        _, _, tarball, _ = sessions_env
+        snap = _extract(tarball, tmp_path / "extract_dorplace")
+        fresh = tmp_path / "fresh_doreplace"
+        fresh.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(fresh))
+        snapshot_mod._do_replace(snap, fresh, None)
+        assert not (fresh / "sessions").exists()
+        assert (fresh / "memory.db").is_file()
+
+
+class TestSessionsLinkGuards:
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+    def test_linked_sessions_root_refused(self, tmp_path, monkeypatch, capsys):
+        """A sessions/ root that is a symlink stages nothing."""
+        src = tmp_path / "src_root_link"
+        _setup_fake_kirocrew(src)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("credential material")
+        (src / "sessions").symlink_to(outside)
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        out = tmp_path / "out_root_link"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_root_link")
+        assert not (snap / "sessions" / "secret.txt").exists()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+    def test_linked_child_dir_skipped(self, tmp_path, monkeypatch):
+        """A symlinked entry inside sessions/ never enters the snapshot."""
+        src = tmp_path / "src_child_link"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        outside = tmp_path / "outside_child"
+        outside.mkdir()
+        (outside / "id_rsa").write_text("credential material")
+        (src / "sessions" / "chat-1-111" / "linked").symlink_to(outside)
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_child"))
+        out = tmp_path / "out_child_link"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_child_link")
+        assert not (snap / "sessions" / "chat-1-111" / "linked").exists()
+        assert (snap / "sessions" / "chat-1-111" / "agent-abc.md").is_file()
+
+    def test_orphaned_workspace_dir_excluded(self, tmp_path, monkeypatch):
+        """A workspace dir with no staged owning transcript never rides along.
+
+        Covers a deleted incognito session whose subagent results were
+        retained: with the transcript gone the directory cannot be classified,
+        so like archive segments it is allowlisted against staged transcripts.
+        """
+        src = tmp_path / "src_orphan_ws"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        (src / "sessions" / "chat-5-555").mkdir()
+        (src / "sessions" / "chat-5-555" / "agent-xyz.md").write_text("orphaned private result")
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_orphan"))
+        out = tmp_path / "out_orphan_ws"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_orphan_ws")
+        assert not (snap / "sessions" / "chat-5-555").exists()
+        assert (snap / "sessions" / "chat-1-111" / "agent-abc.md").is_file()
+
+    def test_restricted_sibling_archive_not_leaked_by_prefix(self, tmp_path, monkeypatch):
+        """An incognito stem that extends a staged stem never leaks its archives.
+
+        The archive owner is everything before the LAST segment delimiter, so
+        a segment owned by ``<staged>__private`` must not ride just because its
+        name starts with ``<staged>__``.
+        """
+        src = tmp_path / "src_prefix_leak"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        s = src / "sessions"
+        # Incognito sibling whose stem extends the staged persistent stem.
+        (s / "dashboard_chat-1-111__private.jsonl").write_text(
+            _meta_line("incognito") + _msg_line("secret")
+        )
+        (s / "archive" / "dashboard_chat-1-111__private__20260101T000000Z.jsonl").write_text(
+            _msg_line("secret rotated")
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_prefix"))
+        out = tmp_path / "out_prefix_leak"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_prefix_leak")
+        assert not (snap / "sessions" / "dashboard_chat-1-111__private.jsonl").exists()
+        assert not (
+            snap / "sessions" / "archive" / "dashboard_chat-1-111__private__20260101T000000Z.jsonl"
+        ).exists()
+        # The genuinely staged session's artifacts still ride.
+        assert (
+            snap / "sessions" / "archive" / "dashboard_chat-1-111__20260101T000000Z.jsonl"
+        ).is_file()
+
+    def test_legacy_slack_session_artifacts_staged(self, tmp_path, monkeypatch):
+        """A pre-migration Slack transcript's canonical-stem artifacts ride along.
+
+        The live transcript keeps the bare thread_ts filename, but archive
+        segments and the workspace directory are named by the canonical
+        ``slack:`` key — the allowlist must recognize both spellings.
+        """
+        src = tmp_path / "src_legacy_slack"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        s = src / "sessions"
+        # Legacy live transcript: bare thread_ts stem, persistent.
+        (s / "999.111.jsonl").write_text(_meta_line("persistent") + _msg_line("legacy hi"))
+        # Canonical-stem archive segment + workspace dir for the same session.
+        (s / "archive" / "slack_999.111__20260101T000000Z.jsonl").write_text(
+            _msg_line("legacy rotated")
+        )
+        (s / "slack_999.111").mkdir()
+        (s / "slack_999.111" / "agent-leg.md").write_text("legacy subagent result")
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_legacy"))
+        out = tmp_path / "out_legacy_slack"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_legacy_slack")
+        assert (snap / "sessions" / "999.111.jsonl").is_file()
+        assert (snap / "sessions" / "archive" / "slack_999.111__20260101T000000Z.jsonl").is_file()
+        assert (snap / "sessions" / "slack_999.111" / "agent-leg.md").is_file()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+    def test_linked_transcript_does_not_authorize_artifacts(self, tmp_path, monkeypatch):
+        """A linked transcript never vouches for its stem's archives/workspace.
+
+        The link itself is skipped at copy time, but it must also be excluded
+        from the staging allowlist — otherwise its canonical alias would let
+        orphaned archive segments and workspace files ride the snapshot.
+        """
+        src = tmp_path / "src_linked_transcript"
+        _setup_fake_kirocrew(src)
+        _add_fake_sessions(src)
+        s = src / "sessions"
+        outside = tmp_path / "outside_transcript"
+        outside.mkdir()
+        (outside / "real.jsonl").write_text(_meta_line("persistent") + _msg_line("elsewhere"))
+        # Legacy-shaped stem via a symlink, plus canonical-stem artifacts that
+        # only this link could authorize.
+        (s / "888.222.jsonl").symlink_to(outside / "real.jsonl")
+        (s / "archive" / "slack_888.222__20260101T000000Z.jsonl").write_text(
+            _msg_line("orphaned rotated")
+        )
+        (s / "slack_888.222").mkdir()
+        (s / "slack_888.222" / "agent-orph.md").write_text("orphaned result")
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        monkeypatch.setenv("KIRO_HOME", str(tmp_path / "kiro_home_linked_tr"))
+        out = tmp_path / "out_linked_transcript"
+        tarball = _make_snapshot(src, out)
+        snap = _extract(tarball, tmp_path / "extract_linked_transcript")
+        assert not (snap / "sessions" / "888.222.jsonl").exists()
+        assert not (
+            snap / "sessions" / "archive" / "slack_888.222__20260101T000000Z.jsonl"
+        ).exists()
+        assert not (snap / "sessions" / "slack_888.222").exists()


### PR DESCRIPTION
## Problem / Motivation

`kirocrew snapshot` ships `session_map.json` (part of the `config` component) but not `~/.kiro/crew/sessions/` — the directory holding the chat transcripts that map refers to. Restoring a snapshot on another machine therefore yields a session map pointing at transcripts that do not exist: the dashboard has no chat history to rehydrate, and no conversation is resumable. On my install the sessions directory is ~55 MB of transcripts that a "portable snapshot of KiroCrew state" silently leaves behind while still shipping the index that references them.

## Why it matters

The snapshot is the disaster-recovery story: anyone restoring onto a new machine loses every conversation while memory, crons, and config come back fine — and the restored `session_map.json` actively claims sessions exist that don't. That internal inconsistency is worse than a documented omission, because nothing in the restore output tells you the chats are gone until you open the dashboard.

## What changed (motivation → approach → change)

Symptom: restores come back with a session map but no transcripts. Root cause: snapshot staging copies an explicit allowlist (CORE_FILES plus `workspace/`, `plan_memory/`, `skills/`), and `sessions/` was never added to it — while `session_map.json` rode along inside the `config` component. The fix adds a `sessions` component and reconciles the map:

- **Staging**: the `sessions/` tree (live transcripts, rotated `archive/` segments, per-session workspace dirs with subagent results) is staged via the existing symlink-safe copy. It rides through the same `_data_filter` tar pass as every other tree (traversal/symlink/hardlink rejection); no new basenames were added to `NEVER_SNAPSHOT_FILES`, so no user file can be silently dropped by basename collision.
- **Privacy**: incognito/temporary transcripts are persisted on disk like any other (their `memory_mode` marker lives in the metadata line at the head of the file — the same marker `history.recent_from_source` reads to skip them), but they are private by contract everywhere else in the product (never searched, listed, or summarized), so they are never staged. Their archive segments and per-session workspace directories are excluded with them. A transcript whose head can't be read is treated as restricted (fail closed). Archive segments AND per-session workspace directories are allowlisted by their owning live transcript rather than denylisted: a rotated segment or a workspace whose transcript is absent (e.g. a deleted incognito session with retained subagent results) has no reliable privacy marker of its own, so an orphaned one never rides. Archive ownership is matched exactly (owner = everything before the last segment delimiter), so a restricted sibling whose stem merely extends a staged stem can never leak through a prefix match. Pre-migration Slack sessions (live transcript under the bare `thread_ts` filename) have their canonical `slack_` stem allowlisted too, since archive segments and workspace dirs are always written under the canonical key — unless that canonical transcript exists and is itself restricted, in which case privacy wins. `.lock` files are excluded as per-process runtime artifacts.
- **Link hardening**: the sessions root is refused outright when it is a POSIX symlink or Windows junction (`platform_compat.is_link_or_junction`), every child entry is checked the same way during the copy walk, and link-shaped transcripts are excluded from the staging allowlist itself — so a linked transcript can neither be copied nor vouch for archive segments and workspace directories it does not actually own. The same discipline applies on the way back in: restore refuses a linked local sessions root and never writes through a linked destination component (including dangling links, which a naive existence check would write through).
- **Positive privacy classification**: a transcript stages only when its metadata head record positively classifies it as persistent — an absent `memory_mode` field (the store's own default, so legacy transcripts ride) or the literal `persistent`. Unknown modes, present-but-malformed values (null/empty/list), heads with no metadata record, unreadable files, and undecodable bytes all fail closed. The copy walk additionally allowlists root transcripts against the scanned candidate set, so a session created mid-snapshot is unclassified and skipped rather than riding unexamined.
- **CLI-only restore surface**: session restoration is invoked only from `restore_main`, never from the shared `_do_replace`/`_do_merge` helpers — the dashboard ZIP import (`portability.apply_import_zip`) reuses those helpers and documents that conversation data is excluded, so a manifest-valid ZIP carrying a sessions/ directory cannot smuggle transcripts in.
- **Restore semantics**: additive in both modes — a file that already exists locally is never overwritten, so a restore can never destroy local conversation history. This deliberately differs from the replace-mode semantics of other components (transcripts are irreplaceable user data, so there is no wholesale replace and no backup/rmtree step for them). Old snapshots (created before this change) simply have no `sessions/` directory and restore exactly as before; requesting `--components sessions` against one prints an explanatory note.
- **Session-map reconciliation**: after a restore in which `session_map.json` could have arrived from the snapshot (replace mode, or merge mode when no local map existed) AND the snapshot actually carries a sessions tree, entries that reference neither a local Kiro Crew transcript (via `history.transcript_stems`, so legacy Slack stems are honored) nor a local kiro-cli session file are dropped. The sessions-tree gate matters: a pre-sessions snapshot ships a map but no transcripts, and reconciling against that would delete every restored mapping instead of preserving history. This mirrors the conservatism of `SessionMap.prune`: linkage-only entries (no sid) and `claude_code`-provider entries are kept, sid values are shape-validated before being joined onto a path, and the write is tmp+rename. A pre-existing local map in merge mode is never touched.
- **Manifest**: gains additive `session_transcripts` / `session_files` counts and the restore banner prints the transcript count when present. No manifest version bump: old restorers ignore the extra directory and extra keys, and the new restorer guards on the directory's existence, so both directions are compatible at version 2.

## Tests

21 new tests in `test/test_snapshot.py`, extending the existing fixture patterns (tmp `KIROCREW_HOME`, real tarball round-trips through `snapshot_main` → `restore_main`; `KIRO_HOME` pinned to a tmp dir so the kiro-cli store stays hermetic):

- Staging: persistent transcripts + their archive segments + workspace dirs are staged; incognito and temporary transcripts, their archive segments, and their workspace dirs are not; `.lock` files are not; an orphaned archive segment (no live transcript) is not; an orphaned workspace dir (no staged owning transcript) is not; a restricted sibling whose stem extends a staged stem cannot leak its archives through prefix matching; a pre-migration Slack transcript's canonical-stem archives and workspace ride along; manifest counts are correct.
- Link guards: a symlinked sessions root stages nothing; a symlinked child entry is skipped; a symlinked transcript cannot authorize its canonical-stem archives or workspace.
- Restore: fresh restore lands the tree; an existing local transcript survives byte-identical through both replace and merge restores while missing files are still copied in; `--components memory` does not touch sessions; `--components sessions` restores only sessions; a pre-sessions snapshot restores unchanged and notes the absence when sessions are explicitly requested.
- Reconciliation: dangling sid entries are dropped, entries backed by a staged transcript or an existing kiro-cli session file are kept, linkage-only and `claude_code` entries are kept, a pre-existing local map in merge mode is untouched, and a pre-sessions snapshot (map but no sessions tree) never triggers reconciliation at all.

Full snapshot suite (67 tests) plus the suites that import `kiro_crew.snapshot` (`test_portability.py`, `test_beacon.py`, `test_knowledge.py` — the portability profile import reuses `_do_replace` and is unaffected, since export zips contain no `sessions/`) all pass locally, along with isort/flake8/mypy/black on the changed files.

## Manual verification

N/A — unit coverage exercises the real end-to-end path (actual tarball creation and extraction through `snapshot_main`/`restore_main`, not mocks), including the privacy exclusions against transcripts with real metadata head lines.

## Related Issues

None filed — found while designing a backup strategy for my own install and verifying what `kirocrew snapshot` actually covers.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: the owning doc (`docs/system-specs/modules/cli.md`) describes the snapshot/restore commands generically and enumerates no component list, so nothing becomes stale; `--list-components` output is generated from `COMPONENT_HELP`.
- [x] No secrets, credentials, or internal references in the diff


