### PR TITLE
fix(dashboard): stop a hung usage fetch parking the credit pill forever

### DIFF
--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -120,6 +120,11 @@ async def api_sessions_health(request: web.Request) -> web.Response:
 _usage_cache: dict[str, object] = {}
 _usage_cache_ts: float = 0.0
 _USAGE_REFRESH_SECS = 600  # background refresh every 10 min
+# Ceiling on ONE whole refresh. Sized above the sum of the inner bounded steps
+# (whoami ≤30s + the billed scrape ≤60s, plus the unbounded API read between
+# them) so a healthy slow refresh still completes, while a wedged one is
+# guaranteed to release the in-flight guard instead of parking it forever.
+_USAGE_FETCH_DEADLINE_SECS = 180
 _usage_fetching = False
 
 # --- Text-scrape gate ------------------------------------------------------
@@ -652,7 +657,11 @@ async def _fetch_usage_bg() -> None:
     # backoff — an API-path error or a missing kiro-cli says nothing about
     # whether the scrape works.
     scrape_attempted = False
-    try:
+
+    async def _refresh() -> None:
+        nonlocal proc, sandbox_cleanup, kiro_bin, scrape_attempted
+        global _usage_cache, _usage_cache_ts
+
         kiro_bin = await _resolve_kiro_bin_for_spawn()
         if not kiro_bin:
             # kiro-cli absent (non-Kiro provider): cache an unavailable marker so
@@ -815,6 +824,18 @@ async def _fetch_usage_bg() -> None:
             # blanking the pill; only hide when we have nothing to show.
             _record_scrape_outcome(False)
             _cache_transient_failure()
+
+    try:
+        # ONE deadline over the whole refresh. Every await inside is either
+        # already bounded or an executor call that can block on DNS or a wedged
+        # TLS handshake; without a ceiling on the total, one such hang means
+        # this coroutine never reaches its `finally`, `_usage_fetching` stays
+        # True for the process lifetime, and every later refresh returns at the
+        # guard above — so the cache is never populated and the dashboard's
+        # credit pill shows "Checking usage..." forever with nothing logged.
+        # A timeout here lands in the handler below, which keeps the last good
+        # value or marks usage unavailable, so the pill always resolves.
+        await asyncio.wait_for(_refresh(), timeout=_USAGE_FETCH_DEADLINE_SECS)
     except asyncio.TimeoutError:
         # Transient hang — keep the last good value (stale) instead of blanking.
         logger.debug("Background usage fetch timed out")

--- a/test/test_session_usage.py
+++ b/test/test_session_usage.py
@@ -5,6 +5,7 @@ _fetch_usage_bg gating/redaction logic.
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -352,6 +353,90 @@ class TestFetchUsageBg:
         assert sessions_mod._usage_cache == {"available": False}
         proc.kill.assert_called_once()
         proc.wait.assert_awaited_once()  # reaped (FDs closed) on the error path
+
+
+class TestFetchUsageDeadline:
+    """A hung refresh must release the in-flight guard, not park it forever.
+
+    `_usage_fetching` gates every refresh, and it is only cleared in
+    `_fetch_usage_bg`'s `finally`. That `finally` does run on cancellation — but
+    not on a hang, so without an overall deadline one wedged call leaves the
+    guard True for the process lifetime: the cache is never populated and the
+    dashboard's credit pill shows "Checking usage..." indefinitely.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset(self, monkeypatch):
+        _reset_usage_globals()
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.sessions.wrap_argv",
+            lambda argv, **k: (list(argv), None),
+        )
+        yield
+        _reset_usage_globals()
+
+    @pytest.mark.asyncio
+    async def test_hung_api_read_still_clears_the_guard(self, monkeypatch):
+        # Short deadline so the test does not wait on the production ceiling.
+        # raising=False keeps the test independent of the constant existing, so
+        # on unfixed code it exercises the real hang instead of erroring on a
+        # missing attribute.
+        monkeypatch.setattr(
+            sessions_mod, "_USAGE_FETCH_DEADLINE_SECS", 0.2, raising=False
+        )
+        released = threading.Event()
+
+        def _hang(*_args, **_kwargs):
+            # Blocks like a wedged TLS handshake or a DNS lookup with no
+            # resolver: urlopen's own timeout does not cover either.
+            released.wait(30)
+            return None
+
+        try:
+            with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+                 patch.object(sessions_mod, "_fetch_whoami", AsyncMock(return_value={})), \
+                 patch.object(sessions_mod.kiro_usage_api, "fetch_usage_limits", _hang):
+                # The outer wait_for is the assertion: unfixed, _fetch_usage_bg
+                # never returns and this raises instead of hanging the suite.
+                await asyncio.wait_for(sessions_mod._fetch_usage_bg(), timeout=10)
+        finally:
+            released.set()
+
+        assert sessions_mod._usage_fetching is False, "in-flight guard was left set"
+        # The pill must resolve rather than spin: no credit plan was obtained, so
+        # usage is reported unavailable.
+        assert sessions_mod._usage_cache.get("available") is False
+        assert sessions_mod._usage_cache_ts > 0
+
+    @pytest.mark.asyncio
+    async def test_refresh_after_a_hang_can_still_succeed(self, monkeypatch):
+        monkeypatch.setattr(
+            sessions_mod, "_USAGE_FETCH_DEADLINE_SECS", 0.2, raising=False
+        )
+        released = threading.Event()
+
+        def _hang(*_args, **_kwargs):
+            released.wait(30)
+            return None
+
+        try:
+            with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+                 patch.object(sessions_mod, "_fetch_whoami", AsyncMock(return_value={})), \
+                 patch.object(sessions_mod.kiro_usage_api, "fetch_usage_limits", _hang):
+                await asyncio.wait_for(sessions_mod._fetch_usage_bg(), timeout=10)
+        finally:
+            released.set()
+
+        api_dict = {"credits_used": 12.0, "credits_plan": 100.0, "source": "api"}
+        arn = "arn:aws:codewhisperer:us-east-1:1:profile/A"
+        with patch.object(sessions_mod, "_resolve_kiro_bin_for_spawn", return_value="/bin/kiro"), \
+             patch.object(sessions_mod, "_fetch_whoami",
+                          AsyncMock(return_value={"email": "me@corp.com", "_profile_arn": arn})), \
+             patch.object(sessions_mod.kiro_usage_api, "fetch_usage_limits",
+                          return_value={**api_dict, "_profile_arn": arn}):
+            await asyncio.wait_for(sessions_mod._fetch_usage_bg(), timeout=10)
+
+        assert sessions_mod._usage_cache.get("credits_plan") == 100.0
 
 
 class TestNormalizeTextUsage:


### PR DESCRIPTION
Fixes #2364.

## The bug

`_fetch_usage_bg()` is gated by a module-level `_usage_fetching` flag that is set
before the work and cleared only in the function's `finally`. That `finally` is
correct as far as it goes — it *does* run on `CancelledError`, so the cancellation
mechanism named in the report is not the cause.

What it cannot survive is a **hang**, because the refresh has no overall deadline.
`fetch_usage_limits` is awaited via `run_in_executor(subprocess_executor(), ...)`
with no `wait_for`, and the `urlopen(timeout=15)` inside it does not cover
`getaddrinfo` — nor the wait for a free worker in a bounded pool. If that call
blocks, the coroutine never reaches its `finally`, `_usage_fetching` stays `True`
for the **process lifetime**, and every subsequent refresh returns immediately at
the guard.

`_usage_cache` therefore stays `{}` forever. The frontend cannot recover on its
own: the `useQuery` at `App.tsx` returns `null` unless `credits_plan` is finite or
`available === false`, and `!kiroUsage` renders the spinner — so a never-populated
cache is indistinguishable from a warming one, and the pill reads
"Checking usage..." indefinitely with nothing logged.

## The fix

One ceiling over the whole refresh. Every await inside is either already bounded
(`whoami` ≤30s, the billed scrape ≤60s) or an executor call that can block
indefinitely; bounding the total is the invariant that actually matters, and it
cannot be defeated by a future await being added inside.

A timeout lands in the existing `except asyncio.TimeoutError` handler, which
calls `_cache_transient_failure()` — keeping the last good value as stale, or
caching `{"available": False}` when there is nothing to show. Either way the pill
resolves instead of spinning.

`asyncio.timeout()` would express this without restructuring, but it needs 3.11
and `requires-python` is `>=3.10`, so the body is lifted into a nested coroutine
for `wait_for`. Its indentation is unchanged, so the real diff is 22 lines —
`git diff -w` and `git diff` agree.

## Verification

Two tests in the new `TestFetchUsageDeadline`:

- `test_hung_api_read_still_clears_the_guard` — `fetch_usage_limits` blocks on an
  event; asserts `_fetch_usage_bg()` returns, `_usage_fetching is False`, and the
  cache resolves to `available: False`.
- `test_refresh_after_a_hang_can_still_succeed` — proves the guard is not merely
  cleared but that a later refresh populates the cache normally.

Both patch the deadline with `raising=False` so they do not depend on the new
constant existing, which is what makes them exercise the real hang on unfixed
code rather than erroring on a missing attribute.

Causal proof — with the tests in place, reverting only
`src/kiro_crew/dashboard/handlers/sessions.py` to `origin/main`:

```
$ git checkout origin/main -- src/kiro_crew/dashboard/handlers/sessions.py
$ pytest test/test_session_usage.py::TestFetchUsageDeadline
E   TimeoutError          # the test's own wait_for(10) fires — _fetch_usage_bg never returns
2 failed
```

With the fix restored: `2 passed in 0.70s`.

Local gates: every test file importing this module — `test_session_usage.py`,
`test_usage.py`, `test_sessions_health_cache.py`, `test_session_keepalive.py`,
`test_computer_use_api.py`, `test_dashboard_sessions_memory.py` and 8 more —
737 passed, 0 failures. Plus `test_kiro_usage_api.py` and
`test_kiro_spawn_readiness_gate.py`. isort, flake8 clean; mypy clean on
`sessions.py` (mypy 1.14.1, matching the `pyproject.toml` pin).

## Scope notes

- The deadline is 180s: above the sum of the bounded inner steps so a healthy
  slow refresh still completes, well below the 600s refresh interval so a wedged
  one always clears before the next attempt.
- A timestamped guard (so the flag self-heals independently) was considered and
  left out — with the deadline in place there is no path from `_usage_fetching =
  True` to a missed `finally`, so it would be redundant machinery.
- The report also predicted an API-key-auth readiness asymmetry (`KIRO_API_KEY`
  appears nowhere in the repo, and the readiness probe's env allowlist omits it,
  which would 503 this endpoint). That is a separate question — it would also
  break `/api/models`, regenerate and rewind, which the reporter did not observe
  — so it is deliberately not addressed here. This change fixes the wedge that
  makes the pill spin with no error at all.
- The frontend spinner-vs-error state is untouched: it is a product call whether
  `undefined` (fetch rejected) should render differently from `null`.
