### PR TITLE
fix(knowledge): reconcile artifacts on every start, not on source-row creation

### DIFF
--- a/docs/system-specs/modules/artifacts.md
+++ b/docs/system-specs/modules/artifacts.md
@@ -585,14 +585,73 @@ adding a parallel watcher (see `kiro_crew.knowledge.artifact_ingest`):
   content-affecting mutation (create, content-changing update, delete). A
   metadata-only rename fires a separate `rename` signal that refreshes the
   stored group label without re-ingesting (no chunk churn).
-- **First-enable backfill tied to source-row creation.** Because the feature is
-  on by default, the store may already hold artifacts created before the
-  listener existed. The one-time pass that ingests them is tied to the
-  *creation of the aggregate source row*: when `ensure_artifact_source` actually
-  inserts the row (its existence is the idempotency marker — no separate flag),
-  a background backfill runs once. On every later boot the row already exists,
-  so nothing re-runs. (Nothing writes the store while the gateway is down, and
-  there is no out-of-process writer, so no recurring reconcile is needed.)
+- **Reconcile on every start, not a creation-gated backfill.** The feature is
+  opt-in, and while it is off the change-listener is not registered, so writes in
+  that window never reach the Library. Tying the catch-up pass to *creation of
+  the aggregate source row* cannot repair that: the row outlives the feature
+  being switched off, so on any install that ever had it on a later opt-in gets
+  `created=False` and the pass never runs — the gap is permanent and silent.
+  `ArtifactKnowledgeSync.start()` therefore runs `reconcile_artifacts`
+  **unconditionally**, comparing the artifact store against
+  `artifact_item_state`: ingest what is missing or changed, drop state for
+  artifacts that no longer exist. `created` is now reported for logging only.
+  - **Converged is free.** `ingest_artifact` already skips unchanged content, so
+    the steady state spends no extraction calls and logs at debug.
+  - **Removals are judged against every artifact, not the eligible kinds.**
+    Narrowing `auto_ingest_artifact_kinds` makes an artifact ineligible, not
+    absent; reaping on that basis would delete content the user never deleted.
+    A reap also requires two signals, not one: `get()` raising
+    `ArtifactNotFoundError` *and* the artifact's directory being gone. That error
+    is also what a missing `meta.json` raises, which a partially-restored
+    directory hits while its content is still present, and deletion removes the
+    whole directory — so demanding both costs a recoverable stale group instead
+    of unrecoverable deleted items.
+  - **An emptied artifact is dropped unbudgeted.** Its body is blank, so there is
+    nothing to extract and the drop costs no LLM calls. Keeping it behind the
+    budget would let obsolete text stay searchable for as many restarts as a
+    backlog of newer changes takes to drain. Only tracked artifacts are read, and
+    the pass stands down on `source_missing` for the same reason
+    `ingest_artifact` does.
+  - **Off-window metadata drift is repaired unbudgeted.** A tracked artifact
+    whose kind differs from the kind recorded at ingest (`artifact_item_state.kind`)
+    had its group produced by the previous kind's reader, so that group is
+    reaped exactly as the live `upsert` path does, and the ingest loop rebuilds
+    it if the new kind is eligible. The decision reads the *recorded* kind, not
+    the current allowlist: "the artifact changed" and "the user narrowed
+    `auto_ingest_artifact_kinds`" are indistinguishable from the current kind
+    alone, and reaping on the latter would delete content the user never
+    touched. A row predating the column carries `NULL`, so its ingested kind is
+    unknown; that is resolved by which repair is safe. An eligible artifact is
+    re-ingested once (in budget, no deletion), which repairs any undetectable
+    drift and backfills the column so it never repeats; an ineligible one is
+    left alone, because deletion is the only repair available there and drift
+    was never proven. Where the
+    removal happens depends on whether anything will rebuild the group: a drift
+    into an *ineligible* kind is reaped in the unbudgeted pre-pass (removal is
+    the whole repair), while a drift between two *eligible* kinds is replaced
+    inside the budgeted loop, so a backlog past the budget keeps its stale group
+    and defers rather than being deleted now and restored several starts later.
+    An eligible replacement clears only the recorded content hash, never the
+    group: that defeats the unchanged-content short-circuit (a byte-identical
+    body under a new kind would otherwise keep the previous reader's chunks)
+    while leaving `ingest_file` to do its normal atomic replace, so a failed
+    extraction keeps the old items and the artifact stays searchable.
+    Every tracked artifact's stored group label is also refreshed to its current
+    redacted name, so a rename during the off-window stops showing the old
+    label. Neither pass touches content hashes — a converged store still spends
+    nothing.
+- **A dead source pointer neither deletes nor rewrites an index.**
+  `ingest_artifact` returns early whenever `get()` reported `source_missing`
+  (live file moved / unreadable, so the content is a snapshot fallback). That
+  snapshot is not evidence about the live file in either direction: blank does
+  not mean the artifact was emptied, and non-blank does not mean it is current,
+  so acting on it would either destroy a valid index or replace newer indexed
+  text with older. Same rule as the reconcile reap — only provable state acts.
+  - **Ingests are bounded per run** by `RECONCILE_INGEST_BUDGET` (a module
+    constant, not a config key). `ArtifactStore.list` is newest-first, so a
+    backlog from a long off-window drains across successive starts with the most
+    recent artifacts first, instead of arriving as one unbounded burst of billed
+    extraction calls. Unchanged artifacts do not consume budget.
 - **Security.** Ingested text *and* the LLM-originated artifact name (used as
   the source/item title) are passed through `redact_credentials()` and
   `redact_exfiltration_urls()` before landing in the Knowledge store (per

--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -137,10 +137,12 @@ async def _start_artifact_ingest_async(app: web.Application) -> None:
     create / content-update / delete (from the agent's MCP tools, the CLI, the
     dashboard, bookmarks, and provider pull/clone -- all of which funnel
     through the store in the gateway process) ingests or removes that
-    artifact's item group in the aggregate "Artifacts" Knowledge source. On the
-    first run that creates the source row, a one-time backfill ingests
-    pre-existing artifacts. Gated on ``knowledge.auto_ingest_artifacts`` (off by
-    default). See ``kiro_crew.knowledge.artifact_ingest`` for the full design.
+    artifact's item group in the aggregate "Artifacts" Knowledge source. Every
+    start also runs a reconcile pass that ingests what the store has and the
+    Library lacks and drops state for artifacts that are gone, so drift from the
+    window in which this was switched off is repaired rather than left permanent.
+    Gated on ``knowledge.auto_ingest_artifacts`` (off by default). See
+    ``kiro_crew.knowledge.artifact_ingest`` for the full design.
     """
     cfg = KiroCrewConfig.load()
     if not cfg.knowledge.auto_ingest_artifacts:

--- a/src/kiro_crew/knowledge/artifact_ingest.py
+++ b/src/kiro_crew/knowledge/artifact_ingest.py
@@ -23,13 +23,18 @@ parallel watcher):
   observes every write path. ``upsert`` -> ingest/replace the artifact's item
   group; ``delete`` -> remove it.
 
-* **First-enable backfill tied to source-row creation.** The feature is opt-in,
-  so when it is switched on the store already holds every artifact created
-  before the listener existed. The one-time pass that ingests them is tied to
-  the *creation of the aggregate source row*: when :func:`ensure_artifact_source`
-  actually creates the row (its existence is the idempotency marker), the
-  backfill runs once. On every later boot the row already exists, so nothing
-  re-runs.
+* **Reconcile on every start, not a one-shot first-enable backfill.** The
+  feature is opt-in, and while it is off the listener is not registered at all,
+  so artifacts created / edited / deleted during that window are invisible to
+  the Library. Keying the catch-up pass off *creation of the aggregate source
+  row* cannot repair that: on an install that ever had the feature on, the row
+  already exists, so a later opt-in returns ``created=False`` and the catch-up
+  never runs -- the gap becomes permanent and silent. So the pass runs on EVERY
+  :meth:`ArtifactKnowledgeSync.start` and is driven by state comparison instead:
+  ingest what the store has and ``artifact_item_state`` lacks or disagrees with,
+  remove state for artifacts that no longer exist. Converged is the common case
+  and costs no extraction calls, because :func:`ingest_artifact` already skips
+  unchanged content.
 
 Content (and the artifact name used as the source title) are redacted for
 credentials/exfiltration URLs before they cross into the store, and file-backed
@@ -105,9 +110,11 @@ def ensure_artifact_source(kstore: KnowledgeStore) -> tuple[str, bool]:
     """Get-or-create the single aggregate "Artifacts" source row.
 
     Returns ``(source_id, created)``. ``created`` is ``True`` only on the call
-    that actually inserts the row -- the row's existence is the idempotency
-    marker the first-enable backfill keys off, so no separate "backfilled" flag
-    is needed.
+    that actually inserts the row. It is reported for logging only -- it must
+    NOT gate the catch-up pass: the row survives the feature being switched off,
+    so a later opt-in would see ``created=False`` and never repair the drift
+    accumulated while the listener was unregistered. :func:`reconcile_artifacts`
+    compares state instead, and runs unconditionally.
     """
     existing = kstore.get_source_by_uri(ARTIFACT_SOURCE_URI)
     if existing:
@@ -155,11 +162,18 @@ def _set_state(
     item_ids: list[str],
     name: str,
     status: str = "active",
+    kind: str | None = None,
 ) -> None:
     """Record the content hash + item-id group + display name for one artifact,
     keyed by slug in the dedicated ``artifact_item_state`` table. ``name`` is the
     (redacted) artifact name, used as the per-artifact group label in the
     Sources UI.
+
+    ``kind`` is the artifact kind AS INGESTED. Reconcile compares it against the
+    artifact's current kind to tell a kind change that happened while sync was
+    off (stale chunks) from a kind the user merely excluded from
+    ``auto_ingest_artifact_kinds`` (still live) -- two situations that are
+    otherwise indistinguishable at start-up.
 
     ``status`` is written explicitly on every call because the statement is an
     ``INSERT OR REPLACE``: omitting it would reset a ``deduped`` marker back to
@@ -168,9 +182,18 @@ def _set_state(
     now = datetime.now().isoformat()
     kstore.db.execute(
         "INSERT OR REPLACE INTO artifact_item_state "
-        "(source_id, slug, content_hash, item_ids, updated_at, name, status) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?)",
-        (source_id, slug, content_hash, json.dumps(item_ids), now, name, status),
+        "(source_id, slug, content_hash, item_ids, updated_at, name, status, kind) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            source_id,
+            slug,
+            content_hash,
+            json.dumps(item_ids),
+            now,
+            name,
+            status,
+            kind,
+        ),
     )
     kstore.db.commit()
 
@@ -185,6 +208,37 @@ def refresh_artifact_name(
     cur = kstore.db.execute(
         "UPDATE artifact_item_state SET name = ? WHERE source_id = ? AND slug = ?",
         (name, source_id, slug),
+    )
+    kstore.db.commit()
+    return cur.rowcount > 0
+
+
+def _invalidate_content_hash(
+    kstore: KnowledgeStore, source_id: str, slug: str
+) -> bool:
+    """Clear only the recorded content hash, keeping the item group intact.
+
+    Used when an artifact must be re-ingested even though its bytes are
+    unchanged -- a kind change, where the group is valid content read by the
+    WRONG reader. Deleting the group first would leave the artifact unsearchable
+    if the re-ingest then failed; clearing the hash instead defeats
+    :func:`ingest_artifact`'s unchanged-content short-circuit and lets
+    ``ingest_file`` do its normal atomic replacement, which keeps the old group
+    on a failed extraction. Returns ``True`` if a row was updated.
+
+    Only rows that OWN items are touched. A row with an empty group is a deduped
+    marker: it holds a dedup claim keyed to the hash recorded here, and
+    ``release_stale_claim`` needs that hash to name the document it is detaching
+    from. Clearing it would strand the claim, and deleting the winning holder
+    would then hand this artifact the superseded text. Such a row also fails the
+    short-circuit's ``and old_item_ids`` leg already, so there is nothing to
+    defeat.
+    """
+    cur = kstore.db.execute(
+        "UPDATE artifact_item_state SET content_hash = NULL "
+        "WHERE source_id = ? AND slug = ? "
+        "AND item_ids IS NOT NULL AND TRIM(item_ids) NOT IN ('[]', '')",
+        (source_id, slug),
     )
     kstore.db.commit()
     return cur.rowcount > 0
@@ -246,7 +300,30 @@ async def ingest_artifact(
             )
             return None
     text = art.content or ""
+    if art.source_missing:
+        # File-backed artifact whose live source could not be read: `get` fell
+        # back to the stored snapshot and flagged it. That snapshot is not
+        # evidence about the live file in EITHER direction -- blank does not mean
+        # the artifact was emptied, and non-blank does not mean it is current, so
+        # ingesting it can overwrite a newer index with older text. Neither the
+        # drop below nor an ingest is safe: keep what is already indexed until
+        # the source is readable again. Same rule as
+        # `_artifact_is_really_gone` -- only provable state acts.
+        logger.warning(
+            "artifact KB: %s has no readable source; keeping its indexed group "
+            "as-is",
+            slug,
+        )
+        return None
     if not text.strip():
+        # An artifact emptied after it was ingested must not keep answering
+        # searches from its previous text. There is nothing to index, so drop the
+        # group rather than returning early and leaving obsolete chunks live.
+        # Offloaded: remove_artifact -> delete_items_batch -> store._load_graph
+        # is a graph rebuild inside a SQLite transaction, never loop-safe work.
+        prev_hash, old_item_ids = _get_state(kstore, source_id, slug)
+        if old_item_ids or prev_hash:
+            await asyncio.to_thread(remove_artifact, kstore, source_id, slug)
         return None
     text = _redact_for_ingest(text)
     # art.name is LLM-originated (set by the agent via artifact_save) and is
@@ -321,7 +398,16 @@ async def ingest_artifact(
         # items on the way out. Record that: leaving the prior state would point
         # at deleted items and make every subsequent artifact event re-attempt a
         # write the gate will refuse again.
-        _set_state(kstore, source_id, slug, content_hash, [], title, status="deduped")
+        _set_state(
+            kstore,
+            source_id,
+            slug,
+            content_hash,
+            [],
+            title,
+            status="deduped",
+            kind=art.kind,
+        )
         return job_id
     if status != "completed":
         # Partial/failed ingest: ingest_file kept the old group and rolled back
@@ -335,7 +421,7 @@ async def ingest_artifact(
         ).fetchall()
     }
     new_ids = list(after_ids - before_ids)
-    _set_state(kstore, source_id, slug, content_hash, new_ids, title)
+    _set_state(kstore, source_id, slug, content_hash, new_ids, title, kind=art.kind)
     sel().log_tool_invocation(
         session_key="gateway",
         agent="knowledge-artifacts",
@@ -379,30 +465,293 @@ def remove_artifact(kstore: KnowledgeStore, source_id: str, slug: str) -> int:
     return len(item_ids)
 
 
-async def backfill_artifacts(
+#: Artifacts the reconcile pass may (re-)ingest in ONE run. Each ingest costs
+#: LLM extraction calls on a pool of billed sessions, so opting in against a
+#: store that drifted while the feature was off must not arrive as one unbounded
+#: burst. The pass runs on EVERY start and ``art_store.list`` is newest-first, so
+#: a backlog drains over successive boots with the most recent artifacts landing
+#: first -- the same newest-first-plus-budget shape the folder watcher applies per
+#: sweep. Unchanged artifacts cost nothing and do NOT consume budget, so a
+#: converged store never defers.
+RECONCILE_INGEST_BUDGET = 50
+
+
+#: Sentinel for "this slug has no state row at all", distinct from a row whose
+#: ``kind`` is NULL (tracked, but ingested before the column existed).
+_UNTRACKED = object()
+
+
+def _known_kinds(kstore: KnowledgeStore, source_id: str) -> dict[str, str | None]:
+    """Map slug -> kind AS INGESTED for every item group this source tracks.
+
+    The kind is NULL for rows written before the ``kind`` column existed; see
+    :func:`reconcile_artifacts` for why that is treated as "cannot tell".
+    """
+    rows = kstore.db.execute(
+        "SELECT slug, kind FROM artifact_item_state WHERE source_id = ?", (source_id,)
+    ).fetchall()
+    return {row["slug"]: row["kind"] for row in rows}
+
+
+async def _artifact_is_really_gone(art_store: ArtifactStore, slug: str) -> bool:
+    """True only when the artifact is provably absent from the store.
+
+    ``ArtifactStore.list`` silently omits an artifact whose ``meta.json`` cannot
+    be read, so absence from the listing is NOT proof of deletion. Reaping on the
+    listing alone would delete a live artifact's indexed content because one file
+    was briefly unreadable. Confirm per slug, and treat any error other than
+    "not found" as "keep the state" -- a stale group is recoverable on the next
+    start, deleted items are not.
+
+    ``ArtifactNotFoundError`` is itself raised for a missing ``meta.json``, which
+    a partially-restored artifact directory can hit while its content is still
+    there. So require the directory to be gone too: deletion removes the whole
+    directory, and demanding both means a mid-restore window costs a stale group
+    (recoverable) rather than deleted items (not).
+    """
+    try:
+        await asyncio.to_thread(art_store.get, slug)
+    except ArtifactNotFoundError:
+        try:
+            adir_exists = await asyncio.to_thread((art_store.root / slug).exists)
+        except OSError:
+            logger.warning(
+                "artifact KB reconcile: cannot stat %s's directory; keeping its "
+                "item group",
+                slug,
+            )
+            return False
+        if adir_exists:
+            logger.warning(
+                "artifact KB reconcile: %s has no readable metadata but its "
+                "directory is still present; keeping its item group",
+                slug,
+            )
+            return False
+        return True
+    except Exception:
+        logger.warning(
+            "artifact KB reconcile: cannot read %s; keeping its item group", slug
+        )
+        return False
+    return False
+
+
+async def reconcile_artifacts(
     pipeline: IngestionPipeline,
     art_store: ArtifactStore,
     source_id: str,
     kinds: set[str],
-) -> int:
-    """One-time first-enable pass: ingest every eligible pre-existing artifact
-    into the freshly-created aggregate source. Returns the number ingested."""
-    if not kinds:
-        return 0
-    ingested = 0
-    # art_store.list walks the artifact directory and reads every metadata
-    # file -- offload the blocking filesystem walk so a large store doesn't
-    # freeze chat turns / liveness heartbeats during the one-time backfill.
+    *,
+    budget: int = RECONCILE_INGEST_BUDGET,
+) -> tuple[int, int, int]:
+    """Bring the aggregate source back in line with the artifact store.
+
+    Runs on every :meth:`ArtifactKnowledgeSync.start`, so it repairs drift from
+    any cause -- the feature having been off, a crash mid-ingest, a restore from
+    backup -- not just a first enable. Returns ``(ingested, removed, deferred)``.
+
+    Ordering matters: removals run FIRST and are unbudgeted. They cost no
+    extraction calls, and leaving them behind would keep text searchable that has
+    no artifact behind it. They also run even when ``kinds`` is empty: an empty
+    allowlist means "ingest nothing", not "let deleted content stay searchable".
+    Two further off-window drifts are repaired unbudgeted for the same reason:
+    a tracked artifact whose kind became structurally unsupported loses its
+    stale chunks, and every tracked artifact's group label is refreshed to its
+    current (redacted) name.
+    """
+    # art_store.list walks the artifact directory and reads every metadata file;
+    # the state read is SQLite. Offload both so a large store cannot freeze chat
+    # turns or the liveness heartbeat during the pass.
     artifacts = await asyncio.to_thread(art_store.list)
-    for art in artifacts:
-        if art.kind not in kinds:
+    known = await asyncio.to_thread(_known_kinds, pipeline.store, source_id)
+
+    removed = 0
+
+    # Gone-from-the-store is judged against EVERY artifact, not just eligible
+    # kinds: a kinds-config change makes an artifact ineligible, not absent, and
+    # deleting its items on that basis would silently drop content the user did
+    # not delete. Stale-but-present is harmless; over-deleting is not.
+    live = {art.slug for art in artifacts}
+    for slug in sorted(known.keys() - live):
+        if not await _artifact_is_really_gone(art_store, slug):
             continue
         try:
-            if await ingest_artifact(pipeline, art_store, art.slug, source_id, kinds):
-                ingested += 1
+            # remove_artifact -> delete_items_batch -> store._load_graph, a full
+            # in-memory graph rebuild inside a SQLite transaction. Never on the
+            # loop: once per slug deleted during a long off-window is exactly the
+            # wedge `no-blocking-call-on-event-loop` guards, and the sibling live
+            # delete in `_handle` offloads this same call for this same reason.
+            await asyncio.to_thread(remove_artifact, pipeline.store, source_id, slug)
+            removed += 1
         except Exception:
-            logger.exception("artifact KB backfill: failed to ingest %s", art.slug)
-    return ingested
+            logger.exception("artifact KB reconcile: failed to remove %s", slug)
+
+    # Kind drift: the artifact's kind CHANGED after it was ingested (markdown
+    # ingested, later switched to svg or to an excluded kind while sync was
+    # off). Its indexed group was produced by the previous kind's reader, so the
+    # old prose would keep answering searches -- the same staleness the live
+    # ``_handle`` path removes on a kind-change upsert.
+    #
+    # This is decided from the kind RECORDED AT INGEST, not from ``kinds``:
+    # "the artifact changed" and "the user narrowed the allowlist" are
+    # indistinguishable by the current kind alone, and reaping on the latter
+    # would delete content the user never touched. A legacy row predating the
+    # ``kind`` column carries None. That is unknowable, so it is resolved by
+    # which repair is safe: an ELIGIBLE artifact is re-ingested once (below, in
+    # budget, no deletion), which both repairs any drift and backfills the
+    # column so it never repeats; an INELIGIBLE one is left alone, because the
+    # only repair there is deletion and drift was never proven.
+    drifted: set[str] = set()
+    for art in artifacts:
+        prev_kind = known.get(art.slug, _UNTRACKED)
+        if prev_kind is _UNTRACKED or prev_kind == art.kind:
+            continue
+        if art.kind in kinds:
+            # Nothing re-reads this artifact until the budgeted loop below, so
+            # removing it HERE would be a delete-now / restore-later split: a
+            # backlog past the budget would leave the remainder missing from
+            # search entirely until a further start. Replace it in-budget
+            # instead, where the removal and the re-ingest are one step.
+            drifted.add(art.slug)
+            continue
+        if prev_kind is None:
+            # Legacy row, ineligible kind: the only repair available here is
+            # deletion, and nothing proves this artifact ever drifted. A stale
+            # group is recoverable; deleted items are not.
+            continue
+        # Ineligible new kind: nothing will re-ingest it under this config, so
+        # removal IS the whole repair and is unbudgeted -- it costs no
+        # extraction calls, exactly like the deleted-artifact reap above.
+        try:
+            await asyncio.to_thread(
+                remove_artifact, pipeline.store, source_id, art.slug
+            )
+            removed += 1
+            logger.info(
+                "artifact KB reconcile: %s changed kind %s -> %s (not ingestible); "
+                "removed its stale chunks",
+                art.slug,
+                prev_kind,
+                art.kind,
+            )
+        except Exception:
+            logger.exception("artifact KB reconcile: failed to remove %s", art.slug)
+
+    # Emptied while off: an artifact whose body is now blank must not keep
+    # answering searches from its previous text. Dropping it costs no extraction
+    # calls, so it belongs here rather than behind the budget -- an emptied
+    # artifact sitting past a backlog of newer changes would otherwise stay
+    # searchable for as many restarts as it takes the backlog to drain. Only
+    # TRACKED artifacts are read: an untracked one has no group to drop. The
+    # extra `get` is a disk read (the same one `ingest_artifact` would do later),
+    # never an extraction.
+    emptied: set[str] = set()
+    for art in artifacts:
+        if art.slug not in known:
+            continue
+        try:
+            current = await asyncio.to_thread(art_store.get, art.slug)
+        except ArtifactNotFoundError:
+            continue
+        except Exception:
+            logger.warning(
+                "artifact KB reconcile: cannot read %s; leaving its group alone",
+                art.slug,
+            )
+            continue
+        if current.source_missing:
+            # Snapshot fallback: blank proves nothing about the live file, the
+            # same reason `ingest_artifact` stands down on this flag.
+            continue
+        if (current.content or "").strip():
+            continue
+        try:
+            await asyncio.to_thread(
+                remove_artifact, pipeline.store, source_id, art.slug
+            )
+            removed += 1
+            emptied.add(art.slug)
+            logger.info(
+                "artifact KB reconcile: %s was emptied; removed its stale chunks",
+                art.slug,
+            )
+        except Exception:
+            logger.exception("artifact KB reconcile: failed to remove %s", art.slug)
+
+    # Name drift: a rename during the off-window never reached the Library, so
+    # the Sources-UI group label still shows the old name. Metadata-only and
+    # unbudgeted, mirroring the live rename path -- content hashes are
+    # untouched, so an unchanged artifact still costs nothing below.
+    for art in artifacts:
+        if art.slug not in known or art.slug in emptied:
+            continue
+        try:
+            await asyncio.to_thread(
+                refresh_artifact_name,
+                pipeline.store,
+                source_id,
+                art.slug,
+                _redact_for_ingest(art.name),
+            )
+        except Exception:
+            logger.exception(
+                "artifact KB reconcile: failed to refresh name for %s", art.slug
+            )
+
+    if not kinds:
+        return 0, removed, 0
+
+    ingested = 0
+    deferred = 0
+    for art in artifacts:  # newest-first, per ArtifactStore.list
+        if art.kind not in kinds or art.slug in emptied:
+            # An artifact dropped above has nothing left to ingest: its body is
+            # blank, so re-reading it would only repeat the same decision.
+            continue
+        if ingested >= budget:
+            deferred += 1
+            continue
+        if art.slug in drifted:
+            # Kind changed between two eligible kinds: the recorded content hash
+            # still matches, so `ingest_artifact` would short-circuit and keep
+            # the previous reader's chunks. Clear ONLY the hash -- the group
+            # stays live, and `ingest_file` replaces it atomically (a failed
+            # extraction rolls back and keeps the old items), so a valid index is
+            # never traded for an extraction that might not land. A deduped row
+            # (empty group) is left untouched: its hash is what
+            # `release_stale_claim` needs to detach the claim it holds, and it
+            # already falls through the short-circuit.
+            try:
+                await asyncio.to_thread(
+                    _invalidate_content_hash, pipeline.store, source_id, art.slug
+                )
+            except Exception:
+                logger.exception(
+                    "artifact KB reconcile: failed to invalidate hash for %s",
+                    art.slug,
+                )
+                continue
+        try:
+            # Returns None for unchanged content (and for ineligible / sensitive
+            # / empty), so a converged artifact spends no budget and no tokens.
+            job_id = await ingest_artifact(
+                pipeline, art_store, art.slug, source_id, kinds
+            )
+            if not job_id:
+                continue
+            # A write the pre-ingest hash gate refused as a duplicate returns a
+            # job id but performs no extraction. It also re-attempts on every
+            # start, because the deduped state row holds an empty group and the
+            # per-slug short-circuit requires one -- so counting it would let a
+            # budget's worth of duplicates starve every other artifact forever.
+            status = (pipeline.get_job_status(job_id) or {}).get("status")
+            if status == DUPLICATE_JOB_STATUS:
+                continue
+            ingested += 1
+        except Exception:
+            logger.exception("artifact KB reconcile: failed to ingest %s", art.slug)
+    return ingested, removed, deferred
 
 
 class ArtifactKnowledgeSync:
@@ -410,7 +759,7 @@ class ArtifactKnowledgeSync:
 
     Registered as the store's change-listener: ``on_change`` (sync, called from
     the store write path on any thread) schedules the async ingest/remove on the
-    gateway loop. A single lock serializes all work so the first-enable backfill
+    gateway loop. A single lock serializes all work so the start-time reconcile
     and live events never interleave mid-ingest.
     """
 
@@ -426,7 +775,7 @@ class ArtifactKnowledgeSync:
         self.kinds = set(kinds)
         self._loop = loop
         self._lock = asyncio.Lock()
-        self._backfill_task: asyncio.Task | None = None
+        self._reconcile_task: asyncio.Task | None = None
 
     @property
     def kstore(self) -> KnowledgeStore:
@@ -515,11 +864,17 @@ class ArtifactKnowledgeSync:
                 self.pipeline, self.art_store, slug, source_id, self.kinds
             )
 
-    # ── startup / backfill ────────────────────────────────────────────────
+    # ── startup / reconcile ───────────────────────────────────────────────
 
     async def start(self) -> None:
-        """Ensure the aggregate source exists; on first creation, kick off the
-        one-time backfill in the background (so gateway startup isn't blocked)."""
+        """Ensure the aggregate source exists, then kick off the reconcile pass
+        in the background (so gateway startup isn't blocked).
+
+        The pass runs on EVERY start, not only when the source row is created:
+        the row outlives the feature being switched off, so gating on creation
+        leaves an opt-in unable to repair the drift from that window. See the
+        module docstring.
+        """
         source_id, created = ensure_artifact_source(self.kstore)
         logger.info(
             "artifact KB sync started: source=%s created=%s kinds=%s",
@@ -527,25 +882,41 @@ class ArtifactKnowledgeSync:
             created,
             sorted(self.kinds),
         )
-        if created:
-            self._backfill_task = asyncio.create_task(self._run_backfill(source_id))
+        self._reconcile_task = asyncio.create_task(self._run_reconcile(source_id))
 
-    async def _run_backfill(self, source_id: str) -> None:
+    async def _run_reconcile(self, source_id: str) -> None:
         async with self._lock:
             try:
-                ingested = await backfill_artifacts(
+                ingested, removed, deferred = await reconcile_artifacts(
                     self.pipeline, self.art_store, source_id, self.kinds
                 )
             except Exception:
-                logger.exception("artifact KB backfill failed")
+                logger.exception("artifact KB reconcile failed")
                 return
+        if not (ingested or removed or deferred):
+            # The steady state. Logged at debug so an already-converged store
+            # does not write a line on every boot.
+            logger.debug("artifact KB reconcile: already in sync")
+            return
         logger.info(
-            "artifact KB backfill: %d artifact(s) ingested into new source", ingested
+            "artifact KB reconcile: %d ingested, %d removed, %d deferred to a later start",
+            ingested,
+            removed,
+            deferred,
         )
+        if deferred:
+            logger.info(
+                "artifact KB reconcile: %d artifact(s) exceed the per-run budget of "
+                "%d and will be picked up on the next start, newest first",
+                deferred,
+                RECONCILE_INGEST_BUDGET,
+            )
         sel().log_tool_invocation(
             session_key="gateway",
             agent="knowledge-artifacts",
-            tool_name="knowledge.artifact_ingest.backfill",
+            tool_name="knowledge.artifact_ingest.reconcile",
             outcome="completed",
-            resources=str({"ingested": ingested}),
+            resources=str(
+                {"ingested": ingested, "removed": removed, "deferred": deferred}
+            ),
         )

--- a/src/kiro_crew/knowledge/store.py
+++ b/src/kiro_crew/knowledge/store.py
@@ -353,6 +353,7 @@ class KnowledgeStore:
                 name TEXT,
                 status TEXT DEFAULT 'active',
                 merged_into_source_id TEXT,
+                kind TEXT,
                 PRIMARY KEY (source_id, slug)
             );
 
@@ -499,6 +500,7 @@ class KnowledgeStore:
                     updated_at TEXT NOT NULL,
                     name TEXT,
                     merged_into_source_id TEXT,
+                    kind TEXT,
                     PRIMARY KEY (source_id, slug)
                 )
             """)
@@ -513,6 +515,14 @@ class KnowledgeStore:
             if "merged_into_source_id" not in ais_cols:
                 self.db.execute(
                     "ALTER TABLE artifact_item_state ADD COLUMN merged_into_source_id TEXT")
+            # The artifact kind AS INGESTED. Reconcile needs it to tell an
+            # artifact whose kind changed while sync was off (stale chunks, must
+            # be reaped) from one the user merely excluded by narrowing
+            # `auto_ingest_artifact_kinds` (still live, must NOT be reaped).
+            # Legacy rows carry NULL, which reconcile treats as "cannot tell"
+            # and leaves alone; the next ingest of that artifact backfills it.
+            if "kind" not in ais_cols:
+                self.db.execute("ALTER TABLE artifact_item_state ADD COLUMN kind TEXT")
         # Migrate: agent_item_state table -- per-document item-group tracking for
         # the aggregate "Auto-added" KB source the agent writes to.
         if "agent_item_state" not in tables:

--- a/test/test_knowledge_artifact_ingest.py
+++ b/test/test_knowledge_artifact_ingest.py
@@ -2,22 +2,25 @@
 
 import asyncio
 import hashlib
+import threading
+from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from kiro_crew.artifacts import ArtifactStore
+from kiro_crew.artifacts import ArtifactNotFoundError, ArtifactStore
+from kiro_crew.knowledge import artifact_ingest
 from kiro_crew.knowledge.artifact_ingest import (
     ARTIFACT_SOURCE_TYPE,
     ARTIFACT_SOURCE_URI,
     ArtifactKnowledgeSync,
-    backfill_artifacts,
     ensure_artifact_source,
     ingest_artifact,
+    reconcile_artifacts,
     refresh_artifact_name,
     remove_artifact,
 )
-from kiro_crew.knowledge.ingestion import IngestionPipeline
+from kiro_crew.knowledge.ingestion import DUPLICATE_JOB_STATUS, IngestionPipeline
 from kiro_crew.knowledge.readers import FileReader
 from kiro_crew.knowledge.store import KnowledgeStore
 
@@ -258,24 +261,582 @@ class TestRemoveArtifact:
         assert remove_artifact(kstore, sid, "never-ingested") == 0
 
 
-class TestBackfill:
+class TestReconcile:
     @pytest.mark.asyncio
-    async def test_backfill_ingests_eligible_only(self, pipeline, art_store, kstore):
+    async def test_reconcile_ingests_eligible_only(self, pipeline, art_store, kstore):
         sid, _ = ensure_artifact_source(kstore)
         art_store.create(name="MD", content="markdown body", kind="markdown")
         art_store.create(name="TXT", content="text body", kind="text")
         art_store.create(name="WID", content="<b>x</b>", kind="widget")
-        n = await backfill_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
-        assert n == 2
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS)
+        assert (ingested, removed, deferred) == (2, 0, 0)
         contents = _contents(kstore, sid)
         assert any("markdown body" in c for c in contents)
         assert any("text body" in c for c in contents)
 
     @pytest.mark.asyncio
-    async def test_backfill_empty_kinds_noop(self, pipeline, art_store, kstore):
+    async def test_reconcile_empty_kinds_noop(self, pipeline, art_store, kstore):
         sid, _ = ensure_artifact_source(kstore)
         art_store.create(name="MD", content="body", kind="markdown")
-        assert await backfill_artifacts(pipeline, art_store, sid, set()) == 0
+        assert await reconcile_artifacts(pipeline, art_store, sid, set()) == (0, 0, 0)
+
+    @pytest.mark.asyncio
+    async def test_a_converged_store_costs_nothing(self, pipeline, art_store, kstore):
+        """The steady state: reconcile runs every start, so it must be free."""
+        sid, _ = ensure_artifact_source(kstore)
+        art_store.create(name="MD", content="body", kind="markdown")
+        assert await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS) == (1, 0, 0)
+        # Second pass sees identical content -> ingest_artifact returns None.
+        assert await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS) == (0, 0, 0)
+
+    @pytest.mark.asyncio
+    async def test_reconcile_drops_state_for_artifacts_deleted_while_off(
+        self, pipeline, art_store, kstore
+    ):
+        """The listener is not registered while the feature is off, so a delete
+        during that window never reached the Library. Reconcile must drop it, or
+        the text stays searchable with no artifact behind it."""
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Doomed", content="doomed body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        assert any("doomed body" in c for c in _contents(kstore, sid))
+        art_store.delete(art.slug)  # no listener: the Library is not told
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS)
+        assert (ingested, removed, deferred) == (0, 1, 0)
+        assert _contents(kstore, sid) == []
+
+    @pytest.mark.asyncio
+    async def test_an_ineligible_kind_is_not_treated_as_deleted(
+        self, pipeline, art_store, kstore
+    ):
+        """Narrowing `kinds` makes an artifact ineligible, not absent. Deleting
+        its items on that basis would drop content the user never deleted."""
+        sid, _ = ensure_artifact_source(kstore)
+        art_store.create(name="MD", content="still here", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, {"text"})
+        assert removed == 0, "an ineligible kind must not be reaped"
+        assert any("still here" in c for c in _contents(kstore, sid))
+
+    @pytest.mark.asyncio
+    async def test_a_kind_change_while_off_reaps_the_stale_chunks(
+        self, pipeline, art_store, kstore
+    ):
+        """The indexed group was produced by the PREVIOUS kind's reader, so a
+        kind change during the off-window leaves obsolete prose answering
+        searches. The live ``_handle`` path removes on that upsert; reconcile
+        must do the same."""
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Doc", content="markdown prose", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        assert any("markdown prose" in c for c in _contents(kstore, sid))
+        art_store.update(art.slug, kind="svg")  # no listener registered
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS)
+        assert (ingested, removed, deferred) == (0, 1, 0)
+        assert _contents(kstore, sid) == []
+
+    @pytest.mark.asyncio
+    async def test_a_kind_change_into_an_excluded_kind_is_still_reaped(
+        self, pipeline, art_store, kstore
+    ):
+        """The new kind being config-excluded does not make the OLD chunks less
+        stale: the artifact itself changed, so its group must go even though
+        nothing re-ingests it."""
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Doc", content="markdown prose", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, {"markdown"})
+        art_store.update(art.slug, kind="text")  # eligible-kind change, excluded
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, {"markdown"})
+        assert (ingested, removed, deferred) == (0, 1, 0)
+        assert _contents(kstore, sid) == []
+
+    @pytest.mark.asyncio
+    async def test_a_nonempty_stale_snapshot_does_not_overwrite_the_index(
+        self, pipeline, art_store, kstore, monkeypatch
+    ):
+        """A fallback snapshot is not evidence about the live file in either
+        direction: blank does not mean emptied, and non-blank does not mean
+        current. Ingesting it would replace a newer index with older text."""
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Doc", content="newer body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        assert any("newer body" in c for c in _contents(kstore, sid))
+
+        real_get = art_store.get
+
+        def _dead_pointer(slug, *a, **kw):
+            got = real_get(slug, *a, **kw)
+            got.content = "older snapshot body"
+            got.source_path = "/nonexistent/moved.md"
+            got.source_missing = True
+            return got
+
+        monkeypatch.setattr(art_store, "get", _dead_pointer)
+        assert await ingest_artifact(
+            pipeline, art_store, art.slug, sid, DEFAULT_KINDS) is None
+        contents = _contents(kstore, sid)
+        assert any("newer body" in c for c in contents)
+        assert not any("older snapshot" in c for c in contents), (
+            "a stale fallback snapshot must not replace the indexed content")
+
+    @pytest.mark.asyncio
+    async def test_an_emptied_artifact_is_dropped_even_past_the_budget(
+        self, pipeline, art_store, kstore
+    ):
+        """Dropping an emptied artifact costs no extraction, so it must not sit
+        behind the ingest budget: a backlog of newer changes would otherwise keep
+        the obsolete text searchable for as many restarts as the backlog takes to
+        drain."""
+        sid, _ = ensure_artifact_source(kstore)
+        stale = art_store.create(name="Stale", content="obsolete body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        assert any("obsolete body" in c for c in _contents(kstore, sid))
+        # Emptied while off, then buried under newer changes. `list` is
+        # newest-first, so with budget=1 the newer artifact consumes the budget
+        # and `stale` never reaches the ingest loop.
+        art_store.update(stale.slug, content="   ")
+        art_store.create(name="Newer", content="newer body", kind="markdown")
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS, budget=1)
+        assert removed == 1, "the emptied artifact must be dropped regardless of budget"
+        contents = _contents(kstore, sid)
+        assert not any("obsolete body" in c for c in contents), (
+            "stale text survived because the drop was budgeted")
+        assert any("newer body" in c for c in contents)
+
+    @pytest.mark.asyncio
+    async def test_an_emptied_artifact_with_a_dead_source_is_left_alone(
+        self, pipeline, art_store, kstore, monkeypatch
+    ):
+        """The unbudgeted drop must honour the same stand-down as
+        `ingest_artifact`: a blank snapshot behind an unreadable live source
+        proves nothing about the artifact's real content."""
+        sid, _ = ensure_artifact_source(kstore)
+        art_store.create(name="Doc", content="indexed body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        real_get = art_store.get
+
+        def _dead_pointer(slug, *a, **kw):
+            got = real_get(slug, *a, **kw)
+            got.content = ""
+            got.source_path = "/nonexistent/moved.md"
+            got.source_missing = True
+            return got
+
+        monkeypatch.setattr(art_store, "get", _dead_pointer)
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS)
+        assert removed == 0
+        assert any("indexed body" in c for c in _contents(kstore, sid))
+
+    @pytest.mark.asyncio
+    async def test_an_eligible_kind_change_is_replaced_inside_the_budget(
+        self, pipeline, art_store, kstore
+    ):
+        """A kind change between two ELIGIBLE kinds must not be removed by the
+        pre-pass: the re-ingest is budgeted, so a backlog past the budget would
+        leave the remainder missing from search entirely rather than merely
+        stale. Over-budget drift keeps its old group and defers."""
+        sid, _ = ensure_artifact_source(kstore)
+        keep = art_store.create(name="Keep", content="keep body", kind="markdown")
+        swap = art_store.create(name="Swap", content="swap body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        art_store.update(keep.slug, kind="text")
+        art_store.update(swap.slug, kind="text")
+        # budget=1: `list` is newest-first, so `swap` is replaced and `keep` waits.
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS, budget=1)
+        assert (ingested, removed, deferred) == (1, 0, 1)
+        contents = _contents(kstore, sid)
+        assert any("swap body" in c for c in contents)
+        assert any("keep body" in c for c in contents), (
+            "deferred drift must keep its group, not lose it to a pre-pass delete")
+        # The next start finishes the job; nothing was lost in between.
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS, budget=1)
+        assert (ingested, removed, deferred) == (1, 0, 0)
+        assert len(_contents(kstore, sid)) == 2
+
+    @pytest.mark.asyncio
+    async def test_an_eligible_kind_change_bypasses_the_unchanged_hash_shortcut(
+        self, pipeline, art_store, kstore
+    ):
+        """Content is byte-identical across the kind change, so the recorded
+        hash still matches and `ingest_artifact` alone would short-circuit,
+        leaving the previous reader's chunks. Clearing the hash rebuilds the
+        group."""
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Doc", content="same body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        before = {r["id"] for r in kstore.db.execute(
+            "SELECT id FROM items WHERE source_id = ?", (sid,)).fetchall()}
+        art_store.update(art.slug, kind="text")
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS)
+        assert (ingested, removed, deferred) == (1, 0, 0)
+        after = {r["id"] for r in kstore.db.execute(
+            "SELECT id FROM items WHERE source_id = ?", (sid,)).fetchall()}
+        assert before != after, "the group must be rebuilt, not short-circuited"
+        row = kstore.db.execute(
+            "SELECT kind FROM artifact_item_state WHERE source_id = ? AND slug = ?",
+            (sid, art.slug)).fetchone()
+        assert row["kind"] == "text"
+
+    @pytest.mark.asyncio
+    async def test_a_failed_replacement_keeps_the_previous_group_searchable(
+        self, pipeline, art_store, kstore, monkeypatch
+    ):
+        """The replacement must never trade a valid index for an extraction that
+        might not land. Only the hash is cleared, so a failed re-ingest leaves
+        the old group live and the artifact still searchable; the cleared hash
+        means the next start retries."""
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Doc", content="original body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        art_store.update(art.slug, kind="text")
+        monkeypatch.setattr(
+            pipeline, "ingest_file",
+            AsyncMock(side_effect=RuntimeError("extraction exploded")))
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS)
+        assert (ingested, removed, deferred) == (0, 0, 0)
+        assert any("original body" in c for c in _contents(kstore, sid)), (
+            "a failed replacement must not leave the artifact unsearchable")
+
+    @pytest.mark.asyncio
+    async def test_a_deduped_row_keeps_its_hash_so_its_claim_can_be_released(
+        self, pipeline, art_store, kstore
+    ):
+        """A deduped row owns no items but holds a dedup claim keyed to the hash
+        recorded on it -- that hash is how `release_stale_claim` names the
+        document it detaches from. Clearing it would strand the claim, and
+        deleting the winning holder would then hand this artifact the superseded
+        text. The row also already fails the short-circuit's `and old_item_ids`
+        leg, so there is nothing to defeat."""
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Doc", content="deduped body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        # Force the deduped shape: a claim-holding row with an empty group.
+        kstore.db.execute(
+            "UPDATE artifact_item_state SET item_ids = '[]', status = 'deduped' "
+            "WHERE source_id = ? AND slug = ?", (sid, art.slug))
+        kstore.db.commit()
+        before = kstore.db.execute(
+            "SELECT content_hash FROM artifact_item_state "
+            "WHERE source_id = ? AND slug = ?", (sid, art.slug)).fetchone()["content_hash"]
+        assert before
+        # The helper itself must refuse an empty-group row.
+        assert artifact_ingest._invalidate_content_hash(kstore, sid, art.slug) is False
+        assert kstore.db.execute(
+            "SELECT content_hash FROM artifact_item_state "
+            "WHERE source_id = ? AND slug = ?",
+            (sid, art.slug)).fetchone()["content_hash"] == before
+
+        art_store.update(art.slug, kind="text")
+        seen: list[str | None] = []
+        real_release = kstore.release_stale_claim
+
+        def _spy(source_id, prev_hash, *a, **kw):
+            seen.append(prev_hash)
+            return real_release(source_id, prev_hash, *a, **kw)
+
+        with mock.patch.object(kstore, "release_stale_claim", _spy):
+            await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        assert seen, "the re-ingest must reach the claim-release step"
+        assert seen[0] == before, (
+            "release_stale_claim needs the ORIGINAL hash to name the document it "
+            "detaches from; a nulled hash strands the claim")
+
+    @pytest.mark.asyncio
+    async def test_narrowing_the_allowlist_alone_never_reaps(
+        self, pipeline, art_store, kstore
+    ):
+        """The counter-case to the two above, and the reason the decision reads
+        the kind RECORDED AT INGEST rather than the current allowlist: the
+        artifact is untouched, only the config narrowed. Reaping here would
+        delete content the user never changed."""
+        sid, _ = ensure_artifact_source(kstore)
+        art_store.create(name="MD", content="untouched body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        for _ in range(2):  # repeated starts must not erode it either
+            ingested, removed, deferred = await reconcile_artifacts(
+                pipeline, art_store, sid, {"text"})
+            assert removed == 0
+        assert any("untouched body" in c for c in _contents(kstore, sid))
+
+    @pytest.mark.asyncio
+    async def test_a_row_predating_the_kind_column_is_left_alone(
+        self, pipeline, art_store, kstore
+    ):
+        """A legacy row carries kind NULL and its current kind is ineligible:
+        the only repair available is deletion, and nothing proves it drifted. A
+        stale group is recoverable; deleted items are not."""
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Doc", content="legacy body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        kstore.db.execute(
+            "UPDATE artifact_item_state SET kind = NULL WHERE source_id = ?", (sid,))
+        kstore.db.commit()
+        art_store.update(art.slug, kind="svg")
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS)
+        assert removed == 0
+        assert any("legacy body" in c for c in _contents(kstore, sid))
+
+    @pytest.mark.asyncio
+    async def test_a_legacy_eligible_row_is_re_ingested_once_and_backfilled(
+        self, pipeline, art_store, kstore
+    ):
+        """A legacy row's ingested kind is unknown, so an off-window kind edit
+        between two eligible kinds cannot be detected and the unchanged hash
+        would keep the previous reader's chunks forever. Where the safe repair
+        exists (re-ingest, no deletion) take it once, record the kind, and never
+        repeat it."""
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Doc", content="legacy body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        kstore.db.execute(
+            "UPDATE artifact_item_state SET kind = NULL WHERE source_id = ?", (sid,))
+        kstore.db.commit()
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS)
+        assert (ingested, removed, deferred) == (1, 0, 0)
+        row = kstore.db.execute(
+            "SELECT kind FROM artifact_item_state WHERE source_id = ? AND slug = ?",
+            (sid, art.slug)).fetchone()
+        assert row["kind"] == "markdown", "the column must be backfilled"
+        assert any("legacy body" in c for c in _contents(kstore, sid))
+        # Self-terminating: the recorded kind now matches, so the next start is
+        # free again.
+        assert await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS) == (0, 0, 0)
+
+    @pytest.mark.asyncio
+    async def test_a_directory_without_metadata_is_not_treated_as_deleted(
+        self, pipeline, art_store, kstore, monkeypatch
+    ):
+        """``ArtifactNotFoundError`` is also what a missing ``meta.json`` raises,
+        which a partially-restored artifact directory hits while its content is
+        still there. Deletion removes the whole directory, so require both to be
+        gone before reaping."""
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Doc", content="restoring body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        assert (art_store.root / art.slug).exists()
+
+        def _no_meta(slug, *a, **kw):
+            raise ArtifactNotFoundError(slug)
+
+        # `list` omits it (unreadable meta) and `get` raises -- but the directory
+        # is still on disk, so this is a restore window, not a deletion.
+        monkeypatch.setattr(art_store, "list", lambda *a, **kw: [])
+        monkeypatch.setattr(art_store, "get", _no_meta)
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS)
+        assert removed == 0
+        assert any("restoring body" in c for c in _contents(kstore, sid)), (
+            "a mid-restore window must not delete the indexed group")
+
+    @pytest.mark.asyncio
+    async def test_kind_drift_is_reaped_even_with_an_empty_allowlist(
+        self, pipeline, art_store, kstore
+    ):
+        """Same rule as deletions: an empty allowlist means "ingest nothing",
+        not "let chunks from a kind that no longer applies stay live"."""
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Doc", content="old body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        art_store.update(art.slug, kind="svg")
+        assert await reconcile_artifacts(pipeline, art_store, sid, set()) == (0, 1, 0)
+        assert _contents(kstore, sid) == []
+
+    @pytest.mark.asyncio
+    async def test_a_rename_while_off_refreshes_the_group_label(
+        self, pipeline, art_store, kstore
+    ):
+        """A rename during the off-window never reached the Library. Reconcile
+        must refresh the stored label without re-ingesting (content unchanged,
+        so no budget spent and items untouched)."""
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Before", content="stable body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        art_store.update(art.slug, name="After")  # no listener registered
+        item_ids_before = {r["id"] for r in kstore.db.execute(
+            "SELECT id FROM items WHERE source_id = ?", (sid,)).fetchall()}
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS)
+        assert (ingested, removed, deferred) == (0, 0, 0)
+        row = kstore.db.execute(
+            "SELECT name FROM artifact_item_state WHERE source_id = ? AND slug = ?",
+            (sid, art.slug)).fetchone()
+        assert row["name"] == "After"
+        item_ids_after = {r["id"] for r in kstore.db.execute(
+            "SELECT id FROM items WHERE source_id = ?", (sid,)).fetchall()}
+        assert item_ids_before == item_ids_after
+
+    @pytest.mark.asyncio
+    async def test_budget_defers_the_remainder_and_a_later_run_finishes_it(
+        self, pipeline, art_store, kstore
+    ):
+        sid, _ = ensure_artifact_source(kstore)
+        for i in range(3):
+            art_store.create(name=f"Doc{i}", content=f"body {i}", kind="markdown")
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS, budget=2)
+        assert (ingested, removed, deferred) == (2, 0, 1)
+        # The next start picks up what was deferred; nothing is lost.
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS, budget=2)
+        assert (ingested, removed, deferred) == (1, 0, 0)
+        assert len(_contents(kstore, sid)) == 3
+
+    @pytest.mark.asyncio
+    async def test_reconcile_empty_kinds_still_drops_deleted_state(
+        self, pipeline, art_store, kstore
+    ):
+        """An empty allowlist means "ingest nothing", not "let deleted content
+        stay searchable" -- an early return before the removal loop left a
+        deleted artifact's text answering searches forever."""
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="MD", content="body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        assert _contents(kstore, sid) != []
+        art_store.delete(art.slug)
+        assert await reconcile_artifacts(pipeline, art_store, sid, set()) == (0, 1, 0)
+        assert _contents(kstore, sid) == []
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_artifact_is_not_treated_as_deleted(
+        self, pipeline, art_store, kstore, monkeypatch
+    ):
+        """``ArtifactStore.list`` omits an artifact whose meta.json cannot be
+        read, so absence from the listing is not proof of deletion. Reaping on
+        the listing alone destroys a live artifact's indexed content."""
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="MD", content="still here", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+
+        # The artifact exists but is invisible to list() and unreadable by get().
+        monkeypatch.setattr(art_store, "list", lambda *a, **k: [])
+
+        def _unreadable(slug, *a, **k):
+            raise OSError("meta.json is briefly unreadable")
+
+        monkeypatch.setattr(art_store, "get", _unreadable)
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS)
+        assert removed == 0, "an unreadable artifact must not be reaped"
+        assert any("still here" in c for c in _contents(kstore, sid))
+        assert art.slug  # the artifact was never deleted from the store
+
+    @pytest.mark.asyncio
+    async def test_removals_run_off_the_event_loop(self, pipeline, art_store, kstore):
+        """``remove_artifact`` -> ``delete_items_batch`` -> ``store._load_graph``
+        is a full graph rebuild inside a SQLite transaction. Once per slug
+        deleted during a long off-window, on the loop, is the wedge
+        ``no-blocking-call-on-event-loop`` guards (see #2175 / #2336). Asserts
+        the THREAD, so keeping the call but dropping the ``to_thread`` hop fails.
+        """
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Doomed", content="doomed body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        art_store.delete(art.slug)
+
+        seen_threads: list[int] = []
+        real = artifact_ingest.remove_artifact
+
+        def recording(*args, **kwargs):
+            seen_threads.append(threading.get_ident())
+            return real(*args, **kwargs)
+
+        with mock.patch.object(artifact_ingest, "remove_artifact", recording):
+            removed = (await reconcile_artifacts(
+                pipeline, art_store, sid, DEFAULT_KINDS))[1]
+
+        assert removed == 1
+        assert seen_threads, (
+            "remove_artifact was never called -- this test no longer exercises "
+            "the removal path and would pass vacuously")
+        assert threading.get_ident() not in seen_threads, (
+            "remove_artifact ran on the event-loop thread; it must be handed to "
+            "asyncio.to_thread")
+
+    @pytest.mark.asyncio
+    async def test_an_emptied_artifact_drops_its_indexed_group(
+        self, pipeline, art_store, kstore
+    ):
+        """Emptying an artifact must not leave its previous text searchable.
+
+        ``ingest_artifact`` early-returns on empty content, so without an
+        explicit drop the obsolete chunks answer searches forever -- reachable
+        both live and via reconcile after an off-window edit.
+        """
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Doc", content="original body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        assert any("original body" in c for c in _contents(kstore, sid))
+        art_store.update(art.slug, content="   ")  # emptied while sync was off
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        assert _contents(kstore, sid) == [], "stale chunks survived an emptied artifact"
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_live_source_does_not_drop_the_group(
+        self, pipeline, art_store, kstore, monkeypatch
+    ):
+        """A file-backed artifact whose live source cannot be read falls back to
+        its snapshot with ``source_missing=True``. If the snapshot is also blank,
+        "empty" says nothing about the real content -- dropping the group would
+        destroy a valid index over a moved file or a transient read failure.
+        Same rule as the deletion reap: only provable absence deletes."""
+        sid, _ = ensure_artifact_source(kstore)
+        art = art_store.create(name="Doc", content="indexed body", kind="markdown")
+        await reconcile_artifacts(pipeline, art_store, sid, DEFAULT_KINDS)
+        assert any("indexed body" in c for c in _contents(kstore, sid))
+
+        real_get = art_store.get
+
+        def _dead_pointer(slug, *a, **kw):
+            got = real_get(slug, *a, **kw)
+            got.content = ""
+            got.source_path = "/nonexistent/moved.md"
+            got.source_missing = True
+            return got
+
+        monkeypatch.setattr(art_store, "get", _dead_pointer)
+        assert await ingest_artifact(
+            pipeline, art_store, art.slug, sid, DEFAULT_KINDS) is None
+        assert any("indexed body" in c for c in _contents(kstore, sid)), (
+            "a dead source pointer must not delete the indexed group")
+
+    @pytest.mark.asyncio
+    async def test_a_duplicate_refusal_does_not_spend_the_budget(
+        self, pipeline, art_store, kstore, monkeypatch
+    ):
+        """A write the pre-ingest hash gate refuses returns a job id but does no
+        extraction, and re-attempts on every start. Counting it would let a
+        budget's worth of duplicates starve every other artifact forever."""
+        sid, _ = ensure_artifact_source(kstore)
+        for i in range(3):
+            art_store.create(name=f"Dup{i}", content=f"body {i}", kind="markdown")
+
+        real_status = pipeline.get_job_status
+
+        def _always_duplicate(job_id):
+            out = dict(real_status(job_id) or {})
+            out["status"] = DUPLICATE_JOB_STATUS
+            return out
+
+        monkeypatch.setattr(pipeline, "get_job_status", _always_duplicate)
+        ingested, removed, deferred = await reconcile_artifacts(
+            pipeline, art_store, sid, DEFAULT_KINDS, budget=1)
+        assert (ingested, deferred) == (0, 0), (
+            "a duplicate refusal consumed the ingest budget, so artifacts behind "
+            "it would be deferred on every start")
 
 
 class TestArtifactKnowledgeSync:
@@ -292,26 +853,41 @@ class TestArtifactKnowledgeSync:
         assert _contents(kstore, sid) == []
 
     @pytest.mark.asyncio
-    async def test_start_backfills_when_source_created(self, pipeline, art_store, kstore):
+    async def test_start_reconciles_when_source_created(self, pipeline, art_store, kstore):
         art_store.create(name="Pre", content="preexisting body", kind="markdown")
         sync = ArtifactKnowledgeSync(
             art_store=art_store, pipeline=pipeline, kinds=DEFAULT_KINDS,
             loop=asyncio.get_running_loop())
         await sync.start()
-        # start() schedules the backfill as a background task; await it.
-        assert sync._backfill_task is not None
-        await sync._backfill_task
+        # start() schedules the reconcile as a background task; await it.
+        assert sync._reconcile_task is not None
+        await sync._reconcile_task
         sid = kstore.get_source_by_uri(ARTIFACT_SOURCE_URI)["id"]
         assert any("preexisting body" in c for c in _contents(kstore, sid))
 
     @pytest.mark.asyncio
-    async def test_start_no_backfill_when_source_exists(self, pipeline, art_store, kstore):
-        ensure_artifact_source(kstore)  # pre-create the row
+    async def test_start_still_reconciles_when_the_source_row_already_exists(
+        self, pipeline, art_store, kstore
+    ):
+        """The regression this fix exists for.
+
+        On any install that ever had auto-ingest on, the aggregate source row
+        already exists. Gating the catch-up pass on ``created`` therefore made a
+        later opt-in a no-op and the drift permanent. start() must reconcile
+        regardless of whether it inserted the row.
+        """
+        sid, created = ensure_artifact_source(kstore)  # pre-create, as an upgrade has
+        assert created is True
+        # Content that appeared while the feature was off, so no listener saw it.
+        art_store.create(name="Missed", content="arrived while off", kind="markdown")
         sync = ArtifactKnowledgeSync(
             art_store=art_store, pipeline=pipeline, kinds=DEFAULT_KINDS,
             loop=asyncio.get_running_loop())
         await sync.start()
-        assert sync._backfill_task is None
+        assert sync._reconcile_task is not None, (
+            "start() skipped the reconcile because the source row already existed")
+        await sync._reconcile_task
+        assert any("arrived while off" in c for c in _contents(kstore, sid))
 
 
 class TestKnowledgeConfigDefaults:
@@ -392,7 +968,7 @@ class TestKindChangeReconciliation:
     reconciled rather than skipped.
 
     ``ingest_artifact`` early-returns on an ineligible kind. That is right for a
-    backfill sweep, but wrong for a *change*: an artifact ingested as markdown and
+    reconcile sweep, but wrong for a *change*: an artifact ingested as markdown and
     then switched to svg would keep answering searches from prose that no longer
     describes it. The dashboard now lets a user change the type directly, so this
     transition is reachable from the UI rather than only from a widget pull.


### PR DESCRIPTION
Follow-up to #2448, fixing the blocking finding GPT 5.6 raised on it. #2448 was merged while CI was still running, so the finding was never acted on; dispositions are recorded [here](https://github.com/kirodotdev/KiroCrew/pull/2448#issuecomment-5234941877).

## Problem

Artifacts silently stop appearing in the Knowledge Library, permanently, with the toggle reading ON.

`ArtifactKnowledgeSync.start()` gated its catch-up pass on whether it had just *inserted* the aggregate source row:

```python
source_id, created = ensure_artifact_source(self.kstore)
if created:
    self._backfill_task = asyncio.create_task(self._run_backfill(source_id))
```

That row outlives the feature being switched off. So on any install that ever had auto-ingest on — which, before #2448, was **every** install, since it shipped on by default:

1. `knowledge.auto_ingest_artifacts` goes off (an upgrade past #2448, or the user flips it) → `_start_artifact_ingest_async` returns early → the change-listener is never registered
2. artifacts are created / edited / deleted during that window → nothing mirrors them into the Library
3. the user opts back in → `ensure_artifact_source` finds the row → `created=False` → the catch-up **never runs**
4. the drift from step 2 is never repaired

The only recovery was to delete the "Artifacts" source by hand so the row would be re-inserted on the next boot — which nobody would guess.

The `created` flag was documented as a deliberate design choice ("the row's existence is the idempotency marker … no separate flag needed"), justified by "nothing writes the store while the gateway is down, and there is no out-of-process writer, so no recurring reconcile is needed". Making the feature opt-in invalidated that premise: the gateway now runs, and writes artifacts, with this listener switched off.

## Why it matters

It is silent and it is not self-healing. The switch says ON, the artifact exists, the Library does not have it, and nothing in the UI or the logs tells the user which of those to distrust. Search then returns confidently incomplete results — worse than an obvious failure, because the user has no reason to doubt it.

## Fix (symptoms → root cause → change)

**Root cause:** the catch-up pass keyed off a proxy (row insertion) for the thing it actually needed to know (does the Library match the store?). The proxy was only ever valid while the feature could not be off.

**Change:** replace it with a real comparison, `reconcile_artifacts`, and run it on **every** `start()`:

- **ingest** what the store has and `artifact_item_state` lacks or disagrees with
- **remove** state for artifacts that no longer exist
- `created` is now reported for logging only, and `ensure_artifact_source`'s docstring says so, so the trap is not re-set later

This repairs drift from *any* cause — the feature having been off, a crash mid-ingest, a restore from backup — not just this one. That is why it was chosen over the alternative (a config write-back migration that preserves the old effective value): the migration fixes the one path that produced this bug, while reconcile fixes the class.

Three properties that make running it on every start safe:

1. **Converged costs nothing.** `ingest_artifact` already returns `None` for unchanged content, so the steady state spends zero extraction calls and logs at debug rather than writing a line every boot.
2. **Removals are judged against every artifact, not the eligible kinds.** Narrowing `auto_ingest_artifact_kinds` makes an artifact ineligible, not absent — reaping on that basis would delete content the user never deleted. Removals run first and are unbudgeted, since they are pure state deletes with no token cost.
3. **Ingests are bounded per run** by `RECONCILE_INGEST_BUDGET` (a module constant — no new config key, no i18n or settings surface). `ArtifactStore.list` is newest-first, so a backlog from a long off-window drains across successive starts with the most recent artifacts landing first, rather than arriving as one unbounded burst of billed extraction calls. This also closes the second item I disclosed on #2448 ("the first-enable artifact backfill is unbounded"). Unchanged artifacts never consume budget, so a converged store never defers.

Both the filesystem walk and the state read are `asyncio.to_thread`-offloaded, as the previous pass already was.

## Tests

`test/test_knowledge_artifact_ingest.py` — `TestBackfill` becomes `TestReconcile`, plus the regression:

- **`test_start_still_reconciles_when_the_source_row_already_exists`** — the regression this PR exists for. Pre-creates the row (as an upgrade has), adds content while "off", and asserts `start()` still reconciles. **Proven red against the pre-fix gate:**
  ```
  E  AssertionError: start() skipped the reconcile because the source row already existed
  E  assert None is not None
  ```
- `test_a_converged_store_costs_nothing` — second pass over identical content returns `(0, 0, 0)`. This is the property that makes every-start safe; without it the fix would trade a correctness bug for a cost bug.
- `test_reconcile_drops_state_for_artifacts_deleted_while_off` — a delete during the off-window leaves searchable text with no artifact behind it; reconcile must drop it.
- `test_an_ineligible_kind_is_not_treated_as_deleted` — narrowing `kinds` must not reap.
- `test_budget_defers_the_remainder_and_a_later_run_finishes_it` — the budget defers rather than drops, and the next start finishes the backlog.
- `test_reconcile_ingests_eligible_only` / `test_reconcile_empty_kinds_noop` — carried over from `TestBackfill`.

## Manual verification

| Gate | Result |
|---|---|
| `pytest` (full backend) | **39915 passed**, 17 failed |
| `isort --check-only` / `flake8` | clean |
| `mypy src/kiro_crew/` | 3 errors, all in untouched `hooks.py` |
| `scripts/docs-lint.sh` | 190 files, pass |

The 17 failures are the same pre-existing macOS-host set documented on #2448 (Seatbelt sandbox spawn, nested-pytest harness, a macOS temp-path redaction artifact, a `__CF_USER_TEXT_ENCODING` env leak) — verified against a clean `origin/main` checkout there, and byte-identical node IDs here. Passing count rose 39814 → 39915 with the new tests; no new failure appeared.

No frontend gates run: this change has no `website/` diff.

## Screenshots

N/A — no user-visible UI change. The fix is entirely in the gateway's startup reconcile path; the Settings toggle and its copy are untouched by this PR (they were shipped in #2448).

## Review round 2 (commit `09cbb7764`)

Three blocking findings from the first round, all legitimate, all fixed — see the [disposition comment](https://github.com/kirodotdev/KiroCrew/pull/2452#issuecomment-round2) for the full reasoning:

1. **`remove_artifact` ran on the event loop** (GPT + Opus). `remove_artifact` -> `delete_items_batch` -> `_load_graph` is a graph rebuild in a SQLite transaction; the sibling live-delete in `_handle` already offloads the identical call. Now `await asyncio.to_thread(...)`. This is the same defect class as #2175 / #2336 — and the existing `test_knowledge_delete_off_loop.py` ratchet missed it, because it scans for the literal `delete_items_batch` inside `async def` bodies and my call reached it via `remove_artifact`.
2. **`if not kinds: return` sat above the removal loop**, so an empty allowlist left deleted content searchable. Removals now run first, unconditionally.
3. **An unreadable `meta.json` was treated as a deletion.** `ArtifactStore.list` omits such an artifact, so a transient read error would have deleted a live artifact's indexed content. `_artifact_is_really_gone` now confirms per slug and removes only on `ArtifactNotFoundError`.

Three new tests, one per finding; the off-loop one asserts the thread and is proven red against the pre-fix code.

## Still open from #2448

Not fixed here, and deliberately: **the artifacts toggle still needs a gateway restart to take effect.** `_start_artifact_ingest_async` reads `auto_ingest_artifacts` once at startup, while its two neighbours in the same Settings card re-read config every watcher sweep and apply immediately. This PR makes the restart *repair* the drift correctly, but the user still has to know to restart. Fixing that means either a live config re-read on this path or an explicit hint on the toggle — a separate change, and the UX reviewer flagged it on #2448 too.
