### PR TITLE
fix(notifications): preserve optimistic acknowledgements

### DIFF
--- a/website/src/store/notificationsSlice.ts
+++ b/website/src/store/notificationsSlice.ts
@@ -10,9 +10,20 @@ interface NotificationsState {
    *  instead of replacing the emptied list — which would resurrect the rows
    *  and the bell badge with them. */
   clearSeq: number
+  mutationVersion: number
+  latestFetchSequence: number
+  fetchSnapshots: Record<string, { mutationVersion: number, sequence: number }>
+  optimisticMutationCount: number
 }
 
-const initialState: NotificationsState = { items: [], clearSeq: 0 }
+const initialState: NotificationsState = {
+  items: [],
+  clearSeq: 0,
+  mutationVersion: 0,
+  latestFetchSequence: 0,
+  fetchSnapshots: {},
+  optimisticMutationCount: 0,
+}
 
 /** Ring-buffer cap on the notifications list. Without it, `items` grows
  *  monotonically for the tab's lifetime (ack only flips a flag) — part of
@@ -24,6 +35,44 @@ export const NOTIFICATIONS_RING_CAP = 200
 
 const capped = (items: Notification[]): Notification[] =>
   items.length > NOTIFICATIONS_RING_CAP ? items.slice(items.length - NOTIFICATIONS_RING_CAP) : items
+
+const markMutation = (state: NotificationsState) => {
+  state.mutationVersion = (state.mutationVersion ?? 0) + 1
+}
+
+const beginOptimisticMutation = (state: NotificationsState) => {
+  markMutation(state)
+  state.optimisticMutationCount = (state.optimisticMutationCount ?? 0) + 1
+}
+
+const finishOptimisticMutation = (state: NotificationsState) => {
+  if (!(state.optimisticMutationCount ?? 0)) return
+  state.optimisticMutationCount--
+  markMutation(state)
+}
+
+const beginFetch = (state: NotificationsState, requestId: string) => {
+  const sequence = (state.latestFetchSequence ?? 0) + 1
+  state.latestFetchSequence = sequence
+  const snapshots = state.fetchSnapshots ?? (state.fetchSnapshots = {})
+  snapshots[requestId] = { mutationVersion: state.mutationVersion ?? 0, sequence }
+}
+
+const applyFetchedNotifications = (
+  state: NotificationsState,
+  payload: { items: Notification[], seq: number },
+  requestId: string,
+) => {
+  const snapshots = state.fetchSnapshots ?? {}
+  const snapshot = snapshots[requestId]
+  delete snapshots[requestId]
+  if (!snapshot
+    || snapshot.sequence !== state.latestFetchSequence
+    || state.optimisticMutationCount
+    || snapshot.mutationVersion < (state.mutationVersion ?? 0)
+    || payload.seq !== (state.clearSeq ?? 0)) return
+  state.items = capped(payload.items)
+}
 
 export const fetchNotifications = createAsyncThunk(
   'notifications/fetch',
@@ -55,17 +104,17 @@ export const deleteNotification = createAsyncThunk(
 
 export const ackNotification = createAsyncThunk(
   'notifications/ack',
-  async (ts: string) => { api.ackNotification(ts).catch(() => {}); return ts },
+  async (ts: string) => { await api.ackNotification(ts); return ts },
 )
 
 export const unackNotification = createAsyncThunk(
   'notifications/unack',
-  async (ts: string) => { api.unackNotification(ts).catch(() => {}); return ts },
+  async (ts: string) => { await api.unackNotification(ts); return ts },
 )
 
 export const ackAllNotifications = createAsyncThunk(
   'notifications/ackAll',
-  async () => { api.ackAllNotifications().catch(() => {}) },
+  async () => { await api.ackAllNotifications() },
 )
 
 const notificationsSlice = createSlice({
@@ -76,67 +125,103 @@ const notificationsSlice = createSlice({
       if (!state.items.some(n => n.ts === action.payload.ts)) {
         state.items.push(action.payload)
         state.items = capped(state.items)
+        markMutation(state)
       }
     },
     ackNotificationByTs(state, action: PayloadAction<string>) {
       if (action.payload === '*') {
-        for (const n of state.items) n.acked = true
+        let changed = false
+        for (const n of state.items) {
+          if (!n.acked) {
+            n.acked = true
+            changed = true
+          }
+        }
+        if (changed) markMutation(state)
       } else {
-        state.items = state.items.map(n =>
-          n.ts === action.payload ? { ...n, acked: true } : n
-        )
+        const notification = state.items.find(n => n.ts === action.payload)
+        if (notification && !notification.acked) {
+          notification.acked = true
+          markMutation(state)
+        }
       }
     },
     unackNotificationByTs(state, action: PayloadAction<string>) {
-      state.items = state.items.map(n =>
-        n.ts === action.payload ? { ...n, acked: false } : n
-      )
+      const notification = state.items.find(n => n.ts === action.payload)
+      if (notification && notification.acked !== false) {
+        notification.acked = false
+        markMutation(state)
+      }
     },
     removeNotificationByTs(state, action: PayloadAction<string>) {
-      state.items = state.items.filter(n => n.ts !== action.payload)
+      const items = state.items.filter(n => n.ts !== action.payload)
+      if (items.length !== state.items.length) {
+        state.items = items
+        markMutation(state)
+      }
     },
-    /** WS `notifications_clear` sync: another view cleared the inbox, so this
-     *  view drops its copy too (the bell badge derives from `items`).
-     *  Idempotent — clearing an already-empty list is a no-op. */
+    /** WS `notifications_clear` sync drops this view's copy and advances the
+     *  fetch epoch, so a response started before the clear cannot restore it. */
     clearAllNotifications(state) {
       state.items = []
-      state.clearSeq += 1
+      state.clearSeq = (state.clearSeq ?? 0) + 1
+      markMutation(state)
     },
   },
   extraReducers: (builder) => {
     builder
+      .addCase(fetchNotifications.pending, (state, action) => {
+        beginFetch(state, action.meta.requestId)
+      })
       .addCase(fetchNotifications.fulfilled, (state, action) => {
-        // Stale response: a clear landed while this fetch was in flight, so
-        // its payload predates the clear. Applying it would restore the rows
-        // and the badge with them.
-        if (action.payload.seq !== state.clearSeq) return
-        state.items = capped(action.payload.items)
+        applyFetchedNotifications(state, action.payload, action.meta.requestId)
+      })
+      .addCase(fetchNotifications.rejected, (state, action) => {
+        delete (state.fetchSnapshots ?? {})[action.meta.requestId]
       })
       .addCase(clearNotifications.fulfilled, (state, action) => {
-        // The generation moved while the request was in flight, so the
-        // `notifications_clear` frame for this clear already emptied the list.
-        // Anything present now was delivered AFTER the clear and is still held
-        // by the backend — emptying again would delete a live notification.
-        // This reducer remains the fallback for a view whose socket is down;
-        // such a view converges here, and on reconnect via the refetch.
-        if (action.payload.seq !== state.clearSeq) return
+        // The clear's socket frame can already have emptied this view. In that
+        // case, leave notifications delivered after the clear intact.
+        if (action.payload.seq !== (state.clearSeq ?? 0)) return
         state.items = []
-        state.clearSeq += 1
+        state.clearSeq = (state.clearSeq ?? 0) + 1
+        markMutation(state)
       })
       .addCase(deleteNotification.fulfilled, (state, action) => {
         state.items = state.items.filter(n => n.ts !== action.payload)
+        markMutation(state)
       })
-      // Optimistic: update Redux immediately, fire-and-forget to backend
       .addCase(ackNotification.pending, (state, action) => {
         const n = state.items.find(i => i.ts === action.meta.arg)
         if (n) n.acked = true
+        beginOptimisticMutation(state)
+      })
+      .addCase(ackNotification.fulfilled, (state) => {
+        finishOptimisticMutation(state)
+      })
+      .addCase(ackNotification.rejected, (state) => {
+        finishOptimisticMutation(state)
       })
       .addCase(unackNotification.pending, (state, action) => {
         const n = state.items.find(i => i.ts === action.meta.arg)
         if (n) n.acked = false
+        beginOptimisticMutation(state)
+      })
+      .addCase(unackNotification.fulfilled, (state) => {
+        finishOptimisticMutation(state)
+      })
+      .addCase(unackNotification.rejected, (state) => {
+        finishOptimisticMutation(state)
       })
       .addCase(ackAllNotifications.pending, (state) => {
         for (const n of state.items) n.acked = true
+        beginOptimisticMutation(state)
+      })
+      .addCase(ackAllNotifications.fulfilled, (state) => {
+        finishOptimisticMutation(state)
+      })
+      .addCase(ackAllNotifications.rejected, (state) => {
+        finishOptimisticMutation(state)
       })
   },
 })

--- a/website/src/test/chatSlice.slotPrune.test.ts
+++ b/website/src/test/chatSlice.slotPrune.test.ts
@@ -97,9 +97,8 @@ describe('notificationsSlice ring cap', () => {
 
   it('caps the fetch path too, keeping the newest entries', () => {
     const items = Array.from({ length: NOTIFICATIONS_RING_CAP + 50 }, (_, i) => notif(i))
-    // seq 0 matches the initial clear generation, so the payload is applied.
-    const payload = { items, seq: 0 }
-    const state = notifReducer(undefined, { type: fetchNotifications.fulfilled.type, payload })
+    let state = notifReducer(undefined, fetchNotifications.pending('notification-cap', undefined))
+    state = notifReducer(state, fetchNotifications.fulfilled({ items, seq: 0 }, 'notification-cap'))
     expect(state.items).toHaveLength(NOTIFICATIONS_RING_CAP)
     expect(state.items[0].ts).toBe('50')
   })

--- a/website/src/test/notificationsSlice.test.ts
+++ b/website/src/test/notificationsSlice.test.ts
@@ -25,6 +25,7 @@ vi.mock('../api/client', () => ({
 
 const n1: Notification = { kind: 'cron', title: 'Job done', body: 'output', ts: '1' }
 const n2: Notification = { kind: 'approval', title: 'Approve?', body: 'tool X', ts: '2' }
+const fetched = (items: Notification[], seq = 0) => ({ items, seq })
 
 describe('notificationsSlice', () => {
   describe('reducers', () => {
@@ -53,26 +54,71 @@ describe('notificationsSlice', () => {
 
   describe('extraReducers', () => {
     it('fetchNotifications.fulfilled replaces items', () => {
-      const state = reducer({ items: [n1], clearSeq: 0 }, fetchNotifications.fulfilled({ items: [n2], seq: 0 }, ''))
+      let state = reducer({ items: [n1] }, fetchNotifications.pending('fetch', undefined))
+      state = reducer(state, fetchNotifications.fulfilled(fetched([n2]), 'fetch'))
       expect(state.items).toEqual([n2])
     })
 
-    it('fetchNotifications.fulfilled is dropped when a clear landed mid-flight', () => {
-      // The fetch started at generation 0; a clear bumped it to 1 while the
-      // request was in flight, so this payload predates the clear. Applying it
-      // would resurrect the rows and the bell badge with them.
-      const state = reducer({ items: [], clearSeq: 1 }, fetchNotifications.fulfilled({ items: [n1, n2], seq: 0 }, ''))
-      expect(state.items).toEqual([])
+    it('keeps the newest fetch response when requests overlap', () => {
+      let state = reducer(undefined, addNotification(n1))
+      state = reducer(state, fetchNotifications.pending('older', undefined))
+      state = reducer(state, fetchNotifications.pending('newer', undefined))
+
+      state = reducer(state, fetchNotifications.fulfilled(fetched([n2]), 'newer'))
+      expect(state.items).toEqual([n2])
+
+      state = reducer(state, fetchNotifications.fulfilled(fetched([n1]), 'older'))
+      expect(state.items).toEqual([n2])
     })
 
-    it('a fetch started after the clear still applies', () => {
-      const state = reducer({ items: [], clearSeq: 1 }, fetchNotifications.fulfilled({ items: [n1], seq: 1 }, ''))
-      expect(state.items).toEqual([n1])
+    it('keeps an acknowledgement while its request is unsettled', () => {
+      let state = reducer(undefined, addNotification(n1))
+      state = reducer(state, ackNotification.pending('ack', '1'))
+      state = reducer(state, fetchNotifications.pending('stale', undefined))
+      state = reducer(state, fetchNotifications.fulfilled(fetched([{ ...n1, acked: false }]), 'stale'))
+
+      expect(state.items[0]?.acked).toBe(true)
+      state = reducer(state, ackNotification.fulfilled('1', 'ack', '1'))
+      expect(state.items[0]?.acked).toBe(true)
+    })
+
+    it('does not let a server-sent acknowledgement get overwritten by an earlier fetch', () => {
+      let state = reducer(undefined, addNotification(n1))
+      state = reducer(state, fetchNotifications.pending('stale', undefined))
+      state = reducer(state, ackNotificationByTs('1'))
+      state = reducer(state, fetchNotifications.fulfilled(fetched([{ ...n1, acked: false }]), 'stale'))
+
+      expect(state.items[0]?.acked).toBe(true)
+    })
+
+    it('does not resurrect a deleted notification from an earlier fetch', () => {
+      let state = reducer(undefined, addNotification(n1))
+      state = reducer(state, addNotification(n2))
+      state = reducer(state, fetchNotifications.pending('stale', undefined))
+      state = reducer(state, deleteNotification.fulfilled('1', 'delete', '1'))
+      state = reducer(state, fetchNotifications.fulfilled(fetched([n1, n2]), 'stale'))
+
+      expect(state.items).toEqual([n2])
+    })
+
+    it('does not restore notifications after a clear', () => {
+      let state = reducer(undefined, addNotification(n1))
+      state = reducer(state, fetchNotifications.pending('stale', undefined))
+      state = reducer(state, clearNotifications.fulfilled({ seq: 0 }, 'clear'))
+      state = reducer(state, fetchNotifications.fulfilled(fetched([n1]), 'stale'))
+
+      expect(state.items).toEqual([])
     })
 
     it('clearNotifications.fulfilled empties items', () => {
       const state = reducer({ items: [n1, n2], clearSeq: 0 }, clearNotifications.fulfilled({ seq: 0 }, ''))
       expect(state.items).toEqual([])
+    })
+
+    it('a fetch started after the clear still applies', () => {
+      let state = reducer({ items: [], clearSeq: 1 }, fetchNotifications.pending('after-clear', undefined))
+      state = reducer(state, fetchNotifications.fulfilled(fetched([n1], 1), 'after-clear'))
+      expect(state.items).toEqual([n1])
     })
 
     it('clearNotifications.fulfilled does not re-empty after the WS frame applied the clear', () => {


### PR DESCRIPTION
## Problem / motivation

An older notification fetch can finish after a newer local notification change and replace the current list with its stale server snapshot. That could revert an acknowledgement, resurrect a deletion, or restore a cleared feed.

## Why it matters

Notification state is updated by fetches, local actions, and server-sent events. A late response must not erase work that became visible after that request began.

## Approach

- Order fetches and apply only the latest request response.
- Snapshot the notification mutation version at request start and discard a response when later local changes exist.
- Keep responses out while an optimistic acknowledgement request is still pending, then invalidate fetches that began before it settled.
- Preserve the clear epoch so a clear confirmation cannot erase notifications delivered after its WebSocket frame.
- Use the same rule for acknowledgement, delete, clear, and server-sent notification updates.
- Keep fetch bookkeeping bounded and make tests dispatch the real thunk lifecycle.

## Test details

- npx vitest run src/test/notificationsSlice.test.ts src/test/chatSlice.slotPrune.test.ts: 25 passed
- npx tsc -b
- npx eslint src/store/notificationsSlice.ts src/test/notificationsSlice.test.ts src/test/chatSlice.slotPrune.test.ts
- npm run build

## Manual verification

N/A. This is a reducer-only concurrency fix covered by lifecycle-level tests.

## Screenshot

N/A. No component or visual layout changed.

Fixes #2519

## Checklist

- [x] I have read the contribution guidance.
- [x] I have added focused regression coverage.
- [x] I have run the relevant local checks.
- [x] I have not changed user-visible copy or visual layout.
- [x] CLA: N/A