### PR TITLE
test(dashboard): make chat-pins transient-I/O test portable on Windows

### DIFF
--- a/test/test_dashboard_chat_pins.py
+++ b/test/test_dashboard_chat_pins.py
@@ -1938,19 +1938,21 @@ async def test_load_transient_io_error_preserves_existing_state(tmp_path, monkey
     # Pre-populate in-memory state with the valid pin (simulating a prior good load)
     state._chat_pins = [valid_pin.copy()]
 
-    # Now make the file unreadable (simulate transient I/O permission error)
-    (tmp_path / "chat_pins.json").chmod(0o000)
+    # Simulate a transient read I/O error (e.g. permission/sharing violation).
+    # Patch read_text rather than chmod(0o000): Windows ignores POSIX permission
+    # bits for read access, so a chmod'd file still opens there and no OSError is
+    # raised — the test must inject the error portably to exercise the re-raise.
+    def _failing_read(*args, **kwargs):
+        raise PermissionError("transient disk permission error")
 
-    try:
-        with pytest.raises(OSError):
-            state.load_chat_pins()
+    monkeypatch.setattr(type(tmp_path / "chat_pins.json"), "read_text", _failing_read)
 
-        # Critical: in-memory state was NOT clobbered
-        assert len(state._chat_pins) == 1
-        assert state._chat_pins[0]["id"] == "existing-pin-1"
-    finally:
-        # Restore permissions for tmp_path cleanup
-        (tmp_path / "chat_pins.json").chmod(0o644)
+    with pytest.raises(OSError):
+        state.load_chat_pins()
+
+    # Critical: in-memory state was NOT clobbered
+    assert len(state._chat_pins) == 1
+    assert state._chat_pins[0]["id"] == "existing-pin-1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The Windows backend CI shard fails deterministically:

```
FAILED test/test_dashboard_chat_pins.py::test_load_transient_io_error_preserves_existing_state
  - Failed: DID NOT RAISE <class 'OSError'>
```

## Why it matters

This is a base breakage on `main` (the test landed via #1676), so it turns the Windows shard red on **every** open PR, not just the branch that introduced it — masking real regressions behind a known-failing check.

## Fix (symptom → root cause → change)

- **Symptom:** the test expects `load_chat_pins()` to re-raise `OSError`, but on Windows nothing is raised.
- **Root cause:** the test simulated the transient read error with `(tmp_path / "chat_pins.json").chmod(0o000)`. Windows ignores POSIX permission bits for **read** access — a `0o000` file still opens there — so `path.read_text(...)` succeeds, `load_chat_pins()` returns normally, and `pytest.raises(OSError)` sees no exception. The production code under test is correct; only the failure-injection was non-portable.
- **Change:** inject the error at the read boundary instead — `monkeypatch.setattr(type(path), "read_text", _failing_read)` where `_failing_read` raises `PermissionError` (an `OSError` subclass). This deterministically hits the `except OSError: raise` branch on every OS. The assertion that in-memory `_chat_pins` is preserved is unchanged. This mirrors the sibling test `test_load_transient_io_error_no_destructive_followon` in the same file, which already uses exactly this pattern. As a side benefit it removes the `chmod` `try/finally` cleanup dance, which on POSIX could leave an unreadable temp file if the body failed before the `finally`.

## Tests

- `test/test_dashboard_chat_pins.py::test_load_transient_io_error_preserves_existing_state` — reworked to inject the transient read error portably; still asserts the `OSError` re-raise and that valid in-memory pins are not clobbered.
- Full file re-run locally: 77 passed. `isort`/`flake8` clean. No production code changed.

## Manual verification

N/A — unit coverage is sufficient; this is a test-only portability fix and the change is exercised by the reworked test itself on the local (non-Windows) run.
