### PR TITLE
fix(dev-fleet): actionable error when no trusted git resolves (#2530)

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/server.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/server.py
@@ -722,6 +722,43 @@ _SANDBOX_ERR_MAX = 900
 # an arbitrarily long stderr from a broken repo.
 _GIT_ERR_MAX = 300
 
+# Identity for the "no trusted executable" failure, so callers can branch on
+# the CLASS of failure instead of re-matching prose: `_run_cmd` puts this
+# prefix on the stderr it synthesizes when `_trusted_bin` resolves nothing,
+# and error paths that want to name the remedy (set the per-tool override in
+# the service environment) test `startswith` on it. Deliberately a constant,
+# not an exception type: `_run_cmd` reports every failure through its
+# (rc, stdout, stderr) tuple and callers already handle it that way.
+_UNRESOLVED_TOOL_PREFIX = "no trusted executable for "
+
+
+def _bin_override_var(name: str) -> str:
+    """Env var that overrides trusted-bin resolution for *name*.
+
+    Single source of truth shared by `_trusted_bin` (which reads it) and the
+    user-facing remedy messages (which name it) — deriving it twice is how the
+    advertised remedy drifts from the one that works.
+    """
+    return f"KIROCREW_DEVFLEET_BIN_{name.upper().replace('-', '_')}"
+
+
+def _unresolved_tool_message(name: str) -> str:
+    """User-facing message for an unresolved trusted tool.
+
+    Blames the HOST toolchain, not the checkout (issue #2530: the previous
+    wording folded this failure into "git worktree discovery failed in
+    <repo>", sending users to debug a healthy repository), and names the
+    operator remedy in the same voice as the missing-checkout branch. The
+    trusted-PATH detail stays in the log line, not here: it is unactionable
+    noise in a UI banner.
+    """
+    return (
+        f"no trusted {name!r} executable found on this host — the checkout "
+        f"itself is not the problem. Set {_bin_override_var(name)} to an "
+        f"absolute path in the gateway's service environment (it needs a "
+        "restart to be seen)."
+    )
+
 
 def _trusted_bin(name: str) -> str | None:
     """Resolve *name* to a canonical executable in a system or Homebrew bin dir.
@@ -739,7 +776,7 @@ def _trusted_bin(name: str) -> str | None:
     # system dirs (e.g. gh in ~/.local/bin): an explicit absolute path set
     # in the SERVICE environment (operator-owned unit file), never derived
     # from the inherited PATH.
-    override = os.environ.get(f"KIROCREW_DEVFLEET_BIN_{name.upper().replace('-', '_')}")
+    override = os.environ.get(_bin_override_var(name))
     if override and Path(override).is_absolute() and Path(override).is_file() \
             and os.access(override, os.X_OK):
         _TRUSTED_BIN_CACHE[name] = override
@@ -830,7 +867,9 @@ async def _run_cmd(
     if cmd and "/" not in cmd[0]:
         trusted = _trusted_bin(cmd[0])
         if trusted is None:
-            return -1, "", f"no trusted executable for {cmd[0]!r} in {_TRUSTED_PATH}"
+            return -1, "", (
+                f"{_UNRESOLVED_TOOL_PREFIX}{cmd[0]!r} in {_TRUSTED_PATH}"
+            )
         cmd = [trusted, *cmd[1:]]
     base_env["PATH"] = _TRUSTED_PATH
     base_env.update(_GIT_ENV_NEUTRALIZERS)
@@ -1509,6 +1548,15 @@ async def _discover_worktrees() -> list[dict]:
             # swallow the fix. Keep a generous bound purely to stop an unbounded
             # stderr reaching the UI.
             raise RuntimeError(raw[:_SANDBOX_ERR_MAX])  # already prefixed by _run_cmd
+        if raw.startswith(_UNRESOLVED_TOOL_PREFIX):
+            # git never ran: the HOST has no git the resolver is willing to
+            # execute. Checked before the .git probe because the probe's
+            # outcome is irrelevant here — wrapping this in "worktree
+            # discovery failed in <repo>" (the old behavior) sent users to
+            # debug a healthy checkout (#2530). The trusted-PATH detail is
+            # operator-diagnostic, so it goes to the log, not the banner.
+            logger.warning("dev-fleet: %s", raw)
+            raise RuntimeError(_unresolved_tool_message("git"))
         # Every other git failure was previously swallowed into a silent [] —
         # which the UI renders as the "No worktrees found / Nothing under the
         # worktrees root yet" empty state. When MAIN_REPO is wrong that empty
@@ -2970,9 +3018,17 @@ async def _sync_start_locked() -> dict:
         ),
     )
     if git_bin is None:
-        return {"ok": False, "error": (
-            f"no trusted executable for 'git' in {_TRUSTED_PATH}"
-        )}
+        # Same failure class as the discovery path: name the remedy in the
+        # response; the log records the event. The searched dirs are the
+        # static _TRUSTED_BIN_DIRS constant (and the discovery-path warning
+        # already prints them when it fires) — repeating them here trips
+        # CodeQL's name-based secret heuristic on _TRUSTED_PATH for no
+        # diagnostic gain.
+        logger.warning(
+            "dev-fleet: %s'git' — no trusted-dir candidate passed vetting "
+            "and no override is set", _UNRESOLVED_TOOL_PREFIX
+        )
+        return {"ok": False, "error": _unresolved_tool_message("git")}
     if npm_bin is None:
         # Drop the memoized resolution so the remedy this message advertises
         # actually works. `node_bin_dirs()` is lru_cached and `_BUILD_PATH_CACHE`

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -1897,6 +1897,73 @@ async def test_discover_worktrees_git_failure_is_bounded(tmp_path):
     assert len(str(exc.value)) <= mod._GIT_ERR_MAX + 200
 
 
+@pytest.mark.asyncio
+async def test_discover_worktrees_unresolved_git_blames_host_not_repo(tmp_path):
+    """No trusted git => the error names the tool + override, not the repo.
+
+    Issue #2530: this failure used to surface as "git worktree discovery
+    failed in <repo>: no trusted executable for 'git' in <PATH>" — blaming a
+    healthy checkout, echoing the whole trusted PATH into the UI, and never
+    naming KIROCREW_DEVFLEET_BIN_GIT, the override that is the actual remedy.
+    """
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    stderr = f"{mod._UNRESOLVED_TOOL_PREFIX}'git' in {mod._TRUSTED_PATH}"
+    with patch.object(mod, "MAIN_REPO", str(repo)), \
+         patch.object(mod, "_run_cmd", new=AsyncMock(
+             return_value=(-1, "", stderr)
+         )):
+        with pytest.raises(RuntimeError) as exc:
+            await mod._discover_worktrees()
+    msg = str(exc.value)
+    assert "'git'" in msg  # names the tool that could not be resolved
+    assert "KIROCREW_DEVFLEET_BIN_GIT" in msg  # names the remedy
+    assert mod._TRUSTED_PATH not in msg  # PATH stays in the log, not the UI
+    assert "worktree discovery failed" not in msg  # not blamed on the repo
+    assert str(repo) not in msg  # the checkout is not implicated at all
+
+
+@pytest.mark.asyncio
+async def test_discover_worktrees_real_git_error_not_misclassified(tmp_path):
+    """A git failure merely MENTIONING the sentinel text mid-string is not
+    reclassified: only a stderr `_run_cmd` itself synthesized (prefix at
+    position 0) takes the unresolved-tool branch; everything else still
+    surfaces git's own redacted, bounded message."""
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    with patch.object(mod, "MAIN_REPO", str(repo)), \
+         patch.object(mod, "_run_cmd", new=AsyncMock(
+             return_value=(128, "", f"fatal: {mod._UNRESOLVED_TOOL_PREFIX}'hook'")
+         )):
+        with pytest.raises(RuntimeError, match="worktree discovery failed"):
+            await mod._discover_worktrees()
+
+
+@pytest.mark.asyncio
+async def test_sync_unresolved_git_names_override_not_path(monkeypatch):
+    """/api/sync with no trusted git returns the same remedy-first message."""
+    with patch.object(mod, "_git", new_callable=AsyncMock,
+                      return_value=mod.BASE_BRANCH), \
+         patch.object(mod, "_venv_python",
+                      return_value=Path("/fake/.venv/bin/python")), \
+         patch.object(mod, "_trusted_bin", side_effect=lambda n: None), \
+         patch.object(mod, "_write_locked_console_scripts", return_value=[]):
+        mod._SYNC_RID = None
+        res = await mod._sync()
+    assert res["ok"] is False
+    assert "'git'" in res["error"]
+    assert "KIROCREW_DEVFLEET_BIN_GIT" in res["error"]
+    assert mod._TRUSTED_PATH not in res["error"]
+
+
+def test_bin_override_var_derivation():
+    """The advertised override var matches what _trusted_bin actually reads,
+    including dash-to-underscore mapping for non-git tools."""
+    assert mod._bin_override_var("git") == "KIROCREW_DEVFLEET_BIN_GIT"
+    assert mod._bin_override_var("some-tool") == "KIROCREW_DEVFLEET_BIN_SOME_TOOL"
+    assert "KIROCREW_DEVFLEET_BIN_GIT" in mod._unresolved_tool_message("git")
+
+
 # =============================================================================
 # HMAC middleware tests
 # =============================================================================


### PR DESCRIPTION
## Summary

When Dev Fleet's trusted-binary resolver cannot find a `git` it is willing to run, the failure surfaced as a repository problem: `git worktree discovery failed in <repo>: no trusted executable for 'git' in <PATH>` — blaming a healthy checkout, echoing the whole trusted PATH into the UI as unactionable noise, and never naming `KIROCREW_DEVFLEET_BIN_GIT`, the operator override that is the actual remedy (already read at `_trusted_bin`).

## Changes

- **`_UNRESOLVED_TOOL_PREFIX`** — module constant giving the unresolved-tool failure an identity callers can branch on (`startswith`) instead of re-matching prose. `_run_cmd` uses it when synthesizing the stderr; the text itself is unchanged, so no existing consumer breaks.
- **`_bin_override_var(name)`** — single source of truth for the override env-var name, shared by `_trusted_bin` (reads it) and the remedy messages (advertise it). Derived from the tool name (`KIROCREW_DEVFLEET_BIN_{NAME}`, dash→underscore), not hardcoded for git.
- **`_discover_worktrees`** — checks the unresolved-tool case BEFORE the `.git` probe and the generic wrapper; raises a message that names the tool, states the checkout is not the problem, and gives the override remedy in the same voice as the missing-checkout branch. The trusted-PATH detail moves to a `logger.warning` line.
- **`/api/sync`** (`_sync_start_locked`) — same remedy-first message at the `git_bin is None` branch; consistent with discovery.
- **Preserved:** genuine git failures still surface `_redact(raw)[:_GIT_ERR_MAX]`; the sandbox-unavailable branch is unaffected (checked first, and unresolved-tool returns before the sandbox layer runs).

## Tests

4 new tests, each verified to FAIL against unmodified code:
- `test_discover_worktrees_unresolved_git_blames_host_not_repo` — message names git + `KIROCREW_DEVFLEET_BIN_GIT`, contains neither the trusted PATH, nor "worktree discovery failed", nor the repo path
- `test_discover_worktrees_real_git_error_not_misclassified` — mid-string sentinel text still takes the genuine-git-error path
- `test_sync_unresolved_git_names_override_not_path` — `/api/sync` returns the same remedy-first message
- `test_bin_override_var_derivation` — env-var derivation incl. dash mapping

Local gates: isort / flake8 / mypy clean; full pytest green in the dev_fleet area (host-env-only failures in unrelated modules).

Backend-only — no dashboard/API/i18n surface.

Closes #2530