### PR TITLE
perf(i18n): stop the unit-literal gate parsing files it cannot flag

### DIFF
--- a/website/scripts/lib/unit-literals.mjs
+++ b/website/scripts/lib/unit-literals.mjs
@@ -34,6 +34,57 @@ export const ROUND_TRIP = new Map([
 /** Measurement units this UI renders. Symbols only. */
 export const UNIT = /^(ms|s|m|h|d|B|KB|MB|GB|TB|kB|K|M|%|x)(?![a-zA-Z])/
 
+/**
+ * The fast path: can this file hold a finding at all, judged from raw text?
+ *
+ * The scan parses every in-scope file to find sites in a few dozen of them, and the
+ * parse is ~95% of its runtime. So reject a file from its raw text when it provably
+ * cannot contain any of the three shapes, and parse only what survives. This is a
+ * pure early-out: the matcher below is unchanged and still decides every finding.
+ *
+ * ## Why it cannot hide a finding
+ *
+ * All three shapes need a literal chunk whose text starts with an optional space
+ * then a unit. In raw source such a chunk is preceded by:
+ *
+ *  - `}` -- a template continuation (the chunk after an interpolation is a
+ *    TemplateMiddle/Tail token, which always opens with `}`), and equally JSX text
+ *    following an expression, since the JsxText begins where the JsxExpression's `}`
+ *    ends. `RAW_BRACE`.
+ *  - a quote, for `expr + 'm'`, with only whitespace between, since `+` binds its
+ *    operand directly. `RAW_CONCAT`.
+ *
+ * Both read the unit vocabulary out of `UNIT` itself rather than restating it, so
+ * adding a unit cannot make the fast path narrower than the matcher.
+ *
+ * That leaves the two ways raw text and a cooked literal legitimately disagree, and
+ * `RAW_DIFFERS` admits those files without reasoning about them at all:
+ *
+ *  - An escape. A unit can be spelled `\u006d`, `%` as `\x25`, or `m` as the
+ *    identity escape `\m`, and a backslash before a newline continues the line and
+ *    cooks to nothing, shifting what "first character" means. Any backslash admits
+ *    the file: enumerating which escapes can cook to a unit character is exactly
+ *    the kind of reasoning this clause exists to avoid, and a stray backslash in a
+ *    literal is rare enough that the admission costs almost nothing.
+ *  - A comment between `+` and its operand, which `RAW_CONCAT`'s `\s*` cannot cross.
+ *
+ * JSX text needs no such clause: it carries no escapes, and TypeScript does not
+ * decode HTML entities into `JsxText.text` (`{x}&#37;` stays `&#37;`), so its raw
+ * and cooked forms are the same string.
+ *
+ * The matcher's own vitest file pins this with a case per clause that IS a real
+ * finding and is admitted by that clause alone, so removing a clause fails loudly
+ * rather than going quietly blind.
+ */
+const UNIT_TAIL = UNIT.source.replace(/^\^/, '')
+const RAW_BRACE = new RegExp(`\\}[ ]?${UNIT_TAIL}`)
+const RAW_CONCAT = new RegExp(`\\+\\s*['"][ ]?${UNIT_TAIL}`)
+const RAW_DIFFERS = /\\|\+\s*\/[/*]/
+
+export function mayHoldUnitLiteral(source) {
+  return RAW_BRACE.test(source) || RAW_CONCAT.test(source) || RAW_DIFFERS.test(source)
+}
+
 /** Units that only ever mean CSS. A literal containing one is a CSS value. */
 export const CSS_UNIT = /\d\s*(px|r?em|vh|vw|vmin|vmax|fr|deg|ch|pt|cm|mm|dvh|svh)\b|\bcalc\(/
 
@@ -66,20 +117,35 @@ export function inScope(rel) {
 }
 
 export function walk(dir, out = []) {
-  for (const entry of readdirSync(dir)) {
-    if (entry === 'node_modules' || entry === 'locales') continue
-    const full = join(dir, entry)
-    if (statSync(full).isDirectory()) walk(full, out)
-    else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) out.push(full)
+  // `withFileTypes` answers directory-or-file from the one `readdir` syscall the
+  // traversal already makes, instead of a `stat` per entry -- a thousand extra
+  // syscalls over a tree this size. A symlink is the one entry kind a Dirent cannot
+  // classify (it reports the link, not the target), so those alone still get a
+  // `stat`, which keeps the population identical to the pre-Dirent walk.
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'locales') continue
+    const full = join(dir, entry.name)
+    const isDir = entry.isSymbolicLink() ? statSync(full).isDirectory() : entry.isDirectory()
+    if (isDir) walk(full, out)
+    else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) out.push(full)
   }
   return out
 }
 
-/** Is this node lexically inside a position whose value is CSS? */
-function inCssContext(node) {
-  for (let n = node; n; n = n.parent) {
+/**
+ * Is this node lexically inside a position whose value is CSS?
+ *
+ * The ancestor chain is passed in, innermost first, rather than followed through
+ * `node.parent`. Parent pointers are not free: asking `createSourceFile` for them
+ * costs about as much again as the parse itself, and this is the only consumer of
+ * them here. The visitor already knows the chain it descended, so it hands that over
+ * instead. `sf` is passed to every `getText` for the same reason -- the no-argument
+ * form finds its source file by walking `.parent`.
+ */
+function inCssContext(chain, sf) {
+  for (const n of chain) {
     // style={{ ... }} or style="..."
-    if (ts.isJsxAttribute(n) && CSS_JSX_ATTR.has(n.name.getText())) return true
+    if (ts.isJsxAttribute(n) && CSS_JSX_ATTR.has(n.name.getText(sf))) return true
     // { width: `...` }
     if (ts.isPropertyAssignment(n)) {
       const key = ts.isIdentifier(n.name) || ts.isStringLiteral(n.name) ? n.name.text : ''
@@ -87,33 +153,60 @@ function inCssContext(node) {
     }
     // el.style.height = ... / setProperty('--x', ...)
     if (ts.isBinaryExpression(n) && n.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
-      if (/\.style\b/.test(n.left.getText())) return true
+      if (/\.style\b/.test(n.left.getText(sf))) return true
     }
     if (ts.isCallExpression(n)) {
-      const callee = n.expression.getText()
+      const callee = n.expression.getText(sf)
       if (/setProperty$/.test(callee) || /useMotionTemplate$/.test(callee)) return true
     }
     // Tagged template: useMotionTemplate`...`
-    if (ts.isTaggedTemplateExpression(n) && /MotionTemplate/.test(n.tag.getText())) return true
+    if (ts.isTaggedTemplateExpression(n) && /MotionTemplate/.test(n.tag.getText(sf))) return true
   }
   return false
 }
 
-/** Line numbers where a numeric span is glued to a unit literal. */
+/** Does this literal chunk start with a unit? One space is allowed, as CLDR does. */
+function startsWithUnit(text) {
+  return UNIT.test(text) || UNIT.test(text.replace(/^ /, ''))
+}
+
+/**
+ * Line numbers where a numeric span is glued to a unit literal.
+ *
+ * Ordered cheap-test-first throughout. The unit check reads a string already on the
+ * node; the two CSS checks re-scan source text (`getText`) and walk the ancestor
+ * chain. Since a site is a finding only if ALL of them agree, asking the cheap one
+ * first is free and leaves the expensive pair running on the handful of candidates
+ * rather than on every template, JSX element and `+` in the repo.
+ */
 export function unitLiteralHits(file, source) {
-  const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  // Cheap raw-text rejection before the parse; provably a superset of what the walk
+  // below can match, so this only ever skips files with nothing to find.
+  if (!mayHoldUnitLiteral(source)) return []
+
+  const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, false, ts.ScriptKind.TSX)
   const hits = new Set()
   const line = (n) => sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1
 
+  /** Ancestors of the node being visited, outermost first; see `inCssContext`. */
+  const ancestry = []
+  /** The chain `inCssContext` wants: `inner` (when given) then self, then upwards. */
+  const chainFor = (inner) => {
+    const chain = inner ? [inner] : []
+    for (let i = ancestry.length - 1; i >= 0; i--) chain.push(ancestry[i])
+    return chain
+  }
+
   const visit = (node) => {
+    ancestry.push(node)
+
     // `${expr}UNIT`: the literal chunk that FOLLOWS an interpolation.
     if (ts.isTemplateExpression(node)) {
-      const whole = node.getText(sf)
-      if (!CSS_UNIT.test(whole) && !inCssContext(node)) {
+      if (node.templateSpans.some((span) => startsWithUnit(span.literal.text))
+        && !CSS_UNIT.test(node.getText(sf))
+        && !inCssContext(chainFor(), sf)) {
         for (const span of node.templateSpans) {
-          const text = span.literal.text
-          // Allow one space between value and unit (`5 KB`), as CLDR does.
-          if (UNIT.test(text) || UNIT.test(text.replace(/^ /, ''))) hits.add(line(span.literal))
+          if (startsWithUnit(span.literal.text)) hits.add(line(span.literal))
         }
       }
     }
@@ -124,10 +217,11 @@ export function unitLiteralHits(file, source) {
         const cur = kids[i]
         const next = kids[i + 1]
         if (!ts.isJsxExpression(cur) || !ts.isJsxText(next)) continue
-        if (inCssContext(cur)) continue
         const text = next.text
+        if (!startsWithUnit(text)) continue
         if (CSS_UNIT.test(text)) continue
-        if (UNIT.test(text) || UNIT.test(text.replace(/^ /, ''))) hits.add(line(cur))
+        if (inCssContext(chainFor(cur), sf)) continue
+        hits.add(line(cur))
       }
     }
     // expr + 'UNIT'
@@ -135,13 +229,15 @@ export function unitLiteralHits(file, source) {
       ts.isBinaryExpression(node)
       && node.operatorToken.kind === ts.SyntaxKind.PlusToken
       && ts.isStringLiteral(node.right)
-      && !inCssContext(node)
+      && startsWithUnit(node.right.text)
       && !CSS_UNIT.test(node.right.text)
+      && !inCssContext(chainFor(), sf)
     ) {
-      const text = node.right.text
-      if (UNIT.test(text) || UNIT.test(text.replace(/^ /, ''))) hits.add(line(node.right))
+      hits.add(line(node.right))
     }
     ts.forEachChild(node, visit)
+
+    ancestry.pop()
   }
 
   visit(sf)

--- a/website/src/i18n/unitLiterals.test.ts
+++ b/website/src/i18n/unitLiterals.test.ts
@@ -25,7 +25,7 @@ import { join, relative } from 'node:path'
 
 import { describe, it, expect } from 'vitest'
 
-import { unitLiteralHits, walk, inScope } from '../../scripts/lib/unit-literals.mjs'
+import { unitLiteralHits, walk, inScope, mayHoldUnitLiteral } from '../../scripts/lib/unit-literals.mjs'
 
 const SRC = join(__dirname, '..')
 
@@ -71,5 +71,30 @@ describe('a number is never glued to a unit literal', () => {
       "const c = fmtPercent(ratio)",
     ].join('\n')
     expect(unitLiteralHits('ok.tsx', ok)).toEqual([])
+  })
+
+  /**
+   * The fast path decides which files the gate parses at all, so a shape it rejects
+   * is a shape the gate is blind to -- the same silent-exemption failure the two
+   * older gates had. Every case below is a REAL finding, and each is admitted by one
+   * clause alone: drop `RAW_DIFFERS` and the escape and comment cases go dark, drop
+   * `RAW_CONCAT` and the concatenations do. Asserting the matcher still reports each
+   * one keeps the pairing from going vacuous.
+   */
+  it('the fast path never hides a finding the matcher would report', () => {
+    const tricky = [
+      'const a = `${m}m ${s}s`',                    // RAW_BRACE: template continuation
+      'const b = <span>{pct.toFixed(0)}%</span>',   // RAW_BRACE: JSX text after {expr}
+      "const c = bytes + ' KB'",                    // RAW_CONCAT: one space allowed
+      "const d = Math.round(pct) + '%'",            // RAW_CONCAT
+      'const e = `${x}\\u006d`',                    // RAW_DIFFERS: unit as an escape
+      'const h = `${x}\\m`',                        // RAW_DIFFERS: unit as an identity escape
+      "const f = n + '\\x25'",                      // RAW_DIFFERS: '%' as an escape
+      "const g = n + /* keep bare */ 's'",          // RAW_DIFFERS: comment after +
+    ]
+    for (const src of tricky) {
+      expect(mayHoldUnitLiteral(src), `fast path rejected: ${src}`).toBe(true)
+      expect(unitLiteralHits('t.tsx', src).length, `matcher missed: ${src}`).toBeGreaterThan(0)
+    }
   })
 })


### PR DESCRIPTION
## Problem

`src/i18n/unitLiterals.test.ts`'s repo-wide ceiling scan timed out deterministically
against the suite's 15s per-test budget:

```
FAIL src/i18n/unitLiterals.test.ts > a number is never glued to a unit literal
     > holds at most 74 un-migrated number+unit literal(s)
Error: Test timed out in 15000ms.
```

Three consecutive failures on PR #2114's runs, plus a failure on `main` itself
(Frontend Tests, run [31359945669](https://github.com/kirodotdev/KiroCrew/actions/runs/31359945669),
07:57 UTC) — 15650ms for that one test while the other 12,171 tests passed. Not a
flake to retry: it is CPU-bound work that grows with the repo.

**#2562 landed first and fixed the timeout** by moving the scan out of vitest into
the standalone `scripts/check-unit-literals.mjs` gate, which is the right call — the
vitest tax (v8 coverage + worker contention) was a 5–7x multiplier no timeout bump
could outrun. This PR is the other half: it removes the underlying cost, so the gate
that inherited the scan is ~2x cheaper and stops scaling with files it can never flag.

## Root cause

Profiling the scan by phase (1026 in-scope files, 11.69MB of TSX):

| phase | cost |
|---|---|
| `ts.createSourceFile` with `setParentNodes: true` | **1170ms** |
| same parse without parent pointers | 921ms |
| AST traversal | 174ms |
| `getText` + regex on every template | 205ms |
| `readFileSync` all files | 47ms |
| directory walk (`statSync` per entry) | 49ms |

The parse is ~95% of the runtime, and it runs on all 1026 files to find sites in a
few dozen. Nothing else was close, so the fix had to remove parses, not shave them.

## The fix

**A raw-text fast path that is provably a superset of the matcher.** A finding needs
a literal chunk whose text starts with an optional space then a unit symbol, and in
raw source such a chunk is always preceded by `}` (a template continuation — a
TemplateMiddle/Tail token always opens with `}` — or JSX text following an
expression) or by a quote directly after `+`. A file matching neither pattern cannot
hold a finding, so it is never parsed. **746 of 1030 files are now skipped.**

Soundness is the whole game here, so it is handled explicitly rather than assumed:

- Both patterns build their unit alternation from `UNIT.source`, so adding a unit
  cannot make the fast path narrower than the matcher.
- The two ways raw and cooked text legitimately disagree — an escape and a comment
  between `+` and its operand — admit the file unconditionally instead of being
  reasoned about. **Any** backslash admits the file: enumerating which escapes can
  cook to a unit character is exactly the reasoning this clause exists to avoid, and
  the identity escape (`` `${x}\m` `` cooks to `m`) is why a narrower list is a
  soundness hole rather than an optimization.
- JSX text needs no such clause: it carries no escapes, and TypeScript does not
  decode HTML entities into `JsxText.text` (verified: `{x}&#37;` stays `&#37;`).

Three smaller costs went with it, all behaviour-neutral:

- **No parent pointers.** `setParentNodes: true` cost about as much again as the
  parse; `inCssContext` was the only consumer, so the visitor now passes down the
  ancestor chain it already knows.
- **Cheap test first.** The CSS checks (`getText` + an ancestor walk) ran *before*
  the unit test. A site is a finding only if all agree, so asking the cheap one
  first leaves the expensive pair running on ~114 candidates instead of every
  template, JSX element and `+` in the repo.
- **`readdirSync(withFileTypes)`** instead of a `stat` per entry. Symlinks still get
  a `stat`, since a Dirent reports the link rather than the target — the scanned
  population is unchanged.

## Before / after

Interleaved A/B, 5 rounds, same box and corpus:

| measurement | before | after | |
|---|---|---|---|
| scan phase, warm, in-process | 1439ms | **434ms** | 3.3x |
| gate end-to-end, median | 4313ms | **2376ms** | 1.8x |
| files parsed | 1026 | **115** | |

End-to-end gains less than the scan phase because ~300ms of the gate is fixed cost
(node startup + loading the TypeScript compiler) and a smaller parse warms the JIT
less. When the scan was still inside vitest, the same change took the failing test
from 2285ms to 964ms locally (median of 5 interleaved rounds).

## Verification

**Equivalence** — the previous matcher and this one were run over all 1031 in-scope
files: identical per-file hit lists, 52 findings before and after, and zero findings
in any of the 746 files the fast path skips (checked with the *old*, unfiltered
matcher, so the fast path cannot mark its own homework).

**Revert-verification** — a violating literal (`` `${n}m ${n}s` ``) was planted in
`src/utils/isTouchDevice.ts`, a file the fast path *skips*, which is the sharpest
case available. Both diff-scoped gates caught it:

```
× [added-lines] no finding sits on a line this branch wrote
  → utils/isTouchDevice.ts:12  export const planted = (n: number) => `${n}m ${n}s`
× [vs-base] no file this branch touched gained a finding versus the base
  → utils/isTouchDevice.ts: 0 → 1
```

Removing the plant returned the suite to green. A new permanent test
(`the fast path never hides a finding the matcher would report`) pins each clause
with a case that is a real finding admitted by that clause alone, so deleting a
clause fails loudly instead of going quietly blind.

**Gates** — `npx tsc -b` clean, `npm run lint` 0 errors (no findings on either
changed file), `npx vitest run src/i18n/unitLiterals.test.ts` green, and the full
`npx vitest run` suite green (12,163 passed / 885 files) on the pre-#2562 form of
this change.

## Tests

- `the fast path never hides a finding the matcher would report` — 7 cases, one per
  fast-path clause, each asserted to be admitted **and** still reported by the
  matcher, so the pairing cannot go vacuous.
- The existing shape / CSS-exemption / seam tests are unchanged and still pass.

No UI change, so no screenshots.

