### PR TITLE
fix(agent): un-pin the spec model when agent.model returns to auto

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -1541,14 +1541,48 @@ def build_agent_config() -> dict:
     return config
 
 
-def _refresh_dynamic_fields(config: dict) -> None:
+def _resolve_config_model_record(name_or_config: dict) -> None:
+    """Retire the propagated-model record once a spec that supersedes it is on disk.
+
+    Call ONLY after a successful spec write. The record exists to recognize a spec
+    model this propagation wrote, so a record that still equals the persisted model
+    describes the live value and is kept. Anything else — the ``"auto"`` sentinel an
+    un-pin just wrote, or a value some other writer owns — means the record is spent,
+    and keeping it would let a later raw edit back to that value be mistaken for the
+    old propagation and un-pinned.
+
+    Deliberately after the write rather than at the decision: nothing is retired
+    unless the spec that supersedes it actually landed, so an interrupted or failed
+    write leaves the record in place and the un-pin retries on the next refresh.
+    """
+    name = name_or_config.get("name")
+    if not isinstance(name, str) or not name:
+        # A spec with no `name` is still the main agent's file — the sidecar is
+        # keyed by agent name, so falling back here is what lets a spent record be
+        # retired instead of outliving the spec it described.
+        name = _MAIN_AGENT_NAME
+    recorded = agent_state.get_config_model(name)
+    if recorded and name_or_config.get("model") != recorded:
+        # Compare-and-clear: a concurrent rebuild propagating a concrete model may
+        # have recorded a NEWER value since this one was read, and discarding that
+        # would leave its pin un-un-pinnable.
+        agent_state.clear_config_model_if(name, recorded)
+
+
+def _refresh_dynamic_fields(config: dict) -> str:
     """Update security-critical and dynamic fields in an existing config.
 
     Called when ``kirocrew.json`` already exists so user customizations are
     preserved while security controls and runtime paths stay current.
+
+    Returns the model that the global ``agent.model`` propagated into *config*, or
+    ``""`` when it propagated nothing. The caller MUST record it (via
+    :func:`agent_state.set_config_model`) only after the spec is written — see the
+    note at the propagation site for why the record must not outrun the spec.
     """
     # Prompt URI — always resolve at install time
     config["prompt"] = f"file://{_prompt_path()}"
+    pending_config_model = ""
 
     # Managed MCP servers — ensure present and up-to-date.
     # Only refresh command/args; preserve user customizations (e.g. autoApprove).
@@ -1660,9 +1694,60 @@ def _refresh_dynamic_fields(config: dict) -> None:
     # the agent file so kiro-cli's --agent startup load matches it; otherwise the
     # stale agent-file model shadows config.json and session/set_model loses the
     # startup race. "auto" defers to managed/shipped resolution above.
+    #
+    # The propagated value is recorded in the sidecar so that write can be UNDONE.
+    # Without a reverse branch the propagation is one-way: resolve_effective_model
+    # ranks the spec model ABOVE the global, so a model propagated once outranks
+    # the global forever and returning agent.model to "auto" changes nothing —
+    # sessions keep running (and billing at) a model the user believes they turned
+    # off. Only a spec model still EQUAL to what was propagated is cleared; a
+    # value that diverged since belongs to whoever wrote it (the Agent Templates
+    # editor writes the spec directly) and is left alone.
+    #
+    # Cleared to the "auto" sentinel rather than by dropping the field: an absent
+    # model lets kiro-cli fall through to its own configured default, which is not
+    # necessarily auto, while the sentinel says what the user actually chose.
     mc_model = (mc_cfg.get("agent") or {}).get("model")
     if mc_model and mc_model != "auto":
+        # Provenance is recorded ONLY when this write replaces a different value.
+        # Equality is not proof of authorship: the Agent Templates editor and a
+        # hand edit both write the spec directly, so a spec that already reads
+        # `mc_model` may be someone else's explicit pick that happens to agree
+        # with the global. Recording it would let the un-pin below erase a value
+        # this code never wrote. The consequence is that the un-pin only ever
+        # reaches pins THIS code is known to have made — see the note on
+        # pre-existing pins in the module docstring of agent_state.
+        if config.get("model") != mc_model:
+            # NOT written here. The record must not outrun the spec: if it lands
+            # and the spec write then fails, the record names the new model while
+            # disk still holds the old pin, and a later return to "auto" cannot
+            # un-pin either of them. Returned instead, for the caller to commit
+            # once the spec is actually on disk. Nothing is persisted if this
+            # process dies first, which retains the previous record — the safe
+            # direction, since it still describes what is on disk.
+            pending_config_model = mc_model
         config["model"] = mc_model
+    else:
+        # A record can only exist for a value the propagation overwrote, so a
+        # record still equal to the spec model proves the live value is ours and
+        # no editor pick is being destroyed. That is why `model_managed` is not
+        # consulted here: an editor pick that merely COINCIDES with the global
+        # never gets a record, so it is already out of reach of this branch.
+        # Compared against the pre-migration value too: the deprecated-alias
+        # migration above rewrites the spec model in place, so a record holding
+        # the old alias would stop matching and the migrated replacement would
+        # stay pinned.
+        propagated = agent_state.get_config_model(name)
+        if propagated and propagated in (config.get("model"), cur_model):
+            config["model"] = "auto"
+        # The record is NOT retired here. This function mutates an in-memory dict
+        # and the spec reaches disk much later, so retiring it on the spot would
+        # make an interrupted or failed write permanent: the spec would still hold
+        # the pinned model with no record left to recognize it by, and no later
+        # refresh could ever un-pin it. `_resolve_config_model_record` retires it
+        # after the write succeeds instead, which both keeps the un-pin
+        # retry-safe and stops a spent record from outliving the spec it
+        # described.
 
     # Ensure kiro-cli uses agent-level mcpServers exclusively (not global
     # mcp.json).  Existing configs created before this field was added lack
@@ -1700,6 +1785,8 @@ def _refresh_dynamic_fields(config: dict) -> None:
     ):
         tools.append("tool_search")
 
+    return pending_config_model
+
 
 def get_shipped_tools() -> dict[str, list[str]]:
     """Return shipped tool lists. Public API for cross-module use."""
@@ -1707,24 +1794,26 @@ def get_shipped_tools() -> dict[str, list[str]]:
     return {k: shipped.get(k, []) for k in ("tools", "allowedTools")}
 
 
-def _load_existing_config(path: Path) -> tuple[dict, bool]:
+def _load_existing_config(path: Path) -> tuple[dict, bool, str]:
     """Load and refresh an existing kirocrew.json.
 
-    Returns (config, fresh_install).  Falls back to build_agent_config()
-    when the file is corrupt or refresh fails.
+    Returns (config, fresh_install, pending_config_model).  Falls back to
+    build_agent_config() when the file is corrupt or refresh fails.
+    ``pending_config_model`` is the propagated model the caller must record only
+    after the spec write succeeds (see :func:`_refresh_dynamic_fields`).
     """
     try:
         config = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError, ValueError):
         config = None
     if not isinstance(config, dict):
-        return build_agent_config(), True
+        return build_agent_config(), True, ""
     try:
-        _refresh_dynamic_fields(config)
+        pending = _refresh_dynamic_fields(config)
     except (AttributeError, TypeError, RuntimeError) as exc:
         logger.error("Refresh failed, rebuilding from defaults: %s", exc)
-        return build_agent_config(), True
-    return config, False
+        return build_agent_config(), True, ""
+    return config, False, pending
 
 
 def _norm_mcp_spec(spec: Any) -> Any:
@@ -2193,10 +2282,11 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
     if not clean and path.exists():
         # Existing config — preserve user customizations, only refresh
         # security-critical and dynamic fields.
-        config, fresh_install = _load_existing_config(path)
+        config, fresh_install, pending_config_model = _load_existing_config(path)
     else:
         config = build_agent_config()
         fresh_install = True
+        pending_config_model = ""
 
     # Seed default-model tracking for a fresh/clean build. A clean regen always
     # resumes tracking the shipped default; a first-time install seeds tracking
@@ -2743,6 +2833,26 @@ def rebuild_agent_config(*, clean: bool = False) -> Path:
             # imported config; filtering here, on the final map, covers every source.
             config["mcpServers"] = _strip_ungoverned_auto_approve(servers_map)
         _atomic_json_write(path, config)
+        # Bookkeeping, strictly AFTER the spec is committed. Both directions are
+        # ordered this way on purpose: a record that lands before a failed spec
+        # write would name a model that is not on disk, and a retirement that
+        # lands before one would strand a pin with nothing to recognize it by.
+        # A sidecar failure here is logged, never raised — the spec is already
+        # written, and turning that into an exception would skip the remaining
+        # agent installs. Both operations are retried by the next refresh.
+        try:
+            if pending_config_model:
+                agent_state.set_config_model(
+                    config.get("name") or _MAIN_AGENT_NAME, pending_config_model
+                )
+            _resolve_config_model_record(config)
+        except OSError:
+            logger.warning(
+                "Could not update the propagated-model record for %s; "
+                "it will be retried on the next refresh",
+                config.get("name"),
+                exc_info=True,
+            )
 
     try:
         is_kirocrew_json = path.resolve() == _mcp_json_path().resolve()

--- a/src/kiro_crew/agent_state.py
+++ b/src/kiro_crew/agent_state.py
@@ -7,18 +7,33 @@ the default agent (``--agent <name>`` resolves to default with only a stderr
 per-agent bookkeeping OUT of the kiro spec and in this sidecar, so every spec
 stays schema-valid for kiro-cli.
 
-Two values are tracked, both kept in this sidecar rather than the kiro spec:
+Three values are tracked, all kept in this sidecar rather than the kiro spec:
 
 - ``model_managed`` (bool): whether an agent's ``model`` should track the
   shipped ``defaults.json`` (so a default bump propagates) or is an explicit
   user pick frozen against future bumps.
 - ``cc_model`` (str): a per-agent model for the ``claude_code`` provider (that
   backend can't pick a per-agent model from ``--agent`` the way kiro-cli does).
+- ``config_model`` (str): the model the global ``agent.model`` last propagated
+  into this agent's spec, recorded only when that write REPLACED a different
+  value. Provenance for the write, so returning the global to "auto" can un-pin
+  a spec model Kiro Crew itself wrote. Equality is deliberately not treated as
+  provenance: the Agent Templates editor and a hand edit also write the spec, so
+  a spec that already agrees with the global may be someone else's pick. The
+  accepted cost is that a pin made before this record existed has no provenance
+  and is never un-pinned.
+
+  **Obligation for any new writer of a spec's ``model``:** if your write leaves
+  the value EQUAL to this record, void the record (``set_config_model(name,
+  None)``) after your spec write succeeds — otherwise the un-pin will later read
+  your value as the old propagation and replace it with "auto". A write that
+  leaves the value DIFFERENT needs nothing: the post-write retirement in
+  ``agent._resolve_config_model_record`` clears a spent record on its own.
 
 State file (``~/.kiro/crew/agent_model_state.json``, honoring ``KIROCREW_HOME``)::
 
     {
-      "kirocrew":           {"model_managed": true},
+      "kirocrew":           {"model_managed": true, "config_model": "<pinned id>"},
       "kirocrew-heartbeat": {"cc_model": "claude-sonnet-4.6"}
     }
 
@@ -42,6 +57,7 @@ logger = logging.getLogger(__name__)
 _STATE_FILENAME = "agent_model_state.json"
 _MODEL_MANAGED = "model_managed"
 _CC_MODEL = "cc_model"
+_CONFIG_MODEL = "config_model"
 
 # Guards in-process read-modify-write races (e.g. dashboard PATCH vs gateway
 # refresh). Cross-process atomicity is provided by ``atomic_write``.
@@ -111,6 +127,56 @@ def set_cc_model(name: str, value: str | None) -> None:
         else:
             data.pop(name, None)
         _write(data)
+
+
+def get_config_model(name: str) -> str | None:
+    """Return the model the global ``agent.model`` propagated into this agent's
+    spec, or ``None`` when the global never pinned one."""
+    with _lock:
+        value = _entry(_read(), name).get(_CONFIG_MODEL)
+    return value if isinstance(value, str) and value else None
+
+
+def set_config_model(name: str, value: str | None) -> None:
+    """Record (or clear, when ``value`` is falsy) the propagated global model."""
+    with _lock:
+        data = _read()
+        entry = data.get(name)
+        if not isinstance(entry, dict):
+            entry = {}
+        if value:
+            entry[_CONFIG_MODEL] = str(value)
+        else:
+            entry.pop(_CONFIG_MODEL, None)
+        if entry:
+            data[name] = entry
+        else:
+            data.pop(name, None)
+        _write(data)
+
+
+def clear_config_model_if(name: str, expected: str) -> bool:
+    """Clear ``config_model`` only if it still equals *expected*.
+
+    Compare-and-clear under the same lock as the read, so a retirement decided
+    against one observed value cannot discard a NEWER record written between the
+    decision and the write (two rebuilds overlapping — one going to "auto", one
+    propagating a concrete model). Returns True when the clear happened.
+    """
+    if not expected:
+        return False
+    with _lock:
+        data = _read()
+        entry = data.get(name)
+        if not isinstance(entry, dict) or entry.get(_CONFIG_MODEL) != expected:
+            return False
+        entry.pop(_CONFIG_MODEL, None)
+        if entry:
+            data[name] = entry
+        else:
+            data.pop(name, None)
+        _write(data)
+    return True
 
 
 def prune(name: str) -> None:

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -1334,6 +1334,15 @@ async def api_agent_detail(request: web.Request) -> web.Response:
                         data.pop("model_managed", None)
                         data.pop("cc_model", None)
                         f.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+                        if "model" in patch_body:
+                            # AFTER the spec write: this write makes the spec's
+                            # model THIS editor's, so any propagated-model
+                            # provenance for it is void — but only once the value
+                            # it describes is actually on disk. Voiding it first
+                            # and then failing the write would leave the old
+                            # propagated pin in place with nothing left to
+                            # recognize it by, so it could never be un-pinned.
+                            agent_state.set_config_model(agent_name, None)
                     # The list_agents() cache keys on a (count, newest-mtime-ns)
                     # signature; two writes inside the same mtime granularity
                     # would otherwise serve a stale skill list.

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -4290,6 +4290,446 @@ class TestRefreshDynamicFieldsSyncsConfigModel:
         assert config["model"] == "claude-sonnet-4.6"
 
 
+class TestRefreshDynamicFieldsUnpinsOnAuto:
+    """Returning ``agent.model`` to "auto" must un-pin a model the propagation
+    itself wrote, or the spec value outranks the global forever and Auto becomes
+    unreachable (at a higher credit multiplier than the user asked for)."""
+
+    def _write_mc_config(self, tmp_path: Path, model) -> Path:
+        mc = tmp_path / "config.json"
+        body = {} if model is None else {"agent": {"model": model}}
+        mc.write_text(json.dumps(body), encoding="utf-8")
+        return mc
+
+    @pytest.fixture(autouse=True)
+    def _clean_sidecar(self):
+        # Belt-and-braces on top of conftest's per-test sidecar isolation: these
+        # cases are decided BY the sidecar, so each states its own start state.
+        agent_state.prune("kirocrew")
+        yield
+        agent_state.prune("kirocrew")
+
+    def _refresh(self, tmp_path: Path, global_model, config: dict) -> dict:
+        from kiro_crew.agent import _refresh_dynamic_fields
+
+        mc = self._write_mc_config(tmp_path, global_model)
+        with patch("kiro_crew.agent._mc_config_path", return_value=mc):
+            pending = _refresh_dynamic_fields(config)
+        # Mirror the caller: the propagated model is recorded only after the spec
+        # write would have succeeded. See test_a_failed_spec_write_records_nothing
+        # for the ordering itself.
+        if pending:
+            agent_state.set_config_model(config.get("name") or "kirocrew", pending)
+        return config
+
+    def test_propagation_records_provenance(self, tmp_path: Path):
+        agent_state.set_model_managed("kirocrew", True)
+        config = self._refresh(
+            tmp_path, "claude-opus-4.8", {"name": "kirocrew", "model": "stale"}
+        )
+        assert config["model"] == "claude-opus-4.8"
+        assert agent_state.get_config_model("kirocrew") == "claude-opus-4.8"
+
+    def test_returning_global_to_auto_unpins_the_propagated_model(self, tmp_path: Path):
+        # The reporter's state: a model propagated by an older config, and no
+        # model_managed entry, so the shipped-default re-sync never fires.
+        agent_state.set_config_model("kirocrew", "claude-opus-4.8")
+        assert agent_state.get_model_managed("kirocrew") is None
+        config = self._refresh(
+            tmp_path, "auto", {"name": "kirocrew", "model": "claude-opus-4.8"}
+        )
+        assert config["model"] == "auto"
+
+    def test_the_record_survives_the_unpin_so_a_lost_spec_write_retries(self, tmp_path: Path):
+        # The spec reaches disk long after this function returns. If the record
+        # were cleared here, a crash in between would leave the spec pinned with
+        # nothing left to recognize it by, and no later refresh could un-pin it.
+        agent_state.set_config_model("kirocrew", "claude-opus-4.8")
+        interrupted = {"name": "kirocrew", "model": "claude-opus-4.8"}
+        self._refresh(tmp_path, "auto", interrupted)
+        assert agent_state.get_config_model("kirocrew") == "claude-opus-4.8"
+        # Next refresh sees the spec as the failed write left it, and heals it.
+        retried = self._refresh(
+            tmp_path, "auto", {"name": "kirocrew", "model": "claude-opus-4.8"}
+        )
+        assert retried["model"] == "auto"
+
+    def test_unpin_is_idempotent(self, tmp_path: Path):
+        agent_state.set_config_model("kirocrew", "claude-opus-4.8")
+        config = {"name": "kirocrew", "model": "claude-opus-4.8"}
+        self._refresh(tmp_path, "auto", config)
+        self._refresh(tmp_path, "auto", config)
+        assert config["model"] == "auto"
+
+    def test_a_value_the_propagation_never_wrote_is_left_alone(self, tmp_path: Path):
+        # No provenance record → the spec model came from somewhere else (a hand
+        # edit, an older build's shipped default). Clearing it would be a
+        # one-way delete of a value this code never authored.
+        agent_state.set_config_model("kirocrew", None)
+        config = self._refresh(
+            tmp_path, "auto", {"name": "kirocrew", "model": "claude-haiku-4.5"}
+        )
+        assert config["model"] == "claude-haiku-4.5"
+
+    def test_a_diverged_value_is_left_alone(self, tmp_path: Path):
+        # Propagated 4.8, but the spec now says something else — the Agent
+        # Templates editor writes the spec directly, so that pick is its own.
+        agent_state.set_config_model("kirocrew", "claude-opus-4.8")
+        config = self._refresh(
+            tmp_path, "auto", {"name": "kirocrew", "model": "claude-haiku-4.5"}
+        )
+        assert config["model"] == "claude-haiku-4.5"
+
+    def test_an_editor_pick_that_coincides_with_the_global_never_gets_a_record(
+        self, tmp_path: Path
+    ):
+        # Equality is not provenance. A pick that already agrees with the global is
+        # not recorded, which is what keeps it out of reach of the un-pin.
+        agent_state.set_model_managed("kirocrew", False)
+        config = {"name": "kirocrew", "model": "claude-opus-4.8"}
+        self._refresh(tmp_path, "claude-opus-4.8", config)
+        assert agent_state.get_config_model("kirocrew") is None
+        self._refresh(tmp_path, "auto", config)
+        assert config["model"] == "claude-opus-4.8"
+
+    def test_a_hand_edited_pin_matching_the_global_is_not_erased(self, tmp_path: Path):
+        # Same rule, without any editor marker: a raw spec edit that happens to
+        # equal the global must survive a later return to auto.
+        assert agent_state.get_model_managed("kirocrew") is None
+        config = {"name": "kirocrew", "model": "claude-opus-4.8"}
+        self._refresh(tmp_path, "claude-opus-4.8", config)
+        assert agent_state.get_config_model("kirocrew") is None
+        self._refresh(tmp_path, "auto", config)
+        assert config["model"] == "claude-opus-4.8"
+
+    def test_editor_pick_then_global_then_auto_still_reaches_auto(self, tmp_path: Path):
+        # A pick the propagation actually REPLACED is ours to un-pin, and the
+        # editor's freeze marker is not consulted — a record can only exist for a
+        # value this code overwrote.
+        agent_state.set_model_managed("kirocrew", False)
+        config = {"name": "kirocrew", "model": "claude-haiku-4.5"}
+        self._refresh(tmp_path, "claude-opus-4.8", config)
+        assert agent_state.get_config_model("kirocrew") == "claude-opus-4.8"
+        self._refresh(tmp_path, "auto", config)
+        assert config["model"] == "auto"
+
+    def test_a_reselected_editor_pick_matching_the_record_is_not_erased(self, tmp_path: Path):
+        # The editor clears provenance on every explicit write, so re-selecting the
+        # recorded value makes it the editor's, not ours.
+        agent_state.set_config_model("kirocrew", "claude-opus-4.8")
+        agent_state.set_config_model("kirocrew", None)  # what the editor write does
+        config = self._refresh(
+            tmp_path, "auto", {"name": "kirocrew", "model": "claude-opus-4.8"}
+        )
+        assert config["model"] == "claude-opus-4.8"
+
+    def test_a_deprecated_alias_record_still_unpins_after_migration(self, tmp_path: Path):
+        # The deprecated-alias migration rewrites the spec model in place, so the
+        # un-pin must recognise the pre-migration value the record holds.
+        agent_state.set_config_model("kirocrew", "claude-opus-4.6-1m")
+        config = self._refresh(
+            tmp_path, "auto", {"name": "kirocrew", "model": "claude-opus-4.6-1m"}
+        )
+        assert config["model"] == "auto"
+
+    def test_the_refresh_itself_writes_no_record(self, tmp_path: Path):
+        # The record must not outrun the spec, so the refresh only REPORTS it.
+        from kiro_crew.agent import _refresh_dynamic_fields
+
+        mc = self._write_mc_config(tmp_path, "claude-opus-4.8")
+        config = {"name": "kirocrew", "model": "claude-haiku-4.5"}
+        with patch("kiro_crew.agent._mc_config_path", return_value=mc):
+            pending = _refresh_dynamic_fields(config)
+        assert pending == "claude-opus-4.8"
+        assert agent_state.get_config_model("kirocrew") is None
+
+    def test_propagating_the_same_value_reports_nothing_to_record(self, tmp_path: Path):
+        from kiro_crew.agent import _refresh_dynamic_fields
+
+        mc = self._write_mc_config(tmp_path, "claude-opus-4.8")
+        config = {"name": "kirocrew", "model": "claude-opus-4.8"}
+        with patch("kiro_crew.agent._mc_config_path", return_value=mc):
+            pending = _refresh_dynamic_fields(config)
+        assert pending == ""
+
+    def test_managed_resync_still_wins_when_global_is_auto(self, tmp_path: Path):
+        # A managed agent already heals via the shipped-default re-sync; the
+        # unpin must not fight it.
+        agent_state.set_model_managed("kirocrew", True)
+        agent_state.set_config_model("kirocrew", "claude-opus-4.8")
+        config = self._refresh(
+            tmp_path, "auto", {"name": "kirocrew", "model": "claude-opus-4.8"}
+        )
+        assert config["model"] == "auto"
+
+    def test_repin_after_unpin_records_the_new_value(self, tmp_path: Path):
+        agent_state.set_config_model("kirocrew", None)
+        config = {"name": "kirocrew", "model": "auto"}
+        self._refresh(tmp_path, "claude-sonnet-4.6", config)
+        assert config["model"] == "claude-sonnet-4.6"
+        assert agent_state.get_config_model("kirocrew") == "claude-sonnet-4.6"
+        self._refresh(tmp_path, "auto", config)
+        assert config["model"] == "auto"
+
+
+class TestResolveConfigModelRecord:
+    """The propagated-model record is retired only after a spec that supersedes it
+    reaches disk, so an un-pin cannot outlive its own record and a failed write
+    cannot strand one."""
+
+    @pytest.fixture(autouse=True)
+    def _clean(self):
+        agent_state.prune("kirocrew")
+        yield
+        agent_state.prune("kirocrew")
+
+    def _install_with_global(self, tmp_path: Path, spec_model: str, global_model: str):
+        """Run a real install with an existing spec pin and a concrete global.
+
+        Seeds `_run_install`'s own mc_config (it only writes that file when absent)
+        rather than patching `_mc_config_path`, which `_run_install` patches itself.
+        """
+        cfg_dir = _bundled_defaults(tmp_path)
+        kiro_dir = tmp_path / "kiro_agents"
+        kiro_dir.mkdir(exist_ok=True)
+        (kiro_dir / "kirocrew.json").write_text(
+            json.dumps(
+                {
+                    "name": "kirocrew",
+                    "model": spec_model,
+                    "tools": [],
+                    "allowedTools": [],
+                    "mcpServers": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+        (tmp_path / "empty_mc_config.json").write_text(
+            json.dumps({"agent": {"model": global_model, "kiro_hooks_autoimport": False}}),
+            encoding="utf-8",
+        )
+        return cfg_dir
+
+    def test_a_failed_spec_write_records_nothing(self, tmp_path: Path):
+        # The finding this closes: an existing pin A, global B, and a spec write
+        # that fails. If B were recorded anyway, the record would name a model
+        # that is not on disk and a later return to "auto" could un-pin neither.
+        cfg_dir = self._install_with_global(tmp_path, "claude-pin-a", "claude-pin-b")
+        agent_state.set_config_model("kirocrew", "claude-pin-a")
+
+        with patch("kiro_crew.agent._atomic_json_write", side_effect=OSError("unwritable")):
+            with pytest.raises(OSError):
+                _run_install(tmp_path, cfg_dir)
+        # A, which is what is still on disk — not B.
+        assert agent_state.get_config_model("kirocrew") == "claude-pin-a"
+
+    def test_a_successful_spec_write_records_the_propagated_model(self, tmp_path: Path):
+        cfg_dir = self._install_with_global(tmp_path, "claude-pin-a", "claude-pin-b")
+        path = _run_install(tmp_path, cfg_dir)
+        assert json.loads(path.read_text(encoding="utf-8"))["model"] == "claude-pin-b"
+        assert agent_state.get_config_model("kirocrew") == "claude-pin-b"
+
+    def test_a_failing_record_write_does_not_fail_the_rebuild(self, tmp_path: Path):
+        # The spec is already committed when the record is written, so a sidecar
+        # error must be swallowed rather than skipping the remaining installs.
+        cfg_dir = self._install_with_global(tmp_path, "claude-pin-a", "claude-pin-b")
+        with patch(
+            "kiro_crew.agent_state.set_config_model", side_effect=OSError("unwritable")
+        ):
+            path = _run_install(tmp_path, cfg_dir)
+        assert json.loads(path.read_text(encoding="utf-8"))["model"] == "claude-pin-b"
+
+    def test_a_persisted_heal_retires_the_record(self):
+        from kiro_crew.agent import _resolve_config_model_record
+
+        agent_state.set_config_model("kirocrew", "claude-opus-4.8")
+        # What the un-pin wrote, now persisted.
+        _resolve_config_model_record({"name": "kirocrew", "model": "auto"})
+        assert agent_state.get_config_model("kirocrew") is None
+
+    def test_a_persisted_pin_keeps_its_record(self):
+        from kiro_crew.agent import _resolve_config_model_record
+
+        agent_state.set_config_model("kirocrew", "claude-opus-4.8")
+        _resolve_config_model_record({"name": "kirocrew", "model": "claude-opus-4.8"})
+        assert agent_state.get_config_model("kirocrew") == "claude-opus-4.8"
+
+    def test_a_persisted_value_owned_elsewhere_retires_the_record(self):
+        from kiro_crew.agent import _resolve_config_model_record
+
+        agent_state.set_config_model("kirocrew", "claude-opus-4.8")
+        _resolve_config_model_record({"name": "kirocrew", "model": "claude-haiku-4.5"})
+        assert agent_state.get_config_model("kirocrew") is None
+
+    def test_a_concurrent_newer_record_is_not_discarded(self):
+        from kiro_crew.agent import _resolve_config_model_record
+
+        agent_state.set_config_model("kirocrew", "claude-opus-4.8")
+        persisted = {"name": "kirocrew", "model": "auto"}
+
+        # A concurrent rebuild records a NEWER pin between the read and the clear.
+        real_get = agent_state.get_config_model
+
+        def racing_get(name: str):
+            value = real_get(name)
+            agent_state.set_config_model("kirocrew", "claude-sonnet-4.6")
+            return value
+
+        with patch("kiro_crew.agent_state.get_config_model", side_effect=racing_get):
+            _resolve_config_model_record(persisted)
+        assert agent_state.get_config_model("kirocrew") == "claude-sonnet-4.6"
+
+    def test_no_record_is_a_noop(self):
+        from kiro_crew.agent import _resolve_config_model_record
+
+        _resolve_config_model_record({"name": "kirocrew", "model": "auto"})
+        assert agent_state.get_config_model("kirocrew") is None
+
+    def test_a_nameless_spec_still_retires_under_the_main_agent_name(self):
+        from kiro_crew.agent import _resolve_config_model_record
+
+        # A spec with no `name` is still the main agent's file; without the
+        # fallback its record would outlive the spec and a later hand edit back to
+        # that model would be mistaken for the original propagation.
+        agent_state.set_config_model("kirocrew", "claude-opus-4.8")
+        _resolve_config_model_record({"model": "auto"})
+        assert agent_state.get_config_model("kirocrew") is None
+
+    def test_a_raw_edit_back_to_the_value_is_not_unpinned_after_a_persisted_heal(
+        self, tmp_path: Path
+    ):
+        # The window this closes: heal, then a raw spec edit back to the model.
+        # Once the heal has persisted the record is gone, so the later value is
+        # not mistaken for the old propagation.
+        from kiro_crew.agent import _refresh_dynamic_fields, _resolve_config_model_record
+
+        mc = tmp_path / "config.json"
+        mc.write_text(json.dumps({"agent": {"model": "auto"}}), encoding="utf-8")
+        agent_state.set_config_model("kirocrew", "claude-opus-4.8")
+        healed = {"name": "kirocrew", "model": "claude-opus-4.8"}
+        with patch("kiro_crew.agent._mc_config_path", return_value=mc):
+            _refresh_dynamic_fields(healed)
+        assert healed["model"] == "auto"
+        _resolve_config_model_record(healed)  # the spec write lands
+
+        raw_edit = {"name": "kirocrew", "model": "claude-opus-4.8"}
+        with patch("kiro_crew.agent._mc_config_path", return_value=mc):
+            _refresh_dynamic_fields(raw_edit)
+        assert raw_edit["model"] == "claude-opus-4.8"
+
+    def test_an_unpersisted_heal_keeps_the_record_so_it_retries(self, tmp_path: Path):
+        # The crash case: the heal never reaches disk, so nothing is retired and
+        # the next refresh un-pins again.
+        from kiro_crew.agent import _refresh_dynamic_fields
+
+        mc = tmp_path / "config.json"
+        mc.write_text(json.dumps({"agent": {"model": "auto"}}), encoding="utf-8")
+        agent_state.set_config_model("kirocrew", "claude-opus-4.8")
+        lost = {"name": "kirocrew", "model": "claude-opus-4.8"}
+        with patch("kiro_crew.agent._mc_config_path", return_value=mc):
+            _refresh_dynamic_fields(lost)
+        # _resolve_config_model_record is deliberately NOT called — no write landed.
+        assert agent_state.get_config_model("kirocrew") == "claude-opus-4.8"
+        retried = {"name": "kirocrew", "model": "claude-opus-4.8"}
+        with patch("kiro_crew.agent._mc_config_path", return_value=mc):
+            _refresh_dynamic_fields(retried)
+        assert retried["model"] == "auto"
+
+    def test_the_real_write_path_retires_the_record(self, tmp_path: Path):
+        # Pins the CALL SITE, not just the helper: a real install writes the spec
+        # and must retire a record the un-pin superseded.
+        cfg_dir = _bundled_defaults(tmp_path)
+        kiro_dir = tmp_path / "kiro_agents"
+        kiro_dir.mkdir(exist_ok=True)
+        (kiro_dir / "kirocrew.json").write_text(
+            json.dumps(
+                {
+                    "name": "kirocrew",
+                    "model": "claude-user-pinned",
+                    "tools": [],
+                    "allowedTools": [],
+                    "mcpServers": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+        agent_state.set_config_model("kirocrew", "claude-user-pinned")
+        path = _run_install(tmp_path, cfg_dir)
+        written = json.loads(path.read_text(encoding="utf-8"))
+        assert written["model"] == "auto"
+        assert agent_state.get_config_model("kirocrew") is None
+
+    def test_a_failing_sidecar_write_does_not_fail_the_rebuild(self, tmp_path: Path):
+        # The spec is already committed by the time the record is retired, so a
+        # sidecar write error must not raise out and skip the remaining installs.
+        cfg_dir = _bundled_defaults(tmp_path)
+        kiro_dir = tmp_path / "kiro_agents"
+        kiro_dir.mkdir(exist_ok=True)
+        (kiro_dir / "kirocrew.json").write_text(
+            json.dumps(
+                {
+                    "name": "kirocrew",
+                    "model": "claude-user-pinned",
+                    "tools": [],
+                    "allowedTools": [],
+                    "mcpServers": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+        agent_state.set_config_model("kirocrew", "claude-user-pinned")
+        with patch(
+            "kiro_crew.agent_state.clear_config_model_if",
+            side_effect=OSError("read-only sidecar dir"),
+        ):
+            path = _run_install(tmp_path, cfg_dir)
+        written = json.loads(path.read_text(encoding="utf-8"))
+        assert written["model"] == "auto"
+        # Retained, so the next refresh retries the retirement.
+        assert agent_state.get_config_model("kirocrew") == "claude-user-pinned"
+
+
+class TestConfigModelSidecar:
+    """``config_model`` records what the global propagated, alongside the other
+    per-agent bookkeeping rather than in the kiro spec (which rejects unknown
+    fields)."""
+
+    @pytest.fixture(autouse=True)
+    def _clean(self):
+        agent_state.prune("probe")
+        yield
+        agent_state.prune("probe")
+
+    def test_unset_reads_as_none(self):
+        assert agent_state.get_config_model("probe") is None
+
+    def test_round_trip(self):
+        agent_state.set_config_model("probe", "claude-opus-4.8")
+        assert agent_state.get_config_model("probe") == "claude-opus-4.8"
+
+    def test_clearing_drops_the_key(self):
+        agent_state.set_config_model("probe", "claude-opus-4.8")
+        agent_state.set_config_model("probe", None)
+        assert agent_state.get_config_model("probe") is None
+
+    def test_clearing_preserves_sibling_keys(self):
+        agent_state.set_model_managed("probe", True)
+        agent_state.set_cc_model("probe", "claude-sonnet-4.6")
+        agent_state.set_config_model("probe", "claude-opus-4.8")
+        agent_state.set_config_model("probe", None)
+        assert agent_state.get_model_managed("probe") is True
+        assert agent_state.get_cc_model("probe") == "claude-sonnet-4.6"
+
+    def test_empty_string_reads_as_unset(self):
+        agent_state.set_config_model("probe", "")
+        assert agent_state.get_config_model("probe") is None
+
+    def test_prune_removes_it(self):
+        agent_state.set_config_model("probe", "claude-opus-4.8")
+        agent_state.prune("probe")
+        assert agent_state.get_config_model("probe") is None
+
+
 # ── ensure_agent_materialized (self-heal for kiro-cli "Mode not found") ──
 
 

--- a/test/test_agent_default_model.py
+++ b/test/test_agent_default_model.py
@@ -272,6 +272,39 @@ class TestEffectiveModelPrecedence:
         assert resolve_effective_model(cfg, None) == "claude-opus-5"
 
 
+class TestUnpinnedSpecReachesTheResolver:
+    """End-to-end for the tier-4 read: once the propagation un-pins the spec,
+    the one resolver the composer chip and the wire both read must report Auto.
+    """
+
+    def test_spec_unpinned_by_a_return_to_auto_resolves_to_auto(
+        self, specs_dir: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from kiro_crew import agent_state
+        from kiro_crew.agent import _refresh_dynamic_fields
+
+        spec = specs_dir / "kirocrew.json"
+        spec.write_text(
+            json.dumps({"name": "kirocrew", "model": "claude-opus-4.8"}), encoding="utf-8"
+        )
+        cfg = _cfg({"crew": {"kiro_agent": "kirocrew", "model": ""}}, "auto")
+        # The pin is what the global propagated before it was set back to auto.
+        assert resolve_effective_model(cfg, "crew") == "claude-opus-4.8"
+
+        agent_state.prune("kirocrew")
+        agent_state.set_config_model("kirocrew", "claude-opus-4.8")
+        mc = tmp_path / "config.json"
+        mc.write_text(json.dumps({"agent": {"model": "auto"}}), encoding="utf-8")
+        spec_data = json.loads(spec.read_text(encoding="utf-8"))
+        try:
+            with unittest.mock.patch("kiro_crew.agent._mc_config_path", return_value=mc):
+                _refresh_dynamic_fields(spec_data)
+            spec.write_text(json.dumps(spec_data), encoding="utf-8")
+            assert resolve_effective_model(cfg, "crew") == ""
+        finally:
+            agent_state.prune("kirocrew")
+
+
 class TestSessionModelCoversEverySurface:
     """The crew tier must apply to Slack / cron / spawn, not just dashboard chat.
 

--- a/test/test_agent_detail_model_managed.py
+++ b/test/test_agent_detail_model_managed.py
@@ -47,6 +47,25 @@ async def test_patch_explicit_model_freezes(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_patch_model_voids_propagated_provenance(tmp_path):
+    """An explicit editor write makes the spec model the editor's, so the
+    propagated-model record for it must not survive — otherwise re-selecting the
+    recorded value would be read as the old propagation and un-pinned when the
+    global returns to "auto"."""
+    agent_state.set_config_model("kirocrew", "claude-recorded")
+    cfg = tmp_path / "kirocrew.json"
+    cfg.write_text(json.dumps({"name": "kirocrew", "model": "claude-other"}))
+    request = _patch_request("kirocrew", {"model": "claude-recorded"})
+
+    with patch("kiro_crew.agent.KIRO_AGENTS_DIR", tmp_path):
+        resp = await api_agent_detail(request)
+
+    assert resp.status == 200
+    assert json.loads(cfg.read_text(encoding="utf-8"))["model"] == "claude-recorded"
+    assert agent_state.get_config_model("kirocrew") is None
+
+
+@pytest.mark.asyncio
 async def test_patch_clear_model_resumes_tracking(tmp_path):
     cfg = tmp_path / "kirocrew.json"
     cfg.write_text(


### PR DESCRIPTION
## Problem

Setting `agent.model` back to `auto` does nothing. A user with every level of
configuration on Auto — `config.json` `agent.model = "auto"`, agent definitions on
`auto` or omitting the field, Settings → Chat → Fallback Model on "Default (auto)" —
still gets `claude-opus-4.8` in the model selector of **every new session**, with no
signal that the setting was ignored.

## Why it matters

Not a display artifact. `resolve_effective_model` is the single resolver behind both
the composer chip and the wire, and `providers/acp.py` sends the resolved model
whenever it is not the `auto` sentinel — so the session really runs the stale pin.
`auto` bills at a 1.0x rate multiplier and `claude-opus-4.8` at 2.2x, so the user
pays a premium on every turn for a model they believe they turned off.

`claude-opus-4.8` is exactly the pre-#1423 shipped default, i.e. a value an older
build propagated into the spec and that nothing has been able to clear since.

## Fix (symptom → root cause → change)

**Symptom:** Auto is unreachable from the configuration surface.

**Root cause:** `_refresh_dynamic_fields` propagates `config.json`'s `agent.model`
**into** the kiro agent spec, but only when it is not the `auto` sentinel:

```python
if mc_model and mc_model != "auto":
    config["model"] = mc_model
```

There is no reverse branch. The spec model **outranks** the global in
`resolve_effective_model` (spec is tier 2/4, the global is tier 3), so a model
propagated once outranks the global forever. The write is one-way.

**Change:** record what the propagation wrote, so the write can be undone.

- `agent_state` gains `config_model` — the model the global last propagated into
  this agent's spec — alongside the existing `model_managed` / `cc_model`
  bookkeeping. It lives in the sidecar, not the spec, because kiro-cli validates
  specs with `deny_unknown_fields` and silently falls back to the default agent on
  an unknown key.
- When the global returns to `auto` and the spec model still equals the recorded
  value, it is cleared to the `auto` sentinel. A value that **diverged** since
  belongs to whoever wrote it and is left alone.
- **Provenance is recorded only when the propagation replaces a different value.**
  Equality is not proof of authorship: the Agent Templates editor and a hand edit
  both write the spec directly, so a spec that already agrees with the global may be
  someone else's explicit pick, and recording it would let the un-pin erase a value
  this code never wrote. That rule is also what makes the editor's `model_managed`
  freeze marker irrelevant here — a record can only exist for a value the
  propagation overwrote, so an editor pick that merely *coincides* with the global
  never gets one and is already out of reach of the un-pin.
- Cleared to the sentinel rather than by dropping the field: an absent model lets
  kiro-cli fall through to its own configured default, which is not necessarily
  auto, while the sentinel says what the user actually chose. `"auto"` is
  `DEFAULT_MODEL` and `defaults.json` already ships it, so a healed spec is
  byte-identical in that slot to a fresh install.
- The record is retired by `_resolve_config_model_record` **after the spec write
  succeeds**, not at the point the decision is made — the two are ~1100 lines apart
  (`_refresh_dynamic_fields` mutates an in-memory dict; the spec reaches disk in
  `_finalize_and_write`). Both of the simpler orderings are wrong: retiring at
  decision time makes an interrupted or failed write permanent (the spec still holds
  the pinned model with no record left to recognize it by), while never retiring it
  lets a spent record outlive the spec it described, so a raw edit back to that value
  is mistaken for the old propagation and un-pinned. Resolving after the write gives
  both properties — nothing is retired unless the spec that supersedes it landed, and
  a record whose value is no longer what persisted is dropped.

Scope note: `_refresh_dynamic_fields` has one caller chain and only ever rewrites
`kirocrew.json`, so no other agent's spec is touched.

## Tests

26 new tests. Six were revert-verified against the first round and the two
round-two fixes were each revert-verified in isolation (removing only the
freeze-voiding fails 2; re-introducing only the early record clear fails 1).

| Test | Locks in |
|---|---|
| `test_propagation_records_provenance` | a concrete global is written to the spec **and** recorded |
| `test_returning_global_to_auto_unpins_the_propagated_model` | the reported state (no `model_managed` entry) reaches `auto` |
| `test_the_record_survives_the_unpin_so_a_lost_spec_write_retries` | an interrupted spec write still heals on the next refresh |
| `test_unpin_is_idempotent` | repeated refreshes are non-destructive |
| `test_a_value_the_propagation_never_wrote_is_left_alone` | no record → not ours → untouched |
| `test_a_diverged_value_is_left_alone` | record present but spec changed → untouched |
| `test_an_editor_pick_that_coincides_with_the_global_never_gets_a_record` | equality is not provenance, so a coincident editor pick is never recorded |
| `test_a_hand_edited_pin_matching_the_global_is_not_erased` | same rule for a raw spec edit, with no editor marker |
| `test_editor_pick_then_global_then_auto_still_reaches_auto` | a pick the propagation actually replaced is ours to un-pin |
| `TestResolveConfigModelRecord` (9) | post-write retirement: persisted heal retires, persisted pin keeps, value owned elsewhere retires, the ABA sequence, the crash case, the real `install_agent` write path, and a failing sidecar write not breaking a committed rebuild |
| `test_managed_resync_still_wins_when_global_is_auto` | the un-pin does not fight the shipped-default re-sync |
| `test_repin_after_unpin_records_the_new_value` | re-pin updates the record |
| `TestConfigModelSidecar` (6) | sidecar accessors: unset, round-trip, clear, sibling-key preservation, empty-string, prune |
| `TestUnpinnedSpecReachesTheResolver` | end-to-end: `resolve_effective_model` returns `""` (Auto) after the un-pin |

The end-to-end one is the load-bearing test: it asserts through the same resolver
the composer chip and the wire both read, so it fails with `assert
'claude-opus-4.8' == ''` without the fix.

## Manual verification

N/A — unit coverage is sufficient and this path has no UI. The behaviour is decided
entirely inside `_refresh_dynamic_fields` and read back through
`resolve_effective_model`, and both are asserted directly, including the end-to-end
tier-4 read via a real spec file on disk.

Gates: pytest (the 53 failures on this host are a missing OS sandbox backend and
reproduce identically with the diff reverted to `origin/main`), isort, flake8, mypy
across 866 files. No frontend files touched.

## Screenshots

N/A — no user-visible UI change. The user-visible *effect* is the model id shown in
the composer picker, which is produced by the resolver asserted in
`TestUnpinnedSpecReachesTheResolver`.

## Known limits, deliberately out of scope

- **This fix is forward-looking: a pin that already exists has no provenance and is
  never un-pinned.** The un-pin only reaches pins recorded after this ships, i.e.
  ones where a later propagation replaced a different value. Seeding a record from a
  spec that merely *equals* the global was the obvious way to reach existing installs
  and is deliberately NOT done — equality is not provenance, and doing it would erase
  a hand-edited or editor-set pin that happens to agree with the global. So the
  originally reported install is not repaired by this change; it stops the bug being
  *created*, and recovering already-pinned installs needs the #2559 migration.
- **The grandfathered no-heal gap (#2559)** is otherwise untouched: an agent with no
  `model_managed` entry still never re-syncs from the shipped default. This change
  *improves* that population rather than worsening it — the un-pin is precisely what
  catches them once a record exists.
- **No freeze marker is written at all**, so the earlier concern about freeze state
  being committed before the spec write no longer applies — there is nothing to
  defer.
- **`PATCH agent.model` does not rebuild the spec** (it only calls
  `refresh_defaults()`), so both the pin and the un-pin land at the next gateway
  start rather than on save. Pre-existing and symmetric.

**This PR does not close #2558.** The fix is forward-only: a pin that already exists
has no provenance record, so it is never un-pinned. Closing the issue on merge would
leave every currently affected install with a closed ticket and no repair, so the
reference is deliberately non-closing — #2559's migration owns that population.

Refs #2558
Fixes #2610
