### PR TITLE
test(cron): pin Skip-is-success semantic; strike reset owned by CronScheduler._execute

### DIFF
--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -2476,6 +2476,17 @@ class GatewayOrchestrator:
                             logger.debug("SEL logging failed in cron script ok path", exc_info=True)
                         return "ok"
                     elif status == "skip":
+                        # A completed Skip is a successful run that chose no-op —
+                        # the same "success" outcome as the ok/done/report
+                        # siblings above. Unlike them it deliberately does NOT
+                        # call job.record_success() here: CronScheduler._execute
+                        # is the backstop that resets consecutive_failures (and
+                        # lifts auto-pause) on every non-error return — Skip
+                        # included, since this branch returns None without
+                        # setting last_status="error" — and its reset is guarded
+                        # by the _cancelled_jobs cancel-race check. Resetting in
+                        # this branch would bypass that guard and could re-enable
+                        # a job cancelled mid-tick.
                         try:
                             sel().log_tool_invocation(
                                 session_key=f"cron:{job.id}",

--- a/test/test_cron_gateway_integration.py
+++ b/test/test_cron_gateway_integration.py
@@ -143,6 +143,45 @@ class TestScriptExecution:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_skip_is_success_not_failure(self):
+        # A completed Skip is a SUCCESS outcome (mirrors the ok/done/report
+        # siblings): the branch returns None and never marks the run
+        # last_status="error", so CronScheduler._execute treats the tick as
+        # healthy and resets the strike counter for it one frame up. Long-lived
+        # pollers end EVERY tick with Skip, so mis-classifying Skip as a failure
+        # would trip the 5-strike auto-pause on a >99% healthy job.
+        gw = _make_gw()
+        job = _make_script_job()
+        job.consecutive_failures = 3
+        result, _ = await _run_script_callback(gw, job, {"status": "skip"})
+        assert result is None
+        assert job.last_status != "error"
+
+    @pytest.mark.asyncio
+    async def test_skip_defers_strike_reset_to_execute(self):
+        # The Skip branch must NOT reset the counter or lift auto-pause itself:
+        # that is record_success's job, reached only through
+        # CronScheduler._execute, whose reset is guarded by the _cancelled_jobs
+        # cancel-race check. An unguarded reset in this branch would clear the
+        # pause and re-enable a job cancelled mid-tick, so the callback layer
+        # leaves the bookkeeping untouched and defers to _execute. (The guarded
+        # _execute reset — and the cancel guard — are covered by
+        # TestExecuteSuccessResetsCounter in test_cron_autopause_persist.)
+        gw = _make_gw()
+        job = _make_script_job()
+        job.consecutive_failures = 5
+        job.auto_paused = True
+        job.user_paused = True
+        job.enabled = False
+        result, _ = await _run_script_callback(gw, job, {"status": "skip"})
+        assert result is None
+        assert job.last_status != "error"
+        assert job.consecutive_failures == 5
+        assert job.auto_paused is True
+        assert job.user_paused is True
+        assert job.enabled is False
+
+    @pytest.mark.asyncio
     async def test_done_removes_job(self):
         gw = _make_gw()
         job = _make_script_job()


### PR DESCRIPTION
## Summary

Test + documentation only — **no runtime behavior change.** This PR pins, with regression tests and an explanatory comment, the invariant that a completed `Skip` is a *success* outcome whose strike-counter reset is owned by `CronScheduler._execute`, not by the script-cron callback's `skip` branch.

## Background

Script crons that end every tick with `raise Skip()` — the documented long-lived poller pattern — must not accumulate `consecutive_failures` and trip the 5-strike auto-pause breaker on an otherwise-healthy job.

That reset already happens correctly. The `skip` branch of the gateway's `_cron_callback` returns `None` **without** setting `last_status="error"`, so `CronScheduler._execute` — the backstop that resets `consecutive_failures` and lifts auto-pause on every non-error return — treats the Skip as a healthy tick and clears the strikes one frame up. Its reset is deliberately guarded by the `_cancelled_jobs` cancel-race check.

An earlier revision of this PR reset the counter *inside* the `skip` branch by calling `job.record_success()` there directly. That approach was dropped: resetting in the callback branch bypasses the `_execute` cancel-race guard and could re-enable a job that was cancelled mid-tick. The reset must stay in `_execute`.

## What changed

- **`src/kiro_crew/slack/gateway.py`** — adds an explanatory comment to the `skip` branch documenting *why* it deliberately does **not** call `job.record_success()` (the reset is owned by the guarded `_execute` path). No functional change.
- **`test/test_cron_gateway_integration.py`** — two regression tests pinning the semantic.

## Tests

- `test_skip_is_success_not_failure` — a Skip returns `None` and never sets `last_status="error"`, so `_execute` treats the tick as healthy. Guards against mis-classifying Skip as a failure and tripping auto-pause on a >99%-healthy poller.
- `test_skip_defers_strike_reset_to_execute` — the `skip` branch itself leaves `consecutive_failures`, `auto_paused`, `user_paused`, and `enabled` untouched, confirming the reset is deferred to `_execute`. (The guarded `_execute` reset and its cancel guard are covered by `TestExecuteSuccessResetsCounter` in `test_cron_autopause_persist`.)
