### PR TITLE
fix: stop consolidator replacing memory files with "unchanged"

### DIFF
--- a/docs/system-specs/modules/history.md
+++ b/docs/system-specs/modules/history.md
@@ -413,6 +413,19 @@ cron/heartbeat/lesson extraction) to extract:
 - `preferences_update` → overwrites `preferences.md` if changed
 - `projects_update` → overwrites `projects.md` if changed
 
+Both markdown writes are **guarded compare-and-swap** writes, offloaded via
+`asyncio.to_thread` because the guarded writers take a cross-process advisory
+lock and this coroutine runs on the event loop thread. The prompt asks for the
+complete file and the reply is written verbatim, so the consolidator passes the
+pre-LLM snapshot as `expected=` to `write_preferences` / `write_projects`: if a
+concurrent session rewrote the file during the LLM turn (seconds), the reply was
+computed from a stale view and is dropped rather than clobbering the newer
+content, and the next consolidation re-merges from fresh. The same writers
+reject degenerate bodies — see the guard in `memory-skills-hooks.md`. Both
+prompt keys explicitly forbid answering with a placeholder such as `unchanged`,
+which a model would otherwise emit in response to "repeat the existing content
+if nothing changed" and which used to replace the entire file with that word.
+
 Non-blocking via `asyncio.create_task`. Requires `SessionManager` to be passed
 at construction time; consolidation is silently skipped if no session manager
 is available.

--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -48,6 +48,16 @@ FTS5 search via `~/.kiro/crew/memory_index.db` (SQLite via `pysqlite3-binary` on
 
 Context injection includes source citations per section. Agent can update memory files via kiro-cli's file tools.
 
+### Guarded Writes (`write_preferences`, `write_projects`)
+
+Both files are replaced wholesale by the consolidator from an LLM reply, so the writers protect against the two ways that destroys content. Each returns `True` when the write landed and `False` when it was rejected, and runs its check plus the write under an exclusive cross-process advisory lock (`memory/.write.lock`) with an atomic `atomic_write` rename.
+
+**Loop safety:** lock acquisition is non-blocking with a bounded retry (`_WRITE_LOCK_TIMEOUT_SECS`, 5s; never a bare blocking `flock`), so a wedged holder makes the write fail closed: it raises `MemoryWriteLockTimeout` rather than write unserialized (which could lose a concurrent update) or stall the caller forever, and callers on the event loop offload the write and turn the timeout into a transient retry. The writers are nonetheless synchronous and must not run on the event loop thread: `_consolidate` and the dashboard memory handlers offload them via `asyncio.to_thread`, and `test_context.py::TestAsyncCallSitesUseToThread` fails the build if a new coroutine calls either writer inline (same static-guard treatment as `build_message`).
+
+- **Degenerate-write guard.** `degenerate_write_reason(new, current)` rejects a body that is empty, that is a placeholder from `_DEGENERATE_BODIES` (`unchanged`, `no changes`, `n/a`, …), or that keeps less than `_MIN_RETAINED_FRACTION` (20%) of a substantive existing file (`_SHRINK_GUARD_MIN_CHARS`, 400 chars). Comparison runs on the *body* (`_memory_body`), which strips the H1 title, the `_Updated:` stamp, and HTML comments, so `unchanged` and `# Active Projects\n\nunchanged` are caught alike.
+- **Compare-and-swap.** When `expected=` is supplied, the write lands only if the on-disk content still matches it. Callers that read, compute for seconds, then write (the consolidator) pass their pre-computation snapshot so a concurrent session's update is never silently lost. Omitting `expected` keeps the old last-writer-wins behavior.
+- **`force=True`** bypasses both checks for an explicit human or fixture write that intends to shrink or clear the file: the dashboard memory editor (`PUT /api/memory/projects`), the legacy combined `write()`, and eval seeding.
+
 ### Decaying Memory (`read_recent_history`)
 
 History context uses natural decay: recent days in full detail, older days

--- a/src/kiro_crew/dashboard/handlers/memory.py
+++ b/src/kiro_crew/dashboard/handlers/memory.py
@@ -40,6 +40,7 @@ from kiro_crew.embeddings import (
     validate_custom_model_path,
 )
 from kiro_crew.executors import embed_executor, run_in_embed_pool
+from kiro_crew.memory import MemoryWriteLockTimeout
 from kiro_crew.sandbox import (
     SandboxUnavailableError,
     cgroup_scope_argv,
@@ -75,7 +76,16 @@ async def api_memory_preferences(request: web.Request) -> web.Response:
         except Exception:
             return web.json_response({"error": "invalid JSON"}, status=400)
         content = body.get("content", "")
-        mem.write_preferences(content)
+        # Explicit human edit from the memory editor: honour it even when it
+        # shrinks or clears the file.  Offloaded — the guarded writer takes a
+        # cross-process lock and this handler runs on the event loop.
+        try:
+            await asyncio.to_thread(mem.write_preferences, content, force=True)
+        except MemoryWriteLockTimeout:
+            return web.json_response(
+                {"error": "memory busy, retry", "code": "memory_write_locked"},
+                status=503,
+            )
         return web.json_response({"ok": True})
     return web.json_response({"content": mem.read_preferences()})
 
@@ -90,7 +100,16 @@ async def api_memory_projects(request: web.Request) -> web.Response:
         except Exception:
             return web.json_response({"error": "invalid JSON"}, status=400)
         content = body.get("content", "")
-        mem.write_projects(content)
+        # Explicit human edit from the memory editor: honour it even when it
+        # shrinks or clears the file.  Offloaded — the guarded writer takes a
+        # cross-process lock and this handler runs on the event loop.
+        try:
+            await asyncio.to_thread(mem.write_projects, content, force=True)
+        except MemoryWriteLockTimeout:
+            return web.json_response(
+                {"error": "memory busy, retry", "code": "memory_write_locked"},
+                status=503,
+            )
         return web.json_response({"ok": True})
     return web.json_response({"content": mem.read_projects()})
 

--- a/src/kiro_crew/eval/runner.py
+++ b/src/kiro_crew/eval/runner.py
@@ -136,9 +136,9 @@ def _seed_profile(ws: Path, seed: SeedProfile) -> None:
     memory = MemoryStore(workspace=ws)
     memory.init()
     if seed.preferences:
-        memory.write_preferences(seed.preferences)
+        memory.write_preferences(seed.preferences, force=True)
     if seed.projects:
-        memory.write_projects(seed.projects)
+        memory.write_projects(seed.projects, force=True)
     if seed.lessons:
         lessons_file = ws / "lessons.jsonl"
         with lessons_file.open("a", encoding="utf-8") as f:

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -28,6 +28,7 @@ from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.llm_helpers import ToolApprovalPolicy, stream_and_collect, stream_and_collect_json
+from kiro_crew.memory import MemoryWriteLockTimeout, degenerate_write_reason
 from kiro_crew.messaging.link import legacy_key
 from kiro_crew.preview_text import strip_markdown_preview
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
@@ -4542,12 +4543,19 @@ class HistoryConsolidator:
                     '"preferences_update": The COMPLETE updated preferences file. '
                     "Merge duplicates, keep only newest if contradicted, remove stale "
                     "one-off observations. Keep '# User Preferences' header. "
-                    "Return existing content exactly if nothing changed."
+                    "If nothing changed, repeat the existing content above verbatim. "
+                    "NEVER answer with a placeholder such as 'unchanged' or 'no "
+                    "changes': the reply is written directly to the file, so a "
+                    "placeholder destroys it."
                 )
                 keys.append(
                     '"projects_update": The COMPLETE updated projects file. '
                     "Only active projects, remove stale entries, update facts. "
-                    "Keep '# Active Projects' header. Return existing if unchanged."
+                    "Keep '# Active Projects' header. "
+                    "If nothing changed, repeat the existing content above verbatim. "
+                    "NEVER answer with a placeholder such as 'unchanged' or 'no "
+                    "changes': the reply is written directly to the file, so a "
+                    "placeholder destroys it."
                 )
 
             if include_history:
@@ -4609,6 +4617,60 @@ class HistoryConsolidator:
                     )
                 return None
 
+            # Markdown writes FIRST, before any durable side effect
+            # (append_history, structured memory, lessons, mark_consolidated).
+            # current_prefs / current_projects were read BEFORE the LLM turn,
+            # which takes seconds; a concurrent session can rewrite either file
+            # in that window. Passing the snapshot as expected= makes each write
+            # a compare-and-swap. A placeholder/degenerate reply is a benign
+            # no-op (the guard rejects it and we proceed). But if an otherwise
+            # substantive reply is rejected, the file moved on: this reply was
+            # computed from a stale view, so abort the whole consolidation
+            # before anything durable is written and retry the full span next
+            # cycle -- otherwise we would append a history summary while leaving
+            # the offset unadvanced, duplicating it on retry.
+            #
+            # Offloaded: this coroutine runs on the event loop thread and the
+            # guarded writers take a cross-process advisory lock; waiting inline
+            # would stall heartbeats, Slack and the dashboard.
+            if not self._migrated:
+                stale = False
+                try:
+                    if prefs := result.get("preferences_update"):
+                        if prefs.strip() != current_prefs.strip():
+                            wrote = await asyncio.to_thread(
+                                memory.write_preferences, prefs, expected=current_prefs
+                            )
+                            if not wrote and degenerate_write_reason(prefs, current_prefs) is None:
+                                stale = True
+                    if projects := result.get("projects_update"):
+                        if projects.strip() != current_projects.strip():
+                            wrote = await asyncio.to_thread(
+                                memory.write_projects, projects, expected=current_projects
+                            )
+                            if (
+                                not wrote
+                                and degenerate_write_reason(projects, current_projects) is None
+                            ):
+                                stale = True
+                except MemoryWriteLockTimeout:
+                    # A wedged cross-process lock is transient (a concurrent
+                    # holder), so treat it like a stale reject: defer.
+                    stale = True
+                if stale:
+                    # Defer WITHOUT charging the attempt budget: a concurrency
+                    # event (stale CAS, or a held lock) is not a failure and must
+                    # not count toward permanent abandonment. Nothing durable ran
+                    # yet (this precedes append_history / mark_consolidated), so
+                    # the full span is retried cleanly next cycle.
+                    logger.info(
+                        "Deferring consolidation for %s: a concurrent session "
+                        "held the memory lock or rewrote a file during the LLM "
+                        "turn; retrying the full span next cycle",
+                        key,
+                    )
+                    return None
+
             if entry := result.get("history_entry"):
                 # Offloaded to a worker thread: append_history takes a blocking
                 # advisory file lock (cross-process) and does synchronous file
@@ -4625,16 +4687,6 @@ class HistoryConsolidator:
             # if the embedding endpoint is slow/hung (heartbeats, Slack, dashboard).
             if self._vector_store:
                 await run_in_embed_pool(self._write_structured_memory, result, key)
-
-            # Markdown writes (backward compat — skip if migrated)
-            if not self._migrated:
-                if prefs := result.get("preferences_update"):
-                    if prefs.strip() != current_prefs.strip():
-                        memory.write_preferences(prefs)
-
-                if projects := result.get("projects_update"):
-                    if projects.strip() != current_projects.strip():
-                        memory.write_projects(projects)
 
             # Lesson extraction: _save_lessons calls write_lesson which embeds
             # each rule (+ up to 5 lazy backfills) via blocking urllib to Ollama.

--- a/src/kiro_crew/memory.py
+++ b/src/kiro_crew/memory.py
@@ -12,14 +12,20 @@ Structure:
 
 from __future__ import annotations
 
+import contextlib
 import logging
+import os
+import re
 import time
+from collections.abc import Iterator
 from datetime import date as _date
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from kiro_crew import platform_compat
 from kiro_crew._sqlite_compat import FTS5_UNAVAILABLE_HINT, fts5_available, sqlite3
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
 from kiro_crew.metrics.db_metrics import timed, timed_query
 from kiro_crew.platform_compat import file_lock
@@ -39,6 +45,66 @@ PROJECTS_FILE = "projects.md"
 
 _DEFAULT_PREFERENCES = "# User Preferences\n\n<!-- Learned from conversations -->\n"
 _DEFAULT_PROJECTS = "# Active Projects\n\n<!-- Current work context -->\n"
+
+# ── Degenerate-write guard ──
+#
+# The consolidator asks an LLM for "the COMPLETE updated file" and writes the
+# reply verbatim as the new file body.  A model that reads the "return the
+# existing content if nothing changed" instruction as a sentinel request answers
+# with a placeholder word instead of the file, and the whole memory file is
+# replaced by that word.  Such a reply is never a legitimate memory file, so
+# guarded writes reject it rather than destroying real content.
+_DEGENERATE_BODIES = frozenset(
+    {
+        "unchanged",
+        "(unchanged)",
+        "no change",
+        "no changes",
+        "no changes needed",
+        "no changes to make",
+        "nothing changed",
+        "nothing to change",
+        "nothing to update",
+        "nochange",
+        "not changed",
+        "no update",
+        "no updates",
+        "no change required",
+        "no changes required",
+        "no update required",
+        "no updates required",
+        "no changes necessary",
+        "same",
+        "same as above",
+        "same as before",
+        "none",
+        "n/a",
+        "na",
+        "null",
+        "nil",
+    }
+)
+
+# A guarded write that keeps less than this fraction of a substantive existing
+# file is a truncation, not an edit.  The consolidator does prune stale entries,
+# but dropping four fifths of the file in one pass is the clobber signature.
+_MIN_RETAINED_FRACTION = 0.2
+
+# Below this size the shrink heuristic is meaningless (a nearly empty file can
+# legitimately be replaced by something equally small).
+_SHRINK_GUARD_MIN_CHARS = 400
+
+# Lock file serializing read-modify-write of the markdown memory files across
+# processes.  Concurrent Kiro Crew sessions each rewrite these files wholesale.
+_WRITE_LOCK_FILE = ".write.lock"
+
+# Bounded wait for that lock.  The hold window is a read, a compare and an
+# atomic rename (sub-millisecond), so real contention clears immediately; the
+# ceiling exists so a wedged or crashed holder can never stall a caller
+# indefinitely.  Acquisition is always non-blocking + retry, never a bare
+# blocking ``flock``, so the worst case for any caller is a bounded wait.
+_WRITE_LOCK_TIMEOUT_SECS = 5.0
+_WRITE_LOCK_POLL_SECS = 0.02
 
 # read_recent_history runs on every message turn (context build) and statting +
 # reading up to 181 daily files synchronously on the event loop is a per-message
@@ -120,6 +186,123 @@ def legacy_memory_present() -> bool:
     return False
 
 
+# ── Guarded-write helpers ──
+
+
+def _memory_body(content: str) -> str:
+    """Return *content* stripped of chrome that carries no memory of its own.
+
+    Drops the leading ``# H1`` title, the ``_Updated: <date>_`` stamp that
+    :meth:`MemoryStore.write_projects` adds, HTML comment placeholders, and
+    blank lines.  What remains is the substance of the file, which is what the
+    guard below reasons about: a reply of ``"unchanged"`` and a reply of
+    ``"# Active Projects\\n\\nunchanged"`` are equally destructive, and only
+    comparing bodies catches both.
+    """
+    kept: list[str] = []
+    for line in content.strip().splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("# "):
+            continue
+        if stripped.startswith("_Updated:") and stripped.endswith("_"):
+            continue
+        if stripped.startswith("<!--") and stripped.endswith("-->"):
+            continue
+        kept.append(stripped)
+    return "\n".join(kept).strip()
+
+
+def _normalize_placeholder(body: str) -> str:
+    """Reduce a body to a bare token for placeholder matching.
+
+    Lowercases, collapses inner whitespace, and strips surrounding markdown
+    emphasis/code/quote/bracket characters and trailing punctuation, so
+    "Unchanged.", "*unchanged*" and "`no changes`" all reduce to a token the
+    _DEGENERATE_BODIES lookup can catch.
+    """
+    s = re.sub(r"\s+", " ", body.strip().lower())
+    s = re.sub(r"^[\s*_`~\"'()\[\]-]+", "", s)
+    s = re.sub(r"[\s*_`~\"'()\[\].,!?;:-]+$", "", s)
+    return s
+
+
+def degenerate_write_reason(new: str, current: str) -> str | None:
+    """Return why writing *new* over *current* would destroy memory, else ``None``.
+
+    Three rejections, cheapest first: an empty body, a placeholder body (the
+    consolidator answering the prompt instead of returning the file), and a
+    write that discards most of a substantive file.
+    """
+    body = _memory_body(new)
+    if not body:
+        return "empty body"
+    if _normalize_placeholder(body) in _DEGENERATE_BODIES:
+        return f"placeholder body {body!r}"
+    current_body = _memory_body(current)
+    if (
+        len(current_body) >= _SHRINK_GUARD_MIN_CHARS
+        and len(body) < len(current_body) * _MIN_RETAINED_FRACTION
+    ):
+        return f"truncation: {len(body)} chars would replace {len(current_body)}"
+    return None
+
+
+class MemoryWriteLockTimeout(RuntimeError):
+    """Raised when the memory write lock cannot be acquired within the bound.
+
+    Fail-closed signal: the guarded writers refuse rather than write
+    unserialized (which could lose a concurrent update). Callers on the event
+    loop offload the write and turn this into a transient error / retry.
+    """
+
+
+@contextlib.contextmanager
+def _memory_write_lock(memory_dir_path: Path) -> Iterator[None]:
+    """Hold an exclusive advisory lock over the markdown memory files.
+
+    Serializes the read-compare-write sequence in the guarded writers across
+    processes, so two concurrent sessions cannot interleave their read and
+    their write and lose one another's update.
+
+    Acquisition is non-blocking with a bounded retry (never a bare blocking
+    ``flock``): a wedged holder makes this fail closed -- it raises
+    ``MemoryWriteLockTimeout`` rather than write unserialized (which could lose
+    a concurrent update) or stall the caller forever.  Even so, the whole write
+    is synchronous and must not run
+    on the event loop thread; the async call sites offload it (see
+    ``history.py`` ``_consolidate`` and the dashboard memory handlers), and
+    ``test_context.py::TestAsyncCallSitesUseToThread`` fails the build if a new
+    coroutine calls a guarded writer inline.
+    """
+    memory_dir_path.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(memory_dir_path / _WRITE_LOCK_FILE), os.O_RDWR | os.O_CREAT, 0o600)
+    acquired = False
+    try:
+        deadline = time.monotonic() + _WRITE_LOCK_TIMEOUT_SECS
+        while True:
+            acquired = platform_compat.try_acquire_lock(fd, exclusive=True)
+            if acquired or time.monotonic() >= deadline:
+                break
+            time.sleep(_WRITE_LOCK_POLL_SECS)
+        if not acquired:
+            # Fail closed: a wedged holder means we cannot serialize the
+            # read-compare-write, so refuse rather than write unserialized and
+            # risk losing the holder's concurrent update. The wait is bounded
+            # (never blocks the caller); callers on the event loop offload the
+            # write and translate this into a transient retry.
+            raise MemoryWriteLockTimeout(
+                "memory write lock not acquired within "
+                f"{_WRITE_LOCK_TIMEOUT_SECS:.1f}s"
+            )
+        yield
+    finally:
+        if acquired:
+            platform_compat.release_lock(fd)
+        os.close(fd)
+
+
 # ── MemoryStore ──
 
 
@@ -164,11 +347,23 @@ class MemoryStore:
             return self._preferences_file.read_text(encoding="utf-8")
         return ""
 
-    def write_preferences(self, content: str) -> None:
-        """Write user preferences and update FTS index."""
+    def write_preferences(
+        self, content: str, *, expected: str | None = None, force: bool = False
+    ) -> bool:
+        """Write user preferences and update FTS index.
+
+        See :meth:`write_projects` for the guard semantics; they are identical.
+        Returns ``True`` when the file was written.
+        """
         self._memory_dir.mkdir(parents=True, exist_ok=True)
-        self._preferences_file.write_text(content, encoding="utf-8")
+        with _memory_write_lock(self._memory_dir):
+            if not force and not self._write_allowed(
+                PREFERENCES_FILE, content, self.read_preferences(), expected
+            ):
+                return False
+            atomic_write(self._preferences_file, content)
         self._index_file(self._preferences_file, content)
+        return True
 
     def add_preference(self, preference: str) -> None:
         """Append a preference line, avoiding duplicates."""
@@ -185,8 +380,46 @@ class MemoryStore:
             return self._projects_file.read_text(encoding="utf-8")
         return ""
 
-    def write_projects(self, content: str) -> None:
-        """Write active projects, adding header if missing, and update FTS index."""
+    def _write_allowed(
+        self, name: str, content: str, current: str, expected: str | None
+    ) -> bool:
+        """Return whether a guarded write of *content* over *current* may proceed.
+
+        Must be called with the memory write lock held, so *current* is the
+        content the write will actually replace.
+        """
+        if expected is not None and current.strip() != expected.strip():
+            logger.warning(
+                "Rejected stale %s write: on-disk content changed after it was "
+                "read, so this update was computed from a stale view and would "
+                "drop a concurrent writer's changes",
+                name,
+            )
+            return False
+        if reason := degenerate_write_reason(content, current):
+            logger.warning("Rejected degenerate %s write: %s", name, reason)
+            return False
+        return True
+
+    def write_projects(
+        self, content: str, *, expected: str | None = None, force: bool = False
+    ) -> bool:
+        """Write active projects, adding header if missing, and update FTS index.
+
+        Returns ``True`` when the file was written and ``False`` when the write
+        was rejected.  Automated callers (the consolidator) get two protections:
+
+        - **Degenerate-write guard.** A body that is empty, a placeholder such
+          as ``unchanged``, or a truncation of a substantive file is rejected
+          instead of overwriting real content.
+        - **Compare-and-swap.** When *expected* is supplied, the write lands
+          only if the on-disk content still matches it, so an update computed
+          from a stale read never silently overwrites a concurrent writer.
+
+        Both checks and the write run under an exclusive cross-process lock.
+        Pass ``force=True`` for an explicit human edit that intends to shrink or
+        clear the file.
+        """
         self._memory_dir.mkdir(parents=True, exist_ok=True)
         date = datetime.now().strftime("%Y-%m-%d")
         # Don't double-wrap if content already has the header
@@ -194,8 +427,14 @@ class MemoryStore:
             full = content.strip() + "\n"
         else:
             full = f"# Active Projects\n\n_Updated: {date}_\n\n{content}\n"
-        self._projects_file.write_text(full, encoding="utf-8")
+        with _memory_write_lock(self._memory_dir):
+            if not force and not self._write_allowed(
+                PROJECTS_FILE, full, self.read_projects(), expected
+            ):
+                return False
+            atomic_write(self._projects_file, full)
         self._index_file(self._projects_file, full)
+        return True
 
     # ── Legacy read/write (used by consolidator) ──
 
@@ -211,17 +450,21 @@ class MemoryStore:
         return "\n\n".join(parts)
 
     def write(self, content: str) -> None:
-        """Write combined memory — splits into preferences + projects sections."""
+        """Write combined memory — splits into preferences + projects sections.
+
+        An explicit whole-memory set (CLI, eval seeding), so it bypasses the
+        guards that protect the consolidator from itself.
+        """
         if "# Active Projects" in content:
             idx = content.index("# Active Projects")
-            self.write_preferences(content[:idx].strip() + "\n")
-            # Use write_text + index (not write_projects which adds header)
+            self.write_preferences(content[:idx].strip() + "\n", force=True)
+            # Use atomic_write + index (not write_projects which adds header)
             projects_content = content[idx:].strip() + "\n"
             self._memory_dir.mkdir(parents=True, exist_ok=True)
-            self._projects_file.write_text(projects_content, encoding="utf-8")
+            atomic_write(self._projects_file, projects_content)
             self._index_file(self._projects_file, projects_content)
         else:
-            self.write_preferences(content)
+            self.write_preferences(content, force=True)
 
     # ── Daily History ──
 

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -1052,6 +1052,59 @@ class TestBuildMessageOffloadedAtCallSites:
         vector_store.get_episodic_context.assert_not_called()
 
 
+def _inline_async_attr_calls(attr_names: set[str]) -> list[str]:
+    """Return production call sites where an ``async def`` calls one of *attr_names* inline.
+
+    Shared by the loop-stall guards below.  A nested ``def`` / ``async def`` /
+    ``lambda`` is a separate frame (a sync helper, a thread target, an offloaded
+    callable) and is NOT scanned as part of the enclosing coroutine, so both
+    sanctioned offload shapes pass: passing the method as an ARG to
+    ``run_in_embed_pool`` / ``asyncio.to_thread`` never matches, because the
+    Call's own func is the offload helper. A ``# loop-ok: <reason>`` trailing
+    comment suppresses a finding.
+    """
+    import ast
+    from pathlib import Path
+
+    nested_scopes = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+    src_root = Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
+    offenders: list[str] = []
+
+    def _iter_frame_calls(fn: ast.AsyncFunctionDef):
+        """Yield Call nodes lexically in *fn*'s own frame — skip nested scopes."""
+        stack: list[ast.AST] = list(ast.iter_child_nodes(fn))
+        while stack:
+            node = stack.pop()
+            if isinstance(node, nested_scopes):
+                continue  # separate frame: sync helper / thread target / lambda
+            if isinstance(node, ast.Call):
+                yield node
+            stack.extend(ast.iter_child_nodes(node))
+
+    for py in src_root.rglob("*.py"):
+        try:
+            text = py.read_text(encoding="utf-8")
+            tree = ast.parse(text)
+        except SyntaxError:
+            continue
+        lines = text.splitlines()
+        for fn in ast.walk(tree):
+            if not isinstance(fn, ast.AsyncFunctionDef):
+                continue
+            for call in _iter_frame_calls(fn):
+                func = call.func
+                if not (isinstance(func, ast.Attribute) and func.attr in attr_names):
+                    continue
+                src_line = lines[call.lineno - 1] if call.lineno <= len(lines) else ""
+                if "# loop-ok" in src_line:
+                    continue
+                offenders.append(
+                    f"{py.relative_to(src_root)}:{call.lineno} in async {fn.name} "
+                    f"({func.attr})"
+                )
+    return offenders
+
+
 class TestAsyncCallSitesUseToThread:
     """Static guard: no async coroutine may call build_message inline.
 
@@ -1071,49 +1124,26 @@ class TestAsyncCallSitesUseToThread:
     """
 
     def test_no_inline_build_message_in_async_functions(self):
-        import ast
-        from pathlib import Path
-
-        nested_scopes = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
-        src_root = Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
-        offenders: list[str] = []
-
-        def _iter_frame_calls(fn: ast.AsyncFunctionDef):
-            """Yield Call nodes lexically in *fn*'s own frame — skip nested scopes."""
-            stack: list[ast.AST] = list(ast.iter_child_nodes(fn))
-            while stack:
-                node = stack.pop()
-                if isinstance(node, nested_scopes):
-                    continue  # separate frame: sync helper / thread target / lambda
-                if isinstance(node, ast.Call):
-                    yield node
-                stack.extend(ast.iter_child_nodes(node))
-
-        for py in src_root.rglob("*.py"):
-            try:
-                text = py.read_text(encoding="utf-8")
-                tree = ast.parse(text)
-            except SyntaxError:
-                continue
-            lines = text.splitlines()
-            for fn in ast.walk(tree):
-                if not isinstance(fn, ast.AsyncFunctionDef):
-                    continue
-                for call in _iter_frame_calls(fn):
-                    func = call.func
-                    # Inline call: the Call's func IS .build_message. The
-                    # sanctioned run_in_embed_pool(x.build_message, ...) form
-                    # passes the method as an ARG, so its Call func is
-                    # to_thread and never matches here.
-                    if not (isinstance(func, ast.Attribute) and func.attr == "build_message"):
-                        continue
-                    src_line = lines[call.lineno - 1] if call.lineno <= len(lines) else ""
-                    if "# loop-ok" in src_line:
-                        continue
-                    offenders.append(f"{py.relative_to(src_root)}:{call.lineno} in async {fn.name}")
+        offenders = _inline_async_attr_calls({"build_message"})
 
         assert not offenders, (
             "build_message called inline from async coroutine(s) — the episodic "
             "query embed blocks the event loop; wrap in run_in_embed_pool (or "
             "add '# loop-ok: <reason>' if genuinely safe):\n  " + "\n  ".join(offenders)
+        )
+
+    def test_no_inline_memory_markdown_writes_in_async_functions(self):
+        """write_preferences / write_projects take a cross-process advisory lock.
+
+        The wait is bounded, but waiting inline on the loop still stalls
+        heartbeats, Slack and the dashboard for its duration, so every async
+        call site must offload.
+        """
+        offenders = _inline_async_attr_calls({"write_preferences", "write_projects"})
+
+        assert not offenders, (
+            "guarded memory writer called inline from async coroutine(s) — it "
+            "takes a cross-process advisory lock and would stall the event "
+            "loop; wrap in asyncio.to_thread (or add '# loop-ok: <reason>' if "
+            "genuinely safe):\n  " + "\n  ".join(offenders)
         )

--- a/test/test_handlers_memory_coverage.py
+++ b/test/test_handlers_memory_coverage.py
@@ -146,7 +146,7 @@ class TestPreferencesProjectsHistory:
         req = _make_request(state, method="PUT", json_body={"content": "- new"})
         resp = await mem_mod.api_memory_preferences(req)
         assert _body(resp) == {"ok": True}
-        mem.write_preferences.assert_called_once_with("- new")
+        mem.write_preferences.assert_called_once_with("- new", force=True)
 
     @pytest.mark.asyncio
     async def test_preferences_put_defaults_missing_content_to_empty(self) -> None:
@@ -154,7 +154,7 @@ class TestPreferencesProjectsHistory:
         state = _make_state(memory=mem)
         req = _make_request(state, method="PUT", json_body={})
         assert (await mem_mod.api_memory_preferences(req)).status == 200
-        mem.write_preferences.assert_called_once_with("")
+        mem.write_preferences.assert_called_once_with("", force=True)
 
     @pytest.mark.asyncio
     async def test_preferences_put_rejects_invalid_json(self) -> None:
@@ -180,7 +180,7 @@ class TestPreferencesProjectsHistory:
         state = _make_state(memory=mem)
         req = _make_request(state, method="PUT", json_body={"content": "## New"})
         assert (await mem_mod.api_memory_projects(req)).status == 200
-        mem.write_projects.assert_called_once_with("## New")
+        mem.write_projects.assert_called_once_with("## New", force=True)
 
     @pytest.mark.asyncio
     async def test_projects_put_rejects_invalid_json(self) -> None:

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -3765,3 +3765,104 @@ class TestMetadataReadSurvivesATransientSharingViolation:
         assert any(
             "could not read metadata" in r.getMessage() for r in caplog.records
         ), f"no warning recorded; got {[r.getMessage() for r in caplog.records]}"
+
+
+class TestMarkdownMemoryClobberGuard:
+    """Regression tests for the projects.md 'unchanged' clobber.
+
+    The consolidation prompt asked for "the COMPLETE updated projects file"
+    and added "Return existing if unchanged".  A model reading that as a
+    sentinel request answered ``{"projects_update": "unchanged"}``, and the
+    whole file was replaced by that word.
+    """
+
+    def _consolidator(self, tmp_path):
+        from kiro_crew.memory import MemoryStore
+
+        conv_log = ConversationLog(base_dir=tmp_path / "sessions")
+        conv_log.init()
+        mem = MemoryStore(workspace=tmp_path / "memory")
+        mem.init()
+        return conv_log, mem, HistoryConsolidator(log=conv_log, memory=mem, migrated=False)
+
+    @pytest.mark.asyncio
+    async def test_prompt_forbids_placeholder_reply(self, tmp_path):
+        conv_log, mem, consolidator = self._consolidator(tmp_path)
+        conv_log.append("dashboard:chat-1", "user", "we started project foo")
+
+        captured: list[str] = []
+
+        async def fake_llm(prompt):
+            captured.append(prompt)
+            return {}
+
+        with patch.object(consolidator, "_call_llm", side_effect=fake_llm):
+            await consolidator._consolidate("dashboard:chat-1", include_history=True)
+
+        prompt = captured[0]
+        # The ambiguous phrasing that invited the placeholder reply is gone,
+        # and the placeholder is now explicitly forbidden for both keys.
+        assert "Return existing if unchanged" not in prompt
+        assert prompt.count("repeat the existing content above verbatim") == 2
+        assert prompt.count("NEVER answer with a placeholder") == 2
+
+    @pytest.mark.asyncio
+    async def test_placeholder_reply_does_not_clobber(self, tmp_path):
+        conv_log, mem, consolidator = self._consolidator(tmp_path)
+        real = "# Active Projects\n\n" + "".join(
+            f"## Project {i}\n- owner: someone\n- status: being actively tracked\n\n"
+            for i in range(12)
+        )
+        mem.write_projects(real, force=True)
+        conv_log.append("dashboard:chat-1", "user", "nothing new today")
+
+        async def fake_llm(_prompt):
+            return {"history_entry": "quiet day", "projects_update": "unchanged"}
+
+        with patch.object(consolidator, "_call_llm", side_effect=fake_llm), patch.object(
+            conv_log, "mark_consolidated"
+        ) as marked:
+            await consolidator._consolidate("dashboard:chat-1", include_history=True)
+
+        assert "Project 7" in mem.read_projects()
+        # A placeholder is a benign no-op: consolidation still advances.
+        marked.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stale_reply_does_not_drop_concurrent_update(self, tmp_path):
+        """A concurrent session's write must survive a slow LLM turn."""
+        conv_log, mem, consolidator = self._consolidator(tmp_path)
+        real = "# Active Projects\n\n" + "".join(
+            f"## Project {i}\n- owner: someone\n- status: being actively tracked\n\n"
+            for i in range(12)
+        )
+        mem.write_projects(real, force=True)
+        conv_log.append("dashboard:chat-1", "user", "add project bar")
+
+        snapshot = mem.read_projects()
+
+        async def fake_llm(_prompt):
+            # Another session lands its update while this "LLM turn" runs.
+            mem.write_projects(snapshot + "\n## Project from other session\n- new\n", force=True)
+            return {
+                "history_entry": "added bar",
+                "projects_update": snapshot + "\n## Project bar\n- from stale view\n",
+            }
+
+        with patch.object(consolidator, "_call_llm", side_effect=fake_llm), patch.object(
+            conv_log, "mark_consolidated"
+        ) as marked, patch.object(mem, "append_history") as appended, patch.object(
+            consolidator, "_note_failed_attempt"
+        ) as charged:
+            await consolidator._consolidate("dashboard:chat-1", include_history=True)
+
+        current = mem.read_projects()
+        assert "Project from other session" in current
+        assert "Project bar" not in current
+        # Stale-CAS reject aborts BEFORE any durable side effect, so the offset
+        # is not advanced and no history summary is written; the full span is
+        # retried against the fresh file next cycle (no duplicate summary).
+        marked.assert_not_called()
+        appended.assert_not_called()
+        # A concurrency event must not count toward permanent abandonment.
+        charged.assert_not_called()

--- a/test/test_memory.py
+++ b/test/test_memory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from kiro_crew import platform_compat
 from kiro_crew.memory import MemoryStore
 
 
@@ -204,3 +205,208 @@ class TestRecentHistoryCache:
         prefs = store.read_preferences()
         # Empty pref should not add a blank bullet
         assert "\n- \n" not in prefs
+
+
+_REAL_PROJECTS = "# Active Projects\n\n" + "".join(
+    f"## Project {i}\n- owner: someone\n- status: in progress and being tracked\n\n"
+    for i in range(12)
+)
+
+
+class TestDegenerateWriteGuard:
+    """The consolidator asks an LLM for the whole file and writes the reply.
+
+    A model that answers the "return existing content if nothing changed"
+    instruction with a placeholder used to replace the entire file with that
+    word.  Guarded writes must reject those replies.
+    """
+
+    def test_placeholder_body_rejected(self, tmp_path):
+        store = MemoryStore(workspace=tmp_path)
+        store.write_projects(_REAL_PROJECTS, force=True)
+
+        assert store.write_projects("unchanged") is False
+        assert "Project 7" in store.read_projects()
+
+    def test_placeholder_variants_rejected(self, tmp_path):
+        store = MemoryStore(workspace=tmp_path)
+        store.write_projects(_REAL_PROJECTS, force=True)
+
+        for body in (
+            "Unchanged",
+            "no changes",
+            "(unchanged)",
+            "N/A",
+            "same as before",
+            "unchanged.",
+            "*unchanged*",
+            "`no changes`",
+            "Nothing changed!",
+            "_N/A_",
+            "nothing to update",
+            "No changes required.",
+            "no updates required",
+        ):
+            assert store.write_projects(body) is False, body
+        assert "Project 7" in store.read_projects()
+
+    def test_placeholder_under_header_rejected(self, tmp_path):
+        """The wrapped form is just as destructive as the bare word."""
+        store = MemoryStore(workspace=tmp_path)
+        store.write_projects(_REAL_PROJECTS, force=True)
+
+        assert store.write_projects("# Active Projects\n\n_Updated: 2026-08-05_\n\nunchanged") is False
+        assert "Project 7" in store.read_projects()
+
+    def test_empty_body_rejected(self, tmp_path):
+        store = MemoryStore(workspace=tmp_path)
+        store.write_projects(_REAL_PROJECTS, force=True)
+
+        assert store.write_projects("") is False
+        assert store.write_projects("# Active Projects\n\n") is False
+        assert "Project 7" in store.read_projects()
+
+    def test_truncation_rejected(self, tmp_path):
+        store = MemoryStore(workspace=tmp_path)
+        store.write_projects(_REAL_PROJECTS, force=True)
+
+        assert store.write_projects("## Project 0\n- still here\n") is False
+        assert "Project 7" in store.read_projects()
+
+    def test_legitimate_prune_allowed(self, tmp_path):
+        """Dropping some entries is normal consolidation, not a clobber."""
+        store = MemoryStore(workspace=tmp_path)
+        store.write_projects(_REAL_PROJECTS, force=True)
+
+        pruned = "# Active Projects\n\n" + "".join(
+            f"## Project {i}\n- owner: someone\n- status: in progress and being tracked\n\n"
+            for i in range(8)
+        )
+        assert store.write_projects(pruned) is True
+        assert "Project 7" in store.read_projects()
+        assert "Project 11" not in store.read_projects()
+
+    def test_force_allows_clearing(self, tmp_path):
+        """An explicit human edit may shrink or clear the file."""
+        store = MemoryStore(workspace=tmp_path)
+        store.write_projects(_REAL_PROJECTS, force=True)
+
+        assert store.write_projects("## Only one left\n", force=True) is True
+        assert "Project 7" not in store.read_projects()
+
+    def test_guard_does_not_block_first_write(self, tmp_path):
+        store = MemoryStore(workspace=tmp_path)
+        store.init()
+        assert store.write_projects("## Fresh start\n- doing things\n") is True
+        assert "Fresh start" in store.read_projects()
+
+    def test_preferences_guarded_too(self, tmp_path):
+        store = MemoryStore(workspace=tmp_path)
+        big = "# User Preferences\n\n" + "".join(
+            f"- preference number {i} that the user stated explicitly\n" for i in range(20)
+        )
+        store.write_preferences(big, force=True)
+
+        assert store.write_preferences("unchanged") is False
+        assert "preference number 17" in store.read_preferences()
+
+
+class TestWriteLockIsBounded:
+    """The lock must never block a caller indefinitely.
+
+    A blocking ``flock`` would freeze whichever thread waits on it for as long
+    as a wedged holder lives. Acquisition is non-blocking with a bounded retry,
+    so a stuck holder makes the write fail closed (raises
+    ``MemoryWriteLockTimeout``) rather than write unserialized.
+    """
+
+    def test_raises_when_lock_is_held_elsewhere(self, tmp_path, monkeypatch):
+        import os
+        import time
+
+        import pytest
+
+        from kiro_crew import memory as memory_mod
+
+        store = MemoryStore(workspace=tmp_path)
+        store.write_projects(_REAL_PROJECTS, force=True)
+
+        monkeypatch.setattr(memory_mod, "_WRITE_LOCK_TIMEOUT_SECS", 0.2)
+
+        # Hold the lock from an independent fd, as another process would.
+        lock_path = tmp_path / "memory" / memory_mod._WRITE_LOCK_FILE
+        fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+        assert platform_compat.try_acquire_lock(fd, exclusive=True)
+        try:
+            started = time.monotonic()
+            updated = _REAL_PROJECTS + "## Project 12\n- added under contention\n"
+            # Fail closed: refuse rather than write unserialized.
+            with pytest.raises(memory_mod.MemoryWriteLockTimeout):
+                store.write_projects(updated)
+            elapsed = time.monotonic() - started
+        finally:
+            platform_compat.release_lock(fd)
+            os.close(fd)
+
+        # Bounded: it gave up waiting (raised) rather than hanging.
+        assert elapsed < 5.0
+        # The contended write did not land.
+        assert "added under contention" not in store.read_projects()
+
+    def test_lock_is_released_after_write(self, tmp_path):
+        import os
+
+        from kiro_crew import memory as memory_mod
+
+        store = MemoryStore(workspace=tmp_path)
+        store.write_projects(_REAL_PROJECTS, force=True)
+
+        lock_path = tmp_path / "memory" / memory_mod._WRITE_LOCK_FILE
+        fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            # Nothing still holds it, so an outside acquire succeeds immediately.
+            assert platform_compat.try_acquire_lock(fd, exclusive=True)
+            platform_compat.release_lock(fd)
+        finally:
+            os.close(fd)
+
+    """Concurrent sessions rewrite these files wholesale from their own view."""
+
+    def test_stale_write_rejected(self, tmp_path):
+        store = MemoryStore(workspace=tmp_path)
+        store.write_projects(_REAL_PROJECTS, force=True)
+
+        snapshot = store.read_projects()  # what a session read before its LLM turn
+
+        # A concurrent session lands its own update in the meantime.
+        concurrent = snapshot + "\n## Project from other session\n- new work\n"
+        assert store.write_projects(concurrent, force=True) is True
+
+        # The first session's reply was computed from the stale snapshot.
+        stale = snapshot + "\n## Project from first session\n- other work\n"
+        assert store.write_projects(stale, expected=snapshot) is False
+
+        current = store.read_projects()
+        assert "Project from other session" in current
+        assert "Project from first session" not in current
+
+    def test_fresh_write_accepted(self, tmp_path):
+        store = MemoryStore(workspace=tmp_path)
+        store.write_projects(_REAL_PROJECTS, force=True)
+
+        snapshot = store.read_projects()
+        updated = snapshot + "\n## Newly tracked project\n- just started\n"
+        assert store.write_projects(updated, expected=snapshot) is True
+        assert "Newly tracked project" in store.read_projects()
+
+    def test_expected_none_skips_cas(self, tmp_path):
+        """Callers that pass no expectation keep the old last-writer-wins path."""
+        store = MemoryStore(workspace=tmp_path)
+        store.write_projects(_REAL_PROJECTS, force=True)
+
+        replacement = "# Active Projects\n\n" + "".join(
+            f"## Replacement {i}\n- owner: someone else\n- status: also in progress\n\n"
+            for i in range(12)
+        )
+        assert store.write_projects(replacement) is True
+        assert "Replacement 3" in store.read_projects()


### PR DESCRIPTION
The history consolidator periodically rewrites preferences.md and projects.md from an LLM reply. The prompt asked for "the COMPLETE updated projects file" and closed with "Return existing if unchanged", which a model reads as a sentinel request and answers {"projects_update": "unchanged"} - replacing the entire file with that one word. The only write guard suppressed an exact-match no-op, so the bare word passed through and write_projects() wrapped it in the header template, destroying all tracked content.

Three layers, so neither a prompt regression nor a differently-worded placeholder can destroy a memory file again:

1. Prompt: both markdown keys now instruct the model to repeat the existing content verbatim when nothing changed, and explicitly forbid a placeholder reply, stating the answer is written straight to the file.

2. Degenerate-write guard (memory.py): write_preferences/write_projects reject a body that is empty, a known placeholder (_DEGENERATE_BODIES), or a truncation keeping under 20% of a substantive file. Comparison runs on the body via _memory_body(), which strips the H1 title, the _Updated: stamp, and HTML comments, so the bare word and the header-wrapped form are both caught. force=True bypasses the guard for explicit human edits (dashboard editor, legacy write(), eval seeding).

3. Compare-and-swap + locking: the consolidator passes its pre-LLM snapshot as expected=. The writers verify it under an exclusive cross-process advisory lock and commit via atomic_write, so a reply computed from a stale view is dropped rather than clobbering newer content. The lock uses a bounded non-blocking retry (never a bare flock), and the async consolidator and dashboard handlers offload the now-locking writers via asyncio.to_thread.

Both writers now return bool (written / rejected) instead of None.

Adds tests for placeholder variants, the header-wrapped form, empty/truncating bodies, a legitimate prune, force, preferences symmetry, both CAS directions, and a static guard that fails the build if an async coroutine calls the guarded writers inline.

<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

<!-- Bug fix: the concrete symptom — what is broken or missing, ideally what the
     user observes.
     New feature / enhancement: the gap, use case, or opportunity this addresses
     — what a user cannot do (or does awkwardly) today. -->

## Why it matters

<!-- Impact if this is left undone: for a fix, who is hit by the bug and how
     badly; for a feature, the user/business value it unlocks. -->

## What changed (motivation → approach → change)

<!-- A short chain of thought so the reader sees *why this is the right change*,
     not just what changed:
     - Bug fix: observed symptom → underlying root cause → the specific change
       that addresses that cause.
     - New feature / enhancement: goal → the approach/design you chose (and why,
       over the alternatives you considered) → what you actually built. -->

## Tests

<!-- Automated tests added/updated and the behavior each one locks in. -->

## Manual verification

<!-- Manual steps performed or still required where unit tests fall short
     (integration paths, UI, external services). State "N/A — unit coverage
     sufficient" only when genuinely true, with a one-line why. -->

## Screenshots / video

<!-- MANDATORY for any user-visible UI change (new/changed panels, components,
     layouts, themes); delete this section otherwise.

     - Show each affected surface in its meaningful variants (e.g. desktop vs
       browser, empty vs populated, light vs dark).
     - Prefer a short video/GIF when the change involves motion or a multi-step
       flow (animations, transitions, interactions) — a still image cannot
       prove those.
     - Commit media to the PR branch under a top-level, ephemeral, never-packaged
       dir `temp-screenshots/<feature>/` (never under docs/ or src/kiro_crew/**)
       and embed with commit-SHA-pinned URLs so they survive branch deletion on
       merge and periodic cleanup:
       ![alt](https://github.com/<owner>/<repo>/raw/<sha>/temp-screenshots/<feature>/<name>.png)
     - Put the two or three most telling shots inline; fold full-page context
       into a <details> block. -->

## Related Issues

<!-- Link to relevant issues, e.g. Fixes #123 -->

## Checklist

- [ ] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [ ] Existing tests pass and new tests added for new functionality
- [ ] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
