### PR TITLE
fix: restore isort ordering in token_auth broken by merge collision

### DIFF
--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -39,13 +39,6 @@ from kiro_crew.dashboard.refresh_tokens import (
     generate_refresh_token,
     refresh_cookie_name,
 )
-from kiro_crew.dashboard.tailnet import (
-    ForwardedPeer,
-    TailnetTrust,
-    login_allowed,
-    peer_pin_key,
-    resolve_forwarded_peer,
-)
 
 # Canonical revocation-generation definitions live in revocation_gen so the
 # refresh-token module can consult the counter without recreating the
@@ -59,6 +52,13 @@ from kiro_crew.dashboard.revocation_gen import (  # noqa: F401  # re-exports
     bump_revocation_gen,
     current_revocation_gen,
     current_revocation_gen_or_none,
+)
+from kiro_crew.dashboard.tailnet import (
+    ForwardedPeer,
+    TailnetTrust,
+    login_allowed,
+    peer_pin_key,
+    resolve_forwarded_peer,
 )
 
 # Canonical HMAC-secret definitions live in token_secret to break the import


### PR DESCRIPTION
## Summary

Main is red: `Backend Lint & Type Check` fails on every PR with

```
ERROR: src/kiro_crew/dashboard/token_auth.py Imports are incorrectly sorted and/or formatted.
```

#2411 (tailnet imports) and #2388 (revocation_gen imports) each passed CI alone, but their merges interleaved two import blocks out of alphabetical order — a classic semantic merge collision that git resolves textually.

## Changes

Mechanical `isort` re-order of the two blocks only. No import added, removed, or renamed; the revocation_gen re-export comment stays attached to its block.

## Testing

- `isort --check-only src/kiro_crew/dashboard/token_auth.py` — clean
- `flake8 src/kiro_crew/dashboard/token_auth.py` — clean
- `python -c 'import ast; ast.parse(...)'` — parses

This unblocks every open PR currently failing Backend Lint on a base-tree file they don't touch (e.g. #2482).