### PR TITLE
fix(ci): stop discarding Code Review Sage's measured coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,7 +352,7 @@ jobs:
           fi
           pytest -q -n auto --timeout=120 \
             --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
-            ${{ matrix.python-version == '3.12' && '--cov=kiro_crew' || '--no-cov' }} \
+            ${{ matrix.python-version == '3.12' && '--cov=kiro_crew --cov=sage_lib' || '--no-cov' }} \
             $BACKEND_DESELECTS
         # Deselected tests require capabilities unavailable on GH Actions:
         #   test_script_hooks, test_cron_script: Linux namespace sandbox (unshare NEWNS)

--- a/setup.cfg
+++ b/setup.cfg
@@ -306,6 +306,32 @@ source =
     src/
     build/lib/*/site-packages/
 
+# Code Review Sage puts its OWN app root on sys.path (backend/routes.py and
+# sage_lib/*.py do this so the app also runs standalone as
+# `python3 sage_lib/learning.py`), so its 27-file suite imports the library as
+# the TOP-LEVEL package `sage_lib` -- `from sage_lib import learning` -- not as
+# kiro_crew.apps.builtins.code_review_sage.sage_lib.learning.
+#
+# `--cov=kiro_crew` resolves its inclusion set from that package's module tree,
+# so execution attributed to a foreign top-level module was discarded -- while
+# the FILES, which do live under src/kiro_crew/, were still listed in the report
+# as never-executed. Result: sage_lib's 2437 statements sat in the denominator
+# at a reported 0.0% even though 693 passing tests cover 83.7% of them, costing
+# ~0.96pp of the measured backend rate.
+#
+# ci.yml therefore also passes `--cov=sage_lib`, and this paths entry collapses
+# the two filename shapes coverage then sees ("sage_lib/learning.py" from the
+# top-level import, and the canonical in-package path) onto ONE canonical file.
+# Without the merge, the same module lands twice -- once covered, once at 0% --
+# which double-counts the denominator and cancels the correction out entirely.
+#
+# Same class of measurement fix as the deselected-test omit above: it changes
+# what the number MEANS, not how much code is tested.
+sagelib =
+    src/kiro_crew/apps/builtins/code_review_sage/sage_lib
+    */code_review_sage/sage_lib
+    sage_lib
+
 # Kept here rather than as an addopts --cov-report so that an explicit
 # `pytest --cov=kiro_crew` still shows uncovered lines now that coverage is
 # opt-in.


### PR DESCRIPTION
## Problem

All ten modules in `src/kiro_crew/apps/builtins/code_review_sage/sage_lib/` report **0.0%** coverage. They are not untested — **693 passing tests** in that app's 27-file suite exercise **83.7%** of them.

So 2,437 statements sat in the coverage denominator with an empty numerator.

## Why it matters

It understated the measured backend rate by **0.97pp** (83.67% instead of 84.64%), against a floor we ratchet against. Worse, it pointed coverage work at the wrong target: `sage_lib` was the single largest apparent gap in the whole backend and topped every "what to cover next" list, when in reality it is already better covered than the backend average.

## Fix (symptom → root cause → change)

The symptom is an import-shape mismatch, not missing tests.

Code Review Sage puts its **own app root** on `sys.path` — `backend/routes.py`, `sage_lib/learning.py`, and `sage_lib/pipeline.py` all do this deliberately, so the app also runs standalone as `python3 sage_lib/learning.py`. Its suite therefore imports the library as the **top-level** package:

```python
from sage_lib import learning as L      # not kiro_crew.apps.builtins.…sage_lib.learning
```

Confirmed by probe: `sage_lib.learning.__package__ == 'sage_lib'`, while `__file__` is `src/kiro_crew/apps/builtins/code_review_sage/sage_lib/learning.py` — the file **is** under the measured directory.

`--cov=kiro_crew` resolves its inclusion set from *that package's module tree*, so lines executed under a foreign top-level module name were attributed out-of-source and discarded. Because the files nonetheless live under `src/kiro_crew/`, coverage kept listing them — as never-executed.

Two halves, and it needs both:

| file | change |
|---|---|
| `.github/workflows/ci.yml` | also pass `--cov=sage_lib` so the executed module tree is measured |
| `setup.cfg` | `[coverage:paths] sagelib` collapses the two filename shapes onto one canonical file |

**The paths merge is load-bearing.** Without it the module lands twice — once covered, once at 0% — adding 2,437 to the denominator and cancelling the correction to *zero net gain*. I measured that failure mode before settling on this shape.

## Tests

No test is added, changed, or skipped, and no product code is touched — this is a measurement fix. The existing drift guard covers it:

- `test/test_coverage_omit_contract.py` — **5/5 pass**, including the fail-safe that rejects any omit pattern broader than one specific test file.

## Manual verification

Ran the same selection twice in the worktree against the repo's **own** coverage config (real omit lists, real paths section), once per `--cov` form:

| | files | denominator | numerator | `sage_lib` |
|---|---|---|---|---|
| before (`--cov=kiro_crew`) | 801 | 211,582 | 14,273 | 0 / 2,437 |
| after (`+ --cov=sage_lib`) | 801 | 211,582 | 16,314 | **2,039 / 2,437** |

- denominator change **+0** — the statements were already being counted
- numerator change **+2,041**
- **0** duplicate file entries (the check that the paths merge actually fired)
- per-module rates after the fix: `blast_radius` 97.5%, `adapters` 94.9%, `report` 91.4%, `results` 88.5%, `store` 84.2%, `review_pool` 83.7%, `learning` 80.8%, `discovery` 79.3%, `pipeline` 76.4%, `review_driver` 73.4%

Gate effect: **backend 83.67% → 84.64%** against the 80% floor.

`ci.yml` parses; `setup.cfg` reads back with both `source` and `sagelib` keys.

## Scope notes

- **The floor is deliberately not ratcheted here.** A threshold move belongs in its own change rather than riding along with the measurement correction that justifies it.
- I surveyed every other builtin app for the same pattern (app root on `sys.path` enabling a top-level lib import). `code_review_sage` is the **only** one — and only its `sage_lib`; the same app's `backend/` is imported by full package path and was always measured correctly at 70.6%.
- This is the same class of fix as the deselected-test `omit` block already documented in `setup.cfg`: it changes what the number **means**, not how much code is tested.

## Screenshots

N/A — CI configuration only, no user-visible surface.
