### PR TITLE
fix: match multi-word chat-history queries token-wise

### DIFF
--- a/src/kiro_crew/discord/session_resume.py
+++ b/src/kiro_crew/discord/session_resume.py
@@ -206,15 +206,15 @@ class DiscordSessionResume:
                     self.conv_log.search_sessions, query, _SEARCH_FETCH_LIMIT
                 )
                 if not rows and len(normalized_query.split()) > 1:
-                    # search_sessions matches the query as ONE phrase
-                    # (``needle = query.casefold()``), so out-of-order words miss:
-                    # "specific link" does not match "Link to a Specific Session".
-                    # Fall back to an all-words TITLE match so a remembered-but-
-                    # reordered title still resolves. Deliberately last-resort and
-                    # only on zero hits, so the shared search stays authoritative
-                    # and we are not running two rankers in parallel. The proper
-                    # home for multi-word support is search_sessions itself, which
-                    # would fix the dashboard too -- tracked as a follow-up.
+                    # search_sessions now matches multi-word queries token-wise
+                    # (all tokens must appear, in the title or the content), so
+                    # out-of-order words like "specific link" DO resolve
+                    # "Link to a Specific Session". What it still cannot reach is
+                    # a session older than its _SEARCH_SCAN_WINDOW most-recent
+                    # cap, so keep this unbounded all-words TITLE match as the
+                    # last resort for a long-lived install. Only on zero hits, so
+                    # the shared search stays authoritative and we are not
+                    # running two rankers in parallel.
                     listed = await asyncio.to_thread(self.conv_log.list_sessions)
                     words = normalized_query.split()
                     rows = [

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -586,8 +586,41 @@ def update_metadata_off_loop(
 
 
 SEARCH_MIN_CHARS = 2  # shortest query string that triggers backend search
+SEARCH_MAX_TOKENS = 12  # distinct terms scored per query — see search_query_tokens
 _TITLE_BOOST = 10  # field-boost multiplier for title matches in search_sessions
+_PHRASE_BOOST = 4  # extra weight per exact whole-query hit in a multi-word search
 _SEARCH_SCAN_WINDOW = 500  # cap files scanned per search to bound I/O
+
+
+def search_query_tokens(query: str) -> tuple[list[str], str]:
+    """Return ``(tokens, phrase)`` for a search *query*, casefolded.
+
+    ``tokens`` are the DISTINCT whitespace-separated terms in first-seen order,
+    capped at :data:`SEARCH_MAX_TOKENS`; ``phrase`` is the whole normalized
+    query. Callers requiring every token (:meth:`ConversationLog.search_sessions`)
+    and callers locating one (the snippet builders) share this so the two halves
+    of a query cannot drift apart.
+
+    Both bounds exist because **every token costs one full scan** of a session's
+    text, so token count multiplies search cost on a user-supplied string:
+
+    * Deduplication is free correctness — a repeated term cannot change an AND
+      match, so scanning for it twice buys nothing. A 256-character query of
+      repeated ``"a "`` would otherwise run 128 scans per session instead of 1.
+    * The cap bounds the distinct case, which dedup cannot: 100 distinct short
+      terms is still 100 scans. Truncating makes the query only LOOSER (fewer
+      required terms), so it can admit extra results but never hide a session
+      that would have matched — the safe direction when the alternative is a
+      keystroke-driven search stalling for seconds.
+
+    A whitespace-only query yields ``([], "")``; callers treat that as "matches
+    nothing" rather than "matches everything".
+    """
+    parts = query.casefold().split()
+    if not parts:
+        return ([], "")
+    return (list(dict.fromkeys(parts))[:SEARCH_MAX_TOKENS], " ".join(parts))
+
 
 # Hard ceilings on the memory the two search memos may hold, in real retained
 # bytes as reported by ``str.__sizeof__`` — NOT in characters.
@@ -2544,41 +2577,85 @@ class ConversationLog:
     def search_sessions(self, query: str, limit: int = 50) -> list[dict]:
         """Return session metadata for files whose message content matches *query*.
 
-        Case-insensitive substring match over each message's ``content``
-        field using full Unicode case folding via :meth:`str.casefold`
-        (so e.g. German ``ß`` folds to ``ss``).  Matching only on parsed
-        ``content`` avoids false positives from JSON structural elements
-        (e.g. the word ``"user"`` matching every ``"role": "user"`` line).
+        The query is split on whitespace into tokens, and a session matches only
+        when **every** token appears somewhere in its title or content — an AND
+        over the whole document, not a single whole-query substring. That is what
+        makes a natural multi-word query work: ``"ack contention hypotheses"``
+        finds a session discussing all three, which a whole-phrase match missed
+        because those exact words never sit adjacent. A single-token query is
+        unchanged by this — one token IS the phrase.
+
+        Each token is matched case-insensitively as a SUBSTRING (so ``"cont"``
+        hits ``"contention"``, which keeps search-as-you-type responsive) using
+        full Unicode case folding via :meth:`str.casefold` (so e.g. German ``ß``
+        folds to ``ss``).  Matching only on parsed ``content`` avoids false
+        positives from JSON structural elements (e.g. the word ``"user"``
+        matching every ``"role": "user"`` line).
 
         Ranking (higher is better)::
 
-            score = (title_matches * _TITLE_BOOST)
-                  + (content_matches / sqrt(1 + doc_chars / 1024))
+            score = (title_hits * _TITLE_BOOST)
+                  + (content_hits / sqrt(1 + doc_chars / 1024))
+
+        where ``*_hits`` sum the per-token counts, plus ``_PHRASE_BOOST`` per
+        occurrence of the exact whole query when it has more than one token.
+        The phrase bonus rewards adjacency: at comparable token frequency, the
+        session containing the words TOGETHER as typed ranks above one that
+        merely mentions them far apart.  It is deliberately a bonus and not an
+        override — a session repeating one token far more often still wins on
+        raw term frequency, exactly as it already did for a single-token query.
+        (Saturating term frequency, BM25-style, would change that; it would also
+        re-rank every existing single-token query, so it is out of scope here.)
 
         Title matches get a strong field boost - titles are short and
         intentional, so a hit there is strong evidence.  Content matches
         are normalized by a sqrt length factor so a long session with a
         casual mention doesn't outrank a short, focused one.  (Simpler
         than BM25's ``(1-b) + b*(dl/avgdl)`` because we avoid the
-        two-pass scan needed for corpus stats.)  Sessions with zero
-        matches are dropped.  Ties break by recency (existing
+        two-pass scan needed for corpus stats.)  Sessions missing any
+        token are dropped.  Ties break by recency (existing
         ``list_sessions`` order - newest first).  Caps results at *limit*.
         Only the ``_SEARCH_SCAN_WINDOW`` most recent files are scored, so
         I/O stays bounded even with hundreds of sessions.
         """
         if not query or limit <= 0 or not self._dir.exists():
             return []
-        needle = query.casefold()
+        tokens, phrase = search_query_tokens(query)
+        if not tokens:
+            # Whitespace-only query: no tokens to require, so nothing can match.
+            # Returning [] keeps this from degenerating into "match everything",
+            # and skips reading every session file to reach that conclusion.
+            return []
+        # True when the phrase carries more than the single token does, so an
+        # exact-phrase bonus is meaningful. Not `len(tokens) > 1`: dedup collapses
+        # "a a" to one token while its phrase is still two words.
+        multi = tokens != [phrase]
         # (score, -rank, meta, needs_snippet)
         scored: list[tuple[float, int, dict, bool]] = []
         window = self.list_sessions()[:_SEARCH_SCAN_WINDOW]
         self._prune_search_memos({m["key"] for m in window})
         for rank, meta in enumerate(window):
             doc_chars, folded = self._folded_content(meta["key"])
-            content_hits = folded.count(needle) if folded else 0
-            title_hits = (meta.get("title") or "").casefold().count(needle)
-            if not title_hits and not content_hits:
+            title_folded = (meta.get("title") or "").casefold()
+            content_hits = 0
+            title_hits = 0
+            for token in tokens:
+                in_content = folded.count(token) if folded else 0
+                in_title = title_folded.count(token)
+                if not in_content and not in_title:
+                    # AND semantics: one absent token disqualifies the session,
+                    # so stop counting the rest.
+                    content_hits = title_hits = 0
+                    break
+                content_hits += in_content
+                title_hits += in_title
+            if not content_hits and not title_hits:
                 continue
+            if multi:
+                # Reward the words appearing together, in order, as typed.
+                if folded:
+                    content_hits += folded.count(phrase) * _PHRASE_BOOST
+                title_hits += title_folded.count(phrase) * _PHRASE_BOOST
             length_norm = math.sqrt(1 + doc_chars / 1024)
             score = title_hits * _TITLE_BOOST + content_hits / length_norm
             # Negate rank so a smaller (newer) rank wins ties after score desc sort.
@@ -2817,23 +2894,34 @@ class ConversationLog:
         an empty snippet despite a nonzero hit count), but folding can change a
         string's length, so the window may be off by a character or two.
 
-        Returns ``''`` when the query is not locatable in any single message, or
+        For a multi-word query the exact phrase is tried first and each token is
+        tried as a fallback, mirroring :meth:`search_sessions`' AND-over-tokens
+        matching — otherwise every session that matched on scattered words would
+        come back with no snippet at all. Needles are tried per message, so the
+        first MESSAGE containing any of them wins rather than the best needle
+        overall; that preserves the streaming early-exit above, and this string
+        is display-only.
+
+        Returns ``''`` when no needle is locatable in any single message, or
         when the file cannot be read (display-only — never raises at the caller).
         """
-        needle = query.casefold()
-        if not needle:
+        tokens, phrase = search_query_tokens(query)
+        if not tokens:
             return ""
+        needles = [phrase] if tokens == [phrase] else [phrase, *tokens]
         try:
             for text in self._snippet_texts(key):
-                pos = text.casefold().find(needle)
-                if pos < 0:
-                    continue
-                start = max(0, pos - self._SNIPPET_LEAD)
-                end = min(len(text), pos + len(query) + self._SNIPPET_TRAIL)
-                frag = " ".join(text[start:end].split())
-                prefix = "…" if start > 0 else ""
-                suffix = "…" if end < len(text) else ""
-                return (prefix + frag + suffix)[: self._SNIPPET_MAX]
+                folded = text.casefold()
+                for needle in needles:
+                    pos = folded.find(needle)
+                    if pos < 0:
+                        continue
+                    start = max(0, pos - self._SNIPPET_LEAD)
+                    end = min(len(text), pos + len(needle) + self._SNIPPET_TRAIL)
+                    frag = " ".join(text[start:end].split())
+                    prefix = "…" if start > 0 else ""
+                    suffix = "…" if end < len(text) else ""
+                    return (prefix + frag + suffix)[: self._SNIPPET_MAX]
         except OSError:
             return ""
         return ""

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -50,7 +50,7 @@ from kiro_crew.config.loader import (
 from kiro_crew.context_management import COMPLETION_KEEP_DEFAULT_CHARS, summarize_result
 from kiro_crew.dashboard.origin import parse_dashboard_url
 from kiro_crew.history import _SEARCH_SCAN_WINDOW as SEARCH_SCAN_WINDOW
-from kiro_crew.history import INCOGNITO_MEMORY_MODES, ConversationLog
+from kiro_crew.history import INCOGNITO_MEMORY_MODES, ConversationLog, search_query_tokens
 from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes
 from kiro_crew.knowledge.dedup import dedup_sweep
 from kiro_crew.knowledge.embedder import create_embedder_from_config
@@ -3461,7 +3461,14 @@ def _extract_history_snippet(messages: list[dict], needle: str) -> str:
     # is independently callable.
     if not needle.strip():
         return ""
-    needle_cf = needle.casefold()
+    # Same tokenizer as search_sessions: that call decides a session MATCHED on
+    # scattered tokens, so searching only the whole phrase here would return ""
+    # and suppress the row's snippet for exactly the multi-word queries the
+    # token-wise match enables. Bounded + deduplicated for the same reason.
+    tokens, phrase = search_query_tokens(needle)
+    if not tokens:
+        return ""
+    needles_cf = [phrase] if tokens == [phrase] else [phrase, *tokens]
     for m in messages:
         # Only surface user/assistant content (mirror get_chat_session) so the
         # snippet is the human-facing context, not a tool/system trace blob.
@@ -3470,31 +3477,35 @@ def _extract_history_snippet(messages: list[dict], needle: str) -> str:
         content = m.get("content")
         if not isinstance(content, str) or not content:
             continue
-        idx = content.casefold().find(needle_cf)
-        if idx < 0:
-            continue
-        start = max(0, idx - _SNIPPET_RADIUS)
-        end = min(len(content), idx + len(needle) + _SNIPPET_RADIUS)
-        seg = content[start:end]
-        # Redact BEFORE inserting <<<...>>> markers: marker insertion would split
-        # a credential/URL token and defeat the contiguous-match redactors, so a
-        # query that is a substring of a secret in stored content could leak it.
-        seg = _redact_history_output(seg)
-        # Locate the match span in the (possibly redacted) original text using the
-        # SAME full casefolding as the selection above — a case-insensitive regex
-        # does only simple per-char mapping and would miss multi-char folds
-        # (ß→ss), leaving a selected-but-unwrapped snippet with no <<<...>>>.
-        span = _casefold_match_span(seg, needle_cf)
-        if span:
-            s, e = span
-            seg = seg[:s] + "<<<" + seg[s:e] + ">>>" + seg[e:]
-        seg = ("…" if start > 0 else "") + seg + ("…" if end < len(content) else "")
-        result = seg[:_SNIPPET_MAX_LEN]
-        # If the hard cap sliced through the match delimiters (possible with a
-        # long query), re-close so the consumer never sees a dangling "<<<".
-        if "<<<" in result and ">>>" not in result:
-            result = result[: _SNIPPET_MAX_LEN - 3] + ">>>"
-        return result
+        folded = content.casefold()
+        for needle_cf in needles_cf:
+            idx = folded.find(needle_cf)
+            if idx < 0:
+                continue
+            start = max(0, idx - _SNIPPET_RADIUS)
+            end = min(len(content), idx + len(needle_cf) + _SNIPPET_RADIUS)
+            seg = content[start:end]
+            # Redact BEFORE inserting <<<...>>> markers: marker insertion would
+            # split a credential/URL token and defeat the contiguous-match
+            # redactors, so a query that is a substring of a secret in stored
+            # content could leak it.
+            seg = _redact_history_output(seg)
+            # Locate the match span in the (possibly redacted) original text using
+            # the SAME full casefolding as the selection above — a case-insensitive
+            # regex does only simple per-char mapping and would miss multi-char
+            # folds (ß→ss), leaving a selected-but-unwrapped snippet with no
+            # <<<...>>>.
+            span = _casefold_match_span(seg, needle_cf)
+            if span:
+                s, e = span
+                seg = seg[:s] + "<<<" + seg[s:e] + ">>>" + seg[e:]
+            seg = ("…" if start > 0 else "") + seg + ("…" if end < len(content) else "")
+            result = seg[:_SNIPPET_MAX_LEN]
+            # If the hard cap sliced through the match delimiters (possible with a
+            # long query), re-close so the consumer never sees a dangling "<<<".
+            if "<<<" in result and ">>>" not in result:
+                result = result[: _SNIPPET_MAX_LEN - 3] + ">>>"
+            return result
     return ""
 
 

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from windows_sim import builtin_open_sharing_violation
 
+from kiro_crew import history
 from kiro_crew.history import (
     _CONSOLIDATION_THRESHOLD,
     _SESSION_KEEP_LINES,
@@ -876,6 +877,177 @@ class TestSearchSessions:
         assert "apollo" in hits[0]["snippet"]
         assert calls == [], "the search path must not enter _read_messages"
         assert len(log._msg_cache) == 0, "searching must not pin a parsed transcript"
+
+    def test_multi_word_query_matches_scattered_tokens(self, tmp_path):
+        """A multi-word query matches when its words appear APART, not adjacent.
+
+        Regression: the query was matched as one whole-phrase substring, so a
+        natural query like "ack contention hypotheses" silently returned nothing
+        even though the session discussed all three — the exact phrase never
+        occurs. Silent zero results are the worst failure mode for search: the
+        caller cannot tell "not in history" from "phrased it wrong".
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("hit", "user", "the ack path shows contention under load")
+        log.append("hit", "assistant", "ranked the hypotheses by expected effect")
+        log.append("miss", "user", "unrelated disk cleanup chatter")
+
+        results = log.search_sessions("ack contention hypotheses")
+
+        assert [s["key"] for s in results] == ["hit"]
+
+    def test_multi_word_query_requires_every_token(self, tmp_path):
+        """AND, not OR: a session missing one token must not surface.
+
+        OR semantics would make a common word drag in the whole corpus, which is
+        a different way of being useless than the phrase bug.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("both", "user", "contention in the hypotheses list")
+        log.append("partial", "user", "contention everywhere but no hypothesis list")
+
+        results = log.search_sessions("contention hypotheses")
+
+        assert [s["key"] for s in results] == ["both"]
+
+    def test_exact_phrase_outranks_same_words_apart(self, tmp_path):
+        """At comparable token frequency, words appearing TOGETHER rank first.
+
+        This is what ``_PHRASE_BOOST`` buys, and all it buys: adjacency wins the
+        tie. It is not an override of term frequency — a session repeating one
+        token far more often still ranks higher on raw count, which is the
+        behaviour this ranker already had for single-token queries.
+
+        Titles are written explicitly because ``list_sessions`` otherwise
+        derives a title from the first message, which would hand a
+        content-heavy session a ``_TITLE_BOOST`` and mask what is being tested.
+        """
+        (tmp_path / "apart.jsonl").write_text(
+            '{"_type": "metadata", "title": "session one"}\n'
+            '{"role": "user", "content": "ping at the start and pong at the end"}\n',
+            encoding="utf-8",
+        )
+        (tmp_path / "together.jsonl").write_text(
+            '{"_type": "metadata", "title": "session two"}\n'
+            '{"role": "user", "content": "the ping pong bench numbers"}\n',
+            encoding="utf-8",
+        )
+        log = ConversationLog(base_dir=tmp_path)
+
+        results = log.search_sessions("ping pong")
+
+        assert {s["key"] for s in results} == {"apart", "together"}
+        assert results[0]["key"] == "together"
+
+    def test_multi_word_scattered_match_still_gets_a_snippet(self, tmp_path):
+        """A scattered multi-word match must show WHY it surfaced.
+
+        The snippet builder searched for the whole phrase, so every session that
+        newly matches on scattered tokens would otherwise come back with no
+        snippet — surfacing rows a caller cannot evaluate.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("hit", "user", "the ack path shows contention under load")
+        log.append("hit", "assistant", "ranked the hypotheses by expected effect")
+
+        results = log.search_sessions("ack contention hypotheses")
+
+        assert results[0]["snippet"], "expected a non-empty snippet"
+        assert "contention" in results[0]["snippet"].casefold()
+
+    def test_whitespace_only_query_matches_nothing_and_reads_no_file(self, tmp_path):
+        """A whitespace-only query returns [] *and* reads no session file.
+
+        It tokenizes to an empty list. Asserting only on the empty result would
+        pass with or without the early return, because a tokenless loop scores
+        nothing anyway — so this pins the I/O too: without the guard every
+        session in the scan window still gets read and folded to reach a
+        foregone conclusion.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("alpha", "user", "some content here")
+        reads: list[str] = []
+        real = log._folded_content
+
+        def counting(key: str) -> tuple[int, str]:
+            reads.append(key)
+            return real(key)
+
+        log._folded_content = counting  # type: ignore[assignment]
+
+        assert log.search_sessions("   ") == []
+        assert log.search_sessions("\t\n") == []
+        assert reads == [], "a tokenless query must not read any session file"
+
+    def test_single_token_query_behaviour_is_unchanged(self, tmp_path):
+        """One token IS the phrase — substring matching must still apply.
+
+        Guards the search-as-you-type path: a partial word has to keep matching
+        the longer word it prefixes.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("alpha", "user", "deep contention analysis")
+
+        assert [s["key"] for s in log.search_sessions("cont")] == ["alpha"]
+        assert [s["key"] for s in log.search_sessions("contention")] == ["alpha"]
+
+
+class TestSearchQueryTokens:
+    """Bounds on the tokenizer shared by the matcher and the snippet builders.
+
+    Every token costs one full scan of a session's text, so the token list is
+    the knob that multiplies search cost on a user-supplied string.
+    """
+
+    def test_repeated_terms_collapse_to_one_token(self):
+        """A repeated term must not buy extra scans — it cannot change an AND match.
+
+        Regression: a 256-char query of repeated "a " tokenized to 128 terms and
+        drove 128 full scans per session instead of 1, stalling a keystroke-driven
+        search.
+        """
+        tokens, phrase = history.search_query_tokens("a " * 128)
+
+        assert tokens == ["a"], "duplicates must collapse"
+        assert phrase == " ".join(["a"] * 128), "the phrase keeps the query as typed"
+
+    def test_distinct_terms_are_capped(self):
+        """Dedup cannot bound the distinct case, so the cap does.
+
+        Truncation keeps the FIRST terms, making the query looser rather than
+        wrong — it can admit extra results but never hide a matching session.
+        """
+        query = " ".join(f"t{i}" for i in range(history.SEARCH_MAX_TOKENS + 25))
+
+        tokens, _ = history.search_query_tokens(query)
+
+        assert len(tokens) == history.SEARCH_MAX_TOKENS
+        assert tokens[0] == "t0", "the cap keeps the first terms, in order"
+
+    def test_whitespace_only_query_yields_no_tokens(self):
+        """No tokens, so an all-tokens-present check cannot be vacuously true."""
+        assert history.search_query_tokens("   \t\n") == ([], "")
+
+    def test_order_is_first_seen(self):
+        """Token order is stable and first-seen, so the snippet fallback is predictable."""
+        tokens, _ = history.search_query_tokens("beta alpha beta gamma")
+
+        assert tokens == ["beta", "alpha", "gamma"]
+
+    def test_deduped_query_still_gets_phrase_treatment(self, tmp_path):
+        """"a a" dedups to ONE token but its phrase is still two words.
+
+        Keyed off `tokens != [phrase]` rather than `len(tokens) > 1`, so the
+        session matched on the single token still resolves a snippet instead of
+        searching only for a phrase it may not contain.
+        """
+        log = ConversationLog(base_dir=tmp_path)
+        log.append("hit", "user", "the letter a stands alone here")
+
+        results = log.search_sessions("a a")
+
+        assert [s["key"] for s in results] == ["hit"]
+        assert results[0]["snippet"], "a deduped multi-word query must still snippet"
 
 
 class TestArchive:

--- a/test/test_search_chat_history.py
+++ b/test/test_search_chat_history.py
@@ -42,6 +42,23 @@ class TestHelpers:
         assert mcp_core._extract_history_snippet([{"role": "user", "content": "abc"}], "") == ""
         assert mcp_core._extract_history_snippet([{"role": "user", "content": "abc"}], "   ") == ""
 
+    def test_snippet_multi_word_query_falls_back_to_a_token(self):
+        # search_sessions matches a session when every TOKEN appears somewhere, so
+        # this extractor must locate a token too. Searching only the whole phrase
+        # returned "" and the handler suppresses snippet-less rows -- so exactly
+        # the multi-word queries token-wise matching enables came back bare.
+        msgs = [{"role": "user", "content": "the ack path shows contention under load"}]
+        snip = mcp_core._extract_history_snippet(msgs, "ack contention hypotheses")
+        assert snip, "a scattered multi-word match must still yield a snippet"
+        assert "<<<" in snip and ">>>" in snip, "the located token must be delimited"
+
+    def test_snippet_prefers_the_exact_phrase_over_a_token(self):
+        # Phrase first: when the words DO sit together, the snippet centres on the
+        # phrase rather than on whichever token happens to appear earliest.
+        msgs = [{"role": "user", "content": "ping alone, then the ping pong bench"}]
+        snip = mcp_core._extract_history_snippet(msgs, "ping pong")
+        assert "<<<ping pong>>>" in snip
+
     def test_snippet_full_casefold_match_is_delimited(self):
         # The selection (str.casefold().find) and the wrap must use the SAME full
         # casefolding: 'straße'.casefold() == 'strasse' matches 'STRASSE', but a


### PR DESCRIPTION
## Problem

A natural multi-word query against chat history silently returned **nothing**.

```
search_chat_history("ack contention hypotheses")  ->  "No matching conversations found."
search_chat_history("contention")                 ->  5 hits, including the very
                                                       session that discussed all three
```

The session contained all three words — just never adjacent.

## Why it matters

Silent zero results are the worst failure mode for search: the caller cannot tell
"not in history" from "you phrased it wrong", so it stops looking. This is the
retrieval path behind the dashboard session search, the Discord `!sessions`
picker, and the `search_chat_history` MCP tool — the surface an agent uses to
recover context it does not have. It was already a known, deliberately-deferred
defect: `src/kiro_crew/discord/session_resume.py` carried a client-side
workaround whose comment read *"The proper home for multi-word support is
search_sessions itself, which would fix the dashboard too -- tracked as a
follow-up."*

## Fix (symptom -> root cause -> change)

**Symptom:** multi-word queries return nothing.

**Root cause:** `ConversationLog.search_sessions` matched the query as one
literal substring — `needle = query.casefold()`, then
`folded.count(needle)`. There was no tokenization at all, so the words had to
sit adjacent, in order, to match anything.

**Change:** split the query into tokens and require **every** token to appear in
the session's title or content (AND over the document, not OR — OR lets one
common word drag in the whole corpus, which is a different way of being
useless). `_PHRASE_BOOST` per exact whole-query occurrence keeps an adjacent
match ranked above the same words scattered far apart.

Two things fell out of that and are fixed in the same change because they are
the same root cause — the query was being tokenized in more than one place:

1. **Token count multiplied search cost.** Each token costs one full scan of a
   session's text, so the old single scan became N scans on a *user-supplied*
   string. All tokenization now goes through one helper,
   `search_query_tokens`, which **deduplicates** (a repeated term cannot change
   an AND match, so scanning for it twice buys nothing) and **caps** distinct
   terms at `SEARCH_MAX_TOKENS`. Truncation makes the query only looser, so it
   can admit extra results but never hide a session that would have matched —
   the safe direction when the alternative is a keystroke-driven search stalling.
2. **The MCP tool dropped its snippets.** `mcp_core._extract_history_snippet` is
   a *second*, independent extractor that still searched the whole phrase, and
   the handler suppresses snippet-less rows. So exactly the multi-word queries
   this change enables would have come back as bare title + date. It now shares
   the same helper: phrase first, then each token.

The Discord title-only fallback is **kept**, and its stale comment corrected. It
is not dead code: `search_sessions` only scores the `_SEARCH_SCAN_WINDOW` (500)
most recent sessions, while the fallback's `list_sessions()` is uncapped, so on a
long-lived install it remains the only route to an older session.

## Tests

Added to `test/test_history.py` and `test/test_search_chat_history.py`:

| Test | Locks in |
|---|---|
| `test_multi_word_query_matches_scattered_tokens` | the reported bug — words apart still match |
| `test_multi_word_query_requires_every_token` | AND, not OR: a missing token disqualifies |
| `test_exact_phrase_outranks_same_words_apart` | adjacency wins at comparable frequency |
| `test_multi_word_scattered_match_still_gets_a_snippet` | a surfaced row shows *why* it surfaced |
| `test_whitespace_only_query_matches_nothing_and_reads_no_file` | the early return, **and** that it reads no session file |
| `test_single_token_query_behaviour_is_unchanged` | no regression to search-as-you-type substrings |
| `test_repeated_terms_collapse_to_one_token` | the cost blocker: 128 repeats -> 1 scan |
| `test_distinct_terms_are_capped` | the distinct case dedup cannot bound |
| `test_snippet_multi_word_query_falls_back_to_a_token` | the MCP extractor no longer returns "" |
| `test_snippet_prefers_the_exact_phrase_over_a_token` | phrase preferred when words are adjacent |

**Mutation-proven.** Against the pre-fix code, 4 of the 6 matcher tests and the
MCP fallback test fail. Two (`test_deduped_query_still_gets_phrase_treatment`,
`test_snippet_prefers_the_exact_phrase_over_a_token`) pass pre-fix by
construction — they are no-regression guards, not proof of the fix.

## Manual verification

Reproduced the original bug live through the MCP tool before fixing:
`"ack contention hypotheses"` returned *No matching conversations found* while
`"contention"` alone returned 5 hits including the same session. Otherwise N/A —
unit coverage is sufficient, since this is a pure-function matcher with no
I/O-dependent behaviour beyond the file reads already asserted.

## Screenshots

N/A — no user-visible UI change. The dashboard search box is unchanged; only the
backend matcher it calls.

## Deliberately out of scope

Two advisory findings from local review, both accepted-and-deferred rather than
widened into this PR:

- **Phrase bonus compounds with `_TITLE_BOOST`** — one phrase hit in a title is
  worth ~40 points against ~4 for the same hit in content, a wider field
  asymmetry than the pre-existing ~10x design intended. No session is dropped
  and no result is wrong; the minimal fix is a ranking redesign.
- **Short substring tokens** — a query like `"a b"` (past `SEARCH_MIN_CHARS`)
  now matches nearly every in-window session where the phrase match matched
  nothing. A relevance regression, not a defect class; the fix needs a
  minimum-token-length rule.

## Pre-existing failure, not from this change

`test/test_search_sessions_cost.py::TestAdmissionControlIsNotAOneWayRatchet::test_a_session_that_left_the_window_stops_holding_budget`
fails on this host. It **also fails with `history.py` reverted to `origin/main`**
and with only that module collected, so it is independent of this change. Flagged
rather than fixed to keep this PR scoped.
