### PR TITLE
fix(apps): reject Windows-reserved device stems as non-portable app names

### DIFF
--- a/docs/app-kit/manifest-reference.md
+++ b/docs/app-kit/manifest-reference.md
@@ -420,6 +420,14 @@ the user to run locally instead of executing it on the server.
 ## Validation Rules
 
 - `name` must match `/^[a-z0-9]+(?:-[a-z0-9]+)*$/` (kebab-case)
+- `name` must not be `system` (it would shadow the `system.*` notification-channel
+  namespace)
+- `name` must not be a Windows reserved device stem — `con`, `prn`, `aux`, `nul`,
+  `com1`–`com9`, `lpt1`–`lpt9` — because the app name becomes a directory and
+  Windows resolves those inside every directory. Names that merely resemble one
+  (`console`, `com10`, `null-app`) are fine. Refused on every platform: an app
+  name is a persistent published identity, so it must mean the same thing on
+  whichever host installs the app.
 - `version` must match semver (`X.Y.Z`)
 - Paths in `agents`, `skills`, `sops`, `ui.entry`, `ui.pages[].entryPoint`, and `backend.entryPoint` must be relative and stay inside the app root: absolute paths and `..` traversal are rejected (canonical resolve + containment when the app dir is known). `backend.hooks.*` are format-checked (`module.path:callable`, which cannot express traversal) and containment-checked again at load time. `mcpServers` entries use `command`/`args`/`url`/`env` (not app-relative file paths) and are not path-checked.
 - All required fields must be non-empty strings

--- a/docs/app-kit/publishing-guide.md
+++ b/docs/app-kit/publishing-guide.md
@@ -48,7 +48,7 @@ own repo.
 
 | Field | Rules |
 |-------|-------|
-| `name` | Required. Kebab-case, matched against `^[a-z0-9]+(?:-[a-z0-9]+)*$`, unique across all apps. This is the install id and the on-disk directory name. `system` is reserved (it would shadow the `system.*` notification-channel namespace). |
+| `name` | Required. Kebab-case, matched against `^[a-z0-9]+(?:-[a-z0-9]+)*$`, unique across all apps. This is the install id and the on-disk directory name. `system` is reserved (it would shadow the `system.*` notification-channel namespace), as are the Windows device stems `con`, `prn`, `aux`, `nul`, `com1`–`com9` and `lpt1`–`lpt9` (the name becomes a directory, and Windows resolves those inside every directory). Names that merely resemble one — `console`, `com10`, `null-app` — are fine. All are refused on every platform, so an app that installs on Linux also installs on Windows. |
 | `version` | Required. Semver (`major.minor.patch`, optionally with a pre-release or build suffix). Bump on every release. |
 | `displayName` | Required. Rendered in a fixed-width row that truncates, so keep it short. |
 | `description` | Required. Plain text, no markdown. Discover's list row shows one truncated line; the feature cards clamp to two; the detail page shows it in full. Two or three sentences is the useful range. |

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -29,7 +29,7 @@ from kiro_crew.apps.execution import (
     app_execution_denied,
     shipped_builtin_app_root,
 )
-from kiro_crew.apps.manifest import AppManifest
+from kiro_crew.apps.manifest import AppManifest, app_name_error
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import (
     config_dir,
@@ -1440,20 +1440,16 @@ def register_external_app(
     if not _check_path_safety(name):
         return AppResult(ok=False, error=f"unsafe app name: {name!r}")
 
-    # Enforce the canonical lowercase-ASCII kebab-case form on the
-    # self-registration path (CWE-178). Admission normalizes with
-    # NFKC+casefold+strip, but the backend below stores/resolves the app by the
-    # RAW name (app_dir(name), _write_installed(name), write_app_secret(name)),
-    # so without this an admitted "Safe-App"/"safe-app "/Unicode-equivalent
-    # would diverge from the approved identity. install_app/update_app already
-    # gate on KEBAB_RE via AppManifest; this closes the register_external gap.
-    from kiro_crew.apps.manifest import KEBAB_RE
-
-    if not KEBAB_RE.match(name):
-        return AppResult(
-            ok=False, name=name,
-            error=f"invalid app name (must be lowercase kebab-case): {name!r}",
-        )
+    # Enforce the canonical app-name contract on the self-registration path
+    # (CWE-178). Admission normalizes with NFKC+casefold+strip, but the backend
+    # below stores/resolves the app by the RAW name (app_dir(name),
+    # _write_installed(name), write_app_secret(name)), so without this an
+    # admitted "Safe-App"/"safe-app "/Unicode-equivalent would diverge from the
+    # approved identity. install_app/update_app reach the same contract via
+    # AppManifest.validate(); this closes the register_external gap.
+    name_error = app_name_error(name)
+    if name_error:
+        return AppResult(ok=False, name=name, error=f"invalid app name: {name_error}")
 
     # Builtin provenance is assigned only by register_builtin_apps(). Accepting
     # it from self-registration would make the execution exemption caller-controlled.
@@ -1679,6 +1675,13 @@ def _validate_builtin_app(app_data: dict[str, Any]) -> list[str]:
     name = app_data.get("name", "")
     if name and not _check_path_safety(name):
         errors.append(f"unsafe app name: {name!r}")
+    elif name:
+        # Builtins are registered from a dict, never through AppManifest, so the
+        # shared contract has to be applied here too — otherwise an edition's
+        # AppsLoader could contribute a name the manifest path would refuse.
+        name_error = app_name_error(name)
+        if name_error:
+            errors.append(name_error)
     # migratedTo validation is lenient — invalid formats are handled by
     # _effective_migrated_to() which returns "" for bad values.  We log a
     # warning in register_builtin_apps() but do NOT block registration.

--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -18,10 +18,16 @@ from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 
+from kiro_crew.constants import WINDOWS_DEVICE_STEMS
+
 # ---------------------------------------------------------------------------
 # Nested manifest types
 # ---------------------------------------------------------------------------
 
+# `$` matches at the true end of the string AND just before a trailing newline,
+# so this pattern only carries its intended grammar under ``fullmatch``:
+# ``KEBAB_RE.match("demo\n")`` succeeds. Any caller gating an identity on it must
+# use ``fullmatch`` — see ``app_name_error``.
 KEBAB_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+([+-]|$)")
 
@@ -30,6 +36,60 @@ SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+([+-]|$)")
 # reserved system channels (e.g. "system.approval"). Rejected at manifest
 # validation AND defense-in-depth at the push endpoint.
 RESERVED_APP_NAMES = frozenset({"system"})
+
+# App names that are not safe portable filesystem identities. An app name becomes
+# a directory (``apps/<name>/``, plus ``apps/<name>/data`` at first startup), and
+# Windows reserves these stems as device names by naming contract.
+#
+# Only ``nul`` has a measured failure here — ``mkdir`` raises WinError 3 on
+# Windows 11 26200 via CPython — while the other stems created usable directories
+# on that same path. They are refused anyway, as policy rather than reproduction:
+# the reservation is a documented Windows naming rule whose observable behaviour
+# differs across Windows APIs and builds, so one host's success does not make the
+# name portable. An app name is a PERSISTENT published identity, which makes the
+# directions asymmetric: admitting a stem is the one-way door, since tightening
+# later invalidates an app already published and installed, while relaxing an
+# over-strict rule costs nothing.
+#
+# Rejected on all platforms, not only Windows. Resource paths in this file are
+# already validated under both path flavours for the same reason (see
+# ``_has_dotdot_segment``), and ``is_valid_followup_branch`` applies this same
+# vocabulary to git branch names on every platform so that grammar does not
+# depend on where the gateway runs.
+#
+# The set is lowercase and ``KEBAB_RE`` already forces lowercase, so membership
+# is tested directly with no case folding.
+UNPORTABLE_APP_NAMES = WINDOWS_DEVICE_STEMS
+
+
+def app_name_error(name: str) -> str | None:
+    """Return why *name* is inadmissible as an app identifier, else ``None``.
+
+    The single app-name contract. Every path that admits a new app funnels
+    through here — manifest validation (install, update, discovery), external
+    self-registration, and builtin registration — so that a name refused at one
+    door cannot be admitted at another. The name is an identity AND a directory
+    component, so the same string has to satisfy both roles.
+    """
+    if not name:
+        return "app name must not be empty"
+    # fullmatch, not match: the pattern's `$` also matches before a trailing
+    # newline, so `match` admits "demo\n" — and the reserved-name comparisons
+    # below test the exact string, so "nul\n" and "system\n" would evade those
+    # too and reach a backend that stores and joins the RAW name.
+    if not KEBAB_RE.fullmatch(name):
+        return f"app name must be kebab-case (lowercase alphanumeric + hyphens): {name!r}"
+    if name in RESERVED_APP_NAMES:
+        return (
+            f"app name {name!r} is reserved (would shadow the "
+            f"{name}.* notification channel namespace)"
+        )
+    if name in UNPORTABLE_APP_NAMES:
+        return (
+            f"app name {name!r} is not portable: Windows reserves it as a device name, "
+            f"so the app directory is not safe to create there"
+        )
+    return None
 
 
 def _is_rooted_path(rel_path: str) -> bool:
@@ -946,15 +1006,10 @@ class AppManifest:
         # Required fields
         if not self.name:
             errors.append("missing required field: name")
-        elif not KEBAB_RE.match(self.name):
-            errors.append(
-                f"name must be kebab-case (lowercase alphanumeric + hyphens), got: {self.name!r}"
-            )
-        elif self.name in RESERVED_APP_NAMES:
-            errors.append(
-                f"app name {self.name!r} is reserved (would shadow the "
-                f"{self.name}.* notification channel namespace)"
-            )
+        else:
+            name_error = app_name_error(self.name)
+            if name_error:
+                errors.append(name_error)
 
         if not self.version:
             errors.append("missing required field: version")

--- a/src/kiro_crew/constants.py
+++ b/src/kiro_crew/constants.py
@@ -197,6 +197,24 @@ SUBAGENT_COMPLETION_PREFIX = "[Subagent completion event]"
 SUBAGENT_BATCH_COMPLETION_PREFIX = "[Subagent batch completion event]"
 
 
+# Windows reserved device names, lowercase stems. Windows resolves these inside
+# EVERY directory, so no file OR directory may be named after one — the rule is
+# part of the documented Win32 file-naming contract, not a quirk of one build,
+# and it applies to any host the identifier might travel to.
+#
+# ONE definition on purpose. Every Kiro Crew identifier that becomes a path
+# component on disk — a git branch (a loose ref FILE under `.git/refs/heads/`),
+# an app name (a directory under the apps root) — has to refuse the same set,
+# and two copies would drift. Callers lowercase before testing; a caller whose
+# own grammar already forces lowercase can test membership directly.
+#
+# Only `com1`-`com9` and `lpt1`-`lpt9` are reserved: `com10` is an ordinary name.
+WINDOWS_DEVICE_STEMS = frozenset(
+    {"con", "prn", "aux", "nul"}
+    | {f"com{n}" for n in range(1, 10)}
+    | {f"lpt{n}" for n in range(1, 10)}
+)
+
 # The product wordmark, figlet `small`. ONE definition on purpose: copy-pasting
 # it into cli.py and cli_chat.py risks a rename leaving a stale product name in
 # the two most-seen surfaces (bare `kirocrew`, the chat REPL). Import it; never

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -31,6 +31,7 @@ from typing import Any
 # no native library is loaded on any platform. Aliased so the schema block below
 # reads as "the computer-use vocabulary" rather than bare names.
 from kiro_crew.computer_use import types as _cu_types
+from kiro_crew.constants import WINDOWS_DEVICE_STEMS
 
 # ── Constants ──
 
@@ -1201,16 +1202,12 @@ FOLLOWUP_BRANCH_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(?:/[A-Za-z0-9][A-Z
 # instead, per component so ``feat/x.lock`` is caught as well as ``x.lock``.
 _GIT_RESERVED_REFS = frozenset({"HEAD"})
 
-# Windows reserved device names. A branch is a loose ref FILE
-# (`.git/refs/heads/<component>`), and Windows cannot create a file whose stem is
-# a device name — so `feat/CON` claims fine but the checkout fails, surfacing as
-# a false "Branch already exists". Rejected on every
-# platform so the grammar does not depend on where the gateway runs.
-_WINDOWS_DEVICE_STEMS = frozenset(
-    {"con", "prn", "aux", "nul"}
-    | {f"com{n}" for n in range(1, 10)}
-    | {f"lpt{n}" for n in range(1, 10)}
-)
+# A branch is a loose ref FILE (`.git/refs/heads/<component>`), and Windows
+# cannot create a file whose stem is a device name — so `feat/CON` claims fine
+# but the checkout fails, surfacing as a false "Branch already exists". Rejected
+# on every platform so the grammar does not depend on where the gateway runs.
+# The stem vocabulary is shared with the app-name grammar; see
+# ``constants.WINDOWS_DEVICE_STEMS``.
 
 
 def is_valid_followup_branch(branch: str) -> bool:
@@ -1223,7 +1220,7 @@ def is_valid_followup_branch(branch: str) -> bool:
         if not part or part.endswith(".") or part.endswith(".lock"):
             return False
         # Device names are reserved with OR without an extension (CON, CON.txt).
-        if part.split(".")[0].lower() in _WINDOWS_DEVICE_STEMS:
+        if part.split(".")[0].lower() in WINDOWS_DEVICE_STEMS:
             return False
     return True
 

--- a/test/test_app_manager.py
+++ b/test/test_app_manager.py
@@ -63,6 +63,79 @@ def app_home(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# App-name admission contract
+# ---------------------------------------------------------------------------
+
+
+class TestUnportableAppName:
+    """``nul`` must be refused by EVERY door, not just the manifest one.
+
+    These are behavior-level rather than one test per gate: the defect was not
+    that a single check was wrong, it was that three doors carried three
+    different name checks and a name refused at one was admitted at another.
+    Asserting the outcome at each entry point is what actually pins the shared
+    contract — a future fourth door that grows its own check fails here.
+    """
+
+    def test_install_refuses_it_before_anything_lands_on_disk(self, tmp_path, app_home):
+        """Windows cannot create apps/nul/, so install must refuse rather than
+        half-create an app that can never start.
+
+        The source directory is deliberately NOT named ``nul``: a POSIX host can
+        author that tree and hand it to a Windows host, which is the case the
+        contract exists for, and the destination name comes from the manifest
+        anyway. Naming the source dir ``nul`` would also make the test itself
+        unrunnable on Windows.
+        """
+        src = tmp_path / "source" / "nul-src"
+        src.mkdir(parents=True)
+        (src / APP_MANIFEST_FILENAME).write_text(
+            json.dumps(
+                {
+                    "name": "nul",
+                    "version": "1.0.0",
+                    "displayName": "Null App",
+                    "description": "A test app for unit tests",
+                    "author": "tester",
+                }
+            )
+        )
+        result = install_app(src)
+        assert not result.ok
+        assert "not portable" in result.error, result.error
+        assert not (app_home / "apps" / "nul").exists()
+
+    def test_register_external_refuses_it_before_materialization(self, app_home):
+        from kiro_crew.apps.manager import register_external_app
+
+        result = register_external_app("nul", "1.0.0", "Null App")
+        assert not result.ok
+        assert "not portable" in result.error, result.error
+        assert _read_installed("nul") is None
+        assert not (app_home / "apps" / "nul").exists()
+
+    def test_builtin_registration_refuses_it(self):
+        from kiro_crew.apps.manager import _validate_builtin_app
+
+        errors = _validate_builtin_app(
+            {
+                "name": "nul",
+                "version": "1.0.0",
+                "displayName": "Null App",
+                "description": "d",
+                "author": "tester",
+            }
+        )
+        assert any("not portable" in e for e in errors), errors
+
+    def test_a_normal_app_still_installs(self, tmp_path, app_home):
+        """Preservation: the contract refuses one name, not names in general."""
+        result = install_app(_make_app_source(tmp_path, name="null-app"))
+        assert result.ok, result.error
+        assert (app_home / "apps" / "null-app").is_dir()
+
+
+# ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
 

--- a/test/test_app_manifest.py
+++ b/test/test_app_manifest.py
@@ -15,6 +15,7 @@ from kiro_crew.apps.manifest import (
     Dependencies,
     SetupConfig,
 )
+from kiro_crew.constants import WINDOWS_DEVICE_STEMS
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -68,6 +69,46 @@ class TestValidation:
         m = AppManifest.from_dict(_valid_manifest(name="Not_Kebab"))
         errors = m.validate()
         assert any("kebab-case" in e for e in errors)
+
+    def test_reserved_name_rejected(self):
+        """The system.* notification namespace stays un-shadowable."""
+        m = AppManifest.from_dict(_valid_manifest(name="system"))
+        errors = m.validate()
+        assert any("reserved" in e for e in errors)
+
+    @pytest.mark.parametrize("name", sorted(WINDOWS_DEVICE_STEMS))
+    def test_every_windows_device_stem_is_rejected(self, name):
+        """The whole documented device-name set, not just the stems that happen
+        to fail on one build. An app name is a persistent published identity, so
+        admitting a stem is a one-way door while over-refusing is freely
+        relaxable."""
+        m = AppManifest.from_dict(_valid_manifest(name=name))
+        errors = m.validate()
+        assert any("not portable" in e for e in errors), (name, errors)
+
+    def test_device_stem_vocabulary_is_not_duplicated(self):
+        """One definition, shared with the git-branch grammar. Two copies of a
+        22-name set drift, and the branch rule is the precedent this follows."""
+        from kiro_crew.apps.manifest import UNPORTABLE_APP_NAMES
+
+        assert UNPORTABLE_APP_NAMES is WINDOWS_DEVICE_STEMS
+
+    @pytest.mark.parametrize("name", ["null-app", "console", "com10", "lpt10", "connect"])
+    def test_names_merely_resembling_a_device_stay_valid(self, name):
+        """The rule matches the exact stem. ``com10``/``lpt10`` are outside the
+        reserved 1-9 range and the rest are ordinary words."""
+        m = AppManifest.from_dict(_valid_manifest(name=name))
+        assert m.validate() == []
+
+    @pytest.mark.parametrize("name", ["demo\n", "nul\n", "system\n", "demo\r\n", "demo\n\n"])
+    def test_a_trailing_newline_cannot_slip_through(self, name):
+        """``$`` also matches before a trailing newline, so a ``$``-anchored
+        grammar admits ``"demo\\n"`` — and worse, ``"nul\\n"`` and ``"system\\n"``
+        evade the reserved-name checks that run after it, because those compare
+        against the exact string. ``KEBAB_RE`` is anchored with ``\\Z``."""
+        m = AppManifest.from_dict(_valid_manifest(name=name))
+        errors = m.validate()
+        assert any("kebab-case" in e for e in errors), (name, errors)
 
     def test_invalid_version_format(self):
         m = AppManifest.from_dict(_valid_manifest(version="not-semver"))

--- a/test/test_lifecycle_hooks.py
+++ b/test/test_lifecycle_hooks.py
@@ -6,6 +6,7 @@ Properties 9, 14: Deterministic ordering and shell-before-Python.
 from __future__ import annotations
 
 import asyncio
+import re
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,7 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from kiro_crew.apps.lifecycle import LifecycleDispatcher
+from kiro_crew.apps.manifest import app_name_error
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -42,13 +44,40 @@ def _make_app_info(name: str, *, on_startup: str = "", on_shutdown: str = "") ->
 # ---------------------------------------------------------------------------
 
 def _app_names() -> st.SearchStrategy[list[str]]:
-    """Generate lists of unique app names."""
+    """Generate lists of unique app names the admission contract actually accepts.
+
+    The dispatcher creates ``apps/<name>/data`` for every app it starts, so a
+    name production would never admit describes an impossible state rather than
+    a bug worth finding. The regex is the kebab-case grammar narrowed to a
+    leading letter and the original 3-11 char range, which keeps the filter
+    rejection rate near zero; ``app_name_error`` then removes the reserved and
+    unportable names, so this file never carries a second copy of that list.
+    """
     return st.lists(
-        st.from_regex(r"[a-z][a-z0-9-]{2,10}", fullmatch=True),
+        st.from_regex(r"[a-z][a-z0-9]{2,6}(?:-[a-z0-9]{1,3})?", fullmatch=True).filter(
+            lambda name: app_name_error(name) is None
+        ),
         min_size=2,
         max_size=8,
         unique=True,
     )
+
+
+def test_generator_cannot_sample_an_inadmissible_app_name() -> None:
+    """Deterministic guard for the sampling domain.
+
+    ``dispatch_startup`` creates ``apps/<name>/data`` for every app it starts.
+    ``nul`` is kebab-case and inside the length range, so the grammar alone still
+    reaches it — on Windows that mkdir fails with WinError 3. The dispatcher is
+    not the bug: the admission contract that let such an app exist was, and it
+    now refuses the name, so this strategy must not invent one either. The
+    exclusion is delegated to ``app_name_error`` rather than restated, so the
+    test domain cannot drift away from what production admits.
+    """
+    grammar = r"[a-z][a-z0-9]{2,6}(?:-[a-z0-9]{1,3})?"
+    assert re.fullmatch(grammar, "nul"), "grammar no longer reaches the name under test"
+    assert app_name_error("nul") is not None, "production must refuse it first"
+    assert app_name_error("null-app") is None, "ordinary names stay in the domain"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Motivation

An app name is both an identity and a directory component: `install_app` creates
`apps/<name>/`, and `LifecycleDispatcher._build_context` creates
`apps/<name>/data` before any startup hook runs. Windows reserves the device
stems `con`, `prn`, `aux`, `nul`, `com1`–`com9` and `lpt1`–`lpt9` by naming
contract, so they are not safe portable filesystem identities — yet all of them
are valid kebab-case and nothing refused them.

Measured on Windows 11 10.0.26200 / py3.10.6, running `AppManifest.validate()`
against each name and then creating `apps/<name>/data` the way the dispatcher
does:

| name | `validate()` accepts | `mkdir(apps/<name>/data)` |
|---|---|---|
| `nul` | yes | **`FileNotFoundError`, WinError 3** |
| `con`, `prn`, `aux`, `com1`–`com9`, `lpt1`–`lpt9` | yes | **OK on this path** |

**Read that second row plainly: 21 of the 22 stems materialized successfully
here.** This PR does not claim they fail, and the fix does not rest on their
failing — see *Direct evidence vs. policy*.

A second defect in the same grammar: `app_name_error` gated on `KEBAB_RE.match`,
and the pattern ends in `$`, which matches at the true end of the string *and*
just before a trailing newline. So `"demo\n"` was admitted — and because the
reserved-name checks that follow compare the **exact** string, `"nul\n"` and
`"system\n"` evaded those too:

| name | `.match()` | `.fullmatch()` | admitted before | admitted after |
|---|---|---|---|---|
| `demo` | ✅ | ✅ | yes | yes |
| `demo\n` | ✅ | ❌ | **yes** | no |
| `nul\n` | ✅ | ❌ | **yes** | no |
| `system\n` | ✅ | ❌ | **yes** | no |
| `demo\r\n`, `demo ` | ❌ | ❌ | no | no |

The name reaches a backend that stores and joins it raw (`app_dir(name)`,
`_write_installed(name)`, `write_app_secret(name)`).

## Why it matters

Four paths admit an app and they carried three different name checks, so this is
a hole in the contract rather than one missing line:

| admission path | name gate before | refused a device stem? |
|---|---|---|
| install / update | `AppManifest.validate()` → `KEBAB_RE` + `RESERVED_APP_NAMES` | no |
| discovery | same `manifest.validate()` | no |
| external self-registration | `register_external_app`'s own `KEBAB_RE` re-check | no |
| builtin registration | `_validate_builtin_app` → `_check_path_safety` only | no |

For `nul` the observed outcome is a raw `WinError 3` on Windows rather than a
refusal, while the same `app.json` installs fine on Linux and macOS. For the rest
the risk is the reservation itself: the name is admitted as a durable identity
that Windows does not guarantee is usable as a path component. Either way the
identifier is not portable, which is exactly what a manifest is supposed to be.

## What changed (motivation → approach → change)

**One canonical boundary.** `manifest.app_name_error(name)` is the single
authority on what may be admitted. `AppManifest.validate()`,
`register_external_app` and `_validate_builtin_app` all call it; install, update
and discovery inherit it through `AppManifest`. The kebab-case and `system` rules
move in unchanged.

**Direct evidence vs. policy — kept separate.**

- *Reproduction* establishes exactly one thing: `nul` deterministically fails to
  materialize on the Windows build measured above.
- *Policy* is what justifies refusing the other 21. Windows reserves this
  vocabulary; an app name is a **persistent published identity**; this repo
  already applies the same device-stem vocabulary cross-platform to another
  portable identifier (`validation.is_valid_followup_branch`, rejecting on every
  platform "so the grammar does not depend on where the gateway runs"); and the
  directions are not symmetric — admitting a stem now is the one-way door, since
  tightening later invalidates an app already published and installed, whereas
  relaxing an over-strict rule costs nothing.

  A single measurement through one API on one build also cannot speak for other
  Windows APIs, for Windows 10, or for Server 2022, and CI runners are Win11-era,
  so no test here could detect the difference.

**Compatibility.** This is a tightening. Checked in-repo: no shipped builtin app,
no `app.json` anywhere in the tree, and no test fixture or doc uses one of these
names, so no existing app in this repository changes status. An app published
outside this repo under such a name would be refused on update/discovery — that
is the intended trade above, stated plainly.

**One definition of the vocabulary.** The stem set lives in
`constants.WINDOWS_DEVICE_STEMS` and is now shared with
`is_valid_followup_branch`, which already refused exactly these names. Two copies
of a 22-name set drift; `test_device_stem_vocabulary_is_not_duplicated` pins that
they are one object.

**The newline fix is scoped to app names.** `app_name_error` now uses
`KEBAB_RE.fullmatch`. `KEBAB_RE` keeps its grammar and its `$` anchor: its other
consumers (registry entry names, notification channel ids, install receipts) sit
outside app-name admission, and re-anchoring the shared pattern would tighten all
of them inside a PR about app names. If one of those has its own reachable
newline bypass it deserves its own change and its own verification.

## Tests

**Fail-before / pass-after** (fail on pristine `main`, pass after):

- `test_every_windows_device_stem_is_rejected` — 22 parametrized cases.
- `test_a_trailing_newline_cannot_slip_through` — `demo\n`, `nul\n`, `system\n`,
  `demo\r\n`, `demo\n\n`, all driven through `AppManifest.validate()` rather than
  the regex, so it pins the admission boundary and not an implementation detail.
- `TestUnportableAppName::test_install_refuses_it_before_anything_lands_on_disk`
- `TestUnportableAppName::test_register_external_refuses_it_before_materialization`
- `TestUnportableAppName::test_builtin_registration_refuses_it`

The three `TestUnportableAppName` cases are behavior-level, one per entry point,
rather than one unit test of the shared helper: the defect was that three doors
carried three different checks, so asserting the outcome at each door is what
pins the contract. A future fourth door that grows its own check fails there.

**Preservation guards** (pass before and after):

- `test_reserved_name_rejected` — the `system.*` namespace rule is unchanged.
- `test_names_merely_resembling_a_device_stay_valid` — `null-app`, `console`,
  `com10`, `lpt10`, `connect`. The rule matches the exact stem and nothing wider.
- `test_device_stem_vocabulary_is_not_duplicated` — one shared frozenset.
- `test_a_normal_app_still_installs` — `null-app` installs normally.
- `test_generator_cannot_sample_an_inadmissible_app_name` — deterministic guard
  that the lifecycle strategy's grammar still reaches the name and the filter,
  delegated to `app_name_error`, is what excludes it.

**Why the property test changed too.** `test_lifecycle_hooks._app_names()` drew
names straight from `[a-z][a-z0-9-]{2,10}`, bypassing admission entirely, so it
could generate a name production would never admit and ask the dispatcher to
materialize it (it also generated names like `ab-` that `KEBAB_RE` rejects). It
now draws from the kebab grammar and defers to `app_name_error`. Filtering
without the production fix was rejected: that hides the defect instead of closing
it. The lifecycle Hypothesis red is **not** used as regression evidence — it
surfaces this only at low probability, and an RNG re-roll proves nothing. Every
test above is deterministic.

## Manual verification

- Reproduction and the scope table measured directly on Windows 11 10.0.26200 /
  py3.10.6, values read from the code rather than restated.
- All 19 shipped builtin app names checked against the new contract before adding
  it to `_validate_builtin_app` — all pass.
- 418 passed / 2 skipped across `test_app_manifest.py`, `test_app_manager.py`,
  `test_lifecycle_hooks.py`, `test_validation.py`, `test_followup_suggest.py`
  (the last two cover the shared-constant move). The wider 19-suite app run is
  903 passed / 3 failed, all three pre-existing on this Windows host and failing
  identically on `origin/main`, which shows 4.
- `flake8`, `isort`, `mypy`, `git diff --check`, `scripts/docs_lint.py` and
  `BRAND_BASE_REF=origin/main scripts/check_brand_name.py` all clean.

## Scope

Nine files. Deliberately excluded: NUL *bytes* in names (a different problem),
the shared `KEBAB_RE` anchor and its non-app-name consumers, the
`_SLUG_PATTERN` / `_SERVER_SLUG_RE` copies of this grammar in `connections/` (a
different identifier), and any change to `RESERVED_APP_NAMES` itself, which
`dashboard/handlers/notifications_push.py` consumes for a different reason
(channel shadowing) and must not silently widen.

## Related Issues

Fixes #2575

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
