### PR TITLE
fix(dashboard): strip agent bookkeeping keys on config PUT

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -620,6 +620,14 @@ name:
   them (idempotent), fixing installs polluted by older builds.
 - The dashboard model PATCH writes the sidecar, never the spec; agent DELETE
   prunes the sidecar entry.
+- `agent_state.lift_and_strip_bookkeeping()` is the single shared
+  implementation of the lift/strip/no-clobber rule above (with a type guard —
+  a non-`bool` `model_managed` or non-`str` `cc_model` is stripped but never
+  lifted, since coercing it could silently flip its meaning). All four spec
+  writers call it — the dashboard's whole-config `PUT /api/agent/config`
+  handler, the per-agent `PATCH /api/agent/<name>` handler,
+  `migrate_agent_specs()`, and `_refresh_dynamic_fields()` — so none of them
+  can drift from the other three.
 
 Note: KiroCrew is KiroACP (kiro-cli) only — the deleted `claude_code` provider
 was the sole reader of spec `cc_model`, so `cc_model` is now dead config. The

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -1920,14 +1920,7 @@ def _refresh_dynamic_fields(
     # builds on the next refresh; the one-time migrate_agent_specs() at startup
     # handles the rest of ~/.kiro/agents/.
     name = config.get("name") or _MAIN_AGENT_NAME
-    if "model_managed" in config:
-        if agent_state.get_model_managed(name) is None:
-            agent_state.set_model_managed(name, bool(config["model_managed"]))
-        del config["model_managed"]
-    if "cc_model" in config:
-        if agent_state.get_cc_model(name) is None and config["cc_model"]:
-            agent_state.set_cc_model(name, str(config["cc_model"]))
-        del config["cc_model"]
+    agent_state.lift_and_strip_bookkeeping(config, name)
 
     # Imported lazily: config.loader imports this module, so a top-level import
     # would close the cycle. Warm by the time this runs (importing agent pulls
@@ -2168,15 +2161,7 @@ def migrate_agent_specs() -> int:
         if "model_managed" not in data and "cc_model" not in data:
             continue
         name = data.get("name") or spec_path.stem
-        if "model_managed" in data:
-            # Don't clobber an authoritative sidecar value with a stale spec one.
-            if agent_state.get_model_managed(name) is None:
-                agent_state.set_model_managed(name, bool(data["model_managed"]))
-            del data["model_managed"]
-        if "cc_model" in data:
-            if agent_state.get_cc_model(name) is None and data["cc_model"]:
-                agent_state.set_cc_model(name, str(data["cc_model"]))
-            del data["cc_model"]
+        agent_state.lift_and_strip_bookkeeping(data, name)
         try:
             _atomic_json_write(spec_path, data)
             cleaned += 1

--- a/src/kiro_crew/agent_state.py
+++ b/src/kiro_crew/agent_state.py
@@ -19,7 +19,7 @@ State file (``~/.kiro/crew/agent_model_state.json``, honoring ``KIROCREW_HOME``)
 
     {
       "kirocrew":           {"model_managed": true},
-      "kirocrew-heartbeat": {"cc_model": "claude-sonnet-4.6"}
+      "kirocrew-heartbeat": {"cc_model": "auto"}
     }
 
 This is a near-leaf module: it imports only the stdlib plus the leaf
@@ -33,6 +33,7 @@ import json
 import logging
 import threading
 from pathlib import Path
+from typing import MutableMapping
 
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
@@ -120,3 +121,54 @@ def prune(name: str) -> None:
         if name in data:
             data.pop(name, None)
             _write(data)
+
+
+def lift_and_strip_bookkeeping(config: MutableMapping[str, object], name: str) -> bool:
+    """Lift ``model_managed`` / ``cc_model`` into the sidecar when unset; strip both.
+
+    kiro-cli rejects unknown fields on the whole agent spec. Every writer that
+    persists a kiro agent JSON must run this so those keys, owned only by
+    Kiro Crew, never land on disk. When the sidecar already holds a value, a
+    stale key in *config* is discarded rather than clobbering the
+    authoritative sidecar (same rule as ``migrate_agent_specs`` /
+    ``_refresh_dynamic_fields`` / the per-agent PATCH handler).
+
+    A key is only LIFTED when it has the right type — ``bool`` for
+    ``model_managed``, non-empty ``str`` for ``cc_model`` — mirroring the read
+    guards in :func:`get_model_managed` / :func:`get_cc_model`. A hand-edited
+    PUT body (the dashboard's free-text Agent Config textarea) can carry e.g.
+    ``"model_managed": "false"``, and ``bool("false")`` is ``True``: silently
+    coercing that would flip the flag's meaning rather than just ignore the
+    bad value. The key is ALWAYS stripped from *config* regardless of type,
+    since it must never reach the kiro spec either way.
+
+    Returns True if either key was present on *config* (and removed).
+    """
+    changed = False
+    if _MODEL_MANAGED in config:
+        value = config[_MODEL_MANAGED]
+        if isinstance(value, bool):
+            # Hold the lock across the get-and-set so a concurrent writer
+            # (e.g. an explicit-model PATCH racing a stale config PUT)
+            # can't sneak a value in between the unset check and the lift —
+            # the lifted stale value would clobber the fresher one.
+            # ``_lock`` is an RLock, so the nested get/set acquisitions are
+            # re-entrant and safe.
+            with _lock:
+                if get_model_managed(name) is None:
+                    set_model_managed(name, value)
+        else:
+            logger.warning("Discarding non-bool model_managed=%r for agent %r", value, name)
+        config.pop(_MODEL_MANAGED, None)
+        changed = True
+    if _CC_MODEL in config:
+        value = config[_CC_MODEL]
+        if isinstance(value, str):
+            with _lock:
+                if value and get_cc_model(name) is None:
+                    set_cc_model(name, value)
+        elif value:
+            logger.warning("Discarding non-string cc_model=%r for agent %r", value, name)
+        config.pop(_CC_MODEL, None)
+        changed = True
+    return changed

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -201,6 +201,22 @@ async def api_agent_config(request: web.Request) -> web.Response:
             # directory per ref, which is synchronous filesystem work — running it
             # inline would stall the aiohttp event loop for the duration.
             await asyncio.to_thread(sanitize_agent_config_governance, config)
+            # Never persist Kiro Crew bookkeeping into the kiro spec —
+            # kiro-cli rejects unknown fields and drops the agent (#2570).
+            # Offloaded like the governance filter above: this reads/writes the
+            # agent_model_state.json sidecar, the same class of synchronous
+            # filesystem work that would otherwise stall the event loop.
+            # Only trust a submitted name when it is a non-empty string — any
+            # other JSON type (list, dict, number) would flow into the sidecar
+            # helper as a dict key and crash the endpoint with a 500.
+            raw_name = config.get("name")
+            name = raw_name if isinstance(raw_name, str) and raw_name.strip() else installed_path.stem
+            changed = await asyncio.to_thread(agent_state.lift_and_strip_bookkeeping, config, name)
+            if changed:
+                logger.info(
+                    "Stripped Kiro Crew bookkeeping keys from a PUT to agent config for %r",
+                    name,
+                )
             installed_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
             # Restart kiro-cli sessions so new config takes effect
             await _h._reset_all_sessions(request)
@@ -1272,7 +1288,11 @@ async def api_agent_detail(request: web.Request) -> web.Response:
                         # Re-read under the lock: the copy above was read before
                         # the lock and a concurrent PATCH may have superseded it.
                         data = json.loads(f.read_text(encoding="utf-8"))
-                        agent_name = data.get("name") or name
+                        # `spec_str` for the same reason as `declared` above: a
+                        # hand-edited spec can carry a structured (non-string)
+                        # "name", which would crash the sidecar helper's dict
+                        # lookup with an unhashable key.
+                        agent_name = spec_str(data, "name") or name
                         # Skills FIRST, before any state mutation. The mapping can
                         # reject the request (unknown key -> 400) and the model
                         # branch below writes the agent_state sidecar; doing model
@@ -1320,10 +1340,19 @@ async def api_agent_detail(request: web.Request) -> web.Response:
                             else:
                                 # Explicit pick: freeze it against default bumps.
                                 agent_state.set_model_managed(agent_name, False)
-                        # Never persist KiroCrew bookkeeping into the kiro spec —
-                        # kiro-cli rejects unknown fields and drops the agent.
-                        data.pop("model_managed", None)
-                        data.pop("cc_model", None)
+                        # Never persist Kiro Crew bookkeeping into the kiro spec —
+                        # kiro-cli rejects unknown fields and drops the agent. Same
+                        # shared helper as the PUT handler and migrate_agent_specs(),
+                        # so this fourth writer can't drift from the other three
+                        # (#2570). The model branch above may have just set the
+                        # sidecar explicitly; the helper only lifts a stale key out
+                        # of `data` when the sidecar is still unset, so it can't
+                        # clobber that just-written value. Offloaded like the PUT
+                        # handler: the helper does synchronous sidecar read/write
+                        # filesystem work that would stall the event loop.
+                        await asyncio.to_thread(
+                            agent_state.lift_and_strip_bookkeeping, data, agent_name
+                        )
                         f.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
                     # The list_agents() cache keys on a (count, newest-mtime-ns)
                     # signature; two writes inside the same mtime granularity

--- a/test/test_agent_detail_model_managed.py
+++ b/test/test_agent_detail_model_managed.py
@@ -62,3 +62,30 @@ async def test_patch_clear_model_resumes_tracking(tmp_path):
     assert "model" not in data
     assert "model_managed" not in data
     assert agent_state.get_model_managed("kirocrew") is True
+
+
+@pytest.mark.asyncio
+async def test_patch_without_model_lifts_stale_bookkeeping_keys(tmp_path):
+    """A PATCH that never touches ``model`` still runs the shared strip/lift rule.
+
+    Regression for a design-review follow-up on #2570: this PATCH handler used
+    to unconditionally ``data.pop(...)`` these two keys, discarding a legacy
+    value already on disk instead of lifting it into the sidecar the way the
+    other three writers (PUT, migrate_agent_specs, _refresh_dynamic_fields) do.
+    Routing through ``agent_state.lift_and_strip_bookkeeping`` closes that gap.
+    """
+    cfg = tmp_path / "kirocrew.json"
+    cfg.write_text(
+        json.dumps({"name": "kirocrew", "model_managed": False, "cc_model": "claude-sonnet-4.6"})
+    )
+    request = _patch_request("kirocrew", {})
+
+    with patch("kiro_crew.agent.KIRO_AGENTS_DIR", tmp_path):
+        resp = await api_agent_detail(request)
+
+    assert resp.status == 200
+    data = json.loads(cfg.read_text(encoding="utf-8"))
+    assert "model_managed" not in data
+    assert "cc_model" not in data
+    assert agent_state.get_model_managed("kirocrew") is False
+    assert agent_state.get_cc_model("kirocrew") == "claude-sonnet-4.6"

--- a/test/test_agent_state.py
+++ b/test/test_agent_state.py
@@ -1,0 +1,87 @@
+"""Tests for ``agent_state.lift_and_strip_bookkeeping``.
+
+kiro-cli's ``deny_unknown_fields`` rejects an entire agent spec on any
+unrecognized key, so ``model_managed`` / ``cc_model`` must never reach a kiro
+JSON file. This is the single helper shared by the PUT handler,
+``migrate_agent_specs``, and ``_refresh_dynamic_fields`` (see #2570) — pin its
+lift/strip/no-clobber/type-guard contract directly, independent of any caller.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from kiro_crew import agent_state
+
+
+def test_lifts_when_unset():
+    config = {"name": "kirocrew", "model_managed": True, "cc_model": "claude-sonnet-4.6"}
+
+    changed = agent_state.lift_and_strip_bookkeeping(config, "kirocrew")
+
+    assert changed is True
+    assert "model_managed" not in config
+    assert "cc_model" not in config
+    assert agent_state.get_model_managed("kirocrew") is True
+    assert agent_state.get_cc_model("kirocrew") == "claude-sonnet-4.6"
+
+
+def test_does_not_clobber_existing_sidecar_value():
+    agent_state.set_model_managed("kirocrew", False)
+    agent_state.set_cc_model("kirocrew", "test-model-stub")
+    config = {"model_managed": True, "cc_model": "claude-sonnet-4.6"}
+
+    changed = agent_state.lift_and_strip_bookkeeping(config, "kirocrew")
+
+    assert changed is True
+    assert "model_managed" not in config
+    assert "cc_model" not in config
+    assert agent_state.get_model_managed("kirocrew") is False
+    assert agent_state.get_cc_model("kirocrew") == "test-model-stub"
+
+
+def test_non_bool_model_managed_discarded_not_lifted(caplog):
+    config = {"model_managed": "false"}
+
+    with caplog.at_level(logging.WARNING):
+        changed = agent_state.lift_and_strip_bookkeeping(config, "kirocrew")
+
+    assert changed is True
+    assert "model_managed" not in config
+    # Not lifted: bool("false") is True, which would have silently flipped
+    # the flag's meaning had the raw value been coerced instead of guarded.
+    assert agent_state.get_model_managed("kirocrew") is None
+    assert "non-bool model_managed" in caplog.text
+
+
+def test_non_string_cc_model_discarded_not_lifted(caplog):
+    config = {"cc_model": 123}
+
+    with caplog.at_level(logging.WARNING):
+        changed = agent_state.lift_and_strip_bookkeeping(config, "kirocrew")
+
+    assert changed is True
+    assert "cc_model" not in config
+    assert agent_state.get_cc_model("kirocrew") is None
+    assert "non-string cc_model" in caplog.text
+
+
+def test_returns_false_when_neither_key_present():
+    config = {"name": "kirocrew", "model": "auto"}
+
+    changed = agent_state.lift_and_strip_bookkeeping(config, "kirocrew")
+
+    assert changed is False
+    assert config == {"name": "kirocrew", "model": "auto"}
+
+
+def test_falsy_cc_model_strips_without_lifting(caplog):
+    config = {"cc_model": ""}
+
+    with caplog.at_level(logging.WARNING):
+        changed = agent_state.lift_and_strip_bookkeeping(config, "kirocrew")
+
+    assert changed is True
+    assert "cc_model" not in config
+    assert agent_state.get_cc_model("kirocrew") is None
+    assert caplog.text == ""

--- a/test/test_api_agent_config_put_succeeds.py
+++ b/test/test_api_agent_config_put_succeeds.py
@@ -110,3 +110,102 @@ async def test_api_agent_config_put_strips_governed_grants(tmp_path, monkeypatch
     # Governed server loses autoApprove; ungoverned server keeps it.
     assert "autoApprove" not in written["mcpServers"]["denied"]
     assert written["mcpServers"]["ok"]["autoApprove"] == ["fine"]
+
+
+@pytest.mark.asyncio
+async def test_api_agent_config_put_strips_bookkeeping_keys(tmp_path):
+    """A dashboard PUT must not re-pollute the kiro spec with Kiro Crew keys.
+
+    Regression for #2570: the agent-detail PATCH strips ``model_managed`` /
+    ``cc_model``, but the whole-config PUT used to persist them verbatim.
+    kiro-cli ``deny_unknown_fields`` then rejects the entire agent until the
+    next ``migrate_agent_specs`` heal on gateway rebuild.
+    """
+    from kiro_crew import agent_state
+
+    installed = tmp_path / "kirocrew.json"
+    installed.write_text(json.dumps({"name": "kirocrew"}))
+    defaults = tmp_path / "defaults.json"
+    mc_cfg = tmp_path / "config.json"
+
+    request = MagicMock(spec=web.Request)
+    request.method = "PUT"
+    request.app = {"state": MagicMock()}
+
+    async def mock_json():
+        return {
+            "config": {
+                "name": "kirocrew",
+                "tools": ["a"],
+                "allowedTools": ["b"],
+                "model_managed": True,
+                "cc_model": "claude-sonnet-4.6",
+            }
+        }
+
+    request.json = mock_json
+
+    with (
+        patch("kiro_crew.dashboard.handlers._installed_agent_config", return_value=installed),
+        patch("kiro_crew.dashboard.handlers._find_agent_config", return_value=defaults),
+        patch("kiro_crew.dashboard.handlers._reset_all_sessions", new_callable=AsyncMock),
+        patch("kiro_crew.dashboard.handlers.config_path", return_value=mc_cfg),
+        patch("kiro_crew.agent.get_shipped_tools", return_value={"tools": [], "allowedTools": []}),
+    ):
+        response = await api_agent_config(request)
+
+    assert response.status == 200
+    written = json.loads(installed.read_text(encoding="utf-8"))
+    assert "model_managed" not in written
+    assert "cc_model" not in written
+    assert written["name"] == "kirocrew"
+    # Lifted into the sidecar when previously unset (same rule as migrate).
+    assert agent_state.get_model_managed("kirocrew") is True
+    assert agent_state.get_cc_model("kirocrew") == "claude-sonnet-4.6"
+
+
+@pytest.mark.asyncio
+async def test_api_agent_config_put_does_not_clobber_sidecar(tmp_path):
+    """A stale bookkeeping key in the PUT body must not overwrite the sidecar."""
+    from kiro_crew import agent_state
+
+    installed = tmp_path / "kirocrew.json"
+    installed.write_text(json.dumps({"name": "kirocrew"}))
+    defaults = tmp_path / "defaults.json"
+    mc_cfg = tmp_path / "config.json"
+
+    agent_state.set_model_managed("kirocrew", False)
+    agent_state.set_cc_model("kirocrew", "test-model-stub")
+
+    request = MagicMock(spec=web.Request)
+    request.method = "PUT"
+    request.app = {"state": MagicMock()}
+
+    async def mock_json():
+        return {
+            "config": {
+                "name": "kirocrew",
+                "tools": ["a"],
+                "allowedTools": ["b"],
+                "model_managed": True,
+                "cc_model": "claude-sonnet-4.6",
+            }
+        }
+
+    request.json = mock_json
+
+    with (
+        patch("kiro_crew.dashboard.handlers._installed_agent_config", return_value=installed),
+        patch("kiro_crew.dashboard.handlers._find_agent_config", return_value=defaults),
+        patch("kiro_crew.dashboard.handlers._reset_all_sessions", new_callable=AsyncMock),
+        patch("kiro_crew.dashboard.handlers.config_path", return_value=mc_cfg),
+        patch("kiro_crew.agent.get_shipped_tools", return_value={"tools": [], "allowedTools": []}),
+    ):
+        response = await api_agent_config(request)
+
+    assert response.status == 200
+    written = json.loads(installed.read_text(encoding="utf-8"))
+    assert "model_managed" not in written
+    assert "cc_model" not in written
+    assert agent_state.get_model_managed("kirocrew") is False
+    assert agent_state.get_cc_model("kirocrew") == "test-model-stub"


### PR DESCRIPTION
Fixes #2570

## Problem / Motivation

`PUT /api/agent/config` (the dashboard's whole-config editor) writes the submitted JSON straight to `kirocrew.json`, including two KiroCrew-only bookkeeping keys, `model_managed` and `cc_model`, that are not part of the kiro-cli agent schema.

`PATCH /api/agent/<name>` already stripped these two keys before writing, and `migrate_agent_specs()` heals them out of `kirocrew.json` on gateway startup — but the whole-config `PUT` path had no equivalent guard, so it could reintroduce them.

kiro-cli validates the whole agent spec with `deny_unknown_fields`, so any `kirocrew.json` still carrying either key gets **rejected in full** on the next `kiro-cli` reload — not just that field, the entire agent — until the next `migrate_agent_specs()` heal on gateway restart.

### Repro

1. Open **Agent Capabilities → Agent Config** in the dashboard for the default agent (whose sidecar already carries `model_managed`/`cc_model` from normal use).
2. Edit anything in the free-text config textarea and save — the payload the frontend posts is the full `kirocrew.json` as currently rendered, which client-side JSON round-tripping can reintroduce these keys into, and `PUT` persists them verbatim.
3. `kirocrew.json` on disk now has `model_managed` / `cc_model` at the top level. The agent breaks on the next `kiro-cli` reload with `deny_unknown_fields`, and the fix only self-heals after a full gateway restart re-runs `migrate_agent_specs()`.

## Why it matters

A successful dashboard save can silently poison the agent spec. kiro-cli then drops the **entire** agent, not just the stray field. The operator sees a working config editor and a 200 response; the breakage only shows up on the next kiro-cli reload, and the only self-heal is a full gateway restart. That is unbounded, silent loss of the agent until someone restarts the process.

## What changed (motivation → approach → change)

Rather than patch the `PUT` handler in isolation, this centralizes the lift-into-sidecar / strip-from-spec rule into one shared helper, and routes all four writers through it so they can't drift from each other again:

- **`agent_state.lift_and_strip_bookkeeping(config, name)`** (new) — the single implementation of: if the sidecar has no value yet, lift the key out of `config` into the sidecar; either way, strip the key from `config` before it can reach disk. Never clobbers an existing sidecar value with a stale one from `config`.
- Type guards: a non-`bool` `model_managed` or non-`str`/empty `cc_model` is **discarded, never lifted** — coercing e.g. `"model_managed": "false"` (`bool("false")` is `True`) would silently flip its meaning. Both cases log a warning and the key is still stripped from `config` either way.
- Writers routed through the helper:
  - `PUT /api/agent/config` (offloaded via `asyncio.to_thread`, with a log when something was stripped)
  - `PATCH /api/agent/<name>` (replaces the previous inline `data.pop(...)`)
  - `migrate_agent_specs()`
  - `_refresh_dynamic_fields()`

## Tests

- New `test/test_agent_state.py`: 6 unit tests covering the helper's lift/strip/no-clobber/type-guard contract.
- `test/test_api_agent_config_put_succeeds.py`: regression tests that a `PUT` with `model_managed`/`cc_model` is stripped and lifted, and that an existing sidecar value is never clobbered.
- `test/test_agent_detail_model_managed.py`: PATCH without a `model` field still lifts stale bookkeeping keys into the sidecar.
- `black`, `isort`, `flake8`, brand-name gate, and the targeted test suite all pass.

## Manual verification

Not applicable for this backend-only change. Reproduction is covered by the PUT/PATCH regression tests above.

## Screenshots / video

N/A — backend API handler only; no rendered UI delta. Labelled `no-screenshots`.

## Related Issues

Fixes #2570

## Checklist

- [x] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

