### PR TITLE
fix: audit safety-override renew fail-closed before commit (#2453)

### DIFF
--- a/docs/architecture/security-deep-dive.md
+++ b/docs/architecture/security-deep-dive.md
@@ -418,7 +418,11 @@ enterprise policy can deny it via the `yolo_duration` scope's `permanent` member
 which downgrades it to the ordinary ad-hoc duration.
 
 Every lifecycle transition (`activate`, `renew`, `expired`, `deactivate`) is
-SEL-audited, and fleet-visibility endpoints expose the live state
+SEL-audited. The transitions that create or extend auto-approval authority
+(`activate`, `activate_scoped`, `renew`) audit **fail-closed**: the SEL event is
+written before the grant is committed, and if the write fails the grant (or the
+extension) is refused — auto-approval authority never exists without an audit
+record. Fleet-visibility endpoints expose the live state
 (`/api/status` reports `yolo_active` / `yolo_expires_at`;
 `/api/admin/compliance/yolo-status` carries the full override status).
 

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -1186,6 +1186,18 @@ SEL audit events are emitted on every lifecycle transition:
 - `safety_override:expired` — TTL reached, auto-deactivated
 - `safety_override:deactivate` — manually disabled
 
+Transitions that create or extend auto-approval authority (`activate`,
+`activate_scoped`, `renew`) are audited fail-closed: the SEL event is written
+with `critical=True` before the state commits, and a failed write refuses the
+grant or extension (`renew` returns `reason: audit_failed` with the deadline
+unmoved). Because the SEL write runs outside the state lock, `renew` re-verifies
+under the re-acquired lock before committing: a grant deactivated during the
+audit window is not resurrected, a fresh activation that landed in that
+window keeps its own deadline instead of being overwritten by the stale
+renewal, and a renewal that began on a live grant refuses to commit through
+the grace window (so a grant that lapsed or was switched off mid-audit stays
+off).
+
 Fleet governance endpoints:
 - `/api/status` now reports `yolo_active` (bool) and `yolo_expires_at` (ISO 8601) fields
 - `/api/admin/compliance/yolo-status` provides full override status (source, remaining time, activation count, renewal history)

--- a/src/kiro_crew/safety_override.py
+++ b/src/kiro_crew/safety_override.py
@@ -363,38 +363,47 @@ class SafetyOverride:
         Succeeds if the override is currently active OR if it expired within
         the ``_RENEW_GRACE_SECS`` grace window.
 
+        A renewal extends auto-approval authority, so it follows the same
+        fail-closed discipline as ``_commit_activation``: the SEL event is
+        written with ``critical=True`` BEFORE the deadline moves, and an audit
+        failure leaves the grant untouched. The SEL write must not run under
+        ``_lock`` (it is I/O and would stall every concurrent ``is_active()``),
+        so eligibility is re-verified under the lock before committing — a
+        grant deactivated during the audit window must not be resurrected.
+
         Returns:
             RenewResult.renewed=True on success, False otherwise.
         """
         now_mono = time.monotonic()
-        ttl = 0
         # Resolved BEFORE taking the lock: the resolver reads config from disk,
         # and holding the state lock across that I/O would stall every concurrent
         # is_active() check.
         renew_ttl = min(self.current_adhoc_duration()[0], self._MAX_TTL)
 
-        denied = False
+        def _arms(at: float) -> tuple[bool, bool]:
+            # (currently_active, in_grace). Caller must hold ``_lock``. A
+            # deactivate() on a LIVE grant zeroes ``_expires_at``, so both arms
+            # go false; a lapsed grant keeps its past deadline and stays
+            # renewable within the grace window.
+            currently_active = self._active and self._expires_at > at
+            in_grace = (
+                not currently_active
+                and self._expires_at > 0
+                and (at - self._expires_at) <= self._RENEW_GRACE_SECS
+            )
+            return currently_active, in_grace
+
         with self._lock:
             # A permanent grant has nothing to extend and must never be
             # downgraded to a finite deadline by a renew.
             if self._active and self._permanent:
                 return RenewResult(renewed=True, ttl=-1, source=source)
-            currently_active = self._active and self._expires_at > now_mono
-            in_grace = (
-                not currently_active
-                and self._expires_at > 0
-                and (now_mono - self._expires_at) <= self._RENEW_GRACE_SECS
-            )
-            if currently_active or in_grace:
-                ttl = renew_ttl
-                self._active = True
-                self._expires_at = now_mono + ttl
-                self._last_renewed_at = now_mono
-                self._last_renewed_by = source
-            else:
-                denied = True
+            began_active, began_in_grace = _arms(now_mono)
+            # Every activation bumps the count, so an unchanged count proves no
+            # new grant was installed while the audit ran with the lock released.
+            count_snapshot = self._activation_count
 
-        if denied:
+        if not (began_active or began_in_grace):
             self._log_sel(
                 caller="safety_override",
                 operation="safety_override:renew",
@@ -403,12 +412,69 @@ class SafetyOverride:
             )
             return RenewResult(renewed=False, ttl=0, source=source, reason="not_active")
 
-        self._log_sel(
-            caller="safety_override",
-            operation="safety_override:renew",
-            outcome="renewed",
-            resources=f"source:{source}, new_ttl:{ttl}s",
-        )
+        ttl = renew_ttl
+        # Audit BEFORE committing — fail-closed with no unrecorded extension:
+        # a renewal that cannot be written to the SEL must not move the deadline.
+        try:
+            self._log_sel(
+                caller="safety_override",
+                operation="safety_override:renew",
+                outcome="renewed",
+                resources=f"source:{source}, new_ttl:{ttl}s",
+                critical=True,
+            )
+        except Exception:
+            logger.error("SEL audit failed; refusing safety override renewal", exc_info=True)
+            return RenewResult(renewed=False, ttl=0, source=source, reason="audit_failed")
+
+        # The audit ran with the lock released, so re-verify before committing:
+        # a concurrent deactivate() during that window must not be undone here,
+        # and a concurrent activate() (which re-audits its own grant) must not
+        # have its fresh deadline overwritten by this stale renewal.
+        commit_mono = time.monotonic()
+        commit_refused = False
+        refusal_reason = ""
+        with self._lock:
+            still_active, still_in_grace = _arms(commit_mono)
+            # The commit must hold on the ARM the renewal began on. A renewal
+            # that began active may not slide into the grace arm: a grant that
+            # went from active to lapsed during the audit window either expired
+            # naturally near its deadline or was explicitly deactivated (an
+            # explicit deactivate of an already-LAPSED grant leaves
+            # ``_expires_at`` intact, so lapsed-plus-in-grace cannot distinguish
+            # "expired" from "operator said off") — refuse rather than risk
+            # undoing an operator's explicit off. A renewal that began in grace
+            # may still commit from grace: nothing new lapsed in the window.
+            arm_holds = still_active if began_active else (still_active or still_in_grace)
+            # Every activation bumps the count, and a permanent grant can only
+            # appear via an activation, so this one guard also covers a
+            # permanent grant installed during the audit window — the refusal
+            # below keeps it untouched.
+            if self._activation_count != count_snapshot:
+                commit_refused = True
+                refusal_reason = "superseded_by_activation"
+            elif arm_holds:
+                self._active = True
+                self._expires_at = commit_mono + ttl
+                self._last_renewed_at = commit_mono
+                self._last_renewed_by = source
+            else:
+                commit_refused = True
+                refusal_reason = "not_active_at_commit"
+
+        if commit_refused:
+            # The "renewed" event above is already persisted; record that the
+            # commit was refused so an auditor does not read a renewal that
+            # never took effect. Non-critical: audited-but-not-extended is the
+            # safe direction.
+            self._log_sel(
+                caller="safety_override",
+                operation="safety_override:renew",
+                outcome="denied",
+                resources=f"reason:{refusal_reason}",
+            )
+            return RenewResult(renewed=False, ttl=0, source=source, reason="not_active")
+
         return RenewResult(renewed=True, ttl=ttl, source=source)
 
     def deactivate(self, source: str) -> None:

--- a/src/kiro_crew/slack/events.py
+++ b/src/kiro_crew/slack/events.py
@@ -390,7 +390,9 @@ async def _handle_yolo(
             orch.dashboard_state.push_slots_update()
         await respond("🔴 YOLO mode *OFF* — tools require approval.")
     elif arg == "renew":
-        renew_result = so.renew("slack")
+        # renew() audits fail-closed with a synchronous SEL write; keep that
+        # filesystem I/O off the event loop.
+        renew_result = await asyncio.to_thread(so.renew, "slack")
         if renew_result.renewed:
             sel().log_api_access(
                 caller=caller_id,

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -1483,7 +1483,9 @@ async def _handle_slash_command(
                     channel, f"YOLO mode is already on ({describe_grant_lifetime()}).", reply_ts
                 )
         elif len(parts) >= 2 and parts[1].lower() == "renew":
-            result = safety_override().renew("slack")
+            # renew() audits fail-closed with a synchronous SEL write; keep
+            # that filesystem I/O off the event loop.
+            result = await asyncio.to_thread(safety_override().renew, "slack")
             if result.renewed:
                 sel().log_api_access(
                     caller=user_id,

--- a/test/test_safety_override.py
+++ b/test/test_safety_override.py
@@ -242,6 +242,26 @@ class TestRenewal:
         outcomes = [c.kwargs["outcome"] for c in calls]
         assert "denied" in outcomes
 
+    def test_renew_extends_deadline_with_exactly_one_renewed_event(
+        self, override: SafetyOverride
+    ) -> None:
+        """Happy path: the deadline moves forward and ONE renewed event is logged."""
+        mock_sel_instance = MagicMock()
+        with patch("kiro_crew.safety_override.sel", return_value=mock_sel_instance):
+            override.activate("slack", ttl=60)
+            deadline_before = override._expires_at
+            result = override.renew("slack")
+        assert result.renewed is True
+        assert result.ttl > 0
+        assert override._expires_at > deadline_before
+        renew_events = [
+            c
+            for c in mock_sel_instance.log_api_access.call_args_list
+            if c.kwargs["operation"] == "safety_override:renew"
+        ]
+        assert len(renew_events) == 1
+        assert renew_events[0].kwargs["outcome"] == "renewed"
+
 
 # ─── Status ─────────────────────────────────────────────────────────────────
 
@@ -340,6 +360,184 @@ class TestSelFaultTolerance:
             # Should not raise
             override.deactivate("slack")
         assert not override.is_active()
+
+    def test_sel_crash_refuses_renew_and_leaves_deadline_unmoved(
+        self, override: SafetyOverride
+    ) -> None:
+        """SEL audit failure during renew() must refuse the extension — fail closed.
+
+        The sink (``log_api_access``) raises, not ``_log_sel``: patching
+        ``_log_sel`` would pass regardless of the ``critical`` flag, and the
+        flag is exactly what this test pins.
+        """
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.activate("slack", ttl=60)
+        deadline_before = override._expires_at
+        last_renewed_before = override._last_renewed_at
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock(
+                log_api_access=MagicMock(side_effect=RuntimeError("boom"))
+            )
+            result = override.renew("slack")
+        assert result.renewed is False
+        assert result.ttl == 0
+        assert result.reason == "audit_failed"
+        # The grant itself is untouched: still active, deadline unmoved.
+        assert override._expires_at == deadline_before
+        assert override._last_renewed_at == last_renewed_before
+        assert override.is_active()
+
+    def test_renew_does_not_resurrect_grant_deactivated_during_audit(
+        self, override: SafetyOverride
+    ) -> None:
+        """A deactivate() landing while the renew audit is being written wins.
+
+        The renew SEL event is written outside ``_lock``, so a concurrent
+        deactivate() can zero the grant in that window; the post-audit
+        re-verify must refuse the commit rather than resurrect the grant.
+        """
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.activate("slack", ttl=60)
+
+        sink = MagicMock()
+
+        def _deactivate_on_renew(**kwargs: object) -> None:
+            if (
+                kwargs.get("operation") == "safety_override:renew"
+                and kwargs.get("outcome") == "renewed"
+            ):
+                override.deactivate("dashboard")
+
+        sink.log_api_access.side_effect = _deactivate_on_renew
+        with patch("kiro_crew.safety_override.sel", return_value=sink):
+            result = override.renew("slack")
+
+        assert result.renewed is False
+        assert result.reason == "not_active"
+        # The deactivation stands: no resurrection, no deadline.
+        assert override._active is False
+        assert override._expires_at == 0.0
+        assert not override.is_active()
+
+    def test_renew_does_not_overwrite_activation_landed_during_audit(
+        self, override: SafetyOverride
+    ) -> None:
+        """A fresh activate() landing during the renew audit window wins.
+
+        The new activation audited its own grant and installed its own
+        deadline; a stale renewal committing afterwards would overwrite it
+        with a deadline computed for the OLD grant. The activation-count
+        snapshot must refuse the commit.
+        """
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.activate("slack", ttl=60)
+
+        sink = MagicMock()
+
+        def _activate_on_renew(**kwargs: object) -> None:
+            if (
+                kwargs.get("operation") == "safety_override:renew"
+                and kwargs.get("outcome") == "renewed"
+            ):
+                override.activate("dashboard", ttl=30)
+
+        sink.log_api_access.side_effect = _activate_on_renew
+        with patch("kiro_crew.safety_override.sel", return_value=sink):
+            result = override.renew("slack")
+
+        assert result.renewed is False
+        # The fresh activation's grant is intact: its deadline (~30s out) was
+        # not replaced by the stale renewal's much longer TTL, and the renewal
+        # left no bookkeeping behind.
+        assert override.is_active()
+        assert override._source == "dashboard"
+        assert override._expires_at - time.monotonic() <= 30 + 1
+        assert override._last_renewed_at == 0.0
+
+    def test_renew_refuses_when_permanent_activation_lands_during_audit(
+        self, override: SafetyOverride
+    ) -> None:
+        """A permanent grant installed during the audit window is left alone.
+
+        The renewal must neither report success (it committed nothing) nor
+        touch the permanent grant, and the already-persisted renewed event
+        must be followed by a corrective denied event so the SEL stays
+        truthful.
+        """
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.activate("slack", ttl=60)
+
+        sink = MagicMock()
+
+        def _go_permanent_on_renew(**kwargs: object) -> None:
+            if (
+                kwargs.get("operation") == "safety_override:renew"
+                and kwargs.get("outcome") == "renewed"
+            ):
+                override.activate_declared()
+
+        sink.log_api_access.side_effect = _go_permanent_on_renew
+        with patch("kiro_crew.safety_override.sel", return_value=sink):
+            result = override.renew("slack")
+
+        assert result.renewed is False
+        # The permanent grant is untouched and still permanent.
+        assert override.is_permanent is True
+        assert override._last_renewed_at == 0.0
+        # A corrective denied event follows the persisted renewed event.
+        renew_events = [
+            c
+            for c in sink.log_api_access.call_args_list
+            if c.kwargs["operation"] == "safety_override:renew"
+        ]
+        assert [c.kwargs["outcome"] for c in renew_events] == ["renewed", "denied"]
+        assert "superseded_by_activation" in renew_events[-1].kwargs["resources"]
+
+    def test_renew_begun_active_refuses_grace_commit_after_midaudit_off(
+        self, override: SafetyOverride
+    ) -> None:
+        """A renewal that began ACTIVE may not commit through the grace arm.
+
+        Mid-audit the grant lapses and the operator switches it off: the
+        expiry bookkeeping clears ``_active`` but keeps the past deadline, and
+        deactivate() on an already-lapsed grant is an early-return no-op, so
+        the grace arm alone cannot distinguish "expired" from "operator said
+        off". The renewal began on the active arm, so the commit must require
+        the grant to STILL be active — not slide into grace and restore
+        auto-approval over the operator's off.
+        """
+        with patch("kiro_crew.safety_override.sel") as mock_sel:
+            mock_sel.return_value = MagicMock()
+            override.activate("slack", ttl=60)
+
+        sink = MagicMock()
+
+        def _lapse_and_off_on_renew(**kwargs: object) -> None:
+            if (
+                kwargs.get("operation") == "safety_override:renew"
+                and kwargs.get("outcome") == "renewed"
+            ):
+                # The deadline passes mid-audit and is_active() bookkeeping
+                # runs (e.g. from the operator's off flow reading status).
+                override._expires_at = time.monotonic() - 1  # lapsed, in grace
+                override._active = False
+                # The operator's explicit off: early-return no-op on a lapsed
+                # grant, deadline stays intact.
+                override.deactivate("dashboard")
+
+        sink.log_api_access.side_effect = _lapse_and_off_on_renew
+        with patch("kiro_crew.safety_override.sel", return_value=sink):
+            result = override.renew("slack")
+
+        assert result.renewed is False
+        assert result.reason == "not_active"
+        assert override._active is False
+        assert not override.is_active()
+        assert override._last_renewed_at == 0.0
 
     def test_sel_import_error_rolls_back_activate(self, override: SafetyOverride) -> None:
         """SEL import error during activate() must roll back — fail closed."""


### PR DESCRIPTION
## Summary

`SafetyOverride.renew()` extended a YOLO grant's deadline first and wrote its `safety_override:renew` SEL event afterwards, non-critically — a failed audit write was swallowed and auto-approval stayed extended with no record. Every other path in the file that creates auto-approval authority (`_commit_activation`, `activate_scoped`) audits fail-closed BEFORE committing.

This brings `renew()` onto the same pattern:

- **Eligibility decision stays under `_lock`** (no mutation): permanent-grant and denied early paths are byte-for-byte behavior-preserved.
- **Audit before commit, outside the lock**: the `renewed` SEL event is written with `critical=True`; on failure `renew()` logs at error level and returns `RenewResult(renewed=False, ttl=0, reason="audit_failed")` with the deadline unmoved. (No call site or frontend matches reason strings — both Slack call sites branch only on `.renewed`.)
- **Post-audit re-verify**: the SEL write runs with the lock released, so `renew()` re-acquires `_lock` and re-derives the full live-or-in-grace predicate before committing. A concurrent `deactivate()` (which zeroes `_expires_at`) during the audit window refuses the commit — no resurrection. A refused commit emits a corrective `denied` / `reason:not_active_at_commit` event so an auditor never reads a renewal that didn't take effect.
- Grace-window semantics, the TTL clamp, and the pre-lock `current_adhoc_duration()` resolution are unchanged.

## Tests (mutation-verified)

- `test_sel_crash_refuses_renew_and_leaves_deadline_unmoved` — patches the SINK (`log_api_access` raises, not `_log_sel`, which would pass vacuously regardless of the `critical` flag): asserts not-renewed AND deadline unmoved. **Fails on unfixed code.**
- `test_renew_does_not_resurrect_grant_deactivated_during_audit` — sink side effect calls `deactivate()` during the audit window: asserts no resurrection. **Fails on unfixed code.**
- `test_renew_extends_deadline_with_exactly_one_renewed_event` — happy-path pin.
- Existing permanent-grant, grace-window, and denied-path tests pass unchanged.

## Verification

- isort / flake8 / mypy clean on changed files (the `token_auth.py` isort failure is a base-branch break, fix already open as #2478 — will rebase once it lands).
- Full pytest: 40201 passed; the 77 failures are environment-baseline and reproduce identically with the fix reverted (same 20/1549 subset result with and without the change).
- Docs updated in the same commit (`security-deep-dive.md`, `modules/security.md`).

## Residual notes for reviewers

- The critical SEL write is synchronous by design — it mirrors the post-pentest `activate()` pattern exactly (same sink, same flag); renewals are rare, human-triggered events.
- On `audit_failed`, the Slack handlers' failure text still says "not active" (they branch only on `.renewed`). Fail-closed and out of this issue's scope; happy to file a follow-up for distinguished messaging.

Coordination: scoped strictly to `renew()` — does not touch `deactivate()` (#2475) nor pre-empt `renew_lease()` (#2443).

Closes #2453
