### PR TITLE
fix(cli): match macOS framework Python in stop/restart gateway detection

### DIFF
--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -622,8 +622,13 @@ def _args_look_like_kirocrew(args: str) -> bool:
         if token == "-m" and index + 1 < len(tokens):
             # Only treat "-m" as Python's module flag when a Python interpreter
             # precedes it; otherwise an unrelated tool's "-m" option could be
-            # misread (e.g. "grep -m kiro_crew gateway file").
-            interpreter_seen = any(_basename_stem(t).startswith("python") for t in tokens[:index])
+            # misread (e.g. "grep -m kiro_crew gateway file"). The match is
+            # case-insensitive: the macOS framework build's interpreter basename
+            # is "Python" (capital P), which a case-sensitive startswith would
+            # miss, leaving stop/restart unable to find the gateway.
+            interpreter_seen = any(
+                _basename_stem(t).lower().startswith("python") for t in tokens[:index]
+            )
             if interpreter_seen:
                 # "kiro_crew.gateway" -> ("kiro_crew", "gateway"); a bare
                 # "kiro_crew" -> ("kiro_crew", "").

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1746,6 +1746,13 @@ class TestArgsLookLikeKirocrew:
             "python3 -m kiro_crew gateway",
             "python -m kiro_crew dashboard",
             "python3.10 -m kiro_crew start",
+            # macOS framework build: the vendored interpreter's basename is
+            # "Python" (capital P) — a case-sensitive startswith("python") missed
+            # it, so stop/restart no-oped on macOS framework-build installs
+            # (Toolbox being the common one).
+            "/Library/Frameworks/Python.framework/Versions/3.10/Resources/"
+            "Python.app/Contents/MacOS/Python -m kiro_crew gateway --no-open",
+            "Python -m kiro_crew gateway",
             # Subcommand followed by trailing flags.
             "python -m kiro_crew gateway --no-open --port 7777",
             # Legacy dotted-submodule form.


### PR DESCRIPTION
## Problem / Motivation
On macOS, `kirocrew stop` (and `restart`) print "No Kiro Crew gateway currently running on port <p>" even when the gateway is live and listening on that port — so neither command can stop the server.

## Why it matters
Hits any macOS install whose interpreter is a framework build (Toolbox is the common one): `stop` is a no-op and `restart` can't kill the old gateway then fails to rebind, while `status` still reports "running" — the commands contradict each other. Users fall back to `kill $(lsof -ti TCP:<port> -sTCP:LISTEN)`.

## What changed (motivation → approach → change)
- Symptom: `kirocrew stop` says no gateway while one is listening on the port.
- Root cause: `_stop`/`_restart` locate the PID via `lsof`, then gate the kill on `_is_kirocrew_process` → `_args_look_like_kirocrew`. The module-invocation branch requires a token before `-m` whose basename starts with "python", but the check was case-sensitive (`_basename_stem(t).startswith("python")`). A macOS framework build's interpreter basename is `Python` (capital P) — e.g. `.../Python.app/Contents/MacOS/Python -m kiro_crew gateway` — so the guard rejects the real gateway and the command no-ops.
- Change: lower-case the interpreter basename before the prefix match (`_basename_stem(t).lower().startswith("python")`). One line; strictly widens to include `Python`/`PYTHON`, no effect on the negative cases (which fail for structural reasons, not interpreter case).

## Tests
Added two launch forms to `TestArgsLookLikeKirocrew.test_matches_server_launch_forms`: a macOS framework path (`/Library/Frameworks/Python.framework/Versions/3.10/Resources/Python.app/Contents/MacOS/Python -m kiro_crew gateway --no-open`) and a bare `Python -m kiro_crew gateway`. Both fail before the fix and pass after; existing negative cases (`GATEWAY`, `grep -m`, `run gateway`, editor) unchanged.

## Manual verification
Reproduced on macOS: gateway live on the port (`lsof` shows `Python … (LISTEN)`), `kirocrew stop` printed "No Kiro Crew gateway currently running"; `ps -o command=` confirmed the process is `.../Python.app/Contents/MacOS/Python -m kiro_crew gateway`. With the fix, the classifier recognizes that command line.

## Related Issues
None found in a search of open issues/PRs.

## Checklist
- [x] Single commit with a Conventional Commits title (`fix(cli): ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated — N/A
- [x] No secrets, credentials, or internal references in the diff