### PR TITLE
feat(stt): add Parakeet (NVIDIA) local provider via parakeet-mlx

### DIFF
--- a/docs/reference/kiro-cli/chat/voice.md
+++ b/docs/reference/kiro-cli/chat/voice.md
@@ -112,6 +112,27 @@ Measured on a 32-vCPU Graviton3 host with an 11-second clip, 16 threads beat 31
 than raw speed: 8 threads measured 4.9–5.0s across repeats, while taking all 32
 ranged 8.1–68.4s depending on how busy the machine was.
 
+### Parakeet provider (Apple Silicon GPU)
+
+On Apple Silicon Macs, the `parakeet` provider runs NVIDIA's
+[Parakeet](https://github.com/senstella/parakeet-mlx) ASR models on the Metal
+GPU via MLX. Parakeet TDT 0.6b v3 is multilingual (25 languages), streams much
+faster than Whisper, and needs only about 600 MB of memory, which makes it a
+strong local default. Like `mlx`, the `parakeet` provider is selectable on every
+platform but only *available* on arm64 macOS.
+
+1. In the Speech-to-Text card, set **Provider** to `parakeet`.
+2. Click **📦 Install**, which runs `pipx install parakeet-mlx` plus `ffmpeg`
+   (the provider-aware install button installs the right runtime for whichever
+   provider is selected).
+3. The Parakeet model (`parakeet_model`, default
+   `mlx-community/parakeet-tdt-0.6b-v3`) downloads from Hugging Face on first
+   transcription and is cached under `~/.cache/huggingface/hub/`.
+
+`parakeet-mlx` is installed out-of-band via `pipx` for the same arm64-only
+reason as `mlx-whisper`; Kiro Crew invokes the `parakeet-mlx` CLI as a
+subprocess, reusing the same runner as the `whisper` and `mlx` providers.
+
 ## Voice Output (Text-to-Speech)
 
 Kiro Crew can speak responses aloud using Amazon Polly. Two modes are available:

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -73,7 +73,7 @@ from kiro_crew.service import common as common_service
 from kiro_crew.service import controller as service_controller
 from kiro_crew.service import linux as service_linux
 from kiro_crew.session_pid_sig import signing_health
-from kiro_crew.transcribe import _find_whisper, ensure_ffmpeg_in_path
+from kiro_crew.transcribe import _find_parakeet_mlx, _find_whisper, ensure_ffmpeg_in_path
 
 logger = logging.getLogger(__name__)
 
@@ -1536,6 +1536,19 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
         except ImportError:
             print("  boto3:       ⏹ optional AWS SDK not installed")
             print("               Install: pip install 'kirocrew[voice]'")
+
+    # Parakeet (NVIDIA Parakeet via parakeet-mlx) is Apple-Silicon-only and, like
+    # mlx_whisper, installed out-of-band — so report its CLI the same way.
+    if stt_active and cfg.stt.provider == "parakeet":
+        parakeet_bin = _find_parakeet_mlx()
+        if parakeet_bin:
+            print(f"  parakeet:    ✅ {parakeet_bin}")
+        else:
+            mark = "❌" if stt_fatal else "⚠️ "
+            print(f"  parakeet:    {mark} parakeet-mlx not found")
+            print("               Fix: pipx install parakeet-mlx  (Apple Silicon only)")
+            if stt_fatal:
+                issues.append("parakeet-mlx")
 
     # ── Slack (optional) ──
     print("\nSlack Integration")

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -3869,7 +3869,7 @@ class ChannelConfig:
         )
 
 
-_VALID_STT_PROVIDERS = ("whisper", "mlx", "apple", "transcribe")
+_VALID_STT_PROVIDERS = ("whisper", "mlx", "apple", "parakeet", "transcribe")
 _VALID_CHANNEL_PREFIXES = ("C", "D", "G")
 
 
@@ -4148,6 +4148,13 @@ class SttConfig:
         metadata=_meta(
             "MLX Model",
             "Hugging Face repo for the mlx_whisper model (mlx provider only).",
+        ),
+    )
+    parakeet_model: str = field(
+        default="mlx-community/parakeet-tdt-0.6b-v3",
+        metadata=_meta(
+            "Parakeet Model",
+            "Hugging Face repo for the parakeet-mlx model (parakeet provider only).",
         ),
     )
     device: str = field(
@@ -6478,6 +6485,9 @@ class KiroCrewConfig:
                 # (809M vs 74M, but much better latency).
                 model=stt_data.get("model", "turbo"),
                 mlx_model=stt_data.get("mlx_model", "mlx-community/whisper-large-v3-turbo"),
+                parakeet_model=stt_data.get(
+                    "parakeet_model", "mlx-community/parakeet-tdt-0.6b-v3"
+                ),
                 device=stt_data.get("device", "cpu"),
                 timeout_secs=stt_data.get("timeout_secs", 300),
                 transcribe_region=stt_data.get("transcribe_region", "us-east-1"),

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -444,6 +444,14 @@ _STT_MLX_MODELS: dict[str, str] = {
     "mlx-community/whisper-large-v3-turbo": "~809 MB",
 }
 
+# Curated parakeet-mlx model repos surfaced in the STT picker and accepted on
+# PUT. Maps Hugging Face repo -> approximate on-disk download size. Parakeet TDT
+# 0.6b v3 is multilingual (25 languages) and streams far faster than Whisper for
+# a fraction of the RAM, which is why it is the default.
+_STT_PARAKEET_MODELS: dict[str, str] = {
+    "mlx-community/parakeet-tdt-0.6b-v3": "~600 MB",
+}
+
 
 def _is_apple_silicon() -> bool:
     """True if running on Apple Silicon hardware.
@@ -475,12 +483,22 @@ def _stt_providers() -> list[str]:
     ``mlx`` (Whisper on Apple's MLX framework) only runs on Apple Silicon, and
     ``apple`` (the on-device SpeechAnalyzer framework) needs macOS 26 or later plus
     a Swift toolchain — both are omitted entirely elsewhere rather than being shown
-    as unusable options. This is the single source of truth for which providers are
-    advertised (GET) and accepted (PUT).
+    as unusable options. ``parakeet`` (NVIDIA Parakeet via parakeet-mlx) is likewise
+    Apple-Silicon-only and gated the same way as ``mlx``. This is the single source
+    of truth for which providers are advertised (GET) and accepted (PUT).
     """
     providers = list(_VALID_STT_PROVIDERS)
-    if not _is_apple_silicon() and "mlx" in providers:
+    is_apple_silicon = _is_apple_silicon()
+    if not is_apple_silicon and "mlx" in providers:
         providers.remove("mlx")
+    # `parakeet` shares the exact same Apple-Silicon gate as `mlx`. Reuse the
+    # result computed above rather than calling `_is_apple_silicon()` again —
+    # off Apple Silicon (e.g. under Rosetta) that call shells out to `sysctl`
+    # synchronously, and `_stt_providers()` runs on the dashboard's event loop
+    # (GET/PUT /api/config/stt), so a second call doubles that blocking cost
+    # on every request.
+    if not is_apple_silicon and "parakeet" in providers:
+        providers.remove("parakeet")
     if "apple" in providers:
         from kiro_crew import apple_speech
 
@@ -555,6 +573,12 @@ async def api_stt_config(request: web.Request) -> web.Response:
                 and body["mlx_model"] in _STT_MLX_MODELS
             ):
                 stt["mlx_model"] = body["mlx_model"]
+            if (
+                "parakeet_model" in body
+                and isinstance(body["parakeet_model"], str)
+                and body["parakeet_model"] in _STT_PARAKEET_MODELS
+            ):
+                stt["parakeet_model"] = body["parakeet_model"]
             if "transcribe_region" in body and isinstance(body["transcribe_region"], str):
                 stt["transcribe_region"] = body["transcribe_region"]
             if "transcribe_profile" in body and isinstance(body["transcribe_profile"], str):
@@ -601,6 +625,7 @@ async def api_stt_config(request: web.Request) -> web.Response:
             "provider": provider,
             "model": cfg.stt.model,
             "mlx_model": cfg.stt.mlx_model,
+            "parakeet_model": cfg.stt.parakeet_model,
             "available": available,
             "streaming": cfg.stt.streaming,
             "endpointing": cfg.stt.endpointing,
@@ -610,6 +635,7 @@ async def api_stt_config(request: web.Request) -> web.Response:
             "language_code": cfg.stt.language_code,
             "models": _STT_MODEL_SIZES,
             "mlx_models": _STT_MLX_MODELS,
+            "parakeet_models": _STT_PARAKEET_MODELS,
             "providers": _stt_providers(),
             # Which of those providers can stream partial results. Served from the
             # backend's own `_STREAMING_PROVIDERS` so the Settings UI gates the
@@ -724,9 +750,9 @@ def _ffmpeg_install_commands() -> list[str]:
 def _stt_prereq_commands(provider: str = "whisper") -> list[str]:
     """Return shell commands the user must run manually (need sudo/GUI).
 
-    The ``mlx`` provider has its own lightweight prerequisite (``pipx install
-    mlx-whisper``) and only needs ffmpeg beyond that — it does not require the
-    system-python/whisper toolchain.
+    The ``mlx`` and ``parakeet`` providers have their own lightweight prerequisite
+    (``pipx install mlx-whisper`` / ``pipx install parakeet-mlx``) and only need
+    ffmpeg beyond that — they do not require the system-python/whisper toolchain.
     """
     if provider == "transcribe":
         # AWS Transcribe's availability is "boto3 + amazon-transcribe importable
@@ -762,13 +788,13 @@ def _stt_prereq_commands(provider: str = "whisper") -> list[str]:
     cmds = []
     has_ffmpeg = shutil.which("ffmpeg") is not None
 
-    if provider == "mlx":
-        # mlx is only advertised on Apple Silicon (see _stt_providers); on any
-        # other platform there are no prerequisites to surface.
+    if provider in ("mlx", "parakeet"):
+        # mlx/parakeet are only advertised on Apple Silicon (see _stt_providers);
+        # on any other platform there are no prerequisites to surface.
         if not _is_apple_silicon():
             return []
         # The Install button (see _build_stt_install_script) installs ffmpeg,
-        # pipx, and mlx-whisper itself. The only thing it cannot bootstrap
+        # pipx, and the mlx-based CLI itself. The only thing it cannot bootstrap
         # non-interactively is Homebrew, so that is the sole manual prereq —
         # listing the others here would duplicate the button. ``find_brew``
         # rather than ``shutil.which``: the desktop app's gateway inherits
@@ -938,6 +964,11 @@ async def api_stt_install(request: web.Request) -> web.Response:
                 _stt_install_status = {"step": "installing_whisper", "detail": line, "error": ""}
             elif "Installing mlx-whisper" in line:
                 _stt_install_status = {"step": "installing_mlx", "detail": line, "error": ""}
+            elif "Installing parakeet-mlx" in line:
+                # Reuse the mlx progress step: same pipx phase and bar position.
+                # The detail line carries the accurate "parakeet-mlx" text, so a
+                # dedicated step (and its 14-locale i18n key) is not warranted.
+                _stt_install_status = {"step": "installing_mlx", "detail": line, "error": ""}
             elif "No suitable python3" in line:
                 _stt_install_status = {"step": "installing_python", "detail": line, "error": ""}
             elif "Using:" in line:
@@ -1032,6 +1063,7 @@ def _build_stt_install_script(provider: str = "whisper") -> str:
     """Shell script that installs the runtime for the selected STT provider.
 
     - ``mlx``: installs mlx-whisper via pipx (Apple Silicon only) plus ffmpeg.
+    - ``parakeet``: installs parakeet-mlx via pipx (Apple Silicon only) plus ffmpeg.
     - ``whisper`` (default): installs openai-whisper + ffmpeg via brew or pip.
 
     The pip fallback deliberately targets a SYSTEM python with ``--user`` (never
@@ -1043,8 +1075,12 @@ def _build_stt_install_script(provider: str = "whisper") -> str:
     wheel otherwise reports itself as a compiler error.
     """
     prelude = _stt_install_path_prelude()
-    if provider == "mlx":
-        return prelude + r"""
+    if provider in ("mlx", "parakeet"):
+        pipx_pkg = "parakeet-mlx" if provider == "parakeet" else "mlx-whisper"
+        verify_bin = "parakeet-mlx" if provider == "parakeet" else "mlx_whisper"
+        return (
+            prelude
+            + rf"""
 [ -d "$HOME/ffmpeg" ] && export PATH="$HOME/ffmpeg:$PATH"
 
 if ! command -v brew >/dev/null 2>&1; then
@@ -1057,14 +1093,15 @@ brew install ffmpeg 2>&1 || true
 
 if ! command -v pipx >/dev/null 2>&1; then
     echo "Installing pipx via brew..."
-    brew install pipx 2>&1 || { echo "ERROR: pipx install failed"; exit 1; }
+    brew install pipx 2>&1 || {{ echo "ERROR: pipx install failed"; exit 1; }}
 fi
 
-echo "Installing mlx-whisper via pipx..."
-pipx install --force mlx-whisper 2>&1 || { echo "ERROR: pipx install mlx-whisper failed"; exit 1; }
+echo "Installing {pipx_pkg} via pipx..."
+pipx install --force {pipx_pkg} 2>&1 || {{ echo "ERROR: pipx install {pipx_pkg} failed"; exit 1; }}
 
-echo "Done. mlx_whisper=$(command -v mlx_whisper 2>/dev/null || echo 'check PATH') ffmpeg=$(command -v ffmpeg 2>/dev/null || echo 'MISSING')"
+echo "Done. {verify_bin}=$(command -v {verify_bin} 2>/dev/null || echo 'check PATH') ffmpeg=$(command -v ffmpeg 2>/dev/null || echo 'MISSING')"
 """
+        )
     return prelude + r"""
 # Pick up ffmpeg from ~/ffmpeg if installed there
 [ -d "$HOME/ffmpeg" ] && export PATH="$HOME/ffmpeg:$PATH"

--- a/src/kiro_crew/docs/configuration.md
+++ b/src/kiro_crew/docs/configuration.md
@@ -244,7 +244,8 @@ from the dashboard — see each channel's doc for keys and credentials.
 | Key | Description | Default |
 |-----|-------------|---------|
 | `stt.enabled` | Enable voice-memo transcription | `true` |
-| `stt.provider` | `"whisper"` (local), `"mlx"` (local, Apple silicon), or `"transcribe"` (AWS, needs the `voice` extra) | `"whisper"` |
+| `stt.provider` | `"whisper"` (local), `"mlx"` (local, Apple silicon), `"parakeet"` (local, Apple silicon, NVIDIA Parakeet), `"apple"` (local, macOS 26+), or `"transcribe"` (AWS, needs the `voice` extra) | `"whisper"` |
+| `stt.parakeet_model` | Hugging Face repo for the parakeet-mlx model (parakeet provider only) | `"mlx-community/parakeet-tdt-0.6b-v3"` |
 | `stt.streaming` | Stream partial transcripts live into the dashboard input. Transcribe provider only | `false` |
 | `stt.transcribe_region` | AWS region for the Transcribe API (transcribe provider only) | `"us-east-1"` |
 | `stt.language_code` | Language for speech recognition, e.g. `en-US`, `fr-FR` | `"en-US"` |

--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -196,6 +196,12 @@ _MLX_WHISPER_SEARCH_PATHS = [
     "/usr/local/bin/mlx_whisper",
 ]
 
+_PARAKEET_MLX_SEARCH_PATHS = [
+    os.path.expanduser("~/.local/bin/parakeet-mlx"),
+    "/opt/homebrew/bin/parakeet-mlx",
+    "/usr/local/bin/parakeet-mlx",
+]
+
 # Homebrew installs its ``brew`` shim at a fixed prefix per platform, and none of
 # those prefixes are on the PATH a GUI-launched gateway inherits: the desktop app
 # (Dock / Finder / launchd) starts with ``/usr/bin:/bin:/usr/sbin:/sbin``, so
@@ -271,6 +277,41 @@ def _find_mlx_whisper() -> str | None:
     return None
 
 
+def _find_parakeet_mlx() -> str | None:
+    """Return the parakeet-mlx binary path or None if not found.
+
+    parakeet-mlx runs NVIDIA's Parakeet ASR models on Apple Silicon via MLX. Like
+    mlx_whisper it is installed out-of-band (``pipx install parakeet-mlx`` or
+    ``uv tool install parakeet-mlx``) rather than as a package dependency, because
+    the ``mlx`` wheel only exists for arm64 and would break installs on every
+    other architecture. We therefore locate and invoke the CLI as a subprocess,
+    largely mirroring ``_find_mlx_whisper`` — but see the note below on why it
+    deliberately skips that finder's system-Python scripts-dir fallback.
+    """
+    found = shutil.which("parakeet-mlx")
+    if found:
+        return found
+    # Same venv gap as `_find_whisper` — see `_own_scripts_dir`.
+    own_bin = _own_scripts_dir()
+    if own_bin:
+        found_own = _find_script_in_dir(own_bin, "parakeet-mlx")
+        if found_own:
+            return found_own
+    # No system-Python scripts-dir probe here (unlike `_find_whisper`/
+    # `_find_mlx_whisper`): that fallback exists for `pip install --user`,
+    # which is how `openai-whisper` lands outside PATH. `parakeet-mlx` is
+    # installed via `pipx` (see `_build_stt_install_script`), which always
+    # puts its shim on PATH or in one of `_PARAKEET_MLX_SEARCH_PATHS` below —
+    # so the probe would never find anything here, while still paying its
+    # cost: it shells out to a system Python synchronously (`subprocess.
+    # check_output`, 5s timeout) on the event loop this function runs on
+    # (dashboard GET/PUT /api/config/stt), which can stall the gateway.
+    for p in _PARAKEET_MLX_SEARCH_PATHS:
+        if os.path.isfile(p) and os.access(p, os.X_OK):
+            return p
+    return None
+
+
 def is_available(stt_config=None) -> bool:  # type: ignore[no-untyped-def]
     """Check if STT is enabled in config and a provider is usable."""
     if stt_config is None:
@@ -296,6 +337,9 @@ def is_available(stt_config=None) -> bool:  # type: ignore[no-untyped-def]
     if provider == "mlx":
         ensure_ffmpeg_in_path()
         return _find_mlx_whisper() is not None
+    if provider == "parakeet":
+        ensure_ffmpeg_in_path()
+        return _find_parakeet_mlx() is not None
     if provider == "apple":
         from kiro_crew import apple_speech
 
@@ -350,6 +394,9 @@ async def transcribe_audio(audio_path: str, stt_config=None) -> str | None:  # t
     elif provider == "mlx":
         await asyncio.to_thread(ensure_ffmpeg_in_path)
         result = await _transcribe_mlx(audio_path, stt_config)
+    elif provider == "parakeet":
+        await asyncio.to_thread(ensure_ffmpeg_in_path)
+        result = await _transcribe_parakeet(audio_path, stt_config)
     elif provider == "apple":
         result = await _transcribe_apple(audio_path, stt_config)
     else:
@@ -752,6 +799,51 @@ async def _transcribe_mlx(audio_path: str, stt_config) -> str | None:  # type: i
         ],
         stt_config.timeout_secs,
         label="mlx_whisper",
+    )
+
+
+async def _transcribe_parakeet(audio_path: str, stt_config) -> str | None:  # type: ignore[no-untyped-def]
+    """Transcribe using the parakeet-mlx CLI (NVIDIA Parakeet, Apple Silicon).
+
+    parakeet-mlx is installed out-of-band (the ``mlx`` wheel is arm64-only), and
+    shares mlx_whisper's hyphenated flags (``--output-dir``/``--output-format``)
+    plus its ``<filename>.txt`` output convention, so it reuses the same
+    ``_run_whisper_cli`` runner and ``.txt`` collection. ``parakeet_model`` is
+    validated against the shared HuggingFace ``owner/repo`` regex for the same
+    defense-in-depth reason as ``mlx_model`` (a hand-edited config could inject
+    an arbitrary value passed straight to the subprocess).
+    """
+    parakeet_bin = await asyncio.to_thread(_find_parakeet_mlx)
+    if not parakeet_bin:
+        logger.error("parakeet-mlx not found — install: pipx install parakeet-mlx")
+        return None
+
+    model = stt_config.parakeet_model
+    # `model or ""` only substitutes on a falsy value (None, ""); a non-string
+    # truthy value (e.g. an int from a hand-edited config.json) would reach
+    # `_MLX_MODEL_RE.match()` as-is and raise TypeError there instead of
+    # producing the clean "invalid parakeet_model" refusal below.
+    if not isinstance(model, str) or not _MLX_MODEL_RE.match(model or ""):
+        logger.error(
+            "Refusing to run parakeet-mlx: invalid parakeet_model %r "
+            "(expected a HuggingFace 'owner/repo' id)",
+            model,
+        )
+        return None
+
+    return await _run_whisper_cli(
+        parakeet_bin,
+        lambda out_dir: [
+            audio_path,
+            "--model",
+            model,
+            "--output-dir",
+            out_dir,
+            "--output-format",
+            "txt",
+        ],
+        stt_config.timeout_secs,
+        label="parakeet-mlx",
     )
 
 

--- a/test/test_stt_stream.py
+++ b/test/test_stt_stream.py
@@ -1029,7 +1029,32 @@ class TestSttProviderGating:
         monkeypatch.setattr(
             apple_speech, "availability", lambda: apple_speech.Availability(False, "pinned off")
         )
-        assert core._stt_providers() == ["whisper", "mlx", "transcribe"]
+        # `parakeet` is gated the same way as `mlx` (Apple-Silicon-only), so both
+        # are present here.
+        assert core._stt_providers() == ["whisper", "mlx", "parakeet", "transcribe"]
+
+    def test_stt_providers_calls_is_apple_silicon_exactly_once(self, monkeypatch):
+        """`parakeet` reuses the `mlx` gate's already-computed Apple-Silicon
+        result rather than re-probing. Off Apple Silicon (e.g. under Rosetta),
+        `_is_apple_silicon()` shells out to `sysctl` synchronously, and
+        `_stt_providers()` runs on the dashboard's event loop (GET/PUT
+        /api/config/stt) -- a second call would double that blocking cost on
+        every request."""
+        from kiro_crew import apple_speech
+        from kiro_crew.dashboard.handlers import core
+
+        calls = []
+
+        def fake_is_apple_silicon():
+            calls.append(1)
+            return True
+
+        monkeypatch.setattr(core, "_is_apple_silicon", fake_is_apple_silicon)
+        monkeypatch.setattr(
+            apple_speech, "availability", lambda: apple_speech.Availability(False, "pinned off")
+        )
+        core._stt_providers()
+        assert len(calls) == 1
 
     def test_providers_exclude_mlx_off_apple_silicon(self, monkeypatch):
         from kiro_crew import apple_speech
@@ -1050,7 +1075,7 @@ class TestSttProviderGating:
 
         monkeypatch.setattr(core, "_is_apple_silicon", lambda: True)
         monkeypatch.setattr(apple_speech, "availability", lambda: apple_speech.Availability(True))
-        assert core._stt_providers() == ["whisper", "mlx", "apple", "transcribe"]
+        assert core._stt_providers() == ["whisper", "mlx", "apple", "parakeet", "transcribe"]
 
     def test_providers_exclude_apple_when_toolchain_missing(self, monkeypatch):
         """A host that could run the framework but has no Swift toolchain must not be

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -17,6 +17,7 @@ from kiro_crew.transcribe import (
     _WHISPER_THREAD_CEILING,
     BREW_PATH_DIRS,
     _find_mlx_whisper,
+    _find_parakeet_mlx,
     _find_whisper,
     _is_openai_whisper,
     _ProfileCredentialResolver,
@@ -425,6 +426,51 @@ class TestFindMlxWhisper:
 
 
 # ---------------------------------------------------------------------------
+# _find_parakeet_mlx
+# ---------------------------------------------------------------------------
+
+
+class TestFindParakeetMlx:
+    def test_found_on_path(self):
+        with patch(
+            "kiro_crew.transcribe.shutil.which", return_value="/usr/local/bin/parakeet-mlx"
+        ):
+            assert _find_parakeet_mlx() == "/usr/local/bin/parakeet-mlx"
+
+    def test_not_found(self, monkeypatch):
+        with patch("kiro_crew.transcribe.shutil.which", return_value=None):
+            monkeypatch.setattr(
+                "kiro_crew.transcribe._PARAKEET_MLX_SEARCH_PATHS", ["/nonexistent"]
+            )
+            assert _find_parakeet_mlx() is None
+
+    def test_found_in_search_paths(self, tmp_path, monkeypatch):
+        binary = tmp_path / "parakeet-mlx"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        with patch("kiro_crew.transcribe.shutil.which", return_value=None):
+            monkeypatch.setattr(
+                "kiro_crew.transcribe._PARAKEET_MLX_SEARCH_PATHS", [str(binary)]
+            )
+            assert _find_parakeet_mlx() == str(binary)
+
+    def test_never_probes_system_python(self, monkeypatch):
+        """Unlike `_find_whisper`/`_find_mlx_whisper`, this finder must NOT fall
+        back to a system-Python scripts-dir probe: `parakeet-mlx` is installed
+        via pipx (always on PATH or a fixed search path), so that probe would
+        never find anything here while still paying its cost -- a synchronous
+        subprocess spawn on the event loop this function runs on (dashboard
+        GET/PUT /api/config/stt)."""
+        with patch("kiro_crew.transcribe.shutil.which", return_value=None):
+            with patch("kiro_crew.transcribe._python3_bin_dir") as py3_bin_dir:
+                monkeypatch.setattr(
+                    "kiro_crew.transcribe._PARAKEET_MLX_SEARCH_PATHS", ["/nonexistent"]
+                )
+                assert _find_parakeet_mlx() is None
+            py3_bin_dir.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # find_brew
 # ---------------------------------------------------------------------------
 class TestFindBrew:
@@ -498,6 +544,18 @@ class TestIsAvailable:
     def test_mlx_unavailable_when_binary_missing(self):
         cfg = SttConfig(enabled=True, provider="mlx")
         with patch("kiro_crew.transcribe._find_mlx_whisper", return_value=None):
+            assert is_available(cfg) is False
+
+    def test_parakeet_available_when_binary_found(self):
+        cfg = SttConfig(enabled=True, provider="parakeet")
+        with patch(
+            "kiro_crew.transcribe._find_parakeet_mlx", return_value="/usr/bin/parakeet-mlx"
+        ):
+            assert is_available(cfg) is True
+
+    def test_parakeet_unavailable_when_binary_missing(self):
+        cfg = SttConfig(enabled=True, provider="parakeet")
+        with patch("kiro_crew.transcribe._find_parakeet_mlx", return_value=None):
             assert is_available(cfg) is False
 
 
@@ -817,6 +875,132 @@ class TestTranscribeAudio:
         mock_proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
 
         with patch("kiro_crew.transcribe._find_mlx_whisper", return_value="/usr/bin/mlx_whisper"):
+            with patch(
+                "kiro_crew.transcribe.asyncio.create_subprocess_exec", return_value=mock_proc
+            ):
+                with patch(
+                    "kiro_crew.transcribe.asyncio.wait_for", side_effect=asyncio.TimeoutError
+                ):
+                    result = await transcribe_audio(str(audio), cfg)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# parakeet provider (parakeet-mlx CLI)
+# ---------------------------------------------------------------------------
+
+
+class TestTranscribeParakeet:
+    @pytest.mark.asyncio
+    async def test_parakeet_no_binary_returns_none(self, tmp_path):
+        audio = tmp_path / "test.webm"
+        audio.write_text("fake audio")
+        cfg = SttConfig(enabled=True, provider="parakeet")
+        with patch("kiro_crew.transcribe._find_parakeet_mlx", return_value=None):
+            result = await transcribe_audio(str(audio), cfg)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_parakeet_invalid_model_rejected_before_subprocess(self, tmp_path):
+        """A malformed parakeet_model (e.g. from a hand-edited config) must be
+        rejected before it is ever passed to the subprocess."""
+        audio = tmp_path / "test.webm"
+        audio.write_text("fake audio")
+        cfg = SttConfig(
+            enabled=True, provider="parakeet", parakeet_model="; rm -rf ~", timeout_secs=10
+        )
+        with patch(
+            "kiro_crew.transcribe._find_parakeet_mlx", return_value="/usr/bin/parakeet-mlx"
+        ):
+            with patch("kiro_crew.transcribe.asyncio.create_subprocess_exec") as spawn:
+                result = await transcribe_audio(str(audio), cfg)
+        assert result is None
+        spawn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_parakeet_non_string_model_rejected_cleanly(self, tmp_path):
+        """A non-string parakeet_model (e.g. a numeric value from a hand-edited
+        config.json) must be rejected with the same clean refusal as a malformed
+        string, not raise TypeError out of the regex match."""
+        audio = tmp_path / "test.webm"
+        audio.write_text("fake audio")
+        cfg = SttConfig(enabled=True, provider="parakeet", timeout_secs=10)
+        cfg.parakeet_model = 12345  # type: ignore[assignment]
+        with patch(
+            "kiro_crew.transcribe._find_parakeet_mlx", return_value="/usr/bin/parakeet-mlx"
+        ):
+            with patch("kiro_crew.transcribe.asyncio.create_subprocess_exec") as spawn:
+                result = await transcribe_audio(str(audio), cfg)
+        assert result is None
+        spawn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_parakeet_successful_transcription(self, tmp_path):
+        audio = tmp_path / "test.webm"
+        audio.write_text("fake audio")
+        cfg = SttConfig(
+            enabled=True,
+            provider="parakeet",
+            parakeet_model="mlx-community/parakeet-tdt-0.6b-v3",
+            timeout_secs=10,
+        )
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        captured: dict = {}
+
+        async def fake_exec(*args, **kwargs):
+            captured["args"] = args
+            out_dir = args[args.index("--output-dir") + 1]
+            Path(out_dir).joinpath("test.txt").write_text("Hola mundo")
+            return mock_proc
+
+        with patch(
+            "kiro_crew.transcribe._find_parakeet_mlx", return_value="/usr/bin/parakeet-mlx"
+        ):
+            with patch(
+                "kiro_crew.transcribe.asyncio.create_subprocess_exec", side_effect=fake_exec
+            ):
+                result = await transcribe_audio(str(audio), cfg)
+        assert result == "Hola mundo"
+        # The configured HF repo must be passed via --model, and the CLI uses the
+        # hyphenated mlx-style output flags.
+        assert "mlx-community/parakeet-tdt-0.6b-v3" in captured["args"]
+        assert "--output-dir" in captured["args"]
+        assert "--output-format" in captured["args"]
+
+    @pytest.mark.asyncio
+    async def test_parakeet_failure_returns_none(self, tmp_path):
+        audio = tmp_path / "test.webm"
+        audio.write_text("fake audio")
+        cfg = SttConfig(enabled=True, provider="parakeet", timeout_secs=10)
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate = AsyncMock(return_value=(b"", b"boom"))
+
+        with patch(
+            "kiro_crew.transcribe._find_parakeet_mlx", return_value="/usr/bin/parakeet-mlx"
+        ):
+            with patch(
+                "kiro_crew.transcribe.asyncio.create_subprocess_exec", return_value=mock_proc
+            ):
+                result = await transcribe_audio(str(audio), cfg)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_parakeet_timeout_returns_none(self, tmp_path):
+        audio = tmp_path / "test.webm"
+        audio.write_text("fake audio")
+        cfg = SttConfig(enabled=True, provider="parakeet", timeout_secs=1)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
+
+        with patch(
+            "kiro_crew.transcribe._find_parakeet_mlx", return_value="/usr/bin/parakeet-mlx"
+        ):
             with patch(
                 "kiro_crew.transcribe.asyncio.create_subprocess_exec", return_value=mock_proc
             ):


### PR DESCRIPTION
Add a fourth local STT provider, 'parakeet', that runs NVIDIA's Parakeet ASR models on Apple Silicon via the parakeet-mlx CLI. Parakeet TDT 0.6b v3 is multilingual (25 languages), streams far faster than Whisper, and needs about 600 MB of RAM, making it a strong local default.

Mirrors the existing 'mlx' provider end to end:
- config: add 'parakeet' to _VALID_STT_PROVIDERS + SttConfig.parakeet_model (default mlx-community/parakeet-tdt-0.6b-v3), wired through from-dict.
- transcribe: _find_parakeet_mlx locator + _transcribe_parakeet, reusing the shared _run_whisper_cli runner and the _MLX_MODEL_RE owner/repo guard; is_available + dispatch branches.
- dashboard handler: curated model allowlist, Apple-Silicon provider gating, GET/PUT for parakeet_model, prereq commands, and a pipx install-script branch (install parakeet-mlx).
- doctor: parakeet-mlx runtime check in the STT section.
- docs: voice.md provider section + configuration.md rows.
- tests: locator, availability, and transcription cases mirroring mlx, including a case that rejects a malformed model id before it ever reaches the subprocess (same defense-in-depth as the mlx_model guard).

Follow-up (not in this PR): Settings UI model picker and install-button copy for parakeet, which would add new i18n keys across 14 locale files. The provider is already selectable via the auto-derived dropdown and works with its default model today.

<!-- Fill in each section below. Omit a section only when it is genuinely not
     applicable, and say so (e.g. "N/A — ..."). Keep the diff and this
     description in sync: every claim here must be supported by the diff. -->

## Problem / Motivation

<!-- Bug fix: the concrete symptom — what is broken or missing, ideally what the
     user observes.
     New feature / enhancement: the gap, use case, or opportunity this addresses
     — what a user cannot do (or does awkwardly) today. -->

## Why it matters

<!-- Impact if this is left undone: for a fix, who is hit by the bug and how
     badly; for a feature, the user/business value it unlocks. -->

## What changed (motivation → approach → change)

<!-- A short chain of thought so the reader sees *why this is the right change*,
     not just what changed:
     - Bug fix: observed symptom → underlying root cause → the specific change
       that addresses that cause.
     - New feature / enhancement: goal → the approach/design you chose (and why,
       over the alternatives you considered) → what you actually built. -->

## Tests

<!-- Automated tests added/updated and the behavior each one locks in. -->

## Manual verification

<!-- Manual steps performed or still required where unit tests fall short
     (integration paths, UI, external services). State "N/A — unit coverage
     sufficient" only when genuinely true, with a one-line why. -->

## Screenshots / video

<!-- MANDATORY for any user-visible UI change (new/changed panels, components,
     layouts, themes); delete this section otherwise.

     - Show each affected surface in its meaningful variants (e.g. desktop vs
       browser, empty vs populated, light vs dark).
     - Prefer a short video/GIF when the change involves motion or a multi-step
       flow (animations, transitions, interactions) — a still image cannot
       prove those.
     - Commit media to the PR branch under a top-level, ephemeral, never-packaged
       dir `temp-screenshots/<feature>/` (never under docs/ or src/kiro_crew/**)
       and embed with commit-SHA-pinned URLs so they survive branch deletion on
       merge and periodic cleanup:
       ![alt](https://github.com/<owner>/<repo>/raw/<sha>/temp-screenshots/<feature>/<name>.png)
     - Put the two or three most telling shots inline; fold full-page context
       into a <details> block. -->

## Related Issues

<!-- Link to relevant issues, e.g. Fixes #123 -->

## Checklist

- [ ] Single commit with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [ ] Existing tests pass and new tests added for new functionality
- [ ] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->
