### PR TITLE
test(website): cover six app surfaces that had no tests at all

### DIFF
--- a/website/src/test/CrewCompanionGallery.coverage.test.tsx
+++ b/website/src/test/CrewCompanionGallery.coverage.test.tsx
@@ -1,0 +1,903 @@
+/**
+ * The avatar gallery's own behaviour, end to end through its bridge.
+ *
+ * `GalleryPanel` is the whole gallery window: the grid, the per-pack detail sheet,
+ * the PetDex import dialog, and the editor overlay. Every one of those talks to the
+ * desktop app through `galleryApi`, so the bridge is the only thing mocked here —
+ * the component, its state machine, and the real i18n strings run for real.
+ *
+ * Three child surfaces are stubbed deliberately, not incidentally:
+ *   - `PackEditor` / `SpriteImporter` are separate multi-step editors with their own
+ *     tests; here they stand in as prop harnesses so the gallery's OWN save / cancel
+ *     / refused-save wiring is what gets asserted.
+ *   - `petdexImport` decodes a sprite sheet through `new Image()` + canvas, which
+ *     never settles under happy-dom — an unmocked `firstFramePreview` leaves the
+ *     import dialog stuck on "Looking it up…" forever.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup, act, within } from '@testing-library/react'
+
+import type { PackMeta } from '../apps/crew-companion/appearanceTypes'
+
+// ── Bridge double ──────────────────────────────────────────────────────────
+
+type Unsub = () => void
+
+const mocks = vi.hoisted(() => {
+  const listeners: {
+    active?: (data?: { packId?: string }) => void
+    packs?: () => void
+    color?: (data: { packId: string; colorMap: Record<string, string> }) => void
+    config?: (kiro?: { language?: string }) => void
+  } = {}
+  const api = {
+    galleryListPacks: vi.fn(),
+    galleryGetPackDetail: vi.fn(),
+    gallerySetActive: vi.fn(),
+    galleryDelete: vi.fn(),
+    galleryExport: vi.fn(),
+    gallerySaveSpritePack: vi.fn(),
+    getCrewCompanionConfig: vi.fn(),
+    presetsGetColorMap: vi.fn(),
+    petdexFetch: vi.fn(),
+    updateConfig: vi.fn(),
+    openExternal: vi.fn(),
+    closeGallery: vi.fn(),
+    onGalleryActiveChanged: vi.fn((cb: (d?: { packId?: string }) => void): Unsub => {
+      listeners.active = cb
+      return () => { listeners.active = undefined }
+    }),
+    onGalleryPacksChanged: vi.fn((cb: () => void): Unsub => {
+      listeners.packs = cb
+      return () => { listeners.packs = undefined }
+    }),
+    onColorMapChanged: vi.fn((cb: (d: { packId: string; colorMap: Record<string, string> }) => void): Unsub => {
+      listeners.color = cb
+      return () => { listeners.color = undefined }
+    }),
+    onConfigUpdated: vi.fn((cb: (k?: { language?: string }) => void): Unsub => {
+      listeners.config = cb
+      return () => { listeners.config = undefined }
+    }),
+  }
+  const firstFramePreview = vi.fn()
+  const buildSpritePackData = vi.fn()
+  return { api, listeners, firstFramePreview, buildSpritePackData }
+})
+
+vi.mock('../apps/crew-companion/petBridge', () => ({
+  galleryApi: mocks.api,
+  petBridge: mocks.api,
+}))
+
+vi.mock('../apps/crew-companion/petdexImport', () => ({
+  firstFramePreview: mocks.firstFramePreview,
+  buildSpritePackData: mocks.buildSpritePackData,
+  STATE_MAP: [],
+  RANDOM_MAP: [],
+}))
+
+vi.mock('../apps/crew-companion/PackEditor', () => ({
+  PackEditor: ({ existingPack, onSave, onCancel }: {
+    existingPack?: { name: string }
+    onSave: () => void
+    onCancel: () => void
+  }) => (
+    <div>
+      <span>editor-for:{existingPack ? existingPack.name : 'new-pack'}</span>
+      <button onClick={onSave}>editor-save</button>
+      <button onClick={onCancel}>editor-cancel</button>
+    </div>
+  ),
+}))
+
+vi.mock('../apps/crew-companion/SpriteImporter', () => ({
+  SpriteImporter: ({ existingPack, onDone, onCancel, saveError }: {
+    existingPack?: { id: string }
+    onDone: (r: { overwriteId?: string }) => void
+    onCancel: () => void
+    saveError?: string | null
+  }) => (
+    <div>
+      <span>sprite-importer-for:{existingPack ? existingPack.id : 'new-pack'}</span>
+      {saveError ? <span>sprite-save-error:{saveError}</span> : null}
+      <button onClick={() => onDone({ overwriteId: existingPack?.id })}>sprite-done</button>
+      <button onClick={onCancel}>sprite-cancel</button>
+    </div>
+  ),
+}))
+
+// Imported AFTER the mocks are registered.
+const { GalleryPanel } = await import('../apps/crew-companion/GalleryPanel')
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+/** The backend's canonical built-in id (appearances.py `DEFAULT_PACK`). */
+const BUILTIN_ID = 'kiro-ghost'
+
+const SVG = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="4" height="4"/></svg>'
+
+const builtin: PackMeta = {
+  id: BUILTIN_ID,
+  name: 'Kiro',
+  author: 'Kiro Crew',
+  description: 'the bundled ghost',
+  type: 'built-in',
+  format: 'svg',
+  thumbnail: '',
+}
+
+const custom: PackMeta = {
+  id: 'boba-pack',
+  name: 'Boba',
+  author: 'community',
+  description: 'a very round cat',
+  type: 'custom',
+  format: 'svg',
+  thumbnail: '',
+}
+
+const spritePack: PackMeta = {
+  id: 'pixel-pack',
+  name: 'Pixel Pal',
+  author: 'pixelsmith',
+  description: '',
+  type: 'custom',
+  format: 'sprite',
+  thumbnail: '',
+}
+
+/** A detail payload shaped the way the bridge returns it. */
+const detailFor = (
+  meta: PackMeta,
+  animations: Record<string, string> = { idle: SVG },
+  sprite?: { frameWidth?: number; frameHeight?: number; fps?: number },
+) => ({ meta, animations, sprite })
+
+const api = mocks.api
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.listeners.active = undefined
+  mocks.listeners.packs = undefined
+  mocks.listeners.color = undefined
+  mocks.listeners.config = undefined
+
+  api.galleryListPacks.mockResolvedValue([builtin, custom])
+  api.galleryGetPackDetail.mockImplementation((id: string) => {
+    if (id === custom.id) return Promise.resolve(detailFor(custom))
+    if (id === spritePack.id) return Promise.resolve(detailFor(spritePack, { idle: SVG }, { fps: 6 }))
+    return Promise.resolve(detailFor(builtin, {}))
+  })
+  api.getCrewCompanionConfig.mockResolvedValue({ activeAppearance: BUILTIN_ID, language: 'en' })
+  api.presetsGetColorMap.mockResolvedValue({})
+  api.gallerySetActive.mockResolvedValue({ ok: true })
+  api.galleryDelete.mockResolvedValue({ ok: true })
+  api.galleryExport.mockResolvedValue({ ok: true })
+  api.gallerySaveSpritePack.mockResolvedValue({ ok: true, packId: 'saved-pack' })
+  api.firstFramePreview?.mockReset?.()
+  mocks.firstFramePreview.mockResolvedValue('data:image/png;base64,AAA')
+  mocks.buildSpritePackData.mockResolvedValue({ name: 'Boba', assignments: {} })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+/** Mount and wait for the initial two-call load to settle. */
+async function mount() {
+  const utils = render(<GalleryPanel />)
+  await waitFor(() => expect(screen.queryByText('Loading…')).not.toBeInTheDocument())
+  return utils
+}
+
+/** The grid card for a pack — a role=button div wrapping the pack's name. */
+const cardFor = (name: string): HTMLElement => {
+  const grid = document.querySelector('[style*="grid-template-columns"]') as HTMLElement
+  const card = within(grid).getByText(name).closest('[role="button"]')
+  if (!card) throw new Error(`no card for ${name}`)
+  return card as HTMLElement
+}
+
+/** The dim layer a dialog is painted on — its click target for "outside". */
+const overlayOf = (dialog: HTMLElement) => dialog.parentElement as HTMLElement
+
+/**
+ * The Edit label carries an orphaned U+FE0F variation selector in the catalogue
+ * (`"\uFE0F Edit"`), a leftover from a stripped emoji — so it is matched loosely.
+ */
+const EDIT = /Edit/
+
+/** Open a custom pack's detail sheet through its Manage affordance. */
+async function openDetail(name: string) {
+  const manage = cardFor(name).querySelector('button[aria-label="Manage"]')
+  fireEvent.click(manage as HTMLElement)
+  await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+}
+
+/**
+ * The built-in ghost's body is a bundled asset the thumbnail re-fetches in order to
+ * recolour it. Serve a known one-colour body so the recolour is observable.
+ */
+const GHOST_BODY = '<svg xmlns="http://www.w3.org/2000/svg"><path fill="#FFFFFF"/></svg>'
+const stubGhostBody = () =>
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(GHOST_BODY, { status: 200 }))
+
+/** The built-in card's art, decoded back out of its data URI. */
+const builtinArt = () =>
+  decodeURIComponent((cardFor('Kiro').querySelector('img') as HTMLImageElement).getAttribute('src') ?? '')
+
+// ── The grid ───────────────────────────────────────────────────────────────
+
+describe('gallery grid', () => {
+  it('shows a loading line until the packs and the active id have both landed', async () => {
+    let release: (packs: PackMeta[]) => void = () => {}
+    api.galleryListPacks.mockReturnValue(new Promise<PackMeta[]>((res) => { release = res }))
+
+    render(<GalleryPanel />)
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+    expect(screen.queryByText('Boba')).not.toBeInTheDocument()
+
+    release([builtin, custom])
+    await waitFor(() => expect(screen.getByText('Boba')).toBeInTheDocument())
+    expect(screen.queryByText('Loading…')).not.toBeInTheDocument()
+  })
+
+  it('renders one card per pack with its name and author', async () => {
+    await mount()
+    expect(screen.getByText('Kiro')).toBeInTheDocument()
+    expect(screen.getByText('Kiro Crew')).toBeInTheDocument()
+    expect(screen.getByText('Boba')).toBeInTheDocument()
+    expect(screen.getByText('community')).toBeInTheDocument()
+  })
+
+  it('badges only the active pack, and invites a tap on the others', async () => {
+    await mount()
+    expect(cardFor('Kiro')).toHaveTextContent('Active')
+    expect(cardFor('Kiro')).toHaveAttribute('aria-pressed', 'true')
+    expect(cardFor('Boba')).toHaveTextContent('Tap to use')
+    expect(cardFor('Boba')).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('offers Manage on custom packs only — a built-in has nothing to manage', async () => {
+    await mount()
+    expect(cardFor('Boba').querySelector('button[aria-label="Manage"]')).not.toBeNull()
+    expect(cardFor('Kiro').querySelector('button[aria-label="Manage"]')).toBeNull()
+  })
+
+  it('surfaces a failed pack list as a dismissable banner', async () => {
+    api.galleryListPacks.mockRejectedValue(new Error('the pack directory went away'))
+    await mount()
+
+    expect(screen.getByText('the pack directory went away')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(screen.queryByText('the pack directory went away')).not.toBeInTheDocument()
+  })
+
+  it('falls back to the built-in as active when the config read fails', async () => {
+    api.getCrewCompanionConfig.mockRejectedValue(new Error('no config'))
+    await mount()
+    expect(cardFor('Kiro')).toHaveTextContent('Active')
+  })
+
+  it('recolours the built-in thumbnail when a colour map is stored for it', async () => {
+    stubGhostBody()
+    api.presetsGetColorMap.mockResolvedValue({ '#FFFFFF': '#00ff00' })
+    await mount()
+    // The bundled body is fetched and rewritten, so the card's art is the recoloured
+    // SVG rather than the asset PetAvatar would otherwise point straight at.
+    await waitFor(() => expect(builtinArt()).toContain('fill="#00ff00"'))
+  })
+})
+
+// ── Switching avatar straight from a card ───────────────────────────────────
+
+describe('applying a pack from its card', () => {
+  it('switches to the tapped pack and says so', async () => {
+    await mount()
+    fireEvent.click(cardFor('Boba'))
+
+    await waitFor(() => expect(api.gallerySetActive).toHaveBeenCalledWith('boba-pack'))
+    expect(await screen.findByText('Avatar switched')).toBeInTheDocument()
+    expect(cardFor('Boba')).toHaveTextContent('Active')
+  })
+
+  it('applies on Enter, so the grid is reachable without a mouse', async () => {
+    await mount()
+    fireEvent.keyDown(cardFor('Boba'), { key: 'Enter' })
+    await waitFor(() => expect(api.gallerySetActive).toHaveBeenCalledWith('boba-pack'))
+  })
+
+  it('ignores a tap on the pack that is already active', async () => {
+    await mount()
+    fireEvent.click(cardFor('Kiro'))
+    fireEvent.keyDown(cardFor('Kiro'), { key: ' ' })
+    await waitFor(() => expect(screen.getByText('Kiro')).toBeInTheDocument())
+    expect(api.gallerySetActive).not.toHaveBeenCalled()
+  })
+
+  it('reports a refused switch and leaves the old pack active', async () => {
+    api.gallerySetActive.mockResolvedValue({ ok: false, error: 'that pack is broken' })
+    await mount()
+    fireEvent.click(cardFor('Boba'))
+
+    expect(await screen.findByText('that pack is broken')).toBeInTheDocument()
+    expect(cardFor('Kiro')).toHaveTextContent('Active')
+  })
+
+  it('reports a thrown switch through the shared error text', async () => {
+    api.gallerySetActive.mockRejectedValue(new Error('bridge is down'))
+    await mount()
+    fireEvent.click(cardFor('Boba'))
+    expect(await screen.findByText('bridge is down')).toBeInTheDocument()
+  })
+})
+
+// ── Broadcasts from the other windows ──────────────────────────────────────
+
+describe('gallery broadcasts', () => {
+  it('moves the Active badge when another window switches the avatar', async () => {
+    await mount()
+    expect(cardFor('Kiro')).toHaveTextContent('Active')
+
+    await act(async () => { mocks.listeners.active?.({ packId: custom.id }) })
+    expect(cardFor('Boba')).toHaveTextContent('Active')
+    expect(cardFor('Kiro')).toHaveTextContent('Tap to use')
+  })
+
+  it('re-reads the config when the broadcast carries no pack id', async () => {
+    await mount()
+    api.getCrewCompanionConfig.mockResolvedValue({ activeAppearance: custom.id })
+
+    await act(async () => { mocks.listeners.active?.({}) })
+    await waitFor(() => expect(cardFor('Boba')).toHaveTextContent('Active'))
+  })
+
+  it('refetches the grid when the pack set changes elsewhere', async () => {
+    await mount()
+    api.galleryListPacks.mockResolvedValue([builtin, custom, spritePack])
+
+    await act(async () => { mocks.listeners.packs?.() })
+    await waitFor(() => expect(screen.getByText('Pixel Pal')).toBeInTheDocument())
+  })
+
+  it('picks up a colour-map change for the built-in and ignores one for another pack', async () => {
+    stubGhostBody()
+    await mount()
+    await act(async () => {
+      mocks.listeners.color?.({ packId: 'some-other-pack', colorMap: { '#FFFFFF': '#00ff00' } })
+    })
+    expect(builtinArt()).not.toContain('#00ff00')
+
+    await act(async () => {
+      mocks.listeners.color?.({ packId: BUILTIN_ID, colorMap: { '#FFFFFF': '#00ff00' } })
+    })
+    await waitFor(() => expect(builtinArt()).toContain('fill="#00ff00"'))
+  })
+
+  it('survives a language broadcast without losing the grid', async () => {
+    await mount()
+    await act(async () => { mocks.listeners.config?.({ language: 'ja' }) })
+    expect(screen.getByText('Boba')).toBeInTheDocument()
+  })
+})
+
+// ── The detail sheet ───────────────────────────────────────────────────────
+
+describe('pack detail sheet', () => {
+  it('shows the pack identity, its slots, and the custom-pack actions', async () => {
+    await mount()
+    await openDetail('Boba')
+
+    const sheet = screen.getByRole('dialog')
+    expect(sheet).toHaveTextContent('community · SVG')
+    expect(sheet).toHaveTextContent('a very round cat')
+    expect(sheet).toHaveTextContent('State Animations')
+    expect(sheet).toHaveTextContent('Idle')
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Export' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+  })
+
+  it('lists only the optional groups the pack actually provides', async () => {
+    api.galleryGetPackDetail.mockResolvedValue(
+      detailFor(custom, { idle: SVG, done: SVG, walking: SVG }),
+    )
+    await mount()
+    await openDetail('Boba')
+
+    const sheet = screen.getByRole('dialog')
+    expect(sheet).toHaveTextContent('Status')
+    expect(sheet).toHaveTextContent('Done')
+    expect(sheet).toHaveTextContent('Random')
+    expect(sheet).toHaveTextContent('Walking')
+    // Nothing legacy in this pack, so that heading must not appear at all.
+    expect(sheet).not.toHaveTextContent('Legacy')
+  })
+
+  it('renders the legacy group for a pack authored before the split', async () => {
+    api.galleryGetPackDetail.mockResolvedValue(
+      detailFor(custom, { idle: SVG, thinking: SVG }),
+    )
+    await mount()
+    await openDetail('Boba')
+    expect(screen.getByRole('dialog')).toHaveTextContent('Legacy')
+    expect(screen.getByRole('dialog')).toHaveTextContent('Thinking')
+  })
+
+  it('toggles closed when Manage is pressed a second time', async () => {
+    await mount()
+    const manage = cardFor('Boba').querySelector('button[aria-label="Manage"]') as HTMLElement
+    await openDetail('Boba')
+    fireEvent.click(manage)
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  it('closes on the ✕ and on a click outside the sheet', async () => {
+    await mount()
+    await openDetail('Boba')
+    // The window's own ✕ carries the same label, so this is scoped to the sheet.
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Close (Esc)' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    expect(api.closeGallery).not.toHaveBeenCalled()
+
+    await openDetail('Boba')
+    fireEvent.click(overlayOf(screen.getByRole('dialog')))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  it('reports a detail fetch that fails and opens no sheet', async () => {
+    api.galleryGetPackDetail.mockImplementation((id: string) =>
+      id === custom.id
+        ? Promise.reject(new Error('that manifest is corrupt'))
+        : Promise.resolve(detailFor(builtin, {})),
+    )
+    await mount()
+    fireEvent.click(cardFor('Boba').querySelector('button[aria-label="Manage"]') as HTMLElement)
+
+    expect(await screen.findByText('that manifest is corrupt')).toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('opens no sheet, and blames nothing, when the pack has no detail at all', async () => {
+    await mount()
+    api.galleryGetPackDetail.mockResolvedValue(null)
+    fireEvent.click(cardFor('Boba').querySelector('button[aria-label="Manage"]') as HTMLElement)
+
+    await waitFor(() => expect(api.galleryGetPackDetail).toHaveBeenLastCalledWith('boba-pack'))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.queryByText('Could not load that avatar')).not.toBeInTheDocument()
+  })
+
+  it('draws a neutral thumbnail and an empty slot for a pack with no idle art', async () => {
+    api.galleryGetPackDetail.mockResolvedValue(detailFor(custom, {}))
+    await mount()
+    // No art to draw: a blank box, never an emoji stand-in.
+    expect(cardFor('Boba').querySelector('img')).toBeNull()
+
+    await openDetail('Boba')
+    const sheet = screen.getByRole('dialog')
+    expect(sheet).toHaveTextContent('Idle')
+    expect(sheet).toHaveTextContent('—')
+  })
+
+  it('applies from the sheet and then drops the Apply button', async () => {
+    await mount()
+    await openDetail('Boba')
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
+
+    await waitFor(() => expect(api.gallerySetActive).toHaveBeenCalledWith('boba-pack'))
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Apply' })).not.toBeInTheDocument())
+    expect(screen.getByRole('dialog')).toHaveTextContent('Active')
+  })
+
+  it('reports a refused apply from the sheet', async () => {
+    api.gallerySetActive.mockResolvedValue({ ok: false, error: 'refused by the app' })
+    await mount()
+    await openDetail('Boba')
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
+    expect(await screen.findByText('refused by the app')).toBeInTheDocument()
+  })
+
+  it('confirms a successful export and reports a refused one', async () => {
+    await mount()
+    await openDetail('Boba')
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
+    expect(await screen.findByText('Exported successfully')).toBeInTheDocument()
+
+    api.galleryExport.mockResolvedValue({ ok: false, error: 'no write permission' })
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
+    expect(await screen.findByText('no write permission')).toBeInTheDocument()
+  })
+
+  it('stays quiet when the export dialog is cancelled', async () => {
+    api.galleryExport.mockResolvedValue(null)
+    await mount()
+    await openDetail('Boba')
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
+
+    await waitFor(() => expect(api.galleryExport).toHaveBeenCalled())
+    expect(screen.queryByText('Exported successfully')).not.toBeInTheDocument()
+    expect(screen.queryByText('Export failed')).not.toBeInTheDocument()
+  })
+})
+
+// ── Deleting a pack ────────────────────────────────────────────────────────
+
+describe('deleting a pack', () => {
+  it('asks first, and does nothing when the user declines', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    await mount()
+    await openDetail('Boba')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(confirmSpy).toHaveBeenCalledWith('Delete appearance pack "Boba"? This cannot be undone.')
+    expect(api.galleryDelete).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('deletes an inactive pack and closes the sheet', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    await mount()
+    await openDetail('Boba')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(api.galleryDelete).toHaveBeenCalledWith('boba-pack'))
+    // Inactive pack: no need to repoint the active reference.
+    expect(api.gallerySetActive).not.toHaveBeenCalled()
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    expect(api.galleryListPacks).toHaveBeenCalledTimes(2)
+  })
+
+  it('repoints the active reference to the built-in BEFORE deleting the active pack', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    api.getCrewCompanionConfig.mockResolvedValue({ activeAppearance: custom.id })
+    await mount()
+    await openDetail('Boba')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(api.galleryDelete).toHaveBeenCalledWith('boba-pack'))
+    expect(api.gallerySetActive).toHaveBeenCalledWith(BUILTIN_ID)
+    // Order is the whole point: a failed delete must never leave the config
+    // pointing at a pack that is already gone.
+    const switched = api.gallerySetActive.mock.invocationCallOrder[0]
+    const deleted = api.galleryDelete.mock.invocationCallOrder[0]
+    expect(switched).toBeLessThan(deleted)
+  })
+
+  it('aborts the delete when the pre-delete switch fails', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    api.getCrewCompanionConfig.mockResolvedValue({ activeAppearance: custom.id })
+    api.gallerySetActive.mockResolvedValue({ ok: false })
+    await mount()
+    await openDetail('Boba')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(await screen.findByText('Delete failed')).toBeInTheDocument()
+    expect(api.galleryDelete).not.toHaveBeenCalled()
+  })
+
+  it('reports a refused delete', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    api.galleryDelete.mockResolvedValue(null)
+    await mount()
+    await openDetail('Boba')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(await screen.findByText('Delete failed')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('reports a thrown delete', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    api.galleryDelete.mockRejectedValue(new Error('the file is locked'))
+    await mount()
+    await openDetail('Boba')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(await screen.findByText('the file is locked')).toBeInTheDocument()
+  })
+})
+
+// ── The editor overlay ─────────────────────────────────────────────────────
+
+describe('editor overlay', () => {
+  it('opens a blank editor from "Make your own" and cancels back to the grid', async () => {
+    await mount()
+    fireEvent.click(screen.getByRole('button', { name: 'Make your own' }))
+
+    expect(screen.getByText('editor-for:new-pack')).toBeInTheDocument()
+    // The gallery stays mounted behind the overlay.
+    expect(screen.getByText('Boba')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'editor-cancel' }))
+    expect(screen.queryByText('editor-for:new-pack')).not.toBeInTheDocument()
+  })
+
+  it('confirms a brand-new pack with the create toast and refetches', async () => {
+    await mount()
+    fireEvent.click(screen.getByRole('button', { name: 'Make your own' }))
+    fireEvent.click(screen.getByRole('button', { name: 'editor-save' }))
+
+    expect(await screen.findByText('Pack created')).toBeInTheDocument()
+    await waitFor(() => expect(api.galleryListPacks).toHaveBeenCalledTimes(2))
+  })
+
+  it('edits an existing SVG pack and reports the save as an update', async () => {
+    await mount()
+    await openDetail('Boba')
+    fireEvent.click(screen.getByRole('button', { name: EDIT }))
+
+    // The sheet gives way to the editor, carrying the pack being edited.
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    expect(screen.getByText('editor-for:Boba')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'editor-save' }))
+    expect(await screen.findByText('Pack saved')).toBeInTheDocument()
+  })
+
+  it('routes a sprite pack to the sprite importer instead of the editor', async () => {
+    api.galleryListPacks.mockResolvedValue([builtin, spritePack])
+    await mount()
+    await openDetail('Pixel Pal')
+    fireEvent.click(screen.getByRole('button', { name: EDIT }))
+
+    expect(await screen.findByText('sprite-importer-for:pixel-pack')).toBeInTheDocument()
+    // Sprite mode REPLACES the gallery, so the grid is gone.
+    expect(screen.queryByText('Pixel Pal')).not.toBeInTheDocument()
+  })
+
+  it('keeps the sprite importer open, with its message, when the save is refused', async () => {
+    api.galleryListPacks.mockResolvedValue([builtin, spritePack])
+    api.gallerySaveSpritePack.mockResolvedValue({ ok: false, error: 'that sheet is not a grid' })
+    await mount()
+    await openDetail('Pixel Pal')
+    fireEvent.click(screen.getByRole('button', { name: EDIT }))
+    fireEvent.click(await screen.findByRole('button', { name: 'sprite-done' }))
+
+    // The importer must NOT unmount: the gallery's error banner cannot be seen
+    // from sprite mode, so a refusal there would otherwise vanish with the edits.
+    expect(await screen.findByText('sprite-save-error:that sheet is not a grid')).toBeInTheDocument()
+    expect(screen.getByText('sprite-importer-for:pixel-pack')).toBeInTheDocument()
+  })
+
+  it('returns to the grid on a successful sprite save and re-applies the active pack', async () => {
+    api.galleryListPacks.mockResolvedValue([builtin, spritePack])
+    api.getCrewCompanionConfig.mockResolvedValue({ activeAppearance: spritePack.id })
+    await mount()
+    await openDetail('Pixel Pal')
+    fireEvent.click(screen.getByRole('button', { name: EDIT }))
+    fireEvent.click(await screen.findByRole('button', { name: 'sprite-done' }))
+
+    expect(await screen.findByText('Pack saved')).toBeInTheDocument()
+    expect(screen.getByText('Pixel Pal')).toBeInTheDocument()
+    // Overwriting the pack that is currently worn re-applies it.
+    expect(api.gallerySetActive).toHaveBeenCalledWith(spritePack.id)
+  })
+
+  it('leaves the sprite importer on cancel without saving', async () => {
+    api.galleryListPacks.mockResolvedValue([builtin, spritePack])
+    await mount()
+    await openDetail('Pixel Pal')
+    fireEvent.click(screen.getByRole('button', { name: EDIT }))
+    fireEvent.click(await screen.findByRole('button', { name: 'sprite-cancel' }))
+
+    expect(await screen.findByText('Pixel Pal')).toBeInTheDocument()
+    expect(api.gallerySaveSpritePack).not.toHaveBeenCalled()
+  })
+})
+
+// ── Import from PetDex ─────────────────────────────────────────────────────
+
+describe('importing a pet from PetDex', () => {
+  /** Drive the debounce deterministically: no wall clock, no arbitrary sleeps. */
+  const tick = async (ms: number) => {
+    await act(async () => { await vi.advanceTimersByTimeAsync(ms) })
+  }
+
+  /** Mount + open the import dialog under fake timers (no waitFor: see below). */
+  async function openImport() {
+    // RTL's waitFor cannot drive vitest's fake timers, so this path settles the
+    // component with explicit act() flushes instead.
+    render(<GalleryPanel />)
+    await tick(0)
+    await tick(0)
+    fireEvent.click(screen.getByRole('button', { name: 'Import from PetDex' }))
+    expect(screen.getByText('Import a pet')).toBeInTheDocument()
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    api.petdexFetch.mockResolvedValue({
+      ok: true,
+      slug: 'boba',
+      displayName: 'Boba',
+      author: 'someone',
+      description: 'round cat',
+      spriteBase64: 'AAAA',
+    })
+  })
+
+  it('looks the pet up only after typing settles, then shows what it found', async () => {
+    await openImport()
+    const input = screen.getByRole('textbox')
+
+    fireEvent.change(input, { target: { value: 'bo' } })
+    fireEvent.change(input, { target: { value: 'boba' } })
+    // Before the debounce elapses there must be no lookup at all.
+    await tick(400)
+    expect(api.petdexFetch).not.toHaveBeenCalled()
+
+    await tick(100)
+    // One call for the settled value, not one per keystroke.
+    expect(api.petdexFetch).toHaveBeenCalledTimes(1)
+    expect(api.petdexFetch).toHaveBeenCalledWith('boba')
+    expect(screen.getByText('Found · by someone')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Use this pet' })).toBeEnabled()
+  })
+
+  it('does not look up a value too short to be a slug', async () => {
+    await openImport()
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'b' } })
+    await tick(1000)
+    expect(api.petdexFetch).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Use this pet' })).toBeDisabled()
+  })
+
+  it('shows the miss message when the pet is unknown, and keeps Use disabled', async () => {
+    api.petdexFetch.mockResolvedValue({ ok: false })
+    await openImport()
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'nope' } })
+    await tick(500)
+
+    expect(screen.getByText('Could not find that pet')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Use this pet' })).toBeDisabled()
+  })
+
+  it('reports a lookup that threw', async () => {
+    api.petdexFetch.mockRejectedValue(new Error('petdex is unreachable'))
+    await openImport()
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'boba' } })
+    await tick(500)
+    expect(screen.getByText('petdex is unreachable')).toBeInTheDocument()
+  })
+
+  it('still resolves the pet when its preview frame cannot be decoded', async () => {
+    mocks.firstFramePreview.mockRejectedValue(new Error('bad sheet'))
+    await openImport()
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'boba' } })
+    await tick(500)
+    // The preview is optional; the identity card still appears.
+    expect(screen.getByText('Found · by someone')).toBeInTheDocument()
+  })
+
+  it('adds the pet, wears it, and closes the dialog', async () => {
+    await openImport()
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'boba' } })
+    await tick(500)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use this pet' }))
+    await tick(0)
+
+    expect(mocks.buildSpritePackData).toHaveBeenCalledWith('AAAA', {
+      displayName: 'Boba', author: 'someone', description: 'round cat',
+    })
+    expect(api.gallerySetActive).toHaveBeenCalledWith('saved-pack')
+    expect(screen.getByText('Boba is now your companion')).toBeInTheDocument()
+    expect(screen.queryByText('Import a pet')).not.toBeInTheDocument()
+  })
+
+  it('confirms with Enter once a pet has resolved', async () => {
+    await openImport()
+    const input = screen.getByRole('textbox')
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(api.gallerySaveSpritePack).not.toHaveBeenCalled()
+
+    fireEvent.change(input, { target: { value: 'boba' } })
+    await tick(500)
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await tick(0)
+    expect(api.gallerySaveSpritePack).toHaveBeenCalled()
+  })
+
+  it('keeps the dialog open with the reason when the save is refused', async () => {
+    api.gallerySaveSpritePack.mockResolvedValue({ ok: false, error: 'disk is full' })
+    await openImport()
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'boba' } })
+    await tick(500)
+    fireEvent.click(screen.getByRole('button', { name: 'Use this pet' }))
+    await tick(0)
+
+    expect(screen.getByText('disk is full')).toBeInTheDocument()
+    expect(screen.getByText('Import a pet')).toBeInTheDocument()
+  })
+
+  it('reports a save that threw', async () => {
+    mocks.buildSpritePackData.mockRejectedValue(new Error('could not build the pack'))
+    await openImport()
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'boba' } })
+    await tick(500)
+    fireEvent.click(screen.getByRole('button', { name: 'Use this pet' }))
+    await tick(0)
+    expect(screen.getByText('could not build the pack')).toBeInTheDocument()
+  })
+
+  it('closes on Cancel and clears what was typed', async () => {
+    await openImport()
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'boba' } })
+    await tick(500)
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByText('Import a pet')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Import from PetDex' }))
+    expect(screen.getByRole('textbox')).toHaveValue('')
+  })
+
+  it('closes on a click outside the dialog', async () => {
+    await openImport()
+    fireEvent.click(overlayOf(screen.getByRole('dialog')))
+    expect(screen.queryByText('Import a pet')).not.toBeInTheDocument()
+  })
+
+  it('backs out on Escape — which today also closes the whole window', async () => {
+    await openImport()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    await tick(0)
+    expect(screen.queryByText('Import a pet')).not.toBeInTheDocument()
+    // Pinning current behaviour, not endorsing it: the dialog and the gallery
+    // window BOTH listen for Escape on `window` and neither stops propagation,
+    // so backing out of the dialog tears down the window under it.
+    expect(api.closeGallery).toHaveBeenCalled()
+  })
+
+  it('offers the PetDex gallery from inside the dialog', async () => {
+    await openImport()
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'petdex.dev' }))
+    expect(api.openExternal).toHaveBeenCalledWith('https://petdex.dev')
+  })
+})
+
+// ── Window chrome ──────────────────────────────────────────────────────────
+
+describe('the toast', () => {
+  it('fades itself out and then leaves, without a click', async () => {
+    vi.useFakeTimers()
+    const tick = async (ms: number) => {
+      await act(async () => { await vi.advanceTimersByTimeAsync(ms) })
+    }
+    render(<GalleryPanel />)
+    await tick(0)
+    await tick(0)
+    fireEvent.click(cardFor('Boba'))
+    await tick(0)
+
+    const toast = screen.getByText('Avatar switched')
+    expect(toast.style.animation).toContain('toastIn')
+
+    await tick(2000)
+    expect(screen.getByText('Avatar switched').style.animation).toContain('toastOut')
+
+    await tick(500)
+    expect(screen.queryByText('Avatar switched')).not.toBeInTheDocument()
+  })
+})
+
+describe('gallery window chrome', () => {
+  it('closes the window from its ✕', async () => {
+    await mount()
+    fireEvent.click(screen.getByRole('button', { name: 'Close (Esc)' }))
+    expect(api.closeGallery).toHaveBeenCalled()
+  })
+
+  it('closes the window on Escape — a frameless window has no OS button', async () => {
+    await mount()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(api.closeGallery).toHaveBeenCalled()
+  })
+
+  it('opens the PetDex gallery from the footer', async () => {
+    await mount()
+    fireEvent.click(screen.getByRole('button', { name: 'petdex.dev' }))
+    expect(api.openExternal).toHaveBeenCalledWith('https://petdex.dev')
+  })
+})

--- a/website/src/test/CrewCompanionPet.coverage.test.tsx
+++ b/website/src/test/CrewCompanionPet.coverage.test.tsx
@@ -1,0 +1,747 @@
+/**
+ * The companion overlay itself — `pet.tsx` — driven end to end for the first time.
+ *
+ * Every other file in this app has tests; this one, the 1200-line window that owns
+ * the presence ping, the cursor-based fire drain, the one bubble slot, the window
+ * commands and the tap-vs-drag rule, had none. It is also not importable in the
+ * ordinary way: `Companion` is never exported and the module MOUNTS ITSELF into
+ * `#companion-root` at import time. So the harness below is the module's real entry
+ * path — create the host, register the mocks it reaches for, then import it.
+ *
+ * What is asserted is what the user would see or what the backend would receive: the
+ * presence POST, the bubble text for each kind of fire, the cursor written to
+ * localStorage, the panel opening on a tap and NOT on a drag, and the reactions the
+ * session socket drives.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { waitFor, fireEvent } from '@testing-library/react'
+
+import { PENDING_PATH, PRESENCE_PATH } from '../apps/crew-companion/constants'
+import type { SessionWatchOptions } from '../apps/crew-companion/sessionWatch'
+
+// The theme adopt is a real same-origin read in production; here it just resolves so
+// the bootstrap gets as far as `createRoot`.
+vi.mock('../apps/crew-companion/dashboardTheme', () => ({
+  adoptDashboardTheme: () => Promise.resolve(),
+  watchThemeChanges: () => () => {},
+  applyThemeId: () => {},
+  extractStylesheetHrefs: () => [],
+}))
+
+/** Config the bridge answers with; a test may rewrite it before mounting. */
+let config: Record<string, unknown> = {}
+/** Pack detail for the custom-pack path. */
+let packDetail: unknown = null
+/** The position the main process remembers for the companion. */
+let savedPos: { x: number; y: number } | null = { x: 300, y: 200 }
+
+/** The preload bridge, as the overlay and its hooks see it. */
+const bridge = {
+  getWindowPosition: vi.fn(async () => savedPos),
+  savePosition: vi.fn(),
+  getCrewCompanionConfig: vi.fn(async () => config),
+  galleryGetPackDetail: vi.fn(async () => packDetail),
+  onGalleryActiveChanged: vi.fn(() => () => {}),
+  onColorMapChanged: vi.fn(() => () => {}),
+  presetsGetColorMap: vi.fn(async () => null),
+  updateHitbox: vi.fn(),
+  setMenuHitbox: vi.fn(),
+  contextMenuAction: vi.fn(),
+}
+vi.mock('../apps/crew-companion/petBridge', () => ({ petBridge: bridge }))
+
+/** The gateway socket is replaced by a handle on the callbacks the overlay passes. */
+let watch: SessionWatchOptions | null = null
+vi.mock('../apps/crew-companion/sessionWatch', () => ({
+  watchSessions: (opts: SessionWatchOptions) => {
+    watch = opts
+    return () => {}
+  },
+}))
+
+/**
+ * `pet.tsx` owns its own React root, so nothing in @testing-library can unmount it.
+ * Wrapping `createRoot` is what lets each test tear its overlay down, which keeps one
+ * test's presence/pending polls out of the next.
+ */
+const roots: Array<{ unmount: () => void }> = []
+vi.mock('react-dom/client', async () => {
+  const actual = await vi.importActual<typeof import('react-dom/client')>('react-dom/client')
+  return {
+    ...actual,
+    createRoot: (container: Element | DocumentFragment, options?: never) => {
+      const root = actual.createRoot(container, options)
+      roots.push(root)
+      return root
+    },
+  }
+})
+
+interface Fire {
+  seq: number
+  kind: string
+  text: string
+  key: string
+  at: string
+}
+
+/** What `/pending` answers. `since` is the cursor the overlay asked from. */
+let pending: (since: number) => { cursor: number; fires: Fire[] }
+/** Every URL the overlay fetched, in order. */
+let calls: string[]
+
+function fire(partial: Partial<Fire> & { seq: number }): Fire {
+  return { kind: 'reminder', text: '', key: '', at: new Date().toISOString(), ...partial }
+}
+
+/**
+ * Answer `/pending` the way the backend does: non-destructive, cursor-filtered.
+ *
+ * Filtering on `since` matters — the overlay re-polls every 2s, and a handler that
+ * ignored the cursor would re-deliver the same fire and collapse it into a count,
+ * making every assertion below a race against the poll interval.
+ */
+function queue(fires: Fire[]): void {
+  pending = (since) => ({
+    cursor: fires.length ? fires[fires.length - 1].seq : since,
+    fires: fires.filter((f) => f.seq > since),
+  })
+}
+
+let panelClosedCbs: Array<() => void> = []
+let galleryOpenedCbs: Array<() => void> = []
+let galleryClosedCbs: Array<() => void> = []
+/** When true, the `since=0` re-read after a backend restart answers not-ok. */
+let sinceZeroFails = false
+
+/** The window-level preload bridge the overlay toggles window input through. */
+function installCrewCompanion() {
+  const preload = {
+    setFocusable: vi.fn(),
+    panelOpen: vi.fn(),
+    panelClose: vi.fn(),
+    panelHold: vi.fn(),
+    onPanelClosed: vi.fn((cb: () => void) => {
+      panelClosedCbs.push(cb)
+      return () => {}
+    }),
+    galleryOpen: vi.fn(),
+    onGalleryOpened: vi.fn((cb: () => void) => {
+      galleryOpenedCbs.push(cb)
+      return () => {}
+    }),
+    onGalleryClosed: vi.fn((cb: () => void) => {
+      galleryClosedCbs.push(cb)
+      return () => {}
+    }),
+  }
+  ;(window as unknown as { crewCompanion: typeof preload }).crewCompanion = preload
+  return preload
+}
+let api: ReturnType<typeof installCrewCompanion>
+
+/**
+ * Mount the overlay through its real entry path.
+ *
+ * `vi.resetModules()` is what makes a second mount possible at all: the bootstrap is
+ * module-level, so with a warm registry only the first test would ever render.
+ */
+async function mountPet(): Promise<void> {
+  const host = document.createElement('div')
+  host.id = 'companion-root'
+  document.body.appendChild(host)
+  vi.resetModules()
+  await import('../apps/crew-companion/pet')
+  // The bootstrap awaits the theme before createRoot and the root renders through
+  // React's scheduler, so wait for the companion rather than counting ticks.
+  await waitFor(() => expect(document.querySelector('.cc-pet')).not.toBeNull())
+}
+
+function petEl(): HTMLElement {
+  return document.querySelector('.cc-pet') as HTMLElement
+}
+
+function bubbleText(): string | null {
+  return document.querySelector('.cc-bubble-text')?.textContent ?? null
+}
+
+/** Ring the backend's doorbell so the overlay drains now instead of in 2s. */
+function ringDoorbell(): void {
+  watch?.onFireQueued?.()
+}
+
+/** Press and release on the companion at one point — a tap, not a drag. */
+function tapPet(at = { x: 340, y: 240 }): void {
+  const pet = petEl()
+  fireEvent.mouseDown(pet, { clientX: at.x, clientY: at.y, button: 0 })
+  fireEvent.click(pet, { clientX: at.x, clientY: at.y })
+}
+
+beforeEach(() => {
+  calls = []
+  watch = null
+  panelClosedCbs = []
+  galleryOpenedCbs = []
+  galleryClosedCbs = []
+  sinceZeroFails = false
+  packDetail = null
+  savedPos = { x: 300, y: 200 }
+  config = { activeAppearance: 'kiro-ghost', sessionNotificationsEnabled: true }
+  queue([])
+  window.localStorage.clear()
+  // English is pinned in setup.ts, but `vi.resetModules()` hands pet.tsx a FRESH
+  // i18next whose `initI18n()` (no argument) resolves the language from storage.
+  window.localStorage.setItem('mc-lang', 'en')
+  api = installCrewCompanion()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      calls.push(url)
+      if (url.startsWith(PENDING_PATH)) {
+        const since = Number(new URLSearchParams(url.split('?')[1] ?? '').get('since') ?? 0)
+        if (since === 0 && sinceZeroFails) {
+          return { ok: false, json: async () => ({}) } as unknown as Response
+        }
+        return { ok: true, json: async () => pending(since) } as unknown as Response
+      }
+      return { ok: true, json: async () => ({}) } as unknown as Response
+    }),
+  )
+})
+
+afterEach(() => {
+  for (const root of roots.splice(0)) root.unmount()
+  document.querySelectorAll('#companion-root').forEach((n) => n.remove())
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('the overlay mounts, reports itself and polls', () => {
+  it('renders the companion as the only interactive element in the layer', async () => {
+    await mountPet()
+    const pet = petEl()
+    expect(pet.getAttribute('role')).toBe('button')
+    expect(pet.tabIndex).toBe(0)
+    expect(pet.parentElement?.className).toContain('cc-pet-layer')
+  })
+
+  it('pings presence on mount, or the backend reads the chair as empty', async () => {
+    await mountPet()
+    await waitFor(() => expect(calls).toContain(PRESENCE_PATH))
+  })
+
+  it('drains /pending from cursor 0 the first time it ever runs', async () => {
+    await mountPet()
+    await waitFor(() => expect(calls).toContain(`${PENDING_PATH}?since=0`))
+  })
+
+  it('resumes from the persisted cursor instead of replaying the history', async () => {
+    window.localStorage.setItem('cc:pendingCursor', '42')
+    await mountPet()
+    await waitFor(() => expect(calls).toContain(`${PENDING_PATH}?since=42`))
+  })
+
+  it('ignores a corrupt stored cursor rather than muting every future fire', async () => {
+    window.localStorage.setItem('cc:pendingCursor', 'not-a-number')
+    await mountPet()
+    await waitFor(() => expect(calls).toContain(`${PENDING_PATH}?since=0`))
+  })
+
+  it('re-reads from zero when the backend cursor went BACKWARDS (a restart)', async () => {
+    window.localStorage.setItem('cc:pendingCursor', '42')
+    // A restarted gateway numbers from 1 again, so it answers below what we asked.
+    pending = (since) =>
+      since > 0
+        ? { cursor: 1, fires: [] }
+        : { cursor: 1, fires: [fire({ seq: 1, kind: 'reminder', text: 'stand up' })] }
+    await mountPet()
+    await waitFor(() => expect(calls).toContain(`${PENDING_PATH}?since=0`))
+    await waitFor(() => expect(bubbleText()).toBe('stand up'))
+  })
+
+  it('reports the companion hitbox so the main process can stop click-through', async () => {
+    await mountPet()
+    await waitFor(() => expect(bridge.updateHitbox).toHaveBeenCalled())
+  })
+
+  it('survives a /pending that answers not-ok without crashing the overlay', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        calls.push(String(input))
+        return { ok: false, json: async () => ({}) } as unknown as Response
+      }),
+    )
+    await mountPet()
+    await waitFor(() => expect(calls.some((u) => u.startsWith(PENDING_PATH))).toBe(true))
+    expect(petEl()).not.toBeNull()
+    expect(document.querySelector('.cc-bubble-text')).toBeNull()
+  })
+})
+
+describe('what the companion says when a fire arrives', () => {
+  it('speaks a reminder in the user’s own words, untranslated', async () => {
+    queue([fire({ seq: 7, kind: 'reminder', text: '起床' })])
+    await mountPet()
+    await waitFor(() => expect(bubbleText()).toBe('起床'))
+  })
+
+  it('commits the cursor only for what it actually showed', async () => {
+    queue([fire({ seq: 7, kind: 'reminder', text: '起床' })])
+    await mountPet()
+    await waitFor(() => expect(bubbleText()).toBe('起床'))
+    expect(window.localStorage.getItem('cc:pendingCursor')).toBe('7')
+  })
+
+  it('translates a break nudge from its catalogue key', async () => {
+    queue([fire({ seq: 3, kind: 'break', key: 'break.water.1', text: 'IGNORED' })])
+    await mountPet()
+    await waitFor(() => expect(bubbleText()).toBe('Water break?'))
+  })
+
+  it('stays quiet on an unmapped nudge key, and consumes it so nothing pins behind it', async () => {
+    queue([fire({ seq: 9, kind: 'break', key: 'break.nope.99', text: 'raw key' })])
+    await mountPet()
+    // The cursor moving IS the "deliberately consumed" verdict — drift does not heal
+    // in two seconds, so retrying would hold the whole queue behind it.
+    await waitFor(() => expect(window.localStorage.getItem('cc:pendingCursor')).toBe('9'))
+    expect(document.querySelector('.cc-bubble-text')).toBeNull()
+  })
+
+  it('takes the OLDEST unspoken fire and leaves the rest pending', async () => {
+    queue([
+      fire({ seq: 1, kind: 'reminder', text: 'first' }),
+      fire({ seq: 2, kind: 'reminder', text: 'second' }),
+    ])
+    await mountPet()
+    await waitFor(() => expect(bubbleText()).toBe('first'))
+    expect(window.localStorage.getItem('cc:pendingCursor')).toBe('1')
+  })
+
+  it('offers the breathing nudge a CTA that opens the panel', async () => {
+    queue([fire({ seq: 4, kind: 'break-breathe', key: 'break.breathe.1', text: '' })])
+    await mountPet()
+    await waitFor(() => expect(bubbleText()).toBe('Fancy a few slow breaths?'))
+    const cta = document.querySelector('.cc-bubble-cta') as HTMLButtonElement
+    expect(cta.textContent).toBe('Breathe with me')
+    fireEvent.click(cta)
+    expect(api.panelOpen).toHaveBeenCalled()
+  })
+
+  it('places the bubble once it has been measured, not off-screen', async () => {
+    queue([fire({ seq: 1, kind: 'reminder', text: 'placed' })])
+    await mountPet()
+    await waitFor(() => expect(bubbleText()).toBe('placed'))
+    const host = document.querySelector('.cc-bubble-host') as HTMLElement
+    await waitFor(() => expect(host.style.visibility).not.toBe('hidden'))
+    expect(host.style.position).toBe('absolute')
+    expect(host.style.left).not.toBe('-9999px')
+  })
+
+  it('lets a reminder be dismissed, freeing the slot', async () => {
+    queue([fire({ seq: 1, kind: 'reminder', text: '起床' })])
+    await mountPet()
+    await waitFor(() => expect(bubbleText()).toBe('起床'))
+    fireEvent.click(document.querySelector('.cc-bubble-x') as HTMLElement)
+    // The exit animation runs before the unmount, so wait for the removal.
+    await waitFor(() => expect(document.querySelector('.cc-bubble-text')).toBeNull())
+  })
+})
+
+describe('window commands recorded by the dashboard page', () => {
+  it('opens the panel for a fresh command and grants focus for the keyboard', async () => {
+    queue([fire({ seq: 1, kind: 'command', text: 'panel' })])
+    await mountPet()
+    await waitFor(() => expect(api.panelOpen).toHaveBeenCalled())
+    expect(api.setFocusable).toHaveBeenCalledWith(true)
+    // A command carries no bubble text — it is acted on, never drawn.
+    expect(document.querySelector('.cc-bubble-text')).toBeNull()
+  })
+
+  it('opens the avatar gallery for a gallery command', async () => {
+    queue([fire({ seq: 1, kind: 'command', text: 'gallery' })])
+    await mountPet()
+    await waitFor(() => expect(api.galleryOpen).toHaveBeenCalled())
+  })
+
+  it('SKIPS a stale command — popping a window open minutes later is intrusive', async () => {
+    queue([
+      fire({
+        seq: 1,
+        kind: 'command',
+        text: 'panel',
+        at: new Date(Date.now() - 120_000).toISOString(),
+      }),
+    ])
+    await mountPet()
+    await waitFor(() => expect(window.localStorage.getItem('cc:pendingCursor')).toBe('1'))
+    expect(api.panelOpen).not.toHaveBeenCalled()
+  })
+
+  it('acts on a command and still speaks the reminder behind it', async () => {
+    queue([
+      fire({ seq: 1, kind: 'command', text: 'gallery' }),
+      fire({ seq: 2, kind: 'reminder', text: 'tea' }),
+    ])
+    await mountPet()
+    await waitFor(() => expect(api.galleryOpen).toHaveBeenCalled())
+    await waitFor(() => expect(bubbleText()).toBe('tea'))
+  })
+})
+
+describe('session signals from the gateway socket', () => {
+  it('shows a finished session under its own title', async () => {
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    watch!.onDone({ slot: 'a', title: 'Fix the parser', elapsedMs: 10, failed: false })
+    await waitFor(() => expect(bubbleText()).toBe('Fix the parser'))
+  })
+
+  it('falls back to copy for an untitled finish', async () => {
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    watch!.onDone({ slot: 'a', title: '  ', elapsedMs: 10, failed: false })
+    await waitFor(() => expect(bubbleText()).toBe('Finished a task'))
+  })
+
+  it('says a failure OUT LOUD rather than reading as a finish', async () => {
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    watch!.onDone({ slot: 'a', title: 'Fix the parser', elapsedMs: 10, failed: true })
+    await waitFor(() => expect(bubbleText()).toBe('Stopped: Fix the parser'))
+  })
+
+  it('gives an untitled failure its own sentence, not an empty one', async () => {
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    watch!.onDone({ slot: 'a', title: '', elapsedMs: 10, failed: true })
+    await waitFor(() => expect(bubbleText()).toBe('Stopped a task'))
+  })
+
+  it('collapses a second completion into a count instead of stacking toasts', async () => {
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    watch!.onDone({ slot: 'a', title: 'one', elapsedMs: 1, failed: false })
+    await waitFor(() => expect(bubbleText()).toBe('one'))
+    watch!.onDone({ slot: 'b', title: 'two', elapsedMs: 1, failed: false })
+    await waitFor(() => expect(bubbleText()).toBe('2 jobs finished'))
+  })
+
+  it('raises a sticky approval bubble with the kind as its kicker', async () => {
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    watch!.onApproval!({ slot: 'a', title: 'Run the migration' })
+    await waitFor(() =>
+      expect(document.querySelector('.cc-bubble-kicker')?.textContent).toBe('Approval Pending'),
+    )
+    expect(document.querySelector('.cc-bubble-body')?.textContent).toBe('Run the migration')
+    // Sticky: no ✕, it leaves by being resolved.
+    expect(document.querySelector('.cc-bubble-x')).toBeNull()
+  })
+
+  it('shows the label alone for an untitled approval', async () => {
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    watch!.onApproval!({ slot: 'a', title: '   ' })
+    await waitFor(() => expect(bubbleText()).toBe('Approval Pending'))
+    expect(document.querySelector('.cc-bubble-kicker')).toBeNull()
+  })
+
+  it('clears the sticky bubble the moment the block is answered elsewhere', async () => {
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    watch!.onApproval!({ slot: 'a', title: 'Run the migration' })
+    await waitFor(() => expect(document.querySelector('.cc-bubble-kicker')).not.toBeNull())
+    watch!.onApprovalResolved!()
+    await waitFor(() => expect(document.querySelector('.cc-bubble-text')).toBeNull())
+  })
+
+  it('an approval holds the slot against a routine completion behind it', async () => {
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    watch!.onApproval!({ slot: 'a', title: 'Run the migration' })
+    await waitFor(() => expect(document.querySelector('.cc-bubble-kicker')).not.toBeNull())
+    watch!.onDone({ slot: 'b', title: 'unrelated finish', elapsedMs: 1, failed: false })
+    // Still the approval — unresolved work is not displaced by routine chatter.
+    await waitFor(() =>
+      expect(document.querySelector('.cc-bubble-body')?.textContent).toBe('Run the migration'),
+    )
+  })
+
+  it('reads the live "tell me when sessions are done" switch, not a captured value', async () => {
+    config = { activeAppearance: 'kiro-ghost', sessionNotificationsEnabled: false }
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    await waitFor(() => expect(watch!.isSilent()).toBe(true))
+  })
+})
+
+describe('pointer and keyboard on the companion', () => {
+  it('opens the panel on a tap and closes it on the next one', async () => {
+    await mountPet()
+    tapPet()
+    await waitFor(() => expect(api.panelOpen).toHaveBeenCalled())
+    expect(api.setFocusable).toHaveBeenCalledWith(true)
+    tapPet()
+    await waitFor(() => expect(api.panelClose).toHaveBeenCalled())
+    expect(api.setFocusable).toHaveBeenCalledWith(false)
+  })
+
+  it('does NOT open the panel when the press turned into a drag', async () => {
+    await mountPet()
+    const pet = petEl()
+    fireEvent.mouseDown(pet, { clientX: 340, clientY: 240, button: 0 })
+    // Past CLICK_SLOP (6px) the release is a drop, not a tap.
+    fireEvent.click(pet, { clientX: 420, clientY: 300 })
+    expect(api.panelOpen).not.toHaveBeenCalled()
+  })
+
+  it('holds the panel open from the PRESS and releases it on mouseup', async () => {
+    await mountPet()
+    fireEvent.mouseDown(petEl(), { clientX: 340, clientY: 240, button: 0 })
+    expect(api.panelHold).toHaveBeenCalledWith(true)
+    fireEvent.mouseUp(window)
+    await waitFor(() => expect(api.panelHold).toHaveBeenCalledWith(false))
+  })
+
+  it('toggles the panel from the keyboard', async () => {
+    await mountPet()
+    fireEvent.keyDown(petEl(), { key: 'Enter' })
+    await waitFor(() => expect(api.panelOpen).toHaveBeenCalled())
+    fireEvent.keyDown(petEl(), { key: ' ' })
+    await waitFor(() => expect(api.panelClose).toHaveBeenCalled())
+  })
+
+  it('ignores keys that are not Enter or Space', async () => {
+    await mountPet()
+    fireEvent.keyDown(petEl(), { key: 'a' })
+    expect(api.panelOpen).not.toHaveBeenCalled()
+  })
+
+  it('opens the quick menu on right-click and closes it on a click away', async () => {
+    await mountPet()
+    fireEvent.contextMenu(petEl(), { clientX: 120, clientY: 90 })
+    await waitFor(() => expect(document.querySelector('.cc-menu-host')).not.toBeNull())
+    const labels = [...document.querySelectorAll('.cc-menu-host [role="menuitem"]')].map(
+      (n) => n.textContent,
+    )
+    expect(labels).toEqual(['Change avatar', 'Turn off companion'])
+    // The backdrop is a real element under the cursor, so a press on it closes.
+    fireEvent.mouseDown(document.querySelector('.cc-menu-backdrop') as HTMLElement)
+    await waitFor(() => expect(document.querySelector('.cc-menu-host')).toBeNull())
+  })
+
+  it('runs a menu item and closes the menu behind it', async () => {
+    await mountPet()
+    fireEvent.contextMenu(petEl(), { clientX: 120, clientY: 90 })
+    await waitFor(() => expect(document.querySelector('.cc-menu-host')).not.toBeNull())
+    const change = [...document.querySelectorAll('.cc-menu-host [role="menuitem"]')].find(
+      (n) => n.textContent === 'Change avatar',
+    ) as HTMLElement
+    fireEvent.click(change)
+    await waitFor(() => expect(bridge.contextMenuAction).toHaveBeenCalledWith('gallery'))
+    await waitFor(() => expect(document.querySelector('.cc-menu-host')).toBeNull())
+  })
+
+  it('gives up focus again when the panel window closes on its own', async () => {
+    await mountPet()
+    tapPet()
+    await waitFor(() => expect(api.setFocusable).toHaveBeenCalledWith(true))
+    api.setFocusable.mockClear()
+    // Blur / Escape / its own ✕ — the panel closes without going through closePanel.
+    await waitFor(() => expect(panelClosedCbs.length).toBeGreaterThan(0))
+    panelClosedCbs[panelClosedCbs.length - 1]()
+    await waitFor(() => expect(api.setFocusable).toHaveBeenCalledWith(false))
+  })
+})
+
+describe('the active appearance pack', () => {
+  it('reads the built-in ghost and asks for no pack detail', async () => {
+    await mountPet()
+    await waitFor(() => expect(bridge.getCrewCompanionConfig).toHaveBeenCalled())
+    expect(bridge.galleryGetPackDetail).not.toHaveBeenCalled()
+  })
+
+  it('reads a custom pack’s own random behaviours', async () => {
+    config = { activeAppearance: 'petdex-pack', kiro: { accessory: 'partyhat' } }
+    packDetail = {
+      animations: { idle: '<svg/>', walking: '<svg/>', happy: '<svg/>', wave: '<svg/>' },
+      randomNames: ['wave', 'missing-art'],
+      sprite: {},
+    }
+    await mountPet()
+    await waitFor(() => expect(bridge.galleryGetPackDetail).toHaveBeenCalledWith('petdex-pack'))
+  })
+
+  it('treats an unknown saved accessory as "no prop" rather than guessing', async () => {
+    config = { activeAppearance: 'kiro-ghost', kiro: { accessory: 42 } }
+    await mountPet()
+    await waitFor(() => expect(bridge.getCrewCompanionConfig).toHaveBeenCalled())
+    expect(petEl()).not.toBeNull()
+  })
+
+  it('records the avatar gallery window opening and closing', async () => {
+    await mountPet()
+    await waitFor(() => expect(galleryOpenedCbs.length).toBeGreaterThan(0))
+    await waitFor(() => expect(galleryClosedCbs.length).toBeGreaterThan(0))
+    // Driving both broadcasts must not disturb the overlay. NOTE: the flag they set
+    // (`galleryOpenRef`) is not currently consulted by the autonomous-motion gate, so
+    // there is no observable behaviour to assert beyond survival — see the report.
+    galleryOpenedCbs[galleryOpenedCbs.length - 1]()
+    galleryClosedCbs[galleryClosedCbs.length - 1]()
+    expect(petEl()).not.toBeNull()
+  })
+})
+
+describe('fires that arrive through /pending rather than the socket', () => {
+  it('celebrates a completion that came off the fire queue', async () => {
+    queue([fire({ seq: 1, kind: 'session-done', text: 'built the thing' })])
+    await mountPet()
+    await waitFor(() => expect(bubbleText()).toBe('built the thing'))
+    // Not sticky: a finish is pure FYI, so it keeps its ✕.
+    expect(document.querySelector('.cc-bubble-x')).not.toBeNull()
+  })
+
+  it('shakes on a failure and keeps the ✕ — a failure is not a question', async () => {
+    queue([fire({ seq: 1, kind: 'session-error', text: 'it broke' })])
+    await mountPet()
+    await waitFor(() => expect(bubbleText()).toBe('it broke'))
+    expect(document.querySelector('.cc-bubble-x')).not.toBeNull()
+  })
+
+  it('holds an approval from the queue with no ✕ at all', async () => {
+    queue([fire({ seq: 1, kind: 'approval', text: 'needs your OK' })])
+    await mountPet()
+    await waitFor(() => expect(bubbleText()).toBe('needs your OK'))
+    expect(document.querySelector('.cc-bubble-x')).toBeNull()
+  })
+
+  it('treats an unrecognised kind as routine rather than dropping it', async () => {
+    queue([fire({ seq: 1, kind: '', text: 'something happened' })])
+    await mountPet()
+    await waitFor(() => expect(bubbleText()).toBe('something happened'))
+  })
+
+  it('DEFERS an ambient nudge while blocked work holds the slot, cursor unmoved', async () => {
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    // The empty first drain commits the backend's own cursor, which is 0 here.
+    await waitFor(() => expect(window.localStorage.getItem('cc:pendingCursor')).toBe('0'))
+    watch!.onApproval!({ slot: 'a', title: 'Run the migration' })
+    await waitFor(() => expect(document.querySelector('.cc-bubble-kicker')).not.toBeNull())
+
+    queue([fire({ seq: 5, kind: 'reminder', text: 'tea' })])
+    ringDoorbell()
+    // Unmoved cursor IS the retry mechanism: the reminder must still be pending.
+    await waitFor(() => expect(calls.filter((u) => u.includes('since=0')).length).toBeGreaterThan(1))
+    expect(window.localStorage.getItem('cc:pendingCursor')).toBe('0')
+    expect(document.querySelector('.cc-bubble-body')?.textContent).toBe('Run the migration')
+  })
+
+  it('drains at once when the backend rings the doorbell, not on the next tick', async () => {
+    await mountPet()
+    await waitFor(() => expect(watch).not.toBeNull())
+    queue([fire({ seq: 2, kind: 'reminder', text: 'ring ring' })])
+    ringDoorbell()
+    // waitFor's window is shorter than the 2s poll interval, so passing here means the
+    // doorbell — not the tick — delivered it.
+    await waitFor(() => expect(bubbleText()).toBe('ring ring'), { timeout: 1500 })
+  })
+
+  it('gives up quietly when the post-restart re-read also fails', async () => {
+    window.localStorage.setItem('cc:pendingCursor', '42')
+    sinceZeroFails = true
+    pending = () => ({ cursor: 1, fires: [fire({ seq: 1, text: 'unreachable' })] })
+    await mountPet()
+    await waitFor(() => expect(calls).toContain(`${PENDING_PATH}?since=0`))
+    expect(document.querySelector('.cc-bubble-text')).toBeNull()
+    // Nothing was shown, so nothing was consumed.
+    expect(window.localStorage.getItem('cc:pendingCursor')).toBe('42')
+  })
+})
+
+describe('the overlay survives a hostile localStorage', () => {
+  it('starts from 0 when the stored cursor cannot be read (private mode)', async () => {
+    const original = Storage.prototype.getItem
+    const spy = vi
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation(function (this: Storage, key: string) {
+        if (key === 'cc:pendingCursor') throw new Error('access denied')
+        return original.call(this, key)
+      })
+    try {
+      await mountPet()
+      await waitFor(() => expect(calls).toContain(`${PENDING_PATH}?since=0`))
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('still shows the fire when the cursor cannot be persisted', async () => {
+    const original = Storage.prototype.setItem
+    const spy = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(function (this: Storage, key: string, value: string) {
+        if (key === 'cc:pendingCursor') throw new Error('quota exceeded')
+        original.call(this, key, value)
+      })
+    try {
+      queue([fire({ seq: 3, kind: 'reminder', text: 'replaying is bad, silence is worse' })])
+      await mountPet()
+      await waitFor(() =>
+        expect(bubbleText()).toBe('replaying is bad, silence is worse'),
+      )
+    } finally {
+      spy.mockRestore()
+    }
+  })
+})
+
+describe('docking at a screen edge', () => {
+  it('tucks half the body off the LEFT edge and leans into it', async () => {
+    savedPos = { x: 0, y: 100 }
+    await mountPet()
+    await waitFor(() => expect(petEl().style.transform).toContain('rotate(25deg)'))
+    // Half the width, pushed off the docked edge — not mirrored on the left half.
+    expect(petEl().style.transform).toContain('translateX(-64px)')
+    expect(petEl().style.transform).not.toContain('scaleX(-1)')
+  })
+
+  it('mirrors the art on the RIGHT edge and flips the crop with it', async () => {
+    savedPos = { x: 900, y: 100 }
+    await mountPet()
+    await waitFor(() => expect(petEl().style.transform).toContain('rotate(25deg)'))
+    const transform = petEl().style.transform
+    // scaleX(-1) has already flipped the axis, so the crop is negated to still
+    // travel off-screen — the bug that made the right-edge dock look undocked.
+    expect(transform).toContain('scaleX(-1)')
+    expect(transform).toContain('translateX(-64px)')
+  })
+
+  it('docks at the left edge when no position was ever saved', async () => {
+    savedPos = null
+    await mountPet()
+    await waitFor(() => expect(petEl().style.transform).toContain('rotate(25deg)'))
+    expect(petEl().style.opacity).toBe('1')
+  })
+
+  it('becomes visible only once the saved position has arrived', async () => {
+    await mountPet()
+    await waitFor(() => expect(petEl().style.opacity).toBe('1'))
+    expect(bridge.getWindowPosition).toHaveBeenCalled()
+  })
+})
+
+describe('dragging the companion', () => {
+  it('persists the position it was dropped at', async () => {
+    await mountPet()
+    await waitFor(() => expect(petEl().style.opacity).toBe('1'))
+    const pet = petEl()
+    fireEvent.mouseDown(pet, { clientX: 340, clientY: 240, button: 0 })
+    // Past the 6px threshold the grip is read and the drag really begins.
+    fireEvent.mouseMove(window, { clientX: 420, clientY: 300 })
+    fireEvent.mouseUp(window)
+    await waitFor(() => expect(bridge.savePosition).toHaveBeenCalled())
+  })
+})

--- a/website/src/test/DesignCritiquePage.coverage.test.tsx
+++ b/website/src/test/DesignCritiquePage.coverage.test.tsx
@@ -1,0 +1,796 @@
+// First coverage for the Design Critique page — the app shell that owns every
+// phase of a critique (new → uploading → scanning → scoping → analyzing →
+// report / error), the resume-from-localStorage path, and the History list.
+//
+// The page's only seam to the outside world is `./api`, so that module is mocked
+// and nothing here touches the network. Two things shape the style of this file:
+//
+//   1. The poll loops sleep on `setTimeout(1500)` and end on EVIDENCE (a finished
+//      slot carrying parseable JSON), not on a clock the test can skip. So the
+//      whole file runs on fake timers and drives them explicitly with
+//      `advanceTimersByTimeAsync` inside `act` — the pattern App.test.tsx and
+//      ChannelsPanel.test.tsx already use.
+//   2. Interactions go through `fireEvent` rather than `userEvent`, because
+//      userEvent's own internal delays would have to be threaded through the same
+//      fake clock that is being used to step the poll loop. `fireEvent` keeps each
+//      step synchronous and the timer budget of each test explicit.
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+
+import { designCritiqueApi } from '../apps/design-critique/api'
+import { HKEY, JOBKEY, LIVEKEY, SLOTSKEY } from '../apps/design-critique/constants'
+import type { Ask, HistoryEntry, Report, Scope, SlotData } from '../apps/design-critique/types'
+
+// The single seam between the page and the gateway. `fileUrl` is left real: it is
+// a pure string builder and the page renders its output as an <img src>.
+vi.mock('../apps/design-critique/api', () => ({
+  designCritiqueApi: {
+    openSlot: vi.fn(),
+    getSlot: vi.fn(),
+    send: vi.fn(),
+    deleteSlot: vi.fn(),
+    uploadFiles: vi.fn(),
+  },
+  fileUrl: (p: string) => '/api/file-raw?path=' + encodeURIComponent(p),
+}))
+
+const mockApi = designCritiqueApi as unknown as {
+  openSlot: Mock
+  getSlot: Mock
+  send: Mock
+  deleteSlot: Mock
+  uploadFiles: Mock
+}
+
+const DesignCritiquePage = (await import('../apps/design-critique/DesignCritiquePage')).default
+
+/** A finished slot whose last assistant message carries `payload` as JSON. The
+ *  fence is deliberate — that is how the model actually replies, and
+ *  `extractJson` has to strip it. */
+function assistantJson(payload: unknown): SlotData {
+  return {
+    running: false,
+    messages: [
+      { role: 'user', content: 'critique this' },
+      { role: 'assistant', content: '```json\n' + JSON.stringify(payload) + '\n```' },
+    ],
+  }
+}
+
+const imageFile = (name: string): File => new File(['pixels'], name, { type: 'image/png' })
+
+/** One screenshot's critique: no flow, one located finding, so the report renders
+ *  a pin on the canvas and a single "What I'd tighten" section. */
+const ONE_SCREEN_REPORT: Report = {
+  overallRead: 'Clear enough to use, but the two blue buttons fight each other.',
+  health: 'Nearly there',
+  tally: { major: 1 },
+  keep: ['Generous spacing between the fields.'],
+  couldNotSee: ['The error states — nothing invalid was reachable.'],
+  findings: [{
+    severity: 'major',
+    title: 'Two primary buttons compete',
+    category: 'Hierarchy',
+    location: 'Footer action row',
+    evidence: 'Save and Publish are both filled in the same blue.',
+    fix: 'Demote one of them to a quiet button.',
+    rules: ['Nielsen: consistency & standards'],
+    box: { x: 0.2, y: 0.6, w: 0.3, h: 0.1 },
+  }],
+}
+
+/** What STEP 1 replies for a repo: two candidate screens and one observed flow. */
+const DISCOVERY = {
+  framework: 'React + Vite',
+  screens: [
+    { id: 'cart', label: 'Cart', ref: 'src/routes/Cart.tsx' },
+    { id: 'pay', label: 'Payment', ref: 'src/routes/Pay.tsx' },
+  ],
+  flows: [{ label: 'Checkout', basis: 'observed', screenIds: ['cart', 'pay'] }],
+}
+
+function historyEntry(over: Partial<HistoryEntry> = {}): HistoryEntry {
+  return {
+    id: 1,
+    ts: Date.now(),
+    slotKey: 'slot-old',
+    screens: [{ step: 1, label: 'Dashboard', url: '/api/file-raw?path=%2Ftmp%2Fold.png' }],
+    thumbUrl: '/api/file-raw?path=%2Ftmp%2Fold.png',
+    read: 'A tidy dashboard that hides its most useful control.',
+    report: {
+      overallRead: 'A tidy dashboard that hides its most useful control.',
+      tally: { minor: 1 },
+      findings: [{ severity: 'minor', title: 'The filter is below the fold', box: null }],
+    },
+    ...over,
+  }
+}
+
+/** Step the fake clock and let every promise it releases settle. */
+async function tick(ms = 0): Promise<void> {
+  await act(async () => { await vi.advanceTimersByTimeAsync(ms) })
+}
+
+/** One poll cycle is a 1500ms sleep followed by a slot read. */
+const POLL_MS = 2000
+
+const dropZone = (): HTMLElement =>
+  screen.getByRole('button', { name: /Drop screenshots/ })
+
+/** The drop handler sits on the composer, so any child inside it is a valid drop
+ *  target. Once something is staged the empty-state tile is replaced by the
+ *  staged strip, whose "Add screens" tile is then the child to aim at. */
+const dropTarget = (): HTMLElement =>
+  screen.queryByRole('button', { name: /Drop screenshots/ })
+  ?? screen.getByRole('button', { name: 'Add screens' })
+
+function dropFiles(files: File[]): void {
+  fireEvent.drop(dropTarget(), { dataTransfer: { files, types: ['Files'] } })
+}
+
+const linkField = (): HTMLElement =>
+  screen.getByPlaceholderText(/Figma link · git repo/)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  vi.useFakeTimers()
+  mockApi.openSlot.mockResolvedValue({ key: 'slot-1' })
+  mockApi.send.mockResolvedValue(undefined)
+  mockApi.deleteSlot.mockResolvedValue(undefined)
+  mockApi.uploadFiles.mockResolvedValue({ paths: ['/tmp/shot-1.png'] })
+  // Default: the critic has not answered yet, so a poll loop keeps going until a
+  // test says otherwise.
+  mockApi.getSlot.mockResolvedValue({ running: true, messages: [] })
+})
+
+afterEach(() => {
+  // Unmount before restoring the clock: a component torn down by the automatic
+  // cleanup while its poll promise is mid-flight flips aliveRef and the loop
+  // exits, so no pending work escapes into the next test.
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('Design Critique — first visit', () => {
+  it('introduces itself, offers the example, and admits it has no critiques', () => {
+    render(<DesignCritiquePage />)
+
+    expect(screen.getByText('Design Critique')).toBeInTheDocument()
+    expect(screen.getByText(/read it the way a designer friend would/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /See an example/ })).toBeInTheDocument()
+    expect(screen.getByText('Your critiques')).toBeInTheDocument()
+    expect(screen.getByText(/No critiques yet/)).toBeInTheDocument()
+    // The composer, not a report.
+    expect(screen.getByText('What should I critique?')).toBeInTheDocument()
+    // Nothing to start over from yet, so the rail offers no "New".
+    expect(screen.queryByRole('button', { name: 'New' })).toBeNull()
+  })
+
+  it('reaps a slot left behind by an earlier visit but spares a live run', () => {
+    localStorage.setItem(SLOTSKEY, JSON.stringify(['stray-1', 'resumable-1', 'live-1']))
+    localStorage.setItem(JOBKEY, JSON.stringify({
+      'resumable-1': { stage: 'scanning', slotKey: 'resumable-1', kind: 'repo', ts: Date.now() },
+    }))
+    localStorage.setItem(LIVEKEY, JSON.stringify([{ k: 'live-1', ts: Date.now() }]))
+
+    render(<DesignCritiquePage />)
+
+    expect(mockApi.deleteSlot).toHaveBeenCalledWith('stray-1')
+    expect(mockApi.deleteSlot).toHaveBeenCalledTimes(1)
+    // Both spared keys survive in the tracked list.
+    expect(JSON.parse(localStorage.getItem(SLOTSKEY) || '[]').sort())
+      .toEqual(['live-1', 'resumable-1'])
+  })
+})
+
+describe('Design Critique — the built-in example', () => {
+  const openExample = () => {
+    render(<DesignCritiquePage />)
+    fireEvent.click(screen.getByRole('button', { name: /See an example/ }))
+  }
+
+  it('renders the read, the tally, and every report section', () => {
+    openExample()
+
+    expect(screen.getByText(/it loses momentum in the middle/)).toBeInTheDocument()
+    expect(screen.getByText('Promising, needs work · 4 screens')).toBeInTheDocument()
+    // The tally chips, one per non-zero severity, lower-cased.
+    expect(screen.getByText('2 major')).toBeInTheDocument()
+    expect(screen.getByText('2 minor')).toBeInTheDocument()
+    expect(screen.getByText('1 cosmetic')).toBeInTheDocument()
+    expect(screen.getByText('What’s working')).toBeInTheDocument()
+    // A 4-screen flow, so cross-screen findings get their own section and each
+    // step gets a header.
+    expect(screen.getByText('Across the flow')).toBeInTheDocument()
+    expect(screen.getAllByTitle('Show this screen')).toHaveLength(4)
+    expect(screen.getByText('Couldn’t see')).toBeInTheDocument()
+  })
+
+  it('moves the canvas and the pins as you walk the filmstrip', () => {
+    openExample()
+
+    // Step 1 carries no located finding, so the canvas starts pin-free. Pins are
+    // matched on their numbered title, which the rail's finding rows do not carry.
+    expect(screen.queryByTitle(/^1\. Required fields/)).toBeNull()
+    expect(screen.getByTitle('Step 1 · Cart')).toHaveAttribute('aria-current', 'true')
+
+    fireEvent.click(screen.getByTitle('Step 2 · Shipping'))
+
+    expect(screen.getByTitle('Step 2 · Shipping')).toHaveAttribute('aria-current', 'true')
+    expect(screen.getByTitle('Step 1 · Cart')).toHaveAttribute('aria-current', 'false')
+    // Step 2's finding has a box, so it becomes a numbered pin on the canvas.
+    expect(screen.getByTitle(/^1\. Required fields/)).toBeInTheDocument()
+    expect(screen.getByText('● on screen')).toBeInTheDocument()
+  })
+
+  it('jumps the canvas to a finding\'s own step when its row is opened', () => {
+    openExample()
+
+    // A screen-scoped finding on step 4: opening it must bring step 4 forward.
+    fireEvent.click(screen.getByText('The confirmation is a dead end'))
+
+    expect(screen.getByTitle('Step 4 · Confirmation')).toHaveAttribute('aria-current', 'true')
+    // And the row is expanded, showing the evidence and the heuristics behind it.
+    // The first row is open by default, so this is the SECOND open body.
+    expect(screen.getAllByText('What I saw')).toHaveLength(2)
+    expect(screen.getByText(/no onward action/)).toBeInTheDocument()
+    expect(screen.getByText('Peak-end rule')).toBeInTheDocument()
+  })
+
+  it('enlarges the screen and closes the lightbox with Escape', () => {
+    openExample()
+
+    fireEvent.click(screen.getByTitle('Enlarge'))
+    const box = screen.getByRole('dialog', { name: 'Full size view' })
+    expect(box).toBeInTheDocument()
+    expect(within(box).getByAltText('full size')).toBeInTheDocument()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(screen.queryByRole('dialog', { name: 'Full size view' })).toBeNull()
+  })
+
+  it('closes the lightbox on a click outside the image', () => {
+    openExample()
+
+    fireEvent.click(screen.getByTitle('Enlarge'))
+    const overlay = screen.getByRole('dialog', { name: 'Full size view' })
+      .parentElement as HTMLElement
+    fireEvent.click(overlay)
+    expect(screen.queryByRole('dialog', { name: 'Full size view' })).toBeNull()
+  })
+
+  it('returns to the composer from the report', () => {
+    openExample()
+    expect(screen.queryByText('What should I critique?')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'New' }))
+
+    expect(screen.getByText('What should I critique?')).toBeInTheDocument()
+    expect(screen.queryByText(/it loses momentum in the middle/)).toBeNull()
+  })
+
+  it('offers a way to fill the gaps it could not see', () => {
+    openExample()
+
+    // "Couldn't see" hands the user straight back to the two inputs that fix it.
+    fireEvent.click(screen.getByRole('button', { name: /Point me at a running URL/ }))
+
+    expect(screen.getByText('What should I critique?')).toBeInTheDocument()
+    expect(linkField()).toHaveValue('http://localhost:')
+  })
+})
+
+describe('Design Critique — annotations saved with a critique', () => {
+  /** A critique whose read line was annotated in an earlier session. The ask uses
+   *  the pre-turns shape a previous build wrote, which showReport has to migrate
+   *  rather than crash on. */
+  const legacyAsk = [{
+    id: 'a1',
+    quote: 'buries its save button',
+    q: 'Why is that bad?',
+    a: 'Because nothing tells you the page has unsaved work.',
+  }] as unknown as Ask[]
+
+  const annotated = () => historyEntry({
+    read: 'The settings page buries its save button.',
+    report: {
+      overallRead: 'The settings page buries its save button.',
+      tally: { minor: 1 },
+      findings: [{ severity: 'minor', title: 'The save button is below the fold', box: null }],
+    },
+    asks: legacyAsk,
+  })
+
+  const openAnnotated = () => {
+    localStorage.setItem(HKEY, JSON.stringify([annotated()]))
+    render(<DesignCritiquePage />)
+    fireEvent.click(screen.getByText('The settings page buries its save button.'))
+  }
+
+  it('marks the quoted text and reopens the saved answer, legacy shape included', () => {
+    openAnnotated()
+
+    const mark = screen.getByTitle('Your question — click to see the answer')
+    expect(mark).toHaveTextContent('buries its save button')
+
+    fireEvent.click(mark)
+
+    expect(screen.getByText('“buries its save button”')).toBeInTheDocument()
+    expect(screen.getByText('Why is that bad?')).toBeInTheDocument()
+    expect(screen.getByText('Because nothing tells you the page has unsaved work.'))
+      .toBeInTheDocument()
+  })
+
+  it('asks a follow-up on the same thread and keeps it with the critique', async () => {
+    mockApi.getSlot.mockResolvedValue({
+      running: false,
+      messages: [{ role: 'assistant', content: 'Because the fold hides it on a laptop.' }],
+    })
+    openAnnotated()
+    fireEvent.click(screen.getByTitle('Your question — click to see the answer'))
+
+    const draft = screen.getByPlaceholderText('Ask a follow-up…')
+    fireEvent.change(draft, { target: { value: 'How would you fix it?' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Ask' }))
+
+    // The turn is optimistic: the question is on screen before the answer lands.
+    expect(screen.getByText('How would you fix it?')).toBeInTheDocument()
+    expect(screen.getByText('Thinking…')).toBeInTheDocument()
+
+    // Two text polls at 1200ms: one for the context turn, one for the answer.
+    await tick(4000)
+    expect(screen.getByText('Because the fold hides it on a laptop.')).toBeInTheDocument()
+    // Follow-ups share ONE slot so the thread keeps its context.
+    expect(mockApi.openSlot).toHaveBeenCalledTimes(1)
+    // And the answer is written back onto this critique's history entry.
+    const saved = JSON.parse(localStorage.getItem(HKEY) || '[]')
+    expect(saved[0].asks[0].turns).toHaveLength(2)
+    expect(saved[0].asks[0].turns[1].a).toBe('Because the fold hides it on a laptop.')
+  })
+
+  it('reports a failed follow-up on the turn itself', async () => {
+    mockApi.send.mockRejectedValue(new Error('the critic is gone'))
+    openAnnotated()
+    fireEvent.click(screen.getByTitle('Your question — click to see the answer'))
+
+    fireEvent.change(screen.getByPlaceholderText('Ask a follow-up…'), {
+      target: { value: 'Still there?' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Ask' }))
+    await tick()
+
+    expect(screen.getByText('the critic is gone')).toBeInTheDocument()
+    // The gate is released, so a second question is still possible.
+    expect(screen.getByPlaceholderText('Ask a follow-up…')).not.toBeDisabled()
+  })
+
+  it('removes an annotation and unmarks the text', () => {
+    openAnnotated()
+    fireEvent.click(screen.getByTitle('Your question — click to see the answer'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove this annotation' }))
+
+    expect(screen.queryByTitle('Your question — click to see the answer')).toBeNull()
+    expect(screen.queryByText('Why is that bad?')).toBeNull()
+    expect(JSON.parse(localStorage.getItem(HKEY) || '[]')[0].asks).toEqual([])
+  })
+})
+
+describe('Design Critique — staging screenshots', () => {
+  it('stages dropped images in order and names the flow', () => {
+    render(<DesignCritiquePage />)
+
+    dropFiles([imageFile('cart.png'), imageFile('pay.png')])
+
+    expect(screen.getByText(/2 screens · this order is the flow order/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Critique this flow · 2 screens/ }))
+      .toBeInTheDocument()
+    expect(screen.getByAltText('cart.png')).toBeInTheDocument()
+    expect(screen.getByAltText('pay.png')).toBeInTheDocument()
+  })
+
+  it('refuses a drop that carries no images', () => {
+    render(<DesignCritiquePage />)
+
+    dropFiles([new File(['notes'], 'notes.txt', { type: 'text/plain' })])
+
+    expect(screen.getByText('Those weren’t image files.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Critique$/ })).toBeDisabled()
+  })
+
+  it('caps staging at 20 screens and says so both times', () => {
+    render(<DesignCritiquePage />)
+
+    dropFiles(Array.from({ length: 21 }, (_, i) => imageFile('s' + i + '.png')))
+    expect(screen.getByText('Only added the first 20 — the limit is 20 screens.'))
+      .toBeInTheDocument()
+
+    dropFiles([imageFile('one-more.png')])
+    expect(screen.getByText('That’s the limit of 20 screens.')).toBeInTheDocument()
+    expect(screen.queryByAltText('one-more.png')).toBeNull()
+  })
+
+  it('removes a staged screen and drops back to a single-screen critique', () => {
+    render(<DesignCritiquePage />)
+    dropFiles([imageFile('cart.png'), imageFile('pay.png')])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove pay.png' }))
+
+    expect(screen.queryByAltText('pay.png')).toBeNull()
+    expect(screen.getByRole('button', { name: /Critique this screen/ })).toBeInTheDocument()
+  })
+
+  it('reorders staged screens, because the order IS the flow order', () => {
+    render(<DesignCritiquePage />)
+    dropFiles([imageFile('cart.png'), imageFile('pay.png')])
+
+    const names = () => screen.getAllByRole('img').map(i => i.getAttribute('alt'))
+    expect(names()).toEqual(['cart.png', 'pay.png'])
+
+    // "Move later" on the first tile: only the first tile's control is enabled at
+    // index 0's left edge, so pick the later-mover belonging to that tile.
+    const firstTile = screen.getByAltText('cart.png').closest('div')
+      ?.parentElement as HTMLElement
+    fireEvent.click(within(firstTile).getByRole('button', { name: 'Move later' }))
+
+    expect(names()).toEqual(['pay.png', 'cart.png'])
+  })
+
+  it('clears every staged screen at once', () => {
+    render(<DesignCritiquePage />)
+    dropFiles([imageFile('cart.png'), imageFile('pay.png')])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear all' }))
+
+    expect(screen.queryByAltText('cart.png')).toBeNull()
+    expect(screen.getByRole('button', { name: /Drop screenshots/ })).toBeInTheDocument()
+  })
+
+  it('highlights the drop zone only while a drag is over it', () => {
+    render(<DesignCritiquePage />)
+    const zone = dropZone()
+    expect(zone.style.borderColor).not.toContain('--accent')
+
+    fireEvent.dragOver(zone)
+    expect(dropZone().style.borderColor).toContain('--accent')
+
+    fireEvent.dragLeave(dropZone())
+    expect(dropZone().style.borderColor).not.toContain('--accent')
+  })
+
+  it('accepts images chosen through the file picker', () => {
+    const { container } = render(<DesignCritiquePage />)
+    const picker = container.querySelector('input[type="file"]') as HTMLInputElement
+
+    // `files` is read-only on the element, so it is installed directly rather
+    // than through fireEvent's target shorthand.
+    Object.defineProperty(picker, 'files', { value: [imageFile('picked.png')], configurable: true })
+    fireEvent.change(picker)
+
+    expect(screen.getByAltText('picked.png')).toBeInTheDocument()
+  })
+})
+
+describe('Design Critique — critiquing screenshots', () => {
+  it('uploads, waits on real evidence, then renders and remembers the critique', async () => {
+    mockApi.getSlot.mockResolvedValue(assistantJson(ONE_SCREEN_REPORT))
+    render(<DesignCritiquePage />)
+    dropFiles([imageFile('cart.png')])
+
+    fireEvent.click(screen.getByRole('button', { name: /Critique this screen/ }))
+
+    // Upload first, and the waiting screen says which stage it is in.
+    await tick()
+    expect(mockApi.uploadFiles).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('Reading your screen')).toBeInTheDocument()
+    expect(screen.getByText('Reading your design…')).toBeInTheDocument()
+    expect(mockApi.send).toHaveBeenCalledWith('slot-1', expect.stringContaining('/tmp/shot-1.png'))
+
+    // One poll cycle later the critic has answered.
+    await tick(POLL_MS)
+    expect(screen.getByText(/the two blue buttons fight each other/)).toBeInTheDocument()
+    expect(screen.getByText('1 major')).toBeInTheDocument()
+    expect(screen.getByText('What I\'d tighten')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /1\. Two primary buttons compete/ }))
+      .toBeInTheDocument()
+
+    // The finished run is written to History and its slot released.
+    const saved = JSON.parse(localStorage.getItem(HKEY) || '[]')
+    expect(saved).toHaveLength(1)
+    expect(saved[0].read).toContain('the two blue buttons fight each other')
+    expect(mockApi.deleteSlot).toHaveBeenCalledWith('slot-1')
+    expect(localStorage.getItem(JOBKEY)).toBeNull()
+  })
+
+  it('surfaces an upload failure instead of waiting for ever', async () => {
+    mockApi.uploadFiles.mockRejectedValue(new Error('upload failed (413)'))
+    render(<DesignCritiquePage />)
+    dropFiles([imageFile('cart.png')])
+
+    fireEvent.click(screen.getByRole('button', { name: /Critique this screen/ }))
+    await tick()
+
+    expect(screen.getByText('upload failed (413)')).toBeInTheDocument()
+    // No slot was ever opened, so nothing needs releasing.
+    expect(mockApi.openSlot).not.toHaveBeenCalled()
+  })
+
+  it('says so when the critic replies with something unreadable', async () => {
+    mockApi.getSlot.mockResolvedValue({
+      running: false, messages: [{ role: 'assistant', content: 'I had a look and it seems fine.' }],
+    })
+    render(<DesignCritiquePage />)
+    dropFiles([imageFile('cart.png')])
+
+    fireEvent.click(screen.getByRole('button', { name: /Critique this screen/ }))
+    await tick(POLL_MS)
+
+    expect(screen.getByText('The critic replied but not in a readable format.'))
+      .toBeInTheDocument()
+  })
+
+  it('cancels a run, releases its slot, and returns to the composer', async () => {
+    render(<DesignCritiquePage />)
+    dropFiles([imageFile('cart.png')])
+    fireEvent.click(screen.getByRole('button', { name: /Critique this screen/ }))
+    await tick()
+
+    fireEvent.click(screen.getByRole('button', { name: /Cancel this run/ }))
+
+    expect(screen.getByText('What should I critique?')).toBeInTheDocument()
+    expect(mockApi.deleteSlot).toHaveBeenCalledWith('slot-1')
+    expect(localStorage.getItem(JOBKEY)).toBeNull()
+  })
+
+  it('gives up on a slot that has gone missing rather than polling for ever', async () => {
+    mockApi.getSlot.mockRejectedValue(new Error('404'))
+    render(<DesignCritiquePage />)
+    dropFiles([imageFile('cart.png')])
+    fireEvent.click(screen.getByRole('button', { name: /Critique this screen/ }))
+
+    // Eight consecutive misses is the give-up threshold; one miss is not.
+    await tick(POLL_MS)
+    expect(screen.getByText('Reading your screen')).toBeInTheDocument()
+
+    await tick(8 * 1500)
+    expect(screen.getByText('That run is no longer available — start a new critique.'))
+      .toBeInTheDocument()
+  })
+
+  it('keeps a run that outlives the backstop instead of calling it failed', async () => {
+    // The slot answers, but never finishes. Past HARD_CAP_MS the page stops
+    // watching WITHOUT destroying the run — it is resumable on the next visit.
+    mockApi.getSlot.mockResolvedValue({ running: true, messages: [] })
+    render(<DesignCritiquePage />)
+    dropFiles([imageFile('cart.png')])
+    fireEvent.click(screen.getByRole('button', { name: /Critique this screen/ }))
+
+    await tick(15 * 60 * 1000 + 2000)
+
+    expect(screen.getByText(/Still working on this one/)).toBeInTheDocument()
+    // Deliberately NOT torn down: the slot and its job record survive.
+    expect(mockApi.deleteSlot).not.toHaveBeenCalled()
+    expect(localStorage.getItem(JOBKEY)).not.toBeNull()
+  })
+
+  it('keeps a run alive in the background when a new critique is started', async () => {
+    mockApi.getSlot.mockResolvedValue({ running: true, messages: [] })
+    render(<DesignCritiquePage />)
+    dropFiles([imageFile('cart.png')])
+    fireEvent.click(screen.getByRole('button', { name: /Critique this screen/ }))
+    await tick()
+
+    // "New" is explicitly NOT a cancel: the run keeps going and earns a row.
+    fireEvent.click(screen.getByRole('button', { name: 'New' }))
+    expect(screen.getByText('What should I critique?')).toBeInTheDocument()
+    expect(screen.getByTitle('A critique is still running — click to watch it'))
+      .toBeInTheDocument()
+    expect(mockApi.deleteSlot).not.toHaveBeenCalled()
+
+    // When it lands it fills its own row in place and announces itself instead of
+    // hijacking the screen the user moved to.
+    mockApi.getSlot.mockResolvedValue(assistantJson(ONE_SCREEN_REPORT))
+    await tick(POLL_MS)
+    expect(screen.getByText('What should I critique?')).toBeInTheDocument()
+    const chip = screen.getByRole('button', { name: /critique ready/ })
+    const saved = JSON.parse(localStorage.getItem(HKEY) || '[]')
+    expect(saved).toHaveLength(1)
+    expect(saved[0].pending).toBe(false)
+
+    fireEvent.click(chip)
+    expect(screen.getByText(/the two blue buttons fight each other/)).toBeInTheDocument()
+  })
+})
+
+describe('Design Critique — critiquing a reference', () => {
+  const start = (text: string) => {
+    render(<DesignCritiquePage />)
+    fireEvent.change(linkField(), { target: { value: text } })
+    fireEvent.keyDown(linkField(), { key: 'Enter' })
+  }
+
+  it('rejects text that is not a design reference at all', () => {
+    start('some notes about the design')
+
+    expect(screen.getByText(/I couldn’t tell what that is/)).toBeInTheDocument()
+    expect(mockApi.openSlot).not.toHaveBeenCalled()
+  })
+
+  it('discovers the screens, then critiques only the picked flow', async () => {
+    mockApi.getSlot.mockResolvedValue(assistantJson(DISCOVERY))
+    start('https://github.com/acme/widgets')
+
+    await tick()
+    expect(screen.getByText('Looking for screens to audit')).toBeInTheDocument()
+
+    await tick(POLL_MS)
+    expect(screen.getByText('What should I audit?')).toBeInTheDocument()
+    expect(screen.getByText(/2 screens found · 2 I can render/)).toBeInTheDocument()
+    expect(screen.getByText('React + Vite')).toBeInTheDocument()
+    // The observed flow presets the pick, in its own order.
+    expect(screen.getAllByRole('checkbox', { checked: true })).toHaveLength(2)
+
+    // The brief travels with the scoped run, and the same slot is reused.
+    fireEvent.change(screen.getByPlaceholderText(/who is it for/), {
+      target: { value: 'first-time buyers' },
+    })
+    mockApi.getSlot.mockResolvedValue(assistantJson(ONE_SCREEN_REPORT))
+    fireEvent.click(screen.getByRole('button', { name: /Critique this flow · 2 screens/ }))
+
+    await tick(POLL_MS)
+    expect(screen.getByText(/the two blue buttons fight each other/)).toBeInTheDocument()
+    expect(mockApi.openSlot).toHaveBeenCalledTimes(1)
+    expect(mockApi.send).toHaveBeenLastCalledWith('slot-1', expect.stringContaining('first-time buyers'))
+  })
+
+  it('narrows the pick to one screen and says what it will do', async () => {
+    mockApi.getSlot.mockResolvedValue(assistantJson(DISCOVERY))
+    start('https://github.com/acme/widgets')
+    await tick(POLL_MS)
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Cart/ }))
+
+    expect(screen.getByRole('button', { name: /Critique this screen/ })).toBeInTheDocument()
+    expect(screen.getByText(/Click a screen to pick it/)).toBeInTheDocument()
+
+    // The suggested flow puts the whole set back in its own order.
+    fireEvent.click(screen.getByText('Checkout'))
+    expect(screen.getAllByRole('checkbox', { checked: true })).toHaveLength(2)
+  })
+
+  it('reorders the picked screens, since the order is the walk order', async () => {
+    mockApi.getSlot.mockResolvedValue(assistantJson(DISCOVERY))
+    start('https://github.com/acme/widgets')
+    await tick(POLL_MS)
+
+    const cart = screen.getByRole('checkbox', { name: /Cart/ })
+    // Cart is picked first, so its "move later" swaps it with Payment. The rows
+    // keep their discovery order; it is the ORDINAL badge that carries the walk
+    // order, so that is what has to move.
+    expect(cart.textContent).toContain('1')
+    fireEvent.click(within(cart).getByRole('button', { name: 'Move later' }))
+    expect(cart.textContent).toContain('2')
+
+    // Dragging one picked row onto another reorders it back.
+    fireEvent.dragStart(cart, { dataTransfer: { effectAllowed: 'move' } })
+    fireEvent.dragOver(screen.getByRole('checkbox', { name: /Payment/ }))
+    fireEvent.drop(cart)
+    expect(cart.textContent).toContain('1')
+  })
+
+  it('explains a blocked reference and offers the access steps', async () => {
+    mockApi.getSlot.mockResolvedValue(assistantJson({
+      blocked: { reason: 'no-access', detail: 'HTTP 404 from github.com' },
+    }))
+    start('https://github.com/acme/private-thing')
+    await tick(POLL_MS)
+
+    expect(screen.getByText('I couldn’t get in')).toBeInTheDocument()
+    expect(screen.getByText(/It’s either private/)).toBeInTheDocument()
+    expect(screen.getByText('HTTP 404 from github.com')).toBeInTheDocument()
+    // The slot is released as soon as the run is known to be over.
+    expect(mockApi.deleteSlot).toHaveBeenCalledWith('slot-1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fix my access' }))
+    expect(screen.getByText(/Git access is set up per machine/)).toBeInTheDocument()
+    expect(screen.getByText(/gh auth login/)).toBeInTheDocument()
+  })
+
+  it('says it got in but found nothing renderable, using the critic\'s own note', async () => {
+    mockApi.getSlot.mockResolvedValue(assistantJson({
+      screens: [], cannotSee: ['Every route needs a running server.'],
+    }))
+    start('https://github.com/acme/widgets')
+    await tick(POLL_MS)
+
+    expect(screen.getByText('Every route needs a running server.')).toBeInTheDocument()
+  })
+})
+
+describe('Design Critique — resuming and History', () => {
+  it('resumes a run that was left at the scoping step', () => {
+    const scope: Scope = {
+      framework: 'Next.js',
+      screens: [{ id: 'home', label: 'Home' }, { id: 'about', label: 'About' }],
+      flows: [],
+    }
+    localStorage.setItem(JOBKEY, JSON.stringify({
+      'slot-resume': {
+        stage: 'scoping', slotKey: 'slot-resume', kind: 'repo', ts: Date.now(),
+        scope, picked: ['home'], refBrief: 'returning visitors',
+      },
+    }))
+
+    render(<DesignCritiquePage />)
+
+    expect(screen.getByText('What should I audit?')).toBeInTheDocument()
+    expect(screen.getByText('Next.js')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('returning visitors')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Critique this screen/ })).toBeInTheDocument()
+  })
+
+  it('resumes an analyzing run and collects its report', async () => {
+    mockApi.getSlot.mockResolvedValue(assistantJson(ONE_SCREEN_REPORT))
+    localStorage.setItem(JOBKEY, JSON.stringify({
+      'slot-resume': {
+        stage: 'analyzing', slotKey: 'slot-resume', ts: Date.now(),
+        screens: [{ step: 1, label: 'Screen 1', url: '/api/file-raw?path=%2Ftmp%2Fa.png' }],
+      },
+    }))
+
+    render(<DesignCritiquePage />)
+    expect(screen.getByText('Reading your screen')).toBeInTheDocument()
+
+    await tick(POLL_MS)
+    expect(screen.getByText(/the two blue buttons fight each other/)).toBeInTheDocument()
+  })
+
+  it('lists a finished critique and reopens it from the rail', () => {
+    localStorage.setItem(HKEY, JSON.stringify([historyEntry()]))
+    render(<DesignCritiquePage />)
+
+    expect(screen.getByText('A tidy dashboard that hides its most useful control.'))
+      .toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('A tidy dashboard that hides its most useful control.'))
+
+    expect(screen.getByText('The filter is below the fold')).toBeInTheDocument()
+    expect(screen.getByText('1 minor')).toBeInTheDocument()
+  })
+
+  it('shows a backgrounded run as still running and re-attaches to it', () => {
+    localStorage.setItem(HKEY, JSON.stringify([
+      historyEntry({ slotKey: 'slot-bg', read: '', report: null, pending: true }),
+    ]))
+    render(<DesignCritiquePage />)
+
+    const row = screen.getByTitle('A critique is still running — click to watch it')
+    expect(row).toHaveAttribute('aria-busy', 'true')
+    expect(within(row).getByText('running')).toBeInTheDocument()
+
+    fireEvent.click(row)
+
+    // Watching it puts the waiting screen back, driven by a fresh poller.
+    expect(screen.getByText('Reading your screen')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Cancel this run/ })).toBeInTheDocument()
+  })
+
+  it('switches between critiques from the History menu', () => {
+    localStorage.setItem(HKEY, JSON.stringify([
+      historyEntry(),
+      historyEntry({
+        id: 2, slotKey: 'slot-older', read: 'The settings page buries its save button.',
+        report: { overallRead: 'The settings page buries its save button.', findings: [] },
+      }),
+    ]))
+    render(<DesignCritiquePage />)
+    fireEvent.click(screen.getByText('A tidy dashboard that hides its most useful control.'))
+
+    fireEvent.click(screen.getByRole('button', { name: /History \(2\)/ }))
+    fireEvent.click(screen.getByText('The settings page buries its save button.'))
+
+    expect(screen.getByText('The settings page buries its save button.')).toBeInTheDocument()
+    expect(screen.getByText('nothing major')).toBeInTheDocument()
+  })
+})

--- a/website/src/test/MdNotebookPage.coverage.test.tsx
+++ b/website/src/test/MdNotebookPage.coverage.test.tsx
@@ -1,0 +1,781 @@
+/**
+ * `MdNotebookPage` — the Notes app shell.
+ *
+ * The page owns every stateful decision the Notes app makes: which vault is
+ * active, which note is open, when a debounced edit reaches disk, and what to do
+ * when a save is refused because the file moved underneath it. None of that was
+ * covered — only `NoteRow`'s delete affordance had a test — so this file pins the
+ * behaviour a user can observe: the three boot states, opening and editing a
+ * note, the save-guard conflict banner and both of its exits, sync (success,
+ * merge conflict, local-only vault, keyboard shortcut), search, the sort/view
+ * menu, vault switching, row actions (pin, rename, duplicate, drag-to-file,
+ * trash) and the stale-backend warning.
+ *
+ * The API module is mocked wholesale: the real client fetches through the
+ * gateway proxy, and these tests are about what the page does with the replies,
+ * not how they are transported.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, within, fireEvent, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { SAVE_DEBOUNCE_MS } from '../apps/md-notebook/constants'
+import type { Note, Vault } from '../apps/md-notebook/types'
+
+// Every capability the page requires. Kept as a literal rather than imported so
+// a feature silently dropped from the page's own list shows up as a failing
+// stale-backend test instead of passing by construction.
+const ALL_FEATURES = [
+  'createdAt',
+  'attach',
+  'changes',
+  'saveGuard',
+  'forget',
+  'pat',
+  'newNote',
+  'move',
+  'duplicate',
+  'localOnly',
+  'autoCommit',
+  'trash',
+  'trashOpen',
+  'knowledge',
+  'pickFolder',
+]
+
+const mockApi = {
+  health: vi.fn(),
+  listVaults: vi.fn(),
+  cloneVault: vi.fn(),
+  attachVault: vi.fn(),
+  forgetVault: vi.fn(),
+  setVaultKnowledge: vi.fn(),
+  setPat: vi.fn(),
+  pickFolder: vi.fn(),
+  listNotes: vi.fn(),
+  readNote: vi.fn(),
+  saveNote: vi.fn(),
+  deleteNote: vi.fn(),
+  newNote: vi.fn(),
+  duplicateNote: vi.fn(),
+  moveNote: vi.fn(),
+  sync: vi.fn(),
+  commit: vi.fn(),
+  openTrash: vi.fn(),
+  search: vi.fn(),
+  changes: vi.fn(),
+}
+
+vi.mock('../apps/md-notebook/api', async () => {
+  const actual = await vi.importActual<typeof import('../apps/md-notebook/api')>(
+    '../apps/md-notebook/api',
+  )
+  return { ...actual, notesApi: mockApi }
+})
+
+function vault(over: Partial<Vault> = {}): Vault {
+  return {
+    id: 'v1',
+    name: 'Notebook',
+    repo: 'you/notes',
+    branch: 'main',
+    localPath: '/home/u/notes',
+    readOnly: false,
+    ...over,
+  }
+}
+
+// Fixed timestamps: the row's relative-time label is derived from these, and a
+// `Date.now()` fixture would make that label straddle a bucket boundary.
+const T = new Date('2026-01-15T10:00:00Z').getTime()
+
+function baseNotes(): Note[] {
+  return [
+    { path: 'One.md', title: 'One', modifiedAt: T, createdAt: T, syncStatus: 'synced' },
+    {
+      path: 'folder/Two.md',
+      title: 'Two',
+      modifiedAt: T + 1000,
+      createdAt: T + 1000,
+      syncStatus: 'pending',
+    },
+  ]
+}
+
+/** The listing the backend currently reports, so a delete can actually remove one. */
+let notesState: Note[] = []
+
+const DOC = {
+  path: 'One.md',
+  content: '# Hello\n\nBody text',
+  mtime: 7,
+  meta: { frontmatter: {}, tags: [], links: [] },
+  backlinks: [{ sourcePath: 'folder/Two.md', line: 3, context: 'see [[One]]' }],
+}
+
+async function renderPage() {
+  const { default: MdNotebookPage } = await import('../apps/md-notebook/MdNotebookPage')
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchInterval: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <MdNotebookPage />
+    </QueryClientProvider>,
+  )
+}
+
+/** Render, wait for the panel, then open `One.md`. */
+async function renderWithOpenNote() {
+  const view = await renderPage()
+  await userEvent.click(await screen.findByRole('button', { name: 'One' }))
+  await screen.findByText('Body text')
+  return view
+}
+
+/** The row element for a note, so its hover actions can be scoped to it. */
+function row(title: string): HTMLElement {
+  return screen.getByRole('button', { name: title })
+}
+
+/**
+ * Click one of a row's hover actions.
+ *
+ * `fireEvent`, not `userEvent`: the action bar is `pointer-events: none` until
+ * the row is hovered (styles.ts), and there is no layout under test to hover
+ * against — `userEvent` refuses the click on that basis alone.
+ */
+function clickRowAction(title: string, action: string): void {
+  fireEvent.click(within(row(title)).getByRole('button', { name: action }))
+}
+
+describe('MdNotebookPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    notesState = baseNotes()
+    mockApi.health.mockResolvedValue({ ok: true, features: ALL_FEATURES })
+    mockApi.listVaults.mockResolvedValue({
+      vaults: [vault(), vault({ id: 'v2', name: 'Second vault' })],
+      hasPat: false,
+      hasGhAuth: true,
+    })
+    mockApi.listNotes.mockImplementation(async (v: string | null) => ({
+      notes: v === 'v2' ? [{ path: 'Other.md', title: 'Other', modifiedAt: T, syncStatus: 'synced' }] : notesState,
+    }))
+    mockApi.readNote.mockImplementation(async (_v: string | null, path: string) => ({
+      ...DOC,
+      path,
+    }))
+    mockApi.saveNote.mockResolvedValue({ ok: true, mtime: 8 })
+    mockApi.deleteNote.mockImplementation(async (_v: string | null, path: string) => {
+      notesState = notesState.filter(n => n.path !== path)
+      return { ok: true }
+    })
+    mockApi.newNote.mockResolvedValue({ path: 'Untitled.md' })
+    mockApi.duplicateNote.mockResolvedValue({ path: 'One 1.md' })
+    mockApi.moveNote.mockResolvedValue({ ok: true, path: 'moved.md' })
+    mockApi.sync.mockResolvedValue({
+      result: { pushed: true, pulled: true, committed: [], conflicts: [] },
+    })
+    mockApi.commit.mockResolvedValue({
+      result: { pushed: false, pulled: false, committed: [], conflicts: [] },
+    })
+    mockApi.openTrash.mockResolvedValue({ opened: true, empty: false, path: '/home/u/notes/.trash' })
+    mockApi.search.mockResolvedValue({ results: [] })
+    mockApi.changes.mockResolvedValue({ rev: 0, changed: [], watching: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // ── boot states ───────────────────────────────────────────────────────────
+
+  it('shows a loading line until the vault list arrives', async () => {
+    // Never resolves: the point is the state BEFORE any reply, which the page
+    // reaches by `vaults === null` rather than a separate flag.
+    mockApi.listVaults.mockReturnValue(new Promise(() => {}))
+    await renderPage()
+    expect(await screen.findByText('Loading…')).toBeTruthy()
+  })
+
+  it('names the backend as unreachable when the vault list fails', async () => {
+    mockApi.listVaults.mockRejectedValue(new Error('connect ECONNREFUSED'))
+    await renderPage()
+    expect(
+      await screen.findByText(/Could not reach the Notes backend: connect ECONNREFUSED/),
+    ).toBeTruthy()
+  })
+
+  it('offers the connect screen instead of an empty notebook when no vault exists', async () => {
+    mockApi.listVaults.mockResolvedValue({ vaults: [], hasPat: false, hasGhAuth: false })
+    await renderPage()
+    // The connect screen's own tabs, not its title — the panel's menu carries an
+    // identically-worded entry, so the title alone would not prove which surface
+    // rendered.
+    expect(await screen.findByText('Clone a repo')).toBeTruthy()
+    expect(screen.getByText('Attach a folder')).toBeTruthy()
+  })
+
+  // ── listing ───────────────────────────────────────────────────────────────
+
+  it('renders the vault name, its notes in a folder tree, and the empty-body prompt', async () => {
+    await renderPage()
+    expect(await screen.findByRole('button', { name: 'One' })).toBeTruthy()
+    // Folders view is the default, so the nested note sits under a folder row.
+    expect(screen.getByRole('button', { name: 'folder' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Two' })).toBeTruthy()
+    expect(screen.getByText('Notebook')).toBeTruthy()
+    expect(screen.getByText('Select a note, or create one with the + button.')).toBeTruthy()
+  })
+
+  it('surfaces a listing failure as an alert rather than an empty panel', async () => {
+    mockApi.listNotes.mockRejectedValue(new Error('git index locked'))
+    await renderPage()
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('git index locked')
+  })
+
+  it('collapses a folder, hiding the notes inside it', async () => {
+    await renderPage()
+    await userEvent.click(await screen.findByRole('button', { name: 'folder' }))
+    expect(screen.queryByRole('button', { name: 'Two' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'One' })).toBeTruthy()
+  })
+
+  // ── opening a note ────────────────────────────────────────────────────────
+
+  it('opens a note on click, showing its body and its backlinks', async () => {
+    await renderWithOpenNote()
+    expect(mockApi.readNote).toHaveBeenCalledWith('v1', 'One.md')
+    expect(screen.getByText('Hello')).toBeTruthy()
+    expect(screen.getByText('Linked from 1')).toBeTruthy()
+    // The open note is remembered so a reload lands back on it.
+    expect(localStorage.getItem('mdnb-open-note')).toBe('"One.md"')
+  })
+
+  it('opens the source note when a backlink is clicked', async () => {
+    await renderWithOpenNote()
+    await userEvent.click(screen.getByRole('button', { name: 'folder/Two.md' }))
+    await waitFor(() => expect(mockApi.readNote).toHaveBeenCalledWith('v1', 'folder/Two.md'))
+  })
+
+  it('restores the remembered note on mount', async () => {
+    localStorage.setItem('mdnb-open-note', '"folder/Two.md"')
+    await renderPage()
+    await waitFor(() => expect(mockApi.readNote).toHaveBeenCalledWith('v1', 'folder/Two.md'))
+  })
+
+  it('does not restore a remembered note the vault no longer has', async () => {
+    localStorage.setItem('mdnb-open-note', '"Deleted.md"')
+    await renderPage()
+    await screen.findByRole('button', { name: 'One' })
+    expect(mockApi.readNote).not.toHaveBeenCalled()
+  })
+
+  // ── raw / rendered ────────────────────────────────────────────────────────
+
+  it('switches between rendered and raw markdown, remembering the choice', async () => {
+    await renderWithOpenNote()
+    await userEvent.click(screen.getByRole('button', { name: 'Markdown source' }))
+    const ta = screen.getByRole('textbox', { name: 'Markdown source' }) as HTMLTextAreaElement
+    expect(ta.value).toBe('# Hello\n\nBody text')
+    expect(localStorage.getItem('mdnb-view')).toBe('"raw"')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Rendered' }))
+    expect(screen.queryByRole('textbox', { name: 'Markdown source' })).toBeNull()
+    expect(localStorage.getItem('mdnb-view')).toBe('"rendered"')
+  })
+
+  it('debounces an edit before persisting it, and does not save on the keystroke', async () => {
+    await renderWithOpenNote()
+    await userEvent.click(screen.getByRole('button', { name: 'Markdown source' }))
+    const ta = screen.getByRole('textbox', { name: 'Markdown source' })
+
+    // Fake timers only from here: the debounce is the thing under test, and the
+    // mount above needs real promise scheduling to settle first.
+    vi.useFakeTimers()
+    fireEvent.change(ta, { target: { value: '# Hello\n\nEdited body' } })
+    expect(mockApi.saveNote).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS)
+    })
+    expect(mockApi.saveNote).toHaveBeenCalledWith('v1', 'One.md', '# Hello\n\nEdited body', 7)
+  })
+
+  // ── save guard ────────────────────────────────────────────────────────────
+
+  /** Put the page in the state where a save has been refused as stale. */
+  async function reachDiskConflict() {
+    await renderWithOpenNote()
+    await userEvent.click(screen.getByRole('button', { name: 'Markdown source' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Markdown source' }), {
+      target: { value: 'mine' },
+    })
+    mockApi.saveNote.mockRejectedValueOnce(
+      Object.assign(new Error('stale'), {
+        body: { code: 'ESTALE', mtime: 99, disk: 'theirs' },
+      }),
+    )
+    // Sync flushes the pending edit immediately, which is what trips the guard.
+    await userEvent.click(screen.getByRole('button', { name: 'Sync' }))
+    await screen.findByText('This note changed on disk since you opened it.')
+  }
+
+  it('offers both versions when the file changed on disk instead of clobbering either', async () => {
+    await reachDiskConflict()
+    expect(screen.getByRole('button', { name: 'Use the version on disk' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Keep my version' })).toBeTruthy()
+    // A refused save must not be reported as a completed sync.
+    expect(screen.getByRole('button', { name: 'Sync' })).toBeTruthy()
+  })
+
+  it('takes the version on disk, discarding the in-memory edit', async () => {
+    await reachDiskConflict()
+    await userEvent.click(screen.getByRole('button', { name: 'Use the version on disk' }))
+    const ta = screen.getByRole('textbox', { name: 'Markdown source' }) as HTMLTextAreaElement
+    expect(ta.value).toBe('theirs')
+    expect(screen.queryByText('This note changed on disk since you opened it.')).toBeNull()
+  })
+
+  it("keeps the editor's version, re-saving it against the fresh mtime", async () => {
+    await reachDiskConflict()
+    await userEvent.click(screen.getByRole('button', { name: 'Keep my version' }))
+    // 99 is the mtime the backend reported with the refusal — without adopting it
+    // the retry would be refused again forever.
+    await waitFor(() => expect(mockApi.saveNote).toHaveBeenCalledWith('v1', 'One.md', 'mine', 99))
+  })
+
+  // ── sync ──────────────────────────────────────────────────────────────────
+
+  it('syncs and then reports how long ago that was', async () => {
+    await renderPage()
+    await userEvent.click(await screen.findByRole('button', { name: 'Sync' }))
+    await waitFor(() => expect(mockApi.sync).toHaveBeenCalledWith('v1'))
+    expect(await screen.findByRole('button', { name: 'Synced just now' })).toBeTruthy()
+  })
+
+  it('reports a merge conflict rather than claiming a successful sync', async () => {
+    mockApi.sync.mockResolvedValue({
+      result: {
+        pushed: false,
+        pulled: true,
+        committed: [],
+        conflicts: [{ path: 'One.md', local: 'a', remote: 'b' }],
+      },
+    })
+    await renderPage()
+    await userEvent.click(await screen.findByRole('button', { name: 'Sync' }))
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('Sync stopped on a merge conflict')
+    expect(alert.textContent).toContain('One.md')
+    // Still "Sync", never "Synced just now": nothing was pushed.
+    expect(screen.getByRole('button', { name: 'Sync' })).toBeTruthy()
+  })
+
+  it('surfaces a sync failure as an alert', async () => {
+    mockApi.sync.mockRejectedValue(new Error('remote hung up'))
+    await renderPage()
+    await userEvent.click(await screen.findByRole('button', { name: 'Sync' }))
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('remote hung up')
+  })
+
+  it('labels the action for what it does on a vault with no remote, and drops the pending badge', async () => {
+    mockApi.listVaults.mockResolvedValue({
+      vaults: [vault({ localOnly: true })],
+      hasPat: false,
+      hasGhAuth: false,
+    })
+    await renderPage()
+    expect(await screen.findByRole('button', { name: 'Save locally' })).toBeTruthy()
+    // "pending" means "not yet pushed", which has no meaning without a remote.
+    expect(screen.queryByText('pending')).toBeNull()
+  })
+
+  it('runs a sync from the keyboard shortcut', async () => {
+    await renderPage()
+    await screen.findByRole('button', { name: 'One' })
+    fireEvent.keyDown(window, { key: 's', metaKey: true })
+    await waitFor(() => expect(mockApi.sync).toHaveBeenCalledWith('v1'))
+  })
+
+  // ── stale backend ─────────────────────────────────────────────────────────
+
+  it('names the capabilities a stale backend is missing, and withholds delete', async () => {
+    mockApi.health.mockResolvedValue({
+      ok: true,
+      features: ALL_FEATURES.filter(f => f !== 'trash' && f !== 'knowledge'),
+    })
+    await renderPage()
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('running older code than this page')
+    expect(alert.textContent).toContain('trash, knowledge')
+    // The confirmation promises the note is restorable from `.trash`; without the
+    // capability the honest UI offers no delete at all.
+    expect(screen.queryByRole('button', { name: 'Delete note' })).toBeNull()
+  })
+
+  // ── search ────────────────────────────────────────────────────────────────
+
+  it('swaps the tree for ranked results while searching, and restores it when cleared', async () => {
+    mockApi.search.mockResolvedValue({
+      results: [{ path: 'folder/Two.md', title: 'Two', score: 1, snippet: null }],
+    })
+    await renderPage()
+    const box = await screen.findByRole('textbox', { name: 'Search notes' })
+    await userEvent.type(box, 'two')
+    // The tree is dropped the moment the query is non-empty; the ranked results
+    // arrive after the 150ms debounce, so wait on the RESULT, not the absence.
+    expect(await screen.findByRole('button', { name: 'Two' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'One' })).toBeNull()
+    // Flat results, so the folder row is gone too.
+    expect(screen.queryByRole('button', { name: 'folder' })).toBeNull()
+
+    await userEvent.clear(box)
+    expect(await screen.findByRole('button', { name: 'One' })).toBeTruthy()
+  })
+
+  it('says so when a search matches nothing', async () => {
+    await renderPage()
+    await userEvent.type(await screen.findByRole('textbox', { name: 'Search notes' }), 'zzz')
+    expect(await screen.findByText('No matches')).toBeTruthy()
+  })
+
+  // ── sort and view menu ────────────────────────────────────────────────────
+
+  it('switches to the flat list view and remembers it', async () => {
+    await renderPage()
+    await userEvent.click(await screen.findByRole('button', { name: 'Sort and view' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Flat list' }))
+    expect(localStorage.getItem('mdnb-list-view')).toBe('"list"')
+    // No folder tree in flat view; the note itself is still listed.
+    expect(screen.queryByRole('button', { name: 'folder' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Two' })).toBeTruthy()
+  })
+
+  it('changes the sort order, remembers it, and closes the menu', async () => {
+    await renderPage()
+    await userEvent.click(await screen.findByRole('button', { name: 'Sort and view' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Modified — new to old' }))
+    expect(localStorage.getItem('mdnb-sort')).toBe('"modified-desc"')
+    expect(screen.queryByRole('button', { name: 'Flat list' })).toBeNull()
+  })
+
+  it('falls back to the default sort when the stored one no longer exists', async () => {
+    localStorage.setItem('mdnb-sort', '"invented-order"')
+    await renderPage()
+    await userEvent.click(await screen.findByRole('button', { name: 'Sort and view' }))
+    // A dropped sort id must not crash the list or leave nothing selected.
+    expect(screen.getByRole('button', { name: 'File name — A to Z' })).toBeTruthy()
+  })
+
+  // ── vault switching ───────────────────────────────────────────────────────
+
+  it('switches vault, clearing the editor and loading that vault’s notes', async () => {
+    await renderWithOpenNote()
+    await userEvent.click(screen.getByRole('button', { name: 'Switch vault' }))
+    await userEvent.click(screen.getByRole('option', { name: /Second vault/ }))
+    expect(await screen.findByRole('button', { name: 'Other' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'One' })).toBeNull()
+    // The editor is cleared rather than left showing the old vault's note.
+    expect(screen.getByText('Select a note, or create one with the + button.')).toBeTruthy()
+    expect(localStorage.getItem('mdnb-active-vault')).toBe('"v2"')
+  })
+
+  it('reaches the connect screen from the vault menu', async () => {
+    await renderPage()
+    await userEvent.click(await screen.findByRole('button', { name: 'Switch vault' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Connect a vault' }))
+    expect(await screen.findByText('Clone a repo')).toBeTruthy()
+  })
+
+  // ── panel ─────────────────────────────────────────────────────────────────
+
+  it('hides and shows the notes panel, remembering the choice', async () => {
+    await renderPage()
+    await userEvent.click(await screen.findByRole('button', { name: 'Hide notes panel' }))
+    expect(screen.queryByRole('textbox', { name: 'Search notes' })).toBeNull()
+    expect(localStorage.getItem('mdnb-panel-open')).toBe('false')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show notes panel' }))
+    expect(screen.getByRole('textbox', { name: 'Search notes' })).toBeTruthy()
+  })
+
+  it('ignores a stored panel width outside the drag bounds', async () => {
+    localStorage.setItem('mdnb-panel-width', '5000')
+    await renderPage()
+    // A corrupt width must not collapse or overflow the panel — the list still
+    // renders at the default width.
+    expect(await screen.findByRole('button', { name: 'One' })).toBeTruthy()
+  })
+
+  // ── settings ──────────────────────────────────────────────────────────────
+
+  it('opens Settings as a page in the note pane', async () => {
+    await renderPage()
+    await screen.findByRole('button', { name: 'One' })
+    // Two controls carry this name — the whole row and the gear pinned inside it.
+    // The row is the one a user aims at.
+    await userEvent.click(screen.getAllByRole('button', { name: 'Settings' })[0])
+    expect(await screen.findByText('Vaults, GitHub access and sync')).toBeTruthy()
+    // Settings replaces the note column, so the document controls go with it.
+    expect(screen.queryByRole('button', { name: 'Markdown source' })).toBeNull()
+  })
+
+  // ── note actions ──────────────────────────────────────────────────────────
+
+  it('creates a note at the top level and opens it', async () => {
+    await renderPage()
+    await userEvent.click(await screen.findByRole('button', { name: 'New note at the top level' }))
+    await waitFor(() => expect(mockApi.newNote).toHaveBeenCalledWith('v1'))
+    await waitFor(() => expect(mockApi.readNote).toHaveBeenCalledWith('v1', 'Untitled.md'))
+  })
+
+  it('reports a failure to create a note', async () => {
+    mockApi.newNote.mockRejectedValue(new Error('read-only vault'))
+    await renderPage()
+    await userEvent.click(await screen.findByRole('button', { name: 'New note at the top level' }))
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('read-only vault')
+  })
+
+  it('duplicates a note and opens the copy', async () => {
+    await renderPage()
+    await screen.findByRole('button', { name: 'One' })
+    clickRowAction('One', 'Duplicate note')
+    await waitFor(() => expect(mockApi.duplicateNote).toHaveBeenCalledWith('v1', 'One.md'))
+    await waitFor(() => expect(mockApi.readNote).toHaveBeenCalledWith('v1', 'One 1.md'))
+  })
+
+  it('pins a note, persists the pin per vault, and offers to unpin', async () => {
+    await renderPage()
+    await screen.findByRole('button', { name: 'One' })
+    clickRowAction('One', 'Pin note')
+    expect(localStorage.getItem('mdnb-pinned-v1')).toBe('["One.md"]')
+    expect(within(row('One')).getByRole('button', { name: 'Unpin note' })).toBeTruthy()
+
+    clickRowAction('One', 'Unpin note')
+    expect(localStorage.getItem('mdnb-pinned-v1')).toBe('[]')
+  })
+
+  it('renames a note in place, keeping its folder', async () => {
+    await renderPage()
+    await screen.findByRole('button', { name: 'Two' })
+    clickRowAction('Two', 'Rename note')
+    const field = await screen.findByRole('textbox', { name: 'Note name' })
+    await userEvent.clear(field)
+    await userEvent.type(field, 'Renamed{Enter}')
+    await waitFor(() =>
+      expect(mockApi.moveNote).toHaveBeenCalledWith('v1', 'folder/Two.md', 'folder/Renamed.md'),
+    )
+  })
+
+  it('strips path separators from a rename so a title edit cannot move the note', async () => {
+    await renderPage()
+    await screen.findByRole('button', { name: 'One' })
+    clickRowAction('One', 'Rename note')
+    const field = await screen.findByRole('textbox', { name: 'Note name' })
+    await userEvent.clear(field)
+    await userEvent.type(field, '../etc/passwd{Enter}')
+    await waitFor(() =>
+      expect(mockApi.moveNote).toHaveBeenCalledWith('v1', 'One.md', '..etcpasswd.md'),
+    )
+  })
+
+  it('files a dragged note into the folder it is dropped on', async () => {
+    await renderPage()
+    const folderRow = await screen.findByRole('button', { name: 'folder' })
+    fireEvent.drop(folderRow, { dataTransfer: { getData: () => 'One.md' } })
+    await waitFor(() => expect(mockApi.moveNote).toHaveBeenCalledWith('v1', 'One.md', 'folder/One.md'))
+  })
+
+  it('files a note at the vault root when dropped on the list background', async () => {
+    await renderPage()
+    const twoRow = await screen.findByRole('button', { name: 'Two' })
+    // The scrolling list is the drop target that means "outside every folder".
+    const list = twoRow.parentElement!.parentElement!
+    fireEvent.drop(list, { dataTransfer: { getData: () => 'folder/Two.md' } })
+    await waitFor(() => expect(mockApi.moveNote).toHaveBeenCalledWith('v1', 'folder/Two.md', 'Two.md'))
+  })
+
+  // ── delete ────────────────────────────────────────────────────────────────
+
+  it('confirms before trashing a note, then removes it from the listing', async () => {
+    await renderPage()
+    await screen.findByRole('button', { name: 'One' })
+    clickRowAction('One', 'Delete note')
+    expect(await screen.findByRole('dialog')).toBeTruthy()
+    expect(screen.getByText(/to trash\?/)).toBeTruthy()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(mockApi.deleteNote).toHaveBeenCalledWith('v1', 'One.md'))
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'One' })).toBeNull())
+  })
+
+  it('cancels the confirmation without deleting anything', async () => {
+    await renderPage()
+    await screen.findByRole('button', { name: 'One' })
+    clickRowAction('One', 'Delete note')
+    await userEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(mockApi.deleteNote).not.toHaveBeenCalled()
+  })
+
+  it('says nothing has been trashed yet rather than opening an empty folder', async () => {
+    mockApi.openTrash.mockResolvedValue({ opened: false, empty: true, path: '' })
+    await renderPage()
+    await screen.findByRole('button', { name: 'One' })
+    clickRowAction('One', 'Delete note')
+    await userEvent.click(await screen.findByRole('button', { name: '.trash' }))
+    expect(
+      await screen.findByText(
+        'Nothing has been deleted from this vault yet, so there is no .trash folder.',
+      ),
+    ).toBeTruthy()
+    // The message is feedback, not a third choice — the dialog stays open.
+    expect(screen.getByRole('dialog')).toBeTruthy()
+  })
+
+  it('explains when the host cannot open a folder at all', async () => {
+    mockApi.openTrash.mockRejectedValue(
+      Object.assign(new Error('nope'), { body: { code: 'folder_open_unsupported' } }),
+    )
+    await renderPage()
+    await screen.findByRole('button', { name: 'One' })
+    clickRowAction('One', 'Delete note')
+    await userEvent.click(await screen.findByRole('button', { name: '.trash' }))
+    expect(
+      await screen.findByText('Opening a folder is not supported on this system.'),
+    ).toBeTruthy()
+  })
+
+  it('reports a failed delete instead of leaving the row pending forever', async () => {
+    mockApi.deleteNote.mockRejectedValue(new Error('permission denied'))
+    await renderPage()
+    await screen.findByRole('button', { name: 'One' })
+    clickRowAction('One', 'Delete note')
+    await userEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('permission denied')
+    // The row is interactive again, not stuck dimmed.
+    expect(row('One').getAttribute('aria-disabled')).toBeNull()
+  })
+
+  // ── editing a rendered block ──────────────────────────────────────────────
+
+  it('edits a rendered block in place and writes the result back into the note', async () => {
+    await renderWithOpenNote()
+    await userEvent.click(screen.getByRole('button', { name: 'Body text' }))
+    const editor = screen.getByRole('textbox', { name: 'Edit block' })
+    fireEvent.change(editor, { target: { value: 'Rewritten body' } })
+    fireEvent.blur(editor)
+    // The editor closes and the rewritten source is what the preview now shows.
+    expect(await screen.findByText('Rewritten body')).toBeTruthy()
+    expect(screen.queryByRole('textbox', { name: 'Edit block' })).toBeNull()
+  })
+
+  it('refuses to sync while a block is being edited, so the draft is not lost', async () => {
+    await renderWithOpenNote()
+    await userEvent.click(screen.getByRole('button', { name: 'Body text' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Edit block' }), {
+      target: { value: 'half-typed' },
+    })
+    // Via the shortcut, not the button: clicking the button blurs the editor,
+    // which commits the draft first, so the button can never reach the guard.
+    fireEvent.keyDown(window, { key: 's', metaKey: true })
+    // A sync would flush the stale buffer and then reload the note, unmounting
+    // the editor with the typed text still only in its local state.
+    expect(mockApi.sync).not.toHaveBeenCalled()
+    expect(screen.getByRole('textbox', { name: 'Edit block' })).toBeTruthy()
+  })
+
+  it('ticks a task checkbox in the rendered view', async () => {
+    mockApi.readNote.mockResolvedValue({ ...DOC, content: '- [ ] water the plants' })
+    await renderPage()
+    await userEvent.click(await screen.findByRole('button', { name: 'One' }))
+    const box = (await screen.findByRole('checkbox')) as HTMLInputElement
+    expect(box.checked).toBe(false)
+    fireEvent.click(box)
+    await waitFor(() => expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(true))
+  })
+
+  // ── background timers ─────────────────────────────────────────────────────
+
+  /** Mount under fake timers, so the page's own intervals can be driven. */
+  async function renderOnFakeTimers() {
+    vi.useFakeTimers()
+    const view = await renderPage()
+    // Two ticks: the vault read and the note read it triggers.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    return view
+  }
+
+  it('reloads the listing when the external-change poll reports a new revision', async () => {
+    mockApi.changes.mockResolvedValue({ rev: 1, changed: ['One.md'], watching: true })
+    await renderOnFakeTimers()
+    expect(mockApi.listNotes).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000)
+    })
+    expect(mockApi.changes).toHaveBeenCalled()
+    expect(mockApi.listNotes).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores a poll that reports the revision it already has', async () => {
+    await renderOnFakeTimers()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000)
+    })
+    // Same rev: a quiet tick must stay invisible rather than re-fetching.
+    expect(mockApi.listNotes).toHaveBeenCalledTimes(1)
+  })
+
+  it('commits to local history on the autosave timer without pushing', async () => {
+    await renderOnFakeTimers()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60_000)
+    })
+    expect(mockApi.commit).toHaveBeenCalledWith('v1')
+    expect(mockApi.sync).not.toHaveBeenCalled()
+  })
+
+  it('does not poke a read-only vault with autosave commits', async () => {
+    mockApi.listVaults.mockResolvedValue({
+      vaults: [vault({ readOnly: true })],
+      hasPat: false,
+      hasGhAuth: false,
+    })
+    await renderOnFakeTimers()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60_000)
+    })
+    expect(mockApi.commit).not.toHaveBeenCalled()
+  })
+
+  it('syncs on the auto-sync timer once it is enabled', async () => {
+    localStorage.setItem('mdnb-auto-sync', 'true')
+    localStorage.setItem('mdnb-auto-sync-mins', '1')
+    await renderOnFakeTimers()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+    expect(mockApi.sync).toHaveBeenCalledWith('v1')
+  })
+
+  // NOT covered on purpose: a stored `mdnb-auto-sync-mins` of 0 is read back
+  // unclamped (only the setter clamps), so the auto-sync effect schedules
+  // `setInterval(…, 0)` — a tight sync loop. A test for that either pins the
+  // defect or fails, so it is reported rather than written; the page clamps the
+  // stored panel width and validates the stored sort id, and this value needs
+  // the same treatment at load.
+})

--- a/website/src/test/MochiChatPanel.coverage.test.tsx
+++ b/website/src/test/MochiChatPanel.coverage.test.tsx
@@ -1,0 +1,1065 @@
+/**
+ * Mochi chat panel — first tests for `apps/mochi/src/renderer/ChatPanel.tsx`.
+ *
+ * The panel is the pet's whole conversation surface and had no test at all, so
+ * these cover the behaviours a user can actually reach: the header and its
+ * toggles, history load, the composer (send, failure recovery, slash commands),
+ * the destructive confirmations behind the context menu, edit-and-resend, and
+ * the inline approval card — including the two paths that must never fabricate
+ * a security verdict (a failed POST, and a resolution that happened on another
+ * surface).
+ *
+ * The panel talks to the backend exclusively through `mochiApi`, so that module
+ * is the single mock. Its `on*` subscribers are captured into an emitter table
+ * so a test can push a real backend frame (`chat:message`, `approval`,
+ * `slots:update`, …) and assert what the panel renders in response.
+ *
+ * No test depends on an animation frame landing: the streaming channel throttles
+ * through `requestAnimationFrame`, so the committed-message channel is used to
+ * drive turn state instead.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+type AnyFn = (...args: never[]) => unknown
+
+/** Captured `on*` subscribers, keyed by the api method that registered them. */
+const subscribers = new Map<string, Set<AnyFn>>()
+
+/** Build an `on*` implementation that records its callback and returns an unsubscribe. */
+function subscribe(channel: string) {
+  return (cb: AnyFn) => {
+    const set = subscribers.get(channel) ?? new Set<AnyFn>()
+    set.add(cb)
+    subscribers.set(channel, set)
+    return () => { set.delete(cb) }
+  }
+}
+
+/** Push a backend frame to whatever the panel registered on `channel`. */
+function emit(channel: string, ...args: unknown[]): void {
+  for (const cb of Array.from(subscribers.get(channel) ?? [])) {
+    ;(cb as (...a: unknown[]) => unknown)(...args)
+  }
+}
+
+/** Chat history handed back by `getChatHistory`; set per test before render. */
+let history: unknown[] = []
+/** Initial backend reachability, so the offline banner can be exercised. */
+let backendOnline = true
+
+const sendMessage = vi.fn(async () => undefined)
+const editResend = vi.fn(async () => ({ ok: true }))
+const newSession = vi.fn(async () => undefined)
+const respondApproval = vi.fn(async () => undefined as unknown)
+const stopGeneration = vi.fn(async () => undefined)
+const retryConnect = vi.fn(async () => ({ ok: true } as { ok: boolean; message?: string }))
+const resetMochi = vi.fn(async () => undefined)
+const deleteHistory = vi.fn(async () => undefined)
+const closeChat = vi.fn()
+const openSettings = vi.fn()
+const galleryOpen = vi.fn()
+const openDashboard = vi.fn()
+const openLightbox = vi.fn()
+const previewFile = vi.fn()
+const revealFile = vi.fn()
+const markPinnedSeen = vi.fn()
+const unpinFile = vi.fn()
+const openExternal = vi.fn()
+/** Local image bytes, so an inline image can render without touching disk. */
+const readLocalImage = vi.fn(async (_path: string): Promise<string | null> => null)
+
+vi.mock('../apps/mochi/src/mochiApi', () => ({
+  api: {
+    getMochiConfig: async () => ({ petName: 'Mochi', theme: 'mocha' }),
+    getConfig: async () => ({
+      shortcuts: {
+        toggleWindow: 'CommandOrControl+Shift+M',
+        screenCapture: 'CommandOrControl+Shift+X',
+        hideAll: 'CommandOrControl+Shift+H',
+      },
+    }),
+    getPetStateInfo: async () => ({ state: 'idle', mood: 'happy' }),
+    getChatHistory: async () => history,
+    getBackendStatus: async () => backendOnline,
+    onStateChange: subscribe('onStateChange'),
+    onMood: subscribe('onMood'),
+    onPeeking: subscribe('onPeeking'),
+    onConfigUpdated: subscribe('onConfigUpdated'),
+    onChatChunk: subscribe('onChatChunk'),
+    onChatDone: subscribe('onChatDone'),
+    onChatMessage: subscribe('onChatMessage'),
+    onBackendStatus: subscribe('onBackendStatus'),
+    onBackendSwitching: subscribe('onBackendSwitching'),
+    onSlotsUpdate: subscribe('onSlotsUpdate'),
+    onCaptureDone: subscribe('onCaptureDone'),
+    onApprovalRequest: subscribe('onApprovalRequest'),
+    onApprovalResolvedExternal: subscribe('onApprovalResolvedExternal'),
+    onThemeChanged: subscribe('onThemeChanged'),
+    onContextUsage: subscribe('onContextUsage'),
+    sendMessage,
+    editResend,
+    newSession,
+    respondApproval,
+    stopGeneration,
+    retryConnect,
+    resetMochi,
+    deleteHistory,
+    closeChat,
+    openSettings,
+    galleryOpen,
+    openDashboard,
+    openLightbox,
+    previewFile,
+    revealFile,
+    markPinnedSeen,
+    unpinFile,
+    openExternal,
+    readLocalImage,
+  },
+}))
+
+const { ChatPanel, PinnedSidePanel, parseApproval, externalApprovalApproved } =
+  await import('../apps/mochi/src/renderer/ChatPanel')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  subscribers.clear()
+  history = []
+  backendOnline = true
+  sendMessage.mockResolvedValue(undefined)
+  editResend.mockResolvedValue({ ok: true })
+  respondApproval.mockResolvedValue(undefined)
+  retryConnect.mockResolvedValue({ ok: true })
+  readLocalImage.mockResolvedValue(null)
+})
+
+/** Render the panel and wait until the mount-time config reads have settled. */
+async function renderPanel(props: Partial<React.ComponentProps<typeof ChatPanel>> = {}) {
+  const view = render(<ChatPanel {...props} />)
+  // The header state comes from `getPetStateInfo`; waiting on it means every
+  // mount effect has flushed before a test starts interacting.
+  await screen.findByText(/Idle/)
+  return view
+}
+
+/** The panel's composer. */
+function composer(): HTMLTextAreaElement {
+  return screen.getByPlaceholderText(/./) as HTMLTextAreaElement
+}
+
+/**
+ * The disconnected banner is deferred 1.5s so a brief socket blip does not
+ * flash it, which outlasts the default find window.
+ */
+function findOfflineBanner() {
+  return screen.findByText('Kiro Crew disconnected', {}, { timeout: 5000 })
+}
+
+/** An approval frame as the gateway pushes it. */
+function approvalFrame(extra: Record<string, unknown> = {}) {
+  return { id: 'req-1', tool: 'execute_bash', toolInput: 'ls -la', ...extra }
+}
+
+describe('parseApproval', () => {
+  it('returns the payload when id and tool are both strings', () => {
+    expect(parseApproval('{"id":"a","tool":"execute_bash"}')).toEqual({
+      id: 'a',
+      tool: 'execute_bash',
+    })
+  })
+
+  it('rejects a payload that parses to a non-object', () => {
+    // `__approval__"hi"` is valid JSON; reading `.tool` off a string would
+    // render `undefined` into the bubble instead of what the user typed.
+    expect(parseApproval('"hi"')).toBeNull()
+    expect(parseApproval('null')).toBeNull()
+  })
+
+  it('rejects an object missing the id or tool field', () => {
+    expect(parseApproval('{"tool":"execute_bash"}')).toBeNull()
+    expect(parseApproval('{"id":"a"}')).toBeNull()
+    expect(parseApproval('{"id":1,"tool":"x"}')).toBeNull()
+  })
+
+  it('returns null instead of throwing on malformed JSON', () => {
+    expect(parseApproval('not json at all')).toBeNull()
+  })
+})
+
+describe('externalApprovalApproved', () => {
+  it('is true only for an explicit approved flag', () => {
+    expect(externalApprovalApproved({ approved: true })).toBe(true)
+  })
+
+  it('treats a reject, a missing flag, and a missing frame as not approved', () => {
+    expect(externalApprovalApproved({ approved: false })).toBe(false)
+    expect(externalApprovalApproved({})).toBe(false)
+    expect(externalApprovalApproved(undefined)).toBe(false)
+    // A truthy non-boolean must not read as approved either.
+    expect(externalApprovalApproved({ approved: 'yes' })).toBe(false)
+  })
+})
+
+describe('PinnedSidePanel', () => {
+  const pin = (path: string, label = '') => ({ path, label, pinnedAt: 1 })
+
+  it('renders nothing when not visible', () => {
+    const { container } = render(
+      <PinnedSidePanel pins={[pin('/home/u/a.ts')]} updatedPaths={new Set()}
+        deletedPaths={new Set()} visible={false} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('names the pet in the empty hint', () => {
+    render(
+      <PinnedSidePanel pins={[]} updatedPaths={new Set()} deletedPaths={new Set()}
+        visible petName="Kiro" />,
+    )
+    expect(screen.getByText('Ask Kiro to pin files you want to track')).toBeInTheDocument()
+  })
+
+  it('falls back to the default pet name when none is supplied', () => {
+    render(
+      <PinnedSidePanel pins={[]} updatedPaths={new Set()} deletedPaths={new Set()} visible />,
+    )
+    expect(screen.getByText('Ask Mochi to pin files you want to track')).toBeInTheDocument()
+  })
+
+  it('groups pins under their parent folder and prefers an explicit label', () => {
+    render(
+      <PinnedSidePanel
+        pins={[pin('/home/u/src/a.ts'), pin('/home/u/src/b.py'), pin('/home/u/docs/c.md', 'Notes')]}
+        updatedPaths={new Set()} deletedPaths={new Set()} visible />,
+    )
+    expect(screen.getByText('src')).toBeInTheDocument()
+    expect(screen.getByText('docs')).toBeInTheDocument()
+    expect(screen.getByText('a.ts')).toBeInTheDocument()
+    expect(screen.getByText('b.py')).toBeInTheDocument()
+    // The label wins over the basename.
+    expect(screen.getByText('Notes')).toBeInTheDocument()
+    expect(screen.queryByText('c.md')).not.toBeInTheDocument()
+  })
+
+  it('previews a pin and marks it seen on click', async () => {
+    const onMarkSeen = vi.fn()
+    render(
+      <PinnedSidePanel pins={[pin('/home/u/src/a.ts')]} updatedPaths={new Set(['/home/u/src/a.ts'])}
+        deletedPaths={new Set()} visible onMarkSeen={onMarkSeen} />,
+    )
+    await userEvent.click(screen.getByText('a.ts'))
+    expect(markPinnedSeen).toHaveBeenCalledWith('/home/u/src/a.ts')
+    expect(previewFile).toHaveBeenCalledWith('/home/u/src/a.ts')
+    expect(onMarkSeen).toHaveBeenCalledWith('/home/u/src/a.ts')
+  })
+
+  it('reveals Unpin on hover and unpins on click', async () => {
+    render(
+      <PinnedSidePanel pins={[pin('/home/u/src/a.ts')]} updatedPaths={new Set()}
+        deletedPaths={new Set()} visible />,
+    )
+    expect(screen.queryByRole('button', { name: 'Unpin' })).not.toBeInTheDocument()
+    await userEvent.hover(screen.getByText('a.ts'))
+    await userEvent.click(screen.getByRole('button', { name: 'Unpin' }))
+    expect(unpinFile).toHaveBeenCalledWith('/home/u/src/a.ts')
+  })
+
+  it('offers no unpin affordance for a deleted pin', async () => {
+    render(
+      <PinnedSidePanel pins={[pin('/home/u/src/gone.ts')]} updatedPaths={new Set()}
+        deletedPaths={new Set(['/home/u/src/gone.ts'])} visible />,
+    )
+    await userEvent.hover(screen.getByText('gone.ts'))
+    expect(screen.queryByRole('button', { name: 'Unpin' })).not.toBeInTheDocument()
+  })
+})
+
+describe('ChatPanel header', () => {
+  it('shows the pet name with its state and mood', async () => {
+    await renderPanel()
+    expect(screen.getByText('Mochi')).toBeInTheDocument()
+    expect(screen.getByText(/Idle/)).toHaveTextContent('Happy')
+  })
+
+  it('re-labels the state when the backend pushes a change', async () => {
+    await renderPanel()
+    emit('onStateChange', 'working')
+    expect(await screen.findByText(/Working/)).toBeInTheDocument()
+  })
+
+  it('drops a neutral mood rather than labelling it', async () => {
+    await renderPanel()
+    emit('onMood', 'neutral')
+    await waitFor(() => expect(screen.getByText(/Idle/)).not.toHaveTextContent('Happy'))
+  })
+
+  it('wires the pins and watchlist toggles to their callbacks', async () => {
+    const onTogglePinned = vi.fn()
+    const onToggleWatch = vi.fn()
+    await renderPanel({ onTogglePinned, onToggleWatch, pinnedFileCount: 2 })
+    await userEvent.click(screen.getByRole('button', { name: 'Pinned Files' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Watch List' }))
+    expect(onTogglePinned).toHaveBeenCalledTimes(1)
+    expect(onToggleWatch).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the chat window from the header', async () => {
+    await renderPanel()
+    await userEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(closeChat).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the context ring only once usage is known', async () => {
+    await renderPanel()
+    expect(screen.queryByTitle(/^Context:/)).not.toBeInTheDocument()
+    emit('onContextUsage', 75)
+    const ring = await screen.findByTitle('Context: 75%')
+    expect(ring).toHaveTextContent('75')
+  })
+})
+
+describe('ChatPanel history', () => {
+  it('renders the loaded conversation, dropping non-chat roles', async () => {
+    history = [
+      { role: 'user', content: 'ping', timestamp: 1700000000000 },
+      { role: 'assistant', content: 'pong', timestamp: 1700000001000 },
+      { role: 'system', content: 'internal bookkeeping', timestamp: 1700000002000 },
+    ]
+    await renderPanel()
+    expect(await screen.findByText('ping')).toBeInTheDocument()
+    expect(screen.getByText('pong')).toBeInTheDocument()
+    expect(screen.queryByText('internal bookkeeping')).not.toBeInTheDocument()
+  })
+})
+
+describe('ChatPanel composer', () => {
+  it('sends the typed text and clears the box', async () => {
+    await renderPanel()
+    await userEvent.type(composer(), 'hello pet')
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledWith('hello pet', undefined))
+    expect(composer()).toHaveValue('')
+  })
+
+  it('sends on Enter and keeps a Shift+Enter newline in the box', async () => {
+    await renderPanel()
+    await userEvent.type(composer(), 'first{Shift>}{Enter}{/Shift}second')
+    expect(composer().value).toContain('\n')
+    expect(sendMessage).not.toHaveBeenCalled()
+    await userEvent.type(composer(), '{Enter}')
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledWith('first\nsecond', undefined))
+  })
+
+  it('does nothing when the box is empty', async () => {
+    await renderPanel()
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('restores the text and explains the failure when the send is refused', async () => {
+    await renderPanel()
+    sendMessage.mockRejectedValueOnce(new Error('offline'))
+    await userEvent.type(composer(), 'keep me')
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(
+      await screen.findByText("Couldn't send — check your connection and try again."),
+    ).toBeInTheDocument()
+    // The typed text is not lost, so the user can retry.
+    expect(composer()).toHaveValue('keep me')
+  })
+
+  it('dismisses the failure banner', async () => {
+    await renderPanel()
+    sendMessage.mockRejectedValueOnce(new Error('offline'))
+    await userEvent.type(composer(), 'x')
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+    await screen.findByText("Couldn't send — check your connection and try again.")
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Couldn't send — check your connection and try again."),
+      ).not.toBeInTheDocument(),
+    )
+  })
+})
+
+describe('ChatPanel slash commands', () => {
+  it('suggests matching commands with their descriptions', async () => {
+    await renderPanel()
+    await userEvent.type(composer(), '/c')
+    expect(await screen.findByText('/clear')).toBeInTheDocument()
+    expect(screen.getByText('Clear screen (history preserved)')).toBeInTheDocument()
+    expect(screen.getByText('/compact')).toBeInTheDocument()
+    expect(screen.getByText('/context')).toBeInTheDocument()
+    // A non-matching command is filtered out.
+    expect(screen.queryByText('/model')).not.toBeInTheDocument()
+  })
+
+  it('completes a command when its row is clicked', async () => {
+    await renderPanel()
+    await userEvent.type(composer(), '/co')
+    await userEvent.click(screen.getByText('/compact'))
+    expect(composer()).toHaveValue('/compact')
+  })
+
+  it('completes the highlighted command on Tab', async () => {
+    await renderPanel()
+    await userEvent.type(composer(), '/c{ArrowDown}{Tab}')
+    // ArrowDown moves off /clear onto the second match.
+    expect(composer()).toHaveValue('/compact')
+  })
+
+  it('wraps the highlight when arrowing up from the first row', async () => {
+    await renderPanel()
+    await userEvent.type(composer(), '/c{ArrowUp}{Enter}')
+    expect(composer()).toHaveValue('/context')
+  })
+
+  it('hides the suggestions once the command is typed in full', async () => {
+    await renderPanel()
+    await userEvent.type(composer(), '/clear')
+    expect(screen.queryByText('Clear screen (history preserved)')).not.toBeInTheDocument()
+  })
+
+  it('/clear empties the transcript without sending anything', async () => {
+    history = [{ role: 'user', content: 'earlier turn', timestamp: 1700000000000 }]
+    await renderPanel()
+    await screen.findByText('earlier turn')
+    await userEvent.type(composer(), '/clear')
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+    await waitFor(() => expect(screen.queryByText('earlier turn')).not.toBeInTheDocument())
+    expect(sendMessage).not.toHaveBeenCalled()
+    // History is preserved, so it can be pulled back in.
+    expect(screen.getByRole('button', { name: 'Load earlier messages' })).toBeInTheDocument()
+  })
+
+  it('restores cleared messages from the load-earlier button', async () => {
+    history = [{ role: 'user', content: 'earlier turn', timestamp: 1700000000000 }]
+    await renderPanel()
+    await screen.findByText('earlier turn')
+    await userEvent.type(composer(), '/clear')
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+    await waitFor(() => expect(screen.queryByText('earlier turn')).not.toBeInTheDocument())
+    await userEvent.click(screen.getByRole('button', { name: 'Load earlier messages' }))
+    expect(await screen.findByText('earlier turn')).toBeInTheDocument()
+  })
+
+  it('/new starts a fresh session and reports both ends of it', async () => {
+    await renderPanel()
+    await userEvent.type(composer(), '/new')
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(await screen.findByText('Starting fresh session…')).toBeInTheDocument()
+    expect(await screen.findByText('New session started — context is fresh!')).toBeInTheDocument()
+    expect(newSession).toHaveBeenCalledTimes(1)
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('/new surfaces a failure instead of claiming success', async () => {
+    await renderPanel()
+    newSession.mockRejectedValueOnce(new Error('no gateway'))
+    await userEvent.type(composer(), '/new')
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(await screen.findByText('Failed to start new session')).toBeInTheDocument()
+    expect(screen.queryByText('New session started — context is fresh!')).not.toBeInTheDocument()
+  })
+})
+
+describe('ChatPanel turn state', () => {
+  it('raises the stop capsule for a turn and clears it on stop', async () => {
+    await renderPanel()
+    emit('onChatMessage', { id: 'm-1', role: 'user', content: 'do a thing', timestamp: 1700000000000 })
+    expect(await screen.findByText('do a thing')).toBeInTheDocument()
+    const stop = await screen.findByRole('button', { name: /Stop/ })
+    await userEvent.click(stop)
+    expect(stopGeneration).toHaveBeenCalledTimes(1)
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /Stop/ })).not.toBeInTheDocument(),
+    )
+  })
+
+  it('ends the turn on a running -> idle slot transition', async () => {
+    await renderPanel()
+    emit('onChatMessage', { id: 'm-2', role: 'user', content: 'go', timestamp: 1700000000000 })
+    await screen.findByRole('button', { name: /Stop/ })
+    emit('onSlotsUpdate', [{ key: 'mochi', running: true }])
+    emit('onSlotsUpdate', [{ key: 'mochi', running: false }])
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /Stop/ })).not.toBeInTheDocument(),
+    )
+  })
+
+  it('does not re-count a backfilled message as a live turn', async () => {
+    await renderPanel()
+    emit('onChatMessage', {
+      id: 'm-3', role: 'user', content: 'replayed', timestamp: 1700000000000, backfill: true,
+    })
+    expect(await screen.findByText('replayed')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Stop/ })).not.toBeInTheDocument()
+  })
+})
+
+describe('ChatPanel offline banner', () => {
+  it('offers to start the gateway and reports why it did not', async () => {
+    backendOnline = false
+    await renderPanel()
+    expect(await findOfflineBanner()).toBeInTheDocument()
+    retryConnect.mockResolvedValueOnce({ ok: false, message: 'Gateway refused' })
+    await userEvent.click(screen.getByRole('button', { name: 'Start Kiro Crew' }))
+    expect(await screen.findByText('Gateway refused')).toBeInTheDocument()
+  })
+
+  it('falls back to the timeout message when the retry throws', async () => {
+    backendOnline = false
+    await renderPanel()
+    await findOfflineBanner()
+    retryConnect.mockRejectedValueOnce(new Error('boom'))
+    await userEvent.click(screen.getByRole('button', { name: 'Start Kiro Crew' }))
+    expect(await screen.findByText(/Timed out/)).toBeInTheDocument()
+  })
+
+  it('hides the banner once the backend reports online', async () => {
+    backendOnline = false
+    await renderPanel()
+    await findOfflineBanner()
+    emit('onBackendStatus', true)
+    await waitFor(() =>
+      expect(screen.queryByText('Kiro Crew disconnected')).not.toBeInTheDocument(),
+    )
+  })
+})
+
+describe('ChatPanel context menu', () => {
+  /** Right-click the panel shell to open its menu. */
+  async function openMenu(container: HTMLElement) {
+    fireEvent.contextMenu(container.firstChild as HTMLElement, { clientX: 5, clientY: 5 })
+    return within(await screen.findByRole('menu'))
+  }
+
+  it('clears the screen from the menu', async () => {
+    history = [{ role: 'user', content: 'visible turn', timestamp: 1700000000000 }]
+    const { container } = await renderPanel()
+    await screen.findByText('visible turn')
+    const menu = await openMenu(container)
+    await userEvent.click(menu.getByRole('menuitem', { name: 'Clear screen' }))
+    await waitFor(() => expect(screen.queryByText('visible turn')).not.toBeInTheDocument())
+  })
+
+  it('opens settings, gallery, and the dashboard', async () => {
+    const { container } = await renderPanel()
+    let menu = await openMenu(container)
+    await userEvent.click(menu.getByRole('menuitem', { name: 'Settings' }))
+    menu = await openMenu(container)
+    await userEvent.click(menu.getByRole('menuitem', { name: 'Appearance Gallery' }))
+    menu = await openMenu(container)
+    await userEvent.click(menu.getByRole('menuitem', { name: 'Kiro Crew Dashboard' }))
+    expect(openSettings).toHaveBeenCalledTimes(1)
+    expect(galleryOpen).toHaveBeenCalledTimes(1)
+    expect(openDashboard).toHaveBeenCalledTimes(1)
+  })
+
+  it('confirms before deleting history, and can be cancelled', async () => {
+    history = [{ role: 'user', content: 'doomed turn', timestamp: 1700000000000 }]
+    const { container } = await renderPanel()
+    await screen.findByText('doomed turn')
+
+    let menu = await openMenu(container)
+    await userEvent.click(menu.getByRole('menuitem', { name: 'Delete chat history' }))
+    expect(await screen.findByText('Delete chat history?')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(deleteHistory).not.toHaveBeenCalled()
+    expect(screen.getByText('doomed turn')).toBeInTheDocument()
+
+    menu = await openMenu(container)
+    await userEvent.click(menu.getByRole('menuitem', { name: 'Delete chat history' }))
+    await userEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(deleteHistory).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(screen.queryByText('doomed turn')).not.toBeInTheDocument())
+  })
+
+  it('confirms before a full reset', async () => {
+    history = [{ role: 'user', content: 'old turn', timestamp: 1700000000000 }]
+    const { container } = await renderPanel()
+    await screen.findByText('old turn')
+    const menu = await openMenu(container)
+    await userEvent.click(menu.getByRole('menuitem', { name: 'Reset Mochi' }))
+    expect(await screen.findByText('Reset Mochi?')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Reset' }))
+    await waitFor(() => expect(resetMochi).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(screen.queryByText('old turn')).not.toBeInTheDocument())
+  })
+})
+
+describe('ChatPanel edit and resend', () => {
+  it('loads the message back into the composer and resends it to the edit route', async () => {
+    history = [{ role: 'user', content: 'typo here', timestamp: 1700000000000 }]
+    await renderPanel()
+    await screen.findByText('typo here')
+    await userEvent.click(screen.getByRole('button', { name: 'Edit & resend' }))
+    expect(composer()).toHaveValue('typo here')
+    expect(screen.getByText('Editing — send to replace, or cancel')).toBeInTheDocument()
+
+    await userEvent.clear(composer())
+    await userEvent.type(composer(), 'fixed')
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+    await waitFor(() => expect(editResend).toHaveBeenCalledWith('fixed', '1700000000000'))
+    // The edited turn and everything after it is dropped locally.
+    await waitFor(() => expect(screen.queryByText('typo here')).not.toBeInTheDocument())
+  })
+
+  it('falls back to a plain send when the edit route refuses', async () => {
+    history = [{ role: 'user', content: 'original', timestamp: 1700000000000 }]
+    await renderPanel()
+    await screen.findByText('original')
+    editResend.mockResolvedValueOnce({ ok: false })
+    await userEvent.click(screen.getByRole('button', { name: 'Edit & resend' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledWith('original', undefined))
+  })
+
+  it('cancels edit mode and empties the composer', async () => {
+    history = [{ role: 'user', content: 'never mind', timestamp: 1700000000000 }]
+    await renderPanel()
+    await screen.findByText('never mind')
+    await userEvent.click(screen.getByRole('button', { name: 'Edit & resend' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(composer()).toHaveValue('')
+    expect(screen.queryByText('Editing — send to replace, or cancel')).not.toBeInTheDocument()
+  })
+})
+
+describe('ChatPanel approval card', () => {
+  it('asks about the tool and its input, with a trust hint when nothing is scopable', async () => {
+    await renderPanel()
+    emit('onApprovalRequest', approvalFrame())
+    expect(await screen.findByText('execute_bash')).toBeInTheDocument()
+    expect(screen.getByText('ls -la')).toBeInTheDocument()
+    expect(screen.getByText(/Wants to run/)).toBeInTheDocument()
+    expect(
+      screen.getByText('Trust also auto-approves execute_bash from now on.'),
+    ).toBeInTheDocument()
+  })
+
+  it('relabels the card once the approval reaches the agent', async () => {
+    await renderPanel()
+    emit('onApprovalRequest', approvalFrame())
+    await userEvent.click(await screen.findByRole('button', { name: 'Approve' }))
+    expect(respondApproval).toHaveBeenCalledWith('req-1', 'approve', undefined)
+    expect(await screen.findByText('Approved')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument()
+  })
+
+  it('says Rejected, not Approved, when the user rejects', async () => {
+    await renderPanel()
+    emit('onApprovalRequest', approvalFrame())
+    await userEvent.click(await screen.findByRole('button', { name: 'Reject' }))
+    expect(respondApproval).toHaveBeenCalledWith('req-1', 'reject', undefined)
+    expect(await screen.findByText('Rejected')).toBeInTheDocument()
+  })
+
+  it('keeps the card and reports the error when the POST fails', async () => {
+    await renderPanel()
+    respondApproval.mockResolvedValueOnce({ ok: false })
+    emit('onApprovalRequest', approvalFrame())
+    await userEvent.click(await screen.findByRole('button', { name: 'Approve' }))
+    expect(
+      await screen.findByText("Couldn't send — check your connection and try again."),
+    ).toBeInTheDocument()
+    // Claiming "Approved" here would fabricate a decision the agent never got.
+    expect(screen.queryByText('Approved')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument()
+  })
+
+  it('reveals the scoped grants behind Trust instead of firing the widest one', async () => {
+    await renderPanel()
+    emit('onApprovalRequest', approvalFrame({ fullCommand: 'cat /etc/hosts', baseCommand: 'cat,wc' }))
+    const trust = await screen.findByRole('button', { name: 'Trust' })
+    expect(trust).toHaveAttribute('aria-expanded', 'false')
+    await userEvent.click(trust)
+    expect(respondApproval).not.toHaveBeenCalled()
+    expect(trust).toHaveAttribute('aria-expanded', 'true')
+
+    expect(screen.getByRole('button', { name: /cat \/etc\/hosts/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Trust all tools' })).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Trust all cat, wc commands' }))
+    expect(respondApproval).toHaveBeenCalledWith('req-1', 'trust_base', 'cat *,wc *')
+    expect(await screen.findByText('Trusted')).toBeInTheDocument()
+  })
+
+  it('grants only this command when the exact-command scope is picked', async () => {
+    await renderPanel()
+    emit('onApprovalRequest', approvalFrame({ fullCommand: 'cat /etc/hosts', baseCommand: 'cat' }))
+    await userEvent.click(await screen.findByRole('button', { name: 'Trust' }))
+    await userEvent.click(screen.getByRole('button', { name: /cat \/etc\/hosts/ }))
+    expect(respondApproval).toHaveBeenCalledWith('req-1', 'trust_command', 'cat /etc/hosts')
+  })
+
+  it('offers no family grant when it would duplicate the command grant', async () => {
+    await renderPanel()
+    emit('onApprovalRequest', approvalFrame({ fullCommand: 'fs_read', baseCommand: 'fs_read' }))
+    await userEvent.click(await screen.findByRole('button', { name: 'Trust' }))
+    expect(screen.queryByRole('button', { name: /Trust all .* commands/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Trust all tools' })).toBeInTheDocument()
+  })
+
+  it('ignores a duplicate approval frame instead of stacking a second card', async () => {
+    await renderPanel()
+    emit('onApprovalRequest', approvalFrame())
+    emit('onApprovalRequest', approvalFrame())
+    await screen.findByText('execute_bash')
+    expect(screen.getAllByRole('button', { name: 'Approve' })).toHaveLength(1)
+  })
+
+  it('carries the real verdict when the approval is resolved elsewhere', async () => {
+    await renderPanel()
+    emit('onApprovalRequest', approvalFrame())
+    await screen.findByText('execute_bash')
+    emit('onApprovalResolvedExternal', { id: 'req-1', approved: false })
+    expect(await screen.findByText('Rejected')).toBeInTheDocument()
+  })
+
+  it('resolves every pending card when the frame names no request', async () => {
+    await renderPanel()
+    emit('onApprovalRequest', approvalFrame())
+    emit('onApprovalRequest', approvalFrame({ id: 'req-2', tool: 'fs_write' }))
+    await screen.findByText('fs_write')
+    emit('onApprovalResolvedExternal', { approved: true })
+    await waitFor(() => expect(screen.getAllByText('Approved')).toHaveLength(2))
+  })
+})
+
+describe('ChatPanel bubbles', () => {
+  it('treats a user-typed approval marker as ordinary text', async () => {
+    // The marker is internal, but nothing stops a user typing it — parsing it
+    // as a payload used to take the whole panel down to the error boundary.
+    history = [{ role: 'user', content: '__approval__not-a-payload', timestamp: 1700000000000 }]
+    await renderPanel()
+    expect(await screen.findByText('__approval__not-a-payload')).toBeInTheDocument()
+  })
+
+  it('turns a trailing options list into buttons that send the choice', async () => {
+    history = [
+      {
+        role: 'assistant',
+        content: 'Pick one\n[OPTIONS: Merge it now | Show me the diff]',
+        timestamp: 1700000000000,
+      },
+    ]
+    await renderPanel()
+    expect(await screen.findByText('Pick one')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Show me the diff' }))
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledWith('Show me the diff', undefined))
+  })
+
+  it('draws nothing for a message whose only content is markup', async () => {
+    history = [
+      { role: 'assistant', content: '<br>', timestamp: 1700000000000 },
+      { role: 'assistant', content: 'real answer', timestamp: 1700000001000 },
+    ]
+    await renderPanel()
+    await screen.findByText('real answer')
+    // One bubble, not two — an empty one would show a lone timestamp.
+    expect(screen.getAllByRole('button', { name: 'Copy markdown' })).toHaveLength(1)
+  })
+})
+
+describe('ChatPanel streaming footer', () => {
+  /**
+   * The chunk channel throttles through `requestAnimationFrame`, but the done
+   * frame flushes whatever is still buffered synchronously — so driving both
+   * gives the streaming bubble without waiting on a frame.
+   */
+  function stream(text: string) {
+    emit('onChatChunk', text)
+    emit('onChatDone')
+  }
+
+  it('renders the streamed answer as markdown', async () => {
+    await renderPanel()
+    stream('**bold** answer')
+    const bold = await screen.findByText('bold')
+    expect(bold.tagName).toBe('STRONG')
+  })
+
+  it('closes a code fence the stream has not finished yet', async () => {
+    await renderPanel()
+    stream('Here you go:\n```python\nprint(1)')
+    // An unclosed fence would otherwise render as raw text with the backticks.
+    expect(await screen.findByText('print(1)')).toBeInTheDocument()
+    expect(screen.getByText('python')).toBeInTheDocument()
+    expect(screen.queryByText(/```/)).not.toBeInTheDocument()
+  })
+
+  it('drops a half-arrived widget tag rather than showing its markup', async () => {
+    await renderPanel()
+    stream('Building it now <mcwidget title="Half')
+    expect(await screen.findByText('Building it now')).toBeInTheDocument()
+    expect(screen.queryByText(/mcwidget/)).not.toBeInTheDocument()
+  })
+
+  it('replaces the streamed text with the committed message', async () => {
+    await renderPanel()
+    stream('partial')
+    await screen.findByText('partial')
+    emit('onChatMessage', {
+      id: 'a-1', role: 'assistant', content: 'final answer', timestamp: 1700000000000,
+    })
+    expect(await screen.findByText('final answer')).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText('partial')).not.toBeInTheDocument())
+  })
+})
+
+describe('ChatPanel markdown affordances', () => {
+  it('turns an inline file path into a chip that previews and reveals the file', async () => {
+    history = [
+      { role: 'assistant', content: 'Look at `src/main.py` first.', timestamp: 1700000000000 },
+    ]
+    await renderPanel()
+    expect(await screen.findByTitle('src/main.py')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Preview' }))
+    expect(previewFile).toHaveBeenCalledWith('src/main.py')
+    await userEvent.click(screen.getByRole('button', { name: 'Show in file manager' }))
+    expect(revealFile).toHaveBeenCalledWith('src/main.py')
+  })
+
+  it('chips an absolute path found in ordinary prose', async () => {
+    history = [
+      { role: 'assistant', content: 'Wrote /home/u/notes.md for you.', timestamp: 1700000000000 },
+    ]
+    await renderPanel()
+    const chip = await screen.findByTitle('/home/u/notes.md')
+    // Long paths are shortened for display but keep the full path in the title.
+    expect(chip).toHaveTextContent('u/notes.md')
+    await userEvent.click(chip)
+    expect(previewFile).toHaveBeenCalledWith('/home/u/notes.md')
+  })
+
+  it('opens a link in the OS browser instead of navigating the panel', async () => {
+    history = [
+      {
+        role: 'assistant',
+        content: 'See [the docs](https://example.com/guide).',
+        timestamp: 1700000000000,
+      },
+    ]
+    await renderPanel()
+    await userEvent.click(await screen.findByText('the docs'))
+    expect(openExternal).toHaveBeenCalledWith('https://example.com/guide')
+  })
+
+  it('reads local image bytes over the app api and opens the file on click', async () => {
+    readLocalImage.mockResolvedValue('QUJD')
+    history = [
+      {
+        role: 'assistant',
+        content: 'Here it is ![shot](/home/u/shot.png)',
+        timestamp: 1700000000000,
+      },
+    ]
+    const { container } = await renderPanel()
+    await waitFor(() => expect(readLocalImage).toHaveBeenCalledWith('/home/u/shot.png'))
+    const img = await waitFor(() => {
+      const found = container.querySelector('img[src^="data:image/png;base64,"]')
+      expect(found).not.toBeNull()
+      return found as HTMLImageElement
+    })
+    await userEvent.click(img)
+    // The PATH, not the data URL — the OS viewer cannot open a data URL.
+    expect(openLightbox).toHaveBeenCalledWith('/home/u/shot.png')
+  })
+
+  it('renders a bare image path the user typed as the image itself', async () => {
+    readLocalImage.mockResolvedValue('QUJD')
+    history = [{ role: 'user', content: '/home/u/photo.jpg', timestamp: 1700000000000 }]
+    await renderPanel()
+    await waitFor(() => expect(readLocalImage).toHaveBeenCalledWith('/home/u/photo.jpg'))
+  })
+
+  it('routes every absolute image path in a reply through the local reader', async () => {
+    // The reply renderer lifts image references out of the markdown and hands
+    // the PATH to LocalImage, because a bare `<img src="/…">` would be resolved
+    // against the gateway origin and 404.
+    history = [
+      { role: 'assistant', content: '![logo](/home/u/logo.png)', timestamp: 1700000000000 },
+    ]
+    const { container } = await renderPanel()
+    await waitFor(() => expect(readLocalImage).toHaveBeenCalledWith('/home/u/logo.png'))
+    expect(container.querySelector('img[src="/home/u/logo.png"]')).toBeNull()
+  })
+})
+
+describe('ChatPanel live config and presence', () => {
+  it('renames the pet when the config is updated', async () => {
+    await renderPanel()
+    emit('onConfigUpdated', { petName: 'Kiro', theme: 'mocha' })
+    expect(await screen.findByText('Kiro')).toBeInTheDocument()
+  })
+
+  it('survives a theme change pushed from settings', async () => {
+    await renderPanel()
+    emit('onThemeChanged', 'mocha')
+    expect(screen.getByText('Mochi')).toBeInTheDocument()
+  })
+
+  it('labels a peek distinctly from plain idle', async () => {
+    await renderPanel()
+    emit('onPeeking', true)
+    expect(await screen.findByText(/Peeking/)).toBeInTheDocument()
+  })
+
+  it('reports a backend switch as connecting rather than disconnected', async () => {
+    backendOnline = false
+    await renderPanel()
+    emit('onBackendSwitching', true)
+    expect(await screen.findByText('Connecting to Kiro Crew...', {}, { timeout: 5000 }))
+      .toBeInTheDocument()
+    expect(screen.queryByText('Kiro Crew disconnected')).not.toBeInTheDocument()
+  })
+})
+
+describe('ChatPanel screenshot capture', () => {
+  /** Answer the upload route without touching the network. */
+  function stubUpload(response: { ok: boolean; body: unknown }) {
+    return vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify(response.body), { status: response.ok ? 200 : 415 }),
+    )
+  }
+
+  it('keeps a crop locally when the upload yields no attachment, and can remove it', async () => {
+    const fetchSpy = stubUpload({ ok: true, body: { paths: [] } })
+    try {
+      const { container } = await renderPanel()
+      // 'QUJD' is base64 for 'ABC' — cropToFile runs it through atob.
+      emit('onCaptureDone', 'QUJD')
+      const preview = await waitFor(() => {
+        const found = container.querySelector('img[src="data:image/png;base64,QUJD"]')
+        expect(found).not.toBeNull()
+        return found as HTMLImageElement
+      })
+      await userEvent.click(screen.getByRole('button', { name: 'Remove screenshot' }))
+      // The preview leaves on an exit animation, so it is still mounted until
+      // that animation reports it finished.
+      fireEvent.animationEnd(preview.parentElement!.parentElement!)
+      await waitFor(() =>
+        expect(container.querySelector('img[src="data:image/png;base64,QUJD"]')).toBeNull(),
+      )
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it('sends the pending crop alongside the text', async () => {
+    const fetchSpy = stubUpload({ ok: true, body: { paths: [] } })
+    try {
+      const { container } = await renderPanel()
+      emit('onCaptureDone', 'QUJD')
+      await waitFor(() =>
+        expect(container.querySelector('img[src="data:image/png;base64,QUJD"]')).not.toBeNull(),
+      )
+      await userEvent.type(composer(), 'what is this')
+      await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+      await waitFor(() => expect(sendMessage).toHaveBeenCalledWith('what is this', 'QUJD'))
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it('attaches an uploaded crop and references it in the sent message', async () => {
+    const fetchSpy = stubUpload({ ok: true, body: { paths: ['/home/u/uploads/snip.png'] } })
+    try {
+      await renderPanel()
+      emit('onCaptureDone', 'QUJD')
+      // The strip is the record of what will be sent; the composer text stays clean.
+      expect(await screen.findByAltText('snip.png')).toBeInTheDocument()
+      await userEvent.type(composer(), 'crop it')
+      expect(composer()).toHaveValue('crop it')
+      await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+      // Referenced by path, so the crop reaches the agent as a real image
+      // instead of living only in this window.
+      await waitFor(() =>
+        expect(sendMessage).toHaveBeenCalledWith(
+          'crop it\n\n![image](/home/u/uploads/snip.png)',
+          undefined,
+        ),
+      )
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it('drops a queued attachment from the strip', async () => {
+    const fetchSpy = stubUpload({ ok: true, body: { paths: ['/home/u/uploads/snip.png'] } })
+    try {
+      await renderPanel()
+      emit('onCaptureDone', 'QUJD')
+      await screen.findByAltText('snip.png')
+      await userEvent.click(screen.getByRole('button', { name: 'Remove: snip.png' }))
+      await waitFor(() => expect(screen.queryByAltText('snip.png')).not.toBeInTheDocument())
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+})
+
+describe('ChatPanel drop and paste', () => {
+  /** A DataTransfer-shaped payload carrying one file. */
+  function transferWith(file: File) {
+    return {
+      items: [{ kind: 'file', type: file.type, getAsFile: () => file }],
+      files: [file],
+      types: ['Files'],
+    }
+  }
+
+  it('explains why a dropped file was refused instead of discarding it silently', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({ error: 'Unsupported file type' }), { status: 415 }),
+    )
+    try {
+      await renderPanel()
+      const file = new File(['x'], 'thing.xyz', { type: 'application/octet-stream' })
+      fireEvent.dragEnter(composer(), { dataTransfer: transferWith(file) })
+      fireEvent.drop(composer(), { dataTransfer: transferWith(file) })
+      expect(await screen.findByText('Unsupported file type')).toBeInTheDocument()
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it('ignores an ordinary text paste', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    try {
+      await renderPanel()
+      fireEvent.paste(composer(), { clipboardData: { items: [], files: [], types: ['text/plain'] } })
+      // No upload attempt: a text paste is just typing.
+      expect(fetchSpy).not.toHaveBeenCalledWith('/api/upload/file', expect.anything())
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+})
+
+describe('ChatPanel copy to clipboard', () => {
+  it('copies the reply markdown and confirms it on the button', async () => {
+    const user = userEvent.setup()
+    history = [{ role: 'assistant', content: 'the answer', timestamp: 1700000000000 }]
+    await renderPanel()
+    await user.click(await screen.findByRole('button', { name: 'Copy markdown' }))
+    expect(await navigator.clipboard.readText()).toBe('the answer')
+    // The button relabels itself so the copy is acknowledged.
+    expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument()
+  })
+})
+
+describe('ChatPanel drag highlight', () => {
+  it('marks the composer as a drop target while a file is over it', async () => {
+    await renderPanel()
+    const box = composer()
+    fireEvent.dragEnter(box, { dataTransfer: { items: [], files: [], types: ['Files'] } })
+    fireEvent.dragOver(box, { dataTransfer: { items: [], files: [], types: ['Files'] } })
+    expect(box.style.border).toContain('dashed')
+    fireEvent.dragLeave(box)
+    expect(box.style.border).not.toContain('dashed')
+  })
+})

--- a/website/src/test/MochiPetWidget.coverage.test.tsx
+++ b/website/src/test/MochiPetWidget.coverage.test.tsx
@@ -1,0 +1,714 @@
+/**
+ * Mochi PetWidget — the desktop pet overlay.
+ *
+ * The widget had no test at all, so every behaviour below is pinned here for the
+ * first time. The whole component talks to the Electron main process through one
+ * seam (`api` in `mochiApi`), so the harness mocks that module and drives the
+ * widget the way the main process does: an activation frame, then IPC events
+ * (state change, bubble, appearance switch, hide, drag).
+ *
+ * Everything is on fake timers on purpose — the widget stages its art swaps
+ * behind 150ms fades, holds a state for a 2s minimum, auto-dismisses bubbles
+ * after 6s, and walks on requestAnimationFrame. Fake timers make all of that
+ * deterministic instead of a race.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+
+import svgIdleRaw from '../apps/mochi/assets/animations/mochi_idle.svg?raw'
+import svgPeekRaw from '../apps/mochi/assets/animations/mochi_peek.svg?raw'
+
+const mocks = vi.hoisted(() => {
+  type Listener = (...args: never[]) => void
+  const listeners = new Map<string, Set<Listener>>()
+  /** Mirrors the preload's `onX(cb) => off` subscription shape. */
+  const on = (event: string) => (cb: Listener) => {
+    const set = listeners.get(event) ?? new Set<Listener>()
+    set.add(cb)
+    listeners.set(event, set)
+    return () => { set.delete(cb) }
+  }
+  const api = {
+    // ── one-shot reads ──
+    getPetState: vi.fn<() => Promise<string>>(),
+    getMochiConfig: vi.fn<() => Promise<unknown>>(),
+    getWindowPosition: vi.fn<() => Promise<{ x: number; y: number } | null>>(),
+    presetsGetColorMap: vi.fn<(packId: string) => Promise<Record<string, string>>>(),
+    galleryGetPackDetail: vi.fn<(packId: string) => Promise<unknown>>(),
+    // ── reads the context menu makes ──
+    getQuietUntil: vi.fn<() => Promise<number>>(),
+    getConfig: vi.fn<() => Promise<unknown>>(),
+    setQuiet: vi.fn<(minutes: number) => Promise<number>>(),
+    contextMenuAction: vi.fn(),
+    setMenuHitbox: vi.fn(),
+    menuOpened: vi.fn(),
+    menuClosed: vi.fn(),
+    // ── commands ──
+    savePosition: vi.fn(),
+    walkDone: vi.fn(),
+    openChat: vi.fn(),
+    dismissBubble: vi.fn(),
+    setPeeking: vi.fn(),
+    updateHitbox: vi.fn(),
+    dragStart: vi.fn(),
+    dragEnd: vi.fn(),
+    dragMouseup: vi.fn(),
+    reportWalkDistance: vi.fn(),
+    // ── subscriptions ──
+    onSetActive: on('setActive'),
+    onDisplaysInfo: on('displaysInfo'),
+    onStateChange: on('stateChange'),
+    onBubble: on('bubble'),
+    onMood: on('mood'),
+    onThemeChanged: on('themeChanged'),
+    onConfigUpdated: on('configUpdated'),
+    onColorMapChanged: on('colorMapChanged'),
+    onGalleryActiveChanged: on('galleryActiveChanged'),
+    onDragListenMouseup: on('dragListenMouseup'),
+    onDragUpdate: on('dragUpdate'),
+    onDragEnded: on('dragEnded'),
+    onWalk: on('walk'),
+    onWalkPath: on('walkPath'),
+    onWalkCancel: on('walkCancel'),
+    onWalkAppend: on('walkAppend'),
+    onHide: on('hide'),
+    onApprovalRequest: on('approvalRequest'),
+    onApprovalResolvedExternal: on('approvalResolvedExternal'),
+  }
+  const emit = (event: string, ...args: unknown[]) => {
+    for (const cb of [...(listeners.get(event) ?? [])]) {
+      ;(cb as (...a: unknown[]) => void)(...args)
+    }
+  }
+  return { api, emit, clearListeners: () => listeners.clear() }
+})
+
+vi.mock('../apps/mochi/src/mochiApi', () => ({ api: mocks.api }))
+
+import { PetWidget } from '../apps/mochi/src/renderer/PetWidget'
+
+const api = mocks.api
+const SVG_PREFIX = 'data:image/svg+xml,'
+/** `toDataUri` strips the XML declaration before encoding. */
+const stripXmlDecl = (raw: string) => raw.replace(/<\?xml[^?]*\?>\s*/, '')
+
+function petImg(): HTMLImageElement {
+  const img = document.body.querySelector('img')
+  if (!img) throw new Error('pet art is not rendered')
+  return img as HTMLImageElement
+}
+
+/** The pet's own draggable container — the art's direct parent. */
+function petBox(): HTMLElement {
+  const parent = petImg().parentElement
+  if (!parent) throw new Error('pet container is not rendered')
+  return parent
+}
+
+/** The SVG source actually painted, decoded back out of the data URI. */
+function petArt(): string {
+  const src = petImg().getAttribute('src') ?? ''
+  expect(src.startsWith(SVG_PREFIX)).toBe(true)
+  return decodeURIComponent(src.slice(SVG_PREFIX.length))
+}
+
+/** Let promise chains settle and staged timers fire. */
+async function tick(ms = 0): Promise<void> {
+  await act(async () => { await vi.advanceTimersByTimeAsync(ms) })
+}
+
+/**
+ * Mount the widget and let the main process activate this overlay, which is the
+ * only way anything renders at all.
+ *
+ * Activated WITHOUT coordinates, so the pet stays wherever the saved-position
+ * read put it — that read is what each test controls via `getWindowPosition`.
+ */
+async function mountActive(): Promise<void> {
+  render(<PetWidget />)
+  // 300ms saved-position read (useDrag) + 500ms activation fallback (useDisplayActivation).
+  await tick(600)
+  await act(async () => { mocks.emit('setActive', true) })
+}
+
+const ghostPack = (over: Record<string, unknown> = {}) => ({
+  meta: { id: 'kiro-ghost', name: 'Kiro Ghost', format: 'svg' },
+  animations: {
+    idle: '<svg id="ghost-idle"></svg>',
+    walking: '<svg id="ghost-walk"></svg>',
+    happy: '<svg id="ghost-happy"></svg>',
+  },
+  ...over,
+})
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mocks.clearListeners()
+  vi.resetAllMocks()
+  api.getPetState.mockResolvedValue('idle')
+  api.getMochiConfig.mockResolvedValue({ theme: 'kirocrew' })
+  api.getWindowPosition.mockResolvedValue({ x: 300, y: 400 })
+  api.presetsGetColorMap.mockResolvedValue({})
+  api.galleryGetPackDetail.mockResolvedValue(null)
+  api.getQuietUntil.mockResolvedValue(0)
+  api.getConfig.mockResolvedValue({ shortcuts: {} })
+  api.setQuiet.mockResolvedValue(0)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('PetWidget overlay activation', () => {
+  it('renders nothing until the main process activates this display', async () => {
+    const { container } = render(<PetWidget />)
+    await tick(600)
+    // One overlay exists per display; the pet lives in exactly one of them.
+    expect(container.querySelector('img')).toBeNull()
+
+    await act(async () => { mocks.emit('setActive', true, 300, 400, false) })
+    expect(container.querySelector('img')).not.toBeNull()
+  })
+
+  it('unmounts the pet again when the overlay is deactivated', async () => {
+    await mountActive()
+    expect(petImg()).toBeTruthy()
+
+    await act(async () => { mocks.emit('setActive', false) })
+    expect(document.body.querySelector('img')).toBeNull()
+  })
+
+  it('places the pet at the saved position and reveals it once the read lands', async () => {
+    await mountActive()
+    expect(petBox().style.left).toBe('300px')
+    expect(petBox().style.top).toBe('400px')
+    expect(petBox().style.opacity).toBe('1')
+  })
+
+  it('adopts the coordinates it is activated with, so a cross-display drag lands in place', async () => {
+    render(<PetWidget />)
+    await tick(600)
+    // The pet was dragged onto THIS display: the main process hands over both
+    // the position and the fact that a drag is still in progress.
+    await act(async () => { mocks.emit('setActive', true, 640, 120, true) })
+
+    expect(petBox().style.left).toBe('640px')
+    expect(petBox().style.top).toBe('120px')
+    // Mid-drag hand-over: the drag ends here, not on the display it started on.
+    await act(async () => { mocks.emit('dragEnded', 640, 120) })
+    expect(api.savePosition).toHaveBeenCalledWith(640, 120)
+  })
+
+  it('falls back to the bottom-left edge when there is no saved position', async () => {
+    api.getWindowPosition.mockResolvedValue(null)
+    await mountActive()
+    // No saved position → parked against the left edge, and peeking from it.
+    expect(api.setPeeking).toHaveBeenCalledWith(true)
+    expect(petArt()).toBe(stripXmlDecl(svgPeekRaw))
+  })
+})
+
+describe('PetWidget art and state', () => {
+  it('names the pet and its displayed state in the art tooltip', async () => {
+    await mountActive()
+    expect(screen.getByTitle('Mochi: idle')).toBe(petImg())
+  })
+
+  it('uses the name the user configured', async () => {
+    api.getMochiConfig.mockResolvedValue({ theme: 'kirocrew', petName: '  Ghosty  ' })
+    await mountActive()
+    expect(screen.getByTitle('Ghosty: idle')).toBeTruthy()
+  })
+
+  it('swaps art on a state change, after the fade', async () => {
+    await mountActive()
+    await act(async () => { mocks.emit('stateChange', 'working') })
+    // The swap is staged behind a 150ms fade-out so the art never pops.
+    expect(petImg().style.opacity).toBe('0')
+
+    await tick(150)
+    expect(screen.getByTitle('Mochi: working')).toBeTruthy()
+    expect(petImg().style.opacity).toBe('1')
+  })
+
+  it('holds a non-idle state for its minimum display time before applying the next one', async () => {
+    await mountActive()
+    await act(async () => { mocks.emit('stateChange', 'working') })
+    await tick(150)
+    expect(screen.getByTitle('Mochi: working')).toBeTruthy()
+
+    // Arrives inside the 2s lock — queued rather than applied, so the art
+    // cannot flicker through a state nobody could read.
+    await act(async () => { mocks.emit('stateChange', 'idle') })
+    expect(screen.getByTitle('Mochi: working')).toBeTruthy()
+
+    await tick(2000)
+    expect(screen.getByTitle('Mochi: idle')).toBeTruthy()
+  })
+
+  it('ignores a state event that repeats the state already shown', async () => {
+    await mountActive()
+    await act(async () => { mocks.emit('stateChange', 'idle') })
+    // Same state as the current one → no fade, no re-render churn.
+    expect(petImg().style.opacity).toBe('1')
+    expect(screen.getByTitle('Mochi: idle')).toBeTruthy()
+  })
+
+  it('paints the built-in art, recoloured by the saved colour map', async () => {
+    api.presetsGetColorMap.mockResolvedValue({ '#E98649': '#00FF00' })
+    await mountActive()
+    expect(api.presetsGetColorMap).toHaveBeenCalledWith('default-mochi')
+    expect(petArt()).toContain('#00FF00')
+  })
+
+  it('recolours live when the colour map changes for the built-in pack', async () => {
+    await mountActive()
+    expect(petArt()).toContain('#E98649')
+
+    await act(async () => {
+      mocks.emit('colorMapChanged', { packId: 'default-mochi', colorMap: { '#E98649': '#123456' } })
+    })
+    expect(petArt()).toContain('#123456')
+
+    // A colour map for some OTHER pack must not repaint this one.
+    await act(async () => {
+      mocks.emit('colorMapChanged', { packId: 'some-other-pack', colorMap: { '#123456': '#ABCDEF' } })
+    })
+    expect(petArt()).toContain('#123456')
+  })
+})
+
+describe('PetWidget appearance packs', () => {
+  it('paints art from the active pack instead of the built-in cat', async () => {
+    api.getMochiConfig.mockResolvedValue({ theme: 'kirocrew', activeAppearance: 'kiro-ghost' })
+    api.galleryGetPackDetail.mockResolvedValue(ghostPack())
+    await mountActive()
+
+    expect(api.galleryGetPackDetail).toHaveBeenCalledWith('kiro-ghost')
+    // A non-built-in pack is not recolourable, so no colour map is read for it.
+    expect(api.presetsGetColorMap).not.toHaveBeenCalled()
+    expect(petArt()).toContain('ghost-idle')
+  })
+
+  it('mirrors a pack that declares its art faces the other way', async () => {
+    api.getMochiConfig.mockResolvedValue({ theme: 'kirocrew', activeAppearance: 'kiro-ghost' })
+    api.galleryGetPackDetail.mockResolvedValue(ghostPack({ flipX: true }))
+    await mountActive()
+    expect(petBox().style.transform).toContain('scaleX(-1)')
+  })
+
+  it('mirrors the pet when it sits on the right half of the screen', async () => {
+    const rightSide = Math.floor(window.innerWidth * 0.6)
+    api.getWindowPosition.mockResolvedValue({ x: rightSide, y: 400 })
+    await mountActive()
+    expect(petBox().style.transform).toContain('scaleX(-1)')
+  })
+
+  it('keeps the built-in art and says why when a pack ships no idle drawing', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    api.getMochiConfig.mockResolvedValue({ theme: 'kirocrew', activeAppearance: 'kiro-ghost' })
+    api.galleryGetPackDetail.mockResolvedValue({
+      meta: { id: 'kiro-ghost', format: 'svg' },
+      animations: { walking: '<svg id="ghost-walk"></svg>' },
+    })
+    await mountActive()
+
+    expect(err).toHaveBeenCalledWith(
+      '[mochi] pack cannot drive the pet — no idle art',
+      expect.objectContaining({ packId: 'kiro-ghost' }),
+    )
+    expect(petArt()).toBe(stripXmlDecl(svgIdleRaw))
+    err.mockRestore()
+  })
+
+  it('reports a pack whose detail carries no art at all', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    api.getMochiConfig.mockResolvedValue({ theme: 'kirocrew', activeAppearance: 'kiro-ghost' })
+    api.galleryGetPackDetail.mockResolvedValue({ meta: { id: 'kiro-ghost' } })
+    await mountActive()
+
+    expect(err).toHaveBeenCalledWith(
+      '[mochi] active pack returned no usable detail',
+      expect.objectContaining({ packId: 'kiro-ghost', hasAnimations: false }),
+    )
+    expect(petArt()).toBe(stripXmlDecl(svgIdleRaw))
+    err.mockRestore()
+  })
+
+  it('reports a pack that could not be loaded, and still draws a pet', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    api.getMochiConfig.mockResolvedValue({ theme: 'kirocrew', activeAppearance: 'kiro-ghost' })
+    api.galleryGetPackDetail.mockRejectedValue(new Error('pack file is gone'))
+    await mountActive()
+
+    expect(err).toHaveBeenCalledWith(
+      '[mochi] could not load the active pack',
+      'kiro-ghost',
+      expect.any(Error),
+    )
+    expect(petArt()).toBe(stripXmlDecl(svgIdleRaw))
+    err.mockRestore()
+  })
+
+  it('switches art live when the user applies another pack, and back again', async () => {
+    await mountActive()
+    expect(petArt()).toContain('#E98649')
+
+    await act(async () => {
+      mocks.emit('galleryActiveChanged', {
+        packId: 'kiro-ghost',
+        meta: { id: 'kiro-ghost', format: 'svg' },
+        animations: { idle: '<svg id="live-ghost"></svg>' },
+      })
+    })
+    await tick(150)
+    expect(petArt()).toContain('live-ghost')
+
+    // Back to the built-in pack: its saved colour map is restored with it.
+    api.presetsGetColorMap.mockResolvedValue({ '#E98649': '#00FF00' })
+    await act(async () => { mocks.emit('galleryActiveChanged', { packId: 'default-mochi' }) })
+    await tick(150)
+    expect(petArt()).toContain('#00FF00')
+  })
+
+  it('reports a live switch that carried no usable art, and keeps the current art', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await mountActive()
+
+    await act(async () => { mocks.emit('galleryActiveChanged', { packId: 'kiro-ghost' }) })
+    await tick(150)
+
+    expect(err).toHaveBeenCalledWith(
+      '[mochi] live appearance switch carried no usable art',
+      expect.objectContaining({ packId: 'kiro-ghost' }),
+    )
+    expect(petArt()).toBe(stripXmlDecl(svgIdleRaw))
+    err.mockRestore()
+  })
+
+  it('slides a pack with no peek drawing partly off-screen while it peeks', async () => {
+    api.getMochiConfig.mockResolvedValue({ theme: 'kirocrew', activeAppearance: 'kiro-ghost' })
+    api.galleryGetPackDetail.mockResolvedValue(ghostPack())
+    api.getWindowPosition.mockResolvedValue({ x: 0, y: 400 })
+    await mountActive()
+
+    // The pack falls back to `idle` for the peek pose, so the POSITION has to
+    // carry the meaning the missing drawing would have.
+    expect(petBox().style.transform).toContain('translateX(-60px)')
+  })
+
+  it('draws the BUILT-IN peek art even when a pack is active (current behaviour — see comment)', async () => {
+    api.getMochiConfig.mockResolvedValue({ theme: 'kirocrew', activeAppearance: 'kiro-ghost' })
+    api.galleryGetPackDetail.mockResolvedValue(ghostPack())
+    api.getWindowPosition.mockResolvedValue({ x: 0, y: 400 })
+    await mountActive()
+
+    // DEFECT, pinned rather than endorsed: the render path computes the pack's
+    // own source (`currentSource`) and then throws it away for the SVG case,
+    // calling `resolveSvg` instead — whose first branch returns the compiled-in
+    // cat peek whenever the pet is peeking, with no resolver check. So a user on
+    // another pack sees the CAT's peek drawing at the screen edge (and, via
+    // peekNudgeFor, sees it nudged off-screen at the same time). The comment on
+    // that branch claims it is "only reached when no resolver/pack", which is
+    // exactly the assumption that does not hold.
+    expect(petArt()).toBe(stripXmlDecl(svgPeekRaw))
+    expect(petArt()).not.toContain('ghost-idle')
+  })
+})
+
+describe('PetWidget speech bubble', () => {
+  it('shows a bubble and dismisses it on click', async () => {
+    await mountActive()
+    await act(async () => { mocks.emit('bubble', 'Build finished', false) })
+    expect(screen.getByText('Build finished')).toBeTruthy()
+
+    const dismiss = screen.getByRole('button', { name: 'Dismiss message' })
+    await act(async () => { fireEvent.click(dismiss) })
+    expect(api.dismissBubble).toHaveBeenCalled()
+
+    await tick(300) // fade-out
+    expect(screen.queryByText('Build finished')).toBeNull()
+  })
+
+  it('auto-dismisses a non-sticky bubble', async () => {
+    await mountActive()
+    await act(async () => { mocks.emit('bubble', 'Walking to the corner', false) })
+
+    await tick(5000)
+    expect(screen.getByText('Walking to the corner')).toBeTruthy()
+
+    await tick(1000 + 300) // auto-dismiss, then the fade
+    expect(screen.queryByText('Walking to the corner')).toBeNull()
+  })
+
+  it('survives a retired theme id from stored settings', async () => {
+    // Theme ids were collapsed to one; a pre-consolidation value read from disk
+    // used to take the whole pet tree down on the first bubble render.
+    api.getMochiConfig.mockResolvedValue({ theme: 'mocha' })
+    await mountActive()
+    await act(async () => { mocks.emit('bubble', 'still here', false) })
+
+    expect(screen.getByText('still here')).toBeTruthy()
+    expect(petImg()).toBeTruthy()
+  })
+
+  it('keeps rendering across live theme and config updates', async () => {
+    await mountActive()
+    await act(async () => {
+      mocks.emit('themeChanged', 'kirocrew')
+      mocks.emit('configUpdated', { theme: 'kirocrew' })
+    })
+    await act(async () => { mocks.emit('bubble', 'after the theme change', false) })
+    expect(screen.getByText('after the theme change')).toBeTruthy()
+  })
+
+  it('raises a sticky bubble for a pending approval and retracts it when answered elsewhere', async () => {
+    await mountActive()
+    await act(async () => { mocks.emit('approvalRequest', { purpose: 'reading the repo' }) })
+    expect(screen.getByText('Mochi needs your approval for reading the repo')).toBeTruthy()
+
+    // Sticky: an approval blocks the agent, so it must not time out unanswered.
+    await tick(30_000)
+    expect(screen.getByText('Mochi needs your approval for reading the repo')).toBeTruthy()
+
+    await act(async () => { mocks.emit('approvalResolvedExternal') })
+    await tick(300)
+    expect(screen.queryByText(/needs your approval/)).toBeNull()
+  })
+})
+
+describe('PetWidget interaction', () => {
+  it('opens the chat on double-click', async () => {
+    await mountActive()
+    await act(async () => { fireEvent.dblClick(petBox()) })
+    expect(api.openChat).toHaveBeenCalled()
+  })
+
+  it('opens the pet menu on right-click and closes it again', async () => {
+    await mountActive()
+    await act(async () => { fireEvent.contextMenu(petBox(), { clientX: 40, clientY: 60 }) })
+    await tick()
+
+    const quiet = screen.getByText('Quiet for 1 hour')
+    expect(quiet).toBeTruthy()
+
+    await act(async () => { fireEvent.click(quiet) })
+    expect(api.setQuiet).toHaveBeenCalledWith(60)
+  })
+
+  it('moves the pet with the mouse and persists where it was dropped', async () => {
+    await mountActive()
+    await act(async () => { fireEvent.mouseDown(petBox(), { clientX: 350, clientY: 400 }) })
+    // Grab offset is 50px into the body, so the pet trails the cursor by that.
+    await act(async () => { fireEvent.mouseMove(window, { clientX: 500, clientY: 420 }) })
+
+    expect(api.dragStart).toHaveBeenCalledWith(50, 0)
+    expect(petBox().style.left).toBe('450px')
+
+    await act(async () => { fireEvent.mouseUp(window) })
+    expect(api.dragEnd).toHaveBeenCalled()
+    expect(api.savePosition).toHaveBeenCalledWith(450, 420)
+  })
+
+  it('snaps to the edge and starts peeking when the drag ends near one', async () => {
+    await mountActive()
+    await act(async () => { mocks.emit('dragEnded', 10, 200) })
+
+    expect(petBox().style.left).toBe('0px')
+    expect(api.savePosition).toHaveBeenCalledWith(0, 200)
+    expect(api.setPeeking).toHaveBeenLastCalledWith(true)
+  })
+
+  it('listens for a cross-display drag mouseup exactly once', async () => {
+    await mountActive()
+    await act(async () => { mocks.emit('dragListenMouseup') })
+
+    await act(async () => { fireEvent.mouseUp(window) })
+    expect(api.dragMouseup).toHaveBeenCalledTimes(1)
+
+    // The one-shot handler removes itself, so a later mouseup is not reported.
+    await act(async () => { fireEvent.mouseUp(window) })
+    expect(api.dragMouseup).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('PetWidget walking and hiding', () => {
+  it('walks to a target, then persists the position and reports the distance', async () => {
+    await mountActive()
+    await act(async () => { mocks.emit('walk', 500, 400) })
+    // 200px at 6ms/px → 1200ms of rAF steps.
+    await tick(1500)
+
+    expect(petBox().style.left).toBe('500px')
+    expect(api.savePosition).toHaveBeenCalledWith(500, 400)
+    expect(api.walkDone).toHaveBeenCalled()
+    expect(api.reportWalkDistance).toHaveBeenCalled()
+    // Landed mid-screen, so it is not peeking from an edge.
+    expect(api.setPeeking).toHaveBeenLastCalledWith(false)
+  })
+
+  it('walks to the edge and peeks from it when told to hide', async () => {
+    await mountActive()
+    await act(async () => { mocks.emit('hide', 'left') })
+    await tick(3000)
+
+    expect(petBox().style.left).toBe('0px')
+    expect(api.savePosition).toHaveBeenCalledWith(0, 400)
+    expect(api.setPeeking).toHaveBeenLastCalledWith(true)
+    // At the edge with the built-in pack, the peek POSE is what gets drawn.
+    expect(petArt()).toBe(stripXmlDecl(svgPeekRaw))
+  })
+
+  it('draws the thinking peek pose when it is busy at the edge', async () => {
+    api.getWindowPosition.mockResolvedValue({ x: 0, y: 400 })
+    await mountActive()
+    await act(async () => { mocks.emit('stateChange', 'thinking') })
+    await tick(150)
+
+    expect(screen.getByTitle('Mochi: thinking')).toBeTruthy()
+    // Peek art is compiled in rather than part of any pack, so a busy pet at
+    // the edge gets the dedicated thinking-peek drawing.
+    expect(petArt()).not.toBe(stripXmlDecl(svgPeekRaw))
+    expect(petArt()).toContain('<svg')
+  })
+
+  it('cancels a walk as soon as the user grabs the pet', async () => {
+    await mountActive()
+    await act(async () => { mocks.emit('walk', 900, 400) })
+    await tick(300) // mid-walk
+
+    const midX = parseFloat(petBox().style.left)
+    expect(midX).toBeGreaterThan(300)
+    expect(midX).toBeLessThan(900)
+
+    await act(async () => { fireEvent.mouseDown(petBox(), { clientX: midX, clientY: 400 }) })
+    await tick(2000)
+    // The walk is abandoned where the grab happened — it does not resume.
+    expect(parseFloat(petBox().style.left)).toBeCloseTo(midX, 0)
+  })
+
+  it('reflects the pet mood in the art it draws', async () => {
+    await mountActive()
+    const idleArt = petArt()
+
+    await act(async () => { mocks.emit('mood', 'happy', 1) })
+    await act(async () => { mocks.emit('stateChange', 'working') })
+    await tick(150)
+
+    // A mood outranks the state art for the built-in pack.
+    expect(petArt()).not.toBe(idleArt)
+  })
+
+  it('draws the walking art from the active pack while it moves', async () => {
+    api.getMochiConfig.mockResolvedValue({ theme: 'kirocrew', activeAppearance: 'kiro-ghost' })
+    api.galleryGetPackDetail.mockResolvedValue(ghostPack())
+    await mountActive()
+
+    await act(async () => { mocks.emit('walk', 500, 400) })
+    await tick(300) // mid-walk
+    expect(petArt()).toContain('ghost-walk')
+
+    await tick(1500) // arrives
+    expect(petArt()).toContain('ghost-idle')
+  })
+
+  it('tilts the pet on a diagonal walk', async () => {
+    await mountActive()
+    await act(async () => { mocks.emit('walk', 500, 600) })
+    await tick(300)
+    // 45° of travel reads as a diagonal, which leans the body into the move.
+    expect(petBox().style.transform).toMatch(/rotate\([\d.]+deg\)/)
+  })
+})
+
+describe('PetWidget non-SVG pack formats', () => {
+  it('renders a sprite-sheet pack on a canvas, honouring the sheet geometry', async () => {
+    api.getMochiConfig.mockResolvedValue({ theme: 'kirocrew', activeAppearance: 'boba-sprite' })
+    api.galleryGetPackDetail.mockResolvedValue({
+      meta: { id: 'boba-sprite', name: 'Boba', format: 'sprite' },
+      animations: { idle: 'iVBORw0KGgo=' },
+      sprite: { frameWidth: 64, frameHeight: 64, fps: 12 },
+      flipX: true,
+    })
+    await mountActive()
+
+    const canvas = document.body.querySelector('canvas')
+    expect(canvas).not.toBeNull()
+    // A sprite pack draws frames, so there is no <img> art element at all.
+    expect(document.body.querySelector('img')).toBeNull()
+
+    const box = canvas!.parentElement!.parentElement!
+    // The pack declares its art is mirrored, so the container un-mirrors it.
+    expect(box.style.transform).toContain('scaleX(-1)')
+  })
+
+  it("prefers the pack's own mood art over its state art", async () => {
+    api.getMochiConfig.mockResolvedValue({ theme: 'kirocrew', activeAppearance: 'kiro-ghost' })
+    api.galleryGetPackDetail.mockResolvedValue(ghostPack())
+    await mountActive()
+    expect(petArt()).toContain('ghost-idle')
+
+    await act(async () => { mocks.emit('mood', 'happy', 1) })
+    await act(async () => { mocks.emit('stateChange', 'working') })
+    await tick(150)
+    // The pack ships a `happy` drawing, which outranks the state slot.
+    expect(petArt()).toContain('ghost-happy')
+  })
+
+  it('warns once when the active pack resolves to no art at all', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    api.getMochiConfig.mockResolvedValue({ theme: 'kirocrew', activeAppearance: 'ghost-lottie' })
+    api.galleryGetPackDetail.mockResolvedValue({
+      meta: { id: 'ghost-lottie', format: 'lottie' },
+      animations: { idle: { content: '', format: 'lottie' } },
+    })
+    await mountActive()
+
+    // Empty art, a pack that never loaded, and a slot with no drawing all look
+    // identical on screen — this is the one that is a genuine fault, so it is
+    // the one that gets a line in the console.
+    expect(warn).toHaveBeenCalledWith('[mochi-pet] pack resolved NO art for', 'idle')
+    warn.mockRestore()
+  })
+
+  it('hands a lottie-format pack to the lottie renderer, and reports a clip it cannot parse', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    api.getMochiConfig.mockResolvedValue({ theme: 'kirocrew', activeAppearance: 'ghost-lottie' })
+    api.galleryGetPackDetail.mockResolvedValue({
+      meta: { id: 'ghost-lottie', name: 'Ghost', format: 'lottie' },
+      // Per-slot format, the shape the gallery sends for a mixed pack.
+      animations: { idle: { content: 'not-json-at-all', format: 'lottie' } },
+    })
+    await mountActive()
+
+    // Lottie art is built into a container, never an <img>.
+    expect(document.body.querySelector('img')).toBeNull()
+    // A clip that cannot be parsed used to render as a silent empty box.
+    expect(err).toHaveBeenCalledWith(
+      '[mochi] lottie JSON parse failed',
+      expect.objectContaining({ head: 'not-json-at-all' }),
+      expect.anything(),
+    )
+    err.mockRestore()
+  })
+
+  it('recolours the built-in pack through an active resolver', async () => {
+    await mountActive()
+    // Switch to a pack so a resolver exists, then send a built-in colour map:
+    // the resolver has to be told, or its cached art keeps the old colours.
+    await act(async () => {
+      mocks.emit('galleryActiveChanged', {
+        packId: 'kiro-ghost',
+        meta: { id: 'kiro-ghost', format: 'svg' },
+        animations: { idle: '<svg fill="#E98649" id="ghost-idle"></svg>' },
+      })
+    })
+    await tick(150)
+    expect(petArt()).toContain('#E98649')
+
+    await act(async () => {
+      mocks.emit('colorMapChanged', { packId: 'default-mochi', colorMap: { '#E98649': '#00FF00' } })
+    })
+    expect(petArt()).toContain('#00FF00')
+  })
+})


### PR DESCRIPTION
## What

Six components under `website/src/apps` were at **exactly 0%** statement coverage — whole features with not a single test between them. This adds **332 tests** in six new files.

| component | statements | before | after |
|---|---|---|---|
| `mochi/src/renderer/ChatPanel.tsx` | 650 | 0% | 88.6% |
| `design-critique/DesignCritiquePage.tsx` | 568 | 0% | 89.1% |
| `md-notebook/MdNotebookPage.tsx` | 564 | 0% | 79.6% |
| `crew-companion/pet.tsx` | 310 | 0% | 92.9% |
| `crew-companion/GalleryPanel.tsx` | 282 | 0% | 95.4% |
| `mochi/src/renderer/PetWidget.tsx` | 244 | 0% | 100% |

**+2,332 covered statements → frontend coverage 63.28% → 67.11%.**

Since all six were at zero, no existing test touched these lines, so the gain is exactly additive rather than an estimate.

The frontend floor stays at **60** here. Ratcheting it belongs in its own change — a threshold move should never ride along with the tests that justify it.

## Why these six

Backend coverage work has hit diminishing returns: the last two waves converted 1,040 tests into +1.35pp and then 1,883 tests into +0.44pp, because the remaining backend lines sit behind I/O a unit test cannot reach. Untested frontend surfaces convert far better — this PR is **7.0 statements per test**, roughly 3x the best backend wave and ~15x the last one.

The other reason is that never-executed code is where the bugs are.

## Nine defects the tests surfaced

**None are fixed in this PR.** It adds tests only, so the fixes can be reviewed on their own merits instead of buried in 5,000 lines of new test code. Where a test would otherwise have had to assert buggy output, it **pins current behaviour and carries a comment naming the defect** — so whoever fixes it gets a failing test pointing straight at the explanation. Reviewers should read those comments as filed bugs, not as endorsements.

1. **`ChatPanel` image extraction corrupts remote image URLs.** `bareRe` matches the `//host/path.png` portion of an ordinary `https` URL, so a reply containing `![logo](https://example.com/logo.png)` has the URL torn out of the text and handed to `LocalImage` as `//example.com/logo.png`. The read fails, a placeholder renders, and the leftover text shows a broken `![logo](https:)`.
2. **`MdNotebookPage` does not validate the persisted auto-sync interval.** Panel width is range-checked and the sort id is membership-checked; `autoSyncMins` is not — clamping lives only in the setter. A stored `0` reaches the effect and schedules `setInterval(sync, 0)`, a zero-delay loop against the backend for the life of the tab. Confirmed empirically: the test asserting the clamped behaviour hung the runner until timeout.
3. **`PetWidget` draws the built-in cat's peek art whatever pack is active.** The render path computes the pack's own `currentSource`, discards it for the SVG case, and re-resolves — returning the compiled-in peek asset with no resolver check. It compounds with `peekNudgeFor`, which then concludes the pack has no peek art and slides the pet 60px off-screen.
4. **The built-in ghost's colour customizer and dress-up row are unreachable.** The grid passes `onManage` only when `type === 'custom'`, and `onManage` is the only thing that opens the detail sheet, so the built-in pack can only ever be applied.
5. **Escape inside the PetDex import dialog closes the whole gallery window.** `GalleryPanel` and `ImportPetDialog` both listen on `window` and neither stops propagation.
6. **crew-companion's pet keeps fidgeting while the avatar gallery is open.** `galleryOpenRef` is written by the subscription effect and never read — it appears in no gate anywhere in the file — so the behaviour its own comment describes ("must not wander off while the user is picking an avatar") does not hold.
7. **`apps.crewCompanion.gallery.edit` carries an orphaned `U+FE0F`** left over from a stripped emoji, rendering a stray leading space and making the button unmatchable by exact accessible name.
8. **`PetWidget` never displays the pet state it fetches at mount.** `getPetState` sets `state`, but the art renders from `displayState`, which only moves on an `onStateChange` event.
9. **`pet.tsx` `dismissRef` is dead code** — nothing assigns a timer id, so the `clearTimeout` branch in `dismiss` cannot run. Auto-dismiss moved into `Bubble`'s own effect and this ref was left behind.

## Testing

Verified in the worktree, not self-reported:

- `npx vitest run` — **332/332 pass** across all six files
- `npx tsc --noEmit` — clean
- `npx eslint` on all six files — clean
- `npm run jscpd` — **0 clones** (relevant: 5,006 lines of new test code)
- Coverage measured with the reporter scoped to the four app directories

No existing file is modified — the diff is six new files and nothing else. Tests avoid real network, real elapsed timers, fixed ports, and the developer's home directory; interactions are driven synchronously so nothing depends on wall-clock timing or test order.

## Not covered, deliberately

- A **second** `GalleryPanel.tsx` (mochi renderer, 204 statements) is still at 0% — a separate target, not in this PR.
- `PackEditor` / `SpriteImporter` internals and `petdexImport`'s canvas decode are stubbed at the module boundary; each has its own tests, and `firstFramePreview` uses `new Image()` + canvas, which never settles under happy-dom.
- `AnimThumbnail`'s Lottie branch would boot `lottie-web` inside happy-dom, which needs a real renderer.
- The built-in-ghost-only blocks in `DetailPanel` are unreachable through the UI (finding 4), so covering them would mean fabricating a pack shape no backend produces.
