### PR TITLE
fix(mcp-apps): advertise a published SEP-1865 revision, document deviations

### DIFF
--- a/src/kiro_crew/docs/dashboard-iframe-hosts.md
+++ b/src/kiro_crew/docs/dashboard-iframe-hosts.md
@@ -25,7 +25,11 @@ reused for another's job:
   server-supplied or model-supplied HTML in it.
 - `McpAppFrame` is the **least** privileged (no `allow-same-origin`, no popups)
   *and* the **most** connected. It is the only host with a live bidirectional
-  bridge, and it is null-origin precisely because it must be.
+  bridge, and it is null-origin precisely because it must be. Note this is a
+  deliberate divergence from SEP-1865, which mandates a two-frame *sandbox proxy*
+  whose outer frame carries `allow-same-origin`; the trade and what it costs an
+  app are documented in [MCP Apps](mcp-apps.md#deviations-from-sep-1865). Do not
+  "fix" the sandbox attribute to match the spec without reading that section.
 - `WidgetFrame` is closest to `McpAppFrame` on content, but is built on the
   opposite bridge assumption. Reusing it for an MCP App would mean adopting a
   host that is designed to distrust exactly the messages the App protocol needs.

--- a/src/kiro_crew/docs/mcp-apps.md
+++ b/src/kiro_crew/docs/mcp-apps.md
@@ -5,8 +5,9 @@ alongside its text, the dashboard mounts that resource as a live, interactive
 component in the chat instead of showing you a wall of JSON. Ask for a diagram and
 the excalidraw server gives you an editable Excalidraw canvas in the conversation;
 other servers ship PDF viewers, forms, and dashboards the same way. This is the
-[SEP-1865](https://modelcontextprotocol.io) `ui` extension, and it works with any
-conforming server — nothing is hardcoded per vendor.
+[SEP-1865](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx)
+`ui` extension — Kiro Crew targets the **Stable 2026-01-26** revision — and it works
+with any conforming server: nothing is hardcoded per vendor.
 
 If you just want it working: **Developer → Shared MCP gateway → on**, then switch
 your server on under **Poolable MCP servers**. The rest of this page explains why
@@ -187,6 +188,54 @@ The per-result `_meta` is optional and some servers omit it, which is why
 Kiro Crew harvests declared URIs from `tools/list` when the backend starts — a
 tool that declared a `ui://` resource renders even when its individual results
 carry no `_meta`.
+
+## Deviations from SEP-1865
+
+Kiro Crew targets the Stable 2026-01-26 revision. Two things an app author should
+know, because a spec-conforming app may otherwise wait for something that never
+arrives.
+
+**No sandbox proxy — the frame is null-origin instead.** The spec requires a web
+host to wrap the view in an intermediate *sandbox proxy* at a different origin
+(`allow-scripts allow-same-origin` on the outer frame) and to hand the HTML over
+via a `ui/notifications/sandbox-proxy-ready` → `ui/notifications/sandbox-resource-ready`
+handshake. Kiro Crew does not do this. It renders app HTML in a **single
+null-origin iframe** — `sandbox="allow-scripts allow-forms"`, deliberately
+without `allow-same-origin` — with the CSP injected as a `<meta>` element ahead
+of any server-supplied byte.
+
+This is a deliberate trade, not an oversight: the spec's proxy arrangement gives
+the *inner* frame `allow-same-origin` relative to the proxy origin, whereas a
+null-origin frame has no origin to share at all. The consequences for an app:
+
+- The two `sandbox-*` notifications are never sent and never answered. Do not
+  wait for them; the `ui/initialize` handshake is the only entry point.
+- There is no stable per-app origin, so `_meta.ui.domain` has no effect. Anything
+  keyed to an origin — OAuth callbacks, CORS allowlists, API-key origin pinning —
+  will not work. Cookies and `localStorage` are unavailable for the same reason.
+- Because the frame has no storage, unmounting it loses in-canvas state. That is
+  why the panel goes to such lengths to keep frames mounted (see above).
+
+**Methods this host does not implement yet.** A conforming app must tolerate
+these being absent, per the spec's own graceful-degradation rule:
+
+| Method | Status |
+|---|---|
+| `ui/message` | not implemented |
+| `ui/update-model-context` | answered `-32601` |
+| `ui/resource-teardown` | not sent |
+| `ui/notifications/tool-cancelled` | not sent |
+| app-initiated `resources/read`, `ping` | not answered |
+| `pip` display mode | not offered (`availableDisplayModes` is `inline`, `fullscreen`) |
+
+`HostContext` carries `theme`, `displayMode`, `availableDisplayModes` and
+`containerDimensions`. The spec's `styles.variables` theming channel is not sent,
+so an app should declare its own fallbacks for every CSS variable it consumes and
+key off `theme` for light/dark.
+
+Everything in the spec's `draft` revision — app-provided tools,
+`sampling/createMessage`, `ui/download-file` — is out of scope until that revision
+stabilises.
 
 ## How a render actually reaches your screen
 

--- a/website/src/components/McpAppFrame.tsx
+++ b/website/src/components/McpAppFrame.tsx
@@ -20,7 +20,12 @@ const MAX_HEIGHT = 1200
 // MCP Apps UI-channel JSON-RPC method names (SEP-1865). The `ui/` namespace is
 // disjoint from the MCP tools namespace, carried over postMessage between the
 // host (this component) and the app iframe.
-const PROTOCOL_VERSION = '2025-11-21'
+/** The SEP-1865 revision this host speaks, returned in the `ui/initialize`
+ *  result. Must be a PUBLISHED revision id — the spec's own handshake examples
+ *  use the revision, and an app comparing against a value that was never
+ *  published cannot negotiate. Revisions live at
+ *  github.com/modelcontextprotocol/ext-apps/tree/main/specification. */
+const PROTOCOL_VERSION = '2026-01-26'
 const M_INITIALIZE = 'ui/initialize'
 const M_TOOLS_CALL = 'tools/call'
 const M_REQUEST_DISPLAY_MODE = 'ui/request-display-mode'

--- a/website/src/test/McpAppFrame.test.tsx
+++ b/website/src/test/McpAppFrame.test.tsx
@@ -78,7 +78,10 @@ describe('McpAppFrame', () => {
     expect(target).toBe('*')
     expect(reply.jsonrpc).toBe('2.0')
     expect(reply.id).toBe(1)
-    expect(reply.result.protocolVersion).toBe('2025-11-21')
+    // A PUBLISHED SEP-1865 revision id, not the SEP's creation date. If this
+    // assertion fails, check the new value exists under
+    // ext-apps/specification/ before updating it to match the source.
+    expect(reply.result.protocolVersion).toBe('2026-01-26')
     expect(reply.result.hostInfo).toEqual({ name: 'kirocrew', version: '0.1' })
     expect(reply.result.hostContext.displayMode).toBe('inline')
     expect(reply.result.hostContext.availableDisplayModes).toEqual(['inline', 'fullscreen'])


### PR DESCRIPTION
## Problem

Two audit findings against **SEP-1865 Stable 2026-01-26** (the normative text lives in [`ext-apps/specification/2026-01-26/apps.mdx`](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx), not the prose pages on modelcontextprotocol.io).

**1. We advertise a protocol version that does not exist.** `McpAppFrame.tsx` returned `protocolVersion: '2025-11-21'` from `ui/initialize`. That is SEP-1865's **creation date**, not a published revision — the only published ids are `2026-01-26` (Stable) and `draft`. The spec's own handshake examples use `protocolVersion: "2026-01-26"`, so an app comparing against what we send cannot match a real version.

**2. Our sandbox architecture knowingly diverges from the spec, undocumented.** The spec makes a two-frame *sandbox proxy* a MUST for web hosts. We render app HTML in a single **null-origin** iframe instead. That is the stronger choice — the spec's arrangement gives the inner frame `allow-same-origin` relative to the proxy origin, whereas null-origin has no origin to share — but it read as an unmet MUST, and an app author had no way to know the `sandbox-*` handshake will never arrive or that `_meta.ui.domain` is inert here.

## Change

- `PROTOCOL_VERSION` → `'2026-01-26'`, with a comment stating the constraint (must be a *published* revision) so the next person does not "correct" it back.
- New **Deviations from SEP-1865** section in `mcp-apps.md`: the null-origin trade and its three concrete consequences for an app (no `sandbox-*` notifications, no stable origin so `_meta.ui.domain`/OAuth/CORS/storage do not work, no storage means unmount loses canvas state), plus a table of the six unimplemented methods and the missing `styles.variables` theming channel.
- `dashboard-iframe-hosts.md` cross-links it with an explicit "do not 'fix' the sandbox attribute to match the spec without reading that section."
- Spec link now points at the pinned revision instead of bare `modelcontextprotocol.io`.

## Corrected during the audit

The plan behind this stack claimed spec drift would degrade renders to text **silently**. That was wrong: `_parse_ui_contents` already raises with both the received and expected mimetype, and `_fetch_and_deliver_ui` logs it at WARNING. No new logging was needed, so this PR is smaller than scoped.

## Verification

- Revert-verified: restoring `'2025-11-21'` fails exactly one test.
- `tsc -b` clean · eslint **0 errors** · vitest **12303 passed** (2 expected-fail, 3 skipped) · `I18N_BASE_REF=origin/main npm run i18n:check` all gates OK.
- No Python touched, so backend gates are unaffected.

## Scope notes

- Docs still say **Developer** where the page is now **Settings**. That correction is already committed on `fix/mcp-app-panel-autoopen` and is deliberately not duplicated here.
- First of a stack of three. Next: `ui/resource-teardown` + `ui/notifications/tool-cancelled` (two Stable MUSTs), then the `tools/list` model-visibility filter (the third).
