### PR TITLE
fix: surface permanent turn-failure reasons in Telegram replies (#1831)

### DIFF
--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -456,6 +456,15 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "The direct-send path that bypasses TurnDriver, redacted independently.",
     ),
     (
+        "Telegram failure reason",
+        "telegram/transport_dispatch.py",
+        "The bounded failure reason a permanent AcpError surfaces in the chat "
+        "reply instead of the generic retry text. The message is backend error "
+        "text rather than stream output, so it bypasses the shared TurnDriver "
+        "redaction and is scanned (credentials, exfiltration URLs, local "
+        "paths) at this egress before the renderer posts it.",
+    ),
+    (
         "Discord session-resume replay",
         "discord/session_resume.py",
         "Session titles in the `!sessions` picker and the transcript replayed when a "

--- a/src/kiro_crew/telegram/renderer.py
+++ b/src/kiro_crew/telegram/renderer.py
@@ -59,6 +59,13 @@ _EDIT_THROTTLE_S = 1.0
 # Interactive approval wait; deny-by-default when it elapses with no press.
 _APPROVAL_TIMEOUT_S = 300.0
 
+# Fallback placeholder for a turn that failed without a user-safe reason. The
+# retry wording is only correct for transient failures; a permanent failure
+# (e.g. the account lacks the selected model) passes its own bounded reason via
+# ``close(failure_reason=...)`` so the user is never told to retry an error
+# that says retrying will not help.
+_GENERIC_ERROR_TEXT = "⚠️ Error — please try again"
+
 # Trailing "[OPTIONS: a | b | c]" -- extracted for inline-keyboard rendering.
 # Matched only at the very END of the message, so use the DOTALL/trailer
 # canonical parser. Defined once in constants.py (shared with the Slack/
@@ -424,6 +431,13 @@ class TelegramRenderer(Renderer):
         self._tool = ""
         self._finalized = False
         self._closed = False
+        # Pre-sanitized, user-safe reason for a failed turn, set by
+        # ``close(failure_reason=...)``. When present it replaces the generic
+        # error placeholder at finalization so a permanent failure (wrong
+        # model entitlement, misconfiguration) surfaces its actionable message
+        # instead of misleading retry advice. The caller owns sanitization
+        # (bounded, single-line, redacted); this field is display-only.
+        self._failure_reason: str | None = None
         self._typing_task: "asyncio.Task[None] | None" = None
         # Live edit-streaming (send one real message, edit it in place as text
         # arrives — no draft, which fails for bots / ghosts). On a steer boundary
@@ -764,7 +778,7 @@ class TelegramRenderer(Renderer):
             # the user — attach it to the placeholder instead of dropping it.
             if self._seal_count > 0 and keyboard is None:
                 return
-            placeholder = "…" if ok else "⚠️ Error — please try again"
+            placeholder = "…" if ok else (self._failure_reason or _GENERIC_ERROR_TEXT)
             if self._stream_mid is not None:
                 await self._client.edit_message(
                     self._chat_id,
@@ -811,11 +825,19 @@ class TelegramRenderer(Renderer):
             return f"> {t}" if t else None
         return None
 
-    async def close(self) -> None:
+    async def close(self, failure_reason: str | None = None) -> None:
         """Idempotent teardown: stop the typing indicator and finalize the turn
-        if it never reached on_done."""
+        if it never reached on_done.
+
+        ``failure_reason`` is an optional, already-sanitized user-safe message
+        (see ``transport_dispatch._user_safe_failure_reason``) shown instead of
+        the generic error placeholder. It is display-only and ignored once the
+        turn is finalized, so every existing no-argument caller is unaffected.
+        """
         self._stop_typing()
         if not self._finalized:
+            if failure_reason:
+                self._failure_reason = failure_reason
             await self.on_done(stop_reason="error")
 
     # -- helpers ------------------------------------------------------------

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -29,6 +29,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from kiro_crew.acp.client import AcpError
 from kiro_crew.executors import run_in_embed_pool
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.messaging.attachments import IngestLimits, append_attachment_context
@@ -45,6 +46,7 @@ from kiro_crew.messaging.link import (
     seed_generation,
 )
 from kiro_crew.messaging.transport import InboundMessage
+from kiro_crew.security import redact, redact_local_paths
 from kiro_crew.sel import sel
 from kiro_crew.telegram.attachments import process_telegram_attachments
 from kiro_crew.telegram.commands import (
@@ -108,6 +110,43 @@ def _short(text: str, limit: int = 40) -> str:
     """Collapse whitespace and truncate for compact receipt display."""
     collapsed = " ".join(text.split())
     return collapsed if len(collapsed) <= limit else collapsed[: limit - 1] + "…"
+
+
+# Hard cap for a user-visible failure reason: one short chat message, never a
+# traceback. Generous enough for the ACP entitlement message (which lists the
+# models the account does include) while still bounding hostile input.
+_FAILURE_REASON_MAX_CHARS = 500
+
+
+def _user_safe_failure_reason(exc: BaseException) -> str | None:
+    """A bounded, user-safe reason for a failed turn, or None for the generic text.
+
+    Only a *permanent* :class:`AcpError` (``transient is False``) yields a
+    reason: its message is already user-facing and actionable (e.g. names the
+    models the account does include), and the generic "please try again"
+    placeholder would be actively wrong for it. Transient and unclassified
+    failures keep the retry wording, and any other exception type returns
+    None — arbitrary internal errors must never leak into chat (CWE-209).
+
+    The text is untrusted output: credentials/exfil URLs and local filesystem
+    paths are redacted, newlines are collapsed, and the length is hard-capped.
+    """
+    if not isinstance(exc, AcpError) or exc.transient is not False:
+        return None
+    try:
+        text = redact_local_paths(redact(str(exc)))[0]
+        text = " ".join(text.split())
+    except Exception:
+        # Fail closed to the generic placeholder: this helper runs inside the
+        # turn's except block, so it must never raise (that would skip
+        # record_failure and propagate out of the handler).
+        logger.debug("Telegram: failure-reason sanitization failed", exc_info=True)
+        return None
+    if not text:
+        return None
+    if len(text) > _FAILURE_REASON_MAX_CHARS:
+        text = text[: _FAILURE_REASON_MAX_CHARS - 1].rstrip() + "…"
+    return f"⚠️ {text}"
 
 
 _RECEIPT_MAX_ITEMS = 5  # verbatim items shown in a receipt before "…and N more"
@@ -323,6 +362,7 @@ class TelegramDispatcher:
         # on _acquired so we never release a semaphore we didn't hold. Mirrors
         # slack/transport_dispatch.py.
         _acquired = False
+        failure_reason: str | None = None
         attachment_temp_paths: list[str] = []
         try:
             # Ack placeholder first (before the potentially slow cold-start);
@@ -433,15 +473,19 @@ class TelegramDispatcher:
                 )
             except Exception:
                 logger.debug("Telegram: success audit failed", exc_info=True)
-        except Exception:
+        except Exception as exc:
             logger.exception("Telegram transport_dispatch: error handling message")
+            # Permanent, user-actionable failures (e.g. model entitlement)
+            # surface their own bounded reason instead of the misleading
+            # generic retry text; everything else stays generic (None).
+            failure_reason = _user_safe_failure_reason(exc)
             if _acquired:
                 await self.sessions.record_failure(session_key)
         finally:
             # Always finalize the placeholder (no perma-"🤔 …"), even if
             # get_or_create raised before the semaphore was held. Only release
             # the semaphore if we actually acquired it.
-            await renderer.close()
+            await renderer.close(failure_reason=failure_reason)
             self._active_renderers.pop(session_key, None)
             if _acquired:
                 self.sessions.release(session_key)

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
+from kiro_crew.acp.client import AcpError
 from kiro_crew.acp.types import EVENT_COMPACTION_STATUS, EVENT_COMPLETE, EVENT_TEXT_CHUNK
 from kiro_crew.messaging.link import ChannelLink, legacy_dashboard_mirror_key
 from kiro_crew.messaging.renderer import (
@@ -57,7 +58,11 @@ from kiro_crew.telegram.transport import (
     TelegramTransport,
     forum_gate_outcome,
 )
-from kiro_crew.telegram.transport_dispatch import _STEER_ACK_EMOJI, TelegramDispatcher
+from kiro_crew.telegram.transport_dispatch import (
+    _STEER_ACK_EMOJI,
+    TelegramDispatcher,
+    _user_safe_failure_reason,
+)
 
 # ── Fakes ──────────────────────────────────────────────────────────────────
 
@@ -1411,6 +1416,48 @@ class TestRenderer:
 
         assert asyncio.run(_go()) == 0
 
+    def test_close_with_failure_reason_replaces_generic_placeholder(self) -> None:
+        # A permanent failure's sanitized reason must reach the user instead of
+        # the misleading "please try again" text (issue #1831).
+        cli = FakeClient()
+        r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES)  # type: ignore[arg-type]
+        reason = "⚠️ Your account does not have access to model 'x'. Pick one in the picker."
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.close(failure_reason=reason)
+
+        asyncio.run(_go())
+        assert cli.sent[-1][0] == reason
+        assert "please try again" not in cli.sent[-1][0]
+
+    def test_close_without_reason_keeps_generic_error_text(self) -> None:
+        cli = FakeClient()
+        r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES)  # type: ignore[arg-type]
+
+        async def _go() -> None:
+            await r.on_turn_start()
+            await r.close()
+
+        asyncio.run(_go())
+        assert "please try again" in cli.sent[-1][0]
+
+    def test_close_reason_ignored_after_normal_done(self) -> None:
+        # A reason arriving after on_done already finalized must not post
+        # anything: close() stays a strict no-op post-finalization.
+        cli = FakeClient()
+        r = TelegramRenderer(cli, 55, TELEGRAM_CAPABILITIES)  # type: ignore[arg-type]
+
+        async def _go() -> int:
+            await r.on_turn_start()
+            await r.dispatch(OutputEvent(kind=TEXT_CHUNK, text="hi"))
+            await r.dispatch(OutputEvent(kind=DONE, stop_reason=""))
+            n = len(cli.sent)
+            await r.close(failure_reason="⚠️ too late")
+            return len(cli.sent) - n
+
+        assert asyncio.run(_go()) == 0
+
 
 # ── renderer.py: interactive approval decider ───────────────────────────────
 
@@ -1590,6 +1637,80 @@ class TestDispatcher:
         assert cli.sent and "Error" in cli.sent[-1][0]  # finalized by close()
         assert sess.released == []  # never acquired -> never released
         assert sess.failures == []  # not acquired -> not recorded as a failed turn
+
+    def test_permanent_acp_error_reason_reaches_user(self) -> None:
+        # Issue #1831: a permanent AcpError (model entitlement) must surface
+        # its actionable message, not the generic retry advice.
+        msg = "Your account does not have access to model 'x'. Available: a, b."
+
+        class _FailingProvider(FakeProvider):
+            async def stream(self, message: str) -> Any:
+                raise AcpError(msg, transient=False)
+                yield  # pragma: no cover — makes this an async generator
+
+        class _Sessions(FakeSessions):
+            async def get_or_create(self, key: str, **kw: Any) -> Any:
+                return _FailingProvider(), True, False
+
+        d, cli, sess = _dispatcher({7})
+        d.sessions = _Sessions()  # type: ignore[assignment]
+
+        async def _go() -> None:
+            await d.handle_message(
+                InboundMessage(channel_type="telegram", user_id="7", conversation_id="7", text="hi")
+            )
+
+        asyncio.run(_go())
+        final = cli.sent[-1][0]
+        assert msg in final
+        assert "please try again" not in final
+        assert "\n" not in final  # single-line, bounded output
+
+    def test_transient_acp_error_keeps_retry_text(self) -> None:
+        class _FailingProvider(FakeProvider):
+            async def stream(self, message: str) -> Any:
+                raise AcpError("backend hit a transient error (HTTP 5xx)", transient=True)
+                yield  # pragma: no cover
+
+        class _Sessions(FakeSessions):
+            async def get_or_create(self, key: str, **kw: Any) -> Any:
+                return _FailingProvider(), True, False
+
+        d, cli, sess = _dispatcher({7})
+        d.sessions = _Sessions()  # type: ignore[assignment]
+
+        async def _go() -> None:
+            await d.handle_message(
+                InboundMessage(channel_type="telegram", user_id="7", conversation_id="7", text="hi")
+            )
+
+        asyncio.run(_go())
+        assert "please try again" in cli.sent[-1][0]
+        assert "5xx" not in cli.sent[-1][0]
+
+    def test_non_acp_error_stays_generic_and_leaks_nothing(self) -> None:
+        class _FailingProvider(FakeProvider):
+            async def stream(self, message: str) -> Any:
+                raise ValueError("secret internal detail /home/alice/.kiro/x")
+                yield  # pragma: no cover
+
+        class _Sessions(FakeSessions):
+            async def get_or_create(self, key: str, **kw: Any) -> Any:
+                return _FailingProvider(), True, False
+
+        d, cli, sess = _dispatcher({7})
+        d.sessions = _Sessions()  # type: ignore[assignment]
+
+        async def _go() -> None:
+            await d.handle_message(
+                InboundMessage(channel_type="telegram", user_id="7", conversation_id="7", text="hi")
+            )
+
+        asyncio.run(_go())
+        final = cli.sent[-1][0]
+        assert "please try again" in final
+        assert "secret internal detail" not in final
+        assert "/home/alice" not in final
 
     def test_new_command_bumps_gen_and_replies(self) -> None:
         d, cli, sess = _dispatcher({7})
@@ -3093,3 +3214,37 @@ class TestTelegramSessionPidPublish:
                 pub.assert_awaited_once_with(sess, "telegram:kirocrew:direct:7")
 
         asyncio.run(_go())
+
+
+# ── transport_dispatch.py: _user_safe_failure_reason sanitizer ──────────────
+
+
+class TestUserSafeFailureReason:
+    def test_permanent_acp_error_yields_bounded_single_line(self) -> None:
+        exc = AcpError("line one\nline two\ttail", transient=False)
+        assert _user_safe_failure_reason(exc) == "⚠️ line one line two tail"
+
+    def test_local_paths_are_redacted(self) -> None:
+        exc = AcpError("failed reading /home/alice/.kiro/crew/creds", transient=False)
+        out = _user_safe_failure_reason(exc)
+        assert out is not None
+        assert "/home/alice" not in out
+
+    def test_length_hard_cap(self) -> None:
+        out = _user_safe_failure_reason(AcpError("x" * 5000, transient=False))
+        assert out is not None
+        # "⚠️ " prefix + capped body (ellipsis included in the cap).
+        assert len(out) <= 500 + len("⚠️ ")
+        assert out.endswith("…")
+
+    def test_transient_returns_none(self) -> None:
+        assert _user_safe_failure_reason(AcpError("5xx", transient=True)) is None
+
+    def test_unclassified_returns_none(self) -> None:
+        assert _user_safe_failure_reason(AcpError("unknown", transient=None)) is None
+
+    def test_non_acp_returns_none(self) -> None:
+        assert _user_safe_failure_reason(ValueError("boom")) is None
+
+    def test_empty_message_returns_none(self) -> None:
+        assert _user_safe_failure_reason(AcpError("   \n ", transient=False)) is None


### PR DESCRIPTION
## Summary

Fixes the Telegram surface replying `⚠️ Error — please try again` to every failed turn, even when the failure is **permanent** and the underlying `AcpError` already carries a complete, actionable remedy (e.g. *"Your account does not have access to model X — available: …, pick one in the model picker or set agent.model to auto. Retrying will not help."*). The reporter's own unblock is switching the session's agent off the unavailable model — this change makes that discoverable from the chat itself, without reading gateway logs.

## What changed

- `telegram/transport_dispatch.py`: the `handle_message` exception handler derives a bounded, user-safe failure reason via a new `_user_safe_failure_reason()` and hands it to the renderer's finalization. **Only a permanent `AcpError` (`transient is False`) qualifies** — transient and unclassified failures keep the retry wording, and non-Acp exceptions never leak internals (CWE-209). The reason is treated as untrusted output: `security.redact()` (credentials + exfil URLs), `redact_local_paths()`, newline collapse, 500-char hard cap. The sanitizer is fail-closed: any internal error falls back to the generic text. Existing `logger.exception` + `record_failure` behavior is unchanged.
- `telegram/renderer.py`: `close()` accepts an optional pre-sanitized `failure_reason` used as the finalization placeholder instead of the generic string. The generic text is preserved as the default, so every other caller is unaffected; the reason is ignored once the turn is finalized. The placeholder path sends plain text (`parse_mode=None`), so the reason cannot inject Telegram HTML.

## Scope

Deliberately Telegram-only (the reported surface). **Discord has the identical pattern** at `src/kiro_crew/discord/renderer.py:541` — noted as a follow-up candidate rather than widening this change to every transport.

## Testing

- 13 new tests in `test/test_telegram.py`, verified to fail before the fix:
  - end-to-end through `handle_message`: permanent `AcpError` message reaches the finalized placeholder (single-line, no retry text); transient error keeps the retry text; non-Acp exception stays generic and leaks nothing (asserts the message and a `/home/...` path do not appear)
  - renderer: reason replaces the placeholder; no-reason keeps generic; reason ignored after normal `on_done`
  - sanitizer unit tests: newline collapse, local-path redaction, 500-char hard cap, transient/unclassified/non-Acp/empty → `None`
- Full local gates green: `isort`, `flake8`, `mypy` (865 files), `python -m pytest` (40366 passed; 75 failures verified pre-existing parallel-run environment flakes in unrelated app tests — the failing files pass standalone), `test_telegram.py` 190/190.

Backend-only: no dashboard surface, no screenshots required.

Closes #1831
