### PR TITLE
fix(browser): declare every open chat as reachable, not just the active one

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -4340,23 +4340,58 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     window.addEventListener('kirocrew-browser-frame', onFrame)
     return () => window.removeEventListener('kirocrew-browser-frame', onFrame)
   }, [dispatch])
-  // Reachability: declare the active slot to the Electron main process so the
-  // agent command channel polls for it (see listPanelIds) even before the Browser
+  // Reachability: declare open chat slots to the Electron main process so the
+  // agent command channel polls for them (see listPanelIds) even before the Browser
   // tab is ever opened — this is what makes the built-in browser the default for a
   // fresh chat. It is NOT a grant: authorization to drive the built-in browser is
   // Browser Mode (the Settings toggle), and the main-process gate is just the view
-  // precondition. There is no longer a separate per-session consent registration —
-  // the command channel can only deliver an op for a session key it polls for, and
-  // it must poll before any URL is known, so gating reachability on a per-session
+  // precondition. There is no separate per-session consent registration — the
+  // command channel can only deliver an op for a session key it polls for, and it
+  // must poll before any URL is known, so gating reachability on a per-session
   // grant would make the whole native path unreachable for a fresh chat.
+  //
+  // EVERY open chat is declared, not just the active one.
+  //
+  // The command channel can only deliver an op for a session key it polls for,
+  // and it must poll BEFORE any URL is known. Declaring only `activeSlot` made
+  // that a moving target, and both consequences were observed live in a diagnostic
+  // run:
+  //   * a chat created and messaged within seconds RACED the registration — the
+  //     navigate reached the gateway first, which answered `no-native-panel` (503)
+  //     because no poller held that key yet, so the proxy fell back to the
+  //     Playwright mirror for the whole turn (observed: slot created at T+0, the
+  //     navigate at T+15s, the key first reported 9 minutes later);
+  //   * a BACKGROUND chat was never reachable at all, even when it was the session
+  //     the agent was acting for.
+  //
+  // Declaring a key is NOT authorization — it grants nothing, and every op still
+  // runs the same gate — so there is no reason to report one key instead of all of
+  // them. Tracking is diffed rather than torn down per change: re-registering the
+  // same keys on every slot-list edit would churn IPC for no reason, and dropping
+  // them mid-turn is exactly the race above.
+  const trackedSlotsRef = useRef<Set<string>>(new Set())
+  const trackableSlotKeys = useMemo(
+    () => slots.map(s => s.key).filter((k): k is string => !!k),
+    [slots],
+  )
   useEffect(() => {
     const api = (window as unknown as {
       browserAPI?: { trackSession?: (id: string, tracked: boolean) => Promise<unknown> }
     }).browserAPI
-    if (!api?.trackSession || !activeSlot) return
-    void api.trackSession(activeSlot, true)
-    return () => { void api.trackSession?.(activeSlot, false) }
-  }, [activeSlot])
+    if (!api?.trackSession) return      // plain browser (no bridge)
+    const want = new Set(trackableSlotKeys)
+    const tracked = trackedSlotsRef.current
+    for (const key of want) {
+      if (tracked.has(key)) continue
+      tracked.add(key)
+      void api.trackSession(key, true)
+    }
+    for (const key of [...tracked]) {
+      if (want.has(key)) continue
+      tracked.delete(key)
+      void api.trackSession(key, false)
+    }
+  }, [trackableSlotKeys])
   // Native counterpart of the mirror auto-open above. When the agent opens a page
   // in the BUILT-IN browser, the WebContentsView is created in the Electron main
   // process but the dashboard owns layout — until the Browser panel mounts and

--- a/website/src/test/ChatPage.reachability.test.tsx
+++ b/website/src/test/ChatPage.reachability.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Guards the native-browser reachability declaration in ChatPage.
+ *
+ * The Electron command channel can only deliver a `browser_*` op for a session
+ * key it is already polling for (see `listPanelIds` in electron/main.js), and it
+ * must poll BEFORE any URL is known. An earlier revision declared only
+ * `activeSlot`, which produced two failures seen in a live diagnostic run:
+ *
+ *   1. a chat created and messaged within seconds RACED the registration — the
+ *      navigate reached the gateway first, got `no-native-panel` (503) because no
+ *      poller held that key yet, and the proxy fell back to the Playwright mirror
+ *      for the whole turn;
+ *   2. a BACKGROUND chat was never reachable at all, even when it was the session
+ *      the agent was acting for.
+ *
+ * Declaring a key is not authorization (Browser Mode is), so reporting every open
+ * slot costs nothing and removes both.
+ *
+ * This is a SOURCE-CONTRACT test, matching the existing ChatPage convention (see
+ * ChatPage.mcpOAuth.test.tsx): ChatPage's message list is driven by a custom
+ * virtualizer that mounts an empty window under jsdom, so a full-page render
+ * cannot exercise this effect. The behaviour under test is an IPC side effect of
+ * a Redux-derived list, and what regressed before was precisely the source shape
+ * — which input the effect reads — so that is what this locks in.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const chatPageSrc = readFileSync(resolve(here, '../pages/ChatPage.tsx'), 'utf8')
+
+describe('ChatPage – native browser reachability', () => {
+  it('derives the tracked keys from the open slot list, not the active slot', () => {
+    // The regression shape: `trackSession(activeSlot, ...)`. If that ever comes
+    // back, a background chat is unreachable and a fresh chat races the poller.
+    expect(chatPageSrc).not.toMatch(/trackSession\(\s*activeSlot/)
+    expect(chatPageSrc).toMatch(/trackableSlotKeys\s*=\s*useMemo\(/)
+    expect(chatPageSrc).toMatch(/slots\.map\(s => s\.key\)/)
+  })
+
+  it('runs the declaration off the slot-key list', () => {
+    // A dependency on `activeSlot` would re-run (and previously re-register) on
+    // every tab switch while still only ever declaring one key.
+    expect(chatPageSrc).toMatch(/\}, \[trackableSlotKeys\]\)/)
+  })
+
+  it('untracks only keys that disappeared, never the whole set per change', () => {
+    // A cleanup that untracked everything on each slot-list edit would drop a key
+    // mid-turn — the same race, re-introduced through teardown instead of setup.
+    expect(chatPageSrc).toMatch(/trackedSlotsRef/)
+    expect(chatPageSrc).toMatch(/if \(want\.has\(key\)\) continue/)
+  })
+})


### PR DESCRIPTION
## Problem

Ask a freshly-created chat to open a page and it still renders as a Playwright
screenshot instead of the built-in browser — the exact symptom #2082 was supposed to
end. A background chat never reaches the built-in browser at all.

This was caught by instrumenting a real reproduction rather than by reading code. The
diagnostic run says it plainly:

```
16:45:23   slot chat-172-1786380323 created
16:45:38   [proxy] entry {"name":"browser_navigate","session_key_env":null,"pid":72616}
16:45:38   [proxy] native:http-error {"op":"navigate","code":503,"falls_back":true}
16:45:36   [electron] listPanelIds {"reachable":["chat-171-1786262495"], ...}   ← the OLD slot
16:54:21   [electron] listPanelIds {"reachable":["chat-172-1786380323"], ...}   ← 9 min later
```

The gateway resolved the right session from `host_pid` (`session_key_env: null` is
normal for a warm-pool worker), but **no poller held that key yet**, so it answered
`no-native-panel` (503) and the proxy fell back to the mirror for the whole turn.

## Why it matters

Two distinct failures, both from one cause:

1. **A race on every new chat.** Create a chat, ask it to open a page within a few
   seconds, and the navigate arrives before the key is declared. There is no retry —
   that turn is a screenshot mirror, and the user sees the pre-#2082 behaviour.
2. **Background chats are permanently unreachable.** If the agent acts for a session
   that is not the foreground tab, its ops can never reach the built-in browser.

## Fix (symptoms → root cause → change)

**Symptom:** a fresh or background chat degrades to the Playwright mirror.
**Root cause:** the renderer declared only `activeSlot`. The command channel can only
deliver an op for a key it is already polling for, and it must poll *before* any URL
is known — so a one-key, moving-target declaration cannot cover either case. The
effect's cleanup also untracked the previous slot on every switch, making the single
declared key churn.
**Change:** declare **every open chat slot**. The key list is derived from
`s.dashboard.slots` instead of `activeSlot`, and tracking is **diffed** — newly
present keys are added, and only keys that actually disappeared are untracked.
Re-registering the whole set on each slot-list edit would churn IPC for nothing, and
tearing it down per change would re-introduce the same race through teardown instead
of setup.

Declaring a key is **not** authorization and this PR does not touch that boundary:
Browser Mode remains the sole authorization, and every op still runs the same
main-process gate. Reachability only decides whether a request can be *judged* at all
rather than silently becoming a mirror — which is why reporting all slots costs
nothing.

No Electron-side change is needed: `listPanelIds` already unions the reported set,
and its remote-gateway guard (report nothing unless the backend URL is loopback) is
untouched and still verified by its own test.

## Tests

- `website/src/test/ChatPage.reachability.test.tsx` — new. Pins that the declaration
  derives from the open-slot list and not `activeSlot` (the exact regression shape),
  that it runs off the slot-key list, and that untracking happens only for keys that
  disappeared rather than for the whole set on every change.

This is a **source-contract** test, matching the existing ChatPage convention (see
`ChatPage.mcpOAuth.test.tsx`): ChatPage's message list is driven by a custom
virtualizer that mounts an empty window under jsdom, so a full-page render cannot
exercise this effect. What regressed was the source shape — which input the effect
reads — so that is what is locked in. Stated plainly because it is weaker than a
behavioural test.

12196 frontend tests pass across 889 files, `tsc -b` clean, eslint 0 errors.

`src/test/App.test.tsx` is flaky on `main` independently of this branch: two
consecutive full-suite runs each failed a *different* test in that one file, it fails
standalone, and it fails the same way with this branch's changes stashed on pristine
`origin/main`.

## Manual verification

Needs a rebuilt desktop app, and it is the point of this change:

1. Create a **new** chat and immediately ask it to open a page → it must land in the
   built-in browser, not the mirror. This is the race.
2. With two chats open, switch to chat A and have the agent act for chat **B** → B's
   page must still reach the built-in browser.
3. Close a chat → its key must stop being declared (no leak of stale keys).

The signal to watch is `listPanelIds` reporting every open slot rather than one.
