### PR TITLE
perf(chat): skip redundant transcript replace on slot switch

### DIFF
--- a/website/src/store/chatSlice.ts
+++ b/website/src/store/chatSlice.ts
@@ -259,6 +259,37 @@ export const captureStatelessCard = (
  *  slot-detail `queue` field. */
 type SlotQueueItem = { content: string; queueId: string; ts: string }
 
+/** Structural equality for the JSON-shaped message fields (`meta`, `variants`). */
+function jsonEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false
+  const aArr = Array.isArray(a), bArr = Array.isArray(b)
+  if (aArr !== bArr) return false
+  if (aArr && bArr) return a.length === b.length && a.every((v, i) => jsonEqual(v, b[i]))
+  const ak = Object.keys(a), bk = Object.keys(b)
+  if (ak.length !== bk.length) return false
+  return ak.every(k => Object.prototype.hasOwnProperty.call(b, k)
+    && jsonEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]))
+}
+
+/** Field-for-field equality over every `ChatMessage` field a consumer can render. */
+function sameMessage(a: ChatMessage, b: ChatMessage): boolean {
+  if (a === b) return true
+  return a.role === b.role && a.content === b.content && a.cls === b.cls
+    && a.ts === b.ts && a.rawText === b.rawText && a.kind === b.kind
+    && a.variant_idx === b.variant_idx && a._toolCount === b._toolCount
+    && jsonEqual(a.variants, b.variants) && jsonEqual(a.meta, b.meta)
+}
+
+/** True when `next` renders identically to `prev`, so a reducer can leave
+ *  `state.messages` untouched and every consumer keeps its existing reference. */
+function sameTranscript(prev: ChatMessage[], next: ChatMessage[]): boolean {
+  if (prev === next) return true
+  if (prev.length !== next.length) return false
+  for (let i = 0; i < prev.length; i++) if (!sameMessage(prev[i], next[i])) return false
+  return true
+}
+
 /** SINGLE hydration path for the slot-detail `queue` field — the one place that
  *  turns backend queue entries into `queued` message bubbles. Every reducer that
  *  consumes a `fetchSlotDetail` payload (`switchSlot`, `warmSlotCache`,
@@ -2932,13 +2963,17 @@ const chatSlice = createSlice({
             ? preserved.some(m => m.role === 'assistant' && m.meta?.mid === localMid)
             : preserved.some(m => m.role === 'assistant' && m.content === lastLocal.content)
         )
+        // Hold the pre-fetch array so the assignment below can be skipped when
+        // the fetched history turns out to be redundant (see sameTranscript).
+        const existing = state.messages
+        let next: ChatMessage[]
         if (
           state._wsChunkedDuringFetch
           && lastLocal?.role === 'streaming'
           && lastLocal.content.length > 0
         ) {
           // WS chunks arrived during fetch — use fetched history + local streaming
-          state.messages = [...preserved.filter(m => m.role !== 'streaming'), lastLocal]
+          next = [...preserved.filter(m => m.role !== 'streaming'), lastLocal]
         } else if (
           lastLocal
           && (lastLocal.role === 'assistant' || lastLocal.role === 'streaming')
@@ -2966,9 +3001,9 @@ const chatSlice = createSlice({
           const finalized: ChatMessage = (lastLocal.role === 'streaming' && !running)
             ? { ...lastLocal, role: 'assistant' }
             : lastLocal
-          state.messages = [...preserved.filter(m => m.role !== 'streaming'), finalized]
+          next = [...preserved.filter(m => m.role !== 'streaming'), finalized]
         } else {
-          state.messages = preserved
+          next = preserved
         }
         state.slotRunning = running
         state.slotStopping = action.payload.stopping ?? false
@@ -2980,7 +3015,10 @@ const chatSlice = createSlice({
         // from warmSlotCache/refreshSlot. It strips any WS-delivered queued
         // bubbles first (a queue_push may have arrived during the fetch) so the
         // server queue set stays canonical and non-duplicated.
-        state.messages = hydrateQueuedBubbles(state.messages, queue)
+        next = hydrateQueuedBubbles(next, queue)
+        // Switching back to an already-loaded slot re-fetches a history that is
+        // usually identical; skipping the write keeps every existing reference.
+        if (!sameTranscript(existing, next)) state.messages = next
         // Update cache and clear loading state
         state.slotMessages[safeKey(key)] = state.messages
         state.slotLoading = false

--- a/website/src/test/chatSlice.test.ts
+++ b/website/src/test/chatSlice.test.ts
@@ -437,6 +437,131 @@ describe('switchSlot.pending', () => {
     expect(tail.content).toBe('partial repl')
     expect(state.messages.filter(m => m.role === 'streaming')).toHaveLength(1)
   })
+  it('fulfilled keeps the existing array when the fetched history is identical', () => {
+    const bCache: ChatMessage[] = [
+      { role: 'user', content: 'question', cls: '' },
+      { role: 'assistant', content: 'the latest reply', cls: 'msg msg-a' },
+    ]
+    let state = { ...initial, activeSlot: 'A',
+      messages: [{ role: 'user' as const, content: 'A msg', cls: '' }],
+      slotMessages: { 'B': bCache } }
+    state = reducer(state, { type: 'chat/switchSlot/pending', meta: { arg: 'B', requestId: 'r1', requestStatus: 'pending' } })
+    // Positive control: pending restores the cached array BY REFERENCE, so the
+    // assertion below can tell a preserved array from a re-created one.
+    expect(state.messages).toBe(bCache)
+    state = reducer(state, {
+      type: 'chat/switchSlot/fulfilled',
+      meta: { arg: 'B', requestId: 'r1', requestStatus: 'fulfilled' },
+      payload: { key: 'B', messages: [
+        { role: 'user', content: 'question', cls: '' },
+        { role: 'assistant', content: 'the latest reply', cls: 'msg msg-a' },
+      ], running: false, stopping: false, hasMore: false, total: 2, queue: [] },
+    })
+    expect(state.messages).toBe(bCache)
+    expect(state.slotLoading).toBe(false)
+  })
+
+  it('fulfilled replaces the array when the fetched history appends a message', () => {
+    const bCache: ChatMessage[] = [
+      { role: 'user', content: 'question', cls: '' },
+      { role: 'assistant', content: 'the latest reply', cls: 'msg msg-a' },
+    ]
+    let state = { ...initial, activeSlot: 'A',
+      messages: [{ role: 'user' as const, content: 'A msg', cls: '' }],
+      slotMessages: { 'B': bCache } }
+    state = reducer(state, { type: 'chat/switchSlot/pending', meta: { arg: 'B', requestId: 'r1', requestStatus: 'pending' } })
+    state = reducer(state, {
+      type: 'chat/switchSlot/fulfilled',
+      meta: { arg: 'B', requestId: 'r1', requestStatus: 'fulfilled' },
+      payload: { key: 'B', messages: [
+        { role: 'user', content: 'question', cls: '' },
+        { role: 'assistant', content: 'the latest reply', cls: 'msg msg-a' },
+        { role: 'user', content: 'follow-up', cls: '' },
+      ], running: false, stopping: false, hasMore: false, total: 3, queue: [] },
+    })
+    expect(state.messages).not.toBe(bCache)
+    expect(state.messages).toHaveLength(3)
+    expect(state.messages[2].content).toBe('follow-up')
+  })
+
+  it('fulfilled replaces the array when a message body changed', () => {
+    const bCache: ChatMessage[] = [
+      { role: 'user', content: 'question', cls: '' },
+      { role: 'assistant', content: 'the latest reply', cls: 'msg msg-a' },
+    ]
+    let state = { ...initial, activeSlot: 'A',
+      messages: [{ role: 'user' as const, content: 'A msg', cls: '' }],
+      slotMessages: { 'B': bCache } }
+    state = reducer(state, { type: 'chat/switchSlot/pending', meta: { arg: 'B', requestId: 'r1', requestStatus: 'pending' } })
+    // Same shape, one differing body — the guard must not mask a real change.
+    state = reducer(state, {
+      type: 'chat/switchSlot/fulfilled',
+      meta: { arg: 'B', requestId: 'r1', requestStatus: 'fulfilled' },
+      payload: { key: 'B', messages: [
+        { role: 'user', content: 'question (edited)', cls: '' },
+        { role: 'assistant', content: 'the latest reply', cls: 'msg msg-a' },
+      ], running: false, stopping: false, hasMore: false, total: 2, queue: [] },
+    })
+    expect(state.messages).not.toBe(bCache)
+    expect(state.messages).toHaveLength(2)
+    expect(state.messages[0].content).toBe('question (edited)')
+  })
+
+  it('fulfilled populates messages when the slot had no cache', () => {
+    let state = { ...initial, activeSlot: 'A',
+      messages: [{ role: 'user' as const, content: 'A msg', cls: '' }] }
+    state = reducer(state, { type: 'chat/switchSlot/pending', meta: { arg: 'B', requestId: 'r1', requestStatus: 'pending' } })
+    expect(state.messages).toEqual([])
+    state = reducer(state, {
+      type: 'chat/switchSlot/fulfilled',
+      meta: { arg: 'B', requestId: 'r1', requestStatus: 'fulfilled' },
+      payload: { key: 'B', messages: [{ role: 'user', content: 'B msg', cls: '' }], running: false, stopping: false, hasMore: false, total: 1, queue: [] },
+    })
+    expect(state.messages).toHaveLength(1)
+    expect(state.messages[0].content).toBe('B msg')
+  })
+
+  it('fulfilled still appends the in-flight streaming tail past the guard', () => {
+    const bCache: ChatMessage[] = [{ role: 'user', content: 'question', cls: '' }]
+    let state = { ...initial, activeSlot: 'A',
+      messages: [{ role: 'user' as const, content: 'A msg', cls: '' }],
+      slotMessages: { 'B': bCache } }
+    state = reducer(state, { type: 'chat/switchSlot/pending', meta: { arg: 'B', requestId: 'r1', requestStatus: 'pending' } })
+    state = reducer(state, sseChatMessage({ slot: 'B', role: 'chunk', content: 'live text' }))
+    expect(state.messages[state.messages.length - 1].role).toBe('streaming')
+    // Server history is behind the live stream: the WS branch must still win.
+    state = reducer(state, {
+      type: 'chat/switchSlot/fulfilled',
+      meta: { arg: 'B', requestId: 'r1', requestStatus: 'fulfilled' },
+      payload: { key: 'B', messages: [
+        { role: 'user', content: 'question', cls: '' },
+        { role: 'assistant', content: 'older reply', cls: 'msg msg-a' },
+      ], running: true, stopping: false, hasMore: false, total: 2, queue: [] },
+    })
+    expect(state.messages).toHaveLength(3)
+    expect(state.messages[state.messages.length - 1].role).toBe('streaming')
+    expect(state.messages[state.messages.length - 1].content).toBe('live text')
+    expect(state.messages.filter(m => m.role === 'streaming')).toHaveLength(1)
+  })
+
+  it('fulfilled still adopts the stale-permission sweep past the guard', () => {
+    const bCache: ChatMessage[] = [{ role: 'permission', content: 'approve?', cls: '', meta: { tool: 'x' } }]
+    let state = { ...initial, activeSlot: 'A',
+      messages: [{ role: 'user' as const, content: 'A msg', cls: '' }],
+      slotMessages: { 'B': bCache } }
+    state = reducer(state, { type: 'chat/switchSlot/pending', meta: { arg: 'B', requestId: 'r1', requestStatus: 'pending' } })
+    expect(state.messages[0].meta?.resolved).toBeUndefined()
+    // The sweep marks the fetched row resolved, so the guard must see a
+    // difference in meta and adopt the fetched history rather than keep ours.
+    state = reducer(state, {
+      type: 'chat/switchSlot/fulfilled',
+      meta: { arg: 'B', requestId: 'r1', requestStatus: 'fulfilled' },
+      payload: { key: 'B', messages: [{ role: 'permission', content: 'approve?', cls: '', meta: { tool: 'x' } }], running: false, stopping: false, hasMore: false, total: 1, queue: [] },
+    })
+    expect(state.messages).not.toBe(bCache)
+    expect(state.messages[0].meta?.resolved).toBe('stale')
+  })
+
   it('pending restores cached messages instantly without loading', () => {
     let state = { ...initial, activeSlot: 'A',
       messages: [{ role: 'user' as const, content: 'A msg', cls: '' }],


### PR DESCRIPTION
## Problem

Switching back to a chat that was already open re-created every message object in the transcript. `switchSlot.fulfilled` assigned a freshly allocated array to `state.messages` on every path: each of its three history branches builds one, and the queue-hydration step that follows reallocates unconditionally. The fetched history is a new object graph, so every row was replaced by an equal-but-distinct object even when nothing about it had changed.

## Why it matters

Memoised selectors and the virtualiser key on object identity, so every row presented as changed. Switching chats therefore paid for a full transcript's worth of re-render and re-measure even when the server returned exactly what was already on screen — which is the common case, because the slot's messages are cached and restored synchronously in `switchSlot.pending` and the subsequent fetch usually returns the same history. The cost scales with transcript length, so it is worst in the long conversations where switching back and forth is most frequent.

## Fix (symptoms → root cause → change)

The symptom is a full-transcript re-render when switching back to an already-loaded chat. The root cause is that the reducer replaced `state.messages` unconditionally, so identity changed even when content did not. The change routes the three branch results through a local and assigns it only when it differs from what state already holds; leaving the draft untouched is what preserves the reference, since Immer returns the original array when it is never assigned.

Equivalence is field-for-field over every `ChatMessage` field a consumer can render, with `meta` and `variants` compared structurally, and any difference at all falls through to the existing replace. That keeps the guard's blast radius to *whether* a new object graph is allocated, never *what* gets rendered.

The guard sits after queue hydration on purpose, so the stale-permission sweep, the WS-chunk branch that preserves a local streaming tail, and the re-attach of a locally-finalized trailing reply are all fully evaluated first. It decides only whether the result is written.

## Tests

Six reducer cases in `website/src/test/chatSlice.test.ts`:

- identical fetched history keeps the existing array — asserts reference identity, and is preceded by a positive control that the cache really is restored by reference, so the assertion is capable of failing
- an appended message replaces the array
- a changed message body replaces the array, so the guard cannot mask a real change
- empty-to-populated, for a slot with no cache
- an in-flight streaming tail is still appended past the guard
- the stale-permission sweep is still adopted past the guard

I also confirmed the tests discriminate: with the guard reverted to an unconditional assignment, exactly one of these fails, reporting a deep-equal array that is not reference-equal.

## Manual verification

Not done in a browser, and worth stating plainly: the tests prove the reducer now preserves array and row identity, but I did not measure the resulting reduction in React re-renders or virtualiser re-measures. The performance claim rests on memoisation semantics rather than a profile capture.

## Related Issues

None.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A, no user-facing or API surface change
- [x] No secrets, credentials, or internal references in the diff
