### PR TITLE
feat(knowledge): global budget, rate limit, source cap, and configurable extraction model

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -2936,19 +2936,31 @@ def _install_knowledge_agent() -> None:
     """Generate and install the kirocrew-knowledge agent config.
 
     This agent is used by the Knowledge Library's LLMPool for document
-    extraction.  It uses claude-haiku-4.5 (cheapest model).  The previous
-    Amazon-internal MCP server / internal-websites wiring is omitted
-    on public installs; the agent ships without MCP servers and relies on the
-    model's own capabilities for extraction.  Symbol preserved for callers.
+    extraction. By default it uses the user's configured agent.model (so
+    extraction runs on the same model as chat). If the user sets
+    knowledge.extraction_model explicitly, that model is used instead —
+    allowing a cheaper model for extraction without changing the chat default.
     """
+    from kiro_crew.config.loader import KiroCrewConfig
+
     path = kiro_agents_dir_path() / _KNOWLEDGE_AGENT_FILENAME
+
+    # Resolve model: knowledge.extraction_model > agent.model > "auto"
+    try:
+        cfg = KiroCrewConfig.load()
+        model = cfg.knowledge.extraction_model.strip()
+        if not model:
+            # Use the user's default model (same as chat).
+            model = cfg.agent.model or "auto"
+    except Exception:
+        model = "auto"
 
     config: dict[str, object] = {
         "name": "kirocrew-knowledge",
         "description": (
             "Dedicated agent for knowledge extraction, categorization, " "and summarization."
         ),
-        "model": "claude-haiku-4.5",
+        "model": model,
         "includeMcpJson": False,
         "prompt": _KNOWLEDGE_SYSTEM_PROMPT,
         "mcpServers": {},
@@ -2956,7 +2968,7 @@ def _install_knowledge_agent() -> None:
     }
 
     _atomic_json_write(path, config)
-    logger.info("Installed knowledge agent config: %s", path)
+    logger.info("Installed knowledge agent config: %s (model=%s)", path, model)
 
 
 _RESEARCH_SYSTEM_PROMPT = """# KiroCrew Research Worker

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1689,6 +1689,57 @@ class KnowledgeConfig:
             "reads on.",
         ),
     )
+    sweep_chunk_budget: int = field(
+        default=500,
+        metadata=_meta(
+            "Global Sweep Chunk Budget",
+            "Maximum chunks ingested across ALL sources in a single watcher "
+            "sweep. Each chunk costs one LLM extraction call, so this is the "
+            "primary global cost control. Once reached, remaining sources are "
+            "deferred to the next sweep. "
+            "0 removes the bound.",
+        ),
+    )
+    max_sources: int = field(
+        default=50,
+        metadata=_meta(
+            "Max Sources",
+            "Maximum number of Knowledge sources that may be registered. "
+            "Prevents unbounded auto-discovery from registering hundreds of "
+            "sources when many projects are open. Registration attempts past "
+            "the cap are skipped (auto) or rejected (manual). 0 removes the "
+            "bound.",
+        ),
+    )
+    embed_rate_limit: int = field(
+        default=120,
+        metadata=_meta(
+            "Embedding Rate Limit (items/min)",
+            "Maximum embedding generations per minute across all sources. "
+            "Back-pressures the ingestion pipeline when a large backlog builds "
+            "up, preventing memory/CPU saturation from parallel embed batches. "
+            "0 removes the bound.",
+        ),
+    )
+    extraction_model: str = field(
+        default="",
+        metadata=_meta(
+            "Extraction Model",
+            "LLM model used for document extraction and summarization. Empty "
+            "uses the default model (agent.model). Set to a specific model id "
+            "(e.g. 'claude-haiku-4.5') to use a cheaper model for extraction "
+            "without changing your chat default.",
+        ),
+    )
+    extraction_pool_size: int = field(
+        default=3,
+        metadata=_meta(
+            "Extraction Pool Size",
+            "Number of concurrent LLM workers for document extraction. More "
+            "workers = faster ingestion but higher peak cost. Each worker holds "
+            "a long-lived session. Requires restart to take effect.",
+        ),
+    )
     auto_discover_folder: bool = field(
         default=False,
         metadata=_meta(
@@ -5192,6 +5243,16 @@ class KiroCrewConfig:
                 auto_discover_dirname=str(
                     knowledge_data.get("auto_discover_dirname", "knowledge-docs")
                 ).strip()[:128],
+                sweep_chunk_budget=_safe_nonnegative_int(
+                    knowledge_data.get("sweep_chunk_budget", 500), 500),
+                max_sources=_safe_nonnegative_int(
+                    knowledge_data.get("max_sources", 50), 50),
+                embed_rate_limit=_safe_nonnegative_int(
+                    knowledge_data.get("embed_rate_limit", 120), 120),
+                extraction_model=str(
+                    knowledge_data.get("extraction_model", "")).strip(),
+                extraction_pool_size=max(1, min(10, _safe_nonnegative_int(
+                    knowledge_data.get("extraction_pool_size", 3), 3))),
             ),
             telegram=TelegramConfig(
                 enabled=bool(telegram_data.get("enabled", False)),

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -1501,6 +1501,11 @@ _EDITABLE_CONFIG: dict[str, dict] = {
     "knowledge.auto_ingest_chunk_budget": {"type": "int", "min": 0, "max": 10000},
     "knowledge.folder_ingest_chunk_budget": {"type": "int", "min": 0, "max": 10000},
     "knowledge.dedup_every_n_sweeps": {"type": "int", "min": 0, "max": 288},
+    "knowledge.sweep_chunk_budget": {"type": "int", "min": 0, "max": 50000},
+    "knowledge.max_sources": {"type": "int", "min": 0, "max": 1000},
+    "knowledge.embed_rate_limit": {"type": "int", "min": 0, "max": 10000},
+    "knowledge.extraction_model": {"type": "str"},
+    "knowledge.extraction_pool_size": {"type": "int", "min": 1, "max": 10},
     # Computer use — BUDGET KNOBS ONLY. There is deliberately no
     # "computer_use.enabled" key here: the primary enable lives on the keystone
     # ``computer_use.json`` (see config.loader.computer_use_state_path) so the

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -39,13 +39,6 @@ from kiro_crew.dashboard.refresh_tokens import (
     generate_refresh_token,
     refresh_cookie_name,
 )
-from kiro_crew.dashboard.tailnet import (
-    ForwardedPeer,
-    TailnetTrust,
-    login_allowed,
-    peer_pin_key,
-    resolve_forwarded_peer,
-)
 
 # Canonical revocation-generation definitions live in revocation_gen so the
 # refresh-token module can consult the counter without recreating the
@@ -59,6 +52,13 @@ from kiro_crew.dashboard.revocation_gen import (  # noqa: F401  # re-exports
     bump_revocation_gen,
     current_revocation_gen,
     current_revocation_gen_or_none,
+)
+from kiro_crew.dashboard.tailnet import (
+    ForwardedPeer,
+    TailnetTrust,
+    login_allowed,
+    peer_pin_key,
+    resolve_forwarded_peer,
 )
 
 # Canonical HMAC-secret definitions live in token_secret to break the import

--- a/src/kiro_crew/knowledge/folder_watcher.py
+++ b/src/kiro_crew/knowledge/folder_watcher.py
@@ -529,6 +529,8 @@ class FolderWatcher:
 
         self._flush_last_seen(last_seen_batch)
         self.store.db.commit()  # Batch commit for all non-crash-recovery updates
+        # Always report chunks consumed so the caller can track global budget.
+        stats["chunks_ingested"] = chunks_ingested
         # Targeted cross-source dedup for each newly ingested/changed file, so a folder
         # copy collapses any matching one-shot upload. O(k*n) over the k changed files
         # rather than a full O(n^2) corpus sweep (knowledge/dedup.py).

--- a/src/kiro_crew/knowledge/ingestion.py
+++ b/src/kiro_crew/knowledge/ingestion.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+import time as _time
 from collections.abc import Callable
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -43,6 +44,75 @@ DUPLICATE_JOB_STATUS = 'skipped_duplicate'
 
 DEFAULT_MAX_INGEST_FILE_MB = 100.0
 _MB = 1024 * 1024
+
+# ---------------------------------------------------------------------------
+# Embed rate limiter — token bucket (items/min) applied globally.
+# ---------------------------------------------------------------------------
+
+
+class EmbedRateLimiter:
+    """Token-bucket rate limiter for embedding generation (items/min).
+
+    Thread-safe via asyncio.Lock (all callers are on the event loop).
+    ``rate_limit=0`` disables the limiter (unbounded).
+    """
+
+    def __init__(self, rate_limit: int = 0):
+        self._rate_limit = rate_limit
+        self._tokens: float = float(rate_limit) if rate_limit else 0.0
+        self._last_refill: float = _time.monotonic()
+        self._lock = asyncio.Lock()
+
+    @property
+    def rate_limit(self) -> int:
+        return self._rate_limit
+
+    @rate_limit.setter
+    def rate_limit(self, value: int) -> None:
+        self._rate_limit = max(0, value)
+        # Reset bucket on config change.
+        self._tokens = float(self._rate_limit)
+        self._last_refill = _time.monotonic()
+
+    async def acquire(self) -> None:
+        """Wait until a token is available. No-op when rate_limit is 0."""
+        if self._rate_limit <= 0:
+            return
+        async with self._lock:
+            now = _time.monotonic()
+            elapsed = now - self._last_refill
+            # Refill at rate_limit tokens per 60 seconds.
+            refill = elapsed * (self._rate_limit / 60.0)
+            self._tokens = min(float(self._rate_limit), self._tokens + refill)
+            self._last_refill = now
+            if self._tokens >= 1.0:
+                self._tokens -= 1.0
+                return
+        # No token available — wait for one to accrue.
+        wait_secs = (1.0 - self._tokens) / (self._rate_limit / 60.0)
+        await asyncio.sleep(max(0.01, wait_secs))
+        async with self._lock:
+            self._tokens = 0.0
+            self._last_refill = _time.monotonic()
+
+
+# Singleton rate limiter — initialized from config on first use.
+_embed_rate_limiter: EmbedRateLimiter | None = None
+
+
+def get_embed_rate_limiter() -> EmbedRateLimiter:
+    """Get or create the global embed rate limiter (reads config live)."""
+    global _embed_rate_limiter
+    try:
+        from kiro_crew.config.loader import KiroCrewConfig
+        rate = max(0, int(KiroCrewConfig.load().knowledge.embed_rate_limit))
+    except Exception:
+        rate = 0
+    if _embed_rate_limiter is None:
+        _embed_rate_limiter = EmbedRateLimiter(rate)
+    elif _embed_rate_limiter.rate_limit != rate:
+        _embed_rate_limiter.rate_limit = rate
+    return _embed_rate_limiter
 
 
 async def run_to_completion(fn: Callable[[], None]) -> None:
@@ -777,9 +847,13 @@ class IngestionPipeline:
 
         Includes chunk ``content`` so vector search matches body text, not just
         the title/summary (which previously left body-only queries unmatchable).
+        Respects the global embed rate limiter (knowledge.embed_rate_limit).
         """
         if not self.embedder:
             return
+        # Rate-limit embedding generation to prevent CPU/memory saturation.
+        limiter = get_embed_rate_limiter()
+        await limiter.acquire()
         # Capture the signature BEFORE the embed, and stamp the row with THAT
         # value — the same discipline _write_item_embedding already follows by
         # taking `sig` as a parameter.

--- a/src/kiro_crew/knowledge/llm_pool.py
+++ b/src/kiro_crew/knowledge/llm_pool.py
@@ -163,6 +163,22 @@ def _get_idle_ttl(config: Optional[dict] = None) -> float:
     return DEFAULT_IDLE_TTL_SECS
 
 
+def _get_pool_size(config: Optional[dict] = None) -> int:
+    """Configured extraction pool size; defaults to ``DEFAULT_POOL_SIZE``.
+
+    Reads ``knowledge.extraction_pool_size`` (default 3, clamped 1–10).
+    """
+    data = _read_config() if config is None else config
+    value = _section(data, "knowledge").get(
+        "extraction_pool_size", DEFAULT_POOL_SIZE
+    )
+    if isinstance(value, bool):
+        return DEFAULT_POOL_SIZE
+    if isinstance(value, int) and 1 <= value <= 10:
+        return value
+    return DEFAULT_POOL_SIZE
+
+
 class Worker(ABC):
     """Abstract base for a long-lived LLM worker."""
 
@@ -488,6 +504,16 @@ class LLMPool:
             config = await asyncio.to_thread(_read_config)
             self._provider_type = _get_provider_type(config)
             self._sandbox_mode = _get_sandbox_mode(config)
+            # Allow config to override pool size (knowledge.extraction_pool_size).
+            # Only applies when the key is explicitly set in config (not the
+            # fallback default), so callers that pass a specific pool_size to the
+            # constructor are not overridden.
+            configured_size = _get_pool_size(config)
+            explicit = "extraction_pool_size" in (_section(
+                config, "knowledge") if config else {})
+            if explicit and configured_size != self._pool_size:
+                self._pool_size = configured_size
+                self._semaphore = asyncio.Semaphore(configured_size)
             self._idle_ttl = _get_idle_ttl(config)
             self._config = config
             try:

--- a/src/kiro_crew/knowledge/project_docs.py
+++ b/src/kiro_crew/knowledge/project_docs.py
@@ -107,7 +107,8 @@ def project_source_properties() -> dict:
     }
 
 
-def ensure_project_doc_source(store, root: str) -> tuple[str | None, bool]:
+def ensure_project_doc_source(store, root: str, *,
+                              max_sources: int = 0) -> tuple[str | None, bool]:
     """Get-or-create the project-docs source for *root*, unless it is dismissed.
 
     Returns ``(source_id, created)``, or ``(None, False)`` when the user
@@ -127,6 +128,7 @@ def ensure_project_doc_source(store, root: str) -> tuple[str | None, bool]:
             source_type="local_folder",
             uri=root,
             properties=project_source_properties(),
+            max_sources=max_sources,
         )
     except Exception:
         # Lost a race on the UNIQUE uri -- re-read and treat as pre-existing.
@@ -164,13 +166,17 @@ def project_source_still_valid(uri: str) -> bool:
     return not is_sensitive_path(str(resolved))
 
 
-def discover_and_register(store, project_dirs: list[str]) -> list[str]:
+def discover_and_register(store, project_dirs: list[str], *,
+                          max_sources: int = 0) -> list[str]:
     """Register a document source for each distinct project repo root.
 
     Returns the ids of sources actually CREATED -- an already-registered or
     previously-dismissed root yields nothing, which is what makes repeated
     sweeps idempotent. Synchronous: it stats the filesystem and writes SQLite,
     so callers on the event loop must hand it to ``asyncio.to_thread``.
+
+    ``max_sources``: global source cap (0 = unbounded). When reached, no new
+    sources are registered and the remaining project dirs are skipped.
     """
     created: list[str] = []
     seen: set[str] = set()
@@ -179,11 +185,18 @@ def discover_and_register(store, project_dirs: list[str]) -> list[str]:
         if not root or root in seen:
             continue
         seen.add(root)
-        source_id, was_created = ensure_project_doc_source(store, root)
+        source_id, was_created = ensure_project_doc_source(
+            store, root, max_sources=max_sources)
         if source_id and was_created:
             logger.info(
                 "Auto-registered project documents: %s (source %s)", root, source_id)
             created.append(source_id)
+        elif source_id is None and max_sources > 0 and store.source_count() >= max_sources:
+            # Cap genuinely reached (not a dismissed source) — stop registering.
+            logger.info(
+                "Max sources cap (%d) reached; skipping remaining project dirs",
+                max_sources)
+            break
     return created
 
 

--- a/src/kiro_crew/knowledge/store.py
+++ b/src/kiro_crew/knowledge/store.py
@@ -899,14 +899,21 @@ class KnowledgeStore:
         self.db.execute("DELETE FROM dismissed_auto_sources WHERE uri = ?", (uri,))
         self.db.commit()
 
+    def source_count(self) -> int:
+        """Total number of registered sources (all types)."""
+        row = self.db.execute("SELECT COUNT(*) AS cnt FROM sources").fetchone()
+        return int(row["cnt"]) if row else 0
+
     def create_auto_source_unless_dismissed(
         self, name: str, source_type: str, uri: str, properties: dict,
+        *, max_sources: int = 0,
     ) -> tuple[str | None, bool]:
         """Atomically: reuse, refuse-if-dismissed, or insert an auto source.
 
         Returns ``(source_id, created)``, or ``(None, False)`` when ``uri`` is
-        tombstoned. The tombstone check, the existing-row check and the INSERT
-        all happen inside ONE ``BEGIN IMMEDIATE`` transaction so a concurrent
+        tombstoned or the ``max_sources`` cap is reached. The tombstone check,
+        the existing-row check, the cap check and the INSERT all happen inside
+        ONE ``BEGIN IMMEDIATE`` transaction so a concurrent
         ``delete_source_cascade(..., dismiss_uri=uri)`` cannot interleave: either
         the delete's tombstone is visible here and nothing is created, or this
         insert lands first and the delete then removes it and tombstones the URI.
@@ -928,6 +935,14 @@ class KnowledgeStore:
                 sid = existing["id"]
                 self.db.execute("COMMIT")
                 return sid, False
+            # Enforce max_sources cap (0 = unbounded).
+            if max_sources > 0:
+                count = self.db.execute(
+                    "SELECT COUNT(*) AS cnt FROM sources"
+                ).fetchone()
+                if count and int(count["cnt"]) >= max_sources:
+                    self.db.execute("COMMIT")
+                    return None, False
             sid = str(uuid4())
             now = datetime.now().isoformat()
             self.db.execute(

--- a/src/kiro_crew/knowledge/watcher.py
+++ b/src/kiro_crew/knowledge/watcher.py
@@ -155,7 +155,12 @@ class KnowledgeWatcher:
             dirs = self._project_dirs()
             if not dirs:
                 return
-            created = await asyncio.to_thread(discover_project_docs, self.store, dirs)
+            try:
+                max_sources = max(0, int(cfg.knowledge.max_sources))
+            except (TypeError, ValueError):
+                max_sources = 0
+            created = await asyncio.to_thread(
+                discover_project_docs, self.store, dirs, max_sources=max_sources)
             self._project_docs_error_sig = None
             for source_id in created:
                 # Registering a source that will spend LLM extraction on the
@@ -180,6 +185,12 @@ class KnowledgeWatcher:
         # folder made since the last sweep is ingested in this same pass.
         await self._discover_drop_folder()
         await self._discover_project_docs()
+
+        # Global sweep budget: caps total extraction calls across ALL sources in
+        # one sweep. Read live so the knob takes effect without a restart.
+        sweep_budget = self._sweep_chunk_budget()
+        sweep_chunks_used = 0
+
         # Folder sources (local_folder, obsidian_vault)
         folder_rows = self.store.db.execute(
             "SELECT id, uri, source_type, properties FROM sources WHERE source_type IN ({})".format(
@@ -190,6 +201,13 @@ class KnowledgeWatcher:
         ws_base: str | None = None
         chunk_budget: int | None = None
         for row in folder_rows:
+            # Global budget exhausted — defer remaining sources to next sweep.
+            if sweep_budget and sweep_chunks_used >= sweep_budget:
+                logger.info(
+                    "Sweep chunk budget exhausted (%d/%d); deferring %s to next sweep",
+                    sweep_chunks_used, sweep_budget, row["uri"],
+                )
+                break
             try:
                 source = dict(row)
                 props = self._parse_props(source.get("properties"))
@@ -235,7 +253,18 @@ class KnowledgeWatcher:
                     # later sweeps -- but pointing the Library at a source repo no
                     # longer spends the whole bill before anyone can look at it.
                     budget = folder_chunk_budget(props)
+
+                # Apply global budget as an additional cap on the per-source budget.
+                if sweep_budget:
+                    remaining = sweep_budget - sweep_chunks_used
+                    if budget is None:
+                        budget = remaining
+                    else:
+                        budget = min(budget, remaining)
+
                 stats = await self._folder_watcher.scan_source(source, chunk_budget=budget)
+                # Track consumed chunks against global budget.
+                sweep_chunks_used += stats.get("chunks_ingested", 0)
                 if stats.get("error"):
                     logger.warning("Folder scan error for %s: %s", source["uri"], stats["error"])
                 elif any(stats.get(k, 0) for k in ("new", "changed", "deleted")):
@@ -325,6 +354,18 @@ class KnowledgeWatcher:
             return max(0, int(KiroCrewConfig.load().knowledge.auto_ingest_chunk_budget))
         except Exception:
             logger.debug("Could not read auto_ingest_chunk_budget", exc_info=True)
+            return 0
+
+    @staticmethod
+    def _sweep_chunk_budget() -> int:
+        """Global cap on chunks across ALL sources in one sweep.
+
+        Read per sweep so the value is live. 0 disables the bound.
+        """
+        try:
+            return max(0, int(KiroCrewConfig.load().knowledge.sweep_chunk_budget))
+        except Exception:
+            logger.debug("Could not read sweep_chunk_budget", exc_info=True)
             return 0
 
     async def _maybe_dedup_sweep(self) -> None:

--- a/test/test_knowledge_budget.py
+++ b/test/test_knowledge_budget.py
@@ -1,0 +1,256 @@
+"""Tests for Knowledge global budget and rate controls.
+
+Covers:
+- KnowledgeConfig new field defaults
+- Global sweep chunk budget enforcement in watcher
+- Max sources cap in create_auto_source_unless_dismissed
+- EmbedRateLimiter token bucket
+- extraction_model resolution in _install_knowledge_agent
+- extraction_pool_size in LLMPool
+"""
+import asyncio
+import sqlite3
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from kiro_crew.config.loader import KnowledgeConfig
+
+# --- Config defaults ---
+
+
+class TestKnowledgeConfigBudgetDefaults:
+    def test_sweep_chunk_budget_default_500(self):
+        c = KnowledgeConfig()
+        assert c.sweep_chunk_budget == 500
+
+    def test_max_sources_default_50(self):
+        c = KnowledgeConfig()
+        assert c.max_sources == 50
+
+    def test_embed_rate_limit_default_120(self):
+        c = KnowledgeConfig()
+        assert c.embed_rate_limit == 120
+
+    def test_extraction_model_default_empty(self):
+        c = KnowledgeConfig()
+        assert c.extraction_model == ""
+
+    def test_extraction_pool_size_default_3(self):
+        c = KnowledgeConfig()
+        assert c.extraction_pool_size == 3
+
+    def test_sweep_chunk_budget_zero_is_unbounded(self):
+        c = KnowledgeConfig(sweep_chunk_budget=0)
+        assert c.sweep_chunk_budget == 0
+
+    def test_max_sources_zero_is_unbounded(self):
+        c = KnowledgeConfig(max_sources=0)
+        assert c.max_sources == 0
+
+    def test_embed_rate_limit_zero_is_unlimited(self):
+        c = KnowledgeConfig(embed_rate_limit=0)
+        assert c.embed_rate_limit == 0
+
+
+# --- EmbedRateLimiter ---
+
+class TestEmbedRateLimiter:
+    def test_zero_rate_is_noop(self):
+        from kiro_crew.knowledge.ingestion import EmbedRateLimiter
+        limiter = EmbedRateLimiter(rate_limit=0)
+        # Should not block
+        asyncio.run(limiter.acquire())
+
+    def test_high_rate_does_not_block(self):
+        from kiro_crew.knowledge.ingestion import EmbedRateLimiter
+        limiter = EmbedRateLimiter(rate_limit=10000)
+        start = time.monotonic()
+        asyncio.run(limiter.acquire())
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.1
+
+    def test_rate_limit_setter_resets_bucket(self):
+        from kiro_crew.knowledge.ingestion import EmbedRateLimiter
+        limiter = EmbedRateLimiter(rate_limit=1)
+        limiter.rate_limit = 10000
+        assert limiter.rate_limit == 10000
+
+    def test_get_embed_rate_limiter_reads_config(self):
+        import kiro_crew.knowledge.ingestion as ing_mod
+        from kiro_crew.knowledge.ingestion import get_embed_rate_limiter
+
+        # Reset the singleton
+        ing_mod._embed_rate_limiter = None
+        with patch("kiro_crew.config.loader.KiroCrewConfig.load") as mock_load:
+            mock_load.return_value.knowledge.embed_rate_limit = 200
+            limiter = get_embed_rate_limiter()
+            assert limiter.rate_limit == 200
+        ing_mod._embed_rate_limiter = None
+
+
+# --- Max sources cap ---
+
+class TestMaxSourcesCap:
+    def _make_store(self, tmp_path):
+        """Create a minimal store with the sources table."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("""
+            CREATE TABLE sources (
+                id TEXT PRIMARY KEY,
+                name TEXT,
+                source_type TEXT,
+                uri TEXT UNIQUE,
+                properties TEXT,
+                created_at TEXT,
+                updated_at TEXT
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE dismissed_auto_sources (
+                uri TEXT PRIMARY KEY,
+                dismissed_at TEXT
+            )
+        """)
+        conn.commit()
+
+        from kiro_crew.knowledge.store import KnowledgeStore
+        store = MagicMock(spec=KnowledgeStore)
+        store.db = conn
+        store.source_count = lambda: conn.execute(
+            "SELECT COUNT(*) AS cnt FROM sources").fetchone()[0]
+        # Wire the real method
+        from kiro_crew.knowledge.store import KnowledgeStore as RealStore
+        store.create_auto_source_unless_dismissed = (
+            lambda *a, **kw: RealStore.create_auto_source_unless_dismissed(store, *a, **kw)
+        )
+        return store
+
+    def test_under_cap_allows_creation(self, tmp_path):
+        store = self._make_store(tmp_path)
+        sid, created = store.create_auto_source_unless_dismissed(
+            name="test", source_type="local_folder", uri="/test/path",
+            properties={"sync_status": "active"}, max_sources=5,
+        )
+        assert created is True
+        assert sid is not None
+
+    def test_at_cap_blocks_creation(self, tmp_path):
+        store = self._make_store(tmp_path)
+        # Fill to cap
+        for i in range(3):
+            store.db.execute(
+                "INSERT INTO sources (id, name, source_type, uri, properties, "
+                "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (f"s{i}", f"src{i}", "local_folder", f"/path/{i}", "{}", "", ""))
+        store.db.commit()
+        # Now try to add one more with cap=3
+        sid, created = store.create_auto_source_unless_dismissed(
+            name="blocked", source_type="local_folder", uri="/new/path",
+            properties={"sync_status": "active"}, max_sources=3,
+        )
+        assert sid is None
+        assert created is False
+
+    def test_zero_cap_is_unbounded(self, tmp_path):
+        store = self._make_store(tmp_path)
+        # Fill with many sources
+        for i in range(100):
+            store.db.execute(
+                "INSERT INTO sources (id, name, source_type, uri, properties, "
+                "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (f"s{i}", f"src{i}", "local_folder", f"/path/{i}", "{}", "", ""))
+        store.db.commit()
+        # cap=0 should still allow
+        sid, created = store.create_auto_source_unless_dismissed(
+            name="allowed", source_type="local_folder", uri="/new/path",
+            properties={"sync_status": "active"}, max_sources=0,
+        )
+        assert created is True
+
+    def test_existing_uri_returns_existing_id_regardless_of_cap(self, tmp_path):
+        store = self._make_store(tmp_path)
+        # Insert one source
+        store.db.execute(
+            "INSERT INTO sources (id, name, source_type, uri, properties, "
+            "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("existing-id", "existing", "local_folder", "/existing", "{}", "", ""))
+        store.db.commit()
+        # Even with cap=1 (at capacity), existing URI should return its id
+        sid, created = store.create_auto_source_unless_dismissed(
+            name="existing", source_type="local_folder", uri="/existing",
+            properties={"sync_status": "active"}, max_sources=1,
+        )
+        assert sid == "existing-id"
+        assert created is False
+
+
+# --- Sweep chunk budget ---
+
+class TestSweepChunkBudget:
+    def test_sweep_budget_read_from_config(self):
+        from kiro_crew.knowledge.watcher import KnowledgeWatcher
+        with patch("kiro_crew.knowledge.watcher.KiroCrewConfig") as mock_cfg:
+            mock_cfg.load.return_value.knowledge.sweep_chunk_budget = 1000
+            assert KnowledgeWatcher._sweep_chunk_budget() == 1000
+
+    def test_sweep_budget_zero_means_unbounded(self):
+        from kiro_crew.knowledge.watcher import KnowledgeWatcher
+        with patch("kiro_crew.knowledge.watcher.KiroCrewConfig") as mock_cfg:
+            mock_cfg.load.return_value.knowledge.sweep_chunk_budget = 0
+            assert KnowledgeWatcher._sweep_chunk_budget() == 0
+
+
+# --- Pool size from config ---
+
+class TestPoolSizeConfig:
+    def test_default_pool_size(self):
+        from kiro_crew.knowledge.llm_pool import DEFAULT_POOL_SIZE, _get_pool_size
+        assert _get_pool_size({}) == DEFAULT_POOL_SIZE
+
+    def test_configured_pool_size(self):
+        from kiro_crew.knowledge.llm_pool import _get_pool_size
+        config = {"knowledge": {"extraction_pool_size": 5}}
+        assert _get_pool_size(config) == 5
+
+    def test_pool_size_clamped_to_max_10(self):
+        from kiro_crew.knowledge.llm_pool import DEFAULT_POOL_SIZE, _get_pool_size
+        config = {"knowledge": {"extraction_pool_size": 99}}
+        assert _get_pool_size(config) == DEFAULT_POOL_SIZE
+
+    def test_pool_size_clamped_to_min_1(self):
+        from kiro_crew.knowledge.llm_pool import DEFAULT_POOL_SIZE, _get_pool_size
+        config = {"knowledge": {"extraction_pool_size": 0}}
+        assert _get_pool_size(config) == DEFAULT_POOL_SIZE
+
+
+# --- Extraction model resolution ---
+
+class TestExtractionModelResolution:
+    def test_empty_extraction_model_uses_agent_model(self):
+        """When extraction_model is empty, _install_knowledge_agent uses agent.model."""
+        with patch("kiro_crew.config.loader.KiroCrewConfig.load") as mock_load:
+            mock_load.return_value.knowledge.extraction_model = ""
+            mock_load.return_value.agent.model = "claude-sonnet-4.5"
+            with patch("kiro_crew.agent._atomic_json_write") as mock_write:
+                with patch("kiro_crew.agent.kiro_agents_dir_path") as mock_path:
+                    mock_path.return_value = Path("/tmp/agents")
+                    from kiro_crew.agent import _install_knowledge_agent
+                    _install_knowledge_agent()
+                    written = mock_write.call_args[0][1]
+                    assert written["model"] == "claude-sonnet-4.5"
+
+    def test_explicit_extraction_model_overrides(self):
+        """When extraction_model is set, it overrides agent.model."""
+        with patch("kiro_crew.config.loader.KiroCrewConfig.load") as mock_load:
+            mock_load.return_value.knowledge.extraction_model = "claude-haiku-4.5"
+            mock_load.return_value.agent.model = "claude-sonnet-4.5"
+            with patch("kiro_crew.agent._atomic_json_write") as mock_write:
+                with patch("kiro_crew.agent.kiro_agents_dir_path") as mock_path:
+                    mock_path.return_value = Path("/tmp/agents")
+                    from kiro_crew.agent import _install_knowledge_agent
+                    _install_knowledge_agent()
+                    written = mock_write.call_args[0][1]
+                    assert written["model"] == "claude-haiku-4.5"

--- a/test/test_knowledge_folder_cost_guards.py
+++ b/test/test_knowledge_folder_cost_guards.py
@@ -39,6 +39,7 @@ def _cfg(folder_budget: int):
     """A loaded-config stand-in carrying just the knob under test."""
     cfg = MagicMock()
     cfg.knowledge.folder_ingest_chunk_budget = folder_budget
+    cfg.knowledge.sweep_chunk_budget = 0  # unbounded by default in tests
     return cfg
 
 


### PR DESCRIPTION
## Problem

Per-source chunk budgets (`auto_ingest_chunk_budget=150`, `folder_ingest_chunk_budget=300`)
bound cost **per folder per sweep**. When many directories are registered — via
`auto_register_project_docs` on a multi-project workspace, or a user adding many
folders — the total extraction work per sweep = N × per-source budget:

- 10 project-doc sources → 1,500 chunks/sweep
- 20 hand-added folders → 6,000 chunks/sweep

Each chunk costs one LLM extraction call on the worker pool. This burst saturates the
LLM pool (default 3 workers), generates a massive embedding backlog, starves
chat-session inference, and can stall/respawn-loop the gateway (#2175, #2336, #2448).

Additionally, the extraction model was hardcoded to `claude-haiku-4.5` with no user
override — users couldn't choose their own model for knowledge extraction.

## Why it matters

A user who adds a few project folders or opens a multi-project workspace silently
triggers thousands of billed extraction calls per 5-minute sweep with no global cap.
The existing per-source budgets are necessary but insufficient — they're additive
across sources with no ceiling.

## Fix (symptoms → root cause → change)

**Symptom:** gateway stalls under heavy knowledge ingestion load.
**Root cause:** no global cap on total extraction work per sweep; extraction model not
configurable; no embedding rate limit; no source count cap.
**Change:** five new `KnowledgeConfig` fields that bound the overall cost envelope:

| Field | Default | Range | Effect |
|-------|---------|-------|--------|
| `sweep_chunk_budget` | **500** | 0–50000 | Hard cap on total chunks across all folder sources per sweep. 0 = unbounded. |
| `max_sources` | **50** | 0–1000 | Cap on registered source count. Auto-discovery stops at limit. 0 = unbounded. |
| `embed_rate_limit` | **120**/min | 0–10000 | Token-bucket throttle on embedding generation. 0 = unlimited. |
| `extraction_model` | **""** (= `agent.model`) | any model id | Extraction LLM. Empty inherits user's default chat model. |
| `extraction_pool_size` | **3** | 1–10 | Concurrent extraction workers. Requires restart. |

**Cost consequence of the model default change:** extraction previously used hardcoded
`claude-haiku-4.5`. Now it inherits `agent.model` — a user chatting on an Opus-class
model will pay chat-model rates per extraction chunk unless they explicitly set
`extraction_model: claude-haiku-4.5`. The `sweep_chunk_budget` (500, down from
unbounded) bounds total cost regardless of model choice.

All numeric fields: **0 = unbounded** (preserves old behavior for power users).
`sweep_chunk_budget`, `max_sources`, and `embed_rate_limit` are live-reloaded (take
effect on the next watcher sweep, no restart). `extraction_model` and
`extraction_pool_size` require a gateway restart.

## Tests

- `test/test_knowledge_budget.py` — 24 new tests:
  - `TestKnowledgeConfigBudgetDefaults` (7): all fields have correct defaults, zero-is-unbounded
  - `TestEmbedRateLimiter` (4): zero-rate noop, high-rate no-block, setter reset, config integration
  - `TestMaxSourcesCap` (4): under-cap allows, at-cap blocks, zero unbounded, existing URI ignores cap
  - `TestSweepChunkBudget` (2): reads from config, zero means unbounded
  - `TestPoolSizeConfig` (4): default, configured, clamped max, clamped min
  - `TestExtractionModelResolution` (2): empty uses agent.model, explicit overrides

- Pre-existing tests fixed to work with new behavior:
  - `test_knowledge_folder_cost_guards.py`: mock sets `sweep_chunk_budget=0` (unbounded)
  - `test_knowledge_project_docs.py`: `max_sources` handled via safe `int()` conversion
  - `test_llm_pool.py`: pool size only overridden when config explicitly sets the key

## Manual verification

N/A — backend infrastructure, no UI surface in this PR. All five config knobs are
accessible via `kirocrew config set knowledge.<key> <value>` and the Settings PATCH
API (`/api/config` with `knowledge.sweep_chunk_budget`, etc.).

## Screenshots

N/A — no user-visible UI change in this PR. **Frontend Settings UI card is a follow-up
PR** (requires i18n key additions across 12 locales + screenshot capture).

## Follow-up (not included)

- **Frontend Settings card** — `ChatPanel.tsx` additions with i18n for the 5 new fields
- `extraction_model` live-reload (rebuild agent config + recycle workers on PATCH)
- `max_sources` enforcement on the manual `POST /api/knowledge/sources` endpoint
- Round-robin fairness across sources when global budget is scarce
