### PR TITLE
fix(chat): stop the session a linked slot's turn actually runs on

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1399,
+    "missing_code": 1397,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 758,
+  "_compliant": 762,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -40,7 +40,7 @@
       "missing_code": 17
     },
     "dashboard/chat_handlers.py": {
-      "missing_code": 76
+      "missing_code": 74
     },
     "dashboard/chat_mirror.py": {
       "missing_code": 11

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -1410,6 +1410,97 @@ def _make_stop_resolver(
     return _resolve
 
 
+def _slot_not_found() -> web.Response:
+    """The one 404 every cancel-route refusal returns.
+
+    A denial and a genuinely missing slot MUST be byte-identical, or an app can
+    tell "this slot is not mine" from "this slot does not exist" and enumerate
+    foreign slot names. Single-sourced so the two cannot diverge; the shape
+    matches ``api_chat_slot_continue``.
+    """
+    return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
+
+
+def _cancel_target(slot: _ChatSlot) -> str:
+    """The session a cancel on *slot* must address.
+
+    Never ``_history_key_for(name)``: every slot carrying a
+    ``linked_session_key`` — a cron-born tab (``cron:<job_id>``), a channel-born
+    tab (``slack:<ts>``), a workflow-born tab — runs its turns under that key,
+    while the dashboard-prefixed spelling names a session that never existed.
+    ``SessionManager.stop_turn`` then finds nothing and returns ``"idle"``, the
+    handler settles the card as "stopped", and the turn keeps streaming, so Stop
+    is a silent no-op that reports success once per press.
+
+    Routing alone is not enough either. A running turn owns a stable identity:
+    ``_run_chat`` captures the key it acquires and keeps using that one for the
+    whole turn, while
+    ``linked_session_key`` remains mutable underneath it — a cron injection
+    binds an already-live slot with no ``running`` gate. Re-deriving the key at
+    cancel time therefore names wherever the slot routes the NEXT turn, which
+    after a mid-turn rebind is not the turn the operator is trying to stop.
+
+    Falls back to the routing when no turn is in flight (nothing to have
+    captured an identity), which is also what a slot restored from disk answers
+    — the field is runtime-only and empty after a restart.
+    """
+    return getattr(slot, "_active_turn_session_key", "") or effective_session_key(slot)
+
+
+def _app_cancel_denied(
+    request: web.Request, slot: _ChatSlot, operation: str, target_key: str
+) -> web.Response | None:
+    """Whether *request* may cancel *target_key*, as an indistinguishable 404.
+
+    Two conditions for an app token, because slot ownership does NOT imply
+    ownership of the session the cancel would land on:
+
+    1. the app owns the slot (App Kit §5.2, deny-by-default), and
+    2. the session about to be cancelled is still the slot's own dashboard
+       session, not one the app has no claim on.
+
+    Condition 2 is load-bearing. ``get_or_create_slot`` takes ``app`` and, for a
+    name shaped like a channel session stem, resolves ``linked_session_key``
+    from the session map in the same call — so an app that names a live channel
+    thread ends up owning a slot bound to a conversation it has no claim on.
+    Ownership alone would then authorize cancelling that channel's turn, turning
+    a slot binding into capability escalation.
+
+    It tests *target_key* — the key the caller will actually cancel — rather
+    than re-reading the slot, so authorization and action cannot disagree. That
+    is not only a TOCTOU guard: for a turn that started on the app's own session
+    and was rebound mid-flight, re-reading would DENY the app its own running
+    turn, because the routing now points somewhere it does not own.
+
+    A dashboard caller has no app scope and may cancel either kind.
+
+    Shared by the cancel routes so /stop and /interrupt cannot drift onto two
+    policies.
+    """
+    request_app = request.get("app", "")
+    if not request_app:
+        return None
+
+    if request_app != slot._app:
+        reason = (
+            "app cannot access unscoped slots" if not slot._app else "app does not own this slot"
+        )
+    elif target_key != _history_key_for(slot.key):
+        reason = "app does not own the session this slot is linked to"
+    else:
+        return None
+
+    sel().log_api_access(
+        caller=request_app,
+        operation=operation,
+        outcome="denied",
+        source="app_isolation",
+        resources=f"slot={slot.key}",
+        error=reason,
+    )
+    return _slot_not_found()
+
+
 async def api_chat_slot_stop(request: web.Request) -> web.Response:
     """POST /api/chat/slots/{slot}/stop — cooperative stop with kill fallback.
 
@@ -1420,20 +1511,20 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
     name = request.match_info["slot"]
     slot = state._slots.get(name)
     if not slot:
-        return web.json_response({"error": "not found"}, status=404)
+        return _slot_not_found()
+    # Before ANY side effect — the escalation branch below clears the queue and
+    # drops pending steers before it reaches stop_turn, so a guard placed later
+    # would still let a foreign caller mutate the slot.
+    # One target, resolved once: the session the in-flight turn actually runs
+    # on. Authorization and every stop_turn below are handed this same value, so
+    # they cannot disagree — neither across the request-body await in
+    # /interrupt, nor across two presses of Stop while a rebind lands between
+    # them.
+    cancel_key = _cancel_target(slot)
+    denied = _app_cancel_denied(request, slot, "chat_stop", cancel_key)
+    if denied is not None:
+        return denied
     force = request.query.get("force", "").lower() == "true"
-    # The session the slot's turns actually RUN on, which is what has to be
-    # cancelled. `_history_key_for(name)` is wrong for every slot that carries a
-    # `linked_session_key`: a cron-born tab (`cron-<job_id>` → `cron:<job_id>`),
-    # a channel-born tab (`slack:<ts>`) and a workflow-born tab all run their
-    # turns under that key (`chat_runner` resolves it with
-    # `effective_session_key`), while the dashboard-prefixed spelling names a
-    # session that never existed. `SessionManager.stop_turn` then finds nothing
-    # and returns "idle", the handler settles the card as "stopped", and the
-    # turn keeps streaming — so Stop is a silent no-op that reports success,
-    # once per press.
-    session_key = effective_session_key(slot)
-
     # Escalation path: a second stop press while a cooperative cancel is
     # already pending hard-kills. We escalate on ANY second press — not only
     # when the client computed force=true — because the client derives force
@@ -1461,9 +1552,15 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
         # Unblock chat runner if it's suspended waiting for tool approval or on
         # a pending ask_question card.
         _unblock_pending_waits(state, slot)
-        await state.sessions.stop_turn(session_key, force=True, on_hard=_on_hard_force)
+        # Stop addresses the SESSION, so it resolves through
+        # effective_session_key: a channel-linked slot's turns run under its
+        # linked_session_key (slack:<ts>), and handing stop_turn the
+        # dashboard:<slot> key names a session no running turn owns — the stop
+        # reports success and cancels nothing. The SEL record below stays on the
+        # slot-derived key, which identifies the tab the operator pressed.
+        await state.sessions.stop_turn(cancel_key, force=True, on_hard=_on_hard_force)
         sel().log_tool_invocation(
-            session_key=session_key,
+            session_key=_history_key_for(name),
             agent=getattr(slot, "agent", "") or "kirocrew",
             source="dashboard",
             tool_name="dashboard_stop",
@@ -1483,7 +1580,7 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
         else:
             _info = "stop already in progress"
         sel().log_tool_invocation(
-            session_key=session_key,
+            session_key=_history_key_for(name),
             agent=getattr(slot, "agent", "") or "kirocrew",
             source="dashboard",
             tool_name="dashboard_stop",
@@ -1546,7 +1643,11 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
     _unblock_pending_waits(state, slot)
 
     outcome = await state.sessions.stop_turn(
-        session_key, force=False, preserve_queue=True, on_soft=_on_soft, on_hard=_on_hard
+        cancel_key,
+        force=False,
+        preserve_queue=True,
+        on_soft=_on_soft,
+        on_hard=_on_hard,
     )
     # Resolve orphaned card when provider reports no active turn
     if outcome == "idle" and slot._stop_event_id:
@@ -1554,7 +1655,7 @@ async def api_chat_slot_stop(request: web.Request) -> web.Response:
         slot._stop_state = "idle"
         state.push_slots_update()
     sel().log_tool_invocation(
-        session_key=session_key,
+        session_key=_history_key_for(name),
         agent=getattr(slot, "agent", "") or "kirocrew",
         source="dashboard",
         tool_name="dashboard_stop",
@@ -1897,20 +1998,24 @@ async def api_chat_slot_interrupt(request: web.Request) -> web.Response:
     name = request.match_info["slot"]
     slot = state._slots.get(name)
     if not slot:
-        return web.json_response({"error": "not found"}, status=404)
+        return _slot_not_found()
+    # Before the _stop_state claim and the queue promotion below, both of which
+    # mutate the slot ahead of stop_turn.
+    # Resolved once, before the request-body await below, and used for both the
+    # guard and the cancel — see api_chat_slot_stop for the same rule.
+    cancel_key = _cancel_target(slot)
+    denied = _app_cancel_denied(request, slot, "chat_interrupt", cancel_key)
+    if denied is not None:
+        return denied
     if not slot.running:
         return web.json_response({"ok": True, "info": "not running"})
-    # Same reason as `api_chat_slot_stop`: cancel the session the turns RUN on,
-    # not the dashboard-prefixed spelling of the slot key, which names nothing
-    # for a slot carrying a `linked_session_key`.
-    session_key = effective_session_key(slot)
     # Idempotent guard: interrupt already in progress. State alone decides —
     # do NOT also require _stop_event_id: after the early soft_pending claim
     # below, a concurrent request can arrive before the stop card is created
     # (event id still None), and a compound condition would let it through.
     if slot._stop_state != "idle":
         sel().log_tool_invocation(
-            session_key=session_key,
+            session_key=_history_key_for(name),
             agent=getattr(slot, "agent", "") or "kirocrew",
             source="dashboard",
             tool_name="dashboard_interrupt",
@@ -1978,7 +2083,7 @@ async def api_chat_slot_interrupt(request: web.Request) -> web.Response:
     _unblock_pending_waits(state, slot)
 
     outcome = await state.sessions.stop_turn(
-        session_key,
+        cancel_key,
         force=False,
         preserve_queue=True,
         on_soft=_on_soft,
@@ -1990,7 +2095,7 @@ async def api_chat_slot_interrupt(request: web.Request) -> web.Response:
         slot._stop_state = "idle"
         state.push_slots_update()
     sel().log_tool_invocation(
-        session_key=session_key,
+        session_key=_history_key_for(name),
         agent=getattr(slot, "agent", "") or "kirocrew",
         source="dashboard",
         tool_name="dashboard_interrupt",

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -4078,6 +4078,29 @@ async def _run_chat(
     if _prompt_depth == 0:
         await expire_slack_options(state, session_key)
 
+    # Publish the identity of the turn this call is about to run. From here down
+    # the local `session_key` is what the turn acquires, audits and releases,
+    # while `slot.linked_session_key` stays mutable underneath it: a cron
+    # injection binds an existing slot with no `running` gate, so a turn that
+    # started on `dashboard:<slot>` can find the slot routed at `cron:<id>`
+    # before it ends. A cancel that re-derived the key would then address a
+    # session this turn never ran on, so the cancel routes read this instead.
+    #
+    # Placed at the same boundary as the OPTIONS expiry above, and for the same
+    # reason: `/goal`, a `/prompts` listing or error, and a blocked slash command
+    # all return without starting an agent turn, so none of them owns a turn
+    # identity. `/prompts get` re-enters at `_prompt_depth=1`, and it is that
+    # depth-1 call which reaches the machinery below while its depth-0 wrapper
+    # returns above — so keying on the BOUNDARY is what puts the identity on the
+    # invocation that actually runs the turn. Keying on `_prompt_depth == 0`
+    # would put it on the wrapper instead.
+    #
+    # BELOW the expiry, not above it: that await is the only thing between the
+    # boundary and the try, so installing after it means every exit that can
+    # happen while the identity is live reaches the teardown that retires it.
+    # Only plain assignments separate this line from the try.
+    slot._active_turn_session_key = session_key
+
     _acquired = False
     _mirror_stream_ts: str = ""
     _mirror_chan: str | None = ""
@@ -7644,6 +7667,23 @@ async def _run_chat(
                 # so a reset that failed or was cancelled still hands back the
                 # permit rather than stranding the session.
                 state.sessions.release(session_key)
+            # This turn's identity dies WITH its session, and inside the same
+            # finally for the same reason the release is: the reset above can be
+            # cancelled, and CancelledError derives from BaseException, so a
+            # clear placed after this block is simply skipped and the slot keeps
+            # advertising a turn that is gone.
+            #
+            # It must also land before `_start_next_queued_turn` further down
+            # can install the SUCCESSOR's key — a clear after that would wipe a
+            # live turn's identity and drop the cancel routes back to mutable
+            # routing. Compare-and-clear keeps that true if the ordering is ever
+            # rearranged: only the turn that installed a key may retire it.
+            #
+            # Outside the `_acquired` guard: the identity is published before
+            # the permit is taken, so a cold start that never acquired one still
+            # has something to retire.
+            if slot._active_turn_session_key == session_key:
+                slot._active_turn_session_key = ""
         # End-of-turn fallback: catches set_project calls that fired mid-turn,
         # after the start-of-turn consume already ran. Guarded because a raise
         # here would skip the steer requeue and queue drain below, silently

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -948,6 +948,7 @@ class _ChatSlot:
         "_pending_rewrite",
         "_file_changes",
         "linked_session_key",
+        "_active_turn_session_key",
         "_side",
         "_acp_client",
         "_steer_segment_cut",
@@ -1313,6 +1314,15 @@ class _ChatSlot:
             []
         )  # [{path, content}] before-snapshots accumulated per turn for file-chip diffs
         self.linked_session_key: str = ""  # when set, _run_chat uses this as session key
+        # Where the turn CURRENTLY in flight actually started, as opposed to
+        # where the slot would route a new one. The two diverge whenever the
+        # routing above is reassigned on a live slot — a cron injection binds an
+        # existing slot to ``cron:<id>`` with no ``running`` gate — and a cancel
+        # must address the turn, not the routing. Runtime-only: never persisted,
+        # never serialized, empty after a restart, and ``_run_chat`` is its sole
+        # lifecycle owner (installed once the turn is committed, cleared after
+        # its session is released).
+        self._active_turn_session_key: str = ""
         # True only when this slot was created to DISPLAY a conversation that
         # already lives in a channel transcript (the reconciler surfacing a
         # thread, a restore, a History resume). It is what separates such a tab

--- a/test/test_active_turn_session_key.py
+++ b/test/test_active_turn_session_key.py
@@ -1,0 +1,248 @@
+"""``_ChatSlot._active_turn_session_key`` — the running turn's own identity.
+
+``linked_session_key`` says where the slot routes a NEW turn, and it is mutable
+on a live slot: ``inject_cron_result_to_dashboard`` binds an already-running
+slot to ``cron:<id>`` with no ``running`` gate. ``_run_chat`` captures its
+session key once, at the boundary below every local-command return, and uses
+that one key to acquire, audit and release for the whole turn.
+
+These tests pin the field's LIFECYCLE against the real ``_run_chat``; the
+cancel routes that consume it are covered in
+``test_stop_addresses_linked_session.py``. The two things that can go wrong are
+a key that outlives its turn (a later cancel aims at a session that is gone) and
+a key retired by the wrong turn (a cancel falls back to mutable routing while a
+successor is running).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from chat_test_helpers import _make_state
+
+from kiro_crew.acp.client import AcpAuthRequired
+from kiro_crew.dashboard.chat_runner import _run_chat
+
+LINKED_KEY = "slack:1730000000.123456"
+
+
+def _state_and_slot(tmp_path: Path, name: str = "turn-id-slot"):
+    """The harness ``test_turn_teardown_release`` uses, so the turn is real."""
+    state = _make_state(tmp_path)
+    state.sessions.get_or_create = AsyncMock(return_value=(MagicMock(), False, False))
+    state.sessions.release = MagicMock()
+    state.sessions.reset = AsyncMock()
+    state.sessions.set_approval_policy = MagicMock()
+    state.sessions.check_context_usage = MagicMock()
+    state.sessions.get_slack_link = MagicMock(return_value=(None, None))
+    state.sessions.record_failure = AsyncMock()
+    state.broadcast_ws = MagicMock()
+    state.push_slots_update = MagicMock()
+    state.is_yolo_active = MagicMock(return_value=False)
+    state._background_tasks = set()
+    slot = state.get_or_create_slot(name)
+    slot.append("user", "hello", "msg msg-u")
+    client = state.sessions.get_or_create.return_value[0]
+    client.shutdown = AsyncMock()
+    return state, slot, client
+
+
+def _stream_empty(client: MagicMock) -> None:
+    async def _empty(msg):
+        return
+        yield  # pragma: no cover - generator shape only
+
+    client.stream = _empty
+    client.stream_command = _empty
+
+
+def _stream_observes(client: MagicMock, sink: list) -> None:
+    """A stream that records the slot's identity from INSIDE the live turn."""
+
+    def _make(slot):
+        async def _observe(msg):
+            sink.append(slot._active_turn_session_key)
+            return
+            yield  # pragma: no cover - generator shape only
+
+        return _observe
+
+    return _make
+
+
+class TestTheKeyIsInstalledForTheRunningTurn:
+    @pytest.mark.asyncio
+    async def test_a_plain_turn_publishes_its_own_session(self, tmp_path) -> None:
+        state, slot, client = _state_and_slot(tmp_path)
+        seen: list[str] = []
+        client.stream = _stream_observes(client, seen)(slot)
+        client.stream_command = client.stream
+
+        await _run_chat(state, slot, "test message")
+
+        assert seen == ["dashboard:turn-id-slot"]
+
+    @pytest.mark.asyncio
+    async def test_a_linked_slot_publishes_the_session_it_runs_on(self, tmp_path) -> None:
+        """A channel-born tab is bound before its turn starts, so the captured
+        identity IS the channel session — which is what keeps the #2462 fix."""
+        state, slot, client = _state_and_slot(tmp_path)
+        slot.linked_session_key = LINKED_KEY
+        seen: list[str] = []
+        client.stream = _stream_observes(client, seen)(slot)
+        client.stream_command = client.stream
+
+        await _run_chat(state, slot, "test message")
+
+        assert seen == [LINKED_KEY]
+
+    @pytest.mark.asyncio
+    async def test_a_rebind_mid_turn_does_not_move_the_published_identity(self, tmp_path) -> None:
+        """The whole point: the cron injection's assignment must not retarget a
+        turn that is already running."""
+        state, slot, client = _state_and_slot(tmp_path)
+        seen: list[str] = []
+
+        async def _rebind_then_finish(msg):
+            slot.linked_session_key = "cron:nightly-report"
+            seen.append(slot._active_turn_session_key)
+            return
+            yield  # pragma: no cover - generator shape only
+
+        client.stream = _rebind_then_finish
+        client.stream_command = _rebind_then_finish
+
+        await _run_chat(state, slot, "test message")
+
+        assert seen == ["dashboard:turn-id-slot"]
+
+
+class TestTheKeyDoesNotOutliveItsTurn:
+    @pytest.mark.asyncio
+    async def test_cleared_after_a_normal_completion(self, tmp_path) -> None:
+        state, slot, client = _state_and_slot(tmp_path)
+        _stream_empty(client)
+
+        await _run_chat(state, slot, "test message")
+
+        assert slot._active_turn_session_key == ""
+
+    @pytest.mark.asyncio
+    async def test_cleared_when_teardown_itself_is_cancelled(self, tmp_path) -> None:
+        """CancelledError derives from BaseException, so an ``except Exception``
+        cleanup misses it — the shape that once stranded the session permit.
+
+        Cancelled at the same place ``test_turn_teardown_release`` cancels:
+        ``AcpAuthRequired`` sets ``needs_session_reset``, which puts an ``await``
+        inside the teardown, and the cancel lands on it.
+        """
+        state, slot, client = _state_and_slot(tmp_path)
+
+        async def _raise(msg):
+            raise AcpAuthRequired("kiro-cli is not logged in.")
+            yield  # pragma: no cover - generator shape only
+
+        client.stream = _raise
+        client.stream_command = _raise
+        state.sessions.reset = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with pytest.raises(asyncio.CancelledError):
+            await _run_chat(state, slot, "test message")
+
+        assert slot._active_turn_session_key == ""
+
+    @pytest.mark.asyncio
+    async def test_cleared_after_a_provider_error(self, tmp_path) -> None:
+        state, slot, client = _state_and_slot(tmp_path)
+
+        async def _raise(msg):
+            raise AcpAuthRequired("kiro-cli is not logged in.")
+            yield  # pragma: no cover - generator shape only
+
+        client.stream = _raise
+        client.stream_command = _raise
+
+        await _run_chat(state, slot, "test message")
+
+        assert slot._active_turn_session_key == ""
+
+    @pytest.mark.asyncio
+    async def test_cleared_when_the_session_was_never_acquired(self, tmp_path) -> None:
+        state, slot, _client = _state_and_slot(tmp_path)
+        state.sessions.get_or_create = AsyncMock(side_effect=RuntimeError("cold start failed"))
+
+        await _run_chat(state, slot, "test message")
+
+        assert slot._active_turn_session_key == ""
+
+
+class TestOneTurnCannotRetireAnother:
+    @pytest.mark.asyncio
+    async def test_the_clear_lands_before_a_successor_can_start(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """``_start_next_queued_turn`` runs inside the FIRST turn's teardown.
+
+        Two orderings have to hold and both are invisible to a post-hoc read, so
+        this observes the dispatch point itself: the retiring turn's identity
+        must already be gone when the successor is dispatched, and whatever the
+        successor installs must survive the rest of turn one's teardown.
+        """
+        state, slot, client = _state_and_slot(tmp_path)
+        _stream_empty(client)
+        slot.queue_append("second message")
+        observed: dict[str, str] = {}
+
+        async def _fake_start(st, sl) -> bool:
+            observed["at_dispatch"] = sl._active_turn_session_key
+            # Stand in for the successor publishing its own identity.
+            sl._active_turn_session_key = "dashboard:successor"
+            return True
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_runner._start_next_queued_turn", _fake_start)
+
+        await _run_chat(state, slot, "first message")
+
+        assert (
+            observed.get("at_dispatch") == ""
+        ), "the finished turn still advertised an identity when its successor started"
+        assert (
+            slot._active_turn_session_key == "dashboard:successor"
+        ), "the retiring turn erased its successor's identity"
+
+
+class TestThePromptsGetReEntry:
+    """``/prompts get`` calls ``_run_chat`` again at ``_prompt_depth=1``.
+
+    The depth-0 invocation is a local wrapper that returns without reaching the
+    turn machinery; the depth-1 one is the turn. Keying the identity on
+    ``_prompt_depth == 0`` would put it on the wrapper — which is why it is
+    keyed on the local-command boundary instead.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_inner_invocation_owns_the_identity(self, tmp_path, monkeypatch) -> None:
+        state, slot, client = _state_and_slot(tmp_path)
+        seen: list[str] = []
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner._expand_prompt_mention",
+            lambda mention, st, sl: ("expanded prompt body", "ok"),
+        )
+
+        async def _observe(msg):
+            seen.append((msg, slot._active_turn_session_key))
+            return
+            yield  # pragma: no cover - generator shape only
+
+        client.stream = _observe
+        client.stream_command = _observe
+
+        await _run_chat(state, slot, "/prompts get demo")
+
+        assert seen == [
+            ("expanded prompt body", "dashboard:turn-id-slot")
+        ], "the real turn ran without a published identity"
+        assert slot._active_turn_session_key == ""

--- a/test/test_stop_addresses_linked_session.py
+++ b/test/test_stop_addresses_linked_session.py
@@ -1,0 +1,565 @@
+"""The dashboard Stop must address the session the turn actually runs on.
+
+A channel-linked slot's turns run under its ``linked_session_key``
+(``slack:<ts>``), not under ``dashboard:<slot>``. Handing ``stop_turn`` the
+slot-derived key names a session no running turn owns, so the cancel is a no-op
+while the handler still inserts the stop card and answers ``{"ok": true}`` — the
+operator is told the turn stopped and it keeps executing.
+
+Each test asserts the KEY the handler passes, because that is the whole defect:
+the surrounding card/state bookkeeping was already correct.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+
+LINKED_KEY = "slack:1730000000.123456"
+
+#: What both a missing slot and a refused caller must return, byte for byte.
+MISSING_SLOT_BODY = {"error": "not found", "code": "slot_not_found"}
+
+
+class _FakeSlot:
+    """Minimal ChatSlot stand-in, optionally linked to a channel session."""
+
+    def __init__(self, linked: str = "", app: str = ""):
+        self._app = app
+        # Runtime-only turn identity; empty until _run_chat installs one, which
+        # is also what a slot rehydrated from disk answers.
+        self._active_turn_session_key = ""
+        self._stop_state = "idle"
+        self._stop_event_id = None
+        self._stop_escalated_card_id = None
+        self._queue: list[dict] = []
+        self._pending_steers: list[dict] = []
+        self._auto_run = False
+        self.running = True
+        self.key = "test-slot"
+        self.agent = "kirocrew"
+        self.linked_session_key = linked
+        self.messages: list[dict] = []
+        self.source_links_invalidated = 0
+
+    def append(self, role, content, cls_meta):
+        self.messages.append({"role": role, "content": content, "cls": cls_meta})
+
+    def invalidate_source_links(self):
+        self.source_links_invalidated += 1
+
+    def queue_insert(self, index, content, kind=""):
+        self._queue.insert(index, {"content": content, "kind": kind})
+
+
+class _FakeState:
+    def __init__(self, slot):
+        self._slots = {"test-slot": slot}
+        self.sessions = MagicMock()
+        self.sessions.stop_turn = AsyncMock(return_value="cancelled")
+
+    def push_slots_update(self):
+        pass
+
+    def cancel_questions_for_slot(self, slot_key):
+        return 0
+
+
+def _request(state, query=None, caller_app=""):
+    app = web.Application()
+    app["state"] = state
+    request = MagicMock()
+    request.app = app
+    request.match_info = {"slot": "test-slot"}
+    request.query = query or {}
+    request.json = AsyncMock(return_value={})
+    # The auth middleware stashes the calling app's name here; a dashboard user
+    # leaves it absent, which `request.get("app", "")` reads as "".
+    request.get = lambda key, default="": caller_app if key == "app" else default
+    return request
+
+
+def _stopped_key(state) -> str:
+    """The session key the handler handed to ``stop_turn``."""
+    assert state.sessions.stop_turn.await_count == 1, "stop_turn was not called exactly once"
+    return state.sessions.stop_turn.await_args.args[0]
+
+
+def api_chat_slot_stop_h():
+    from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+    return api_chat_slot_stop
+
+
+async def _run(handler, state, query=None, caller_app=""):
+    with patch("kiro_crew.dashboard.chat_handlers.sel") as mock_sel:
+        mock_sel.return_value.log_tool_invocation = MagicMock()
+        mock_sel.return_value.log = MagicMock()
+        mock_sel.return_value.log_api_access = MagicMock()
+        with patch("kiro_crew.dashboard.chat_handlers._reject_pending_approvals"):
+            return await handler(_request(state, query, caller_app))
+
+
+class TestStopAddressesTheRunningSession:
+    @pytest.mark.asyncio
+    async def test_soft_stop_on_a_linked_slot_cancels_the_channel_session(self):
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        state = _FakeState(_FakeSlot(linked=LINKED_KEY))
+        await _run(api_chat_slot_stop, state)
+
+        assert _stopped_key(state) == LINKED_KEY
+
+    @pytest.mark.asyncio
+    async def test_hard_kill_on_a_linked_slot_cancels_the_channel_session(self):
+        """The escalation path is the one a user reaches when the soft stop did
+        nothing, so it must not repeat the same mis-addressing."""
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot(linked=LINKED_KEY)
+        slot._stop_state = "soft_pending"
+        slot._stop_event_id = "stop-abc"
+        state = _FakeState(slot)
+
+        await _run(api_chat_slot_stop, state, query={"force": "true"})
+
+        assert _stopped_key(state) == LINKED_KEY
+
+    @pytest.mark.asyncio
+    async def test_interrupt_on_a_linked_slot_cancels_the_channel_session(self):
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_interrupt
+
+        # /interrupt refuses an empty queue (400, "use /stop instead"), so the
+        # slot needs a queued message to reach the cancel at all.
+        slot = _FakeSlot(linked=LINKED_KEY)
+        slot._queue = [{"queue_id": "q1", "content": "next"}]
+        state = _FakeState(slot)
+        await _run(api_chat_slot_interrupt, state)
+
+        assert _stopped_key(state) == LINKED_KEY
+
+
+class TestUnlinkedSlotsAreUnchanged:
+    """Preservation: an ordinary dashboard slot has no link, so
+    ``effective_session_key`` falls back to exactly the previous key."""
+
+    @pytest.mark.asyncio
+    async def test_soft_stop_still_uses_the_dashboard_key(self):
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        state = _FakeState(_FakeSlot())
+        await _run(api_chat_slot_stop, state)
+
+        assert _stopped_key(state) == "dashboard:test-slot"
+
+    @pytest.mark.asyncio
+    async def test_hard_kill_still_uses_the_dashboard_key(self):
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot()
+        slot._stop_state = "soft_pending"
+        slot._stop_event_id = "stop-abc"
+        state = _FakeState(slot)
+
+        await _run(api_chat_slot_stop, state, query={"force": "true"})
+
+        assert _stopped_key(state) == "dashboard:test-slot"
+
+    @pytest.mark.asyncio
+    async def test_interrupt_still_uses_the_dashboard_key(self):
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_interrupt
+
+        slot = _FakeSlot()
+        slot._queue = [{"queue_id": "q1", "content": "next"}]
+        state = _FakeState(slot)
+        await _run(api_chat_slot_interrupt, state)
+
+        assert _stopped_key(state) == "dashboard:test-slot"
+
+
+class TestAppTokensCannotCancelForeignSlots:
+    """App Kit §5.2 ownership, enforced before any side effect.
+
+    Resolving the real session key is what makes this reachable: addressing
+    `dashboard:<slot>` cancelled nothing, so the missing guard on /stop and
+    /interrupt was inert. Now the cancel lands, and an app token holding
+    `/api/chat/*` could otherwise name a foreign linked slot and kill the
+    channel turn running on it.
+
+    `_unblock_pending_waits`, the stop card, the `_stop_state` claim and the
+    queue clear all happen before `stop_turn`, so "no side effect" is asserted
+    on the slot as well as on the mock.
+    """
+
+    def _assert_untouched(self, resp, state, slot):
+        assert resp.status == 404
+        # Byte-identical to a missing slot, not merely the same status: a
+        # differing `code` would let an app tell "not mine" from "not there"
+        # and enumerate foreign slot names.
+        assert json.loads(resp.body) == MISSING_SLOT_BODY
+        assert state.sessions.stop_turn.await_count == 0
+        assert slot.messages == [], "a stop card was written for a denied caller"
+        assert slot._stop_state == "idle"
+        assert slot._queue == []
+
+    @pytest.mark.asyncio
+    async def test_app_token_cannot_stop_a_dashboard_owned_linked_slot(self):
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot(linked=LINKED_KEY)  # dashboard-owned: _app == ""
+        state = _FakeState(slot)
+        resp = await _run(api_chat_slot_stop, state, caller_app="rogue-app")
+        self._assert_untouched(resp, state, slot)
+
+    @pytest.mark.asyncio
+    async def test_app_a_cannot_stop_app_bs_slot(self):
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot(linked=LINKED_KEY, app="app-b")
+        state = _FakeState(slot)
+        resp = await _run(api_chat_slot_stop, state, caller_app="app-a")
+        self._assert_untouched(resp, state, slot)
+
+    @pytest.mark.asyncio
+    async def test_the_hard_kill_path_cannot_bypass_the_guard(self):
+        """The escalation branch clears the queue and drops pending steers
+        before it reaches stop_turn, so the guard must precede it."""
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot(linked=LINKED_KEY)
+        slot._stop_state = "soft_pending"
+        slot._queue = [{"queue_id": "q1", "content": "keep me"}]
+        slot._pending_steers = [{"content": "keep me too"}]
+        state = _FakeState(slot)
+
+        resp = await _run(
+            api_chat_slot_stop, state, query={"force": "true"}, caller_app="rogue-app"
+        )
+
+        assert resp.status == 404
+        assert state.sessions.stop_turn.await_count == 0
+        assert slot._queue == [{"queue_id": "q1", "content": "keep me"}]
+        assert slot._pending_steers == [{"content": "keep me too"}]
+        assert slot._stop_state == "soft_pending"
+
+    @pytest.mark.asyncio
+    async def test_app_token_cannot_interrupt_a_foreign_slot(self):
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_interrupt
+
+        slot = _FakeSlot(linked=LINKED_KEY)
+        slot._queue = [{"queue_id": "q1", "content": "next"}]
+        state = _FakeState(slot)
+
+        resp = await _run(api_chat_slot_interrupt, state, caller_app="rogue-app")
+
+        assert resp.status == 404
+        assert state.sessions.stop_turn.await_count == 0
+        assert slot._stop_state == "idle"
+        assert slot.messages == []
+
+    @pytest.mark.asyncio
+    async def test_an_owned_but_channel_linked_slot_is_still_refused(self):
+        """Slot ownership does not prove ownership of the linked session.
+
+        ``get_or_create_slot`` takes ``app`` and, for a name shaped like a
+        channel session stem, resolves ``linked_session_key`` from the session
+        map in the SAME call — so an app that names a live channel thread ends
+        up legitimately owning a slot bound to a conversation it has no claim
+        on. An ownership-only guard authorizes cancelling that channel's turn,
+        which turns the slot binding into capability escalation.
+        """
+        slot = _FakeSlot(linked=LINKED_KEY, app="app-a")
+        state = _FakeState(slot)
+
+        resp = await _run(api_chat_slot_stop_h(), state, caller_app="app-a")
+
+        # Ownership alone would have allowed this.
+        assert slot._app == "app-a"
+        self._assert_untouched(resp, state, slot)
+
+    @pytest.mark.asyncio
+    async def test_an_owned_channel_linked_slot_is_refused_on_interrupt_too(self):
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_interrupt
+
+        slot = _FakeSlot(linked=LINKED_KEY, app="app-a")
+        slot._queue = [{"queue_id": "q1", "content": "next"}]
+        state = _FakeState(slot)
+
+        resp = await _run(api_chat_slot_interrupt, state, caller_app="app-a")
+
+        assert resp.status == 404
+        assert json.loads(resp.body) == MISSING_SLOT_BODY
+        assert state.sessions.stop_turn.await_count == 0
+        assert slot._stop_state == "idle"
+        assert slot.messages == []
+        assert slot._queue == [{"queue_id": "q1", "content": "next"}]
+
+    @pytest.mark.asyncio
+    async def test_an_owned_channel_linked_slot_is_refused_on_hard_kill_too(self):
+        slot = _FakeSlot(linked=LINKED_KEY, app="app-a")
+        slot._stop_state = "soft_pending"
+        slot._queue = [{"queue_id": "q1", "content": "keep me"}]
+        slot._pending_steers = [{"content": "keep me too"}]
+        state = _FakeState(slot)
+
+        resp = await _run(
+            api_chat_slot_stop_h(), state, query={"force": "true"}, caller_app="app-a"
+        )
+
+        assert resp.status == 404
+        assert json.loads(resp.body) == MISSING_SLOT_BODY
+        assert state.sessions.stop_turn.await_count == 0
+        assert slot._queue == [{"queue_id": "q1", "content": "keep me"}]
+        assert slot._pending_steers == [{"content": "keep me too"}]
+
+    @pytest.mark.asyncio
+    async def test_a_missing_slot_answers_exactly_like_a_refusal(self):
+        """The oracle check from the other side: if these two bodies ever
+        diverge, every denial above becomes an existence probe."""
+        state = _FakeState(_FakeSlot())
+        state._slots = {}  # no such slot
+
+        resp = await _run(api_chat_slot_stop_h(), state, caller_app="rogue-app")
+
+        assert resp.status == 404
+        assert json.loads(resp.body) == MISSING_SLOT_BODY
+
+    @pytest.mark.asyncio
+    async def test_the_owning_app_may_still_stop_its_own_slot(self):
+        """No app-owned slot carries a linked_session_key today (only
+        auto-research and spec-builder pass ``app=``, neither with a link), so
+        the owning-app case is exercised on the shape that actually exists. The
+        rule is ownership, not linkage, matching api_chat_slot_continue."""
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot(app="auto-research")
+        state = _FakeState(slot)
+
+        await _run(api_chat_slot_stop, state, caller_app="auto-research")
+
+        assert _stopped_key(state) == "dashboard:test-slot"
+
+    @pytest.mark.asyncio
+    async def test_dashboard_user_is_not_treated_as_an_app(self):
+        """Empty request app = dashboard user, who reaches every slot."""
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot(linked=LINKED_KEY, app="some-app")
+        state = _FakeState(slot)
+
+        await _run(api_chat_slot_stop, state, caller_app="")
+
+        assert _stopped_key(state) == LINKED_KEY
+
+
+class TestAuditKeepsTheSlotIdentity:
+    """The SEL record answers "which tab did the operator press", so it stays on
+    the slot-derived key even when the session addressed is the channel's.
+    ``api_chat_slot_continue`` already splits the two the same way."""
+
+    @pytest.mark.asyncio
+    async def test_sel_record_is_keyed_on_the_slot_not_the_link(self):
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        state = _FakeState(_FakeSlot(linked=LINKED_KEY))
+        with patch("kiro_crew.dashboard.chat_handlers.sel") as mock_sel:
+            log = MagicMock()
+            mock_sel.return_value.log_tool_invocation = log
+            mock_sel.return_value.log = MagicMock()
+            with patch("kiro_crew.dashboard.chat_handlers._reject_pending_approvals"):
+                await api_chat_slot_stop(_request(state, caller_app=""))
+
+        assert log.call_args.kwargs["session_key"] == "dashboard:test-slot"
+        assert _stopped_key(state) == LINKED_KEY
+
+
+class TestTheRunningTurnOwnsTheTarget:
+    """A cancel addresses the turn in flight, not the slot's current routing.
+
+    ``linked_session_key`` is mutable on a LIVE slot:
+    ``inject_cron_result_to_dashboard`` binds an existing slot to ``cron:<id>``
+    and does not gate on ``slot.running``. ``_run_chat`` captures its session
+    key once and uses that one for the whole turn, so after a mid-turn rebind
+    the two disagree — and a cancel that re-derives the key stops a session this
+    turn never ran on while the real turn keeps executing.
+    """
+
+    @pytest.mark.asyncio
+    async def test_soft_stop_after_a_mid_turn_rebind_stops_the_running_turn(self):
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot()
+        # The turn started on the slot's own session ...
+        slot._active_turn_session_key = "dashboard:test-slot"
+        # ... and a cron injection rebound the slot while it was still running.
+        slot.linked_session_key = "cron:nightly-report"
+        state = _FakeState(slot)
+
+        await _run(api_chat_slot_stop, state)
+
+        assert (
+            _stopped_key(state) == "dashboard:test-slot"
+        ), "the stop followed the slot's new routing instead of the running turn"
+
+    @pytest.mark.asyncio
+    async def test_the_hard_escalation_follows_the_same_turn(self):
+        """The second press must not retarget where the first one could not."""
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot()
+        slot._active_turn_session_key = "dashboard:test-slot"
+        slot.linked_session_key = "cron:nightly-report"
+        slot._stop_state = "soft_pending"  # the first press already landed
+        state = _FakeState(slot)
+
+        await _run(api_chat_slot_stop, state, query={"force": "true"})
+
+        assert _stopped_key(state) == "dashboard:test-slot"
+
+    @pytest.mark.asyncio
+    async def test_interrupt_after_a_mid_turn_rebind_stops_the_running_turn(self):
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_interrupt
+
+        slot = _FakeSlot()
+        slot._active_turn_session_key = "dashboard:test-slot"
+        slot.linked_session_key = "cron:nightly-report"
+        slot._queue.append({"queue_id": "q1", "content": "next"})
+        state = _FakeState(slot)
+        request = _request(state, caller_app="")
+        request.content_length = 0
+        with patch("kiro_crew.dashboard.chat_handlers.sel") as mock_sel:
+            mock_sel.return_value.log_tool_invocation = MagicMock()
+            mock_sel.return_value.log = MagicMock()
+            mock_sel.return_value.log_api_access = MagicMock()
+            with patch("kiro_crew.dashboard.chat_handlers._reject_pending_approvals"):
+                await api_chat_slot_interrupt(request)
+
+        assert _stopped_key(state) == "dashboard:test-slot"
+
+    @pytest.mark.asyncio
+    async def test_a_turn_that_started_on_the_link_is_still_stopped_there(self):
+        """The #2462 fix, restated on the stronger rule.
+
+        A channel-born slot is bound before its turn starts, so the turn's own
+        identity IS the channel session — the cancel reaches it because that is
+        where the turn runs, not because the slot happens to be linked now.
+        """
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot(linked=LINKED_KEY)
+        slot._active_turn_session_key = LINKED_KEY
+        state = _FakeState(slot)
+
+        await _run(api_chat_slot_stop, state)
+
+        assert _stopped_key(state) == LINKED_KEY
+
+    @pytest.mark.asyncio
+    async def test_an_app_may_still_stop_its_own_turn_after_a_rebind(self):
+        """Authorization reads the same target, so mutable routing cannot
+        lock an app out of the turn it legitimately started."""
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot(app="auto-research")
+        slot._active_turn_session_key = "dashboard:test-slot"
+        slot.linked_session_key = "cron:nightly-report"
+        state = _FakeState(slot)
+
+        await _run(api_chat_slot_stop, state, caller_app="auto-research")
+
+        assert _stopped_key(state) == "dashboard:test-slot"
+
+    @pytest.mark.asyncio
+    async def test_an_app_is_still_refused_a_turn_running_on_a_foreign_session(self):
+        """The security boundary is unchanged: the guard now tests the key the
+        cancel will actually use, and a turn running on a channel session the
+        app does not own is still refused."""
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot(linked=LINKED_KEY, app="auto-research")
+        slot._active_turn_session_key = LINKED_KEY
+        state = _FakeState(slot)
+
+        resp = await _run(api_chat_slot_stop, state, caller_app="auto-research")
+
+        assert resp.status == 404
+        assert json.loads(resp.body) == MISSING_SLOT_BODY
+        assert state.sessions.stop_turn.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_an_idle_slot_falls_back_to_its_routing(self):
+        """No turn in flight means no captured identity — and a slot restored
+        from disk has none either, because the field is runtime-only."""
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_stop
+
+        slot = _FakeSlot(linked=LINKED_KEY)
+        assert slot._active_turn_session_key == ""
+        state = _FakeState(slot)
+
+        await _run(api_chat_slot_stop, state)
+
+        assert _stopped_key(state) == LINKED_KEY
+
+
+class TestTheAuthorizedSessionCannotMoveMidFlight:
+    """What the guard cleared is what gets cancelled.
+
+    ``linked_session_key`` is assignable on a LIVE slot: promoting a cron to a
+    tab (``POST /api/crons/{id}/to-chat``) binds an already-existing slot to
+    ``cron:<id>``. ``/interrupt`` awaits the request body between the guard and
+    ``stop_turn``, so a key re-read at the call site can name a session the
+    guard never saw — the authorization and the action would be about two
+    different conversations.
+    """
+
+    @pytest.mark.asyncio
+    async def test_interrupt_cancels_the_session_the_guard_cleared(self):
+        """The app owns an unbound slot; the guard allows it; the slot is bound
+        during the body await. The cancel must still address the cleared key."""
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_interrupt
+
+        slot = _FakeSlot(app="auto-research")
+        slot._queue.append({"queue_id": "q1", "content": "next"})
+        state = _FakeState(slot)
+        request = _request(state, caller_app="auto-research")
+        request.content_length = 2
+
+        async def _bind_then_return_body():
+            # Stands in for the concurrent to-chat handler resuming inside this
+            # await; it only assigns the field, exactly as that handler does.
+            slot.linked_session_key = "cron:nightly-report"
+            return {}
+
+        request.json = _bind_then_return_body
+        with patch("kiro_crew.dashboard.chat_handlers.sel") as mock_sel:
+            mock_sel.return_value.log_tool_invocation = MagicMock()
+            mock_sel.return_value.log = MagicMock()
+            mock_sel.return_value.log_api_access = MagicMock()
+            with patch("kiro_crew.dashboard.chat_handlers._reject_pending_approvals"):
+                await api_chat_slot_interrupt(request)
+
+        assert (
+            _stopped_key(state) == "dashboard:test-slot"
+        ), "the cancel followed a binding applied after authorization"
+
+    @pytest.mark.asyncio
+    async def test_a_legitimately_linked_slot_is_still_addressed_by_its_link(self):
+        """The snapshot must not degrade the fix this PR exists for."""
+        from kiro_crew.dashboard.chat_handlers import api_chat_slot_interrupt
+
+        slot = _FakeSlot(linked=LINKED_KEY)
+        slot._queue.append({"queue_id": "q1", "content": "next"})
+        state = _FakeState(slot)
+        request = _request(state, caller_app="")
+        request.content_length = 0
+        with patch("kiro_crew.dashboard.chat_handlers.sel") as mock_sel:
+            mock_sel.return_value.log_tool_invocation = MagicMock()
+            mock_sel.return_value.log = MagicMock()
+            mock_sel.return_value.log_api_access = MagicMock()
+            with patch("kiro_crew.dashboard.chat_handlers._reject_pending_approvals"):
+                await api_chat_slot_interrupt(request)
+
+        assert _stopped_key(state) == LINKED_KEY

--- a/test/test_stop_handler_idempotent.py
+++ b/test/test_stop_handler_idempotent.py
@@ -26,6 +26,10 @@ class _FakeSlot:
         #: itself — a cron-born tab (``cron:<job_id>``), a channel-born tab
         #: (``slack:<ts>``), a workflow-born tab. Empty for a plain chat tab.
         self.linked_session_key = ""
+        #: No owning app: the App Kit §5.2 cancel guard reads this, and a slot
+        #: nobody owns is cancellable by the dashboard caller.
+        self._app = None
+        self._active_turn_session_key = ""
         self.agent = "kirocrew"
         self.messages: list[dict] = []
         self._dirty = False
@@ -83,6 +87,10 @@ class TestStopHandlerIdempotent:
         app["state"] = state
 
         request = MagicMock()
+        # A bare MagicMock answers .get("app") with a truthy mock, which the
+        # App Kit 5.2 ownership guard would read as an app token. These cases
+        # are dashboard-user presses, so model the absent header explicitly.
+        request.get = lambda key, default="": default
         request.app = app
         request.match_info = {"slot": "test-slot"}
         request.query = {}  # no force flag
@@ -110,6 +118,10 @@ class TestStopHandlerIdempotent:
         app["state"] = state
 
         request = MagicMock()
+        # A bare MagicMock answers .get("app") with a truthy mock, which the
+        # App Kit 5.2 ownership guard would read as an app token. These cases
+        # are dashboard-user presses, so model the absent header explicitly.
+        request.get = lambda key, default="": default
         request.app = app
         request.match_info = {"slot": "test-slot"}
         request.query = {}
@@ -148,6 +160,10 @@ class TestInterruptHandlerIdempotent:
         app["state"] = state
 
         request = MagicMock()
+        # A bare MagicMock answers .get("app") with a truthy mock, which the
+        # App Kit 5.2 ownership guard would read as an app token. These cases
+        # are dashboard-user presses, so model the absent header explicitly.
+        request.get = lambda key, default="": default
         request.app = app
         request.match_info = {"slot": "test-slot"}
         request.content_length = 0
@@ -230,6 +246,10 @@ class TestStopCardTeardownRace:
         app["state"] = state
 
         request = MagicMock()
+        # A bare MagicMock answers .get("app") with a truthy mock, which the
+        # App Kit 5.2 ownership guard would read as an app token. These cases
+        # are dashboard-user presses, so model the absent header explicitly.
+        request.get = lambda key, default="": default
         request.app = app
         request.match_info = {"slot": "test-slot"}
         request.query = {}
@@ -460,6 +480,10 @@ class TestStopCancelsTheSessionTheTurnRunsOn:
         app = web.Application()
         app["state"] = state
         request = MagicMock()
+        # A bare MagicMock answers .get("app") with a truthy mock, which the
+        # App Kit 5.2 ownership guard would read as an app token. These cases
+        # are dashboard-user presses, so model the absent header explicitly.
+        request.get = lambda key, default="": default
         request.app = app
         request.match_info = {"slot": "test-slot"}
         request.query = {}


### PR DESCRIPTION
## Problem / Motivation

Pressing **Stop** on a channel-linked chat slot (a Slack/Discord-linked session)
reports success and cancels nothing.

A channel-linked slot's turns run under its `linked_session_key` (`slack:<ts>`),
which is what `chat_utils.effective_session_key` resolves. All three stop paths in
`chat_handlers.py` instead addressed the session as `_history_key_for(slot)` —
`dashboard:<slot>` — a key no running session owns:

| handler | path | key passed to `stop_turn` |
|---|---|---|
| `api_chat_slot_stop` | cooperative stop (first press) | `_history_key_for(name)` |
| `api_chat_slot_stop` | hard-kill escalation (second press) | `_history_key_for(name)` |
| `api_chat_slot_interrupt` | interrupt + run next queued | `_history_key_for(name)` |

`stop_turn` therefore had nothing to cancel, while the handler still inserted the
`stop_event` card and returned `{"ok": true}`.

## Why it matters

Stop is the control a user reaches for when something is going wrong, and this is
a **silent** failure: the UI shows a clean stop, so the user stops watching. The
blast radius is whatever the turn does next — file writes, pushes, tool calls. A
stop that errors is recoverable; one that lies is not.

The escalation path is affected too, which removes the natural fallback: a user
whose first press did nothing presses again, and the hard kill mis-addresses the
same way.

## What changed (motivation → approach → change)

**Root cause.** The slot's TRANSCRIPT key was used where its SESSION key was
required. Those coincide for an ordinary dashboard slot and diverge for a linked
one, so the bug is invisible until a channel link exists.

**Change.** The three `stop_turn` calls now resolve the session through
`effective_session_key(slot)`. This is not a new convention — it is the one
already written down:

- `effective_session_key`'s own docstring: *"Use this anywhere a slot's SESSION is
  addressed — resolving the session its turns run on, mirroring its links. For the
  slot's TRANSCRIPT use `slot_history_key`."*
- `api_chat_slot_continue`, in this same module, already resolves its session with
  `effective_session_key(slot)`.

**The SEL records deliberately keep the slot-derived key.** They answer *which tab
the operator pressed*, not *which session was cancelled*, and
`api_chat_slot_continue` already splits the two exactly this way
(`effective_session_key` for the session, `_history_key_for(name)` for the audit).
`TestAuditKeepsTheSlotIdentity` pins that split so a later cleanup does not
"tidy" the audit key along with the session key.

**Unlinked slots are unaffected by construction:** with no `linked_session_key`,
`effective_session_key` falls back to `_history_key_for(slot.key)` — byte for byte
the previous value.

## Authorization: two conditions, because ownership is not enough

`/stop` and `/interrupt` never applied the App Kit §5.2 ownership check that
`api_chat` and `api_chat_slot_continue` apply. **That gap is on `main` today, not
introduced here** — the ownership tests below fail against pristine `origin/main`
as well. What resolving the real session key changes is *exploitability*: while
the handlers addressed `dashboard:<slot>`, a cross-tenant cancel hit a key no
session owned and did nothing. Reverting the key resolution would reopen #2462
and leave the gap in place, so the guard ships here.

**Ownership alone is insufficient, and this is the substantive finding.** An app
caller must satisfy *both*:

1. the app owns the slot, and
2. the effective session is still the slot's own dashboard session —
   `effective_session_key(slot) == _history_key_for(slot.key)`.

Condition 2 is load-bearing because an app can legitimately come to own a
channel-linked slot. `POST /api/chat` passes a caller-supplied slot name
straight into `get_or_create_slot(slot_name, app=request.get("app", ""))`, and
that function sets `_app` and then, for a name shaped like a channel session
stem, resolves the binding itself:

```python
if is_channel_session_key(name):
    resolved = self.sessions.channel_key_for_stem(name)
    if isinstance(resolved, str) and is_channel_session_key(resolved):
        slot.linked_session_key = resolved
```

So an app that names a live Slack thread owns a slot bound to a conversation it
has no claim on, and an ownership-only guard authorizes cancelling that
channel's turn — a slot binding becomes capability escalation. A dashboard
caller has no app scope and may cancel either kind.

An earlier revision of this PR checked ownership only. The three
`test_an_owned_*_channel_linked_slot_*` cases fail against it.

**Indistinguishable 404, actually indistinguishable.** Refusals and genuinely
missing slots both return `_slot_not_found()` —
`{"error": "not found", "code": "slot_not_found"}`, matching
`api_chat_slot_continue`. Previously a refusal carried `code` and a missing slot
did not, so an app could tell "not mine" from "not there" and enumerate foreign
slot names. `test_a_missing_slot_answers_exactly_like_a_refusal` asserts the two
bodies are equal, and every denial test compares the whole body rather than the
status.

The guard runs **before every side effect**. The escalation branch clears the
queue and drops pending steers, and both handlers write a stop card and claim
`_stop_state`, all before `stop_turn`.

## The running turn owns a stable session identity

Resolving the session at cancel time is not safe, because the field it resolves
from changes underneath a live turn:

* `linked_session_key` says where the slot routes a **new** turn, and it is
  mutable on a running one — `inject_cron_result_to_dashboard`
  (`dashboard/cron_inject.py:29`) binds an already-live slot to `cron:<id>` and
  does not gate on `slot.running`. `api_cron_to_chat` does the same on a click.
* `_run_chat` captures its key **once**, at the boundary below every
  local-command return, and uses that one key to acquire, audit and release for
  the whole turn.

So after a mid-turn rebind the two disagree, and a cancel that re-derives the key
stops a session this turn never ran on while the real turn keeps executing. On
`origin/main` the cancel used `_history_key_for(name)`, which in that scenario
happens to be correct — so an earlier revision of this PR, by switching to
`effective_session_key`, regressed it. Fixing that is part of making this PR
correct, not a separate concern.

`_ChatSlot._active_turn_session_key` publishes the running turn's own identity:

* **runtime only** — never persisted, never serialized, empty after a restart;
* `_run_chat` is its sole lifecycle owner, installing it at the local-command
  boundary and retiring it in the same `finally` that releases the session;
* deliberately a plain field, not a property — it has exactly one writer.

Two placement details are load-bearing and each has a test:

* **Not keyed on `_prompt_depth == 0`.** `/prompts get` re-enters `_run_chat` at
  `_prompt_depth=1`, and the depth-0 invocation is a local wrapper that returns
  before the turn machinery. Keying on depth would put the identity on the
  wrapper; keying on the boundary puts it on the invocation that actually runs
  the turn.
* **Retired inside the release `finally`, not at the end of teardown.** The
  reset there can be cancelled and `CancelledError` derives from
  `BaseException`, so a clear placed after that block is skipped and the slot
  keeps advertising a turn that is gone. It also has to land before
  `_start_next_queued_turn`, which runs later in the same teardown and installs
  the successor's key — compare-and-clear so only the turn that installed a key
  may retire it.

Each cancel route now derives **one** target and hands the same value to both
authorization and `stop_turn`:

```python
cancel_key = _cancel_target(slot)   # the running turn's key, else the routing
denied = _app_cancel_denied(request, slot, "chat_stop", cancel_key)
```

Authorization tests `cancel_key` rather than re-reading the slot. That is not
only a TOCTOU guard: for a turn that started on the app's own session and was
rebound mid-flight, re-reading would **deny the app its own running turn**,
because the routing now points somewhere it does not own.

### Disposition of the automated review findings

Both came from GPT 5.6 on the fork pipeline and both were verified against the
production mutation path before being acted on.

* *"Authorized session key is re-resolved after an await"* — correct; the
  request-body await in `/interrupt` is a real window.
* *"Escalation can kill a newly linked, unrelated session"* — correct, and
  broader than stated. Its suggested fix, retaining the first soft stop's key
  for the escalation, is insufficient: a rebind can land before the **first**
  Stop, so that leaves a single press wrong, and it cannot help `/interrupt`
  either. The turn-owned identity fixes soft stop, hard escalation and interrupt
  uniformly, and needs no state carried between two requests.

The send/continue capability escalation that the ownership guard below refers to
is fixed at its own root in #2783 rather than by widening this PR.

## Tests

New file `test/test_stop_addresses_linked_session.py`, asserting the key the
handler hands to `stop_turn`, because that is the entire defect — the card and
state bookkeeping around it were already correct.

26 tests in `test/test_stop_addresses_linked_session.py`, in five groups, plus 9 lifecycle tests in a new file. The
failure classes are deliberately distinguished, because they have different
provenance:

**Class 1 — the #2462 session-key defect** (5; fail on `origin/main`, pass from
this PR's first head onward):

- `test_soft_stop_on_a_linked_slot_cancels_the_channel_session`
- `test_hard_kill_on_a_linked_slot_cancels_the_channel_session`
- `test_interrupt_on_a_linked_slot_cancels_the_channel_session`
- `test_dashboard_user_is_not_treated_as_an_app`
- `test_sel_record_is_keyed_on_the_slot_not_the_link` — also pins the
  audit/session split going forward.

**Class 2 — the authorization gap** (fail on `origin/main` too, which is the
evidence that it pre-dates this PR):

- `test_app_token_cannot_stop_a_dashboard_owned_linked_slot`
- `test_app_a_cannot_stop_app_bs_slot`
- `test_the_hard_kill_path_cannot_bypass_the_guard`
- `test_app_token_cannot_interrupt_a_foreign_slot`

**Class 3 — linked-session escalation and the existence oracle** (fail against
the ownership-only revision of this PR):

- `test_an_owned_but_channel_linked_slot_is_still_refused`
- `test_an_owned_channel_linked_slot_is_refused_on_interrupt_too`
- `test_an_owned_channel_linked_slot_is_refused_on_hard_kill_too`
- `test_a_missing_slot_answers_exactly_like_a_refusal`

Each asserts the 404 body, that `stop_turn` was never awaited, and that no stop
card, `_stop_state` change, queue clear or steer drop occurred.

**Class 4 — the running turn owns the target** (`TestTheRunningTurnOwnsTheTarget`,
7; fail against the previous head `f0704dc6d`). Each starts a turn on one
session and rebinds the slot underneath it:

- `test_soft_stop_after_a_mid_turn_rebind_stops_the_running_turn`
- `test_the_hard_escalation_follows_the_same_turn`
- `test_interrupt_after_a_mid_turn_rebind_stops_the_running_turn`
- `test_a_turn_that_started_on_the_link_is_still_stopped_there` — the #2462 fix
  restated on the stronger rule.
- `test_an_app_may_still_stop_its_own_turn_after_a_rebind` — mutable routing
  must not lock an app out of a turn it legitimately started.
- `test_an_app_is_still_refused_a_turn_running_on_a_foreign_session` — and the
  security boundary is unchanged.
- `test_an_idle_slot_falls_back_to_its_routing`

**Lifecycle** — new file `test/test_active_turn_session_key.py` (9), driving the
real `_run_chat` through the harness `test_turn_teardown_release.py` uses:
identity published for a plain turn, for a linked turn, and unmoved by a
mid-turn rebind; retired after normal completion, after a provider error, after
a cancellation delivered into the teardown, and when the session was never
acquired; the clear observed to land before `_start_next_queued_turn` and to
leave a successor's identity intact; and the `/prompts get` re-entry proving the
depth-1 invocation owns the key while its depth-0 wrapper owns nothing.

**Preservation guards** (pass throughout) — an unlinked slot's stop, hard kill
and interrupt still address `dashboard:test-slot`; a dashboard user is not
treated as an app; and the owning app may still cancel its own *unlinked* slot,
so the guard costs apps nothing they legitimately had.

## Manual verification

- `test_stop_addresses_linked_session.py`, `test_stop_handler_idempotent.py`,
  `test_chat_slot_interrupt.py`, `test_chat_slot_end_wait.py`,
  `test_dashboard_chat.py`, `test_dashboard_chat_pins.py`,
  `test_dashboard_chat_rewind.py`, `test_error_code_contract.py`,
  `test_active_turn_session_key.py`, `test_turn_teardown_release.py` →
  **734 passed, 1 skipped, 0 failed** (Windows 11 26200 / py3.10.6).
- Fail-before for the turn-identity work: **13 failed, 22 passed** against
  `f0704dc6d`; **35 passed** after.
- `pytest test/ -k "chat or slot or stop or interrupt or turn or cron or session or app"`
  → **11012 passed, 212 skipped, 4 xfailed, 21 failed**. All 21 are pre-existing
  on this machine and unrelated to the diff — symlink-creation tests hitting
  `WinError 1314` without elevation, two CloudFormation-template assertions, two
  app-backend env-allowlist tests and a cookie-expiry parse test — and every one
  reproduces with the three changed source files reverted to the previous head.
- `test_stop_kill_cancel.py` fails 8 on the same machine
  (`asyncio.start_unix_server`, POSIX-only `os` attributes), likewise
  pre-existing and platform-only.
- Four fixtures in `test_stop_handler_idempotent.py` gained an explicit absent
  app header. A bare `MagicMock` answers `.get("app")` with a truthy mock, which
  the guard correctly reads as an app token; those cases are dashboard-user
  presses, so the fixture was modelling the request wrong. No assertion weakened.
- `flake8`, `isort`, `mypy src/kiro_crew/dashboard/chat_handlers.py`,
  `git diff --check` and `BRAND_BASE_REF=origin/main scripts/check_brand_name.py`
  all clean.
- No spec change: `docs/system-specs/modules/session.md` documents `stop_turn(key,
  ...)` as the shared orchestration layer without prescribing which key a caller
  passes, and this restores the contract `effective_session_key`'s docstring
  already states.

**`error-code-baseline.json` regenerated on the current base.** This branch was
rebased onto `24a6f8ee5` after #2300 landed; the baseline was regenerated there
rather than carried across from the old base, so these numbers are against
current `main`:

| field | main | this PR |
|---|---|---|
| `_totals.missing_code` | 1409 | **1407** |
| `dashboard/chat_handlers.py` `missing_code` | 76 | **74** |
| `_compliant` | 706 | 721 |

The `missing_code` drop is this PR: the two 404s in these handlers now carry a
`code`, and `test_baseline_is_not_stale` requires an improved count to be
recorded. Regenerated with the documented `python test/test_error_code_contract.py
--update` rather than hand-edited.

`_compliant` needs a word, because +15 looks larger than a two-response change.
Regenerating on a **pristine** `main` already yields 720, so 14 of that delta is
pre-existing drift in the committed file and only **+1** is attributable to this
PR. `_compliant` is also the one field the contract tests do not assert — the
ratchet is `missing_code` per file, `_totals` matching the per-file map, and the
staleness check.

## Scope

The three `stop_turn` call sites plus the ownership guard the cancel routes were
missing. Not touched: the SEL `session_key`
arguments (see above), the Slack-side stop paths in `slack/interactions.py` (they
already receive a real session key), and `spec_builder`'s own stop, which is a
different surface with its own slot model.

Note for scheduling: **#2435** is open against the same file. It is not an overlap
— that PR refuses channel-linked targets outright rather than reaching this path,
and its description says this was left deliberately for its own change and its own
verification. Whichever lands second needs a trivial rebase.

## Related Issues

Fixes #2462

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, see Manual verification
- [x] No secrets, credentials, or internal references in the diff

