### PR TITLE
fix: self-heal dangling storageState in playwright config at load time (#2491)

### DIFF
--- a/src/kiro_crew/browser/setup.py
+++ b/src/kiro_crew/browser/setup.py
@@ -34,6 +34,7 @@ from kiro_crew.mcp_playwright_proxy import (
     _resolve_playwright_cmd,
 )
 from kiro_crew.mcp_utils import mcp_server_alias
+from kiro_crew.security import is_sensitive_path
 
 logger = logging.getLogger(__name__)
 
@@ -719,6 +720,61 @@ def get_playwright_mcp_env() -> dict[str, str]:
     return env
 
 
+@contextlib.contextmanager
+def _playwright_config_locked(config_path: Path) -> Iterator[None]:
+    """Hold the exclusive advisory lock guarding ``playwright-config.json``.
+
+    Every writer of that file must serialize on the shared ``.lock`` sidecar:
+    :func:`generate_playwright_config` (Settings saves via
+    ``asyncio.to_thread``, ``browse setup``/``cli_setup`` pre-loop) and
+    :func:`repair_playwright_config` (proxy startup, pre-loop). A lock-free
+    read-modify-write races the others and installs a stale snapshot over
+    whichever side wrote first — e.g. the proxy's self-heal discarding a
+    just-selected browser engine. Same sidecar pattern as
+    :func:`_kiro_mcp_locked`.
+
+    Blocking: callers on the event loop must dispatch through
+    ``asyncio.to_thread``. Not reentrant.
+    """
+    # Derive the sidecar from the RESOLVED path: a symlinked config and its
+    # target must converge on ONE lock file, or a writer addressing the link
+    # and a writer addressing the target would lock independently and race.
+    config_path = config_path.resolve()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = config_path.with_name(config_path.name + ".lock")
+    # Never follow a pre-planted symlink at the sidecar name: config_dir()
+    # also holds security keystone flag files, and a follow-through
+    # touch/open would create or truncate whatever the link points at (an
+    # agent-plantable capability grant). POSIX: O_NOFOLLOW refuses the
+    # symlink at the kernel (ELOOP). Windows has no O_NOFOLLOW (and
+    # Developer Mode allows unprivileged symlink creation), so there the
+    # link is refused via lstat BEFORE opening, and the opened fd's identity
+    # is re-verified against the directory entry AFTER opening (samestat),
+    # which also closes the lstat->open swap window.
+    flags = os.O_RDWR | os.O_CREAT
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    flags |= nofollow
+    if not nofollow:
+        try:
+            if stat.S_ISLNK(os.lstat(lock_path).st_mode):
+                raise OSError(f"lock sidecar {lock_path} is a symlink")
+        except FileNotFoundError:
+            pass
+    fd = os.open(str(lock_path), flags, 0o600)
+    try:
+        st_fd = os.fstat(fd)
+        if not stat.S_ISREG(st_fd.st_mode):
+            raise OSError(f"lock sidecar {lock_path} is not a regular file")
+        if not nofollow:
+            st_path = os.lstat(lock_path)
+            if stat.S_ISLNK(st_path.st_mode) or not os.path.samestat(st_path, st_fd):
+                raise OSError(f"lock sidecar {lock_path} changed identity during open")
+        with platform_compat.file_lock(fd, exclusive=True):
+            yield
+    finally:
+        os.close(fd)
+
+
 def generate_playwright_config(engine: str | None = None) -> Path:
     """Generate ``<config_dir>/playwright-config.json`` with absolute paths.
 
@@ -768,8 +824,149 @@ def generate_playwright_config(engine: str | None = None) -> Path:
         "capabilities": ["network", "storage"],
     }
 
-    config_path.write_text(json.dumps(config, indent=2))
+    # Serialize with the other writer of this file (repair_playwright_config's
+    # proxy-startup self-heal) so a concurrent repair cannot install its stale
+    # snapshot over this fresh generation. See _playwright_config_locked.
+    with _playwright_config_locked(config_path):
+        config_path.write_text(json.dumps(config, indent=2))
     return config_path
+
+
+def repair_playwright_config(config_path: Path | str | None = None) -> bool:
+    """Self-heal a stale ``playwright-config.json`` on load (#2491).
+
+    :func:`generate_playwright_config` only attaches
+    ``contextOptions.storageState`` when the file exists at GENERATION time
+    (#2209), but nothing re-validated an already-written config: one generated
+    before that fix — or whose storage-state file was later removed — kept a
+    dangling reference forever. Playwright raises ENOENT at context creation
+    for it, breaking every ``browser_*`` call, and the running playwright-mcp
+    process caches the config, so regenerating it did not recover a live
+    session (#2491).
+
+    Called at proxy startup — the config's load moment — from
+    ``mcp_playwright_proxy.run_proxy``. When the on-disk config references a
+    storage-state file that no longer exists, drop the key (the same
+    degrade-to-unauthenticated-context behaviour a fresh
+    :func:`generate_playwright_config` produces, so both paths converge on one
+    behaviour) and rewrite the config so the repair survives restarts.
+    Deliberately does NOT try to re-seed via :func:`refresh_storage_state`:
+    that is a no-op without a cookie source (the OSS default), and if a cookie
+    source ever writes the file back, the untouched-when-present branch keeps
+    the key on the next load.
+
+    Returns ``True`` when a repair was written. A config that is valid,
+    keyless, absent, or unparseable is left byte-for-byte untouched —
+    unparseable ones fall through to Playwright MCP's own config error, which
+    names the file, whereas guessing at a rewrite here could destroy a config
+    the user hand-edited.
+
+    The read-validate-write runs under :func:`_playwright_config_locked`, the
+    same interprocess lock :func:`generate_playwright_config` takes, so the
+    repair can neither tear a concurrent generation nor install a stale
+    snapshot over one (e.g. discarding a just-selected browser engine).
+    """
+    path = Path(config_path) if config_path is not None else config_dir() / "playwright-config.json"
+    # Playwright resolves a relative storageState against the config path AS
+    # GIVEN to it — the link's directory when ``--config`` names a symlink —
+    # so capture that lexical base BEFORE resolving the link.
+    lexical_base = path.parent
+    # Repair THROUGH a symlink, not over it: ``os.replace`` inside
+    # ``atomic_write`` would swap a symlinked config for a regular file,
+    # destroying the user's link while leaving the linked target unrepaired.
+    # An unresolvable path (symlink loop -> ELOOP OSError; RuntimeError on
+    # older resolve() implementations) must not crash the proxy before it
+    # spawns Playwright — an unrepairable config is Playwright MCP's own
+    # error to report, same as an unparseable one.
+    try:
+        path = path.resolve()
+    except (OSError, RuntimeError):
+        return False
+    # Refuse sensitive locations BEFORE locking or reading: the ``--config``
+    # value comes from the proxy's argv (normally Kiro Crew's own fixed
+    # registration, but a hand-edited mcp.json could point anywhere), the lock
+    # helper creates a sidecar file NEXT to the target, and this module must
+    # never read credential paths (see security.is_sensitive_path).
+    if is_sensitive_path(str(path)):
+        logger.warning(
+            "refusing to inspect %s for a storageState repair: sensitive path", path
+        )
+        return False
+    try:
+        with _playwright_config_locked(path):
+            try:
+                raw = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                return False
+            try:
+                config = json.loads(raw)
+            except json.JSONDecodeError:
+                return False
+            if not isinstance(config, dict):
+                return False
+            browser = config.get("browser")
+            if not isinstance(browser, dict):
+                return False
+            context_options = browser.get("contextOptions")
+            if not isinstance(context_options, dict):
+                return False
+            storage_state = context_options.get("storageState")
+            if not isinstance(storage_state, str) or not storage_state:
+                return False
+            # Playwright resolves a relative storageState against the config
+            # file's directory AS GIVEN (``lexical_base``, the link's dir for
+            # a symlinked config) — judge existence from the same vantage, not
+            # the proxy CWD or the resolved target's dir, or a working
+            # hand-edited relative reference would be judged missing and
+            # dropped (the inverse of the bug being fixed). Kiro Crew's own
+            # generator always writes an absolute path.
+            state_path = Path(storage_state)
+            if not state_path.is_absolute():
+                state_path = lexical_base / state_path
+            if state_path.exists():
+                return False
+            del context_options["storageState"]
+            logger.warning(
+                "playwright-config.json references a storage-state file that does "
+                "not exist (%s); dropping contextOptions.storageState so the "
+                "browser context starts unauthenticated instead of failing with "
+                "ENOENT (#2491)",
+                storage_state,
+            )
+            # Preserve the file's permissions: other rewrite sites in this
+            # module do the same, and an operator-tightened 0600 must not
+            # silently widen to the umask default.
+            mode = stat.S_IMODE(path.stat().st_mode)
+            # Belt to the lock's suspenders: the interprocess lock serializes
+            # every in-codebase writer, but a MANUAL edit (an operator's text
+            # editor) takes no lock. Re-read immediately before writing and
+            # stand down if the file changed since our snapshot — the edit
+            # wins, and a still-dangling reference is repaired on the next
+            # proxy start. A concurrent save of undecodable bytes counts as
+            # changed (UnicodeDecodeError must not crash the proxy pre-spawn).
+            try:
+                unchanged = path.read_text(encoding="utf-8") == raw
+            except UnicodeDecodeError:
+                unchanged = False
+            if not unchanged:
+                logger.warning(
+                    "%s changed while repairing; leaving the concurrent edit in place",
+                    path,
+                )
+                return False
+            atomic_write(path, json.dumps(config, indent=2), mode=mode)
+            return True
+    except OSError:
+        # Unwritable config location (lock sidecar or rewrite failed): the
+        # drop cannot take effect (Playwright MCP reads the file itself), so
+        # surface that plainly instead of pretending the repair landed.
+        logger.warning(
+            "could not rewrite %s after dropping the stale storageState reference; "
+            "browser_* calls will keep failing until it is writable or regenerated "
+            "via 'kirocrew browse setup'",
+            path,
+        )
+        return False
 
 
 def refresh_storage_state() -> dict[str, Any]:

--- a/src/kiro_crew/mcp_playwright_proxy.py
+++ b/src/kiro_crew/mcp_playwright_proxy.py
@@ -1057,6 +1057,32 @@ def run_proxy(args: list[str]) -> None:
     from kiro_crew.env import node_augmented_path
 
     os.environ["PATH"] = node_augmented_path(os.environ.get("PATH", ""))
+
+    # Self-heal a stale config BEFORE handing it to @playwright/mcp: a
+    # contextOptions.storageState pointing at a missing file makes Playwright
+    # raise ENOENT at context creation, breaking every browser_* call (#2491).
+    # This spawn is the config's load moment — the one place every config-mode
+    # launch passes through — so repairing here (the helper drops the dangling
+    # key and rewrites the file to disk) closes the trap for configs written
+    # before the #2209 generation-time fix or whose storage-state file was
+    # later removed. No-config (extension-mode) launches skip this entirely.
+    # Both argv shapes @playwright/mcp accepts are matched: ``--config <path>``
+    # and ``--config=<path>``.
+    config_arg: str | None = None
+    for i, arg in enumerate(args):
+        if arg == "--config" and i + 1 < len(args):
+            config_arg = args[i + 1]
+            break
+        if arg.startswith("--config="):
+            config_arg = arg.split("=", 1)[1]
+            break
+    if config_arg:
+        # circular import: browser.setup imports from THIS module at its
+        # top level, so import at call time (once per proxy spawn, not hot).
+        from kiro_crew.browser.setup import repair_playwright_config
+
+        repair_playwright_config(config_arg)
+
     playwright_cmd = _resolve_playwright_cmd()
     if playwright_cmd is None:
         error_resp = {

--- a/test/test_browser_setup.py
+++ b/test/test_browser_setup.py
@@ -11,6 +11,7 @@ regardless. The enterprise-SSO cookie/storage-state flow remains OSS-neutralized
 from __future__ import annotations
 
 import json
+import logging
 import os
 import shutil
 import stat
@@ -37,6 +38,7 @@ from kiro_crew.browser.setup import (
     patch_mcp_headless,
     refresh_storage_state,
     register_playwright_proxy,
+    repair_playwright_config,
 )
 from kiro_crew.config.paths import config_dir
 from kiro_crew.mcp_utils import mcp_server_alias
@@ -715,6 +717,383 @@ class TestGeneratePlaywrightConfig:
         monkeypatch.setattr(setup_mod, "get_browser_engine", lambda: "webkit")
         config = json.loads(generate_playwright_config().read_text(encoding="utf-8"))
         assert config["browser"]["browserName"] == "webkit"
+
+
+class TestRepairPlaywrightConfig:
+    """Load-time self-heal of a dangling contextOptions.storageState (#2491).
+
+    #2209 fixed GENERATION (storageState only attached when the file exists),
+    but a config written before that fix — or whose storage-state file was
+    later removed — kept the dangling reference forever and broke every
+    browser_* call with ENOENT. repair_playwright_config() runs at the load
+    moment (proxy startup) and drops the key, persisting the repair to disk.
+    """
+
+    def _write_config(self, path: Path, context_options: dict | None) -> None:
+        config: dict = {
+            "browser": {
+                "browserName": "chromium",
+                "isolated": True,
+                "launchOptions": {"headless": True, "args": [], "channel": "chromium"},
+            },
+            "capabilities": ["network", "storage"],
+        }
+        if context_options is not None:
+            config["browser"]["contextOptions"] = context_options
+        path.write_text(json.dumps(config, indent=2), encoding="utf-8")
+
+    def test_dangling_storage_state_is_dropped_and_persisted(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ):
+        cfg = tmp_path / "playwright-config.json"
+        missing = tmp_path / "playwright-storage-state.json"
+        self._write_config(cfg, {"storageState": str(missing)})
+        assert not missing.exists()
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.browser.setup"):
+            assert repair_playwright_config(cfg) is True
+        # Persisted to disk: the repair must survive a restart, else the
+        # cached-config trap from the issue report stays reachable.
+        on_disk = json.loads(cfg.read_text(encoding="utf-8"))
+        assert "storageState" not in on_disk["browser"]["contextOptions"]
+        # The rest of the config is untouched.
+        assert on_disk["browser"]["browserName"] == "chromium"
+        assert on_disk["capabilities"] == ["network", "storage"]
+        # One clear WARNING names the missing file and the action taken.
+        assert any(
+            str(missing) in rec.message and "storageState" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_existing_storage_state_left_byte_identical(self, tmp_path: Path):
+        cfg = tmp_path / "playwright-config.json"
+        state = tmp_path / "playwright-storage-state.json"
+        state.write_text('{"cookies": [], "origins": []}', encoding="utf-8")
+        self._write_config(cfg, {"storageState": str(state)})
+        before = cfg.read_bytes()
+        assert repair_playwright_config(cfg) is False
+        assert cfg.read_bytes() == before
+
+    def test_config_without_storage_state_key_untouched(self, tmp_path: Path):
+        cfg = tmp_path / "playwright-config.json"
+        self._write_config(cfg, {})
+        before = cfg.read_bytes()
+        assert repair_playwright_config(cfg) is False
+        assert cfg.read_bytes() == before
+
+    def test_repair_is_idempotent_across_two_loads(self, tmp_path: Path):
+        cfg = tmp_path / "playwright-config.json"
+        self._write_config(cfg, {"storageState": str(tmp_path / "gone.json")})
+        assert repair_playwright_config(cfg) is True
+        after_first = cfg.read_bytes()
+        # Second load: already repaired — no gratuitous rewrite.
+        assert repair_playwright_config(cfg) is False
+        assert cfg.read_bytes() == after_first
+
+    def test_missing_config_file_is_noop(self, tmp_path: Path):
+        assert repair_playwright_config(tmp_path / "playwright-config.json") is False
+
+    def test_unparseable_config_untouched(self, tmp_path: Path):
+        # Never guess at rewriting a broken config the user may have
+        # hand-edited; Playwright MCP's own config error names the file.
+        cfg = tmp_path / "playwright-config.json"
+        cfg.write_text("{not json", encoding="utf-8")
+        before = cfg.read_bytes()
+        assert repair_playwright_config(cfg) is False
+        assert cfg.read_bytes() == before
+
+    def test_non_dict_shapes_untouched(self, tmp_path: Path):
+        cfg = tmp_path / "playwright-config.json"
+        for payload in ("[]", '{"browser": "nope"}', '{"browser": {"contextOptions": []}}'):
+            cfg.write_text(payload, encoding="utf-8")
+            before = cfg.read_bytes()
+            assert repair_playwright_config(cfg) is False
+            assert cfg.read_bytes() == before
+
+    def test_relative_storage_state_resolved_against_config_dir(self, tmp_path: Path):
+        # Playwright resolves a relative storageState against the CONFIG file's
+        # directory. A working relative reference must not be judged missing
+        # from the proxy's CWD and dropped — that would delete a valid
+        # authenticated-context reference, the inverse of the bug being fixed.
+        cfg = tmp_path / "playwright-config.json"
+        (tmp_path / "playwright-storage-state.json").write_text("{}", encoding="utf-8")
+        self._write_config(cfg, {"storageState": "playwright-storage-state.json"})
+        before = cfg.read_bytes()
+        assert repair_playwright_config(cfg) is False
+        assert cfg.read_bytes() == before
+
+    def test_relative_dangling_storage_state_repaired(self, tmp_path: Path):
+        cfg = tmp_path / "playwright-config.json"
+        self._write_config(cfg, {"storageState": "gone.json"})
+        assert repair_playwright_config(cfg) is True
+        on_disk = json.loads(cfg.read_text(encoding="utf-8"))
+        assert "storageState" not in on_disk["browser"]["contextOptions"]
+
+    @pytest.mark.skipif(not IS_POSIX, reason="POSIX permission bits")
+    def test_repair_preserves_file_mode(self, tmp_path: Path):
+        # An operator-tightened 0600 must not silently widen to the umask
+        # default when the repair rewrites the file.
+        cfg = tmp_path / "playwright-config.json"
+        self._write_config(cfg, {"storageState": str(tmp_path / "gone.json")})
+        cfg.chmod(0o600)
+        assert repair_playwright_config(cfg) is True
+        assert stat.S_IMODE(cfg.stat().st_mode) == 0o600
+
+    @pytest.mark.skipif(not IS_POSIX, reason="symlink semantics")
+    def test_repair_writes_through_symlink(self, tmp_path: Path):
+        # os.replace over the symlink path would swap the user's link for a
+        # regular file and leave the linked target unrepaired; the repair must
+        # resolve first and heal the target, preserving the link.
+        real = tmp_path / "real-config.json"
+        self._write_config(real, {"storageState": str(tmp_path / "gone.json")})
+        link = tmp_path / "playwright-config.json"
+        link.symlink_to(real)
+        assert repair_playwright_config(link) is True
+        assert link.is_symlink()
+        on_disk = json.loads(real.read_text(encoding="utf-8"))
+        assert "storageState" not in on_disk["browser"]["contextOptions"]
+
+    @pytest.mark.skipif(not IS_POSIX, reason="symlink semantics")
+    def test_relative_state_beside_symlink_is_kept(self, tmp_path: Path):
+        # Playwright resolves a relative storageState against the config path
+        # AS GIVEN — the LINK's directory. A valid state file beside the link
+        # must not be judged missing from the resolved target's directory and
+        # dropped.
+        link_dir = tmp_path / "linkside"
+        target_dir = tmp_path / "targetside"
+        link_dir.mkdir()
+        target_dir.mkdir()
+        real = target_dir / "real-config.json"
+        self._write_config(real, {"storageState": "state.json"})
+        (link_dir / "state.json").write_text("{}", encoding="utf-8")  # beside the LINK only
+        link = link_dir / "playwright-config.json"
+        link.symlink_to(real)
+        before = real.read_bytes()
+        assert repair_playwright_config(link) is False
+        assert real.read_bytes() == before
+
+    @pytest.mark.skipif(not IS_POSIX, reason="symlink semantics")
+    def test_link_and_target_share_one_lock_sidecar(self, tmp_path: Path):
+        # A writer addressing the link and one addressing the target must
+        # serialize on the SAME sidecar, or they lock independently and race.
+        from kiro_crew.browser.setup import _playwright_config_locked
+
+        real = tmp_path / "real-config.json"
+        real.write_text("{}", encoding="utf-8")
+        link_dir = tmp_path / "links"
+        link_dir.mkdir()
+        link = link_dir / "playwright-config.json"
+        link.symlink_to(real)
+        with _playwright_config_locked(link):
+            pass
+        with _playwright_config_locked(real):
+            pass
+        # Sidecar derived from the resolved path in both cases.
+        assert (tmp_path / "real-config.json.lock").exists()
+        assert not (link_dir / "playwright-config.json.lock").exists()
+
+    def test_repair_read_modify_write_runs_under_config_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The repair must serialize with generate_playwright_config via the
+        # shared interprocess lock, or its read-modify-write could install a
+        # stale snapshot over a concurrent generation (e.g. discarding a
+        # just-selected browser engine).
+        import contextlib as _contextlib
+
+        cfg = tmp_path / "playwright-config.json"
+        self._write_config(cfg, {"storageState": str(tmp_path / "gone.json")})
+        events: list[str] = []
+        real_atomic_write = setup_mod.atomic_write
+
+        @_contextlib.contextmanager
+        def recording_lock(path):
+            assert path == cfg.resolve()
+            events.append("lock-enter")
+            yield
+            events.append("lock-exit")
+
+        def recording_write(*a, **kw):
+            events.append("write")
+            return real_atomic_write(*a, **kw)
+
+        monkeypatch.setattr(setup_mod, "_playwright_config_locked", recording_lock)
+        monkeypatch.setattr(setup_mod, "atomic_write", recording_write)
+        assert repair_playwright_config(cfg) is True
+        # The write happened INSIDE the locked region.
+        assert events == ["lock-enter", "write", "lock-exit"]
+
+    def test_generate_takes_the_same_config_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        import contextlib as _contextlib
+
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        entered: list[Path] = []
+
+        @_contextlib.contextmanager
+        def recording_lock(path):
+            entered.append(path)
+            yield
+
+        monkeypatch.setattr(setup_mod, "_playwright_config_locked", recording_lock)
+        cfg_path = generate_playwright_config()
+        assert entered == [cfg_path]
+
+    def test_sensitive_path_refused_before_lock_or_read(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A --config argv pointing into a credential dir must be refused before
+        # the lock helper writes a sidecar next to it or any byte is read.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        ssh_dir = tmp_path / ".ssh"
+        ssh_dir.mkdir()
+        cfg = ssh_dir / "playwright-config.json"
+        self._write_config(cfg, {"storageState": str(tmp_path / "gone.json")})
+        before = cfg.read_bytes()
+        assert repair_playwright_config(cfg) is False
+        assert cfg.read_bytes() == before
+        # No lock sidecar was created inside the sensitive dir.
+        assert not (ssh_dir / "playwright-config.json.lock").exists()
+
+    @pytest.mark.skipif(not IS_POSIX, reason="symlink semantics")
+    def test_symlink_loop_is_safe_noop(self, tmp_path: Path):
+        # A --config path whose resolution hits a symlink loop (ELOOP) must not
+        # crash the proxy before it spawns Playwright — the unrepairable config
+        # is Playwright MCP's own error to report.
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        a.symlink_to(b)
+        b.symlink_to(a)
+        assert repair_playwright_config(a) is False
+
+    def test_concurrent_manual_edit_wins_over_repair(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The interprocess lock serializes in-codebase writers, but a manual
+        # editor takes no lock: if the file changes between the repair's
+        # snapshot and its write, the repair must stand down.
+        cfg = tmp_path / "playwright-config.json"
+        self._write_config(cfg, {"storageState": str(tmp_path / "gone.json")})
+        real_read_text = Path.read_text
+        winner = json.dumps({"browser": {"browserName": "firefox", "contextOptions": {}}})
+        cfg_paths = {cfg, cfg.resolve()}
+        calls = {"n": 0}
+
+        def racing_read_text(self, *a, **kw):  # noqa: ANN001
+            out = real_read_text(self, *a, **kw)
+            if self in cfg_paths:
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    # Simulate an unlocked manual edit landing right after the
+                    # repair's snapshot read.
+                    cfg.write_bytes(winner.encode("utf-8"))
+            return out
+
+        monkeypatch.setattr(Path, "read_text", racing_read_text)
+        assert repair_playwright_config(cfg) is False
+        monkeypatch.undo()
+        # The manual edit survived untouched.
+        assert cfg.read_text(encoding="utf-8") == winner
+
+    def test_concurrent_undecodable_save_stands_down_without_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A concurrent manual save of non-UTF-8 bytes between snapshot and
+        # write must count as "changed" (stand down), not raise
+        # UnicodeDecodeError and kill the proxy before it spawns Playwright.
+        cfg = tmp_path / "playwright-config.json"
+        self._write_config(cfg, {"storageState": str(tmp_path / "gone.json")})
+        real_read_text = Path.read_text
+        cfg_paths = {cfg, cfg.resolve()}
+        calls = {"n": 0}
+
+        def racing_read_text(self, *a, **kw):  # noqa: ANN001
+            if self in cfg_paths:
+                calls["n"] += 1
+                if calls["n"] == 2:
+                    # Second read (the pre-write recheck) sees undecodable bytes.
+                    raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+            return real_read_text(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "read_text", racing_read_text)
+        assert repair_playwright_config(cfg) is False
+
+    @pytest.mark.skipif(not IS_POSIX, reason="symlink semantics")
+    def test_planted_sidecar_symlink_is_refused_and_target_untouched(self, tmp_path: Path):
+        # An agent-plantable attack: a symlink pre-planted at the sidecar name
+        # (<config>.lock) pointing at a keystone flag file must NOT be followed
+        # — a follow-through create/truncate would forge the flag. The lock
+        # helper opens with O_NOFOLLOW and rejects non-regular files; the
+        # repair degrades to a safe no-op.
+        cfg = tmp_path / "playwright-config.json"
+        self._write_config(cfg, {"storageState": str(tmp_path / "gone.json")})
+        keystone = tmp_path / "browser-mode-enabled"
+        (tmp_path / "playwright-config.json.lock").symlink_to(keystone)
+        assert not keystone.exists()
+        assert repair_playwright_config(cfg) is False
+        # The planted link's target was neither created nor truncated, and the
+        # config was left untouched (repair refused, not half-applied).
+        assert not keystone.exists()
+        assert "storageState" in json.loads(cfg.read_text(encoding="utf-8"))["browser"][
+            "contextOptions"
+        ]
+
+    @pytest.mark.skipif(not IS_POSIX, reason="symlink semantics")
+    def test_planted_sidecar_refused_without_o_nofollow(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Windows has no O_NOFOLLOW: simulate that fallback path (lstat
+        # pre-check + samestat identity verify) by forcing the constant to 0.
+        from kiro_crew.browser.setup import _playwright_config_locked
+
+        monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+        cfg = tmp_path / "playwright-config.json"
+        self._write_config(cfg, {"storageState": str(tmp_path / "gone.json")})
+        keystone = tmp_path / "browser-mode-enabled"
+        (tmp_path / "playwright-config.json.lock").symlink_to(keystone)
+        with pytest.raises(OSError, match="symlink"):
+            with _playwright_config_locked(cfg):
+                pass
+        assert not keystone.exists()
+
+    def test_default_path_resolves_config_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # No explicit path: the helper targets <config_dir>/playwright-config.json
+        # — the file generate_playwright_config() writes and the proxy loads.
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        cfg = config_dir() / "playwright-config.json"
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        self._write_config(cfg, {"storageState": str(tmp_path / "gone.json")})
+        assert repair_playwright_config() is True
+        on_disk = json.loads(cfg.read_text(encoding="utf-8"))
+        assert "storageState" not in on_disk["browser"]["contextOptions"]
+
+    def test_generated_then_orphaned_config_round_trip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # End-to-end shape of the field failure: generate while the state file
+        # exists (key attached), delete the state file, then load — the repair
+        # converges the config on what a fresh generation would produce.
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        state = config_dir() / "playwright-storage-state.json"
+        state.parent.mkdir(parents=True, exist_ok=True)
+        state.write_text('{"cookies": [], "origins": []}', encoding="utf-8")
+        cfg_path = generate_playwright_config()
+        assert (
+            json.loads(cfg_path.read_text(encoding="utf-8"))["browser"]["contextOptions"][
+                "storageState"
+            ]
+            == str(state)
+        )
+        state.unlink()
+        assert repair_playwright_config(cfg_path) is True
+        repaired = json.loads(cfg_path.read_text(encoding="utf-8"))
+        fresh = json.loads(generate_playwright_config().read_text(encoding="utf-8"))
+        assert repaired == fresh
 
 
 # ── TestBrowseSetupHelpers (guided one-command setup) ────────────────────────

--- a/test/test_mcp_playwright_proxy.py
+++ b/test/test_mcp_playwright_proxy.py
@@ -1,5 +1,7 @@
 """Unit tests for mcp_playwright_proxy — compression, framing, error handling."""
 
+import json
+
 from kiro_crew import mcp_playwright_proxy as proxy
 from kiro_crew.mcp_playwright_proxy import (
     _compress_to_outline,
@@ -307,6 +309,119 @@ class TestResolvePlaywrightCmd:
 
         assert captured["cmd"] == [launcher]
         assert "npm_config_registry" not in captured["env"]
+
+
+class TestRunProxyConfigRepair:
+    """run_proxy self-heals the config at its load moment (#2491).
+
+    A stale contextOptions.storageState (file deleted, or config written
+    before the #2209 generation-time fix) made Playwright raise ENOENT at
+    context creation on every browser_* call, and the running playwright-mcp
+    process caches the config — so the repair must happen HERE, before the
+    spawn, not only at generation time.
+    """
+
+    def _arm(self, monkeypatch, captured):
+        class _FakeProc:
+            returncode = 0
+
+            def __init__(self, cmd, **kw):
+                captured["cmd"] = cmd
+                self.stdin = None
+                self.stdout = None
+
+            def wait(self, timeout=None):
+                return 0
+
+        monkeypatch.setattr(proxy, "_resolve_playwright_cmd", lambda: "/usr/bin/playwright-mcp")
+        monkeypatch.setattr(proxy.subprocess, "Popen", _FakeProc)
+        monkeypatch.setattr(proxy.threading, "Thread", lambda *a, **k: _NoopThread())
+        monkeypatch.setattr(proxy, "_read_message", lambda *a, **k: None)
+
+    def test_dangling_storage_state_repaired_before_spawn(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "playwright-config.json"
+        missing = tmp_path / "playwright-storage-state.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "browser": {
+                        "browserName": "chromium",
+                        "contextOptions": {"storageState": str(missing)},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        captured: dict = {}
+        self._arm(monkeypatch, captured)
+        try:
+            proxy.run_proxy(["--config", str(cfg)])
+        except SystemExit:
+            pass
+        # The on-disk config was healed BEFORE @playwright/mcp got spawned with it.
+        on_disk = json.loads(cfg.read_text(encoding="utf-8"))
+        assert "storageState" not in on_disk["browser"]["contextOptions"]
+        assert captured["cmd"][-2:] == ["--config", str(cfg)]
+
+    def test_config_equals_form_also_repaired(self, monkeypatch, tmp_path):
+        # @playwright/mcp accepts --config=<path> too; a hand-written mcp.json
+        # entry using the equals form must get the same self-heal.
+        cfg = tmp_path / "playwright-config.json"
+        missing = tmp_path / "playwright-storage-state.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "browser": {
+                        "browserName": "chromium",
+                        "contextOptions": {"storageState": str(missing)},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        captured: dict = {}
+        self._arm(monkeypatch, captured)
+        try:
+            proxy.run_proxy([f"--config={cfg}"])
+        except SystemExit:
+            pass
+        on_disk = json.loads(cfg.read_text(encoding="utf-8"))
+        assert "storageState" not in on_disk["browser"]["contextOptions"]
+
+    def test_no_config_arg_skips_repair(self, monkeypatch, tmp_path):
+        # Extension-mode launches carry no --config; the repair must not run
+        # (and must not guess at the default path from inside the proxy).
+        calls: list = []
+        import kiro_crew.browser.setup as setup_mod
+
+        monkeypatch.setattr(
+            setup_mod, "repair_playwright_config", lambda *a, **k: calls.append(a)
+        )
+        captured: dict = {}
+        self._arm(monkeypatch, captured)
+        try:
+            proxy.run_proxy(["--extension"])
+        except SystemExit:
+            pass
+        assert calls == []
+
+    def test_trailing_config_flag_without_value_is_safe(self, monkeypatch):
+        # Malformed argv (--config as last arg) must neither crash the proxy
+        # nor invoke the repair (which would guess at a path).
+        calls: list = []
+        import kiro_crew.browser.setup as setup_mod
+
+        monkeypatch.setattr(
+            setup_mod, "repair_playwright_config", lambda *a, **k: calls.append(a)
+        )
+        captured: dict = {}
+        self._arm(monkeypatch, captured)
+        try:
+            proxy.run_proxy(["--config"])
+        except SystemExit:
+            pass
+        assert captured["cmd"][-1] == "--config"
+        assert calls == []
 
 
 class _NoopThread:


### PR DESCRIPTION
## Summary

Fixes the rc.8 regression where Browser Mode hard-breaks forever when `playwright-config.json` carries a `contextOptions.storageState` pointing at a file that no longer exists (#2209 reproduced). #2209 fixed **generation** — `generate_playwright_config()` only attaches the key when the file exists — but nothing re-validated an already-written config, so one generated before that fix (or whose storage-state file was later removed) kept the dangling reference forever. Playwright raises ENOENT at context creation for it, breaking every `browser_*` call, and the running playwright-mcp process caches the config, so regeneration alone couldn't recover a live session.

**The fix:** `repair_playwright_config()` (`browser/setup.py`) runs at the config's load moment — proxy startup in `run_proxy()`, the one place every config-mode launch passes through (both `--config <path>` and `--config=<path>` forms). When the referenced storage-state file is missing, it drops the key — converging on the exact behaviour a fresh generation produces, so Browser Mode degrades to an unauthenticated context instead of dying — rewrites the config atomically so the repair survives restarts, and logs one WARNING naming the missing file and the action taken.

Deliberately NOT done (per the issue): no process-killing, no transport-restart — those were symptoms; once a stale config self-heals at load, the manual recovery sequence is unnecessary. No re-seeding via `refresh_storage_state()` — it is a documented no-op without a cookie source (the OSS default); if a cookie source ever writes the file back, the untouched-when-present branch keeps the key on the next load.

### Hardening (pre-push review fleet findings, all applied)
- **Symlinked configs** are repaired *through* the link (`path.resolve()` before read/write) — `os.replace` would otherwise swap the user's link for a regular file.
- **Relative `storageState`** is judged from the config file's directory (Playwright's vantage), not the proxy CWD — a working hand-edited relative reference is never dropped.
- **File mode preserved** on rewrite (an operator-tightened 0600 doesn't widen to umask default).
- **Interprocess lock:** a new `_playwright_config_locked` flock sidecar (pattern from the module's existing `_kiro_mcp_locked`) serializes BOTH writers of `playwright-config.json` — `generate_playwright_config()` and the repair's read-validate-write. The sidecar is derived from the resolved path (link and target converge on one lock), created with `O_NOFOLLOW` + regular-file re-check so a pre-planted symlink at the sidecar name cannot forge a keystone flag. A re-read stand-down inside the locked region additionally yields to unlocked MANUAL edits (decode errors count as changed).
- A config that is **valid, keyless, absent, or unparseable is left byte-for-byte untouched** (unparseable falls through to Playwright MCP's own config error, which names the file — never guess-rewrite a hand-edited config).

## Testing

- 12 new tests: `TestRepairPlaywrightConfig` (repair + persist + WARNING; present-file byte-identical; keyless untouched; idempotent across two loads; missing/unparseable/non-dict shapes untouched; relative-path both branches; 0600 preserved (POSIX); symlink write-through (POSIX); concurrent-writer stand-down; default-path resolution; generate→orphan→repair round-trip converges with fresh generation) and `TestRunProxyConfigRepair` (repaired before spawn; `--config=` form; no-config skip; trailing-flag safe + repair not invoked).
- Full backend suite: 40,276 passed; the 78 residual failures were re-run against pristine `origin/main` on the same host — **identical failure sets** (host forbids user namespaces → `SandboxUnavailableError`; zero net-new failures).
- `isort` / `flake8` clean; `mypy`: 0 errors in touched files.

## Review fleet

Pre-push model-pinned reviewers: GPT 5.6 Sol (3 findings — mode preservation, symlink clobber, lost-update race) and Opus 5 (0 blocking, 4 advisories — relative-path vantage, `--config=` form, mode preservation, test strengthening). All applied; the interprocess-lock suggestion for the race was scoped down to the read-recheck stand-down documented above, since no lock exists for this file today and adding one across all generation paths exceeds this fix's blast radius.

Closes #2491

