### PR TITLE
fix(test): stop the unit-literal ratchet failing on runner speed

### DIFF
--- a/website/src/i18n/unitLiterals.test.ts
+++ b/website/src/i18n/unitLiterals.test.ts
@@ -455,7 +455,18 @@ describe('a number is never glued to a unit literal', () => {
       offenders.length,
       `${ADVICE}\n\n${offenders.slice(0, 15).join('\n')}`,
     ).toBeLessThanOrEqual(BASELINE)
-  })
+    // Explicit timeout: this is the only test here that parses the WHOLE tree, and
+    // it is inherently expensive — `ts.createSourceFile(..., setParentNodes: true)`
+    // over ~1000 files, because `inCssContext` walks `node.parent`. It measures
+    // ~4.3s on a dev machine but 15-16s on a CI runner, which straddles vitest's
+    // 15s default: `main` fails this test roughly one run in six, and any branch
+    // adding files tips it over reliably. The verdict of a ratchet must not depend
+    // on runner speed, so the budget is stated rather than inherited.
+    //
+    // This buys headroom; it does not make the scan cheap. The real win is dropping
+    // `setParentNodes` by tracking ancestry during the walk instead — worth doing,
+    // but a refactor of a gate rather than a timeout change.
+  }, 60_000)
 
   /**
    * Zero tolerance, no stored state. A finding on a line this branch wrote fails,


### PR DESCRIPTION
## Problem

`Frontend Tests` fails on a **timeout**, not an assertion:

```
FAIL src/i18n/unitLiterals.test.ts > holds at most 74 un-migrated number+unit literal(s)
Error: Test timed out in 15000ms.
```

The whole-repo scan inherits vitest's 15 s default `testTimeout` and does not fit
inside it on CI:

| where | time |
|---|---|
| dev machine | ~4.3 s |
| CI runner | **15.8 s**, then **16.4 s** on the re-run |

That straddles the limit, so:

- **`main` fails this test roughly one run in six** — e.g. run
  [31359945669](https://github.com/kirodotdev/KiroCrew/actions/runs/31359945669),
  same file, same 15000 ms message, on `main` with no PR involved.
- Any branch that **adds source files** tips it from occasional to consistent.
  Found from #2056, a frontend PR whose three new files pushed it over on two
  consecutive runs.

The failure mode is also actively misleading. Because the test times out before
reaching its comparison, the message names `BASELINE` (74) while saying nothing
about the actual count — so it reads like a real ratchet breach and costs a fresh
diagnosis every time it happens.

## Root cause

The cost is inherent, not accidental waste. This is the only test in the file that
parses the **entire tree**, and it does so via

```ts
ts.createSourceFile(file, source, ts.ScriptTarget.Latest, /* setParentNodes */ true, ts.ScriptKind.TSX)
```

over ~1000 files, because `inCssContext` walks `node.parent` to decide whether a
literal sits in a CSS position. I checked for the cheaper explanations first and
ruled them out:

- It is **not** scanning `node_modules`, `locales`, or `.test.*` files — `walk()`
  already excludes all three.
- Nothing is read or parsed **twice**; each file is read once in this test.

## Fix

State the budget instead of inheriting it: `}, 60_000)` on that one test.

A ratchet's verdict must not depend on how fast the runner is. 60 s is ~3.5×
headroom over the worst observed CI time, and it costs nothing on a passing run
because the scan is synchronous and returns as soon as it finishes.

**Deliberately not done here:** making the scan cheap. Dropping `setParentNodes`
by tracking ancestry during the walk is the real win and would likely remove most
of the time, but that is a refactor of a live gate and wants its own review rather
than riding along in a timeout change. It is noted at the call site so the next
reader has the thread.

## Tests

No new tests — this changes only how long an existing test may take. What is
verified:

- The test passes, and the **assertion still enforces**: with `BASELINE` forced to
  `0` the test fails, so the larger timeout has not quietly neutered the ratchet.
- `tsc -b` and `eslint` clean on the changed file.
- The two diff-scoped siblings (`[added-lines]`, `[vs-base]`) are untouched — they
  are the gates that actually stop a new site, and they were already passing.

## Manual verification

N/A — a test-timeout change with no product surface. The measurements above are
the verification.
