### PR TITLE
fix(cron): forward per-server env, sanitized, and pin wrappers at their source

### DIFF
--- a/src/kiro_crew/cron_script.py
+++ b/src/kiro_crew/cron_script.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, Any
 from kiro_crew import platform_compat
 from kiro_crew.config.loader import config_dir, read_local_secret
 from kiro_crew.config.paths import kiro_agents_dir
+from kiro_crew.env import sanitize_spec_env
 from kiro_crew.github_runner import prevalidated_gh_env
 from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.port_resolution import resolve_serving_port
@@ -396,11 +397,62 @@ class McpToolClient:
 
     def __init__(self, server_name: str):
         self._server_name = server_name
-        argv = _resolve_mcp_server(server_name)
-        if not argv:
+        resolved = _resolve_mcp_server(server_name)
+        if not resolved:
             raise RuntimeError(f"MCP server '{server_name}' not found in agent config")
+        argv, spec_env = resolved
         sandboxed_argv, self._sandbox_cleanup = wrap_argv(list(argv), mode="standard")
         sandboxed_argv = cgroup_scope_argv(sandboxed_argv)  # cgroup DoS ceiling
+        # SECURITY: the confinement wrappers prepended above (`systemd-run` on
+        # Linux, `env` -> `sandbox-exec` on macOS) are absolute paths, pinned by
+        # the functions that prepend them. That matters here because Popen is
+        # handed an env whose PATH is overlaid from the per-server agent config
+        # below, and CPython resolves a slash-less argv[0] through THAT env's PATH
+        # (os.get_exec_path) -- a bare-name wrapper would be redirectable to an
+        # attacker binary running BEFORE confinement exists. Pinning belongs in
+        # those producers, not here: re-pinning at the spawn site would also
+        # rewrite argv[0] on the fail-open no-sandbox path, where argv[0] is the
+        # OPERATOR-declared command and silently resolving it against the
+        # gateway's own directories would override the very PATH selection the
+        # spec `env` block exists to provide.
+        #
+        # Build the subprocess env: start from the secret-scrubbed cron env, then
+        # overlay the per-server `env` block from the agent config (e.g. the PATH
+        # that lets a launcher resolve a helper binary it shells out to). A
+        # launcher that execs a binary reachable only via that env dies before the
+        # initialize handshake if the env is dropped. Three filters apply, and all
+        # three are load-bearing:
+        #   * _clean_cron_env() strips secrets from the INHERITED env;
+        #   * _CRON_ENV_DENY is re-applied to the spec overlay so a denied key
+        #     cannot be reintroduced through the config;
+        #   * sanitize_spec_env() drops loader/interpreter-injection keys
+        #     (LD_*, DYLD_*, and the specific PYTHONPATH/HOME/STARTUP/USERBASE
+        #     startup channels -- see env._SPEC_ENV_DENIED_PREFIXES; it is a prefix
+        #     set, NOT all of PYTHON*). Those are NOT in _CRON_ENV_DENY, and the spec
+        #     env is externally authorable, so without this an `LD_PRELOAD` in a
+        #     server's `env` block would be honoured by the dynamic loader inside
+        #     the confinement wrapper process -- executing attacker code before
+        #     the wrapper establishes containment. Pinning argv[0] does not help:
+        #     the loader acts on the pinned binary. This is the same reason
+        #     mcp_discovery routes its probe's spec env through the sanitizer;
+        #     PATH is deliberately NOT denied, since forwarding it is the point.
+        #   * sanitize_spec_env() ALSO drops the reserved KIROCREW_ namespace
+        #     (env._SPEC_ENV_RESERVED_PREFIXES), which is an authorization control
+        #     rather than a containment one and is the reason the two other filters
+        #     are not sufficient here. The server this bridge most often spawns is
+        #     `kirocrew-cron` itself, and mcp_cron._caller_is_cli() is just
+        #     `os.environ.get("KIROCREW_CLI") == "1"` -- so a `KIROCREW_CLI: "1"`
+        #     in that server's `env` block would make the spawned server treat a
+        #     SCRIPT CRON as the admin CLI and let it run cron_remove_all across
+        #     every session. Sandboxing does not bound that: confinement limits what
+        #     the child may touch, not whose jobs Kiro Crew thinks it owns. The deny
+        #     lives in the shared sanitizer rather than in _CRON_ENV_DENY so the
+        #     discovery probe -- which applies no cron deny-set at all -- is covered
+        #     by the same control instead of a second copy of it.
+        proc_env = _clean_cron_env()
+        proc_env.update(
+            sanitize_spec_env((k, v) for k, v in spec_env.items() if k not in _CRON_ENV_DENY)
+        )
         # Capture stderr to a tempfile instead of DEVNULL so spawn/handshake
         # failures are legible. DEVNULL hid the real cause -- wrong
         # Node version, expired auth cookies, OOM kill, sandbox failure -- behind
@@ -415,6 +467,7 @@ class McpToolClient:
                 stdout=subprocess.PIPE,
                 stderr=self._stderr_file,
                 text=True,
+                env=proc_env,
             )
         except Exception:
             self._stderr_file.close()
@@ -532,8 +585,15 @@ class McpToolClient:
 
 
 @lru_cache(maxsize=16)
-def _resolve_mcp_server(name: str) -> tuple[str, ...] | None:
-    """Read MCP server command from agent config (cached per process)."""
+def _resolve_mcp_server(name: str) -> tuple[tuple[str, ...], dict[str, str]] | None:
+    """Read MCP server command + env from agent config (cached per process).
+
+    Returns ``(argv, env)``. The per-server ``env`` block is required for
+    launchers that shell out to a helper binary only reachable via the ``PATH``
+    the config supplies: dropping it makes the spawned MCP die at the JSON-RPC
+    ``initialize`` handshake. When the config has no ``env`` block -- or declares
+    one that is not a JSON object -- the env dict is empty.
+    """
     cfg_path = kiro_agents_dir() / "kirocrew.json"
     if not cfg_path.exists():
         # Fall back to any kirocrew-named agent spec in the same agents dir.
@@ -546,7 +606,60 @@ def _resolve_mcp_server(name: str) -> tuple[str, ...] | None:
     spec = cfg.get("mcpServers", {}).get(name)
     if not spec:
         return None
-    return tuple([spec["command"]] + spec.get("args", []))
+    argv = tuple([spec["command"]] + spec.get("args", []))
+    # A hand-edited config can spell `env` as anything JSON allows. Only a
+    # mapping has .items(), so a string/list/number would raise AttributeError
+    # here and fail EVERY ctx.call_tool for that server with a traceback that
+    # names this function rather than the malformed config. Treat a non-mapping
+    # as absent and say so once: the declaration cannot be honoured either way,
+    # and a silent drop reads as the env-drop bug this function exists to fix.
+    raw_env = spec.get("env")
+    if raw_env is not None and not isinstance(raw_env, dict):
+        logger.warning(
+            "MCP server %r declares a non-object 'env' (%s); ignoring it",
+            name,
+            type(raw_env).__name__,
+        )
+        raw_env = None
+    env: dict[str, str] = {}
+    for raw_key, raw_value in (raw_env or {}).items():
+        key, value = str(raw_key), str(raw_value)
+        # Stringifying is not enough: `Popen` validates the env at the execve
+        # boundary and rejects the WHOLE spawn over one bad pair -- ValueError
+        # "illegal environment variable name" for `=` in a name, "embedded null
+        # byte" for a NUL in either half. Since that fires before the fork, a
+        # single malformed entry in this block aborts EVERY ctx.call_tool for the
+        # server, and the traceback names Popen rather than the config that is
+        # actually wrong -- the same failure shape, for the same reason, as the
+        # non-object `env` handled above. An empty name is not a crash but is
+        # unreachable (`getenv("")` is always NULL), so it is dropped on the same
+        # "cannot be honoured either way" ground.
+        #
+        # Dropped per ENTRY rather than rejected per SERVER: the sibling entries
+        # are still honourable, and the whole point of this function is that a
+        # server whose launcher needs a config-supplied PATH must keep working.
+        # Logged for the reason the non-object branch logs -- a silent drop reads
+        # as the env-drop bug this function exists to fix. The name is named so
+        # the operator knows which entry to edit; the value never is, since it
+        # can hold a credential.
+        if not key:
+            reason = "empty name"
+        elif "=" in key:
+            reason = "'=' in name"
+        elif "\0" in key:
+            reason = "NUL byte in name"
+        elif "\0" in value:
+            reason = "NUL byte in value"
+        else:
+            env[key] = value
+            continue
+        logger.warning(
+            "MCP server %r declares an invalid 'env' entry %r (%s); ignoring it",
+            name,
+            key,
+            reason,
+        )
+    return argv, env
 
 
 def _split_script_spec(script_path: str) -> tuple[str, str]:

--- a/src/kiro_crew/env.py
+++ b/src/kiro_crew/env.py
@@ -874,13 +874,23 @@ def mcp_search_path(env_path: str) -> str:
 #
 # * ``LD_*`` / ``DYLD_*`` are dynamic-loader channels honoured by every
 #   ELF/Mach-O binary in the spawn chain, the sandbox wrapper included.
-# * ``PYTHON*`` matters because Kiro Crew's Linux sandbox launcher IS a Python
-#   process: ``sandbox._python_launcher_argv`` returns
-#   ``[sys.executable, <generated script>, *argv]`` (sandbox.py), and that
-#   interpreter starts with the env we hand ``Popen``. A declared
+# * The listed ``PYTHON*`` keys matter because Kiro Crew's Linux sandbox launcher
+#   IS a Python process: ``sandbox.namespace_argv`` returns
+#   ``[sys.executable, "-I", "-S", <generated script>, *argv]`` (sandbox.py), and
+#   that interpreter starts with the env we hand ``Popen``. A declared
 #   ``PYTHONPATH`` carrying ``sitecustomize.py`` — or a shadowing ``os.py`` —
-#   is imported at interpreter startup, i.e. before ``unshare`` and before the
-#   target is exec'd. ``PYTHONSTARTUP``/``PYTHONHOME`` are the same channel.
+#   would be imported at interpreter startup, i.e. before ``unshare`` and before
+#   the target is exec'd. ``PYTHONSTARTUP``/``PYTHONHOME`` are the same channel.
+#   ``PYTHONUSERBASE`` is too: it relocates user-site, whose ``.pth`` files are
+#   EXECUTED during startup.
+#
+# NOTE this list is a prefix set, not the glob ``PYTHON*`` — do not describe it as
+# such. It does not cover ``HOME``, which also derives the user-site path when
+# ``PYTHONUSERBASE`` is unset, and stripping ``HOME`` from a spec overlay would
+# break servers that legitimately need it. The launcher's ``-I -S`` is what
+# actually closes that class (site processing never happens, so no ``.pth`` runs
+# whatever the paths point at); these prefixes are defense in depth for it and the
+# primary control for any future launcher that forgets those flags.
 #
 # Prefix-matched, case-insensitively (Windows env is case-insensitive).
 #
@@ -899,17 +909,81 @@ _SPEC_ENV_DENIED_PREFIXES: tuple[str, ...] = (
     "PYTHONPATH",
     "PYTHONHOME",
     "PYTHONSTARTUP",
+    "PYTHONUSERBASE",
 )
+
+# The env namespace Kiro Crew reserves for ITSELF. A spec-declared ``env`` may
+# not set any key in it.
+#
+# This is an AUTHORIZATION boundary, and it is a different class from the loader
+# prefixes above — not a variant of them. Several ``KIROCREW_*`` variables are
+# how the gateway tells a process it spawns WHO IS CALLING, and the consumers
+# treat them as vouched-for:
+#
+# * ``KIROCREW_CLI`` — ``mcp_cron._caller_is_cli()`` is exactly
+#   ``os.environ.get("KIROCREW_CLI") == "1"``, and a true return makes the cron
+#   tools skip per-session ownership entirely. Forged, it turns
+#   ``cron_remove_all`` into "delete every session's jobs" and ``cron_list``
+#   into the cross-principal disclosure ``mcp_cron`` explicitly refuses (see its
+#   ownerless-row note: an allowlisted Slack participant is not the operator).
+# * ``KIROCREW_SESSION_KEY`` / ``KIROCREW_HOST_PID`` — two of the three sources
+#   ``mcp_core._resolve_session_key_strict()`` accepts, chosen precisely because
+#   they are, in its own words, sources "the gateway authors and an agent cannot
+#   write". A spec overlay authoring one makes that claim false, which is worse
+#   than the loader class: it corrupts the resolver the ownership checks are
+#   built on rather than the process that hosts them.
+# * ``KIROCREW_OWNER_ID`` / ``KIROCREW_INTERNAL_SECRET`` — the Slack owner
+#   identity and the loopback shared secret. ``cron_script`` already denies these
+#   two on its own path; putting them here extends the same control to the probe,
+#   which had no such deny.
+#
+# Denying the NAMESPACE rather than those five keys is deliberate. Dozens of
+# ``KIROCREW_*`` variables are read across the tree today, several of them
+# security-relevant beyond identity (sandbox level, approval mode, admission
+# policy), and a key-by-key list fails open for the next one somebody adds —
+# the reviewable property we want is "a config cannot author our namespace",
+# which a prefix states and a list only approximates.
+#
+# Nothing legitimately needs the namespace in a spec overlay. Every caller of
+# this sanitizer builds its child env from ``os.environ`` FIRST and overlays the
+# spec on top (``cron_script._clean_cron_env()``, ``mcp_discovery``'s
+# ``dict(os.environ)``), so a gateway-authored ``KIROCREW_*`` value is INHERITED
+# either way. Denying it here removes only a config file's ability to OVERRIDE
+# one — exactly the capability being abused, and nothing else. Kiro Crew's own
+# spawn paths set these variables directly on the child env
+# (``apps.backend``'s ``KIROCREW_APP_NAME``, the gateway's
+# ``KIROCREW_MCP_TARGET_*``), never by declaring them in an ``mcpServers``
+# ``env`` block, so no first-party surface depends on the overlay either.
+#
+# Prefix-matched case-insensitively, like the loader set above.
+_SPEC_ENV_RESERVED_PREFIXES: tuple[str, ...] = ("KIROCREW_",)
 
 
 def sanitize_spec_env(pairs: Iterable[tuple[str, str]]) -> dict[str, str]:
-    """Drop loader/interpreter-injection keys from a spec-declared env.
+    """Drop loader-injection and reserved-namespace keys from a spec env.
 
     For spawn paths that apply a config-declared ``env`` to a child THEY
     launch (the probe). The declared env is config-file
     text — the same trust level as the command itself, which those paths
     already refuse to run unsandboxed — so a key that executes code in the
     launcher before confinement is established must not pass through.
+
+    Two independent classes are dropped, for two different reasons:
+
+    * ``_SPEC_ENV_DENIED_PREFIXES`` — loader/interpreter channels that execute
+      code in the launcher before confinement exists.
+    * ``_SPEC_ENV_RESERVED_PREFIXES`` — Kiro Crew's own namespace, which carries
+      the caller identity our authorization checks read. Sandboxing does not
+      mitigate this one at all: confinement bounds what the child may touch, not
+      whose jobs Kiro Crew believes the child is entitled to. That is why "the
+      command is equally config-authored, and it runs sandboxed" does not settle
+      this class the way it settles the command itself. This prefix set is
+      interim depth, not the authorization control: it stops the ``env`` block
+      from spelling an identity key, while the same config's ``command`` field
+      reaches the identical consumer (``sh -c 'KIROCREW_CLI=1 exec ...'``). The
+      real fix is consumer-side vouching so the claim is one a config cannot
+      author -- tracked in #6624. Keep this set when that lands; it also covers
+      KIROCREW_SESSION_KEY / KIROCREW_HOST_PID.
 
     Matching is case-INSENSITIVE on purpose: Windows environment variables
     are case-insensitive, so ``pythonpath`` reaches Python exactly like
@@ -928,6 +1002,17 @@ def sanitize_spec_env(pairs: Iterable[tuple[str, str]]) -> dict[str, str]:
                 "dropping spec env key %r: loader/interpreter injection channel", key
             )
             continue
+        if any(folded.startswith(p) for p in _SPEC_ENV_RESERVED_PREFIXES):
+            # Distinct message on purpose: reporting a forged KIROCREW_CLI as a
+            # "loader injection channel" would send the next reader looking for a
+            # sandbox-escape that is not there, and hide the one that is.
+            logger.warning(
+                "dropping spec env key %r: the KIROCREW_ namespace is reserved for "
+                "the gateway's own caller-identity channel and cannot be declared "
+                "by a config",
+                key,
+            )
+            continue
         out[key] = value
     return out
 
@@ -940,6 +1025,18 @@ def denied_spec_env_keys(env: "Mapping[str, object]") -> list[str]:
     looking: a Python server configured through ``env.PYTHONPATH`` probes as an
     error while working fine in a session, and without naming the dropped key
     that reads as a probe bug rather than a policy decision.
+
+    Deliberately covers the LOADER prefixes only, not
+    ``_SPEC_ENV_RESERVED_PREFIXES``. The consumer
+    (``mcp_discovery._note_denied_env``) tells the reader the drop happens
+    because the key "execute[s] in the sandbox launcher before confinement, so
+    the probe cannot honour them — a session still does", and every clause of
+    that is false for a reserved key: it is not a launcher-execution channel, and
+    a session must not honour a forged caller identity either. Reserved-namespace
+    drops are therefore log-only. A spec declaring one is a policy violation to
+    be recorded, not a working server to be apologised to — so this stays the
+    "here is why your legitimate config was refused" surface, and does not become
+    a hint sheet for the identity boundary.
     """
     return [
         k

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -2270,6 +2270,35 @@ def _ensure_run_dir() -> str:
     return run_dir
 
 
+# Interpreter flags for the namespace launcher. These matter for CONFINEMENT
+# ORDERING, not tidiness: the launcher IS a Python process, and everything the
+# interpreter does at startup happens BEFORE the script reaches ``unshare``. With
+# site processing enabled, ``site`` executes code from env-derived paths at startup
+# -- user-site ``.pth`` files (whose location comes from ``PYTHONUSERBASE``, else
+# ``HOME``) and ``sitecustomize`` (from ``PYTHONPATH``). For a config-declared
+# server ``env`` block that is externally authorable text, so it is arbitrary code
+# running unconfined. No argv[0] pin helps: the interpreter is the pinned binary.
+#   -I (isolated) ignores PYTHON* startup vars and drops the script dir from
+#      sys.path; implies -E and -s.
+#   -S skips ``site`` altogether, which is what closes the class rather than
+#      individual keys -- no .pth and no sitecustomize run at all.
+# Safe because the generated launcher imports stdlib only (sys, os, stat, struct,
+# tempfile, platform, ctypes) and never needs site-packages. The namespace probe
+# and spawn shims already start their interpreters with these exact flags; this
+# launcher was the one Python entrypoint that did not.
+_LAUNCHER_INTERPRETER_FLAGS: tuple[str, ...] = ("-I", "-S")
+
+
+def _launcher_script_of(launcher_argv: list[str]) -> str:
+    """The generated launcher script inside a ``namespace_argv`` result.
+
+    Derived from the flag count rather than hardcoded, so adding a flag cannot
+    silently return a flag token where a path is expected — which would both leak
+    the tempfile and hand the caller ``"-I"`` to ``unlink``.
+    """
+    return launcher_argv[1 + len(_LAUNCHER_INTERPRETER_FLAGS)]
+
+
 def namespace_argv(
     argv: list[str],
     sandbox_level: str = "strict",
@@ -2302,7 +2331,7 @@ def namespace_argv(
     os.close(fd)
     platform_compat.chmod_safe(path, 0o700)
 
-    return [sys.executable, path, *resolved_argv]
+    return [sys.executable, *_LAUNCHER_INTERPRETER_FLAGS, path, *resolved_argv]
 
 
 # ── Backend: macOS sandbox-exec ──
@@ -2429,6 +2458,33 @@ _KIRO_INTERNAL_SANDBOX_KEY = "sandbox"
 # One loud warning per process for the delegation decision (per-spawn logs
 # would spam warm-pool refills); every delegated spawn is still SEL-audited.
 _kiro_delegation_warned = False
+
+
+def _pinned_env_bin() -> str:
+    """Absolute path to ``env``, resolved WITHOUT consulting PATH.
+
+    ``env`` is the process that applies the credential scrub (``env -u KEY ...``)
+    on the delegation paths, where no Seatbelt/namespace layer wraps the child.
+    A bare ``"env"`` token is resolved by the OS through the PATH in the
+    environment we hand ``Popen`` -- and on the script-cron MCP path that PATH can
+    come from a config-declared server ``env`` block. Redirecting ``env`` does not
+    merely run an attacker binary: it means the scrub NEVER RUNS, so the child
+    receives the very credentials (Slack tokens, owner id) the ``-u`` flags exist
+    to strip, and can exfiltrate them. Pinning is therefore load-bearing on these
+    paths even though they intentionally apply no OS confinement of our own.
+
+    ``trusted_system_bin`` ignores ``os.environ`` PATH entirely (fixed system dirs
+    only); the ``/usr/bin/env`` fallback matches the idiom already used by
+    ``sandbox_exec_argv`` and ``cgroup_scope_argv`` so an unusual host layout
+    still yields an absolute path rather than a redirectable bare name.
+
+    Deliberately does NOT pin the inner command: that is the operator's agent or
+    server binary (``kiro-cli``, ``npx``, ...), which legitimately must be found on
+    PATH, and it carries the same config-file trust level as the ``env`` block
+    itself -- an author who can set PATH can already set ``command`` directly, so
+    pinning it would buy nothing while breaking normal installs.
+    """
+    return platform_compat.trusted_system_bin("env") or "/usr/bin/env"
 
 
 def kiro_internal_sandbox_enabled() -> bool:
@@ -2558,7 +2614,7 @@ def _delegate_to_kiro_internal_sandbox(
         return list(argv), None
     unset_args = _sandbox_env_unset_args(sandbox_level, strip_python_env)
     if unset_args:
-        return ["env", *unset_args, *argv], None
+        return [_pinned_env_bin(), *unset_args, *argv], None
     return list(argv), None
 
 
@@ -2608,8 +2664,24 @@ def sandbox_exec_argv(
     # position so the scrub cannot drop it — an in-sandbox wrap_argv
     # passthrough compares it against the requested tier to detect downgrades.
     level_assign = f"{_IN_SANDBOX_LEVEL_VAR}={sandbox_level}"
+    # SECURITY: BOTH wrappers this function prepends are pinned here, at the layer
+    # that prepends them, so no spawn site has to remember to re-pin (the caller's
+    # ``env`` may carry a config-declared PATH, and CPython resolves a slash-less
+    # argv[0] through THAT PATH via os.get_exec_path):
+    #   * the outer ``env`` (argv[0]), which runs first of all;
+    #   * the inner ``sandbox-exec``, which ``env`` itself resolves through the
+    #     PATH in the environment it is handed -- BEFORE the Seatbelt profile is
+    #     applied, so a hostile PATH there is a pre-confinement escape.
+    # ``trusted_system_bin`` ignores PATH entirely rather than reading os.environ:
+    # a gateway's PATH can legitimately lead with agent-writable directories
+    # (a worktree venv's bin, ~/.local/bin), so resolving through it would leave
+    # the hole half-open. Both fall back to their canonical macOS locations,
+    # matching the _probe_sandbox_exec probe, so a host with an unusual layout
+    # still gets an absolute path rather than a redirectable bare name.
+    outer_env = _pinned_env_bin()
+    sandbox_exec = platform_compat.trusted_system_bin("sandbox-exec") or "/usr/bin/sandbox-exec"
     return (
-        ["env", *unset_args, marker, level_assign, "sandbox-exec", "-f", path, *resolved_argv],
+        [outer_env, *unset_args, marker, level_assign, sandbox_exec, "-f", path, *resolved_argv],
         path,
     )
 
@@ -3675,7 +3747,7 @@ def wrap_argv(
                 )
             unset_args = _sandbox_env_unset_args("standard", strip_python_env)
             if unset_args:
-                return ["env", *unset_args, *argv], None
+                return [_pinned_env_bin(), *unset_args, *argv], None
             return list(argv), None
         # Fix #3: Make the degradation loud — both layers are inactive.
         _warn_mode_off_unconfined(argv, kiro_spawn_off)
@@ -3885,8 +3957,11 @@ def wrap_argv(
                 sandbox_level,
                 strip_python_env=strip_python_env,
             )
-        # The launcher script is argv[1] — caller should clean it up
-        return wrapped, wrapped[1]
+        # Caller deletes the generated launcher script. Its position is
+        # ``1 + len(flags)``, NOT a hardcoded 1: the interpreter flags sit between
+        # the executable and the script, so hardcoding leaks the tempfile (and
+        # hands the caller a flag to unlink) the moment that list changes.
+        return wrapped, _launcher_script_of(wrapped)
     if backend == "sandbox-exec":
         if extra_hidden_dirs or extra_visible_dirs:
             return sandbox_exec_argv(
@@ -4889,11 +4964,34 @@ def cgroup_scope_argv(argv: list[str]) -> list[str]:
     On a host without cgroup v2 delegation (older Linux, no systemd user
     session, macOS), returns *argv* unchanged and logs a one-time loud SECURITY
     warning — the RLIMIT_NOFILE preexec still applies, but the fork-bomb/memory
-    DoS ceiling is NOT enforced there.
+    DoS ceiling is NOT enforced there. The same degradation applies when
+    ``systemd-run`` resolves outside the trusted system directories: prepending
+    an unpinned wrapper name would trade a DoS ceiling for an exec-hijack
+    channel, which is the worse of the two.
+
+    The returned wrapper is an ABSOLUTE path, so callers may hand the result to
+    a spawn whose ``env`` carries a config-declared PATH without that PATH being
+    able to redirect argv[0].
     """
     available, reason = _probe_cgroup_scope()
     if not available:
         _warn_cgroup_unavailable(reason)
+        return argv
+    # SECURITY: the wrapper this function prepends becomes argv[0], and a caller
+    # that hands the result to a spawn with a config-influenced ``env`` has
+    # CPython resolve a slash-less argv[0] through THAT env's PATH
+    # (os.get_exec_path) -- so a bare name here is an exec-hijack channel that
+    # runs BEFORE ``--scope`` establishes confinement. Pin it at the layer that
+    # prepends it, so every caller inherits the protection rather than each
+    # spawn site remembering to re-pin (the same reason ``sandbox_exec_argv``
+    # pins its own wrappers). ``trusted_system_bin`` ignores PATH entirely: a
+    # gateway's PATH can legitimately lead with agent-writable directories, so
+    # resolving through it would leave the hole half-open. An unresolvable
+    # wrapper degrades exactly like a missing cgroup backend -- no ceiling, loud
+    # warning -- rather than emitting an unpinned name.
+    systemd_run = platform_compat.trusted_system_bin("systemd-run")
+    if not systemd_run:
+        _warn_cgroup_unavailable("systemd-run is not in a trusted system directory")
         return argv
     # Reconcile the slice-level aggregate ceiling off-thread: this call site
     # runs on the gateway event loop during agent spawn, and reconciliation
@@ -4916,7 +5014,7 @@ def cgroup_scope_argv(argv: list[str]) -> list[str]:
         if max_cpu_percent > 0:
             props += ["-p", f"CPUQuota={max_cpu_percent}%"]
     return [
-        "systemd-run",
+        systemd_run,
         "--user",
         "--scope",
         "-q",

--- a/test/test_cron_script.py
+++ b/test/test_cron_script.py
@@ -642,11 +642,13 @@ class TestResolveMcpServer:
     """Tests for _resolve_mcp_server config lookup."""
 
     def test_returns_none_for_missing_config(self, tmp_path):
+        _resolve_mcp_server.cache_clear()
         with patch("pathlib.Path.home", return_value=tmp_path):
             result = _resolve_mcp_server("nonexistent-server")
         assert result is None
 
-    def test_returns_argv_for_valid_config(self, tmp_path):
+    def test_returns_argv_and_env_for_valid_config(self, tmp_path):
+        _resolve_mcp_server.cache_clear()
         agents_dir = tmp_path / ".kiro" / "agents"
         agents_dir.mkdir(parents=True)
         config = {
@@ -657,7 +659,128 @@ class TestResolveMcpServer:
         (agents_dir / "kirocrew.json").write_text(json.dumps(config))
         with patch("pathlib.Path.home", return_value=tmp_path):
             result = _resolve_mcp_server("test-server")
-        assert result == ("node", "server.js", "--port", "3000")
+        # New shape: (argv, env). No env block in config -> empty env dict.
+        assert result == (("node", "server.js", "--port", "3000"), {})
+
+    def test_returns_env_block_from_config(self, tmp_path):
+        """Regression: the per-server `env` block (e.g. the PATH that makes a
+        launcher's helper binary resolvable) must be returned, not silently
+        dropped."""
+        _resolve_mcp_server.cache_clear()
+        agents_dir = tmp_path / ".kiro" / "agents"
+        agents_dir.mkdir(parents=True)
+        config = {
+            "mcpServers": {
+                "path-server": {
+                    "command": "some-mcp",
+                    "args": ["--mode", "stdio"],
+                    "env": {"PATH": "/custom/path", "MCP_REGION": "us-east-1"},
+                }
+            }
+        }
+        (agents_dir / "kirocrew.json").write_text(json.dumps(config))
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            argv, env = _resolve_mcp_server("path-server")
+        assert argv == ("some-mcp", "--mode", "stdio")
+        assert env == {"PATH": "/custom/path", "MCP_REGION": "us-east-1"}
+
+    def test_env_values_coerced_to_str(self, tmp_path):
+        """env keys/values are stringified so a numeric config value can't crash
+        the subprocess env update."""
+        _resolve_mcp_server.cache_clear()
+        agents_dir = tmp_path / ".kiro" / "agents"
+        agents_dir.mkdir(parents=True)
+        config = {
+            "mcpServers": {
+                "num-env": {
+                    "command": "node",
+                    "args": [],
+                    "env": {"PORT": 3000},
+                }
+            }
+        }
+        (agents_dir / "kirocrew.json").write_text(json.dumps(config))
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            _argv, env = _resolve_mcp_server("num-env")
+        assert env == {"PORT": "3000"}
+
+    @staticmethod
+    def _write_env_config(tmp_path, env_block):
+        """Write an agent config whose sole server declares *env_block*."""
+        agents_dir = tmp_path / ".kiro" / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        (agents_dir / "kirocrew.json").write_text(
+            json.dumps(
+                {"mcpServers": {"bad-env": {"command": "some-mcp", "env": env_block}}}
+            )
+        )
+
+    @pytest.mark.parametrize(
+        "bad_key,bad_value,label",
+        [
+            ("A=B", "v", "'=' in name -> ValueError('illegal environment variable name')"),
+            ("A\0B", "v", "NUL in name -> ValueError('embedded null byte')"),
+            ("A", "v\0w", "NUL in value -> ValueError('embedded null byte')"),
+            ("", "v", "empty name -> unreachable, getenv('') is always NULL"),
+        ],
+    )
+    def test_env_entry_popen_would_reject_is_dropped(
+        self, tmp_path, bad_key, bad_value, label
+    ):
+        """An env pair Popen refuses is dropped here, not carried to the spawn.
+
+        Popen validates the env BEFORE the fork and fails the whole spawn over
+        one bad pair, so carrying any of these through aborted every
+        ``ctx.call_tool`` for the server with a traceback naming Popen instead of
+        the config. Dropping is per-entry: the well-formed sibling must survive,
+        or the fix would trade a crash for the env-drop bug this function exists
+        to fix.
+        """
+        _resolve_mcp_server.cache_clear()
+        self._write_env_config(tmp_path, {bad_key: bad_value, "MCP_REGION": "us-east-1"})
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            _argv, env = _resolve_mcp_server("bad-env")
+        # The malformed entry is gone...
+        assert bad_key not in env, label
+        # ...and the honourable sibling is untouched.
+        assert env == {"MCP_REGION": "us-east-1"}
+
+    @pytest.mark.skipif(
+        not pc.IS_POSIX,
+        reason="asserts the POSIX execve env contract Popen enforces "
+               "(`=`/NUL -> ValueError); Windows validates its env block differently",
+    )
+    def test_resolved_env_clears_the_popen_boundary_that_rejected_it(self, tmp_path):
+        """End of the crash path, asserted where it actually decides.
+
+        The test above proves the pairs are filtered. This one hands both shapes
+        to the real ``Popen`` and pins the difference: the raw config env raises
+        ValueError before any fork, the resolved env gets far enough to fail on
+        the missing binary instead. The baseline half matters -- without it a
+        future refactor that stops filtering would still pass, since a test that
+        only asserts "no ValueError" cannot tell a fixed boundary from one that
+        never rejected anything.
+        """
+        import subprocess
+
+        _resolve_mcp_server.cache_clear()
+        raw_block = {"A=B": "v", "N\0K": "v", "NV": "v\0w", "": "v", "MCP_REGION": "us-east-1"}
+        self._write_env_config(tmp_path, raw_block)
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            _argv, env = _resolve_mcp_server("bad-env")
+
+        missing = str(tmp_path / "does-not-exist")
+        # Baseline: each rejected shape really is a spawn-killer, so the pass
+        # below means the filter worked rather than that Popen tolerates it.
+        # The empty name is absent here on purpose -- Popen accepts it, and it is
+        # dropped for being unreachable by the child rather than for crashing.
+        for key, value in [("A=B", "v"), ("N\0K", "v"), ("NV", "v\0w")]:
+            with pytest.raises(ValueError):
+                subprocess.Popen([missing], env={**env, key: value})
+        # The resolved env clears env encoding and dies on the absent command --
+        # a different failure, reached only after the env was accepted.
+        with pytest.raises(FileNotFoundError):
+            subprocess.Popen([missing], env=env)
 
 
 class TestExceptionClasses:
@@ -707,6 +830,287 @@ class TestMcpToolClient:
         client._sandbox_cleanup = None
         client.close()
         client._proc.terminate.assert_called_once()
+
+    def test_init_passes_spec_env_to_popen_and_scrubs_secrets(self, monkeypatch):
+        """Regression: McpToolClient must hand the spawned MCP subprocess the
+        per-server `env` (so a launcher can resolve its helper binary on PATH)
+        while still scrubbing cron secrets (Slack tokens / owner id)."""
+        from kiro_crew.cron_script import (
+            _CRON_ENV_DENY,
+            McpToolClient,
+            _resolve_mcp_server,
+        )
+
+        _resolve_mcp_server.cache_clear()
+        # A secret that must NEVER reach the child subprocess env...
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-should-not-leak")
+        # ...and an ordinary var that SHOULD be inherited from the cron env.
+        monkeypatch.setenv("KIROCREW_PROBE_VAR", "keep-me")
+
+        # Mock proc whose stdout answers the initialize handshake (id == 1).
+        mock_proc = MagicMock()
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdout = MagicMock()
+        mock_proc.stdout.readline.return_value = (
+            '{"jsonrpc":"2.0","id":1,"result":{}}\n'
+        )
+
+        # The spec env carries the PATH the launcher needs, plus a denied key to
+        # prove the deny-set is applied to the spec overlay too.
+        spec_env = {"PATH": "/custom/launcher/path", "SLACK_BOT_TOKEN": "spec-also-blocked"}
+        with patch(
+            "kiro_crew.cron_script._resolve_mcp_server",
+            return_value=(("some-mcp", "--mode", "stdio"), spec_env),
+        ), patch(
+            "kiro_crew.cron_script.wrap_argv",
+            return_value=(["some-mcp", "--mode", "stdio"], None),
+        ), patch(
+            "kiro_crew.cron_script.cgroup_scope_argv",
+            side_effect=lambda argv: argv,
+        ), patch(
+            "kiro_crew.cron_script.popen_limited", return_value=mock_proc
+        ) as mock_popen:
+            client = McpToolClient("path-server")
+            client.close()
+
+        passed_env = mock_popen.call_args.kwargs["env"]
+        # Spec PATH is forwarded so the launcher can find its helper binary.
+        assert passed_env["PATH"] == "/custom/launcher/path"
+        # Ordinary inherited vars survive.
+        assert passed_env.get("KIROCREW_PROBE_VAR") == "keep-me"
+        # The denied secret is scrubbed from BOTH the inherited env and the
+        # spec overlay (it never reaches the child).
+        assert "SLACK_BOT_TOKEN" not in passed_env
+        assert "SLACK_BOT_TOKEN" in _CRON_ENV_DENY
+
+    def _mock_handshake_proc(self):
+        mock_proc = MagicMock()
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdout = MagicMock()
+        mock_proc.stdout.readline.return_value = '{"jsonrpc":"2.0","id":1,"result":{}}\n'
+        return mock_proc
+
+    def test_init_leaves_an_operator_command_argv0_for_the_spec_path_to_resolve(
+        self, tmp_path, monkeypatch
+    ):
+        """The spawn site must NOT re-pin argv[0].
+
+        Confinement wrappers are pinned to absolute paths by the functions that
+        prepend them (``cgroup_scope_argv``, ``sandbox_exec_argv``), so nothing is
+        left for this spawn site to protect. Re-pinning here would be actively
+        wrong on the fail-open no-sandbox path, where NO wrapper is prepended and
+        argv[0] is the OPERATOR-declared command: resolving that against the
+        gateway's own directories would silently run a different copy than the one
+        the spec ``PATH`` selects -- overriding the very PATH forwarding this PR
+        exists to deliver. Regression guard for that inversion.
+        """
+        from kiro_crew.cron_script import McpToolClient, _resolve_mcp_server
+
+        _resolve_mcp_server.cache_clear()
+
+        # The SAME command name exists in two places: one on the gateway's PATH,
+        # one on the spec PATH. The spec's copy is the one the operator asked for.
+        gateway_dir = tmp_path / "gateway"
+        gateway_dir.mkdir()
+        spec_dir = tmp_path / "spec"
+        spec_dir.mkdir()
+        for d in (gateway_dir, spec_dir):
+            binary = d / "some-mcp"
+            binary.write_text("#!/bin/sh\n")
+            binary.chmod(0o755)
+        monkeypatch.setenv("PATH", str(gateway_dir))
+
+        spec_env = {"PATH": str(spec_dir)}
+        with patch(
+            "kiro_crew.cron_script._resolve_mcp_server",
+            return_value=(("some-mcp",), spec_env),
+        ), patch(
+            # Fail-open no-sandbox path: neither helper prepends a wrapper, so
+            # argv[0] stays the operator's own command.
+            "kiro_crew.cron_script.wrap_argv",
+            return_value=(["some-mcp"], None),
+        ), patch(
+            "kiro_crew.cron_script.cgroup_scope_argv",
+            side_effect=lambda argv: list(argv),
+        ), patch(
+            "kiro_crew.cron_script.popen_limited", return_value=self._mock_handshake_proc()
+        ) as mock_popen:
+            client = McpToolClient("path-server")
+            client.close()
+
+        popen_argv = mock_popen.call_args.args[0]
+        passed_env = mock_popen.call_args.kwargs["env"]
+        # Handed to Popen verbatim -- NOT rewritten to the gateway's copy.
+        assert popen_argv[0] == "some-mcp"
+        assert str(gateway_dir) not in popen_argv[0]
+        # ...so the spec PATH is what resolves it.
+        assert passed_env["PATH"] == str(spec_dir)
+
+    def test_init_drops_loader_injection_keys_from_spec_env(self, monkeypatch):
+        """SECURITY regression: a spec ``env`` must not carry loader/interpreter
+        injection keys into the spawn.
+
+        ``_CRON_ENV_DENY`` covers secrets, NOT ``LD_*``/``DYLD_*``/``PYTHON*``, and
+        the spec env is externally authorable (pasted ``mcpServers`` blocks). Those
+        keys are honoured by the dynamic loader/interpreter INSIDE the confinement
+        wrapper process -- i.e. before the wrapper establishes containment -- so
+        forwarding them is arbitrary pre-confinement code execution. Pinning
+        argv[0] does not help: the loader acts on the pinned binary. The spec env
+        therefore goes through ``env.sanitize_spec_env``, the same filter the
+        discovery probe uses. ``PATH`` is deliberately NOT dropped -- forwarding it
+        is the feature.
+        """
+        from kiro_crew.cron_script import McpToolClient, _resolve_mcp_server
+
+        _resolve_mcp_server.cache_clear()
+        for key in ("LD_PRELOAD", "LD_LIBRARY_PATH", "DYLD_INSERT_LIBRARIES", "PYTHONPATH"):
+            monkeypatch.delenv(key, raising=False)
+
+        spec_env = {
+            "LD_PRELOAD": "/tmp/evil.so",
+            "LD_LIBRARY_PATH": "/tmp/evil-libs",
+            "DYLD_INSERT_LIBRARIES": "/tmp/evil.dylib",
+            "PYTHONPATH": "/tmp/evil-py",
+            # Lowercase reaches the loader on Windows, where env names are
+            # case-insensitive; the sanitizer folds case for that reason.
+            "ld_preload": "/tmp/evil-lower.so",
+            "PATH": "/opt/helper/bin",
+            "MCP_TOKEN": "keep-me",
+        }
+        with patch(
+            "kiro_crew.cron_script._resolve_mcp_server",
+            return_value=(("some-mcp",), spec_env),
+        ), patch(
+            "kiro_crew.cron_script.wrap_argv", return_value=(["some-mcp"], None)
+        ), patch(
+            "kiro_crew.cron_script.cgroup_scope_argv", side_effect=lambda argv: list(argv)
+        ), patch(
+            "kiro_crew.cron_script.popen_limited", return_value=self._mock_handshake_proc()
+        ) as mock_popen:
+            client = McpToolClient("path-server")
+            client.close()
+
+        passed_env = mock_popen.call_args.kwargs["env"]
+        for denied in (
+            "LD_PRELOAD",
+            "LD_LIBRARY_PATH",
+            "DYLD_INSERT_LIBRARIES",
+            "PYTHONPATH",
+            "ld_preload",
+        ):
+            assert denied not in passed_env, f"{denied} reached the spawn"
+        # The point of the PR survives the filter.
+        assert passed_env["PATH"] == "/opt/helper/bin"
+        assert passed_env["MCP_TOKEN"] == "keep-me"
+
+    def test_init_drops_reserved_kirocrew_namespace_from_spec_env(self, monkeypatch):
+        """SECURITY regression: a spec ``env`` must not forge caller identity.
+
+        The server this bridge most often spawns is ``kirocrew-cron`` itself, and
+        ``mcp_cron._caller_is_cli()`` is just ``os.environ.get("KIROCREW_CLI") ==
+        "1"`` -- a true return makes every cron tool skip per-session ownership.
+        So a ``KIROCREW_CLI: "1"`` in that server's ``env`` block would let a
+        SCRIPT CRON present itself as the admin CLI and call ``cron_remove_all``
+        over every session's jobs, plus read every session's rows through
+        ``cron_list``.
+
+        Neither existing filter stops it: ``_CRON_ENV_DENY`` covers secrets and
+        ``KIROCREW_OWNER_ID``, and the loader prefixes cover ``LD_*``/``PYTHON*``.
+        And unlike those, the OS sandbox is not a mitigation at all -- confinement
+        bounds what the child may touch, not whose jobs Kiro Crew believes it
+        owns. Hence the reserved-namespace deny in the shared sanitizer.
+        """
+        from kiro_crew.cron_script import McpToolClient, _resolve_mcp_server
+
+        _resolve_mcp_server.cache_clear()
+        for key in ("KIROCREW_CLI", "KIROCREW_SESSION_KEY", "KIROCREW_HOST_PID"):
+            monkeypatch.delenv(key, raising=False)
+
+        spec_env = {
+            # The reported finding.
+            "KIROCREW_CLI": "1",
+            # Siblings in the same class: two of the three sources the STRICT
+            # session resolver accepts because "an agent cannot write them".
+            "KIROCREW_SESSION_KEY": "some-other-session",
+            "KIROCREW_HOST_PID": "4242",
+            # Lowercase reaches the same lookup on Windows.
+            "kirocrew_cli": "1",
+            # ...and the forwarding this PR exists to deliver still works.
+            "PATH": "/opt/helper/bin",
+            "MCP_TOKEN": "keep-me",
+        }
+        with patch(
+            "kiro_crew.cron_script._resolve_mcp_server",
+            return_value=(("some-mcp",), spec_env),
+        ), patch(
+            "kiro_crew.cron_script.wrap_argv", return_value=(["some-mcp"], None)
+        ), patch(
+            "kiro_crew.cron_script.cgroup_scope_argv", side_effect=lambda argv: list(argv)
+        ), patch(
+            "kiro_crew.cron_script.popen_limited", return_value=self._mock_handshake_proc()
+        ) as mock_popen:
+            client = McpToolClient("kirocrew-cron")
+            client.close()
+
+        passed_env = mock_popen.call_args.kwargs["env"]
+        for denied in (
+            "KIROCREW_CLI",
+            "KIROCREW_SESSION_KEY",
+            "KIROCREW_HOST_PID",
+            "kirocrew_cli",
+        ):
+            assert denied not in passed_env, f"{denied} reached the spawn"
+        assert passed_env["PATH"] == "/opt/helper/bin"
+        assert passed_env["MCP_TOKEN"] == "keep-me"
+
+    def test_caller_is_cli_cannot_be_forged_through_a_cron_spec_env_block(
+        self, monkeypatch
+    ):
+        """The end of the attack path, asserted where it actually decides.
+
+        The test above proves the key never reaches the child env. This one runs
+        the real consumer against that env: ``_caller_is_cli()`` evaluated in the
+        environment the spawned server would have started with must be False, so
+        the admin bypass is unreachable from a cron spec's ``env`` block even if
+        some future refactor changes which filter drops the key.
+
+        SCOPE, deliberately narrow: this covers the ``env`` block only, which is
+        the channel ``sanitize_spec_env`` controls. The same spec's ``command``
+        field is equally config-authored and reaches the identical consumer
+        (``sh -c 'KIROCREW_CLI=1 exec kirocrew-cron'``), so it is a sibling
+        forgery channel this filter does not close and this test does not claim
+        to -- confinement bounds what the child may touch, not whose jobs Kiro
+        Crew believes it owns. Closing it needs consumer-side vouching rather
+        than another deny-list, which is a separate change; naming the boundary
+        here keeps the assertion honest about which half is proven.
+        """
+        from kiro_crew.cron_script import McpToolClient, _resolve_mcp_server
+        from kiro_crew.mcp_cron import _caller_is_cli
+
+        _resolve_mcp_server.cache_clear()
+        monkeypatch.delenv("KIROCREW_CLI", raising=False)
+        # Baseline: the flag really is the bypass, so a False below means the
+        # filter worked rather than that the flag never mattered.
+        monkeypatch.setenv("KIROCREW_CLI", "1")
+        assert _caller_is_cli() is True
+        monkeypatch.delenv("KIROCREW_CLI")
+
+        with patch(
+            "kiro_crew.cron_script._resolve_mcp_server",
+            return_value=(("some-mcp",), {"KIROCREW_CLI": "1"}),
+        ), patch(
+            "kiro_crew.cron_script.wrap_argv", return_value=(["some-mcp"], None)
+        ), patch(
+            "kiro_crew.cron_script.cgroup_scope_argv", side_effect=lambda argv: list(argv)
+        ), patch(
+            "kiro_crew.cron_script.popen_limited", return_value=self._mock_handshake_proc()
+        ) as mock_popen:
+            client = McpToolClient("kirocrew-cron")
+            client.close()
+
+        child_env = mock_popen.call_args.kwargs["env"]
+        with patch.dict("os.environ", child_env, clear=True):
+            assert _caller_is_cli() is False
 
     def test_rpc_disconnect_includes_rc_and_stderr_tail(self, tmp_path):
         """a handshake EOF must surface exit code + stderr tail."""
@@ -1130,16 +1534,19 @@ class TestResolveMcpServerAimFallback:
     """Tests for _resolve_mcp_server AIM agent spec fallback."""
 
     def test_aim_fallback_path(self, tmp_path):
-        # No kirocrew.json, but an AIM agent spec exists
+        # No kirocrew.json, but a fallback agent spec exists
+        _resolve_mcp_server.cache_clear()
         agents_dir = tmp_path / ".kiro" / "agents"
         agents_dir.mkdir(parents=True)
         config = {"mcpServers": {"builder-mcp": {"command": "npx", "args": ["-y", "builder-mcp"]}}}
         (agents_dir / "my-kirocrew-agent.json").write_text(json.dumps(config))
         with patch("pathlib.Path.home", return_value=tmp_path):
             result = _resolve_mcp_server("builder-mcp")
-        assert result == ("npx", "-y", "builder-mcp")
+        # Fallback path returns the same (argv, env) shape; no env block -> {}.
+        assert result == (("npx", "-y", "builder-mcp"), {})
 
     def test_server_not_in_config(self, tmp_path):
+        _resolve_mcp_server.cache_clear()
         agents_dir = tmp_path / ".kiro" / "agents"
         agents_dir.mkdir(parents=True)
         config = {"mcpServers": {"other-server": {"command": "node", "args": []}}}

--- a/test/test_cron_script_more_coverage.py
+++ b/test/test_cron_script_more_coverage.py
@@ -613,7 +613,11 @@ class TestScriptContextAudit:
 @pytest.fixture
 def mcp_spawn(monkeypatch):
     """Patch the spawn chain so McpToolClient never starts a real process."""
-    monkeypatch.setattr(cron_script, "_resolve_mcp_server", lambda name: ("srv-bin", "--stdio"))
+    # _resolve_mcp_server returns (argv, spec_env) — the per-server env block is
+    # forwarded to the spawned server, so the mock must supply both halves.
+    monkeypatch.setattr(
+        cron_script, "_resolve_mcp_server", lambda name: (("srv-bin", "--stdio"), {})
+    )
     monkeypatch.setattr(cron_script, "wrap_argv", lambda argv, **k: (list(argv), None))
     monkeypatch.setattr(cron_script, "cgroup_scope_argv", lambda argv: list(argv))
     state = SimpleNamespace(proc=None, popen_exc=None, calls=[])
@@ -870,7 +874,7 @@ class TestResolveMcpServer:
         )
         monkeypatch.setattr(cron_script, "kiro_agents_dir", lambda: agents)
 
-        assert _resolve_mcp_server("core") == ("node", "srv.js")
+        assert _resolve_mcp_server("core") == (("node", "srv.js"), {})
 
     def test_absent_server_entry_returns_none(self, tmp_path, monkeypatch):
         agents = tmp_path / "agents"
@@ -882,7 +886,7 @@ class TestResolveMcpServer:
 
         assert _resolve_mcp_server("server-b") is None
 
-    def test_argless_spec_yields_a_single_element_tuple(self, tmp_path, monkeypatch):
+    def test_argless_spec_yields_a_single_element_argv(self, tmp_path, monkeypatch):
         agents = tmp_path / "agents"
         agents.mkdir()
         (agents / "kirocrew.json").write_text(
@@ -890,7 +894,7 @@ class TestResolveMcpServer:
         )
         monkeypatch.setattr(cron_script, "kiro_agents_dir", lambda: agents)
 
-        assert _resolve_mcp_server("bare") == ("srv-bin",)
+        assert _resolve_mcp_server("bare") == (("srv-bin",), {})
 
 
 # ── path + secret resolution ──

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -1185,6 +1185,30 @@ class TestSanitizeSpecEnv:
         )
         assert out == {"TOKEN": "t"}
 
+    def test_pythonuserbase_is_dropped(self) -> None:
+        """User-site relocation is the same startup-execution channel.
+
+        ``PYTHONUSERBASE`` moves user-site, and ``site.py`` EXECUTES ``.pth`` lines
+        found there during interpreter startup. The launcher now also runs ``-I
+        -S`` (which is what truly closes this), but the sanitizer is the primary
+        control for any future launcher that forgets those flags, so it must cover
+        the key in its own right.
+        """
+        out = env_mod.sanitize_spec_env(
+            [("PYTHONUSERBASE", "/tmp/evil"), ("pythonuserbase", "/tmp/evil2"), ("OK", "1")]
+        )
+        assert out == {"OK": "1"}
+
+    def test_home_is_deliberately_not_dropped(self) -> None:
+        """Documents a deliberate boundary, so a future reader does not "fix" it.
+
+        ``HOME`` also derives user-site when ``PYTHONUSERBASE`` is unset, but many
+        servers legitimately need it, so stripping it would break real configs. The
+        launcher's ``-I -S`` closes that path instead: with site processing off, no
+        ``.pth`` runs regardless of where the paths point.
+        """
+        assert env_mod.sanitize_spec_env([("HOME", "/home/u")]) == {"HOME": "/home/u"}
+
     def test_benign_env_passes_untouched(self) -> None:
         pairs = [("TOKEN", "t"), ("MODE", "prod"), ("LANG", "C")]
         assert env_mod.sanitize_spec_env(pairs) == dict(pairs)
@@ -1213,6 +1237,96 @@ class TestSanitizeSpecEnv:
         assert out["LD_PRELOAD"] == "/x.so"
 
 
+class TestSanitizeSpecEnvReservedNamespace:
+    """SECURITY: a config-declared ``env`` may not author the ``KIROCREW_``
+    namespace, because that namespace carries the caller identity our own
+    authorization checks read.
+
+    Distinct class from the loader prefixes: confinement does not mitigate it.
+    A sandbox bounds what the child may touch, not whose scheduled jobs Kiro
+    Crew believes the child is entitled to delete.
+    """
+
+    def test_caller_identity_keys_are_dropped(self) -> None:
+        """The four vouched-for identity channels, and the shared secret.
+
+        ``KIROCREW_CLI`` is the admin-bypass flag (``_caller_is_cli``);
+        ``KIROCREW_SESSION_KEY``/``KIROCREW_HOST_PID`` are two of the three
+        sources ``_resolve_session_key_strict`` accepts *on the grounds that an
+        agent cannot write them*; ``KIROCREW_OWNER_ID`` is the Slack owner.
+        """
+        out = env_mod.sanitize_spec_env(
+            [
+                ("KIROCREW_CLI", "1"),
+                ("KIROCREW_SESSION_KEY", "victim-session"),
+                ("KIROCREW_HOST_PID", "4242"),
+                ("KIROCREW_CHANNEL_ID", "C0DEADBEEF"),
+                ("KIROCREW_OWNER_ID", "UATTACKER"),
+                ("KIROCREW_INTERNAL_SECRET", "s3cret"),
+                ("MCP_TOKEN", "keep-me"),
+                ("PATH", "/opt/helper/bin"),
+            ]
+        )
+        assert out == {"MCP_TOKEN": "keep-me", "PATH": "/opt/helper/bin"}
+
+    def test_whole_namespace_is_denied_not_a_key_list(self) -> None:
+        """The point of the prefix: a variable nobody has invented yet is
+        already covered.
+
+        A key-by-key denylist fails open for the next identity variable someone
+        adds, which is why the control is stated as "a config cannot author our
+        namespace" instead.
+        """
+        out = env_mod.sanitize_spec_env(
+            [
+                ("KIROCREW_SANDBOX_LEVEL", "none"),
+                ("KIROCREW_APPROVAL_MODE", "yolo"),
+                ("KIROCREW_NOT_A_REAL_VAR_YET", "x"),
+                ("OK", "1"),
+            ]
+        )
+        assert out == {"OK": "1"}
+
+    def test_matching_is_case_insensitive(self) -> None:
+        """Windows env names are case-insensitive, so ``kirocrew_cli`` reaches
+        ``os.environ.get("KIROCREW_CLI")`` there exactly like the upper spelling.
+        """
+        out = env_mod.sanitize_spec_env(
+            [("kirocrew_cli", "1"), ("KiroCrew_Session_Key", "v"), ("OK", "1")]
+        )
+        assert out == {"OK": "1"}
+
+    def test_unrelated_namespaces_are_untouched(self) -> None:
+        """Scoped deliberately: only OUR namespace is reserved.
+
+        ``MC_*`` is the legacy prefix and carries no identity variable (only
+        ``MC_MCP_SOCKET``/``MC_MCP_LOG``/``MC_GATEWAYD_LOG`` diagnostics), and a
+        server's own ``KIRO*`` settings are its business.
+        """
+        pairs = [
+            ("MC_MCP_LOG", "/tmp/x.log"),
+            ("KIRO_SOMETHING", "1"),
+            ("MY_KIROCREW_VAR", "1"),
+        ]
+        assert env_mod.sanitize_spec_env(pairs) == dict(pairs)
+
+    def test_denying_the_overlay_cannot_strip_an_inherited_value(self) -> None:
+        """Why the namespace deny is safe, stated as a test.
+
+        Callers build the child env from ``os.environ`` FIRST and overlay the
+        spec on top, so a gateway-authored ``KIROCREW_*`` value is inherited
+        regardless. The sanitizer only decides whether a config may OVERRIDE
+        one — so filtering the overlay removes the forgery and keeps the real
+        value.
+        """
+        inherited = {"KIROCREW_HOME": "/real/home", "KIROCREW_CLI": ""}
+        child = dict(inherited)
+        child.update(env_mod.sanitize_spec_env([("KIROCREW_CLI", "1"), ("OK", "1")]))
+        assert child["KIROCREW_HOME"] == "/real/home"
+        assert child["KIROCREW_CLI"] == ""
+        assert child["OK"] == "1"
+
+
 class TestDeniedSpecEnvKeys:
     """The reporting counterpart of the sanitizer: what did policy remove?"""
 
@@ -1234,3 +1348,21 @@ class TestDeniedSpecEnvKeys:
     def test_non_string_keys_are_ignored(self) -> None:
         """Config JSON is unvalidated; a malformed key must not raise here."""
         assert env_mod.denied_spec_env_keys({1: "x"}) == []  # type: ignore[dict-item]
+
+    def test_reserved_namespace_is_deliberately_not_reported(self) -> None:
+        """Pinned so a future change does not "align" the two and make the
+        dashboard lie.
+
+        This function feeds ``_note_denied_env``, whose message says the key
+        "execute[s] in the sandbox launcher before confinement, so the probe
+        cannot honour them — a session still does". Every clause of that is false
+        for ``KIROCREW_CLI``: it is not a launcher-execution channel, and a
+        session must not honour a forged caller identity either. The sanitizer
+        still drops it (log-only); only the user-facing explanation is scoped to
+        the loader class.
+        """
+        env = {"KIROCREW_CLI": "1", "PYTHONPATH": "/srv", "TOKEN": "t"}
+        assert env_mod.denied_spec_env_keys(env) == ["PYTHONPATH"]
+        assert "KIROCREW_CLI" not in env_mod.sanitize_spec_env(
+            [(k, v) for k, v in env.items()]
+        )

--- a/test/test_mcp_discovery.py
+++ b/test/test_mcp_discovery.py
@@ -2502,6 +2502,50 @@ class TestProbeTempContainment:
         root = home / "run" / "mcp-tmp"
         assert not root.exists() or not any(root.iterdir())
 
+    @pytest.mark.asyncio
+    async def test_probe_drops_reserved_kirocrew_namespace_from_spec_env(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """SECURITY: the probe is the SIBLING site of the cron tool bridge.
+
+        Both apply a config-declared ``env`` to a child they spawn themselves, but
+        only ``cron_script`` had a ``KIROCREW_*`` deny (``_CRON_ENV_DENY``, via
+        ``KIROCREW_OWNER_ID``) -- the probe applied none. Putting the
+        reserved-namespace deny in the shared sanitizer rather than in the cron
+        deny-set is what covers this path too, so this test is the reason for that
+        placement. A gateway-authored value must still be INHERITED: the probe
+        builds its env from ``dict(os.environ)`` and only the OVERRIDE is refused.
+        """
+        import sys
+
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "real-home"))
+        monkeypatch.delenv("KIROCREW_CLI", raising=False)
+
+        server = McpServerInfo(
+            name="identity-forger",
+            command=sys.executable,
+            args=["-c", "pass"],
+            env={
+                "KIROCREW_CLI": "1",
+                "KIROCREW_SESSION_KEY": "some-other-session",
+                "KIROCREW_HOME": str(tmp_path / "attacker-home"),
+                "MCP_TOKEN": "keep-me",
+            },
+        )
+        with patch(
+            "kiro_crew.mcp_discovery.create_subprocess_limited",
+            new_callable=AsyncMock,
+            side_effect=OSError("stop after env capture"),
+        ) as spawn_mock:
+            await probe_server(server)
+
+        captured = spawn_mock.call_args.kwargs["env"]
+        assert "KIROCREW_CLI" not in captured
+        assert "KIROCREW_SESSION_KEY" not in captured
+        # Inherited value survives; the spec's override of it does not.
+        assert captured["KIROCREW_HOME"] == str(tmp_path / "real-home")
+        assert captured["MCP_TOKEN"] == "keep-me"
+
     @pytest.mark.skipif(
         not platform_compat.IS_POSIX,
         reason="POSIX-only control: on Windows the finally-path deferral to the "

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -8,6 +8,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -136,7 +137,14 @@ class TestWrapArgv:
     @patch("kiro_crew.sandbox.detect_backend", return_value="namespace")
     @patch("kiro_crew.sandbox.namespace_argv")
     def test_namespace_backend(self, mock_ns_argv, mock_detect):
-        mock_ns_argv.return_value = [sys.executable, "/tmp/launcher.py", "kiro-cli"]
+        # Stub must carry the real shape: [python, *flags, script, *argv]. Without
+        # the flags, wrap_argv's cleanup-path lookup reads past the end.
+        mock_ns_argv.return_value = [
+            sys.executable,
+            *sandbox_mod._LAUNCHER_INTERPRETER_FLAGS,
+            "/tmp/launcher.py",
+            "kiro-cli",
+        ]
         result, cleanup = wrap_argv(["kiro-cli"], mode="strict")
         mock_ns_argv.assert_called_once_with(["kiro-cli"], "strict", strip_python_env=False)
 
@@ -796,8 +804,14 @@ class TestSandboxExecArgv:
         try:
             marker = f"{sandbox_mod._IN_SANDBOX_MARKER}=1"
             assert marker in argv
-            assert argv.index(marker) < argv.index("sandbox-exec")
-            assert argv[0] == "env"
+            # The confiner is emitted as an absolute path, not a bare name, so a
+            # PATH overlay handed to the outer ``env`` cannot redirect it (see
+            # TestSandboxExecArgvPinsInnerConfiner). Locate it by basename.
+            confiner = next(i for i, a in enumerate(argv) if os.path.basename(a) == "sandbox-exec")
+            assert argv.index(marker) < confiner
+            # Both wrappers are absolute for the same reason, so the outer ``env``
+            # is matched by basename too.
+            assert os.path.basename(argv[0]) == "env"
         finally:
             if profile_path:
                 os.unlink(profile_path)
@@ -806,11 +820,13 @@ class TestSandboxExecArgv:
     def test_includes_env_unset_flags(self):
         argv, profile_path = sandbox_exec_argv(["kiro-cli", "acp"], "strict")
         try:
-            assert "env" == argv[0]
+            assert os.path.basename(argv[0]) == "env"
             assert "-u" in argv
             assert "AWS_SECRET_ACCESS_KEY" in argv
             assert "SSH_AUTH_SOCK" in argv
-            assert "sandbox-exec" in argv
+            # Absolute, not a bare name — the confiner is pinned so an overlaid
+            # PATH cannot redirect it (see TestSandboxExecArgvPinsInnerConfiner).
+            assert any(os.path.basename(a) == "sandbox-exec" for a in argv)
             assert "-f" in argv
             assert profile_path is not None
             assert os.path.exists(profile_path)
@@ -862,19 +878,165 @@ class TestNamespaceArgv:
     def test_wraps_with_python_launcher(self, mock_resolve):
         result = namespace_argv(["kiro-cli", "acp"], "strict")
         assert result[0] == sys.executable
-        assert result[1].endswith(".py")
-        assert result[2] == "/usr/local/bin/kiro-cli"
-        assert result[3] == "acp"
+        assert result[1] == "-I"
+        assert result[2] == "-S"
+        assert result[3].endswith(".py")
+        assert result[4] == "/usr/local/bin/kiro-cli"
+        assert result[5] == "acp"
         # Cleanup temp file
-        os.unlink(result[1])
+        os.unlink(result[3])
 
     @patch("kiro_crew.sandbox._resolve_agent_executable", return_value="/usr/local/bin/kiro-cli")
     def test_launcher_script_is_executable(self, mock_resolve):
         result = namespace_argv(["kiro-cli"], "strict")
-        launcher_path = result[1]
+        launcher_path = result[3]
         mode = os.stat(launcher_path).st_mode
         assert mode & 0o700 == 0o700
         os.unlink(launcher_path)
+
+    @patch("kiro_crew.sandbox._resolve_agent_executable", return_value="/usr/local/bin/kiro-cli")
+    def test_launcher_flags_precede_the_script_path(self, mock_resolve):
+        """``-I -S`` must precede the script, or they are script args not flags.
+
+        Everything the interpreter does at startup happens BEFORE the launcher
+        reaches ``unshare``. With site processing on, a ``PYTHONUSERBASE``/``HOME``
+        taken from a config-declared server ``env`` relocates user-site, whose
+        ``.pth`` files EXECUTE during startup -- unconfined code, which no argv[0]
+        pin can stop because the interpreter is the pinned binary.
+        """
+        result = namespace_argv(["kiro-cli"], "strict")
+        script = next(a for a in result if a.endswith(".py"))
+        try:
+            flags = result[1 : result.index(script)]
+            assert "-I" in flags, f"-I must be an interpreter flag, got {result!r}"
+            assert "-S" in flags, f"-S must be an interpreter flag, got {result!r}"
+        finally:
+            os.unlink(script)
+
+    @patch("kiro_crew.sandbox._resolve_agent_executable", return_value="/bin/true")
+    def test_launcher_flags_block_startup_code_execution(self, mock_resolve):
+        """End-to-end: the emitted flags must neutralise env-driven startup code.
+
+        Runs the REAL interpreter with the REAL flags ``namespace_argv`` emits and
+        an env that would otherwise execute attacker code during startup — i.e.
+        before the launcher script reaches ``unshare``, so outside any confinement.
+
+        Uses ``sitecustomize`` (imported by ``site`` at startup) rather than a
+        user-site ``.pth``: ``site.ENABLE_USER_SITE`` is False inside a virtualenv,
+        so a user-site fixture is silently inert under the project's own test venv
+        and would prove nothing. Both are the same class — code ``site`` runs at
+        startup from env-derived paths — and ``-S`` (no ``site`` at all) closes the
+        class rather than either instance. The self-check below enforces that the
+        fixture is live, so this cannot rot into a vacuous pass.
+        """
+        result = namespace_argv(["/bin/true"], "strict")
+        script = next(a for a in result if a.endswith(".py"))
+        flags = result[1 : result.index(script)]
+        try:
+            with tempfile.TemporaryDirectory() as payload_dir:
+                marker = Path(payload_dir) / "pwned"
+                Path(payload_dir, "sitecustomize.py").write_text(
+                    f"import pathlib; pathlib.Path({str(marker)!r}).write_text('x')\n",
+                    encoding="utf-8",
+                )
+                env = dict(os.environ)
+                env["PYTHONPATH"] = payload_dir
+
+                # Self-check: WITHOUT the flags the payload must fire, otherwise a
+                # pass below would mean nothing.
+                subprocess.run(
+                    [result[0], "-c", "pass"], env=env, capture_output=True, timeout=60
+                )
+                assert marker.exists(), (
+                    "fixture is inert: payload did not execute even WITHOUT the "
+                    "hardening flags, so this test proves nothing"
+                )
+                marker.unlink()
+
+                subprocess.run(
+                    [result[0], *flags, "-c", "pass"],
+                    env=env,
+                    capture_output=True,
+                    timeout=60,
+                )
+                assert not marker.exists(), (
+                    "env-derived code executed at interpreter startup despite the "
+                    "launcher flags; that runs unconfined, before unshare"
+                )
+        finally:
+            os.unlink(script)
+
+
+@_POSIX_ONLY
+class TestLauncherCleanupPath:
+    """``wrap_argv`` must hand back the script path, never an interpreter flag.
+
+    Regression guard for a real break introduced while adding ``-I -S``: the
+    namespace branch returned a hardcoded ``wrapped[1]`` as the tempfile to delete.
+    Once flags sat between the executable and the script that became ``"-I"``, so
+    every launcher script leaked and the caller tried to ``unlink("-I")``.
+    """
+
+    @patch("kiro_crew.sandbox.detect_backend", return_value="namespace")
+    @patch("kiro_crew.sandbox._resolve_agent_executable", return_value="/bin/true")
+    def test_cleanup_path_is_the_script_not_a_flag(self, _mock_resolve, _mock_backend):
+        argv, cleanup = wrap_argv(["/bin/true"], mode="standard")
+        try:
+            assert cleanup is not None
+            assert not cleanup.startswith("-"), f"cleanup is a flag, not a path: {cleanup!r}"
+            assert cleanup.endswith(".py")
+            assert os.path.exists(cleanup), "cleanup path must be the real tempfile"
+            assert cleanup in argv
+        finally:
+            if cleanup and os.path.exists(cleanup):
+                os.unlink(cleanup)
+
+    def test_accessor_tracks_the_flag_tuple(self):
+        """The accessor must be derived from the flag list, not a constant.
+
+        Simulates a future flag being added: if the offset were hardcoded this
+        returns a flag instead of the path.
+        """
+        with patch.object(sandbox_mod, "_LAUNCHER_INTERPRETER_FLAGS", ("-I", "-S", "-X", "y")):
+            fake = ["/usr/bin/python", "-I", "-S", "-X", "y", "/run/l.py", "cmd"]
+            assert sandbox_mod._launcher_script_of(fake) == "/run/l.py"
+
+
+@_POSIX_ONLY
+class TestPinnedEnvBin:
+    """The credential scrub's own binary must not be PATH-redirectable.
+
+    On the delegation paths no Seatbelt/namespace layer wraps the child, so
+    ``env -u KEY ...`` IS the only control stripping Slack tokens / owner id. A
+    bare ``"env"`` token resolves through the PATH we hand ``Popen`` -- which on
+    the script-cron MCP path can come from a config-declared ``env`` block. If it
+    is redirected the scrub never runs and the child inherits the credentials.
+    """
+
+    def test_pins_absolute_path_from_trusted_system_bin(self):
+        with patch(
+            "kiro_crew.platform_compat.trusted_system_bin",
+            return_value="/usr/bin/env",
+        ):
+            assert sandbox_mod._pinned_env_bin() == "/usr/bin/env"
+
+    def test_falls_back_to_canonical_location_not_bare_name(self):
+        with patch("kiro_crew.platform_compat.trusted_system_bin", return_value=None):
+            resolved = sandbox_mod._pinned_env_bin()
+        assert os.path.isabs(resolved), f"fallback must be absolute, got {resolved!r}"
+        assert resolved == "/usr/bin/env"
+
+    def test_no_producer_emits_a_bare_env_token(self):
+        """Guards the sibling-site class across all producers.
+
+        Two delegation returns plus ``sandbox_exec_argv`` build an ``env`` prefix;
+        a future producer could reintroduce the bare form, which is invisible in
+        review because it looks identical to the pinned one at the call site.
+        """
+        source = Path(sandbox_mod.__file__).read_text(encoding="utf-8")
+        assert '["env",' not in source, (
+            'a bare ["env", ...] argv prefix is PATH-redirectable; use _pinned_env_bin()'
+        )
 
 
 class TestSshSupportsAcceptNew:
@@ -1182,7 +1344,9 @@ class TestCgroupScopeArgv:
                 patch("kiro_crew.sandbox._cpu_controller_delegated", return_value=True),
             ):
                 out = sb.cgroup_scope_argv(["kiro-cli", "chat"])
-            assert out[0] == "systemd-run"
+            # Absolute: the wrapper is pinned where it is prepended, so a caller
+            # passing a config-declared PATH in env= cannot redirect argv[0].
+            assert os.path.basename(out[0]) == "systemd-run"
             assert "--user" in out and "--scope" in out
             assert "TasksMax=8192" in out
             assert "MemoryMax=8192M" in out
@@ -1254,7 +1418,7 @@ class TestCgroupScopeArgv:
                 patch("kiro_crew.sandbox._cpu_controller_delegated", return_value=False),
             ):
                 out = sb.cgroup_scope_argv(["kiro-cli", "chat"])
-            assert out[0] == "systemd-run"
+            assert os.path.basename(out[0]) == "systemd-run"
             assert "TasksMax=8192" in out
             assert not any(a.startswith("CPUWeight=") for a in out)
             assert not any(a.startswith("CPUQuota=") for a in out)
@@ -1943,7 +2107,7 @@ class TestCgroupScopeBusEnv:
                     ["gh", "pr", "view"],
                     env={"PATH": "/usr/bin:/bin", "HOME": "/home/u"},
                 )
-            assert argv[0] == "systemd-run"
+            assert os.path.basename(argv[0]) == "systemd-run"
             assert env["XDG_RUNTIME_DIR"] == "/run/user/4242"
             assert env["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/run/user/4242/bus"
             # The shim sits INSIDE the scope, immediately after `--`, so the real
@@ -2077,7 +2241,11 @@ class TestKiroInternalSandboxExclusion:
         monkeypatch.setattr("kiro_crew.sandbox.sys.platform", "darwin")
         monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "sentinel")
         argv, _ = wrap_argv(["kiro-cli", "acp"], mode="auto")
-        assert argv[0] == "env"
+        # Absolute, not the bare "env": this path applies no Seatbelt of ours, so
+        # the scrub IS the only control here -- a PATH-redirectable scrubber means
+        # the scrub silently never runs and the child keeps the credentials.
+        assert os.path.isabs(argv[0]), f"scrubber must be pinned, got {argv[0]!r}"
+        assert os.path.basename(argv[0]) == "env"
         assert "-u" in argv
         assert "AWS_SECRET_ACCESS_KEY" in argv
 
@@ -2117,7 +2285,12 @@ class TestKiroInternalSandboxExclusion:
             patch("kiro_crew.sandbox.detect_backend", return_value="namespace"),
             patch(
                 "kiro_crew.sandbox.namespace_argv",
-                return_value=["/bin/sh", "/tmp/launcher.sh", "kiro-cli"],
+                return_value=[
+                    sys.executable,
+                    *sandbox_mod._LAUNCHER_INTERPRETER_FLAGS,
+                    "/tmp/launcher.py",
+                    "kiro-cli",
+                ],
             ) as mock_ns,
         ):
             wrap_argv(["kiro-cli", "acp"], mode="auto")
@@ -2797,3 +2970,88 @@ class TestAgentSliceMemoryHigh:
         with patch.object(sb, "_USER_MANAGER_CGROUP_BASE", str(tmp_path)):
             assert sb._agents_slice_cgroup_dir() == nested
             assert sb._slice_memory_events_high() == 7
+
+
+class TestSandboxExecArgvPinsInnerConfiner:
+    """SECURITY (PR #2602 macOS hop): the outer ``env`` (argv[0]) is pinned to an
+    absolute path at the spawn site, but ``env`` then resolves the NEXT bare name
+    -- ``sandbox-exec``, the inner confiner -- through the PATH it is handed, which
+    may carry a per-server config PATH overlay. ``sandbox_exec_argv`` must emit
+    ``sandbox-exec`` as an absolute path so a hostile PATH cannot redirect it.
+
+    Pure argv-construction assertions: no macOS dependency, so they run on Linux
+    CI (where ``sandbox-exec`` is absent and the canonical fallback applies).
+    """
+
+    def test_sandbox_exec_token_is_absolute(self):
+        argv, cleanup = sandbox_exec_argv(["echo", "hi"], sandbox_level="standard")
+        try:
+            # The bare name must NOT appear as its own argv token.
+            assert "sandbox-exec" not in argv
+            # An absolute path ending in /sandbox-exec is present instead, and it
+            # is immediately followed by the ``-f <profile>`` flags.
+            sb = next(a for a in argv if a.endswith("sandbox-exec"))
+            assert os.path.isabs(sb), f"sandbox-exec must be absolute, got {sb!r}"
+            assert argv[argv.index(sb) + 1] == "-f"
+        finally:
+            if cleanup:
+                os.unlink(cleanup)
+
+    def test_cgroup_wrapper_is_absolute_or_refused(self):
+        """``cgroup_scope_argv`` pins the ``systemd-run`` IT prepends.
+
+        Callers hand the result to spawns whose ``env`` may carry a config-declared
+        PATH, and CPython resolves a slash-less argv[0] through that PATH -- so a
+        bare wrapper here is an exec-hijack channel that runs before ``--scope``
+        confines anything. When the wrapper is not in a trusted system directory
+        the function degrades to no cgroup ceiling (its documented fail-open) rather
+        than emitting an unpinned name: losing a DoS ceiling beats gaining an
+        arbitrary-exec channel.
+        """
+        with patch.object(sandbox_mod, "_probe_cgroup_scope", return_value=(True, "")), patch.object(
+            sandbox_mod, "_reconcile_slice_memory_high_off_thread"
+        ), patch.object(sandbox_mod, "_cpu_controller_delegated", return_value=False):
+            with patch.object(
+                sandbox_mod.platform_compat, "trusted_system_bin", return_value="/usr/bin/systemd-run"
+            ):
+                pinned = sandbox_mod.cgroup_scope_argv(["kiro-cli", "chat"])
+            assert pinned[0] == "/usr/bin/systemd-run"
+            assert "systemd-run" not in pinned
+
+            # Unresolvable -> no wrapper at all, never a bare name.
+            with patch.object(
+                sandbox_mod.platform_compat, "trusted_system_bin", return_value=None
+            ):
+                unwrapped = sandbox_mod.cgroup_scope_argv(["kiro-cli", "chat"])
+            assert unwrapped == ["kiro-cli", "chat"]
+
+    def test_outer_env_token_is_absolute(self):
+        """argv[0] runs FIRST of all, so it is pinned for the same reason.
+
+        It is resolved through ``trusted_system_bin`` (fixed system directories,
+        PATH ignored) rather than the gateway's PATH, which can legitimately lead
+        with agent-writable directories.
+        """
+        argv, cleanup = sandbox_exec_argv(["echo", "hi"], sandbox_level="standard")
+        try:
+            assert argv[0] != "env"
+            assert os.path.isabs(argv[0]), f"outer env must be absolute, got {argv[0]!r}"
+            assert os.path.basename(argv[0]) == "env"
+        finally:
+            if cleanup:
+                os.unlink(cleanup)
+
+    def test_falls_back_to_canonical_paths_when_not_resolvable(self):
+        """When a wrapper is not in a trusted system directory (e.g. ``sandbox-exec``
+        on Linux CI), the canonical macOS location is used -- never a bare name a
+        PATH overlay could redirect."""
+        with patch.object(sandbox_mod.platform_compat, "trusted_system_bin", return_value=None):
+            argv, cleanup = sandbox_exec_argv(["echo", "hi"], sandbox_level="standard")
+        try:
+            assert argv[0] == "/usr/bin/env"
+            assert "/usr/bin/sandbox-exec" in argv
+            assert "sandbox-exec" not in argv
+            assert "env" not in argv
+        finally:
+            if cleanup:
+                os.unlink(cleanup)

--- a/test/test_sandbox_default_fix.py
+++ b/test/test_sandbox_default_fix.py
@@ -13,6 +13,7 @@ Verifies the fixes from the security audit:
 from __future__ import annotations
 
 import logging
+import os
 import sys
 
 import pytest
@@ -76,8 +77,11 @@ class TestFix2DelegationVerification:
         monkeypatch.setenv("SSH_AUTH_SOCK", "/tmp/agent.sock")
 
         argv, cleanup = sb.wrap_argv(["kiro-cli", "chat"], mode="off", is_kiro_cli=True)
-        # Should have env -u prefix (scrubbing the sensitive var)
-        assert argv[0] == "env", "expected env scrub prefix on delegation"
+        # Should have env -u prefix (scrubbing the sensitive var), pinned absolute:
+        # this path applies no confinement of ours, so the scrub is the only
+        # control, and a PATH-redirectable scrubber means it silently never runs.
+        assert os.path.isabs(argv[0]), f"expected pinned env scrubber, got {argv[0]!r}"
+        assert os.path.basename(argv[0]) == "env", "expected env scrub prefix on delegation"
         assert "-u" in argv
         assert "kiro-cli" in argv
         assert cleanup is None  # No seatbelt profile to clean up

--- a/test/test_sandbox_first_party_exec.py
+++ b/test/test_sandbox_first_party_exec.py
@@ -337,7 +337,9 @@ class TestFlagIsOtherwiseInert:
         assert with_flag == without_flag == (_ARGV, None)
 
     def test_backend_available_flag_is_inert(self, monkeypatch):
-        stub = ["launcher", "/tmp/launcher.py", *_ARGV]
+        # Real namespace_argv shape: [python, *interpreter_flags, script, *argv].
+        script = "/tmp/launcher.py"
+        stub = ["launcher", *sandbox_mod._LAUNCHER_INTERPRETER_FLAGS, script, *_ARGV]
         monkeypatch.setattr(
             sandbox_mod, "detect_backend", lambda config_mode="auto": "namespace"
         )
@@ -346,7 +348,7 @@ class TestFlagIsOtherwiseInert:
         )
         with_flag = wrap_argv(_ARGV, mode="standard", first_party_fixed_argv=True)
         without_flag = wrap_argv(_ARGV, mode="standard")
-        assert with_flag == without_flag == (stub, stub[1])
+        assert with_flag == without_flag == (stub, script)
 
 
 class TestChokepointThreading:

--- a/test/test_sandbox_launcher_sweep.py
+++ b/test/test_sandbox_launcher_sweep.py
@@ -62,20 +62,31 @@ def _isolated_legacy_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 class TestNamespaceArgvPlacement:
     """namespace_argv() launcher lands in ~/.kirocrew/run/ with PID."""
 
+    @staticmethod
+    def _launcher_of(argv: list[str]) -> str:
+        """The generated launcher script within *argv*.
+
+        Located by suffix rather than a fixed index: the argv is
+        ``[python, *interpreter_flags, launcher_path, *real_argv]`` and that flag
+        list is itself a security control that can legitimately grow (it gained
+        ``-I -S`` to stop startup-time code execution), so indexing would make
+        these placement tests break on unrelated hardening.
+        """
+        return next(a for a in argv if a.endswith(".py"))
+
     @patch("kiro_crew.sandbox.detect_backend", return_value="namespace")
     def test_launcher_in_run_dir(self, _mock_detect, fake_home: Path):
         run_dir = fake_home / ".kirocrew" / "run"
         result = namespace_argv(["kiro-cli", "--version"])
 
-        # Result should be [python, launcher_path, *real_argv]
         assert len(result) >= 2
-        launcher = result[1]
+        launcher = self._launcher_of(result)
         assert launcher.startswith(str(run_dir)), f"launcher {launcher} not under {run_dir}"
 
     @patch("kiro_crew.sandbox.detect_backend", return_value="namespace")
     def test_launcher_has_pid_in_name(self, _mock_detect, fake_home: Path):
         result = namespace_argv(["kiro-cli", "--version"])
-        launcher = Path(result[1])
+        launcher = Path(self._launcher_of(result))
         # Filename pattern: kirocrew_sandbox_{pid}_{random}.py
         assert launcher.name.startswith(f"kirocrew_sandbox_{os.getpid()}_")
         assert launcher.suffix == ".py"
@@ -83,7 +94,7 @@ class TestNamespaceArgvPlacement:
     @patch("kiro_crew.sandbox.detect_backend", return_value="namespace")
     def test_launcher_is_executable(self, _mock_detect, fake_home: Path):
         result = namespace_argv(["kiro-cli", "--version"])
-        launcher = result[1]
+        launcher = self._launcher_of(result)
         stat = os.stat(launcher)
         assert stat.st_mode & 0o700 == 0o700
 

--- a/test/test_sandbox_nested_tier.py
+++ b/test/test_sandbox_nested_tier.py
@@ -80,7 +80,9 @@ class TestLauncherExportsLevel:
         monkeypatch.setattr(sandbox_mod, "_ensure_run_dir", lambda: str(tmp_path))
         wrapped, profile = sandbox_exec_argv(["echo", "hi"], level)
         try:
-            assert wrapped[0] == "env"
+            # Absolute: the wrapper is pinned where it is prepended, so a
+            # config-declared PATH in a caller's env= cannot redirect argv[0].
+            assert os.path.basename(wrapped[0]) == "env"
             assert f"KIROCREW_SANDBOX_LEVEL={level}" in wrapped
             # Positioned after every -u flag so the scrub cannot drop it —
             # same non-droppable placement as the ACTIVE marker.


### PR DESCRIPTION
## Problem / Motivation

`_resolve_mcp_server` dropped the agent config's per-server `env` block, so `McpToolClient` spawned the MCP server subprocess with no `env=`. A launcher that shells out to a helper binary reachable **only** via the `PATH` that env block supplies then runs without it — the binary is not found, the server dies before the JSON-RPC `initialize` handshake, and the failure surfaces as a generic "disconnected during initialize". After 5 consecutive failures the cron circuit breaker auto-pauses the job, so `ctx.call_tool()` from a script cron silently stops working for any MCP server that relies on a config-supplied env.

Forwarding that env is a two-line fix in isolation. It is not safe in isolation, and most of this diff is the reason why: the moment a config-authored `env` reaches `Popen`, three pre-existing assumptions elsewhere in the spawn chain stop holding. Each was found by a review round on this PR, and each is load-bearing rather than incidental hardening — see **Why the diff is larger than the headline fix** below.

## Why it matters

- **Reliability:** any script cron that calls `ctx.call_tool()` against an MCP server needing a config-supplied `PATH` silently stops working, and the circuit breaker then auto-pauses the entire cron job after 5 failures — a zero-token deterministic polling cron just quietly dies with only "disconnected during initialize" to debug from.
- **Confinement ordering:** a config `env` block is externally authorable text (people paste `mcpServers` blocks). Both the dynamic loader (`LD_*`/`DYLD_*`) and Python's own startup (`site` executing `.pth` / `sitecustomize`) act **before** the sandbox launcher reaches `unshare`, and `PATH` resolution of a slash-less `argv[0]` happens before any confinement wrapper runs. Forwarding an unfiltered env would therefore convert a reliability fix into a pre-confinement arbitrary-execution channel.
- **Authorization:** separately from containment, several `KIROCREW_*` variables are how the gateway tells a spawned process *who is calling*, and the consumers treat them as vouched-for. Confinement does not bound that class at all — a sandbox limits what the child may touch, not whose jobs Kiro Crew believes the child owns.

## What changed (motivation → approach → change)

**Root cause:** `_resolve_mcp_server` returned only `argv` and never read the per-server `env` block, so `McpToolClient` called `Popen` with no `env=` and dropped the config `PATH` the launcher needed.

**Approach:** carry the per-server env through resolution and overlay it onto the already-secret-scrubbed cron env when spawning — then close each channel that a config-authored env would otherwise open, at the layer that owns it rather than at the spawn site.

**Change:**

### `src/kiro_crew/cron_script.py`

- `_resolve_mcp_server` now returns `(argv, env)` instead of just `argv`, reading the per-server `env` block from `mcpServers[name]` and stringifying keys/values so a numeric config value cannot crash the env update. The no-config path still returns `None`; a resolved server with no `env` block returns an empty dict.
- A non-object `env` (`"env": "PATH=/x"`) previously reached `.items()` and raised `AttributeError`, failing **every** `ctx.call_tool` for that server with a traceback naming `_resolve_mcp_server` rather than the malformed config. It is now treated as absent and logged once, so the ignored declaration is not a silent drop.
- `McpToolClient.__init__` unpacks `(argv, spec_env)` and builds the child env through three filters, each of which is load-bearing:
  - `_clean_cron_env()` strips secrets from the **inherited** env;
  - `_CRON_ENV_DENY` is re-applied to the spec overlay, so a denied key cannot be reintroduced through the config;
  - `env.sanitize_spec_env()` drops the loader/interpreter channels and the reserved `KIROCREW_` namespace (below).
  `PATH` is deliberately **not** denied — forwarding it is the point.

### `src/kiro_crew/env.py`

- `sanitize_spec_env()` now drops two independent classes, for two different reasons:
  - **`_SPEC_ENV_DENIED_PREFIXES`** (loader/interpreter): `LD_*`, `DYLD_*`, and the specific `PYTHONPATH` / `PYTHONHOME` / `PYTHONSTARTUP` / `PYTHONUSERBASE` startup channels. `PYTHONUSERBASE` is new here — it relocates user-site, whose `.pth` files are *executed* during interpreter startup. **This is a prefix set, not the glob `PYTHON*`**, and the in-code comment that previously claimed otherwise has been corrected; it overstated the guarantee.
  - **`_SPEC_ENV_RESERVED_PREFIXES`** (`KIROCREW_`): an *authorization* boundary, not a containment one. `mcp_cron._caller_is_cli()` is exactly `os.environ.get("KIROCREW_CLI") == "1"`, and a true return makes the cron tools skip per-session ownership entirely — so a `KIROCREW_CLI: "1"` in the `env` block of the server this bridge most often spawns (`kirocrew-cron` itself) would let a **script cron** present itself as the admin CLI, turning `cron_remove_all` into "delete every session's jobs" and `cron_list` into the cross-principal disclosure `mcp_cron` explicitly refuses. `KIROCREW_SESSION_KEY` / `KIROCREW_HOST_PID` are two of the three sources `mcp_core._resolve_session_key_strict()` accepts *precisely because* they are, in its own words, sources "the gateway authors and an agent cannot write" — a spec overlay authoring one makes that claim false.
- Two choices there are deliberate and are documented in-code:
  - It denies the **namespace**, not those five keys. Dozens of `KIROCREW_*` variables are read across the tree (several security-relevant beyond identity — sandbox level, approval mode, admission policy), and a key list fails open for the next one somebody adds.
  - It lives in the **shared sanitizer** rather than in `_CRON_ENV_DENY`, because the discovery probe applies no cron deny-set at all — one control covers both spawn paths instead of two copies that can drift.
- Denying the namespace cannot strip a *gateway-authored* value: every caller builds the child env from `os.environ` first and overlays the spec on top, so only a config's ability to **override** one is removed.
- `denied_spec_env_keys()` stays **loader-only** on purpose. Its consumer tells the reader the key "execute[s] in the sandbox launcher before confinement … a session still does", and every clause of that is false for a forged identity. Reserved-namespace drops are log-only — a policy violation to record, not a working server to apologise to, and not a hint sheet for the identity boundary.

### `src/kiro_crew/sandbox.py`

- **Launcher interpreter flags.** `namespace_argv` now emits `[sys.executable, "-I", "-S", <script>, *argv]`. Everything the interpreter does at startup happens before the launcher script reaches `unshare`, so with site processing enabled `site` executes env-derived code (`.pth` from `PYTHONUSERBASE`, else `HOME`; `sitecustomize` from `PYTHONPATH`) unconfined. No `argv[0]` pin helps — the interpreter *is* the pinned binary. `-I` ignores `PYTHON*` startup vars (implies `-E -s`); `-S` skips `site` altogether, which closes the class rather than individual keys. Safe because the generated launcher imports stdlib only and never needs site-packages. The namespace probe and spawn shims already started their interpreters with these exact flags — this launcher was the one Python entrypoint that did not, so this brings it in line rather than inventing a control.
  - Key-listing alone would not have closed it: `HOME` also derives the user-site path when `PYTHONUSERBASE` is unset, and stripping `HOME` from a spec overlay would break servers that legitimately need it.
  - The flags are a named constant (`_LAUNCHER_INTERPRETER_FLAGS`) read through `_launcher_script_of()`, so the caller's cleanup path derives the tempfile position from the flag count instead of a hardcoded `argv[1]`. Hardcoding would leak the tempfile *and* hand the caller `"-I"` to `unlink` the moment the flag list changes.
- **Wrapper pinning, at the producer.** Every wrapper is pinned by the function that **prepends** it, so no spawn site has to remember:
  - `sandbox_exec_argv` pins **both** the outer `env` (argv[0], first to run) and the inner `sandbox-exec` that `env` resolves through the PATH it is handed *before* the Seatbelt profile applies.
  - `cgroup_scope_argv` pins the `systemd-run` it prepends; when that is not in a trusted system directory it degrades to no cgroup ceiling — its documented fail-open — rather than emitting an unpinned name. Losing a DoS ceiling beats gaining an arbitrary-exec channel.
  - The two **delegation** producers (`_delegate_to_kiro_internal_sandbox`, and `wrap_argv`'s `mode="off"` branch) previously returned a bare `["env", *unset_args, *argv]`. They now share `_pinned_env_bin()`. The impact here is narrower than "attacker binary before confinement" and worse: these paths apply no confinement of ours *by design* (nested Seatbelt is impossible; kiro-cli confines itself), so there is no confinement layer to get in front of. What `env -u` does on these paths is the **credential scrub** — it is the only control stripping the Slack tokens and owner id. Redirect `env` and the scrub silently never runs.
  - Resolution goes through `platform_compat.trusted_system_bin`, which ignores `PATH` entirely (fixed system dirs only), **not** `shutil.which`: a gateway's PATH can legitimately lead with agent-writable directories (a worktree venv's `bin`, `~/.local/bin`), so resolving through it would leave the hole half-open. *(An earlier revision of this PR used `shutil.which` at the spawn site; both choices were corrected in review.)*
- `McpToolClient` deliberately does **not** re-pin. On the fail-open no-sandbox path no wrapper is prepended and `argv[0]` is the **operator-declared** command; resolving that against the gateway's own directories would silently run a different copy than the spec `PATH` selects, overriding the forwarding this change exists to deliver.

## Why the diff is larger than the headline fix

Flagged in review as scope creep, so stating the provenance explicitly: none of the hardening above is drive-by. Each hunk exists because a review round on **this** PR identified the env-forwarding fix as what makes that channel reachable.

| Hunk | Origin |
| --- | --- |
| Loader-key filtering (`LD_*`/`DYLD_*`/Python startup) | Blocking finding, round 2 — `LD_PRELOAD` in a spec `env` honoured by the loader inside the wrapper process |
| Non-dict `env` guard | Blocking finding, round 2 — `AttributeError` on a malformed config |
| Wrapper pins moved to producers; `trusted_system_bin` over `shutil.which` | Advisory findings, round 2 — wrong layer, and PATH-derived resolution for a security decision |
| `-I -S` launcher flags + `PYTHONUSERBASE` | Blocking finding, round 3 — Python startup executes `.pth`/`sitecustomize` pre-`unshare`; key-listing cannot close it |
| Delegation-path `env` pinning (2 sites) | Blocking finding, round 3 — the redirected `env` is the credential scrub, not a confinement layer |
| `KIROCREW_` reserved namespace | Authorization hole reachable only once a config `env` is forwarded — `KIROCREW_CLI=1` self-elevates a script cron to the admin CLI |

Reverting them would ship the reliability fix with the escalation channels it opens. The alternative — landing forwarding first and hardening in follow-ups — leaves those channels open in the interim, on a path the sandbox does not cover.

Source is 285 lines across 3 files; the remaining 806 lines are tests.

## Tests

- `test/test_cron_script.py` — `(argv, env)` return shape on the primary and fallback resolve paths; env-block regression; non-object `env` treated as absent; str-coercion of numeric values; `Popen`-env test proving the spec env reaches the child while a denied secret is scrubbed from **both** the inherited env and the spec overlay; the loader-injection filter including a **lowercase** spelling (which reaches the loader on Windows); `argv[0]` left alone on the no-wrapper path so the spec `PATH` resolves it. `_resolve_mcp_server.cache_clear()` added where needed (the resolver is `lru_cache`d).
- `test/test_env.py` (new) — the five identity keys **and** a not-yet-invented `KIROCREW_` variable are both dropped, case-insensitively, while `MC_*` / `KIRO_*` / `MY_KIROCREW_*` pass through; an inherited value survives a spec override; `_caller_is_cli()` evaluated in the env the spawned server *would* have started with is `False`, with a baseline asserting the flag really is the bypass so that `False` means the filter worked; `denied_spec_env_keys` pinned to **not** report reserved keys, so a future change cannot align the two and make the dashboard message lie.
- `test/test_mcp_discovery.py` — the sibling spawn site drops reserved keys too, while keeping its inherited `KIROCREW_HOME`.
- `test/test_sandbox_argv.py` — producer-level assertions that both `sandbox_exec_argv` wrappers and `cgroup_scope_argv`'s wrapper are absolute, and that `cgroup_scope_argv` refuses to wrap at all when the wrapper is unresolvable.
- Pre-existing assertions on the bare `env` / `systemd-run` / `sandbox-exec` tokens now match by **basename**, since those tokens are intentionally absolute (`test_sandbox_default_fix.py`, `test_sandbox_first_party_exec.py`, `test_sandbox_launcher_sweep.py`, `test_sandbox_nested_tier.py`).

Full backend suite green on this head across 3.10, 3.12, and Windows (12 shards), plus the namespace-sandbox job.

## Manual verification

N/A — subprocess-env and argv-resolution change with no user-visible UI. Behavior is covered by the unit tests above.

## Related Issues

N/A.

## Checklist

- [x] Single commit with a Conventional Commits title (`fix(cron): ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A (no docs affected); one inaccurate in-code comment corrected
- [x] No secrets, credentials, or internal references in the diff
