### PR TITLE
docs(autosde): forbid new work on the gateway boot path

### DIFF
--- a/AUTOSDE.yaml
+++ b/AUTOSDE.yaml
@@ -98,6 +98,69 @@ custom-rules:
       When in doubt, offload — a leaked worker thread is survivable; a frozen
       loop is not.
 
+  - id: no-new-work-on-gateway-boot-path
+    blocking: true
+    file-patterns:
+      - "src/kiro_crew/slack/gateway.py"
+      - "src/kiro_crew/dashboard/server.py"
+      - "src/kiro_crew/dashboard/handlers/**/*.py"
+      - "src/kiro_crew/cli.py"
+    rule: |
+      Do NOT add work to the gateway boot path. Everything between process
+      start and the moment the dashboard socket accepts requests runs once, in
+      order, on one thread — so every statement added there is paid by every
+      user on every launch, and it delays the point at which the app is usable.
+      A slow boot also compounds: the longer startup holds the event loop, the
+      more likely the loop-stall watchdog kills the process and the supervisor
+      respawns into the same startup, turning a latency bug into a crash loop.
+
+      The boot path means, specifically:
+      - `GatewayOrchestrator.run()` up to the `KIROCREW_READY` print
+      - `start_dashboard()` up to `await _start_site(site, port)`
+      - any `_init_*()` or `setup_*_routes()` reached from those
+      - `cli.py`'s gateway command before `asyncio.run()`
+
+      Reject a diff that puts any of these on that path:
+
+      1. A new awaited or synchronous step before the socket binds. Adding one
+         is a product decision about startup latency, not a detail.
+      2. Subsystem construction as a side effect of route registration. A
+         `setup_*_routes()` function must only register routes
+         (`app.router.add_*`). Building a pipeline, opening a store, or
+         constructing a client there drags that subsystem's whole init onto the
+         boot path, where nobody looking at the route file will find it.
+      3. Work whose cost scales with user data — row counts, corpus size,
+         file counts, session history. This is forbidden on the boot path at
+         any measured speed, because the measurement was taken on an empty
+         profile and the growth is unbounded.
+      4. Unconditional maintenance: orphan sweeps, integrity scans, vacuum,
+         reindex, or a migration that scans rather than checks a version. Boot
+         is not a maintenance window. Work that finds nothing on a healthy
+         install still costs every user every launch.
+      5. Eager import or instantiation of a subsystem that is optional,
+         disabled, or feature-flagged off. Gate the import, not just the
+         handler — an import the enabled-check happens after is not gated.
+      6. Touching a lazily-initialized accessor from boot code. A `@property`
+         documented as lazy-init is a contract; reading it at startup breaks
+         that contract silently and moves the cost to a place its author did
+         not intend.
+
+      Instead, defer it:
+      - a first-use accessor that constructs once and memoizes on the app
+      - `asyncio.create_task(...)` for work that may finish after readiness
+      - `await asyncio.to_thread(...)` when init genuinely must happen at boot
+        and genuinely blocks, so it does not hold the loop
+      - let dependent routes return 503 until the subsystem is ready, rather
+        than making every launch wait for a subsystem most launches never use
+
+      Allowed: route registration itself, in-memory wiring, O(1) config reads,
+      and bounded fail-closed safety checks that must precede serving traffic
+      (those still belong off the loop).
+
+      If a step genuinely must run at boot, the PR must say why it cannot be
+      deferred and state its worst-case bound on a large profile — not on the
+      author's machine.
+
   - id: no-test-side-effects
     blocking: true
     file-patterns:


### PR DESCRIPTION
# What

Adds a blocking AutoSDE rule, `no-new-work-on-gateway-boot-path`, to `AUTOSDE.yaml`.

# Why

Gateway startup on a real profile has grown to roughly 20s, and none of it is a
regression in the boot code — the boot statements are materially unchanged since
`v0.1.2`. What changed is that the data those statements traverse became
non-empty. A cold boot on an empty `KIROCREW_HOME` still reaches HTTP 200 in
2.34s; the same code against a populated knowledge corpus spends ~4.55s on the
event loop before the socket binds, and three of its scans return zero rows.

That shape — a boot step that is free until it isn't, with no scaling guard and
no reviewer prompt to notice — is what this rule is for. The cost also compounds:
startup that holds the loop long enough for the stall watchdog to fire gets the
process killed and respawned into the same startup, converting a latency bug
into a crash loop.

# The rule

It names the boot path precisely, so a reviewer can tell whether a diff is on it:

- `GatewayOrchestrator.run()` up to the `KIROCREW_READY` print
- `start_dashboard()` up to `await _start_site(site, port)`
- any `_init_*()` or `setup_*_routes()` reached from those
- `cli.py`'s gateway command before `asyncio.run()`

Six rejected shapes, each drawn from a defect actually found in this codebase
rather than from principle:

1. A new awaited or synchronous step before the socket binds.
2. Subsystem construction as a side effect of route registration — a
   `setup_*_routes()` that also builds a pipeline or opens a store drags that
   init onto the boot path where nobody reading the route file will find it.
3. Work whose cost scales with user data. Forbidden at any measured speed,
   because the measurement was taken on an empty profile.
4. Unconditional maintenance — orphan sweeps, integrity scans, vacuum, reindex,
   or a migration that scans instead of checking a version.
5. Eager import or instantiation of a subsystem that is optional or disabled.
   Gate the import, not just the handler.
6. Reading a lazily-initialized accessor from boot code, which silently breaks
   the lazy-init contract its author wrote.

It also lists the accepted alternatives — memoized first-use accessor,
`asyncio.create_task`, `await asyncio.to_thread`, or letting dependent routes
503 until ready — so a reviewer can point at a fix rather than only object. If a
step genuinely must run at boot, the rule requires the PR to say why it cannot
be deferred and to state its worst-case bound on a large profile.

# Scope

Judgment tier only, following the two-tier split this repo already documents in
`test/test_no_blocking_call_on_loop.py`: deterministic cases become a hard gate,
judgment cases become an AutoSDE rule. "Does this step need to be on the
critical path?" cannot be decided statically, so it belongs here. A deterministic
companion is possible — AST-count the pre-bind statements in `run()` /
`start_dashboard()` and pin them in a baseline, in the style of
`config-baseline.json` — and is deliberately left for a follow-up.

# Testing

- `AUTOSDE.yaml` parses; 5 rules present, the new one carries 4 file-patterns.
- No Python or TypeScript touched, so pytest / isort / flake8 / mypy / tsc /
  vitest are unaffected. There is no schema test over `AUTOSDE.yaml` — the only
  test-tree references to rule ids are `# loop-ok:` suppression comments.

# Note on when it takes effect

All four review workflows extract rules from the base commit rather than the PR
HEAD (`git show "$BASE_SHA:AUTOSDE.yaml"`), so that a PR cannot weaken the rules
it is reviewed against. This rule therefore does not gate its own PR; it starts
applying to PRs opened after it merges. `AUTOSDE.yaml` is also in the
`:(exclude)` list in `code-review.yml`, so the deterministic job skips it.
