### PR TITLE
fix(dev-fleet): reattach to in-flight sync on page revisit

### DIFF
--- a/website/src/pages/DevFleetPage.tsx
+++ b/website/src/pages/DevFleetPage.tsx
@@ -559,6 +559,7 @@ export default function DevFleetPage() {
     queryKey: ['dev-fleet', 'fleet'],
     queryFn: () => api.get<FleetData>('/fleet'),
     refetchInterval: POLL_MS,
+    refetchOnMount: 'always',
   })
 
   /* ─── react-query: disk data ─── */
@@ -661,14 +662,22 @@ export default function DevFleetPage() {
   /* ─── Sync reattach on page load ─── */
   useEffect(() => {
     if (!fleet?.sync_run_id || syncAttachedRef.current) return
+    if (syncRun?.rid === fleet.sync_run_id) return // already tracking this run
     syncAttachedRef.current = true
     const rid = fleet.sync_run_id
-    api.get<{ status?: string; output?: string[]; started?: number; step_label?: string }>('/run?id=' + rid)
+    api.get<{ status?: string; output?: string[]; exit_code?: number; started?: number; step_label?: string }>('/run?id=' + rid)
       .then((run) => {
-        if (run?.status === 'running') {
-          const t0 = run.started ? run.started * 1000 : Date.now()
-          setSyncRun({ rid, status: 'running', lines: run.output || [], startedAt: t0, stepLabel: run.step_label })
+        if (!run) return
+        const t0 = run.started ? run.started * 1000 : Date.now()
+        const out = run.output || []
+        const last = [...out].reverse().find((l) => l?.trim() && !STEP_MARKER_RE.test(l)) || ''
+        if (run.status === 'running') {
+          setSyncRun({ rid, status: 'running', lines: out, startedAt: t0, stepLabel: run.step_label })
           pollSyncRun(rid, t0)
+        } else if (run.status === 'done' || run.status === 'timeout') {
+          // Show the completed/failed result so user sees it on revisit
+          const okRun = run.exit_code === 0
+          setSyncRun({ rid, status: okRun ? 'done' : 'error', lines: out, startedAt: t0, exit: run.exit_code, last })
         }
       })
       .catch(() => { /* run endpoint unreachable — nothing to reattach */ })
@@ -862,6 +871,12 @@ export default function DevFleetPage() {
     setFlag('__syncmain', true)
     try {
       const r = await api.post<{ ok?: boolean; run_id?: string; error?: string }>('/sync', {})
+      if (!r?.ok && r?.run_id) {
+        // Sync already running — reattach to the in-flight run instead of erroring
+        setSyncRun({ rid: r.run_id, status: 'running', lines: [], startedAt: Date.now() })
+        pollSyncRun(r.run_id, Date.now())
+        return
+      }
       if (!r?.ok || !r.run_id) { notify(r?.error || i18nT('pages.devFleetPage.pull_build_failed_to_start'), { type: 'error' }); setFlag('__syncmain', false); return }
       setSyncRun({ rid: r.run_id, status: 'running', lines: [], startedAt: Date.now() })
       pollSyncRun(r.run_id, Date.now())

--- a/website/src/test/DevFleetPage.test.tsx
+++ b/website/src/test/DevFleetPage.test.tsx
@@ -219,6 +219,60 @@ describe('DevFleetPage', () => {
     await waitFor(() => expect(runCalls).toBeGreaterThan(0), { timeout: 3000 })
   })
 
+  it('reattaches to in-flight sync when syncMain gets "already running" with run_id', async () => {
+    let runPolls = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url, opts) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
+      // POST /sync returns "already running" with the in-flight run_id
+      if (u.includes('/sync') && opts?.method?.toUpperCase() === 'POST') {
+        return Promise.resolve(new Response(JSON.stringify({ ok: false, error: 'sync already running', run_id: 'run-inflight-99' }), { status: 200 }))
+      }
+      if (u.includes('/run?id=run-inflight-99')) {
+        runPolls++
+        return Promise.resolve(new Response(JSON.stringify({
+          status: 'running', output: ['npm ci...'], started: Date.now() / 1000 - 10,
+        }), { status: 200 }))
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('feature-x')).toBeInTheDocument())
+    // Click Pull+Build confirm
+    const trigger = screen.getByText('Pull+Build').closest('button') as HTMLButtonElement
+    fireEvent.click(trigger)
+    const start = await screen.findByRole('button', { name: 'Start' })
+    fireEvent.click(start)
+    // Should reattach and start polling the in-flight run
+    await waitFor(() => expect(runPolls).toBeGreaterThan(0), { timeout: 3000 })
+  })
+
+  it('reattaches to completed sync on page load showing result', async () => {
+    const FLEET_WITH_DONE_SYNC = {
+      ...FLEET,
+      sync_run_id: 'run-done-456',
+      build_pending: true,
+    }
+    let runCalls = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      const u = typeof url === 'string' ? url : (url as Request).url
+      if (u.includes('/fleet')) return Promise.resolve(new Response(JSON.stringify(FLEET_WITH_DONE_SYNC), { status: 200 }))
+      if (u.includes('/disk')) return Promise.resolve(new Response(JSON.stringify({ total_mb: 51200 }), { status: 200 }))
+      if (u.includes('/run?id=run-done-456')) {
+        runCalls++
+        return Promise.resolve(new Response(JSON.stringify({
+          status: 'done', exit_code: 0, output: ['All steps complete'], started: Date.now() / 1000 - 120,
+        }), { status: 200 }))
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getAllByText('main').length).toBeGreaterThan(0))
+    // Should fetch and display the completed run result
+    await waitFor(() => expect(runCalls).toBeGreaterThan(0), { timeout: 3000 })
+  })
+
   it('renders sort dropdown with all 4 options', async () => {
     vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
       const u = typeof url === 'string' ? url : (url as Request).url


### PR DESCRIPTION
## Problem

Navigating away from the Dev Fleet page during Pull+Build and returning shows no sync progress. Clicking Pull+Build again shows "sync already running" — the user is stuck with no visibility into what's happening.

## Root Cause

1. **syncMain() discarded the run_id** from the backend's "already running" response, showing an error toast instead of reattaching to the in-flight run.
2. **Reattach on mount only showed running syncs** — a completed or failed sync from moments ago was invisible on revisit.
3. **Stale react-query cache** from before the sync started could delay reattach by up to 12s (the poll interval).

## Fix

1. When `POST /sync` returns `{ok: false, run_id: ...}`, reattach to that run instead of erroring.
2. Reattach effect now also displays completed/failed run results on page revisit.
3. Fleet query uses `refetchOnMount: 'always'` to get fresh data immediately on navigation back.

## Testing

- 71/71 DevFleetPage tests pass (2 new regression tests added)
- TypeScript clean
- Manually verified the scenario: start sync → navigate away → return → sync bar reappears

Fixes #2616

## Demo

![Sync reattach on page revisit](https://raw.githubusercontent.com/RohanK6/KiroCrew/pr-media/devfleet-sync-reattach.gif)

The GIF shows: Dev Fleet page → Pull+Build starts (sync bar appears) → navigate away → navigate back → **sync bar reattaches automatically** (the fix).