### PR TITLE
fix: audit deactivate of an already-lapsed safety override grant (#2475)

### DIFF
--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -1184,7 +1184,7 @@ SEL audit events are emitted on every lifecycle transition:
 - `safety_override:activate` — override enabled
 - `safety_override:renew` — session extended within grace window
 - `safety_override:expired` — TTL reached, auto-deactivated
-- `safety_override:deactivate` — manually disabled
+- `safety_override:deactivate` — manually disabled; emitted for every explicit deactivation against a grant that exists in any form, including one whose TTL already lapsed (`resources` records the pre-call state: `was_active`, `was_permanent`, `remaining`, `prior_source`). Only a never-activated instance stays silent.
 
 Fleet governance endpoints:
 - `/api/status` now reports `yolo_active` (bool) and `yolo_expires_at` (ISO 8601) fields

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -39,13 +39,6 @@ from kiro_crew.dashboard.refresh_tokens import (
     generate_refresh_token,
     refresh_cookie_name,
 )
-from kiro_crew.dashboard.tailnet import (
-    ForwardedPeer,
-    TailnetTrust,
-    login_allowed,
-    peer_pin_key,
-    resolve_forwarded_peer,
-)
 
 # Canonical revocation-generation definitions live in revocation_gen so the
 # refresh-token module can consult the counter without recreating the
@@ -59,6 +52,13 @@ from kiro_crew.dashboard.revocation_gen import (  # noqa: F401  # re-exports
     bump_revocation_gen,
     current_revocation_gen,
     current_revocation_gen_or_none,
+)
+from kiro_crew.dashboard.tailnet import (
+    ForwardedPeer,
+    TailnetTrust,
+    login_allowed,
+    peer_pin_key,
+    resolve_forwarded_peer,
 )
 
 # Canonical HMAC-secret definitions live in token_secret to break the import

--- a/src/kiro_crew/safety_override.py
+++ b/src/kiro_crew/safety_override.py
@@ -412,19 +412,57 @@ class SafetyOverride:
         return RenewResult(renewed=True, ttl=ttl, source=source)
 
     def deactivate(self, source: str) -> None:
-        """Deactivate the override immediately.  No-op if already inactive."""
+        """Deactivate the override immediately.
+
+        Emits a ``safety_override:deactivate`` SEL event whenever a grant
+        exists in ANY form — live, or already lapsed via lazy expiry. Lazy
+        expiry (``is_active``) clears only ``_active`` and leaves the rest of
+        the grant's state in place, so ``_expires_at`` still holding a nonzero
+        deadline is what distinguishes "lapsed" from "never activated": the
+        0.0 sentinel means no grant ever existed (or it was already explicitly
+        deactivated), and only that case stays silent. The SEL stream is the
+        durable record of who changed the auto-approval posture, so an
+        operator's explicit decision to switch back to normal mode must be
+        recorded even when the TTL happened to elapse first.
+
+        Zeroing ``_expires_at`` here also closes the renew grace window, so a
+        grant the operator explicitly revoked cannot be resurrected by a
+        subsequent ``renew()`` — regardless of whether it was live or lapsed
+        at the time of the call.
+        """
+        now_mono = time.monotonic()
         with self._lock:
-            if not self._active:
+            if not self._active and self._expires_at <= 0.0:
                 return
+            # _active alone can overstate liveness: a lapsed TTL is only
+            # reconciled when is_active() polls, so derive liveness the same
+            # way renew() does — permanence or an unexpired deadline.
+            was_active = self._active and (self._permanent or self._expires_at > now_mono)
+            was_permanent = was_active and self._permanent
+            prior_source = self._source
+            remaining = (
+                -1
+                if was_permanent
+                else (max(0, int(self._expires_at - now_mono)) if was_active else 0)
+            )
             self._active = False
             self._permanent = False
             self._expires_at = 0.0
 
+        # SEL write happens OUTSIDE the lock (same rule as renew(): never hold
+        # the state lock across I/O). This is a REVOCATION, not a grant, so it
+        # is deliberately NOT fail-closed like _commit_activation: refusing to
+        # deactivate because an audit write failed would leave auto-approval
+        # ON, which is strictly worse. The state change above is unconditional.
         self._log_sel(
             caller="safety_override",
             operation="safety_override:deactivate",
             outcome="disabled",
-            resources=f"source:{source}",
+            resources=(
+                f"source:{source}, was_active:{was_active}, "
+                f"was_permanent:{was_permanent}, remaining:{remaining}s, "
+                f"prior_source:{prior_source}"
+            ),
         )
 
     # ── Task-scoped grants ───────────────────────────────────────────────────

--- a/test/test_safety_override.py
+++ b/test/test_safety_override.py
@@ -182,6 +182,113 @@ class TestDeactivation:
         assert result.renewed is False
         assert result.reason == "not_active"
 
+    def test_deactivate_lapsed_grant_emits_sel(self, override: SafetyOverride) -> None:
+        """An explicit deactivate against a grant that already lapsed is an
+        operator DECISION and must reach the SEL sink — lazy expiry clearing
+        ``_active`` first must not swallow it."""
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.activate("slack")
+        override._expires_at = time.monotonic() - 1
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            assert not override.is_active()  # trips lazy expiry
+        # Pin the discriminator: lazy expiry clears _active but NOT _expires_at,
+        # which is exactly why the deactivate guard must not key off _active.
+        assert override._active is False
+        assert override._expires_at > 0.0
+
+        mock_sel_instance = MagicMock()
+        with patch("kiro_crew.safety_override.sel", return_value=mock_sel_instance):
+            override.deactivate("dashboard")
+        mock_sel_instance.log_api_access.assert_called_once()
+        kwargs = mock_sel_instance.log_api_access.call_args.kwargs
+        assert kwargs["operation"] == "safety_override:deactivate"
+        assert kwargs["outcome"] == "disabled"
+        assert "source:dashboard" in kwargs["resources"]
+        assert "was_active:False" in kwargs["resources"]
+        assert "was_permanent:False" in kwargs["resources"]
+        assert "remaining:0s" in kwargs["resources"]
+        assert "prior_source:slack" in kwargs["resources"]
+
+    def test_deactivate_live_grant_emits_sel_with_was_active(
+        self, override: SafetyOverride
+    ) -> None:
+        """A live-grant deactivate keeps its event, with was_active recording
+        that a real grant was revoked — the lapsed-grant event does not
+        replace or dilute the existing signal."""
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.activate("slack", ttl=600)
+        mock_sel_instance = MagicMock()
+        with patch("kiro_crew.safety_override.sel", return_value=mock_sel_instance):
+            override.deactivate("slack")
+        mock_sel_instance.log_api_access.assert_called_once()
+        kwargs = mock_sel_instance.log_api_access.call_args.kwargs
+        assert kwargs["operation"] == "safety_override:deactivate"
+        assert kwargs["outcome"] == "disabled"
+        assert "was_active:True" in kwargs["resources"]
+
+    def test_deactivate_permanent_grant_records_permanence(
+        self, override: SafetyOverride
+    ) -> None:
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.activate_declared()
+        mock_sel_instance = MagicMock()
+        with patch("kiro_crew.safety_override.sel", return_value=mock_sel_instance):
+            override.deactivate("dashboard")
+        kwargs = mock_sel_instance.log_api_access.call_args.kwargs
+        assert "was_active:True" in kwargs["resources"]
+        assert "was_permanent:True" in kwargs["resources"]
+        assert "remaining:-1s" in kwargs["resources"]
+
+    def test_second_deactivate_is_silent(self, override: SafetyOverride) -> None:
+        """After an explicit deactivate the 0.0 sentinel is restored, so a
+        repeat call has no grant to report and emits nothing."""
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.activate("slack")
+            override.deactivate("slack")
+        mock_sel_instance = MagicMock()
+        with patch("kiro_crew.safety_override.sel", return_value=mock_sel_instance):
+            override.deactivate("slack")
+        mock_sel_instance.log_api_access.assert_not_called()
+
+    def test_deactivate_lapsed_unpolled_grant_reports_inactive(
+        self, override: SafetyOverride
+    ) -> None:
+        """A TTL that lapsed WITHOUT an intervening is_active() poll leaves
+        _active stale at True; the event must still report was_active:False —
+        liveness is derived from the deadline, not the unreconciled flag."""
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.activate("slack")
+        override._expires_at = time.monotonic() - 1
+        assert override._active is True  # lazy expiry has NOT run
+        mock_sel_instance = MagicMock()
+        with patch("kiro_crew.safety_override.sel", return_value=mock_sel_instance):
+            override.deactivate("dashboard")
+        mock_sel_instance.log_api_access.assert_called_once()
+        kwargs = mock_sel_instance.log_api_access.call_args.kwargs
+        assert "was_active:False" in kwargs["resources"]
+        assert "remaining:0s" in kwargs["resources"]
+
+    def test_renew_after_deactivating_lapsed_grant_fails(
+        self, override: SafetyOverride
+    ) -> None:
+        """Deactivating a lapsed grant zeroes _expires_at, so the renew grace
+        window cannot resurrect an explicitly revoked grant."""
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.activate("slack")
+            override._expires_at = time.monotonic() - 60  # lapsed, within 300s grace
+            assert not override.is_active()
+            override.deactivate("slack")
+            result = override.renew("slack")
+        assert result.renewed is False
+        assert result.reason == "not_active"
+
 
 # ─── Renewal ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

`SafetyOverride.deactivate()` returned early when `_active` was false, and that early return sat **above** the `safety_override:deactivate` SEL audit write. Lazy expiry (`is_active()`) clears `_active` while leaving `_expires_at`/`_source`/`_permanent` in place, so an operator switching back to normal mode on a grant whose TTL had already elapsed was recorded **nowhere** — the common path, not an edge case. The SEL stream is the only durable record of who changed the auto-approval posture; an auditor saw the `activate` event and then nothing.

## The contract decision (explicit, per the issue)

The issue frames this as a contract disagreement on the same object. This PR resolves it as:

- **`deactivate()` logs every operator DECISION** — it now emits its SEL event whenever a grant exists in any form, live or lapsed. Only a never-activated instance stays silent.
- **`deactivate_scope()` stays on "log every state change"** — no operator decision is lost there (revoking an absent scope changes nothing), so it is intentionally left untouched.

## How

- The guard now keys on the `_expires_at` **0.0 sentinel** — the one field lazy expiry does *not* clear (verified against `is_active()`, and pinned by a test asserting `_expires_at > 0` after lazy expiry) — instead of `_active`, which is exactly what expiry zeroes.
- Pre-call state is snapshotted under `_lock`, then the SEL write happens **outside** the lock (same rule as `renew()`: never hold the state lock across I/O).
- `resources` now carries the pre-call state: `source:<who>, was_active:<bool>, was_permanent:<bool>, remaining:<n>s, prior_source:<grant origin>`, so a no-change deactivate is distinguishable from one that revoked a live grant. `operation`/`outcome` (`safety_override:deactivate` / `disabled`) are **unchanged**; nothing in `src/` or `website/src/` parses the resources string.
- **Deliberate asymmetry with `_commit_activation` (and the fail-closed posture in #2453's area):** this is a REVOCATION, not a grant. The audit stays non-critical and the state change unconditional — refusing to deactivate because an audit write failed would leave auto-approval ON, which is strictly worse. This is not an oversight; it is stated in the code comment.

## Latent bug fixed as a direct consequence

The old early return left `_expires_at` intact on a lapsed grant, so a `renew()` inside the 300s grace window could **resurrect a grant the operator had just explicitly revoked**. Zeroing `_expires_at` on every existing-grant deactivate closes that; `test_renew_after_deactivating_lapsed_grant_fails` fails on unfixed main and pins it.

## Tests (mutation-verified: 4 of the new tests fail on unfixed code)

All inject at the SEL **sink** (`log_api_access` on the patched `sel()` instance), not `_log_sel`, so assertions cannot pass vacuously:

- lapsed grant → deactivate emits, with `was_active:False, remaining:0s, prior_source:slack`; also pins the discriminator (lazy expiry clears `_active` but not `_expires_at`)
- live grant → still emits with `was_active:True` (existing signal not diluted)
- declared/permanent grant → `was_permanent:True, remaining:-1s`
- never-activated instance → silent (pre-existing test retained)
- second deactivate → silent (sentinel restored)
- renew after deactivating a lapsed grant → refused

## Out-of-scope note

`src/kiro_crew/dashboard/token_auth.py` gets a mechanical import reorder: main HEAD (584bbb0) currently **fails the repo-wide `isort --check-only` gate** on that file (a cross-PR merge artifact between the tailnet and revocation_gen import blocks). Without it this PR cannot pass lint. No code change, imports only.

## Coordination

Scoped strictly to `deactivate()`. Sibling issue #2453 (`renew()`) and PR #2443 touch the same file in disjoint hunks; rebased onto fresh `origin/main` immediately before pushing. This PR does NOT attempt #2453.

Closes #2475
