### PR TITLE
fix(sel): keep the HMAC chain intact when two processes append

### DIFF
--- a/docs/system-specs/modules/sel.md
+++ b/docs/system-specs/modules/sel.md
@@ -117,8 +117,44 @@ kirocrew security verify            # Verify HMAC chain integrity
 
 ## Thread Safety
 
-Singleton pattern. The chain state (`_last_hash`) and the file append are
-guarded by `threading.Lock`, held only inside the writer thread (and the
-synchronous fallback / `prune`), never by enqueuing callers. Enqueue is
-lock-free via the thread-safe `queue.Queue`. Safe for concurrent access from the
-asyncio event loop + MCP server stdio processes.
+Singleton pattern. Two locks guard the chain, and they are always taken in this
+order: the cross-process **chain lock** first, then the in-process
+`threading.Lock`.
+
+`threading.Lock` guards the chain state (`_last_hash`) and the file append inside
+one interpreter, held only by the writer thread (and the synchronous fallback /
+`prune`), never by enqueuing callers. Enqueue is lock-free via the thread-safe
+`queue.Queue`.
+
+A `threading.Lock` cannot order the gateway against the MCP server stdio
+processes, which are separate processes sharing one log file — each holds its own
+singleton with its own cached chain tip, so two of them chaining off the same
+`prev_hash` fork the HMAC chain permanently. Cross-process ordering therefore
+comes from an advisory lock on a sidecar file, `trust/security_events.lock`. The
+sidecar lives in the trust subdirectory (owner-only, inside the sensitive-path
+floor) so the audited agent cannot unlink or hold it out from under the writers;
+a linked or hard-linked sidecar is refused rather than followed. When the trust
+directory could not be created at init and the HMAC key fell back to its legacy
+location beside the log, the lock is taken on the legacy key file itself — the
+one sibling of the log the deny list has protected all along — rather than
+failing every append on a mkdir that cannot succeed.
+
+The chain lock is taken **before** `threading.Lock`. The reverse order would let
+a cross-process wait stall the event loop indirectly: a writer thread holding the
+thread lock while it waits leaves a loop-side critical audit blocking on that
+lock, which has no bound of its own.
+
+On the event-loop thread neither potentially-slow step may wait:
+
+- **Acquire** — a SINGLE nonblocking `try_acquire_lock` attempt, then a
+  fail-closed refusal. No retry and no sleep: a poll spin would sleep the
+  gateway's event loop, stalling every session it serves, so contention is
+  refused here and absorbed off-loop (the background writer and `prune` in an
+  executor take the blocking lock).
+- **Chain-tip read** — capped at a single tail chunk. A healthy log yields the
+  tip from one read; only an already-corrupt multi-kilobyte tail would walk
+  further, and exhausting the cap raises rather than returning a genesis tip.
+
+Both refusals surface as `OSError`, which the append path turns into a rollback
+plus warning, or into a propagated error for a `critical=True` audit — the
+audit-or-deny contract. Off the loop, both steps are unbounded and recover fully.

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -25,8 +25,11 @@ Retention: configurable, default 365 days per Amazon Security Event Logging Stan
 
 from __future__ import annotations
 
+import asyncio
 import atexit
+import contextlib
 import errno
+import functools
 import hashlib
 import hmac
 import json
@@ -65,7 +68,129 @@ def _default_dir() -> Path:
     return config_dir()
 
 
+def _on_event_loop() -> bool:
+    """True when called on a thread running an asyncio event loop.
+
+    Used to refuse a contended lock acquire, and to bound an otherwise unbounded
+    tail scan, so neither stalls that loop.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
+def _acquire_chain_lock_on_loop(fd: int) -> bool:
+    """Try the chain lock ONCE, without blocking. False if it is contended.
+
+    Single-shot by design: there is no retry and no sleep on this path. A poll
+    spin here — however short each nap — sleeps the GATEWAY EVENT LOOP, so the
+    stall is paid by every session the loop serves, not just the caller being
+    audited. Refusing immediately keeps the loop responsive and leaves the
+    append path fail-closed: the loop-side caller raises and the action it was
+    about to audit is refused rather than proceeding unaudited. Off-loop callers
+    (the background writer, the sync path) still take the blocking cross-process
+    lock, which is where routine overlap is absorbed at no cost to the loop.
+    """
+    return platform_compat.try_acquire_lock(fd, exclusive=True)
+
+
+class _ChainTipBeyondBound(OSError):
+    """The chain tip lies past a bounded tail read.
+
+    An OSError subclass so the append path's existing fail-closed handling
+    covers it, but a distinct type so _read_last_hash's fail-soft ``except
+    OSError`` (which exists for genuine read errors and returns "") cannot
+    swallow it and hand back a genesis tip.
+    """
+
+
 _SEL_FILE = "security_events.jsonl"
+# Sidecar whose advisory lock serializes chain writes ACROSS PROCESSES. It lives
+# in _TRUST_SUBDIR, not beside the log: that directory is owner-only and inside
+# the sensitive-path floor, so the audited agent cannot unlink or hold the lock
+# out from under the writers. It is also deliberately not the log file itself —
+# msvcrt.locking() locks a byte range at offset 0 and so needs an fd whose offset
+# the caller may move freely, which the O_APPEND log fd is not.
+_SEL_LOCK_FILE = "security_events.lock"
+
+
+class _ChainHold:
+    """One process-wide cross-process chain-lock hold, keyed by lock path.
+
+    MODULE-level (not per-instance) because flock is per open file
+    description: a second ``SecurityEventLog`` instance in the same process
+    (test suites churn the singleton; embedded deployments may hold several)
+    opening its own fd reads its own process as a FOREIGN writer, and the
+    loop-side single-shot then denies critical audits spuriously -- measured
+    as the issue-radar trust tests failing whenever a sibling instance's
+    writer was mid-append. ``gate`` serializes the critical sections of every
+    holder and joiner within the process, which is what makes a cross-instance
+    join chain-safe: instances do not share ``_lock``, so without the gate two
+    of them could chain and append concurrently.
+    """
+
+    __slots__ = ("fd", "unlock", "count", "kind", "gate")
+
+    def __init__(self, fd: int, unlock: Callable[[], None], kind: str) -> None:
+        self.fd = fd
+        self.unlock = unlock
+        self.count = 1
+        self.kind = kind
+        self.gate = threading.Lock()
+
+
+_CHAIN_HOLDS: dict[str, _ChainHold] = {}
+_CHAIN_HOLDS_MUTEX = threading.Lock()
+
+
+def _try_join_chain_hold(key: str, kind: str) -> _ChainHold | None:
+    """Join this process's existing hold on *key*, or ``None`` when none exists.
+
+    Raises on the event-loop thread when the hold's label is a heavy step
+    (prune, rotation) -- joining those is the stall the label exists to
+    prevent. A non-"append" joiner promotes the label: the promotion is sticky
+    until the hold fully drains, so if the promoting joiner leaves first the
+    label may briefly over-refuse loop-side joins while only an append remains
+    -- the fail-closed direction, bounded by that append's own short work.
+    """
+    with _CHAIN_HOLDS_MUTEX:
+        hold = _CHAIN_HOLDS.get(key)
+        if hold is None:
+            return None
+        if _on_event_loop() and hold.kind != "append":
+            raise OSError(
+                f"SEL chain lock is held by this process's {hold.kind}; "
+                "refusing to wait for it on the event-loop thread"
+            )
+        hold.count += 1
+        if kind != "append":
+            hold.kind = kind
+        return hold
+
+
+def _chain_hold_release(key: str) -> None:
+    """Leave the chain-lock hold; the last thread out releases the flock.
+
+    The unlock and close run UNDER the registry mutex: releasing the flock
+    after deleting the record would open a window where the lock is still
+    held but the registry is empty, and a loop-side single shot in that
+    window would read its own process as a foreign writer and refuse a
+    critical audit. Both syscalls are fast and local.
+    """
+    with _CHAIN_HOLDS_MUTEX:
+        hold = _CHAIN_HOLDS[key]
+        hold.count -= 1
+        if hold.count > 0:
+            return
+        try:
+            hold.unlock()
+        finally:
+            os.close(hold.fd)
+        del _CHAIN_HOLDS[key]
+
+
 _RETENTION_DAYS = 365
 # ── Size rotation ──
 # The live log is closed (renamed into _SEGMENT_SUBDIR) once an append would
@@ -333,7 +458,9 @@ class SecurityEvent:
 class SecurityEventLog:
     """Append-only, HMAC-chained security event log.
 
-    Thread-safe. Singleton pattern — all callers share one instance.
+    Safe against concurrent writers both across threads (one singleton per
+    interpreter) and across processes (an advisory lock on a sidecar file
+    orders the chain writes of every process sharing the log).
     """
 
     _instance: SecurityEventLog | None = None
@@ -377,6 +504,10 @@ class SecurityEventLog:
         self._segment_dir = self._dir / _SEGMENT_SUBDIR
         # _lock guards _last_hash + the file append (held only inside the writer
         # thread and by synchronous fallbacks / prune, never by enqueuing callers).
+        # Ordering across processes is _chain_lock's job, not this lock's.
+        # (The process's ONE cross-process chain-lock hold lives in the
+        # MODULE-level _CHAIN_HOLDS registry, keyed by lock path, so sibling
+        # instances in this process share it -- see _ChainHold.)
         self._lock = threading.Lock()
         self._hmac_key = self._load_or_create_hmac_key()
         self._last_hash = self._read_last_hash()
@@ -465,6 +596,217 @@ class SecurityEventLog:
             if self._pending == 0:
                 self._pending_cond.notify_all()
 
+    @contextlib.contextmanager
+    def _chain_lock(self, *, kind: str = "append") -> Iterator[None]:
+        """Serialize the read-tip → chain → append sequence across PROCESSES.
+
+        ``_lock`` is a ``threading.Lock``, so it only orders writers inside one
+        interpreter. The gateway and each managed MCP server are separate
+        processes sharing one log file, and each holds its own singleton with
+        its own cached tip — so two of them chain off the same ``prev_hash``,
+        and because each only ever advances its OWN cache the two lineages fork
+        permanently, making verify_integrity() report every later entry from the
+        losing process as tampered. ``O_APPEND`` guarantees no torn or
+        overwritten bytes; it guarantees nothing about the read-compute-append
+        sequence, which is what the chain depends on.
+
+        The sidecar lives in the trust subdirectory, not beside the log: that
+        directory is owner-only and inside the sensitive-path floor, whereas a
+        sibling of ``security_events.jsonl`` is not covered by its exact-leaf
+        deny-list entry. An audited agent able to unlink the sidecar mid-hold
+        would leave two writers holding locks on different inodes — the very
+        fork this serialization exists to prevent — and one able to hold it
+        could wedge every writer.
+
+        On the asyncio event-loop thread the acquire is a SINGLE nonblocking
+        attempt that then fails closed, because waiting there — even a short
+        poll spin — stalls chat and the heartbeat for every session the loop
+        serves, and ``prune`` holds this lock across a whole streaming rewrite.
+        A refused acquire raises, which ``_flush_batch`` already turns into a
+        rollback plus warning — or into a propagated error for a critical audit,
+        which is the audit-or-deny contract working rather than a stalled
+        gateway. Off the loop (the background writer thread, and ``prune`` in an
+        executor) the acquire waits normally, which is where routine overlap
+        between processes is absorbed.
+
+        Callers must take this lock BEFORE ``_lock``, in both write paths. The
+        reverse order lets a cross-process wait stall the loop indirectly: a
+        writer thread holding ``_lock`` while it waits here leaves a loop-side
+        critical audit blocking on ``_lock``, which has no fail-closed gate of
+        its own.
+
+        SAME-PROCESS callers JOIN the one hold instead of contending. flock is
+        per open file description, so a second fd opened in this process --
+        another thread of this instance, or a SIBLING instance on the same
+        directory -- reads its own process as a foreign writer, and the
+        loop-side single shot then fails a critical audit closed against our
+        own background writer mid-batch (measured twice: the fingerprint
+        read's terminal audit racing the writer flushing the same call's
+        earlier best-effort event, and the issue-radar trust tests failing
+        whenever a sibling instance's writer held the lock). The hold registry
+        is therefore MODULE-level, keyed by lock path, and each hold carries a
+        gate that serializes the critical sections of holders and joiners --
+        instances do not share ``_lock``, so the gate is what keeps a
+        cross-instance join chain-safe. What a loop-side joiner waits on is
+        one append's bounded local disk work; the heavy holds are refused by
+        label instead: ``prune`` (``kind="prune"``) spans a whole streaming
+        rewrite, and rotation relabels the hold for its step
+        (:meth:`_chain_hold_relabel`).
+        """
+        lock_path = self._chain_lock_path()
+        key = str(lock_path)
+        hold = _try_join_chain_hold(key, kind)
+        if hold is not None:
+            # The gate serializes the critical sections of holders and joiners
+            # ACROSS instances (they do not share ``_lock``); a loop-side
+            # joiner's wait here is bounded by one append's local disk work --
+            # the heavy holds (prune, rotation) were already refused by their
+            # label inside _try_join_chain_hold.
+            try:
+                with hold.gate:
+                    yield
+            finally:
+                _chain_hold_release(key)
+            return
+        if lock_path != self._hmac_key_file:
+            # 0o700 to match how the trust dir is created for the HMAC key:
+            # the sidecar's protection is the directory's, so a laxer mode
+            # here would quietly undo it.
+            lock_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        # A sidecar that is a LINK is not a lock. If the path resolves elsewhere,
+        # replacing its target hands two writers locks on different inodes — the
+        # exact fork this serialization exists to prevent — so a link planted
+        # before this code ran must be refused, not followed. O_NOFOLLOW makes
+        # that atomic on POSIX (no TOCTOU window between checking and opening);
+        # the explicit probe carries Windows junctions, which O_NOFOLLOW does not
+        # exist for. This is the same defense _load_or_create_hmac_key already
+        # applies to this directory.
+        if platform_compat.is_link_or_junction(lock_path):
+            raise OSError(
+                f"SEL chain-lock sidecar {lock_path} is a link; refusing to lock it"
+            )
+        fd = os.open(
+            lock_path,
+            os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+        joined: _ChainHold | None = None
+        unlock: Callable[[], None] | None = None
+        try:
+            # A hard link makes the same inode reachable under a second name the
+            # deny-list does not cover; O_NOFOLLOW says nothing about that.
+            if os.fstat(fd).st_nlink > 1:
+                raise OSError(
+                    f"SEL chain-lock sidecar {lock_path} is hard-linked; refusing to lock it"
+                )
+            # Windows locks a byte RANGE (msvcrt.locking on byte 0), so a fresh
+            # empty sidecar has nothing to lock — same shape as the rotation
+            # lock, which primes itself with one NUL byte. Prime only the
+            # sidecar we created: the legacy-key fallback path never writes
+            # through this fd (the key file is never empty — init rejects a
+            # short key — and its bytes must not be touched).
+            if lock_path != self._hmac_key_file and os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+            if _on_event_loop():
+                if _acquire_chain_lock_on_loop(fd):
+                    unlock = functools.partial(platform_compat.release_lock, fd)
+                else:
+                    # The flock is held -- but by WHOM? A sibling thread or
+                    # instance of THIS process may have won the acquire between
+                    # our registry check above and this attempt (its record is
+                    # published right after its flock succeeds). Re-check and
+                    # JOIN it; only a genuinely foreign process is refused.
+                    joined = _try_join_chain_hold(key, kind)
+                    if joined is None:
+                        raise OSError(
+                            "SEL chain lock is held by another writer; refusing "
+                            "to wait for it on the event-loop thread"
+                        )
+            else:
+                # Blocking acquire through the same context manager the rest of
+                # the codebase uses, held open in an ExitStack so the LAST
+                # thread out of the hold can run its platform-correct release
+                # (a plain `with` would release at this frame's exit, pulling
+                # the lock out from under a joiner still inside).
+                lock_scope = contextlib.ExitStack()
+                lock_scope.enter_context(platform_compat.file_lock(fd, exclusive=True))
+                unlock = lock_scope.close
+        except BaseException:
+            os.close(fd)
+            raise
+        if joined is not None:
+            os.close(fd)  # our probe fd; the hold keeps its own
+            try:
+                with joined.gate:
+                    yield
+            finally:
+                _chain_hold_release(key)
+            return
+        assert unlock is not None
+        # The flock is ours. Publish the hold so same-process callers join it;
+        # the LAST one out releases (see _chain_hold_release) — releasing in
+        # this frame's finally would pull the lock out from under a joiner
+        # still inside its critical section.
+        hold = _ChainHold(fd, unlock, kind)
+        with _CHAIN_HOLDS_MUTEX:
+            _CHAIN_HOLDS[key] = hold
+        hold.gate.acquire()
+        try:
+            yield
+        finally:
+            hold.gate.release()
+            _chain_hold_release(key)
+
+    def _chain_lock_path(self) -> Path:
+        """The file the cross-process chain lock is taken on.
+
+        Normally the sidecar in the trust subdirectory. When
+        ``_load_or_create_hmac_key`` fell back to the legacy key location
+        (uncreatable trust dir, or a planted link on it that could not be
+        removed), the LEGACY KEY FILE itself: retrying the mkdir on every
+        append would fail the same way — dropping every best-effort audit and
+        denying every critical action on an install that is otherwise signing
+        fine — and the legacy key is the one sibling of the log the
+        sensitive-path deny list has protected all along. The lock is advisory
+        and the fd is never written, so locking the key file cannot disturb
+        its bytes.
+        """
+        lock_dir = self._dir / _TRUST_SUBDIR
+        if self._hmac_key_file.parent != lock_dir:
+            return self._hmac_key_file
+        return lock_dir / _SEL_LOCK_FILE
+
+    @contextlib.contextmanager
+    def _chain_hold_relabel(self, kind: str) -> Iterator[None]:
+        """Temporarily relabel this process's chain hold for a heavy step.
+
+        Loop-side joins are refused for any non-"append" label, so elevating
+        the label around a slow step that runs INSIDE an append hold (rotation:
+        a directory scan, a rename, a retention sweep) makes a loop-side
+        critical audit arriving during that step fail closed -- audit-or-deny --
+        instead of joining and then blocking for the step's whole duration.
+        Plain appends before and after stay joinable.
+
+        The restore is conditional: if another thread promoted the label while
+        the step ran (a prune joining mid-step), that stricter label is kept --
+        blindly restoring would re-admit loop-side joins into the prune's
+        streaming rewrite. No-op when this process holds no chain lock (the
+        label then has no reader).
+        """
+        key = str(self._chain_lock_path())
+        with _CHAIN_HOLDS_MUTEX:
+            hold = _CHAIN_HOLDS.get(key)
+            previous = hold.kind if hold is not None else ""
+            if hold is not None:
+                hold.kind = kind
+        try:
+            yield
+        finally:
+            if hold is not None:
+                with _CHAIN_HOLDS_MUTEX:
+                    if _CHAIN_HOLDS.get(key) is hold and hold.kind == kind:
+                        hold.kind = previous
+
     def _flush_batch(
         self,
         events: list[SecurityEvent],
@@ -551,40 +893,66 @@ class SecurityEventLog:
                     list(event.metadata),
                 )
             event.metadata = redacted
-        callback: Callable[[dict], None] | None
-        with self._lock:
-            try:
-                self._dir.mkdir(parents=True, exist_ok=True)
-            except OSError:
-                if raise_on_error:
-                    raise
-                logger.warning("SEL dir create failed for %d events", len(events), exc_info=True)
-                return
-            # Close the live log first when it is already at the size cap, so
-            # this batch lands in a fresh segment, and keep the cross-process
-            # rotation lock held across our own chain + append (see
-            # _rotation_window). Rotation is best-effort and never raises: a
-            # rotation that cannot happen must not stop the audit record it
-            # precedes from being written.
-            with self._rotation_window() if self._may_rotate() else _no_rotation():
-                # Remember the chain tip so we can roll back if the append
-                # fails: we advance _last_hash per event below, but nothing is
-                # persisted until the write() succeeds. Without the rollback, a
-                # failed write would leave _last_hash pointing at a phantom hash
-                # never on disk, and the next batch would chain off it —
-                # silently corrupting the HMAC chain (verify_integrity would
-                # then report a break). Read INSIDE the window: rotation resets
-                # the tip to genesis, and rolling back to a pre-rotation tip
-                # would chain this batch off a record in a different segment.
-                try:
-                    self._append_chained_locked(events)
-                except OSError:
-                    if raise_on_error:
-                        raise
-                    logger.warning(
-                        "SEL append failed for %d events", len(events), exc_info=True
-                    )
-            callback = self._forward_callback
+        callback: Callable[[dict], None] | None = None
+        # Chain lock FIRST, thread lock second — and in that order everywhere.
+        # The reverse order lets a cross-process wait stall the event loop
+        # indirectly: the background writer takes _lock, then blocks waiting for
+        # another process's chain lock, and a loop-side critical audit then
+        # blocks on _lock itself, which is an ordinary blocking threading.Lock.
+        # Taking the chain lock first means the loop-side path reaches its
+        # single-shot fail-closed gate (see _chain_lock) BEFORE it can wait on
+        # anything, so it raises instead of stalling. Serializing the whole
+        # read-tip → chain → append sequence across processes is what keeps two
+        # writers from chaining off the same prev_hash; the FD-identity guard in
+        # _append_lines_locked stays as the second line of defense — a sibling's
+        # ROTATION holds the rotation lock, not this one, and this instance's
+        # cached tip can be stale when a sibling appended before we took the
+        # lock, both of which the guard turns into a re-anchor + re-chain.
+        try:
+            with self._chain_lock():
+                with self._lock:
+                    try:
+                        self._dir.mkdir(parents=True, exist_ok=True)
+                    except OSError:
+                        if raise_on_error:
+                            raise
+                        logger.warning("SEL dir create failed for %d events", len(events), exc_info=True)
+                        return
+                    # Close the live log first when it is already at the size cap, so
+                    # this batch lands in a fresh segment, and keep the cross-process
+                    # rotation lock held across our own chain + append (see
+                    # _rotation_window). Rotation is best-effort and never raises: a
+                    # rotation that cannot happen must not stop the audit record it
+                    # precedes from being written.
+                    with self._rotation_window() if self._may_rotate() else _no_rotation():
+                        # Remember the chain tip so we can roll back if the append
+                        # fails: we advance _last_hash per event below, but nothing is
+                        # persisted until the write() succeeds. Without the rollback, a
+                        # failed write would leave _last_hash pointing at a phantom hash
+                        # never on disk, and the next batch would chain off it —
+                        # silently corrupting the HMAC chain (verify_integrity would
+                        # then report a break). Read INSIDE the window: rotation resets
+                        # the tip to genesis, and rolling back to a pre-rotation tip
+                        # would chain this batch off a record in a different segment.
+                        try:
+                            self._append_chained_locked(events)
+                        except OSError:
+                            if raise_on_error:
+                                raise
+                            logger.warning(
+                                "SEL append failed for %d events", len(events), exc_info=True
+                            )
+                    callback = self._forward_callback
+        except OSError:
+            # The chain lock itself was unavailable: held by another writer while
+            # this thread is the event loop (single-shot fail-closed acquire), or
+            # its sidecar was unusable. Audit-or-deny for a critical caller; a
+            # best-effort caller drops the batch with a warning.
+            if raise_on_error:
+                raise
+            logger.warning(
+                "SEL chain lock unavailable for %d events", len(events), exc_info=True
+            )
         if callback:
             for event in events:
                 self._forward_event(callback, event)
@@ -592,13 +960,16 @@ class SecurityEventLog:
     def _append_chained_locked(self, events: list[SecurityEvent]) -> None:
         """Chain *events* onto the live log, re-chaining if it moves under us.
 
-        Caller holds ``_lock``. The tip is rolled back on any failure so a
-        record never chains off a hash that was not persisted.
+        Caller holds the cross-process chain lock AND ``_lock``. The tip is
+        rolled back on any failure so a record never chains off a hash that was
+        not persisted.
 
-        The retry exists because the append is deliberately lock-free (a blocking
-        cross-process acquire on this path could park an event-loop caller writing
-        a critical audit). Instead of serializing, the append VALIDATES the file it
-        opened and re-chains when another process moved it on — see
+        The retry survives under the chain lock because the lock orders sibling
+        APPENDS, not everything that can move the file: this instance's cached
+        tip is stale when a sibling appended before we took the lock, and a
+        sibling's ROTATION — serialized by the rotation lock, not this one —
+        can rename the file between our chaining and our open. In both cases
+        the append VALIDATES the file it opened and re-chains — see
         :meth:`_append_lines_locked`.
 
         EVERY attempt is validated, including the last. When the retries are
@@ -1038,7 +1409,12 @@ class SecurityEventLog:
                 yield
                 return
             try:
-                self._rotate_under_lock()
+                # Elevate the chain-hold label for the duration of the heavy
+                # step: a loop-side critical audit arriving now must fail
+                # closed rather than join and block on ``_lock`` behind the
+                # scan + rename + retention sweep.
+                with self._chain_hold_relabel("rotation"):
+                    self._rotate_under_lock()
                 yield
             finally:
                 platform_compat.release_lock(lock_fh.fileno())
@@ -1168,7 +1544,15 @@ class SecurityEventLog:
                 "SEL live log moved on since our last write (another process "
                 "rotated or appended); re-reading the chain tip before appending"
             )
-            self._last_hash = self._read_last_hash()
+            # Bounded on the event-loop thread for the same reason as
+            # _reanchor_now: only an already-corrupt multi-kilobyte tail needs
+            # more than one tail chunk, and scanning it under a loop-side
+            # critical audit would stall every session the loop serves.
+            # Exhausting the bound raises (an OSError), failing the audit
+            # closed instead of chaining from a guessed tip.
+            self._last_hash = self._read_last_hash(
+                max_chunks=1 if _on_event_loop() else None
+            )
         return identity[2]
 
     def _reanchor_now(self) -> None:
@@ -1183,7 +1567,16 @@ class SecurityEventLog:
         wrote it. Both now share one predicate, and this path skips it entirely.
         """
         self._live_seen = self._live_identity()
-        self._last_hash = self._read_last_hash()
+        # Bounded on the event-loop thread: a normal log yields the tip from a
+        # single tail read, so only an already-corrupt multi-kilobyte tail could
+        # walk further, and an unbounded backward scan there would stall chat and
+        # the heartbeat for every session the loop serves. Exhausting the bound
+        # raises (_ChainTipBeyondBound is an OSError), so a critical audit fails
+        # closed instead of chaining from a guessed tip; callers off the loop
+        # recover as far back as needed.
+        self._last_hash = self._read_last_hash(
+            max_chunks=1 if _on_event_loop() else None
+        )
 
     def _ensure_segment_dir(self) -> bool:
         """Create the segment dir (owner-only), refusing a planted link.
@@ -1553,7 +1946,9 @@ class SecurityEventLog:
         except OSError:
             return False
 
-    def _read_last_hash(self, path: Path | None = None) -> str:
+    def _read_last_hash(
+        self, path: Path | None = None, *, max_chunks: int | None = None
+    ) -> str:
         """Return the entry_hash of the last COMPLETE record, or "" if none.
 
         Reads the live log by default; *path* names a closed segment instead
@@ -1587,11 +1982,27 @@ class SecurityEventLog:
                 # the last complete record.
                 buf = b""
                 skipped_corrupt = False
+                chunks_read = 0
                 while pos > 0:
+                    # ``max_chunks`` bounds how far back the scan may walk. The
+                    # append path passes 1 on the event-loop thread: a normal log
+                    # yields the tip from a single tail read, so only an already
+                    # corrupt multi-kilobyte tail could walk further, and doing
+                    # that on the loop would stall chat and the heartbeat.
+                    # Exhausting the bound raises rather than returning a guessed
+                    # tip, so the caller fails closed instead of chaining from the
+                    # wrong record. Callers off the loop pass None and recover as
+                    # far back as needed.
+                    if max_chunks is not None and chunks_read >= max_chunks:
+                        raise _ChainTipBeyondBound(
+                            "SEL chain tip lies beyond the bounded tail read "
+                            "(corrupt tail); refusing to scan further here"
+                        )
                     read_start = max(pos - 4096, 0)
                     f.seek(read_start)
                     buf = f.read(pos - read_start) + buf
                     pos = read_start
+                    chunks_read += 1
                     parts = buf.split(b"\n")
                     if pos > 0:
                         # First element may be incomplete — defer it.
@@ -1638,6 +2049,10 @@ class SecurityEventLog:
                         return data.get("entry_hash", "")
             # No parseable record anywhere in the file — nothing to chain from.
             return ""
+        except _ChainTipBeyondBound:
+            # Not a read failure: the bound was deliberately hit. Propagate so
+            # the caller fails closed rather than chaining from genesis.
+            raise
         except OSError:
             logger.warning(
                 "SEL: failed to read chain tip from %s", target, exc_info=True
@@ -1680,7 +2095,20 @@ class SecurityEventLog:
         if critical:
             # Preserve chain order: drain the async backlog, then write this
             # event inline so PermissionError/OSError propagates to the caller.
-            self.flush()
+            # NEVER wait for the drain on the event-loop thread: the background
+            # writer may be parked on another process's chain lock (prune holds
+            # it across a whole streaming rewrite), so waiting on ``_pending``
+            # here re-imports the cross-process wait the single-shot acquire in
+            # ``_chain_lock`` exists to keep off the loop — chat and the
+            # heartbeat stall for every session it serves. The wait also cannot
+            # help in exactly that case: the inline append below takes the same
+            # chain lock with a single nonblocking attempt and fails closed
+            # while the sibling holds it. Enqueue order on disk is already
+            # best-effort — this same ``flush()`` gives up at its timeout and
+            # the inline write proceeds regardless — so skipping the wait
+            # changes no guarantee, it only removes the loop stall.
+            if not _on_event_loop():
+                self.flush()
             self._flush_batch([event], raise_on_error=True)
             return
         try:
@@ -2250,26 +2678,26 @@ class SecurityEventLog:
         is held across the whole read+replace critical section so a concurrent
         append cannot land in the old file after the read pass and be lost by
         the replace: appends either complete before the read (and are copied)
-        or block until after the replace (and land in the new file). Appends
+        or block until after the replace (and land in the new file). Both the
+        cross-process chain lock and the thread lock are held, in that order —
+        a writer in ANOTHER process is ordered only by the former, and taking it
+        first is what keeps a cross-process wait off the event loop. Appends
         run on the background writer thread, so blocking them for the prune
         duration never touches the event loop.
 
-        ``_lock`` is a THREAD lock, so it does nothing about a sibling process --
-        and prune's read-then-replace is the one window where that is
-        destructive rather than merely untidy. If another process rotates while
-        we are streaming, our ``os.replace`` drops a snapshot of the OLD file
-        over the fresh live log, discarding its rotation record and every event
-        appended since. That is the only path in this class that can lose
-        already-persisted audit events, so the window is serialized with the
-        cross-process ROTATION lock (the same one rotation takes) via
-        :meth:`_prune_live_locked`.
-
-        Unlike rotation, prune WAITS for that lock instead of skipping. Rotation
-        is deferrable and runs on the audit hot path; prune is a once-a-day sweep
-        on the maintenance executor, never on the event loop, and skipping it
-        would postpone retention for a whole day. When the lock cannot be taken
-        at all the live sweep is skipped and reported, because doing it
-        unserialized is what loses events.
+        The chain lock orders sibling APPENDS; rotation by a sibling is ordered
+        by the cross-process ROTATION lock (the same one rotation takes), which
+        the live sweep additionally holds via :meth:`_prune_live_locked`. The
+        read-then-replace below is the one window where an unserialized sibling
+        is destructive rather than merely untidy: an append or rotation landing
+        in the old file after the read pass would be dropped by the replace —
+        the only path in this class that can lose already-persisted audit
+        events. Unlike rotation, prune WAITS for the rotation lock instead of
+        skipping. Rotation is deferrable and runs on the audit hot path; prune
+        is a once-a-day sweep on the maintenance executor, never on the event
+        loop, and skipping it would postpone retention for a whole day. When
+        the lock cannot be taken at all the live sweep is skipped and reported,
+        because doing it unserialized is what loses events.
 
         Rotated segments are aged out WHOLE rather than rewritten: a segment
         whose newest record is past the cutoff is deleted outright, which keeps
@@ -2281,7 +2709,7 @@ class SecurityEventLog:
         cutoff_dt = datetime.now(tz=timezone.utc) - timedelta(days=keep_days)
 
         removed = 0
-        with self._lock:
+        with self._chain_lock(kind="prune"), self._lock:
             removed += self._prune_segments_locked(cutoff_dt)
             if not self._path.exists():
                 return removed

--- a/test/test_sel.py
+++ b/test/test_sel.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import errno
+import inspect
 import json
 import os
+import subprocess
+import sys
 import threading
 import time
 from dataclasses import asdict
@@ -16,6 +20,7 @@ import pytest
 
 import kiro_crew.sel as sel_mod
 from kiro_crew import platform_compat
+from kiro_crew import sel as kiro_crew_sel
 from kiro_crew.sel import SecurityEvent, SecurityEventLog, _infer_source, sel, sel_hmac_key_path
 
 
@@ -422,6 +427,656 @@ class TestThreadSafety:
         # All lines should be valid JSON
         for line in lines:
             json.loads(line)
+
+
+class TestCrossProcessSafety:
+    """Two PROCESSES sharing one log must produce one contiguous HMAC chain.
+
+    TestThreadSafety above only exercises threads inside one interpreter, which
+    a threading.Lock already orders. The gateway and each managed MCP server are
+    separate processes sharing this file, and each holds its own singleton with
+    its own cached chain tip — the case a thread lock cannot cover.
+    """
+
+    _CHILD = '''
+import sys
+import time
+from pathlib import Path
+
+from kiro_crew.sel import SecurityEvent, SecurityEventLog
+
+sel_dir, sync_dir, tag, count = Path(sys.argv[1]), Path(sys.argv[2]), sys.argv[3], int(sys.argv[4])
+log = SecurityEventLog(base_dir=sel_dir, sync=True)
+
+# Announce readiness, then wait for the parent's start signal, so both children
+# hold a chain tip they read BEFORE either has written.
+(sync_dir / ("ready-" + tag)).write_text("1", encoding="utf-8")
+deadline = time.monotonic() + 60
+while not (sync_dir / "go").exists():
+    if time.monotonic() > deadline:
+        raise SystemExit("barrier timeout")
+    time.sleep(0.005)
+
+for i in range(count):
+    log.log(SecurityEvent(
+        event_id=tag + "-" + str(i),
+        timestamp="2026-01-01T00:00:00+00:00",
+        event_type="tool_invocation",
+        caller_identity="dashboard:" + tag,
+        agent="kirocrew",
+        source="dashboard",
+        operation="op-" + tag + "-" + str(i),
+    ))
+log.flush()
+'''
+
+    def test_concurrent_processes_keep_one_unbroken_chain(self, tmp_path):
+        sel_dir = tmp_path / "sel"
+        sync_dir = tmp_path / "sync"
+        sync_dir.mkdir()
+        events_per_child = 12
+        tags = ("alpha", "beta")
+
+        # Materialize the HMAC key up front so the children share one key: two
+        # processes racing to create it would sign with different keys, which
+        # would fail this test for a reason that is not the chain ordering.
+        SecurityEventLog(base_dir=sel_dir, sync=True)
+        assert (sel_dir / kiro_crew_sel._TRUST_SUBDIR / kiro_crew_sel._HMAC_KEY_FILE).exists()
+
+        child = tmp_path / "sel_child.py"
+        child.write_text(self._CHILD, encoding="utf-8")
+
+        env = dict(os.environ)
+        # parents[1] is the src/ root holding kiro_crew, so the children import
+        # the same tree as this test rather than any installed copy.
+        env["PYTHONPATH"] = str(Path(kiro_crew_sel.__file__).parents[1])
+
+        procs = [
+            subprocess.Popen(
+                [sys.executable, str(child), str(sel_dir), str(sync_dir), tag, str(events_per_child)],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                cwd=tmp_path,
+            )
+            for tag in tags
+        ]
+        try:
+            deadline = time.monotonic() + 60
+            while not all((sync_dir / f"ready-{tag}").exists() for tag in tags):
+                assert time.monotonic() < deadline, "children never became ready"
+                for proc in procs:
+                    assert proc.poll() is None, f"child exited early: {proc.communicate()}"
+                time.sleep(0.01)
+            (sync_dir / "go").write_text("1", encoding="utf-8")
+
+            for proc in procs:
+                out, err = proc.communicate(timeout=60)
+                assert proc.returncode == 0, f"child failed: {out}\n{err}"
+        finally:
+            for proc in procs:
+                if proc.poll() is None:
+                    proc.kill()
+                    # Reap the killed child: without the wait() the zombie
+                    # lingers for the rest of the test run and the ResourceWarning
+                    # from Popen.__del__ can fail an unrelated -W error test.
+                    proc.wait()
+
+        SecurityEventLog._instance = None
+        SecurityEventLog._initialized = False
+        verifier = SecurityEventLog(base_dir=sel_dir, sync=True)
+        total, valid = verifier.verify_integrity()
+
+        expected = len(tags) * events_per_child
+        assert total == expected, f"expected {expected} entries on disk, found {total}"
+        # Pre-fix, each process chains every entry off the tip it cached at
+        # construction, so the two lineages fork and verify_integrity reports
+        # the breaks: valid < total.
+        assert valid == total, f"HMAC chain broken: only {valid}/{total} entries verify"
+
+    def test_lock_sidecar_lives_in_the_protected_trust_dir(self, tmp_path):
+        """The sidecar must sit where the agent cannot reach it.
+
+        A sibling of security_events.jsonl is NOT covered: the sensitive-path
+        floor lists that log by exact leaf name. An agent able to unlink the
+        sidecar mid-hold leaves two writers holding locks on different inodes —
+        the fork this serialization prevents — and one able to hold it wedges
+        every writer.
+        """
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log(_make_event(event_id="lockloc-1"))
+
+        expected = tmp_path / kiro_crew_sel._TRUST_SUBDIR / kiro_crew_sel._SEL_LOCK_FILE
+        assert expected.exists(), "lock sidecar was not created under the trust dir"
+        assert not list(tmp_path.glob("*.lock")), "a lock file sits beside the log"
+
+    def test_appends_survive_when_the_trust_dir_is_uncreatable(self, tmp_path):
+        """A legacy install that cannot create trust/ must keep auditing.
+
+        When the key loader falls back to the deny-list-protected legacy key
+        (read-only config dir, uncreatable trust dir), the chain lock must
+        follow it there — locking the legacy key file itself — instead of
+        retrying the mkdir on every append, which would drop every best-effort
+        audit and deny every critical action on an install that is otherwise
+        signing fine.
+        """
+        legacy = tmp_path / kiro_crew_sel._HMAC_KEY_FILE
+        legacy.write_bytes(os.urandom(64))
+        trust = tmp_path / kiro_crew_sel._TRUST_SUBDIR
+
+        real_mkdir = Path.mkdir
+
+        def uncreatable_trust(self, *args, **kwargs):
+            if self == trust:
+                raise PermissionError("read-only config dir")
+            return real_mkdir(self, *args, **kwargs)
+
+        with patch.object(Path, "mkdir", uncreatable_trust):
+            log = SecurityEventLog(base_dir=tmp_path, sync=True)
+            assert log._hmac_key_file == legacy, "precondition: fallback not taken"
+            log.log(_make_event(event_id="legacy-lock-crit"), critical=True)
+            log.log(_make_event(event_id="legacy-lock-soft"))
+
+        body = log._path.read_text(encoding="utf-8")
+        assert "legacy-lock-crit" in body and "legacy-lock-soft" in body
+        total, valid = log.verify_integrity()
+        assert (total, valid) == (2, 2)
+        # The key bytes are untouched: the lock fd is never written through.
+        assert legacy.read_bytes() == log._hmac_key
+
+    def test_fresh_sidecar_is_primed_for_byte_range_locking(self, tmp_path):
+        """A fresh sidecar must not be empty after its first use.
+
+        Windows locks a byte RANGE (msvcrt.locking on byte 0), so an empty
+        sidecar has nothing to lock -- best-effort audits would vanish and
+        critical actions would be denied on every fresh Windows install. Same
+        priming the rotation lock already does for itself.
+        """
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log(_make_event(event_id="prime-1"))
+        sidecar = tmp_path / kiro_crew_sel._TRUST_SUBDIR / kiro_crew_sel._SEL_LOCK_FILE
+        assert sidecar.stat().st_size >= 1, "sidecar left empty; unlockable on Windows"
+
+    @pytest.mark.asyncio
+    async def test_loop_critical_audit_does_not_wait_for_a_blocked_writer_drain(self):
+        """``flush()``'s backlog wait must never run on the event-loop thread.
+
+        With the background writer parked on another process's chain lock and
+        events pending, a loop-side critical audit that drains first sits out
+        ``flush()``'s full timeout ON THE LOOP -- the same cross-process wait
+        the single-shot acquire keeps off the loop, re-imported one level up
+        through ``_pending``. It must reach its fail-closed gate immediately
+        instead; the wait could not have helped anyway, because the inline
+        append fails closed at that gate while the sibling holds the lock.
+
+        Uses the SESSION-scoped SEL default directory, not a per-test tmp dir:
+        this test needs the ASYNC writer, and a daemon writer bound to a
+        per-test directory outlives its test and re-creates the deleted path on
+        its next flush (see the rootdir ``_isolate_sel_default_dir`` fixture).
+        """
+        log = SecurityEventLog()  # async writer in the session-scoped dir
+        log.log(_make_event(event_id="drain-preheat"))
+        log.flush()
+        lock_path = log._dir / kiro_crew_sel._TRUST_SUBDIR / kiro_crew_sel._SEL_LOCK_FILE
+        lock_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+        # Stand in for another process holding the chain lock (e.g. prune).
+        holder = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        assert platform_compat.try_acquire_lock(holder, exclusive=True)
+        try:
+            # Queue a normal event; the writer dequeues it and blocks on the
+            # chain lock, leaving _pending nonzero either way.
+            log.log(_make_event(event_id="drain-queued"))
+            await asyncio.sleep(0.3)
+
+            started = time.monotonic()
+            with pytest.raises(OSError):
+                log.log(_make_event(event_id="drain-critical"), critical=True)
+            elapsed = time.monotonic() - started
+            assert elapsed < 2.0, (
+                f"loop-side critical audit waited {elapsed:.2f}s on the writer's "
+                "backlog (flush timeout is 5s); it must fail closed immediately"
+            )
+        finally:
+            platform_compat.release_lock(holder)
+            os.close(holder)
+        # Once the holder releases, the queued event drains normally.
+        log.flush()
+        assert "drain-queued" in log._path.read_text(encoding="utf-8")
+        # Stop THIS test's writer deterministically. The session directory is
+        # shared by every later test in this worker, and flock treats each
+        # instance's fd as its own holder -- so a leftover live writer here can
+        # hold the chain lock at the very instant a LATER test's loop-side
+        # critical audit takes its single shot, denying it spuriously
+        # (measured: the issue-radar trust re-establishment tests). The writer
+        # loop exits on its None sentinel.
+        log._queue.put(None)
+        writer = log._writer
+        if writer is not None:
+            writer.join(timeout=10)
+            assert not writer.is_alive(), "sel-writer did not stop"
+
+    @pytest.mark.asyncio
+    async def test_loop_critical_audit_joins_its_own_processes_hold(self, tmp_path):
+        """Own-process contention must JOIN the hold, not fail closed.
+
+        flock is per open file description, so a second fd in the same process
+        reads as a foreign writer -- and the loop-side single shot would then
+        deny a critical action because our own background writer was flushing a
+        batch at the same instant (measured: the fingerprint read's terminal
+        audit racing the writer flushing the same call's earlier best-effort
+        event). The flock excludes OTHER processes; threads of this process are
+        serialized by ``_lock``, so joining is safe, and the joiner's wait is
+        bounded local append work.
+        """
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log(_make_event(event_id="join-preheat"))
+
+        entered = threading.Event()
+        release = threading.Event()
+
+        def holder():
+            with log._chain_lock():  # this process's own append-kind hold
+                entered.set()
+                release.wait(10)
+
+        t = threading.Thread(target=holder, daemon=True)
+        t.start()
+        try:
+            assert entered.wait(5)
+            # Pre-fix: single-shot flock attempt on a second fd fails closed.
+            # The join waits its turn at the hold's gate, so release the holder
+            # on a short timer and assert the critical write went through
+            # promptly rather than being refused.
+            threading.Timer(0.3, release.set).start()
+            started = time.monotonic()
+            log.log(_make_event(event_id="join-critical"), critical=True)
+            assert time.monotonic() - started < 5.0
+        finally:
+            release.set()
+            t.join(timeout=10)
+        body = log._path.read_text(encoding="utf-8")
+        assert "join-critical" in body
+        total, valid = log.verify_integrity()
+        assert valid == total
+
+    @pytest.mark.asyncio
+    async def test_loop_critical_audit_does_not_join_its_own_prune(self, tmp_path):
+        """prune's hold spans a whole streaming rewrite -- joining it from the
+        loop is the stall the single-shot gate exists to prevent, so that one
+        own-process hold is refused, exactly like a foreign holder."""
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log(_make_event(event_id="prune-hold-preheat"))
+
+        entered = threading.Event()
+        release = threading.Event()
+
+        def holder():
+            with log._chain_lock(kind="prune"):
+                entered.set()
+                release.wait(10)
+
+        t = threading.Thread(target=holder, daemon=True)
+        t.start()
+        try:
+            assert entered.wait(5)
+            with pytest.raises(OSError):
+                log.log(_make_event(event_id="prune-hold-critical"), critical=True)
+        finally:
+            release.set()
+            t.join(timeout=10)
+        assert "prune-hold-critical" not in log._path.read_text(encoding="utf-8")
+
+    @pytest.mark.asyncio
+    async def test_a_joining_prune_is_visible_to_loop_side_callers(self, tmp_path):
+        """A prune that JOINS an append-kind hold must promote the hold's kind.
+
+        Without the promotion, the shared kind stays "append" and a loop-side
+        critical audit arriving mid-rewrite joins and waits behind the whole
+        streaming rewrite -- the exact stall the prune-kind refusal exists for.
+        The promotion happens when the prune joins (before it waits its turn at
+        the hold's gate), so it is observable while the append holder is still
+        inside.
+        """
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log(_make_event(event_id="promote-preheat"))
+        key = str(log._chain_lock_path())
+
+        entered = threading.Event()
+        release = threading.Event()
+
+        def append_holder():
+            with log._chain_lock():
+                entered.set()
+                release.wait(10)
+
+        def prune_joiner():
+            entered.wait(5)
+            with log._chain_lock(kind="prune"):
+                pass
+
+        t1 = threading.Thread(target=append_holder, daemon=True)
+        t2 = threading.Thread(target=prune_joiner, daemon=True)
+        t1.start()
+        t2.start()
+        try:
+            assert entered.wait(5)
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                with kiro_crew_sel._CHAIN_HOLDS_MUTEX:
+                    hold = kiro_crew_sel._CHAIN_HOLDS.get(key)
+                    if hold is not None and hold.kind == "prune":
+                        break
+                time.sleep(0.01)
+            else:
+                pytest.fail("prune join never promoted the hold's kind")
+            # Pre-fix: the hold still reads "append", so this JOINS -- and in
+            # production would wait behind the streaming rewrite.
+            with pytest.raises(OSError):
+                log.log(_make_event(event_id="promote-critical"), critical=True)
+        finally:
+            release.set()
+            t1.join(timeout=10)
+            t2.join(timeout=10)
+        assert "promote-critical" not in log._path.read_text(encoding="utf-8")
+
+    @pytest.mark.asyncio
+    async def test_rotation_inside_an_append_hold_refuses_loop_side_joins(self, tmp_path):
+        """The rotation step inside an append hold must not be joinable from the loop.
+
+        The writer's hold is append-kind, but while it runs rotation's scan +
+        rename + retention sweep, a joining loop-side critical audit would
+        block on ``_lock`` for that whole step. The hold is relabeled for
+        exactly the step's duration, and joins work again afterwards.
+        """
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log(_make_event(event_id="rot-preheat"))
+
+        in_rotation = threading.Event()
+        leave_rotation = threading.Event()
+        after_rotation = threading.Event()
+        release = threading.Event()
+
+        def holder():
+            with log._chain_lock():  # the writer's ordinary append-kind hold
+                with log._chain_hold_relabel("rotation"):
+                    in_rotation.set()
+                    leave_rotation.wait(10)
+                after_rotation.set()
+                release.wait(10)
+
+        t = threading.Thread(target=holder, daemon=True)
+        t.start()
+        try:
+            assert in_rotation.wait(5)
+            # During the rotation step: fail closed, do not join.
+            with pytest.raises(OSError):
+                log.log(_make_event(event_id="rot-critical"), critical=True)
+            leave_rotation.set()
+            assert after_rotation.wait(5)
+            # After the step the hold reads "append" again: the join works.
+            # It waits its turn at the gate, so release the holder on a short
+            # timer and assert the write went through promptly.
+            threading.Timer(0.3, release.set).start()
+            started = time.monotonic()
+            log.log(_make_event(event_id="rot-after"), critical=True)
+            assert time.monotonic() - started < 5.0
+        finally:
+            leave_rotation.set()
+            release.set()
+            t.join(timeout=10)
+        body = log._path.read_text(encoding="utf-8")
+        assert "rot-critical" not in body
+        assert "rot-after" in body
+
+    @pytest.mark.asyncio
+    async def test_loop_critical_audit_joins_a_sibling_instances_hold(self, tmp_path):
+        """Two instances on one directory are still ONE process.
+
+        flock is per open file description, so a second SecurityEventLog
+        instance (test suites churn the singleton) contending on its own fd
+        reads its own process as a foreign writer -- the loop-side single shot
+        then denies a critical audit because a SIBLING instance's writer was
+        mid-append (measured: the issue-radar trust tests failing whenever the
+        session directory carried another instance's live writer). The hold
+        registry is keyed by lock path at module level, so the sibling joins
+        and waits its bounded turn instead.
+        """
+        log_a = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log_a.log(_make_event(event_id="xinst-preheat"))
+        SecurityEventLog._instance = None
+        SecurityEventLog._initialized = False
+        log_b = SecurityEventLog(base_dir=tmp_path, sync=True)
+        assert log_a is not log_b
+
+        entered = threading.Event()
+        release = threading.Event()
+
+        def holder():
+            with log_a._chain_lock():  # sibling instance's hold
+                entered.set()
+                release.wait(10)
+
+        t = threading.Thread(target=holder, daemon=True)
+        t.start()
+        try:
+            assert entered.wait(5)
+            threading.Timer(0.3, release.set).start()
+            started = time.monotonic()
+            # Pre-fix: refused with "held by another writer".
+            log_b.log(_make_event(event_id="xinst-critical"), critical=True)
+            assert time.monotonic() - started < 5.0
+        finally:
+            release.set()
+            t.join(timeout=10)
+        assert "xinst-critical" in log_b._path.read_text(encoding="utf-8")
+
+    @pytest.mark.asyncio
+    async def test_contended_lock_fails_closed_on_the_event_loop(self, tmp_path):
+        """On the loop thread a held lock must refuse, not wait.
+
+        prune holds this lock across a whole streaming rewrite, so waiting here
+        would stall chat and the heartbeat for that entire duration. Refusing
+        surfaces as OSError, which a critical audit turns into audit-or-deny.
+        """
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log(_make_event(event_id="preheat-1"))  # materialize dir + sidecar
+        lock_path = tmp_path / kiro_crew_sel._TRUST_SUBDIR / kiro_crew_sel._SEL_LOCK_FILE
+
+        # A second open file description contends with the writer's own, so this
+        # stands in for another process holding the lock.
+        holder = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        assert platform_compat.try_acquire_lock(holder, exclusive=True)
+        try:
+            before = log._path.read_text(encoding="utf-8")
+            with pytest.raises(OSError):
+                log.log(_make_event(event_id="contended-1"), critical=True)
+            assert log._path.read_text(encoding="utf-8") == before, "wrote while locked out"
+        finally:
+            platform_compat.release_lock(holder)
+            os.close(holder)
+
+        # Once the holder releases, the same instance appends normally again.
+        log.log(_make_event(event_id="after-release-1"))
+        assert "after-release-1" in log._path.read_text(encoding="utf-8")
+
+    def test_symlinked_sidecar_is_refused(self, tmp_path):
+        """A planted link is not a lock — following it defeats serialization.
+
+        If the sidecar resolves elsewhere, replacing its target hands two writers
+        locks on different inodes, which is the fork this serialization prevents.
+        """
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        trust = tmp_path / kiro_crew_sel._TRUST_SUBDIR
+        trust.mkdir(mode=0o700, parents=True, exist_ok=True)
+        elsewhere = tmp_path / "planted-target"
+        elsewhere.write_text("", encoding="utf-8")
+        (trust / kiro_crew_sel._SEL_LOCK_FILE).symlink_to(elsewhere)
+
+        with pytest.raises(OSError):
+            log.log(_make_event(event_id="symlink-1"), critical=True)
+        assert not log._path.exists() or "symlink-1" not in log._path.read_text(
+            encoding="utf-8"
+        )
+
+    def test_hard_linked_sidecar_is_refused(self, tmp_path):
+        """A second name for the same inode is outside the deny-list's reach."""
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        trust = tmp_path / kiro_crew_sel._TRUST_SUBDIR
+        trust.mkdir(mode=0o700, parents=True, exist_ok=True)
+        sidecar = trust / kiro_crew_sel._SEL_LOCK_FILE
+        sidecar.write_text("", encoding="utf-8")
+        os.link(sidecar, tmp_path / "second-name")
+
+        with pytest.raises(OSError):
+            log.log(_make_event(event_id="hardlink-1"), critical=True)
+
+    @pytest.mark.asyncio
+    async def test_corrupt_tail_does_not_scan_the_log_on_the_event_loop(self, tmp_path):
+        """On the loop the tip read is bounded, so it fails closed instead of scanning.
+
+        A corrupt tail with no newline would otherwise walk the whole file, and
+        doing that under a synchronous critical audit stalls chat and the
+        heartbeat.
+        """
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log(_make_event(event_id="preheat-2"))
+        # A single unterminated record longer than the bounded tail read, so the
+        # last COMPLETE record lies more than one chunk back.
+        with open(log._path, "a", encoding="utf-8") as f:
+            f.write("x" * 9000)
+
+        with pytest.raises(OSError):
+            log.log(_make_event(event_id="onloop-corrupt-1"), critical=True)
+
+        # Off the loop the same log still recovers: the unbounded scan walks past
+        # the corrupt tail to the last complete record.
+        assert log._read_last_hash() != ""
+
+    @pytest.mark.asyncio
+    async def test_loop_is_not_blocked_by_a_writer_waiting_cross_process(self, tmp_path):
+        """A writer waiting on the chain lock must not stall a loop-side audit.
+
+        With the thread lock taken first, a background writer blocked on another
+        process's chain lock would hold _lock, and a loop-side critical audit
+        would then block on _lock — an ordinary blocking lock with no fail-closed
+        gate. Taking the chain lock first means the loop-side path reaches its
+        single-shot gate before it can wait on anything.
+        """
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log(_make_event(event_id="order-preheat"))
+        lock_path = tmp_path / kiro_crew_sel._TRUST_SUBDIR / kiro_crew_sel._SEL_LOCK_FILE
+
+        # Stand in for another process holding the sidecar (e.g. tail recovery).
+        holder = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        assert platform_compat.try_acquire_lock(holder, exclusive=True)
+        released = threading.Event()
+
+        def _release_holder():
+            if released.is_set():
+                return
+            released.set()
+            platform_compat.release_lock(holder)
+
+        # Watchdog: with the lock order reversed this test would DEADLOCK (the
+        # loop-side audit blocks on _lock, so the release below is never
+        # reached). Releasing from a timer converts that into a clean, fast
+        # assertion failure on the elapsed time rather than a CI timeout.
+        watchdog = threading.Timer(5.0, _release_holder)
+        watchdog.daemon = True
+        watchdog.start()
+
+        writer_reached_wait = threading.Event()
+        writer_done = threading.Event()
+
+        def _blocked_writer():
+            # Off the loop, so this waits on the chain lock the way the real
+            # background writer would.
+            writer_reached_wait.set()
+            log.log(_make_event(event_id="order-writer"))
+            writer_done.set()
+
+        t = threading.Thread(target=_blocked_writer, daemon=True)
+        t.start()
+        try:
+            assert writer_reached_wait.wait(5)
+            # Give the writer time to actually enter its wait.
+            await asyncio.sleep(0.2)
+            assert not writer_done.is_set(), "writer should still be waiting"
+
+            # The loop-side audit must fail fast, not block behind the writer.
+            started = time.monotonic()
+            with pytest.raises(OSError):
+                log.log(_make_event(event_id="order-loop"), critical=True)
+            assert time.monotonic() - started < 2.0, "loop-side audit blocked"
+        finally:
+            watchdog.cancel()
+            _release_holder()
+            os.close(holder)
+            t.join(timeout=10)
+
+        assert writer_done.is_set(), "writer never completed after release"
+        body = log._path.read_text(encoding="utf-8")
+        assert "order-writer" in body
+        assert "order-loop" not in body
+
+    @pytest.mark.asyncio
+    async def test_on_loop_contention_makes_exactly_one_nonblocking_attempt(
+        self, tmp_path, monkeypatch
+    ):
+        """The loop-side acquire must try ONCE and refuse — never poll.
+
+        A retry spin, however short each nap, sleeps the gateway event loop, so
+        the stall is paid by every session it serves. This pins the contract:
+        one ``try_acquire_lock`` call, an immediate fail-closed raise, and no
+        sleep anywhere on the path.
+        """
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        log.log(_make_event(event_id="single-shot-preheat"))
+        lock_path = tmp_path / kiro_crew_sel._TRUST_SUBDIR / kiro_crew_sel._SEL_LOCK_FILE
+
+        # Stand in for a sibling process holding the sidecar.
+        holder = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        assert platform_compat.try_acquire_lock(holder, exclusive=True)
+
+        attempts = []
+        real_try = platform_compat.try_acquire_lock
+
+        def _counting_try(fd: int, *, exclusive: bool = False) -> bool:
+            attempts.append(fd)
+            return real_try(fd, exclusive=exclusive)
+
+        monkeypatch.setattr(
+            kiro_crew_sel.platform_compat, "try_acquire_lock", _counting_try
+        )
+        try:
+            started = time.monotonic()
+            with pytest.raises(OSError):
+                log.log(_make_event(event_id="single-shot-critical"), critical=True)
+            elapsed = time.monotonic() - started
+        finally:
+            platform_compat.release_lock(holder)
+            os.close(holder)
+
+        assert len(attempts) == 1, f"on-loop acquire polled {len(attempts)} times"
+        assert elapsed < 0.05, f"on-loop acquire took {elapsed:.3f}s"
+        assert "single-shot-critical" not in log._path.read_text(encoding="utf-8")
+
+    def test_on_loop_acquire_helper_never_sleeps(self):
+        """No sleep may reappear in the on-loop acquire, in any form.
+
+        A source-level assertion rather than a timing one: a future poll spin
+        would be reintroduced as a sleep call, and a wall-clock bound alone
+        would tolerate a short one.
+        """
+        src = inspect.getsource(kiro_crew_sel._acquire_chain_lock_on_loop)
+        body = src.split('"""')[-1]
+        assert "sleep" not in body, "on-loop chain-lock acquire sleeps on the event loop"
+        assert not hasattr(kiro_crew_sel, "time"), (
+            "kiro_crew.sel imports time again — the on-loop path must not sleep"
+        )
 
 
 class TestInferSource:
@@ -1952,12 +2607,30 @@ class TestRotationIsSerializedAcrossProcesses:
 
         Parking that caller on another process's rotation is the
         no-blocking-call-on-event-loop hazard, and rotation is deferrable while an
-        audit write is not -- so the blocking lock helper must not be used here.
+        audit write is not -- so the blocking lock helper must not be used for
+        ROTATION. The cross-process CHAIN lock is the one sanctioned exception:
+        off the event loop it blocks by design (the background writer absorbs
+        contention there), and its on-loop path is a single nonblocking attempt
+        covered by TestCrossProcessSafety -- so the guard here permits exactly
+        the chain-lock sidecar's fd and nothing else.
         """
         log = SecurityEventLog(base_dir=sel_dir, sync=True)
+        sidecar = sel_dir / kiro_crew_sel._TRUST_SUBDIR / kiro_crew_sel._SEL_LOCK_FILE
+        real_file_lock = platform_compat.file_lock
+
+        def rotation_must_not_block(fd, *, exclusive):
+            st = os.fstat(fd)
+            try:
+                side = sidecar.stat()
+            except OSError:
+                side = None
+            if side is None or (st.st_dev, st.st_ino) != (side.st_dev, side.st_ino):
+                raise AssertionError("blocking lock helper used on the audit path")
+            return real_file_lock(fd, exclusive=exclusive)
+
         with patch(
             "kiro_crew.sel.platform_compat.file_lock",
-            side_effect=AssertionError("blocking lock helper used on the audit path"),
+            side_effect=rotation_must_not_block,
         ):
             _fill(log, 200)
         assert log._segments_oldest_first(), "precondition: rotation happened"
@@ -3220,7 +3893,25 @@ class TestSegmentDirIsNotFollowedThroughALink:
         """
         log = SecurityEventLog(base_dir=sel_dir, sync=True)
         _fill(log, 200)
-        with patch("kiro_crew.sel.platform_compat.is_link_or_junction", return_value=True):
+        # Answer "link" only for rotation's paths (the segment dir and its
+        # rotation lock). A blanket True would also condemn the chain-lock
+        # sidecar in trust/, whose refusal correctly drops best-effort appends
+        # -- a different, deliberate behavior with its own test
+        # (test_symlinked_sidecar_is_refused) -- and this test is about
+        # rotation refusing while audit records still land.
+        real_probe = platform_compat.is_link_or_junction
+        segment_dir = log._segment_dir
+
+        def rotation_paths_are_links(path):
+            p = Path(path)
+            if p == segment_dir or p.parent == segment_dir:
+                return True
+            return real_probe(path)
+
+        with patch(
+            "kiro_crew.sel.platform_compat.is_link_or_junction",
+            side_effect=rotation_paths_are_links,
+        ):
             with patch(
                 "kiro_crew.sel.platform_compat.unlink_link_or_junction",
                 side_effect=OSError("read-only"),


### PR DESCRIPTION
Fixes #2308.

## Problem / Motivation

`SecurityEventLog` guards its read-tip → compute-HMAC → append sequence with a
`threading.Lock`, which only orders writers inside one interpreter. The gateway
and each managed MCP server are **separate processes** sharing one
`security_events.jsonl`, and each holds its own singleton whose chain tip is read
once in `__init__` and then only ever advanced from its own writes.

So two processes chain off the same `prev_hash`. `verify_integrity()` walks disk
order, finds the second entry's `prev_hash` pointing at the first's predecessor,
and reports a break. And because neither process ever re-reads the tip, the two
lineages **fork permanently** — every later entry from the losing process is
reported tampered too. That is why the report shows 24 bad entries out of 317
rather than one.

`O_APPEND` is doing its job here: no bytes are torn or overwritten. It just says
nothing about the ordering of a read-compute-append sequence, which is exactly
what an HMAC chain depends on.

## Why it matters

The SEL log is the install's tamper-evidence anchor: `kirocrew security verify`
reporting COMPROMISED on a healthy install is a false alarm an operator cannot
distinguish from real tampering, and every entry the losing process writes after
the fork stays permanently unverifiable. Any install running the gateway plus
managed MCP servers hits this in normal operation -- no attacker required.

## What changed

Take an advisory lock on a sidecar file across the chain-and-append critical
section, and **re-read the tip from disk inside it** — another process's
`entry_hash`, not the cached guess, is what the batch must chain from.

`platform_compat.file_lock()` already provides this (POSIX `flock`, Windows
`msvcrt.locking` with a bounded spin, fail-closed on both), so there is no new
platform-divergent code. The lock is a sidecar rather than the log itself because
`msvcrt.locking` locks a byte range at offset 0 and needs an fd whose offset the
caller may move.

`prune()` takes the same lock: it already held the thread lock across its
read+replace so a concurrent append could not be lost by `os.replace`, and a
writer in another process is ordered only by the file lock.

Lock ordering is chain-lock-then-thread-lock in both write paths (see review
round 3 below for why the original thread-lock-first order was inverted), so they
cannot deadlock. `flush()` waits on `_pending_cond` and takes neither.

## Tests

New `TestCrossProcessSafety::test_concurrent_processes_keep_one_unbroken_chain`
spawns two real subprocesses against one log directory, barriers them so both
hold a tip read before either has written, then asserts
`verify_integrity()` returns `valid == total`.

It has to be subprocesses: the existing `TestThreadSafety::test_concurrent_writes`
and `TestAsyncWriter::test_async_concurrent_writes_no_loss` are thread-only and
pass on unfixed code.

Causal proof — with the test in place, reverting only `src/kiro_crew/sel.py` to
`origin/main`:

```
$ git checkout origin/main -- src/kiro_crew/sel.py
$ pytest test/test_sel.py::TestCrossProcessSafety
WARNING  kiro_crew.sel: SEL chain break at entry 20
WARNING  kiro_crew.sel: SEL chain break at entry 21
... (breaks through entry 24)
1 failed
```

With the fix restored: `1 passed`.

Local gates: `test_sel.py` 115 passed, `test_sel_prune_streaming.py` green,
plus `test_security.py` / `test_safety_override.py` / `test_workflows_audit.py` /
`test_computer_use_gate.py` / `test_notification_phase5.py` /
`test_heartbeat_safe_tools.py` / `test_sandbox_argv.py` / `test_reveal_path.py` /
`test_dashboard_file_io.py` — 889 passed, 4 skipped, 0 failures.
isort, flake8 clean; mypy clean on `sel.py` (mypy 1.14.1, matching the
`pyproject.toml` pin).

## Scope notes

- No change to the event schema, the `_compute_hash` payload, key handling, or
  what is permitted or logged. This is an ordering fix only.
- Entries that already forked on an affected install stay unverifiable after this
  change — the chain cannot be retroactively re-linked without re-signing, which
  would defeat the point. Whether to document that as a discontinuity or offer a
  re-seal is a maintainer call and is deliberately not attempted here.
- `verify_integrity()` still reports a fork as "tamper" rather than
  distinguishing a concurrent region. Left alone for the same reason.
- The read paths (`verify_integrity`, `recent`) take no shared lock, so a read
  concurrent with a large batch from another process can still observe a
  partially-flushed final line. That is pre-existing and tolerated by the
  corrupt-tail handling in `_read_last_hash`; out of scope here.


---

## Review round 1 — both blocking findings addressed

**Unprotected sidecar (GPT 5.6, and Design Review's Watch item).** Correct, and it
undid part of the fix: `_SENSITIVE_HOME_DIRS` covers `trust` and the *exact leaf*
`security_events.jsonl`, so a sibling `security_events.jsonl.lock` was outside the
floor. An agent able to unlink it mid-hold leaves two writers holding locks on
different inodes — exactly the fork this PR prevents — and one able to hold it
wedges every writer. The sidecar now lives at `trust/security_events.lock`, inside
the owner-only directory that already protects the HMAC key, created with the same
`0o700`. Pinned by
`test_lock_sidecar_lives_in_the_protected_trust_dir`, which also asserts no `.lock`
sits beside the log.

**POSIX flock on the event-loop thread (GPT 5.6).** The two AI reviewers disagreed
here — Opus 4.8 traced the call sites and found no on-loop regression, since the
flock is always taken while `_lock` is held and critical writes are offloaded. Opus
is right about the call sites but the *duration* changes in kind: `_lock` only ever
waited on another thread's batch append, while the file lock can wait on another
**process**, and `prune` holds it across a whole streaming rewrite. So the
conservative reading wins.

`_chain_lock` now detects the event-loop thread and takes a **single-shot,
fail-closed** acquire there — the same shape `platform_compat.file_lock` already
uses on Windows, rather than a new mechanism. A refused acquire raises `OSError`,
which `_flush_batch` already turns into a rollback plus warning, or into a
propagated error for a critical audit: audit-or-deny working as designed instead of
a stalled gateway. Off the loop (the background writer, and `prune` in an executor)
the acquire waits normally. Pinned by
`test_contended_lock_fails_closed_on_the_event_loop`.

**Not addressed, deliberately.** Design Review's second Watch item — that the
already-forked region on affected installs stays flagged as tamper — remains a
maintainer call between a documented discontinuity and a re-seal, as the original
scope notes said. Re-signing history from a fork PR is not something I should
decide.

Rebased onto `adbec83b`; local gates re-run after the rebase (125 SEL tests, 658
across the SEL-adjacent files, isort/flake8/mypy clean).


---

## Review round 2

**Pre-planted sidecar link (blocking).** Fixed. The scenario is narrow — `trust`
is already in `_SENSITIVE_HOME_DIRS`, so an agent's own tools cannot plant there —
but the repo's own doctrine settles it: `_load_or_create_hmac_key` already probes
this exact directory with `is_link_or_junction`, so a link here is a threat model
the codebase treats as real. `_chain_lock` now refuses a linked sidecar before
locking it, `O_NOFOLLOW` makes that atomic on POSIX (no check-then-open window),
the explicit probe carries Windows junctions, and an `st_nlink > 1` check on the
open fd catches a hard link, which `O_NOFOLLOW` says nothing about. Pinned by
`test_symlinked_sidecar_is_refused` and `test_hard_linked_sidecar_is_refused`.

**Chain-tip scan on the event loop (blocking).** Addressed, but bounded rather
than by offloading — the diagnosis is right and the prescribed remedy is out of
scope for this PR.

`_read_last_hash` is not a scan in the normal case: it seeks to the end and reads
one 4096-byte chunk, which contains the last complete record for any healthy log.
It only walks further when the tail is *already* corrupt — and this path already
did on-loop file I/O before this PR (`_ends_without_newline`, and `__init__`'s own
`_read_last_hash`), so the risk named here is a pre-existing property of
synchronous critical audits, not something this change introduces.

What this change *can* own is the incremental exposure, so it does: on the
event-loop thread the tip read is now bounded to a single tail chunk, and
exhausting that bound raises instead of returning a genesis tip — the caller fails
closed rather than chaining from the wrong record. Off the loop (the background
writer, `prune` in an executor) the unbounded recovery walk is unchanged, so a
corrupt tail is still recovered from, just not on the loop. The bound raises a
distinct `_ChainTipBeyondBound` so `_read_last_hash`'s fail-soft `except OSError`
— which exists for genuine read errors — cannot swallow it. Pinned by
`test_corrupt_tail_does_not_scan_the_log_on_the_event_loop`, which also asserts
the off-loop path still recovers from the same log.

The other half of the suggested fix — "offload the complete critical write from
the event loop" — means changing every `critical=True` call site (`slack/gateway.py`,
`sandbox.py`, `github_runner.py`, `cli_setup.py`, `platform/governance_profiles.py`
and more), which is a maintainer-scope decision about the audit-or-deny contract,
not something a fork PR should decide unilaterally. Happy to open it as a separate
issue with the call-site inventory if that is wanted. Reverting the hunk is the
one option I would push back on: the tip re-read under the lock is what makes the
cross-process chain correct.

Local gates after this round: 128 SEL tests, 661 across the SEL-adjacent files,
isort/flake8/mypy clean.


---

## Review round 3 — lock order inverted

One blocking finding this round, and it is a genuine hole in round 1's fix.

Round 1 made the loop-side path fail closed rather than *wait on the chain lock*.
It did nothing about waiting on `_lock`. With the thread lock taken first, a
background writer that blocks waiting for another process's chain lock does so
while **holding `_lock`** — and a loop-side critical audit then blocks on `_lock`,
which is an ordinary `threading.Lock` with no fail-closed gate of its own. The
gateway stalls anyway, one level of indirection down. Correct catch.

Both write paths now take the chain lock **before** `_lock`, consistently, so the
loop-side path reaches its single-shot gate before it can wait on anything. Same
order in `_flush_batch` and `prune`, so there is still no deadlock, and
`set_forward_callback` only ever takes `_lock` as a leaf. `_chain_lock` also
creates the audit directory, so the old separate dir-create branch folded into the
one `OSError` handler.

`test_loop_is_not_blocked_by_a_writer_waiting_cross_process` pins it: another
holder takes the sidecar, a background thread blocks waiting for it, then a
loop-side `critical=True` audit must raise within 2s instead of queueing behind
the writer. Against the previous commit's order that test **deadlocked** — the
loop-side audit blocked on `_lock`, so the test's own release was never reached —
which is precisely the stall described. It now carries a 5s watchdog that releases
the holder, so a regression fails in ~5s with `DID NOT RAISE OSError` rather than
hanging a CI shard.

Verified against `4644f7be`: fails in 5.22s there, passes here. Local gates: 129
SEL tests, 662 across the SEL-adjacent files, isort/flake8/mypy clean.


---

## Review round 4+5 — Design Review + GPT Review addressed

**On-loop acquire is now single-shot by design (no sleep, no retry).** The earlier
bounded-retry approach (5 attempts × 10ms) was rejected by GPT 5.6 Review as still
sleeping on the event loop. The fix: `_acquire_chain_lock_on_loop` performs exactly
one nonblocking `try_acquire_lock` call and returns immediately — if contended, the
caller raises `OSError` and the action is refused rather than stalled.

This is the correct trade-off: a refused critical audit degrades one user action
(the sandbox delegation falls to seatbelt/EPERM), but a sleeping acquire stalls
the gateway event loop for **every** session it serves. The on-loop path is
fail-closed: the action being audited is refused, not executed unaudited. Off-loop
callers (background writer, prune in an executor) still take the blocking
cross-process lock, where routine overlap is absorbed at no cost to the loop.

Three tests pin the contract:
- `test_on_loop_contention_makes_exactly_one_nonblocking_attempt`: holds the
  sidecar, asserts exactly 1 `try_acquire_lock` call, elapsed < 50ms, and the
  critical audit raises (not silently dropped).
- `test_on_loop_acquire_helper_never_sleeps`: source-level assertion that no
  `sleep` call exists in the function body, and `time` is not imported.
- `test_loop_is_not_blocked_by_a_writer_waiting_cross_process`: the off-loop
  writer waits normally without blocking the loop.

**Spec doc.** `docs/system-specs/modules/sel.md` § Thread Safety rewritten to
document the two-lock model, the sidecar trust-dir placement and link refusal,
and the single-shot on-loop semantics with fail-closed behaviour.

**Follow-up (deferred).** Offloading all `critical=True` audit call sites from
the event loop would retire the single-shot compromise entirely — every audit
would take the blocking lock off-loop. Filed as a tracked follow-up rather than
widening this PR.




---

## Rebase onto current main (head `9d13b4aa6`)

Main's rotation + re-anchor machinery (#4857 and successors) landed after this
PR's base, so the two designs were composed rather than one replacing the other:

- `_flush_batch` takes the chain lock first, then `_lock`, and runs main's
  current body inside them (redaction convergence point, rotation window,
  identity-guarded retry append). The retry stays as the second line of defense:
  a sibling's ROTATION is serialized by the rotation lock, not the chain lock,
  and a stale cached tip after a sibling's append becomes a re-anchor + re-chain.
- The bounded single-chunk on-loop tip read moved into the two re-anchor sites
  (`_reanchor_now`, `_reanchor_if_replaced`); `_read_last_hash` merges both
  signatures (`path` from main, `max_chunks` from this PR).
- `prune` keeps main's whole-segment sweep and rotation-lock serialization,
  wrapped in the chain lock.

Review fixes folded in: `_chain_lock` follows the HMAC key to its legacy
location when the trust dir is uncreatable (locking the deny-list-protected
legacy key file instead of failing every append; pinned by a mutation-verified
test), and the cross-process test reaps its killed children with `proc.wait()`.
Two main-owned tests whose global patches over-reached under the chain-lock
design were scoped (`test_the_acquire_never_blocks` permits blocking on exactly
the chain-lock sidecar's fd; `test_an_unremovable_link_refuses_to_rotate` limits
its everything-is-a-link patch to rotation's paths).

Gates on the rebased head: 249/249 `test_sel.py`, isort, flake8, mypy, baselined
black.
