### PR TITLE
fix: cron history attributes previous run's result to result-less runs

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -237,6 +237,17 @@ class CronJob:
     # Reset at the start of every run.
     fire_time_denied: bool = False
     last_result: str | None = None
+    # Runtime-only (never serialized): True once THIS run produced a result
+    # via set_run_result(). ``last_result`` is a cross-run context-carry
+    # field that result-less runs (timeout, callback exception, no-output
+    # command, script Skip) deliberately leave in place for the next run's
+    # prompt dedup, so the history recorder needs this marker — not the
+    # value — to decide attribution. Identity/equality checks on the string
+    # cannot do that job: CPython interns equal literals and caches
+    # single-character latin-1 strings, so a run re-producing the same text
+    # is indistinguishable from a run that produced nothing. Reset at the
+    # start of every run by _run_job_isolated.
+    result_produced: bool = False
     context_enabled: bool = False
     agent_id: str = ""
     approval_mode: str = ""  # "" (default/hook-based) | "auto" (auto-approve all tools)
@@ -276,6 +287,19 @@ class CronJob:
     timeout: int = (
         0  # script/command timeout in seconds (0 = use default: 30s script, 300s command)
     )
+
+    def set_run_result(self, value: str) -> None:
+        """Record a result produced by the CURRENT run.
+
+        Sole write path for executor callbacks: pairs the ``last_result``
+        assignment with the runtime-only ``result_produced`` marker so the
+        history recorder can attribute the value to this run. Direct
+        ``last_result`` assignment stays reserved for store merge and
+        deserialization paths, which restore prior state rather than
+        produce a new result.
+        """
+        self.last_result = value
+        self.result_produced = True
 
     def _audit_pause_change(self, outcome: str) -> None:
         """Emit a SEL audit event for an auto-pause permission transition.
@@ -2222,6 +2246,19 @@ class CronService:
         # Provisional; refined once the jitter sleep completes. Only read on
         # the history path, which a cancelled-during-jitter run never reaches.
         exec_started_at = started_at
+        # ``last_result`` is a cross-run context-carry field (see
+        # build_cron_session_context): runs that end without producing a
+        # result — timeout, callback exception, no-output command, script
+        # Skip — deliberately leave the previous run's value in place so the
+        # next run's prompt keeps its dedup context. The history recorder in
+        # the finally block must NOT attribute that carried-over value to
+        # THIS run, so clear the freshness marker here; executor callbacks
+        # set it via CronJob.set_run_result() when the run actually produces
+        # a result. (String identity/equality can't stand in for the marker:
+        # CPython interns equal literals and caches single-char strings, so
+        # a run re-producing the previous text looks identical to one that
+        # produced nothing.)
+        job.result_produced = False
         try:
             # The jitter sleep MUST live inside this try: hourly/daily jobs
             # sleep up to 59 min here, and a user cancel() during that window
@@ -2283,6 +2320,15 @@ class CronService:
                 # Record history
                 try:
                     status = "success" if job.last_status == "ok" else "failure"
+                    # Attribute last_result to this run only if the run
+                    # actually produced it (set_run_result sets the marker).
+                    # Reading it unconditionally recorded the PREVIOUS run's
+                    # result as this run's summary/trace whenever the run
+                    # ended without producing one (observed in the wild: a
+                    # timed-out run's history row carried the prior success's
+                    # summary verbatim — fabricated history on a
+                    # status=failure record).
+                    run_result = job.last_result if job.result_produced else None
                     record = CronRunRecord(
                         job_id=job.id,
                         trigger=trigger,
@@ -2290,8 +2336,8 @@ class CronService:
                         finished_at=finished_at,
                         duration_ms=int((finished_at - exec_started_at) * 1000),
                         status=status,
-                        summary=(job.last_result or job.last_error or "")[:200],
-                        trace=job.last_result or "",
+                        summary=(run_result or job.last_error or "")[:200],
+                        trace=run_result or "",
                         error=job.last_error or "",
                     )
                     await self._history.append(record)

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -2073,7 +2073,7 @@ class GatewayOrchestrator:
                             )
                             job.record_failure()
                         return None  # no output = no delivery
-                    job.last_result = redact(output)
+                    job.set_run_result(redact(output))
                     job.last_error = ""
                     if result.get("status") == "ok":
                         job.last_status = "ok"
@@ -2195,7 +2195,7 @@ class GatewayOrchestrator:
                         # bookkeeping/history — no failure counting, no delivery.
                         return None
                     if status == "ok":
-                        job.last_result = "ok"
+                        job.set_run_result("ok")
                         job.last_error = ""
                         job.last_status = "ok"
                         job.record_success()
@@ -2224,12 +2224,13 @@ class GatewayOrchestrator:
                         return None
                     elif status == "done":
                         msg = result.get("message", "")
-                        job.last_result = redact(msg) if msg else ""
+                        script_msg = redact(msg) if msg else ""
+                        job.set_run_result(script_msg)
                         job.last_error = ""
                         job.last_status = "ok"
                         job.record_success()
                         # Deliver Done message and remove job
-                        await _deliver_script_result(job, job.last_result, remove=True)
+                        await _deliver_script_result(job, script_msg, remove=True)
                         try:
                             sel().log_tool_invocation(
                                 session_key=f"cron:{job.id}",
@@ -2241,15 +2242,16 @@ class GatewayOrchestrator:
                             logger.debug(
                                 "SEL logging failed in cron script done path", exc_info=True
                             )
-                        return job.last_result or "done"
+                        return script_msg or "done"
                     elif status == "report":
                         msg = result.get("message", "")
-                        job.last_result = redact(msg) if msg else ""
+                        script_msg = redact(msg) if msg else ""
+                        job.set_run_result(script_msg)
                         job.last_error = ""
                         job.last_status = "ok"
                         job.record_success()
                         # Deliver Report message (keep job running)
-                        await _deliver_script_result(job, job.last_result)
+                        await _deliver_script_result(job, script_msg)
                         try:
                             sel().log_tool_invocation(
                                 session_key=f"cron:{job.id}",
@@ -2261,7 +2263,7 @@ class GatewayOrchestrator:
                             logger.debug(
                                 "SEL logging failed in cron script report path", exc_info=True
                             )
-                        return job.last_result or "report"
+                        return script_msg or "report"
                     else:
                         err = result.get("error", "unknown error")
                         raise RuntimeError(err)
@@ -2543,7 +2545,7 @@ class GatewayOrchestrator:
                                     self.cron_svc.clear_active_session_key(job.id)
                 if _seq_downgraded:
                     result_text = _annotate_model_downgrade(result_text)
-                job.last_result = result_text
+                job.set_run_result(result_text)
                 return result_text
 
             # ── Single-agent path (existing behavior) ──
@@ -2605,7 +2607,7 @@ class GatewayOrchestrator:
                 if _model_downgraded:
                     result_text = _annotate_model_downgrade(result_text)
 
-                job.last_result = result_text
+                job.set_run_result(result_text)
 
                 # Context-meter reading for the dashboard slot, captured NOW:
                 # the finally block below resets this session, so the open

--- a/test/test_cron_history.py
+++ b/test/test_cron_history.py
@@ -327,3 +327,229 @@ async def test_run_job_stores_manual_trigger_meta() -> None:
 
     assert "j1" in svc._job_run_meta
     assert svc._job_run_meta["j1"][1] == "manual"
+
+
+# ── Run-result freshness (stale-summary fabrication regression) ──────────
+#
+# ``job.last_result`` is a cross-run context-carry field: failure paths
+# (timeout, callback exception, no-output command) and script Skip end the
+# run WITHOUT assigning it. The history recorder must not attribute the
+# carried-over previous result to the current run — a timed-out run was
+# observed recording the prior success's summary verbatim.
+
+
+def _read_history_rows(tmp_path: Path, job_id: str) -> list[dict]:
+    job_file = tmp_path / "cron-history" / f"{job_id}.jsonl"
+    assert job_file.exists(), "history record was not written"
+    return [
+        json.loads(line)
+        for line in job_file.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _freshness_job(**kw):
+    from kiro_crew.cron import CronJob, CronSchedule
+
+    return CronJob(
+        id=kw.pop("id", "j1"),
+        name=kw.pop("name", "test"),
+        message=kw.pop("message", "go"),
+        schedule=kw.pop("schedule", CronSchedule(kind="every", every_secs=60)),
+        **kw,
+    )
+
+
+class TestRunResultFreshness:
+    def test_timeout_does_not_inherit_previous_result(self, tmp_path: Path) -> None:
+        """A timed-out run must record its own error, not the prior run's summary."""
+        import asyncio
+
+        from kiro_crew.cron import CronService
+
+        async def _hang(*args, **kwargs):
+            await asyncio.sleep(9999)
+
+        svc = CronService(base_dir=tmp_path)
+        job = _freshness_job(last_result="prior run success summary", timeout_secs=0)
+        svc._jobs = [job]
+        svc._save()
+        with patch.object(svc, "_execute", side_effect=_hang), patch(
+            "kiro_crew.cron._JOB_TIMEOUT_SECS", 0.05
+        ):
+            asyncio.run(svc._run_job_isolated(job))
+
+        (row,) = _read_history_rows(tmp_path, job.id)
+        assert row["status"] == "failure"
+        assert row["summary"].startswith("Timed out")
+        assert row["trace"] == ""
+        assert row["error"].startswith("Timed out")
+        assert "prior run success summary" not in json.dumps(row)
+        # Context-carry is preserved: the next run's prompt still sees the
+        # last produced result (value-equal; the run itself made no new one).
+        assert job.last_result == "prior run success summary"
+
+    def test_first_run_timeout_with_no_prior_result(self, tmp_path: Path) -> None:
+        """None snapshot branch: first-ever run timing out records its error."""
+        import asyncio
+
+        from kiro_crew.cron import CronService
+
+        async def _hang(*args, **kwargs):
+            await asyncio.sleep(9999)
+
+        svc = CronService(base_dir=tmp_path)
+        job = _freshness_job(timeout_secs=0)
+        assert job.last_result is None
+        svc._jobs = [job]
+        svc._save()
+        with patch.object(svc, "_execute", side_effect=_hang), patch(
+            "kiro_crew.cron._JOB_TIMEOUT_SECS", 0.05
+        ):
+            asyncio.run(svc._run_job_isolated(job))
+
+        (row,) = _read_history_rows(tmp_path, job.id)
+        assert row["status"] == "failure"
+        assert row["summary"].startswith("Timed out")
+        assert row["trace"] == ""
+
+    def test_fresh_result_still_attributed(self, tmp_path: Path) -> None:
+        """A run that produces a new result records it as summary and trace."""
+        import asyncio
+
+        from kiro_crew.cron import CronService
+
+        async def _produce(job):
+            job.set_run_result("new run output")
+            job.last_status = "ok"
+            job.last_error = None
+
+        svc = CronService(base_dir=tmp_path)
+        job = _freshness_job(last_result="prior run output")
+        svc._jobs = [job]
+        svc._save()
+        with patch.object(svc, "_execute", side_effect=_produce):
+            asyncio.run(svc._run_job_isolated(job))
+
+        (row,) = _read_history_rows(tmp_path, job.id)
+        assert row["status"] == "success"
+        assert row["summary"] == "new run output"
+        assert row["trace"] == "new run output"
+
+    def test_reassigning_identical_interned_literal_counts_as_fresh(
+        self, tmp_path: Path
+    ) -> None:
+        """Re-producing the interned literal "ok" (script-ok path) is fresh.
+
+        String identity/equality cannot distinguish this from a result-less
+        run — CPython interns the literal — which is why freshness comes
+        from the ``result_produced`` marker set by ``set_run_result``.
+        """
+        import asyncio
+
+        from kiro_crew.cron import CronService
+
+        async def _script_ok(job):
+            job.set_run_result("ok")  # interned literal, same object every run
+            job.last_status = "ok"
+            job.last_error = None
+
+        svc = CronService(base_dir=tmp_path)
+        job = _freshness_job(last_result="ok")
+        svc._jobs = [job]
+        svc._save()
+        with patch.object(svc, "_execute", side_effect=_script_ok):
+            asyncio.run(svc._run_job_isolated(job))
+
+        (row,) = _read_history_rows(tmp_path, job.id)
+        assert row["status"] == "success"
+        assert row["summary"] == "ok"
+
+    def test_repeated_single_char_result_counts_as_fresh(self, tmp_path: Path) -> None:
+        """Re-producing a single-char result (e.g. "y") is fresh.
+
+        CPython caches single-character latin-1 strings as singletons, so
+        even a re-boxed snapshot ``(s + " ")[:-1]`` collapses back to the
+        cached object — the case that broke the identity-snapshot approach.
+        The ``result_produced`` marker is immune to it.
+        """
+        import asyncio
+
+        from kiro_crew.cron import CronService
+
+        async def _one_char(job):
+            job.set_run_result("y")
+            job.last_status = "ok"
+            job.last_error = None
+
+        svc = CronService(base_dir=tmp_path)
+        job = _freshness_job(last_result="y")
+        svc._jobs = [job]
+        svc._save()
+        with patch.object(svc, "_execute", side_effect=_one_char):
+            asyncio.run(svc._run_job_isolated(job))
+
+        (row,) = _read_history_rows(tmp_path, job.id)
+        assert row["status"] == "success"
+        assert row["summary"] == "y"
+        assert row["trace"] == "y"
+
+    def test_successful_run_without_result_records_empty_summary(
+        self, tmp_path: Path
+    ) -> None:
+        """A run ending ok without producing output (e.g. script Skip, command
+        with empty output) must not surface the previous run's result."""
+        import asyncio
+
+        from kiro_crew.cron import CronService
+
+        async def _no_output(job):
+            job.last_status = "ok"
+            job.last_error = None
+
+        svc = CronService(base_dir=tmp_path)
+        job = _freshness_job(last_result="prior run output")
+        svc._jobs = [job]
+        svc._save()
+        with patch.object(svc, "_execute", side_effect=_no_output):
+            asyncio.run(svc._run_job_isolated(job))
+
+        (row,) = _read_history_rows(tmp_path, job.id)
+        assert row["status"] == "success"
+        assert row["summary"] == ""
+        assert row["trace"] == ""
+        # Carried-over context is untouched for the next prompt build.
+        assert job.last_result == "prior run output"
+
+    def test_freshness_marker_resets_between_runs(self, tmp_path: Path) -> None:
+        """A producing run followed by a result-less run on the SAME job
+        object must not leak run 1's freshness marker into run 2's history."""
+        import asyncio
+
+        from kiro_crew.cron import CronService
+
+        async def _produce(job):
+            job.set_run_result("run one output")
+            job.last_status = "ok"
+            job.last_error = None
+
+        async def _no_output(job):
+            job.last_status = "ok"
+            job.last_error = None
+
+        svc = CronService(base_dir=tmp_path)
+        job = _freshness_job()
+        svc._jobs = [job]
+        svc._save()
+        with patch.object(svc, "_execute", side_effect=_produce):
+            asyncio.run(svc._run_job_isolated(job))
+        with patch.object(svc, "_execute", side_effect=_no_output):
+            asyncio.run(svc._run_job_isolated(job))
+
+        row1, row2 = _read_history_rows(tmp_path, job.id)
+        assert row1["summary"] == "run one output"
+        assert row2["status"] == "success"
+        assert row2["summary"] == ""
+        assert row2["trace"] == ""
+        # Context-carry for the next prompt still holds run 1's value.
+        assert job.last_result == "run one output"

--- a/test/test_slack_gateway.py
+++ b/test/test_slack_gateway.py
@@ -1066,7 +1066,7 @@ class TestInitCron:
                 result = await callback(job)
 
         assert result == "cron result"
-        assert job.last_result == "cron result"
+        job.set_run_result.assert_called_once_with("cron result")
 
     @pytest.mark.asyncio
     async def test_cron_callback_publishes_turn_identity(self):
@@ -2238,7 +2238,7 @@ class TestCronFailurePaths:
                 result = await callback(job)
 
         assert result == "agent result"
-        assert job.last_result == "agent result"
+        job.set_run_result.assert_called_once_with("agent result")
         # get_or_create called twice (once per agent)
         assert orch.sessions.get_or_create.await_count == 2
 


### PR DESCRIPTION
## Problem

A cron run that ends without producing a result — job-level timeout, callback exception, no-output command, script `Skip` — records the **previous** run's `last_result` as its own `summary` and `trace` in cron history.

Observed in the wild: a job hit its 1800s timeout and its history row was recorded as `status=failure` carrying the **byte-identical summary of the prior successful run** — fabricated history. Sanitized evidence (job id `14f40d17`, two adjacent rows):

```
run 4b416eca…  status=success  summary="…scan clean, tracker updated…"
run 700ed373…  status=failure  error="Timed out after 1800s"
                               summary="…scan clean, tracker updated…"   <-- prior run's summary, verbatim
```

## Root cause

`CronJob.last_result` is a deliberate cross-run context-carry field: `build_cron_session_context` prepends it to the next run's prompt (`[Previous run result — do NOT repeat…]`), so failure paths intentionally leave it in place. But the history recorder in `_run_job_isolated` read it unconditionally:

```python
summary=(job.last_result or job.last_error or "")[:200],
trace=job.last_result or "",
```

`last_status`/`last_error` are reset per run; `last_result` is not — so any run that never reassigns it inherits the previous run's result in its own history record. The stale value even shadows the fresh timeout error in `summary` (`last_result or last_error`).

## Fix

Scoped to the history recorder — the field's cross-run semantics (prompt context-carry, delivery dedup) are unchanged:

- Snapshot `last_result` at the start of `_run_job_isolated`, re-boxed to a distinct-but-equal object so the freshness check can't be fooled by string interning (the script-ok path assigns the literal `"ok"` every run — an identity check against the raw previous value would misclassify it as stale).
- When recording history, attribute `last_result` to the run only if the run actually reassigned it (`job.last_result is not prev_result`); otherwise `summary` falls through to `last_error` and `trace` is empty.

## Tests

5 regression tests in `test/test_cron_history.py` (`TestRunResultFreshness`):
- timed-out run records its own error, not the prior summary (**fails pre-fix**)
- successful run with no output records empty summary, not the prior result (**fails pre-fix**)
- fresh results are still attributed (summary + trace)
- re-assigning the identical interned literal `"ok"` still counts as fresh (mutation guard for the snapshot re-boxing)
- first-ever run (no prior result) timeout — `None` snapshot branch
- context-carry preserved: after a result-less run, `job.last_result` still holds the prior value for the next prompt

Verification: 31/31 `test_cron_history.py`, 1204 passed across `-k cron` (one pre-existing failure `test_run_command_sandboxed_can_be_cancelled_mid_run` reproduces identically at pristine `origin/main` in this environment — unrelated), isort/flake8/mypy clean.
