### PR TITLE
fix: keep the config.json meta stamp on dataclass round-trip writes

### DIFF
--- a/src/kiro_crew/cli_config.py
+++ b/src/kiro_crew/cli_config.py
@@ -15,6 +15,7 @@ from kiro_crew.config.loader import (
     _subtract_overlay,
     config_local_path,
     config_path,
+    stamp_config_meta,
     write_config_atomically,
 )
 from kiro_crew.hooks import safe_read_file
@@ -63,7 +64,17 @@ def _config_cmd(args: argparse.Namespace) -> None:
             except (json.JSONDecodeError, OSError) as e:
                 print(f"❌ Invalid JSON: {e}", file=sys.stderr)
                 sys.exit(1)
-            write_config_atomically(config_path(), data)
+            if not isinstance(data, dict):
+                # A JSON array or scalar parses fine but is not a config. Refusing
+                # here keeps the file untouched; writing it through would leave a
+                # config.json that every reader rejects.
+                print(
+                    f"❌ Not a config object: {fp} holds a JSON "
+                    f"{type(data).__name__}, expected an object",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            write_config_atomically(config_path(), stamp_config_meta(data))
             sel().log_api_access(
                 caller="cli",
                 operation="config_set_file",
@@ -174,7 +185,7 @@ def _config_cmd(args: argparse.Namespace) -> None:
                             d = _subtract_overlay(d, raw_local)
                     except (json.JSONDecodeError, OSError):
                         pass
-                write_config_atomically(config_path(), d)
+                write_config_atomically(config_path(), stamp_config_meta(d))
                 sel().log_api_access(
                     caller="cli",
                     operation="config_set",

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -664,6 +664,33 @@ def write_config_atomically(path: Path, data: dict, *, fsync: bool = False) -> N
     atomic_write(path, json.dumps(data, indent=2) + "\n", fsync=fsync, mode=mode)
 
 
+def stamp_config_meta(data: dict) -> dict:
+    """Return *data* with a freshly stamped ``meta`` block in front.
+
+    ``meta.lastTouchedVersion`` names the build that wrote the bytes now on
+    disk, which is the first thing to check when a ``config.json`` looks like
+    it came from an older schema. An existing stamp is therefore replaced
+    rather than merged.
+
+    Every writer that rebuilds the whole file from a dataclass round-trip has
+    to stamp through here: ``to_dict()`` models only the schema, so such a
+    write drops any top-level key the dataclass does not carry — ``meta``
+    among them. Writers that mutate the raw dict they read keep the block
+    without help.
+
+    Only ``config.json`` carries the block. ``config.local.json``, agent
+    specs, and the other JSON that shares :func:`write_config_atomically` do
+    not, so the stamping is deliberately separate from that function.
+    """
+    return {
+        "meta": {
+            "lastTouchedVersion": __version__,
+            "lastTouchedAt": datetime.now(timezone.utc).isoformat(),
+        },
+        **{k: v for k, v in data.items() if k != "meta"},
+    }
+
+
 def workspace_dir_for(workspace: str | None = None) -> Path:
     """Resolve a named workspace to its directory path.
 
@@ -5804,10 +5831,6 @@ class KiroCrewConfig:
         output to prevent overlay settings from leaking into the base file.
         """
 
-        meta = {
-            "lastTouchedVersion": __version__,
-            "lastTouchedAt": datetime.now(timezone.utc).isoformat(),
-        }
         d = self.to_dict()
 
         # Strip overlay-owned values so they don't leak into config.json
@@ -5820,11 +5843,10 @@ class KiroCrewConfig:
             except (json.JSONDecodeError, OSError):
                 pass
 
-        d = {"meta": meta, **d}
         # Atomic + mode-preserving: a concurrent reader must never observe a
         # half-written config, and the write must not widen who can read a file
         # that may hold inline credentials. See write_config_atomically.
-        write_config_atomically(config_path(), d)
+        write_config_atomically(config_path(), stamp_config_meta(d))
         # Drop the validated-data cache so the next load() re-reads this write.
         # mtime-keying already detects the change; this makes it immediate even
         # if the filesystem mtime resolution is coarse.

--- a/test/test_config_meta_stamp.py
+++ b/test/test_config_meta_stamp.py
@@ -1,0 +1,178 @@
+"""``config.json`` always carries a ``meta`` stamp naming the build that wrote it.
+
+The stamp is the first thing to check when a config looks like it came from an
+older schema, so a write must never leave the file without one. The hazard is
+specific to writers that rebuild the file from ``KiroCrewConfig.to_dict()``:
+that mapping models the schema only, so any top-level key the dataclass does
+not carry — ``meta`` among them — is absent from the output and the write drops
+it. Writers that mutate the raw dict they read keep the block for free.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew import __version__
+from kiro_crew.config.loader import stamp_config_meta
+
+_OLD_STAMP = {"lastTouchedVersion": "0.0.1", "lastTouchedAt": "2020-01-01T00:00:00+00:00"}
+
+# Values a user would notice losing, spread over several sections so a write
+# that rebuilds the file has something to preserve besides the stamp.
+_REAL_SETTINGS = {
+    "agent": {"approval_mode": "interactive", "max_subagents": 8},
+    "dashboard": {"theme_mode": "dark", "language": "zh-CN"},
+    "session": {"timeout_secs": 7200},
+    "timezone": "Asia/Shanghai",
+}
+
+
+def _set_args(key: str, value: str, *, local: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(config_action="set", key=key, value=value, file=None, local=local)
+
+
+def _run_config_cmd(args: argparse.Namespace, config_dir: Path) -> None:
+    from kiro_crew.cli_config import _config_cmd
+
+    with (
+        patch("kiro_crew.cli_config.config_path", return_value=config_dir / "config.json"),
+        patch(
+            "kiro_crew.cli_config.config_local_path",
+            return_value=config_dir / "config.local.json",
+        ),
+        patch("kiro_crew.config.loader.config_dir", return_value=config_dir),
+        patch("kiro_crew.cli_config.sel"),
+    ):
+        _config_cmd(args)
+
+
+class TestStampConfigMeta:
+    def test_stamps_current_version_and_a_timestamp(self):
+        out = stamp_config_meta({"timezone": "UTC"})
+        assert out["meta"]["lastTouchedVersion"] == __version__
+        assert out["meta"]["lastTouchedAt"]
+
+    def test_replaces_an_existing_stamp_rather_than_merging(self):
+        """The block names the build writing now, so a stale one cannot survive."""
+        out = stamp_config_meta({"meta": _OLD_STAMP, "timezone": "UTC"})
+        assert out["meta"]["lastTouchedVersion"] == __version__
+        assert out["meta"]["lastTouchedAt"] != _OLD_STAMP["lastTouchedAt"]
+
+    def test_keeps_every_other_key(self):
+        out = stamp_config_meta({"meta": _OLD_STAMP, **_REAL_SETTINGS})
+        assert {k: v for k, v in out.items() if k != "meta"} == _REAL_SETTINGS
+
+    def test_meta_is_written_first(self):
+        """Leading position keeps the stamp readable in a hand-opened config."""
+        assert next(iter(stamp_config_meta(_REAL_SETTINGS))) == "meta"
+
+    def test_does_not_mutate_the_input(self):
+        source = {"meta": _OLD_STAMP, "timezone": "UTC"}
+        stamp_config_meta(source)
+        assert source["meta"] == _OLD_STAMP
+
+
+class TestCliConfigSetKeepsMeta:
+    """``kirocrew config set <key> <value>`` rebuilds the file from the dataclass."""
+
+    def test_set_refreshes_the_stamp_instead_of_dropping_it(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / "crew"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            json.dumps({"meta": _OLD_STAMP, **_REAL_SETTINGS}), encoding="utf-8"
+        )
+
+        _run_config_cmd(_set_args("timezone", "Europe/Berlin"), config_dir)
+
+        saved = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+        assert saved["meta"]["lastTouchedVersion"] == __version__
+        assert saved["meta"]["lastTouchedAt"] != _OLD_STAMP["lastTouchedAt"]
+        assert saved["timezone"] == "Europe/Berlin"
+
+    def test_set_stamps_a_config_that_never_had_meta(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / "crew"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(json.dumps(_REAL_SETTINGS), encoding="utf-8")
+
+        _run_config_cmd(_set_args("timezone", "Europe/Berlin"), config_dir)
+
+        saved = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+        assert saved["meta"]["lastTouchedVersion"] == __version__
+
+    def test_set_from_file_stamps_the_written_config(self, tmp_path: Path) -> None:
+        """``--file`` replaces the whole config, so it owns the new stamp too."""
+        config_dir = tmp_path / "crew"
+        config_dir.mkdir()
+        source = tmp_path / "incoming.json"
+        source.write_text(json.dumps({"meta": _OLD_STAMP, **_REAL_SETTINGS}), encoding="utf-8")
+
+        args = argparse.Namespace(
+            config_action="set", key=None, value=None, file=str(source), local=False
+        )
+        _run_config_cmd(args, config_dir)
+
+        saved = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+        assert saved["meta"]["lastTouchedVersion"] == __version__
+        assert saved["timezone"] == "Asia/Shanghai"
+
+    def test_local_set_does_not_stamp_the_overlay(self, tmp_path: Path) -> None:
+        """Only the base file carries the block; the overlay holds settings alone."""
+        config_dir = tmp_path / "crew"
+        config_dir.mkdir()
+
+        _run_config_cmd(_set_args("timezone", "Europe/Berlin", local=True), config_dir)
+
+        overlay = json.loads((config_dir / "config.local.json").read_text(encoding="utf-8"))
+        assert "meta" not in overlay
+        assert overlay["timezone"] == "Europe/Berlin"
+
+    def test_set_from_file_refuses_a_non_object_payload(self, tmp_path: Path, capsys) -> None:
+        """A JSON array parses but is not a config: refuse, leaving the file alone."""
+        config_dir = tmp_path / "crew"
+        config_dir.mkdir()
+        existing = {"meta": _OLD_STAMP, **_REAL_SETTINGS}
+        (config_dir / "config.json").write_text(json.dumps(existing), encoding="utf-8")
+        source = tmp_path / "incoming.json"
+        source.write_text("[1, 2, 3]", encoding="utf-8")
+
+        args = argparse.Namespace(
+            config_action="set", key=None, value=None, file=str(source), local=False
+        )
+        with pytest.raises(SystemExit) as exc:
+            _run_config_cmd(args, config_dir)
+
+        assert exc.value.code == 1
+        assert "Not a config object" in capsys.readouterr().err
+        assert json.loads((config_dir / "config.json").read_text(encoding="utf-8")) == existing
+
+
+class TestConfigSaveKeepsMeta:
+    def test_save_stamps_the_current_build(self, tmp_path: Path) -> None:
+        from kiro_crew.config import KiroCrewConfig
+
+        config_dir = tmp_path / "crew"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            json.dumps({"meta": _OLD_STAMP, **_REAL_SETTINGS}), encoding="utf-8"
+        )
+
+        with (
+            patch(
+                "kiro_crew.config.loader.config_path", return_value=config_dir / "config.json"
+            ),
+            patch(
+                "kiro_crew.config.loader.config_local_path",
+                return_value=config_dir / "config.local.json",
+            ),
+            patch("kiro_crew.config.loader.config_dir", return_value=config_dir),
+        ):
+            KiroCrewConfig.load().save()
+            saved = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+
+        assert saved["meta"]["lastTouchedVersion"] == __version__
+        assert saved["agent"]["approval_mode"] == "interactive"


### PR DESCRIPTION
## Problem

`kirocrew config set <key> <value>` deletes the `meta` block from `config.json`.

The base-file branch of `_config_cmd` rebuilds the whole file from
`KiroCrewConfig.to_dict()`. That mapping models the schema only, so every
top-level key the dataclass does not carry is absent from the output —
`meta` among them — and the atomic write replaces the file without it. One
`config set` and the stamp naming the build that last wrote your config is
gone.

Reproduced on `origin/main` (745bb432c) with a seeded stamp:

```
tree under test: <pristine main>/src/kiro_crew/__init__.py
meta after `config set`: null
RESULT: BUG REPRODUCED — meta was dropped
```

Same script on this branch:

```
meta after `config set`: {"lastTouchedVersion": "0.2.0", "lastTouchedAt": "..."}
RESULT: FIXED — meta present and refreshed to 0.2.0
```

`config set --file` had the same hole: it wrote the operator's file verbatim,
so an incoming config without a stamp produced a `config.json` without one.

Every other writer of `config.json` was audited (all 29 `write_config_atomically`
call sites): they either go through `KiroCrewConfig.save()` or mutate the raw
dict they read via `read_config_for_update`, which preserves the block for free.
The two CLI paths above were the only ones dropping it.

## Fix

`stamp_config_meta(data)` in `config/loader.py`, next to
`write_config_atomically`, is now the single place that builds the block.
`save()` calls it instead of hand-rolling the dict, and both CLI base-file
writes stamp through it. An existing stamp is replaced, not merged — the
block names the build that wrote the bytes now on disk.

Deliberately NOT folded into `write_config_atomically`: that function is
shared with `config.local.json`, agent specs, hooks and app manifests, none
of which carry a `meta` block.

Out of scope: the raw-dict writers preserve the stamp but do not refresh it,
so `lastTouchedVersion` can name an older build than the one that last
touched the file. That is a separate change across ~20 call sites, and
preserving beats refreshing for this fix.

## Tests

New `test/test_config_meta_stamp.py`, 10 tests:

- helper stamps the current `__version__` and a timestamp
- an existing stale stamp is replaced, not merged
- every other key survives; `meta` is written first; the input dict is not mutated
- `config set <key> <value>` refreshes a stale stamp and keeps the edited value
- `config set` stamps a config that never had a block
- `config set --file` stamps the config it writes and keeps the file's settings
- `config set --local` does NOT add a block to the overlay
- `save()` still stamps the current build

The four CLI tests are red on `origin/main` (the two `config set` ones assert
on a block main deletes) and green here.

## Verification

- `pytest test/test_config_meta_stamp.py` — 10 passed
- All `test_config*.py` + `test_beacon.py` + `test_tailnet_governance.py` +
  `test_snapshot.py` — 712 passed
- `isort --check-only src/kiro_crew test` — exit 0
- `flake8 src/kiro_crew test` — exit 0
- `mypy src/kiro_crew/` — Success, 866 source files (mypy 1.14.1, matching the
  `pyproject.toml` pin; no faiss in the venv, so CI-parity)

Backend-only change; no frontend surface touched.
