### PR TITLE
fix(pod): make teardown zero-residue instead of racing the pod's own processes

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -170,20 +170,29 @@ step needs before using them, so provisioning a **fresh** worktree (no
   it skips (fast idempotent path). Without this, a fresh worktree's `npm run
   build` dies with `tsc: command not found` (issue #229).
 
-### Pod Unit ExecStart Self-Heal
+### Pod Unit Self-Heal
 
-On `pod up`, if the installed systemd unit template's `ExecStart` binary no longer exists
-(typically because the worktree it resolved into was pruned), the pod CLI:
+The unit template is written once by `pod install`, so a machine keeps whatever it
+installed. On `pod up`, the pod CLI re-renders it when the installed unit is one this
+build will not boot:
 
-1. Detects the dangling binary via `unit.unit_exec_ok(cfg)` (reads the unit file, checks
-   `os.access(exe, os.X_OK)` on the baked path)
+1. Detects a stale unit via `unit.unit_is_current(cfg)`, which fails on either of two
+   triggers:
+   - the baked `ExecStart` binary no longer exists — `unit.unit_exec_ok(cfg)` reads the
+     unit file and checks `os.access(exe, os.X_OK)` on the baked path (typically the
+     worktree it resolved into was pruned)
+   - the unit carries a directive this build has removed (`unit._REMOVED_DIRECTIVES`,
+     currently `ExecStopPost=` — see the pod module's teardown section)
 2. Re-renders the unit with a currently-valid binary (`unit.install_unit(cfg)`)
 3. Runs `daemon-reload`
 4. Audits the self-heal event
 5. Proceeds to start the pod normally
 
-This prevents the permanent EXEC 203 failure loop that occurs when worktrees are pruned
-after the unit was installed.
+The first trigger prevents the permanent EXEC 203 failure loop that occurs when
+worktrees are pruned after the unit was installed. The second is the upgrade path: a
+unit installed by an older build would otherwise keep a teardown hook that races the
+pod's own subprocesses and wipes the HOME on the stop half of a `Restart=`, and it
+would keep doing so until someone reinstalled by hand.
 
 ## Background Tasks
 

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md
@@ -9,7 +9,8 @@ triggers: e2e test, smoke test, pod test, verify worktree, test pod, run e2e, en
 A worktree's full stack (backend API **and** frontend SPA) runs as **one process
 on one port** — exactly like a Docker container. The `kirocrew pod` CLI is the
 only interface you need: spin one up, get a `{base_url, token}` handle, test
-against it, tear it down to zero residue. The live gateway is **never touched**.
+against it, tear it down and have the teardown VERIFIED. The live gateway is
+**never touched**.
 
 ## Quickstart — run the bundled e2e suite
 
@@ -48,7 +49,8 @@ kirocrew pod up <wt> --json
 curl -s "$base_url/api/<anything>?token=$token"      # backend API
 #    open  $base_url/?token=$token  in Playwright     # frontend SPA (same port)
 
-# 3. destroy it — zero residue, live gateway untouched
+# 3. destroy it — deletes the HOME and verifies it is gone (nonzero if not),
+#    live gateway untouched
 kirocrew pod down <wt>
 ```
 
@@ -57,7 +59,7 @@ Other verbs: `ls` (list running pods) · `status <wt>` · `token <wt>` · `url <
 
 **Isolation guarantees** (enforced by the pod runtime):
 own `KIROCREW_HOME`, own port, **no tunnel** (can't grab the real Slack identity),
-`--no-crons`, and cleanup on stop.
+`--no-crons`, and cleanup on `pod down`.
 A pod can **never** collide with the live gateway and many can run at once.
 
 **Resource ceilings are Linux-only.** On Linux the unit sets cgroup
@@ -68,11 +70,17 @@ covers one process's address space, not resident memory, and the gateway spawns
 agent subprocesses that each get their own limit). So on a Mac a runaway pod can
 starve the machine; every other isolation property above still holds.
 
-**Teardown differs too.** Linux reaps the pod's isolated HOME from the unit's
-`ExecStopPost`, so it happens whatever stopped the service. launchd has no
-post-stop hook, so `pod down` does it — meaning a pod killed without an explicit
-`down` (host crash, force-reboot) leaves its HOME behind on macOS. `pod ls` reports those
-(reclaim each with `pod down <name>`).
+**Teardown belongs to `pod down`, on both platforms.** It stops the service,
+waits for the process tree to drain, deletes the isolated HOME, and verifies the
+directory is gone — a HOME that survives is reported as a failure, never as zero
+residue. Nothing reclaims from a post-stop service hook: systemd would run one
+before the final kill of the pod's cgroup (racing the pod's own subprocesses) and
+on the stop half of a restart. So a pod that goes away WITHOUT a `down` (host
+crash, force-reboot, a raw `systemctl --user stop`) leaves its HOME behind on
+either OS; `pod ls` reports those (reclaim each with `pod down <name>`).
+
+This is also what makes a **seeded** pod home survive `systemctl --user restart`
+and `Restart=on-failure` instead of silently reverting to a blank instance.
 
 ## Bundled suite (quick path)
 
@@ -130,7 +138,10 @@ green). Flags:
    phase — so it can never show a previous run's rows. The rest of the artifact
    dir DOES persist across runs, so check timestamps before trusting an old
    screenshot.
-7. **stop** — `kirocrew pod down <wt>` (zero residue). Skipped if `--keep` or if
+7. **stop** — `kirocrew pod down <wt>`: stops the service, waits for its process
+   tree to drain, deletes the isolated HOME, and verifies it is gone — a HOME that
+   survives fails the command rather than being reported as zero residue. Skipped
+   if `--keep` or if
    the pod was already up.
 
 ## The test manifest (`.pod-test.sh`)

--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
@@ -7,7 +7,8 @@
 #   kirocrew pod up --json  →  health poll  →  auth check  →  API tests  →  Playwright  →  pod down
 #
 # Everything runs on the pod's own port + its own KIROCREW_HOME. The live
-# gateway is never bounced. Teardown is zero-residue unless
+# gateway is never bounced. Teardown deletes the pod's HOME and verifies it is
+# gone (a survivor is reported, not called zero residue) unless
 # --keep / --no-stop is passed.
 #
 # Exit code = number of failed phases (0 = all green). Structured summary + an
@@ -115,6 +116,33 @@ if [ -z "$CHECKOUT" ] || [ ! -d "$CHECKOUT" ]; then
   echo "  Ensure a git worktree with basename '$NAME' exists, or set KIROCREW_POD_REPO / KIROCREW_POD_WORKTREES_ROOT" >&2
   exit 66
 fi
+
+# Prefer the WORKTREE'S OWN CLI for the pod verbs, now that the checkout is known.
+# The PATH-resolved binary above is whatever build happens to be installed on the
+# host, so on a machine whose install predates the branch under test, `pod up` /
+# `pod down` exercise the INSTALLED code and the verdict describes the wrong build.
+# That is not hypothetical: it is how a teardown fix was verified green while the
+# harness's own `down` — running the older CLI — left the pod HOME on disk.
+#
+# The venv is built FIRST, because selecting on "is it already executable" silently
+# fell back to the installed CLI for the common case of a checkout that has a built
+# dist but no venv yet: `pod up` would create the venv while every lifecycle command
+# kept using the stale build. Provision it with the installed CLI (that is what it
+# is for), then REQUIRE the worktree's own binary — running the wrong build is a
+# false verdict, so it is a hard failure, not a fallback.
+_wt_kc="$CHECKOUT/.venv/bin/kirocrew"
+if [ ! -x "$_wt_kc" ]; then
+  echo "provisioning the worktree venv so the suite runs its own build..."
+  "$KIROCREW_CLI" pod provision "$NAME" --venv-only || true
+fi
+if [ ! -x "$_wt_kc" ] || ! "$_wt_kc" pod --help >/dev/null 2>&1; then
+  echo "FATAL: no usable CLI in the worktree venv at $_wt_kc" >&2
+  echo "  The suite must run the branch under test, not the host's installed build." >&2
+  echo "  Build it: kirocrew pod provision $NAME --venv-only" >&2
+  exit 67
+fi
+KIROCREW_CLI="$_wt_kc"
+echo "kirocrew CLI: $KIROCREW_CLI"
 
 # Playwright runner (sibling script)
 PW_PY="${KIROCREW_PW_PY:-}"

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -1438,7 +1438,8 @@ Examples:
         "--venv-only", action="store_true", help="Build only the venv (skip the slow dist)"
     )
     pod_sub.add_parser("install", help="Lay down the systemd --user template unit (once)")
-    # Hidden verbs re-entered by the systemd unit (ExecStart / ExecStopPost).
+    # Hidden verbs: `_run` is the unit's ExecStart body; `_cleanup` is the
+    # single-name manual reclaim (teardown itself lives on the `down` path).
     # Registered without `help=` so they stay out of `pod --help` while remaining
     # dispatchable (the metavar above also omits them from the usage line).
     pod_run = pod_sub.add_parser("_run")

--- a/src/kiro_crew/pod/README.md
+++ b/src/kiro_crew/pod/README.md
@@ -2,8 +2,8 @@
 
 Spin up a **throwaway, full-stack KiroCrew gateway** for any feature worktree —
 its own port, its own `KIROCREW_HOME` (own DB / sessions / memory), no Slack
-tunnel, `--no-crons` (unless you pass `--crons`), resource-capped, and `rm -rf`'d
-on stop. Test a branch's
+tunnel, `--no-crons` (unless you pass `--crons`), resource-capped, and reclaimed
+by `pod down`. Test a branch's
 backend `/api/*` **and** the SPA bundle it serves, all **without touching your
 live gateway or your shared `~/.kiro/crew` data**.
 
@@ -20,12 +20,12 @@ kirocrew pod up   <wt> [--json]   # bring up an isolated pod → {base_url, toke
 kirocrew pod up   <wt> --provision# provision (if needed) then bring it up
 kirocrew pod up   <wt> --approval reads  # boot its gateway in an approval mode
 kirocrew pod up   <wt> --crons          # boot its gateway with the cron scheduler on
-kirocrew pod ls                   # what's running (≈ kubectl get pods)
+kirocrew pod ls                   # what's running (≈ kubectl get pods) + orphaned HOMEs
 kirocrew pod status <wt>          # up/down + health
 kirocrew pod token  <wt> [--ttl]  # (re)mint a dashboard token for a running pod
 kirocrew pod url    <wt>          # print its base_url
 kirocrew pod logs   <wt> [-n N]   # tail its journal
-kirocrew pod down   <wt>          # evict → rm -rf its HOME (zero residue)
+kirocrew pod down   <wt>          # evict → delete its HOME, verified (zero residue)
 ```
 
 `<wt>` is a friendly worktree name. It is resolved to a checkout **git-natively**:
@@ -66,11 +66,22 @@ dist is missing — pointing you at the slow build — while `pod up <wt> --prov
 
 `kirocrew pod install` writes a template unit `kirocrew-pod@.service` whose
 `ExecStart` re-enters `kirocrew pod _run <wt>` (boot logic lives in
-`kiro_crew.pod.runtime.boot`) and whose `ExecStopPost` re-enters
-`kirocrew pod _cleanup <wt>`, which re-validates the name and refuses
-`..`/absolute/empty before deleting the pod's isolated HOME. Teardown is routed
-through Python (not a raw `rm -rf` on `%i`) because a systemd instance name *can*
-be `..`. `MemoryMax`/`CPUQuota` cap a runaway pod; `Restart=on-failure` self-heals.
+`kiro_crew.pod.runtime.boot`). `MemoryMax`/`CPUQuota` cap a runaway pod;
+`Restart=on-failure` self-heals.
+
+The unit has **no `ExecStopPost` teardown hook**, on purpose. systemd runs
+`ExecStopPost` *before* the final kill of the unit's cgroup, so a hook that
+deleted the pod's HOME raced the pod's own surviving subprocesses — they
+recreated the directory by reopening their audit log in append mode — and it also
+fired on the stop half of a `Restart=`, bringing the pod back on a home stripped
+of its sessions and config. So `kirocrew pod down` owns reclamation on every
+platform: it stops the service, waits for the unit's cgroup to drain, deletes the
+HOME through `runtime.cleanup_home` (which re-validates the name and refuses
+`..`/absolute/empty, since teardown safety must not rely on systemd `%i`
+semantics), then VERIFIES the directory is gone and fails loudly if it is not.
+The trade is that a pod which goes away without a `down` — a crash, a raw
+`systemctl --user stop`, a reboot — leaves its HOME behind; `pod ls` reports
+those, and `pod down <wt>` reclaims one.
 
 ### Port derivation
 
@@ -84,7 +95,7 @@ port ever resolves to the live port.
 |---|---|---|
 | `KIROCREW_POD_REPO` | invoking cwd | repo git is queried from to resolve worktree names |
 | `KIROCREW_POD_WORKTREES_ROOT` | (unset) | optional `name→path` fallback root (hermetic planes) |
-| `KIROCREW_POD_ROOT` | `~/.kirocrew-pods` | isolated pod HOMEs (nuked on stop) |
+| `KIROCREW_POD_ROOT` | `~/.kirocrew-pods` | isolated pod HOMEs (reclaimed by `pod down`) |
 | `KIROCREW_POD_ENV_DIR` | `~/.kiro/crew/pods` | per-pod `CHECKOUT=`/`PORT=`/`SEED=` files |
 | `KIROCREW_POD_BASE_PORT` | `7810` | port derivation base |
 | `KIROCREW_POD_LIVE_PORT` | `5476` | the port a pod must never bind |

--- a/src/kiro_crew/pod/__init__.py
+++ b/src/kiro_crew/pod/__init__.py
@@ -3,7 +3,7 @@
 A *pod* is an ephemeral KiroCrew gateway booted from one feature worktree's own
 ``.venv``, on its own deterministic port, with its own ``KIROCREW_HOME`` (own DB /
 sessions / memory), no Slack tunnel, ``--no-crons``, resource-capped, and
-``rm -rf``'d on stop. It lets you test a worktree's full stack (backend ``/api/*``
+reclaimed by ``pod down``. It lets you test a worktree's full stack (backend ``/api/*``
 + the SPA bundle the gateway serves on the same port) **without touching the live
 gateway or the shared ``~/.kiro/crew`` data**. Think ``kubectl`` for local worktree
 test rigs.
@@ -30,16 +30,19 @@ gateway never re-resolves. Mechanism, per platform:
 
 * **Linux (``systemd --user``)**: one template unit ``kirocrew-pod@<wt>.service``
   whose ``ExecStart`` re-enters ``kirocrew pod _run <wt>`` (boots the worktree's own
-  gateway) and whose ``ExecStopPost`` ``rm -rf``'s the pod's isolated HOME. cgroup
-  ``MemoryMax``/``CPUQuota`` cap the pod.
+  gateway). cgroup ``MemoryMax``/``CPUQuota`` cap the pod.
 * **macOS (``launchd``)**: one agent plist per pod under the pod plane's own directory (not
   ``~/Library/LaunchAgents`` — that would auto-resurrect pods at login)
-  (launchd has no template units), bootstrapped into ``gui/<uid>``. Two capabilities
-  have no equivalent: there is no post-stop hook, so ``pod down`` performs the HOME
-  teardown and ``pod ls`` reports HOMEs left by a crash (reclaimed via ``pod down <name>``); and there are no
-  cgroups, so **the resource ceiling is not enforced** — see
-  :mod:`kiro_crew.pod.launchd` for why a weaker key is deliberately not emitted in
-  its place. Logs go to files instead of the journal.
+  (launchd has no template units), bootstrapped into ``gui/<uid>``. One capability
+  has no equivalent: there are no cgroups, so **the resource ceiling is not
+  enforced** — see :mod:`kiro_crew.pod.launchd` for why a weaker key is
+  deliberately not emitted in its place. Logs go to files instead of the journal.
+
+Reclaiming a pod's isolated HOME belongs to ``pod down`` on both platforms rather
+than to a post-stop service hook, which on systemd ran before the final kill of
+the pod's own cgroup and also fired on the stop half of a ``Restart=``. ``down``
+stops the service, waits for its process tree to drain, deletes, and verifies;
+``pod ls`` reports the HOMEs left by a pod that went away without one.
 
 Nothing is shipped outside this Python package.
 """

--- a/src/kiro_crew/pod/cli.py
+++ b/src/kiro_crew/pod/cli.py
@@ -15,7 +15,6 @@ import time
 from pathlib import Path
 from typing import Callable, NoReturn
 
-from kiro_crew.pod import launchd
 from kiro_crew.pod import provision as prov
 from kiro_crew.pod import runtime as rt
 from kiro_crew.pod.config import PodConfig
@@ -107,12 +106,14 @@ def _up(cfg: PodConfig, args: argparse.Namespace) -> None:
         _audit("pod.up", "denied", f"name={name}", error="derived port is the live plane")
         _die(f"refusing: derived port is the live plane :{cfg.live_port}")
 
-    # Pin the resolved checkout BEFORE starting the unit so the systemd-booted
+    # Pin the resolved checkout BEFORE starting the unit so the service-booted
     # gateway (and any Restart= re-exec) resolves it without shelling git from a
     # clean environment. SEED (if any) is merged in without clobbering the pin.
-    # The whole pin -> start transaction holds the per-name mutex (no-op on
-    # Linux): without it, a concurrent `down` finishing its sweep after our pin
-    # would delete the pin we just wrote and this pod would crash-loop on boot.
+    # The whole pin -> start transaction holds the per-name mutex: without it, a
+    # concurrent `down` finishing its sweep after our pin would delete the pin we
+    # just wrote and this pod would crash-loop on boot. The pod's own boot
+    # (`pod _run`) deliberately takes no lock, so holding this across the health
+    # wait cannot deadlock against the process we are waiting for.
     with rt.pod_name_mutex(cfg, name):
         rt.pin_checkout(cfg, name, checkout)
         # Boot-time settings, merged into a single env-file write. ``boot`` reads
@@ -221,20 +222,33 @@ def _up(cfg: PodConfig, args: argparse.Namespace) -> None:
 
 def _down(cfg: PodConfig, args: argparse.Namespace) -> None:
     name = rt.validate_name(args.name)
-    was_up = rt.is_active(cfg, name)
-    # The stop and the env-file removal move together under the per-name mutex
-    # (no-op on Linux): unlinking the env file after releasing the lock let a
-    # concurrent `up` — which pins its checkout under the same mutex — have its
-    # fresh pin deleted by this stale teardown.
+    # The stop, the state it is judged against, and the env-file removal all move
+    # together under the per-name mutex: unlinking the env file after releasing
+    # the lock let a concurrent `up` — which pins its checkout under the same
+    # mutex — have its fresh pin deleted by this stale teardown. Sampling
+    # was_up/had_home OUTSIDE the lock had the same shape: a concurrent `up`
+    # holding the lock meant we sampled "not running, nothing to reclaim", waited,
+    # and then judged a REAL failure against that stale answer — swallowing it and
+    # deleting the live pod's checkout pin.
     with rt.pod_name_mutex(cfg, name):
+        was_up = rt.is_active(cfg, name)
+        # Whether there is residue to reclaim is a separate question from whether
+        # the pod is running: `down` is also the documented way to reclaim an
+        # orphaned HOME left by a pod that went away without one.
+        had_home = cfg.home_dir(name).exists()
         cp = rt.stop_pod(cfg, name)
-        # A nonzero stop means the pod may still be live — don't claim success or
-        # delete the env file. On macOS this must hold even when was_up is False:
-        # a loaded-but-dead agent has no pid (is_active False) yet still needs its
-        # unload CONFIRMED; swallowing the failure deleted the metadata while
-        # leaving the service, plist and HOME behind. An absent service is rc 0 on
-        # both backends, so this cannot fire for plain "was not running".
-        if cp.returncode != 0 and (was_up or rt.IS_MACOS):
+        # A nonzero stop means the pod may still be live, or its HOME survived —
+        # don't claim success or delete the env file. Gated on there being
+        # something at stake: an inactive Linux name with no HOME left behind has
+        # nothing to lose, and `systemctl stop` on an instance of a template that
+        # was never installed reports "unit not loaded" — swallowing that keeps
+        # `pod down <never-used-name>` the documented no-op it has always been.
+        # When the pod WAS up, or a HOME is there to reclaim, the failure is
+        # fatal: a reclaim that could not finish must not report success.
+        # On macOS it is always fatal, because a loaded-but-dead agent has no pid
+        # (was_up False) yet still needs its unload CONFIRMED before anything is
+        # torn down.
+        if cp.returncode != 0 and (was_up or had_home or rt.IS_MACOS):
             _audit("pod.down", "failure", f"name={name}", error=f"stop rc={cp.returncode}")
             _die(f"stopping pod {name} failed: {(cp.stderr or '').strip()}")
         if rt.RECLAIMED_MARKER in (cp.stdout or ""):
@@ -254,16 +268,18 @@ def _down(cfg: PodConfig, args: argparse.Namespace) -> None:
     _audit("pod.down", "allowed", f"name={name} was_up={was_up}")
     if was_up:
         print(f"pod '{name}' stopped — isolated HOME nuked (zero residue), live plane untouched")
+    elif had_home:
+        print(f"pod '{name}' was not running — reclaimed the isolated HOME it left behind")
     else:
         print(f"pod '{name}' was not running (nothing to stop)")
 
 
 def _ls(cfg: PodConfig, args: argparse.Namespace) -> None:
     names = sorted(rt.active_names(cfg))
-    # macOS only: launchd has no ExecStopPost, so a pod killed without an
-    # explicit `down` leaves its isolated HOME behind. Surface those here —
-    # the docs promise `ls`/`down` make them visible — but keep the JSON array
-    # shape unchanged (three callers parse it); orphans are human-output only.
+    # Teardown belongs to `pod down` on BOTH platforms, so a pod that went away
+    # without one leaves its isolated HOME. Surface those here — the docs promise
+    # `ls`/`down` make them visible — but keep the JSON array shape unchanged
+    # (three callers parse it); orphans are human-output only.
     if args.json:
         rows = [
             {"name": n, "port": rt.derive_port(cfg, n), "health": rt.health(rt.derive_port(cfg, n))}
@@ -271,15 +287,9 @@ def _ls(cfg: PodConfig, args: argparse.Namespace) -> None:
         ]
         print(json.dumps(rows))
         return
-    orphans: list[str] = []
-    if rt.IS_MACOS:
-        try:
-            orphans = launchd.orphan_homes(cfg)
-        except launchd.LaunchdError as exc:
-            # Same translation the runtime seam does: the dispatch layer's
-            # documented contract is PodError -> one-line `pod: <msg>` + exit 1,
-            # not a traceback from the fail-closed probe underneath.
-            raise rt.PodError(str(exc)) from exc
+    # Any fail-closed probe underneath surfaces as PodError, which the dispatch
+    # layer renders as the documented one-line `pod: <msg>` refusal.
+    orphans = rt.orphan_homes(cfg)
     if not names:
         print("no pods running")
         _print_orphans(cfg, orphans)
@@ -292,12 +302,12 @@ def _ls(cfg: PodConfig, args: argparse.Namespace) -> None:
 
 
 def _print_orphans(cfg: PodConfig, orphans: list[str]) -> None:
-    """Human-readable orphan-HOME report (macOS only; empty elsewhere)."""
+    """Human-readable report of pod HOMEs with no live pod behind them."""
     if not orphans:
         return
     print(
-        f"\n{len(orphans)} orphaned pod HOME(s) — left by a pod that died without "
-        "an explicit `down` (launchd has no post-stop hook):"
+        f"\n{len(orphans)} orphaned pod HOME(s) — left by a pod that went away "
+        "without an explicit `down` (a crash, a raw service stop, a reboot):"
     )
     for n in orphans:
         print(f"  {n:<26} reclaim: kirocrew pod down {n}")
@@ -415,11 +425,14 @@ def _run_internal(cfg: PodConfig, args: argparse.Namespace) -> None:
 
 
 def _cleanup_internal(cfg: PodConfig, args: argparse.Namespace) -> None:
-    """Hidden: ExecStopPost body. Safe-deletes the pod's isolated HOME.
+    """Hidden: reclaim ONE pod's isolated HOME by name.
 
-    Re-validates the systemd ``%i`` instance name (which is NOT gated by the CLI's
-    validate_name) and refuses ``..``/absolute/empty before deleting, so a unit
-    started directly as ``kirocrew-pod@..`` can't ``rm`` outside the pod root.
+    Not wired to a service-manager hook (see :mod:`kiro_crew.pod.unit` for why
+    teardown belongs to the ``down`` path) — this is the single-name safe-delete
+    entry point for a manual reclaim, and it re-validates the name, refusing
+    ``..``/absolute/empty, so a caller that never went through the CLI's
+    ``validate_name`` still cannot ``rm`` outside the pod root. Prefer
+    ``kirocrew pod down <name>``, which stops the service first.
     """
     rc = rt.cleanup_home(cfg, args.name)
     outcome = "allowed" if rc == 0 else "failure"

--- a/src/kiro_crew/pod/launchd.py
+++ b/src/kiro_crew/pod/launchd.py
@@ -17,13 +17,14 @@ absolute ``kirocrew`` path at *install* time, which goes stale when the worktree
 it points into is pruned (``unit_exec_ok``'s self-heal exists for exactly that);
 re-rendering per ``up`` cannot go stale.
 
-**2. No ``ExecStopPost``.** systemd guarantees zero-residue teardown by running
-``kirocrew pod _cleanup <name>`` after the service stops, whatever stopped it.
-launchd has no post-stop hook, so the ``down`` path must invoke
-``runtime.cleanup_home`` itself after ``bootout`` succeeds. The consequence is
-real and documented rather than hidden: a pod whose process dies without an
-explicit ``down`` (host crash, force-reboot) leaves its isolated HOME behind on
-macOS where Linux would have reaped it. :func:`orphan_homes` exists so ``pod ls`` can REPORT those
+**2. No ``ExecStopPost``.** Neither platform reclaims a pod's isolated HOME from a
+post-stop service hook: systemd's would run before the final kill of the unit's
+cgroup (racing the pod's own surviving subprocesses) and would also fire on the
+stop half of a ``Restart=``, so :func:`kiro_crew.pod.runtime.stop_pod` owns
+reclamation on both. launchd simply never had such a hook, which is why the
+consequence was visible here first: a pod whose process dies without an explicit
+``down`` (host crash, force-reboot) leaves its isolated HOME behind.
+:func:`kiro_crew.pod.runtime.orphan_homes` exists so ``pod ls`` can REPORT those
 (reclaim is `pod down <name>`, run by the user — nothing deletes them
 automatically).
 
@@ -52,21 +53,14 @@ derived port, no tunnel, ``--no-crons``, and the refusal to bind the live port.
 
 from __future__ import annotations
 
-import contextlib
 import os
 import plistlib
 import re
 import shlex
 import shutil
 import subprocess
-import threading
 import time
 from pathlib import Path
-
-try:  # POSIX only; the backend refuses to run where launchd is absent anyway
-    import fcntl
-except ImportError:  # pragma: no cover - Windows
-    fcntl = None  # type: ignore[assignment]
 
 from kiro_crew.pod.config import PodConfig, environment_vars
 from kiro_crew.pod.unit import _kirocrew_bin
@@ -165,61 +159,6 @@ def plist_path(cfg: PodConfig, name: str) -> Path:
     return cfg.pods_dir / f"{pod_label(cfg, name)}.plist"
 
 
-_MUTEX_STATE = threading.local()
-
-
-@contextlib.contextmanager
-def pod_mutex(cfg: PodConfig, name: str):
-    """Serialize this pod's lifecycle transactions per name.
-
-    ``down`` and ``up`` are independent entry points (CLI and Dev Fleet, which
-    shells out to the CLI) with no other per-name coordination. Without a mutex,
-    a stop that has just confirmed the label absent races a concurrent start:
-    the start writes its checkout pin and a fresh plist, and the stop's sweep
-    then deletes the NEW pod's definition, HOME, or env file — each a
-    review-blocking data-loss bug in earlier rounds. An exclusive flock on a
-    sibling lock file makes the whole transaction (pin + plist + bootstrap on
-    the up side; bootout + confirmation + HOME sweep + env unlink on the down
-    side) atomic with respect to the same name.
-
-    **Reentrant within a thread** so the CLI can hold it across a transaction
-    while ``runtime.start_pod``/``stop_pod`` re-acquire it internally (their own
-    protection for direct callers): flock is per open-file-description, so a
-    naive second acquisition in the same thread would deadlock against itself.
-
-    Advisory and cooperative by design: every mutating path routes through
-    here. On platforms without ``fcntl`` the mutex degrades to a no-op —
-    acceptable because launchd never runs there (:func:`require_backend`
-    refuses); only unit tests do. The lock file is deliberately never deleted:
-    unlinking a lock file another process may be opening reintroduces the race
-    the lock exists to close.
-    """
-    if fcntl is None:
-        yield
-        return
-    held = getattr(_MUTEX_STATE, "held", None)
-    if held is None:
-        held = _MUTEX_STATE.held = {}
-    key = pod_label(cfg, name)
-    if held.get(key, 0):
-        held[key] += 1
-        try:
-            yield
-        finally:
-            held[key] -= 1
-        return
-    cfg.pods_dir.mkdir(parents=True, exist_ok=True)
-    lock_file = cfg.pods_dir / f"{key}.lock"
-    with open(lock_file, "w") as fh:
-        fcntl.flock(fh, fcntl.LOCK_EX)
-        held[key] = 1
-        try:
-            yield
-        finally:
-            held[key] = 0
-            fcntl.flock(fh, fcntl.LOCK_UN)
-
-
 def log_paths(cfg: PodConfig, name: str) -> tuple[Path, Path]:
     """stdout/stderr files that stand in for the journal."""
     d = cfg.artifacts_dir / name
@@ -315,7 +254,7 @@ def stop(cfg: PodConfig, name: str, *, timeout: float = 15.0) -> subprocess.Comp
 
     **A per-pod plist must not outlive its pod.** systemd's template unit is
     machine-wide and deliberately persists; a launchd plist is per-pod, so leaving
-    it behind makes :func:`orphan_homes` classify the leftover HOME as "installed,
+    it behind makes :func:`kiro_crew.pod.runtime.orphan_homes` classify the leftover HOME as "installed,
     not orphaned" and never collect it, and leaves a stale definition that could be
     bootstrapped later.
 
@@ -452,28 +391,3 @@ def recent_journal(cfg: PodConfig, name: str, lines: int = 50) -> str:
             "that never started writes nothing here."
         )
     return "\n\n".join(chunks)
-
-
-def orphan_homes(cfg: PodConfig) -> list[str]:
-    """Pod HOMEs left behind with no live pod and no installed plist.
-
-    Only reachable on macOS: with no ``ExecStopPost``, a pod killed without an
-    explicit ``down`` leaves its isolated HOME. Reported (not deleted) here so the
-    caller decides, and so deletion still goes through
-    ``runtime.cleanup_home``'s re-validation rather than a raw recursive remove.
-    """
-    try:
-        entries = [p for p in cfg.pod_root.iterdir() if p.is_dir()]
-    except OSError:
-        return []
-    live = active_names(cfg)
-    out = []
-    for p in entries:
-        if p.name.startswith("."):
-            continue
-        if p.name in live:
-            continue
-        if plist_path(cfg, p.name).exists():
-            continue
-        out.append(p.name)
-    return sorted(out)

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -17,11 +17,17 @@ import shutil
 import stat
 import subprocess
 import sys
+import threading
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
+
+try:  # POSIX only; pods are refused on hosts without it (require_backend)
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
 
 from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.platform_compat import IS_LINUX, IS_MACOS
@@ -437,115 +443,378 @@ RECLAIMED_MARKER = "pod-name-reclaimed-by-new-pod"
 # service manager it is talking to — and so the launchd-only teardown obligation
 # (below) cannot be forgotten at one call site and honoured at another.
 # --------------------------------------------------------------------------- #
-def pod_name_mutex(cfg: PodConfig, name: str):
-    """Per-name lifecycle mutex for callers composing multi-step transactions.
+_MUTEX_STATE = threading.local()
 
-    The CLI wraps `up` (pin -> plist -> bootstrap) and `down` (stop -> sweep ->
-    env unlink) in this so per-name METADATA moves atomically with the service
-    operations — the review-blocking down/up races all lived in those seams.
-    Reentrant with the acquisition inside start_pod/stop_pod. On Linux the unit
-    (ExecStopPost) owns teardown ordering, so this is a no-op there.
+
+@contextlib.contextmanager
+def pod_name_mutex(cfg: PodConfig, name: str):
+    """Serialize this pod's lifecycle transactions per name, on every platform.
+
+    ``down`` and ``up`` are independent entry points (the CLI, and Dev Fleet which
+    shells out to it) with no other per-name coordination. Both platforms reclaim
+    the isolated HOME on the ``down`` path, so both have the same race: a
+    stop that has just confirmed the service gone races a concurrent start, whose
+    checkout pin and service definition the stop's sweep would then delete. An
+    exclusive flock on a sibling lock file makes each whole transaction (pin +
+    definition + start on the up side; stop + drain + HOME sweep + env unlink on
+    the down side) atomic with respect to the same name.
+
+    **Reentrant within a thread** so the CLI can hold it across a transaction
+    while :func:`start_pod` / :func:`stop_pod` re-acquire it internally (their own
+    protection for direct callers): flock is per open-file-description, so a naive
+    second acquisition in the same thread would deadlock against itself.
+
+    Advisory and cooperative by design: every mutating path routes through here.
+    Without ``fcntl`` it degrades to a no-op, which only unit tests reach — pods
+    are refused on those hosts. The lock file is deliberately never deleted:
+    unlinking a lock file another process may be opening reintroduces the race the
+    lock exists to close.
     """
-    if IS_MACOS:
-        return launchd.pod_mutex(cfg, name)
-    return contextlib.nullcontext()
+    if fcntl is None:
+        yield
+        return
+    held = getattr(_MUTEX_STATE, "held", None)
+    if held is None:
+        held = _MUTEX_STATE.held = {}
+    key = f"{cfg.unit_prefix}@{name}"
+    if held.get(key, 0):
+        held[key] += 1
+        try:
+            yield
+        finally:
+            held[key] -= 1
+        return
+    cfg.pods_dir.mkdir(parents=True, exist_ok=True)
+    lock_file = cfg.pods_dir / f"{key}.lock"
+    with open(lock_file, "w") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        held[key] = 1
+        try:
+            yield
+        finally:
+            held[key] = 0
+            fcntl.flock(fh, fcntl.LOCK_UN)
+
+
+def _write_and_load_unit(cfg: PodConfig) -> subprocess.CompletedProcess | None:
+    """Render the template unit AND load it, or leave nothing behind.
+
+    The single writer of the unit file, because the invariant it maintains has to
+    hold for EVERY writer: *a unit file present on disk has been loaded by
+    systemd.* :func:`kiro_crew.pod.unit.unit_is_current` reads the file, but what
+    systemd executes is the definition it loaded — so a writer that renders the
+    current hookless template and then fails to reload leaves a file that reads
+    "current" in front of a cached definition still carrying the destructive
+    ``ExecStopPost``. Every later caller then skips the refresh and the pod's HOME
+    is deleted from a stop hook. Unlinking on failure keeps the on-disk state
+    honest, so the next call re-renders and retries.
+
+    Returns ``None`` on success, or the failing ``daemon-reload`` result.
+    """
+    unit_mod.install_unit(cfg)
+    cp = systemctl("daemon-reload")
+    if cp.returncode == 0:
+        return None
+    unit_mod.unit_path(cfg).unlink(missing_ok=True)
+    return cp
+
+
+def _refresh_stale_unit(cfg: PodConfig) -> subprocess.CompletedProcess | None:
+    """Re-render and load the template unit; report why the caller must not proceed.
+
+    Returns ``None`` once systemd is running the current definition, or a failure
+    carrying the remedy when it is not.
+    """
+    cp = _write_and_load_unit(cfg)
+    if cp is None:
+        return None
+    detail = f" {cp.stderr.strip()}" if (cp.stderr or "").strip() else ""
+    return subprocess.CompletedProcess(
+        args=[],
+        returncode=cp.returncode or 1,
+        stdout=cp.stdout or "",
+        stderr=(
+            f"refreshed the pod template unit but `systemctl --user daemon-reload` "
+            f"failed (rc={cp.returncode}), so systemd would still run the previous "
+            "definition — which deletes a pod's HOME from a stop hook. Refusing to "
+            "start or stop a pod until the unit is loaded: run `kirocrew pod install` "
+            f"and retry.{detail}"
+        ),
+    )
+
+
+def loaded_teardown_hook(cfg: PodConfig, name: str) -> bool | None:
+    """Whether systemd will run a teardown hook when THIS pod's unit stops.
+
+    Asks systemd what it has LOADED instead of reading the unit file. Disk
+    freshness is not proof of a load — a hand-edited unit, or any writer whose
+    reload failed, leaves the two disagreeing — and the question that decides
+    whether a stop is safe is only ever "what will systemd execute now".
+
+    ``None`` means the question could not be answered; callers must treat that as
+    "assume the hook is there" rather than as absence.
+    """
+    cp = systemctl("show", pod_unit(cfg, name), "-p", "ExecStopPost", "--value")
+    if cp.returncode != 0:
+        return None
+    return bool((cp.stdout or "").strip())
 
 
 def start_pod(cfg: PodConfig, name: str) -> subprocess.CompletedProcess:
     """Bring pod *name* up through whichever service manager this host uses."""
-    if IS_MACOS:
-        # Re-rendered every start, which is why launchd needs no equivalent of
-        # the systemd path's stale-ExecStart self-heal. The mutex serializes
-        # against a concurrent stop of the same name, whose plist unlink and
-        # HOME sweep would otherwise race this write (see launchd.pod_mutex).
-        with launchd.pod_mutex(cfg, name):
+    with pod_name_mutex(cfg, name):
+        if IS_MACOS:
+            # Re-rendered every start, which is why launchd needs no equivalent
+            # of the systemd path's stale-ExecStart self-heal. The mutex
+            # serializes against a concurrent stop of the same name, whose
+            # definition unlink and HOME sweep would otherwise race this write.
             launchd.write_plist(cfg, name)
             return launchd.start(cfg, name)
 
-    # Self-heal a dangling ExecStart binary: the template unit bakes an absolute
-    # kirocrew path at install time; if the worktree it resolved into was pruned
-    # since, every start fails EXEC (203).
-    if not unit_mod.unit_exec_ok(cfg):
-        unit_mod.install_unit(cfg)
-        rel = systemctl("daemon-reload")
-        if rel.returncode != 0:
-            return rel
-    return systemctl("start", pod_unit(cfg, name))
+        # Self-heal a stale installed unit before booting it: the template bakes
+        # an absolute kirocrew path at install time (a pruned worktree leaves it
+        # failing EXEC 203), and a unit installed by an older build can still
+        # carry the teardown hook this one removed.
+        if not unit_mod.unit_is_current(cfg):
+            refused = _refresh_stale_unit(cfg)
+            if refused is not None:
+                return refused
+        return systemctl("start", pod_unit(cfg, name))
+
+
+# Where a systemd cgroup's process list lives on a cgroup-v2 host.
+_CGROUP_ROOT = Path("/sys/fs/cgroup")
+
+# How long teardown waits for a stopped unit's process tree to go away. Named so
+# the wait and the message that reports it expiring cannot drift apart.
+DRAIN_TIMEOUT_SECS = 15.0
+
+
+def cgroup_procs_file(cfg: PodConfig, name: str) -> Path | None:
+    """``cgroup.procs`` for pod *name*'s unit, or ``None`` when unresolvable.
+
+    Must be read while the unit is still up: systemd reports an empty
+    ``ControlGroup`` once it goes inactive, so asking after the stop is too late.
+    Returns ``None`` off cgroup-v2 layouts (and on any host where the path does
+    not exist), which makes the drain wait an optimisation rather than a
+    dependency — the post-delete verification in :func:`stop_pod` is what actually
+    decides whether teardown succeeded.
+    """
+    cp = systemctl("show", pod_unit(cfg, name), "-p", "ControlGroup", "--value")
+    rel = (cp.stdout or "").strip()
+    if cp.returncode != 0 or not rel.startswith("/"):
+        return None
+    procs = _CGROUP_ROOT / rel.lstrip("/") / "cgroup.procs"
+    return procs if procs.parent.is_dir() else None
+
+
+def drain_cgroup(procs: Path, timeout: float = DRAIN_TIMEOUT_SECS) -> list[str]:
+    """Wait for a stopped unit's cgroup to empty; return the PIDs still in it.
+
+    An empty list means every pod-scoped process is gone, so the HOME can be
+    deleted without racing a writer that would recreate it. A vanished cgroup
+    directory counts as drained — systemd removes it once the last process exits.
+    An unreadable one is reported as drained too: nothing better can be observed
+    from here, and the caller verifies the deleted HOME afterwards regardless.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            pids = [ln.strip() for ln in procs.read_text().splitlines() if ln.strip()]
+        except OSError:
+            return []
+        if not pids:
+            return []
+        if time.monotonic() >= deadline:
+            return pids
+        time.sleep(0.2)
+
+
+def resolved_pod_home(cfg: PodConfig, name: str) -> Path:
+    """Pod *name*'s HOME as :func:`cleanup_home` reports it.
+
+    Teardown messages must agree on one spelling of the path. ``pod_home`` returns
+    it unresolved, while ``cleanup_home`` resolves before deleting (its safety
+    check needs the real parent), so quoting both in one failure read as two
+    different directories wherever ``$HOME`` is a symlink — which is the default
+    layout on a dev desktop.
+    """
+    try:
+        return (cfg.pod_root / name).resolve()
+    except OSError:
+        return pod_home(cfg, name)
 
 
 def stop_pod(cfg: PodConfig, name: str) -> subprocess.CompletedProcess:
-    """Stop pod *name* and guarantee its isolated HOME is gone.
+    """Stop pod *name* and reclaim its isolated HOME, or say why it could not.
 
-    On Linux the unit's ``ExecStopPost`` runs ``pod _cleanup``, so teardown
-    happens whatever stopped the service. launchd has **no post-stop hook**, so
-    the HOME removal is done here after a successful ``bootout`` — routed through
-    :func:`cleanup_home`, which re-validates the name, rather than a raw
-    recursive delete. Both paths therefore end with zero residue; only the macOS
-    one depends on this call being reached, which is why the crash case is
-    covered separately by ``launchd.orphan_homes()``.
+    Teardown lives HERE on both platforms rather than in a post-stop service hook.
+    systemd runs ``ExecStopPost`` before the final kill of the unit's cgroup, so a
+    hook-based delete raced the pod's own surviving subprocesses — they reopened
+    their audit log in append mode and recreated the directory behind it — and it
+    also ran on the stop half of a ``Restart=``, bringing the pod back up on a
+    home that no longer had its sessions or config. Reclaiming after the service
+    is confirmed down fixes both, at the cost of a pod that goes away without a
+    ``down`` leaving its HOME behind; :func:`orphan_homes` reports those.
+
+    Sequenced so nothing is deleted while a writer could still be alive: stop the
+    service, wait for its process tree to drain, delete, then VERIFY. A HOME that
+    survives is reported as a failure — never as zero residue.
     """
-    if IS_MACOS:
-        # One mutex across bootout + confirmation + the HOME sweep: a
-        # concurrent `up` of the same name blocks until teardown fully
-        # finishes instead of interleaving with it (the plist-presence
-        # reclaim check below stays as defense-in-depth — the flock is
-        # advisory and only guards paths that route through it).
-        with launchd.pod_mutex(cfg, name):
-            # launchd.stop() is authoritative: rc 0 means the label is confirmed
-            # unloaded (a bootout of an unloaded label is a no-op success). A non-zero
-            # rc means the unload could NOT be confirmed — in that case do NOT touch
-            # the HOME: it may belong to a live gateway, and deleting it while
-            # returning success was exactly the blocking review finding here.
-            cp = launchd.stop(cfg, name)
-            if cp.returncode != 0:
-                return cp
-            # Reap with a short grace window. launchd confirms the SERVICE process is
-            # unloaded, but a dying child can outlive it by a beat and flush state on
-            # exit — observed in a real teardown: cleanup ran, verification passed,
-            # then a child wrote settings back and resurrected the HOME milliseconds
-            # later. Retry the reap a few times so a final write cannot win the race;
-            # if the directory still reappears after the window, someone is genuinely
-            # alive in there and we must say so, not shrug.
-            leftover = pod_home(cfg, name)
-            # Observe the FULL window — no early exit on a clean sample (the dying
-            # child that motivated this flushed state after a beat). But DO exit the
-            # moment the name is claimed by a NEW pod: `down` and `up` are
-            # independent Dev Fleet endpoints with no per-name lock, so a quick
-            # down→up would otherwise put the fresh gateway's HOME under the
-            # remaining rmtree passes. Our unload was already confirmed, and a new
-            # `up` re-writes the plist BEFORE bootstrapping — so plist presence is
-            # the claim marker. Deliberately a pure filesystem check: probing
-            # launchctl here would shell out on every sweep and break on hosts
-            # without launchd (the unit suites run this path on Linux/Windows CI).
-            #
-            # A reclaimed name is reported via RECLAIMED_MARKER in stdout so the
-            # caller knows the teardown handed over: it must NOT delete the per-pod
-            # env file, which now pins the NEW pod's checkout.
-            for _ in range(6):
-                if launchd.plist_path(cfg, name).exists():
-                    return subprocess.CompletedProcess(
-                        args=[], returncode=0, stdout=RECLAIMED_MARKER, stderr=""
-                    )
-                cleanup_home(cfg, name)
-                time.sleep(0.5)
-            if launchd.plist_path(cfg, name).exists():
-                return subprocess.CompletedProcess(
-                    args=[], returncode=0, stdout=RECLAIMED_MARKER, stderr=""
-                )
-            cleanup_home(cfg, name)
-            if leftover.exists():
-                return subprocess.CompletedProcess(
-                    args=[],
-                    returncode=1,
-                    stdout=cp.stdout or "",
-                    stderr=(
-                        f"pod stopped but its isolated HOME keeps reappearing at "
-                        f"{leftover} — a process is still writing there, so teardown "
-                        "is incomplete. Remove it by hand and report this."
-                    ),
-                )
-            return subprocess.CompletedProcess(args=[], returncode=0, stdout=cp.stdout or "", stderr="")
-    return systemctl("stop", pod_unit(cfg, name))
+    with pod_name_mutex(cfg, name):
+        if IS_MACOS:
+            return _stop_pod_launchd(cfg, name)
+        # A unit installed by an OLDER build still carries the destructive
+        # ExecStopPost, and `systemctl stop` runs it before our drain — deleting
+        # the HOME under the pod's own live processes, which is the exact defect
+        # this path exists to remove. Refresh BEFORE stopping: daemon-reload
+        # re-parses the fragment for an already-running unit, and the stop job has
+        # not started yet, so the refreshed (hookless) definition is what runs.
+        #
+        # Gated on what systemd has LOADED, never on the unit file: disk freshness
+        # is not proof of a load, so a hookless file can sit in front of a cached
+        # definition that still deletes the HOME. An unanswerable query counts as
+        # "hook present" — the only safe reading.
+        #
+        # Refuse rather than proceed when the reload fails. Proceeding would mean
+        # knowingly triggering the hook-races-live-processes defect this change
+        # removes, on the argument that the HOME is being deleted anyway — the
+        # same reasoning the fix rejects. A pod left running after a loud,
+        # retryable failure is the safer end state.
+        if loaded_teardown_hook(cfg, name) is not False:
+            refused = _refresh_stale_unit(cfg)
+            if refused is not None:
+                return refused
+        # Read the cgroup path BEFORE stopping: systemd clears ControlGroup on
+        # an inactive unit.
+        procs_file = cgroup_procs_file(cfg, name)
+        cp = systemctl("stop", pod_unit(cfg, name))
+        if cp.returncode != 0:
+            # The unit may still be live; deleting its HOME here is exactly the
+            # race this ordering exists to avoid.
+            return cp
+        survivors = drain_cgroup(procs_file) if procs_file is not None else []
+        # Resolved, because cleanup_home reports the resolved path: on a host
+        # whose home is a symlink, naming it both ways reads as two directories.
+        leftover = resolved_pod_home(cfg, name)
+        if survivors:
+            # Deleting now would BE the original defect. A process that outlived
+            # the drain either holds the tree open or reopens its audit log in
+            # append mode right behind the delete, and the verification below
+            # cannot catch that because the recreation lands after it. So leave
+            # the HOME alone and name what is holding it.
+            shown = ", ".join(survivors[:5])
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout=cp.stdout or "",
+                stderr=(
+                    f"pod stopped but {len(survivors)} pod process(es) are still in "
+                    f"its cgroup (pid {shown}) after {DRAIN_TIMEOUT_SECS:.0f}s, so "
+                    f"its isolated HOME at {leftover} was NOT deleted — this pod is "
+                    f"NOT zero-residue. Reclaim it with `kirocrew pod down {name}` "
+                    "once nothing is writing there."
+                ),
+            )
+        rc = cleanup_home(cfg, name)
+        if rc != 0 or leftover.exists():
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout=cp.stdout or "",
+                stderr=(
+                    f"pod stopped but its isolated HOME is still at {leftover} — "
+                    f"teardown is incomplete, so this pod is NOT zero-residue. "
+                    f"Reclaim it with `kirocrew pod down {name}` once nothing is "
+                    "writing there."
+                ),
+            )
+        return cp
+
+
+def _stop_pod_launchd(cfg: PodConfig, name: str) -> subprocess.CompletedProcess:
+    """The macOS half of :func:`stop_pod` — called with the name mutex held.
+
+    launchd has no cgroup to drain, so the surviving-writer problem is handled by
+    sweeping the grace window instead: ``bootout`` confirms the SERVICE process is
+    unloaded, but a dying child can outlive it by a beat and flush state on exit
+    (observed in a real teardown — cleanup ran, verification passed, then a child
+    wrote settings back and resurrected the HOME milliseconds later).
+    """
+    # launchd.stop() is authoritative: rc 0 means the label is confirmed
+    # unloaded (a bootout of an unloaded label is a no-op success). A non-zero
+    # rc means the unload could NOT be confirmed — in that case do NOT touch
+    # the HOME: it may belong to a live gateway.
+    cp = launchd.stop(cfg, name)
+    if cp.returncode != 0:
+        return cp
+    leftover = resolved_pod_home(cfg, name)
+    # Observe the FULL window — no early exit on a clean sample (the dying
+    # child that motivated this flushed state after a beat). But DO exit the
+    # moment the name is claimed by a NEW pod: the mutex serializes callers that
+    # route through it, and a new `up` re-writes the plist BEFORE bootstrapping,
+    # so plist presence is the claim marker for any writer that bypasses it.
+    # Deliberately a pure filesystem check: probing launchctl here would shell
+    # out on every sweep and break on hosts without launchd (the unit suites run
+    # this path on Linux/Windows CI).
+    #
+    # A reclaimed name is reported via RECLAIMED_MARKER in stdout so the caller
+    # knows the teardown handed over: it must NOT delete the per-pod env file,
+    # which now pins the NEW pod's checkout.
+    for _ in range(6):
+        if launchd.plist_path(cfg, name).exists():
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=RECLAIMED_MARKER, stderr=""
+            )
+        cleanup_home(cfg, name)
+        time.sleep(0.5)
+    if launchd.plist_path(cfg, name).exists():
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=RECLAIMED_MARKER, stderr=""
+        )
+    cleanup_home(cfg, name)
+    if leftover.exists():
+        return subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout=cp.stdout or "",
+            stderr=(
+                f"pod stopped but its isolated HOME keeps reappearing at "
+                f"{leftover} — a process is still writing there, so teardown "
+                "is incomplete. Remove it by hand and report this."
+            ),
+        )
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=cp.stdout or "", stderr="")
+
+
+def orphan_homes(cfg: PodConfig) -> list[str]:
+    """Pod HOMEs left on disk with no live pod and no installed definition.
+
+    Reachable on BOTH platforms, because neither reclaims from a post-stop service
+    hook any more (see :func:`stop_pod`): a pod that goes away without an explicit
+    ``down`` — a crash, a raw ``systemctl --user stop`` / ``launchctl bootout``, a
+    host reboot — leaves its isolated HOME behind. Reported rather than deleted so
+    the operator decides, and so the delete still routes through
+    :func:`cleanup_home`'s re-validation via ``kirocrew pod down <name>``.
+    """
+    try:
+        entries = [p for p in cfg.pod_root.iterdir() if p.is_dir()]
+    except OSError:
+        return []
+    live = active_names(cfg)
+    out = []
+    for p in entries:
+        if p.name.startswith("."):
+            continue
+        if p.name in live:
+            continue
+        # macOS writes a per-pod plist at `up` and drops it at `down`, so its
+        # presence means the pod is installed rather than orphaned. systemd's
+        # template unit is machine-wide, so liveness is the only signal there.
+        if IS_MACOS and launchd.plist_path(cfg, p.name).exists():
+            continue
+        out.append(p.name)
+    return sorted(out)
 
 
 def install_backend(cfg: PodConfig) -> tuple[str, subprocess.CompletedProcess | None]:
@@ -561,6 +830,13 @@ def install_backend(cfg: PodConfig) -> tuple[str, subprocess.CompletedProcess | 
     as the second element rather than an exception, because the caller reports
     that as a hard exit while the gate refusal is converted by the CLI's
     dispatch layer — two different documented behaviours.
+
+    Routed through :func:`_write_and_load_unit` so this path upholds the same
+    invariant the lifecycle paths do: a unit file left on disk has been loaded. A
+    reload that fails here used to leave a hookless file behind, which made
+    ``unit_is_current`` report "current" while systemd still ran the old
+    ``ExecStopPost`` — so a later ``down`` skipped its refresh and deleted the
+    pod's HOME from that hook.
     """
     require_backend()
     if IS_MACOS:
@@ -569,11 +845,18 @@ def install_backend(cfg: PodConfig) -> tuple[str, subprocess.CompletedProcess | 
             "pod's agent plist is written at `kirocrew pod up <worktree>`.",
             None,
         )
-    dst = unit_mod.install_unit(cfg)
-    cp = systemctl("daemon-reload")
-    if cp.returncode != 0:
-        return f"installed pod template unit → {dst}", cp
-    return f"installed pod template unit → {dst}\nsystemctl --user daemon-reload OK", cp
+    dst = unit_mod.unit_path(cfg)
+    failed = _write_and_load_unit(cfg)
+    if failed is not None:
+        return (
+            f"rendered the pod template unit but `systemctl --user daemon-reload` "
+            f"failed, so it was removed again rather than left unloaded at {dst}",
+            failed,
+        )
+    return (
+        f"installed pod template unit → {dst}\nsystemctl --user daemon-reload OK",
+        subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+    )
 
 
 def health(port: int, timeout: int = 3) -> int:
@@ -697,8 +980,7 @@ def build_pod_env(cfg: PodConfig, home_dir: Path, port: int, checkout: Path) -> 
         # real lessons). Safe only because every KiroCrew reader of the transcripts
         # dir now resolves through ``kiro_sessions_dir()``; without that the pod
         # would write sessions somewhere KiroCrew never looks and lose resume.
-        # Inside the pod HOME so the zero-residue ``ExecStopPost`` teardown
-        # reclaims it.
+        # Inside the pod HOME so ``pod down``'s teardown reclaims it.
         "KIRO_HOME": str(home_dir / "kiro"),
         # NOTE: deliberately NO ``KIRO_HOME`` here, though it is tempting — it
         # would give the pod its own agent specs and stop pod boots rewriting the
@@ -723,8 +1005,8 @@ def build_pod_env(cfg: PodConfig, home_dir: Path, port: int, checkout: Path) -> 
         # WRITE the live workspace. `KIROCREW_WORKSPACE` is the documented override
         # (config/loader.py:220, used as-is) and `eval/runner.py` already scopes a
         # run the same way, so this is the existing mechanism rather than new
-        # resolution behaviour. Placing it inside the pod HOME means the
-        # zero-residue `ExecStopPost` teardown removes it with everything else.
+        # resolution behaviour. Placing it inside the pod HOME means `pod down`'s
+        # teardown removes it with everything else.
         "KIROCREW_WORKSPACE": str(home_dir / "workspace"),
         # The pod's OWN venv leads PATH, ahead of cfg.gateway_path (which starts
         # with ~/.local/bin). Without this a bare `kirocrew` inside a pod — an
@@ -769,14 +1051,21 @@ def write_pod_config(home_dir: Path, seed: str) -> None:
 
 
 def cleanup_home(cfg: PodConfig, name: str) -> int:
-    """Zero-residue teardown of pod *name*'s HOME — the ``ExecStopPost`` body.
+    """Delete pod *name*'s isolated HOME and report whether it is really gone.
 
-    Routed through Python (not a raw ``rm -rf {pod_root}/%i``) because the rm safety
-    must NOT rely on systemd ``%i`` semantics: ``%i`` cannot contain ``/`` but CAN
-    be ``..``, and the template unit is a standalone artifact that bypasses the
-    CLI's ``validate_name``. Re-validate the name and confirm the target is a direct
-    child of pod_root before deleting, so teardown can never escape to ``$HOME`` or
-    a parent.
+    Routed through Python (not a raw ``rm -rf {pod_root}/<name>``) because the rm
+    safety must NOT rely on a service manager's instance-name semantics: a systemd
+    ``%i`` cannot contain ``/`` but CAN be ``..``, and the template unit is a
+    standalone artifact that bypasses the CLI's ``validate_name``. Re-validate the
+    name and confirm the target is a direct child of pod_root before deleting, so
+    teardown can never escape to ``$HOME`` or a parent.
+
+    Returns 0 only when the directory is gone afterwards. ``rmtree`` runs with
+    ``ignore_errors`` — it has to, since a partially-removed tree is still progress
+    — so the removal itself is silent; a tree that SURVIVES (a live process holds
+    it, or recreated it in append mode right behind the delete) returns 1 and names
+    what is left. Without that check a caller cannot tell a reclaimed HOME from a
+    swallowed failure.
     """
     try:
         validate_name(name)
@@ -789,7 +1078,33 @@ def cleanup_home(cfg: PodConfig, name: str) -> int:
         print(f"refusing pod cleanup: {target} is not a pod dir under {root}")
         return 2
     shutil.rmtree(target, ignore_errors=True)
-    return 0
+    if not target.exists():
+        return 0
+    survivors = _surviving_entries(target)
+    print(
+        f"pod cleanup did not fully remove {target}: still present "
+        f"({', '.join(survivors)}) — either something is still writing there or "
+        "the tree cannot be unlinked (permissions)"
+    )
+    return 1
+
+
+def _surviving_entries(target: Path, limit: int = 5) -> list[str]:
+    """Names of the first few entries left under a HOME that survived teardown.
+
+    Diagnostics only: the point is to name a culprit ("security_events.jsonl")
+    rather than report a bare failure, so an unlistable directory degrades to the
+    directory itself instead of raising inside teardown.
+    """
+    try:
+        names = sorted(p.name for p in target.iterdir())
+    except OSError:
+        return [target.name]
+    if not names:
+        return [f"{target.name} (empty)"]
+    if len(names) > limit:
+        return [*names[:limit], f"… +{len(names) - limit} more"]
+    return names
 
 
 def pod_context(cfg: PodConfig, name: str) -> tuple[Path, dict[str, str]]:
@@ -840,9 +1155,8 @@ def pod_context(cfg: PodConfig, name: str) -> tuple[Path, dict[str, str]]:
 #                    pod install/uninstall would still mutate host state.)
 #   stop, restart  — service-aware: `cli_server._stop` short-circuits to
 #                    systemctl when no explicit --port is passed, so they hit the
-#                    LIVE gateway; and `restart` additionally makes systemd run
-#                    the pod unit's ExecStopPost (erasing the pod HOME) while
-#                    leaving a DETACHED replacement `pod down` cannot stop
+#                    LIVE gateway; and `restart` additionally leaves a DETACHED
+#                    replacement that `pod down` cannot stop
 #   service        — installs/removes the machine-wide systemd unit
 #   gateway        — would race a second gateway against the pod's own unit
 #   pod            — pod management from inside a pod (a nested `pod down` would

--- a/src/kiro_crew/pod/unit.py
+++ b/src/kiro_crew/pod/unit.py
@@ -3,11 +3,16 @@
 The unit's ``ExecStart`` re-enters the installed ``kirocrew`` binary as
 ``kirocrew pod _run %i``, so the boot logic lives in Python (see
 :func:`kiro_crew.pod.runtime.boot`) and nothing is shipped outside the package.
-``ExecStopPost`` re-enters ``kirocrew pod _cleanup %i`` to delete the pod's
-isolated HOME for zero-residue teardown. Teardown goes through Python (not a raw
-``rm -rf`` on ``%i``) because a systemd instance name can be ``..`` even though it
-cannot contain ``/``; :func:`kiro_crew.pod.runtime.cleanup_home` re-validates the
-name and refuses anything that isn't a single safe segment under the pod root.
+
+The unit deliberately has **no ``ExecStopPost`` teardown hook**. systemd runs
+``ExecStopPost`` before the final kill of the unit's cgroup, so a hook that
+deleted the pod's isolated HOME raced the pod's own surviving subprocesses (which
+recreated the directory by reopening their audit log in append mode), and it also
+fired on the stop half of a ``Restart=``, restarting the pod onto a home that no
+longer held its sessions or config. Reclamation therefore belongs to
+:func:`kiro_crew.pod.runtime.stop_pod`, which runs it after the service is
+confirmed down and its process tree has drained; ``pod ls`` reports the HOMEs left
+by a pod that went away without a ``down``.
 """
 
 from __future__ import annotations
@@ -34,10 +39,11 @@ Type=simple
 # kirocrew binary; boot logic is kiro_crew.pod.runtime.boot (no shipped shell).
 ExecStart={kirocrew_bin} pod _run %i
 
-# Zero-residue teardown: delete this pod's isolated HOME on stop. Routed through
-# Python (pod _cleanup) which re-validates %i and refuses '..'/absolute/empty —
-# the teardown safety must NOT rely on systemd %i semantics (%i can be '..').
-ExecStopPost={kirocrew_bin} pod _cleanup %i
+# NO teardown hook here: systemd runs ExecStopPost before the final kill of this
+# cgroup, so one would delete the pod's HOME out from under the pod's own
+# surviving subprocesses — and would also fire on the stop half of a Restart=,
+# bringing the pod back on a wiped home. `kirocrew pod down` owns reclamation
+# (kiro_crew.pod.runtime.stop_pod); `kirocrew pod ls` reports what a crash left.
 
 # Self-heal a crash, but don't fight a deliberate stop.
 Restart=on-failure
@@ -126,3 +132,33 @@ def unit_exec_ok(cfg: PodConfig) -> bool:
             exe = line[len("ExecStart="):].split()[0]
             return os.access(exe, os.X_OK) if os.path.isabs(exe) else True
     return False
+
+
+# Directives an older installed unit may still carry that this build has removed.
+# ``ExecStopPost`` ran teardown before systemd's final kill of the pod's cgroup,
+# so it raced the pod's own subprocesses and also wiped the HOME on the stop half
+# of a ``Restart=``; reclamation now belongs to the ``down`` path.
+_REMOVED_DIRECTIVES = ("ExecStopPost=",)
+
+
+def unit_is_current(cfg: PodConfig) -> bool:
+    """True when the installed unit is one this build is willing to boot.
+
+    Two ways it can be stale, and a start self-heals both by re-rendering: the
+    baked ExecStart binary no longer exists (:func:`unit_exec_ok`), or the unit
+    still carries a directive this build has removed. The second matters on
+    UPGRADE — the unit is written once by ``pod install``, so without this check a
+    machine that installed an older Kiro Crew would keep the teardown hook, and
+    keep the defect, until someone happened to reinstall by hand.
+    """
+    if not unit_exec_ok(cfg):
+        return False
+    try:
+        text = unit_path(cfg).read_text()
+    except OSError:
+        return False
+    return not any(
+        line.startswith(directive)
+        for line in text.splitlines()
+        for directive in _REMOVED_DIRECTIVES
+    )

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -8,6 +8,7 @@ import json
 import os
 import stat
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -24,6 +25,11 @@ from kiro_crew.pod.config import (
     DEFAULT_UNIT_PREFIX,
     PodConfig,
 )
+
+# The invoking user's REAL home, captured at import time — before the autouse
+# fixture below pins HOME to a tmp dir. Used only to assert that pod host state
+# never lands there (see TestHostStateIsFenced).
+_REAL_HOME = Path.home()
 
 # Stand-in for a version-manager node bin dir (mise/nvm/fnm/volta/asdf install
 # under $HOME). Provisioning resolves ``npm`` to an absolute path there.
@@ -48,6 +54,35 @@ def _fake_node_toolchain(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         prov, "node_augmented_path", lambda base="": f"{NODE_BIN}{os.pathsep}{base}"
     )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_pod_host_state(tmp_path_factory, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep pod HOST state out of the developer's real home.
+
+    Two pod paths resolve through ``Path.home()`` rather than ``KIROCREW_HOME``, so
+    conftest's safety net does not cover them, and both are written by ordinary
+    test paths:
+
+    ``unit.unit_path`` — a test reaching ``install_unit`` (via ``_up`` ->
+    ``install_backend``, or the ``start_pod`` self-heal) rewrites the REAL
+    ``kirocrew-pod@.service`` with this test's tmpdir as
+    ``Environment=KIROCREW_POD_ROOT=``. Every later ``pod up`` on the host then dies
+    with "no pinned checkout", so running the suite breaks pods for everyone until
+    someone re-runs ``pod install``. Observed on a real host.
+
+    ``PodConfig.pods_dir`` — resolves off the DEFAULT data home on purpose (a pod
+    process must not be able to redirect the host's pod registry into its own
+    throwaway home). The per-name lifecycle mutex writes its lock file there.
+
+    Pinning ``HOME`` fixes the cause both share instead of patching each function
+    that reads it, so a future path that resolves through the home is covered
+    without a matching change here. ``USERPROFILE`` too, because Windows
+    ``Path.home()`` reads that one. Tests that pin either themselves still win.
+    """
+    home = tmp_path_factory.mktemp("pod-host-home")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
 
 
 @pytest.fixture(autouse=True)
@@ -229,16 +264,34 @@ class TestWorktreeResolution:
         assert rt.resolve_checkout(c, "demo", cwd=tmp_path) == tmp_path / "real"
 
 
+def _uncommented(unit_text: str) -> str:
+    """The unit's directive lines only — comments explain the absent hook by name,
+    so a substring scan over the whole file cannot tell prose from configuration."""
+    return "\n".join(ln for ln in unit_text.splitlines() if not ln.lstrip().startswith("#"))
+
+
 class TestUnitRendering:
     def test_execstart_reenters_pod_run(self, cfg: PodConfig) -> None:
         assert "pod _run %i" in unit_mod.render_unit(cfg)
 
-    def test_execstoppost_routes_through_cleanup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_unit_has_no_teardown_hook(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """ExecStopPost runs BEFORE systemd's final kill of the unit's cgroup, so a
+        teardown hook there deleted the HOME under the pod's own surviving
+        subprocesses — and fired on the stop half of a Restart=, restarting the pod
+        onto a wiped home. Reclamation belongs to `pod down` (runtime.stop_pod)."""
         monkeypatch.setenv("KIROCREW_POD_ROOT", "/tmp/podtest-root")
         txt = unit_mod.render_unit(PodConfig.load())
-        # Teardown re-enters the Python verb (re-validates %i) — NOT a raw rm -rf.
-        assert "pod _cleanup %i" in txt
+        directives = [
+            ln.split("=", 1)[0]
+            for ln in txt.splitlines()
+            if "=" in ln and not ln.lstrip().startswith("#")
+        ]
+        assert "ExecStopPost" not in directives
+        assert "pod _cleanup" not in _uncommented(txt)
+        # ...and teardown never becomes a raw recursive remove in the unit either.
         assert "-rf" not in txt and "$HOME" not in txt
+        # Self-heal is still wanted: it is only safe BECAUSE the hook is gone.
+        assert "Restart=on-failure" in txt
 
     def test_env_block_pins_nondefaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("KIROCREW_POD_ROOT", "/tmp/hermetic-pods")
@@ -615,6 +668,668 @@ class TestCleanupHome:
         assert sentinel.exists() and pods.exists()
 
 
+class TestCleanupHomeVerifies:
+    """``rmtree`` runs with ``ignore_errors`` (a partially-removed tree is still
+    progress), so ``cleanup_home``'s return value is the only signal a caller has
+    that the HOME is actually gone. A constant 0 is what let ``pod down`` print
+    "zero residue" over a directory still on disk."""
+
+    def _held_home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[PodConfig, Path]:
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        c = PodConfig.load()
+        home = c.home_dir("demo")
+        home.mkdir(parents=True)
+        (home / "security_events.jsonl").write_text("{}\n")
+        # A pod-scoped process still holds the tree (or reopens its audit log in
+        # append mode right behind the delete), so the removal achieves nothing
+        # and says nothing — exactly what was measured on a live host.
+        monkeypatch.setattr(rt.shutil, "rmtree", lambda *a, **k: None)
+        return c, home
+
+    def test_reports_a_home_that_survived_the_delete(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        c, home = self._held_home(tmp_path, monkeypatch)
+        assert rt.cleanup_home(c, "demo") == 1
+        out = capsys.readouterr().out
+        assert str(home) in out
+        # Naming the culprit is the point: a bare failure sends the operator
+        # hunting for which writer resurrected the directory.
+        assert "security_events.jsonl" in out
+
+    def test_an_unlistable_survivor_still_fails_instead_of_raising(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The survivor listing is diagnostics; it must never turn teardown into a
+        traceback on a directory the process cannot read."""
+        c, _ = self._held_home(tmp_path, monkeypatch)
+
+        def _boom(self):  # noqa: ANN001 - patched onto Path
+            raise PermissionError("nope")
+
+        monkeypatch.setattr(Path, "iterdir", _boom)
+        assert rt.cleanup_home(c, "demo") == 1
+
+
+class TestDrainCgroup:
+    """The delete waits for the unit's process tree, because that is the set that
+    recreates the HOME behind it."""
+
+    def test_a_vanished_cgroup_counts_as_drained(self, tmp_path: Path) -> None:
+        assert rt.drain_cgroup(tmp_path / "gone" / "cgroup.procs") == []
+
+    def test_waits_until_the_last_process_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        procs = tmp_path / "cgroup.procs"
+        procs.write_text("7\n8\n")
+        remaining = ["8\n", ""]
+        monkeypatch.setattr(rt.time, "sleep", lambda _s: procs.write_text(remaining.pop(0)))
+        assert rt.drain_cgroup(procs) == []
+        assert remaining == [], "it must poll until empty, not sample once"
+
+    def test_reports_the_survivors_when_the_window_expires(self, tmp_path: Path) -> None:
+        procs = tmp_path / "cgroup.procs"
+        procs.write_text("7\n8\n")
+        assert rt.drain_cgroup(procs, timeout=0.0) == ["7", "8"]
+
+
+class TestLinuxTeardownOrdering:
+    """Reclamation lives on the ``down`` path, not in an ``ExecStopPost`` hook that
+    systemd runs BEFORE the final kill of the unit's cgroup. So ``stop_pod`` owns
+    the ordering: stop, drain, delete, verify."""
+
+    def test_the_cgroup_is_read_before_the_stop(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """systemd reports an empty ``ControlGroup`` for an inactive unit, so asking
+        after the stop returns nothing and the drain silently degrades to a no-op."""
+        order: list[str] = []
+
+        def _read_cgroup(c: PodConfig, n: str) -> None:
+            order.append("read-cgroup")
+            return None
+
+        def _systemctl(*args: str, **kwargs: object) -> subprocess.CompletedProcess:
+            order.append(args[0])
+            return _cp()
+
+        monkeypatch.setattr(rt, "cgroup_procs_file", _read_cgroup)
+        monkeypatch.setattr(rt, "systemctl", _systemctl)
+        monkeypatch.setattr(rt, "cleanup_home", lambda c, n: 0)
+        # No teardown hook loaded, so no refresh interleaves with the ordering.
+        monkeypatch.setattr(rt, "loaded_teardown_hook", lambda c, n: False)
+        assert rt.stop_pod(cfg, "demo").returncode == 0
+        assert order == ["read-cgroup", "stop"]
+
+    def test_a_stale_unit_is_refreshed_before_the_stop(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A unit installed by an older build still carries the destructive
+        ExecStopPost, and `systemctl stop` runs it BEFORE our drain — so the first
+        `down` after an upgrade would delete the HOME under the pod's own live
+        processes, losing its sessions and config. Refreshing must therefore happen
+        before the stop, not just before a start."""
+        order: list[str] = []
+
+        def _systemctl(*args: str, **kwargs: object) -> subprocess.CompletedProcess:
+            order.append(args[0])
+            return _cp()
+
+        monkeypatch.setattr(rt, "loaded_teardown_hook", lambda c, n: True)
+        monkeypatch.setattr(
+            rt.unit_mod, "install_unit", lambda c: order.append("re-render")
+        )
+        monkeypatch.setattr(rt, "cgroup_procs_file", lambda c, n: None)
+        monkeypatch.setattr(rt, "systemctl", _systemctl)
+        monkeypatch.setattr(rt, "cleanup_home", lambda c, n: 0)
+        assert rt.stop_pod(cfg, "demo").returncode == 0
+        assert order == ["re-render", "daemon-reload", "stop"]
+
+    def test_a_current_unit_is_not_re_rendered_on_every_stop(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The reverse guard: re-rendering unconditionally would daemon-reload on
+        every single `pod down`."""
+        rendered: list[str] = []
+        monkeypatch.setattr(rt.unit_mod, "unit_is_current", lambda c: True)
+        monkeypatch.setattr(
+            rt.unit_mod, "install_unit", lambda c: rendered.append("re-render")
+        )
+        monkeypatch.setattr(rt, "cgroup_procs_file", lambda c, n: None)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp())
+        monkeypatch.setattr(rt, "cleanup_home", lambda c, n: 0)
+        assert rt.stop_pod(cfg, "demo").returncode == 0
+        assert rendered == []
+
+    def _stale_unit_with_failing_reload(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> list[str]:
+        """A stale unit on disk (it carries the removed directive) plus a
+        daemon-reload that fails. Returns the list systemctl verbs are recorded in."""
+        unit_file = tmp_path / "pod@.service"
+        unit_file.write_text("[Service]\nExecStart=/x\nExecStopPost=/y pod _cleanup %i\n")
+        monkeypatch.setattr(rt.unit_mod, "unit_path", lambda c: unit_file)
+        monkeypatch.setattr(rt.unit_mod, "_kirocrew_bin", lambda: sys.executable)
+        issued: list[str] = []
+
+        def _systemctl(*args: str, **kwargs: object) -> subprocess.CompletedProcess:
+            issued.append(args[0])
+            if args[0] == "daemon-reload":
+                return _cp(returncode=1, stderr="Failed to reload daemon")
+            if args[0] == "show":  # systemd has the destructive hook loaded
+                return _cp(stdout="{ path=/x ; argv[]=pod _cleanup x }\n")
+            return _cp()
+
+        monkeypatch.setattr(rt, "systemctl", _systemctl)
+        return issued
+
+    def test_the_stop_trusts_systemd_not_the_unit_file(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Disk freshness is not proof of a load. A hookless file can sit in front
+        of a cached definition that still deletes the HOME — reached by ANY writer
+        whose reload failed, `pod install` included. So the stop asks systemd what
+        it will execute, and refreshes on that."""
+        order: list[str] = []
+
+        def _systemctl(*args: str, **kwargs: object) -> subprocess.CompletedProcess:
+            order.append(args[0])
+            if args[0] == "show":
+                # systemd still has the destructive hook loaded.
+                return _cp(stdout="{ path=/usr/bin/kirocrew ; argv[]=pod _cleanup x }\n")
+            return _cp()
+
+        # The unit file on disk looks perfectly current — the old gate's signal.
+        monkeypatch.setattr(rt.unit_mod, "unit_is_current", lambda c: True)
+        monkeypatch.setattr(
+            rt.unit_mod, "install_unit", lambda c: order.append("re-render")
+        )
+        monkeypatch.setattr(rt, "systemctl", _systemctl)
+        monkeypatch.setattr(rt, "cgroup_procs_file", lambda c, n: None)
+        monkeypatch.setattr(rt, "cleanup_home", lambda c, n: 0)
+        assert rt.stop_pod(cfg, "demo").returncode == 0
+        assert order == ["show", "re-render", "daemon-reload", "stop"]
+
+    def test_an_unanswerable_hook_query_refreshes_anyway(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """"Cannot tell" must read as "the hook is there"; the other way round
+        silently ships the defect on any host where the query fails."""
+        order: list[str] = []
+
+        def _systemctl(*args: str, **kwargs: object) -> subprocess.CompletedProcess:
+            order.append(args[0])
+            return _cp(returncode=1, stderr="Failed to get properties") if args[0] == "show" else _cp()
+
+        monkeypatch.setattr(
+            rt.unit_mod, "install_unit", lambda c: order.append("re-render")
+        )
+        monkeypatch.setattr(rt, "systemctl", _systemctl)
+        monkeypatch.setattr(rt, "cgroup_procs_file", lambda c, n: None)
+        monkeypatch.setattr(rt, "cleanup_home", lambda c, n: 0)
+        assert rt.stop_pod(cfg, "demo").returncode == 0
+        assert "re-render" in order
+
+    def test_no_refresh_when_systemd_reports_no_hook(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The reverse guard: refreshing unconditionally would daemon-reload on
+        every single `pod down`."""
+        order: list[str] = []
+
+        def _systemctl(*args: str, **kwargs: object) -> subprocess.CompletedProcess:
+            order.append(args[0])
+            return _cp(stdout="\n") if args[0] == "show" else _cp()
+
+        monkeypatch.setattr(
+            rt.unit_mod, "install_unit", lambda c: order.append("re-render")
+        )
+        monkeypatch.setattr(rt, "systemctl", _systemctl)
+        monkeypatch.setattr(rt, "cgroup_procs_file", lambda c, n: None)
+        monkeypatch.setattr(rt, "cleanup_home", lambda c, n: 0)
+        assert rt.stop_pod(cfg, "demo").returncode == 0
+        assert order == ["show", "stop"]
+        assert "daemon-reload" not in order
+
+    def test_a_failed_reload_refuses_the_stop_and_removes_the_fresh_unit(
+        self, cfg: PodConfig, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed reload splits disk from systemd: the fresh hookless file is on
+        disk, but systemd still executes the OLD definition. Leaving that file
+        behind is the real damage — `unit_is_current` reads disk, so every later
+        call would report "current" while a crash restart still wipes the HOME.
+        So remove it, and do not stop a pod whose loaded unit still has the hook."""
+        issued = self._stale_unit_with_failing_reload(tmp_path, monkeypatch)
+        monkeypatch.setattr(rt, "cgroup_procs_file", lambda c, n: None)
+        monkeypatch.setattr(rt, "cleanup_home", lambda c, n: 0)
+        cp = rt.stop_pod(cfg, "demo")
+        assert cp.returncode != 0
+        assert "pod install" in cp.stderr
+        assert "stop" not in issued, "must not stop while systemd runs the old hook"
+        assert not (tmp_path / "pod@.service").exists()
+        # The invariant that matters: staleness must not read as current.
+        assert rt.unit_mod.unit_is_current(cfg) is False
+
+    def test_a_failed_reload_refuses_the_start_and_removes_the_fresh_unit(
+        self, cfg: PodConfig, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        issued = self._stale_unit_with_failing_reload(tmp_path, monkeypatch)
+        cp = rt.start_pod(cfg, "demo")
+        assert cp.returncode != 0
+        assert "pod install" in cp.stderr
+        assert "start" not in issued
+        assert not (tmp_path / "pod@.service").exists()
+
+    def test_the_delete_waits_for_the_process_tree(
+        self, cfg: PodConfig, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        procs = tmp_path / "cgroup.procs"
+        procs.write_text("4242\n")
+        order: list[str] = []
+        monkeypatch.setattr(rt, "cgroup_procs_file", lambda c, n: procs)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp())
+
+        def _last_process_exits(_s: float) -> None:
+            order.append("drained")
+            procs.write_text("")
+
+        def _delete(c: PodConfig, n: str) -> int:
+            order.append("deleted")
+            return 0
+
+        monkeypatch.setattr(rt.time, "sleep", _last_process_exits)
+        monkeypatch.setattr(rt, "cleanup_home", _delete)
+        assert rt.stop_pod(cfg, "demo").returncode == 0
+        assert order == ["drained", "deleted"], "deleting first is the original race"
+
+    def test_both_teardown_messages_name_the_same_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A failed teardown prints twice — once from `stop_pod`, once from
+        `cleanup_home` — and the two must name the HOME identically. `pod_home`
+        returns it unresolved while `cleanup_home` resolves before deleting, so on
+        a host whose home is a symlink (the standard dev-desktop layout) the same
+        directory appeared as `/home/...` and `/local/home/...` and read as two
+        locations. Reproduced here with a symlinked pod root."""
+        real = tmp_path / "real-pods"
+        real.mkdir()
+        link = tmp_path / "linked-pods"
+        link.symlink_to(real)
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(link))
+        c = PodConfig.load()
+        (c.home_dir("demo")).mkdir(parents=True)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp())
+        monkeypatch.setattr(rt, "cgroup_procs_file", lambda cc, n: None)
+        monkeypatch.setattr(rt.shutil, "rmtree", lambda *a, **k: None)
+        cp = rt.stop_pod(c, "demo")
+        assert cp.returncode != 0
+        resolved = str((real / "demo").resolve())
+        assert resolved in cp.stderr
+        assert resolved in capsys.readouterr().out, "cleanup_home must agree"
+        assert str(link / "demo") not in cp.stderr, "the second spelling is the bug"
+
+    def test_a_failed_stop_leaves_a_possibly_live_pods_state_alone(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        c = PodConfig.load()
+        home = c.home_dir("demo")
+        home.mkdir(parents=True)
+        (home / "kirocrew.db").write_text("live")
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(returncode=1, stderr="job failed"))
+        cp = rt.stop_pod(c, "demo")
+        assert cp.returncode != 0
+        assert (home / "kirocrew.db").read_text() == "live"
+
+    def test_a_process_outliving_the_drain_blocks_the_delete_entirely(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Deleting after the drain EXPIRES would be the original defect wearing a
+        verification: the live writer recreates the directory in append mode right
+        behind the delete, which lands after the check, so `down` reports zero
+        residue over a HOME that comes back. Refuse to delete instead."""
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        c = PodConfig.load()
+        home = c.home_dir("demo")
+        home.mkdir(parents=True)
+        (home / "kirocrew.db").write_text("a writer still has this")
+        deleted: list[str] = []
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp())
+        monkeypatch.setattr(rt, "cgroup_procs_file", lambda cc, n: tmp_path / "cgroup.procs")
+        monkeypatch.setattr(rt, "drain_cgroup", lambda procs, **k: ["4242", "4243"])
+        monkeypatch.setattr(rt, "cleanup_home", lambda cc, n: deleted.append(n) or 0)
+        cp = rt.stop_pod(c, "demo")
+        assert cp.returncode != 0
+        assert deleted == [], "must not delete a HOME a live process is still in"
+        assert (home / "kirocrew.db").read_text() == "a writer still has this"
+        assert str(home) in cp.stderr
+        assert "NOT zero-residue" in cp.stderr
+        # The pids that would not exit are the actionable part of the report.
+        assert "4242" in cp.stderr and "4243" in cp.stderr
+
+    def test_a_surviving_home_is_reported_not_called_zero_residue(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Drained cleanly, but the delete still did not take (permissions, or a
+        writer outside the cgroup). The verification is what catches this."""
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        c = PodConfig.load()
+        home = c.home_dir("demo")
+        home.mkdir(parents=True)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp())
+        monkeypatch.setattr(rt, "cgroup_procs_file", lambda cc, n: tmp_path / "cgroup.procs")
+        monkeypatch.setattr(rt, "drain_cgroup", lambda procs, **k: [])
+        monkeypatch.setattr(rt.shutil, "rmtree", lambda *a, **k: None)
+        cp = rt.stop_pod(c, "demo")
+        assert cp.returncode != 0
+        assert str(home) in cp.stderr
+        assert "NOT zero-residue" in cp.stderr
+
+
+class TestTheUnitFileNeverOutlivesAFailedLoad:
+    """The invariant behind three separate defects: a unit file present on disk has
+    been loaded by systemd. Every writer must uphold it — fixing only the lifecycle
+    path left `pod install` able to strand a hookless file in front of a cached
+    destructive definition, which is what made the on-disk freshness check lie."""
+
+    def _plane(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        unit_file = tmp_path / "pod@.service"
+        monkeypatch.setattr(rt.unit_mod, "unit_path", lambda c: unit_file)
+        monkeypatch.setattr(rt.unit_mod, "_kirocrew_bin", lambda: sys.executable)
+        monkeypatch.setattr(rt, "require_backend", lambda: None)
+        return unit_file
+
+    def test_install_removes_the_unit_when_the_reload_fails(
+        self, cfg: PodConfig, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        unit_file = self._plane(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            rt, "systemctl", lambda *a, **k: _cp(returncode=1, stderr="reload failed")
+        )
+        msg, cp = rt.install_backend(cfg)
+        assert cp is not None and cp.returncode != 0
+        assert not unit_file.exists(), "an unloaded unit must not be left on disk"
+        assert rt.unit_mod.unit_is_current(cfg) is False
+        assert "removed" in msg
+
+    def test_install_keeps_the_unit_when_the_reload_succeeds(
+        self, cfg: PodConfig, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        unit_file = self._plane(tmp_path, monkeypatch)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp())
+        msg, cp = rt.install_backend(cfg)
+        assert cp is not None and cp.returncode == 0
+        assert unit_file.exists()
+        assert rt.unit_mod.unit_is_current(cfg) is True
+        assert "installed pod template unit" in msg
+
+
+class TestPodNameMutexOnLinux:
+    """Linux teardown moved onto the ``down`` path, so Linux now has the same
+    down/up race the launchd backend needed the flock for: the mutex can no longer
+    be a no-op there."""
+
+    def test_start_and_stop_hold_it(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import contextlib as _ctx
+
+        held: list[str] = []
+
+        @_ctx.contextmanager
+        def _fake(c: PodConfig, n: str):
+            held.append(f"enter:{n}")
+            yield
+            held.append(f"exit:{n}")
+
+        monkeypatch.setattr(rt, "pod_name_mutex", _fake)
+        monkeypatch.setattr(rt.unit_mod, "unit_is_current", lambda c: True)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp())
+        rt.start_pod(cfg, "demo")
+        assert held == ["enter:demo", "exit:demo"]
+
+        held.clear()
+        monkeypatch.setattr(rt, "cleanup_home", lambda c, n: 0)
+        rt.stop_pod(cfg, "demo")
+        assert held == ["enter:demo", "exit:demo"], "the sweep must run INSIDE the mutex"
+
+    @pytest.mark.skipif(
+        rt.fcntl is None,
+        reason="flock needs POSIX; without it the mutex is a documented no-op",
+    )
+    def test_it_is_a_real_lock(self, cfg: PodConfig) -> None:
+        with rt.pod_name_mutex(cfg, "demo"):
+            pass
+        assert (cfg.pods_dir / f"{cfg.unit_prefix}@demo.lock").exists()
+
+    def test_boot_never_takes_the_lock(self) -> None:
+        """`up` holds the mutex across the health wait, and the process it is
+        waiting for is the pod's own `pod _run` -> boot(). If boot ever acquired
+        the same per-name lock, `up` would wait for a gateway that is blocked on
+        `up` — a deadlock no unit test would notice from either side alone.
+
+        Checked TRANSITIVELY and in both call spellings: a bare
+        `pod_name_mutex(...)`, an `rt.pod_name_mutex(...)` attribute call, or any
+        module-level helper `boot` reaches that takes the lock would all deadlock
+        identically, so pinning only the direct bare-name call would pin the letter
+        of the rule rather than the property.
+        """
+        tree = ast.parse(Path(rt.__file__).read_text(encoding="utf-8"))
+        funcs = {
+            n.name: n
+            for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+
+        def called_names(fn: ast.AST) -> set[str]:
+            out: set[str] = set()
+            for n in ast.walk(fn):
+                if not isinstance(n, ast.Call):
+                    continue
+                if isinstance(n.func, ast.Name):
+                    out.add(n.func.id)
+                elif isinstance(n.func, ast.Attribute):
+                    out.add(n.func.attr)
+            return out
+
+        reached: set[str] = set()
+        stack = ["boot"]
+        while stack:
+            name = stack.pop()
+            if name in reached or name not in funcs:
+                continue
+            reached.add(name)
+            stack.extend(called_names(funcs[name]))
+
+        assert "boot" in reached, "boot must exist for this guard to mean anything"
+        assert "pod_name_mutex" not in reached
+        # The lock is only ever taken by these two, so neither may be reachable
+        # from boot either — that is the same deadlock one level removed.
+        assert "start_pod" not in reached
+        assert "stop_pod" not in reached
+
+
+class TestOrphanHomes:
+    """Neither platform reclaims from a post-stop hook, so a pod that goes away
+    without a ``down`` leaves its HOME on either OS — and the report was gated to
+    macOS, which is why the residue accumulated invisibly on Linux."""
+
+    def _plane(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> PodConfig:
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        c = PodConfig.load()
+        for n in ("orphan", "running"):
+            (c.pod_root / n).mkdir(parents=True)
+        (c.pod_root / ".e2e-artifacts").mkdir()  # dot dirs are not pods
+        monkeypatch.setattr(rt, "active_names", lambda cc: {"running"})
+        return c
+
+    def test_reported_on_linux(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        c = self._plane(tmp_path, monkeypatch)
+        assert rt.orphan_homes(c) == ["orphan"]
+
+    def test_ls_surfaces_them_with_the_reclaim_command(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        c = self._plane(tmp_path, monkeypatch)
+        monkeypatch.setattr(rt, "health", lambda port, timeout=3: 200)
+        pod_cli._ls(c, argparse.Namespace(json=False))
+        out = capsys.readouterr().out
+        assert "1 orphaned pod HOME(s)" in out
+        assert "kirocrew pod down orphan" in out
+
+    def test_the_json_shape_stays_live_pods_only(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Three callers parse this array; orphans are human-output only."""
+        c = self._plane(tmp_path, monkeypatch)
+        monkeypatch.setattr(rt, "health", lambda port, timeout=3: 200)
+        pod_cli._ls(c, argparse.Namespace(json=True))
+        assert [r["name"] for r in json.loads(capsys.readouterr().out)] == ["running"]
+
+
+class TestDownSamplesStateUnderTheLock:
+    """`was_up` / `had_home` decide whether a failed stop is fatal, so sampling
+    them before taking the lock let a concurrent `up` invalidate the answer: we
+    saw "not running, nothing to reclaim", waited on the lock, and then judged a
+    REAL failure against that stale reading — swallowing it and deleting the live
+    pod's checkout pin."""
+
+    def test_state_is_read_after_the_lock_is_held(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import contextlib as _ctx
+
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path / "env"))
+        c = PodConfig.load()
+        rt.pin_checkout(c, "demo", tmp_path / "co")
+        order: list[str] = []
+
+        @_ctx.contextmanager
+        def _mutex(cc: PodConfig, n: str):
+            order.append("lock")
+            # What a concurrent `up` completes while we are blocked on the lock.
+            c.home_dir(n).mkdir(parents=True, exist_ok=True)
+            yield
+
+        def _is_active(cc: PodConfig, n: str) -> bool:
+            order.append("sample")
+            return False
+
+        monkeypatch.setattr(rt, "pod_name_mutex", _mutex)
+        monkeypatch.setattr(rt, "is_active", _is_active)
+        monkeypatch.setattr(rt, "stop_pod", lambda cc, n: _cp(returncode=1, stderr="boom"))
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+
+        # The failure must be fatal, judged against state read INSIDE the lock.
+        with pytest.raises(SystemExit):
+            pod_cli._down(c, argparse.Namespace(name="demo"))
+        assert order == ["lock", "sample"], "state sampled before the lock is stale"
+        assert c.env_file("demo").exists(), "a live pod's checkout pin must survive"
+
+
+class TestDownReclaimsResidue:
+    """``pod down`` is the reclaim command the orphan report points at, so it has
+    to work on a pod that is no longer running."""
+
+    def _orphan(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[PodConfig, Path]:
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path / "env"))
+        c = PodConfig.load()
+        home = c.home_dir("demo")
+        home.mkdir(parents=True)
+        (home / "config.json").write_text("{}")
+        rt.pin_checkout(c, "demo", tmp_path / "co")
+        monkeypatch.setattr(rt, "is_active", lambda cc, n: False)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp())
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+        return c, home
+
+    def test_down_reclaims_a_home_left_behind(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        c, home = self._orphan(tmp_path, monkeypatch)
+        pod_cli._down(c, argparse.Namespace(name="demo"))
+        assert not home.exists()
+        assert not c.env_file("demo").exists()
+        out = capsys.readouterr().out
+        assert "reclaimed the isolated HOME" in out
+        assert "nothing to stop" not in out
+
+    def test_down_on_a_never_used_name_is_still_a_no_op(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """`systemctl stop` on an instance of a template that was never installed
+        reports "unit not loaded" (rc 5). With no HOME to reclaim and the pod not
+        running there is nothing at stake, so `pod down <name>` must stay the
+        documented no-op rather than exiting 1."""
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path / "env"))
+        c = PodConfig.load()
+        monkeypatch.setattr(rt, "is_active", lambda cc, n: False)
+        monkeypatch.setattr(
+            rt,
+            "systemctl",
+            lambda *a, **k: _cp(returncode=5, stderr="Unit kirocrew-pod@demo.service not loaded."),
+        )
+        monkeypatch.setattr(pod_cli, "_audit", lambda *a, **k: None)
+        pod_cli._down(c, argparse.Namespace(name="demo"))  # must not SystemExit
+        assert "nothing to stop" in capsys.readouterr().out
+
+    def test_down_still_fails_loudly_when_a_home_is_there_to_reclaim(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The mirror of the no-op above: the same failed stop, but now there IS
+        residue, so swallowing it would be the silent success being fixed here."""
+        c, home = self._orphan(tmp_path, monkeypatch)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(returncode=5, stderr="nope"))
+        with pytest.raises(SystemExit):
+            pod_cli._down(c, argparse.Namespace(name="demo"))
+        assert home.exists()
+        assert c.env_file("demo").exists()
+
+    def test_down_fails_loudly_when_the_reclaim_could_not_finish(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A silent success here is the whole bug: the operator is told zero
+        residue while the directory (and its checkout pin) are still there."""
+        c, home = self._orphan(tmp_path, monkeypatch)
+        monkeypatch.setattr(rt.shutil, "rmtree", lambda *a, **k: None)
+        with pytest.raises(SystemExit):
+            pod_cli._down(c, argparse.Namespace(name="demo"))
+        assert home.exists()
+        assert c.env_file("demo").exists(), "the pin must survive a failed teardown"
+
+
+class TestHostStateIsFenced:
+    """A pod test must not be able to write the machine's own systemd unit.
+
+    Found on a real host: a suite run rewrote `~/.config/systemd/user/
+    kirocrew-pod@.service` with a test's tmpdir as
+    `Environment=KIROCREW_POD_ROOT=`, after which every `pod up` died with "no
+    pinned checkout" until someone re-ran `pod install`. `unit_path` reads
+    `Path.home()`, which no test patched, and `_up` -> `install_backend` ->
+    `install_unit` reaches it. Asserting the PATH rather than the write keeps this
+    guard from having to clobber the real unit to prove itself.
+    """
+
+    def test_the_home_is_pinned_away_from_the_real_one(self) -> None:
+        """The fixture must actually redirect. Asserted separately from the paths
+        below because on Windows a pytest tmp dir lives UNDER `Path.home()`
+        (`C:/Users/<u>/AppData/Local/Temp/...`), so "not under the real home" is
+        false there by construction and cannot carry the guard."""
+        assert Path.home() != _REAL_HOME
+
+    def test_the_unit_path_follows_the_pinned_home(self, cfg: PodConfig) -> None:
+        assert Path.home() in unit_mod.unit_path(cfg).parents
+
+    def test_pod_host_dirs_follow_the_pinned_home(self, cfg: PodConfig) -> None:
+        # pods_dir carries the lifecycle lock file; pod_root carries pod HOMEs.
+        for path in (cfg.pods_dir, cfg.pod_root):
+            assert Path.home() in path.parents, path
+
+
 class TestRuntimeHelpers:
     def test_is_active(self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(returncode=0))
@@ -981,7 +1696,7 @@ class TestUnitExecSelfHeal:
             unit_mod, "unit_path", lambda cfg: tmp_path / "pod@.service"
         )
         (tmp_path / "pod@.service").write_text(
-            f"[Service]\n{exec_line}\nExecStopPost=/bin/true pod _cleanup %i\n"
+            f"[Service]\n{exec_line}\nRestart=on-failure\n"
         )
         return PodConfig.load()
 
@@ -1013,6 +1728,55 @@ class TestUnitExecSelfHeal:
             unit_mod, "unit_path", lambda cfg: tmp_path / "absent@.service"
         )
         assert unit_mod.unit_exec_ok(PodConfig.load()) is False
+
+    def test_a_unit_carrying_the_removed_teardown_hook_is_not_current(
+        self, tmp_path, monkeypatch
+    ):
+        """Units are written once by `pod install`, so on UPGRADE a machine keeps
+        whatever it installed. Without this, an older unit's ExecStopPost would go
+        on racing the pod's own subprocesses (and wiping the HOME on the stop half
+        of a Restart=) until someone reinstalled by hand."""
+        from kiro_crew.pod import unit as unit_mod
+
+        exe = tmp_path / "kirocrew"
+        exe.write_text("#!/bin/sh\n")
+        exe.chmod(0o755)
+        cfg = self._cfg_with_unit(tmp_path, monkeypatch, f"ExecStart={exe} pod _run %i")
+        unit_path = tmp_path / "pod@.service"
+        assert unit_mod.unit_is_current(cfg) is True  # what this build renders
+        unit_path.write_text(
+            unit_path.read_text() + f"ExecStopPost={exe} pod _cleanup %i\n"
+        )
+        assert unit_mod.unit_is_current(cfg) is False
+
+    def test_what_this_build_renders_is_current(self, cfg, monkeypatch, tmp_path):
+        """Guard against the reverse failure: a check that flagged the CURRENT
+        template would re-render and daemon-reload on every single `pod up`."""
+        from kiro_crew.pod import unit as unit_mod
+
+        monkeypatch.setattr(unit_mod, "unit_path", lambda c: tmp_path / "pod@.service")
+        # An executable that exists on every platform the suite runs on — a POSIX
+        # path here made unit_exec_ok report "stale" on Windows.
+        monkeypatch.setattr(unit_mod, "_kirocrew_bin", lambda: sys.executable)
+        unit_mod.install_unit(cfg)
+        assert unit_mod.unit_is_current(cfg) is True
+
+    def test_start_pod_reinstalls_a_stale_unit_before_booting_it(
+        self, cfg, monkeypatch
+    ):
+        steps: list[str] = []
+        monkeypatch.setattr(rt.unit_mod, "unit_is_current", lambda c: False)
+        monkeypatch.setattr(
+            rt.unit_mod, "install_unit", lambda c: steps.append("reinstall")
+        )
+
+        def _systemctl(*args, **kwargs):
+            steps.append(args[0])
+            return _cp()
+
+        monkeypatch.setattr(rt, "systemctl", _systemctl)
+        assert rt.start_pod(cfg, "demo").returncode == 0
+        assert steps == ["reinstall", "daemon-reload", "start"]
 
     def test_module_invocation_form_passes(self, tmp_path, monkeypatch):
         from kiro_crew.pod import unit as unit_mod

--- a/test/test_pod_launchd.py
+++ b/test/test_pod_launchd.py
@@ -206,16 +206,18 @@ def test_recent_journal_says_why_it_is_empty(cfg):
     assert "no pod log yet" in text
 
 
-def test_orphan_homes_reports_only_reapable_leftovers(cfg, monkeypatch):
-    """With no ExecStopPost, a crashed pod leaves its HOME; ls/down GC it."""
+def test_orphan_homes_skips_a_pod_with_an_installed_plist(cfg, monkeypatch):
+    """A per-pod plist means "installed", not orphaned — a name mid-`up` whose
+    gateway has not gone active yet must not be reported as reapable."""
     cfg.pod_root.mkdir(parents=True, exist_ok=True)
     (cfg.pod_root / "orphan").mkdir()
     (cfg.pod_root / "running").mkdir()
     (cfg.pod_root / "installed").mkdir()
     (cfg.pod_root / ".e2e-artifacts").mkdir()  # dot dirs are not pods
     launchd.write_plist(cfg, "installed")
-    monkeypatch.setattr(launchd, "active_names", lambda c: {"running"})
-    assert launchd.orphan_homes(cfg) == ["orphan"]
+    monkeypatch.setattr(rt, "IS_MACOS", True)
+    monkeypatch.setattr(rt, "active_names", lambda c: {"running"})
+    assert rt.orphan_homes(cfg) == ["orphan"]
 
 
 # --------------------------------------------------------------------------
@@ -434,7 +436,7 @@ def test_start_and_stop_hold_the_per_name_mutex(cfg, monkeypatch):
         yield
         held.append(f"exit:{n}")
 
-    monkeypatch.setattr(rt.launchd, "pod_mutex", _fake_mutex)
+    monkeypatch.setattr(rt, "pod_name_mutex", _fake_mutex)
     monkeypatch.setattr(rt, "IS_MACOS", True)
     monkeypatch.setattr(rt.launchd, "write_plist", lambda c, n: None)
     monkeypatch.setattr(rt.launchd, "start", lambda c, n: _cp(returncode=0))
@@ -464,8 +466,8 @@ def test_pod_mutex_is_reentrant_within_a_thread(cfg):
     """The CLI holds the mutex across a transaction while start_pod/stop_pod
     re-acquire it inside; flock is per open-file-description, so without
     reentrancy that inner acquisition would deadlock against our own lock."""
-    with launchd.pod_mutex(cfg, "smoke"):
-        with launchd.pod_mutex(cfg, "smoke"):  # must not block
+    with rt.pod_name_mutex(cfg, "smoke"):
+        with rt.pod_name_mutex(cfg, "smoke"):  # must not block
             pass
 
 
@@ -592,11 +594,6 @@ def test_ls_translates_orphan_probe_failures_to_the_documented_error(cfg, monkey
     from kiro_crew.pod import cli as pod_cli
 
     monkeypatch.setattr(rt, "IS_MACOS", True)
-    monkeypatch.setattr(rt, "active_names", lambda c: set())
-
-    def _boom(c):
-        raise launchd.LaunchdError("launchctl print failed")
-
-    monkeypatch.setattr(launchd, "orphan_homes", _boom)
+    monkeypatch.setattr(launchd, "launchctl", lambda *a, **k: _cp(returncode=5, stderr="EIO"))
     with pytest.raises(rt.PodError):
         pod_cli._ls(cfg, argparse.Namespace(json=False))


### PR DESCRIPTION
## Issue link

Fixes #2543

## What is the problem?

Pod teardown was documented as zero-residue "whatever stopped the service", and it
was not. The systemd unit deleted the pod's isolated HOME from `ExecStopPost`, and
that one placement produced three separate failures:

1. **Teardown raced the pod's own processes.** systemd runs `ExecStopPost` *before*
   the final kill of the unit's cgroup, so the delete landed while pod-scoped
   subprocesses were still alive. They reopened their audit log in append mode and
   recreated the directory behind it. `cleanup_home` used
   `shutil.rmtree(..., ignore_errors=True)` and returned a constant `0`, so the
   whole race was swallowed and `pod down` printed "zero residue".
2. **On Linux the resulting orphans were invisible.** `pod ls`'s orphan report was
   gated on `IS_MACOS`, on the assumption that Linux always reaps.
3. **`Restart=on-failure` restarted a pod into a wiped home.** A crash ran teardown
   first, then the restart brought the gateway back on a home with no sessions, no
   config and no lessons.

## Why this issue matters to the user

Each failure is silent, which is what made them expensive:

- Orphan homes accumulated on Linux with nothing surfacing them. On the host used
  to develop this, `pod ls` listed one running pod while three dead pod homes sat
  in `~/.kirocrew-pods` unmentioned.
- A pod that self-healed from a crash looked recovered but had silently lost every
  session it held, with no signal that the restart was really a re-provision.
- Anyone seeding a pod home for a test hit this as unexplained data loss, because
  the stop half of a restart runs `ExecStopPost` too — and the platforms disagreed,
  so a fixture-based pod test behaved differently on macOS than on Linux.

## How our fix solves it

Symptom → root cause → change:

The symptom (a HOME that is gone-then-back, or gone-when-it-should-not-be) traces
to one root cause: **teardown was sequenced before the thing that would make it
safe.** `ExecStopPost` cannot distinguish "the service stopped" from "nothing
pod-scoped is running", and it cannot distinguish a stop from the stop half of a
restart. No amount of retry logic inside the hook fixes either, because both are
properties of where the hook runs.

So reclamation moves out of the unit and onto the `down` path, which is where macOS
already had it:

- **`unit.py` no longer emits `ExecStopPost`.** `Restart=on-failure` stays — it is
  only safe *because* the hook is gone.
- **`runtime.stop_pod` owns teardown on both platforms**, sequenced
  stop → drain → delete → **verify**. On Linux it reads the unit's `ControlGroup`
  *before* stopping (systemd clears it on an inactive unit), then waits for
  `cgroup.procs` to empty via `drain_cgroup` before deleting. The pod is in its own
  cgroup, so the set of surviving processes is knowable rather than guessable. If the
  drain *expires* with processes still in there, teardown deletes **nothing** and
  names the pids: deleting at that point would be the original defect with a
  verification bolted on, because the surviving writer recreates the directory after
  the check.
- **`cleanup_home` stops hiding failures.** `rmtree` still runs with
  `ignore_errors` (a partially-removed tree is still progress), but the function now
  returns `1` when the directory survives and names the entries left behind
  (`security_events.jsonl` is the usual culprit), so a caller can tell a reclaimed
  HOME from a swallowed failure. `pod down` fails loudly on that instead of printing
  zero residue, and it keeps the checkout pin so nothing is half-deleted.
- **Orphan reporting is platform-neutral.** `orphan_homes` moved to `runtime` and
  `pod ls` reports on both OSes; `pod down <name>` reclaims one, which is the
  command the report points at. The JSON shape is unchanged (three callers parse
  it) — orphans are human output only.
- **The lifecycle mutex now guards Linux too.** It was a `nullcontext` there on the
  grounds that "the unit owns teardown ordering". That is no longer true, so Linux
  has the same down/up race macOS needed the flock for, and the flock moved from
  `launchd` into `runtime`.
- **Upgrade self-heal.** Units are written once by `pod install`, so a machine that
  installed an older build would keep its `ExecStopPost` — and keep the defect —
  until someone reinstalled by hand. `unit_is_current` extends the existing
  stale-`ExecStart` self-heal to also re-render a unit carrying a directive this
  build removed, so the first `pod up` after upgrading fixes the machine.
  `docs/system-specs/modules/dev-fleet.md` is updated in step with it: that section
  documented `unit_exec_ok` and a single trigger.

The trade is explicit: a pod that goes away *without* a `down` (a crash, a raw
`systemctl --user stop`, a reboot) now leaves its HOME behind on Linux as it always
did on macOS. That is why orphan reporting is part of this change rather than a
follow-up. It also converges the platforms on the seed-then-restart path, which
previously behaved oppositely on the two OSes.

## What tests we did

`test_pod.py` / `test_pod_launchd.py`, 236 passing. New coverage, each verified by
mutation (7 mutants introduced, 7 caught):

| Test | What it locks in |
|---|---|
| `test_unit_has_no_teardown_hook` | no `ExecStopPost` directive, and `Restart=on-failure` kept |
| `TestCleanupHomeVerifies` | a surviving HOME returns non-zero and names the entries left; an unlistable one still fails instead of raising |
| `TestDrainCgroup` | polls until the last process exits; a vanished cgroup counts as drained; survivors reported when the window expires |
| `TestLinuxTeardownOrdering` | the cgroup is read *before* the stop; the delete waits for the drain; a process outliving the drain blocks the delete entirely (nothing is removed, the pod's DB is still readable); a failed stop leaves a possibly-live pod's state alone; a HOME that survives a clean drain is reported, not called zero residue |
| `TestPodNameMutexOnLinux` | `start_pod`/`stop_pod` hold the mutex, and it is a real flock (not a `nullcontext`). Plus an AST guard against the deadlock where `up` would wait on a gateway blocked on `up`: `boot` must not reach the lock, checked in both call spellings (`ast.Name` and `ast.Attribute`) and **transitively** across the module's call graph, also asserting neither `start_pod` nor `stop_pod` is reachable from `boot` |
| `TestOrphanHomes` | reported on Linux, surfaced by `pod ls` with the reclaim command, JSON shape unchanged |
| `TestDownReclaimsResidue` | `down` reclaims a leftover HOME, and fails loudly (keeping the pin) when it cannot; a name that was never used stays the documented no-op even when `systemctl stop` reports "unit not loaded", with the mirrored test proving the same rc is still fatal once there is residue at stake |
| `test_a_unit_carrying_the_removed_teardown_hook_is_not_current` | the upgrade path re-renders a stale unit; the reverse guard asserts the current template is *not* flagged, so `pod up` does not daemon-reload every time |

Also added an autouse fixture pinning `KIROCREW_POD_ENV_DIR` to a tmp dir: the per-pod
env dir resolves off the DEFAULT data home by design, so conftest's `KIROCREW_HOME`
safety net does not cover it, and the new lock file would otherwise land in the
developer's real `~/.kiro/crew/pods`.

Full backend suite, same host and flags: **83 failures on this branch vs 94 on the
base** (`4f70096`). Zero regressions — the failure sets for every affected file are
identical base-vs-branch, and the eight entries that differ between the two full
runs all pass in isolation on this branch (load-sensitive git/gh/subprocess tests;
one earlier baseline run was invalidated by `/tmp` exhaustion and was re-run).
`isort`, `flake8`, `mypy` clean.

Every new test above was mutation-verified: 13 mutants introduced across the fix
(teardown hook restored, `cleanup_home` back to a constant 0, delete before drain,
cgroup read after the stop, orphan report re-gated to macOS, mutex back to a no-op,
`down` swallowing a failed reclaim, delete-anyway after the drain expires, both
directions of the `down` no-op gate, and three against the deadlock guard) — all 13
caught. One of those is worth naming because it nearly produced a false clean: the
attribute-form lock call *appeared* to survive until I checked where the mutation had
landed and found it had been inserted outside `boot`. Re-applied via AST with an
assertion that it was really inside the target function, it was caught.

## Manual verification

Run against the real host, whose residue is what the issue measured:

Before — one live pod, three dead pod homes in `~/.kirocrew-pods`, none reported:

```
POD                          PORT    HEALTH
kirocrew-wt-runauthz         7839    200
```

After, same host, same state:

```
POD                          PORT    HEALTH
kirocrew-wt-runauthz         7839    200

3 orphaned pod HOME(s) — left by a pod that went away without an explicit `down` (a crash, a raw service stop, a reboot):
  kirocrew-wt-library-hero   reclaim: kirocrew pod down kirocrew-wt-library-hero
  kirocrew-wt-live-target    reclaim: kirocrew pod down kirocrew-wt-live-target
  kirocrew-wt-palette-apps   reclaim: kirocrew pod down kirocrew-wt-palette-apps
```

Then the reclaim the report points at, end to end:

```
$ kirocrew pod down kirocrew-wt-library-hero
pod 'kirocrew-wt-library-hero' was not running — reclaimed the isolated HOME it left behind
```

The directory is gone, it drops out of the report, and the live pod is untouched
(still `HEALTH 200`).

## Screenshots

N/A — no user-visible UI change. The surfaces this touches are CLI output, shown
verbatim above.

## Any other suggestions on the work

Reclamation being on the `down` path makes `pod down` the ONLY reclaim path, and
nothing bounds how many orphan HOMEs accumulate: the `pod ls` report is a flat list
with no age and there is no bulk prune. Filed as #2567 (age in the orphan block, a
`pod prune [--older-than]` routed through the same drain-then-verify path) rather than
widened into this PR. Timer-based automatic reclaim is explicitly ruled out there — a
reclaim not sequenced behind a confirmed-stopped service and a drained process tree
reintroduces exactly the class of bug this PR fixes.


The issue's third consequence (`Restart=on-failure` restarting into a wiped home)
was a code reading, not a measurement, and it stays that way here: confirming it
directly means crashing a live pod. It is fixed structurally — with no
`ExecStopPost` there is no teardown on the stop half of a restart — and
`test_unit_has_no_teardown_hook` is what keeps it fixed.
