### PR TITLE
fix(cloud): keep EC2 UserData dist-check free of ${...} so !Sub accepts it

### DIFF
--- a/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
+++ b/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
@@ -489,8 +489,15 @@ Resources:
             # actual npm/vite/tsc error out of the log and fold it into the reason --
             # fail() otherwise only carries the log's tail, which at this point is
             # install.sh's success banner, not the earlier build error.
+            # NB: use only plain "$var" below, never a brace expansion. This whole
+            # UserData is a CloudFormation !Sub, so any dollar-brace token -- even
+            # inside a comment -- is parsed as a Sub variable and breaks change-set
+            # creation (a real bash brace default must be written as the !-escaped form).
             fe_err="$(grep -aiE 'npm error|npm ERR|error TS[0-9]|vite|Killed|Cannot find module|ENOSPC|no space left|out of memory|FATAL ERROR|Skipping frontend build' "$LOG" 2>/dev/null | tr -d '\r"\\' | tail -n 12 | tr '\n' '|' | tail -c 500)"
-            fail "dashboard frontend build missing (no static/dist). Build errors: ${fe_err:-<none captured; check /var/log/kirocrew-setup.log on the instance>}"
+            if [ -z "$fe_err" ]; then
+              fe_err="<none captured; check /var/log/kirocrew-setup.log on the instance>"
+            fi
+            fail "dashboard frontend build missing (no static/dist). Build errors: $fe_err"
           fi
 
           echo "--- installing the systemd service ---"

--- a/test/test_cloud_ec2.py
+++ b/test/test_cloud_ec2.py
@@ -6,11 +6,31 @@ All AWS I/O is mocked at the cloud.aws chokepoint (run_aws / checked / checked_j
 from __future__ import annotations
 
 import json
+import re
 
 import pytest
 
 from kiro_crew.cloud import aws, ec2, sizes
 from kiro_crew.validation import ValidationError
+
+
+class TestSubTemplateSyntax:
+    def test_every_sub_variable_is_legal(self):
+        # The UserData is one big CloudFormation !Sub. Every "${...}" is parsed as a
+        # Sub reference -- INCLUDING ones inside bash "#" comments, which are still part
+        # of the Sub string. Each must be the "${!...}" literal escape or a plausible
+        # reference: an AWS:: pseudo-param, or an identifier starting with a letter
+        # (a Parameter, a Resource logical id, a Sub variable-map key, optionally with
+        # a ".Attribute"). A bare "${...}" ellipsis in a comment matches neither and
+        # broke change-set creation twice, so it must fail here.
+        text = ec2.load_template()
+        ref = re.compile(r"AWS::[A-Za-z0-9]+|[A-Za-z][A-Za-z0-9]*(?:\.[A-Za-z0-9]+)*\Z")
+        bad = [
+            inner
+            for inner in re.findall(r"\$\{([^}]*)\}", text)
+            if not inner.startswith("!") and not ref.match(inner)
+        ]
+        assert not bad, f"illegal !Sub variable(s): {bad}"
 
 
 class TestValidation:


### PR DESCRIPTION
## Problem

Launching an EC2 crew fails immediately at stack creation:

```
cloudformation deploy failed: An error occurred (ValidationError) when calling the
CreateChangeSet operation: Template error: variable names in Fn::Sub syntax must
contain only alphanumeric characters, underscores, periods, and colons
```

The stack never gets created, so the crew can't come up at all. Regression from #2059.

## Why it matters

This is a hard block on the whole dashboard EC2-launch feature: every launch dies at
`CreateChangeSet` before a single resource is provisioned. It slipped past CI because
`cfn-lint` did not flag the offending `${...}` and no test validated the `!Sub` tokens;
only the real AWS `CreateChangeSet` call rejects it.

## Fix

- **Symptom:** `CreateChangeSet` rejects the template with the `Fn::Sub` variable-name error.
- **Root cause:** the dashboard-build guard added in #2059 folds the setup-log tail into
  the `WaitCondition` failure reason using a bash default-expansion,
  `${fe_err:-<none captured; ...>}`. The entire UserData is a CloudFormation **`!Sub`**,
  which parses *every* `${...}` as a Sub variable reference. `fe_err:-<none captured; ...>`
  is not a legal Sub variable name (`:-<`, spaces, `/`, `;`), so the template is invalid.
  The existing code already knows this — sibling escapes use the `${!literal}` form — but
  the new line used a raw brace expansion.
- **Change:** rewrite the dist-check to use only plain `$fe_err` / `$LOG` (no `${...}`),
  with an explicit `if [ -z "$fe_err" ]` default instead of the brace default. Behaviour
  is unchanged; the real npm/vite/tsc error is still folded into the reason.

## Tests

- New `TestSubTemplateSyntax::test_every_sub_variable_is_legal` scans the rendered
  template and asserts every `${...}` is either the `${!...}` literal escape or a valid
  Sub variable name (`[A-Za-z0-9_:.]+`). It fails on the pre-fix line and guards the
  whole class going forward.
- `test/test_cloud_ec2.py` full suite: 74 passed locally.

## Manual verification

Not yet re-launched. Next EC2 launch from a gateway carrying this template should get
past `CreateChangeSet`; if the frontend build then fails, the `WaitCondition` reason now
carries the real build error (the feature #2059 intended, minus the syntax break).
