### PR TITLE
feat(mcp-gateway): emit the stub for every server, not only poolable ones

### DIFF
--- a/docs/architecture/design-notes/README.md
+++ b/docs/architecture/design-notes/README.md
@@ -12,4 +12,5 @@ grows into a subsystem should become a spec under
 | [mcp-oauth-ownership.md](mcp-oauth-ownership.md) | Who owns an MCP server's OAuth tokens, and why that ownership is contested. |
 | [mcp-gateway-claim-push.md](mcp-gateway-claim-push.md) | Event-driven caller identity for pooled MCP stubs. |
 | [mcp-gateway-oversize-response.md](mcp-gateway-oversize-response.md) | Handling an MCP tool response that exceeds the gateway read buffer. |
+| [mcp-stub-decoupling.md](mcp-stub-decoupling.md) | Why the stub is emitted for every server, and why per-connection backends stay outside the pooling budget. |
 | [profiling.md](profiling.md) | The debug-only stack sampler and desktop app metrics. |

--- a/docs/architecture/design-notes/mcp-stub-decoupling.md
+++ b/docs/architecture/design-notes/mcp-stub-decoupling.md
@@ -1,0 +1,149 @@
+# Decoupling the MCP stub from the pooling allowlist
+
+Status: implemented. Records why the stub is emitted for every server and why a
+connection-private backend sits outside the pooling budget.
+
+## Problem
+
+A stub used to be emitted only for a server the operator had marked poolable.
+That welded two unrelated decisions together. The stub is the **addressing
+layer**: it is what gives an `(ACP connection, server)` pair a name that gatewayd
+can route a callback back to. Poolability is a **resource** decision: may several
+connections share one backend process. You could not have the first without
+accepting the second.
+
+The consequences that motivated the change:
+
+- **MCP Apps required pooling.** The render and callback paths live behind the
+  stub, so a server that was not poolable could not host an MCP App at all — no
+  matter how the MCP Apps switch was set.
+- **The default configuration had the feature off in practice.**
+  `poolable_servers` defaults to an empty list, so a fresh install could have MCP
+  Apps on, the broker running, and nothing able to render.
+- **Wanting isolation cost you the feature.** An operator who deliberately kept a
+  stateful server unpooled lost MCP Apps for it as a side effect they never chose.
+
+## Current behaviour
+
+The baseline behaviour of MCP is **one backend per ACP connection per server** —
+what happens with no gateway at all: the agent process spawns its own MCP server
+processes. Pooling is the *deviation* that collapses many connections onto one
+process. The stub is orthogonal to both.
+
+So:
+
+- The stub is emitted **unconditionally** for every stdio server. It is the
+  interposition point, always present.
+- `poolable` does not decide whether a stub exists. It is a field in the stub's
+  `register` payload — an input to *how the backend is acquired*. Absent means
+  private, so an overlay predating the flag never silently starts sharing.
+- Not on the allowlist therefore means exactly one thing: **you get a stub, and
+  your backend stays 1:1 with your ACP connection.** Same process topology as
+  no-gateway, plus a name.
+- `mcp_gateway.enabled` false means no stub is marked shareable — stubs stay,
+  every connection gets its own backend. The broker starts when either that
+  switch or `apps_enabled` is on.
+
+## Why this is not just deleting the guard
+
+Removing the guard alone would silently make every server shared. Backend reuse
+is decided purely by the PoolKey digest: `get_or_create` hashes the key, finds a
+live entry, and returns it.
+
+`PoolKey` carries no session or connection dimension — deliberately, and it must
+stay that way. Its fields are exactly the config/capability inputs that make two
+backends interchangeable; adding a per-connection dimension would make every
+backend connection-private and reduce the pool to a no-op. So two connections to
+the same server compute the **same digest** and land on the same entry.
+
+An unconditional stub therefore needs a way to acquire a backend **without**
+digest reuse.
+
+## Where the stub comes from
+
+Two paths emit stubs, and both are now unconditional for stdio servers:
+
+- **Agent-declared servers** in `~/.kiro/agents/*.json`, wrapped in that agent's
+  overlay.
+- **Global `settings/mcp.json` servers**, relocated into each agent's overlay so
+  the stub carries the right agent identity, and dropped from the settings
+  overlay in the same pass. That relocation is what keeps a server from being
+  wrapped twice under two identities; it previously applied only to poolable
+  servers, leaving everything else to merge raw with no stub and therefore no
+  callback address.
+
+## The acquisition path
+
+Everything downstream of the digest is keyed on the digest *string*, not on the
+`PoolKey` object: storage, lookup, reservation, refcount, idle sweep, LRU, and
+the breaker. Most importantly so is callback resolution — `get_by_digest`, which
+the MCP Apps `app-call` path uses against the digest the spool record persists.
+
+So a private backend needs no new addressing mechanism, only a storage key that
+cannot collide with another connection's. `Backend.storage_digest` supplies it:
+the plain `PoolKey` digest for a shared backend, and that digest plus the
+connection's `stub_uuid` for a private one. The spool record binds
+`storage_digest` rather than recomputing the `PoolKey` hash, so the exact-match
+guarantee `get_by_digest` exists to provide survives: without the discriminator,
+two private backends for one server would share a digest and an app callback
+could execute against another session's process.
+
+Private backends live in their own map keyed by `stub_uuid`, separate from the
+shared index. An entry there is never a reuse candidate — that is the point — and
+the register payload's `poolable` field selects between the two paths at the
+single acquisition site.
+
+## Lifecycle: no new mechanism
+
+A private backend has exactly one stub attached, so its refcount is 1 for its
+whole life. Its stub disconnecting is therefore the end of its life, and the
+connection-teardown path releases and shuts it down there. Because it is
+deliberately outside the pooling maps, no sweeper is watching it, so the release
+is unconditional on every disconnect and a no-op for a pooled stub.
+
+No session-end hook and no bespoke TTL are required. That falls out of binding to
+the connection rather than to a session identifier.
+
+## Decision: private backends do not count against `max_backends`
+
+`max_backends` defaults to 64. Connection-private backends are excluded from that
+budget, and `stats()` reports their count separately so they stay visible.
+
+The conceptual reason: a private backend is a process the host would have had
+anyway with no gateway at all. Counting it against the *pooling* budget makes the
+choice not to pool subject to a pooling limit.
+
+The mechanical reason is stronger. Eviction only ever selects idle entries —
+refcount 0 and unreserved. A private backend is refcount-1 for its entire life,
+so it is **never** an eligible victim. If private entries shared the budget they
+would accumulate as unevictable occupants until `add()` could find no victim at
+all — at which point it raises `PoolAtCapacity` and a new **poolable** session is
+refused. Sharing the budget converts resource pressure into a hard denial on the
+shared path, caused entirely by connections that opted out of sharing.
+
+Excluding them keeps the failure modes separate: pooling pressure stays a pooling
+concern, and per-connection backends fail the way they would without a gateway —
+by exhausting host resources, observably, rather than by silently rejecting an
+unrelated session.
+
+## Costs this accepts
+
+- **Process count.** Servers off the allowlist become one backend per ACP
+  connection instead of one shared. That is the no-gateway baseline, not a
+  regression, but it is a real change from today's collapsed count. `stats()`
+  exposes the count; it is not otherwise capped, which is the deliberate
+  consequence of the decision above.
+- **Head-of-line blocking gets more reachable.** More traffic crossing the stub
+  seam means more traffic through a pooled backend's single-worker dispatch,
+  where `ping` and `tools/list` bypass the queue and answer healthy while tool
+  calls serialise. That defect is tracked separately and is not introduced here,
+  but this change widens the set of paths that can hit it.
+
+## Out of scope
+
+- Changing `PoolKey`. It gains no dimension, in this change or any other.
+- `UNPOOLABLE_SERVERS` — Kiro Crew's own MCP servers, which bind to
+  `KIROCREW_SESSION_KEY` and are passed through unwrapped. They are already
+  per-session by construction; giving them stubs is a separate change.
+- HTTP/SSE MCP entries. They need no stub and stay raw in the settings overlay.
+- Per-server MCP Apps control. Orthogonal to stub emission.

--- a/docs/system-specs/modules/mcp-apps.md
+++ b/docs/system-specs/modules/mcp-apps.md
@@ -1,8 +1,8 @@
 # MCP Apps (SEP-1865 interactive app rendering via gatewayd)
 
-Interactive MCP Apps: a pooled MCP server declares a `ui://` resource on a tool; when that tool's result flows through gatewayd, the gateway fetches the app's HTML document, spools it to disk, and injects an opaque marker into the result text. The dashboard intercepts the marker, renders the app inline at the tool-call transcript row inside a sandboxed null-origin iframe, and relays the app's `tools/call` requests back through the gateway under a deny-by-default visibility gate.
+Interactive MCP Apps: an MCP server declares a `ui://` resource on a tool; when that tool's result flows through gatewayd, the gateway fetches the app's HTML document, spools it to disk, and injects an opaque marker into the result text. The dashboard intercepts the marker, renders the app inline at the tool-call transcript row inside a sandboxed null-origin iframe, and relays the app's `tools/call` requests back through the gateway under a deny-by-default visibility gate.
 
-Producer side is gated by the `KIROCREW_MCP_APPS` env flag (default OFF — flag off is byte-identical legacy behavior). The dashboard consumer side is flag-independent: a marker that appears is handled.
+Producer side is gated by `mcp_gateway.apps_enabled` (default ON), with `KIROCREW_MCP_APPS` as an explicit override in both directions (off value wins over config; on value forces the feature). It is independent of `mcp_gateway.enabled`, which governs whether backends are SHARED: a stub is interposed on every stdio server either way, so a server with a connection-private backend renders apps normally. The dashboard consumer side is flag-independent: a marker that appears is handled.
 
 ## The four durable contracts
 

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -3458,8 +3458,13 @@ class McpGatewayConfig:
     enabled: bool = field(
         default=False,
         metadata=_meta(
-            "Enabled",
-            "Route MCP traffic through the shared sidecar broker. Default False — opt-in.",
+            "Share MCP Backends",
+            "Let sessions with an identical server configuration share one MCP "
+            "server process instead of each getting its own. Off, every session "
+            "gets its own backend — the same process topology as running without "
+            "the broker. Either this or MCP Apps starts the broker; see "
+            "docs/architecture/design-notes/mcp-stub-decoupling.md. "
+            "Default False — opt-in.",
         ),
     )
     apps_enabled: bool = field(
@@ -3467,10 +3472,13 @@ class McpGatewayConfig:
         metadata=_meta(
             "MCP Apps",
             "Render interactive HTML returned by an MCP server (the MCP Apps "
-            "extension) in chat, and accept callbacks from it. Requires the broker: "
-            "the render and callback paths live inside it, so this grants nothing "
-            "while Enabled is off. Default True — turning it off keeps pooling and "
-            "suppresses only server-authored UI.",
+            "extension) in chat, and accept callbacks from it. Independent of "
+            "backend sharing: the broker starts for either, and callbacks are "
+            "routed by a stub that is interposed on every stdio server whether or "
+            "not its backend is shared. Either this or backend sharing starts the "
+            "broker; see docs/architecture/design-notes/mcp-stub-decoupling.md. "
+            "Default True — turning it off suppresses "
+            "server-authored UI and leaves sharing untouched.",
         ),
     )
     forward_declared_env: bool = field(
@@ -5867,10 +5875,14 @@ class KiroCrewConfig:
         # configured default instead of the provider/model default.
         default_effort = self.agent.reasoning_effort
 
-        # MCP gateway: resolve overlay + socket once when enabled. None when
-        # the feature flag is off -> AcpClient falls through to per-session MCP.
+        # MCP gateway: resolve overlay + socket once when the stub layer is
+        # needed. The stub is the addressing layer MCP Apps routes callbacks
+        # through, so it is required whenever EITHER pooling or MCP Apps is on —
+        # with pooling off the stubs are still emitted, each connection just
+        # gets its own backend. None only when neither is on -> AcpClient falls
+        # through to per-session MCP with no gateway in the path at all.
         _gw = self.mcp_gateway
-        if _gw.enabled:
+        if _gw.enabled or _gw.apps_enabled:
             _gw_overlay = _gw.overlay_dir or str(default_overlay_dir())
             _gw_socket = _gw.socket_path or str(default_socket_path())
             _gw_settings = str(Path(_gw_overlay).parent / "settings" / "mcp.json")

--- a/src/kiro_crew/docs/mcp-apps.md
+++ b/src/kiro_crew/docs/mcp-apps.md
@@ -31,14 +31,15 @@ Both live on the **Developer** page (sidebar → **Developer**):
    new MCP routing, so in-flight agent work is interrupted — do it between tasks,
    not mid-turn. Your dashboard stays signed in. The toggle asks for confirmation
    and offers a roll-back.
-2. **In "Poolable MCP servers," switch on the server whose app you want.** The
-   toggle writes the central allowlist and re-applies it in-process — no restart.
-   You can set this up before enabling the gateway; it simply has no effect until
-   the gateway is on.
+2. **Nothing else is required for apps.** "Share MCP Backends" and the poolable
+   allowlist decide whether several sessions reuse one MCP server *process* —
+   a resource choice, independent of whether apps render. A server that is not
+   shared still renders its apps.
 
-   A row is **read-only** when the server can't be pooled: it's denylisted, its
-   transport isn't stdio (HTTP servers aren't poolable), or it's already poolable
-   via its own `poolable: true` and so isn't governed by the allowlist.
+   A row in the allowlist is **read-only** when the server can't be shared: it's
+   denylisted, its transport isn't stdio (HTTP servers aren't shared), or it's
+   already opted in via its own `poolable: true` and so isn't governed by the
+   allowlist.
 
 Optionally, to render apps in the right side panel instead of inline, turn on
 **Settings → Chat → Messages → "MCP Apps in Side Panel."** No restart or refresh
@@ -50,9 +51,16 @@ For scripted or headless setups:
 
 ```json
 {
-  "mcp_gateway": { "enabled": true, "poolable_servers": ["excalidraw"] },
+  "mcp_gateway": { "apps_enabled": true },
   "dashboard":   { "mcp_app_panel": true }
 }
+```
+
+`apps_enabled` defaults to `true`, so an untouched config already renders apps.
+Backend sharing is a separate, opt-in decision:
+
+```json
+{ "mcp_gateway": { "enabled": true, "poolable_servers": ["excalidraw"] } }
 ```
 
 A server can also opt itself in from its own MCP entry, which is the escape hatch
@@ -62,16 +70,16 @@ for third-party configs you don't want to duplicate into the allowlist:
 { "mcpServers": { "excalidraw": { "command": "...", "poolable": true } } }
 ```
 
-MCP Apps have **no enablement flag of their own** — they follow
-`mcp_gateway.enabled`. The full resolution order in `_mcp_apps_enabled()` is:
+MCP Apps have their own switch, `mcp_gateway.apps_enabled`, independent of
+backend sharing. The full resolution order in `_mcp_apps_enabled()` is:
 
 | Condition | Result |
 |---|---|
 | `KIROCREW_MCP_APPS` = `0`/`false`/`no`/`off` | disabled (explicit kill-switch, wins over everything) |
 | `KIROCREW_MCP_APPS` = `1`/`true`/`yes` | enabled (explicit override — tests, e2e harness) |
-| `KIROCREW_MCP_APPS` unset | follows `mcp_gateway.enabled`, read **live** from config |
+| `KIROCREW_MCP_APPS` unset | follows `mcp_gateway.apps_enabled`, read **live** from config |
 
-Read live per call, so toggling the gateway takes effect without restarting the
+Read live per call, so toggling the feature takes effect without restarting the
 daemon.
 
 ### Worked example: excalidraw diagrams
@@ -80,23 +88,21 @@ The excalidraw MCP server ships a `ui://` app, so it is the quickest way to see
 this working end to end:
 
 1. Add the server to your MCP config as usual and confirm the agent can call it.
-2. **Developer → Shared MCP gateway → on.**
-3. **Developer → Poolable MCP servers → `excalidraw` → on.**
-4. Ask for a diagram: *"draw me a sequence diagram of the login flow."*
+2. Ask for a diagram: *"draw me a sequence diagram of the login flow."*
 
 You should get a live, editable Excalidraw canvas in the chat — hand-drawn shapes
-that animate in as they stream, which you can then drag around and edit. If you
-instead get a wall of JSON-ish text, step 3 is almost certainly the one that
-didn't take.
+that animate in as they stream, which you can then drag around and edit.
 
-**Why the poolable gate is the usual culprit:** a server that isn't poolable is
-parented to `kiro-cli` and never passes through the gateway, so nothing intercepts
-its result. The tool still works — you just get its text. There is no error
-message, which is exactly what makes it confusing.
+**If you get a wall of JSON-ish text instead:** nothing intercepted the result.
+Check `KIROCREW_MCP_APPS` is not set to an off value and that
+`mcp_gateway.apps_enabled` is on — those are the only two switches that govern
+rendering. There is no error message when a result goes un-intercepted, which is
+what makes it confusing: the tool still worked, you just got its text.
 
-**Not every server should be pooled.** A pooled backend is shared across
-sessions, so a server that reads per-session credentials or env vars from its own
-process environment must stay unpooled.
+**Sharing is a separate question.** A shared backend serves several sessions from
+one process, so a server that reads per-session credentials or env vars from its
+own process environment should stay unshared. That choice does not affect whether
+its apps render.
 
 ## Where apps render: inline or side panel
 
@@ -230,10 +236,10 @@ app HTML is **server-controlled code running in your dashboard**.
 
 | Symptom | Most likely cause |
 |---|---|
-| Tool output renders as plain text | the server is not switched on in **Developer → Poolable MCP servers** — check this first |
-| Still text after enabling the server | the **Shared MCP gateway** toggle is off, or `KIROCREW_MCP_APPS` is set to an off value and is overriding it |
-| The gateway toggle is disabled / greyed out | you're on Windows — the shared gateway needs Unix-domain sockets (macOS and Linux only) |
-| A server's poolable row won't toggle | it's denylisted, or not stdio transport (HTTP servers can't be pooled), or already poolable via its own `poolable: true` |
+| Tool output renders as plain text | `mcp_gateway.apps_enabled` is off, or `KIROCREW_MCP_APPS` is set to an off value and is overriding it |
+| Still text with both of those right | the broker did not start — check the gateway log for `mcp-gateway: broker ready`, which names the switch that started it |
+| The gateway toggle is disabled / greyed out | you're on Windows — the broker needs Unix-domain sockets (macOS and Linux only) |
+| A server's sharing row won't toggle | it's denylisted, or not stdio transport (HTTP servers can't be shared), or already opted in via its own `poolable: true` |
 | Frame mounts but the canvas is blank | the app's scripts did not execute — check the browser console for CSP or network errors reaching its CDN |
 | Feature toggle missing from Settings | stale frontend bundle — hard-refresh the dashboard |
 | A new render appears inline despite `mcp_app_panel: true` | the flag is read at render time; diagrams already in scrollback do not move |

--- a/src/kiro_crew/mcp_gateway/backend.py
+++ b/src/kiro_crew/mcp_gateway/backend.py
@@ -340,9 +340,10 @@ def _mcp_apps_enabled() -> bool:
         return False
     if not gw.apps_enabled:
         return False
-    if override is True:
-        return True
-    return bool(gw.enabled)
+    # Deliberately NOT gated on ``gw.enabled``: pooling decides whether backends
+    # are shared, not whether the stub exists. The stub carries the app-call
+    # relay either way.
+    return True
 
 
 def _inject_client_extensions(msg: dict[str, Any]) -> dict[str, Any]:
@@ -436,6 +437,12 @@ class Backend:
     _stub_inboxes: dict[str, "asyncio.Queue[bytes]"] = field(default_factory=dict)
     _inbox_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     refcount: int = 0
+    # Non-empty on a backend bound to a single connection, holding that
+    # connection's ``stub_uuid``. It makes ``storage_digest`` unique per
+    # connection: PoolKey is identical across connections to the same server, so
+    # without this discriminator two private backends would share a digest and
+    # an app callback could resolve onto the wrong session's process.
+    exclusive_token: str = ""
     # ``pinned`` marks a backend that the warm-pool prewarmer created ahead of
     # any stub. Such a backend sits at ``refcount == 0`` indefinitely (no stub
     # stays attached to it between chats), so the ordinary idle/LRU rules would
@@ -563,6 +570,19 @@ class Backend:
         queued = sum(inbox.qsize() for inbox in list(self._stub_inboxes.values()))
         unfinished_apps = sum(1 for task in self._apps_tasks if not task.done())
         return len(self._pending_requests) + unfinished_apps + queued
+
+    @property
+    def storage_digest(self) -> str:
+        """The pool's key for this backend, and the identity an app callback
+        resolves against.
+
+        Equal to the PoolKey digest for a shared backend -- two connections that
+        may share a process resolve to the same entry, which is the point. A
+        connection-private backend appends its ``exclusive_token`` so it is
+        addressable without being reachable from any other connection.
+        """
+        base = self.pool_key.stable_hash()
+        return f"{base}:{self.exclusive_token}" if self.exclusive_token else base
 
     @staticmethod
     def _now() -> float:
@@ -1436,7 +1456,7 @@ class Backend:
                 # an app can only ever call back into the same pool partition
                 # (same credentials/sandbox/approval identity) that produced
                 # it — never a co-pooled tenant's backend for the same server.
-                "pool_digest": self.pool_key.stable_hash(),
+                "pool_digest": self.storage_digest,
                 "html": html,
                 "csp": csp,
                 "permissions": permissions,

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -129,6 +129,19 @@ _MAX_FRAME_BYTES = READ_BUFFER_LIMIT_BYTES  # 1 MiB; see pool.READ_BUFFER_LIMIT_
 # accumulating half-open connections that never send anything.
 _REGISTER_TIMEOUT_SECS = 5.0
 
+# Advertised to every stub in the Registered reply so it can negotiate rather
+# than assume. Each entry means "this daemon implements it":
+#   ensure_backend — the pre-flight control frame
+#   bridge_ping    — the bridge-phase liveness monitor
+#   poolable_ack   — the register payload's ``poolable`` field is READ. A stub
+#                    that asked for a private backend has no other way to tell:
+#                    a daemon predating the field ignores it and routes the
+#                    register through the shared index, silently co-tenanting a
+#                    server the operator never allowlisted. Such a daemon is
+#                    reachable, because the manager adopts anything answering
+#                    ``pong`` with no version handshake — so one that outlived a
+#                    package upgrade serves new stubs.
+REGISTERED_CAPABILITIES: tuple[str, ...] = ("ensure_backend", "bridge_ping", "poolable_ack")
 # Upper bound on a single control/handshake reply's ``drain()`` (pong, stats,
 # registered, rejected, ready, forward-error — everything sent via
 # ``_write_json_line``). ``_REGISTER_TIMEOUT_SECS`` only bounds the inbound
@@ -966,7 +979,7 @@ def _has_outstanding_work(pool: BackendPool) -> bool:
 
 
 def _declared_non_secret_env(pool_key: PoolKey) -> dict[str, str]:
-    """Return the FORWARDABLE declared env for ``pool_key``, or ``{}``.
+    """Return the FORWARDABLE declared env for a SHARED ``pool_key``, or ``{}``.
 
     Reads the ``0600`` sidecar the rewriter wrote for this ``(agent, server)``
     and applies two independent filters:
@@ -982,6 +995,21 @@ def _declared_non_secret_env(pool_key: PoolKey) -> dict[str, str]:
 
     What survives is operator-declared, non-secret, and part of the PoolKey —
     every session sharing this backend agrees on it by construction.
+
+    BLOCKING: reads a file. Callers must run it off the event loop.
+    """
+    pairs = _declared_env_pairs(pool_key)
+    return {
+        k: v for k, v in non_secret_env(pairs).items() if not is_credential_env_key(k)
+    }
+
+
+def _declared_env_pairs(pool_key: PoolKey) -> dict[str, str]:
+    """Return the declared env sidecar's contents for ``pool_key``, or ``{}``.
+
+    Unfiltered, but coherence-gated: a sidecar whose contents no longer hash to
+    ``pool_key.effective_env_hash`` yields ``{}``. Callers apply whatever
+    co-tenancy filtering their acquisition path requires.
 
     BLOCKING: reads a file. Callers must run it off the event loop.
     """
@@ -1028,9 +1056,31 @@ def _declared_non_secret_env(pool_key: PoolKey) -> dict[str, str]:
             pool_key.server_name,
         )
         return {}
-    return {
-        k: v for k, v in non_secret_env(pairs).items() if not is_credential_env_key(k)
-    }
+    return pairs
+
+
+def _declared_env_for_private_backend(pool_key: PoolKey) -> dict[str, str]:
+    """Return the declared env for a CONNECTION-PRIVATE backend, or ``{}``.
+
+    A private backend has exactly one stub, so both filters that
+    :func:`_declared_non_secret_env` applies are inapplicable by construction:
+    there is no co-tenant that could disagree on a rotating secret's value, and
+    the credential scrub exists to stop one session's credentials reaching
+    another session's backend. Here the declaring session and the only consuming
+    session are the same one.
+
+    Nor is this gated on ``forward_declared_env``: that switch exists to let an
+    operator accept the co-tenancy hazard for POOLED backends. Withholding the
+    env here would instead be a regression — the same server spawned without a
+    gateway gets its declared env from the agent runtime, so a private backend
+    that silently dropped it would break servers that work today.
+
+    The coherence gate still applies: a sidecar edited after this session
+    started yields ``{}`` rather than values the running stub never hashed.
+
+    BLOCKING: never call this on the event loop.
+    """
+    return _declared_env_pairs(pool_key)
 
 
 def _declared_env_to_forward(pool_key: PoolKey) -> dict[str, str]:
@@ -1838,6 +1888,27 @@ async def _handle_connection(
         return
 
     stub_uuid = str(register.get("stub_uuid", ""))
+    # Absent ``poolable`` means this connection gets its own backend. Absence is
+    # the safe default in both directions: an overlay written before the flag
+    # existed never silently starts sharing, and a malformed frame cannot widen
+    # a connection's blast radius beyond itself.
+    exclusive_stub_uuid = "" if register.get("poolable") is True else stub_uuid
+
+    def _release_reservation() -> None:
+        """Release the hand-out reservation this connection actually took.
+
+        A private backend takes none: it never enters the shared index, so no
+        sweeper can reclaim it between hand-out and attach. Releasing one anyway
+        would be actively harmful — the reservation refcount is per DIGEST, and
+        ``poolable`` is not a PoolKey dimension, so a pooled connection with an
+        identical PoolKey shares the digest. That pairing is reachable whenever
+        the allowlist changes under a daemon that outlives the gateway: the old
+        overlay's stub still registers poolable while the new one does not. The
+        stray decrement would drop the pooled connection's eviction protection
+        before its stub attaches.
+        """
+        if not exclusive_stub_uuid:
+            pool.unreserve(pool_key)
     if not stub_uuid:
         await _write_json_line(
             writer,
@@ -1944,7 +2015,7 @@ async def _handle_connection(
             # the frame would fall through to the forward path and no pong would
             # ever return — turning any call slower than the grace window into a
             # forced degrade of a perfectly healthy pooled session.
-            "capabilities": ["ensure_backend", "bridge_ping"],
+            "capabilities": list(REGISTERED_CAPABILITIES),
         },
     )
     logger.info(
@@ -2102,7 +2173,10 @@ async def _handle_connection(
                 if backend is None:
                     _acquire_t0 = time.monotonic()
                     try:
-                        backend, _was_spawned = await _acquire_backend(pool, pool_key, resolver)
+                        backend, _was_spawned = await _acquire_backend(
+                            pool, pool_key, resolver,
+                            exclusive_stub_uuid=exclusive_stub_uuid,
+                        )
                         # acquire-only duration, captured before the attach_stub
                         # + create_task overhead so the metric stays true to name.
                         _acquire_ms = (time.monotonic() - _acquire_t0) * 1000.0
@@ -2180,9 +2254,9 @@ async def _handle_connection(
                     try:
                         inbox = await backend.attach_stub(stub_uuid)
                     finally:
-                        # Release the hand-out reservation; once attached
-                        # refcount>0 keeps the backend from eviction.
-                        pool.unreserve(pool_key)
+                        # Once attached, refcount>0 keeps the backend from
+                        # eviction, so the hand-out reservation can go.
+                        _release_reservation()
                     writer_task = asyncio.create_task(
                         _drain_inbox_to_stub(inbox, writer, stub_uuid),
                         name=f"mcp-gateway-stub-writer-{stub_uuid[:8]}",
@@ -2199,7 +2273,10 @@ async def _handle_connection(
             if backend is None:
                 _lazy_t0 = time.monotonic()
                 try:
-                    backend, _lazy_was_spawned = await _acquire_backend(pool, pool_key, resolver)
+                    backend, _lazy_was_spawned = await _acquire_backend(
+                        pool, pool_key, resolver,
+                        exclusive_stub_uuid=exclusive_stub_uuid,
+                    )
                     # acquire/spawn-only duration, captured before the attach +
                     # create_task overhead.
                     _lazy_elapsed_ms = (time.monotonic() - _lazy_t0) * 1000.0
@@ -2258,7 +2335,7 @@ async def _handle_connection(
                 try:
                     inbox = await backend.attach_stub(stub_uuid)
                 finally:
-                    pool.unreserve(pool_key)
+                    _release_reservation()
                 writer_task = asyncio.create_task(
                     _drain_inbox_to_stub(inbox, writer, stub_uuid),
                     name=f"mcp-gateway-stub-writer-{stub_uuid[:8]}",
@@ -2370,6 +2447,21 @@ async def _handle_connection(
             # Scope B: if quarantined and now drained, recycle
             elif remaining == 0 and backend.quarantined:
                 await backend.recycle_if_idle()
+        # A connection-private backend has no second consumer to wait for and no
+        # reuse value, so its stub going away is the end of its life. Reap it
+        # here rather than leaving it to a sweeper: it is deliberately outside
+        # the pooling maps, so no sweeper is watching it. A no-op for a pooled
+        # stub, which is why it is unconditional. Fully suppressed: this runs in
+        # ``finally``, where raising would skip the writer-task cancel below and
+        # mask whatever ended the connection.
+        try:
+            orphan = await pool.release_exclusive(stub_uuid)
+            if orphan is not None:
+                await orphan.shutdown(timeout=2.0)
+        except Exception:
+            logger.warning(
+                "releasing private backend for stub %s failed", stub_uuid, exc_info=True
+            )
         if writer_task is not None:
             writer_task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
@@ -2380,6 +2472,8 @@ async def _acquire_backend(
     pool: BackendPool,
     pool_key: PoolKey,
     resolver: TargetResolver,
+    *,
+    exclusive_stub_uuid: str = "",
 ) -> tuple[Backend, bool]:
     """Return ``(backend, was_spawned)`` for ``pool_key`` — spawning one via
     the resolver if absent.
@@ -2389,6 +2483,11 @@ async def _acquire_backend(
     set inside ``pool.get_or_create`` under the per-key create lock, so it is
     the authoritative, race-free signal of a real spawn — callers can gate a
     spawn-only SEL audit on it without a racy ``pool.get()`` pre-check.
+
+    ``exclusive_stub_uuid`` non-empty routes to a backend bound to that
+    connection alone: no reuse lookup, no pooling capacity budget, and released
+    when the connection ends. ``was_spawned`` is then always ``True``, because a
+    private backend has nothing to reuse by construction.
 
     Raises :class:`_TargetUnknown` when the resolver has no mapping for the
     server (a clean rejection, not a crash).
@@ -2413,7 +2512,11 @@ async def _acquire_backend(
         # the flag check reads config and the sidecar read touches the
         # filesystem, either of which would stall gateway traffic and heartbeat
         # processing if done inline after a config invalidation.
-        declared = await asyncio.to_thread(_declared_env_to_forward, pool_key)
+        declared = await asyncio.to_thread(
+            _declared_env_for_private_backend if exclusive_stub_uuid
+            else _declared_env_to_forward,
+            pool_key,
+        )
         if declared:
             # Declared env wins over the daemon's inherited value: the
             # operator wrote it in the agent spec for this server. Safe to
@@ -2424,6 +2527,8 @@ async def _acquire_backend(
                 "forwarding %d declared env key(s) to backend %s: %s",
                 len(declared),
                 pool_key.server_name,
+                # Key NAMES only. A private backend forwards secret-bearing keys
+                # too, so no value may reach the log.
                 ", ".join(sorted(declared)),
             )
         backend = await spawn_backend(
@@ -2441,6 +2546,10 @@ async def _acquire_backend(
             name=f"mcp-gateway-backend-stdout-{backend.pid}",
         )
         return backend
+
+    if exclusive_stub_uuid:
+        backend = await pool.acquire_exclusive(pool_key, exclusive_stub_uuid, _spawn)
+        return backend, was_spawned
 
     backend = await pool.get_or_create(pool_key, _spawn)
     return backend, was_spawned
@@ -2510,7 +2619,12 @@ async def _respawn_backend_for_stub(
         return None
 
     try:
-        new_backend, _ = await _acquire_backend(pool, pool_key, resolver)
+        new_backend, _ = await _acquire_backend(
+            pool, pool_key, resolver,
+            # A respawn must not silently promote a private backend into the
+            # shared bucket: the replacement inherits the original binding.
+            exclusive_stub_uuid=stub_uuid if old_backend.exclusive_token else "",
+        )
     except (_TargetUnknown, BackendUnavailable, PoolAtCapacity, OSError) as exc:
         logger.info(
             "respawn give-up (acquire rejected) stub=%s pool=%s: %s",
@@ -2544,7 +2658,11 @@ async def _respawn_backend_for_stub(
             return None
         new_inbox = await new_backend.attach_stub(stub_uuid)
     finally:
-        pool.unreserve(pool_key)
+        # A private backend never took a reservation, and releasing one would
+        # decrement a POOLED connection sharing this digest (see
+        # ``_release_reservation`` in the connection handler).
+        if not old_backend.exclusive_token:
+            pool.unreserve(pool_key)
     new_writer_task = asyncio.create_task(
         _drain_inbox_to_stub(new_inbox, writer, stub_uuid),
         name=f"mcp-gateway-stub-writer-{stub_uuid[:8]}",

--- a/src/kiro_crew/mcp_gateway/pool.py
+++ b/src/kiro_crew/mcp_gateway/pool.py
@@ -447,6 +447,16 @@ class BackendPool:
         # requests but are invisible to acquire. The heartbeat sweeper reaps
         # them on refcount==0 or deadline expiry.
         self._draining: list[_DrainingBackend] = []
+        # Backends bound to ONE connection, keyed by stub_uuid. Deliberately a
+        # separate map from ``_backends``: an entry here is never a reuse
+        # candidate (that is the point), sits at refcount 1 for its whole life,
+        # and is released when its stub disconnects rather than by the idle or
+        # LRU sweeper. Keeping it out of ``_backends`` also keeps it out of the
+        # ``_max_backends`` budget — a refcount-1 backend can never be an
+        # eviction victim, so counting these would let them accumulate as
+        # unevictable occupants until a new SHARED acquire finds nothing to
+        # evict and is rejected outright.
+        self._exclusive: dict[str, "Backend"] = {}
         # Blue-green cutover generation. Bumped on every drain so an in-flight
         # spawn that started before a credential rotation can detect that a
         # cutover landed while it was suspended and refuse to pool its
@@ -472,6 +482,10 @@ class BackendPool:
             "spawns": self._spawns,
             "capacity_rejects": self._capacity_rejects,
             "draining": len(self._draining),
+            # Reported separately because these sit outside ``max_backends`` by
+            # design: an operator reading "size" against the budget would
+            # otherwise have no way to see the per-connection processes at all.
+            "exclusive": len(self._exclusive),
         }
 
     def _metrics_snapshot(self) -> dict[str, Any]:
@@ -567,6 +581,10 @@ class BackendPool:
         """
         pids = [b.pid for b in self._backends.values() if b.pid is not None]
         pids.extend(e.backend.pid for e in self._draining if e.backend.pid is not None)
+        # Connection-private backends are ordinary child processes; being outside
+        # the reuse index and the capacity budget does not make them any less
+        # orphanable by a SIGKILLed gatewayd.
+        pids.extend(b.pid for b in self._exclusive.values() if b.pid is not None)
         return pids
 
     async def add(
@@ -793,7 +811,7 @@ class BackendPool:
             return self._backends.get(digest)
 
     async def get_by_digest(self, digest: str) -> Optional["Backend"]:
-        """Return the ALIVE backend whose PoolKey digest is exactly ``digest``.
+        """Return the ALIVE backend whose storage digest is exactly ``digest``.
 
         Used by the MCP Apps ``app-call`` control path: the spool record binds
         the PRODUCING backend's full PoolKey digest, and the callback resolves
@@ -802,12 +820,87 @@ class BackendPool:
         (different credentials / sandbox / approval identity) — an exact-digest
         match makes cross-partition execution impossible; a dead or evicted
         backend is a plain deny, never a fallback.
+
+        A per-connection backend's storage digest carries its ``stub_uuid``, so
+        two connections to the same server under an identical PoolKey do NOT
+        share a digest. That is what preserves the exact-match guarantee here:
+        without it an app callback could resolve onto another session's private
+        backend for the same server.
         """
         async with self._lock:
             backend = self._backends.get(digest)
+            if backend is None:
+                backend = next(
+                    (b for b in self._exclusive.values() if b.storage_digest == digest),
+                    None,
+                )
         if backend is not None and backend.is_alive:
             return backend
         return None
+
+    def _spawn_shutdown(self, backend: "Backend") -> None:
+        """Reap ``backend`` on the event loop without awaiting it here.
+
+        Used where the caller may itself be cancelled: an ``await`` on a
+        cancelled task re-raises before the shutdown runs, leaking the child.
+        The task is strongly referenced until done, since the loop holds only a
+        weak reference to a bare ``create_task``.
+        """
+        task = asyncio.create_task(_safe_shutdown(backend))
+        self._shutdown_tasks.add(task)
+        task.add_done_callback(self._shutdown_tasks.discard)
+
+    async def acquire_exclusive(
+        self,
+        key: PoolKey,
+        stub_uuid: str,
+        spawn: Callable[[], Awaitable["Backend"]],
+    ) -> "Backend":
+        """Spawn a backend bound to ``stub_uuid`` alone and register it.
+
+        Never consults ``_backends``, so an identical PoolKey arriving on
+        another connection can never resolve onto this backend. Also skips the
+        ``_max_backends`` budget -- this is the process topology the host would
+        have with no gateway at all, and subjecting it to the pooling capacity
+        limit would let opted-out connections reject pooled ones.
+
+        The caller MUST call :meth:`release_exclusive` when the connection ends.
+        """
+        backend = await spawn()
+        # Before registering: ``storage_digest`` derives from this, and both the
+        # app-call resolver and the spool record read it the moment the backend
+        # is reachable.
+        backend.exclusive_token = stub_uuid
+        try:
+            async with self._lock:
+                existing = self._exclusive.pop(stub_uuid, None)
+                self._exclusive[stub_uuid] = backend
+                self._spawns += 1
+        except BaseException:
+            # Between spawn() returning and registration completing the child is
+            # reachable from NOTHING: not the connection teardown, not
+            # shutdown_all. Acquiring ``_lock`` can yield, so a cancel landing
+            # here would leak the process. Reap it on the way out, as a tracked
+            # task rather than an await — this handler may itself be cancelled,
+            # and an await would re-raise before the shutdown ran.
+            self._spawn_shutdown(backend)
+            raise
+        if existing is not None:
+            # stub_uuid is a fresh uuid4 per connection, so this means the same
+            # connection registered twice. Reap the loser rather than orphaning
+            # a live subprocess by overwriting the entry.
+            await _safe_shutdown(existing)
+        return backend
+
+    async def release_exclusive(self, stub_uuid: str) -> Optional["Backend"]:
+        """Unregister ``stub_uuid``'s private backend and return it for shutdown.
+
+        Returns ``None`` when the connection had no private backend -- the
+        normal case for a pooled stub, which makes this safe to call
+        unconditionally on every disconnect.
+        """
+        async with self._lock:
+            return self._exclusive.pop(stub_uuid, None)
 
     def reserve(self, key: PoolKey) -> None:
         """Mark ``key`` as in-flight (handed out, not yet attached).
@@ -1079,8 +1172,19 @@ class BackendPool:
         calls until refcount-0 or the drain deadline). Omitting them would let a
         stop/abort during the drain window miss in-flight calls on the old
         backend, which would then run to completion instead of being cancelled.
+
+        Includes connection-private backends for the same reason. They are held
+        apart from ``_backends`` to keep them out of the reuse index and the
+        capacity budget — not out of the process lifecycle. Omitting them here
+        would let a shutdown decide no work is outstanding and discard a private
+        backend's pending reply, and would leave a stop/abort unable to cancel
+        its in-flight calls.
         """
-        return list(self._backends.values()) + [e.backend for e in self._draining]
+        return (
+            list(self._backends.values())
+            + [e.backend for e in self._draining]
+            + list(self._exclusive.values())
+        )
 
     async def shutdown_all(self, timeout: float = 5.0) -> None:
         """Shut down every registered backend and clear the pool.
@@ -1094,9 +1198,14 @@ class BackendPool:
             backends = list(self._backends.values())
             # Also collect draining backends so they don't leak on shutdown.
             backends.extend(entry.backend for entry in self._draining)
+            # Per-connection backends are reaped on their stub's disconnect, but
+            # a daemon teardown races that — collect them or they outlive the
+            # gateway as orphans holding their pipes open.
+            backends.extend(self._exclusive.values())
             self._backends.clear()
             self._spawn_locks.clear()
             self._draining.clear()
+            self._exclusive.clear()
             pending = list(self._shutdown_tasks)
         # Shutdowns are independent: fan out + join with gather.
         # ``return_exceptions=True`` keeps one slow/bad backend from

--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -74,6 +74,7 @@ def _build_stub_entry(
     sandbox_mode: str,
     approval_mode: str,
     sidecars_written: set[str] | None = None,
+    poolable: bool = False,
 ) -> dict[str, Any]:
     """Return the rewritten ``mcpServers[name]`` entry.
 
@@ -133,9 +134,20 @@ def _build_stub_entry(
         "--approval-mode", approval_mode,
         "--socket", str(socket_path),
     ]
+    if poolable:
+        stub_args.append("--poolable")
     if env_pairs:
         secret_key_count = sum(1 for k in env_pairs if is_secret_env_key(k))
-        if forward_declared_env_enabled():
+        if not poolable:
+            # A connection-private backend has exactly one stub, so both reasons
+            # the pooled path withholds declared env are absent: no co-tenant can
+            # disagree on a rotating secret, and there is no other session whose
+            # backend could receive these credentials. gatewayd forwards the block
+            # in full. Nothing to warn about — and warning here would be worse
+            # than noise, since the pooled advice ("stop sharing this server")
+            # names a state this server is already in.
+            pass
+        elif forward_declared_env_enabled():
             # Forwarding is ON: the non-secret keys ARE applied to the pooled
             # backend (gatewayd merges them at spawn). Only the rotating-secret
             # keys remain unappliable, because they are excluded from
@@ -148,25 +160,25 @@ def _build_stub_entry(
                 # (clear-text logging of sensitive information), and the server
                 # + agent names are enough for the operator to find the spec.
                 logger.warning(
-                    "rewriter: pooled server %r for agent %r declares "
+                    "rewriter: shared server %r for agent %r declares "
                     "rotating-secret env key(s) that are NOT applied to the "
-                    "shared pooled backend — they are excluded from the PoolKey, "
-                    "so co-tenant sessions may disagree on the value. The backend "
-                    "must read them from disk, or set poolable:false.",
+                    "shared backend — they are excluded from the PoolKey, so "
+                    "co-tenant sessions may disagree on the value. The backend "
+                    "must read them from disk, or stop sharing this server.",
                     server_name, agent_name,
                 )
         else:
             # Forwarding is OFF (the default): the declared env is folded into
             # the PoolKey hash (so differing-env sessions never share a backend)
-            # but is NOT applied to the pooled backend — gatewayd spawns it with
+            # but is NOT applied to the shared backend — gatewayd spawns it with
             # the daemon's own scrubbed environment. A server that genuinely
-            # depends on its declared env will misbehave when pooled.
+            # depends on its declared env will misbehave when shared.
             logger.warning(
-                "rewriter: pooled server %r for agent %r declares a non-empty env "
-                "(%d keys); the declared env is NOT applied to the shared pooled "
+                "rewriter: shared server %r for agent %r declares a non-empty env "
+                "(%d keys); the declared env is NOT applied to the shared "
                 "backend (spawned with the daemon's scrubbed env). Enable "
                 "mcp_gateway.forward_declared_env to apply the non-secret keys, "
-                "or set poolable:false if this server depends on that env.",
+                "or stop sharing this server if it depends on that env.",
                 server_name, agent_name, len(env_pairs),
             )
         # JSON-encode env so values containing ',' or '=' round-trip
@@ -309,6 +321,7 @@ def _rewrite_single_spec(
     sandbox_mode: str,
     approval_mode: str,
     poolable_servers: frozenset[str],
+    pooling_enabled: bool = True,
     inject_servers: dict[str, Any] | None = None,
     target_env: dict[str, str] | None = None,
     sidecars_written: set[str] | None = None,
@@ -373,15 +386,9 @@ def _rewrite_single_spec(
             # in _injectable_settings_servers.
             new_servers[name] = {k: v for k, v in entry.items() if k != "poolable"}
             continue
-        is_poolable = entry.get("poolable") is True or name in poolable_servers
-        if not is_poolable:
-            # Opt-in pooling: a stdio MCP is unpooled (per-session, as today)
-            # unless its author/operator declares it stateless via poolable:true
-            # OR the dashboard-managed allowlist (config mcp_gateway.poolable_servers)
-            # names it. Safe by default — non-declared MCPs are treated as
-            # stateful. Strip the per-entry flag so kiro-cli sees a clean entry.
-            new_servers[name] = {k: v for k, v in entry.items() if k != "poolable"}
-            continue
+        is_poolable = pooling_enabled and (
+            entry.get("poolable") is True or name in poolable_servers
+        )
         new_servers[name] = _build_stub_entry(
             stubs_dir=stubs_dir,
             server_name=name,
@@ -392,6 +399,7 @@ def _rewrite_single_spec(
             sandbox_mode=sandbox_mode,
             approval_mode=approval_mode,
             sidecars_written=sidecars_written,
+            poolable=is_poolable,
         )
         wrapped += 1
 
@@ -461,6 +469,11 @@ def _rewrite_single_spec(
             sandbox_mode=sandbox_mode,
             approval_mode=approval_mode,
             sidecars_written=sidecars_written,
+            poolable=pooling_enabled and (
+                entry.get("poolable") is True
+                or name in poolable_servers
+                or alias in poolable_servers
+            ),
         )
         wrapped += 1
         seen_targets.add(inject_sig)
@@ -472,9 +485,8 @@ def _rewrite_single_spec(
 
 def _injectable_settings_servers(
     settings_spec: dict[str, Any],
-    poolable_servers: frozenset[str],
 ) -> dict[str, Any]:
-    """Return ``{name: raw_entry}`` of poolable stdio servers in the global
+    """Return ``{name: raw_entry}`` of stdio servers in the global
     ``settings/mcp.json`` that must be injected per-agent instead of left in
     the settings overlay.
 
@@ -483,9 +495,9 @@ def _injectable_settings_servers(
     same-named stubs — one with the correct ``--agent``, one with an empty
     ``--agent`` because settings has no ``name``). By relocating them into
     each agent's own overlay (with the right identity) and dropping them from
-    the settings overlay, the duplicate disappears. Non-poolable and HTTP/SSE
-    settings servers are NOT returned — they stay raw in the settings overlay
-    and merge globally as before.
+    the settings overlay, the duplicate disappears. HTTP/SSE settings servers
+    are NOT returned — they need no stub and stay raw in the settings overlay,
+    merging globally.
     """
     servers = settings_spec.get("mcpServers") or {}
     out: dict[str, Any] = {}
@@ -507,9 +519,6 @@ def _injectable_settings_servers(
         if "command" not in entry:
             # HTTP/SSE — shareable, no stub needed; leave in settings overlay.
             continue
-        is_poolable = entry.get("poolable") is True or name in poolable_servers
-        if not is_poolable:
-            continue
         out[name] = entry
     return out
 
@@ -523,6 +532,7 @@ def rewrite_agents(
     sandbox_mode: str = "auto",
     approval_mode: str = "interactive",
     poolable_servers: frozenset[str] | None = None,
+    pooling_enabled: bool = True,
 ) -> tuple[dict[str, int], dict[str, str]]:
     """Populate ``overlay_dir`` with rewritten copies of ``source_dir/*.json``.
 
@@ -541,8 +551,15 @@ def rewrite_agents(
             so the stub's PoolKey matches KiroCrew's sandbox policy.
         approval_mode: Value from ``config.agent.approval_mode`` — same.
         poolable_servers: Server names from ``config.mcp_gateway.poolable_servers``.
-            A stdio server is pooled when its name is in this set OR its entry
-            sets ``poolable: true``. ``None`` is treated as an empty set.
+            A stdio server's backend is SHARED across connections when its name
+            is in this set OR its entry sets ``poolable: true``. Every stdio
+            server gets a stub either way — the stub is the addressing layer, and
+            this set only decides whether the backend behind it is shared.
+            ``None`` is treated as an empty set.
+        pooling_enabled: ``config.mcp_gateway.enabled``. When ``False`` no stub
+            is marked shareable, so every connection gets its own backend while
+            stubs stay in place — the state that lets MCP Apps work with pooling
+            entirely off.
 
     Returns:
         A ``(results, target_env)`` tuple:
@@ -600,7 +617,7 @@ def rewrite_agents(
             loaded = json.loads(kiro_settings_json.read_text())
             if isinstance(loaded, dict):
                 settings_src_spec = loaded
-                settings_poolable = _injectable_settings_servers(loaded, pool_set)
+                settings_poolable = _injectable_settings_servers(loaded)
         except (OSError, json.JSONDecodeError) as exc:
             logger.warning("failed to read global mcp.json: %s", exc)
 
@@ -630,6 +647,7 @@ def rewrite_agents(
             sandbox_mode=sandbox_mode,
             approval_mode=approval_mode,
             poolable_servers=pool_set,
+            pooling_enabled=pooling_enabled,
             inject_servers=settings_poolable,
             target_env=target_env,
             sidecars_written=written_sidecars,

--- a/src/kiro_crew/mcp_gateway/stub.py
+++ b/src/kiro_crew/mcp_gateway/stub.py
@@ -167,6 +167,18 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     p.add_argument("--auto-approve", default="", dest="auto_approve")
     p.add_argument("--approval-mode", default="interactive", dest="approval_mode")
     p.add_argument("--trust-all", action="store_true", dest="trust_all")
+    p.add_argument(
+        "--poolable",
+        action="store_true",
+        dest="poolable",
+        help=(
+            "Declare this connection's backend shareable with other connections "
+            "carrying an identical PoolKey. Absent, the gateway gives this "
+            "connection its own backend -- the same process topology as no "
+            "gateway at all, which is why absent is the safe default: a stub "
+            "from an overlay predating this flag never silently starts sharing."
+        ),
+    )
     p.add_argument("--channel-id", default=None, dest="channel_id")
     p.add_argument(
         "--socket",
@@ -408,6 +420,12 @@ def build_register_payload(args: argparse.Namespace) -> dict:
         ),
         "approval_mode": args.approval_mode,
         "trust_all_tools": bool(args.trust_all),
+        # Not a PoolKey dimension: it selects HOW the backend is acquired
+        # (shared bucket vs this connection's own), not WHICH backends are
+        # interchangeable. Keeping it out of the key is what lets a
+        # per-connection backend exist without making every key
+        # connection-private.
+        "poolable": bool(args.poolable),
         "user_identity": user_identity,
         "channel_id": channel_id,
         "config_snapshot_hash": _CONFIG_SNAPSHOT_PLACEHOLDER,
@@ -468,6 +486,22 @@ async def _safe_close(writer: asyncio.StreamWriter) -> None:
         await writer.wait_closed()
     except Exception:
         pass
+
+
+def must_degrade_unshareable(poolable: bool, capabilities: list[str]) -> bool:
+    """Should this connection abandon the gateway rather than risk being pooled?
+
+    True only when the stub asked for a PRIVATE backend and the daemon did not
+    attest that it reads the ``poolable`` register field. Such a daemon ignores
+    the flag and routes the register through the shared index, so a server the
+    operator never allowlisted would be silently co-tenanted — and a stub cannot
+    detect that after the fact. Degrading gives the per-session exec, which is
+    the private topology it asked for.
+
+    A stub that DID ask to share needs no attestation: an older daemon pools it,
+    which is what it wanted.
+    """
+    return not poolable and "poolable_ack" not in capabilities
 
 
 class FallbackRequestedError(Exception):
@@ -1076,6 +1110,32 @@ async def _amain(argv: Optional[list[str]] = None) -> int:
         return 1  # unreachable
     logger.info("registered stub_uuid=%s pool=%s", stub_uuid, pool_label)
 
+    capabilities = registered.get("capabilities") if isinstance(registered, dict) else None
+    _caps = capabilities if isinstance(capabilities, list) else []
+
+    # A private backend is the one thing this connection cannot verify after the
+    # fact. ``poolable`` is a register-payload field, so a daemon predating it
+    # ignores the flag and routes this register through the shared index —
+    # silently co-tenanting a server the operator never allowlisted. Such a
+    # daemon is reachable: the manager adopts anything answering ``pong``, with
+    # no version handshake, so one that outlived a package upgrade serves new
+    # stubs. Degrade instead: the per-session exec IS the private topology this
+    # connection asked for, and kiro-cli's ``initialize`` is still unread, so the
+    # fallback is clean. A stub that DID ask to share needs no check — an old
+    # daemon pools it, which is what it wanted.
+    if must_degrade_unshareable(bool(args.poolable), _caps):
+        reason = "gateway does not honour the poolable field"
+        log_fallback(reason, payload["stub_uuid"], pool_label, args)
+        logger.warning(
+            "handshake: gateway did not advertise poolable_ack and this server is "
+            "not shareable; falling back to a per-session exec rather than risk "
+            "being pooled pool=%s",
+            pool_label,
+        )
+        await _safe_close(writer)
+        fallback_exec(args)
+        return 1  # unreachable
+
     # B1 pre-flight: trigger the gateway's backend spawn with a
     # control frame BEFORE forwarding any real MCP traffic, so a capacity /
     # breaker rejection reaches us while kiro-cli's ``initialize`` is still
@@ -1084,8 +1144,7 @@ async def _amain(argv: Optional[list[str]] = None) -> int:
     # would treat the control frame as a real MCP frame and never reply, so we
     # skip the pre-flight and bridge directly (legacy lazy-spawn path, no 25s
     # skew penalty).
-    capabilities = registered.get("capabilities") if isinstance(registered, dict) else None
-    if isinstance(capabilities, list) and "ensure_backend" in capabilities:
+    if "ensure_backend" in _caps:
         try:
             await _write_frame(writer, {"type": "ensure_backend"})
             ready = await asyncio.wait_for(

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -5599,12 +5599,15 @@ class GatewayOrchestrator:
     async def _init_mcp_gateway(self) -> None:
         """Start the MCP gateway sidecar and populate the agent-JSON overlay.
 
-        Gated on ``config.mcp_gateway.enabled``.  Any failure downgrades to
-        today's per-session MCP path — the stub's graceful fallback keeps
-        kiro-cli sessions working even when the broker is unreachable.
+        Runs when ``mcp_gateway.enabled`` OR ``mcp_gateway.apps_enabled`` is set:
+        the stub is the addressing layer MCP Apps routes its callbacks through,
+        so it is needed even with pooling off, where every connection simply gets
+        its own backend. Any failure downgrades to today's per-session MCP path —
+        the stub's graceful fallback keeps kiro-cli sessions working even when
+        the broker is unreachable.
         """
         cfg_gw = self._cfg.mcp_gateway
-        if not cfg_gw.enabled:
+        if not (cfg_gw.enabled or cfg_gw.apps_enabled):
             return
         # Runs on every platform the transport layer covers -- an AF_UNIX socket
         # on POSIX, a named pipe on Windows. Stub delivery is ACP session/new
@@ -5633,6 +5636,7 @@ class GatewayOrchestrator:
                     sandbox_mode=self._cfg.agent.sandbox,
                     approval_mode=self._cfg.agent.approval_mode,
                     poolable_servers=frozenset(cfg_gw.poolable_servers),
+                    pooling_enabled=cfg_gw.enabled,
                 ),
             )
         except Exception:
@@ -5650,7 +5654,19 @@ class GatewayOrchestrator:
         )
         if await manager.start():
             self._mcp_gateway_manager = manager
-            logger.info("mcp-gateway: broker ready (socket=%s)", socket_path)
+            # Name the switch that started it. Two independent flags can, and
+            # "Share MCP Backends: off" beside a live daemon is otherwise a
+            # contradiction an operator has to read a design note to resolve.
+            reasons = []
+            if cfg_gw.enabled:
+                reasons.append("backend sharing")
+            if cfg_gw.apps_enabled:
+                reasons.append("mcp-apps")
+            logger.info(
+                "mcp-gateway: broker ready (socket=%s) for %s",
+                socket_path,
+                " + ".join(reasons) or "no switch (unexpected)",
+            )
 
     async def _stop_mcp_broker(self) -> None:
         """Stop the MCP gateway broker if running and clear the handle."""
@@ -5668,15 +5684,24 @@ class GatewayOrchestrator:
 
         Reloads config so it acts on the value the handler just wrote.
         Returns ``{enabled, running, ping_ok}``.
+
+        The flag governs backend SHARING, not the broker's existence: MCP Apps
+        needs the stub either way. So turning sharing off restarts the broker
+        rather than stopping it whenever Apps is still on — a plain stop would
+        leave ``_mcp_apps_enabled()`` reporting a feature whose render and
+        callback paths just went away. The restart is required, not incidental:
+        the rewriter reads the sharing flag when the broker starts, so re-running
+        it is what re-emits every stub WITHOUT ``--poolable`` and actually stops
+        the sharing the operator just turned off.
         """
         from kiro_crew.config.loader import KiroCrewConfig
 
         self._cfg = KiroCrewConfig.load()
-        if enabled:
-            if self._mcp_gateway_manager is None:
-                await self._init_mcp_gateway()
-        else:
+        cfg_gw = self._cfg.mcp_gateway
+        if self._mcp_gateway_manager is not None:
             await self._stop_mcp_broker()
+        if cfg_gw.enabled or cfg_gw.apps_enabled:
+            await self._init_mcp_gateway()
         mgr = self._mcp_gateway_manager
         if self.dashboard_state is not None:
             self.dashboard_state._mcp_gateway_manager = mgr

--- a/test/test_mcp_gateway_apps_capability.py
+++ b/test/test_mcp_gateway_apps_capability.py
@@ -28,18 +28,17 @@ def _init_frame(capabilities=None):
     return {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": params}
 
 
-def _patch_pooling(monkeypatch, *, enabled: bool) -> None:
+def _patch_pooling(monkeypatch, *, enabled: bool, apps_enabled: bool = True) -> None:
     """Force both flags the config-keyed gate reads.
 
-    ``apps_enabled`` is pinned alongside ``enabled`` so these tests assert
-    against a known config rather than whatever the host's config.json happens
-    to carry.
+    Both are pinned so these tests assert against a known config rather than
+    whatever the host's config.json happens to carry.
     """
     import kiro_crew.config.loader as loader
 
     real = loader.KiroCrewConfig.load()
     monkeypatch.setattr(real.mcp_gateway, "enabled", enabled, raising=False)
-    monkeypatch.setattr(real.mcp_gateway, "apps_enabled", True, raising=False)
+    monkeypatch.setattr(real.mcp_gateway, "apps_enabled", apps_enabled, raising=False)
     monkeypatch.setattr(loader.KiroCrewConfig, "load", staticmethod(lambda: real))
 
 
@@ -79,19 +78,32 @@ class TestFlagOff:
         ext = out["params"]["capabilities"]["extensions"]
         assert ext[MCP_APPS_EXTENSION_KEY] == {"mimeTypes": [MCP_APPS_MIME_TYPE]}
 
-    def test_unset_respects_pooling_opt_out(self, monkeypatch):
-        """Pooling disabled => apps off, even with the env var unset.
+    def test_unset_respects_apps_opt_out(self, monkeypatch):
+        """Apps switched off => no capability, even with the env var unset.
 
         This is the adopted-daemon case: ``_shutdown_locked`` refuses to
         terminate a daemon it did not spawn, so a survivor keeps serving stubs
-        after the operator disables ``mcp_gateway``. Keying the gate on "am I
+        after the operator switches the feature off. Keying the gate on "am I
         running" would keep intercepting results and spooling payloads (which
         carry a callback_secret) after an explicit opt-out.
         """
         monkeypatch.delenv(MCP_APPS_ENV_FLAG, raising=False)
-        _patch_pooling(monkeypatch, enabled=False)
+        _patch_pooling(monkeypatch, enabled=True, apps_enabled=False)
         msg = _init_frame(capabilities={})
         assert _inject_client_extensions(msg) is msg
+
+    def test_pooling_opt_out_does_not_disable_apps(self, monkeypatch):
+        """Turning pooling off must not take MCP Apps down with it.
+
+        The stub is still emitted with pooling off — each connection just gets
+        its own backend — so the render path is intact and the capability must
+        still be advertised.
+        """
+        monkeypatch.delenv(MCP_APPS_ENV_FLAG, raising=False)
+        _patch_pooling(monkeypatch, enabled=False, apps_enabled=True)
+        out = _inject_client_extensions(_init_frame(capabilities={}))
+        ext = out["params"]["capabilities"]["extensions"]
+        assert ext[MCP_APPS_EXTENSION_KEY] == {"mimeTypes": [MCP_APPS_MIME_TYPE]}
 
     def test_kill_switch_beats_pooling_enabled(self, monkeypatch):
         monkeypatch.setenv(MCP_APPS_ENV_FLAG, "0")

--- a/test/test_mcp_gateway_apps_switch.py
+++ b/test/test_mcp_gateway_apps_switch.py
@@ -1,8 +1,9 @@
 """Tests for the MCP Apps render switch (``mcp_gateway.apps_enabled``).
 
-The switch is independent of the pooling opt-in in CONFIG but conjoined with it
-in EFFECT: the render and callback paths live inside the broker, so the switch
-can only ever subtract. These tests pin both halves of that contract.
+The switch stands alone: the broker starts whenever EITHER pooling or MCP Apps
+is on, and the stub that carries the app-call relay is emitted for every server
+regardless of poolability. So ``apps_enabled`` is the whole decision, and these
+tests pin that plus the env-override precedence rules around it.
 """
 
 import json
@@ -32,11 +33,13 @@ def _no_env_override(monkeypatch):
     [
         (True, True, True),
         (True, False, False),
-        (False, True, False),
+        # Pooling off, apps on: the stub layer is still emitted (each connection
+        # simply gets its own backend), so the render path exists.
+        (False, True, True),
         (False, False, False),
     ],
 )
-def test_gate_is_the_conjunction(monkeypatch, enabled, apps_enabled, expected):
+def test_gate_follows_apps_enabled_alone(monkeypatch, enabled, apps_enabled, expected):
     _pin_config(monkeypatch, enabled=enabled, apps_enabled=apps_enabled)
     assert _mcp_apps_enabled() is expected
 
@@ -62,15 +65,16 @@ def test_env_on_still_forces_the_feature_when_config_does_not_opt_out(monkeypatc
     assert _mcp_apps_enabled() is True
 
 
-def test_apps_enabled_alone_grants_nothing(monkeypatch):
-    """The (broker off, apps on) cell.
+def test_apps_enabled_alone_is_enough(monkeypatch):
+    """The (pooling off, apps on) cell — the whole point of the decoupling.
 
-    Turning the render switch on while the broker is off must NOT enable the
-    feature: there is no process to intercept a tool result, so reporting it as
-    enabled would be a lie that other code branches on.
+    Pooling off no longer means no broker and no stub: the broker starts for
+    MCP Apps too, and every server still gets a stub, so a tool result can be
+    intercepted and rendered. Only the backend behind the stub changes — one per
+    connection instead of shared.
     """
     _pin_config(monkeypatch, enabled=False, apps_enabled=True)
-    assert _mcp_apps_enabled() is False
+    assert _mcp_apps_enabled() is True
 
 
 def test_env_kill_switch_still_wins_over_config(monkeypatch):

--- a/test/test_mcp_gateway_claim.py
+++ b/test/test_mcp_gateway_claim.py
@@ -189,7 +189,7 @@ def _patch_env(monkeypatch: pytest.MonkeyPatch) -> tuple[_FakeBackend, list[dict
         def log_api_access(self, **kwargs: Any) -> None:
             sel_calls.append(kwargs)
 
-    async def _fake_acquire(_pool: Any, _key: Any, _resolver: Any):
+    async def _fake_acquire(_pool: Any, _key: Any, _resolver: Any, **_kw: Any):
         return fake_backend, True
 
     async def _fake_drain(_inbox: Any, _writer: Any, _stub_uuid: str = "") -> None:

--- a/test/test_mcp_gateway_exclusive_backend.py
+++ b/test/test_mcp_gateway_exclusive_backend.py
@@ -1,0 +1,481 @@
+"""Tests for connection-private (non-poolable) backend acquisition.
+
+A stub is emitted for every server; ``poolable`` decides only whether the
+backend behind it may be shared. These tests pin the four properties that make
+the private path safe, each of which a shared-bucket implementation breaks:
+
+* two connections under an IDENTICAL PoolKey never resolve onto one backend
+* their storage digests differ, so an MCP Apps callback cannot cross sessions
+* they sit outside the ``max_backends`` budget and cannot starve a pooled acquire
+* release hands the backend back for shutdown, and is a no-op for a pooled stub
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.mcp_gateway.backend import Backend
+from kiro_crew.mcp_gateway.pool import BackendPool, PoolKey
+
+pytestmark = pytest.mark.xdist_group("mcp_gateway")
+
+
+def _make_pool_key(server: str = "srv", agent: str = "agent") -> PoolKey:
+    return PoolKey(
+        server_name=server,
+        agent_name=agent,
+        command_args_hash="abc123",
+        effective_env_hash="def456",
+        work_dir="/tmp/test",
+        binary_version="1.0",
+        os_uid=1000,
+        sandbox_mode="none",
+        autoapprove_set_hash="ghi789",
+        approval_mode="reads",
+        trust_all_tools=False,
+        user_identity="testuser",
+        config_snapshot_hash="jkl012",
+    )
+
+
+def _make_mock_backend(pool_key: PoolKey, *, pid: int = 1) -> Backend:
+    proc = MagicMock()
+    proc.returncode = None
+    proc.pid = pid
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock(return_value=0)
+    stdin = MagicMock()
+    stdin.close = MagicMock()
+    stdin.write = MagicMock()
+    stdin.drain = AsyncMock()
+    now = time.monotonic()
+    return Backend(
+        pool_key=pool_key,
+        process=proc,
+        stdin=stdin,
+        stdout=MagicMock(),
+        created_at=now,
+        last_used_at=now,
+    )
+
+
+def _spawner(backend: Backend):
+    async def _spawn() -> Backend:
+        return backend
+    return _spawn
+
+
+@pytest.mark.asyncio
+async def test_identical_keys_do_not_share_a_private_backend() -> None:
+    """The property PoolKey cannot express, so the acquisition path must.
+
+    Both connections compute the SAME digest — that is why routing them through
+    the shared bucket would silently collapse them onto one process.
+    """
+    pool = BackendPool(max_backends=10)
+    key = _make_pool_key()
+    first, second = _make_mock_backend(key, pid=1), _make_mock_backend(key, pid=2)
+
+    got_first = await pool.acquire_exclusive(key, "stub-a", _spawner(first))
+    got_second = await pool.acquire_exclusive(key, "stub-b", _spawner(second))
+
+    assert got_first is first
+    assert got_second is second
+    assert key.stable_hash() == key.stable_hash()  # same key, by construction
+    # Neither is reachable through the shared index, so a later pooled acquire
+    # for the same key cannot land on one of them.
+    assert await pool.get(key) is None
+    assert len(pool) == 0
+
+
+@pytest.mark.asyncio
+async def test_private_backends_get_distinct_storage_digests() -> None:
+    """The MCP Apps callback guarantee.
+
+    ``get_by_digest`` is the ONLY way an app callback resolves a backend. If two
+    private backends for the same server shared a digest, a callback issued by
+    one session could execute against another session's process.
+    """
+    pool = BackendPool(max_backends=10)
+    key = _make_pool_key()
+    first, second = _make_mock_backend(key, pid=1), _make_mock_backend(key, pid=2)
+
+    await pool.acquire_exclusive(key, "stub-a", _spawner(first))
+    await pool.acquire_exclusive(key, "stub-b", _spawner(second))
+
+    assert first.storage_digest != second.storage_digest
+    assert await pool.get_by_digest(first.storage_digest) is first
+    assert await pool.get_by_digest(second.storage_digest) is second
+    # The bare PoolKey digest addresses neither: it is not a private backend's
+    # identity, so it must not resolve to an arbitrary one of them.
+    assert await pool.get_by_digest(key.stable_hash()) is None
+
+
+@pytest.mark.asyncio
+async def test_private_backends_are_outside_the_capacity_budget() -> None:
+    """A private backend sits at refcount 1 for life, so it can never be an
+    eviction victim. Counting it against ``max_backends`` would let private
+    connections accumulate as unevictable occupants until a POOLED acquire found
+    nothing to evict and was rejected — connections that opted out of sharing
+    denying service to one that opted in.
+    """
+    pool = BackendPool(max_backends=1)
+    key_a, key_b = _make_pool_key(server="a"), _make_pool_key(server="b")
+
+    for i in range(5):
+        await pool.acquire_exclusive(
+            key_a, f"stub-{i}", _spawner(_make_mock_backend(key_a, pid=i))
+        )
+
+    assert pool.stats()["exclusive"] == 5
+    assert len(pool) == 0  # none of them consumed the budget
+
+    # The single budgeted slot is still free for a pooled acquire.
+    shared = _make_mock_backend(key_b, pid=99)
+    assert await pool.get_or_create(key_b, _spawner(shared)) is shared
+    assert len(pool) == 1
+
+
+@pytest.mark.asyncio
+async def test_release_returns_the_backend_and_is_a_noop_for_pooled() -> None:
+    pool = BackendPool(max_backends=10)
+    key = _make_pool_key()
+    backend = _make_mock_backend(key)
+    await pool.acquire_exclusive(key, "stub-a", _spawner(backend))
+
+    assert await pool.release_exclusive("stub-a") is backend
+    assert pool.stats()["exclusive"] == 0
+    # Idempotent, and safe on a stub that never had a private backend — the
+    # disconnect path calls this unconditionally.
+    assert await pool.release_exclusive("stub-a") is None
+    assert await pool.release_exclusive("never-existed") is None
+
+
+@pytest.mark.asyncio
+async def test_shutdown_all_reaps_private_backends() -> None:
+    """Daemon teardown races a stub disconnect. Without collecting these, a
+    private backend outlives the gateway holding its pipes open.
+    """
+    pool = BackendPool(max_backends=10)
+    key = _make_pool_key()
+    backend = _make_mock_backend(key)
+    backend.shutdown = AsyncMock()  # type: ignore[method-assign]
+    await pool.acquire_exclusive(key, "stub-a", _spawner(backend))
+
+    await pool.shutdown_all(timeout=0.1)
+
+    backend.shutdown.assert_awaited()
+    assert pool.stats()["exclusive"] == 0
+
+
+@pytest.mark.asyncio
+async def test_double_register_on_one_connection_reaps_the_loser() -> None:
+    """``stub_uuid`` is a fresh uuid4 per connection, so a collision means the
+    same connection registered twice (the respawn path). Overwriting the entry
+    would orphan a live subprocess.
+    """
+    pool = BackendPool(max_backends=10)
+    key = _make_pool_key()
+    first, second = _make_mock_backend(key, pid=1), _make_mock_backend(key, pid=2)
+    first.shutdown = AsyncMock()  # type: ignore[method-assign]
+
+    await pool.acquire_exclusive(key, "stub-a", _spawner(first))
+    await pool.acquire_exclusive(key, "stub-a", _spawner(second))
+
+    first.shutdown.assert_awaited()
+    assert pool.stats()["exclusive"] == 1
+    assert await pool.get_by_digest(second.storage_digest) is second
+
+
+@pytest.mark.asyncio
+async def test_pooled_backend_digest_is_the_plain_poolkey_hash() -> None:
+    """The shared path is unchanged: reuse depends on two connections computing
+    one digest, so a pooled backend must NOT carry a per-connection suffix.
+    """
+    pool = BackendPool(max_backends=10)
+    key = _make_pool_key()
+    backend = _make_mock_backend(key)
+
+    await pool.get_or_create(key, _spawner(backend))
+
+    assert backend.exclusive_token == ""
+    assert backend.storage_digest == key.stable_hash()
+    assert await pool.get_by_digest(key.stable_hash()) is backend
+
+
+@pytest.mark.asyncio
+async def test_cancel_between_spawn_and_registration_reaps_the_child() -> None:
+    """The window where the child is reachable from nothing.
+
+    Registration needs ``_lock``, and acquiring it yields — so a cancel landing
+    between ``spawn()`` returning and the entry appearing leaves a live process
+    that neither the connection teardown (which looks it up by stub_uuid) nor
+    ``shutdown_all`` (which walks the maps) can find.
+    """
+    pool = BackendPool(max_backends=10)
+    key = _make_pool_key()
+    backend = _make_mock_backend(key)
+    backend.shutdown = AsyncMock()  # type: ignore[method-assign]
+
+    # Hold the pool lock so the acquire parks exactly inside the window.
+    await pool._lock.acquire()
+    task = asyncio.create_task(
+        pool.acquire_exclusive(key, "stub-a", _spawner(backend))
+    )
+    # Let it run up to the lock wait, then cancel it there.
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if backend.shutdown.await_count or task.done() or pool._lock.locked():
+            break
+    task.cancel()
+    pool._lock.release()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The reap is scheduled as a task so a cancelled caller cannot skip it.
+    for _ in range(50):
+        await asyncio.sleep(0)
+        if backend.shutdown.await_count:
+            break
+    backend.shutdown.assert_awaited()
+    assert pool.stats()["exclusive"] == 0
+
+
+@pytest.mark.asyncio
+async def test_private_acquire_takes_no_reservation_to_release() -> None:
+    """The reservation refcount is per DIGEST, and ``poolable`` is deliberately
+    not a PoolKey dimension — so a pooled and a private connection can share one
+    digest (reachable when the allowlist changes under a daemon that outlives the
+    gateway: the old overlay's stub still registers poolable, the new one does
+    not).
+
+    A private acquire must therefore not reserve, or the pooled connection's
+    protection would be inflated; and the connection handler must not release on
+    its behalf, or the pooled backend becomes evictable before its stub attaches.
+    This pins the pool half: private acquisition leaves the digest's reservation
+    exactly as it found it.
+    """
+    pool = BackendPool(max_backends=10)
+    key = _make_pool_key()
+    digest = key.stable_hash()
+
+    # A pooled connection is mid-handout: reserved, not yet attached.
+    pool.reserve(key)
+    assert pool._reserved_digests.get(digest) == 1
+
+    await pool.acquire_exclusive(
+        key, "private-stub", _spawner(_make_mock_backend(key, pid=7))
+    )
+
+    # Untouched — the private acquire neither added nor consumed a reservation.
+    assert pool._reserved_digests.get(digest) == 1
+
+
+@pytest.mark.asyncio
+async def test_private_backends_appear_in_lifecycle_enumerators() -> None:
+    """Out of the reuse index and the capacity budget, but NOT out of the process
+    lifecycle.
+
+    ``all_backends()`` feeds the shutdown drain predicate and the abort handler;
+    ``live_backend_pids()`` feeds the pidfile that stops a SIGKILLed gatewayd
+    orphaning children. A private backend missing from either gets its pending
+    reply discarded, its in-flight calls left uncancellable, or its process
+    leaked.
+    """
+    pool = BackendPool(max_backends=10)
+    key = _make_pool_key()
+    private = _make_mock_backend(key, pid=4242)
+    await pool.acquire_exclusive(key, "stub-a", _spawner(private))
+
+    assert private in pool.all_backends()
+    assert 4242 in pool.live_backend_pids()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_private_acquires_do_not_interleave_registrations() -> None:
+    """Distinct connections arriving on the same tick each keep their own entry."""
+    pool = BackendPool(max_backends=2)
+    key = _make_pool_key()
+    backends = [_make_mock_backend(key, pid=i) for i in range(8)]
+
+    await asyncio.gather(*[
+        pool.acquire_exclusive(key, f"stub-{i}", _spawner(b))
+        for i, b in enumerate(backends)
+    ])
+
+    assert pool.stats()["exclusive"] == 8
+    assert len({b.storage_digest for b in backends}) == 8
+
+
+# --- connection-handler half of the reservation contract ---------------------
+#
+# The pool test above proves ``acquire_exclusive`` takes no reservation. This
+# half proves the handler does not RELEASE one on a private connection's behalf,
+# which is where the unbalanced decrement actually lived.
+
+
+def _register_frame(*, poolable: bool) -> dict[str, Any]:
+    return {
+        "type": "register",
+        "stub_uuid": "ex-stub-0001",
+        "server_name": "echo-mcp",
+        "agent_name": "ex-agent",
+        "command_args_hash": "0" * 64,
+        "effective_env_hash": "1" * 64,
+        "work_dir": "/tmp",
+        "binary_version": "deadbeef",
+        "os_uid": 1000,
+        "sandbox_mode": "standard",
+        "autoapprove_set_hash": "2" * 64,
+        "approval_mode": "interactive",
+        "trust_all_tools": False,
+        "poolable": poolable,
+        "user_identity": "ex",
+        "channel_id": "C_EX",
+        "config_snapshot_hash": "3" * 64,
+        "session_key": "dashboard:chat-EX-1",
+        "session_type": "dashboard",
+        "principal_id": "ex",
+    }
+
+
+_TOOL_CALL = {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "x"}}
+
+
+class _FrameReader:
+    def __init__(self, frames: list[dict[str, Any]]) -> None:
+        self._q = [(json.dumps(f) + "\n").encode() for f in frames]
+
+    async def readuntil(self, sep: bytes = b"\n") -> bytes:
+        if not self._q:
+            raise asyncio.IncompleteReadError(b"", None)
+        return self._q.pop(0)
+
+
+class _NullWriter:
+    def write(self, _b: bytes) -> None:
+        pass
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def wait_closed(self) -> None:
+        pass
+
+    def is_closing(self) -> bool:
+        return False
+
+    def get_extra_info(self, _name: str, default: Any = None) -> Any:
+        return default
+
+
+class _HandlerBackend:
+    supports_caller_identity = True
+    quarantined = False
+    exclusive_token = ""
+
+    def __init__(self) -> None:
+        self._pending_requests: dict = {}
+
+    async def attach_stub(self, _uuid: str) -> "asyncio.Queue[bytes]":
+        return asyncio.Queue()
+
+    async def detach_stub(self, _uuid: str) -> int:
+        return 0
+
+    async def cancel_in_flight_for_stub(self, _stub_uuid: str) -> list[str]:
+        return []
+
+    async def recycle_if_idle(self) -> bool:
+        return False
+
+    async def forward_from_stub(self, _uuid: str, _msg: dict, caller: Any = None) -> None:
+        pass
+
+
+class _RecordingPool:
+    """Records whether the handler released a hand-out reservation."""
+
+    def __init__(self) -> None:
+        self.unreserved: list[Any] = []
+
+    def unreserve(self, key: Any) -> None:
+        self.unreserved.append(key)
+
+    async def release_exclusive(self, _stub_uuid: str) -> None:
+        return None
+
+
+async def _drive_handler(monkeypatch: pytest.MonkeyPatch, *, poolable: bool) -> _RecordingPool:
+    from kiro_crew.mcp_gateway import gatewayd as gw
+    from kiro_crew.mcp_gateway import socketsec
+
+    monkeypatch.setattr(socketsec, "PEER_IDENTITY_SUPPORTED", True)
+    monkeypatch.setattr(
+        socketsec, "check_peer_is_self", lambda _w: socketsec.PeerCredResult.MATCH
+    )
+    monkeypatch.setattr(socketsec, "socket_owner_only", lambda _path: True)
+
+    class _NullSEL:
+        def log_api_access(self, **kwargs: Any) -> None:
+            pass
+
+    async def _fake_acquire(_pool: Any, _key: Any, _resolver: Any, **_kw: Any):
+        return _HandlerBackend(), True
+
+    async def _fake_drain(_inbox: Any, _writer: Any, _stub_uuid: str = "") -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(gw, "SecurityEventLog", _NullSEL)
+    monkeypatch.setattr(gw, "_acquire_backend", _fake_acquire)
+    monkeypatch.setattr(gw, "_drain_inbox_to_stub", _fake_drain)
+
+    pool = _RecordingPool()
+    await asyncio.wait_for(
+        gw._handle_connection(
+            _FrameReader([_register_frame(poolable=poolable), _TOOL_CALL]),
+            _NullWriter(),
+            pool=pool,
+            resolver=object(),
+            socket_path=Path("/tmp/ex.sock"),
+            hot_keys=None,
+        ),
+        timeout=5.0,
+    )
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_handler_does_not_release_a_reservation_for_a_private_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The decrement that would drop a pooled connection's eviction protection.
+
+    A private connection reserved nothing, so releasing is not a harmless no-op:
+    ``unreserve`` decrements the shared per-digest refcount, and a pooled
+    connection with an identical PoolKey would lose its protection before its
+    stub attaches.
+    """
+    pool = await _drive_handler(monkeypatch, poolable=False)
+    assert pool.unreserved == []
+
+
+@pytest.mark.asyncio
+async def test_handler_still_releases_for_a_pooled_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard must not leak the other way: a pooled connection DID reserve, so
+    failing to release would pin its backend against idle and LRU eviction for
+    the life of the process."""
+    pool = await _drive_handler(monkeypatch, poolable=True)
+    assert len(pool.unreserved) == 1

--- a/test/test_mcp_gateway_pool_integ.py
+++ b/test/test_mcp_gateway_pool_integ.py
@@ -82,9 +82,20 @@ def _init_frame(req_id: int) -> str:
 
 
 async def _spawn_stub(
-    *, socket_path: Path, server: str, agent: str, work_dir: Path, home: Path
+    *,
+    socket_path: Path,
+    server: str,
+    agent: str,
+    work_dir: Path,
+    home: Path,
+    poolable: bool = True,
 ) -> asyncio.subprocess.Process:
-    """Launch a REAL stub process, exactly as the rewriter's overlay would."""
+    """Launch a REAL stub process, exactly as the rewriter's overlay would.
+
+    ``poolable`` mirrors the flag the rewriter passes: set, the backend may be
+    shared with other connections carrying the same PoolKey; unset, this
+    connection gets its own.
+    """
     return await asyncio.create_subprocess_exec(
         sys.executable,
         "-m",
@@ -97,6 +108,7 @@ async def _spawn_stub(
         "--socket", str(socket_path),
         "--sandbox-mode", "off",
         "--approval-mode", "auto",
+        *(["--poolable"] if poolable else []),
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
@@ -257,6 +269,87 @@ async def test_real_stubs_sharing_a_key_share_one_backend(tmp_path: Path, short_
             f"{_launch_count(launch_log)} backends total, expected 2 — PoolKey "
             "is not partitioning by agent, so two agents would share one MCP "
             "server process and its state."
+        )
+    finally:
+        await _reap(procs)
+        stop.set()
+        try:
+            await asyncio.wait_for(daemon, timeout=30)
+        except asyncio.TimeoutError:  # pragma: no cover - daemon shutdown hang
+            daemon.cancel()
+
+
+@pytest.mark.asyncio
+async def test_real_stubs_without_poolable_get_their_own_backend(
+    tmp_path: Path, short_sock_dir
+) -> None:
+    """The decoupling assertion: a stub exists either way, sharing does not.
+
+    3 real stubs, one identical PoolKey, none declared poolable -> 3 MCP server
+    processes. Two things have to hold at once, and only asserting both
+    distinguishes a real decoupling from either failure mode:
+
+    * 3 backends, not 1 -- opting out of pooling really means opting out. One
+      backend here would be the silent cross-session sharing the PoolKey has no
+      dimension to prevent.
+    * no stub degraded to per-session exec -- the stub IS in the path, which is
+      what gives the connection an address for an MCP Apps callback. 3 backends
+      with 3 fallbacks would be the old behaviour wearing this test's result.
+    """
+    endpoint_root = short_sock_dir
+    sock = endpoint_root / "gw.sock"
+    work_dir = tmp_path / "ws"
+    work_dir.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    launch_log = tmp_path / "launches.txt"
+
+    def _resolver(_key: object) -> tuple[str, list[str], dict[str, str], str]:
+        return (sys.executable, [str(_FAKE_SERVER), str(launch_log)], {}, str(work_dir))
+
+    stop = asyncio.Event()
+    daemon = asyncio.create_task(
+        gw.run_gatewayd(
+            socket_path=sock,
+            # Deliberately smaller than the number of private backends: they are
+            # outside this budget, so a cap of 1 must not throttle or reject
+            # them. A shared-budget implementation fails here.
+            max_backends=1,
+            idle_timeout_secs=300,
+            stop_event=stop,
+            target_resolver=_resolver,
+            prewarm_count=0,
+        )
+    )
+    procs: list[asyncio.subprocess.Process] = []
+    try:
+        for _ in range(100):
+            if transport.endpoint_exists(sock):
+                break
+            await asyncio.sleep(0.05)
+        assert transport.endpoint_exists(sock), "gatewayd never bound its endpoint"
+
+        for i in range(3):
+            proc = await _spawn_stub(
+                socket_path=sock, server="fake", agent="probe",
+                work_dir=work_dir, home=home, poolable=False,
+            )
+            procs.append(proc)
+            reply = await _drive_initialize(proc, req_id=i + 1)
+            assert "result" in reply, f"stub {i} got no initialize result: {reply}"
+
+        assert _launch_count(launch_log) == 3, (
+            f"3 non-poolable stubs sharing one PoolKey produced "
+            f"{_launch_count(launch_log)} backends, expected 3 — they were "
+            "collapsed onto a shared backend, which is the silent cross-session "
+            "sharing this path exists to avoid."
+        )
+
+        fallback = home / "logs" / "stub_fallback.jsonl"
+        assert not fallback.exists(), (
+            "a non-poolable stub degraded to per-session exec instead of going "
+            f"through the gateway, so it has no callback address: "
+            f"{fallback.read_text()}"
         )
     finally:
         await _reap(procs)

--- a/test/test_mcp_gateway_recaller.py
+++ b/test/test_mcp_gateway_recaller.py
@@ -140,7 +140,7 @@ async def _run(
         def log_api_access(self, **kwargs: Any) -> None:
             sel_calls.append(kwargs)
 
-    async def _fake_acquire(_pool: Any, _key: Any, _resolver: Any):
+    async def _fake_acquire(_pool: Any, _key: Any, _resolver: Any, **_kw: Any):
         return fake_backend, True
 
     async def _fake_drain(_inbox: Any, _writer: Any, _stub_uuid: str = "") -> None:

--- a/test/test_mcp_gateway_rewriter.py
+++ b/test/test_mcp_gateway_rewriter.py
@@ -17,7 +17,13 @@ import pytest
 from kiro_crew.mcp_gateway.rewriter import _WRAPPER_MARKER, _rewrite_single_spec
 
 
-def _rewrite(spec: dict, tmp_path: Path) -> tuple[dict, int]:
+def _rewrite(
+    spec: dict,
+    tmp_path: Path,
+    *,
+    poolable_servers: frozenset[str] = frozenset(),
+    pooling_enabled: bool = True,
+) -> tuple[dict, int]:
     return _rewrite_single_spec(
         spec,
         stubs_dir=tmp_path / "stubs",
@@ -25,7 +31,8 @@ def _rewrite(spec: dict, tmp_path: Path) -> tuple[dict, int]:
         work_dir=tmp_path / "wd",
         sandbox_mode="auto",
         approval_mode="interactive",
-        poolable_servers=frozenset(),
+        poolable_servers=poolable_servers,
+        pooling_enabled=pooling_enabled,
     )
 
 
@@ -62,6 +69,133 @@ def test_enabled_poolable_server_is_still_wrapped(tmp_path: Path) -> None:
 
     assert wrapped == 1
     assert entry.get(_WRAPPER_MARKER) is True
+
+
+def test_non_poolable_server_is_wrapped_without_the_poolable_flag(
+    tmp_path: Path,
+) -> None:
+    """The decoupling: a server nobody declared poolable STILL gets a stub.
+
+    The stub is the addressing layer MCP Apps routes callbacks through, so its
+    presence cannot depend on the allowlist. What the allowlist decides is the
+    ``--poolable`` flag on the stub's argv, which the gateway reads to choose
+    between the shared bucket and a backend private to this connection.
+    """
+    spec = {
+        "name": "agent-a",
+        "mcpServers": {
+            "stateful": {"command": "some-mcp"},
+        },
+    }
+    new_spec, wrapped = _rewrite(spec, tmp_path)
+    entry = new_spec["mcpServers"]["stateful"]
+
+    assert wrapped == 1
+    assert entry.get(_WRAPPER_MARKER) is True
+    assert "--poolable" not in entry["args"]
+    # The internal hint never reaches kiro-cli.
+    assert "poolable" not in entry
+
+
+def test_allowlisted_server_gets_the_poolable_flag(tmp_path: Path) -> None:
+    spec = {
+        "name": "agent-a",
+        "mcpServers": {
+            "shareable": {"command": "some-mcp"},
+        },
+    }
+    new_spec, _ = _rewrite(
+        spec, tmp_path, poolable_servers=frozenset({"shareable"})
+    )
+
+    assert "--poolable" in new_spec["mcpServers"]["shareable"]["args"]
+
+
+def test_private_server_with_declared_env_is_not_warned_about(
+    tmp_path: Path, caplog
+) -> None:
+    """The pooled warnings must not fire for a connection-private backend.
+
+    Both reasons the shared path withholds declared env are absent when there is
+    one stub, and gatewayd forwards the block in full — so the warning would be
+    false on its face. Worse, its remedy ("stop sharing this server") names the
+    state the server is already in, which sends an operator chasing a
+    non-problem. This fires on a default install: sharing off plus an empty
+    allowlist makes every env-declaring server private.
+    """
+    import logging
+
+    spec = {
+        "name": "agent-a",
+        "mcpServers": {
+            "needs-env": {
+                "command": "some-mcp",
+                "env": {"API_TOKEN": "x", "REGION": "us-west-2"},
+            },
+        },
+    }
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.mcp_gateway.rewriter"):
+        new_spec, wrapped = _rewrite(spec, tmp_path, pooling_enabled=False)
+
+    assert wrapped == 1  # still stubbed — the stub is unconditional
+    assert "--poolable" not in new_spec["mcpServers"]["needs-env"]["args"]
+    env_warnings = [r for r in caplog.records if "declares" in r.getMessage()]
+    assert env_warnings == [], (
+        "a private backend was warned about with pooled-backend advice: "
+        f"{[r.getMessage() for r in env_warnings]}"
+    )
+
+
+def test_shared_server_with_declared_env_is_still_warned_about(
+    tmp_path: Path, caplog
+) -> None:
+    """The guard must not silence the case that IS real: a shared backend does
+    drop the declared env, and an operator relying on it needs to know."""
+    import logging
+
+    spec = {
+        "name": "agent-a",
+        "mcpServers": {
+            "needs-env": {"command": "some-mcp", "env": {"REGION": "us-west-2"}},
+        },
+    }
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.mcp_gateway.rewriter"):
+        _rewrite(
+            spec, tmp_path, poolable_servers=frozenset({"needs-env"})
+        )
+
+    msgs = [r.getMessage() for r in caplog.records if "declares" in r.getMessage()]
+    assert len(msgs) == 1, msgs
+    assert "shared" in msgs[0]
+
+
+def test_pooling_disabled_still_wraps_but_shares_nothing(tmp_path: Path) -> None:
+    """Pooling off is not stubs off.
+
+    With ``mcp_gateway.enabled`` false every server keeps its stub -- so MCP Apps
+    keeps working -- and nothing is marked shareable, so each connection gets its
+    own backend. An entry declaring ``poolable: true`` cannot override the
+    operator's global switch.
+    """
+    spec = {
+        "name": "agent-a",
+        "mcpServers": {
+            "declared": {"command": "some-mcp", "poolable": True},
+            "listed": {"command": "other-mcp"},
+        },
+    }
+    new_spec, wrapped = _rewrite(
+        spec,
+        tmp_path,
+        poolable_servers=frozenset({"listed"}),
+        pooling_enabled=False,
+    )
+
+    assert wrapped == 2
+    for name in ("declared", "listed"):
+        entry = new_spec["mcpServers"][name]
+        assert entry.get(_WRAPPER_MARKER) is True, f"{name} lost its stub"
+        assert "--poolable" not in entry["args"], f"{name} still marked shareable"
 
 
 def test_rewriter_calls_restrict_to_owner_on_windows(

--- a/test/test_mcp_gateway_shutdown_and_env.py
+++ b/test/test_mcp_gateway_shutdown_and_env.py
@@ -551,3 +551,69 @@ class TestForwardDeclaredEnvFlag:
         assert gatewayd._declared_env_to_forward(key) == {
             "TOOL_PERSONALIZATION_ENABLED": "false"
         }
+
+
+class TestPrivateBackendDeclaredEnv:
+    """A connection-private backend gets its declared env in full.
+
+    Both filters the pooled path applies exist for co-tenancy: no single value is
+    correct when several sessions share one process. A private backend has one
+    stub, so the declaring session and the only consuming session are the same
+    one -- and withholding the env would be a regression, since the same server
+    spawned without a gateway receives it from the agent runtime.
+    """
+
+    def test_forwards_declared_env_with_the_flag_off(self, tmp_path, monkeypatch):
+        """The flag governs the co-tenancy hazard, which does not exist here."""
+        key = _pool_key(server="builder-mcp", agent="gpu-dev")
+        key = TestDeclaredEnvForwarding._write_sidecar(
+            tmp_path, monkeypatch, {"TOOL_PERSONALIZATION_ENABLED": "false"}, key
+        )
+        monkeypatch.setattr(gatewayd, "forward_declared_env_enabled", lambda: False)
+
+        assert gatewayd._declared_env_for_private_backend(key) == {
+            "TOOL_PERSONALIZATION_ENABLED": "false"
+        }
+        # The pooled path is unchanged and still withholds it.
+        assert gatewayd._declared_env_to_forward(key) == {}
+
+    def test_forwards_secret_bearing_keys_the_pooled_path_drops(
+        self, tmp_path, monkeypatch
+    ):
+        """The case that breaks servers: a token the server needs to start.
+
+        The pooled path drops it because co-tenants may hold different values.
+        For a private backend there is no other holder, and dropping it leaves
+        the server unable to authenticate.
+        """
+        pairs = {
+            "AWS_SECRET_ACCESS_KEY": "shh",
+            "OAUTH_CLIENT_SECRET": "shh",
+            "SSH_AUTH_SOCK": "/tmp/agent.sock",
+            "REGION": "us-west-2",
+        }
+        key = _pool_key(server="gh-mcp", agent="dev")
+        key = TestDeclaredEnvForwarding._write_sidecar(
+            tmp_path, monkeypatch, pairs, key
+        )
+        monkeypatch.setattr(gatewayd, "forward_declared_env_enabled", lambda: True)
+
+        assert gatewayd._declared_env_for_private_backend(key) == pairs
+        # The pooled path keeps only the key every co-tenant agrees on.
+        assert gatewayd._declared_env_to_forward(key) == {"REGION": "us-west-2"}
+
+    def test_incoherent_sidecar_still_yields_nothing(self, tmp_path, monkeypatch):
+        """The coherence gate is not a co-tenancy filter and still applies: a
+        spec edited after this session started must not reach the backend under a
+        hash the running stub never registered.
+        """
+        key = _pool_key(server="builder-mcp", agent="gpu-dev")
+        key = TestDeclaredEnvForwarding._write_sidecar(
+            tmp_path, monkeypatch, {"A": "1"}, key
+        )
+        sidecar = env_sidecar_dir(resolve_overlay_dir()) / env_sidecar_name(
+            key.agent_name, key.server_name
+        )
+        sidecar.write_text(json.dumps({"A": "2"}), encoding="utf-8")
+
+        assert gatewayd._declared_env_for_private_backend(key) == {}

--- a/test/test_mcp_gateway_stub_poolable_ack.py
+++ b/test/test_mcp_gateway_stub_poolable_ack.py
@@ -1,0 +1,56 @@
+"""Mixed-version safety: a private backend must never be silently pooled.
+
+``poolable`` is a register-payload field, so a daemon predating it ignores the
+flag and routes every register through the shared index. That daemon is
+reachable in production: ``GatewayManager`` adopts any process answering
+``pong`` with no version handshake, so one that outlived a package upgrade
+serves brand-new stubs. A stub cannot detect the outcome after the fact — by the
+time it would notice, a stateful server the operator never allowlisted is
+already co-tenanted.
+
+So the stub negotiates: no ``poolable_ack`` attestation and no sharing asked for
+means abandon the gateway and exec the real server directly, which IS the
+private topology it wanted.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.mcp_gateway.gatewayd import REGISTERED_CAPABILITIES
+from kiro_crew.mcp_gateway.stub import must_degrade_unshareable
+
+
+def test_current_daemon_advertises_the_attestation() -> None:
+    """The two sides must not drift: the stub's gate is only reachable because
+    a current daemon says the word."""
+    assert "poolable_ack" in REGISTERED_CAPABILITIES
+
+
+def test_private_stub_against_an_old_daemon_degrades() -> None:
+    """The hazard: flag sent, daemon ignores it, register lands in the shared
+    index. Degrading is the only outcome that preserves what was asked for."""
+    assert must_degrade_unshareable(poolable=False, capabilities=["ensure_backend"]) is True
+    assert must_degrade_unshareable(poolable=False, capabilities=[]) is True
+
+
+def test_private_stub_against_a_current_daemon_proceeds() -> None:
+    """Over-degrading would cost every private server the gateway — no stub, no
+    MCP Apps — which is the coupling this whole change removes."""
+    assert (
+        must_degrade_unshareable(
+            poolable=False, capabilities=list(REGISTERED_CAPABILITIES)
+        )
+        is False
+    )
+
+
+def test_shareable_stub_needs_no_attestation() -> None:
+    """A stub that asked to share is not harmed by an old daemon: it pools the
+    register, which is exactly the request. Degrading here would throw away
+    pooling for no safety gain."""
+    assert must_degrade_unshareable(poolable=True, capabilities=[]) is False
+    assert (
+        must_degrade_unshareable(
+            poolable=True, capabilities=list(REGISTERED_CAPABILITIES)
+        )
+        is False
+    )

--- a/test/test_slack_gateway_coverage.py
+++ b/test/test_slack_gateway_coverage.py
@@ -773,13 +773,95 @@ class TestInitMcpGateway:
     """Broker startup, its two early returns and the rewriter-failure fallback."""
 
     @pytest.mark.asyncio
-    async def test_disabled_returns_without_touching_platform_probe(self):
+    async def test_both_switches_off_returns_without_touching_platform_probe(self):
         orch = _make_orchestrator()
         orch._cfg.mcp_gateway.enabled = False
+        orch._cfg.mcp_gateway.apps_enabled = False
         with patch("kiro_crew.slack.gateway.is_gateway_supported") as probe:
             await orch._init_mcp_gateway()
         probe.assert_not_called()
         assert orch._mcp_gateway_manager is None
+
+    @pytest.mark.asyncio
+    async def test_apps_enabled_alone_still_starts_the_broker(self):
+        """Pooling off must not keep the broker down.
+
+        MCP Apps routes its callbacks through the stub, and the stub needs the
+        broker's socket. Returning early here is what made the apps switch a
+        dead end whenever pooling was off.
+        """
+        orch = _make_orchestrator()
+        orch._cfg.mcp_gateway.enabled = False
+        orch._cfg.mcp_gateway.apps_enabled = True
+        with patch(
+            "kiro_crew.slack.gateway.is_gateway_supported", return_value=False
+        ) as probe:
+            await orch._init_mcp_gateway()
+        probe.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_turning_sharing_off_restarts_rather_than_stops_when_apps_on(self):
+        """The live-apply path must not strand MCP Apps.
+
+        Two things have to happen when sharing goes off while apps stays on, and
+        only asserting both distinguishes the fix from either failure mode:
+
+        * the broker must come back — a plain stop would leave
+          ``_mcp_apps_enabled()`` reporting a feature whose render and callback
+          paths just went away;
+        * it must be a RESTART, not a no-op — the rewriter reads the sharing flag
+          when the broker starts, so re-running it is what re-emits every stub
+          without ``--poolable`` and actually stops the sharing just turned off.
+        """
+        orch = _make_orchestrator()
+        orch._cfg.mcp_gateway.enabled = False
+        orch._cfg.mcp_gateway.apps_enabled = True
+        orch._mcp_gateway_manager = object()  # a broker is currently up
+        calls: list[str] = []
+
+        async def _stop() -> None:
+            calls.append("stop")
+            orch._mcp_gateway_manager = None
+
+        async def _init() -> None:
+            calls.append("init")
+
+        with patch(
+            "kiro_crew.config.loader.KiroCrewConfig.load", return_value=orch._cfg
+        ):
+            with patch.object(orch, "_stop_mcp_broker", _stop), patch.object(
+                orch, "_init_mcp_gateway", _init
+            ):
+                await orch._apply_mcp_gateway_enabled(False)
+
+        assert calls == ["stop", "init"]
+
+    @pytest.mark.asyncio
+    async def test_turning_sharing_off_with_apps_off_leaves_the_broker_down(self):
+        """The guard must not leak the other way: with neither switch on, the
+        broker stays stopped rather than being restarted for nothing."""
+        orch = _make_orchestrator()
+        orch._cfg.mcp_gateway.enabled = False
+        orch._cfg.mcp_gateway.apps_enabled = False
+        orch._mcp_gateway_manager = object()
+        calls: list[str] = []
+
+        async def _stop() -> None:
+            calls.append("stop")
+            orch._mcp_gateway_manager = None
+
+        async def _init() -> None:
+            calls.append("init")
+
+        with patch(
+            "kiro_crew.config.loader.KiroCrewConfig.load", return_value=orch._cfg
+        ):
+            with patch.object(orch, "_stop_mcp_broker", _stop), patch.object(
+                orch, "_init_mcp_gateway", _init
+            ):
+                await orch._apply_mcp_gateway_enabled(False)
+
+        assert calls == ["stop"]
 
     @pytest.mark.asyncio
     async def test_unsupported_platform_returns_early(self):

--- a/test/test_stop_kill_cancel.py
+++ b/test/test_stop_kill_cancel.py
@@ -491,7 +491,7 @@ class TestDetachOnCancelFailure:
 
         fake_backend = _RaisingBackend()
 
-        async def _fake_acquire(_pool: Any, _key: Any, _resolver: Any):
+        async def _fake_acquire(_pool: Any, _key: Any, _resolver: Any, **_kw: Any):
             return fake_backend, True
 
         async def _fake_drain(_inbox: Any, _writer: Any, _stub_uuid: str = "") -> None:

--- a/test/test_stub_bridge_liveness.py
+++ b/test/test_stub_bridge_liveness.py
@@ -374,11 +374,15 @@ class TestLivenessIsNegotiated:
         ].default is False
 
     def test_gatewayd_advertises_the_capability(self) -> None:
-        """The stub's gate is only reachable if the daemon actually offers it."""
-        from pathlib import Path
+        """The stub's gate is only reachable if the daemon actually offers it.
 
-        src = Path("src/kiro_crew/mcp_gateway/gatewayd.py").read_text(encoding="utf-8")
-        assert '"capabilities": ["ensure_backend", "bridge_ping"]' in src
+        Asserted against the advertised set rather than gatewayd's source text:
+        a grep for one literal breaks whenever an unrelated capability is added,
+        and passes if the list is built but never sent.
+        """
+        from kiro_crew.mcp_gateway.gatewayd import REGISTERED_CAPABILITIES
+
+        assert "bridge_ping" in REGISTERED_CAPABILITIES
 
     def test_liveness_path_does_not_exec(self) -> None:
         """The degrade path must fail fast, not exec a fresh server.


### PR DESCRIPTION
## What is the problem?

A stub was emitted only for a server on the pooling allowlist. That welded two
unrelated decisions together.

The stub is the **addressing layer** — it gives an `(ACP connection, server)` pair
a name gatewayd can route a callback back to. Poolability is a **resource**
decision: may several connections share one backend process. You could not have
the first without accepting the second.

#2293 and #2337 both worked around this rather than removing it: one added a way to
turn MCP Apps *off* independently, the other made the gateway start automatically
so the switch was not a dead end. Neither touched the weld.

## Why this issue matters to the user

- **MCP Apps required pooling.** A server not on the allowlist could not host an
  MCP App at all, however the MCP Apps switch was set — the render and callback
  paths live behind the stub.
- **The shipped default could render nothing.** `poolable_servers` defaults to an
  empty list, so a fresh install had MCP Apps on, the broker running, and no
  server able to render.
- **Choosing isolation silently cost the feature.** An operator who kept a
  stateful server unpooled lost MCP Apps for it as a side effect they never chose.

## How our fix solves it

The baseline behaviour of MCP is one backend per ACP connection per server — what
happens with no gateway at all. Pooling is the *deviation* that collapses many
connections onto one process. The stub is orthogonal to both, so:

- **A stub is emitted for every stdio server.** Global `settings/mcp.json` servers
  relocate into each agent's overlay on the same terms (and drop out of the
  settings overlay in the same pass, as poolable ones already did), so they gain a
  callback address too.
- **`poolable` is now a field in the `register` payload**, selecting how the
  backend is acquired. Absent means private, so an overlay predating the flag
  never silently starts sharing.
- **Off the allowlist means exactly one thing:** you get a stub, and your backend
  stays 1:1 with your ACP connection. Same process topology as no-gateway, plus a
  name.
- **Pooling off keeps the stubs.** `mcp_gateway.enabled=false` marks nothing
  shareable but still emits stubs, the broker starts for either switch, and
  `_mcp_apps_enabled` no longer requires `gw.enabled`. MCP Apps works with the
  pool entirely disabled.

### Stated plainly: the broker now runs by default, for everyone

This is a default-path change and deserves naming rather than inferring from the
bullets above. `mcp_gateway.apps_enabled` defaults **true** and always has;
`mcp_gateway.enabled` defaults **false**. Because the broker now starts for
either switch, an install that never touched either one goes from *no gateway at
all* to **a gatewayd daemon plus a stub interposed on every stdio MCP server** —
one extra process per (connection, server) and one extra hop per MCP call.

What that does and does not mean:

- It does **not** switch on something an operator declined. `apps_enabled` was
  already on and already shipped; its own help text asserted it granted nothing
  while `enabled` was off, so on a default install the feature was advertised as
  present and was in fact inert. This makes it real.
- It **does** move a gatewayd or socket defect from an opt-in cohort onto every
  install's MCP path, with the stub's degrade-to-direct fallback as the safety
  net rather than an edge case.
- The escape hatch is narrower than it looks: `apps_enabled=false` restores the
  old topology but gives up MCP Apps. There is no setting that keeps both.

Whether that trade is right is a product default, not a correctness question, and
it is flagged for the maintainer rather than settled here. The alternative on the
table is defaulting `apps_enabled` to **false**, making the interposition opt-in;
that also removes the pre-bind boot work GPT flags, since a default install would
then do no gateway work at all. Release-note wording is deliberately not written
yet because it depends on which way that goes.

### Why deleting the guard was not enough

Reuse is decided by the PoolKey digest, and `PoolKey` carries no connection
dimension — deliberately: adding one would make every backend private and reduce
the pool to a no-op. Two connections to the same server compute the same digest,
so an unconditional stub without a separate acquisition path would have made
everything silently shared.

Private backends therefore live in their own map keyed by `stub_uuid`, never
consulted for reuse. `Backend.storage_digest` appends that token so two private
backends for one server cannot collide, and the spool record binds
`storage_digest` rather than recomputing the PoolKey hash. That is what preserves
`get_by_digest`'s exact-match guarantee — **without the discriminator an app
callback could resolve onto another session's process.**

Lifecycle needs no new machinery: refcount is 1 for life, so the connection
teardown path releases and reaps it. No session-end hook, no bespoke TTL.

### The one decision this forced

**Private backends stay outside the `max_backends` budget** (default 64), with
`stats()` reporting their count separately.

Conceptually, a private backend is a process the host would have had anyway with
no gateway; counting it against the *pooling* budget makes the choice not to pool
subject to a pooling limit.

Mechanically the argument is stronger. Eviction only ever selects idle entries
(refcount 0, unreserved). A private backend is refcount-1 for its whole life, so
it is **never** an eligible victim. Sharing the budget would let private entries
accumulate as unevictable occupants until `add()` found no victim and raised
`PoolAtCapacity` — refusing a new **poolable** session because of connections that
opted out of sharing. That converts resource pressure into a hard denial on the
shared path.

## What tests we did

**New behaviour, integration.** `test_real_stubs_without_poolable_get_their_own_backend`
launches 3 real stub processes under one identical PoolKey with no `--poolable`
and asserts 3 backend processes — under `max_backends=1`, so a shared-budget
implementation fails it. It also asserts no stub wrote a fallback record, because
3 backends via 3 degraded per-session execs would be the OLD behaviour wearing the
new result. **Mutation-verified:** forcing `exclusive_stub_uuid = ""` makes it fail
`1 == 3`; restored and green.

**New behaviour, unit** (`test_mcp_gateway_exclusive_backend.py`, 8 tests): two
identical keys do not share; distinct `storage_digest` with `get_by_digest`
resolving each to its own and the bare PoolKey digest resolving to neither;
5 private backends leave `max_backends=1` free for a pooled acquire; release is
idempotent and a no-op for a pooled stub; `shutdown_all` reaps them; a
double-register on one connection reaps the loser instead of orphaning it; a
pooled backend's digest stays the plain PoolKey hash.

**Rewriter contract:** a non-poolable server is now wrapped and its argv lacks
`--poolable`; an allowlisted one carries it; `pooling_enabled=False` wraps
everything and marks nothing, including an entry declaring `poolable: true`.

**Updated tests that encoded the old weld** rather than deleting them: the apps
gate is no longer a conjunction (the `(pooling off, apps on)` cell flips to
enabled), the adopted-daemon opt-out test now keys on `apps_enabled` — the switch
that actually owns that concern — and a new test asserts pooling-off does *not*
disable apps. `_init_mcp_gateway`'s early return now requires both switches off,
with a new test that apps-alone still starts the broker.

**Full gates green:** pytest 36857 passed, isort, flake8, mypy (862 files). The 12
remaining failures are pre-existing host-environment ones — verified by stashing
the change and re-running the same files on clean `main`, which produced an
**identical** 12-item failure set. The extra `TestRunProbe` entries in the parallel
run pass serially and are unrelated to any file this PR touches. No frontend files
changed.

## Any other suggestions on the work

**Process count is the accepted cost, and it is uncapped by design.** Servers off
the allowlist become one backend per connection — the no-gateway baseline, not a
regression, but a real change from today's collapsed count. `stats()` exposes it;
capping it would reintroduce exactly the denial this PR's capacity decision avoids.
Worth watching before widening the allowlist further.

**#2337's dashboard-side follow becomes dead code.** With the stub unconditional,
MCP Apps no longer needs pooling, so auto-starting the broker on apps-enable would
restart active sessions for a dependency that no longer exists. That follow already
carries a `PROVISIONAL` delete-me marker pointing at #2374 — it is frontend-only
and left out of this PR to keep the diff to one layer, but it should go next.

**Head-of-line blocking gets more reachable.** More traffic crossing the stub seam
means more traffic through a pooled backend's single-worker dispatch, where `ping`
and `tools/list` bypass the queue and answer healthy while tool calls serialise.
Not introduced here, but this widens the set of paths that can hit it.

**Scoped out deliberately:** `UNPOOLABLE_SERVERS` (KiroCrew's own servers, which
bind to `KIROCREW_SESSION_KEY` and are already per-session by construction),
HTTP/SSE entries (no stub needed), and per-server MCP Apps control.

Refs #2374

