### PR TITLE
fix: seed artifact companion composer on first open

### DIFF
--- a/website/src/pages/ArtifactDetailPage.tsx
+++ b/website/src/pages/ArtifactDetailPage.tsx
@@ -1088,6 +1088,17 @@ export default function ArtifactDetailPage({ popout = false }: { popout?: boolea
         running: false,
         artifact: artifact.slug,
       } as ChatSlot))
+      // Activate the bound slot NOW — back-to-back with writePrefill, mirroring
+      // ChatPage's follow-up worktree handler — so activeSlot is already this
+      // slot BEFORE boundSlot resolves and ArtifactChatPanel mounts the embedded
+      // ChatPage. Otherwise the switch lands in the same commit as that mount,
+      // where ChatPage's mount-only slot re-fetch effect (StrictMode
+      // double-invoked, empty deps → stale activeSlot capture) re-asserts the
+      // PRIOR active slot as the last write. activeSlot then never becomes this
+      // slot on first open, so the per-slot draft-restore effect can't consume
+      // the staged prefill and the composer opens empty (correct only on the
+      // second open). Idempotent once active === res.key.
+      dispatch(switchSlot(res.key))
       api.chatSlotContext(res.key, buildCompanionContext(), {
         source: 'artifact-companion', ephemeral: true,
       }).catch(() => undefined)

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -1179,6 +1179,14 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
  // forensic attribution. Set on widget pre-fill, consumed
   // and cleared in send(). A genuine from-scratch turn never sets this.
   const widgetPrefillRef = useRef<string | null>(null)
+  // Token (`${slotKey}:${ts}`) of the most recently consumed composer prefill.
+  // Guards the per-slot draft-restore effect against React.StrictMode's mount
+  // double-invoke: the first invoke consumes+removes PREFILL_STORAGE_KEY and
+  // seeds the composer, so without this the second invoke would find no stored
+  // prefill and reset the composer to the (empty) incoming draft — the artifact
+  // companion panel mounts ChatPage fresh, so it hits this double-invoke every
+  // first open. See the draft-restore effect below.
+  const consumedPrefillRef = useRef<string | null>(null)
 
   // Auto-dismiss prefill hint after 10 seconds
   useEffect(() => {
@@ -1384,6 +1392,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     if (prevSlot.current) setFileDraft(fileDrafts.current, prevSlot.current, pendingFilesRef.current)
     if (prevSlot.current) setPasteDraft(pasteDrafts.current, prevSlot.current, pasteBlocksRef.current)
     if (prevSlot.current) setSessionRefDraft(sessionRefDrafts.current, prevSlot.current, pendingSessionsRef.current)
+    const prevSlotVal = prevSlot.current
     prevSlot.current = activeSlot
     const raw = sessionStorage.getItem(PREFILL_STORAGE_KEY)
     const draftFallback = activeSlot ? drafts.current[activeSlot] ?? '' : ''
@@ -1391,9 +1400,16 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       try {
         const { slotKey, prompt, ts } = JSON.parse(raw)
         if (Date.now() - (ts ?? 0) > 30_000) { sessionStorage.removeItem(PREFILL_STORAGE_KEY); setInput(draftFallback) }
-        else if (slotKey === activeSlot) { sessionStorage.removeItem(PREFILL_STORAGE_KEY); setInput(prompt) }
+        else if (slotKey === activeSlot) { sessionStorage.removeItem(PREFILL_STORAGE_KEY); consumedPrefillRef.current = `${slotKey}:${ts}`; setInput(prompt) }
         else { setInput(draftFallback) }
       } catch { sessionStorage.removeItem(PREFILL_STORAGE_KEY); setInput(draftFallback) }
+    } else if (prevSlotVal === activeSlot && !!activeSlot && consumedPrefillRef.current?.startsWith(`${activeSlot}:`)) {
+      // StrictMode re-invoked this mount effect for the SAME active slot after
+      // the first invoke already consumed+removed the prefill. The composer
+      // already holds the staged prompt; a setInput(draftFallback) here would
+      // wipe it back to the empty draft. Leave the composer as-is. (A genuine
+      // slot switch changes activeSlot, so prevSlotVal !== activeSlot and this
+      // branch cannot mask a real draft restore.)
     } else { setInput(draftFallback) }
     // Restore the incoming slot's staged file attachments (copy so the
     // live state array and the stored draft don't share a reference).

--- a/website/src/test/ChatPageEmbeddedPrefill.test.tsx
+++ b/website/src/test/ChatPageEmbeddedPrefill.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Regression: artifact companion chat opens with an EMPTY composer the first
+ * time a comment is sent to the agent (correct only on the second open).
+ *
+ * Root cause: unlike the follow-up worktree flow (which does
+ * `writePrefill(slot)` then `await switchSlot(slot)` back-to-back while ChatPage
+ * is already mounted), the artifact flow writes the prefill in
+ * `createBoundSession` but activates the slot LATER and ELSEWHERE — in
+ * `ArtifactChatPanel`'s `useEffect(() => dispatch(switchSlot(slotKey)))`. The
+ * embedded `<ChatPage>` only mounts once the panel receives a non-null slotKey,
+ * so ChatPage MOUNTS and the slot SWITCH happen in the same beat. The per-slot
+ * draft-restore effect (which consumes PREFILL_STORAGE_KEY) is a child effect,
+ * so it runs on mount BEFORE the panel's parent switch effect — at that point
+ * `activeSlot` is still the previous slot, the prefill's slotKey doesn't match,
+ * and the composer is seeded from the (empty) incoming draft instead.
+ *
+ * This harness reproduces exactly that timing with the REAL ChatPage.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { StrictMode, useEffect, useRef, useState } from 'react'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import type { RootState } from '../store'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ThemeProvider } from '../hooks/useTheme'
+import chatReducer, { switchSlot } from '../store/chatSlice'
+import dashboardReducer from '../store/dashboardSlice'
+import notificationsReducer from '../store/notificationsSlice'
+import { useAppDispatch } from '../store'
+import { writePrefill } from '../utils/navIntent'
+
+vi.mock('react-virtuoso', () => ({
+  Virtuoso: ({ data, itemContent }: { data?: unknown[]; itemContent: (index: number, item: unknown) => ReactNode }) => (
+    <div data-testid="virtuoso">{data?.map((d: unknown, i: number) => <div key={i}>{itemContent(i, d)}</div>)}</div>
+  ),
+}))
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([
+      { key: 'chat-1', messages: 1, running: false, mode: '', project: '/repo' },
+      { key: 'chat-2', messages: 0, running: false, mode: '', project: '/repo' },
+    ]),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0 }),
+    sendChat: vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ ok: true }) }),
+    chatHistory: vi.fn().mockResolvedValue({ sessions: [] }),
+    models: vi.fn().mockResolvedValue([]),
+    agents: vi.fn().mockResolvedValue([]),
+    agentDetail: vi.fn().mockResolvedValue({}),
+    workspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+    slackChannels: vi.fn().mockResolvedValue([]),
+    spawnList: vi.fn().mockResolvedValue({ agents: [] }),
+    uploadFiles: vi.fn().mockResolvedValue({ paths: [] }),
+    screenshot: vi.fn().mockResolvedValue({ path: null }),
+    createChatSlot: vi.fn().mockResolvedValue({ key: 'chat-2', title: 'chat-2', messages: 0, running: false }),
+    deleteChatSlot: vi.fn().mockResolvedValue({ ok: true }),
+    chatSlotContext: vi.fn().mockResolvedValue({ ok: true }),
+  },
+  SEARCH_MIN_CHARS: 2,
+}))
+vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: 'default' }) }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: ({ content }: { content: string }) => <span>{content}</span> }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../components/DetailPanel', () => ({ default: () => null }))
+vi.mock('../hooks/useWebSocket', () => ({ useWebSocket: () => ({ subscribeLogs: () => {} }) }))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+})
+
+import ChatPage from '../pages/ChatPage'
+
+const PROMPT = 'Please review and address the 2 open comments on this artifact.'
+
+function makeStore() {
+  return configureStore({
+    reducer: { dashboard: dashboardReducer, chat: chatReducer, notifications: notificationsReducer },
+    preloadedState: {
+      dashboard: {
+        status: null, connected: true,
+        slots: [
+          { key: 'chat-1', messages: 1, running: false, mode: '', project: '/repo', pending_approval: false, waiting_for_input: false, last_activity_ts: undefined },
+          { key: 'chat-2', messages: 0, running: false, mode: '', project: '/repo', pending_approval: false, waiting_for_input: false, last_activity_ts: undefined },
+        ],
+        unreadSlots: [], refreshTrigger: 0, approvalMode: 'normal',
+        subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      } as unknown as RootState['dashboard'],
+      chat: {
+        activeSlot: 'chat-1', messages: [{ role: 'assistant', content: 'hi', cls: '' }],
+        slotRunning: false, slotStopping: false, slotState: 'idle',
+        history: [], historyHasMore: false, pendingInput: null,
+        subagents: {}, toolLog: [], activityOpen: false, activityTab: 'tools',
+        slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+        slotStatusDetail: {}, slotContextPct: {}, slotActivity: {}, slotHistory: [],
+        historyOffset: 0, _wsChunkedDuringFetch: false,
+        slotMessages: {}, slotLoading: false,
+        followups: {},
+      } as unknown as RootState['chat'],
+      notifications: { items: [] } as unknown as RootState['notifications'],
+    },
+  })
+}
+
+/** Mirror of ArtifactChatPanel: mounts the embedded ChatPage only once a bound
+ *  slotKey exists, and activates that slot from a useEffect. */
+function PanelHarness({ slotKey }: { slotKey: string | null }) {
+  const dispatch = useAppDispatch()
+  const prev = useRef<string | null>(null)
+  useEffect(() => {
+    if (slotKey && slotKey !== prev.current) {
+      prev.current = slotKey
+      dispatch(switchSlot(slotKey))
+    }
+  }, [slotKey, dispatch])
+  if (!slotKey) return <div>no session</div>
+  return <ChatPage embedded embedMode="chat" noUrlSync />
+}
+
+function Wrapper({ store }: { store: ReturnType<typeof makeStore> }) {
+  const [slotKey, setSlotKey] = useState<string | null>(null)
+  ;(globalThis as unknown as { __openCompanion: () => void }).__openCompanion = () => {
+    // Mirror the FIXED createBoundSession ordering (ArtifactDetailPage.tsx):
+    // writePrefill + switchSlot back-to-back BEFORE the bound slot surfaces to
+    // the panel, so the embedded ChatPage mounts with the target already active
+    // — the same contract as ChatPage's follow-up worktree handler. Without the
+    // switchSlot here, this assertion fails under React.StrictMode (the slot is
+    // never activated on first open → empty composer).
+    writePrefill('chat-2', PROMPT)
+    store.dispatch(switchSlot('chat-2'))
+    setSlotKey('chat-2')
+  }
+  return <PanelHarness slotKey={slotKey} />
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+describe('embedded ChatPage prefill on first activation (artifact companion)', () => {
+  const composer = () => screen.getByLabelText('Message input') as HTMLTextAreaElement
+
+  it('seeds the composer with the staged prompt the FIRST time the panel opens', async () => {
+    const store = makeStore()
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    await act(async () => {
+      render(
+        <QueryClientProvider client={qc}>
+          <Provider store={store}>
+            <ThemeProvider>
+              <StrictMode><MemoryRouter><Wrapper store={store} /></MemoryRouter></StrictMode>
+            </ThemeProvider>
+          </Provider>
+        </QueryClientProvider>,
+      )
+    })
+    // Open the companion panel (writes prefill + mounts ChatPage + switches slot).
+    await act(async () => {
+      ;(globalThis as unknown as { __openCompanion: () => void }).__openCompanion()
+    })
+    await waitFor(() => expect(store.getState().chat.activeSlot).toBe('chat-2'))
+    await waitFor(() => expect(composer().value).toBe(PROMPT))
+    expect(sessionStorage.getItem('kirocrew_prefill')).toBeNull()
+  })
+})


### PR DESCRIPTION
## What

Fixes the artifact companion chat opening with an **empty composer the first time** a comment is sent to an agent (the staged prompt only appears on the second open).

Closes #2524.

## Root cause

Two `React.StrictMode`-only races combined (the app mounts under `StrictMode`, and the artifact companion panel mounts `ChatPage` **fresh** every first open, so it hits mount-effect double-invokes the always-mounted `/chat` page never sees):

1. **Slot never activated.** `createBoundSession` (`ArtifactDetailPage.tsx`) wrote the prefill via `writePrefill` but delegated slot activation to `ArtifactChatPanel`'s `useEffect`. That `switchSlot` therefore lands in the *same commit that mounts the embedded `ChatPage`*, where ChatPage's mount-only slot re-fetch effect — StrictMode double-invoked, empty deps so it captures a **stale** `activeSlot` — re-asserts the *prior* active slot as the last write. `activeSlot` never becomes the bound slot, so the prefill is never matched.
2. **Prefill wiped on the second mount invoke.** Once activation is fixed, ChatPage's per-slot draft-restore effect consumes and **removes** `PREFILL_STORAGE_KEY` on StrictMode's first mount invoke, then the second invoke finds nothing and resets the composer to the empty incoming draft.

The follow-up worktree handler in `ChatPage.tsx` already documents the correct sequencing (`writePrefill` then `switchSlot` back-to-back) — but it works there because `/chat`'s ChatPage is already mounted, so its consumer effect runs once on a dep-change, never a mount double-invoke.

## Fix

- **`ArtifactDetailPage.tsx`** — `createBoundSession` now dispatches `switchSlot(res.key)` immediately after `writePrefill` + `addSlotOptimistic`, so `activeSlot` is already the bound slot before the panel mounts ChatPage (idempotent once equal). Covers both the "Ask agent to address" flow and "New chat" (both route through `createBoundSession`).
- **`ChatPage.tsx`** — a `consumedPrefillRef` guards the draft-restore consumer against the mount double-invoke: when the effect re-runs for the *same* active slot after already consuming the prefill, it leaves the composer as-is instead of wiping it to the empty draft. A genuine slot switch changes `activeSlot`, so the guard can never mask a real draft restore.

## Tests

- New `src/test/ChatPageEmbeddedPrefill.test.tsx` mounts the **real** ChatPage the way `ArtifactChatPanel` does, under `StrictMode`, and asserts the composer is seeded with the staged prompt on the first open. It fails on `main` (empty composer) and passes with this change.
- `cd website && npx tsc -b` clean; `eslint` 0 errors; ran the ChatPage + Artifact + Sidebar test surface (65 files / 496 tests) — all green, confirming the shared draft-restore effect change is regression-free.

## Known related edge (not fixed here, flagged for maintainers)

An audit surfaced a narrower sibling: re-staging an "Ask agent to address" prompt while the companion panel is **already open on that same slot** (`openCompanionChat` resume path, `ArtifactDetailPage.tsx:1147`) can strand the prompt, because `ArtifactChatPanel`'s ref-guarded effect no-ops `switchSlot` when the slot is unchanged and nothing re-fires the consumer. It's a distinct trigger from the reported first-open bug and touches hotter shared code; happy to address in a follow-up if you'd like it in scope.
