### PR TITLE
fix: guard memory files against placeholder consolidation output

### DIFF
--- a/docs/system-specs/modules/history.md
+++ b/docs/system-specs/modules/history.md
@@ -419,6 +419,29 @@ cron/heartbeat/lesson extraction) to extract:
 - `preferences_update` → overwrites `preferences.md` if changed
 - `projects_update` → overwrites `projects.md` if changed
 
+The two `*_update` values replace the whole file, so each is gated by
+`_is_plausible_memory_file()` before writing: a value that does not start with
+the file's mandated markdown header (`# User Preferences` / `# Active
+Projects`) is discarded with a warning instead of written. This rejects
+protocol-word answers (the literal string `unchanged` and similar), which would
+otherwise destroy the file AND — because the next consolidation prompt embeds
+the file's current content — prime every later pass to echo the placeholder
+into the other memory file, keeping both destroyed until a human rebuilds them.
+The prompt sanctions omitting the key entirely when nothing changed (the write
+path treats a missing key as no-change), so a compliant model never needs to
+echo the file back — removing the temptation that produces placeholder answers
+and saving output tokens each pass; the header gate remains the backstop.
+The gate requires the exact mandated header as the first line AND a body that
+does not normalize into a known placeholder ("unchanged", "no changes needed",
+"N/A", …); markdown emphasis wrapping is stripped first so a decorated
+placeholder cannot bypass the set. An empty body after the exact header is
+accepted (deleting the last entry is a legitimate complete file), and there is
+deliberately no size floor — a legitimate memory file can be a single tiny
+bullet, and a legitimate consolidation can shrink a bloated file by half or
+more. The discard warning logs only the rejected value's length, never its
+content, because raw model output can contain anything and the log ring feeds
+the dashboard.
+
 Non-blocking via `asyncio.create_task`. Requires `SessionManager` to be passed
 at construction time; consolidation is silently skipped if no session manager
 is available.

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -235,6 +235,75 @@ def _fmt_message(m: dict) -> str:
     return f"[{m.get('ts', '?')[:16]}] {m['role'].upper()}{tools}: {m['content']}"
 
 
+# Normalized placeholder bodies a model emits instead of a real file body.
+# Compared after lowercasing and stripping surrounding whitespace/punctuation,
+# so e.g. "Unchanged.", "(no changes)" and "N/A" all normalize into this set.
+_PLACEHOLDER_BODIES = frozenset(
+    {
+        "unchanged",
+        "no change",
+        "no changes",
+        "no change needed",
+        "no changes needed",
+        "no changes required",
+        "no update",
+        "no updates",
+        "no update needed",
+        "no updates needed",
+        "nothing changed",
+        "nothing to update",
+        "nothing to change",
+        "none",
+        "n/a",
+        "na",
+        "empty",
+        "same",
+        "same as before",
+        "as before",
+        "see above",
+        "content unchanged",
+        "file unchanged",
+    }
+)
+
+
+def _is_plausible_memory_file(content: str, header: str) -> bool:
+    """Gate a consolidation ``*_update`` value before it overwrites a memory file.
+
+    The consolidation prompt asks for the COMPLETE updated file, but a model
+    sometimes answers with a protocol word instead — the literal string
+    ``unchanged``, ``(empty)``, ``no changes needed`` and similar. Writing that
+    placeholder destroys the file, and because the next consolidation prompt
+    embeds the file's current content verbatim, the placeholder then reads as a
+    valid example body and gets echoed into the other memory file on every
+    subsequent pass — a self-reinforcing loop that keeps both files destroyed
+    until a human rebuilds them.
+
+    Two gates:
+
+    1. The first line must be exactly the markdown header the prompt mandates
+       (not merely a prefix — ``# User Preferences (unchanged)`` is not a file).
+    2. The body below the header must not normalize into a known placeholder
+       word/phrase. Markdown emphasis wrapping (``**unchanged**``,
+       ``_unchanged_``, ``~~unchanged~~``) is stripped before the comparison so
+       a decorated placeholder cannot bypass the set. An EMPTY body after the
+       exact header is accepted: it is the legitimate COMPLETE file when the
+       last entry is deleted (e.g. the final project goes inactive), and
+       rejecting it would pin the stale entry in persistent memory forever.
+       There is deliberately no size floor either — a legitimate memory file
+       can be a single tiny bullet (``- Vim``), and rejecting it here would
+       silently lose the learned preference while the consolidation marker
+       advances past it.
+    """
+    first_line, _, body = content.strip().partition("\n")
+    if first_line.strip() != header:
+        return False
+    normalized = body.strip().lower().strip(" \t\"'`*_~.,!()[]")
+    if normalized in _PLACEHOLDER_BODIES:
+        return False
+    return True
+
+
 _SESSION_MAX_BYTES = 2 * 1024 * 1024  # 2MB
 _SESSION_KEEP_LINES = 200
 # Bounded cross-process lock acquisition. The per-session sidecar ``flock`` is
@@ -4954,15 +5023,22 @@ class HistoryConsolidator:
             # Markdown memory (backward compat when not migrated)
             if not self._migrated:
                 keys.append(
-                    '"preferences_update": The COMPLETE updated preferences file. '
-                    "Merge duplicates, keep only newest if contradicted, remove stale "
-                    "one-off observations. Keep '# User Preferences' header. "
-                    "Return existing content exactly if nothing changed."
+                    '"preferences_update": The COMPLETE updated preferences file, '
+                    "included ONLY if the file needs changes. Merge duplicates, keep "
+                    "only newest if contradicted, remove stale one-off observations. "
+                    "Keep '# User Preferences' header. If nothing changed, OMIT this "
+                    "key entirely — never echo the file back and never answer with a "
+                    "placeholder word like 'unchanged': the value overwrites the file, "
+                    "so when present it must be the full file body."
                 )
                 keys.append(
-                    '"projects_update": The COMPLETE updated projects file. '
-                    "Only active projects, remove stale entries, update facts. "
-                    "Keep '# Active Projects' header. Return existing if unchanged."
+                    '"projects_update": The COMPLETE updated projects file, included '
+                    "ONLY if the file needs changes. Only active projects, remove "
+                    "stale entries, update facts. Keep '# Active Projects' header. "
+                    "If nothing changed, OMIT this key entirely — never echo the file "
+                    "back and never answer with a placeholder word like 'unchanged': "
+                    "the value overwrites the file, so when present it must be the "
+                    "full file body."
                 )
 
             if include_history:
@@ -5041,14 +5117,32 @@ class HistoryConsolidator:
             if self._vector_store:
                 await run_in_embed_pool(self._write_structured_memory, result, key)
 
-            # Markdown writes (backward compat — skip if migrated)
+            # Markdown writes (backward compat — skip if migrated). Each value
+            # replaces the whole file, so a non-file answer (e.g. the literal
+            # word "unchanged") must be discarded, not written: once written it
+            # re-enters the next prompt as the file's current content and primes
+            # every later pass to repeat it (see _is_plausible_memory_file).
             if not self._migrated:
                 if prefs := result.get("preferences_update"):
-                    if prefs.strip() != current_prefs.strip():
+                    if not _is_plausible_memory_file(prefs, "# User Preferences"):
+                        logger.warning(
+                            "Discarding implausible preferences_update from "
+                            "consolidation (missing '# User Preferences' header "
+                            "or placeholder body; %d chars)",
+                            len(prefs),
+                        )
+                    elif prefs.strip() != current_prefs.strip():
                         memory.write_preferences(prefs)
 
                 if projects := result.get("projects_update"):
-                    if projects.strip() != current_projects.strip():
+                    if not _is_plausible_memory_file(projects, "# Active Projects"):
+                        logger.warning(
+                            "Discarding implausible projects_update from "
+                            "consolidation (missing '# Active Projects' header "
+                            "or placeholder body; %d chars)",
+                            len(projects),
+                        )
+                    elif projects.strip() != current_projects.strip():
                         memory.write_projects(projects)
 
             # Lesson extraction: _save_lessons calls write_lesson which embeds

--- a/test/test_consolidation_placeholder_guard.py
+++ b/test/test_consolidation_placeholder_guard.py
@@ -1,0 +1,212 @@
+"""Consolidation must never overwrite a memory file with a placeholder body.
+
+The consolidation prompt asks the model for the COMPLETE updated
+preferences/projects file. A model occasionally answers with a protocol word
+instead (the literal string ``unchanged``, ``(empty)``, …). Writing that
+placeholder destroys the file, and because the next consolidation prompt embeds
+the file's current content verbatim, the placeholder then primes every later
+pass to echo it into the other memory file too — a self-reinforcing loop that
+keeps both files destroyed. ``_is_plausible_memory_file`` gates the write on the
+mandated markdown header; these tests pin the gate and the write path around it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.history import HistoryConsolidator, _is_plausible_memory_file
+
+_PREFS_HEADER = "# User Preferences"
+_PROJECTS_HEADER = "# Active Projects"
+
+
+class TestIsPlausibleMemoryFile:
+    def test_real_file_passes(self):
+        body = "# User Preferences\n\n- Prefers concise answers\n"
+        assert _is_plausible_memory_file(body, _PREFS_HEADER)
+
+    def test_leading_whitespace_still_passes(self):
+        body = "\n\n# Active Projects\n\n## Something\n"
+        assert _is_plausible_memory_file(body, _PROJECTS_HEADER)
+
+    @pytest.mark.parametrize(
+        "placeholder",
+        [
+            "unchanged",
+            "Unchanged.",
+            "(empty)",
+            "no changes needed",
+            "N/A",
+            "",
+            "   \n",
+        ],
+    )
+    def test_placeholders_rejected(self, placeholder):
+        assert not _is_plausible_memory_file(placeholder, _PREFS_HEADER)
+        assert not _is_plausible_memory_file(placeholder, _PROJECTS_HEADER)
+
+    def test_wrong_header_rejected(self):
+        # A projects body must not be accepted as a preferences file (and vice
+        # versa): a swapped write would silently destroy the target file.
+        projects_body = "# Active Projects\n\n## Thing\n"
+        assert not _is_plausible_memory_file(projects_body, _PREFS_HEADER)
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "unchanged",
+            "Unchanged.",
+            "(unchanged)",
+            "**unchanged**",
+            "_unchanged_",
+            "~~unchanged~~",
+            "*no changes needed*",
+            "no changes needed",
+            "No changes required.",
+            "N/A",
+            "none",
+            "same as before",
+        ],
+    )
+    def test_header_plus_placeholder_body_rejected(self, body):
+        # GPT 5.6 review finding: a header line followed by a placeholder body
+        # must be rejected too — the header alone does not make it a file.
+        # Markdown emphasis wrapping must not bypass the set.
+        for header in (_PREFS_HEADER, _PROJECTS_HEADER):
+            assert not _is_plausible_memory_file(f"{header}\n\n{body}", header)
+
+    def test_header_prefix_not_exact_line_rejected(self):
+        # The header must be the exact first line, not merely a prefix.
+        assert not _is_plausible_memory_file(
+            "# User Preferences (unchanged)\n\n- real content here\n",
+            _PREFS_HEADER,
+        )
+
+    def test_header_with_empty_body_accepted(self):
+        # An empty body after the exact header is the legitimate COMPLETE file
+        # when the last entry is deleted (final project goes inactive);
+        # rejecting it would pin the stale entry forever (GPT 5.6 finding).
+        assert _is_plausible_memory_file("# User Preferences\n\n", _PREFS_HEADER)
+        assert _is_plausible_memory_file("# Active Projects", _PROJECTS_HEADER)
+
+    def test_header_with_tiny_substantive_body_passes(self):
+        # No size floor: a single tiny bullet is a legitimate memory file, and
+        # rejecting it would silently lose the learned preference while the
+        # consolidation marker advances past it (GPT 5.6 review finding).
+        assert _is_plausible_memory_file(
+            "# User Preferences\n\n- Vim\n", _PREFS_HEADER
+        )
+
+    def test_header_with_substantive_body_passes(self):
+        assert _is_plausible_memory_file(
+            "# User Preferences\n\n- Prefers concise answers\n", _PREFS_HEADER
+        )
+
+
+def _make_consolidator(memory: MagicMock) -> HistoryConsolidator:
+    log = MagicMock()
+    log.snapshot_for_consolidation.return_value = (
+        [{"role": "user", "content": "hi"}],
+        1,
+        0,
+    )
+    log.get_metadata.return_value = {}
+    log.consolidation_retry_state.return_value = (0, 0.0)
+    return HistoryConsolidator(
+        log=log,
+        memory=memory,
+        sessions=None,
+        vector_store=None,
+        migrated=False,
+    )
+
+
+def _make_memory(prefs: str, projects: str) -> MagicMock:
+    memory = MagicMock()
+    memory.read_preferences.return_value = prefs
+    memory.read_projects.return_value = projects
+    return memory
+
+
+class TestConsolidatePlaceholderGuard:
+    @pytest.mark.asyncio
+    async def test_placeholder_update_is_discarded(self):
+        """The literal 'unchanged' must never reach write_preferences/projects."""
+        memory = _make_memory(
+            "# User Preferences\n\n- real content\n",
+            "# Active Projects\n\n## Real project\n",
+        )
+        c = _make_consolidator(memory)
+        with patch.object(c, "_call_llm", new_callable=AsyncMock) as llm:
+            llm.return_value = {
+                "preferences_update": "unchanged",
+                "projects_update": "unchanged",
+            }
+            await c._consolidate("k", include_history=False)
+
+        memory.write_preferences.assert_not_called()
+        memory.write_projects.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_valid_update_is_written(self):
+        """The gate must not block a genuine full-file update."""
+        memory = _make_memory(
+            "# User Preferences\n\n- old\n",
+            "# Active Projects\n\n## Old\n",
+        )
+        c = _make_consolidator(memory)
+        new_prefs = "# User Preferences\n\n- old\n- new fact\n"
+        new_projects = "# Active Projects\n\n## New project\n"
+        with patch.object(c, "_call_llm", new_callable=AsyncMock) as llm:
+            llm.return_value = {
+                "preferences_update": new_prefs,
+                "projects_update": new_projects,
+            }
+            await c._consolidate("k", include_history=False)
+
+        memory.write_preferences.assert_called_once_with(new_prefs)
+        memory.write_projects.assert_called_once_with(new_projects)
+
+    @pytest.mark.asyncio
+    async def test_shrunk_but_valid_update_is_written(self):
+        """No size floor: a consolidation that halves a bloated file is legit."""
+        bloated = "# Active Projects\n\n" + "\n".join(
+            f"## Stale project {i}\n- detail\n" for i in range(40)
+        )
+        memory = _make_memory("# User Preferences\n", bloated)
+        c = _make_consolidator(memory)
+        trimmed = "# Active Projects\n\n## Only live project\n"
+        with patch.object(c, "_call_llm", new_callable=AsyncMock) as llm:
+            llm.return_value = {"projects_update": trimmed}
+            await c._consolidate("k", include_history=False)
+
+        memory.write_projects.assert_called_once_with(trimmed)
+
+    @pytest.mark.asyncio
+    async def test_omitted_update_keys_write_nothing(self):
+        """Omitting the key is the sanctioned no-change path — nothing written."""
+        memory = _make_memory("# User Preferences\n", "# Active Projects\n")
+        c = _make_consolidator(memory)
+        with patch.object(c, "_call_llm", new_callable=AsyncMock) as llm:
+            llm.return_value = {"history_entry": "something happened"}
+            await c._consolidate("k", include_history=False)
+
+        memory.write_preferences.assert_not_called()
+        memory.write_projects.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_prompt_sanctions_omitting_and_forbids_placeholders(self):
+        """The prompt must offer omission for no-change and forbid placeholders,
+        so the model is never tempted to echo a file or answer with a protocol
+        word."""
+        memory = _make_memory("# User Preferences\n", "# Active Projects\n")
+        c = _make_consolidator(memory)
+        with patch.object(c, "_call_llm", new_callable=AsyncMock) as llm:
+            llm.return_value = {}
+            await c._consolidate("k", include_history=False)
+
+        prompt = llm.call_args.args[0]
+        assert prompt.count("OMIT this key entirely") == 2
+        assert prompt.count("placeholder word like 'unchanged'") == 2


### PR DESCRIPTION
## Problem

A memory consolidation pass can destroy `preferences.md` / `projects.md`. The
consolidation prompt asks the model for the COMPLETE updated file, but a model
occasionally answers with a protocol word instead — the literal string
`unchanged`. The write-back accepts any non-empty string that differs from the
current content, so the placeholder overwrites the whole file. The user's
persistent memory is silently replaced by one word.

## Why it matters

This is not a one-off corruption — it self-perpetuates. The next consolidation
prompt embeds the file's current content verbatim (`## Current Preferences`
followed by `unchanged`), which teaches every subsequent pass that a
placeholder is a valid file body, so it gets echoed into the *other* memory
file too. Both files then stay destroyed until a human notices and rebuilds
them by hand, and everything the agent learned about the user in those files is
lost in the meantime. Observed in the wild: a `preferences.md` reduced to the
single word `unchanged`, re-destroyed roughly every 18 minutes by the loop
after each manual repair attempt.

## Fix (symptoms → root cause → change)

Symptom: memory file body becomes `unchanged`; repairs don't stick.

Root cause: two compounding gaps. (1) The write-back in
`HistoryConsolidator._consolidate` trusts any non-empty `preferences_update` /
`projects_update` value. (2) The prompt demands a verbatim echo of the whole
file to signal "no change" ("Return existing if unchanged."), which invites the
protocol-word shortcut, and the prompt's feedback loop (current file content
embedded each pass) turns one bad write into a self-reinforcing priming loop.

Change, at both ends:

- **Write gate** — `_is_plausible_memory_file()` applies two checks before a
  value may overwrite the file: (1) the first line must be exactly the
  markdown header the prompt itself mandates (`# User Preferences` /
  `# Active Projects`); (2) the body below the header must not normalize into
  a known placeholder phrase (`unchanged`, `no changes needed`, `N/A`, … —
  markdown emphasis wrapping is stripped first, so `**unchanged**` is caught
  too). The body check was added during review: the observed defect is fully
  stopped by the header check alone, but a header + placeholder-body answer
  is the same failure shape one prompt-drift away, and it would silently
  destroy the file identically. Known tradeoff: a legitimate file whose
  entire body normalizes into a listed phrase (e.g. just `same`) can never be
  consolidation-written; accepted, because every listed phrase is a no-change
  protocol word — a file consisting solely of one is indistinguishable from
  the failure we're guarding against. Anything rejected is discarded with a
  length-only warning log (never the content — raw model output feeds the
  dashboard log ring). No size floor, and a header-only empty body is
  accepted: deleting the last entry is a legitimate complete file, and a
  legitimate consolidation can shrink a bloated file by half or more.
- **Prompt rework** — both `*_update` keys now sanction OMITTING the key
  entirely when nothing changed (the write path already treats a missing key
  as no-change), and still forbid placeholder words. This removes the
  verbatim-echo burden that produces the placeholder answer in the first
  place, and saves output tokens each pass. The header gate stays as the
  backstop.
- **Spec** — `docs/system-specs/modules/history.md` documents the gate and the
  omit-if-unchanged path in the same commit.

## Tests

`test/test_consolidation_placeholder_guard.py`, 15 tests:

- Guard unit tests: a real file passes (incl. leading whitespace); `unchanged`,
  `(empty)`, `no changes needed`, `N/A`, empty/whitespace bodies are rejected;
  a body with the *wrong* header is rejected (a swapped write would destroy the
  target file).
- `_consolidate` integration (mocked LLM): a placeholder answer never reaches
  `write_preferences` / `write_projects`; an omitted key writes nothing (the
  sanctioned no-change path); a genuine full-file update is written unchanged;
  a valid update that halves a bloated file is written (pins the no-size-floor
  design); the prompt's omit-sanction and placeholder ban are pinned.

isort, flake8, mypy, docs-lint all green. Full-suite failures on my machine
reproduce identically on a clean `origin/main` checkout (environment-specific,
macOS) — none touch this path.

## Manual verification

N/A — unit coverage sufficient: the change is a pure guard on an existing
in-process write path with no I/O, UI, or external-service surface; the
integration tests exercise the exact `_consolidate` code path the gateway runs.

## Related Issues

None — no existing upstream issue for this; the PR carries the full analysis.

## Checklist

- [x] Single commit with a Conventional Commits title (feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
