### PR TITLE
fix: detect kiro-cli API-key auth in the readiness probe

### DIFF
--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -938,7 +938,17 @@ official installer receives a system-only `PATH`. Explicit login
 inherits only the allowlisted user-path, UI/device-flow, TLS, and proxy values;
 passive probes receive a narrower environment that excludes proxy credentials
 and desktop-session IPC as well as ambient cloud, Slack, SSH-agent, and
-application credentials.
+application credentials. The one deliberate *credential* exception is Kiro CLI's
+OWN model credential (`KIRO_API_KEY`, `_IDENTITY_PROBE_ENV_KEYS`), forwarded to the
+`whoami` identity probe only: the CLI reports an API-key session as signed in only
+when it can see that variable, so filtering it out reports a host that ACP
+authenticates on as signed out. The exposure delta is that one probe's argv — the
+credential reaches the same resolved binary the same probe already executes, in the
+same standard sandbox posture, against the same real home. The `--version` probe,
+which is the first execution of a candidate that has not yet answered anything,
+stays credential-free. `whoami` decides identity from the CLI's exit status alone,
+and that status reports which credential kind is configured rather than whether the
+credential is accepted, so a stale or mistyped key reads as signed in.
 
 Output and client-visible errors are bounded and credential/exfiltration-
 redacted. Only HTTPS URLs on the exact official `app.kiro.dev` host or the

--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -215,6 +215,32 @@ _PROBE_ENV_KEYS = frozenset(
     }
 )
 
+# Kiro CLI's OWN model credential, forwarded to the identity probe only.
+#
+# ``kiro-cli`` accepts an API key through the environment as an alternative to a
+# ``kiro-cli login`` token store, and ``whoami`` reports "Authenticated with API
+# key" only when it can see that variable. Filtered out, the probe answers "Not
+# logged in" (exit 1) on a host where an ACP session authenticates fine, because
+# ACP inherits the real environment — so dropping it latches
+# ``authenticated=False`` while chat still works, which is the worst of both: the
+# first-run gate demands a sign-in the user has already done, and every
+# ``verified_ready`` caller (``/api/models``, usage polling, the destructive
+# reruns) answers 503.
+#
+# SECURITY: the exposure delta is one probe's argv, not a new surface. The value
+# reaches the same resolved binary this same probe already executes, in the same
+# standard sandbox posture, against the same real home (see
+# :meth:`KiroPrerequisiteService._run_auth_command`'s ``isolate_home=False`` note),
+# on a fixed ``whoami`` argv. It is kept OUT of :data:`_PROBE_ENV_KEYS` because
+# ``--version`` is the FIRST execution of a candidate that has not yet answered
+# anything, and nothing about resolving a version needs a key.
+#
+# The CLI's exit status reports which credential kind is CONFIGURED, not whether
+# the credential is accepted, so a stale or mistyped key reads as signed in. That
+# is the same answer an ACP session acts on, which is the point — but it means
+# presence of this variable must never become a shortcut that skips the probe.
+_IDENTITY_PROBE_ENV_KEYS = frozenset({"KIRO_API_KEY"})
+
 
 @dataclass
 class ProcessResult:
@@ -830,6 +856,21 @@ def _probe_env(environ: MutableMapping[str, str], search_path: str) -> dict[str,
     result["PATH"] = search_path
     result["NO_COLOR"] = "1"
     result["TERM"] = "dumb"
+    return result
+
+
+def _identity_probe_env(
+    environ: MutableMapping[str, str], probe_environment: dict[str, str]
+) -> dict[str, str]:
+    """Add Kiro CLI's own credential env to a probe environment.
+
+    Separate from :func:`_probe_env` so only the identity probe carries the
+    credential; see :data:`_IDENTITY_PROBE_ENV_KEYS` for why ``whoami`` needs it
+    and why ``--version`` must not get it.
+    """
+
+    result = dict(probe_environment)
+    result.update(_allowlisted_env(environ, _IDENTITY_PROBE_ENV_KEYS))
     return result
 
 
@@ -2018,6 +2059,10 @@ class KiroPrerequisiteService:
         runs against the real home (like an ACP session) and detects CLIs whose
         session or tool registry lives there. ``isolate_home=True`` keeps the
         credential-minimal temporary home for callers that need it.
+
+        Either way the environment carries :data:`_IDENTITY_PROBE_ENV_KEYS`, so a
+        host authenticated by Kiro CLI's own API-key variable is detected as
+        signed in rather than reported "Not logged in".
         """
 
         action = "probe_identity"
@@ -2031,7 +2076,7 @@ class KiroPrerequisiteService:
             result = await self._run_auth_command(
                 executable,
                 ["whoami"],
-                base_env=self._probe_environment,
+                base_env=_identity_probe_env(self._environ, self._probe_environment),
                 timeout_secs=_PROBE_TIMEOUT_SECS,
                 isolate_home=isolate_home,
             )

--- a/test/test_env_allowlist_consolidation.py
+++ b/test/test_env_allowlist_consolidation.py
@@ -20,6 +20,13 @@ These tests pin two things:
    oracle on BOTH platforms, evaluated against the upper-cased key spelling a
    real Windows ``os.environ`` yields — which is exactly why the shared fold
    admits the same set there.
+
+``kiro_prerequisite`` passes two different allowlists through the shared matcher:
+``_PROBE_ENV_KEYS`` for the credential-free ``--version`` probe, and
+``_IDENTITY_PROBE_ENV_KEYS`` for the ``whoami`` identity probe, which names Kiro
+CLI's own credential. Both are pinned, and the credential one additionally pins
+WHAT it admits — one name, admitted by no other site — because a fold that
+widened there would forward more than the carve-out names.
 """
 
 from __future__ import annotations
@@ -64,6 +71,9 @@ _POSIX_ENVIRON = {
     "AWS_SECRET_ACCESS_KEY": "secret",
     "SLACK_BOT_TOKEN": "xoxb-secret",
     "SSH_AUTH_SOCK": "/tmp/agent.sock",
+    # Kiro CLI's own credential: admitted by the identity-probe allowlist alone,
+    # and by no other site. Present here so both claims are checked, not assumed.
+    "KIRO_API_KEY": "kiro-secret",
 }
 
 # Windows-shaped synthetic environ: CPython's os.environ upper-cases every key
@@ -81,6 +91,7 @@ _WINDOWS_ENVIRON = {
     "AWS_SECRET_ACCESS_KEY": "secret",
     "SLACK_BOT_TOKEN": "xoxb-secret",
     "SSH_AUTH_SOCK": "/tmp/agent.sock",
+    "KIRO_API_KEY": "kiro-secret",
 }
 
 
@@ -162,6 +173,57 @@ class TestCallSiteParity:
             folds_on_windows=True,
         )
 
+    def test_kiro_prerequisite_identity_probe_allowlist(self, monkeypatch, windows: bool) -> None:
+        """The identity probe's credential carve-out obeys the same convention.
+
+        Separate site from ``_PROBE_ENV_KEYS`` because only ``whoami`` carries the
+        credential; the ``--version`` probe must not. Pinned here so the shared
+        fold stays behavior-preserving for a CREDENTIAL name too, where a widened
+        match would forward more than the one variable the carve-out names.
+        """
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", windows)
+        environ = _environ_for(windows)
+        filtered = kiro_prerequisite._allowlisted_env(
+            dict(environ), kiro_prerequisite._IDENTITY_PROBE_ENV_KEYS
+        )
+        assert set(filtered) == _oracle_admitted(
+            environ,
+            kiro_prerequisite._IDENTITY_PROBE_ENV_KEYS,
+            windows=windows,
+            folds_on_windows=True,
+        )
+
+    def test_identity_carve_out_is_exactly_one_credential(self, monkeypatch, windows: bool) -> None:
+        """The carve-out admits ``KIRO_API_KEY`` and nothing else, on both platforms.
+
+        The parity test above proves the fold is behavior-preserving; this pins
+        WHAT is admitted. A second credential added to the frozenset — or a
+        prefix/substring match creeping into the matcher — fails here.
+        """
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", windows)
+        environ = _environ_for(windows)
+        admitted = kiro_prerequisite._allowlisted_env(
+            dict(environ), kiro_prerequisite._IDENTITY_PROBE_ENV_KEYS
+        )
+        assert set(admitted) == {"KIRO_API_KEY"}
+
+    def test_no_other_site_admits_the_kiro_credential(self, monkeypatch, windows: bool) -> None:
+        """``KIRO_API_KEY`` is the identity probe's alone — every other site rejects it.
+
+        Kept separate from :meth:`test_no_secret_admitted_by_any_site` because the
+        identity probe admits this one name ON PURPOSE, so it cannot join that
+        test's blanket secret set without asserting a falsehood.
+        """
+        monkeypatch.setattr(platform_compat, "IS_WINDOWS", windows)
+        for allowed in (
+            registry._SAFE_ENV_KEYS,
+            kiro_prerequisite._PROBE_ENV_KEYS,
+            dev_fleet_server._SAFE_ENV_KEYS,
+            gh_profile._MEASURE_ENV_PASSTHROUGH,
+            source_providers._PROVIDER_BASE_ENV_KEYS,
+        ):
+            assert not platform_compat.env_key_allowed("KIRO_API_KEY", allowed)
+
     def test_dev_fleet(self, monkeypatch, windows: bool) -> None:
         monkeypatch.setattr(platform_compat, "IS_WINDOWS", windows)
         environ = _environ_for(windows)
@@ -214,12 +276,17 @@ class TestCallSiteParity:
         )
 
     def test_no_secret_admitted_by_any_site(self, monkeypatch, windows: bool) -> None:
-        """The fold must never turn a credential-bearing name into a match."""
+        """The fold must never turn a credential-bearing name into a match.
+
+        The identity-probe allowlist is included: it names Kiro CLI's own
+        credential deliberately, and must still reject every OTHER one.
+        """
         monkeypatch.setattr(platform_compat, "IS_WINDOWS", windows)
         secrets = {"GITHUB_TOKEN", "AWS_SECRET_ACCESS_KEY", "SLACK_BOT_TOKEN"}
         for allowed in (
             registry._SAFE_ENV_KEYS,
             kiro_prerequisite._PROBE_ENV_KEYS,
+            kiro_prerequisite._IDENTITY_PROBE_ENV_KEYS,
             dev_fleet_server._SAFE_ENV_KEYS,
             gh_profile._MEASURE_ENV_PASSTHROUGH,
             source_providers._PROVIDER_BASE_ENV_KEYS,

--- a/test/test_kiro_prerequisite.py
+++ b/test/test_kiro_prerequisite.py
@@ -4648,3 +4648,133 @@ class TestAgentSpecRepair:
         for payload in (first_result, second_result):
             assert payload["missing_agent_specs"] == []
             assert payload["agent_spec_repair_error"] == ""
+
+
+class TestKiroCliApiKeyCountsAsSignedIn:
+    """A host authenticated by Kiro CLI's own API-key env var reads as signed in.
+
+    ``kiro-cli`` accepts a model credential through ``KIRO_API_KEY`` as an
+    alternative to a ``kiro-cli login`` token store, and ``whoami`` succeeds only
+    when it can see that variable. Filtering it out of the probe environment
+    latches ``authenticated=False`` on a host where an ACP session — which
+    inherits the real environment — authenticates fine, so the first-run gate
+    demands a sign-in the user has already done and every ``verified_ready``
+    caller answers 503.
+    """
+
+    @staticmethod
+    def _service(
+        tmp_path: Path,
+        run: Any,
+        *,
+        api_key: str = "",
+    ) -> KiroPrerequisiteService:
+        _make_executable(tmp_path / ".local" / "bin" / "kiro-cli")
+        environ = {"HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
+        if api_key:
+            environ["KIRO_API_KEY"] = api_key
+        return KiroPrerequisiteService(
+            platform_name="linux",
+            environ=environ,
+            home=tmp_path,
+            process_runner=run,
+            audit_writer=_no_audit,
+        )
+
+    @pytest.mark.asyncio
+    async def test_identity_probe_gets_the_key_and_version_probe_does_not(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Only ``whoami`` carries the credential; ``--version`` never needs one."""
+
+        seen: dict[str, dict[str, str]] = {}
+
+        async def run(
+            _command: str,
+            args: list[str],
+            **kwargs: Any,
+        ) -> ProcessResult:
+            seen[args[0]] = dict(kwargs.get("env") or {})
+            return ProcessResult(ok=True)
+
+        service = self._service(tmp_path, run, api_key="key-value")
+
+        await service.snapshot(force=True)
+
+        assert seen["whoami"].get("KIRO_API_KEY") == "key-value"
+        assert "KIRO_API_KEY" not in seen["--version"]
+
+    @pytest.mark.asyncio
+    async def test_api_key_host_latches_authenticated(self, tmp_path: Path) -> None:
+        """With the key visible, ``whoami`` succeeds and readiness follows it."""
+
+        async def run(
+            _command: str,
+            args: list[str],
+            **kwargs: Any,
+        ) -> ProcessResult:
+            # Mimic the CLI: `whoami` reports a signed-in identity only when the
+            # API key reaches it. `--version` runs regardless.
+            if args == ["--version"]:
+                return ProcessResult(ok=True)
+            env = kwargs.get("env") or {}
+            return ProcessResult(ok=bool(env.get("KIRO_API_KEY")))
+
+        service = self._service(tmp_path, run, api_key="key-value")
+
+        status = await service.snapshot(force=True)
+
+        assert status["authenticated"] is True
+        assert status["ready"] is True
+        assert await service.session_ready() is True
+
+    @pytest.mark.asyncio
+    async def test_a_rejected_key_is_still_signed_out(self, tmp_path: Path) -> None:
+        """Presence of the variable is not itself proof of a signed-in identity.
+
+        ``whoami`` remains the sole authority: a key the CLI rejects must leave
+        readiness signed out. This pins the invariant against the shortcut a later
+        reader might reach for — treating a set ``KIRO_API_KEY`` as authentication
+        and skipping the probe — which would latch ``ready=True`` on a stale or
+        mistyped key and turn a "sign in" prompt into a failure on every turn.
+        """
+
+        async def run(
+            _command: str,
+            args: list[str],
+            **_kwargs: Any,
+        ) -> ProcessResult:
+            # The key reaches the CLI; the CLI does not accept it.
+            return ProcessResult(ok=args == ["--version"])
+
+        service = self._service(tmp_path, run, api_key="rejected-key")
+
+        status = await service.snapshot(force=True)
+
+        assert status["installed"] is True
+        assert status["authenticated"] is False
+        assert status["ready"] is False
+        assert await service.session_ready() is False
+
+    @pytest.mark.asyncio
+    async def test_absent_api_key_is_not_a_false_positive(self, tmp_path: Path) -> None:
+        """No key and no token store must still read as signed out."""
+
+        async def run(
+            _command: str,
+            args: list[str],
+            **kwargs: Any,
+        ) -> ProcessResult:
+            if args == ["--version"]:
+                return ProcessResult(ok=True)
+            env = kwargs.get("env") or {}
+            return ProcessResult(ok=bool(env.get("KIRO_API_KEY")))
+
+        service = self._service(tmp_path, run)
+
+        status = await service.snapshot(force=True)
+
+        assert status["installed"] is True
+        assert status["authenticated"] is False
+        assert status["ready"] is False


### PR DESCRIPTION
## Problem / Motivation

A user authenticated to `kiro-cli` with `KIRO_API_KEY` is reported as signed out.
`kiro-cli whoami` prints "Authenticated with API key" and `kirocrew doctor` prints
`kiro login: ✅`, but the dashboard's first-run gate demands a sign-in that has
already happened, and every readiness-gated endpoint answers 503: `/api/models`,
`/api/sessions/usage`, the destructive reruns (regenerate, edit-resend, rewind),
and `POST /v1/chat/completions`.

Ordinary chat sends are ungated, so chat itself works. The result is a product in a
self-contradictory state: the agent answers prompts while the UI insists it is not
signed in, and `doctor` disagrees with the dashboard about the same fact.

## Why it matters

It hits every API-key user, on every platform, deterministically — not an
environment-specific failure. The visible damage is broad: the model picker has no
list, the credits pill never resolves, the OpenAI-compatible endpoint returns 503 to
SDK clients, and the first-run gate can block the dashboard.

`doctor` reporting success while the dashboard reports failure also sends anyone
debugging this to the wrong place, which is what happened in #2364.

## What changed (motivation → approach → change)

**Symptom** → readiness latches `authenticated=False` for API-key auth.

**Root cause** → readiness runs `kiro-cli whoami` and derives its answer from the
exit code. That part is correct. But the probe environment is built by
`_probe_env()`, which filters `os.environ` through the `_PROBE_ENV_KEYS` allowlist —
`HOME`, `PATH`, locale, XDG, Windows path vars. `KIRO_API_KEY` is not in it, so the
credential never reaches the subprocess and `whoami` exits 1. Confirmed directly:

```
$ kiro-cli whoami                      # key present in the environment
Authenticated with API key   → exit 0
$ env -i HOME=… PATH=… kiro-cli whoami # probe-shaped environment
Not logged in                → exit 1
```

The probe was therefore asking the CLI a different question than a real ACP session
asks, while `docs/system-specs/modules/acp-client.md` documents the intent as
running `whoami` "the same way a real ACP session runs the CLI".

**Change** → forward the credential to the identity probe only, via a separate
one-key allowlist `_IDENTITY_PROBE_ENV_KEYS` layered on by `_identity_probe_env()`.
The `--version` probe keeps the credential-free set: resolving a version number
needs no key.

The exposure delta is that one probe's argv, not a new surface: the credential
reaches the same resolved binary **this same probe already executes**, in the same
`standard` sandbox posture, against the same real home. (`KIRO_API_KEY` is also
absent from both `_SENSITIVE_ENV_PREFIXES` and `_AGENT_DENIED_ENV_KEYS`, so an ACP
session already receives it — but that argument is weaker on its own, because an ACP
spawn needs a user-initiated session while the probe runs at every gateway start.)
`--version` is deliberately excluded: it is the first execution of a candidate that
has not yet answered anything, and resolving a version number needs no key.
`docs/system-specs/modules/security.md` is updated in this commit, because it
claimed passive probes exclude "application credentials" without qualification.

**Trade worth stating plainly.** `whoami`'s exit status reports which credential
kind is *configured*, not whether the credential is *accepted*: on kiro-cli 2.16.2,
`KIRO_API_KEY=not-a-real-key kiro-cli whoami` exits 0 with
`{"accountType":"ApiKey","email":null}`. So this replaces a false negative for every
valid key with a possible false positive for a stale or mistyped one, where the gate
stops prompting for sign-in and turns fail instead. That is the same answer an ACP
session acts on, which is why the probe should agree with it, but it is a change of
direction in the conservative latch and it is now documented in both the constant's
comment and security.md. Discriminating valid from invalid would mean parsing
`whoami -f json` for a non-null `email`, which couples readiness to the CLI's output
format where today it uses the exit status alone — a design change, deliberately not
smuggled into a bug fix.

## Tests

`test/test_kiro_prerequisite.py::TestKiroCliApiKeyCountsAsSignedIn`:

- `test_identity_probe_gets_the_key_and_version_probe_does_not` — locks the routing
  in both directions: `whoami` receives `KIRO_API_KEY`, `--version` does not. Fails
  on the unpatched code.
- `test_api_key_host_latches_authenticated` — drives the service with a runner that
  mimics the CLI (succeed only when the key is visible) and asserts `authenticated`,
  `ready`, and `session_ready()` all become true. Fails on the unpatched code.
- `test_a_rejected_key_is_still_signed_out` — the key reaches the CLI and the CLI
  rejects it; readiness stays signed out. Pins `whoami` as the sole authority
  against the shortcut of treating a set variable as authentication.
- `test_absent_api_key_is_not_a_false_positive` — no key and no token store still
  reads as signed out, so this cannot become a blanket pass.

The first two were confirmed to fail before the fix, so they are not vacuous.

`test/test_env_allowlist_consolidation.py` enumerates every subprocess env allowlist;
`_IDENTITY_PROBE_ENV_KEYS` is registered there as a sixth entry rather than left
uncovered:

- per-site parity for the new allowlist, so the shared Windows case-fold stays
  behaviour-preserving for a credential name (`kiro_api_key` also matches, which is
  correct Windows semantics and now load-bearing);
- `test_identity_carve_out_is_exactly_one_credential` — it admits `KIRO_API_KEY` and
  nothing else, on both simulated platforms;
- `test_no_other_site_admits_the_kiro_credential` — the other five allowlists reject
  it;
- the existing `test_no_secret_admitted_by_any_site` now includes this allowlist, so
  it must still reject every *other* credential.

Verified non-vacuous: temporarily widening the carve-out to
`frozenset({"KIRO_API_KEY", "GITHUB_TOKEN"})` fails 4 of them across both platform
arms.

## Manual verification

Source build on macOS 15 (arm64), Python 3.13, `kiro-cli 2.16.2`, isolated
`KIROCREW_HOME`, real gateway — measured on both branches at the same commit:

| Endpoint | unpatched `main` | this branch |
|---|---|---|
| `GET /api/kiro-prerequisite?refresh=1` | `authenticated: false, ready: false` | `authenticated: true, ready: true` |
| `GET /api/models` | 503 `kiro_prerequisite_required` | 200, real model list |
| `GET /api/sessions/usage` | 503 `kiro_prerequisite_required` | 200 |
| `POST /v1/chat/completions` | 503 | 200, model replied |

Negative control: with `KIRO_API_KEY` unset the same build reports
`authenticated: false`. Also verified the credential can arrive via
`~/.kiro/crew/.env` (`load_credentials()` seeds `os.environ`), which is the path a
Finder-launched desktop app needs, since a GUI process does not inherit a shell
profile.

Backend suite: 40278 passed. 25 failures on this machine are pre-existing and
environmental — verified identical on a clean `main` with these changes stashed
(macOS `AF_UNIX` path length, a git refspec issue in the ops-mission-control ledger
tests, and extra env keys because the run is itself inside a sandbox).
`cd website && npm run check` exits 0 (876 vitest files, 845 electron tests).
`./scripts/docs-lint.sh` passes.

## Related Issues

Refs #2364 — same root cause. That report is this exact configuration (macOS desktop
app, `KIRO_API_KEY`, `whoami` reporting API-key auth, `doctor` green) and its symptom
is the credits pill stuck on "Checking usage…" forever. The 503 above is why: the
fetch rejects, and `website/src/test/App.test.tsx` asserts the pill "stays in loading
state if the usage fetch rejects". With this change the endpoint returns
`{"usage": {"available": false}}`, and the same test file asserts the pill "hides the
pill entirely when usage is unavailable" — so the stuck spinner is resolved.

Deliberately `Refs` and not `Fixes`: this does not make credit numbers appear. The
free usage API cannot serve an API-key user at all — `GetUsageLimits` rejects the key
with `403 AccessDeniedException: "The bearer token included in the request is
invalid."`, and `_candidate_tokens()` finds nothing, because that module only reads
bearer tokens from disk. Real numbers require `dashboard.usage_text_scrape_enabled`,
which is off by default because each refresh is a billed chat turn, and which
currently has no dashboard toggle. Whether to change either is a maintainer call, so
both are out of scope here.

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
