### PR TITLE
fix(dashboard): restore isort-clean import order in the dashboard auth module

### DIFF
--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -39,13 +39,6 @@ from kiro_crew.dashboard.refresh_tokens import (
     generate_refresh_token,
     refresh_cookie_name,
 )
-from kiro_crew.dashboard.tailnet import (
-    ForwardedPeer,
-    TailnetTrust,
-    login_allowed,
-    peer_pin_key,
-    resolve_forwarded_peer,
-)
 
 # Canonical revocation-generation definitions live in revocation_gen so the
 # refresh-token module can consult the counter without recreating the
@@ -59,6 +52,13 @@ from kiro_crew.dashboard.revocation_gen import (  # noqa: F401  # re-exports
     bump_revocation_gen,
     current_revocation_gen,
     current_revocation_gen_or_none,
+)
+from kiro_crew.dashboard.tailnet import (
+    ForwardedPeer,
+    TailnetTrust,
+    login_allowed,
+    peer_pin_key,
+    resolve_forwarded_peer,
 )
 
 # Canonical HMAC-secret definitions live in token_secret to break the import


### PR DESCRIPTION
## Problem

`Backend Lint & Type Check` fails on `origin/main` itself, at the `Check imports (isort)`
step:

```
ERROR: src/kiro_crew/dashboard/token_auth.py Imports are incorrectly sorted and/or formatted.
```

Because the job is a matrix, the 3.12 failure cancels 3.10, so the check reports **two**
red entries. It red-lights every open PR regardless of what that PR changes.

## Why it matters

A base breakage on a blocking lint step makes every PR look broken and buries real
findings — the author's first move is to hunt for a fault in their own diff that is not
there.

## Fix (symptoms → root cause → change)

**Symptom:** isort fails on a file no open PR touches.
**Root cause:** `d2e1109f9` (#2388) added a `kiro_crew.dashboard.tailnet` import block
above the `revocation_gen` block, which is out of alphabetical order for that section.
**Change:** run isort on the file, which moves the `tailnet` block below `revocation_gen`.
Import statements only — no logic, no behaviour.

The two neighbouring blocks carry comments explaining that they exist to break a
`token_auth` ↔ `refresh_tokens` import cycle. Each comment still sits directly above the
block it describes after the move, and the reordering cannot reintroduce a cycle:
`tailnet` does not import this module (its only in-repo imports are `dashboard.urls`,
`executors`, `platform.governance_profiles`, `platform_compat` and `sandbox`), so its
position among the absolute imports is inert at import time.

## Tests

No new tests — this is an import-ordering fix on a lint-only failure, and isort itself is
the assertion. Verified on a clean worktree off `main` (`584bbb05f`):

- `isort --check-only src/kiro_crew test` → exit 0 (was exit 1)
- `flake8 src/kiro_crew test` → exit 0

## Manual verification

N/A — the failing CI step is the verification, and it is deterministic. Import ordering
carries no runtime behaviour beyond module-load order, which is addressed above.
