### PR TITLE
fix(voice): keep the draining transcript after a manual dictation stop

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -1614,6 +1614,82 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // sent. Cross-SLOT safety is handled separately by session-scoped routing
   // (see applyVoiceText + voice.sessionOwner).
   const sttDisarmedRef = useRef(false)
+  // Narrower sibling of `sttDisarmedRef`, for a MANUAL STOP of a streaming
+  // recording that already put a hypothesis in the composer.
+  //
+  // One flag was doing two jobs, and a manual stop only wants one of them.
+  // `applyVoiceText` APPENDS (`base + ' ' + text`), so the close-time final
+  // landing on a composer that already holds the hypothesis duplicates the
+  // utterance ("hello hello") — that has to stay suppressed. But `onPartial`
+  // REPLACES the region at the frozen boundary, and the hook re-emits
+  // `finals.join(' ')` through it on every `final` message while `stop()`
+  // deliberately leaves the socket draining. Suppressing that too meant every
+  // segment Transcribe stabilised AFTER the release was dropped, so the user
+  // was left holding the last UNSTABLE hypothesis. On a push-to-talk hold that
+  // is the common case, not a corner: the hold is short, so the tail of the
+  // utterance is exactly the part still unstable at release.
+  //
+  // So: this flag suppresses the append only, and leaves the drain's own
+  // corrections free to keep replacing the region until the socket closes.
+  // Cancel, send and slot-switch still want EVERYTHING suppressed and keep
+  // using `sttDisarmedRef` — the user discarded, already sent, or left.
+  const sttAppendDisarmedRef = useRef(false)
+  // The composer content UP TO the end of the region onPartial last inserted,
+  // plus the whole value it wrote. Dictation splices at the caret, so it can sit
+  // mid-draft with an existing tail after it — and typing after the release
+  // lands at the restored caret, i.e. between the two. Anchoring on the PREFIX
+  // (not the whole value) is what lets a drain-time update replace the corrected
+  // region and keep everything after it verbatim; anchoring on the whole value
+  // would fail its own startsWith check mid-draft and drop the correction.
+  // The full value distinguishes "the user typed" from "nothing changed", which
+  // decides whether the caret may be moved.
+  const lastDictationAnchorRef = useRef<string | null>(null)
+  const lastDictationValueRef = useRef<string | null>(null)
+  // Sticky for the whole post-stop drain: once the user has typed, the caret is
+  // theirs until dictation restarts. Recomputing "did they edit?" per update is
+  // not enough — after the first correction carries the suffix across, the
+  // composer matches what we wrote again, so a second correction would decide
+  // nothing was edited and yank the caret back in front of the typed text.
+  const postStopEditedRef = useRef(false)
+  // Suppresses ONLY the auto-submit route, and unlike the append flag it is set
+  // by EVERY manual stop of a streaming recording — including a cold-stream stop
+  // where no partial landed. "Stop capturing" is never "send": without this, a
+  // short press against a cold stream leaves the endpointer armed, and a
+  // trailing final's endpoint verdict submits the turn the user never asked to
+  // send. The append flag cannot carry this, because with no partial landed the
+  // close-time final is the only copy of the utterance and must still land.
+  const sttEndpointDisarmedRef = useRef(false)
+  // A frozen caret is a position in the composer as it stood at the release. Once
+  // the user edits after that, it can go stale in two ways, and both corrupt the
+  // splice: a RANGE (dictating over a selection replaces it) whose selection they
+  // have since typed over, and an OFFSET whose meaning shifts when they edit text
+  // BEFORE it. Rebase it onto the current text instead of trusting or discarding
+  // it wholesale — discarding it would put the transcript after text they wrote
+  // later, trusting it would cut into text they wrote earlier.
+  const rebaseFrozenCaret = useCallback(() => {
+    if (!sttEndpointDisarmedRef.current) return
+    const frozen = frozenCaretRef.current
+    const released = lastDictationValueRef.current
+    const cur = inputRef.current ?? ''
+    // Untouched composer: a selection here is still a legitimate replacement
+    // target, which is what dictating over a selection is supposed to do.
+    if (!frozen || released === null || cur === released) return
+    // Bound the edit to the region between the longest common prefix and suffix.
+    let lcp = 0
+    while (lcp < released.length && lcp < cur.length && released[lcp] === cur[lcp]) lcp++
+    let lcs = 0
+    while (
+      lcs < released.length - lcp && lcs < cur.length - lcp &&
+      released[released.length - 1 - lcs] === cur[cur.length - 1 - lcs]
+    ) lcs++
+    const start = frozen.start
+    let next: number
+    if (start <= lcp) next = start                                    // edit is after it
+    else if (start >= released.length - lcs) next = start + (cur.length - released.length)
+    else next = voiceCaretRef.current?.start ?? start                 // edit straddles it
+    next = Math.max(0, Math.min(next, cur.length))
+    frozenCaretRef.current = { start: next, end: next }
+  }, [])
   // The hook's EFFECTIVE streaming mode: streaming is only truly active when the
   // config asks for it AND the browser supports it (AudioWorklet/WS). Mirrored
   // from voice.streamEnabled (set by the effect below, once `voice` exists) so
@@ -1664,7 +1740,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // drop it for EVERY route. Checked FIRST (before the cross-slot branch) so a
     // late final can't slip the already-sent text back into the originating
     // slot's draft.
-    if (sttDisarmedRef.current) return
+    //
+    // `sttAppendDisarmedRef` covers the narrower case: a manual stop whose
+    // hypothesis is already in the composer. This route APPENDS, so letting the
+    // close-time final through there would duplicate the utterance.
+    if (sttDisarmedRef.current || sttAppendDisarmedRef.current) return
     const target = sessionId ?? activeSlotRef.current
     const append = (base: string) => (base ? (base.endsWith(' ') ? base + text : base + ' ' + text) : text)
     // Splice into the LIVE composer only when the target slot is both the active
@@ -1697,6 +1777,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // are null — fall back to the live composer text + caret so the transcript
     // inserts at the cursor instead of overwriting (or blindly appending to)
     // what the user typed.
+    rebaseFrozenCaret()
     const spliced = spliceDictation(frozenInputRef.current ?? inputRef.current ?? '', text)
     // Only arm the caret restore when the value actually changes. If a streaming
     // final equals the last partial, setInput is a no-op and the restore effect
@@ -1707,8 +1788,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       voicePendingCaretRef.current = spliced.caret
     }
     frozenInputRef.current = null
+    lastDictationAnchorRef.current = null
+    lastDictationValueRef.current = null
+    postStopEditedRef.current = false
     frozenCaretRef.current = null
-  }, [saveDrafts, spliceDictation])
+  }, [saveDrafts, spliceDictation, rebaseFrozenCaret])
   const voice = useVoiceInput(
     applyVoiceText,
     {
@@ -1720,6 +1804,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
         // other slot is a late straggler — drop it rather than smear a
         // half-word into the wrong session.
         if (sessionId && sessionId !== activeSlotRef.current) return
+        // Deliberately NOT gated on `sttAppendDisarmedRef`: after a manual stop
+        // the socket is still draining, and this is the route that carries the
+        // stabilised text. It REPLACES the region at the frozen boundary rather
+        // than appending, so letting it keep firing cannot duplicate anything —
+        // it is what turns the last unstable hypothesis into the real transcript.
         if (sttDisarmedRef.current) return
         // Snapshot the pre-dictation text AND caret on the first partial
         // (before setInput, so the updater stays pure — no ref mutation inside a
@@ -1727,21 +1816,103 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
         // insert at the same spot, replacing the growing hypothesis.
         if (frozenInputRef.current === null) {
           frozenInputRef.current = inputRef.current
-          frozenCaretRef.current = voiceCaretRef.current
+          // Do not clobber a caret a cold-stream stop already froze: that one is
+          // the release-time insertion point, and the live caret is now wherever
+          // the user has typed since.
+          frozenCaretRef.current = frozenCaretRef.current ?? voiceCaretRef.current
         }
+        rebaseFrozenCaret()
         const spliced = spliceDictation(frozenInputRef.current ?? '', text)
-        if (spliced.value !== inputRef.current) {
-          setInput(spliced.value)
-          voicePendingCaretRef.current = spliced.caret
+        // Everything up to and including the dictated insertion. What follows it
+        // in the composer (an existing tail, and anything typed after release) is
+        // carried across untouched rather than rebuilt from the snapshot.
+        const anchor = spliced.value.slice(0, spliced.caret)
+        let next = spliced.value
+        // Where the caret should end up. Defaults to the end of the dictated
+        // region (the ordinary "we own the composer" case); the post-stop branch
+        // overrides it when the text is the user's to steer.
+        let caretTarget: number | null = spliced.caret
+        if (sttEndpointDisarmedRef.current) {
+          // POST-STOP DRAIN. The user has let go, so as far as they are concerned
+          // dictation is over and they may already be typing — at the restored
+          // caret, which for mid-draft dictation sits in the MIDDLE of the text.
+          // Rebuilding from the frozen snapshot would delete that typing, so
+          // verify our own prefix is still intact and splice the correction in
+          // ahead of whatever now follows it. If the prefix cannot be verified
+          // the user edited inside the dictated region; leave the composer alone
+          // rather than guess — same policy as cancelVoice, for the same reason:
+          // a heuristic here deletes user-authored text.
+          //
+          // Gated on the ENDPOINT flag, not the append flag: a cold-stream stop
+          // deliberately leaves the append armed (the close-time final is the
+          // only copy of the utterance), so keying off it would skip this branch
+          // in exactly the case where it is still needed.
+          //
+          // During recording this does not apply: the region is being actively
+          // rewritten and that behaviour is unchanged.
+          const prev = lastDictationAnchorRef.current
+          const cur = inputRef.current ?? ''
+          // The composer now holds a copy of the utterance, which is the exact
+          // condition the append flag encodes — so close the close-time route
+          // here rather than at stop time. stopVoice could not decide this: with
+          // frozenInputRef still null it had to leave the append armed, because
+          // back then the close-time final really was the only copy. Once a drain
+          // partial has landed that is no longer true, and letting the final
+          // through would re-splice from the snapshot and delete whatever the
+          // user typed after the release.
+          sttAppendDisarmedRef.current = true
+          // Checked OUTSIDE the anchor guard: on a cold stream the first drain
+          // partial has no anchor yet, but the user may already have typed since
+          // the release, and their caret must still be left alone.
+          if (cur !== lastDictationValueRef.current) postStopEditedRef.current = true
+          // A null anchor means no partial has landed yet — the cold-stream stop.
+          // This IS the first write: there is nothing to preserve and nothing to
+          // verify, and returning here would drop the utterance. Fall through to
+          // the plain write, which establishes the anchor for the next update.
+          // The typed text is inside the snapshot (taken from the LIVE composer)
+          // and the insertion point is the caret stopVoice froze at the release,
+          // so the transcript lands where the user was speaking rather than after
+          // what they wrote afterwards.
+          if (prev !== null) {
+            if (!cur.startsWith(prev)) return
+            next = anchor + cur.slice(prev.length)
+            if (postStopEditedRef.current) {
+              // Their caret is in their own text, so it must not be dragged to the
+              // end of the dictation — but NOT arming it is not "leaving it
+              // alone" either: React replaces the textarea value and the browser
+              // resets the DOM caret to the end. Re-arm it at the same LOGICAL
+              // spot, shifted by how much the region ahead of it grew or shrank.
+              const live = voiceCaretRef.current
+              caretTarget = live && live.start >= prev.length
+                ? live.start + (anchor.length - prev.length)
+                : null
+            }
+          } else if (postStopEditedRef.current) {
+            // Cold-stream first write with typing already done: there is no old
+            // anchor to measure a shift against, and the value commit leaves the
+            // caret at the end — which is past their text, a sane place to be.
+            caretTarget = null
+          }
         }
-      }, [spliceDictation]),
+        if (next !== inputRef.current) {
+          setInput(next)
+          if (caretTarget !== null) voicePendingCaretRef.current = caretTarget
+        }
+        lastDictationAnchorRef.current = anchor
+        lastDictationValueRef.current = next
+      }, [spliceDictation, rebaseFrozenCaret]),
       // Semantic endpointing (stt.endpointing) judged the utterance complete:
       // auto-submit. The composer already holds the streamed transcript via
       // onPartial, and send() reads inputRef.current + stops the live capture
       // itself (its recording+streaming branch), so this is the same path as
       // pressing Enter mid-dictation — just triggered by the backend verdict.
       onEndpoint: useCallback(() => {
-        if (sttDisarmedRef.current) return
+        // A manual stop is the user saying "stop capturing", so a backend
+        // endpoint verdict arriving during the drain must not turn that into an
+        // unrequested send. The endpoint flag is what covers a COLD-stream stop,
+        // where no partial landed and the append flag is deliberately left unset
+        // so the close-time final can still deliver the utterance.
+        if (sttDisarmedRef.current || sttAppendDisarmedRef.current || sttEndpointDisarmedRef.current) return
         sendRef.current?.()
       }, []),
     }
@@ -1804,10 +1975,15 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // needs only a single owner and can never be misattributed.
     if (voice.transcribing) return
     sttDisarmedRef.current = false
+    sttAppendDisarmedRef.current = false
+    sttEndpointDisarmedRef.current = false
     // Reset stale snapshot from a prior session that ended without
     // finals — otherwise onPartial sees a non-null ref, skips
     // re-snapshotting, and text typed between sessions is dropped.
     frozenInputRef.current = null
+    lastDictationAnchorRef.current = null
+    lastDictationValueRef.current = null
+    postStopEditedRef.current = false
     frozenCaretRef.current = null
     return voice.start()
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1816,21 +1992,50 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   /** Stop voice capture. Always allowed — only starting is gated. */
   const stopVoice = useCallback(() => {
     // Manual stop of a STREAMING recording: streamStop() drains the socket
-    // asynchronously and a final can still arrive. Disarming drops that draining
-    // final — but ONLY do so once the composer actually holds a copy of the
-    // speech, which is exactly what frozenInputRef being set means (onPartial
-    // snapshots it on the FIRST partial, then writes each hypothesis into
-    // `input`). Then the final is redundant and dropping it prevents a rebuild
-    // from the stale snapshot clobbering text typed while the socket drains.
+    // asynchronously, so more of the utterance can still arrive. Two routes are
+    // in play and they need OPPOSITE treatment, which is why this sets the
+    // narrow flag rather than the blanket one:
+    //
+    //   - `applyVoiceText` (close-time) APPENDS. The composer already holds the
+    //     hypothesis, so letting it through duplicates the utterance. Suppress.
+    //   - `onPartial` (drain-time) REPLACES the region at the frozen boundary,
+    //     and the hook re-emits `finals.join(' ')` through it as Transcribe
+    //     stabilises each segment. That is the authoritative text. Keep armed.
+    //
+    // Only suppress once the composer actually holds a copy of the speech, which
+    // is exactly what frozenInputRef being set means (onPartial snapshots it on
+    // the FIRST partial, then writes each hypothesis into `input`).
     //
     // With frozenInputRef still null NO partial has landed, so the composer
-    // holds nothing and the draining final is the ONLY copy of the utterance:
-    // disarming there silently deletes what the user just said. That is the
+    // holds nothing and the close-time final is the ONLY copy of the utterance:
+    // suppressing there silently deletes what the user just said. That is the
     // ordinary case for a short press against a COLD stream, where the release
-    // beats the server's first partial. (Batch is likewise never disarmed here:
-    // its onstop transcript is always the only copy.)
+    // beats the server's first partial. (Batch is likewise never suppressed
+    // here: its onstop transcript is always the only copy.)
     if (streamEnabledRef.current && frozenInputRef.current !== null) {
-      sttDisarmedRef.current = true
+      sttAppendDisarmedRef.current = true
+    }
+    // Unconditional for a streaming stop: the auto-submit route must close even
+    // when the append route stays open (the cold-stream case above).
+    if (streamEnabledRef.current) {
+      sttEndpointDisarmedRef.current = true
+    }
+    if (streamEnabledRef.current && frozenInputRef.current === null) {
+      // COLD STREAM: no partial landed, so nothing has pinned the insertion point
+      // yet. Freeze the CARET at the release, so a drain partial arriving after
+      // the user has started typing still inserts where they were speaking
+      // instead of after the text they wrote afterwards.
+      //
+      // Deliberately NOT freezing the text as well: with no partial landed the
+      // close-time final is the only copy of the utterance and must splice into
+      // the LIVE composer. Pinning the text here would make it rebuild from the
+      // release-time snapshot and delete anything typed after the release —
+      // trading a wrong insertion point for lost text.
+      //
+      // The value fingerprint is seeded too, so the first drain partial can tell
+      // that the user has typed since the release and leave their caret alone.
+      frozenCaretRef.current = voiceCaretRef.current
+      lastDictationValueRef.current = inputRef.current
     }
     voice.stop()
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1898,6 +2103,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       // onPartial and a surviving caret would aim the next session's first
       // splice at a position from the discarded one.
       frozenInputRef.current = null
+      lastDictationAnchorRef.current = null
+      lastDictationValueRef.current = null
+      postStopEditedRef.current = false
       frozenCaretRef.current = null
     }
     voiceRef.current.cancel()
@@ -1935,6 +2143,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // are preserved rather than clobbered by a stale snapshot.
   useEffect(() => {
     frozenInputRef.current = null
+    lastDictationAnchorRef.current = null
+    lastDictationValueRef.current = null
+    postStopEditedRef.current = false
     frozenCaretRef.current = null
     // Drop the previous slot's caret so dictating in a freshly switched-to slot
     // (without touching its composer) appends to that slot's draft instead of
@@ -3360,6 +3571,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     if (voiceRef.current.recording && streamEnabledRef.current) {
       sttDisarmedRef.current = true
       frozenInputRef.current = null
+      lastDictationAnchorRef.current = null
+      lastDictationValueRef.current = null
+      postStopEditedRef.current = false
       voiceRef.current.toggle()
     }
 

--- a/website/src/test/ChatPage.sendDuringDictation.test.tsx
+++ b/website/src/test/ChatPage.sendDuringDictation.test.tsx
@@ -45,6 +45,7 @@ const voice = vi.hoisted(() => {
     // the discard path has to set it alongside firing onPartial.
     partial: '',
     onPartial: null as ((t: string) => void) | null,
+    onEndpoint: null as (() => void) | null,
     onText: null as ((t: string) => void) | null,
     toggle: (() => {}) as () => void,
     start: (() => {}) as () => void,
@@ -58,8 +59,9 @@ voice.start = vi.fn(() => { voice.recording = true })
 voice.stop = vi.fn(() => { voice.recording = false })
 voice.cancel = vi.fn(() => { voice.recording = false })
 vi.mock('../hooks/useVoiceInput', () => ({
-  useVoiceInput: (onText: (t: string) => void, opts?: { onPartial?: (t: string) => void; streaming?: boolean }) => {
+  useVoiceInput: (onText: (t: string) => void, opts?: { onPartial?: (t: string) => void; onEndpoint?: () => void; streaming?: boolean }) => {
     voice.onPartial = opts?.onPartial ?? null
+    voice.onEndpoint = opts?.onEndpoint ?? null
     voice.onText = onText
     return ({
     recording: voice.recording,
@@ -406,5 +408,343 @@ describe('ChatPage — sending while dictating', () => {
     await act(async () => { fireEvent.change(ta, { target: { value: 'edited by hand' } }) })
     await act(async () => { voice.onText?.('hello there') })
     expect(ta.value).toBe('edited by hand')
+  })
+
+  it('lets a drain-time correction replace the hypothesis after a manual stop', async () => {
+    // The point of the two flags. `stop()` leaves the socket draining on purpose,
+    // and Transcribe keeps stabilising: the hook re-emits `finals.join(' ')`
+    // through onPartial as each segment settles. That route REPLACES the region
+    // at the frozen boundary, so it cannot duplicate anything — and it carries
+    // the words the release beat. Suppressing it left the user holding the last
+    // UNSTABLE hypothesis, which on a short push-to-talk hold is the common case.
+    setStt(true)
+    const store = makeStore('chat-main', [{ key: 'chat-main' }])
+    await renderAndWaitForInput(store)
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+
+    const mic = screen.getByRole('button', { name: /voice input/i })
+    await act(async () => { fireEvent.click(mic) })
+    await act(async () => { voice.onPartial?.('remind me to') })
+    expect(ta.value).toBe('remind me to')
+
+    await act(async () => { fireEvent.click(mic) })
+    expect(voice.recording).toBe(false)
+
+    // Drain: Transcribe finalises the segment, adding the tail the release cut off.
+    await act(async () => { voice.onPartial?.('remind me to call Ana') })
+    expect(ta.value).toBe('remind me to call Ana')
+
+    // The close-time route still APPENDS, so it must stay suppressed — otherwise
+    // the composer would read "remind me to call Ana remind me to call Ana".
+    await act(async () => { voice.onText?.('remind me to call Ana') })
+    expect(ta.value).toBe('remind me to call Ana')
+  })
+
+  it('keeps text typed after the release when a drain correction lands', async () => {
+    // Release the key and the user reasonably starts typing straight away —
+    // dictation is over as far as they can tell. A drain-time replace must take
+    // the correction WITHOUT deleting what they typed, so the region is verified
+    // and the suffix carried across rather than rebuilt from the snapshot.
+    setStt(true)
+    const store = makeStore('chat-main', [{ key: 'chat-main' }])
+    await renderAndWaitForInput(store)
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+
+    const mic = screen.getByRole('button', { name: /voice input/i })
+    await act(async () => { fireEvent.click(mic) })
+    await act(async () => { voice.onPartial?.('remind me to') })
+    expect(ta.value).toBe('remind me to')
+    await act(async () => { fireEvent.click(mic) })
+
+    // Typing immediately after the release.
+    await act(async () => { fireEvent.change(ta, { target: { value: 'remind me to — urgent' } }) })
+    // The drain then finalises the segment.
+    await act(async () => { voice.onPartial?.('remind me to call Ana') })
+
+    expect(ta.value).toBe('remind me to call Ana — urgent')
+  })
+
+  it('leaves the composer alone when the dictated region was edited', async () => {
+    // If the region cannot be verified the user rewrote it, and a suffix-match
+    // heuristic there would delete text they authored. Same policy cancelVoice
+    // takes: change nothing rather than guess.
+    setStt(true)
+    const store = makeStore('chat-main', [{ key: 'chat-main' }])
+    await renderAndWaitForInput(store)
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+
+    const mic = screen.getByRole('button', { name: /voice input/i })
+    await act(async () => { fireEvent.click(mic) })
+    await act(async () => { voice.onPartial?.('remind me to') })
+    await act(async () => { fireEvent.click(mic) })
+
+    // The user replaces the dictation entirely.
+    await act(async () => { fireEvent.change(ta, { target: { value: 'never mind' } }) })
+    await act(async () => { voice.onPartial?.('remind me to call Ana') })
+
+    expect(ta.value).toBe('never mind')
+  })
+
+  it('keeps a mid-draft correction and everything after it', async () => {
+    // Dictation splices at the caret, so it can land in the MIDDLE of a draft
+    // with an existing tail after it — and typing after the release goes to the
+    // restored caret, i.e. between the dictated words and that tail. The drain
+    // correction must replace only the dictated region: both the typed text and
+    // the original tail have to come through untouched.
+    setStt(true)
+    const store = makeStore('chat-main', [{ key: 'chat-main' }])
+    await renderAndWaitForInput(store)
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+
+    // Draft with the caret parked before "world".
+    await act(async () => {
+      fireEvent.change(ta, { target: { value: 'hello world', selectionStart: 6, selectionEnd: 6 } })
+    })
+
+    const mic = screen.getByRole('button', { name: /voice input/i })
+    await act(async () => { fireEvent.click(mic) })
+    await act(async () => { voice.onPartial?.('remind me') })
+    expect(ta.value).toBe('hello remind me world')
+    await act(async () => { fireEvent.click(mic) })
+
+    // Typing lands where the caret was restored — right after the dictation.
+    await act(async () => {
+      fireEvent.change(ta, { target: { value: 'hello remind me NOW world' } })
+    })
+    await act(async () => { voice.onPartial?.('remind me to call Ana') })
+
+    expect(ta.value).toBe('hello remind me to call Ana NOW world')
+  })
+
+  it('carries the user caret across a drain correction', async () => {
+    // Not arming the caret is not the same as leaving it alone: React replaces the
+    // textarea value and the browser resets the DOM caret to the END. Mid-draft
+    // that end is past the tail, i.e. nowhere near where the user was. Their
+    // logical position must be re-armed, shifted by how much the region ahead of
+    // it grew.
+    setStt(true)
+    const store = makeStore('chat-main', [{ key: 'chat-main' }])
+    await renderAndWaitForInput(store)
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+
+    // Draft with the caret before 'later', so dictation lands mid-draft.
+    await act(async () => {
+      fireEvent.change(ta, { target: { value: 'call later', selectionStart: 5, selectionEnd: 5 } })
+    })
+    const mic = screen.getByRole('button', { name: /voice input/i })
+    await act(async () => { fireEvent.click(mic) })
+    await act(async () => { voice.onPartial?.('remind') })
+    expect(ta.value).toBe('call remind later')
+    await act(async () => { fireEvent.click(mic) })
+
+    // Type ' NOW' right after the dictation; their caret sits at offset 15.
+    await act(async () => {
+      fireEvent.change(ta, { target: { value: 'call remind NOW later', selectionStart: 15, selectionEnd: 15 } })
+    })
+    // The correction grows the region from 'call remind' (11) to
+    // 'call remind me to call Ana' (26) — a shift of 15.
+    await act(async () => { voice.onPartial?.('remind me to call Ana') })
+    expect(ta.value).toBe('call remind me to call Ana NOW later')
+
+    await act(async () => { await new Promise(r => requestAnimationFrame(() => r(null))) })
+    // 15 + 15 = 30, right after ' NOW'. A caret left unarmed would have been
+    // reset to the end of the value (36), past the ' later' tail.
+    expect(ta.selectionStart).toBe('call remind me to call Ana NOW'.length)
+  })
+
+  it('does not reclaim the caret on a later correction in the same drain', async () => {
+    // A drain emits several corrections as segments stabilise. The first one sees
+    // the typed suffix and leaves the caret alone — but it also rewrites the
+    // composer to include that suffix, so a per-update "was it edited?" test
+    // would say no on the SECOND correction and pull the caret back to the end of
+    // the dictation, in front of the user's text. The edited state has to stay
+    // sticky for the whole drain.
+    setStt(true)
+    const store = makeStore('chat-main', [{ key: 'chat-main' }])
+    await renderAndWaitForInput(store)
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+
+    const mic = screen.getByRole('button', { name: /voice input/i })
+    await act(async () => { fireEvent.click(mic) })
+    await act(async () => { voice.onPartial?.('remind me') })
+    await act(async () => { fireEvent.click(mic) })
+
+    await act(async () => { fireEvent.change(ta, { target: { value: 'remind me NOW' } }) })
+    // First drain correction: carries the suffix, must not steer the caret.
+    await act(async () => { voice.onPartial?.('remind me to call') })
+    expect(ta.value).toBe('remind me to call NOW')
+    // Second correction, user has not touched anything since.
+    await act(async () => { voice.onPartial?.('remind me to call Ana') })
+    expect(ta.value).toBe('remind me to call Ana NOW')
+
+    // Let the caret-restore frame run. Nothing should have armed it, so the
+    // caret is wherever the value commit left it — NOT at the end of the
+    // dictated region ('remind me to call Ana' = offset 21), which sits in
+    // front of the typed ' NOW'.
+    await act(async () => { await new Promise(r => requestAnimationFrame(() => r(null))) })
+    expect(ta.selectionStart).not.toBe('remind me to call Ana'.length)
+  })
+
+  it('inserts a cold-stream transcript where the user was speaking', async () => {
+    // Release, then type BEFORE the drain's first partial arrives. Nothing has
+    // pinned the insertion point yet, so without a caret frozen at the release
+    // the partial would snapshot the edited composer and land the transcript
+    // AFTER the newly typed text — reordering the utterance.
+    setStt(true)
+    const store = makeStore('chat-main', [{ key: 'chat-main' }])
+    await renderAndWaitForInput(store)
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+
+    const mic = screen.getByRole('button', { name: /voice input/i })
+    await act(async () => { fireEvent.click(mic) })
+    // A real value change (not a repeat of the same string) is what fires
+    // onChange -> records the caret AND re-renders the button so the next click
+    // reads the flipped `recording`. Caret parked before 'later'.
+    await act(async () => {
+      fireEvent.change(ta, { target: { value: 'call later', selectionStart: 5, selectionEnd: 5 } })
+    })
+    await act(async () => { fireEvent.click(mic) })
+
+    // Typing lands at the end (a fresh change resets the caret there), so the
+    // release-time caret and the live caret genuinely disagree.
+    await act(async () => { fireEvent.change(ta, { target: { value: 'call later today' } }) })
+    await act(async () => { voice.onPartial?.('Ana') })
+
+    // Dictation goes where they were speaking (offset 5), not after 'today'.
+    expect(ta.value).toBe('call Ana later today')
+  })
+
+  it('rebases a frozen caret when the user edits before it', async () => {
+    // A frozen OFFSET only means what it meant at the release if the text before
+    // it is unchanged. Prepend after releasing and offset 5 no longer points at
+    // the same spot — splicing there cuts into the word they just wrote.
+    setStt(true)
+    const store = makeStore('chat-main', [{ key: 'chat-main' }])
+    await renderAndWaitForInput(store)
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+
+    const mic = screen.getByRole('button', { name: /voice input/i })
+    await act(async () => { fireEvent.click(mic) })
+    // Caret before 'later'; no partial fires, so this is the cold-stream path.
+    await act(async () => {
+      fireEvent.change(ta, { target: { value: 'call later', selectionStart: 5, selectionEnd: 5 } })
+    })
+    await act(async () => { fireEvent.click(mic) })
+
+    // Prepend 'Hi, ' — everything after it shifts right by 4.
+    await act(async () => { fireEvent.change(ta, { target: { value: 'Hi, call later' } }) })
+    await act(async () => { voice.onPartial?.('remind') })
+
+    // Offset rebased 5 -> 9, so the transcript lands before 'later' as intended.
+    // Trusting the stale 5 would have produced 'Hi, c remind all later'.
+    expect(ta.value).toBe('Hi, call remind later')
+  })
+
+  it('does not delete a typed replacement for a selection frozen at release', async () => {
+    // Dictating over a selection replaces it, so the frozen caret is a RANGE.
+    // If the user then types over that selection after releasing, the range is
+    // stale: splicing with it would delete exactly the replacement they wrote.
+    setStt(true)
+    const store = makeStore('chat-main', [{ key: 'chat-main' }])
+    await renderAndWaitForInput(store)
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+
+    const mic = screen.getByRole('button', { name: /voice input/i })
+    await act(async () => { fireEvent.click(mic) })
+    // 'Bob' selected (offsets 5..8) at the moment of release.
+    await act(async () => {
+      fireEvent.change(ta, { target: { value: 'call Bob later', selectionStart: 5, selectionEnd: 8 } })
+    })
+    await act(async () => { fireEvent.click(mic) })
+
+    // The user types over the selection, replacing 'Bob' with 'Ana'.
+    await act(async () => { fireEvent.change(ta, { target: { value: 'call Ana later' } }) })
+    await act(async () => { voice.onPartial?.('remind') })
+
+    // 'Ana' must survive: the transcript is inserted at the selection start
+    // rather than overwriting the range that no longer exists.
+    expect(ta.value).toContain('Ana')
+    expect(ta.value).toBe('call remind Ana later')
+  })
+
+  it('keeps post-release typing through a cold-stream drain', async () => {
+    // Cold-stream stop: no partial landed, so the append route stays armed on
+    // purpose. The drain still delivers the utterance through onPartial, and the
+    // suffix-preservation branch must engage there too — gating it on the append
+    // flag would skip it in exactly this case and delete the typed text.
+    setStt(true)
+    const store = makeStore('chat-main', [{ key: 'chat-main' }])
+    await renderAndWaitForInput(store)
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+
+    const mic = screen.getByRole('button', { name: /voice input/i })
+    await act(async () => { fireEvent.click(mic) })
+    // A real value change is what re-renders the button so the second click
+    // reads the flipped `recording` — an unchanged value does not, and the click
+    // would re-run start (resetting every flag) instead of stop. No onPartial
+    // fires, so frozenInputRef is still null at stop: the cold-stream path.
+    await act(async () => { fireEvent.change(ta, { target: { value: 'draft' } }) })
+    await act(async () => { fireEvent.click(mic) })
+
+    // The drain's first partial lands after the release and seeds the anchor.
+    await act(async () => { voice.onPartial?.('remind me') })
+    expect(ta.value).toBe('draft remind me')
+    // The user types, then a later correction arrives.
+    await act(async () => { fireEvent.change(ta, { target: { value: 'draft remind me NOW' } }) })
+    await act(async () => { voice.onPartial?.('remind me to call Ana') })
+
+    expect(ta.value).toBe('draft remind me to call Ana NOW')
+
+    // The socket then closes and delivers its final. On the streaming path
+    // applyVoiceText re-splices from frozenInputRef and OVERWRITES — it does not
+    // append — so letting it through here would delete the typed ' NOW'. The
+    // drain already put the stabilised text in the composer, so the final has
+    // nothing to add and must be suppressed.
+    await act(async () => { voice.onText?.('remind me to call Ana') })
+    expect(ta.value).toBe('draft remind me to call Ana NOW')
+  })
+
+  it('does not auto-send on an endpoint verdict after a cold-stream stop', async () => {
+    // Release before the server's first partial: no partial landed, so the append
+    // route stays OPEN on purpose (the close-time final is the only copy of the
+    // utterance). That must not leave the endpointer armed — "stop capturing" is
+    // not "send". With an existing draft in the composer there IS something to
+    // submit, so a trailing final's verdict would send the user's draft for them.
+    setStt(true)
+    const store = makeStore('chat-main', [{ key: 'chat-main' }])
+    await renderAndWaitForInput(store)
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+
+    const mic = screen.getByRole('button', { name: /voice input/i })
+    await act(async () => { fireEvent.click(mic) })
+    // Typing while holding — this is also what re-renders the button so the
+    // second click reads the mock's flipped `recording` (see the other tests).
+    // No onPartial fires, so frozenInputRef stays null: the cold-stream case.
+    await act(async () => { fireEvent.change(ta, { target: { value: 'draft in progress' } }) })
+    await act(async () => { fireEvent.click(mic) })
+    await act(async () => { voice.onEndpoint?.() })
+
+    expect(vi.mocked(api.sendChat)).not.toHaveBeenCalled()
+    expect(ta.value).toBe('draft in progress')
+  })
+
+  it('does not auto-send on a drain-time endpoint verdict after a manual stop', async () => {
+    // A manual stop is the user saying "stop capturing", not "send". The backend
+    // can still emit its semantic-endpoint verdict while the socket drains, and
+    // splitting the flag must not quietly re-arm that auto-submit.
+    setStt(true)
+    const store = makeStore('chat-main', [{ key: 'chat-main' }])
+    await renderAndWaitForInput(store)
+    const ta = screen.getByLabelText('Message input') as HTMLTextAreaElement
+    expect(typeof voice.onEndpoint).toBe('function')
+
+    const mic = screen.getByRole('button', { name: /voice input/i })
+    await act(async () => { fireEvent.click(mic) })
+    await act(async () => { voice.onPartial?.('send this later') })
+    expect(ta.value).toBe('send this later')
+    await act(async () => { fireEvent.click(mic) })
+
+    await act(async () => { voice.onEndpoint?.() })
+    expect(vi.mocked(api.sendChat)).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Problem

Stop a streaming dictation by hand — the mic button, or releasing the push-to-talk key — and whatever Transcribe stabilises *after* that moment never reaches the composer. The user is left holding the last **unstable** hypothesis instead of the real transcript: a missing tail, an uncorrected word.

On a push-to-talk hold this is the common case rather than a corner. A hold is short, so the tail of the utterance is exactly the part still unstable at release. Say "remind me to call Ana", let go, and the composer can read `remind me to`.

## Why it matters

Dictation is only worth using if what lands is what you said. Silently keeping a half-finished hypothesis is worse than a visible failure, because nothing tells the user to look — they send the truncated text.

## Fix (symptom → root cause → change)

**Symptom:** the composer keeps a truncated hypothesis after a manual stop.

**Root cause:** one boolean, `sttDisarmedRef`, was doing two different jobs, and a manual stop only wants one of them. The two delivery routes need **opposite** treatment:

| route | semantics | what a manual stop wants |
|---|---|---|
| `applyVoiceText` (close-time) | **appends** `base + ' ' + text` | suppressed — the composer already holds the hypothesis, so appending duplicates the utterance (`"hello hello"`) |
| `onPartial` (drain-time) | **replaces** the region at the frozen boundary | kept armed — `stop()` deliberately leaves the socket draining, and the hook re-emits `finals.join(' ')` through this route as each segment stabilises |

Because both were gated by the same flag, suppressing the duplicate append also threw away every correction the drain produced.

**Change, in two parts.**

**1. Split the flag.**

- `sttDisarmedRef` keeps its meaning — suppress **every** route. Still what cancel (Esc), `send()`, and slot-switch set: the user discarded, already sent, or left.
- `sttAppendDisarmedRef` is new and narrower — suppress the **append only**. This is what a manual stop sets, and only once `frozenInputRef` is non-null, i.e. once the composer actually holds a copy of the speech.

The pre-existing conditional is preserved exactly: with `frozenInputRef` still null no partial has landed, the close-time final is the only copy of the utterance, and it must land. That is the cold-stream case where the release beats the server's first partial.

`onEndpoint` gates on **all** the suppression flags, including a third one, `sttEndpointDisarmedRef`, which every streaming manual stop sets **unconditionally**. A manual stop means "stop capturing", not "send". The append flag cannot carry that property, because the cold-stream case deliberately leaves it unset — so without a separate flag a short press against a cold stream left the endpointer armed, and a trailing final's verdict submitted whatever draft was already in the composer.

**2. Preserve what the user types after the release.**

Keeping `onPartial` armed is not enough on its own: it rebuilds from the frozen snapshot, so a correction arriving while the user is already typing would delete that typing. After a release the user has every reason to believe dictation is over, so their text has to survive.

`lastDictationAnchorRef` records the composer content **up to and including** the region `onPartial` last inserted. A drain-time update verifies `cur.startsWith(anchor)` and rebuilds as `newAnchor + cur.slice(anchor.length)` — the corrected region, then everything that now follows it, verbatim.

The prefix (rather than the whole value) is the anchor because dictation splices at the caret, so it can sit **mid-draft** with an existing tail after it, and typing after the release lands at the restored caret — *between* the dictated words and that tail. Anchoring on the whole value fails its own `startsWith` check in exactly that case and drops the correction; anchoring on the prefix keeps the typed text and the original tail both intact.

This branch is gated on the endpoint flag, not the append flag: a cold-stream stop deliberately leaves the append armed, so keying off it would skip the preservation in exactly the case that still needs it. A null anchor (no partial has landed — the cold-stream stop) falls through to a plain write rather than returning, since that write IS the first one and returning would drop the utterance.

A cold-stream stop also freezes the **caret** (not the text) at the release, plus the value fingerprint. Without that, a drain partial arriving after the user has started typing would snapshot the live caret and insert the transcript *after* their new text instead of where they were speaking. The text is deliberately left un-pinned: with no partial landed, `applyVoiceText` must splice into the LIVE composer, and a pinned snapshot there would delete post-release typing — a worse failure than a wrong insertion point.

A frozen caret is only valid against the text it was taken from, so before either splice it is **rebased** onto the current composer. Using the release-time fingerprint, the user's edit is bounded between the longest common prefix and suffix: an edit after the offset leaves it alone, an edit before it shifts it by the length delta, and an edit straddling it falls back to the user's live caret. This covers both ways a frozen position goes stale — a **range** whose selection they have since typed over (which would otherwise delete that replacement) and an **offset** whose meaning moved because they edited earlier text (which would otherwise cut mid-word). An untouched composer keeps the range intact, because replacing a selection is the intended behaviour.

Entering this branch also sets the append flag. `stopVoice` could not decide that: with `frozenInputRef` null the close-time final really was the only copy of the utterance, so the append had to stay armed. That premise expires the moment a drain partial lands — and on the streaming path `applyVoiceText` **overwrites** (it re-splices from `frozenInputRef`) rather than appending, so letting the final through afterwards would delete post-release typing. Deciding it here keeps the original invariant intact: the final is allowed through exactly while it is the only copy.

When the anchor **cannot** be verified the user edited inside the dictated region, and the update leaves the composer untouched rather than guessing; a heuristic there deletes user-authored text. This is the same verify-then-slice shape, and the same leave-it-alone policy, that `cancelVoice` already uses to roll a region back. The caret is handled the same way. While the composer is still exactly what we wrote it goes to the end of the dictated region; once the user has typed it is re-armed at their own LOGICAL position, shifted by how much the region ahead of it grew. Simply not arming it is not the same as leaving it alone — React replaces the textarea value and the browser resets the DOM caret to the end, which mid-draft is past the tail. That edited state is **sticky for the whole drain** (`postStopEditedRef`): a drain emits several corrections, and the first one rewrites the composer to include the typed suffix — so a per-update "was it edited?" test would say no on the second correction and pull the caret back in front of the user's text.

This applies to the **post-stop drain only**. During recording the region is still being actively rewritten and that behaviour is unchanged.

## Tests

`website/src/test/ChatPage.sendDuringDictation.test.tsx`, 10 existing → 22. Each new one is red-before-green against the specific hunk it covers:

- **`lets a drain-time correction replace the hypothesis after a manual stop`** — dictate `remind me to`, stop, deliver the stabilised `remind me to call Ana` through the drain route, assert the composer takes it; then fire the close-time route with the same text and assert no duplication. Reverting the split fails with `expected 'remind me to' to be 'remind me to call Ana'`.
- **`keeps text typed after the release when a drain correction lands`** — type `— urgent` after releasing, then let the correction arrive; the composer must read `remind me to call Ana — urgent`. Reverting the suffix preservation fails with `expected 'remind me to call Ana' to be 'remind me to call Ana — urgent'` — the typing is gone, which is the defect this half fixes.
- **`keeps a mid-draft correction and everything after it`** — dictate into the middle of `hello world`, stop, type `NOW` at the restored caret, then let the correction arrive; the composer must read `hello remind me to call Ana NOW world` — correction applied, typed text and original tail both intact. Anchoring on the whole value instead of the prefix fails with `expected 'hello remind me NOW world' to be 'hello remind me to call Ana NOW world'`, i.e. the correction is silently dropped.
- **`leaves the composer alone when the dictated region was edited`** — replace the dictation with `never mind`, then let a correction arrive; the composer must stay `never mind`.
- **`does not reclaim the caret on a later correction in the same drain`** — type a suffix, then deliver two successive corrections; the caret must not end up at the end of the dictated region (offset 21), which sits in front of the typed text. Making the edited state per-update instead of sticky fails with `expected 21 not to be 21`.
- **`does not auto-send on a drain-time endpoint verdict after a manual stop`** — an endpoint verdict after a manual stop must not call `api.sendChat`.
- **`does not auto-send on an endpoint verdict after a cold-stream stop`** — hold, type a draft, release before any partial arrives, then let an endpoint verdict fire; the draft must neither be sent nor altered. Dropping `sttEndpointDisarmedRef` fails with `expected "vi.fn()" to not be called at all, but actually been called 1 times` — the user's draft sent for them.

The three tests pinning behaviour this change must **not** alter pass unmodified: the cold-stream case where the draining final is the only copy, the close-time drop once partials populated the composer, and hand-typed text surviving the drain.

## Manual verification

N/A — no microphone in this environment, and the change is entirely in which of two already-mocked delivery routes is gated and how the composer value is reassembled. The tests drive both routes directly, which is the actual contract.

## Screenshots

N/A — no user-visible surface changed; the only difference is which text ends up in the composer, covered by the tests above. The path-based `Screenshot Evidence` gate flags any `website/src` change, so this PR carries the `no-screenshots` label the gate itself prescribes for a change with no visual delta.
