### PR TITLE
fix(security): recover session-identity signing and audit every refusal

### DIFF
--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -61,6 +61,7 @@ from kiro_crew.platform import (
 from kiro_crew.platform.governance import CU_MCP_SERVER, may_skip_gate_now
 from kiro_crew.sandbox import warm_backend
 from kiro_crew.sel import sel
+from kiro_crew.session_pid_sig import signing_health
 from kiro_crew.transcribe import _find_whisper, ensure_ffmpeg_in_path
 
 logger = logging.getLogger(__name__)
@@ -346,6 +347,41 @@ def _doctor_data_home() -> None:
             print(
                 f"  legacy:      ⏹ {legacy} still present (migration will retry on next cold start)"
             )
+
+
+def _doctor_trust_root() -> None:
+    """Report whether session identities can be signed, and from which file.
+
+    A gateway whose SEL trust root stops resolving keeps signing its audit
+    chain from bytes cached at init, so nothing looks wrong — while every
+    ``session_pid`` mapping goes out unsigned and the MCP tools that need a
+    verified session are refused. Publication logs that once per process, but
+    only once a session is actually claimed; asking here needs no claim.
+
+    Read-only on purpose: it never constructs ``SecurityEventLog``, so a
+    missing key is reported rather than created as a side effect of the
+    question.
+    """
+    ok, key_path = signing_health()
+    if ok:
+        print(f"  trust root:  ✅ {key_path}")
+        return
+    if not key_path.parent.is_dir():
+        # The trust dir and the key are created together, on the first
+        # SecurityEventLog init. Neither present means no instance has ever run
+        # against this home — a fresh install, not a broken one.
+        print(f"  trust root:  ⏹ {key_path} not created yet (the gateway writes it on first start)")
+        return
+    print(f"  ⚠ trust root: {key_path} is unreadable or shorter than 32 bytes.")
+    print(
+        "               Session identities go out unsigned, so sub-agent "
+        "dispatch and memory"
+    )
+    print(
+        "               writes are refused in sandboxed sessions. Restore the "
+        "key file, or"
+    )
+    print("               restart the gateway if another process relocated it.")
 
 
 def _linger_enabled(user: str) -> bool | None:
@@ -694,6 +730,7 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
 
     # ── Data Home (+ leftover migration archive) ──
     _doctor_data_home()
+    _doctor_trust_root()
 
     # ── Pods (systemd --user session bus) ──
     _doctor_pod_session_bus(issues)

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -337,6 +337,38 @@ _STRICT_INTERNAL_API_PATHS = frozenset(
 )
 
 
+async def _audit_denied(caller: str, request: web.Request, error: str) -> None:
+    """Record a middleware refusal in the SEL, off the event loop, best-effort.
+
+    Shared by every middleware that denies BEFORE ``sel_audit_middleware`` runs
+    (that one is registered inner to them, so a bare raise produces a 403 that
+    appears nowhere in the audit log). One helper rather than per-site calls
+    because both properties below are easy to omit at a new deny site and
+    invisible when omitted:
+
+    * OFF THE LOOP — ``log_api_access`` only enqueues, but the first ``sel()``
+      of a process CONSTRUCTS the log: trust-dir creation, key validation, and
+      on Windows an ``icacls`` subprocess to lock the key file's DACL. A fresh
+      dashboard whose first state-changing request is cross-origin would run
+      that synchronously on the event loop and stall every other request.
+    * BEST-EFFORT — a trust root too short to sign the chain makes construction
+      raise, and an unguarded write would turn the refusal into a 500: losing
+      the denial in order to report it.
+    """
+    try:
+        await asyncio.to_thread(
+            lambda: sel().log_api_access(
+                caller=caller,
+                operation=f"{request.method} {request.path}",
+                outcome="denied",
+                resources=request.path,
+                error=error,
+            )
+        )
+    except Exception:
+        logger.warning("Failed to log a middleware denial to SEL", exc_info=True)
+
+
 def _make_host_validation_middleware(caller: str) -> Callable:
     """Build the DNS-rebinding ``Host``-header barrier middleware.
 
@@ -376,14 +408,11 @@ def _make_host_validation_middleware(caller: str) -> Callable:
         if request.path not in PROBE_PATHS and not check_host(request):
             # SEL audit (security-relevant permission decision): make
             # DNS-rebinding attempts visible in the audit log, mirroring the
-            # API-access audit. Non-critical write (no fail-closed fsync) so
-            # it never wedges the event loop.
-            sel().log_api_access(
-                caller=caller,
-                operation=f"{request.method} {request.path}",
-                outcome="denied",
-                resources=request.path,
-                error=f"host header not allowed: {request.headers.get('Host', '')[:100]}",
+            # API-access audit.
+            await _audit_denied(
+                caller,
+                request,
+                f"host header not allowed: {request.headers.get('Host', '')[:100]}",
             )
             raise web.HTTPForbidden(
                 text="Host header not allowed.",
@@ -3174,6 +3203,12 @@ async def start_dashboard(
     ) -> web.StreamResponse:
         if request.method not in _safe_methods:
             if not check_origin(request, require=True, fallback_header="Referer"):
+                await _audit_denied(
+                    "dashboard_user",
+                    request,
+                    "CSRF check failed: origin not allowed: "
+                    f"{request.headers.get('Origin', '')[:100]}",
+                )
                 raise web.HTTPForbidden(
                     text="CSRF check failed: request origin not allowed.",
                     content_type="text/plain",
@@ -3785,14 +3820,11 @@ async def start_api_server(
         # Origin, so a cross-site page is rejected here even before token auth.
         if request.method not in _safe_methods:
             if not check_origin(request, require=True, fallback_header="Referer"):
-                # Audit the CSRF denial (security-relevant permission decision),
-                # mirroring host_validation_middleware.
-                sel().log_api_access(
-                    caller="mcp_tool",
-                    operation=f"{request.method} {request.path}",
-                    outcome="denied",
-                    resources=request.path,
-                    error=f"CSRF check failed: origin not allowed: {request.headers.get('Origin', '')[:100]}",
+                await _audit_denied(
+                    "mcp_tool",
+                    request,
+                    "CSRF check failed: origin not allowed: "
+                    f"{request.headers.get('Origin', '')[:100]}",
                 )
                 raise web.HTTPForbidden(
                     text="CSRF check failed: request origin not allowed.",

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -119,8 +119,24 @@ class SecurityEventLog:
         return cls._instance
 
     def __init__(self, base_dir: Path | None = None, sync: bool = False) -> None:
+        # Double-checked locking, and the lock is NOT optional: ``__new__``
+        # publishes the instance before ``__init__`` runs, so a second thread
+        # that arrives in between gets the same object with ``_initialized``
+        # still False and would run this body concurrently. Both would then call
+        # ``_load_or_create_hmac_key`` and each could mint a fresh key — one
+        # wins on disk while the other keeps different bytes in memory, which
+        # silently splits the audit chain from the file that every other process
+        # (and ``session_pid_sig``) resolves. Callers reaching this from worker
+        # threads rather than the event loop make that interleaving real.
         if self._initialized:
             return
+        with self._init_lock:
+            if self._initialized:
+                return
+            self._init_locked(base_dir, sync)
+
+    def _init_locked(self, base_dir: Path | None, sync: bool) -> None:
+        """One-time construction body; runs under ``_init_lock`` exactly once."""
         # sync=True writes each event inline (no background thread). Used by
         # tests that read the raw log file immediately after logging; production
         # uses the async writer for off-hot-path appends.
@@ -1129,3 +1145,35 @@ def sel_hmac_key_path() -> Path:
     if inst is not None and getattr(inst, "_initialized", False):
         return inst._hmac_key_file
     return _default_dir() / _TRUST_SUBDIR / _HMAC_KEY_FILE
+
+
+def _sel_hmac_key_bytes() -> bytes | None:
+    """Return the live singleton's trust-root key BYTES, or ``None``.
+
+    Module-private with exactly ONE intended caller
+    (``session_pid_sig._load_hmac_key``), because the safety of handing out raw
+    trust-root material rests on an ordering rule the CALLER enforces, not the
+    accessor: the FILE must be preferred and this used only as a fallback. A
+    readable file is the anchor every OTHER process resolves independently, so a
+    second caller that reached for memory first would sign MACs a separate
+    verifier rejects. Keeping one caller keeps that rule enforceable.
+
+    ``SecurityEventLog`` reads the key once at init and signs every subsequent
+    record from that in-memory copy, so the audit chain is immune to the key
+    file moving, being deleted, losing read permission, or being truncated
+    afterwards. The dependent protocol that re-reads the file on every use is
+    not, and its resolved path is never re-resolved — which is how a gateway
+    ends up publishing unsigned identities forever while its audit chain still
+    looks healthy. These are the same bytes, already validated at init
+    (``>= _HMAC_KEY_MIN_BYTES``, see ``_load_or_create_hmac_key``).
+
+    Returns ``None`` when no initialized singleton exists in this process (the
+    verifying MCP process, typically) or the cached key is unusable.
+    """
+    inst = SecurityEventLog._instance
+    if inst is None or not getattr(inst, "_initialized", False):
+        return None
+    key = getattr(inst, "_hmac_key", None)
+    if isinstance(key, bytes) and len(key) >= _HMAC_KEY_MIN_BYTES:
+        return key
+    return None

--- a/src/kiro_crew/session_pid_sig.py
+++ b/src/kiro_crew/session_pid_sig.py
@@ -76,11 +76,12 @@ import hmac
 import logging
 import os
 import stat
+import threading
 from pathlib import Path
 
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
-from kiro_crew.sel import sel_hmac_key_path
+from kiro_crew.sel import _sel_hmac_key_bytes, sel_hmac_key_path
 
 logger = logging.getLogger(__name__)
 
@@ -125,14 +126,140 @@ def _load_hmac_key() -> bytes | None:
     would let a first-touch race mint a key the SEL then distrusts. The path
     comes from :func:`kiro_crew.sel.sel_hmac_key_path` so both protocols
     always anchor on the same file.
+
+    The FILE is authoritative when it loads: it is the anchor every other
+    process resolves independently, so a publisher must not sign with anything
+    else while a verifier can still read it. When the file does NOT load, fall
+    back to the identical bytes the live ``SecurityEventLog`` validated at init
+    (:func:`kiro_crew.sel.sel_hmac_key_bytes`). Without that fallback this
+    protocol dies permanently the moment the resolved path stops resolving —
+    the path is frozen at SEL init and never re-resolved, while SEL itself
+    keeps signing from its cached copy, so a key file relocated by a concurrent
+    process (legacy -> ``trust/`` migration), deleted, chmod'd, or truncated
+    takes down every identity-dependent MCP tool with no failing audit chain to
+    point at it.
     """
     try:
         raw = sel_hmac_key_path().read_bytes()
     except OSError:
-        return None
-    if len(raw) < _HMAC_KEY_MIN_BYTES:
-        return None
-    return raw
+        raw = b""
+    if len(raw) >= _HMAC_KEY_MIN_BYTES:
+        # The FILE is intact — the only state every OTHER process can observe
+        # too — so re-arm both reports: a later break deserves a fresh
+        # operator-facing message rather than the debug line a retained entry
+        # would produce. Without this a trust root that breaks, is restored,
+        # then breaks again is silent, in the one case (long-lived gateway,
+        # never restarted) where the log is the only signal there is.
+        _clear_trust_root_reports()
+        return raw
+    live = _sel_hmac_key_bytes()
+    if live is not None:
+        _report_trust_root_broken()
+    return live
+
+
+_report_lock = threading.Lock()
+# ``(kind, resolved path)`` pairs already reported, so each operator-facing
+# message is emitted once per path per process instead of once per session
+# claim. Guarded by ``_report_lock``: publication runs on concurrent session
+# claims, and an unlocked check-then-add lets two of them both pass the
+# membership test and emit duplicate reports.
+_reported: set[tuple[str, str]] = set()
+
+
+def _report_once(kind: str) -> tuple[bool, str]:
+    """Claim the first report of *kind* for the current resolved path.
+
+    Returns ``(is_first, path)``. Keyed on the path so a genuine relocation is
+    reported again rather than suppressed by the previous location's entry, and
+    on the KIND so the two messages below — which tell an operator different
+    things — never silence each other.
+    """
+    path = str(sel_hmac_key_path())
+    key = (kind, path)
+    with _report_lock:
+        first = key not in _reported
+        _reported.add(key)
+    return first, path
+
+
+def _clear_trust_root_reports() -> None:
+    """Re-arm every report for the current resolved path."""
+    path = str(sel_hmac_key_path())
+    with _report_lock:
+        _reported.difference_update({k for k in _reported if k[1] == path})
+
+
+def _report_trust_root_broken() -> None:
+    """Report a broken key FILE that this process survived from memory.
+
+    Signing succeeds here, so nothing else in this process would complain — but
+    the file is what every OTHER process resolves, independently and fresh. A
+    verifier that never held these bytes still fails closed, so staying quiet
+    would move the original silent failure one layer over rather than remove
+    it: capability dead elsewhere, clean log here.
+    """
+    first, path = _report_once("file_broken")
+    if not first:
+        logger.debug("SEL trust root %s still unreadable (signing from memory)", path)
+        return
+    logger.error(
+        "SEL trust root %s is unreadable or shorter than %d bytes. This process "
+        "keeps signing session identities from the key bytes SecurityEventLog "
+        "validated at its own init, so publication still succeeds HERE — but "
+        "every other process resolves that file independently, so a verifier "
+        "which never held those bytes refuses the identity and sub-agent "
+        "dispatch and memory writes fail there. Restore the file: the in-memory "
+        "fallback lasts only as long as this process. Repeat occurrences log at "
+        "debug.",
+        path,
+        _HMAC_KEY_MIN_BYTES,
+    )
+
+
+def _report_signing_unavailable() -> None:
+    """Report a trust root this process cannot sign with at all, once per path.
+
+    Publication happens on every session claim, so an unthrottled log drowns
+    the file (observed at several lines a minute) — and a message that names
+    only the mechanism ("published unsigned") leaves an operator with no way to
+    connect it to the capabilities that just disappeared. This names the
+    consequence and the path to fix.
+    """
+    first, path = _report_once("unsignable")
+    if not first:
+        logger.debug("session identity signing still unavailable (trust root %s)", path)
+        return
+    logger.error(
+        "cannot sign session identities: SEL trust root %s is unreadable or "
+        "shorter than %d bytes, so every session_pid mapping is published "
+        "unsigned. Strict identity resolvers refuse an unsigned mapping, which "
+        "means the MCP tools that require a verified session — sub-agent "
+        "dispatch and memory writes among them — are refused in sandboxed "
+        "sessions until this is fixed. Restore the key file at that path, or "
+        "restart the gateway if another process relocated it. Repeat "
+        "occurrences log at debug.",
+        path,
+        _HMAC_KEY_MIN_BYTES,
+    )
+
+
+def signing_health() -> tuple[bool, Path]:
+    """Report whether this process can sign session identities, and from where.
+
+    For diagnostic surfaces (``kirocrew doctor``), which is the only place that
+    asks proactively: publication itself reports through
+    :func:`_report_signing_unavailable`, so an operator whose gateway is
+    actually claiming sessions already gets one loud line. This answers the
+    same question without waiting for a claim, and deliberately does NOT
+    construct :class:`~kiro_crew.sel.SecurityEventLog` — creating the trust
+    root as a side effect of asking about it would make the check report on a
+    state it just produced, and would put a directory mkdir plus a key write
+    behind a read-only command.
+
+    Blocking file I/O: callers on an event loop must offload it.
+    """
+    return _load_hmac_key() is not None, sel_hmac_key_path()
 
 
 def _derive_subkey(root: bytes) -> bytes:
@@ -176,11 +303,7 @@ def publish_session_pid(pid: int, session_key: str) -> None:
     atomic_write(_txt_path(pid, cfg), session_key)
     key = _load_hmac_key()
     if key is None:
-        logger.warning(
-            "sel_hmac.key unavailable — session_pid_%s published unsigned "
-            "(strict resolvers will refuse this identity)",
-            pid,
-        )
+        _report_signing_unavailable()
         try:
             _sig_path(pid, cfg).unlink(missing_ok=True)
         except OSError:

--- a/test/test_api_health.py
+++ b/test/test_api_health.py
@@ -436,6 +436,44 @@ def test_both_servers_install_the_shared_host_barrier() -> None:
         )
 
 
+def test_every_middleware_denial_is_audited_off_the_loop() -> None:
+    """Wiring pin: every middleware that refuses BEFORE ``sel_audit_middleware``
+    must route its audit through the shared ``_audit_denied`` helper.
+
+    That helper owns two properties which are easy to omit at a new deny site
+    and invisible when omitted: the write runs OFF the event loop (the first
+    ``sel()`` of a process constructs the log — trust-dir creation, key
+    validation, an ``icacls`` subprocess on Windows), and it is best-effort (an
+    audit that raises must not turn the 403 into a 500). A bare raise with no
+    audit at all is the third failure: ``sel_audit_middleware`` is registered
+    inner to these, so the refusal would appear nowhere in the audit log.
+    """
+    import inspect
+
+    from kiro_crew.dashboard import server as server_mod
+
+    helper = inspect.getsource(server_mod._audit_denied)
+    assert "asyncio.to_thread" in helper, (
+        "_audit_denied no longer offloads the SEL write off the event loop"
+    )
+    assert "except Exception" in helper, "_audit_denied is no longer best-effort"
+
+    for func, name in (
+        (server_mod.start_dashboard, "start_dashboard"),
+        (server_mod.start_api_server, "start_api_server"),
+        (server_mod._make_host_validation_middleware, "host_validation"),
+    ):
+        src = inspect.getsource(func)
+        assert "_audit_denied(" in src, (
+            f"{name} has a deny arm that no longer audits via _audit_denied"
+        )
+        assert 'outcome="denied"' not in src, (
+            f"{name} re-grew a hand-rolled denial audit; route it through "
+            "_audit_denied so the off-loop and best-effort properties hold "
+            "(sel_audit_middleware's ok/error request audit is unaffected)"
+        )
+
+
 def test_both_servers_warm_the_kiro_readiness_probe() -> None:
     """Wiring pin: BOTH entrypoints must warm the Kiro readiness probe at boot.
 

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -297,3 +297,47 @@ class TestLingerProbe:
     def test_absent_loginctl_is_unknown(self, monkeypatch) -> None:
         monkeypatch.setattr(cli_doctor.shutil, "which", lambda _n: None)
         assert cli_doctor._linger_enabled("tester") is None
+
+
+class TestTrustRoot:
+    """`kirocrew doctor` reports whether session identities can be signed.
+
+    Publication reports the same failure, but only once a session is actually
+    claimed; doctor answers without waiting for one. It must not, however, cry
+    wolf on a fresh install whose key has legitimately never been created.
+    """
+
+    def test_healthy_trust_root_prints_the_resolved_path(
+        self, monkeypatch, tmp_path: Path, capsys
+    ) -> None:
+        key = tmp_path / "trust" / "sel_hmac.key"
+        key.parent.mkdir(parents=True)
+        key.write_bytes(b"\x01" * 32)
+        monkeypatch.setattr(cli_doctor, "signing_health", lambda: (True, key))
+        cli_doctor._doctor_trust_root()
+        out = capsys.readouterr().out
+        assert "trust root:  ✅" in out
+        assert str(key) in out
+
+    def test_broken_trust_root_names_what_stops_working(
+        self, monkeypatch, tmp_path: Path, capsys
+    ) -> None:
+        key = tmp_path / "trust" / "sel_hmac.key"
+        key.parent.mkdir(parents=True)  # dir exists, key gone → genuinely broken
+        monkeypatch.setattr(cli_doctor, "signing_health", lambda: (False, key))
+        cli_doctor._doctor_trust_root()
+        out = capsys.readouterr().out
+        assert "⚠ trust root" in out
+        assert "sub-agent" in out and "memory" in out
+
+    def test_fresh_home_is_informational_not_a_warning(
+        self, monkeypatch, tmp_path: Path, capsys
+    ) -> None:
+        """Trust dir and key are created together, so neither present means no
+        instance has ever run here — not a broken install."""
+        key = tmp_path / "trust" / "sel_hmac.key"
+        monkeypatch.setattr(cli_doctor, "signing_health", lambda: (False, key))
+        cli_doctor._doctor_trust_root()
+        out = capsys.readouterr().out
+        assert "not created yet" in out
+        assert "⚠" not in out

--- a/test/test_sel.py
+++ b/test/test_sel.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import threading
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1455,3 +1456,103 @@ class TestHmacKeyTrustDirMigration:
         (tmp_path / "sel_hmac.key").write_bytes(b"x" * 8)
         with pytest.raises(RuntimeError, match="too short"):
             SecurityEventLog(base_dir=tmp_path, sync=True)
+
+    def test_key_bytes_accessor_returns_the_live_signing_key(
+        self, tmp_path: Path
+    ) -> None:
+        """The recovery path for the dependent protocol: SEL caches the
+        validated bytes at init, so they stay available when the file behind the
+        frozen resolved path no longer loads."""
+        from kiro_crew.sel import _sel_hmac_key_bytes
+
+        log = SecurityEventLog(base_dir=tmp_path, sync=True)
+        assert _sel_hmac_key_bytes() == log._hmac_key
+        # Still available after the file is gone — that is the whole point.
+        (tmp_path / "trust" / "sel_hmac.key").unlink()
+        assert _sel_hmac_key_bytes() == log._hmac_key
+
+    def test_key_bytes_accessor_is_none_without_a_live_singleton(self) -> None:
+        """The verifying MCP process has no singleton; it must get None rather
+        than a partially-constructed instance's attribute."""
+        from kiro_crew.sel import _sel_hmac_key_bytes
+
+        self._reset()
+        assert _sel_hmac_key_bytes() is None
+
+    def test_key_bytes_accessor_is_none_mid_construction(self) -> None:
+        """``__new__`` publishes the instance to ``_instance`` BEFORE ``__init__``
+        loads the key, so a concurrent reader can see an instance whose
+        ``_hmac_key`` does not exist yet. ``_initialized`` is the barrier that
+        makes that window return None instead of raising or yielding garbage."""
+        from kiro_crew.sel import SecurityEventLog as _SEL
+        from kiro_crew.sel import _sel_hmac_key_bytes
+
+        self._reset()
+        try:
+            _SEL.__new__(_SEL)  # publishes _instance, leaves _initialized False
+            assert _SEL._instance is not None
+            assert not getattr(_SEL._instance, "_initialized", False)
+            assert _sel_hmac_key_bytes() is None
+        finally:
+            self._reset()
+
+    def test_key_bytes_accessor_has_exactly_one_production_caller(self) -> None:
+        """Handing out raw trust-root bytes is safe only under the file-first
+        ordering its ONE caller enforces; a second caller would inherit none of
+        it. Pin the caller set rather than trusting the underscore."""
+        root = Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+        callers = {
+            path
+            for path in root.rglob("*.py")
+            if path.name != "sel.py"
+            # encoding is explicit: the default is cp1252 on Windows, which
+            # cannot decode the non-ASCII bytes several sources contain.
+            and "_sel_hmac_key_bytes" in path.read_text(encoding="utf-8")
+        }
+        assert callers == {root / "session_pid_sig.py"}, (
+            f"_sel_hmac_key_bytes gained a caller outside session_pid_sig: {callers}"
+        )
+
+    def test_concurrent_first_construction_initializes_once(self, tmp_path: Path) -> None:
+        """``__new__`` publishes the instance BEFORE ``__init__`` runs, so two
+        threads arriving in between both see ``_initialized`` False. Unserialized,
+        both run the construction body and each can mint a fresh key — one wins
+        on disk while the other signs from different bytes in memory, splitting
+        the audit chain from the file every other process resolves.
+
+        Reachable because SEL is now constructed from worker threads (the
+        middleware deny audits offload via ``asyncio.to_thread``), where the
+        event loop no longer serializes callers for free.
+        """
+        self._reset()
+        calls: list[int] = []
+        real = SecurityEventLog._load_or_create_hmac_key
+
+        def counting(inst):
+            calls.append(1)
+            # Widen the window a real race would need, so an unlocked body
+            # reliably interleaves instead of passing by luck.
+            time.sleep(0.05)
+            return real(inst)
+
+        barrier = threading.Barrier(8)
+
+        def build():
+            barrier.wait()
+            SecurityEventLog(base_dir=tmp_path, sync=True)
+
+        with patch.object(SecurityEventLog, "_load_or_create_hmac_key", counting):
+            threads = [threading.Thread(target=build) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        assert len(calls) == 1, (
+            f"construction body ran {len(calls)} times; concurrent first "
+            "denials can mint competing trust-root keys"
+        )
+        inst = SecurityEventLog._instance
+        assert inst is not None and inst._initialized
+        assert inst._hmac_key == (tmp_path / "trust" / "sel_hmac.key").read_bytes()
+        self._reset()

--- a/test/test_session_pid_sig.py
+++ b/test/test_session_pid_sig.py
@@ -22,15 +22,25 @@ SESSION_KEY = "dashboard:chat-7-123456"
 def cfg(tmp_path):
     """Isolated config dir with a valid SEL trust-root key. Patches both the
     mapping-file dir (config_dir) and the canonical trust-root path accessor
-    (sel_hmac_key_path — single source of truth owned by sel.py)."""
+    (sel_hmac_key_path — single source of truth owned by sel.py).
+
+    ``_sel_hmac_key_bytes`` is stubbed to ``None`` so these tests exercise the
+    FILE path in isolation: the in-memory recovery fallback depends on a live
+    ``SecurityEventLog`` singleton, which other tests in the same process may
+    or may not have initialized. Its own behavior is covered by
+    ``TestTrustRootRecovery``.
+    """
     (tmp_path / "sel_hmac.key").write_bytes(b"\x01" * 32)
     with patch.object(session_pid_sig, "config_dir", return_value=tmp_path), \
+         patch.object(session_pid_sig, "_sel_hmac_key_bytes", return_value=None), \
          patch.object(
              session_pid_sig,
              "sel_hmac_key_path",
              return_value=tmp_path / "sel_hmac.key",
          ):
+        session_pid_sig._reported.clear()
         yield tmp_path
+        session_pid_sig._reported.clear()
 
 
 class TestPublish:
@@ -261,3 +271,191 @@ class TestDomainSeparation:
             subkey, f"4242:{SESSION_KEY}".encode("utf-8"), hashlib.sha256
         ).hexdigest()
         assert stored == derived_mac
+
+
+class TestTrustRootRecovery:
+    """The resolved trust-root path is frozen at ``SecurityEventLog`` init and
+    never re-resolved, while SEL keeps signing from key bytes it cached at that
+    moment. So a key file that later moves (a concurrent legacy -> ``trust/``
+    migration), is deleted, loses read permission, or is truncated silently
+    takes this protocol down for the life of the process — with a healthy audit
+    chain giving no hint. Recovery reads the same bytes SEL validated at init.
+    """
+
+    def test_missing_file_recovers_from_live_sel_key(self, cfg):
+        (cfg / "sel_hmac.key").unlink()
+        with patch.object(
+            session_pid_sig, "_sel_hmac_key_bytes", return_value=b"\x01" * 32
+        ):
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+            assert session_pid_sig.verify_session_pid(4242) == SESSION_KEY
+
+    def test_recovery_still_announces_the_broken_file(self, cfg, caplog):
+        """Recovering from memory must NOT go quiet: signing works HERE, but the
+        file is what every other process resolves, so a verifier that never held
+        these bytes still fails closed. Silence would move the original silent
+        failure one layer over instead of removing it."""
+        (cfg / "sel_hmac.key").unlink()
+        with patch.object(
+            session_pid_sig, "_sel_hmac_key_bytes", return_value=b"\x01" * 32
+        ), caplog.at_level("ERROR", logger="kiro_crew.session_pid_sig"):
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert len(errors) == 1
+        message = errors[0].getMessage()
+        assert str(cfg / "sel_hmac.key") in message
+        assert "every other process" in message
+        assert "sub-agent dispatch" in message and "memory writes" in message
+
+    def test_broken_file_report_is_throttled_per_path(self, cfg, caplog):
+        (cfg / "sel_hmac.key").unlink()
+        with patch.object(
+            session_pid_sig, "_sel_hmac_key_bytes", return_value=b"\x01" * 32
+        ), caplog.at_level("DEBUG", logger="kiro_crew.session_pid_sig"):
+            session_pid_sig.publish_session_pid(1, SESSION_KEY)
+            session_pid_sig.publish_session_pid(2, SESSION_KEY)
+            session_pid_sig.publish_session_pid(3, SESSION_KEY)
+        assert len([r for r in caplog.records if r.levelname == "ERROR"]) == 1
+        assert (
+            len(
+                [
+                    r
+                    for r in caplog.records
+                    if r.levelname == "DEBUG" and "signing from memory" in r.getMessage()
+                ]
+            )
+            == 2
+        )
+
+    def test_truncated_file_recovers_from_live_sel_key(self, cfg):
+        """SEL validates the length only at init, this protocol on every call —
+        so a post-init truncation is exactly the asymmetry to recover from."""
+        (cfg / "sel_hmac.key").write_bytes(b"\x01" * 8)
+        with patch.object(
+            session_pid_sig, "_sel_hmac_key_bytes", return_value=b"\x01" * 32
+        ):
+            assert session_pid_sig._load_hmac_key() == b"\x01" * 32
+
+    def test_readable_file_wins_over_live_sel_key(self, cfg):
+        """The file is the anchor every OTHER process resolves independently, so
+        a readable file must never be overridden by this process's memory —
+        otherwise a publisher signs with bytes its verifier does not have."""
+        with patch.object(
+            session_pid_sig, "_sel_hmac_key_bytes", return_value=b"\x02" * 32
+        ):
+            assert session_pid_sig._load_hmac_key() == b"\x01" * 32
+
+    def test_no_file_and_no_live_key_still_fails_closed(self, cfg):
+        (cfg / "sel_hmac.key").unlink()
+        session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        assert not (cfg / "session_pid_4242.sig").exists()
+        assert session_pid_sig.verify_session_pid(4242) == ""
+
+
+class TestSigningUnavailableReport:
+    """Publication happens on every session claim, so the operator-facing
+    message must not be emitted per publish, and must name what stops working
+    rather than only the mechanism."""
+
+    def test_the_two_reports_do_not_suppress_each_other(self, cfg, caplog):
+        """The broken-file notice and the cannot-sign notice tell an operator
+        different things (signing survives here vs signing is gone), so they are
+        throttled independently. Sharing one key would let whichever fired first
+        silence the other for the rest of the process."""
+        (cfg / "sel_hmac.key").unlink()
+        with caplog.at_level("ERROR", logger="kiro_crew.session_pid_sig"):
+            with patch.object(
+                session_pid_sig, "_sel_hmac_key_bytes", return_value=b"\x01" * 32
+            ):
+                session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+            # Same path, but the in-memory fallback is gone now.
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        messages = [r.getMessage() for r in caplog.records if r.levelname == "ERROR"]
+        assert len(messages) == 2, messages
+        assert "every other process" in messages[0]
+        assert "cannot sign session identities" in messages[1]
+
+    def test_reported_once_per_process_then_debug(self, cfg, caplog):
+        (cfg / "sel_hmac.key").unlink()
+        with caplog.at_level("DEBUG", logger="kiro_crew.session_pid_sig"):
+            session_pid_sig.publish_session_pid(1, SESSION_KEY)
+            session_pid_sig.publish_session_pid(2, SESSION_KEY)
+            session_pid_sig.publish_session_pid(3, SESSION_KEY)
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert len(errors) == 1
+        debugs = [
+            r
+            for r in caplog.records
+            if r.levelname == "DEBUG" and "still unavailable" in r.getMessage()
+        ]
+        assert len(debugs) == 2
+
+    def test_message_names_the_consequence_and_the_path(self, cfg, caplog):
+        (cfg / "sel_hmac.key").unlink()
+        with caplog.at_level("ERROR", logger="kiro_crew.session_pid_sig"):
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        message = caplog.records[0].getMessage()
+        assert str(cfg / "sel_hmac.key") in message
+        assert "sub-agent dispatch" in message
+        assert "memory writes" in message
+
+    def test_relocated_path_is_reported_again(self, cfg, caplog):
+        """Suppression is keyed on the resolved path, so a genuine relocation
+        is not swallowed by the first failure's entry."""
+        (cfg / "sel_hmac.key").unlink()
+        with caplog.at_level("ERROR", logger="kiro_crew.session_pid_sig"):
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+            with patch.object(
+                session_pid_sig,
+                "sel_hmac_key_path",
+                return_value=cfg / "trust" / "sel_hmac.key",
+            ):
+                session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        assert len([r for r in caplog.records if r.levelname == "ERROR"]) == 2
+
+    def test_recovery_rearms_the_report_for_the_same_path(self, cfg, caplog):
+        """Break -> restore -> break again on ONE path must produce a second
+        ERROR: on a long-lived gateway that is never restarted, the log is the
+        only signal the operator gets."""
+        with caplog.at_level("ERROR", logger="kiro_crew.session_pid_sig"):
+            (cfg / "sel_hmac.key").unlink()
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+            (cfg / "sel_hmac.key").write_bytes(b"\x01" * 32)
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+            (cfg / "sel_hmac.key").unlink()
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        assert len([r for r in caplog.records if r.levelname == "ERROR"]) == 2
+
+
+class TestSigningHealth:
+    """The diagnostic surface (`kirocrew doctor`) asks proactively; publication
+    only reports once a session is claimed."""
+
+    def test_reports_healthy_with_the_resolved_path(self, cfg):
+        ok, path = session_pid_sig.signing_health()
+        assert ok is True
+        assert path == cfg / "sel_hmac.key"
+
+    def test_reports_unhealthy_when_the_trust_root_is_gone(self, cfg):
+        (cfg / "sel_hmac.key").unlink()
+        ok, path = session_pid_sig.signing_health()
+        assert ok is False
+        assert path == cfg / "sel_hmac.key"
+
+    def test_never_constructs_the_sel_singleton(self, cfg):
+        """Asking the question must not create the trust root it asks about,
+        and must not put a mkdir + key write behind a read-only command."""
+        with patch("kiro_crew.sel.SecurityEventLog") as sel_cls:
+            session_pid_sig.signing_health()
+        sel_cls.assert_not_called()
+
+    def test_is_not_wired_into_the_gateway_boot_path(self):
+        """`no-new-work-on-gateway-boot-path` forbids a new awaited step before
+        the socket binds, and this check is a diagnostic, not a gate."""
+        import inspect
+
+        from kiro_crew.dashboard import token_auth
+
+        assert "signing_health" not in inspect.getsource(
+            token_auth.warm_auth_singletons
+        )


### PR DESCRIPTION
## What is the problem?

A gateway can permanently lose the ability to sign session identities, and nothing tells the operator.

`SecurityEventLog` reads the SEL trust-root key **once** at init (`sel.py:133`) and signs every later audit record from that in-memory copy. `session_pid_sig` re-reads the **file** on every publish — against a path that was resolved at that same init and is **never re-resolved**. So once the file behind that path stops loading (another process relocates it legacy → `trust/`, it is deleted, it loses read permission, it is truncated), every `session_pid_<pid>` mapping goes out **unsigned for the rest of the process lifetime** while the audit chain keeps verifying and looking perfectly healthy.

Strict identity resolvers refuse an unsigned mapping, so the MCP tools that need a verified session stop working. The only trace was a `WARNING` on every session claim — observed at several lines a minute — that named the mechanism (`published unsigned`) and not one word of the consequence.

Separately, the dashboard's CSRF barrier raised a bare `403`. `sel_audit_middleware` is registered *inner* to it, so that refusal appeared **nowhere** in the audit log — while the `start_api_server` twin logged the identical decision.

## Why this issue matters to the user

Sub-agent dispatch and memory writes silently stop working in sandboxed sessions, and every diagnostic an operator would reach for looks fine: `kirocrew security verify` passes, the audit chain is intact, `kirocrew doctor` says nothing. The failure is unrecoverable without a restart, and the log line that *is* emitted does not connect to the capability that disappeared. A denial with no audit record is also the exact inverse of the deny-or-audit invariant the auth layer documents for itself.

## How our fix solves it

The chain from symptom to root cause:

*Symptom* — identity-dependent MCP tools refused. → *Mechanism* — strict resolvers reject an unsigned mapping. → *Cause* — `_load_hmac_key()` returns `None` forever. → *Root cause* — a **frozen resolved path** re-read on every call, paired with a key that is **cached in memory** by its owner. SEL never notices; the dependent protocol dies.

1. **Recovery.** `_load_hmac_key()` falls back to the live `SecurityEventLog`'s already-validated key bytes when the file no longer loads. The **file stays authoritative whenever it loads** — it is the anchor a separate verifying process resolves independently, so preferring memory would mint MACs that verifier rejects. The accessor is module-private with exactly one intended caller, because that ordering rule lives in the caller, not the accessor; a test pins the caller set.
2. **Say what breaks.** One `ERROR` per resolved path per process, naming the capabilities that stop and the path to fix, with repeats at `debug`. The entry is **released once signing recovers**, so a break → restore → break sequence reports twice instead of downgrading the second one to `debug` — the case where a long-lived gateway's log is the only signal there is.
3. **Ask without waiting for a session claim.** `kirocrew doctor` reports the resolved trust root and whether identities can be signed, and distinguishes a fresh home (trust dir absent → informational) from a genuinely broken one. It is read-only: it never constructs `SecurityEventLog`, so it cannot create the key as a side effect of asking about it.
4. **Audit the refusal.** All three middlewares that deny *before* `sel_audit_middleware` (dashboard CSRF, headless CSRF, host validation) route through one shared `_audit_denied()` helper. It owns the two properties that are easy to omit at a new deny site and invisible when omitted: the write runs **off the event loop** (the first `sel()` of a process constructs the log — trust-dir creation, key validation, an `icacls` subprocess on Windows), and it is **best-effort** so a failed audit cannot turn the `403` into a `500`.

**Reporting is split, not merged.** When the memory fallback succeeds the FILE is still broken, and the file is what every *other* process resolves — a verifier that never held those bytes still fails closed. So a distinct throttled notice fires in that case naming the split, rather than letting a successful local fallback go quiet and move the silent failure one layer over. The two notices are throttled under separate keys so neither silences the other, and the re-arm only fires when the file itself loads again.

**Deliberately NOT on the gateway boot path.** An earlier revision hung this check off `warm_auth_singletons()`. `AUTOSDE.yaml:101` `no-new-work-on-gateway-boot-path` (`blocking: true`) rejects a new awaited step before the socket binds, and its `Allowed:` carve-out covers only bounded fail-closed checks that *must* precede traffic — a non-gating diagnostic is neither, and it would have added SEL construction plus a directory `mkdir` and a key write to every launch. It moved to `doctor`, where a diagnostic belongs and costs boot nothing.

## What tests we did

- **200 targeted tests** across `test_session_pid_sig.py`, `test_sel.py`, `test_api_health.py`, `test_cli_doctor.py`.
- **11/11 mutants caught.** Each claim was broken and the guarding test confirmed to fail: no fallback; memory preferred over a readable file; throttle removed; throttle keyed globally instead of per path; no re-arm after recovery; consequence dropped from the message; `signing_health` constructing SEL; the key-bytes guard removed; the dashboard CSRF denial unaudited again; doctor crying wolf on a fresh home; doctor dropping the consequence.
- **Gates:** `pytest`, `isort`, `flake8`, `mypy` (865 files) all clean. No frontend files touched.
- **Full suite:** 40381 passed / 82 failed. Every failure is host-environment (`gh` CLI absent, sandbox backend unavailable, `git push`) and pre-existing. Verified two ways rather than by inspection: an 18-id subset produced an **identical** failure set on base and branch under the same invocation, and the 10 ids that differed between two full runs **pass in isolation on both base and branch** — order-dependent flakes in `auto_improvement` / `ops_mission_control` / `terminal_commands`, which churn in both directions and touch none of the changed modules.

## Manual verification

The reported symptom is live on this machine: the gateway (PID 1489661) has logged `sel_hmac.key unavailable` since 05:09 while `trust/sel_hmac.key` is present, 32 bytes, mode `0600`, owned by the running user — a process pinned to a path that no longer resolves, with a healthy audit chain. That gateway's `/proc/<pid>/environ` is unreadable, so which path its singleton froze cannot be observed from outside; the fix targets the class rather than that one instance, and `doctor` plus the once-per-process `ERROR` are what make the next occurrence diagnosable.

## Any other suggestions on the work

**Two corrections to the issue's diagnosis**, both verified in code:

- **Unsigned identity does not cause the `403`.** `_verify_unix_peer` treats an empty signed resolution as *unresolvable* and returns `None` — proceed (`token_auth.py:1407-1408`), exactly as its docstring states. The unsigned-publish warning and the `Forbidden` are independent symptoms; the issue linked them causally.
- **The `403` paths on `/api/spawn` and `/api/lessons` are audited.** Every reachable branch writes a SEL `denied` event, directly or via `_log_auth`. The one genuinely unaudited `403` in the chain was the dashboard CSRF middleware, fixed here. Worth noting the `_check_pin` denials audit only under `operation="dashboard.token_auth"`, not the `internal_auth` name their neighbours use — so a query filtered on `internal_auth` misses them. Left alone as out of scope.

One follow-up I did not fold in: the frozen-path problem still applies to any future dependent protocol that re-derives the trust root instead of going through the single accessor. (`host_validation_middleware`'s unguarded `sel()` shape was folded in — see the shared helper above.)

Fixes #2539

