### PR TITLE
fix(test): make the reduced Windows scope green for frontend-only PRs

### DIFF
--- a/test/test_deploy_web_handlers.py
+++ b/test/test_deploy_web_handlers.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import asyncio
 import json as _j2
+import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -10,6 +12,49 @@ import pytest
 
 from kiro_crew.deploy import engine, handlers
 from kiro_crew.deploy import profiles as profiles_mod
+
+# On native Windows the deploy handlers hard-gate on ``os.name == "nt"`` (the
+# deploy scripts need a POSIX bash shell), so every handler test would receive
+# the 400 "requires a POSIX shell" early-return instead of exercising the flow.
+# The full backend suite happens to run these on POSIX, but a frontend-only PR
+# triggers a reduced backend scope on a Windows runner where they fail. This
+# skipif is reserved for the one test whose behaviour is genuinely POSIX-only
+# (file-permission semantics); the handler tests are made platform-independent
+# by the _force_posix_shell fixture below instead. See issue #2041.
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only file-permission semantics; reduced Windows backend scope (#2041)",
+)
+
+
+@pytest.fixture(autouse=True)
+def _force_posix_shell(monkeypatch):
+    """Neutralise the handlers' ``os.name == "nt"`` platform gate.
+
+    The deploy handlers early-return 400/unsupported on Windows because the
+    deploy scripts require a POSIX shell. That gate hides the handler logic the
+    tests actually cover (scan gate, ttl validation, confirm gate, restricted
+    session deny), so on a Windows CI runner these tests get the platform
+    early-return instead of the assertion they expect.
+
+    Patch a handlers-module-local ``os`` proxy instead of the global
+    ``os.name``: pathlib and other stdlib consumers select behaviour from
+    ``os.name`` at call time, so a process-wide patch would break ``Path``
+    construction inside the handlers on a real Windows runner. The proxy
+    changes only what ``handlers.py`` itself sees. On a POSIX host this
+    changes nothing. The dedicated Windows-gate test overrides the same
+    module-local attribute in its own body (#2041).
+    """
+
+    class _PosixNameOs:
+        """Delegate everything to the real ``os`` except ``name``."""
+
+        name = "posix"
+
+        def __getattr__(self, attr):  # pragma: no cover - trivial delegation
+            return getattr(os, attr)
+
+    monkeypatch.setattr(handlers, "os", _PosixNameOs())
 
 
 @pytest.fixture(autouse=True)
@@ -624,7 +669,15 @@ def test_deploy_rejects_on_windows(monkeypatch):
 
     from kiro_crew.deploy import handlers
 
-    monkeypatch.setattr("os.name", "nt")
+    class _NtNameOs:
+        """Delegate everything to the real ``os`` except ``name``."""
+
+        name = "nt"
+
+        def __getattr__(self, attr):  # pragma: no cover - trivial delegation
+            return getattr(os, attr)
+
+    monkeypatch.setattr(handlers, "os", _NtNameOs())
 
     async def scenario():
         status, body = await handlers._do_deploy({"site_id": "test", "artifact_slug": "x"})
@@ -1293,6 +1346,7 @@ def test_internal_secret_teardown_denied_403():
 # F2: Unreadable files produce unreadable-file findings (fail closed)
 # ══════════════════════════════════════════════════════════════════════════════
 
+@_POSIX_ONLY
 def test_scan_tree_unreadable_file_produces_finding(tmp_path):
     """chmod-000 file in scan tree -> deploy blocked with unreadable-file finding."""
     import os

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -23,6 +23,17 @@ from aiohttp.test_utils import TestClient, TestServer  # noqa: F401
 import kiro_crew.apps.builtins.dev_fleet.server as mod
 from kiro_crew import platform_compat
 
+# These Dev Fleet make-live / cancel / sync / build tests assert POSIX-only
+# behaviour that has no Windows equivalent: os.geteuid, the ``.venv/bin`` layout
+# (vs ``.venv\\Scripts\\kirocrew.exe``), systemctl/launchctl service probing, and
+# ``/``-rooted trusted-binary paths. The production code is correct on Windows;
+# only these fixtures/assertions are POSIX-shaped, so they are skipped under the
+# reduced-scope backend CI that runs on Windows. See issue #2041.
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only Dev Fleet make-live/cancel/sync semantics (issue #2041)",
+)
+
 
 # --- worktree porcelain parsing ---
 def test_parse_worktree_porcelain_basic():
@@ -1109,6 +1120,7 @@ async def test_pod_guard_denies_pin_file_without_checkout(monkeypatch, tmp_path)
     assert "ambiguous pod identity" in err
 
 
+@_POSIX_ONLY
 def test_read_pin_strict_propagates_read_errors(tmp_path):
     """_read_pin_strict must raise (not return empty) when the pin file
     exists but cannot be read."""
@@ -2457,6 +2469,7 @@ def _stub_make_live(monkeypatch, wt, *, live=None, in_pod=False, unit_status="ok
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_make_live_dry_run_plan(monkeypatch, tmp_path):
     """dry_run returns the pointer-based plan without writing anything."""
     wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
@@ -2520,6 +2533,7 @@ async def test_make_live_missing_venv(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_make_live_venv_not_executable(monkeypatch, tmp_path):
     """.venv/bin/kirocrew present but NOT executable -> a distinct, actionable
     error (missing_venv is for the not-a-file case). A non-executable binary
@@ -2550,6 +2564,7 @@ async def test_make_live_missing_dist(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_make_live_real_cutover_writes_pointer(monkeypatch, tmp_path):
     """A real cutover on a drivable service writes the pointer AND restages the
     service definition, issues a detached restart, and invalidates the
@@ -2597,6 +2612,7 @@ async def test_make_live_real_cutover_writes_pointer(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_make_live_staged_only_leaves_service_definition_untouched(
     monkeypatch, tmp_path,
 ):
@@ -2627,6 +2643,7 @@ async def test_make_live_staged_only_leaves_service_definition_untouched(
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_make_live_latches_after_cutover(monkeypatch, tmp_path):
     """A successful cutover latches _MAKE_LIVE_COMMITTED. A second request —
     cutover for a DIFFERENT valid target, or even a dry_run — is then refused
@@ -2656,6 +2673,7 @@ async def test_make_live_latches_after_cutover(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_make_live_write_failure_does_not_latch(monkeypatch, tmp_path):
     """A cutover that fails during pointer write (before restart scheduling)
     must NOT latch — the restart never happened, so a subsequent cutover
@@ -2805,6 +2823,7 @@ async def test_make_live_pod_indeterminate_fails_closed(monkeypatch, tmp_path):
 
 # --- make-live: staged-only when service not drivable ---
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_make_live_stages_only_when_service_not_drivable(monkeypatch, tmp_path):
     """A live gateway installed as a SYSTEM unit (or no service at all) succeeds
     as staged_only: the pointer is written, no restart attempted, and a manual
@@ -2995,6 +3014,7 @@ def test_sd_value_rejects_control_char_paths():
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_make_live_escapes_special_char_worktree(monkeypatch, tmp_path):
     """A worktree path with a space yields a valid plan and a real cutover
     writes the resolved path into the pointer file correctly."""
@@ -3282,6 +3302,7 @@ async def test_make_live_refuses_when_prior_pointer_is_unreadable(
 
 # --- make-live: pointer write + failure rollback ---
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_make_live_rolls_back_pointer_on_restart_failure(monkeypatch, tmp_path):
     """A restart failure with a prior pointer restores the PRIOR content and
     reports rolled_back. When there was no prior pointer, the file is deleted."""
@@ -3305,6 +3326,7 @@ async def test_make_live_rolls_back_pointer_on_restart_failure(monkeypatch, tmp_
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_make_live_rolls_back_pointer_preserves_prior(monkeypatch, tmp_path):
     """When a prior pointer existed, restart failure restores its content."""
     wt = _mk_make_live_wt(tmp_path, venv=True, dist=True)
@@ -3330,6 +3352,7 @@ async def test_make_live_rolls_back_pointer_preserves_prior(monkeypatch, tmp_pat
 
 # --- make-live: concurrency single-flight lock ---
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_make_live_concurrent_second_call_busy(monkeypatch, tmp_path):
     """While one cutover holds the make-live lock, a concurrent second call is
     refused immediately with ``busy`` (fail-fast, not queued) and the winner
@@ -3380,6 +3403,7 @@ async def test_make_live_concurrent_second_call_busy(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_make_live_lock_released_after_failure_and_reusable(monkeypatch, tmp_path):
     """The lock is released on the failure-rollback path too, so a subsequent
     cutover proceeds (never wedged on ``busy``)."""
@@ -3412,6 +3436,7 @@ async def test_make_live_lock_released_after_failure_and_reusable(monkeypatch, t
 
 # --- make-live: pointer-based live worktree resolution ---
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_live_worktree_path_prefers_pointer_over_service(monkeypatch, tmp_path):
     """_live_worktree_path returns the pointer target in preference to the
     service definition ONCE THE GATEWAY IS RUNNING IT. A cutover writes the
@@ -3453,6 +3478,7 @@ async def test_live_worktree_path_prefers_pointer_over_service(monkeypatch, tmp_
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_live_worktree_path_reports_running_image_while_staged(monkeypatch, tmp_path):
     """A staged pointer is NOT live: until the gateway restarts it is still
     executing the previous checkout, and reporting the pointer as live would
@@ -3482,6 +3508,7 @@ async def test_live_worktree_path_reports_running_image_while_staged(monkeypatch
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_live_worktree_path_honours_pointer_when_checkout_unknown(monkeypatch, tmp_path):
     """A packaged install is not a checkout, so the running image cannot be
     compared. That is "cannot verify", not a mismatch: the pointer stays
@@ -3507,6 +3534,7 @@ async def test_live_worktree_path_honours_pointer_when_checkout_unknown(monkeypa
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_repointing_at_the_running_checkout_cancels_a_staged_cutover(monkeypatch, tmp_path):
     """While a cutover is staged, naming the checkout that is RUNNING is a cancel.
 
@@ -3565,6 +3593,7 @@ def _stage_a_cutover(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_cutover_unwind_runs_off_the_event_loop(monkeypatch, tmp_path):
     """The rollback must not block the loop.
 
@@ -3600,6 +3629,7 @@ async def test_cutover_unwind_runs_off_the_event_loop(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_drivable_host_with_a_stage_pending_refuses(monkeypatch, tmp_path):
     """On a host Dev Fleet CAN drive, this request must do NOTHING destructive.
 
@@ -3637,6 +3667,7 @@ async def test_drivable_host_with_a_stage_pending_refuses(monkeypatch, tmp_path)
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_cancel_keeps_a_pointer_selected_checkout_live(monkeypatch, tmp_path):
     """The scenario that makes deletion wrong.
 
@@ -3663,6 +3694,7 @@ async def test_cancel_keeps_a_pointer_selected_checkout_live(monkeypatch, tmp_pa
     OSError(30, "Read-only file system"),
 ])
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_cancel_write_failure_is_a_refusal_not_a_crash(monkeypatch, tmp_path, boom):
     """A full or read-only data home must refuse, not raise into a 500.
 
@@ -3685,6 +3717,7 @@ async def test_cancel_write_failure_is_a_refusal_not_a_crash(monkeypatch, tmp_pa
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_cancel_rolls_the_pointer_back_when_hardening_fails(monkeypatch, tmp_path):
     """write_target can fail AFTER replacing the pointer.
 
@@ -3713,6 +3746,7 @@ async def test_cancel_rolls_the_pointer_back_when_hardening_fails(monkeypatch, t
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_cancel_reports_a_failed_rollback(monkeypatch, tmp_path):
     """When the rollback itself fails the operator is told, not left guessing."""
     running, other, ptr = _stage_a_cutover(monkeypatch, tmp_path)
@@ -3730,6 +3764,7 @@ async def test_cancel_reports_a_failed_rollback(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_cancel_invalid_target_is_a_refusal_not_a_crash(monkeypatch, tmp_path):
     """The validation half of the same guard."""
     running, other, ptr = _stage_a_cutover(monkeypatch, tmp_path)
@@ -3746,6 +3781,7 @@ async def test_cancel_invalid_target_is_a_refusal_not_a_crash(monkeypatch, tmp_p
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_dry_run_cancel_reports_the_plan_without_deleting(monkeypatch, tmp_path):
     """`dry_run` must never mutate.
 
@@ -3767,6 +3803,7 @@ async def test_dry_run_cancel_reports_the_plan_without_deleting(monkeypatch, tmp
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_cancel_fails_fast_while_a_cutover_holds_the_lock(monkeypatch, tmp_path):
     """The cancel mutates the same pointer a cutover writes, so it takes the
     same single-flight lock and reports `busy` instead of racing it."""
@@ -3781,6 +3818,7 @@ async def test_cancel_fails_fast_while_a_cutover_holds_the_lock(monkeypatch, tmp
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_cancel_refuses_once_a_cutover_has_committed(monkeypatch, tmp_path):
     """A committed cutover is already restarting; deleting the pointer then would
     land the pending restart somewhere the operator did not choose."""
@@ -3840,6 +3878,7 @@ def test_running_checkout_resolves_this_checkout():
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_make_live_staged_only_allows_subsequent_cutover(monkeypatch, tmp_path):
     """A staged_only cutover does NOT latch, so re-pointing to a DIFFERENT
     worktree proceeds without a restart_pending refusal."""
@@ -4133,6 +4172,7 @@ def _is_stage_step(argv: list) -> bool:
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_sync_stages_dist_on_a_stock_checkout(monkeypatch):
     """The staging step is part of the sync on a stock checkout.
 
@@ -4187,6 +4227,7 @@ async def test_sync_never_stages_dist_on_an_edition_checkout(monkeypatch):
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_sync_build_steps_never_see_credential_helpers(monkeypatch):
     """Only the network fetch step carries operator credential helpers;
     worktree-controlled merge/pip/npm steps must not (token minting via
@@ -4246,6 +4287,7 @@ async def test_fetch_pr_head_oid_refuses_non_merged(monkeypatch):
     assert await mod._fetch_pr_head_oid("feature-x") == "b" * 40
 
 
+@_POSIX_ONLY
 def test_trusted_bin_rejects_agent_writable_path(monkeypatch, tmp_path):
     """Bare command names resolve only inside the trusted bin dirs; a planted
     shim in an agent-writable PATH entry is never selected."""
@@ -4292,6 +4334,7 @@ def test_trusted_bin_pins_the_resolved_target_not_the_symlink(monkeypatch, tmp_p
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_run_cmd_pins_trusted_path(monkeypatch):
     """_run_cmd rewrites bare names to trusted absolute paths and pins PATH."""
     captured: dict = {}
@@ -4490,6 +4533,7 @@ def test_strict_sandbox_hides_gh_config():
     assert ".config/gh" not in sandbox_mod._STANDARD_DIRS
 
 
+@_POSIX_ONLY
 def test_build_preexec_raises_nofile_ceiling(monkeypatch):
     """Build-class spawns get a 65536 NOFILE ceiling (default 1024 EMFILEs vite)."""
     import kiro_crew.sandbox as sandbox_mod
@@ -4507,6 +4551,7 @@ def test_build_preexec_raises_nofile_ceiling(monkeypatch):
     assert captured["max_open_files"] >= 65536
 
 
+@_POSIX_ONLY
 def test_build_preexec_tolerates_malformed_config(monkeypatch):
     """A junk operator value ("lots") must not raise — the spawn falls back
     to the ceiling instead of leaving Dev Fleet unable to start."""
@@ -5768,6 +5813,7 @@ async def test_api_health_start_id_none_safe():
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_make_live_returns_start_id(monkeypatch, tmp_path):
     """A real cutover captures + returns the pre-restart start identity so the
     dashboard reuses the same restart handshake (issue #639)."""
@@ -6097,6 +6143,7 @@ def test_declared_platforms_all_resolve_to_a_real_sys_platform():
 
 
 @pytest.mark.asyncio
+@_POSIX_ONLY
 async def test_sync_builds_and_stages_under_one_lock_holder(monkeypatch, tmp_path):
     """Pull+Build must build and stage inside ONE locked step.
 

--- a/test/test_pid_lifecycle.py
+++ b/test/test_pid_lifecycle.py
@@ -14,6 +14,15 @@ import pytest
 
 from kiro_crew import platform_compat
 
+# These tests exercise POSIX-only process-management semantics: process-group
+# APIs (os.killpg / os.getpgrp / os.getpgid), POSIX identity/age probes
+# (os.getuid / os.sysconf, /proc, ps), the raw signal.SIGKILL constant, and the
+# POSIX kill path of the orphan sweep (which no-ops on Windows). None of these
+# have a Windows equivalent, so they are skipped on Windows. See issue #2041.
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX process-management semantics only; see issue #2041"
+)
+
 
 @pytest.fixture()
 def pid_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
@@ -237,6 +246,7 @@ class TestCleanupOrphanedMcpServers:
 
 
 class TestCleanupOrphanedSessions:
+    @_POSIX_ONLY
     def test_preserves_non_kiro_pids(self, session_pid_file: Path) -> None:
         """Bug fix: non-kiro PIDs (MCP servers) must survive — not killed."""
         from kiro_crew.session_pid import cleanup_orphaned_sessions
@@ -269,6 +279,7 @@ class TestCleanupOrphanedSessions:
         content = session_pid_file.read_text(encoding="utf-8")
         assert content == ""
 
+    @_POSIX_ONLY
     def test_kiro_pids_killed(self, session_pid_file: Path) -> None:
         """Kiro PIDs should be SIGKILL'd."""
         from kiro_crew.session_pid import cleanup_orphaned_sessions
@@ -642,6 +653,7 @@ class TestFindOrphanMcpCandidates:
         assert result == []
 
 
+@_POSIX_ONLY
 class TestKillOrphanMcps:
     """Tests for kill_orphan_mcps (kill confirmed orphans)."""
 
@@ -808,6 +820,7 @@ class TestParseEtime:
         assert _parse_etime("") == 0.0
 
 
+@_POSIX_ONLY
 class TestOurOrphanPids:
     """Direct tests for _our_orphan_pids (Linux /proc and macOS ps branches)."""
 
@@ -902,6 +915,7 @@ class TestOurOrphanPids:
         assert result == []
 
 
+@_POSIX_ONLY
 class TestLinuxPidAge:
     """Direct tests for _linux_pid_age /proc/<pid>/stat starttime parsing."""
 
@@ -1298,6 +1312,7 @@ class TestMarkedLauncherSweepIntegration:
 
         assert result == []
 
+    @_POSIX_ONLY
     def test_kill_reverify_honors_marked_launcher(self) -> None:
         from kiro_crew.session_pid import kill_orphan_mcps
 
@@ -1316,6 +1331,7 @@ class TestMarkedLauncherSweepIntegration:
         assert killed == 1
         mock_killpg.assert_called_once_with(720, signal.SIGKILL)
 
+    @_POSIX_ONLY
     def test_kill_reverify_skips_unmarked_launcher(self) -> None:
         from kiro_crew.session_pid import kill_orphan_mcps
 
@@ -1530,6 +1546,7 @@ class TestPidStartTokenIdentityGuard:
         # Entry retained so the next sweep can retry.
         assert entry in session_pid_file.read_text(encoding="utf-8")
 
+    @_POSIX_ONLY
     def test_matching_token_still_killed(self, session_pid_file: Path) -> None:
         """A genuine orphan (token matches) is still reaped — no regression."""
         from kiro_crew.session_pid import cleanup_orphaned_sessions
@@ -1561,6 +1578,7 @@ class TestPidStartTokenIdentityGuard:
 
         assert (99998, platform_compat.SIGKILL) in kills
 
+    @_POSIX_ONLY
     def test_legacy_entry_without_token_still_swept(self, session_pid_file: Path) -> None:
         """Back-compat: a 2-field entry keeps its old cmdline+grace behavior."""
         from kiro_crew.session_pid import cleanup_orphaned_sessions
@@ -1591,6 +1609,7 @@ class TestPidStartTokenIdentityGuard:
 
         assert (99998, platform_compat.SIGKILL) in kills
 
+    @_POSIX_ONLY
     def test_session_roots_sweep_parses_token_entry(self, session_pid_file: Path) -> None:
         """cleanup_orphaned_session_roots must not mis-prune 3-field entries.
 
@@ -1648,6 +1667,7 @@ class TestPidStartTokenIdentityGuard:
 
 
 class TestSpawnGraceCrossPlatform:
+    @_POSIX_ONLY
     def test_grace_applies_on_macos(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Regression: the grace window was Linux-only, so macOS never got it."""
         import kiro_crew.session_pid as sp
@@ -1663,6 +1683,7 @@ class TestSpawnGraceCrossPlatform:
         monkeypatch.setattr(sp, "_pid_age_seconds", lambda p: sp.SWEEP_SPAWN_GRACE_SECONDS + 1)
         assert sp._pid_in_spawn_grace(4242) is False
 
+    @_POSIX_ONLY
     def test_unknown_age_treated_as_young(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Unreadable age → safe direction (skip the kill)."""
         import kiro_crew.session_pid as sp

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -34,6 +34,15 @@ from kiro_crew.sandbox import (
 # don't starve each other / blow the 30s timeout. Requires --dist loadgroup.
 pytestmark = pytest.mark.xdist_group(name="subprocess_spawn")
 
+# ``_build_launcher_script`` calls POSIX-only ``os.getuid``/``os.getgid`` (the
+# namespace launcher is Linux-only), so any test that builds the launcher script
+# raises AttributeError on Windows. Skip those on win32 -- the reduced-scope
+# Windows CI lane runs them, but they pass in the full POSIX suite. See #2041.
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="_build_launcher_script uses POSIX-only os.getuid (#2041)",
+)
+
 
 @pytest.fixture(autouse=True)
 def clean_backend(monkeypatch):
@@ -275,12 +284,14 @@ class TestBuildSeatbeltProfile:
 
 
 class TestBuildLauncherScript:
+    @_POSIX_ONLY
     def test_strict_script_contains_dirs(self):
         script = _build_launcher_script("strict")
         assert "SENSITIVE_DIRS" in script
         assert ".aws" in script
         assert ".gnupg" in script
 
+    @_POSIX_ONLY
     def test_strict_script_denies_namespace_escape_not_hardlinks(self):
         """Linux seccomp deny list must contain the namespace-escape syscalls
         (mount/umount2/unshare/setns/pivot_root) and must NOT contain
@@ -297,11 +308,13 @@ class TestBuildLauncherScript:
         assert "308, 155, 86, 265)" not in script
         assert "268, 41, 37)" not in script
 
+    @_POSIX_ONLY
     def test_standard_script_excludes_aws(self):
         script = _build_launcher_script("standard")
         # Standard dirs don't include .aws
         assert "HIDE_SSH = False" in script
 
+    @_POSIX_ONLY
     def test_auth_staging_is_hidden_except_for_trusted_auth_spawn(self):
         home = Path.home()
         staging = home / ".kiro" / "crew-auth-staging"
@@ -328,6 +341,7 @@ class TestBuildLauncherScript:
         assert str(data_home) in auth_script
         assert str(data_home) in auth_profile
 
+    @_POSIX_ONLY
     def test_a_file_valued_hidden_path_reaches_the_file_loop(self, tmp_path):
         """A hidden path that is a FILE must reach ``SENSITIVE_FILES``.
 
@@ -392,6 +406,7 @@ class TestBuildLauncherScript:
             f"_build_launcher_script stats the filesystem on the event loop: {probes}"
         )
 
+    @_POSIX_ONLY
     def test_every_sensitive_path_reaches_a_loop_that_can_hide_it(self):
         """Whole-list check against the real sensitive-path list.
 
@@ -413,16 +428,19 @@ class TestBuildLauncherScript:
             assert path in dirs, f"{path} never reaches the directory loop"
             assert path in files, f"{path} never reaches the file loop"
 
+    @_POSIX_ONLY
     def test_cc_script_exposes_aws_config(self):
         script = _build_launcher_script("cc")
         assert ".aws/config" in script
         assert "EXPOSE_FILES" in script
 
+    @_POSIX_ONLY
     def test_script_scrubs_env_vars(self):
         script = _build_launcher_script("strict")
         for prefix in _SENSITIVE_ENV_PREFIXES:
             assert prefix in script
 
+    @_POSIX_ONLY
     def test_strips_self_dir_before_ctypes_import(self):
         """The sys.path hardening must run before the first shadowable import.
 
@@ -436,6 +454,7 @@ class TestBuildLauncherScript:
         # sys must be imported first (it is a builtin and cannot be shadowed).
         assert script.index("import sys") < script.index("sys.path[:]")
 
+    @_POSIX_ONLY
     def test_launcher_has_no_unimportable_kiro_crew_refs(self):
         """The launcher runs as a standalone ~/.kirocrew/run script with the
         launcher dir scrubbed from sys.path, so it CANNOT import kiro_crew.
@@ -470,6 +489,7 @@ class TestBuildLauncherScript:
             ), f"{level}: launcher references un-importable module(s) {forbidden}"
 
 
+@_POSIX_ONLY
 class TestHardlinkScanBudget:
     """Step-7 pre-exec hardlink scan: per-root budgets + loud truncation.
 
@@ -565,6 +585,7 @@ class TestHardlinkScanBudget:
             compile(_build_launcher_script(level), "<launcher>", "exec")
 
 
+@_POSIX_ONLY
 class TestLauncherStdlibShadowing:
     """End-to-end: a sibling /tmp/struct.py must NOT crash the launcher.
 
@@ -681,6 +702,7 @@ class TestSignalBroadcastGuard:
     mechanism (session identity, claim-push, systemd) — stays intact.
     """
 
+    @_POSIX_ONLY
     def test_launcher_script_contains_kill_filter(self):
         """Static: the generated launcher carries the kill-broadcast filter
         (arg-inspection block) and per-arch kill syscall numbers."""
@@ -695,6 +717,7 @@ class TestSignalBroadcastGuard:
         assert "0, 0, 20))" not in script
         assert "0xFFFFFFFF" in script  # 32-bit pid -1 comparison
 
+    @_POSIX_ONLY
     def test_launcher_script_exports_host_pid(self):
         """Static: launcher exports KIROCREW_HOST_PID before fork so the
         whole subtree can resolve session_pid files by the recorded pid."""
@@ -825,6 +848,7 @@ class TestSandboxExecArgv:
                 os.unlink(profile_path)
 
 
+@_POSIX_ONLY
 class TestNamespaceArgv:
     @patch("kiro_crew.sandbox._resolve_agent_executable", return_value="/usr/local/bin/kiro-cli")
     def test_wraps_with_python_launcher(self, mock_resolve):


### PR DESCRIPTION
## Problem

Every **frontend-only PR** fails all 4 Windows Backend Tests shards (issue #2041). When a PR touches no backend files, CI runs a reduced backend test list on Windows, and ~107 tests fail there: they assume POSIX (`os.getuid`, `os.killpg`, `bash`, `.venv/bin` layout, `/`-rooted paths) and only pass in the full suite via xdist distribution masking or platform gates set up by other tests.

Confirmed victims: #2051 (translation-only, 4 consecutive identical red rounds) and #2072 (independent frontend-only PR, identical signature). #2044 fixed only part of `test_acp_client.py`; #2509 completed that file. This PR covers the remaining four files.

## Why it matters

Every contributor shipping a pure frontend change gets a red `PR Readiness` they cannot fix, and either merges over red (normalizing red checks) or stalls. #2051 has been blocked for 3 days on exactly this.

## Fix (symptoms -> root cause -> change)

- `test/test_deploy_web_handlers.py` (32 failing): the handlers early-return on `os.name == "nt"` ("requires a POSIX shell"), so on Windows the tests exercised the gate instead of the logic they assert. **Root-cause fix, not skips**: an autouse fixture monkeypatches `os.name = "posix"` so the real handler logic (scan gate, TTL validation, confirm gate, restricted-session deny) runs on every platform; a no-op on POSIX. `test_deploy_rejects_on_windows` still sets `nt` in its own body and keeps guarding the gate. One genuinely POSIX-only test (`chmod 000` + `os.geteuid`) gets a `skipif` guard.
- `test/test_sandbox_argv.py` (17 failing): all reach `os.getuid`/`os.getgid` via `_build_launcher_script()` — the APIs don't exist on Windows. `skipif(sys.platform == "win32")` guards on exactly the failing tests/classes, per the #2044 pattern. Tests that pass on Windows (e.g. AST-only inspection) deliberately left unguarded.
- `test/test_pid_lifecycle.py` (21 failing): POSIX process-group/kill semantics (`os.killpg`, `SIGKILL`, `os.getpgid`) with no Windows equivalent; the no-kill/retain sibling tests already pass on Windows and are left unguarded.
- `test/test_dev_fleet_app.py` (36 guarded): POSIX venv layout (`.venv/bin` vs `.venv\Scripts`), `os.geteuid`, systemctl/launchctl probing, `/`-rooted trusted-binary paths.

The production code is correct on Windows in all four cases — only the test fixtures/assertions are POSIX-shaped, so guards (or the fixture seam) are the right layer.

## Tests

This PR *is* tests. Verification on POSIX (where all guards are no-ops): 1083 passed across the five affected files — zero behavior change on macOS/Linux, including the previously-guarded `test_acp_client.py`. The Windows proof is this PR's own CI: as a test-only (backend) change it runs the full suite; the definitive reduced-scope proof is rebasing a frontend-only PR (#2051) after merge.

## Manual verification

N/A — CI on this PR plus a post-merge rebase of #2051 (frontend-only) is the end-to-end proof.

## Screenshots

N/A — no user-visible UI change (test files only).

Fixes #2041.
