### PR TITLE
test(subagent): drop the Windows-tick duration floor from the turn-duration test

### DIFF
--- a/test/test_turn_duration_subagent.py
+++ b/test/test_turn_duration_subagent.py
@@ -23,6 +23,7 @@ autouse conftest fixtures.
 from __future__ import annotations
 
 import asyncio
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -140,16 +141,25 @@ async def test_subagent_turn_records_local_wall_clock():
 
         return _gen()
 
+    # Bracket the whole spawn so we have an OUTER wall-clock window that strictly
+    # encloses the subagent's internal one (_turn_t0 at stream start -> persist).
+    observed_start = time.monotonic()
     records = await _spawn_and_capture(stream_factory)
+    observed_elapsed_ms = (time.monotonic() - observed_start) * 1000
 
     assert len(records) == 1
     rec = records[0]
     assert rec["surface"] == "subagent"
-    # The fallback fired: a real, positive local measurement — not the literal
-    # 0 the provider-only read used to write into every row.
-    assert rec["duration_ms"] > 0
-    # Tie it to the real clock: >= the forced sleep, minus scheduling slop.
-    assert rec["duration_ms"] >= 20
+    # The fallback fired: a real, positive local measurement, not the literal 0
+    # the provider-only read used to write into every row. Bound it as
+    # 0 < duration_ms <= observed rather than with a fixed floor. The lower
+    # bound (> 0) proves the clock advanced; the upper bound ties it to a real
+    # measurement (a bug writing an arbitrary constant would exceed the window
+    # that encloses it). Both are race-free: the internal window is a subset of
+    # the outer one on any platform, unlike a fixed floor, which races Windows'
+    # ~15.6 ms timer quantum when a 30 ms sleep rounds to one tick (~15 ms) (see
+    # testing-conventions.md, Determinism class 2, wall-clock races).
+    assert 0 < rec["duration_ms"] <= observed_elapsed_ms
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

`test/test_turn_duration_subagent.py::test_subagent_turn_records_local_wall_clock`
forced roughly 30 ms of real time with `asyncio.sleep` and then asserted
`rec["duration_ms"] >= 20`. On the Windows CI shards that floor is a wall-clock
race: Windows rounds `asyncio.sleep` up to its ~15.6 ms timer resolution, so a
30 ms sleep can read back as a single tick (~15 ms), and on a loaded runner the
start and end timestamps land on the same tick boundary. The failure seen on
shard 4/4 was `assert 15 >= 20`, which is exactly one Windows tick. The margin
between the sleep and the floor is smaller than the platform's own timer
quantum.

This goes red on unrelated PRs (it surfaced on a frontend-only branch that
changes no Python), which is the expensive failure mode: whoever hits it has to
mine CI history to prove their diff is innocent.

## Fix

Replace the fixed millisecond floor with a race-free bound. The test brackets the
spawn with `time.monotonic()` to capture an outer wall-clock window, then asserts
`0 < duration_ms <= observed_elapsed`. The lower bound proves the fallback fired
(the subagent recorded its own local wall clock, not the literal 0 the
provider-only read used to write). The upper bound ties the value to a real
measurement: the internal window (`_turn_t0` at stream start to persist) is
strictly enclosed by the outer one, so the recorded duration can never exceed it
on any platform, and a bug writing an arbitrary positive constant would.

Both bounds are race-free, unlike the old floor. The floor encoded an absolute
number of milliseconds that has to clear the platform timer quantum; the
enclosing-window bound does not depend on timer resolution at all. This matches
`docs/system-specs/common/testing-conventions.md` Determinism class 2 (wall-clock
races), whose prescribed fix is to remove the clock dependency rather than
lengthen the sleep or add a rerun. I did not raise `_TURN_SLEEP_SECS` or add a
retry, as the issue asked.

The negative-control test (`test_provider_reported_duration_wins_over_local_clock`)
is unchanged and still pins that a provider-reported duration wins over the local
clock, so the fallback-precedence contract is covered separately.

The alternative (option 2 in the issue, drive the duration from an injected fake
clock) would also work and let you assert an exact value, but it is a larger
change to the stream factory and the record-builder capture path for no extra
coverage here. Happy to switch to the fake-clock approach if you would prefer an
exact assertion.

## Tests

`test/test_turn_duration_subagent.py` passes, both the positive test and the
negative control:

```
2 passed
```

isort, flake8, and mypy are clean on the changed file.

Closes #2449

## Checklist

- [x] I have read the contributing guidelines
- [x] My change follows the project's determinism conventions (removes the clock dependency rather than retrying or lengthening the sleep)
- [x] Tests pass locally
- [x] No new dependencies
