### PR TITLE
refactor(i18n): run the unit-literal scan as a gate, not a vitest test

### DIFF
--- a/website/scripts/check-unit-literals.mjs
+++ b/website/scripts/check-unit-literals.mjs
@@ -1,0 +1,226 @@
+/**
+ * Number+unit literal gate.
+ *
+ * Three checks, strongest first:
+ *
+ *   [added-lines]  ZERO tolerance, no stored state. A finding on a line this branch
+ *                  wrote fails, whatever the ceiling says.
+ *   [vs-base]      No file this branch touched may hold MORE findings than it did at
+ *                  the base ref. Catches what line attribution cannot: an edit that
+ *                  turns an exempt site into a real one without touching the
+ *                  finding's own line, and an offsetting add-and-remove.
+ *   [ceiling]      One whole-repo count over the frozen debt on lines nobody touched.
+ *                  Reports; does not fail. See the note at the bottom.
+ *
+ * WHY THIS IS A SCRIPT AND NOT A TEST. It parses the whole in-scope tree with the
+ * TypeScript compiler, so its cost scales with the size of the repo rather than with
+ * what a branch changed. Inside vitest that cost is multiplied by v8 coverage
+ * instrumentation and by every sibling worker competing for cores. Measured on one
+ * 6-core box, same commit, only --maxWorkers varying:
+ *
+ *   standalone 2.0s | 2w 11.2s | 4w 13.7s | 6w 16.6s | 8w 20.3s | 12w 28.6s
+ *
+ * against a 15s per-test budget sized for tests that `await import(...)`. The cost
+ * tracks worker count, so raising the budget only moves the number; throttling
+ * workers instead costs the whole suite 82% more wall clock. Out here it runs once,
+ * in one process, uninstrumented, with no timeout to tune.
+ *
+ * The matcher itself stays under test: `src/i18n/unitLiterals.test.ts` proves it
+ * detects the shapes that shipped and exempts CSS and the seam, importing the same
+ * `scripts/lib/unit-literals.mjs` this gate uses. One definition, two consumers.
+ *
+ * The diff-scoped logic below is carried over UNCHANGED from the test it replaces,
+ * including its reliance on `parseAddedLines`. This is a refactor: same findings,
+ * same attribution, same limitations. Known limitations it inherits are listed in
+ * the accompanying issue rather than silently fixed here.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join, relative } from 'node:path'
+
+import { ALL_LINES, parseAddedLines } from './check-i18n-strings.mjs'
+import { inScope, unitLiteralHits, walk } from './lib/unit-literals.mjs'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const WEBSITE = join(HERE, '..')
+const SRC = join(WEBSITE, 'src')
+const REPO = join(WEBSITE, '..')
+const PREFIX = 'website/src/'
+
+/**
+ * Frozen whole-repo debt: un-migrated number+unit literals on lines nobody has
+ * touched since this gate landed.
+ *
+ * UPWARD-ONLY, and lowering it is OPTIONAL, never required to land a change. A
+ * shared count that every branch must edit as it improves is a merge conflict
+ * between all of them; the two diff-scoped checks are what actually stop a new site.
+ * Never raise it. The goal is 0, at which point this constant is deleted.
+ */
+const BASELINE = 74
+
+const ADVICE =
+  'A number is concatenated with a hardcoded unit here, so the unit cannot be '
+  + 'translated, the digits are not localized, and the separator between parts is '
+  + 'wrong outside English. Use the helpers in `src/i18n/format.ts`: `fmtUnit` for one '
+  + "value, `fmtDuration([[h, 'hour'], [m, 'minute']])` for a compound, `fmtBytes` "
+  + 'for a size, `fmtPercent` for a ratio.\n\n'
+  + 'If the value is a CSS length or is parsed back by a regex, it MUST keep bare '
+  + 'digits: put it in a style/CSS position the detector recognises, or add the file '
+  + 'to ROUND_TRIP in scripts/lib/unit-literals.mjs naming the parser.'
+
+const git = (args) =>
+  execFileSync('git', args, { cwd: REPO, encoding: 'utf-8', maxBuffer: 128 * 1024 * 1024 })
+
+/** Findings in the working tree, by path relative to `src`. */
+function hitsNow(rel) {
+  const full = join(SRC, rel)
+  if (!existsSync(full)) return []
+  return unitLiteralHits(rel, readFileSync(full, 'utf-8'))
+}
+
+/**
+ * What this branch changed, measured live against the base ref. Nothing is stored.
+ *
+ * Returns null when there is genuinely nothing to diff (I18N_BASE_REF unset, a bare
+ * local run). When a base ref IS configured but cannot be resolved this exits 2: a
+ * gate that cannot run must fail, not skip itself green on a failed fetch.
+ */
+function computeScope() {
+  const baseRef = process.env.I18N_BASE_REF
+  if (!baseRef) return null
+
+  try {
+    git(['rev-parse', '--verify', `${baseRef}^{commit}`])
+  } catch {
+    console.error(
+      `[unit-literals] cannot resolve ${baseRef}. The diff-scoped checks need the base `
+      + 'ref: fetch it before running, or unset I18N_BASE_REF to check only the ceiling.',
+    )
+    process.exit(2)
+  }
+
+  let from
+  try {
+    from = git(['merge-base', baseRef, 'HEAD']).trim()
+  } catch {
+    from = baseRef
+  }
+
+  const raw = parseAddedLines(git(['diff', '-U0', '--no-color', from, '--', 'website/src']))
+  const written = new Map()
+  for (const [repoRel, lines] of Object.entries(raw)) {
+    written.set(repoRel, lines === ALL_LINES ? null : lines)
+  }
+  // Untracked files produce no hunk, so git never reports them above.
+  for (const repoRel of git(['ls-files', '--others', '--exclude-standard', '--', 'website/src'])
+    .split('\n').filter(Boolean)) {
+    written.set(repoRel, null)
+  }
+
+  const touched = [...written.keys()]
+    .filter((p) => p.startsWith(PREFIX))
+    .map((p) => p.slice(PREFIX.length))
+    .filter(inScope)
+    .sort()
+
+  return {
+    written,
+    touched,
+    readBase: (rel) => {
+      try {
+        return execFileSync('git', ['show', `${from}:${PREFIX}${rel}`], {
+          cwd: REPO,
+          encoding: 'utf-8',
+          maxBuffer: 128 * 1024 * 1024,
+          stdio: ['ignore', 'pipe', 'ignore'],
+        })
+      } catch {
+        return null
+      }
+    },
+  }
+}
+
+// ── run ──────────────────────────────────────────────────────────────────────
+//
+// Output contract: the marker lines below are parsed by `scripts/lib/i18n-gate-table.mjs`.
+// The two diff-scoped markers print ONLY when there was a base to diff against, because
+// printing "[added-lines] 0" with no base would claim a check that never ran, and it
+// would match the table's `find` regex, short-circuiting the table's own
+// `!base && scope === 'diff' -> NOT RUN` branch. Staying silent is what lets the
+// table say NOT RUN, which is both true and already tested.
+const asJson = process.argv.includes('--json')
+const files = walk(SRC).filter((f) => inScope(relative(SRC, f).split('\\').join('/')))
+
+const offenders = []
+for (const file of files) {
+  const rel = relative(SRC, file).split('\\').join('/')
+  const source = readFileSync(file, 'utf-8')
+  const lines = source.split('\n')
+  for (const lineNo of unitLiteralHits(rel, source)) {
+    offenders.push({ rel, line: lineNo, text: (lines[lineNo - 1] ?? '').trim().slice(0, 120) })
+  }
+}
+
+if (asJson) {
+  // Equivalence harness: emit the raw finding set so it can be diffed against any
+  // other implementation of the same predicate.
+  console.log(JSON.stringify({ files: files.length, count: offenders.length, offenders }, null, 1))
+  process.exit(0)
+}
+
+const scope = computeScope()
+const introduced = []
+const grew = []
+
+if (scope) {
+  for (const rel of scope.touched) {
+    const written = scope.written.get(`${PREFIX}${rel}`)
+    if (written === undefined) continue
+    const full = join(SRC, rel)
+    if (!existsSync(full)) continue
+    const lines = readFileSync(full, 'utf-8').split('\n')
+    for (const lineNo of hitsNow(rel)) {
+      // `null` marks a wholly new file: every line in it was written here.
+      if (written !== null && !written.has(lineNo)) continue
+      introduced.push(`${rel}:${lineNo}  ${(lines[lineNo - 1] ?? '').trim().slice(0, 120)}`)
+    }
+  }
+  for (const rel of scope.touched) {
+    const now = hitsNow(rel).length
+    const base = scope.readBase(rel)
+    const then = base === null ? 0 : unitLiteralHits(rel, base).length
+    if (now > then) grew.push(`  ${rel}: ${then} → ${now}`)
+  }
+
+  console.log(`[added-lines] ${introduced.length} number+unit literal(s) on lines you wrote`)
+  console.log(`[vs-base] ${grew.length} touched file(s) gained number+unit literals`)
+}
+
+console.log(`OK: ${offenders.length} un-migrated number+unit literal(s) across ${files.length} `
+  + `file(s), baseline ${BASELINE}.`)
+if (!scope) console.log('note: I18N_BASE_REF unset; the diff-scoped checks did not run.')
+
+if (introduced.length) {
+  console.error(`\n[added-lines] FAIL: ${introduced.length} on lines this branch wrote. There is\n`
+    + `no baseline to raise for these; ${BASELINE} covers only the frozen debt on lines\n`
+    + `nobody touched.\n\n${ADVICE}\n\n  ${introduced.slice(0, 15).join('\n  ')}`)
+}
+if (grew.length) {
+  console.error(`\n[vs-base] FAIL: ${grew.length} file(s) you touched hold MORE than at the base.\n`
+    + `Measured live against the base ref, so re-snapshotting cannot clear it.\n\n${ADVICE}\n\n`
+    + grew.join('\n'))
+}
+
+// The ceiling REPORTS; it does not fail. It covers only lines nobody touched, which no
+// branch can add to; [added-lines] catches those at zero tolerance. The gate table
+// requires a whole-repo count that is not a hard zero to be informational, or one
+// branch's inherited debt fails another branch's build.
+if (offenders.length > BASELINE) {
+  console.log(`\nnote: whole-repo count ${offenders.length} is over the frozen baseline `
+    + `${BASELINE}. Not failing this step; the diff-scoped checks above are the gate.`)
+}
+
+process.exit(introduced.length || grew.length ? 1 : 0)

--- a/website/scripts/lib/i18n-gate-table.mjs
+++ b/website/scripts/lib/i18n-gate-table.mjs
@@ -32,6 +32,7 @@ export const SCRIPTS = [
   { key: 'strings', argv: ['check-i18n-strings.mjs'] },
   { key: 'dnt', argv: ['check-dnt-catalogs.mjs'] },
   { key: 'manifest', argv: ['check-app-manifest-sync.mjs'] },
+  { key: 'units', argv: ['check-unit-literals.mjs'] },
 ]
 
 /**
@@ -64,6 +65,22 @@ export const CHECKS = [
     find: /^\[vs-base\] (\d+) touched file\(s\) gained/m,
     ok: m => m[1] === '0',
     summary: m => `${m[1]} touched file(s) got worse than the base`,
+  },
+  {
+    // The number+unit scan runs as a script rather than a vitest test: it parses the
+    // whole in-scope tree with the TypeScript compiler, so its cost scales with the
+    // repo and, under vitest's coverage instrumentation and worker contention, it
+    // outgrew the suite's per-test budget on wide machines.
+    id: 'unit-added-lines', script: 'units', scope: 'diff', enforce: 'zero',
+    find: /^\[added-lines\] (\d+) number\+unit/m,
+    ok: m => m[1] === '0',
+    summary: m => `${m[1]} number+unit literal(s) on lines you wrote`,
+  },
+  {
+    id: 'unit-vs-base', script: 'units', scope: 'diff', enforce: 'zero',
+    find: /^\[vs-base\] (\d+) touched file\(s\) gained number\+unit/m,
+    ok: m => m[1] === '0',
+    summary: m => `${m[1]} touched file(s) gained number+unit literals`,
   },
   {
     id: 'source-strings', script: 'source', scope: 'diff', enforce: 'zero',
@@ -134,6 +151,11 @@ export const CHECKS = [
       find: /^\[app-manifest-sync\] FAIL — (\d+) problem\(s\)/m,
       summary: m => `${m[1]} manifest/catalog mismatch(es)`,
     },
+  },
+  {
+    id: 'unit-ceiling', script: 'units', scope: 'repo', enforce: 'info',
+    find: /^OK: (\d+) un-migrated number\+unit literal\(s\) across (\d+) file\(s\), baseline (\d+)\./m,
+    summary: m => `${m[1]} un-migrated of ${m[2]} file(s) · baseline ${m[3]}`,
   },
   {
     id: 'dynamic-keys', script: 'keys', scope: 'repo', enforce: 'info',

--- a/website/scripts/lib/unit-literals.mjs
+++ b/website/scripts/lib/unit-literals.mjs
@@ -1,0 +1,149 @@
+/**
+ * Number+unit literal matcher: the shared definition.
+ *
+ * Extracted verbatim from `src/i18n/unitLiterals.test.ts` so the repo-wide scan can
+ * run as a standalone gate while the matcher's own unit tests stay in vitest. Same
+ * move `scripts/lib/qa-checks.mjs` made, and for the same reason: a gate that must
+ * run outside vitest needs its predicate importable from plain Node, and a second
+ * copy would drift from the assertions that prove it works.
+ *
+ * The logic below is unchanged from the test it came from. That is deliberate: the
+ * extraction is a refactor, and equivalence is verified file-by-file rather than
+ * assumed.
+ */
+
+import { readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+import ts from 'typescript'
+
+/** The seam is where a unit is legitimately turned into text. */
+export const SEAM = new Set(['i18n/format.ts'])
+
+/**
+ * Machine formats whose output is parsed back. Localizing these breaks the round
+ * trip, so they are exempt BY PATH with the parser named. Any addition here owes
+ * the same citation.
+ */
+export const ROUND_TRIP = new Map([
+  ['utils/cronUtils.tsx', 'wire shape read back by parseEveryFromSchedule in components/WeekGrid.tsx'],
+  ['utils/pasteTokens.ts', 'token read back by PASTE_TOKEN_REGEX in the same file'],
+  ['utils/tz.ts', 'UTC±HH:MM offset token, and en-US pins that derive cron day-of-week numbers'],
+])
+
+/** Measurement units this UI renders. Symbols only. */
+export const UNIT = /^(ms|s|m|h|d|B|KB|MB|GB|TB|kB|K|M|%|x)(?![a-zA-Z])/
+
+/** Units that only ever mean CSS. A literal containing one is a CSS value. */
+export const CSS_UNIT = /\d\s*(px|r?em|vh|vw|vmin|vmax|fr|deg|ch|pt|cm|mm|dvh|svh)\b|\bcalc\(/
+
+/** JSX attributes whose value is a CSS length, directly or one hop downstream. */
+const CSS_JSX_ATTR = new Set(['style', 'w', 'h', 'width', 'height', 'size', 'delay', 'offset'])
+
+/** Object keys that are CSS properties. */
+const CSS_PROPERTY = new Set([
+  'width', 'height', 'top', 'left', 'right', 'bottom', 'inset', 'transform', 'transition',
+  'animation', 'animationDelay', 'animationDuration', 'transitionDuration', 'transitionDelay',
+  'maxWidth', 'minWidth', 'maxHeight', 'minHeight', 'gridTemplateColumns', 'gridTemplateRows',
+  'aspectRatio', 'boxShadow', 'padding', 'margin', 'lineHeight', 'fontSize', 'gap', 'flexBasis',
+  'strokeDasharray', 'strokeWidth', 'fontWeight', 'borderRadius', 'font', 'filter', 'clipPath',
+  'backgroundSize', 'backgroundPosition', 'translate', 'scale', 'rotate', 'offsetDistance',
+])
+
+/**
+ * The scanned population, as a predicate on a path relative to `src`.
+ *
+ * `walk()` applies the structural half of this while traversing. The diff-scoped
+ * gates get their paths from git instead, so they need the whole predicate in one
+ * place, and it has to be the SAME one. A path the ceiling counts but the diff
+ * gates skip would be a silent exemption that nothing reports.
+ */
+export function inScope(rel) {
+  if (!/\.tsx?$/.test(rel) || /\.test\.tsx?$/.test(rel)) return false
+  const parts = rel.split('/')
+  if (parts.includes('node_modules') || parts[0] === 'locales') return false
+  return !SEAM.has(rel) && !ROUND_TRIP.has(rel)
+}
+
+export function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'locales') continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) out.push(full)
+  }
+  return out
+}
+
+/** Is this node lexically inside a position whose value is CSS? */
+function inCssContext(node) {
+  for (let n = node; n; n = n.parent) {
+    // style={{ ... }} or style="..."
+    if (ts.isJsxAttribute(n) && CSS_JSX_ATTR.has(n.name.getText())) return true
+    // { width: `...` }
+    if (ts.isPropertyAssignment(n)) {
+      const key = ts.isIdentifier(n.name) || ts.isStringLiteral(n.name) ? n.name.text : ''
+      if (CSS_PROPERTY.has(key)) return true
+    }
+    // el.style.height = ... / setProperty('--x', ...)
+    if (ts.isBinaryExpression(n) && n.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      if (/\.style\b/.test(n.left.getText())) return true
+    }
+    if (ts.isCallExpression(n)) {
+      const callee = n.expression.getText()
+      if (/setProperty$/.test(callee) || /useMotionTemplate$/.test(callee)) return true
+    }
+    // Tagged template: useMotionTemplate`...`
+    if (ts.isTaggedTemplateExpression(n) && /MotionTemplate/.test(n.tag.getText())) return true
+  }
+  return false
+}
+
+/** Line numbers where a numeric span is glued to a unit literal. */
+export function unitLiteralHits(file, source) {
+  const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  const hits = new Set()
+  const line = (n) => sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1
+
+  const visit = (node) => {
+    // `${expr}UNIT`: the literal chunk that FOLLOWS an interpolation.
+    if (ts.isTemplateExpression(node)) {
+      const whole = node.getText(sf)
+      if (!CSS_UNIT.test(whole) && !inCssContext(node)) {
+        for (const span of node.templateSpans) {
+          const text = span.literal.text
+          // Allow one space between value and unit (`5 KB`), as CLDR does.
+          if (UNIT.test(text) || UNIT.test(text.replace(/^ /, ''))) hits.add(line(span.literal))
+        }
+      }
+    }
+    // <span>{expr}UNIT</span>: a JSX expression followed by JSX text.
+    if (ts.isJsxElement(node) || ts.isJsxFragment(node)) {
+      const kids = node.children
+      for (let i = 0; i < kids.length - 1; i++) {
+        const cur = kids[i]
+        const next = kids[i + 1]
+        if (!ts.isJsxExpression(cur) || !ts.isJsxText(next)) continue
+        if (inCssContext(cur)) continue
+        const text = next.text
+        if (CSS_UNIT.test(text)) continue
+        if (UNIT.test(text) || UNIT.test(text.replace(/^ /, ''))) hits.add(line(cur))
+      }
+    }
+    // expr + 'UNIT'
+    if (
+      ts.isBinaryExpression(node)
+      && node.operatorToken.kind === ts.SyntaxKind.PlusToken
+      && ts.isStringLiteral(node.right)
+      && !inCssContext(node)
+      && !CSS_UNIT.test(node.right.text)
+    ) {
+      const text = node.right.text
+      if (UNIT.test(text) || UNIT.test(text.replace(/^ /, ''))) hits.add(line(node.right))
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sf)
+  return [...hits].sort((a, b) => a - b)
+}

--- a/website/src/i18n/unitLiterals.test.ts
+++ b/website/src/i18n/unitLiterals.test.ts
@@ -1,392 +1,40 @@
 /**
- * A number must not be glued to a unit literal.
+ * Number+unit literal matcher: unit tests.
  *
- * ## The defect
+ * This file proves the MATCHER. The gate that runs it over the repo lives in
+ * `scripts/check-unit-literals.mjs`, registered in the `i18n:check` table beside
+ * the project's other repo-scale gates.
  *
- * `` `${mins}m ${secs}s` ``, `bytes + ' KB'`, `` `${pct}%` `` — a numeric value
- * concatenated with a hardcoded unit. Three things are wrong with it at once,
- * and none of them is visible in English:
+ * WHY THE SCAN IS NOT HERE. It parses every in-scope file with the TypeScript
+ * compiler, so its cost scales with the size of the repo rather than with what a
+ * branch changed. Inside vitest that cost is multiplied by v8 coverage
+ * instrumentation and by every sibling worker competing for cores, measured on one
+ * machine at 2.0s standalone, 16.6s at 6 workers, 28.6s at 12 (a 14.2x blow-up), against a 15s
+ * per-test budget sized for tests that `await import(...)`. The scan therefore
+ * failed intermittently on wide machines and would have needed its ceiling raised
+ * again as hardware widened. Out in a script it runs once, in one process,
+ * uninstrumented, with no timeout to tune.
  *
- *  1. **The unit is untranslatable.** `m` is `Min.` in German, `分钟` in Chinese,
- *     `мин` in Russian. A literal in the source is a literal in every language.
- *  2. **The number is not localized.** `hi` groups as `12,34,567`, `bn` renders
- *     Bengali digits, and de/fr/ru want `,` as the decimal separator.
- *  3. **The separator is not localized.** Narrow unit lists are space-joined in
- *     en/ru/fr, comma-joined in de (`6 Min., 38 Sek.`) and joined with NOTHING
- *     in zh — so even a correct pair of parts is assembled wrongly.
- *
- * `src/i18n/format.ts` answers all three: `fmtUnit` for one value, `fmtDuration`
- * for a compound, `fmtBytes` for a size, `fmtPercent` for a ratio.
- *
- * ## Why this gate exists at all
- *
- * Because the existing gates provably do not catch it. `hooks/useUptime.ts`
- * rendered `6m 38s` in all ten languages and escaped BOTH:
- *
- *  - the `no-literal-string` eslint gate, whose Tailwind-shaped `words.exclude`
- *    regex treats `Xm Xs` as a class-name token (a known false-negative class
- *    documented in `eslint.i18n.config.js`), and
- *  - the `en-XA` render detector, which skipped it because the label was solo in
- *    its block and its "unaccented word" signal requires three ASCII letters.
- *
- * Two independent gates, one string, both blind. The pattern is *syntactic*, so
- * an AST check is the right shape — and unlike the two above, this one has no
- * regex over prose to be fooled by.
- *
- * ## The rule
- *
- * Three shapes are findings, all of them "a value with a unit welded on":
- *
- *   - a template literal span:      `` `${mins}m ${secs}s` ``
- *   - string concatenation:         `bytes + ' KB'`
- *   - **JSX text after an expression**: `<span>{pct.toFixed(0)}%</span>`
- *
- * The third is the most idiomatic React spelling, and the gate matches it too.
- * Units are the measurement units this UI actually renders: time (`ms s m h d`),
- * data (`B KB MB GB TB`), rate/ratio (`%`, `x`) and compact suffixes (`K`, `M`).
- *
- * ## What is NOT a finding, and why
- *
- * **CSS values.** `` style={{ width: `${pct}%` }} ``, `el.style.height = h + 'px'`,
- * `` `height ${MS}ms ${EASE}` `` — a localized digit in a CSS length is not a
- * cosmetic problem, it is a **silently dropped value**: `lib/cssSanitize.ts`
- * guards five iframe theme surfaces with `/^[a-zA-Z0-9#(),.\- %/]+$/`, which a
- * Bengali digit fails, so the declaration is discarded entirely. Those sites MUST
- * keep bare arithmetic, so this gate excludes them by context rather than
- * inviting someone to "fix" them.
- *
- * CSS context is recognised as: a `style` JSX attribute, an object property whose
- * key is a CSS property, an assignment into `.style.*` or `setProperty`, a
- * `useMotionTemplate` call, a JSX attribute named like a dimension (`w`, `h`,
- * `size`, `delay` — a component prop that flows into a style downstream), or any
- * literal containing a CSS-only unit (`px em rem vh vw fr deg ch pt`) — a
- * template mixing `px` with `ms` is a transition shorthand, not prose.
- *
- * The dimension-prop exclusion is a NAME heuristic and therefore imprecise in
- * both directions: it cannot see that `<ShimmerLine w={`${x}%`} />` ends up in a
- * `width`, and it would wrongly excuse a genuine label passed as `size`. Deciding
- * properly needs cross-file flow analysis, which a syntactic gate does not do.
- *
- * **Machine formats with a parser on the other side.** `utils/cronUtils.tsx`
- * emits `1h`/`30m` as the wire shape `parseEveryFromSchedule` reads back with
- * `/^every\s+(\d+)\s*([sh])/`, and `utils/pasteTokens.ts` emits
- * `[ Paste #N · M lines ]` parsed back by a `\d+` regex. Localizing either
- * silently breaks the round trip. These are listed in `ROUND_TRIP` below with
- * their parser, because "it looks like display text" is exactly the trap.
- *
- * ## Known false negatives, stated explicitly
- *
- *  1. **Indirection.** A unit held in a variable (`const u = 'm'; `${n}${u}``) is
- *     not matched. No such site exists today.
- *  2. **Words, not symbols.** `` `${n} minutes` `` is not matched — the unit
- *     vocabulary is deliberately symbols-only, because matching English words
- *     would collide with ordinary prose. Those sites are caught instead by the
- *     `no-literal-string` gate, which sees a translatable word.
- *  3. **A number formatted correctly but assembled wrongly.** `${fmtNumber(n)}m`
- *     IS matched (the trailing `m` is still a literal), but
- *     `` `${fmtUnit(a,'hour')} ${fmtUnit(b,'minute')}` `` is not — a hand-joined
- *     pair of correct parts passes. `fmtDuration` exists so callers do not
- *     hand-join; this gate cannot tell that they did.
- *  4. **Scope.** Only `.ts`/`.tsx` under `src`, excluding tests.
- *
- * ## How this is enforced: two diff gates that store nothing, one ceiling
- *
- * `[added-lines]` and `[vs-base]` are the real gate. Both are ZERO-TOLERANCE and
- * store NO count anywhere: they read the base ref, so git supplies the previous
- * state and there is no number in this file for a parallel branch to regenerate.
- *
- *   - `[added-lines]` — a finding on a line this branch wrote. No exemption.
- *   - `[vs-base]` — a file this branch touched holds MORE findings than it did at
- *     the base. Catches the two things line attribution cannot: an edit that turns
- *     an exempt site into a real one without touching the finding's own line, and
- *     an offsetting add-and-remove that leaves the whole-repo count flat.
- *
- * `BASELINE` is the third and weakest — one UPWARD-ONLY whole-repo ceiling over the
- * frozen debt on lines nobody touched, which exists only because a hard zero would
- * fail on arrival. Lowering it is OPTIONAL and never required to land a change.
- * That is the point: an exact-equality ratchet fails every branch that FIXES a site
- * and orders it to edit one shared number, which is a merge conflict between all of
- * them and buys no enforcement the two diff gates do not already provide. The goal
- * is 0, at which point the constant and its test are deleted.
- *
- * Per the standing project rule: this is a syntactic floor, not a measurement of
- * "all unlocalized units". The render-time gate in Phase 5 is the ground truth.
+ * What stays here is what a unit test is for: proof that the predicate detects the
+ * shapes that actually shipped, and that it exempts CSS values and the format seam.
+ * Both consumers import the same `scripts/lib/unit-literals.mjs`, so the assertions
+ * below cannot drift from the gate they describe.
  */
+
+import { join, relative } from 'node:path'
 
 import { describe, it, expect } from 'vitest'
-import { execFileSync } from 'node:child_process'
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
-import { join, relative } from 'node:path'
-import ts from 'typescript'
 
-// The hunk parser and its "every line is new" sentinel are imported rather than
-// reimplemented, so this gate and `check-i18n-strings.mjs` cannot come to disagree
-// about what "a line this branch wrote" means.
-import { ALL_LINES, parseAddedLines } from '../../scripts/check-i18n-strings.mjs'
+import { unitLiteralHits, walk, inScope } from '../../scripts/lib/unit-literals.mjs'
 
 const SRC = join(__dirname, '..')
-const REPO = join(SRC, '..', '..')
-
-/**
- * Frozen whole-repo debt: un-migrated number+unit literals on lines nobody has
- * touched since this gate landed.
- *
- * UPWARD-ONLY. Going over fails; coming under does NOT, and lowering this number is
- * OPTIONAL — never required to land a change. That is deliberate: a shared count
- * that every branch must edit as it improves is a merge conflict between all of
- * them, and the `[added-lines]` and `[vs-base]` gates below are what actually stop
- * a new site, measured against the base ref with nothing stored. Never raise it.
- * The goal is 0, at which point this constant and its test are deleted.
- */
-const BASELINE = 74
-
-/** The seam is where a unit is legitimately turned into text. */
-const SEAM = new Set(['i18n/format.ts'])
-
-/**
- * Machine formats whose output is parsed back. Localizing these breaks the round
- * trip, so they are exempt BY PATH with the parser named. Any addition here owes
- * the same citation.
- */
-const ROUND_TRIP = new Map<string, string>([
-  ['utils/cronUtils.tsx', 'wire shape read back by parseEveryFromSchedule in components/WeekGrid.tsx'],
-  ['utils/pasteTokens.ts', 'token read back by PASTE_TOKEN_REGEX in the same file'],
-  ['utils/tz.ts', 'UTC±HH:MM offset token, and en-US pins that derive cron day-of-week numbers'],
-])
-
-/** Measurement units this UI renders. Symbols only — see false negative 2. */
-const UNIT = /^(ms|s|m|h|d|B|KB|MB|GB|TB|kB|K|M|%|x)(?![a-zA-Z])/
-
-/** Units that only ever mean CSS. A literal containing one is a CSS value. */
-const CSS_UNIT = /\d\s*(px|r?em|vh|vw|vmin|vmax|fr|deg|ch|pt|cm|mm|dvh|svh)\b|\bcalc\(/
-
-/** JSX attributes whose value is a CSS length, directly or one hop downstream. */
-const CSS_JSX_ATTR = new Set(['style', 'w', 'h', 'width', 'height', 'size', 'delay', 'offset'])
-
-/** Object keys that are CSS properties. */
-const CSS_PROPERTY = new Set([
-  'width', 'height', 'top', 'left', 'right', 'bottom', 'inset', 'transform', 'transition',
-  'animation', 'animationDelay', 'animationDuration', 'transitionDuration', 'transitionDelay',
-  'maxWidth', 'minWidth', 'maxHeight', 'minHeight', 'gridTemplateColumns', 'gridTemplateRows',
-  'aspectRatio', 'boxShadow', 'padding', 'margin', 'lineHeight', 'fontSize', 'gap', 'flexBasis',
-  'strokeDasharray', 'strokeWidth', 'fontWeight', 'borderRadius', 'font', 'filter', 'clipPath',
-  'backgroundSize', 'backgroundPosition', 'translate', 'scale', 'rotate', 'offsetDistance',
-])
-
-/**
- * The scanned population, as a predicate on a path relative to `src`.
- *
- * `walk()` applies the structural half of this while traversing. The diff-scoped
- * gates get their paths from git instead, so they need the whole predicate in one
- * place — and it has to be the SAME one. A path the ceiling counts but the diff
- * gates skip would be a silent exemption that nothing reports.
- */
-function inScope(rel: string): boolean {
-  if (!/\.tsx?$/.test(rel) || /\.test\.tsx?$/.test(rel)) return false
-  const parts = rel.split('/')
-  if (parts.includes('node_modules') || parts[0] === 'locales') return false
-  return !SEAM.has(rel) && !ROUND_TRIP.has(rel)
-}
-
-function walk(dir: string, out: string[] = []): string[] {
-  for (const entry of readdirSync(dir)) {
-    if (entry === 'node_modules' || entry === 'locales') continue
-    const full = join(dir, entry)
-    if (statSync(full).isDirectory()) walk(full, out)
-    else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) out.push(full)
-  }
-  return out
-}
-
-/** Is this node lexically inside a position whose value is CSS? */
-function inCssContext(node: ts.Node): boolean {
-  for (let n: ts.Node | undefined = node; n; n = n.parent) {
-    // style={{ ... }} or style="..."
-    if (ts.isJsxAttribute(n) && CSS_JSX_ATTR.has(n.name.getText())) return true
-    // { width: `...` }
-    if (ts.isPropertyAssignment(n)) {
-      const key = ts.isIdentifier(n.name) || ts.isStringLiteral(n.name) ? n.name.text : ''
-      if (CSS_PROPERTY.has(key)) return true
-    }
-    // el.style.height = ... / setProperty('--x', ...)
-    if (ts.isBinaryExpression(n) && n.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
-      if (/\.style\b/.test(n.left.getText())) return true
-    }
-    if (ts.isCallExpression(n)) {
-      const callee = n.expression.getText()
-      if (/setProperty$/.test(callee) || /useMotionTemplate$/.test(callee)) return true
-    }
-    // Tagged template: useMotionTemplate`...`
-    if (ts.isTaggedTemplateExpression(n) && /MotionTemplate/.test(n.tag.getText())) return true
-  }
-  return false
-}
-
-/** Line numbers where a numeric span is glued to a unit literal. */
-export function unitLiteralHits(file: string, source: string): number[] {
-  const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
-  const hits = new Set<number>()
-  const line = (n: ts.Node) => sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1
-
-  const visit = (node: ts.Node) => {
-    // `${expr}UNIT` — the literal chunk that FOLLOWS an interpolation.
-    if (ts.isTemplateExpression(node)) {
-      const whole = node.getText(sf)
-      if (!CSS_UNIT.test(whole) && !inCssContext(node)) {
-        for (const span of node.templateSpans) {
-          const text = span.literal.text
-          // Allow one space between value and unit (`5 KB`), as CLDR does.
-          if (UNIT.test(text) || UNIT.test(text.replace(/^ /, ''))) hits.add(line(span.literal))
-        }
-      }
-    }
-    // <span>{expr}UNIT</span> — a JSX expression followed by JSX text. This is
-    // the most idiomatic React spelling of the defect, matched alongside template
-    // literals and string concatenation.
-    if (ts.isJsxElement(node) || ts.isJsxFragment(node)) {
-      const kids = node.children
-      for (let i = 0; i < kids.length - 1; i++) {
-        const cur = kids[i]
-        const next = kids[i + 1]
-        if (!ts.isJsxExpression(cur) || !ts.isJsxText(next)) continue
-        if (inCssContext(cur)) continue
-        const text = next.text
-        if (CSS_UNIT.test(text)) continue
-        if (UNIT.test(text) || UNIT.test(text.replace(/^ /, ''))) hits.add(line(cur))
-      }
-    }
-    // expr + 'UNIT'
-    if (
-      ts.isBinaryExpression(node)
-      && node.operatorToken.kind === ts.SyntaxKind.PlusToken
-      && ts.isStringLiteral(node.right)
-      && !inCssContext(node)
-      && !CSS_UNIT.test(node.right.text)
-    ) {
-      const text = node.right.text
-      if (UNIT.test(text) || UNIT.test(text.replace(/^ /, ''))) hits.add(line(node.right))
-    }
-    ts.forEachChild(node, visit)
-  }
-
-  visit(sf)
-  return [...hits].sort((a, b) => a - b)
-}
-
-/**
- * What this branch changed, measured live against the base ref.
- *
- * Nothing is stored. Git already holds the previous state, so the base count is
- * computed rather than read from a ledger that can go stale or be re-snapshotted
- * past. Returns `null` only when there is genuinely nothing to diff — a bare local
- * run with `I18N_BASE_REF` unset. CI always supplies it, on a PR and on a push to
- * `main` alike.
- *
- * When a base ref IS configured but cannot be resolved this THROWS rather than
- * returning `null`: a gate that cannot run must fail, not skip itself green on a
- * failed fetch.
- *
- * The semantics are copied from `diffScope()` in `scripts/check-i18n-strings.mjs`:
- * the merge-base-then-tip fallback (CI checks out at depth 1, so there is no shared
- * history and `merge-base` fails), untracked files counting as wholly new, and the
- * WORKING TREE as the right-hand side — `base...HEAD` compares commits, so it would
- * exempt exactly the moment a developer runs this locally to check what they wrote.
- */
-type Scope = {
-  /** Lines this branch wrote, keyed by repo-relative path. `null` means every line. */
-  written: Map<string, Set<number> | null>
-  /** Paths relative to `src`, filtered to the scanned population. */
-  touched: string[]
-  /** The file's contents at the base, or `null` if it did not exist there. */
-  readBase: (rel: string) => string | null
-}
-
-const PREFIX = 'website/src/'
-
-function computeScope(): Scope | null {
-  const baseRef = process.env.I18N_BASE_REF
-  if (!baseRef) return null
-  const git = (args: string[]) =>
-    execFileSync('git', args, { cwd: REPO, encoding: 'utf-8', maxBuffer: 128 * 1024 * 1024 })
-
-  try {
-    git(['rev-parse', '--verify', `${baseRef}^{commit}`])
-  } catch {
-    throw new Error(
-      `cannot resolve ${baseRef}. The diff-scoped unit-literal gates need the base ref: `
-      + 'fetch it before running, or unset I18N_BASE_REF to check only the ceiling.',
-    )
-  }
-
-  let from: string
-  try {
-    from = git(['merge-base', baseRef, 'HEAD']).trim()
-  } catch {
-    from = baseRef
-  }
-
-  const raw = parseAddedLines(git(['diff', '-U0', '--no-color', from, '--', 'website/src']))
-  const written = new Map<string, Set<number> | null>()
-  for (const [repoRel, lines] of Object.entries(raw)) {
-    written.set(repoRel, lines === ALL_LINES ? null : (lines as Set<number>))
-  }
-  // Untracked files produce no hunk, so git never reports them above. On CI the tree
-  // is clean and this is empty; locally it is the difference between the gate seeing
-  // a file you just created and silently passing it.
-  for (const repoRel of git(['ls-files', '--others', '--exclude-standard', '--', 'website/src'])
-    .split('\n').filter(Boolean)) {
-    written.set(repoRel, null)
-  }
-
-  const touched = [...written.keys()]
-    .filter((p) => p.startsWith(PREFIX))
-    .map((p) => p.slice(PREFIX.length))
-    .filter(inScope)
-    .sort()
-
-  return {
-    written,
-    touched,
-    // Absent at the base means the file is new on this branch, so its base count is 0.
-    // `git show` writes "path does not exist in <sha>" to stderr on that entirely
-    // expected path, and execFileSync inherits stderr, so silence it here rather than
-    // print a `fatal:` line into CI logs for every file a branch adds.
-    readBase: (rel) => {
-      try {
-        return execFileSync('git', ['show', `${from}:${PREFIX}${rel}`], {
-          cwd: REPO,
-          encoding: 'utf-8',
-          maxBuffer: 128 * 1024 * 1024,
-          stdio: ['ignore', 'pipe', 'ignore'],
-        })
-      } catch {
-        return null
-      }
-    },
-  }
-}
-
-/**
- * Memoised so the two diff gates share one set of git calls. A throw is NOT cached,
- * so an unresolvable base ref fails both gates rather than only the first.
- */
-let cachedScope: Scope | null | undefined
-function scope(): Scope | null {
-  if (cachedScope === undefined) cachedScope = computeScope()
-  return cachedScope
-}
-
-/** Findings in the working tree, by path relative to `src`. */
-function hitsNow(rel: string): number[] {
-  const full = join(SRC, rel)
-  if (!existsSync(full)) return []
-  return unitLiteralHits(rel, readFileSync(full, 'utf-8'))
-}
 
 describe('a number is never glued to a unit literal', () => {
-  const files = walk(SRC).filter((f) => inScope(relative(SRC, f).split('\\').join('/')))
+  const files = walk(SRC).filter((f: string) => inScope(relative(SRC, f).split('\\').join('/')))
 
   it('finds source files to scan', () => {
+    // Guards the population the gate walks: a broken `inScope` that filtered
+    // everything would make the gate pass vacuously.
     expect(files.length).toBeGreaterThan(300)
   })
 
@@ -405,7 +53,7 @@ describe('a number is never glued to a unit literal', () => {
 
   it('does not flag CSS values, which must keep bare digits', () => {
     // A localized digit in a CSS length is dropped outright by
-    // lib/cssSanitize.ts's Latin-only allowlist — a silent total value loss.
+    // lib/cssSanitize.ts's Latin-only allowlist, a silent total value loss.
     const css = [
       'const a = <div style={{ width: `${pct}%` }} />',
       "el.style.height = Math.min(h, maxH) + 'px'",
@@ -423,100 +71,5 @@ describe('a number is never glued to a unit literal', () => {
       "const c = fmtPercent(ratio)",
     ].join('\n')
     expect(unitLiteralHits('ok.tsx', ok)).toEqual([])
-  })
-
-  const ADVICE =
-    'A number is concatenated with a hardcoded unit here, so the unit cannot be '
-    + 'translated, the digits are not localized, and the separator between parts is '
-    + 'wrong outside English. Use the helpers in `src/i18n/format.ts`: `fmtUnit` for one '
-    + 'value, `fmtDuration([[h, \'hour\'], [m, \'minute\']])` for a compound, `fmtBytes` '
-    + 'for a size, `fmtPercent` for a ratio.\n\n'
-    + 'If the value is a CSS length or is parsed back by a regex, it MUST keep bare '
-    + 'digits — put it in a style/CSS position the detector recognises, or add the file '
-    + 'to ROUND_TRIP in this test naming the parser.'
-
-  it(`holds at most ${BASELINE} un-migrated number+unit literal(s)`, () => {
-    const offenders: string[] = []
-    for (const file of files) {
-      const rel = relative(SRC, file).split('\\').join('/')
-      const source = readFileSync(file, 'utf-8')
-      const lines = source.split('\n')
-      for (const lineNo of unitLiteralHits(rel, source)) {
-        offenders.push(`${rel}:${lineNo}  ${(lines[lineNo - 1] ?? '').trim().slice(0, 120)}`)
-      }
-    }
-
-    // UPWARD-ONLY, deliberately. An exact-equality assertion here would fail every
-    // branch that FIXES a site and order it to come back and edit `BASELINE` — one
-    // shared number that every parallel branch has to rewrite. The regression is
-    // covered by the two diff-scoped gates below, which is what licenses relaxing
-    // this one; see the ratchet rule in `docs/ci/i18n-gates.md`.
-    expect(
-      offenders.length,
-      `${ADVICE}\n\n${offenders.slice(0, 15).join('\n')}`,
-    ).toBeLessThanOrEqual(BASELINE)
-  })
-
-  /**
-   * Zero tolerance, no stored state. A finding on a line this branch wrote fails,
-   * whatever the ceiling says — so admitting a new site cannot be bought with a
-   * baseline edit that reads like routine ledger churn.
-   */
-  it('[added-lines] no finding sits on a line this branch wrote', () => {
-    const s = scope()
-    if (!s) return // bare local run: no base commit to diff against
-
-    const introduced: string[] = []
-    for (const rel of s.touched) {
-      const written = s.written.get(`${PREFIX}${rel}`)
-      if (written === undefined) continue
-      const full = join(SRC, rel)
-      if (!existsSync(full)) continue
-      const lines = readFileSync(full, 'utf-8').split('\n')
-      for (const lineNo of hitsNow(rel)) {
-        // `null` marks a wholly new file: every line in it was written here.
-        if (written !== null && !written.has(lineNo)) continue
-        introduced.push(`${rel}:${lineNo}  ${(lines[lineNo - 1] ?? '').trim().slice(0, 120)}`)
-      }
-    }
-
-    expect(
-      introduced,
-      `${introduced.length} number+unit literal(s) on lines this branch wrote. There is no\n`
-      + `baseline to raise for these — ${BASELINE} covers only the frozen debt on lines\n`
-      + `nobody touched.\n\n${ADVICE}\n\n${introduced.slice(0, 15).join('\n')}`,
-    ).toEqual([])
-  })
-
-  /**
-   * What line attribution cannot see, by construction:
-   *
-   *  - An edit that converts an EXEMPT site into a real one without touching the
-   *    finding's own line — dropping the `px` half of `` `${a}% ${b}px` `` moves the
-   *    remaining `%` out of CSS context from a line above it.
-   *  - An offsetting add-and-remove inside one file, which leaves both the whole-repo
-   *    count and the ceiling flat.
-   *
-   * The base count is computed by running the same detector over the file as it was
-   * at the base ref, so there is nothing stored and nothing to keep in sync.
-   */
-  it('[vs-base] no file this branch touched gained a finding versus the base', () => {
-    const s = scope()
-    if (!s) return
-
-    const grew: string[] = []
-    for (const rel of s.touched) {
-      const now = hitsNow(rel).length
-      const base = s.readBase(rel)
-      const then = base === null ? 0 : unitLiteralHits(rel, base).length
-      if (now > then) grew.push(`  ${rel}: ${then} → ${now}`)
-    }
-
-    expect(
-      grew,
-      `${grew.length} file(s) you touched hold MORE number+unit literals than they did at\n`
-      + 'the base. Measured live against the base ref, not against a committed count, so\n'
-      + `re-snapshotting cannot clear it.\n\n${ADVICE}\n\n${grew.join('\n')}`,
-    ).toEqual([])
   })
 })

--- a/website/src/test/i18nGateTable.test.ts
+++ b/website/src/test/i18nGateTable.test.ts
@@ -38,13 +38,24 @@ const HEALTHY: Record<string, { status: number, text: string }> = {
   plural: run(0, "OK: no literal-'s' pluralization found."),
   dnt: run(0, 'OK: 19 DNT term(s) intact across 9 catalog(s) — 62207 value(s) scanned.'),
   manifest: run(0, 'OK: 16 built-in manifests, 147 strings match locales/en.json exactly.'),
+  units: run(0, '[added-lines] 0 number+unit literal(s) on lines you wrote\n[vs-base] 0 touched file(s) gained number+unit literals\nOK: 52 un-migrated number+unit literal(s) across 1026 file(s), baseline 74.'),
   source: run(0, '[source-strings] 0 new key(s) vs origin/main, 0 finding(s).\n[changed-values] 0 catalog QA finding(s) among values changed vs origin/main.'),
   strings: run(0, '[added-lines] 0 untranslated string(s) on lines this branch wrote.\n[vs-base] 0 touched file(s) gained untranslated strings vs the base.\nOK: 1324 untranslated strings across 241 files, at or below the baseline of 1837.\nOK: 1118 untranslated string(s) inside ALL-CAPS constants across 249 files, at or below the ceiling of 1118.'),
 }
 
 const runsOf = (over: Record<string, { status: number, text: string }> = {}) => {
   const m = new Map<string, { status: number, text: string }>()
-  for (const s of SCRIPTS) m.set(s.key, over[s.key] ?? HEALTHY[s.key])
+  for (const s of SCRIPTS) {
+    // A script registered in the table but missing from HEALTHY resolves every row
+    // it owns as MISSING in EVERY scenario below, which surfaces as a pile of
+    // unrelated `expected true to be false`. Name the real problem instead.
+    const r = over[s.key] ?? HEALTHY[s.key]
+    if (!r) {
+      throw new Error(`no HEALTHY fixture for the '${s.key}' script `
+        + `(${s.argv.join(' ')}): add one, or every row it owns reads MISSING here.`)
+    }
+    m.set(s.key, r)
+  }
   return m
 }
 const decide = (over = {}, base = 'origin/main') => {
@@ -141,13 +152,20 @@ describe('no base commit — the diff-scoped checks did not run, and are not bro
   const noBase = () => decide({
     strings: run(0, '[diff-scope] skipped — I18N_BASE_REF is unset, so there is nothing to diff.\nOK: 1324 untranslated strings across 241 files, at or below the baseline of 1837.\nOK: 1118 untranslated string(s) inside ALL-CAPS constants across 249 files, at or below the ceiling of 1118.'),
     source: run(0, 'OK: skipped — cannot read the English catalogs at origin/main (shallow clone?).'),
+    // With no base the unit gate prints its whole-repo line ONLY. Staying silent on
+    // the diff-scoped markers is what lets the table say NOT RUN instead of
+    // inventing a clean result for a check that never ran.
+    units: run(0, 'OK: 52 un-migrated number+unit literal(s) across 1026 file(s), baseline 74.\nnote: I18N_BASE_REF unset; the diff-scoped checks did not run.'),
   }, '')
 
   it('marks them NOT RUN rather than MISSING, and passes', () => {
     const { rows, failed } = noBase()
-    for (const id of ['added-lines', 'vs-base', 'source-strings', 'changed-values']) {
+    for (const id of ['added-lines', 'vs-base', 'source-strings', 'changed-values',
+      'unit-added-lines', 'unit-vs-base']) {
       expect(row(rows, id).state, id).toBe('NOT RUN')
     }
+    // The whole-repo ceiling needs no base and still reports.
+    expect(row(rows, 'unit-ceiling').state).toBe('PASS')
     expect(failed).toBe(false)
   })
 
@@ -223,7 +241,7 @@ describe('a whole-repo total over its ceiling reports and does NOT fail', () => 
 })
 
 describe('the table covers the chain it replaced', () => {
-  it('runs exactly the eight scripts, with the flags the && chain used', () => {
+  it('runs exactly the nine scripts, with the flags the && chain used', () => {
     // Dropping a script from this table is a silent loss of coverage, and this is the
     // only test that would notice. `--baseline=3` is part of the contract: the codemod
     // ratchet lived in the package.json chain and moved here.
@@ -236,6 +254,7 @@ describe('the table covers the chain it replaced', () => {
       'check-i18n-strings.mjs',
       'check-dnt-catalogs.mjs',
       'check-app-manifest-sync.mjs',
+      'check-unit-literals.mjs',
     ])
   })
 
@@ -255,7 +274,7 @@ describe('the table covers the chain it replaced', () => {
     // whole-repo number is a stored total another branch can move without touching your
     // files, so it reports. `dynamic-keys` was the last bidirectional ratchet in the repo.
     expect(CHECKS.filter(c => c.enforce === 'info').map(c => c.id))
-      .toEqual(['dynamic-keys', 'extractable', 'untranslated', 'allcaps'])
+      .toEqual(['unit-ceiling', 'dynamic-keys', 'extractable', 'untranslated', 'allcaps'])
     for (const c of CHECKS.filter(x => x.scope === 'repo' && x.enforce !== 'hard-zero')) {
       expect(c.enforce, `${c.id} is whole-repo and not a hard zero, so it must be info`)
         .toBe('info')


### PR DESCRIPTION
## Problem / Motivation

`src/i18n/unitLiterals.test.ts` runs a whole-repo TypeScript AST scan (every non-test
file under `website/src`) inside vitest's default 15s per-test budget. On a contended,
many-core runner it crosses that line and fails the Frontend Tests job, as reported in
#2501 (and others). The failure is contention, not a code change: a branch that only
touches tests or locale catalogs (both excluded from the scan) can still be the one
that goes red, with nothing in the output to say so.

## Why it matters

A gate that fails on timing rather than on a real violation costs a full re-run of a
~14min job (Coverage Gate consumes its artifact, so one timeout takes two checks
down), and it erodes the ratchet's authority: people learn to re-run reds instead of
reading them. It gets worse as CI and developer machines gain cores.

## What changed (motivation to approach to change)

Symptom: the scan times out under contention.

Root cause: a repo-scale scan, whose cost tracks repo size and worker count and is
multiplied by process-wide v8 coverage, is living under a per-test deadline.
Raising the timeout only moves the cliff (the scan goes 2.0s standalone to 28.6s at
12 workers; full table in #2501), and throttling workers costs the whole suite +82%
wall clock. So the scan moves out of vitest into a standalone gate, which is option 3
from #2501, while the matcher's unit tests stay in vitest.

- **`scripts/lib/unit-literals.mjs`** (new): the matcher, extracted verbatim so the gate
  and the tests share one definition and cannot drift.
- **`scripts/check-unit-literals.mjs`** (new): the gate. Three checks, strongest first:
  `[added-lines]` (zero tolerance), `[vs-base]` (zero tolerance), `[ceiling]` (info).
- **`scripts/lib/i18n-gate-table.mjs`**: one script row plus three check rows. No CI
  workflow change; the `i18n:check` aggregator already runs the table.
- **`src/i18n/unitLiterals.test.ts`**: trimmed 552 to 75 lines; the four matcher
  assertions stay, importing the extracted module.
- **`src/test/i18nGateTable.test.ts`**: fixture and assertions for the new rows.

Enforcement is unchanged where it matters: the two diff-scoped checks stay zero
tolerance, so a new un-migrated literal still fails. The whole-repo ceiling is
`enforce: 'info'`, which the gate table's contract requires for a non-hard-zero
whole-repo count, so one branch's inherited debt cannot fail an unrelated branch's build.
This is a refactor: matcher and diff logic are carried over unchanged, and equivalence is
verified rather than assumed (the gate and the tests import the same module, and the
gate's `--json` mode emits the raw finding set for direct comparison).

## Tests

- `src/i18n/unitLiterals.test.ts`: the four matcher assertions, now importing
  `scripts/lib/unit-literals.mjs`. They lock in that the matcher finds files to scan,
  detects the number+unit shapes that shipped, exempts CSS values, and exempts values
  routed through the format seam.
- `src/test/i18nGateTable.test.ts`: a `HEALTHY` fixture for the new `units` script; a
  guard that throws if a registered script has no fixture; no-base `NOT RUN` assertions
  for the two diff-scoped rows plus a `PASS` for the ceiling; the script-count check; and
  `unit-ceiling` in the info list.

## Manual verification

N/A, unit coverage is sufficient. For reference, the full suite is green (885 files,
12160 pass, 0 fail, 0 lint errors) and the gate runs standalone in 2.0s over 1026 files.

## Related Issues

Fixes #2501.

Related flake context:
- #1832 (a `DevFleetPage` test in the same family of contention flakes, observed alongside this on a 16-core run)
- #1004 (the i18n remediation tracking issue).

## Checklist

- [x] Single commit with a Conventional Commits title (`refactor: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable): N/A, no user-facing docs affected
- [x] No secrets, credentials, or internal references in the diff
