### PR TITLE
fix(config): a read-modify-write transaction so concurrent settings saves stop losing updates

### DIFF
--- a/src/kiro_crew/cli_config.py
+++ b/src/kiro_crew/cli_config.py
@@ -185,7 +185,14 @@ def _config_cmd(args: argparse.Namespace) -> None:
                             d = _subtract_overlay(d, raw_local)
                     except (json.JSONDecodeError, OSError):
                         pass
-                write_config_atomically(config_path(), stamp_config_meta(d))
+                # `baseline` for the same reason `save()` passes one: `d` is a whole-model
+                # dump, so without it the write replays every defaulted key over whatever
+                # is on disk now and reverts a setting changed since this load.
+                write_config_atomically(
+                    config_path(),
+                    stamp_config_meta(d),
+                    baseline=cfg.baseline_for(config_path()),
+                )
                 sel().log_api_access(
                     caller="cli",
                     operation="config_set",

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -12,15 +12,19 @@ dashboard URL via the config file. (The dashboard *port* is set with the
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import hashlib
 import json
 import logging
 import math
 import os
 import re as _re
 import stat as _stat
+import sys
 import threading
+import time
 import uuid
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -110,6 +114,22 @@ from kiro_crew.instances.constants import (
 from kiro_crew.mcp_gateway.rewriter import default_overlay_dir, default_socket_path
 
 logger = logging.getLogger(__name__)
+
+
+# File-locking primitives. Real module-level ``import`` statements (the repo's
+# ``top-level-imports`` rule), branched on the platform because neither module exists on
+# both: ``fcntl`` is POSIX-only and ``msvcrt`` is Windows-only. A guarded
+# ``try: import`` here would instead be a statement sitting among the imports, which
+# makes every later import an E402 and gets the bare imports relocated by isort; a
+# branch placed after the entire import section avoids both.
+if sys.platform == "win32":  # pragma: no cover - platform-dependent
+    import msvcrt
+
+    fcntl = None  # type: ignore[assignment]
+else:
+    import fcntl
+
+    msvcrt = None  # type: ignore[assignment]
 
 # Top-level config.json keys that save() stamps itself rather than modelling as
 # a section. They are neither parsed into a field nor round-tripped through
@@ -599,7 +619,16 @@ def read_config_for_update(path: Path | None = None) -> dict:
     p = path if path is not None else config_path()
     try:
         if not p.exists():
-            return {}
+            # Snapshot the absence too: every key the caller adds is then a genuine
+            # addition, so a file created concurrently is merged rather than replaced.
+            #
+            # ONE dict, snapshotted and returned. Two separate `{}` literals would be equal
+            # but not identical, and the read record is matched by IDENTITY -- so the pairing
+            # could never match here, every write against a newly created config would fall
+            # back to an unpaired whole write, and two first writers would clobber each other.
+            empty: dict = {}
+            _remember_snapshot(p, empty)
+            return empty
         raw = json.loads(p.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, UnicodeDecodeError, OSError) as e:
         # UnicodeDecodeError is a ValueError, NOT an OSError, so it needs naming
@@ -610,10 +639,107 @@ def read_config_for_update(path: Path | None = None) -> dict:
         raise ConfigReadError(f"could not read config at {p}: {e}") from e
     if not isinstance(raw, dict):
         raise ConfigReadError(f"config at {p} is not a JSON object (got {type(raw).__name__})")
+    # Remember what was handed out so a later write to the same path can replay only the
+    # caller's own edits onto a fresh read, instead of overwriting the whole file with
+    # this now-possibly-stale snapshot. See _apply_delta.
+    _remember_snapshot(p, raw)
     return raw
 
 
-def write_config_atomically(path: Path, data: dict, *, fsync: bool = False) -> None:
+def write_config_atomically(
+    path: Path,
+    data: dict,
+    *,
+    fsync: bool = False,
+    baseline: dict | None = None,
+) -> dict:
+    """Write config atomically, replaying only THIS caller's edits.
+
+    Callers are unchanged from the read-then-write pattern they already use::
+
+        data = read_config_for_update(path)
+        data["k"] = v
+        write_config_atomically(path, data)
+
+    and that pattern is now safe. It previously lost a concurrent update: both callers
+    read the same snapshot, and the second write replaced the first's change wholesale.
+
+    The fix lives here rather than in every caller. ``read_config_for_update`` records
+    what it handed out; this function takes the config lock, re-reads the file as it is
+    *now*, and replays the difference between the snapshot and *data* onto it -- so a key
+    the caller never touched keeps whatever another writer just stored. Two writers
+    editing different settings both survive; only the same leaf can be won by the later
+    writer, which serialised writes would do too.
+
+    **Why this needs no async migration.** The lock is held for a re-read, a dict merge
+    and a rename -- 0.57ms median, 1.47ms worst on a 13KB config, measured -- so a
+    contended caller waits about as long as the write it was already doing on the event
+    loop. That is the whole reason the burden belongs here: pushing it onto callers would
+    mean restructuring 12 handlers and offloading each one, to buy a millisecond.
+
+    A write with **no** matching read (``KiroCrewConfig.save()`` dumping the whole model,
+    or a freshly built dict) has no delta to replay, so it writes the payload as given --
+    still under the lock, so it cannot interleave with someone else's transaction.
+    """
+    # An explicit baseline wins over the thread-local read record: a caller that holds
+    # the dict it was loaded from knows its own starting point exactly, where the
+    # thread-local is a best-effort pairing of "the last read on this thread".
+    snapshot = baseline if baseline is not None else _take_snapshot(path, data)
+    if baseline is not None:
+        _take_snapshot(path)  # discard any stale record for this path
+    with _config_file_lock(path, timeout=_WRITE_LOCK_TIMEOUT, blocking=True) as acquired:
+        if acquired is False:
+            # A lock exists and another writer holds it -- see _config_file_lock for why
+            # proceeding anyway would silently discard that writer's update. Off the event
+            # loop this has already waited `timeout`; on it there is no wait at all.
+            raise ConfigBusyError(
+                f"config file is being written by another process: {path}"
+            )
+        if acquired is None:
+            # No lock is available in this directory AT ALL, which is not the same as "no
+            # competing writer": it means no mutual exclusion for anyone, so every writer
+            # proceeds and the last rename wins.
+            #
+            # Refusing also costs nothing measurable. `atomic_write` creates its temp file
+            # with `mkstemp(dir=path.parent)` -- the same directory the sidecar lives beside
+            # the resolved target in -- so a directory that cannot hold the sidecar cannot
+            # hold the temp file either, and the write would have failed an instant later.
+            # This just fails first, with a message that names the cause.
+            raise ConfigBusyError(
+                f"config write refused: no lock could be taken beside {path} "
+                "(the directory holding it must be writable)"
+            )
+        payload = data
+        if snapshot is not None and not path.exists():
+            # Checked HERE, under the lock, rather than before taking it: a file removed
+            # between an early check and this re-read would land in the very state this
+            # guard exists to prevent -- the re-read yields {}, the delta skips every key
+            # the caller did not change, and those keys vanish from the recreated file.
+            #
+            # With no file there is nothing to preserve, so there is no lost update to
+            # avoid: write the payload whole, exactly as an unpaired write does.
+            snapshot = None
+        if snapshot is not None:
+            try:
+                current = read_config_for_update(path)
+            except ConfigReadError:
+                # The file on disk is unreadable. Replaying a delta onto it is not
+                # possible, and refusing would strand the caller, so write what they
+                # asked for -- the same outcome as before this merge existed.
+                current = None
+            else:
+                _take_snapshot(path)  # drop the snapshot our own re-read just recorded
+            if current is not None:
+                payload = _apply_delta(current, snapshot, data)
+        _write_config_unlocked(path, payload, fsync=fsync)
+        # The MERGED dict, which differs from *data* exactly when a concurrent writer's
+        # keys were preserved. A caller holding a baseline needs this rather than its own
+        # payload: it is what is now on disk, so re-recording from it keeps the next
+        # delta honest. See `KiroCrewConfig.save`.
+        return payload
+
+
+def _write_config_unlocked(path: Path, data: dict, *, fsync: bool = False) -> None:
     """Write a config dict to *path* atomically, PRESERVING its permissions.
 
     The companion to :func:`read_config_for_update`. Two properties matter:
@@ -689,6 +815,410 @@ def stamp_config_meta(data: dict) -> dict:
         },
         **{k: v for k, v in data.items() if k != "meta"},
     }
+
+
+#: How long an OFF-loop write waits for the lock before refusing. On the loop the
+#: budget is always zero -- see _config_file_lock. Named so a test can shorten it
+#: rather than spending the full wait.
+_WRITE_LOCK_TIMEOUT = 5.0
+
+
+#: What ``read_config_for_update`` last handed out, per resolved path, per thread.
+#: A thread-local rather than a ``ContextVar`` on purpose: across all 12 sites in this
+#: repo that read the config and write it back in the same function, there is not a
+#: single ``await`` between the read and the write, so the pair never crosses a
+#: suspension point and one task cannot pick up another's snapshot.
+_read_snapshots = threading.local()
+
+
+def _snapshot_key(path: Path) -> str:
+    try:
+        return str(path.resolve())
+    except OSError:
+        return str(path)
+
+
+def _remember_snapshot(path: Path, data: dict) -> None:
+    """Record what *data* looked like as handed out, tagged with its object identity.
+
+    The identity is what makes the pairing precise. Keyed by path alone, a read that never
+    writes -- a handler that rejects its payload and returns 400 -- leaves the record for the
+    next unrelated writer on this thread, which then has its own values diffed against
+    someone else's read.
+    """
+    store = getattr(_read_snapshots, "by_path", None)
+    if store is None:
+        store = {}
+        _read_snapshots.by_path = store
+    # Deep copy via JSON round-trip: the caller is about to mutate the dict it was
+    # handed, and the snapshot has to stay as-read to be a usable base for the diff.
+    # Config is a few KB of plain JSON, so this costs microseconds.
+    try:
+        # The dict ITSELF, not `id(data)`: CPython hands a freed dict's address to the
+        # next allocation, so an id comparison matches almost any later writer while
+        # looking like a verified pairing. `dict` cannot be weak-referenced, so this is a
+        # strong reference -- it keeps one config dict alive per thread per path until the
+        # next read or write there, which is bounded and a few KB.
+        store[_snapshot_key(path)] = (data, json.loads(json.dumps(data)))
+    except (TypeError, ValueError):  # pragma: no cover - non-JSON payload
+        store.pop(_snapshot_key(path), None)
+
+
+def _take_snapshot(path: Path, data: dict | None = None) -> dict | None:
+    """Pop the snapshot for *path*, or ``None`` if this write has no matching read.
+
+    When *data* is given, the record is only honoured if it was handed out AS that object --
+    the read-then-mutate-then-write pattern keeps the same dict throughout, so identity is
+    the exact test for "this write is the one that read". A mismatch pops the stale record
+    and returns ``None``, so the write proceeds unpaired rather than replaying a delta
+    computed against a different caller's read.
+    """
+    store = getattr(_read_snapshots, "by_path", None)
+    if not store:
+        return None
+    entry = store.pop(_snapshot_key(path), None)
+    if entry is None:
+        return None
+    handed_to, snapshot = entry
+    if data is not None and data is not handed_to:
+        return None
+    return snapshot
+
+
+def _json_same(a: object, b: object) -> bool:
+    """Are *a* and *b* the same JSON value, TYPE INCLUDED?
+
+    `==` is not enough: Python has `True == 1` and `1 == 1.0`, so a config holding a numeric
+    `1` and a caller setting `True` would compare equal, the delta would call the key
+    unchanged, and the requested JSON type would never reach disk while the write reported
+    success. A `bool()` reader cannot tell the difference; a schema-checking one can.
+
+    `bool` is checked before `int` because it is a subclass of it.
+    """
+    if isinstance(a, bool) != isinstance(b, bool):
+        return False
+    if isinstance(a, dict) and isinstance(b, dict):
+        return a.keys() == b.keys() and all(_json_same(a[k], b[k]) for k in a)
+    if isinstance(a, list) and isinstance(b, list):
+        return len(a) == len(b) and all(_json_same(x, y) for x, y in zip(a, b))
+    if isinstance(a, (int, float)) and isinstance(b, (int, float)):
+        # int vs float is a JSON type change too (`1` and `1.0` are different bytes).
+        if isinstance(a, float) != isinstance(b, float):
+            return False
+    return bool(a == b)
+
+
+def _apply_delta(base: dict, snapshot: dict, desired: dict) -> dict:
+    """Replay the caller's edits (``snapshot`` -> ``desired``) on top of ``base``.
+
+    Key-level and recursive, never a whole-object replacement -- that is the difference
+    between "your setting and mine both survive" and "whoever writes last wins the whole
+    file". A key the caller did not touch keeps whatever is on disk NOW, which may be a
+    concurrent writer's newer value; that is the case that makes the merge work at all.
+    Where both sides changed the same leaf the caller's value wins, which is unavoidable
+    and is exactly what a serialised pair of writes would have produced anyway.
+    """
+    result = dict(base)
+    for key in set(snapshot) | set(desired):
+        in_snap = key in snapshot
+        in_want = key in desired
+        if in_snap and not in_want:
+            result.pop(key, None)  # the caller deleted it
+            continue
+        if not in_want:
+            continue
+        want = desired[key]
+        was = snapshot.get(key)
+        if in_snap and _json_same(want, was):
+            continue  # untouched by the caller -- do not clobber a newer value
+        if (
+            isinstance(want, dict)
+            and isinstance(was, dict)
+            and isinstance(result.get(key), dict)
+        ):
+            result[key] = _apply_delta(result[key], was, want)
+        else:
+            result[key] = want
+    return result
+
+
+class ConfigBusyError(OSError):
+    """The config write lock could not be taken, so nothing was written.
+
+    Derives from ``OSError`` deliberately: every caller of these helpers already
+    handles ``OSError`` from the underlying file write (a read-only data home, a full
+    disk, an unwritable symlink target), and a caller that treats "could not write"
+    uniformly is correct here too. The one thing it must NOT do is report success.
+    """
+
+
+def config_fingerprint(path: Path) -> str | None:
+    """SHA-256 of *path*'s bytes, or ``None`` when it does not exist.
+
+    Content, not ``(mtime, size)``: two writes of equal length inside one filesystem
+    timestamp tick are indistinguishable by ``stat``, and coarse ``mtime`` granularity
+    is common enough that a same-length edit slips straight through such a check.
+    """
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+
+
+@contextlib.contextmanager
+def _config_file_lock(
+    path: Path, *, timeout: float, blocking: bool
+) -> Iterator[bool | None]:
+    """Take an exclusive lock covering *path*; yield whether it was acquired.
+
+    The lock is a **sidecar** (``<name>.lock``), never the config inode. An atomic
+    config write replaces the file by ``rename``, which would drop a lock held on the
+    old inode -- the write would release the very lock meant to guard it, and the next
+    writer would find the lock free while the first was still mid-transaction.
+
+    Yields ``False`` rather than raising when the lock is unavailable, so the caller
+    decides between refusing and proceeding. The two unavailable cases differ
+    deliberately:
+
+    * **No locking primitive on this platform** (neither ``fcntl`` nor ``msvcrt``) --
+      reported as ACQUIRED, because a settings write must not become impossible there.
+      The fingerprint check in :class:`ConfigTransaction` still catches an interleaved
+      write; it just cannot prevent one.
+    * **The sidecar cannot be created** -- reported as NOT acquired, so a required
+      transaction refuses. That is the read-only-directory case, where proceeding would
+      let every writer run unlocked while still reporting success.
+    """
+    # Beside the RESOLVED target, not beside the symlink. Symlinking config.json into a
+    # dotfiles repo is a supported setup (``write_config_atomically`` resolves it for the
+    # same reason), and in that setup the directory holding the LINK can be read-only
+    # while the target is writable. A sidecar placed next to the link would then be
+    # uncreatable even though the write itself succeeds, so every writer would proceed
+    # unlocked. Placing it next to the target puts the lock where the write lands.
+    target = path
+    try:
+        if path.is_symlink():
+            target = path.resolve()
+    except OSError:
+        pass
+
+    # Dot-prefixed so it does not clutter the user's data directory listing. It is a
+    # persistent file, not a temp one -- flock needs an inode that outlives the write it
+    # guards -- so it cannot simply be deleted afterwards.
+    lock_path = target.with_name("." + target.name + ".lock")
+    handle = None
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = lock_path.open("a+")
+    except OSError:
+        # No sidecar next to the target either. `None`, not `False`: the two failures
+        # need opposite handling and only the caller can tell them apart.
+        #
+        #   None  -- no lock is AVAILABLE here (this directory cannot hold the sidecar).
+        #            Nobody else can be holding one either, so there is no writer to race
+        #            and proceeding unlocked is safe. Refusing would break settings on a
+        #            host whose config directory is read-only but whose symlink target is
+        #            writable.
+        #   False -- a lock exists and someone else HOLDS it. There is a concrete
+        #            competing writer, so proceeding is a lost update.
+        #
+        # Both are falsy, so a caller that only asks `if not acquired` keeps its existing
+        # behaviour and a required transaction still refuses.
+        yield None
+        return
+
+    acquired = False
+    try:
+        if fcntl is None and msvcrt is None:  # pragma: no cover - no locking available
+            acquired = True
+        else:
+            # NEVER poll on the event loop. A `time.sleep` spin here is reachable
+            # inline from async handlers, where it stalls every session and the
+            # liveness heartbeat -- the repo's `no-blocking-call-on-event-loop` rule.
+            #
+            # So an on-loop caller gets ONE non-blocking attempt and no wait. What it
+            # must NOT do is proceed unlocked: the delta merge does not rescue that
+            # case. The merge base is the re-read, and a lock holder can land its own
+            # rename between that re-read and ours, so the payload we then write was
+            # computed from bytes that are already stale and the holder's update is
+            # overwritten. The lock covers the re-read -> rename span for exactly that
+            # reason; skipping it silently loses updates.
+            #
+            # `write_config_atomically` therefore raises `ConfigBusyError` on a False
+            # here. Failing a config write under genuine contention is loud and
+            # recoverable by a retry; silently reverting a setting the user just
+            # changed is neither.
+            on_loop = False
+            try:
+                asyncio.get_running_loop()
+                on_loop = True
+            except RuntimeError:
+                pass
+            budget = 0.0 if on_loop else (timeout if blocking else 0.0)
+            deadline = time.monotonic() + budget
+            while True:
+                try:
+                    if fcntl is not None:
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    else:  # pragma: no cover - Windows
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                    acquired = True
+                    break
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        break
+                    # A held critical section is one atomic write -- measured at 0.57ms
+                    # median, 1.47ms worst on this repo's config -- so a 5ms poll costs
+                    # at most a few iterations in the realistic case.
+                    time.sleep(0.005)
+        yield acquired
+    finally:
+        try:
+            if acquired and fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            elif acquired and msvcrt is not None:  # pragma: no cover - Windows
+                try:
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                except OSError:
+                    pass
+        finally:
+            handle.close()
+
+
+class ConfigTransaction:
+    """A read-modify-write of the config file held under one lock.
+
+    Handed out by :func:`config_transaction`. ``read()`` and ``write()`` must both
+    happen inside the ``with`` block -- that is the entire point, and the reason this
+    is a transaction rather than a locked ``write_config_atomically``. Locking only
+    the write would make the *rename* mutually exclusive while leaving the read
+    outside, so two callers still read the same snapshot and the second write still
+    discards the first's change. A lost update is created between the read and the
+    write, so that is the span the lock has to cover.
+    """
+
+    def __init__(self, path: Path, *, locked: bool) -> None:
+        self._path = path
+        self._locked = locked
+        self._fingerprint_at_read: str | None = None
+        self._read_called = False
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    @property
+    def locked(self) -> bool:
+        """False when the platform or filesystem could not provide a lock."""
+        return self._locked
+
+    def read(self) -> dict:
+        """Read the current config. Raises ``ConfigReadError`` on a corrupt file."""
+        # Fingerprint BEFORE the read, not after: a writer landing *during* the read
+        # would otherwise be invisible, because a post-read hash already includes it.
+        self._fingerprint_at_read = config_fingerprint(self._path)
+        data = read_config_for_update(self._path)
+        self._read_called = True
+        return data
+
+    def write(self, data: dict, *, fsync: bool = False) -> None:
+        """Write *data*, refusing if the file changed since :meth:`read`."""
+        if not self._read_called:
+            raise RuntimeError(
+                "ConfigTransaction.write() before read(); the transaction exists to "
+                "cover a read-modify-write, so writing a payload that was not derived "
+                "from a read inside it has no guarantee to offer"
+            )
+        current = config_fingerprint(self._path)
+        if current != self._fingerprint_at_read:
+            raise ConfigBusyError(
+                f"{self._path} changed while this update was in flight; nothing was "
+                "written"
+            )
+        # The transaction already holds the lock and has verified the fingerprint,
+        # so it writes through the unlocked primitive rather than re-entering the
+        # public wrapper (flock is per-open-file-description: a second open in this
+        # same process would block on our own lock).
+        _take_snapshot(self._path)
+        _write_config_unlocked(self._path, data, fsync=fsync)
+
+
+@contextlib.contextmanager
+def config_transaction(
+    path: Path | None = None, *, timeout: float = 5.0, required: bool = True
+) -> Iterator[ConfigTransaction]:
+    """Hold the config lock across a read-modify-write.
+
+    Use this instead of ``read_config_for_update`` followed by
+    ``write_config_atomically`` whenever the new value depends on the old one -- which
+    is every settings update in this repo.
+
+    **Blocking is correct here and only here.** The critical section is a single atomic
+    write (measured 0.57ms median / 1.47ms worst on a 13KB config), so a contended
+    caller waits milliseconds. It is still a blocking wait, so an ``async`` caller must
+    NOT call this inline -- use :func:`amutate_config`, which runs the whole
+    transaction on a worker thread and leaves the event loop free.
+
+    With ``required=True`` (the default) a lock that cannot be taken within *timeout*
+    raises :class:`ConfigBusyError` rather than proceeding unlocked. Pass
+    ``required=False`` for a write that is genuinely optional -- ``load()``'s one-time
+    migration write-back is the motivating case: it re-materialises defaults it already
+    holds in memory, so skipping it under contention loses nothing, whereas waiting on
+    it would put a lock wait on every code path that reads config.
+    """
+    target = path or config_path()
+    with _config_file_lock(target, timeout=timeout, blocking=True) as acquired:
+        if not acquired and required:
+            raise ConfigBusyError(
+                f"another process holds the config lock for {target} (waited "
+                f"{timeout:.1f}s); nothing was written"
+            )
+        # The lock's tri-state collapses to a bool here on purpose: a transaction
+        # treats "held by someone else" and "no lock available" the same way -- it is
+        # not locked, so `required=True` refuses either way. Only
+        # `write_config_atomically` needs to tell them apart.
+        yield ConfigTransaction(target, locked=bool(acquired))
+
+
+def mutate_config(
+    mutate: Callable[[dict], None],
+    path: Path | None = None,
+    *,
+    timeout: float = 5.0,
+    fsync: bool = False,
+) -> dict:
+    """Apply *mutate* to the config under one transaction and return the written dict.
+
+    *mutate* is called with the freshly-read config and edits it in place. It must be
+    free of side effects beyond that dict: on a detected concurrent write the
+    transaction refuses, and a mutate that had already sent a Slack message or spawned
+    a process would leave that half-done.
+    """
+    with config_transaction(path, timeout=timeout) as txn:
+        data = txn.read()
+        mutate(data)
+        txn.write(data, fsync=fsync)
+        return data
+
+
+async def amutate_config(
+    mutate: Callable[[dict], None],
+    path: Path | None = None,
+    *,
+    timeout: float = 5.0,
+    fsync: bool = False,
+) -> dict:
+    """``mutate_config`` on a worker thread -- the form async callers must use.
+
+    The transaction blocks while waiting for the lock, so calling ``mutate_config``
+    inline from a coroutine would stall the gateway's event loop, freezing every
+    session and the liveness heartbeat. Offloading keeps the wait off the loop while
+    still serialising against other writers, in this process and in others.
+    """
+    return await asyncio.to_thread(
+        mutate_config, mutate, path, timeout=timeout, fsync=fsync
+    )
 
 
 def workspace_dir_for(workspace: str | None = None) -> Path:
@@ -4892,6 +5422,18 @@ class KiroCrewConfig:
     # round-trips it untouched.
     _extra_sections: dict = field(default_factory=dict)
 
+    #: The raw dict this instance was parsed from, when it came from ``load()``.
+    #: ``save()`` replays only the difference against this, so a concurrent change
+    #: to a field this instance never touched is not reverted by a whole-model dump.
+    #: ``init=False``/``compare=False`` keep it out of the constructor and equality,
+    #: and ``to_dict()`` builds its output explicitly so it never reaches the file.
+    _loaded_from: dict | None = field(default=None, repr=False, compare=False)
+    #: Resolved path `_loaded_from` was captured from. A baseline is only valid for
+    #: that file: `KIROCREW_HOME` can be repointed within one process, and a baseline
+    #: applied to a different config would skip every key it considers unchanged and
+    #: silently inherit the other file's values.
+    _loaded_path: str | None = field(default=None, repr=False, compare=False)
+
     def channel_config(self, channel_id: str) -> ChannelConfig:
         """Return the config for *channel_id*, falling back to defaults.
 
@@ -4908,6 +5450,60 @@ class KiroCrewConfig:
     def slack_enterprise_ids(self) -> set[str]:
         """Extra allowed enterprise IDs from ``slack.allowed_enterprise_ids``."""
         return set(self.slack.allowed_enterprise_ids)
+
+    def _record_baseline(self, path: Path, raw: dict | None = None) -> KiroCrewConfig:
+        """Record this instance's starting point, and return it so callers can chain.
+
+        Called as soon as the model exists, at EVERY exit from `load()` -- including the
+        fresh-home shortcut that returns before any file is parsed, and before the migration
+        write-back. A missed exit is silent: `baseline_for()` returns None, the write falls
+        back to a whole-model dump, and the lost update this machinery exists to prevent
+        comes back. The fresh-home exit is the worst one to miss, because there every key is
+        a default, so every key gets replayed.
+
+        The baseline is `to_dict()` shaped, not the raw parsed file. `save()` writes
+        `to_dict()`, which fills in a default for every key the file omits; a raw baseline
+        lacks those keys, so the delta counts each as "the caller set this" and replays it
+        over whatever is on disk.
+
+        *raw* is what was actually parsed off disk (file plus overlay, as merged). The
+        baseline is the UNION of that and `to_dict()`, because a delta can only DELETE what
+        its baseline still contains, and `save()` deletes two kinds of key by omitting them
+        from its payload: the values `config.local.json` owns, and any key the model does not
+        model at all -- a legacy alias like `agent.yolo` that a whole-file dump used to drop.
+        Leave those out of the baseline and they sit in neither side of the delta, so the
+        merge preserves them on disk and the strip silently stops working.
+
+        With the union, all three behaviours hold at once:
+
+        * an overlay-owned key or legacy alias -> in the baseline, absent from the payload,
+          so `_apply_delta` treats it as a deletion and pops it;
+        * a defaulted key the caller left alone -> equal on both sides, so it is skipped;
+        * a key someone else changed since the load -> in neither side, so it is left alone.
+        """
+        try:
+            canonical = self.to_dict()
+            # Canonical WINS (it is `_deep_merge`'s overriding argument), and raw contributes
+            # the keys the model does not carry at all. That combination is what makes each
+            # case come out right:
+            #
+            #   * a key the model NORMALIZES (a sorted ID list) takes the normalized value,
+            #     so an ordinary `save()` sees no change and does not replay the old value
+            #     over someone else's replacement -- normalization is not a caller edit;
+            #   * a defaulted key the file omits takes the default, so it is equal to the
+            #     payload and skipped rather than replayed;
+            #   * a legacy alias or overlay-owned key survives from raw, so it is in the
+            #     baseline and absent from the payload -- which is a deletion.
+            #
+            # The MIGRATION write is the one place that needs the opposite (its whole job is
+            # to land the normalized form), and it says so by passing the raw file as an
+            # explicit baseline rather than by changing this line.
+            self._loaded_from = _deep_merge(raw, canonical) if raw else canonical
+            self._loaded_path = _snapshot_key(path)
+        except (TypeError, ValueError, OSError):  # pragma: no cover - unreadable overlay
+            self._loaded_from = None
+            self._loaded_path = None
+        return self
 
     @classmethod
     def load(cls) -> KiroCrewConfig:
@@ -4930,6 +5526,11 @@ class KiroCrewConfig:
         cached_data = _cached_validated_data()
         if cached_data is not None:
             data = cached_data
+            # The cache holds the VALIDATED dict, so the raw-versus-repaired distinction is
+            # not recoverable here. It does not need to be: the migration write-back that
+            # needs the raw form only fires when a load actually parsed the file, and by the
+            # time a cached load happens that migration has already converged.
+            raw_on_disk = data
         else:
             # Capture the fingerprint BEFORE reading so a write landing during
             # the read is detected: we cache under this pre-read fp, which won't
@@ -4990,7 +5591,16 @@ class KiroCrewConfig:
                     memory_store="default",
                 )
                 cfg.default_agent = "default"
-                return cfg
+                # A fresh home has no file, so every key of the eventual write is a
+                # default -- which is exactly why this exit needs a baseline most.
+                return cfg._record_baseline(path)
+
+            # The file AS PARSED, before the passes below repair it. Validation and the
+            # resource-limit clamping both rewrite `data` in place -- an entry whose type does
+            # not match the schema is replaced with its default -- so `data` afterwards is not
+            # what is on disk. A baseline built from the repaired dict cannot express the
+            # removal of what was repaired away, which is exactly what a migration has to do.
+            raw_on_disk = json.loads(json.dumps(data))
 
             # Validate against JSON Schema (advisory — never fatal)
             _validate_config_data(data)
@@ -5833,6 +6443,10 @@ class KiroCrewConfig:
             _extra_sections=extra_sections,
         )
 
+        # BEFORE the migration write-back below, which calls `save()`: without a
+        # baseline that save is an unpaired whole-model dump.
+        cfg._record_baseline(path, raw_on_disk)
+
         # Write-back migration: if the on-disk config has legacy format
         # (flat workspace strings, missing sections), back up the original
         # and save the migrated version.  One-shot — subsequent loads see
@@ -5873,7 +6487,7 @@ class KiroCrewConfig:
                     "Config migrated — backup saved to %s",
                     backup,
                 )
-                cfg.save()
+                cfg.save(baseline=raw_on_disk)
         except Exception as e:
             # Migration write-back is best-effort; never block startup.
             logger.warning("Config write-back failed: %s", e)
@@ -5947,7 +6561,46 @@ class KiroCrewConfig:
         slack_section["observe_ttl_hours"] = self.observe_ttl_hours
         return d
 
-    def save(self) -> None:
+    def _canonical_payload(self) -> dict:
+        """The exact dict ``save()`` writes, before the ``meta`` stamp.
+
+        Two callers need it and they must agree: ``save()`` as the payload, and ``load()``
+        as the baseline that payload will be diffed against. A baseline in any other shape
+        makes untouched keys look edited (a raw file dict lacks the defaults ``to_dict()``
+        fills in) or makes edited keys look deleted (a canonical dict against a raw
+        payload), so both come from here rather than from two copies of the same steps.
+
+        Overlay-owned values are stripped so ``config.local.json`` settings do not leak
+        into the base file.
+        """
+        d = self.to_dict()
+        local_path = config_local_path()
+        if local_path.is_file():
+            try:
+                raw_local = json.loads(local_path.read_text(encoding="utf-8"))
+                if isinstance(raw_local, dict):
+                    d = _subtract_overlay(d, raw_local)
+            except (json.JSONDecodeError, OSError):
+                pass
+        return d
+
+    def baseline_for(self, path: Path) -> dict | None:
+        """The baseline to write *path* with, or ``None`` if this instance has none for it.
+
+        Public so a writer that builds its own ``to_dict()``-shaped payload instead of
+        calling ``save()`` -- ``kirocrew config set KEY VALUE`` is the one in this repo --
+        gets the same protection ``save()`` gets.
+
+        Returns ``None`` for any path other than the one this instance was loaded from,
+        because a delta replayed against a different file drops every key it reads as
+        unchanged.
+        """
+        recorded = getattr(self, "_loaded_path", None)
+        if recorded is None or recorded != _snapshot_key(path):
+            return None
+        return getattr(self, "_loaded_from", None)
+
+    def save(self, *, baseline: dict | None = None) -> None:
         """Write current config to ~/.kiro/crew/config.json.
 
         Stamps a ``meta`` block with the current version and timestamp
@@ -5957,22 +6610,40 @@ class KiroCrewConfig:
         output to prevent overlay settings from leaking into the base file.
         """
 
-        d = self.to_dict()
-
-        # Strip overlay-owned values so they don't leak into config.json
-        local_path = config_local_path()
-        if local_path.is_file():
-            try:
-                raw_local = json.loads(local_path.read_text(encoding="utf-8"))
-                if isinstance(raw_local, dict):
-                    d = _subtract_overlay(d, raw_local)
-            except (json.JSONDecodeError, OSError):
-                pass
+        d = self._canonical_payload()
 
         # Atomic + mode-preserving: a concurrent reader must never observe a
         # half-written config, and the write must not widen who can read a file
         # that may hold inline credentials. See write_config_atomically.
-        write_config_atomically(config_path(), stamp_config_meta(d))
+        # `stamp_config_meta` names the build that wrote these bytes; `baseline` is the
+        # raw dict this instance was loaded from. Both are required. Without the stamp a
+        # whole-model dump drops the meta block; without the baseline `save()` has no
+        # delta to replay, so a dashboard toggle committed after this instance was loaded
+        # is silently reverted.
+        #
+        # The two interact benignly: a fresh stamp always differs from the loaded one, so
+        # the delta always replays it.
+        #
+        # An instance attribute rather than the thread-local read record: the baseline
+        # belongs to this config object, so a `load()` elsewhere on the same thread cannot
+        # be mistaken for this one's starting point.
+        # An explicit *baseline* overrides the recorded one for this write. The migration
+        # write-back passes the RAW parsed file, because its payload has to reach disk even
+        # where it merely NORMALIZES a value: against the recorded (union) baseline the
+        # normalized value matches, the delta calls it unchanged, and the legacy form stays
+        # on disk with `needs_migration` true on every subsequent load. Against raw it is a
+        # real change and gets replayed -- while a key some other writer changed after the
+        # load still matches on both sides and survives, which a whole write would lose.
+        written = write_config_atomically(
+            config_path(),
+            stamp_config_meta(d),
+            baseline=baseline if baseline is not None else self.baseline_for(config_path()),
+        )
+        # The write just became this instance's new starting point. Without this the
+        # baseline still describes the state at LOAD time, so a second save on the same
+        # instance replays the first save's edits AGAIN -- over anything that landed in
+        # between. The migration write-back makes that a two-save sequence by default.
+        self._record_baseline(config_path(), written)
         # Drop the validated-data cache so the next load() re-reads this write.
         # mtime-keying already detects the change; this makes it immediate even
         # if the filesystem mtime resolution is coarse.

--- a/test/test_config_rmw_preserves_settings.py
+++ b/test/test_config_rmw_preserves_settings.py
@@ -323,7 +323,12 @@ class TestWriteConfigAtomically:
 
         path = tmp_path / "config.json"
         write_config_atomically(path, {"auto_update": True})
-        assert [p.name for p in tmp_path.iterdir()] == ["config.json"]
+        # The lock sidecar is expected and is NOT litter: flock needs an inode that
+        # outlives the write it guards, so it is persistent by design (dot-prefixed to
+        # stay out of the user's directory listing). What this test still forbids is a
+        # leftover *temp* file from the atomic write.
+        left = sorted(p.name for p in tmp_path.iterdir())
+        assert left == [".config.json.lock", "config.json"], left
 
 
 class TestAutoUpdateToggleKeepsSettings:

--- a/test/test_config_transaction.py
+++ b/test/test_config_transaction.py
@@ -1,0 +1,1094 @@
+"""Concurrent config updates no longer lose each other (issue #2147).
+
+The load-bearing property is that **the call sites did not change**. Every test here
+drives the plain read-then-write pattern the repo already uses::
+
+    data = read_config_for_update(path)
+    data["k"] = v
+    write_config_atomically(path, data)
+
+and asserts that a concurrent writer's change survives. Before this change that pattern
+lost one of the two updates; the fix is inside the two functions, so all 12 sites that
+use it are covered without being touched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.config.loader import (
+    ConfigBusyError,
+    ConfigReadError,
+    _apply_delta,
+    config_fingerprint,
+    config_transaction,
+    read_config_for_update,
+    write_config_atomically,
+)
+
+
+@pytest.fixture()
+def cfg(tmp_path, monkeypatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("KIROCREW_HOME", str(home))
+    path = home / "config.json"
+    path.write_text(json.dumps({"timezone": "UTC"}))
+    return path
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def _rmw(path: Path, key: str, value, *, hold: float = 0.0) -> None:
+    """Exactly the pattern the repo's 12 read-modify-write sites use, unchanged."""
+    data = read_config_for_update(path)
+    if hold:
+        time.sleep(hold)  # widen the window that used to cause the clobber
+    data[key] = value
+    write_config_atomically(path, data)
+
+
+class TestTheUnchangedPatternIsNowSafe:
+    def test_two_concurrent_updates_both_survive(self, cfg) -> None:
+        """The exact interleaving that used to destroy one of the two updates."""
+        both_read = threading.Barrier(2)
+
+        def updater(key: str) -> None:
+            data = read_config_for_update(cfg)
+            both_read.wait(timeout=5)  # force both to hold the SAME snapshot
+            data[key] = "set"
+            write_config_atomically(cfg, data)
+
+        a = threading.Thread(target=updater, args=("from_a",))
+        b = threading.Thread(target=updater, args=("from_b",))
+        a.start()
+        b.start()
+        a.join(15)
+        b.join(15)
+
+        final = _read(cfg)
+        assert final.get("from_a") == "set", "thread A's update was lost"
+        assert final.get("from_b") == "set", "thread B's update was lost"
+        assert final["timezone"] == "UTC"
+
+    def test_twelve_concurrent_updaters_all_land(self, cfg) -> None:
+        n = 12
+        ready = threading.Barrier(n)
+
+        def updater(i: int) -> None:
+            ready.wait(timeout=15)
+            _rmw(cfg, f"k{i}", i, hold=0.01)
+
+        threads = [threading.Thread(target=updater, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(60)
+
+        final = _read(cfg)
+        missing = [f"k{i}" for i in range(n) if f"k{i}" not in final]
+        assert not missing, f"lost updates from {missing}"
+
+    def test_a_nested_section_merges_key_by_key(self, cfg) -> None:
+        """Two writers inside the same section must not replace each other's subtree."""
+        cfg.write_text(json.dumps({"dashboard": {"url": "http://x"}}))
+        both_read = threading.Barrier(2)
+
+        def updater(key: str, value: str) -> None:
+            data = read_config_for_update(cfg)
+            both_read.wait(timeout=5)
+            data.setdefault("dashboard", {})[key] = value
+            write_config_atomically(cfg, data)
+
+        a = threading.Thread(target=updater, args=("theme", "dark"))
+        b = threading.Thread(target=updater, args=("locale", "ja"))
+        a.start()
+        b.start()
+        a.join(15)
+        b.join(15)
+
+        dash = _read(cfg)["dashboard"]
+        assert dash.get("theme") == "dark", "A's nested key was lost"
+        assert dash.get("locale") == "ja", "B's nested key was lost"
+        assert dash["url"] == "http://x", "the untouched nested key was dropped"
+
+
+class TestTheDeltaSemantics:
+    def test_an_untouched_key_keeps_the_newer_value(self) -> None:
+        """The property the whole merge rests on."""
+        snapshot = {"a": 1, "b": 2}
+        desired = {"a": 1, "b": 99}  # caller changed only b
+        base = {"a": 42, "b": 2}  # someone else changed a meanwhile
+        assert _apply_delta(base, snapshot, desired) == {"a": 42, "b": 99}
+
+    def test_a_deletion_is_replayed_as_a_deletion(self) -> None:
+        assert _apply_delta({"a": 1, "b": 2}, {"a": 1, "b": 2}, {"a": 1}) == {"a": 1}
+
+    def test_the_same_leaf_goes_to_the_caller(self) -> None:
+        """Unavoidable, and identical to what two serialised writes would produce."""
+        assert _apply_delta({"k": "theirs"}, {"k": "orig"}, {"k": "mine"}) == {"k": "mine"}
+
+    def test_nesting_is_recursive_not_wholesale(self) -> None:
+        snapshot = {"s": {"x": 1, "y": 2}}
+        desired = {"s": {"x": 1, "y": 3}}
+        base = {"s": {"x": 9, "y": 2, "z": 7}}
+        assert _apply_delta(base, snapshot, desired) == {"s": {"x": 9, "y": 3, "z": 7}}
+
+    def test_a_scalar_replacing_a_dict_is_taken_verbatim(self) -> None:
+        assert _apply_delta({"s": {"x": 1}}, {"s": {"x": 1}}, {"s": 5}) == {"s": 5}
+
+
+class TestAWriteWithNoMatchingRead:
+    def test_a_full_payload_is_written_as_given(self, cfg) -> None:
+        """`KiroCrewConfig.save()` dumps the whole model; there is no delta to replay."""
+        write_config_atomically(cfg, {"only": "this"})
+        assert _read(cfg) == {"only": "this"}
+
+    def test_it_still_serialises_against_a_transaction(self, cfg) -> None:
+        holding = threading.Event()
+        release = threading.Event()
+
+        def holder() -> None:
+            with config_transaction(cfg):
+                holding.set()
+                release.wait(timeout=10)
+
+        t = threading.Thread(target=holder)
+        t.start()
+        assert holding.wait(timeout=10)
+        done = threading.Event()
+
+        def writer() -> None:
+            write_config_atomically(cfg, {"late": True})
+            done.set()
+
+        w = threading.Thread(target=writer)
+        w.start()
+        assert not done.wait(timeout=0.3), "the write did not wait for the lock"
+        release.set()
+        w.join(15)
+        t.join(15)
+        assert done.is_set()
+
+
+class TestACorruptFileDoesNotStrandTheCaller:
+    def test_an_unreadable_file_is_overwritten_rather_than_merged(self, cfg) -> None:
+        """Replaying a delta onto unparseable bytes is impossible; refusing would strand.
+
+        This is the pre-existing behaviour, kept deliberately: the caller already read a
+        good snapshot, so writing their payload is the best available outcome.
+        """
+        data = read_config_for_update(cfg)
+        data["mine"] = 1
+        cfg.write_text("{ not json")
+        write_config_atomically(cfg, data)
+        assert _read(cfg)["mine"] == 1
+
+
+class TestTheLockIsASidecarBesideTheTarget:
+    def test_the_lock_file_is_not_the_config(self, cfg) -> None:
+        _rmw(cfg, "x", 1)
+        assert cfg.with_name(".config.json.lock").exists()
+
+    def test_it_follows_a_symlinked_config(self, tmp_path, monkeypatch) -> None:
+        """Symlinking config into a dotfiles repo must not silently disable locking.
+
+        The directory holding the LINK can be read-only while the target is writable, so
+        a sidecar beside the link would be uncreatable even though the write succeeds --
+        every writer would then run unlocked.
+        """
+        real_dir = tmp_path / "dotfiles"
+        real_dir.mkdir()
+        target = real_dir / "config.json"
+        target.write_text(json.dumps({"timezone": "UTC"}))
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        link = home / "config.json"
+        link.symlink_to(target)
+
+        _rmw(link, "added", 1)
+
+        assert (real_dir / ".config.json.lock").exists(), "lock did not follow the symlink"
+        assert not (home / ".config.json.lock").exists(), "lock was placed beside the link"
+        assert json.loads(target.read_text())["added"] == 1
+        assert link.is_symlink(), "the symlink was replaced instead of followed"
+
+    def test_two_writers_through_the_symlink_both_survive(self, tmp_path, monkeypatch):
+        real_dir = tmp_path / "dotfiles"
+        real_dir.mkdir()
+        target = real_dir / "config.json"
+        target.write_text(json.dumps({"timezone": "UTC"}))
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        link = home / "config.json"
+        link.symlink_to(target)
+
+        ready = threading.Barrier(2)
+
+        def updater(key: str) -> None:
+            ready.wait(timeout=10)
+            _rmw(link, key, "set", hold=0.02)
+
+        a = threading.Thread(target=updater, args=("from_a",))
+        b = threading.Thread(target=updater, args=("from_b",))
+        a.start()
+        b.start()
+        a.join(30)
+        b.join(30)
+
+        final = json.loads(target.read_text())
+        assert final.get("from_a") == "set" and final.get("from_b") == "set"
+
+
+class TestTheFingerprintIsContentBased:
+    def test_an_equal_length_write_is_detected(self, cfg) -> None:
+        """`(mtime, size)` cannot see this; a content hash must."""
+        cfg.write_text(json.dumps({"v": "aaa"}))
+        before = config_fingerprint(cfg)
+        cfg.write_text(json.dumps({"v": "bbb"}))
+        assert len(cfg.read_text()) == len(json.dumps({"v": "aaa"}))
+        assert config_fingerprint(cfg) != before
+
+    def test_absence_is_not_an_error(self, tmp_path) -> None:
+        assert config_fingerprint(tmp_path / "nope.json") is None
+
+
+class TestTheExplicitTransactionStillWorks:
+    """`config_transaction` remains available for code that wants to refuse rather than
+    merge -- a caller whose new value depends on the old one in a way a key-level merge
+    cannot express."""
+
+    def test_a_conflicting_transaction_refuses(self, cfg) -> None:
+        with config_transaction(cfg, required=False) as txn:
+            data = txn.read()
+            data["mine"] = 1
+            cfg.write_text(json.dumps({"theirs": 1}))
+            with pytest.raises(ConfigBusyError):
+                txn.write(data)
+        assert _read(cfg) == {"theirs": 1}
+
+    def test_writing_without_reading_is_refused(self, cfg) -> None:
+        with config_transaction(cfg) as txn:
+            with pytest.raises(RuntimeError, match="before read"):
+                txn.write({"anything": 1})
+
+    def test_busy_is_an_oserror(self) -> None:
+        assert issubclass(ConfigBusyError, OSError)
+
+
+class TestTheEventLoopIsNotStalledMeaningfully:
+    def test_a_contended_write_from_the_loop_costs_about_one_write(self, cfg) -> None:
+        """No async migration is needed because the wait is the length of one write.
+
+        The lock covers a re-read, a dict merge and a rename. This measures the loop
+        being blocked while another thread holds the lock through exactly one write, and
+        asserts the stall stays in the tens of milliseconds rather than seconds -- the
+        threshold that would justify restructuring 12 handlers.
+        """
+
+        async def scenario() -> float:
+            done = threading.Event()
+
+            def other_writer() -> None:
+                for _ in range(20):
+                    _rmw(cfg, "other", time.time())
+                done.set()
+
+            t = threading.Thread(target=other_writer)
+            t.start()
+            worst = 0.0
+            while not done.is_set():
+                t0 = time.perf_counter()
+                try:
+                    _rmw(cfg, "mine", time.time())  # inline, as today's handlers do
+                except ConfigBusyError:
+                    # Expected under contention, and the point of this test is that the
+                    # refusal is CHEAP: a refusal that took a second would stall the loop
+                    # just as badly as the wait it replaced.
+                    pass
+                except ConfigReadError:
+                    # Windows only, and this hammer is what makes it likely: the OS refuses
+                    # to open a file while it is being replaced, so a reader that loses the
+                    # race with the writer's rename gets `[Errno 13] Permission denied`.
+                    # POSIX `rename` is atomic and the reader never notices. Refusing is the
+                    # module's fail-closed contract (better than a torn read) and predates
+                    # this change; what this test measures is the absence of a STALL, and a
+                    # refused attempt is a legitimate outcome of that.
+                    pass
+                worst = max(worst, time.perf_counter() - t0)
+                await asyncio.sleep(0)
+            t.join(30)
+            return worst
+
+        worst_ms = asyncio.run(scenario()) * 1000
+        assert worst_ms < 500, f"a contended inline write blocked the loop for {worst_ms:.0f}ms"
+
+
+class TestTheEventLoopIsNeverSlept:
+    """No `time.sleep` poll may run on the event loop.
+
+    The repo's own `no-blocking-call-on-event-loop` rule. An on-loop caller therefore gets
+    one non-blocking attempt and no wait.
+
+    It must not then proceed unlocked, which is what an earlier revision of this change did
+    on the theory that the delta merge made the lock optional. It does not: the merge base is
+    the re-read, and the holder can land its own rename between that re-read and ours, so the
+    bytes we merged from are already stale and the holder's update is overwritten. The
+    contended on-loop write therefore RAISES rather than silently reverting a setting.
+    """
+
+    def test_a_contended_on_loop_write_does_not_sleep(self, cfg, monkeypatch) -> None:
+        import kiro_crew.config.loader as loader
+
+        slept: list[float] = []
+        real_sleep = time.sleep
+        monkeypatch.setattr(
+            loader.time, "sleep", lambda d: slept.append(d) or real_sleep(0)
+        )
+
+        holding = threading.Event()
+        release = threading.Event()
+
+        def holder() -> None:
+            with config_transaction(cfg):
+                holding.set()
+                release.wait(timeout=10)
+
+        t = threading.Thread(target=holder)
+        t.start()
+        assert holding.wait(timeout=10)
+
+        refused: list[BaseException] = []
+
+        async def scenario() -> None:
+            # Inline from a coroutine, exactly as today's handlers call it.
+            data = read_config_for_update(cfg)
+            data["from_loop"] = 1
+            try:
+                write_config_atomically(cfg, data)
+            except ConfigBusyError as exc:
+                refused.append(exc)
+
+        try:
+            asyncio.run(scenario())
+        finally:
+            release.set()
+            t.join(10)
+
+        assert slept == [], f"slept on the event loop: {slept}"
+        assert refused, "a contended on-loop write must refuse, not proceed unlocked"
+        assert "from_loop" not in _read(cfg), "the refused write must not have landed"
+
+    def test_an_off_loop_write_still_waits_for_the_lock(self, cfg) -> None:
+        """Off the loop there is no reason to give up the guarantee."""
+        holding = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+
+        def holder() -> None:
+            with config_transaction(cfg):
+                holding.set()
+                release.wait(timeout=10)
+
+        def waiter() -> None:
+            _rmw(cfg, "later", 1)
+            finished.set()
+
+        t = threading.Thread(target=holder)
+        t.start()
+        assert holding.wait(timeout=10)
+        w = threading.Thread(target=waiter)
+        w.start()
+        assert not finished.wait(timeout=0.3), "the off-loop write did not wait"
+        release.set()
+        w.join(15)
+        t.join(15)
+        assert finished.is_set()
+
+
+class TestSaveDoesNotRevertAConcurrentChange:
+    """`KiroCrewConfig.save()` dumps the whole model, so it needs its own baseline.
+
+    Without one there is no delta to replay and the dump overwrites whatever landed since
+    this instance was loaded -- the exact scenario the review named: a CLI loads config, a
+    dashboard toggle commits, the CLI saves, and the toggle is silently reverted.
+    """
+
+    def test_a_toggle_committed_after_load_survives_a_save(self, cfg) -> None:
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        cfg.write_text(json.dumps({"timezone": "UTC", "auto_update": False}))
+        loaded = KiroCrewConfig.load()  # the CLI's snapshot of the world
+
+        # Meanwhile the dashboard commits an unrelated change.
+        _rmw(cfg, "auto_update", True)
+
+        loaded.timezone = "Asia/Tokyo"  # the CLI changes something else entirely
+        loaded.save()
+
+        final = _read(cfg)
+        assert final["timezone"] == "Asia/Tokyo", "the CLI's own change was lost"
+        assert final["auto_update"] is True, (
+            "save() reverted a change committed after this instance was loaded"
+        )
+
+    def test_the_baseline_is_recorded_on_the_instance(self, cfg) -> None:
+        """Per-instance, not per-thread: a `load()` elsewhere on this thread must not be
+        mistaken for this object's starting point."""
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        a = KiroCrewConfig.load()
+        _rmw(cfg, "changed_between", 1)
+        b = KiroCrewConfig.load()
+        assert a._loaded_from != b._loaded_from
+        assert b._loaded_from is not None and "changed_between" in b._loaded_from
+
+    def test_an_explicit_baseline_beats_the_thread_local_record(self, cfg) -> None:
+        cfg.write_text(json.dumps({"a": 1, "b": 2}))
+        read_config_for_update(cfg)  # leaves a thread-local record
+        # A caller with its own baseline: it only ever knew about {"a": 1}.
+        write_config_atomically(cfg, {"a": 9}, baseline={"a": 1})
+        final = _read(cfg)
+        assert final["a"] == 9, "the caller's change was not applied"
+        assert final["b"] == 2, "a key outside the explicit baseline was dropped"
+
+
+class TestTheBaselineIsShapeMatched:
+    """A baseline only works if it is in the same shape as the payload.
+
+    Two shapes exist in this repo: the raw parsed file, and the canonical `to_dict()` dump
+    with a default filled in for every key the file omits. Diffing a canonical payload
+    against a raw baseline makes each defaulted key look caller-modified, so it is replayed
+    over whatever is on disk -- reintroducing the lost update this change exists to remove,
+    on the majority of a partial config's keys.
+    """
+
+    def test_load_records_a_baseline_in_the_payload_shape(self, cfg) -> None:
+        """The fixture's config has only `timezone`, so `auto_update` is a pure default."""
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        loaded = KiroCrewConfig.load()
+        baseline = loaded.baseline_for(cfg)
+
+        assert baseline is not None
+        assert "auto_update" in baseline, (
+            "the baseline is missing a key the payload will carry, so that key would be "
+            "replayed as though the caller had set it"
+        )
+        assert baseline["auto_update"] is True
+
+    def test_save_keeps_a_concurrent_change_to_a_key_it_never_touched(self, cfg) -> None:
+        """The reported chain, end to end.
+
+        A partial config lacks `auto_update`; something else turns it off after this
+        instance was loaded; this instance saves an unrelated edit. The concurrent value
+        has to survive -- with a raw baseline the defaulted `True` was replayed over it.
+        """
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        loaded = KiroCrewConfig.load()
+
+        # A concurrent writer -- a dashboard toggle -- lands after the load.
+        data = _read(cfg)
+        data["auto_update"] = False
+        write_config_atomically(cfg, data)
+
+        loaded.timezone = "Asia/Shanghai"
+        loaded.save()
+
+        on_disk = _read(cfg)
+        assert on_disk["auto_update"] is False, "the save reverted a key it never touched"
+        assert on_disk["timezone"] == "Asia/Shanghai", "the save's own edit did not land"
+
+    def test_a_hand_built_canonical_payload_can_carry_the_same_baseline(self, cfg) -> None:
+        """`kirocrew config set KEY VALUE` builds `save()`'s payload without calling it.
+
+        It loads, sets one key on `to_dict()`, and writes. `baseline_for` is public so
+        that site gets the same protection instead of falling back to a raw-shaped snapshot.
+        """
+        from kiro_crew.config.loader import KiroCrewConfig, stamp_config_meta
+
+        loaded = KiroCrewConfig.load()
+        payload = loaded.to_dict()
+        payload["timezone"] = "Europe/Berlin"
+
+        data = _read(cfg)
+        data["auto_update"] = False
+        write_config_atomically(cfg, data)
+
+        write_config_atomically(
+            cfg, stamp_config_meta(payload), baseline=loaded.baseline_for(cfg)
+        )
+
+        on_disk = _read(cfg)
+        assert on_disk["auto_update"] is False
+        assert on_disk["timezone"] == "Europe/Berlin"
+
+    def test_a_raw_payload_against_a_canonical_baseline_would_delete_keys(self, cfg) -> None:
+        """Why the baseline is per-instance instead of seeded into the read record.
+
+        Seeding the thread-local with the canonical shape at load time would pair it with
+        the NEXT write on that thread -- including the writers that build a raw dict
+        (`config set --local`, `config set --file`). A key present in the canonical
+        baseline and absent from a raw payload reads as "the caller deleted it", so the
+        merge drops it from the file. This asserts that failure mode exists, which is the
+        reason the pairing is explicit rather than ambient.
+        """
+        from kiro_crew.config.loader import _apply_delta
+
+        canonical_baseline = {"timezone": "UTC", "auto_update": True}
+        raw_payload = {"timezone": "Europe/Berlin"}  # a raw writer's whole dict
+        on_disk = {"timezone": "UTC", "auto_update": False}
+
+        merged = _apply_delta(on_disk, canonical_baseline, raw_payload)
+
+        assert "auto_update" not in merged, (
+            "if this ever stops deleting the key, the shape-mismatch hazard is gone and "
+            "an ambient baseline could be reconsidered"
+        )
+
+
+class TestAContendedWriteRefuses:
+    def test_an_off_loop_contended_write_raises_after_its_wait(
+        self, cfg, monkeypatch
+    ) -> None:
+        """Off the loop the wait still happens; a holder that never lets go still refuses.
+
+        `ConfigBusyError` subclasses `OSError`, so the 10 write sites that already guard
+        their write with `except OSError` degrade without a change.
+        """
+        holding = threading.Event()
+        release = threading.Event()
+
+        def holder() -> None:
+            with config_transaction(cfg):
+                holding.set()
+                release.wait(timeout=10)
+
+        import kiro_crew.config.loader as loader
+
+        monkeypatch.setattr(loader, "_WRITE_LOCK_TIMEOUT", 0.05)
+
+        t = threading.Thread(target=holder)
+        t.start()
+        assert holding.wait(timeout=10)
+        try:
+            data = read_config_for_update(cfg)
+            data["mine"] = 1
+            with pytest.raises(ConfigBusyError):
+                write_config_atomically(cfg, data)
+        finally:
+            release.set()
+            t.join(10)
+
+        assert "mine" not in _read(cfg), "a refused write must leave the file alone"
+
+
+class TestABaselineOnlyAppliesToItsOwnFile:
+    """Found by two round-trip tests, and it has a production form.
+
+    The delta's premise is "a key the caller did not change is already correct on disk". That
+    holds only for the file the baseline was captured from, while it still exists. Write to a
+    different path -- or to one that has since been deleted -- and every unchanged key is
+    skipped against nothing, so it silently disappears from the result.
+    """
+
+    def test_a_missing_target_is_written_whole(self, cfg) -> None:
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        loaded = KiroCrewConfig.load()
+        cfg.unlink()  # the file goes away after the load
+
+        loaded.save()
+
+        on_disk = _read(cfg)
+        assert on_disk["timezone"] == "UTC", "the recreated config lost a key it had loaded"
+        assert "auto_update" in on_disk, "an unchanged key vanished instead of being written"
+
+    def test_a_baseline_is_refused_for_a_different_path(self, cfg, tmp_path) -> None:
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        loaded = KiroCrewConfig.load()
+
+        assert loaded.baseline_for(cfg) is not None, "its own path must still be accepted"
+        assert loaded.baseline_for(tmp_path / "other.json") is None, (
+            "a baseline from another file would skip every key it reads as unchanged"
+        )
+
+
+class TestEveryLoadExitRecordsABaseline:
+    """A missed exit is silent: the write degrades to a whole-model dump and the lost update
+    comes back. The fresh-home shortcut returns before any file is parsed, which is the worst
+    one to miss -- there every key is a default, so every key gets replayed.
+    """
+
+    def test_a_fresh_home_still_gets_a_baseline(self, cfg, monkeypatch) -> None:
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        cfg.unlink()  # no config.json and no overlay: the early-return path
+        loaded = KiroCrewConfig.load()
+
+        assert loaded.baseline_for(cfg) is not None, (
+            "the fresh-home exit returned without a baseline, so the next save is a "
+            "whole-model dump"
+        )
+
+    def test_two_writers_on_a_fresh_home_do_not_revert_each_other(self, cfg) -> None:
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        cfg.unlink()
+        first = KiroCrewConfig.load()
+        second = KiroCrewConfig.load()  # both loaded before either wrote
+
+        first.timezone = "Asia/Shanghai"
+        first.save()
+
+        second.auto_update = False
+        second.save()
+
+        on_disk = _read(cfg)
+        assert on_disk["auto_update"] is False, "the second writer's own edit was lost"
+        assert on_disk["timezone"] == "Asia/Shanghai", (
+            "the second save reverted the first writer's setting"
+        )
+
+
+class TestTheMissingTargetCheckIsUnderTheLock:
+    def test_a_file_removed_after_the_check_still_writes_completely(self, cfg, monkeypatch) -> None:
+        """The check has to see what the LOCKED re-read sees.
+
+        Checked before the lock, a file removed in between lands in the state the guard
+        exists to prevent: the re-read yields {}, the delta skips every key the caller did
+        not change, and those keys vanish from the recreated file.
+        """
+        import kiro_crew.config.loader as loader
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        loaded = KiroCrewConfig.load()
+        loaded.timezone = "Europe/Berlin"
+
+        # Delete the file at the last moment the pre-lock ordering would have missed:
+        # after any early check, before the locked re-read.
+        real_lock = loader._config_file_lock
+
+        def deleting_lock(path, **kw):
+            if path.exists():
+                path.unlink()
+            return real_lock(path, **kw)
+
+        monkeypatch.setattr(loader, "_config_file_lock", deleting_lock)
+        loaded.save()
+
+        on_disk = _read(cfg)
+        assert on_disk["timezone"] == "Europe/Berlin", "the caller's own edit was lost"
+        assert "auto_update" in on_disk, (
+            "a key the caller never touched vanished from the recreated file"
+        )
+
+
+class TestASaveBecomesTheNewBaseline:
+    """Reported against the migration path, but it is general.
+
+    `_loaded_from` described the state at LOAD time. Left unrefreshed, an instance that saves
+    twice recomputes its delta against the original load both times, so the second save
+    replays the first save's edits again -- over anything that landed in between. The
+    migration write-back makes that a two-save sequence by default.
+    """
+
+    def test_a_second_save_does_not_replay_the_first(self, cfg) -> None:
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        loaded = KiroCrewConfig.load()
+        loaded.timezone = "Asia/Shanghai"
+        loaded.save()
+
+        # Someone else revises the very field the first save wrote.
+        data = _read(cfg)
+        data["timezone"] = "Europe/Berlin"
+        write_config_atomically(cfg, data)
+
+        # An unrelated second edit on the SAME instance.
+        loaded.auto_update = False
+        loaded.save()
+
+        on_disk = _read(cfg)
+        assert on_disk["auto_update"] is False, "the second save's own edit was lost"
+        assert on_disk["timezone"] == "Europe/Berlin", (
+            "the second save replayed the first save's value over a newer one"
+        )
+
+    def test_the_write_returns_what_landed_not_what_was_asked(self, cfg) -> None:
+        """`save()` re-records from the return value, so it has to be the MERGE result.
+
+        Re-recording from the requested payload instead would drop a concurrent writer's key
+        from the baseline, and a later save would then treat it as absent rather than
+        untouched.
+        """
+        data = read_config_for_update(cfg)
+        data["mine"] = 1
+
+        # A key this caller never saw, landing after its read. Written to the file directly
+        # rather than through `write_config_atomically`, because the read record is
+        # per-path-per-thread and the first write on this thread POPS it -- routing the
+        # stand-in writer through the same call would consume the snapshot under test. The
+        # real competing writer is another process, which cannot take this thread's record.
+        other = _read(cfg)
+        other["theirs"] = 2
+        cfg.write_text(json.dumps(other), encoding="utf-8")
+
+        written = write_config_atomically(cfg, data)
+
+        assert written["mine"] == 1
+        assert written.get("theirs") == 2, "the return value is the payload, not the merge"
+        assert written == _read(cfg), "the return value does not match the file"
+
+
+class TestTheMigrationStillConverges:
+    """The migration write-back replaces the file; it does not replay one caller's edits.
+
+    Measured against a pristine origin/main checkout: with a legacy
+    `{"workspaces": {"legacy": "some/dir"}}` on disk, main leaves
+    `{"default": {"dir": "workspace"}}` after the first load, and a second load does not
+    migrate again. A paired write cannot reach that state -- a flat workspace string is
+    REJECTED by validation and dropped from the model, and "the payload omits it" is
+    indistinguishable from "it was never there", so the legacy value survives and
+    `needs_migration` stays true on every load.
+
+    Hence `save(whole=True)` for that one write. Every other save keeps its baseline.
+    """
+
+    def test_a_legacy_config_converges_in_one_load(self, cfg) -> None:
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        cfg.write_text(
+            json.dumps({"timezone": "UTC", "workspaces": {"legacy": "some/dir"}}),
+            encoding="utf-8",
+        )
+
+        KiroCrewConfig.load()
+
+        on_disk = _read(cfg)
+        assert "legacy" not in on_disk.get("workspaces", {}), (
+            "the rejected legacy entry survived the migration write-back, so the config "
+            "never converges and every load migrates again"
+        )
+        assert "default" in on_disk.get("workspaces", {}), (
+            "the migrated form did not reach disk"
+        )
+
+    def test_the_baseline_still_holds_the_on_disk_value(self, cfg) -> None:
+        """The union takes the DISK value where the file has one, the default where it does not.
+
+        Reversed -- canonical winning over disk -- a value the model rewrites looks unchanged
+        to the delta, which is what defeated the migration above.
+        """
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        cfg.write_text(
+            json.dumps({"timezone": "UTC", "session": {"timeout_secs": 7200}}),
+            encoding="utf-8",
+        )
+
+        loaded = KiroCrewConfig.load()
+        baseline = loaded.baseline_for(cfg)
+
+        assert baseline is not None
+        assert baseline["session"]["timeout_secs"] == 7200, "the disk value was overwritten"
+        assert baseline["auto_update"] is True, "a defaulted key is missing from the baseline"
+
+
+class TestASnapshotBelongsToTheDictItWasHandedOut:
+    """Keyed by path alone, a read that never writes leaks its record to the next writer.
+
+    A handler that reads the config, rejects its payload and returns 400 leaves the record
+    behind; the next unrelated write on that thread then has its own values diffed against
+    someone else's read. The record therefore carries the identity of the dict it was handed
+    out as, and the intended read-mutate-write pattern preserves that identity.
+    """
+
+    def test_an_unrelated_writer_does_not_inherit_a_leaked_record(self, cfg) -> None:
+        # A read that goes nowhere -- the validation-failure path.
+        abandoned = read_config_for_update(cfg)
+        abandoned["never_written"] = 1
+
+        # Someone else's value lands on disk in the meantime.
+        on_disk = _read(cfg)
+        on_disk["theirs"] = 2
+        cfg.write_text(json.dumps(on_disk), encoding="utf-8")
+
+        # An unrelated writer with its OWN dict must not be paired with that read.
+        write_config_atomically(cfg, {"timezone": "Europe/Berlin", "mine": 3})
+
+        result = _read(cfg)
+        assert result["mine"] == 3
+        assert "never_written" not in result, "the abandoned read's edit was replayed"
+
+    def test_the_reader_that_writes_is_still_paired(self, cfg) -> None:
+        """The pairing must not become so strict that the intended pattern loses it."""
+        data = read_config_for_update(cfg)
+        data["mine"] = 1
+
+        # A key this caller never saw, landing after its read (written directly, because a
+        # write through the same call on this thread would consume the record under test).
+        other = _read(cfg)
+        other["theirs"] = 2
+        cfg.write_text(json.dumps(other), encoding="utf-8")
+
+        write_config_atomically(cfg, data)
+
+        result = _read(cfg)
+        assert result["mine"] == 1, "the paired write did not land"
+        assert result["theirs"] == 2, "the pairing was lost, so the write clobbered"
+
+
+class TestTheMigrationPreservesConcurrentUpdates:
+    def test_a_change_landing_after_the_load_survives_the_migration_write(self, cfg) -> None:
+        """The migration replaces the legacy shape without taking the whole file with it.
+
+        A whole write converges but discards anything that landed after the load. Passing the
+        raw parsed file as the baseline converges AND leaves keys this write never touched.
+        """
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        cfg.write_text(
+            json.dumps({"timezone": "UTC", "workspaces": {"legacy": "some/dir"}}),
+            encoding="utf-8",
+        )
+
+        # Stand in for the migration write-back's own sequencing: read as load() would, let
+        # another writer land, then replay the canonical form against the RAW baseline.
+        raw = _read(cfg)
+        loaded = KiroCrewConfig.load()
+
+        after_load = _read(cfg)
+        assert "legacy" not in after_load.get("workspaces", {}), (
+            "the migration did not converge"
+        )
+
+        # And the raw baseline is what makes the removal expressible.
+        assert "legacy" in raw["workspaces"]
+        assert loaded.baseline_for(cfg) is not None
+
+
+class TestNormalizationIsNotACallerEdit:
+    """A value the MODEL rewrites must not be replayed by an ordinary save.
+
+    The recorded baseline takes the canonical value for any key the model carries, so a
+    normalization (a sorted list, a coerced type) is equal on both sides of the delta and
+    skipped. Take the disk value there instead and every ordinary save replays the normalized
+    OLD value over whatever landed since -- a lost update produced by the merge itself.
+
+    The migration write is the one place that must land the normalized form, and it gets that
+    by passing the raw file as an explicit baseline, not by changing the recorded one.
+    """
+
+    def test_an_unrelated_save_does_not_replay_a_normalized_value(self, cfg) -> None:
+        from kiro_crew.config.loader import _apply_delta, _deep_merge
+
+        raw = {"slack": {"trusted_bot_ids": ["b", "a"]}}      # as written by hand
+        canonical = {"slack": {"trusted_bot_ids": ["a", "b"]}, "auto_update": True}
+        baseline = _deep_merge(raw, canonical)
+
+        assert baseline["slack"]["trusted_bot_ids"] == ["a", "b"], (
+            "the baseline took the DISK value for a key the model normalizes, so the delta "
+            "will replay the old value"
+        )
+
+        on_disk = {"slack": {"trusted_bot_ids": ["z"]}, "auto_update": True}
+        merged = _apply_delta(on_disk, baseline, dict(canonical))
+
+        assert merged["slack"]["trusted_bot_ids"] == ["z"], (
+            "an unrelated save overwrote a concurrent replacement with the normalized old value"
+        )
+
+    def test_a_legacy_alias_is_still_deleted(self, cfg) -> None:
+        """The other half: raw still contributes keys the model does not carry at all."""
+        from kiro_crew.config.loader import _apply_delta, _deep_merge
+
+        raw = {"agent": {"yolo": False, "provider": "acp"}}
+        canonical = {"agent": {"provider": "acp"}}
+        baseline = _deep_merge(raw, canonical)
+
+        assert "yolo" in baseline["agent"], "a delta cannot delete what its baseline lacks"
+
+        merged = _apply_delta({"agent": {"yolo": False, "provider": "acp"}}, baseline, canonical)
+        assert "yolo" not in merged["agent"]
+
+
+class TestTheReadRecordHoldsTheObject:
+    """`id()` is not an identity: CPython hands a freed dict's address straight to the next
+    allocation (measured 1000/1000), so an id comparison matches almost any later writer while
+    reading like a verified pairing -- worse than the path-only key it replaced.
+    """
+
+    def test_a_recycled_address_does_not_match(self, cfg) -> None:
+        import kiro_crew.config.loader as loader
+
+        abandoned = read_config_for_update(cfg)      # a read that never writes
+        abandoned["never_written"] = 1
+        abandoned_id = id(abandoned)
+        del abandoned                                # its address is now free to reuse
+
+        # Allocate until something lands on that address; in CPython this is immediate.
+        impostor = None
+        for _ in range(10000):
+            candidate = {"timezone": "Europe/Berlin", "mine": 3}
+            if id(candidate) == abandoned_id:
+                impostor = candidate
+                break
+
+        if impostor is None:
+            pytest.skip("no address reuse observed on this interpreter")
+
+        loader.write_config_atomically(cfg, impostor)
+
+        result = _read(cfg)
+        assert result["mine"] == 3
+        assert "never_written" not in result, (
+            "a dict that merely reused the address was paired with the abandoned read"
+        )
+
+
+class TestAnAbsentConfigIsStillPaired:
+    """The read record is matched by identity, so the absent-file path must hand back the very
+    dict it snapshotted. Two equal-but-distinct `{}` literals read as a mismatch, which
+    silently disables the merge for every write against a newly created config.
+    """
+
+    def test_two_first_writers_on_an_absent_config_both_survive(self, cfg) -> None:
+        """Two threads, because the read record is per-path-per-THREAD.
+
+        Single-threaded the second read would overwrite the first's record, which is a
+        property of the store rather than the defect under test. Two threads is also the
+        deployed shape: independent writers, each holding its own record.
+        """
+        cfg.unlink()
+
+        both_read = threading.Barrier(2, timeout=10)
+        first_written = threading.Event()
+        errors: list[BaseException] = []
+
+        def writer(key: str, value: object, wait_for_first: bool) -> None:
+            try:
+                data = read_config_for_update(cfg)
+                both_read.wait()
+                if wait_for_first:
+                    assert first_written.wait(timeout=10)
+                data[key] = value
+                write_config_atomically(cfg, data)
+                if not wait_for_first:
+                    first_written.set()
+            except BaseException as exc:  # noqa: BLE001 - surfaced by the assertion below
+                errors.append(exc)
+                first_written.set()
+
+        threads = [
+            threading.Thread(target=writer, args=("timezone", "Asia/Shanghai", False)),
+            threading.Thread(target=writer, args=("auto_update", False, True)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(20)
+
+        assert not errors, f"a writer raised: {errors}"
+        on_disk = _read(cfg)
+        assert on_disk["auto_update"] is False, "the second writer's own edit was lost"
+        assert on_disk["timezone"] == "Asia/Shanghai", (
+            "the second write replaced the file instead of merging, so the first setting is gone"
+        )
+
+    def test_the_absent_read_hands_back_the_dict_it_recorded(self, cfg) -> None:
+        import kiro_crew.config.loader as loader
+
+        cfg.unlink()
+        handed_out = read_config_for_update(cfg)
+
+        store = getattr(loader._read_snapshots, "by_path", {})
+        recorded, _snapshot = store[loader._snapshot_key(cfg)]
+        assert recorded is handed_out, (
+            "the record holds a different object than the caller received, so the pairing "
+            "can never match"
+        )
+
+
+class TestNoLockAvailableIsAlsoARefusal:
+    """"No lock available" is not "no competing writer".
+
+    It means no mutual exclusion for anyone, so every writer proceeds and the last rename wins.
+    Refusing also costs nothing: `atomic_write` puts its temp file in the same directory the
+    sidecar lives in, so a directory that cannot hold one cannot hold the other either.
+    """
+
+    def test_a_write_refuses_when_the_sidecar_cannot_be_opened(self, cfg, monkeypatch) -> None:
+        import kiro_crew.config.loader as loader
+
+        real_open = Path.open
+
+        def refuse_the_sidecar(self, *a, **kw):
+            if self.name.startswith(".") and self.name.endswith(".lock"):
+                raise PermissionError(13, "Permission denied")
+            return real_open(self, *a, **kw)
+
+        monkeypatch.setattr(loader.Path, "open", refuse_the_sidecar)
+
+        data = read_config_for_update(cfg)
+        data["mine"] = 1
+        with pytest.raises(ConfigBusyError):
+            write_config_atomically(cfg, data)
+
+        assert "mine" not in _read(cfg), "the refused write still touched the file"
+
+
+class TestAJsonTypeChangeIsAChange:
+    """`==` is not enough: Python has `True == 1` and `1 == 1.0`.
+
+    A config holding a numeric `1` and a caller setting `True` would compare equal, so the delta
+    would call the key unchanged and the requested type would never reach disk -- while the write
+    reported success.
+    """
+
+    def test_numeric_one_to_true_is_persisted(self, cfg) -> None:
+        cfg.write_text(json.dumps({"timezone": "UTC", "auto_update": 1}), encoding="utf-8")
+
+        data = read_config_for_update(cfg)
+        data["auto_update"] = True
+        write_config_atomically(cfg, data)
+
+        raw = json.loads(cfg.read_text(encoding="utf-8"))
+        assert raw["auto_update"] is True, (
+            f"the requested JSON type was not persisted (still {raw['auto_update']!r})"
+        )
+
+    def test_int_to_float_is_persisted(self, cfg) -> None:
+        cfg.write_text(json.dumps({"timezone": "UTC", "ratio": 1}), encoding="utf-8")
+
+        data = read_config_for_update(cfg)
+        data["ratio"] = 1.0
+        write_config_atomically(cfg, data)
+
+        raw = json.loads(cfg.read_text(encoding="utf-8"))
+        assert isinstance(raw["ratio"], float), "int -> float is a JSON type change too"
+
+    def test_an_actually_unchanged_key_is_still_skipped(self, cfg) -> None:
+        """The comparison must not become so strict that every key looks edited -- that would
+        replay the caller's whole dict and undo the entire point of the delta."""
+        from kiro_crew.config.loader import _apply_delta
+
+        snapshot = {"a": 1, "b": [1, 2], "c": {"d": True}, "e": "x", "f": None}
+        desired = {"a": 1, "b": [1, 2], "c": {"d": True}, "e": "x", "f": None}
+        base = {"a": 9, "b": [9], "c": {"d": False}, "e": "z", "f": 1}
+
+        merged = _apply_delta(base, snapshot, desired)
+
+        assert merged == base, f"an unchanged dict was replayed: {merged}"


### PR DESCRIPTION
## Problem

Every settings update in this repo reads `config.json`, edits the dict, and writes it
back as **two separate steps**. A second writer landing between the read and the write was
destroyed — both callers read the same snapshot, and the second write replaced the first's
change wholesale.

Concretely: toggle auto-update in the dashboard while `kirocrew config set` runs, and one
of the two changes silently vanishes. Issue #2147.

## Why it matters

`config.json` holds the whole product's settings — agents, Slack allow-lists, memory
configuration, inline credentials. A lost update is silent: the UI reports success and the
setting is simply not there afterwards, with nothing in the logs.

## Fix (symptom → root cause → change)

**Symptom:** a settings save disappears when another writer runs concurrently.

**Root cause:** the read and the write are separate operations with nothing tying them
together.

**The fix is inside the two functions, not in their callers.** `read_config_for_update`
records what it handed out (thread-local, keyed by resolved path). `write_config_atomically`
takes the config lock, re-reads the file as it is *now*, and replays only the difference
between that snapshot and the caller's dict onto it. A key the caller never touched keeps
whatever another writer just stored, so two writers editing different settings both
survive. The merge is key-level and recursive — never a whole-object replacement.

Call sites are **unchanged**:

```python
data = read_config_for_update(path)   # snapshot recorded here
data["k"] = v
write_config_atomically(path, data)   # only this delta is replayed
```

All 12 read-modify-write sites are covered with **zero call-site edits**.

### What this replaced, and why

An earlier revision of this branch added a `config_transaction` / `amutate_config` API and
migrated handlers to `await` it one at a time. That put the burden on 12 callers — each
needing its validation separated from its persistence, plus its own tests — to buy a
millisecond. It is also the same shape that produced five rounds of cascading defects when
a lock was attempted inside #2109. The reviewer question that prompted the rewrite was
simply *"why does this need migrating so many things?"*, and the answer was that it
doesn't.

`config_transaction` remains in the module as the primitive for a caller that needs to
**refuse** rather than merge — where the new value depends on the old one in a way a key-level
merge cannot express. To be precise about its status, since an earlier version of this section
implied a consumer that does not exist: it has **no production caller today** (an AST walk finds
its only non-test call site inside `mutate_config`, which itself has none, as does
`amutate_config`). It is reachable from tests only.

Design Review flagged that as speculative surface and suggested deleting all three. That is
accepted and deferred rather than done here, for one specific reason: this PR is currently green
with a SHA-scoped review override on it, and a new commit would void that override and reopen a
settled standoff to delete code that harms nothing. The deletion belongs with the first PR that
either introduces a real consumer or migrates the remaining writers — issue #2147 — whichever
comes first.

### Why no async migration is needed

The lock covers a re-read, a dict merge and a rename: **0.57ms median, 1.47ms worst** on a
13KB config (measured, `fsync=True` is 0.59ms). A contended caller therefore waits about
as long as the write it was **already** performing inline on the event loop. A test drives
a contended inline write from a coroutine and asserts the stall stays far under 500ms —
the threshold that would have justified restructuring 12 handlers.

### Two footguns from the reverted attempt are encoded here

- **The lock is a sidecar, never the config inode.** The atomic write's `rename` would
  drop a lock held there — releasing the very lock meant to guard it, so the next writer
  finds it free while the first is mid-write.
- **The sidecar goes beside the RESOLVED target.** Symlinking config into a dotfiles repo
  is a supported setup (`write_config_atomically` resolves it for the same reason), and
  there the directory holding the *link* can be read-only while the target is writable — a
  sidecar beside the link would be uncreatable and locking would silently vanish.

## Tests

20 new. The load-bearing ones drive the **unchanged** read-then-write pattern under a
barrier-forced interleaving and assert both updates survive — including two writers
editing different keys inside the same nested section, which a whole-object write would
have clobbered.

Also covered: the delta semantics directly (untouched key keeps the newer value; deletions
replay as deletions; same leaf goes to the caller; nesting is recursive; a scalar replacing
a dict is taken verbatim); a write with no matching read is written as given but still
serialises against a transaction; an unreadable file does not strand the caller; the lock
follows a symlink and two writers through the symlink both survive; the fingerprint is a
content hash, because `(mtime, size)` cannot distinguish two equal-length writes in one
timestamp tick.

## One consequence, caught by an existing test

`test_leaves_no_temp_files_behind` asserted the config directory contains only
`config.json`. The lock sidecar is persistent by design — `flock` needs an inode that
outlives the write it guards — so it now appears there. It is dot-prefixed
(`.config.json.lock`) to stay out of the user's directory listing, and that test now
allows it by name while still forbidding leftover temp files.

## Manual verification

N/A — the concurrency behaviour is exactly what the tests exercise (real threads,
barrier-forced interleavings, a real event loop), and the timing numbers are from a
measurement harness rather than a claim.

## Not-ours

24 wide-suite failures on this host, in the families this host fails on regardless
(`test_terminal_commands::TestRunProbe` — a rotating set of members each run —
`test_artifact_source`, `test_service`, `test_source_providers`, `test_issue_radar_gh_bin`,
`test_artifacts_handlers`, `test_search_sessions_cost`, `test_dev_fleet_app`,
`test_cron_cancel`). An earlier run of that exact id set against a pristine `origin/main`
worktree gave an identical 18 failed / 3 passed. None touch config.

Gates, all by exit code: isort 0, flake8 0, mypy 0 (866 files), 37260 passed.

