### PR TITLE
fix(safety-override): say so when auto-approve expires mid-unattended-run

### DIFF
--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -1465,6 +1465,101 @@ async def _revive_intended_instances(
             logger.warning("Startup auto-reconnect of %s failed", inst.id, exc_info=True)
 
 
+def _armed_unattended_loops() -> "list[Any]":
+    """Nudge loops still marked active, for the expiry notice only.
+
+    Deliberately a plain ``active`` read rather than a careful liveness test: this
+    decides whether to TELL someone, and a false positive costs one redundant
+    notice. Nothing is granted on the strength of it, so there is no reason to pay
+    for a stop-sentinel stat or to re-derive the loop's bounds — and this runs on
+    the event loop, reached from tool-approval paths.
+    """
+    try:
+        svc = _autonudge_get()
+        if svc is None:
+            return []
+        return [lp for lp in svc.list_all() if getattr(lp, "active", False)]
+    except Exception:
+        logger.debug("could not enumerate nudge loops for the expiry notice", exc_info=True)
+        return []
+
+
+_UNATTENDED_EXPIRY_TITLE = "🔒 Auto-approve expired while an unattended run was in progress"
+
+
+def _unattended_expiry_text(loop_count: int) -> str:
+    """Body shared by the dashboard note and the owner DM, so the two cannot drift.
+
+    Names the remedy as well as the cause: ``agent.yolo_duration`` accepts
+    ``until_shutdown``, which has no timed expiry. The cheapest half of this
+    problem is that operators do not know that option exists, and the moment it
+    would have helped is the moment worth saying so.
+
+    The stall is stated conditionally because global auto-approve is not the only
+    path to one: a slot carrying its own trust grant is approved by ``slot._trust``
+    independently of the grant, so its cycles keep running after this expiry.
+    Claiming the run has stopped would send an operator to rescue a healthy one.
+    """
+    return (
+        f"{loop_count} monitor loop(s) are still running, but auto-approval has "
+        f"ended, so any cycle that relied on it now waits on a per-tool approval "
+        f"that nobody is there to give. (A session granted its own trust is "
+        f"unaffected.) Re-enable auto-approve to resume. For runs meant to go "
+        f"unattended overnight, Settings → agent.yolo_duration has an "
+        f"'until_shutdown' option that has no timed expiry."
+    )
+
+
+def _notify_unattended_expiry(state: "DashboardState", source: str) -> None:
+    """Report an expiry that landed on an unattended run, on BOTH surfaces.
+
+    An ordinary expiry degrades gracefully — the next tool call asks a human, and
+    a human is there to answer. This one degrades into nothing: the loop keeps
+    waking, dispatches a tool, waits out the approval window with nobody present,
+    and accomplishes no work until someone notices.
+
+    Delivered to the dashboard feed AND pushed to the owner's DM, because the
+    operator this exists for is by definition not looking at a dashboard. Neither
+    delivery is gated behind ``agent.notify_override_expiry``: that switch silences
+    a recurring *expiry* notice, while this says a run in flight stopped being able
+    to work — a different and stronger fact, and one an operator who muted the
+    former did not ask to be uninformed about.
+    """
+    armed = _armed_unattended_loops()
+    if not armed:
+        return
+    logger.warning(
+        "Safety override expired with %d unattended loop(s) still running; "
+        "every further cycle will wait on per-tool approval",
+        len(armed),
+    )
+    body = _unattended_expiry_text(len(armed))
+    try:
+        state.notify(
+            "safety_override",
+            _UNATTENDED_EXPIRY_TITLE,
+            body,
+            meta={"loops": len(armed), "source": source},
+        )
+    except Exception:
+        # ERROR, not debug: this notice is the only operator-visible trace that an
+        # unattended run stopped working rather than finished. Losing it silently
+        # reproduces the failure it exists to explain.
+        logger.error("unattended-expiry notification failed", exc_info=True)
+
+    # The push half. Scheduled directly rather than through
+    # _dispatch_override_expiry_notification, which applies the recurring-expiry
+    # mute this notice deliberately does not inherit.
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.debug("no running event loop — unattended-expiry DM skipped")
+        return
+    task = loop.create_task(_dm_owner(state, f"{_UNATTENDED_EXPIRY_TITLE}\n\n{body}"))
+    state._background_tasks.add(task)
+    task.add_done_callback(state._background_tasks.discard)
+
+
 def _dispatch_override_expiry_notification(state: DashboardState, notify_coro_factory: Any) -> bool:
     """Schedule the Slack override-expiry DM unless disabled via config.
 
@@ -3482,6 +3577,9 @@ async def start_dashboard(
             logger.debug("Could not clear trusted sessions", exc_info=True)
         # Slack notification (prevent GC with background_tasks set)
         _dispatch_override_expiry_notification(state, _notify_slack_override_expired)
+        # An expiry that lands on an unattended run is the one case that cannot
+        # self-report: nobody is present to answer the prompts it produces.
+        _notify_unattended_expiry(state, source)
 
     safety_override().on_expired = _on_override_expired
 

--- a/src/kiro_crew/notifications/bus.py
+++ b/src/kiro_crew/notifications/bus.py
@@ -45,6 +45,12 @@ SYSTEM_CHANNELS: dict[str, str] = {
     # note is the ONLY surface that says it exists -- but it blocks no agent
     # turn, so it is default, not critical.
     "system.skills": _DEFAULT_PRIORITY,
+    # Auto-approve lifecycle: notably an expiry that lands while an unattended
+    # loop is running, where the note is the only trace that the run stopped being
+    # able to act. Default rather than critical by the same rule as skills above:
+    # the prompt that actually blocks a turn has its own critical channel
+    # (system.approval), and this is the report about it, not the prompt.
+    "system.safety_override": _DEFAULT_PRIORITY,
 }
 
 # Fallback channel for legacy kinds that have no dedicated system channel

--- a/test/test_override_expiry_notice.py
+++ b/test/test_override_expiry_notice.py
@@ -1,0 +1,296 @@
+"""An auto-approve expiry that lands on an unattended run must not be silent.
+
+An ordinary expiry degrades gracefully: the next tool call asks a human, and a
+human is there to answer. An expiry that lands while a monitor loop is driving the
+session degrades into nothing at all -- the loop keeps waking on its interval,
+dispatches a tool, waits out the approval window with nobody present, and
+accomplishes no work until someone notices. The observed shape was twenty
+two-hour turn deaths in one night, seventeen of them approval-waits.
+
+Nothing here changes how long a grant lasts. It makes the moment it ends
+attributable on BOTH surfaces -- the dashboard feed and the owner's push channel --
+and points at the setting (`until_shutdown`) that already exists for runs meant to
+go unattended.
+
+Every behavioural claim below is mutation-verified; the mutation is named in the
+test so a future reader can repeat it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kiro_crew.dashboard.server import (
+    _armed_unattended_loops,
+    _notify_unattended_expiry,
+    _unattended_expiry_text,
+)
+from kiro_crew.safety_override import SafetyOverride, reset_singleton
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_singleton()
+    yield
+    reset_singleton()
+
+
+def _quiet_sel():
+    """Silence the SEL sink the way the sibling suites do."""
+    return patch("kiro_crew.safety_override.sel", return_value=MagicMock())
+
+
+def _fake_state() -> SimpleNamespace:
+    return SimpleNamespace(notify=MagicMock(), _background_tasks=set())
+
+
+def _svc_with(*loops) -> MagicMock:
+    svc = MagicMock()
+    svc.list_all.return_value = list(loops)
+    return svc
+
+
+def _loop(active: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(id="L1", active=active, idle_secs=420)
+
+
+class TestWhichLoopsCount:
+    def test_only_active_loops_are_counted(self) -> None:
+        """Mutation: drop the `active` filter -- a stopped loop produces a notice
+        about a run that is not running, and this test fails.
+        """
+        svc = _svc_with(_loop(active=True), _loop(active=False))
+        with patch("kiro_crew.dashboard.server._autonudge_get", return_value=svc):
+            assert len(_armed_unattended_loops()) == 1
+
+    def test_no_service_means_no_loops(self) -> None:
+        with patch("kiro_crew.dashboard.server._autonudge_get", return_value=None):
+            assert _armed_unattended_loops() == []
+
+    def test_an_enumeration_failure_reads_as_no_loops(self) -> None:
+        """Losing the notice is a missing message; letting the exception escape would
+        break the demotion that runs alongside it, which is a security failure.
+
+        Mutation: remove the try/except -- the exception propagates and this fails.
+        """
+        svc = MagicMock()
+        svc.list_all.side_effect = RuntimeError("registry unavailable")
+        with patch("kiro_crew.dashboard.server._autonudge_get", return_value=svc):
+            assert _armed_unattended_loops() == []
+
+
+class TestBothSurfacesAreNotified:
+    """The operator this notice exists for is, by definition, not looking at a
+    dashboard. Delivering only to the dashboard feed would aim the one
+    absent-operator notice at the one surface that requires presence.
+    """
+
+    def _drive(self, state, svc):
+        async def _run():
+            with patch("kiro_crew.dashboard.server._autonudge_get", return_value=svc):
+                with patch("kiro_crew.dashboard.server._dm_owner") as dm:
+                    dm.return_value = asyncio.sleep(0)
+                    _notify_unattended_expiry(state, "dashboard")
+                    # Let the scheduled DM task run to completion.
+                    await asyncio.sleep(0)
+                    await asyncio.sleep(0)
+                    return dm
+
+        return asyncio.run(_run())
+
+    def test_the_dashboard_feed_gets_the_notice(self) -> None:
+        state = _fake_state()
+        self._drive(state, _svc_with(_loop()))
+        assert state.notify.call_count == 1
+        args = state.notify.call_args.args
+        assert "unattended run" in args[1]
+
+    def test_the_owner_push_channel_also_gets_it(self) -> None:
+        """Mutation: delete the `_dm_owner` scheduling -- the away operator gets
+        nothing until they open the dashboard, and this test fails.
+        """
+        state = _fake_state()
+        dm = self._drive(state, _svc_with(_loop()))
+        assert dm.call_count == 1, "the owner DM was never scheduled"
+        assert "until_shutdown" in dm.call_args.args[1]
+
+    def test_both_surfaces_carry_the_same_body(self) -> None:
+        """One source of truth for the text, so the pushed message and the stored
+        note cannot drift into saying different things about the same event."""
+        state = _fake_state()
+        dm = self._drive(state, _svc_with(_loop()))
+        body = _unattended_expiry_text(1)
+        assert state.notify.call_args.args[2] == body
+        assert body in dm.call_args.args[1]
+
+    def test_nothing_is_sent_when_no_loop_is_running(self) -> None:
+        """An ordinary expiry is already reported by the existing path; this notice
+        must not duplicate it.
+
+        Mutation: drop the `if not armed: return` guard -- every ordinary expiry
+        produces a second, wrong notice and this test fails.
+        """
+        state = _fake_state()
+        dm = self._drive(state, _svc_with(_loop(active=False)))
+        assert state.notify.call_count == 0
+        assert dm.call_count == 0
+
+    def test_a_failed_dashboard_note_does_not_block_the_push(self) -> None:
+        """The two surfaces are independent: a broken notification bus must not cost
+        the away operator their only push.
+
+        Mutation: move the DM scheduling inside the notify try-block -- a raising
+        notify swallows the DM and this test fails.
+        """
+        state = _fake_state()
+        state.notify.side_effect = RuntimeError("bus down")
+        dm = self._drive(state, _svc_with(_loop()))
+        assert dm.call_count == 1
+
+    def test_no_running_loop_degrades_to_the_dashboard_note_only(self) -> None:
+        """Called from a synchronous context (the expiry callback can be reached from
+        one), there is no loop to schedule the DM on. The note must still land
+        rather than the whole notice being lost.
+        """
+        state = _fake_state()
+        svc = _svc_with(_loop())
+        with patch("kiro_crew.dashboard.server._autonudge_get", return_value=svc):
+            _notify_unattended_expiry(state, "dashboard")
+        assert state.notify.call_count == 1
+
+
+class TestTheNoticeNamesTheRemedy:
+    def test_the_body_points_at_the_existing_non_expiring_option(self) -> None:
+        """The cheapest half of this problem is that operators do not know
+        `until_shutdown` exists. Saying so at the moment it would have helped is
+        worth more than the notice itself.
+
+        Mutation: drop the mention -- this test fails.
+        """
+        body = _unattended_expiry_text(3)
+        assert "until_shutdown" in body
+        assert "yolo_duration" in body
+
+    def test_the_body_states_the_consequence_not_just_the_event(self) -> None:
+        """"Your grant expired" is not actionable at 4am; "your run is now waiting
+        on approvals nobody will give" is."""
+        body = _unattended_expiry_text(2)
+        assert "2 monitor loop(s)" in body
+        assert "approval" in body
+
+
+class TestTheExpiryCallbackFiresExactlyOnce:
+    """The notice needs no dedupe, and that is a property of the override rather
+    than of the notifier -- so it is asserted here rather than assumed.
+
+    Lazy expiry clears ``_active`` INSIDE the lock before invoking the callback, so
+    every later ``is_active()`` returns early without re-firing. If that ever
+    changes, a per-cycle alarm appears and the notice must grow a dedupe.
+    """
+
+    def test_repeated_is_active_calls_fire_the_callback_once(self) -> None:
+        """Mutation: move the `self._active = False` assignment after the callback
+        invocation -- the callback fires on every poll and this test fails.
+        """
+        override = SafetyOverride()
+        fired: list[str] = []
+        override.on_expired = lambda source: fired.append(source)
+
+        with _quiet_sel():
+            override.activate("dashboard", ttl=600)
+        anchor = override._activated_at
+
+        with _quiet_sel(), patch(
+            "kiro_crew.safety_override.time.monotonic", return_value=anchor + 700
+        ):
+            for _ in range(5):
+                assert override.is_active() is False
+
+        assert fired == ["dashboard"], fired
+
+    def test_a_permanent_grant_never_reaches_the_expiry_path(self) -> None:
+        """`until_shutdown` and the declared grant are exactly the configurations
+        this notice recommends, so they must not produce it themselves.
+        """
+        override = SafetyOverride()
+        fired: list[str] = []
+        override.on_expired = lambda source: fired.append(source)
+
+        with _quiet_sel():
+            override.activate_declared()
+        with _quiet_sel(), patch(
+            "kiro_crew.safety_override.time.monotonic",
+            return_value=override._activated_at + 30 * 24 * 3600,
+        ):
+            assert override.is_active() is True
+
+        assert fired == []
+
+
+class TestTheNoticeDoesNotOverclaimTheStall:
+    """Global auto-approve is not the only path to one.
+
+    A slot carrying its own trust grant is approved by ``slot._trust`` independently
+    of the grant (``chat_runner``: ``if slot._trust or yolo_active``), so its cycles
+    keep running after this expiry. Stating the stall as fact would send an operator
+    to rescue a run that is fine, which costs exactly the attention this notice
+    exists to spend well.
+    """
+
+    def test_the_stall_is_conditional_not_asserted_of_every_cycle(self) -> None:
+        """Mutation: restore the unconditional 'each cycle now waits' -- fails here."""
+        body = _unattended_expiry_text(1)
+        assert "each cycle now waits" not in body
+        assert "relied on it" in body
+
+    def test_the_trust_exception_is_named(self) -> None:
+        """An operator whose loop keeps working needs to know why, or the notice
+        reads as a bug in the notice rather than a description of their setup.
+        """
+        assert "trust" in _unattended_expiry_text(1).lower()
+
+
+class TestTheNoticeHasItsOwnChannel:
+    """The bus maps a legacy ``kind`` to ``system.<kind>`` and falls back to
+    ``system.agent`` for anything unregistered -- a path whose own comment says it
+    is defensive because "nothing emits unknown kinds today".
+
+    Emitting `safety_override` without registering it would have made live code the
+    first thing to violate that, turning a compatibility shim for old JSONL rows
+    into a normal delivery path and making the comment false. Registering the
+    channel is what keeps the fallback defensive.
+    """
+
+    def test_the_kind_routes_to_its_own_channel_not_the_fallback(self) -> None:
+        """Mutation: remove `system.safety_override` from `SYSTEM_CHANNELS` -- the
+        note silently lands on `system.agent` and this test fails.
+        """
+        from kiro_crew.notifications.bus import _FALLBACK_CHANNEL, payload_from_legacy
+
+        payload = payload_from_legacy("safety_override", "t", "b")
+        assert payload.channel == "system.safety_override"
+        assert payload.channel != _FALLBACK_CHANNEL
+
+    def test_the_notifier_emits_that_kind(self) -> None:
+        """Ties the registration to the caller: registering a channel nothing emits,
+        or emitting a kind matching no channel, are both silently wrong.
+        """
+        state = _fake_state()
+        svc = _svc_with(_loop())
+        with patch("kiro_crew.dashboard.server._autonudge_get", return_value=svc):
+            _notify_unattended_expiry(state, "dashboard")
+        assert state.notify.call_args.args[0] == "safety_override"
+
+    def test_it_is_default_priority_not_critical(self) -> None:
+        """The prompt that actually blocks a turn has its own critical channel
+        (`system.approval`); this is the report about it. Asserted so an escalation
+        to critical is a deliberate edit rather than a drift.
+        """
+        from kiro_crew.notifications.bus import SYSTEM_CHANNELS
+
+        assert SYSTEM_CHANNELS["system.safety_override"] == SYSTEM_CHANNELS["system.skills"]
+        assert SYSTEM_CHANNELS["system.safety_override"] != SYSTEM_CHANNELS["system.approval"]


### PR DESCRIPTION
## Problem

Auto-approve (YOLO) expires on a TTL. Normally that degrades gracefully — the next tool call asks a human, and a human is there to answer.

When an AutoNudge loop is driving the session it degrades into **nothing at all**. The loop keeps waking on its interval, dispatches a tool, waits out the approval window with nobody present to answer, is declined, and accomplishes no work. Observed shape: **twenty two-hour turn deaths in one night**, seventeen of them approval-waits (SEL classification: `outcome=invoked` with no `auto_approved`), from a grant that lapsed at 16:31.

The part this PR addresses: **there was no signal anywhere.** Checks looked healthy, the loop looked alive, and the run had simply stopped being able to do anything. It is only diagnosable by reading transcripts afterwards.

## Why it matters

An unattended overnight run that fails loudly costs one morning of re-running it. One that fails silently costs the night *and* the trust — the next time it looks healthy you cannot tell whether it is working.

## Fix (symptom → root cause → change)

- **Symptom:** an overnight run produces nothing, with no error anywhere.
- **Root cause:** the expiry callback treats every expiry the same. The one case that cannot self-report — no human present, by construction — is the one that most needs to.
- **Change:** report that case separately, and name the setting that already solves it.

`agent.yolo_duration` accepts **`until_shutdown`**, a first-class Settings option with no timed expiry. The cheapest half of this problem is that operators do not know it exists; the moment it would have helped is the moment worth saying so. The notice therefore explains what happened, what to do now, and what to choose next time.

Deliberate details, each of which is a test:

- **Delivered to BOTH surfaces.** The dashboard feed *and* the owner's Slack DM, because the operator this exists for is by definition not looking at a dashboard — aiming the one absent-operator notice at the one surface that requires presence would have defeated it. Both bodies come from a single function so the stored note and the pushed message cannot drift, and the two deliveries are independent: a broken notification bus must not cost the away operator their only push.
- **Not gated behind `agent.notify_override_expiry`, on either surface.** That switch silences a recurring *expiry* notice. This reports that a run in flight stopped being able to work — a different and stronger fact. An operator who muted the former did not ask to be uninformed about the latter.
- **No filesystem work.** Loop state is a plain `active` read: no stop-sentinel stat, no config read. The callback runs on the event loop, reached from tool-approval paths. Nothing is *granted* on the strength of this check, so a false positive costs exactly one redundant message — which is not worth paying a stat per loop to avoid.
- **The stall is stated conditionally, not as fact.** Global auto-approve is not the only path to one: a slot carrying its own trust grant is approved by `slot._trust` independently of the grant (`chat_runner`: `if slot._trust or yolo_active`), so its cycles keep running after this expiry. The body says *"any cycle that relied on it"* and names the exception, because telling an operator their run has stopped when it has not spends exactly the attention this notice exists to spend well.
- **The notification kind is registered, not left to the fallback.** The bus maps a legacy `kind` to `system.<kind>` and falls back to `system.agent` for anything unregistered — a path whose own comment says it is defensive because *"nothing emits unknown kinds today"*. Emitting `safety_override` without registering it would have made live code the first thing to violate that, turning a compatibility shim for old JSONL rows into a normal delivery path. `system.safety_override` is registered at **default** priority, by the same rule the neighbouring `system.skills` entry states: the prompt that actually blocks a turn has its own `critical` channel, and this is the report about it.
- **Enumeration failures are swallowed.** Losing the notice is a missing message; losing the demotion below it would be a security failure. The notice never gets to break the thing it comments on.
- **No dedupe, and that is a property rather than an omission.** Lazy expiry clears `_active` *inside* the lock before invoking the callback, so later polls return early without re-firing. Asserted by test, so a future change that turns this into a per-cycle alarm fails loudly instead of shipping.

**No behaviour change to durations, to what auto-approves, or to any documented security contract.** This is observability plus a pointer, which is why it is separate from the question of what auto-approve *should* do for unattended runs.

## Tests

`test/test_override_expiry_notice.py`, 18 tests, all behavioural. **13 mutation verifications, all confirmed catching** — break the production line, observe the named test fail, restore:

| Mutation | Caught by |
|---|---|
| drop the `active` filter (notice about a run that stopped) | `test_only_active_loops_are_counted` |
| let an enumeration failure escape | `test_an_enumeration_failure_reads_as_no_loops` |
| never push to the owner (dashboard-only) | `test_the_owner_push_channel_also_gets_it` |
| notify on every expiry, loop or not | `test_nothing_is_sent_when_no_loop_is_running` |
| a failed dashboard note swallows the push too | `test_a_failed_dashboard_note_does_not_block_the_push` |
| stop naming `until_shutdown` | `test_the_body_points_at_the_existing_non_expiring_option` |
| clear `_active` *after* the callback (notice repeats every poll) | `test_repeated_is_active_calls_fire_the_callback_once` |
| let a permanent grant reach the expiry path | `test_a_permanent_grant_never_reaches_the_expiry_path` |
| unregister the channel (note falls back to `system.agent`) | `test_the_kind_routes_to_its_own_channel_not_the_fallback` |
| register the channel as `critical` instead of default | `test_it_is_default_priority_not_critical` |
| emit a kind matching no registered channel | `test_the_notifier_emits_that_kind` |
| restore the unconditional "each cycle now waits" claim | `test_the_stall_is_conditional_not_asserted_of_every_cycle` |
| drop the trust exception from the body | `test_the_trust_exception_is_named` |

Two of those assert properties of `SafetyOverride` rather than of the notifier — the fire-once behaviour and the permanent-grant exemption — because the no-dedupe decision rests on them, and because `until_shutdown` and the declared grant are precisely the configurations this notice recommends, so they must not produce it themselves.

## Manual verification

N/A — unit coverage is sufficient. The change adds one notification and one in-memory list comprehension on an existing callback; there is no new surface to click, and the notification bus is already exercised by the sibling expiry notice.

## Gates

flake8 0 · isort 0 · **2748 tests pass** (selection widened to cover the notification bus). `mypy src/kiro_crew/` reports 4 errors, all reproduced on a clean `main` checkout at the same commit (2 in `transcribe.py`, 2 in `ops_mission_control/.../cloudwatch.py`) — none in this diff.

Note on tooling for anyone reproducing: `flake8` must be the pinned **7.1.0**. A newer local flake8 (7.3.0 / pyflakes 3.4.0) reports 4 additional `F824` errors across the repo that the pinned version does not — a tool-version artefact, not defects.

## Context

Follows #2443, which tried to solve the same incident by extending the grant in short leases and was closed: `until_shutdown` already covers the need, and the human/machine distinction the lease relied on is provenance rather than authorization — the feature's precondition (no human present) is identical to the threat's. The closing comment on that PR records the full reasoning and the follow-ups it produced (#2453, #2475, #2481, #2494).

Refs #2437



