### PR TITLE
test(i18n): give the module-scope scan a timeout that fits its cost

### DIFF
--- a/website/src/i18n/moduleLevel.test.ts
+++ b/website/src/i18n/moduleLevel.test.ts
@@ -112,5 +112,7 @@ describe('i18nT is never evaluated at module load', () => {
         + 'table and translate at render (see `labelKey` + `surfaceLabel()` in '
         + '`surfaces/registry.ts`).',
     ).toEqual([])
-  })
+    // O(repo) scan: parses ~1k files, so the 15s default leaves too little
+    // margin once a parallel suite contends for CPU.
+  }, 120_000)
 })


### PR DESCRIPTION
## Problem

`website/src/i18n/moduleLevel.test.ts` → "no module-scope i18nT() call" times out intermittently and fails CI on changes unrelated to i18n. It reports `Test timed out in 15000ms` at the `it(...)` line, not an assertion failure.

The same test passes when run alone and times out in the full suite, on CI as well as locally.

## Why it matters

`Coverage Gate` fails closed on `frontend-test=failure` and `PR Readiness` aggregates it, so one flake in this test turns three checks red and reports a blocking readiness item. An author with an unrelated diff has to work out that the red is not theirs, and neither the check name nor the failure text hints at flakiness — so the natural reading is that they broke something.

## Fix (symptoms → root cause → change)

The symptom is an intermittent timeout at the test declaration. The root cause is a mismatch between the work and the budget: the suite does a module-scope recursive walk of `src/` and then parses every in-scope file with `ts.createSourceFile(..., setParentNodes: true)` — around a thousand files — while `vite.config.ts` applies a single `testTimeout: 15000` to every test alike. Isolated the scan takes about 1.6s, but the suite runs across 885 files in parallel and the contention consumes the margin; the full run reports a setup total exceeding its own wall-clock, which is that contention.

The change gives the scan an explicit 120s budget as the third argument to `it()`. The walk, the parse, and the assertion are untouched — only the clock changes. `setParentNodes: true` is load-bearing, since the visitor needs `node.parent`, so the parse cost is not incidental and this change does not try to remove it.

The tradeoff is that a genuinely hung scan now burns 120s before failing instead of 15s.

## Tests

No new tests — this changes the budget of one existing test. The suite passes with the change (2 tests).

Because a passing test would look identical whether or not the argument took effect, I confirmed it is honoured rather than ignored: setting the value to `1` makes the test report `Test timed out in 1ms`, and restoring `120_000` makes it pass again.

## Manual verification

Measured rather than assumed:

- Around a thousand in-scope `.ts`/`.tsx` files under `src/` after the suite's own filter.
- Isolated timing about 1.6s against the 15s default.
- The full-suite timeout reproduced on a clean CI runner, not only locally, which rules out a slow development machine as the explanation.

## Related Issues

The sibling unit-literal scan had the same shape and has already been fixed the better way, by moving out of vitest into a standalone gate. That leaves this module-scope scan as the remaining repo-wide walk still resident in the test suite; moving it out likewise would be the more thorough follow-up, and I am happy to do that instead if maintainers prefer it to a timeout.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality — N/A, budget-only change to one existing test
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
