### PR TITLE
fix(dev-fleet): say which tool is missing instead of blaming the checkout

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -723,6 +723,11 @@ _SANDBOX_ERR_MAX = 900
 _GIT_ERR_MAX = 300
 
 
+def _bin_override_env(name: str) -> str:
+    """The service-environment variable that pins *name* to an absolute path."""
+    return f"KIROCREW_DEVFLEET_BIN_{name.upper().replace('-', '_')}"
+
+
 def _trusted_bin(name: str) -> str | None:
     """Resolve *name* to a canonical executable in a system or Homebrew bin dir.
 
@@ -739,7 +744,7 @@ def _trusted_bin(name: str) -> str | None:
     # system dirs (e.g. gh in ~/.local/bin): an explicit absolute path set
     # in the SERVICE environment (operator-owned unit file), never derived
     # from the inherited PATH.
-    override = os.environ.get(f"KIROCREW_DEVFLEET_BIN_{name.upper().replace('-', '_')}")
+    override = os.environ.get(_bin_override_env(name))
     if override and Path(override).is_absolute() and Path(override).is_file() \
             and os.access(override, os.X_OK):
         _TRUSTED_BIN_CACHE[name] = override
@@ -808,6 +813,29 @@ def _toolchain_bin(name: str) -> str | None:
     return find_node_tool(name, _TRUSTED_PATH) or _trusted_bin(name)
 
 
+_UNRESOLVED_TOOL_PREFIX = "toolchain not found:"
+
+
+def _unresolved_tool_error(name: str) -> str:
+    """Explain an unresolvable tool in terms the reader can act on.
+
+    ``_trusted_bin`` fails closed, and the reasons are many (installed outside the
+    trusted dirs, on another drive, a portable or MSYS2 layout, absent entirely).
+    Enumerating install shapes is a losing game, so say what happened, name the
+    tool, and give the one setting that fixes every one of them.
+
+    Deliberately does NOT include ``_TRUSTED_PATH``: the searched list is long,
+    the reader cannot act on it, and the remedy does not require knowing it. It
+    is not logged either — it is environment-derived on Windows and constant per
+    platform, so it is documented in ``_TRUSTED_BIN_DIRS`` rather than emitted.
+    """
+    return (
+        f"{_UNRESOLVED_TOOL_PREFIX} no trusted {name!r} executable. Set "
+        f"{_bin_override_env(name)} to its absolute path in the gateway's service "
+        f"environment, or install {name} into a system location."
+    )
+
+
 async def _run_cmd(
     cmd: list[str], *, cwd: str | None = None, env: dict | None = None,
     timeout: int = 30, mode: str = "standard"
@@ -830,7 +858,15 @@ async def _run_cmd(
     if cmd and "/" not in cmd[0]:
         trusted = _trusted_bin(cmd[0])
         if trusted is None:
-            return -1, "", f"no trusted executable for {cmd[0]!r} in {_TRUSTED_PATH}"
+            # Deliberately NOT logging _TRUSTED_PATH. It is environment-derived
+            # on Windows (ProgramFiles / SystemRoot), and logging strings that
+            # came from the environment is a habit worth not having — CodeQL
+            # flags it as clear-text logging of sensitive data and cannot know
+            # which variables are benign. It also carries no per-incident
+            # information: the list is a per-platform constant, and the tool
+            # name below is the part that identifies what actually failed.
+            logger.warning("dev-fleet: no trusted %r executable", cmd[0])
+            return -1, "", _unresolved_tool_error(cmd[0])
         cmd = [trusted, *cmd[1:]]
     base_env["PATH"] = _TRUSTED_PATH
     base_env.update(_GIT_ENV_NEUTRALIZERS)
@@ -1501,6 +1537,17 @@ async def _discover_worktrees() -> list[dict]:
         # Propagate sandbox/git failures as a RuntimeError so callers can
         # surface the real reason instead of returning silent empty lists.
         raw = (stderr or stdout or "").strip()
+        # Two classified error classes now reach here as strings — this one and
+        # "sandbox unavailable" below — because `_run_cmd` reports through a
+        # (rc, out, err) tuple with no typed channel. Deliberately matching the
+        # existing idiom rather than inventing a second convention beside it.
+        # THIRD class arriving here is the signal to stop: at that point give
+        # `_run_cmd` a typed failure instead of a third string probe.
+        if raw.startswith(_UNRESOLVED_TOOL_PREFIX):
+            # Surface this one verbatim. Wrapping it in the generic "discovery
+            # failed in {MAIN_REPO}" branch below would aim the reader at their
+            # checkout, which is fine — we never got far enough to read it.
+            raise RuntimeError(raw)
         if "sandbox unavailable" in raw:
             # Do NOT clip to the generic git-error length here. The sandbox layer
             # puts the *remedy* (which opt-in to set, or that an EPERM is a
@@ -2970,9 +3017,7 @@ async def _sync_start_locked() -> dict:
         ),
     )
     if git_bin is None:
-        return {"ok": False, "error": (
-            f"no trusted executable for 'git' in {_TRUSTED_PATH}"
-        )}
+        return {"ok": False, "error": _unresolved_tool_error("git")}
     if npm_bin is None:
         # Drop the memoized resolution so the remedy this message advertises
         # actually works. `node_bin_dirs()` is lru_cached and `_BUILD_PATH_CACHE`

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -4182,6 +4182,7 @@ async def test_fetch_pr_head_oid_refuses_non_merged(monkeypatch):
 def test_trusted_bin_rejects_agent_writable_path(monkeypatch, tmp_path):
     """Bare command names resolve only inside the trusted bin dirs; a planted
     shim in an agent-writable PATH entry is never selected."""
+    monkeypatch.delenv("KIROCREW_DEVFLEET_BIN_GIT", raising=False)
     mod._TRUSTED_BIN_CACHE.clear()
     fake = tmp_path / "git"
     fake.write_text("#!/bin/sh\necho pwned\n")
@@ -4192,6 +4193,68 @@ def test_trusted_bin_rejects_agent_writable_path(monkeypatch, tmp_path):
     mod._TRUSTED_BIN_CACHE.clear()
     assert mod._trusted_bin("definitely-not-a-real-tool-xyz") is None
     mod._TRUSTED_BIN_CACHE.clear()
+
+
+def test_unresolved_tool_error_names_the_tool_and_the_remedy():
+    """The whole point of the message: which tool, and the one setting that fixes
+    every install shape. Enumerating shapes (portable, MSYS2, another drive) is a
+    losing game; the override covers them all."""
+    msg = mod._unresolved_tool_error("git")
+
+    assert "git" in msg
+    assert "KIROCREW_DEVFLEET_BIN_GIT" in msg
+    assert msg.startswith(mod._UNRESOLVED_TOOL_PREFIX)
+    # The searched PATH is long and not actionable — it belongs in the log.
+    assert mod._TRUSTED_PATH not in msg
+
+
+def test_bin_override_env_matches_the_name_trusted_bin_actually_reads(
+    monkeypatch, tmp_path
+):
+    """The remedy has to be the real lever. If `_bin_override_env` and the variable
+    `_trusted_bin` reads ever drift, the message tells the user to set something
+    that does nothing — the worst failure a remedy can have. So set the override
+    THROUGH the advertised name and prove resolution honours it."""
+    exe = tmp_path / "git"
+    exe.write_text("#!/bin/sh\nexit 0\n")
+    exe.chmod(0o755)
+
+    monkeypatch.setenv(mod._bin_override_env("git"), str(exe))
+    mod._TRUSTED_BIN_CACHE.clear()
+    try:
+        assert mod._trusted_bin("git") == str(exe), (
+            "the advertised variable is not the one _trusted_bin reads"
+        )
+    finally:
+        mod._TRUSTED_BIN_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_run_cmd_reports_an_unresolvable_tool_with_the_remedy(monkeypatch):
+    """A bare argv name that cannot be pinned must come back naming the tool and
+    the override, not just 'not found'."""
+    monkeypatch.setattr(mod, "_trusted_bin", lambda n: None)
+
+    rc, out, err = await mod._run_cmd(["git", "status"])
+
+    assert rc == -1 and out == ""
+    assert err == mod._unresolved_tool_error("git")
+
+
+@pytest.mark.asyncio
+async def test_discovery_does_not_blame_the_checkout_for_a_missing_tool(monkeypatch):
+    """The reported defect: an unresolvable git surfaced as "git worktree discovery
+    failed in <MAIN_REPO>", sending the reader to inspect a checkout that is fine.
+    Discovery never got far enough to read it, so the message must not mention it."""
+    monkeypatch.setattr(mod, "_trusted_bin", lambda n: None)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await mod._discover_worktrees()
+
+    msg = str(excinfo.value)
+    assert msg == mod._unresolved_tool_error("git"), "must surface verbatim"
+    assert "worktree discovery failed" not in msg, "must not blame the checkout"
+    assert mod.MAIN_REPO not in msg
 
 
 @pytest.mark.skipif(mod.platform_compat.IS_WINDOWS, reason="POSIX bin dirs")
@@ -4209,6 +4272,7 @@ def test_trusted_bin_pins_the_resolved_target_not_the_symlink(monkeypatch, tmp_p
     """Homebrew's `bin/gh` is a user-writable symlink into `Cellar/`. Caching the
     LINK would let it be repointed between validation and execution, so the
     vetted real path is what gets cached and spawned."""
+    monkeypatch.delenv("KIROCREW_DEVFLEET_BIN_GH", raising=False)
     mod._TRUSTED_BIN_CACHE.clear()
     cellar = tmp_path / "Cellar" / "gh" / "1.0" / "bin"
     cellar.mkdir(parents=True)


### PR DESCRIPTION
Closes #2530. Replaces #1633, which was closed after eight review rounds.

## 1. What is the problem?

When Dev Fleet cannot resolve `git` to a trusted absolute path, it reports the
failure as a **git or repository problem** and offers no way out:

```
git worktree discovery failed in /path/to/checkout: no trusted executable for 'git'
in /usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin
```

Three separate defects in one line:

1. **Wrong subsystem.** The headline says worktree discovery failed *in the
   checkout*, so the reader goes and inspects their repository. The checkout is
   fine — discovery never got far enough to read it.
2. **No remedy.** `KIROCREW_DEVFLEET_BIN_GIT`, an absolute path set in the
   operator-owned service environment, already exists and fixes every instance of
   this. The message does not mention it. The sibling branch in the *same function*
   handles a missing checkout properly ("Set `KIROCREW_DEVFLEET_REPO` … or clone it
   to `~/kirocrew`"), so the pattern to follow was already there.
3. **Unactionable noise.** The searched PATH is dumped into the UI. The reader
   cannot do anything with it.

## 2. Why this issue matters to the user

`_trusted_bin` deliberately fails closed — it will not run a `git` it cannot vouch
for — and the ways to end up there are many: installed outside the trusted
directories, on another drive, a portable or MSYS2 layout, absent entirely. In
every one of those cases the user is told to look at the wrong thing, and the one
setting that would fix it is never named. That is the difference between a
two-minute fix and an afternoon.

It also generalises a bug we already tried to fix the expensive way. #1633
attacked one shape of this (git installed outside `Program Files` on Windows) by
discovering install paths from the registry. Eight review rounds established that
synchronous filesystem discovery inside a loop-bound resolver cannot both stay off
the event loop and avoid reporting nothing useful — the defect relocated six times
without being removed. Fixing the *message* covers every install shape at once, on
every OS, with no probing, no trust inference, and no work on the request path.

## 3. How our fix solves it

Symptom → cause → fix:

- **Reader inspects a healthy checkout** ← the message says "worktree discovery
  failed in `<MAIN_REPO>`" ← `_discover_worktrees` funnels *every* non-sandbox
  `git` failure through one generic branch ← **detect the unresolved-tool case and
  re-raise it verbatim**, so the banner states the real cause and never names the
  repository.
- **User cannot fix it** ← the message never mentions the override ← **phrase the
  failure once, in `_unresolved_tool_error()`, naming the tool and
  `KIROCREW_DEVFLEET_BIN_<TOOL>`.** It lives next to `_run_cmd`, so every caller
  that resolves a bare argv name benefits, not just discovery.
- **Noise in the UI** ← `_TRUSTED_PATH` interpolated into the error ← **dropped,
  not relocated.** It is environment-derived on Windows (`ProgramFiles` /
  `SystemRoot`) and a constant per platform, so it carries no per-incident
  information and belongs in `_TRUSTED_BIN_DIRS`, where it is already readable.
  CodeQL agreed on the first push — it flagged the log line this PR had added as
  clear-text logging of environment-derived data (`py/clear-text-logging-sensitive-data`,
  high). Those two variables are benign, but a scanner cannot know that, and the
  log line was carrying nothing the tool name did not already say. Fixed rather
  than dismissed. The warning now names only the unresolved tool.

The env-var name is derived by `_bin_override_env()`, the same transformation
`_trusted_bin` uses to read it, and a test ties the two together — a message
advertising a variable nothing reads would be worse than saying nothing.

No frontend change. The Discovery Error banner already renders whatever reason the
backend supplies; it was being handed the wrong reason.

## 4. What tests we did

`test/test_dev_fleet_app.py` — 4 new tests:

- the message names the tool and the override, and does **not** leak `_TRUSTED_PATH`;
- `_bin_override_env` is the variable `_trusted_bin` actually honours (set the
  override *through* the advertised name, assert resolution picks it up);
- `_run_cmd` returns that message for an unresolvable bare argv name;
- `_discover_worktrees` surfaces it verbatim and the message contains neither
  "worktree discovery failed" nor `MAIN_REPO` — the reported defect.

**Mutation-verified:** 5 mutants, all caught — discovery wrapping it in the
checkout message again, the remedy dropped, the PATH leaked back into the UI, the
override variable name drifting from the one that is read, and `_run_cmd` reverting
to the bare "not found" string. The env-var mutant initially escaped because the
test set a hardcoded variable name rather than the derived one, which is exactly
the drift it was supposed to detect; rewritten to assert the real contract.

Two neighbouring tests were also made hermetic: `test_trusted_bin_rejects_agent_
writable_path` and `test_trusted_bin_pins_the_resolved_target_not_the_symlink`
assert on the *discovered* path, so they failed on any host with a
`KIROCREW_DEVFLEET_BIN_*` override set — which real Dev Fleet hosts have. (Verified
by the second one failing on this machine before the fix.)

Gates: `isort`, `flake8`, `mypy src/kiro_crew/` clean for this diff; 373 passed
across `test_dev_fleet_app.py`, `test_dev_fleet_node_toolchain.py` and
`test_node_toolchain_resolution.py`. The 2 remaining local failures
(`test_kiro_crew_module_entry_actually_runs`, `test_find_cli_is_module_invocation_
only`) shell out to `python -m kiro_crew` and fail because this worktree's
interpreter has no editable install; baseline-confirmed, untouched by this diff.

## 5. Any other suggestions on the work

- **The premise of #2530 was wrong and I corrected it.** I filed it claiming Dev
  Fleet renders a *silent empty fleet* when the toolchain is missing. It does not:
  `_discover_worktrees` raises, the handler returns `{"worktrees": [], "error":
  ...}`, and the banner renders. I had repeated that claim from #1633's description
  without verifying it. Reproduced the real behaviour by forcing
  `_trusted_bin("git")` to `None`, then rewrote the issue and left a comment saying
  so. The defect is real but smaller and differently shaped than advertised —
  message attribution, not silence — which is why this PR has no frontend change.
- `_resolve_primary_checkout()` silently returns its input unchanged when `git` is
  unavailable, so `MAIN_REPO` is left un-normalized instead of reported. Harmless
  today (the next `git` call fails loudly and now says why), so out of scope here,
  but noted in #2530.
- The `ConfirmBtn` keyboard-focus work from #1633 (focus enters the popover on
  open, returns to the trigger on dismissal, both mutation-verified) is independent
  of all of the above and did not cause any of that PR's findings. It is still
  unlanded; #2533 is the natural home for it, together with the focus trap that
  review asked for.
- #2534 tracks the structural note from that review: `platform_compat.trusted_
  system_bin` and dev-fleet's `_trusted_bin` both resolve tools without trusting
  `PATH`, one import apart, with different trust policies and the weaker one
  holding the more authoritative name.
