### PR TITLE
refactor: centralize title hydration

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -35,8 +35,7 @@ from kiro_crew.dashboard.chat_folders import _unhide_folder
 from kiro_crew.dashboard.chat_orchestrator import _stage_loop
 from kiro_crew.dashboard.chat_persistence import (
     _attach_variants,
-    _rehydrate_title_origin,
-    _rehydrate_title_refresh_mark,
+    _rehydrate_slot_title,
     get_reasoning_effort_values,
     save_slot_off_loop,
 )
@@ -3054,13 +3053,11 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
     persisted_title = raw_persisted_title if isinstance(raw_persisted_title, str) else ""
     title = body.get("title", "")
     if persisted_title:
-        safe_title, _ = redact_exfiltration_urls(persisted_title)
-        safe_title, _ = redact_credentials(safe_title)
-        slot.title = safe_title
-        slot._titled = True
-        slot._title_origin = _rehydrate_title_origin(True, meta.get("title_origin"))
-        slot._title_refresh_mark = _rehydrate_title_refresh_mark(
-            meta.get("title_refresh_mark")
+        _rehydrate_slot_title(
+            slot,
+            persisted_title,
+            titled=True,
+            metadata=meta,
         )
     elif title:
         # Never-titled session with a caller-supplied name: apply it, with

--- a/src/kiro_crew/dashboard/chat_persistence.py
+++ b/src/kiro_crew/dashboard/chat_persistence.py
@@ -10,7 +10,7 @@ import re
 import time
 import uuid
 from collections import deque
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 
 from kiro_crew import model_registry
 from kiro_crew.agent import kiro_agents_dir_path
@@ -70,6 +70,30 @@ def _rehydrate_title_refresh_mark(stored: object) -> int:
     if isinstance(stored, int) and not isinstance(stored, bool) and stored > 0:
         return stored
     return 0
+
+
+def _rehydrate_slot_title(
+    slot: _ChatSlot,
+    raw_title: str,
+    *,
+    titled: bool,
+    metadata: Mapping[str, object],
+) -> None:
+    """Restore the complete persisted title state through one contract.
+
+    Titles may be model-authored, so display redaction must happen before the
+    value reaches the slot. Keeping provenance and refresh-budget restoration
+    beside that assignment prevents hydration paths from restoring only part
+    of the title state.
+    """
+    safe_title, _ = redact_exfiltration_urls(raw_title)
+    safe_title, _ = redact_credentials(safe_title)
+    slot.title = safe_title
+    slot._titled = titled
+    slot._title_origin = _rehydrate_title_origin(titled, metadata.get("title_origin"))
+    slot._title_refresh_mark = _rehydrate_title_refresh_mark(
+        metadata.get("title_refresh_mark")
+    )
 
 
 _MAX_HISTORY_CHARS = 8000
@@ -494,12 +518,12 @@ def _rehydrate_slot_from_history(
         # is user content, so a prompt injection could craft a title with an
         # exfiltration URL or leaked credential.
         raw_title = meta.get("title") or slot_name
-        raw_title, _ = redact_exfiltration_urls(raw_title)
-        raw_title, _ = redact_credentials(raw_title)
-        slot.title = raw_title
-        slot._titled = bool(meta.get("title"))
-        slot._title_origin = _rehydrate_title_origin(slot._titled, meta.get("title_origin"))
-        slot._title_refresh_mark = _rehydrate_title_refresh_mark(meta.get("title_refresh_mark"))
+        _rehydrate_slot_title(
+            slot,
+            raw_title,
+            titled=bool(meta.get("title")),
+            metadata=meta,
+        )
         if meta.get("created_at"):
             slot.created_at = meta["created_at"]
         if meta.get("agent"):
@@ -844,12 +868,12 @@ def _restore_recent_sessions_steps(
         # dashboard — apply the same redaction as assistant content. Matches
         # the treatment in _rehydrate_slot_from_history above.
         raw_title = s.get("title", slot_name)
-        raw_title, _ = redact_exfiltration_urls(raw_title)
-        raw_title, _ = redact_credentials(raw_title)
-        slot.title = raw_title
-        slot._titled = bool(s.get("title"))
-        slot._title_origin = _rehydrate_title_origin(slot._titled, meta.get("title_origin"))
-        slot._title_refresh_mark = _rehydrate_title_refresh_mark(meta.get("title_refresh_mark"))
+        _rehydrate_slot_title(
+            slot,
+            raw_title,
+            titled=bool(s.get("title")),
+            metadata=meta,
+        )
         if meta.get("created_at"):
             slot.created_at = meta["created_at"]
         if meta.get("agent"):

--- a/test/test_title_refresh.py
+++ b/test/test_title_refresh.py
@@ -456,6 +456,37 @@ class TestRevealIsCosmetic:
 
 # ── rehydration: provenance and budget survive a reload ─────────────────────
 class TestRehydration:
+    def test_shared_slot_hydration_restores_complete_title_state(self, monkeypatch):
+        calls: list[tuple[str, str]] = []
+
+        def _redact_urls(value: str):
+            calls.append(("urls", value))
+            return f"url-safe:{value}", []
+
+        def _redact_credentials(value: str):
+            calls.append(("credentials", value))
+            return f"credential-safe:{value}", []
+
+        monkeypatch.setattr(chat_persistence, "redact_exfiltration_urls", _redact_urls)
+        monkeypatch.setattr(chat_persistence, "redact_credentials", _redact_credentials)
+        slot = _ChatSlot("chat-1-1")
+
+        chat_persistence._rehydrate_slot_title(
+            slot,
+            "Model title",
+            titled=True,
+            metadata={"title_origin": "auto", "title_refresh_mark": 8},
+        )
+
+        assert calls == [
+            ("urls", "Model title"),
+            ("credentials", "url-safe:Model title"),
+        ]
+        assert slot.title == "credential-safe:url-safe:Model title"
+        assert slot._titled is True
+        assert slot._title_origin == "auto"
+        assert slot._title_refresh_mark == 8
+
     @pytest.mark.parametrize(
         "titled,stored,expected",
         [


### PR DESCRIPTION
## Problem

Session title hydration is implemented three times: loading a history slot,
restoring recent sessions, and resuming a slot through the dashboard API. Each
copy must independently preserve display redaction, title provenance, and the
refresh milestone.

## Why it matters

These copies currently agree, but a future title-metadata change can easily miss
one resume path. That would make the same persisted session behave differently
depending on how it was restored, including silently losing title-refresh state.

## Fix (symptoms → root cause → change)

The repeated blocks all implement one hydration contract, so this change moves
that contract into `_rehydrate_slot_title` and uses it from all three callers.
The helper keeps the existing URL and credential redaction order, `_titled`
state, legacy title-origin fallback, and refresh-mark normalization unchanged.

## Tests

- Added a focused contract test covering redaction order, title state,
  provenance, and refresh-mark restoration.
- `python -m pytest -q test/test_title_refresh.py` (64 passed).
- Changed-file isort, flake8, and mypy checks passed.
- `npm run build` passed.
- The repository-wide backend suite reached 39,896 passed; its 28 failures are
  confined to untouched host/integration tests (local resource injection, Xcode
  trust, worktree nesting, and host tool paths).

## Manual verification

N/A — the change is a behavior-preserving backend refactor and the three hydration
paths are covered by automated tests.

Closes #2288
