### PR TITLE
fix: surface the wedged thread's stack in doctor and boot replay

### DIFF
--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -960,7 +960,10 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
             if _age_s < 7 * 86400:  # Less than 7 days old
                 _age_h = _age_s / 3600
                 print(f"  last dump:   ⚠️  {_latest.name} ({_age_h:.1f}h ago)")
-                _stack = dump_first_stack_lines(_latest, max_lines=5)
+                # 8 lines = preamble + thread header + ~6 frames: enough to
+                # reach past the asyncio plumbing into the Kiro Crew frame
+                # that identifies WHERE the loop wedged.
+                _stack = dump_first_stack_lines(_latest, max_lines=8)
                 if _stack:
                     print("  MainThread stuck at:")
                     for _line in _stack:

--- a/src/kiro_crew/dashboard/crash_dump_store.py
+++ b/src/kiro_crew/dashboard/crash_dump_store.py
@@ -580,14 +580,80 @@ def dump_age_seconds(dump_path: Path) -> float:
     return max(0.0, time.time() - dump_path.stat().st_mtime)
 
 
+#: Matches a faulthandler per-thread stack header, e.g.
+#: ``Thread 0x00007f72c082b640 (most recent call first):`` or
+#: ``Current thread 0x... (most recent call first):``.
+_THREAD_HEADER_RE = re.compile(r"^(?:Current thread|Thread) 0x[0-9a-fA-F]+")
+
+
+def _split_stack_content(stack_lines: list[str]) -> tuple[list[str], list[list[str]]]:
+    """Split dump stack content into (preamble, per-thread blocks).
+
+    *stack_lines* is the dump content AFTER the file header, empty lines
+    removed.  The preamble is anything before the first thread header
+    (faulthandler's ``Timeout (0:00:25)!`` marker).  Each block starts with a
+    ``Thread 0x...`` / ``Current thread 0x...`` header line and carries that
+    thread's frames.
+    """
+    preamble: list[str] = []
+    blocks: list[list[str]] = []
+    current: list[str] | None = None
+    for ln in stack_lines:
+        if _THREAD_HEADER_RE.match(ln.strip()):
+            current = [ln]
+            blocks.append(current)
+        elif current is None:
+            preamble.append(ln)
+        else:
+            current.append(ln)
+    return preamble, blocks
+
+
+def _wedged_thread_block(blocks: list[list[str]]) -> list[str] | None:
+    """Return the stack block of the thread the event loop wedged on.
+
+    ``faulthandler.dump_traceback_later`` (what the loop watchdog arms) fires
+    from an internal C thread, so no block carries the ``Current thread``
+    marker — and CPython dumps Python threads newest-first, which puts the
+    MAIN thread (where the gateway's asyncio loop runs) LAST in the file.
+    The blocks at the top are typically idle thread-pool workers parked in
+    ``Queue.get``, useless for diagnosing the stall.
+
+    Prefer an explicit ``Current thread`` marker when one exists (dumps taken
+    synchronously from Python mark the dumping thread); otherwise take the
+    last block.
+    """
+    if not blocks:
+        return None
+    for block in blocks:
+        if block[0].lstrip().startswith("Current thread"):
+            return block
+    return blocks[-1]
+
+
 def dump_first_stack_lines(dump_path: Path, max_lines: int = 5) -> list[str]:
-    """Extract the first N lines of actual stack content from a dump file."""
+    """Extract the most diagnostic stack lines from a dump file.
+
+    Returns the faulthandler preamble (``Timeout (...)!``) followed by the top
+    frames of the WEDGED thread's stack — not merely the first lines of the
+    file.  faulthandler writes threads newest-first, so the top of the file is
+    typically an idle thread-pool worker; labelling that "stuck at" (as
+    ``kirocrew doctor`` does) actively misleads whoever is diagnosing the
+    stall, while the actually-wedged main thread sits at the bottom.
+
+    Falls back to the raw top-of-file lines when no thread headers are
+    recognizable (malformed or foreign dump content).
+    """
     try:
         lines = dump_path.read_text(encoding="utf-8", errors="replace").splitlines()
-        stack_lines = [ln for ln in lines[_HEADER_LINES:] if ln.strip()]
-        return stack_lines[:max_lines]
     except OSError:
         return []
+    stack_lines = [ln for ln in lines[_HEADER_LINES:] if ln.strip()]
+    preamble, blocks = _split_stack_content(stack_lines)
+    wedged = _wedged_thread_block(blocks)
+    if wedged is None:
+        return stack_lines[:max_lines]
+    return (preamble + wedged)[:max_lines]
 
 
 def dump_replay_lines(
@@ -598,6 +664,14 @@ def dump_replay_lines(
     Returns (lines, truncated) — up to *max_lines* non-empty stack lines
     totalling at most *max_bytes* of text.  *truncated* is True when the
     dump exceeded either limit.
+
+    The wedged thread's stack (see :func:`_wedged_thread_block`) is replayed
+    FIRST, before the other threads, so the one stack that explains the stall
+    always survives the caps.  Real dumps routinely exceed them — a gateway
+    with a saturated default executor produces 200+ stack lines of idle
+    workers, and top-down order truncated the replay before ever reaching the
+    main thread (observed on the 2026-08-09 stall dumps: the journal showed
+    only ``Queue.get`` workers and ``[truncated]``).
     """
     try:
         content = dump_path.read_text(encoding="utf-8", errors="replace")
@@ -605,6 +679,11 @@ def dump_replay_lines(
         return [], False
     all_lines = content.splitlines()
     stack_lines = [ln for ln in all_lines[_HEADER_LINES:] if ln.strip()]
+    preamble, blocks = _split_stack_content(stack_lines)
+    wedged = _wedged_thread_block(blocks)
+    if wedged is not None:
+        others = [ln for block in blocks if block is not wedged for ln in block]
+        stack_lines = preamble + wedged + others
     result: list[str] = []
     total = 0
     for ln in stack_lines:

--- a/test/test_crash_dump_store.py
+++ b/test/test_crash_dump_store.py
@@ -195,6 +195,89 @@ def test_dump_first_stack_lines_header_only(dumps_dir: Path) -> None:
     assert lines == []
 
 
+def _create_multi_thread_dump(dumps_dir: Path, name: str, *, idle_workers: int = 3) -> Path:
+    """Create a dump mirroring a REAL faulthandler loop-stall dump.
+
+    ``faulthandler.dump_traceback_later`` writes a ``Timeout (...)!`` preamble
+    then every thread newest-first: idle thread-pool workers (parked in
+    ``Queue.get``) come first, and the MAIN thread — the one the asyncio loop
+    wedged on — comes LAST.
+    """
+    idle_block = (
+        "Thread 0x00007f000000{i:04x} (most recent call first):\n"
+        '  File "/usr/lib/python3.12/queue.py", line 171 in get\n'
+        '  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 90 in _worker\n'
+        '  File "/usr/lib/python3.12/threading.py", line 1032 in _bootstrap\n'
+    )
+    main_block = (
+        "Thread 0x00007f0000beef (most recent call first):\n"
+        '  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 166 in submit\n'
+        '  File "/usr/lib/python3.12/asyncio/base_events.py", line 867 in run_in_executor\n'
+        '  File "/home/user/.kirocrew/src/kiro_crew/dashboard/server.py", line 246 in _should_prevent_sleep\n'
+        '  File "/usr/lib/python3.12/asyncio/base_events.py", line 645 in run_forever\n'
+        '  File "/home/user/.kirocrew/src/kiro_crew/cli.py", line 2046 in main\n'
+    )
+    p = dumps_dir / name
+    p.write_text(
+        "# KiroCrew loop-stall crash dump — opened 20260717T020000Z\n"  # brand-ok: mirrors production dump header
+        "# PID: 12345\n"
+        "# If thread stacks appear below, the event loop wedged and faulthandler fired.\n"
+        "\n"
+        "Timeout (0:00:25)!\n"
+        + "".join(idle_block.format(i=i) for i in range(idle_workers))
+        + main_block
+    )
+    return p
+
+
+def test_dump_first_stack_lines_surfaces_wedged_thread(dumps_dir: Path) -> None:
+    """The extracted lines must show the WEDGED (last) thread, not an idle worker.
+
+    Regression: doctor labelled the first thread in the file "MainThread stuck
+    at:" — always an idle ``Queue.get`` thread-pool worker on real dumps —
+    while the actually-wedged main thread sat unread at the bottom.
+    """
+    p = _create_multi_thread_dump(dumps_dir, f"{DUMP_PREFIX}20260717T010000Z{DUMP_SUFFIX}")
+    lines = dump_first_stack_lines(p, max_lines=8)
+    body = "\n".join(lines)
+    assert lines[0] == "Timeout (0:00:25)!"
+    assert "_should_prevent_sleep" in body  # the wedged thread's Kiro Crew frame
+    assert "queue.py" not in body  # no idle-worker frames
+
+
+def test_dump_first_stack_lines_prefers_current_thread_marker(dumps_dir: Path) -> None:
+    """A block explicitly marked ``Current thread`` wins over positional choice."""
+    p = dumps_dir / f"{DUMP_PREFIX}20260717T010000Z{DUMP_SUFFIX}"
+    p.write_text(
+        "# KiroCrew loop-stall crash dump — opened 20260717T020000Z\n"  # brand-ok: mirrors production dump header
+        "# PID: 12345\n"
+        "# If thread stacks appear below, the event loop wedged and faulthandler fired.\n"
+        "\n"
+        "Current thread 0x00007f00000001 (most recent call first):\n"
+        '  File "/home/user/.kirocrew/src/kiro_crew/dashboard/state.py", line 100 in _flush\n'
+        "Thread 0x00007f00000002 (most recent call first):\n"
+        '  File "/usr/lib/python3.12/queue.py", line 171 in get\n'
+    )
+    lines = dump_first_stack_lines(p, max_lines=4)
+    assert lines[0].startswith("Current thread")
+    assert "_flush" in lines[1]
+
+
+def test_dump_first_stack_lines_fallback_without_thread_headers(dumps_dir: Path) -> None:
+    """Unrecognizable content degrades to the raw top-of-file lines."""
+    p = dumps_dir / f"{DUMP_PREFIX}20260717T010000Z{DUMP_SUFFIX}"
+    p.write_text(
+        "# KiroCrew loop-stall crash dump — opened 20260717T020000Z\n"  # brand-ok: mirrors production dump header
+        "# PID: 12345\n"
+        "# If thread stacks appear below, the event loop wedged and faulthandler fired.\n"
+        "\n"
+        "some free-form line 1\n"
+        "some free-form line 2\n"
+    )
+    lines = dump_first_stack_lines(p, max_lines=5)
+    assert lines == ["some free-form line 1", "some free-form line 2"]
+
+
 # ── Age calculation ──
 
 
@@ -413,6 +496,29 @@ def test_dump_replay_lines_header_only(dumps_dir: Path) -> None:
     lines, truncated = dump_replay_lines(p)
     assert lines == []
     assert not truncated
+
+
+def test_dump_replay_lines_wedged_thread_survives_truncation(dumps_dir: Path) -> None:
+    """The wedged thread's stack is replayed FIRST so caps can't cut it.
+
+    Regression: real dumps carry 200+ lines of idle thread-pool workers before
+    the main thread; top-down replay hit the 120-line/8KB caps and the journal
+    showed only ``Queue.get`` workers plus ``[truncated]`` — omitting the one
+    stack that explains the stall (observed on the 2026-08-09 stall dumps).
+    """
+    from kiro_crew.dashboard.crash_dump_store import dump_replay_lines
+
+    # 40 idle workers x 4 lines >> the 12-line cap below; main thread is last.
+    p = _create_multi_thread_dump(
+        dumps_dir, f"{DUMP_PREFIX}20260717T030000Z{DUMP_SUFFIX}", idle_workers=40
+    )
+    lines, truncated = dump_replay_lines(p, max_lines=12)
+    body = "\n".join(lines)
+    assert truncated
+    assert lines[0] == "Timeout (0:00:25)!"
+    # The wedged thread's frames made it into the replay despite truncation.
+    assert "_should_prevent_sleep" in body
+    assert "run_forever" in body
 
 
 # ── Journal replay integration test ──


### PR DESCRIPTION
## Problem

A loop-stall crash dump exists to answer one question: **where did the event loop wedge?** Both consumers of the dump currently answer it wrong.

`faulthandler.dump_traceback_later` (armed by the loop watchdog) writes threads newest-first, so the MAIN thread — where the gateway's asyncio loop runs — lands **last** in the dump, behind dozens of idle thread-pool workers parked in `Queue.get`. Both readers scan top-down:

1. **`kirocrew doctor`** prints the *first* thread in the file under the label `MainThread stuck at:` — on every real dump that is an idle worker (`concurrent/futures/thread.py:90 in _worker`), actively misleading whoever is diagnosing the stall.
2. **The boot-time journal replay** (`Replaying prior crash dump stacks`, capped at 120 lines / 8KB) truncates before ever reaching the wedged stack. A gateway with a saturated default executor produces 200+ lines of idle workers first.

## Evidence (from a real stall, sanitized)

A gateway stalled ≥25s and hard-exited. Doctor reported:

```
  last dump:   ⚠️  loopstall-….txt (12.0h ago)
  MainThread stuck at:
    Timeout (0:00:25)!
    Thread 0x… (most recent call first):
      File ".../concurrent/futures/thread.py", line 90 in _worker      ← idle pool worker
      File ".../threading.py", line 1012 in run
      File ".../threading.py", line 1075 in _bootstrap_inner
```

The journal replay of the same dump ended in `[truncated — full dump at above path]` while still printing idle workers. The actual wedged stack — sitting unread at the bottom of the dump — was:

```
Thread 0x… (most recent call first):
  File ".../concurrent/futures/thread.py", line 166 in submit
  File ".../asyncio/base_events.py", line 867 in run_in_executor
  File ".../asyncio/threads.py", line 25 in to_thread
  File ".../kiro_crew/dashboard/server.py", line 246 in _should_prevent_sleep
  File ".../kiro_crew/dashboard/server.py", line 1654 in _prevent_sleep_poll
```

## Fix

In `crash_dump_store.py`, parse the dump into per-thread blocks and pick the **wedged** thread: a block explicitly marked `Current thread` when present (synchronous Python-initiated dumps mark the dumping thread), otherwise the **last** block (CPython dumps threads newest-first; the main thread is created first, so it is written last — and `dump_traceback_later` fires from an internal C thread, so no marker exists in watchdog dumps).

- `dump_first_stack_lines` (doctor) now returns the preamble (`Timeout (…)!`) + the wedged thread's top frames. Doctor shows 8 lines so the first project frame past the asyncio plumbing is visible.
- `dump_replay_lines` (boot journal replay) now replays the wedged thread **first**, then the remaining threads until the caps — the one stack that explains the stall always survives truncation.
- Unrecognizable content (no thread headers) falls back to the previous top-down behavior.

## Tests

- 4 new tests: wedged-thread selection on a realistic multi-thread dump, `Current thread` marker preference, fallback on unrecognizable content, and replay-truncation survival (40 idle workers, 12-line cap — wedged frames still present).
- Full `test_crash_dump_store.py`: **46 passed**. `test_loop_watchdog.py`: 13 passed. Doctor tests: 3 passed.
- Verified against the two real stall dumps that motivated this: doctor now shows the wedged thread's project frames, and the replay retains them under the 8KB cap (previously cut).
- isort / flake8 / mypy clean on touched files.
