### PR TITLE
fix(dev-fleet): make page usable on phone-sized viewports

### DIFF
--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -204,7 +204,7 @@ function ProvLogPre({ lines, streaming }: { lines: string[]; streaming: boolean 
     if (streaming && ref.current) ref.current.scrollTop = ref.current.scrollHeight
   }, [lines, streaming])
   return (
-    <pre ref={ref} style={{ margin: '2px 0 8px 32px', padding: '8px 10px', maxHeight: 180, overflow: 'auto', fontSize: 11, lineHeight: 1.45, background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: 8, whiteSpace: 'pre-wrap', wordBreak: 'break-all' } as CSSProperties}>{lines.join('\n') || '(no output yet)'}</pre>
+    <pre ref={ref} style={{ margin: '2px 0 8px 32px', padding: '8px 10px', maxHeight: 180, overflow: 'auto', fontSize: 11, lineHeight: 1.45, background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: 8, whiteSpace: 'pre-wrap', wordBreak: 'break-all', minWidth: 640 } as CSSProperties}>{lines.join('\n') || '(no output yet)'}</pre>
   )
 }
 
@@ -331,7 +331,7 @@ interface ConfirmBtnProps { title: string; desc: string; confirmLabel?: string; 
 // keep the popover inside the viewport even when a locale's `desc` wraps to
 // more lines than assumed here.
 const CONFIRM_W = 264
-const CONFIRM_EST_H = 140
+const CONFIRM_EST_H = 180
 function ConfirmBtn({ title, desc, confirmLabel, onConfirm, btn, children }: ConfirmBtnProps) {
   const [open, setOpen] = useState(false)
   // Trigger rect captured on open; drives the portaled popover's fixed
@@ -1314,7 +1314,7 @@ export default function DevFleetPage() {
   }
 
   const columnHeader = (
-    <div style={{ display: 'grid', gridTemplateColumns: '16px 84px minmax(0,1fr) 64px 48px 44px 212px', gap: 8, alignItems: 'center', padding: '2px 0 4px', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)' } as CSSProperties}>
+    <div style={{ display: 'grid', gridTemplateColumns: '16px 84px minmax(0,1fr) 64px 48px 44px 212px', gap: 8, alignItems: 'center', padding: '2px 0 4px', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--muted)', minWidth: 640 } as CSSProperties}>
       <span /><span>{i18nT('pages.devFleetPage.pod_2')}</span><span>{i18nT('pages.devFleetPage.worktree')}</span><span>{i18nT('pages.devFleetPage.pr_2')}</span><span title={i18nT('pages.devFleetPage.commits_behind_main')}>{i18nT('pages.devFleetPage.behind')}</span><span title={i18nT('pages.devFleetPage.last_commit_activity')}>{i18nT('pages.devFleetPage.updated')}</span><span style={{ textAlign: 'right' }}>{i18nT('pages.devFleetPage.actions')}</span>
     </div>
   )
@@ -1328,7 +1328,7 @@ export default function DevFleetPage() {
     const provActive = !w.is_main && !!pr
     return (
       <div key={w.name}>
-        <div style={{ display: 'grid', gridTemplateColumns: '16px 84px minmax(0,1fr) 64px 48px 44px 212px', gap: 8, alignItems: 'center', padding: '5px 0', borderTop: '1px solid var(--border)', minHeight: 30 } as CSSProperties}>
+        <div style={{ display: 'grid', gridTemplateColumns: '16px 84px minmax(0,1fr) 64px 48px 44px 212px', gap: 8, alignItems: 'center', padding: '5px 0', borderTop: '1px solid var(--border)', minHeight: 30, minWidth: 640 } as CSSProperties}>
           {w.is_main
             ? <span style={{ width: 15 }} />
             : <Clickable aria-label={open ? i18nT('pages.devFleetPage.collapse') : i18nT('pages.devFleetPage.expand')} aria-expanded={open} onClick={() => toggleExpand(w.name)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--muted)', display: 'flex', padding: 0, transform: open ? 'rotate(90deg)' : 'none', transition: 'transform .12s' } as CSSProperties}><ChevronRight size={15} className="lucide-inline" /></Clickable>}
@@ -1364,14 +1364,14 @@ export default function DevFleetPage() {
           )}
         </div>
         {w.is_main && syncRun && syncLogOpen ? (
-          <pre style={{ margin: '2px 0 8px 32px', padding: '8px 10px', maxHeight: 180, overflow: 'auto', fontSize: 11, lineHeight: 1.45, background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: 8, whiteSpace: 'pre-wrap', wordBreak: 'break-all' } as CSSProperties}>{filterStepMarkers(syncRun.lines || []).join('\n') || '(no output yet)'}</pre>
+          <pre style={{ margin: '2px 0 8px 32px', padding: '8px 10px', maxHeight: 180, overflow: 'auto', fontSize: 11, lineHeight: 1.45, background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: 8, whiteSpace: 'pre-wrap', wordBreak: 'break-all', minWidth: 640 } as CSSProperties}>{filterStepMarkers(syncRun.lines || []).join('\n') || '(no output yet)'}</pre>
         ) : null}
         {provActive && provLogOpen[w.name] && pr ? (
           <ProvLogPre lines={pr.lines || []} streaming={pr.status === 'running' || pr.status === 'starting'} />
         ) : null}
         {open && detailLoading[w.name] ? <ContentSkeleton rows={3} /> : null}
         {open && detail[w.name] ? (
-          <div style={{ padding: '4px 0 14px 30px', fontSize: 12 }}>
+          <div style={{ padding: '4px 0 14px 30px', fontSize: 12, minWidth: 640 }}>
             {detail[w.name].error
               ? <span style={{ color: 'var(--danger)' }}>{detail[w.name].error}</span>
               : <DetailPanel w={w} d={detail[w.name]} busy={busy} onRemove={() => removeWorktree(w.name, { ...w, ...detail[w.name] })} onLoadLogs={() => loadPodLogs(w.name)} logs={podLogs[w.name]} logsLoading={podLogsLoading[w.name]} />}
@@ -1382,7 +1382,7 @@ export default function DevFleetPage() {
   }
 
   const legacyToggle = legacyAll.length > 0 ? (
-    <Btn onClick={() => setShowLegacy((v) => !v)} style={{ display: 'block', width: '100%', textAlign: 'left', marginTop: 4, fontSize: 11.5, color: 'var(--muted)', background: 'transparent', border: '1px dashed var(--border)' }} title={i18nT('pages.devFleetPage.worktrees_created_under_a_previous_repository_na')}>
+    <Btn onClick={() => setShowLegacy((v) => !v)} style={{ display: 'block', width: '100%', textAlign: 'left', marginTop: 4, fontSize: 11.5, color: 'var(--muted)', background: 'transparent', border: '1px dashed var(--border)', minWidth: 640 }} title={i18nT('pages.devFleetPage.worktrees_created_under_a_previous_repository_na')}>
       {showLegacy ? i18nT('pages.devFleetPage.hide_legacy_worktrees', { n: legacyAll.length }) : i18nT('pages.devFleetPage.legacy_worktrees_hidden_show', { n: legacyAll.length })}
     </Btn>
   ) : null
@@ -1561,7 +1561,7 @@ export default function DevFleetPage() {
                 </div>
               </div>
             )}
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, minmax(0, 1fr))', gap: 12, margin: '14px 0' } as CSSProperties}>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 my-3.5">
               <StatCard label={i18nT('pages.devFleetPage.running_pods')} value={running} accent />
               <StatCard label={i18nT('pages.devFleetPage.worktrees')} value={wts.length} />
               <StatCard label={i18nT('pages.devFleetPage.needs_provision')} value={needsProv} />
@@ -1569,8 +1569,8 @@ export default function DevFleetPage() {
             </div>
             <Card>
               <CardTitle><span className="flex items-center gap-1.5">{i18nT('pages.devFleetPage.worktrees_count', { count: wts.length })}<InfoTip text={i18nT('pages.devFleetPage.every_git_worktree_of_the_main_checkout_pull_bui')} /></span></CardTitle>
-              <div style={{ display: 'flex', gap: 10, alignItems: 'center', margin: '12px 0 4px' } as CSSProperties}>
-                <div className="flex-1 min-w-0">
+              <div className="flex flex-wrap gap-2.5 items-center mt-3 mb-1">
+                <div className="flex-1 min-w-[140px]">
                   <SearchInput placeholder={i18nT('pages.devFleetPage.filter_worktrees')} value={q} onChange={(e) => setQ((e.target as HTMLInputElement).value)} aria-label={i18nT('pages.devFleetPage.filter_worktrees_2')} />
                 </div>
                 <span style={{ fontSize: 11.5, color: 'var(--muted)', flexShrink: 0 }}>{ql ? others.length + ' / ' : ''}{wts.length} {i18nT('pages.devFleetPage.rows')}</span>
@@ -1596,7 +1596,9 @@ export default function DevFleetPage() {
                 <Btn danger onClick={pruneShipped} disabled={!!busy['__prune']} aria-busy={!!busy['__prune']}>{iconLabel(busy['__prune'] ? <LoaderCircle className="lucide-inline animate-spin" /> : <Trash2 size={13} className="lucide-inline" />, i18nT('pages.devFleetPage.prune_merged'))}</Btn>
                 <Btn onClick={() => invalidateAll()} disabled={loading} aria-label={i18nT('pages.devFleetPage.refresh_fleet')}>{iconLabel(<RefreshCw size={14} className="lucide-inline" />, i18nT('pages.devFleetPage.refresh'))}</Btn>
               </div>
-              {body}
+              <div className="overflow-x-auto -mx-1 px-1">
+                {body}
+              </div>
             </Card>
           </div>
         </div>


### PR DESCRIPTION
## Summary

The Dev Fleet page had two viewport/clipping issues:
1. **Phone/tablet**: entire right side (Pull+Build, Actions) permanently invisible with no scroll
2. **Laptop**: the Pull+Build confirm popover clips below the viewport fold — Cancel/Start buttons unreachable

Closes #2536

## Changes

| Area | Before | After |
|------|--------|-------|
| Stat cards | Fixed 4-column grid (squished on mobile) | 2-col on mobile, 4-col on `sm:` breakpoint |
| Toolbar | Single non-wrapping flex row (buttons clip) | `flex-wrap` with min-width on search input |
| Worktree table | Overflows and clips invisibly | `overflow-x-auto` scroll wrapper with `min-width: 640px` |
| Expanded rows | No min-width (blank band when scrolled right) | `min-width: 640` on logs, detail, legacy toggle |
| Confirm popover | `CONFIRM_EST_H=140` underestimates height → clips below fold | Bumped to 180 → flip-up triggers before buttons clip |

## Laptop — Confirm popover: Before / After

| Before (clipped) | After (fixed) |
|-------------------|---------------|
| ![popover-before](https://github.com/RohanK6/KiroCrew/raw/ec979f8ebb7777ac13a0fc65b80c512d824a37cd/devfleet-popover-clip-before.png) | ![popover-after](https://github.com/RohanK6/KiroCrew/raw/ec979f8ebb7777ac13a0fc65b80c512d824a37cd/devfleet-popover-after.png) |
| Cancel/Start buttons clipped below viewport fold | ✅ Full popover visible — Cancel and Start accessible |

## Phone (375px) — Before / After

| Before | After |
|--------|-------|
| ![before-mobile](https://github.com/RohanK6/KiroCrew/raw/ec979f8ebb7777ac13a0fc65b80c512d824a37cd/devfleet-before-mobile-375.png) | ![after-mobile](https://github.com/RohanK6/KiroCrew/raw/ec979f8ebb7777ac13a0fc65b80c512d824a37cd/devfleet-after-mobile-375.png) |
| Stat cards clipped, Actions column invisible, no horizontal scroll | ✅ Stat cards 2×2, toolbar wraps, table scrollable to reach Pull+Build |

## Tablet (768px) — Before / After

| Before | After |
|--------|-------|
| ![before-tablet](https://github.com/RohanK6/KiroCrew/raw/ec979f8ebb7777ac13a0fc65b80c512d824a37cd/devfleet-before-tablet-768.png) | ![after-tablet](https://github.com/RohanK6/KiroCrew/raw/ec979f8ebb7777ac13a0fc65b80c512d824a37cd/devfleet-after-tablet-768.png) |
| Toolbar cramped on one line | ✅ Toolbar wraps: search + sort on line 1, action buttons on line 2 |

## Desktop (1280px) — Before / After

| Before | After |
|--------|-------|
| ![before-desktop](https://github.com/RohanK6/KiroCrew/raw/ec979f8ebb7777ac13a0fc65b80c512d824a37cd/devfleet-before-desktop-1280.png) | ![after-desktop](https://github.com/RohanK6/KiroCrew/raw/ec979f8ebb7777ac13a0fc65b80c512d824a37cd/devfleet-after-desktop-1280.png) |
| All columns visible (reference) | ✅ Identical — no regression at desktop width |

## Testing

- `npx vitest run src/test/DevFleetPage.test.tsx` — all 69 tests pass
- `npm run build` — production bundle compiles clean
- `npx tsc --noEmit` — no type errors
