### PR TITLE
feat: stagger gateway startup after a recent loopstall crash dump

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2062,6 +2062,18 @@ class DashboardConfig:
             "probe wins first and the stack dump is lost.",
         ),
     )
+    cautious_boot: bool = field(
+        default=True,
+        metadata=_meta(
+            "Cautious Boot After Crash",
+            "When the gateway starts and finds a recent loop-stall crash dump "
+            "(under 30 minutes old) from the previous instance, stagger the "
+            "startup burst — MCP servers, cron scheduler, app backends, "
+            "session restores — with short pauses instead of launching "
+            "everything at once, so a host still under memory pressure is "
+            "not pushed straight back into the same collapse.",
+        ),
+    )
     widget_density: str = field(
         default="more",
         metadata=_meta(
@@ -5332,6 +5344,7 @@ class KiroCrewConfig:
                     LOOP_STALL_EXIT_AFTER_MIN,
                     LOOP_STALL_EXIT_AFTER_MAX,
                 ),
+                cautious_boot=_safe_bool(dashboard_data.get("cautious_boot"), True),
                 auto_open_browser=dashboard_data.get("auto_open_browser", True),
                 prevent_sleep=_safe_bool(dashboard_data.get("prevent_sleep"), False),
                 quick_send=dashboard_data.get("quick_send", False),

--- a/src/kiro_crew/dashboard/cautious_boot.py
+++ b/src/kiro_crew/dashboard/cautious_boot.py
@@ -1,0 +1,165 @@
+"""Cautious boot: stagger the startup burst after a recent loop-stall crash.
+
+When the gateway starts and the crash-dump store holds a RECENT loop-stall
+dump, the previous instance wedged and hard-exited only minutes ago — very
+likely under host resource pressure that has not cleared yet. Launching the
+entire startup battery at once (MCP gateway, cron scheduler, app backends,
+MCP probes, session restores) onto such a host is exactly what re-wedges the
+new instance: the gateway *had* the signal (it logs the prior dump at boot)
+but did not act on it.
+
+This module turns that signal into behavior. The decision is made ONCE, early
+in gateway startup, entirely off the event loop (``initialize()``). Battery
+groups then call ``pause_before(<group>)``, which sleeps a short delay when
+cautious mode is active and is a no-op otherwise — the burst becomes a
+sequence of small groups separated by breathing room, giving the host (and
+the kernel's reclaim machinery) time between spikes.
+
+The delay is scaled by the CURRENT resource posture (``resource_status``):
+
+* recent dump + ``tight``/``critical`` host → maximum caution (longer pauses)
+* recent dump + ``ample``/``unknown`` host  → mild stagger only
+
+Everything fails OPEN: an unreadable dump store, a config error, or a probe
+failure means a normal, un-staggered boot. ``pause_before`` called without a
+prior ``initialize()`` (tests, embedded dashboard starts) is also a no-op.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from kiro_crew import resource_status
+from kiro_crew.config import KiroCrewConfig
+from kiro_crew.dashboard.crash_dump_store import dump_age_seconds, newest_dump_with_stacks
+
+logger = logging.getLogger(__name__)
+
+# A dump older than this is history, not an active incident: the host has been
+# up (or the operator intervened) long enough that pressure from the crash has
+# either cleared or become someone's explicit problem. Deliberately a module
+# constant, not config — the config surface is one bool (dashboard.cautious_boot).
+RECENT_DUMP_MAX_AGE_SECS = 30.0 * 60.0
+
+# Pause inserted between startup battery groups. "Maximum" is used when the
+# host is ALSO currently tight/critical on memory; "mild" when the dump is
+# recent but the host looks healthy again (or posture is unknown — an unknown
+# reading must not escalate, only the positive tight/critical signal does).
+MILD_DELAY_SECS = 2.0
+MAX_DELAY_SECS = 10.0
+
+
+@dataclass(frozen=True)
+class CautiousBootDecision:
+    """Immutable boot-scoped verdict. Computed once; only ever read afterwards."""
+
+    active: bool
+    delay_secs: float
+    reason: str
+
+
+# Boot-scoped cache. Written exactly once by ``initialize()`` (awaited on the
+# gateway loop before any pause site runs) and only read by ``pause_before``.
+# ``None`` means "never initialized" and is treated as inactive — deterministic
+# fail-open for tests and any embedded caller that skips initialize().
+_decision: CautiousBootDecision | None = None
+
+
+def _evaluate(
+    cfg: object | None = None,
+    dumps_dir: Path | None = None,
+) -> CautiousBootDecision:
+    """Synchronous evaluation — blocking I/O allowed; callers keep it off-loop.
+
+    *cfg* and *dumps_dir* are injectable for tests (same pattern as the
+    crash-dump store). Never raises: any failure returns an inactive decision.
+    """
+    try:
+        if cfg is None:
+            cfg = KiroCrewConfig.load()
+        if not getattr(getattr(cfg, "dashboard", None), "cautious_boot", True):
+            return CautiousBootDecision(False, 0.0, "disabled via dashboard.cautious_boot")
+
+        dump = newest_dump_with_stacks(dumps_dir)
+        if dump is None:
+            return CautiousBootDecision(False, 0.0, "no prior loop-stall crash dump")
+
+        age = dump_age_seconds(dump)
+        if age >= RECENT_DUMP_MAX_AGE_SECS:
+            return CautiousBootDecision(
+                False, 0.0, f"prior dump is {age / 60.0:.0f} min old (not recent)"
+            )
+
+        # The dump says the LAST boot died under pressure; the posture probe
+        # says whether the pressure is STILL here. Both signals together pick
+        # the delay. probe() never raises (returns "unknown" on failure).
+        posture = resource_status.probe(cfg).posture
+        if posture in (resource_status.POSTURE_TIGHT, resource_status.POSTURE_CRITICAL):
+            delay = MAX_DELAY_SECS
+        else:
+            delay = MILD_DELAY_SECS
+        return CautiousBootDecision(
+            True,
+            delay,
+            (
+                f"prior loop-stall crash dump {dump.name} is {age / 60.0:.1f} min old; "
+                f"current host posture is {posture}"
+            ),
+        )
+    except Exception:
+        # Fail OPEN — a broken evaluation must never delay or block a boot.
+        logger.warning("cautious-boot evaluation failed; booting normally", exc_info=True)
+        return CautiousBootDecision(False, 0.0, "evaluation failed (fail-open)")
+
+
+async def initialize() -> CautiousBootDecision:
+    """Evaluate the cautious-boot decision once, off-loop, and cache it.
+
+    Awaited exactly once, early in gateway startup — before the first battery
+    group. The whole evaluation (config load, dump ``stat``, ``/proc`` reads)
+    runs in a worker thread so nothing blocks the event loop. ``RuntimeError``
+    from ``asyncio.to_thread`` (executor exhaustion/shutdown) fails open.
+    """
+    global _decision
+    try:
+        _decision = await asyncio.to_thread(_evaluate)
+    except RuntimeError:
+        logger.warning("cautious-boot probe skipped (no worker thread); booting normally")
+        _decision = CautiousBootDecision(False, 0.0, "no worker thread (fail-open)")
+    if _decision.active:
+        # Loud on purpose: an operator reading the journal after an incident
+        # must see that the gateway noticed the crash AND changed its behavior.
+        logger.warning(
+            "🐢 Cautious boot ACTIVE: %s — staggering the startup battery "
+            "(%.0fs pause between groups). Disable via dashboard.cautious_boot.",
+            _decision.reason,
+            _decision.delay_secs,
+        )
+    else:
+        logger.debug("cautious boot inactive: %s", _decision.reason)
+    return _decision
+
+
+async def pause_before(group: str) -> None:
+    """Pause briefly before launching *group* when cautious boot is active.
+
+    No-op when inactive or never initialized. The cached decision is immutable,
+    so nothing read before this await can go stale because of it; callers'
+    own post-await state is unaffected (this function only sleeps).
+    """
+    decision = _decision
+    if decision is None or not decision.active:
+        return
+    logger.info(
+        "cautious boot: pausing %.0fs before starting %s", decision.delay_secs, group
+    )
+    await asyncio.sleep(decision.delay_secs)
+
+
+def _reset_for_tests() -> None:
+    """Clear the boot-scoped cache (test isolation only)."""
+    global _decision
+    _decision = None

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -34,6 +34,7 @@ from kiro_crew.config import data_home
 from kiro_crew.config.loader import KiroCrewConfig, refresh_materialized_agents
 from kiro_crew.constants import env_flag_enabled
 from kiro_crew.dashboard import (
+    cautious_boot,
     channel_slots,
     chat,
     handlers,
@@ -2931,6 +2932,7 @@ async def start_dashboard(
     # wedge-prone blocking work that would freeze this event loop if run inline.
     # subprocess_executor (not the default to_thread pool) isolates it so a hung
     # `ps` cannot starve asyncio's default executor (the RFC's bulkhead intent).
+    await cautious_boot.pause_before("app backends")
     started_apps = await asyncio.get_running_loop().run_in_executor(
         subprocess_executor(), start_enabled_app_backends
     )
@@ -3433,7 +3435,10 @@ async def start_dashboard(
                 except Exception:
                     logger.debug("stall-exit notification failed", exc_info=True)
 
-    # Fire background MCP probe at startup (non-blocking)
+    # Fire background MCP probe at startup (non-blocking). The probe spawns a
+    # handshake subprocess per configured MCP server, so under cautious boot it
+    # gets its own launch window instead of landing on top of the app backends.
+    await cautious_boot.pause_before("MCP server probe")
     asyncio.create_task(handlers._bg_mcp_probe())
 
     # Start terminal orphan reaper (kills PTYs with no WS past the reaper window)
@@ -3521,6 +3526,9 @@ async def start_dashboard(
         # messages, so starting up without it is safe.
         logger.warning("channel transcript migration failed", exc_info=True)
 
+    # Session restores spawn a kiro-cli process per restored tab — the last
+    # large group of the startup battery, so it too gets a cautious-boot window.
+    await cautious_boot.pause_before("session restore")
     with state.suspend_slots_push():
         await chat.restore_open_slots_async(state)
         restored = await chat.restore_recent_sessions_async(

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -81,7 +81,7 @@ from kiro_crew.context import ContextBuilder
 from kiro_crew.context_management import summarize_result
 from kiro_crew.cron import CronJob, CronService, CronStoreBusy, build_cron_session_context
 from kiro_crew.cron_script import run_command_sandboxed, run_script_sandboxed
-from kiro_crew.dashboard import start_dashboard
+from kiro_crew.dashboard import cautious_boot, start_dashboard
 from kiro_crew.dashboard.chat_persistence import rehydrate_slot_from_history_async
 from kiro_crew.dashboard.chat_runner import _resolve_channel_target, _run_chat
 from kiro_crew.dashboard.chat_utils import (
@@ -6294,6 +6294,13 @@ class GatewayOrchestrator:
         from kiro_crew.slack.events import SeenCache, init_socket_mode
         from kiro_crew.slack.interactions import init as init_interactions
 
+        # Cautious boot: decide ONCE — off-loop — whether the previous instance
+        # left a recent loop-stall crash dump. If it did, the pause_before()
+        # calls below (and in start_dashboard) stagger the startup battery so
+        # a host that is possibly still under the same memory pressure is not
+        # hit with everything at once. Fails open: any error means normal boot.
+        await cautious_boot.initialize()
+
         seen = SeenCache()
         self._init_services()
 
@@ -6312,8 +6319,13 @@ class GatewayOrchestrator:
         # rewriter writes the agent-JSON overlay first so kiro-cli picks up
         # the broker-wired MCP entries the moment a session starts.  No-op
         # when ``mcp_gateway.enabled`` is False.
+        await cautious_boot.pause_before("MCP gateway sidecar")
         await self._init_mcp_gateway()
 
+        # Arming the cron scheduler fires any overdue jobs immediately, so
+        # under cautious boot this pause also defers the post-restart cron
+        # catch-up burst out of the app/MCP launch window.
+        await cautious_boot.pause_before("cron scheduler")
         await self._init_cron()
         await self._init_heartbeat()
         self._init_mcp_discovery()

--- a/test/test_cautious_boot.py
+++ b/test/test_cautious_boot.py
@@ -1,0 +1,285 @@
+"""Tests for cautious boot — staggered startup after a recent loop-stall crash.
+
+Follows the injectable-dependency pattern of test_crash_dump_store.py: dump
+files are created in a temp dir and passed via ``dumps_dir``; the config and
+the resource-posture probe are injected/monkeypatched so no test touches the
+real data home or the real host's memory state.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import resource_status
+from kiro_crew.dashboard import cautious_boot
+from kiro_crew.dashboard.cautious_boot import (
+    MAX_DELAY_SECS,
+    MILD_DELAY_SECS,
+    RECENT_DUMP_MAX_AGE_SECS,
+    CautiousBootDecision,
+    _evaluate,
+    initialize,
+    pause_before,
+)
+from kiro_crew.dashboard.crash_dump_store import DUMP_PREFIX, DUMP_SUFFIX
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _DashCfg:
+    def __init__(self, cautious: bool) -> None:
+        self.cautious_boot = cautious
+
+
+class _Cfg:
+    """Minimal stand-in for KiroCrewConfig — only what _evaluate reads."""
+
+    def __init__(self, cautious: bool = True) -> None:
+        self.dashboard = _DashCfg(cautious)
+
+
+def _fake_probe(posture: str):
+    """Return a probe() replacement yielding a fixed posture."""
+
+    class _Status:
+        pass
+
+    def probe(cfg=None):  # noqa: ANN001 — matches resource_status.probe
+        s = _Status()
+        s.posture = posture
+        return s
+
+    return probe
+
+
+@pytest.fixture
+def dumps_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "crash-dumps"
+    d.mkdir()
+    return d
+
+
+def _create_stacked_dump(dumps_dir: Path, *, age_secs: float = 0.0) -> Path:
+    """Create a dump with real stack content (a wedge), aged *age_secs*."""
+    p = dumps_dir / f"{DUMP_PREFIX}20260810T010000Z{DUMP_SUFFIX}"
+    p.write_text(
+        "# Kiro Crew loop-stall crash dump — opened 20260810T010000Z\n"
+        "# PID: 12345\n"
+        "# If thread stacks appear below, the event loop wedged and faulthandler fired.\n"
+        "\n"
+        "Thread 0x00007f0000000000 (most recent call first):\n"
+        '  File "example.py", line 1 in main\n'
+    )
+    if age_secs:
+        old = time.time() - age_secs
+        os.utime(p, (old, old))
+    return p
+
+
+def _create_header_only_dump(dumps_dir: Path) -> Path:
+    """Create a header-only dump (clean exit — no wedge)."""
+    p = dumps_dir / f"{DUMP_PREFIX}20260810T020000Z{DUMP_SUFFIX}"
+    p.write_text(
+        "# Kiro Crew loop-stall crash dump — opened 20260810T020000Z\n"
+        "# PID: 12345\n"
+        "# If thread stacks appear below, the event loop wedged and faulthandler fired.\n"
+        "\n"
+    )
+    return p
+
+
+@pytest.fixture(autouse=True)
+def _reset_decision_cache():
+    cautious_boot._reset_for_tests()
+    yield
+    cautious_boot._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# _evaluate — decision matrix
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluate:
+    def test_recent_dump_ample_host_mild_stagger(self, dumps_dir, monkeypatch):
+        _create_stacked_dump(dumps_dir)
+        monkeypatch.setattr(resource_status, "probe", _fake_probe(resource_status.POSTURE_AMPLE))
+        d = _evaluate(cfg=_Cfg(), dumps_dir=dumps_dir)
+        assert d.active
+        assert d.delay_secs == MILD_DELAY_SECS
+
+    @pytest.mark.parametrize(
+        "posture",
+        [resource_status.POSTURE_TIGHT, resource_status.POSTURE_CRITICAL],
+    )
+    def test_recent_dump_pressured_host_maximum_caution(self, dumps_dir, monkeypatch, posture):
+        _create_stacked_dump(dumps_dir)
+        monkeypatch.setattr(resource_status, "probe", _fake_probe(posture))
+        d = _evaluate(cfg=_Cfg(), dumps_dir=dumps_dir)
+        assert d.active
+        assert d.delay_secs == MAX_DELAY_SECS
+
+    def test_unknown_posture_does_not_escalate(self, dumps_dir, monkeypatch):
+        """An unreadable probe must not pick the maximum delay — only a
+        positive tight/critical reading escalates."""
+        _create_stacked_dump(dumps_dir)
+        monkeypatch.setattr(resource_status, "probe", _fake_probe(resource_status.POSTURE_UNKNOWN))
+        d = _evaluate(cfg=_Cfg(), dumps_dir=dumps_dir)
+        assert d.active
+        assert d.delay_secs == MILD_DELAY_SECS
+
+    def test_old_dump_boots_normally(self, dumps_dir, monkeypatch):
+        _create_stacked_dump(dumps_dir, age_secs=RECENT_DUMP_MAX_AGE_SECS + 60)
+        monkeypatch.setattr(
+            resource_status, "probe", _fake_probe(resource_status.POSTURE_CRITICAL)
+        )
+        d = _evaluate(cfg=_Cfg(), dumps_dir=dumps_dir)
+        assert not d.active
+        assert d.delay_secs == 0.0
+
+    def test_no_dump_boots_normally(self, dumps_dir):
+        d = _evaluate(cfg=_Cfg(), dumps_dir=dumps_dir)
+        assert not d.active
+
+    def test_header_only_dump_is_not_a_crash(self, dumps_dir):
+        """A header-only dump means the previous instance exited cleanly."""
+        _create_header_only_dump(dumps_dir)
+        d = _evaluate(cfg=_Cfg(), dumps_dir=dumps_dir)
+        assert not d.active
+
+    def test_config_off_boots_normally(self, dumps_dir, monkeypatch):
+        _create_stacked_dump(dumps_dir)
+        monkeypatch.setattr(
+            resource_status, "probe", _fake_probe(resource_status.POSTURE_CRITICAL)
+        )
+        d = _evaluate(cfg=_Cfg(cautious=False), dumps_dir=dumps_dir)
+        assert not d.active
+        assert "disabled" in d.reason
+
+    def test_unreadable_store_fails_open(self, monkeypatch):
+        def _boom(dumps_dir=None):
+            raise OSError("store unreadable")
+
+        monkeypatch.setattr(cautious_boot, "newest_dump_with_stacks", _boom)
+        d = _evaluate(cfg=_Cfg())
+        assert not d.active
+        assert "fail-open" in d.reason
+
+    def test_probe_exception_fails_open(self, dumps_dir, monkeypatch):
+        _create_stacked_dump(dumps_dir)
+
+        def _boom(cfg=None):
+            raise RuntimeError("probe exploded")
+
+        monkeypatch.setattr(resource_status, "probe", _boom)
+        d = _evaluate(cfg=_Cfg(), dumps_dir=dumps_dir)
+        assert not d.active
+
+    def test_default_config_attribute_missing_defaults_on(self, dumps_dir, monkeypatch):
+        """A config object without the field (older overlay) defaults to ON."""
+
+        class _Bare:
+            dashboard = object()
+
+        _create_stacked_dump(dumps_dir)
+        monkeypatch.setattr(resource_status, "probe", _fake_probe(resource_status.POSTURE_AMPLE))
+        d = _evaluate(cfg=_Bare(), dumps_dir=dumps_dir)
+        assert d.active
+
+
+# ---------------------------------------------------------------------------
+# initialize / pause_before — async plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestInitializeAndPause:
+    @pytest.mark.asyncio
+    async def test_initialize_caches_and_logs_loudly(self, dumps_dir, monkeypatch, caplog):
+        _create_stacked_dump(dumps_dir)
+        monkeypatch.setattr(resource_status, "probe", _fake_probe(resource_status.POSTURE_TIGHT))
+        monkeypatch.setattr(
+            cautious_boot,
+            "_evaluate",
+            lambda cfg=None, dumps_dir_=None: _evaluate(cfg=_Cfg(), dumps_dir=dumps_dir),
+        )
+        with caplog.at_level(logging.WARNING, logger=cautious_boot.__name__):
+            d = await initialize()
+        assert d.active
+        assert cautious_boot._decision is d
+        assert any("Cautious boot ACTIVE" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_initialize_thread_exhaustion_fails_open(self, monkeypatch):
+        async def _no_thread(fn, *a, **kw):
+            raise RuntimeError("no worker thread")
+
+        monkeypatch.setattr(cautious_boot.asyncio, "to_thread", _no_thread)
+        d = await initialize()
+        assert not d.active
+        assert cautious_boot._decision is d
+
+    @pytest.mark.asyncio
+    async def test_pause_before_uninitialized_is_noop(self, monkeypatch):
+        async def _fail_sleep(secs):
+            raise AssertionError(f"pause_before slept ({secs}s) without initialize()")
+
+        monkeypatch.setattr(cautious_boot.asyncio, "sleep", _fail_sleep)
+        await pause_before("app backends")  # must not sleep
+
+    @pytest.mark.asyncio
+    async def test_pause_before_inactive_is_noop(self, monkeypatch):
+        cautious_boot._decision = CautiousBootDecision(False, 0.0, "no dump")
+
+        async def _fail_sleep(secs):
+            raise AssertionError("pause_before slept while inactive")
+
+        monkeypatch.setattr(cautious_boot.asyncio, "sleep", _fail_sleep)
+        await pause_before("cron scheduler")
+
+    @pytest.mark.asyncio
+    async def test_pause_before_active_sleeps_decision_delay(self, monkeypatch):
+        cautious_boot._decision = CautiousBootDecision(True, MAX_DELAY_SECS, "recent dump")
+        slept: list[float] = []
+
+        async def _record_sleep(secs):
+            slept.append(secs)
+
+        monkeypatch.setattr(cautious_boot.asyncio, "sleep", _record_sleep)
+        await pause_before("MCP server probe")
+        assert slept == [MAX_DELAY_SECS]
+
+    @pytest.mark.asyncio
+    async def test_pause_before_never_raises_into_boot(self, monkeypatch):
+        """The pause is best-effort: even a pathological sleep failure must not
+        propagate into (and abort) gateway startup — asyncio.sleep only raises
+        CancelledError in practice, which must propagate; anything else is a
+        no-op guarantee provided by reading an immutable decision."""
+        cautious_boot._decision = CautiousBootDecision(True, 0.0, "recent dump")
+        # Zero delay: still logs + sleeps(0) — just verify it completes.
+        await pause_before("session restore")
+
+
+# ---------------------------------------------------------------------------
+# Config plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestConfigKey:
+    def test_dashboard_config_defaults_on(self):
+        from kiro_crew.config.loader import DashboardConfig
+
+        assert DashboardConfig().cautious_boot is True
+
+    def test_loader_rejects_non_bool(self):
+        from kiro_crew.config.loader import _safe_bool
+
+        assert _safe_bool("yes", True) is True  # non-bool → default
+        assert _safe_bool(False, True) is False
+        assert _safe_bool(None, True) is True


### PR DESCRIPTION
# Cautious boot after a recent loop-stall crash

## Problem

When a Kiro Crew gateway wedges under host memory pressure, the loop-stall watchdog dumps thread stacks and hard-exits so the service manager can restart it. The NEW instance already detects that dump at boot — it logs `⚠️ Prior loop-stall crash dump found: ... (0.0 hours ago)` and notifies the user — and then launches its **entire startup battery at once anyway**: MCP gateway sidecar, cron scheduler (which immediately fires every overdue job), app backends, MCP server probes, and session restores, each of which spawns subprocesses.

On a host that is still under the same memory pressure that killed the previous instance, that simultaneous burst is exactly what re-wedges the new one. This was observed in practice: a gateway died under memory pressure, the restarted instance detected the minutes-old dump, launched everything at once, its own watchdog wedged within seconds, and the host froze shortly after. The gateway **had the signal and did not act on it**.

## What changed

A new `dashboard/cautious_boot.py` module turns the existing detection into behavior:

- **One decision, made once, off the event loop** (`initialize()`, evaluated via `asyncio.to_thread` early in gateway startup): is there a prior loop-stall dump with real stack content younger than 30 minutes?
- **Posture-scaled delay**: the current resource posture (`resource_status.probe`) picks the pause length —
  - recent dump + `tight`/`critical` host → **10s** between battery groups (maximum caution)
  - recent dump + `ample` host → **2s** between groups (mild stagger; an `unknown` posture reading deliberately does *not* escalate)
- **Five pause points** turn the burst into a sequence of small groups: MCP gateway sidecar → cron scheduler (this also defers the post-restart cron catch-up burst out of the app/MCP launch window) → app backends → MCP server probes → session restores. Each pause is a plain `await asyncio.sleep(...)`, so the event loop stays responsive and the loop-stall watchdog keeps getting its heartbeat throughout.
- **Fail-open everywhere**: an unreadable dump store, a config error, a failed posture probe, or worker-thread exhaustion all mean a normal, un-staggered boot. `pause_before()` without a prior `initialize()` (tests, embedded starts) is a no-op.
- **Loud when active**: `🐢 Cautious boot ACTIVE: ...` is logged at WARNING with the dump name, its age, the posture, and the chosen delay, so an operator reading the journal after an incident sees the gateway both noticed the crash and changed its behavior.

One new config key, following the existing loader conventions (typed accessor with default, non-bool values fall back to the default):

- `dashboard.cautious_boot` (bool, default **on**) — the recency threshold (30 min) and the two delays are deliberately module constants, keeping the config surface to a single switch.

## What is deliberately NOT here

- **No scheduling machinery**: no priority queues, no dependency graph, no adaptive back-off. The stagger is sequential groups with short sleeps — the minimal change that spreads the burst.
- **No admission control**: nothing is skipped or refused; every service still starts, just not simultaneously. Posture-gated admission of new work is a separate concern.
- **No configurable thresholds/delays**: one bool. If field experience shows the constants need tuning, that is a follow-up with evidence.
- **No change to the watchdog or the crash-dump store**: detection and dump lifecycle are untouched; this only consumes the existing signal.

## Testing

New `test/test_cautious_boot.py` (19 tests) covering the decision matrix (recent dump × ample/tight/critical/unknown posture, old dump, no dump, header-only dump, config off, missing config attribute), fail-open paths (unreadable store, probe exception, worker-thread exhaustion), and the async plumbing (decision caching, loud activation log, `pause_before` no-op when uninitialized/inactive, correct sleep when active).

Also run green: crash-dump store and resource-status neighbors (65 tests), config schema/loader suites (275 tests), and the dashboard/API server startup suites (96 tests). `isort`, `flake8`, and `mypy` pass on all touched files.
