### PR TITLE
fix(telemetry): round turns-to-compaction up

### DIFF
--- a/src/kiro_crew/dashboard/handlers/usage.py
+++ b/src/kiro_crew/dashboard/handlers/usage.py
@@ -805,7 +805,7 @@ def cost_breakdown(days: int = SPEND_WINDOW_DAYS) -> dict[str, Any]:
             if rate > 0:
                 growth = round(rate, 2)
                 remaining = _COMPACTION_PCT - seg[-1][1]
-                to_90 = int(remaining / rate) if remaining > 0 else 0
+                to_90 = math.ceil(remaining / rate) if remaining > 0 else 0
         convo_rows.append(
             {
                 "slot": c["slot"],

--- a/test/metrics/test_cost_breakdown.py
+++ b/test/metrics/test_cost_breakdown.py
@@ -160,6 +160,15 @@ class TestConversations:
         assert c["growth_pct_per_turn"] == 10.0
         assert c["turns_to_compaction"] == 3
 
+    def test_growth_counts_a_partial_final_turn_to_reach_compaction(self, store):
+        # 35% -> 85% over 6 turns = +10%/turn. The 5 remaining points still
+        # require one more completed turn; truncating 5 / 10 would report zero.
+        store([_row(slot="chat-1-1", credits=1.0, used=350_000 + 100_000 * i,
+                    age_days=1 - i * 0.1) for i in range(6)])
+        c = usage_mod.cost_breakdown(7)["conversations"][0]
+        assert c["growth_pct_per_turn"] == 10.0
+        assert c["turns_to_compaction"] == 1
+
     def test_the_slope_is_fitted_after_the_last_compaction_not_across_it(self, store):
         # Occupancy is a sawtooth, not a ramp. Six turns climbing 10%->60%, a
         # compaction back to 10%, then six more climbing 10%->60% at the same


### PR DESCRIPTION
## Problem / Motivation

`cost_breakdown()` converts the context-growth forecast to a turn count by
truncating:

```python
remaining = _COMPACTION_PCT - seg[-1][1]     # _COMPACTION_PCT = 90.0
to_90 = int(remaining / rate) if remaining > 0 else 0
```

`turns_to_compaction` is meant to answer "how many more turns before this
conversation hits the 90% compaction threshold". A partial turn still has to be
completed to cross the line, so the count needs rounding up, not down.
`int()` drops that turn whenever the quotient is fractional.

Two consequences:

1. **The count is short by one whenever the division is not exact.** A
   conversation at 85% growing 10%/turn has `remaining = 5.0`, `rate = 10.0`, and
   `5.0 / 10.0 = 0.5`. It still requires one completed future turn to reach the
   90% threshold, and the field reports `0`.

2. **Flooring collapses positive headroom onto the value that means "already
   there".** The same expression returns `0` for `remaining <= 0`, where `0` is
   the correct forecast: the threshold has been reached, so no further turns are
   needed. Truncation makes a conversation with positive remaining headroom
   report that same `0`, and no reader can separate the two states.

## Why it matters

`TelemetryPanel.tsx` renders the field literally (`fmtNumber`) and colors it
through `headroomColor`, whose own comment reads "under two turns of headroom the
next turn may compact" and which paints anything `<= 2` as `--danger`. A
conversation that still requires one completed turn to reach the threshold
therefore renders as a red `0`, indistinguishable from one that has already
crossed it.

Direction note, so the severity is not overstated: the module's own comment above
this block says erring toward "plenty of room left" is the damaging direction, and
truncation errs the other way. This is not a safety regression — it is an
arithmetically wrong answer to the question the field's name asks, and a loss of
the distinction between "not yet at 90%" and "at or past 90%".

## What changed (motivation → approach → change)

`int()` becomes `math.ceil()` — a partial final turn counts as the turn it is.
`math` is already imported in the module; `remaining > 0` and `rate > 0` are both
already guarded above, so the ceiling can only move the result up by less than one
turn, never produce a negative or an unbounded value.

The `remaining <= 0` branch still returns `0`, which now unambiguously means "at
or past the threshold".

**Scope:** the slope estimator, the segment-reset rule (`_COMPACTION_DROP_PCT`)
and the `_COMPACTION_PCT = 90.0` constant are all unchanged. This PR changes one
integer conversion.

One regression test covers the discriminating case — 35% climbing to 85% over six
turns at +10%/turn, leaving 5 remaining points. It fails as `assert 0 == 1` under
`int()` and passes under `math.ceil()`.

It sits directly beneath the existing `test_growth_projects_turns_to_compaction`,
which walks 10% to 60% at the same rate and leaves 30 points — an exact division
that must still read `3`. The pair pins both sides: `ceil` may not change the
exact case, and must change the fractional one.

## Tests

- `pytest test/metrics/test_cost_breakdown.py -q -p no:randomly` — 33 passed
- Same file with only `src/kiro_crew/dashboard/handlers/usage.py` reverted to
  `origin/main` — 1 failed (`assert 0 == 1`), 32 passed
- `pytest test/metrics -q -p no:randomly` — 343 passed, 1 skipped
- `isort --check-only src/kiro_crew test`
- `flake8 src/kiro_crew test`
- `mypy --platform linux src/kiro_crew` — no issues in 858 source files
- `git diff --check`

## Manual verification

N/A — the production aggregation path is exercised directly with synthetic
persisted token rows at the boundary that discriminates the two roundings.

## Related Issues

None. Two open items sit on the same column but do not overlap this change:

- #1552 asks for the missing unit on the forecast's turn count, and already notes
  the reading can legitimately be `~1` and so needs plural handling. This change
  makes `~1` reachable in more cases, which strengthens that requirement but does
  not alter it.
- #1564 item 4 asks for the "compaction triggers at 90%" caption and a color
  change on low values. Both are frontend/catalogue work; neither touches the
  arithmetic.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing affected tests pass and a new regression test covers the corrected behavior
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (not applicable: no documented contract changes)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — repository template currently contains a placeholder pending OSPO wording.
