### PR TITLE
fix(session-storage): stop a retired pod home blocking reclaim forever

### DIFF
--- a/docs/system-specs/modules/session-storage.md
+++ b/docs/system-specs/modules/session-storage.md
@@ -99,7 +99,7 @@ the legacy stem fails instead of agreeing with itself.
 
 The exclusion set comes from **this** instance's session map, but the kiro-cli
 replay store can be shared. When `KIROCREW_HOME` is overridden while `KIRO_HOME` is
-not — a dev gateway or a pod — this instance has its own map and the machine-wide
+not — a dev gateway — this instance has its own map and the machine-wide
 store, so every session belonging to the default instance is missing from the map it
 consults: a resumable conversation reads as retired and could be staged and then
 emptied out from under a gateway this process cannot see.
@@ -120,18 +120,39 @@ outright. Two things about how it decides:
   install that has not yet migrated legitimately resolves to `~/.kirocrew`, and
   treating that as an isolated instance refused every such install.
 - The refusal is **symmetric**. A default instance is also blocked when a
-  discoverable co-tenant shares its store: a pod isolates `KIROCREW_HOME` but
-  deliberately not `KIRO_HOME`, so each pod home under the pod root reads the
-  machine-wide replay store while keeping its own session map — and from the default
-  side, the pod's sessions read as retired. `_replay_store_cotenants()` enumerates
-  the pod root (host-side state at a known location) and the message names the
-  eviction command, because a refusal a user cannot act on is not better than the
-  hazard. A dev gateway pointed at some other `KIROCREW_HOME` is **not**
-  discoverable and remains a Known Limitation.
+  discoverable co-tenant shares its store. `_replay_store_cotenants()` enumerates the
+  pod root (host-side state at a known location) and names a pod only when it meets
+  **both** conditions: it has a **live** unit, **and** it does not own its own store.
+  The liveness test is what stops a home left behind by a pod that no longer exists
+  from blocking reclaim forever — the eviction the message recommends cannot clear a
+  directory whose pod is already gone. It comes from `pod.runtime.live_names()`
+  rather than `active_names()`, because the listing shape reports an empty set both
+  when nothing is running and when the query failed.
+- **Owning a store is RECORDED by the pod's own boot and BOUND to it, never inferred
+  by the reader.** `boot()` writes the `KIRO_HOME` it hands the pod into the per-pod
+  env file (`record_replay_store`, taken from `build_pod_env`'s own output at the
+  moment of `exec`) **stamped with that boot's pid** — which is the pod's main
+  process for its whole life, because `boot` execs in place. `bound_replay_store()`
+  returns the store only while that pid is still the unit's live main process
+  (`live_main_pid`, which raises rather than reporting absence when the service
+  manager cannot answer). Three inferences are rejected on purpose: a reader
+  re-deriving the path answers for a pod booted by *today's* code; a directory
+  existing under the pod home survives a version rollback that reuses the pod's
+  name; and an unstamped record survives a downgrade of the pod control binary plus
+  a service-manager restart, which is a pod sharing the store while carrying a record
+  that says it does not. **Anything unprovable therefore counts as sharing**, so a
+  pod is protected unless its own live boot says otherwise. `pod down` deletes the
+  env file, so a record never outlives its pod.
+- **Every uncertainty resolves toward refusing.** Exactly one thing short-circuits to
+  "no co-tenants": a platform that cannot run pods at all (`IS_LINUX or IS_MACOS`) — a
+  static property, not a probe. A *failed* service-manager probe on a platform that
+  can run pods leaves liveness unknown, so every pod counts. An empty pod root also
+  answers with no service-manager call. A dev gateway pointed at some other
+  `KIROCREW_HOME` is **not** discoverable and remains a Known Limitation.
 
-Because that check reads real host state, tests must isolate `KIROCREW_POD_ROOT`
-alongside the homes, or their result depends on whether the machine happens to have
-pods.
+Because that check reads real host state, tests must isolate `KIROCREW_POD_ROOT` and
+`KIROCREW_POD_ENV_DIR` (which holds the recorded store) alongside the homes, or their
+result depends on whether the machine happens to have pods.
 
 The freshness floor narrows the window but does not close it, since a session idle
 for a day is still resumable. Isolating both homes, or neither, is safe. The reason

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -1917,14 +1917,12 @@ def _decline_shared_agent_home(*, audit: bool = True) -> Path | None:
     test's ``tmp_path``), or it is EXACTLY ``isolated_agents_dir(own data home)``
     — the dedicated ``<data home>/kiro/agents`` this instance's teardown owns.
 
-    That second case is the *mechanism* by which a genuinely isolated instance will
-    own its specs; it is NOT advice to set ``KIRO_HOME`` today. Nothing in this
-    repo sets it (``build_pod_env`` deliberately does not) because it also
-    relocates kiro-cli's session storage while KiroCrew still reads the host path
-    — see ``kiro_home()``'s scope caveat. The exemption is matched exactly rather
-    than by ancestry: "beneath the data home" reads the machine-wide
-    ``~/.kiro/agents`` as private the moment the data home is an ancestor of it
-    (``KIROCREW_HOME=$HOME`` is enough).
+    That second case is also how a pod owns its specs: ``build_pod_env`` gives every
+    pod its own ``KIRO_HOME`` under the pod home, which resolves to exactly
+    ``isolated_agents_dir(<pod data home>)`` and takes this exemption. The exemption
+    is matched exactly rather than by ancestry: "beneath the data home" reads the
+    machine-wide ``~/.kiro/agents`` as private the moment the data home is an
+    ancestor of it (``KIROCREW_HOME=$HOME`` is enough).
     """
     target = kiro_agents_dir_path().resolve()
     if target != kiro_agents_dir().resolve():

--- a/src/kiro_crew/config/paths.py
+++ b/src/kiro_crew/config/paths.py
@@ -669,16 +669,14 @@ def kiro_home() -> Path:
     rewriting costs: managed MCP servers that read one credential while calling a
     gateway that expects another, and 403 on every call).
 
-    SCOPE CAVEAT — read before setting this. ``KIRO_HOME`` redirects kiro-cli's
-    WHOLE user directory (agents, prompts, skills, steering, settings, sessions),
-    but KiroCrew currently resolves the host ``~/.kiro`` for most of those readers
-    (session transcripts in ``session_map.py`` / ``acp/*`` / ``providers/acp.py``
-    / ``dashboard/handlers/usage.py``, and the ``settings/mcp.json`` registry).
-    Setting ``KIRO_HOME`` therefore moves where kiro-cli WRITES sessions without
-    moving where KiroCrew READS them, which breaks session resume. Only the agents
-    directory follows it today, so this is not yet a supported way to isolate an
-    instance — ``build_pod_env()`` deliberately does not set it. Bringing the
-    remaining readers through this resolver is the prerequisite.
+    SCOPE — ``KIRO_HOME`` redirects kiro-cli's WHOLE user directory (agents,
+    prompts, skills, steering, settings, sessions), so an instance that sets it must
+    have Kiro Crew resolve the same directory for the transcripts it reads back:
+    setting it while Kiro Crew read the host ``~/.kiro`` would move where kiro-cli
+    WRITES sessions without moving where Kiro Crew READS them, breaking session
+    resume and pruning mappings whose transcripts could no longer be seen. Every
+    transcript reader resolves through :func:`kiro_sessions_dir`, which is what
+    makes ``build_pod_env()``'s isolated ``KIRO_HOME`` safe.
 
     Rejects the same unsafe targets as :func:`_valid_override_home` (a
     filesystem/drive root, or a known POSIX system directory) so a malformed

--- a/src/kiro_crew/pod/config.py
+++ b/src/kiro_crew/pod/config.py
@@ -154,3 +154,18 @@ class PodConfig:
     def env_file(self, name: str) -> Path:
         """Per-pod env file holding pinned ``CHECKOUT=`` / ``PORT=`` / ``SEED=``."""
         return self.pods_dir / f"{name}.env"
+
+
+def pod_kiro_home(home_dir: Path) -> Path:
+    """The ``KIRO_HOME`` a pod runs with: kiro-cli's user dir inside the pod HOME.
+
+    One definition, because two callers must agree on it: ``build_pod_env`` EXPORTS
+    it, and :func:`kiro_crew.session_storage._replay_store_cotenants` decides
+    whether a pod shares the default instance's replay store by RESOLVING it. When
+    those two drift, the reclaim guard answers from a premise the runtime no longer
+    holds — a refusal no operator can clear, or a store shared without one.
+
+    Inside the pod HOME so the zero-residue teardown reclaims it with everything
+    else the pod wrote.
+    """
+    return home_dir / "kiro"

--- a/src/kiro_crew/pod/launchd.py
+++ b/src/kiro_crew/pod/launchd.py
@@ -387,6 +387,27 @@ def is_active(cfg: PodConfig, name: str) -> bool:
     return _PID_RE.search(cp.stdout or "") is not None
 
 
+def main_pid(cfg: PodConfig, name: str) -> int | None:
+    """PID of the pod's live process, or ``None`` when it is not running.
+
+    Same evidence :func:`is_active` reads, returning the pid itself so a caller can
+    bind per-boot state to the process that is actually running. An OPERATIONAL
+    failure raises for the same reason it does there: reporting "not running" would
+    fail open.
+    """
+    cp = _print(cfg, name)
+    if cp.returncode != 0:
+        if _service_absent(cp):
+            return None
+        raise LaunchdError(
+            f"launchctl print failed (rc={cp.returncode}) for "
+            f"{pod_label(cfg, name)}; cannot tell whether the pod is running, "
+            f"refusing to report it absent: {(cp.stderr or cp.stdout or '').strip()}"
+        )
+    found = _PID_RE.search(cp.stdout or "")
+    return int(found.group(1)) if found else None
+
+
 def unit_state(cfg: PodConfig, name: str) -> tuple[str, int]:
     """``(state, restarts)`` shaped like the systemd backend's return.
 
@@ -433,6 +454,32 @@ def active_names(cfg: PodConfig) -> set[str]:
         if candidate and is_active(cfg, candidate):
             names.add(candidate)
     return names
+
+
+def loaded_names(cfg: PodConfig) -> set[str]:
+    """Names of pods launchd has LOADED, whether or not one has a pid right now.
+
+    Wider than :func:`active_names` on purpose. A ``KeepAlive`` label whose process
+    has exited is still registered and will be restarted, so it is a pod that can
+    come back and resume its sessions — while `active_names` filters it out,
+    correctly, for callers asking "is something running this instant".
+
+    A caller deciding whether it may DESTROY a pod's data needs this wider set:
+    treating a restart-pending pod as gone is the fail-open that lets its
+    resumable sessions be reclaimed in the window before launchd brings it back.
+    """
+    cp = launchctl("print", domain())
+    if cp.returncode != 0:
+        raise LaunchdError(
+            f"launchctl print {domain()} failed (rc={cp.returncode}); cannot "
+            f"enumerate pods: {(cp.stderr or cp.stdout or '').strip()}"
+        )
+    prefix = pod_label(cfg, "")
+    return {
+        tok[len(prefix):]
+        for tok in re.findall(rf"{re.escape(prefix)}[A-Za-z0-9._-]+", cp.stdout or "")
+        if tok[len(prefix):]
+    }
 
 
 def recent_journal(cfg: PodConfig, name: str, lines: int = 50) -> str:

--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -21,14 +21,16 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Iterator
 from pathlib import Path
 
+from kiro_crew import platform_compat
 from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.platform_compat import IS_LINUX, IS_MACOS
 from kiro_crew.pod import launchd
 from kiro_crew.pod import provision as prov
 from kiro_crew.pod import unit as unit_mod
-from kiro_crew.pod.config import PodConfig
+from kiro_crew.pod.config import PodConfig, pod_kiro_home
 
 # Pod names become systemd instance names and path segments; keep them strict.
 _NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,60}$")
@@ -64,6 +66,12 @@ APPROVAL_MODES: tuple[str, ...] = ("reads", "yolo", "interactive")
 # is the pre-existing ``--no-crons`` behavior and the safer of the two.
 CRONS_TRUE: frozenset[str] = frozenset({"1", "true", "yes", "on"})
 
+# Env-file keys recording what a boot handed the pod, and which boot did it. A
+# RECORD of what was exported, not a pinned input like ``CHECKOUT=`` — see
+# record_replay_store.
+RESOLVED_KIRO_HOME = "RESOLVED_KIRO_HOME"
+BOOT_PID = "BOOT_PID"
+
 
 def read_env_file(cfg: PodConfig, name: str) -> dict[str, str]:
     out: dict[str, str] = {}
@@ -87,6 +95,31 @@ def read_env_file(cfg: PodConfig, name: str) -> dict[str, str]:
     return out
 
 
+@contextlib.contextmanager
+def _env_file_lock(cfg: PodConfig, name: str) -> Iterator[None]:
+    """Serialize read-modify-write on one pod's env file.
+
+    :func:`write_env_file` merges into the existing file, so two writers racing it
+    lose one side's keys: a boot recording its store can restore the ``CHECKOUT``
+    or ``APPROVAL`` an in-flight ``pod up`` just wrote, leaving the pod configured
+    from a stale read. The boot path makes that concurrency structural — ``pod up``
+    starts the unit, which writes while ``pod up`` is still finishing — so the lock
+    lives here, at the one function every writer goes through, rather than at any
+    single call site.
+
+    A dedicated lock file, because :func:`platform_compat.file_lock` needs a
+    seekable fd it owns, and the env file itself is rewritten under the lock.
+    """
+    cfg.pods_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = cfg.pods_dir / f".{name}.envlock"
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        with platform_compat.file_lock(fd, exclusive=True, required=True):
+            yield
+    finally:
+        os.close(fd)
+
+
 def write_env_file(cfg: PodConfig, name: str, updates: dict[str, str]) -> None:
     """Merge *updates* into the pod's env file, preserving existing keys.
 
@@ -94,15 +127,92 @@ def write_env_file(cfg: PodConfig, name: str, updates: dict[str, str]) -> None:
     newlines, so a multi-line value would not round-trip. ``--seed`` is
     user-supplied, so reject a newline-bearing value loudly (fail-closed) rather
     than silently writing an un-parseable file.
+
+    The merge is serialized per pod name (:func:`_env_file_lock`) so concurrent
+    writers cannot drop each other's keys.
     """
-    data = read_env_file(cfg, name)
-    data.update(updates)
-    for key, val in data.items():
+    for key, val in updates.items():
         if "\n" in val or "\r" in val:
             raise PodError(f"pod env value for {key!r} must be single-line")
-    cfg.pods_dir.mkdir(parents=True, exist_ok=True)
-    body = "".join(f"{k}='{v}'\n" for k, v in data.items())
-    cfg.env_file(name).write_text(body)
+    with _env_file_lock(cfg, name):
+        data = read_env_file(cfg, name)
+        data.update(updates)
+        for key, val in data.items():
+            if "\n" in val or "\r" in val:
+                raise PodError(f"pod env value for {key!r} must be single-line")
+        body = "".join(f"{k}='{v}'\n" for k, v in data.items())
+        cfg.env_file(name).write_text(body)
+
+
+def record_replay_store(cfg: PodConfig, name: str, kiro_home: str) -> None:
+    """Record the ``KIRO_HOME`` this boot is handing the pod, and which boot did it.
+
+    Written from :func:`build_pod_env`'s own output at the moment of ``exec``, so it
+    is what the pod IS running with rather than a value a reader re-derived. That
+    distinction is the point: a reader deriving the store answers for a pod booted
+    by TODAY's code, while a pod already running may have been launched by an older
+    one.
+
+    The record is stamped with this process's pid, which is the pod's main process
+    for its whole life because :func:`boot` ``exec``s in place. That stamp is what
+    BINDS the record to a boot: a record alone would survive a downgrade of the pod
+    control binary plus a service-manager restart, leaving a pod that shares the
+    default store while carrying a record saying it does not. A reader must
+    therefore accept the store only through :func:`bound_replay_store`.
+
+    Lives in the per-pod env file because that is already the host-side registry at
+    a known location, readable by a process with no view into the pod. ``pod down``
+    deletes that file, so a record never outlives the pod that wrote it.
+    """
+    write_env_file(cfg, name, {RESOLVED_KIRO_HOME: kiro_home, BOOT_PID: str(os.getpid())})
+
+
+def live_main_pid(cfg: PodConfig, name: str) -> int | None:
+    """PID of pod *name*'s running main process, or ``None`` when nothing runs.
+
+    Raises :class:`PodError` when the service manager cannot answer, so a caller
+    can tell "nothing is running" from "could not ask" — the same reason
+    :func:`live_names` exists next to :func:`active_names`.
+    """
+    if IS_MACOS:
+        try:
+            return launchd.main_pid(cfg, name)
+        except launchd.LaunchdError as exc:
+            raise PodError(str(exc)) from exc
+    cp = systemctl("show", pod_unit(cfg, name), "-p", "MainPID")
+    if cp.returncode != 0:
+        raise PodError(
+            f"could not read the main pid of pod {name!r} (systemctl exit "
+            f"{cp.returncode}): {cp.stderr.strip() or 'no error output'}"
+        )
+    for line in cp.stdout.splitlines():
+        if line.startswith("MainPID="):
+            raw = line.split("=", 1)[1].strip()
+            # systemd reports 0 for a unit with no running main process.
+            return int(raw) if raw.isdigit() and raw != "0" else None
+    return None
+
+
+def bound_replay_store(cfg: PodConfig, name: str) -> Path | None:
+    """The store pod *name*'s CURRENT boot recorded, or ``None`` when unprovable.
+
+    ``None`` covers every way the answer can fail to be established — nothing
+    recorded, a record from an earlier boot, no running main process, or a service
+    manager that could not be asked. The caller must read it as "cannot be
+    established" and fail closed; see :func:`record_replay_store`.
+    """
+    data = read_env_file(cfg, name)
+    store = data.get(RESOLVED_KIRO_HOME, "").strip()
+    stamped = data.get(BOOT_PID, "").strip()
+    if not store or not stamped.isdigit():
+        return None
+    try:
+        running = live_main_pid(cfg, name)
+    except (PodError, OSError, subprocess.SubprocessError):
+        return None
+    if running is None or running != int(stamped):
+        return None
+    return Path(store).expanduser()
 
 
 def pin_checkout(cfg: PodConfig, name: str, checkout: Path) -> None:
@@ -406,17 +516,61 @@ def recent_journal(cfg: PodConfig, name: str, lines: int = 30) -> str:
 
 
 def active_names(cfg: PodConfig) -> set[str]:
-    """Worktree names with an active pod unit (one cheap call)."""
+    """Worktree names with an active pod unit (one cheap call).
+
+    A listing: an empty set means "none active" AND "the query failed", which is
+    what a display surface wants. A caller that must not ACT while a pod is live
+    needs those told apart — see :func:`live_names`.
+    """
     if IS_MACOS:
         try:
             return launchd.active_names(cfg)
         except launchd.LaunchdError as exc:
             raise PodError(str(exc)) from exc
+    return _parse_active_units(cfg, _list_active_units(cfg).stdout)
+
+
+def live_names(cfg: PodConfig) -> set[str]:
+    """Pod names that could still be RUNNING OR COME BACK, raising when unknown.
+
+    The fail-closed twin of :func:`active_names`, for a caller whose decision is
+    unsafe under a wrong "nothing is running" — reclaiming session storage while a
+    co-tenant pod can still resume a session destroys that conversation.
+
+    Two ways the listing shape is too narrow for that decision, and both are widened
+    here rather than at :func:`active_names`, whose "is it running this instant"
+    contract is right for ``pod ls`` and Dev Fleet:
+
+    * A transient ``systemctl`` failure returns nonzero with empty stdout,
+      indistinguishable from an idle host. Raise instead.
+    * A launchd ``KeepAlive`` label whose process has exited is loaded without a
+      pid, so `active_names` excludes it — but launchd will restart it, and its
+      sessions are still resumable. Enumerate LOADED labels instead
+      (:func:`~kiro_crew.pod.launchd.loaded_names`).
+    """
+    if IS_MACOS:
+        try:
+            return launchd.loaded_names(cfg)
+        except launchd.LaunchdError as exc:
+            raise PodError(str(exc)) from exc
+    cp = _list_active_units(cfg)
+    if cp.returncode != 0:
+        raise PodError(
+            f"could not list active pod units (systemctl exit {cp.returncode}): "
+            f"{cp.stderr.strip() or 'no error output'}"
+        )
+    return _parse_active_units(cfg, cp.stdout)
+
+
+def _list_active_units(cfg: PodConfig) -> subprocess.CompletedProcess:
     pat = f"{cfg.unit_prefix}@*.service"
-    cp = systemctl("list-units", pat, "--state=active", "--no-legend", "--plain", "--no-pager")
+    return systemctl("list-units", pat, "--state=active", "--no-legend", "--plain", "--no-pager")
+
+
+def _parse_active_units(cfg: PodConfig, stdout: str) -> set[str]:
     rx = re.compile(rf"{re.escape(cfg.unit_prefix)}@(.+)\.service")
     names: set[str] = set()
-    for ln in cp.stdout.splitlines():
+    for ln in stdout.splitlines():
         parts = ln.split()
         if not parts:
             continue
@@ -697,24 +851,9 @@ def build_pod_env(cfg: PodConfig, home_dir: Path, port: int, checkout: Path) -> 
         # real lessons). Safe only because every KiroCrew reader of the transcripts
         # dir now resolves through ``kiro_sessions_dir()``; without that the pod
         # would write sessions somewhere KiroCrew never looks and lose resume.
-        # Inside the pod HOME so the zero-residue ``ExecStopPost`` teardown
-        # reclaims it.
-        "KIRO_HOME": str(home_dir / "kiro"),
-        # NOTE: deliberately NO ``KIRO_HOME`` here, though it is tempting — it
-        # would give the pod its own agent specs and stop pod boots rewriting the
-        # machine-wide ``~/.kiro/agents``. ``KIRO_HOME`` is a DIRECTORY-WIDE
-        # kiro-cli override (agents, prompts, skills, steering, settings AND
-        # sessions), while KiroCrew still resolves the host paths for roughly two
-        # dozen of those readers — ``session_map.py``, ``subagent_persistence.py``,
-        # ``acp/{client,session_handle,session_provider}.py``,
-        # ``providers/acp.py``, ``dashboard/handlers/usage.py`` and the
-        # ``settings/mcp.json`` sites. Exporting it here would move where kiro-cli
-        # WRITES session transcripts without moving where KiroCrew READS them, so a
-        # pod restart would lose session resume and ``SessionMap`` would prune
-        # mappings whose transcripts it can no longer see: a worse split brain than
-        # the one this change set fixes. The write guard in ``agent.py`` covers the
-        # shared-spec hazard for pods in the meantime. Setting it here is safe only
-        # once those readers resolve through ``kiro_home()`` too.
+        # Derived through ``pod_kiro_home`` so this export and the value ``boot``
+        # records for the session-storage reclaim guard cannot be two spellings.
+        "KIRO_HOME": str(pod_kiro_home(home_dir)),
         # Give the pod its OWN workspace root. Without this, `workspace_root()`
         # finds no `KIROCREW_WORKSPACE` and no `config_dir()/workspace_dir` file in
         # a fresh pod home, so it falls through to the platform default under the
@@ -1055,6 +1194,7 @@ def boot(cfg: PodConfig, name: str) -> int:
     print(f"kirocrew-pod: name={name} port={port} home={home_dir} checkout={checkout}")
 
     pod_env = build_pod_env(cfg, home_dir, port, checkout)
+    record_replay_store(cfg, name, pod_env["KIRO_HOME"])
     argv = ["gateway"]
     if not crons:
         argv.append("--no-crons")

--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -46,6 +46,7 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 import time
 import uuid
 from collections.abc import Callable, Iterator, Mapping
@@ -64,6 +65,9 @@ from kiro_crew.config.paths import (
     legacy_home,
 )
 from kiro_crew.history import ARCHIVE_DIR_NAME, ARCHIVE_SEGMENT_DELIMITER, SESSIONS_DIR_NAME
+from kiro_crew.pod import runtime as pod_runtime
+from kiro_crew.pod.config import PodConfig
+from kiro_crew.pod.runtime import PodError
 
 logger = logging.getLogger(__name__)
 
@@ -551,28 +555,94 @@ def select_reclaimable(
     return [u for u in _scan_units(index) if not u.active and u.age_days(clock) >= cutoff]
 
 
-def _replay_store_cotenants() -> list[str]:
-    """Names of pod instances that read the same kiro-cli replay store.
+def _resolved(path: Path) -> Path:
+    """*path* with links resolved, or itself when the filesystem cannot say.
 
-    A pod isolates ``KIROCREW_HOME`` but deliberately NOT ``KIRO_HOME``, so every
-    pod reads the machine-wide replay store while keeping its own session map. From
-    the default instance's side that is the mirror of the isolated-instance hazard:
-    the pod's sessions are absent from the map THIS process consults, so they read
-    as retired.
+    Every home/store comparison in this module goes through this: a symlinked HOME
+    would otherwise make the default home compare unequal to itself and report
+    every instance as isolated.
+    """
+    try:
+        return path.resolve()
+    except OSError:  # pragma: no cover - defensive
+        return path
+
+
+def _owns_its_replay_store(cfg: PodConfig, name: str, mine: Path) -> bool:
+    """True when pod *name*'s CURRENT boot recorded a store that is not *mine*.
+
+    The store comes from :func:`~kiro_crew.pod.runtime.bound_replay_store`: the value
+    the boot exported, stamped with that boot's pid and accepted only while that pid
+    is still the pod's running main process. Nothing here is inferred, and nothing
+    here trusts a record on its own:
+
+    * A reader re-deriving the path answers for a pod booted by today's code, while
+      a running pod may have been launched by an older one and would then be writing
+      into the shared store.
+    * A directory existing under the pod home is no better — a stale private store
+      survives a version rollback that reuses the pod's name.
+    * An unstamped record survives a downgrade of the pod control binary plus a
+      service-manager restart, which is a pod sharing the store while carrying a
+      record that says it does not.
+
+    Anything unprovable counts as sharing, so a pod is protected unless its own live
+    boot says otherwise.
+    """
+    store = pod_runtime.bound_replay_store(cfg, name)
+    return store is not None and _resolved(store) != mine
+
+
+def _replay_store_cotenants() -> list[str]:
+    """Names of pod instances that read the same kiro-cli replay store as this one.
+
+    A co-tenant is an instance whose resumable sessions live in THIS store while its
+    session map sits somewhere this process cannot read: from here those sessions
+    look retired, so a reclaim could stage and then empty a conversation a gateway
+    this process cannot see is still able to resume.
+
+    Two conditions, and a pod must meet BOTH:
+
+    * **It is live.** A directory under the pod root is not an instance: a stopped
+      pod holds no resumable session and has no process that could resume one, and a
+      home left behind by a pod that no longer exists holds nothing at all — while
+      being unclearable by the eviction the refusal tells the operator to run.
+      Liveness comes from :func:`~kiro_crew.pod.runtime.live_names` rather than
+      ``active_names`` because the listing shape reports an empty set both when
+      nothing runs and when the query failed, and this decision is unsafe under a
+      wrong "nothing is running".
+    * **It does not own its own store** — see :func:`_owns_its_replay_store`.
+
+    Every uncertainty resolves toward refusing. Only one thing short-circuits to
+    "no co-tenants": a host whose platform cannot run pods at all, which is a static
+    property rather than a probe — a FAILED probe on a platform that can run them
+    means liveness is unknown, so every pod counts. An empty pod root also answers
+    with no service-manager call, which is every install that never ran a pod.
 
     The pod root is host-side state at a known location, which makes this the one
     co-tenant that can actually be discovered. A dev gateway pointed at some other
     ``KIROCREW_HOME`` cannot be, and stays a documented limitation.
     """
-    raw = os.environ.get("KIROCREW_POD_ROOT")
-    pod_root = Path(raw).expanduser() if raw else Path.home() / ".kirocrew-pods"
+    cfg = PodConfig.load()
     try:
-        entries = list(pod_root.iterdir())
+        entries = [
+            entry.name
+            for entry in cfg.pod_root.iterdir()
+            if entry.is_dir() and not entry.name.startswith(".")
+        ]
     except OSError:
         return []
-    return sorted(
-        entry.name for entry in entries if entry.is_dir() and not entry.name.startswith(".")
-    )
+    if not entries:
+        return []
+    if not (platform_compat.IS_LINUX or platform_compat.IS_MACOS):
+        # Pods are service-manager units on Linux and macOS only, so no pod can be
+        # running here. A static platform fact, not a probe that could fail.
+        return []
+    try:
+        live = pod_runtime.live_names(cfg)
+    except (PodError, OSError, subprocess.SubprocessError):
+        return sorted(entries)
+    mine = _resolved(kiro_home())
+    return sorted(name for name in live if not _owns_its_replay_store(cfg, name, mine))
 
 
 def reclaim_block_reason() -> str:
@@ -599,43 +669,33 @@ def reclaim_block_reason() -> str:
     for a day is still resumable — so the operation is refused rather than
     attempted. Isolating both homes together, or neither, is safe.
     """
-
-    def _norm(path: Path) -> Path:
-        # A symlinked HOME would otherwise make the default home compare unequal to
-        # itself and report every instance as isolated.
-        try:
-            return path.resolve()
-        except OSError:  # pragma: no cover - defensive
-            return path
-
-    home = _norm(Path.home())
+    home = _resolved(Path.home())
     # BOTH of these are defaults, not isolation: an install that has not yet
     # migrated legitimately reports the legacy home, and treating that as an
     # isolated instance would refuse every pre-migration install.
-    defaults = {home / KIRO_BASE_DIR_NAME / CONFIG_DIR_LEAF, _norm(legacy_home())}
-    data = _norm(data_home())
+    defaults = {home / KIRO_BASE_DIR_NAME / CONFIG_DIR_LEAF, _resolved(legacy_home())}
+    data = _resolved(data_home())
     if data in defaults:
         # The mirror of the isolated-instance case, and just as destructive: a pod
-        # shares this store while keeping its own map, so ITS sessions read as
-        # retired from here. Only checked when the store is the default one, since
-        # that is the only store a pod reads.
-        if _norm(kiro_home()) == home / KIRO_BASE_DIR_NAME:
-            cotenants = _replay_store_cotenants()
-            if cotenants:
-                listed = ", ".join(cotenants[:3])
-                return (
-                    f"{len(cotenants)} other instance(s) share this kiro-cli session "
-                    f"store ({listed}), so their resumable sessions cannot be told "
-                    "apart from retired ones. Evict them with `kirocrew pod down "
-                    "<name>` to reclaim from here."
-                )
+        # that shares this store keeps its own map, so ITS sessions read as retired
+        # from here. Which pods those are is decided by resolving each pod's own
+        # store against this one, not by assuming what pods do.
+        cotenants = _replay_store_cotenants()
+        if cotenants:
+            listed = ", ".join(cotenants[:3])
+            return (
+                f"{len(cotenants)} other instance(s) share this kiro-cli session "
+                f"store ({listed}), so their resumable sessions cannot be told "
+                "apart from retired ones. Evict them with `kirocrew pod down "
+                "<name>` to reclaim from here."
+            )
         return ""
     # An isolated instance may reclaim only when its replay store is provably its
     # own. Testing against the DEFAULT store location would miss the sharing that
     # matters most: two isolated instances pointed at one custom KIRO_HOME see
     # neither the default store nor each other's maps. Requiring the store to live
     # inside this instance's data home fails closed on every such arrangement.
-    store = _norm(kiro_home())
+    store = _resolved(kiro_home())
     if store == data or data in store.parents:
         return ""
     return (

--- a/test/test_pod.py
+++ b/test/test_pod.py
@@ -8,6 +8,7 @@ import json
 import os
 import stat
 import subprocess
+import threading
 from pathlib import Path
 from unittest.mock import patch
 
@@ -23,6 +24,7 @@ from kiro_crew.pod.config import (
     DEFAULT_LIVE_PORT,
     DEFAULT_UNIT_PREFIX,
     PodConfig,
+    pod_kiro_home,
 )
 
 # Stand-in for a version-manager node bin dir (mise/nvm/fnm/volta/asdf install
@@ -566,6 +568,131 @@ class TestPodEnv:
         assert env["KIROCREW_HOME"].endswith("home")
         assert env["KIROCREW_PROJECT_DIR"].endswith("co")
 
+    def test_kiro_home_is_the_shared_derivation_inside_the_pod_home(
+        self, cfg: PodConfig, tmp_path: Path
+    ) -> None:
+        """The exported value must BE ``pod_kiro_home``, not a parallel spelling.
+
+        ``boot`` records this exact value for the session-storage reclaim guard, so
+        a second spelling here lets the guard decide from a path the pod does not
+        actually read — reclaim refused with no way to clear it, or a store shared
+        without one.
+        """
+        home = tmp_path / "home"
+        env = rt.build_pod_env(cfg, home, 7999, tmp_path / "co")
+        assert env["KIRO_HOME"] == str(pod_kiro_home(home))
+        # And it stays under the pod HOME, so teardown reclaims it.
+        assert Path(env["KIRO_HOME"]).is_relative_to(home)
+
+    def test_the_recorded_store_round_trips_what_was_exported(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The record is bound to its boot, and every unprovable case is ``None``.
+
+        Session-storage reclaim reads this to decide whether a live pod shares its
+        replay store; ``None`` must mean "cannot be established" so the caller can
+        fail closed instead of receiving a re-derived guess or a stale record.
+        """
+        monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path / "pod-env"))
+        c = PodConfig.load()
+
+        assert rt.bound_replay_store(c, "demo") is None  # nothing recorded
+
+        # A store recorded without a boot stamp cannot be bound to anything.
+        rt.write_env_file(c, "demo", {rt.RESOLVED_KIRO_HOME: str(tmp_path / "legacy")})
+        monkeypatch.setattr(rt, "live_main_pid", lambda cfg, n: 4321)
+        assert rt.bound_replay_store(c, "demo") is None
+
+        exported = rt.build_pod_env(c, c.home_dir("demo"), 7999, tmp_path / "co")
+        rt.record_replay_store(c, "demo", exported["KIRO_HOME"])
+        stamped = int(rt.read_env_file(c, "demo")[rt.BOOT_PID])
+
+        monkeypatch.setattr(rt, "live_main_pid", lambda cfg, n: stamped)
+        assert rt.bound_replay_store(c, "demo") == Path(exported["KIRO_HOME"])
+
+        # A different live process means the record belongs to an earlier boot.
+        monkeypatch.setattr(rt, "live_main_pid", lambda cfg, n: stamped + 1)
+        assert rt.bound_replay_store(c, "demo") is None
+        # Nothing running at all is equally unprovable.
+        monkeypatch.setattr(rt, "live_main_pid", lambda cfg, n: None)
+        assert rt.bound_replay_store(c, "demo") is None
+
+        # And a service manager that cannot answer must not read as isolated.
+        def unavailable(cfg: object, n: object) -> int:
+            raise rt.PodError("systemctl timed out")
+
+        monkeypatch.setattr(rt, "live_main_pid", unavailable)
+        assert rt.bound_replay_store(c, "demo") is None
+
+        # Recording must not disturb the pinned inputs sharing the file.
+        rt.pin_checkout(c, "demo", tmp_path / "co")
+        assert rt.read_env_file(c, "demo")[rt.RESOLVED_KIRO_HOME] == exported["KIRO_HOME"]
+        assert rt.read_env_file(c, "demo")["CHECKOUT"] == str(tmp_path / "co")
+
+    def test_a_concurrent_write_does_not_drop_the_other_writers_keys(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The merge is read-modify-write, so it must serialize per pod name.
+
+        ``pod up`` writes settings while the unit it started is already booting and
+        recording its store, so an unserialized stale read would restore the
+        previous CHECKOUT or APPROVAL and leave the pod configured from it.
+
+        Two real threads, each holding the read result across a barrier so both
+        would read the same pre-state if the lock were absent. Threads rather than
+        a nested call because the lock is per open-file-description: a re-entrant
+        call from one thread would deadlock rather than demonstrate anything.
+        """
+        monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path / "env"))
+        c = PodConfig.load()
+        rt.write_env_file(c, "demo", {"CHECKOUT": "/first", "APPROVAL": "reads"})
+
+        entered = threading.Barrier(2, timeout=30)
+        errors: list[BaseException] = []
+
+        def writer(updates: dict[str, str]) -> None:
+            try:
+                # Both threads arrive before either takes the lock, so the losing
+                # thread's read MUST happen after the winner's write to keep keys.
+                entered.wait()
+                rt.write_env_file(c, "demo", updates)
+            except BaseException as exc:  # noqa: BLE001 - reported below
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=writer, args=({"CRONS": "1"},)),
+            threading.Thread(target=writer, args=({rt.RESOLVED_KIRO_HOME: "/store"},)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+            assert not t.is_alive(), "write_env_file deadlocked"
+        assert not errors, f"writer raised: {errors!r}"
+
+        final = rt.read_env_file(c, "demo")
+        # Neither writer's keys may be lost, and the pre-existing ones survive.
+        assert final["CHECKOUT"] == "/first"
+        assert final["APPROVAL"] == "reads"
+        assert final["CRONS"] == "1"
+        assert final[rt.RESOLVED_KIRO_HOME] == "/store"
+
+    def test_live_main_pid_reads_systemd_and_refuses_a_failed_query(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """0 means no main process; a failed query must raise, not read as absent."""
+        monkeypatch.setattr(platform_compat, "IS_MACOS", False)
+        monkeypatch.setattr(rt, "IS_MACOS", False)
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(stdout="MainPID=4321\n"))
+        assert rt.live_main_pid(cfg, "x") == 4321
+
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(stdout="MainPID=0\n"))
+        assert rt.live_main_pid(cfg, "x") is None
+
+        monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(returncode=1, stderr="bus"))
+        with pytest.raises(rt.PodError, match="could not read the main pid"):
+            rt.live_main_pid(cfg, "x")
+
 
 class TestPodConfigWrite:
     def test_blank_pod_writes_tunnel_off_config(self, tmp_path: Path) -> None:
@@ -630,6 +757,23 @@ class TestRuntimeHelpers:
         )
         monkeypatch.setattr(rt, "systemctl", lambda *a, **k: _cp(stdout=out))
         assert rt.active_names(cfg) == {"alpha", "beta-two"}
+        assert rt.live_names(cfg) == {"alpha", "beta-two"}
+
+    def test_live_names_refuses_a_failed_query_that_active_names_reads_as_idle(
+        self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed listing looks exactly like an idle host, so the twin must raise.
+
+        A caller that must not act while a pod is live cannot use the empty set:
+        reclaiming session storage on a wrong "nothing is running" destroys a
+        conversation a live pod could still resume.
+        """
+        monkeypatch.setattr(
+            rt, "systemctl", lambda *a, **k: _cp(returncode=1, stderr="Failed to connect to bus\n")
+        )
+        assert rt.active_names(cfg) == set()  # the listing shape, unchanged
+        with pytest.raises(rt.PodError, match="could not list active pod units"):
+            rt.live_names(cfg)
 
     def test_unit_state(self, cfg: PodConfig, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
@@ -1296,6 +1440,34 @@ class TestBootTimeSettings:
     ) -> None:
         argv = self._booted_argv(tmp_path, monkeypatch, {"APPROVAL": "reads"})
         assert argv == ["gateway", "--no-crons", "--approval", "reads"]
+
+    def test_boot_records_the_store_it_hands_the_pod(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The record must exist by the time the pod is running, not later.
+
+        Session-storage reclaim reads it to decide whether this pod shares the
+        default instance's replay store, and treats absence as sharing — so a boot
+        that execs without recording leaves a live pod indistinguishable from a
+        legacy one and blocks reclaim for as long as it runs.
+        """
+        monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path / "env"))
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(tmp_path / "pods"))
+        c = PodConfig.load()
+        rt.pin_checkout(c, "x", _ready_worktree(tmp_path, "x"))
+        monkeypatch.setattr(rt, "derive_port", lambda cfg, n: 7811)
+        seen: list[dict[str, str]] = []
+        monkeypatch.setattr(os, "execve", lambda path, argv, e: seen.append(e))
+
+        rt.boot(c, "x")
+
+        assert len(seen) == 1, "boot did not exec exactly once"
+        # Recorded, equal to what the pod was handed, and stamped with the boot
+        # that is about to BECOME the pod (``boot`` execs in place, so this pid
+        # stays the pod's main process for its whole life).
+        recorded = rt.read_env_file(c, "x")
+        assert recorded[rt.RESOLVED_KIRO_HOME] == seen[0]["KIRO_HOME"]
+        assert recorded[rt.BOOT_PID] == str(os.getpid())
 
     def test_boot_argv_unchanged_when_unset(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/test/test_pod_launchd.py
+++ b/test/test_pod_launchd.py
@@ -185,6 +185,20 @@ def test_active_names_filters_to_our_prefix_and_liveness(cfg, monkeypatch):
 
     monkeypatch.setattr(launchd, "launchctl", fake)
     assert launchd.active_names(cfg) == {"alpha"}
+    # loaded_names keeps the restart-pending label `active_names` drops. A
+    # KeepAlive agent whose process exited still comes back and can still resume
+    # its sessions, so a caller deciding whether it may DESTROY that data must
+    # see it -- treating it as gone is the fail-open.
+    assert launchd.loaded_names(cfg) == {"alpha", "beta"}
+
+
+def test_loaded_names_refuses_to_guess_on_an_operational_error(cfg, monkeypatch):
+    """An unenumerable domain must raise, not read as "no pods loaded"."""
+    monkeypatch.setattr(
+        launchd, "launchctl", lambda *a, **k: _cp(returncode=1, stderr="boom")
+    )
+    with pytest.raises(launchd.LaunchdError, match="cannot .*enumerate"):
+        launchd.loaded_names(cfg)
 
 
 # --------------------------------------------------------------------------
@@ -458,6 +472,37 @@ def test_runtime_probes_surface_launchd_errors_as_pod_errors(cfg, monkeypatch):
         rt.is_active(cfg, "smoke")
     with pytest.raises(rt.PodError):
         rt.active_names(cfg)
+    with pytest.raises(rt.PodError):
+        rt.live_names(cfg)
+    with pytest.raises(rt.PodError):
+        rt.live_main_pid(cfg, "smoke")
+
+
+def test_live_names_counts_a_restart_pending_launchd_pod(cfg, monkeypatch):
+    """`active_names` answers "running now"; this decision needs "can come back".
+
+    A KeepAlive label whose process exited is loaded without a pid. Dropping it
+    would let a reclaim stage its resumable sessions in the window before launchd
+    restarts it, so `live_names` enumerates LOADED labels on macOS.
+    """
+    monkeypatch.setattr(rt, "IS_MACOS", True)
+    domain_dump = (
+        "dev.kirocrew.pod.kirocrew-pod.alpha\n"
+        "dev.kirocrew.pod.kirocrew-pod.beta\n"
+    )
+
+    def fake(*args, **kwargs):
+        target = args[1] if len(args) > 1 else ""
+        if target.count("/") <= 1:
+            return _cp(domain_dump)
+        return _cp(_RUNNING if target.endswith("alpha") else _DEAD)
+
+    monkeypatch.setattr(launchd, "launchctl", fake)
+    assert rt.active_names(cfg) == {"alpha"}
+    assert rt.live_names(cfg) == {"alpha", "beta"}
+    # And the dead-but-loaded pod cannot pass the store check either, because it
+    # has no live main pid to bind its record to.
+    assert launchd.main_pid(cfg, "beta") is None
 
 
 def test_pod_mutex_is_reentrant_within_a_thread(cfg):

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -22,6 +22,8 @@ import pytest
 from kiro_crew import session_storage
 from kiro_crew.config import paths
 from kiro_crew.history import transcript_stem
+from kiro_crew.pod import runtime as pod_runtime
+from kiro_crew.pod.config import PodConfig
 from kiro_crew.session_storage import SessionIndex, SessionStorageError
 
 _NOW = 1_700_000_000.0
@@ -925,21 +927,183 @@ class TestSharedStoreRefusal:
         # The origin is still absent rather than occupied by a dangling link.
         assert not (kiro_home / "sessions" / "cli" / "aaaa1111.jsonl").exists()
 
-    def test_a_pod_sharing_the_default_store_blocks_the_default_instance(
+    def test_a_stale_pod_directory_does_not_block_reclaim(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The mirror case: a pod reads THIS store while keeping its own map."""
-        pod_root = tmp_path / "pods"
-        (pod_root / "wt-feature").mkdir(parents=True)
-        monkeypatch.setenv("KIROCREW_POD_ROOT", str(pod_root))
-        monkeypatch.delenv("KIROCREW_HOME", raising=False)
-        monkeypatch.delenv("KIRO_HOME", raising=False)
-        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
-        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        """A pod home left behind by a pod that no longer runs is not an instance.
+
+        Counting directories refuses reclaim on every machine that has ever run a
+        pod, and the eviction the message recommends cannot clear a directory whose
+        pod is already gone.
+        """
+        self._default_instance(tmp_path, monkeypatch, pods=["wt-retired"])
+        monkeypatch.setattr(pod_runtime, "live_names", lambda _cfg: set())
+
+        assert session_storage.reclaim_block_reason() == ""
+
+    def test_an_empty_pod_root_costs_no_service_manager_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An install that never ran a pod must not pay for the guard."""
+        self._default_instance(tmp_path, monkeypatch, pods=[])
+
+        def refuse(*_args: object) -> set[str]:
+            raise AssertionError("an empty pod root must not be probed")
+
+        monkeypatch.setattr(pod_runtime, "live_names", refuse)
+
+        assert session_storage.reclaim_block_reason() == ""
+
+    def test_a_live_pod_keeping_its_own_store_does_not_block(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The normal modern pod: its transcripts are inside its own home."""
+        pod_root = self._default_instance(tmp_path, monkeypatch, pods=["wt-feature"])
+        # The store the pod's own boot recorded for itself.
+        self._record_live_boot(
+            monkeypatch, "wt-feature", str(pod_root / "wt-feature" / "kiro")
+        )
+        monkeypatch.setattr(pod_runtime, "live_names", lambda _cfg: {"wt-feature"})
+
+        assert session_storage.reclaim_block_reason() == ""
+
+    def test_a_live_pod_whose_store_was_never_recorded_blocks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unrecorded pod is protected, not assumed isolated.
+
+        A running pod may have been launched by a CLI that recorded nothing, and it
+        would then be writing into this store. Nothing here may re-derive the path
+        to fill that gap: the derivation answers for a pod booted by today's code.
+        """
+        self._default_instance(tmp_path, monkeypatch, pods=["wt-legacy"])
+        monkeypatch.setattr(pod_runtime, "live_names", lambda _cfg: {"wt-legacy"})
+
+        reason = session_storage.reclaim_block_reason()
+        assert "share this kiro-cli session store" in reason
+        assert "wt-legacy" in reason
+
+    def test_a_record_from_an_earlier_boot_does_not_exempt_a_live_pod(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A record is only evidence while the boot that wrote it is still running.
+
+        Downgrading the pod control binary and letting the service manager restart
+        the unit leaves the previous boot's record in place while the pod that comes
+        back shares this store. Binding the record to its boot's pid is what stops
+        that from reading as isolated.
+        """
+        pod_root = self._default_instance(tmp_path, monkeypatch, pods=["wt-feature"])
+        pod_runtime.record_replay_store(
+            PodConfig.load(), "wt-feature", str(pod_root / "wt-feature" / "kiro")
+        )
+        # The pod is running, but not as the process that wrote the record.
+        monkeypatch.setattr(pod_runtime, "live_names", lambda _cfg: {"wt-feature"})
+        monkeypatch.setattr(pod_runtime, "live_main_pid", lambda _cfg, _n: 999999)
 
         reason = session_storage.reclaim_block_reason()
         assert "share this kiro-cli session store" in reason
         assert "wt-feature" in reason
+
+    def test_a_pod_store_pointed_at_this_one_blocks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An existing store is not enough when it IS this instance's store."""
+        pod_root = self._default_instance(tmp_path, monkeypatch, pods=["wt-feature"])
+        shared = pod_root / "wt-feature" / "kiro"
+        shared.mkdir(parents=True)
+        monkeypatch.setenv("KIRO_HOME", str(shared))
+        self._record_live_boot(monkeypatch, "wt-feature", str(shared))
+        monkeypatch.setattr(pod_runtime, "live_names", lambda _cfg: {"wt-feature"})
+
+        assert "share this kiro-cli session store" in session_storage.reclaim_block_reason()
+
+    def test_a_stopped_unrecorded_pod_does_not_block(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No live instance means no resumable session to protect."""
+        self._default_instance(tmp_path, monkeypatch, pods=["wt-legacy"])
+        monkeypatch.setattr(pod_runtime, "live_names", lambda _cfg: set())
+
+        assert session_storage.reclaim_block_reason() == ""
+
+    def test_an_unanswerable_liveness_probe_still_blocks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """"Could not ask" must not be read as "nothing is running"."""
+        pod_root = self._default_instance(tmp_path, monkeypatch, pods=["wt-feature"])
+        # Recorded as isolated, so only the unanswerable probe can block it.
+        self._record_live_boot(
+            monkeypatch, "wt-feature", str(pod_root / "wt-feature" / "kiro")
+        )
+
+        def unavailable(_cfg: object) -> set[str]:
+            raise pod_runtime.PodError("systemctl timed out")
+
+        monkeypatch.setattr(pod_runtime, "live_names", unavailable)
+
+        assert "share this kiro-cli session store" in session_storage.reclaim_block_reason()
+
+    def test_a_platform_that_cannot_run_pods_does_not_block(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pods are service-manager units, so a Windows host can have none live.
+
+        A static platform property, unlike a service-manager probe: a probe that
+        FAILS on a platform that can run pods leaves liveness unknown, which must
+        refuse rather than short-circuit (see the unanswerable-probe test).
+        """
+        self._default_instance(tmp_path, monkeypatch, pods=["wt-legacy"])
+        monkeypatch.setattr(session_storage.platform_compat, "IS_LINUX", False)
+        monkeypatch.setattr(session_storage.platform_compat, "IS_MACOS", False)
+
+        def refuse(*_args: object) -> set[str]:
+            raise AssertionError("a platform without pods must not be probed")
+
+        monkeypatch.setattr(pod_runtime, "live_names", refuse)
+
+        assert session_storage.reclaim_block_reason() == ""
+
+    @staticmethod
+    def _record_live_boot(
+        monkeypatch: pytest.MonkeyPatch, name: str, store: str
+    ) -> None:
+        """Record *store* for *name* and make that boot the live main process."""
+        cfg = PodConfig.load()
+        pod_runtime.record_replay_store(cfg, name, store)
+        stamped = int(pod_runtime.read_env_file(cfg, name)[pod_runtime.BOOT_PID])
+        monkeypatch.setattr(pod_runtime, "live_main_pid", lambda _cfg, _n: stamped)
+
+    @staticmethod
+    def _default_instance(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, pods: list[str]
+    ) -> Path:
+        """A default-home instance with *pods* as directories under the pod root.
+
+        The pod root is real host state, so it is pinned to a temp dir or the result
+        depends on whether the developer's machine happens to have pods.
+        """
+        pod_root = tmp_path / "pods"
+        pod_root.mkdir()
+        for name in pods:
+            (pod_root / name).mkdir()
+        # Pods are service-manager units, and the guard short-circuits on a host
+        # that cannot run them. These cases are about the co-tenant DECISION, so
+        # pin a pod-capable host instead of inheriting the runner's platform --
+        # otherwise the Windows shards never reach the decision under test.
+        monkeypatch.setattr(session_storage.platform_compat, "IS_LINUX", True)
+        monkeypatch.setattr(session_storage.platform_compat, "IS_MACOS", False)
+        monkeypatch.setenv("KIROCREW_POD_ROOT", str(pod_root))
+        # The per-pod env file is real host state too: the recorded store is read
+        # from it, so pin it to the temp dir or a test would read the operator's.
+        monkeypatch.setenv("KIROCREW_POD_ENV_DIR", str(tmp_path / "pod-env"))
+        monkeypatch.delenv("KIROCREW_HOME", raising=False)
+        monkeypatch.delenv("KIRO_HOME", raising=False)
+        # Pin the default home rather than clearing the memo, which would make the
+        # next data_home() initialize or migrate the operator's real data home.
+        monkeypatch.setattr(paths, "_resolved_home", paths._default_home())
+        monkeypatch.setattr(paths, "_config_dir_memo", None)
+        return pod_root
 
     def test_no_pods_leaves_the_default_instance_able_to_reclaim(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## What is the problem?

Session-storage reclaim is refused whenever any directory exists under the pod
root, and on a machine that has ever run a pod that refusal can never be
cleared.

`reclaim_block_reason()` calls `_replay_store_cotenants()`, which answers a
filesystem question — "are there directories under the pod root" — on the premise
that a pod shares the machine-wide kiro-cli replay store while keeping its own
session map, so its resumable sessions would read as retired from the default
instance. `build_pod_env` gives every pod its own `KIRO_HOME` inside the pod
home, so that premise no longer holds.

Two things compound. The check counts **directories, not instances**, so a home
left behind by a pod that no longer exists counts as a co-tenant. And the
remediation the message offers is a dead end: it says to evict them with
`kirocrew pod down <name>`, but those pods were already brought down — their
directories survived anyway (filed separately as #2543). The operator follows
the instruction, nothing changes, and reclaim stays refused.

Measured on this Linux gateway before the fix:

```
>>> session_storage._replay_store_cotenants()
['kirocrew-wt-library-hero', 'kirocrew-wt-live-target',
 'kirocrew-wt-palette-apps', 'kirocrew-wt-runauthz']

>>> session_storage.reclaim_block_reason()
'4 other instance(s) share this kiro-cli session store (...), so their resumable
 sessions cannot be told apart from retired ones. Evict them with `kirocrew pod
 down <name>` to reclaim from here.'
```

Three of those four units were `inactive`.

## Why this issue matters to the user

The storage screen's whole purpose is reclaiming disk from retired sessions, and
it is disabled outright on any machine that has ever run a pod — with an
explanation that points at an action which does not work. The feature is
effectively removed rather than gated. The shared store on this machine holds
469,750 entries.

## How our fix solves it

The chain from symptom to root cause:

1. `reclaim_block_reason()` reaches the pod branch and calls
   `_replay_store_cotenants()`.
2. That function never resolves any pod's actual store. It lists directories, so
   a pod that IS isolated still counts, and so does a directory belonging to no
   instance at all.
3. Nothing else can clear the refusal, because the directory it counts outlives
   the pod that made it.

A pod is now named as a co-tenant only when **both** conditions hold:

- **It is live.** A directory under the pod root is not an instance: a stopped
  pod holds no resumable session and has no process that could resume one.
  Liveness comes from a new `pod.runtime.live_names()`, which raises when
  `systemctl` could not answer. `active_names()` returns an empty set both when
  nothing is running and when the query failed — the right shape for a listing,
  and the wrong one for a decision that destroys a conversation if it is wrong —
  so it keeps its contract and the guard gets a fail-closed twin.
- **It does not own its own store**, where owning is **recorded by the pod's own
  boot and bound to it**. `boot()` writes the `KIROCREW_HOME`-adjacent
  `KIRO_HOME` it hands the pod into the per-pod env file, taken from
  `build_pod_env`'s own output at the moment of `exec`, **stamped with that
  boot's pid** (which is the pod's main process for its whole life, because
  `boot` execs in place). `bound_replay_store()` returns that store only while
  the stamp is still the unit's live main process (`live_main_pid()`, systemd
  `MainPID=` / launchd `pid =`, raising rather than reporting absence when the
  manager cannot answer).

Three tempting inferences are rejected on purpose, because each one fails open:

1. **Re-deriving the path** answers for a pod booted by *today's* code, while a
   running pod may have been launched by an older one and would then be writing
   into the shared store.
2. **A directory existing** under the pod home is no better — a stale private
   store survives a version rollback that reuses the pod's name.
3. **An unstamped record** survives a downgrade of the pod control binary plus a
   service-manager restart: a pod sharing the store while carrying a record that
   says it does not.

So **anything unprovable counts as sharing** — no record, an unstamped record, a
record from an earlier boot, no running main process, or a pid query that failed.
Exactly one thing short-circuits to "no co-tenants": a platform that cannot run
pods at all (`IS_LINUX or IS_MACOS`), which is a static property rather than a
probe. An empty pod root also answers with no service-manager call, which is
every install that has never run a pod. `pod down` deletes the env file, so a
record never outlives its pod.

Same-premise prose retired while here (no behaviour attached):

- the `KIRO_HOME` NOTE in `build_pod_env` arguing at length against an export the
  line above it performs,
- `kiro_home()`'s scope caveat, which said the remaining readers had not been
  routed through the resolver and that `build_pod_env` deliberately does not set
  it,
- `agent.py`'s claim that nothing in this repo sets `KIRO_HOME`, contradicted
  30 lines later in the same docstring,
- the module spec's co-tenant paragraph.

The write guard in `agent.py` is deliberately untouched: a pod's
`kiro_agents_dir()` resolves to exactly `isolated_agents_dir(own_home)`, so it
already takes the private-target exemption.

## What tests we did

Automated, all new unless noted:

- `test_a_stale_pod_directory_does_not_block_reclaim` — the regression itself: a
  home whose pod is gone no longer refuses reclaim.
- `test_a_live_pod_keeping_its_own_store_does_not_block` — the normal modern pod,
  recorded and pid-bound.
- `test_a_live_pod_whose_store_was_never_recorded_blocks` — a running pod that
  cannot prove isolation is still protected.
- `test_a_record_from_an_earlier_boot_does_not_exempt_a_live_pod` — the
  downgrade-plus-restart case: the record survives, the pid does not match.
- `test_a_pod_store_pointed_at_this_one_blocks` — a recorded store that IS this
  instance's store.
- `test_a_stopped_unrecorded_pod_does_not_block`,
  `test_an_unanswerable_liveness_probe_still_blocks`,
  `test_a_platform_that_cannot_run_pods_does_not_block` — the liveness branches,
  including both fail-closed directions and the one legitimate short-circuit.
- `test_an_empty_pod_root_costs_no_service_manager_call` — pins the fast path by
  making the probe raise if called.
- `test_live_names_refuses_a_failed_query_that_active_names_reads_as_idle` — the
  same nonzero `systemctl` result: `active_names` returns `set()`, `live_names`
  raises.
- `test_live_main_pid_reads_systemd_and_refuses_a_failed_query` — `MainPID=0` is
  no process; a failed query raises rather than reading as absent.
- `test_the_recorded_store_round_trips_what_was_exported` — every unprovable
  shape resolves to `None`: nothing recorded, unstamped, wrong pid, nothing
  running, query failed.
- `test_boot_records_the_store_it_hands_the_pod` — the record exists by the time
  the pod is running, and equals what was handed to it.
- `test_kiro_home_is_the_shared_derivation_inside_the_pod_home` — `build_pod_env`
  must export `pod_kiro_home`'s value, not a parallel spelling.

Twelve mutants were applied to the production code and all twelve were caught,
including: restoring directory-counting, treating an unrecorded or unstamped
record as isolated, accepting a record without binding it to the live boot,
reading an unanswerable pid query or liveness probe as "nothing running",
swallowing every host in the platform short-circuit, `MainPID=0` as a real pid,
`boot` skipping the record, and `build_pod_env` drifting from `pod_kiro_home`.

Gates: pytest, isort, flake8, mypy (CI-parity venv, no faiss) and the
diff-scoped brand gate all clean. No frontend change, so `tsc`/`vitest` do not
apply.

## Manual verification

Ran the shipped guard against this host, where the bug reproduces. Before the
change: four co-tenants — three of them `inactive` units — and a refusal with no
way to clear it. After, on a pod root holding seven entries:

- The four entries with no live unit — including the retired homes that caused
  the issue — are **gone from the list entirely**. That is the bug fixed.
- The three live pods **are** named, because they were booted by the pre-change
  CLI and therefore recorded nothing, so their store cannot be established. This
  is the fail-closed direction on a data-loss path, it is clearable with the
  `kirocrew pod down <name>` the message names (which now only ever names live
  pods, so the instruction works), and it self-heals on each pod's next
  `pod up`, which records and stamps.

Worth stating plainly for a reviewer: on a machine whose pods all predate this
change, reclaim stays refused until those pods cycle or are evicted. That is
deliberate — a pod whose store is unprovable is a pod whose sessions we must not
stage — and it is the difference between "refused but actionable" and the
issue's "refused forever with a remediation that does nothing".

## Any other suggestions on the work

The teardown residue that made this refusal unclearable is #2543. The two are
independent: fixing that one stops new orphans accumulating, but the existing
directories would still block reclaim until this check itself changed.

Closes #2542
