### PR TITLE
test(website): cover seven under-tested app surfaces

### DIFF
--- a/website/src/test/ApiClient.coverage.test.tsx
+++ b/website/src/test/ApiClient.coverage.test.tsx
@@ -1,0 +1,1322 @@
+/**
+ * Behavioural coverage for the shared dashboard API client (`src/api/client.ts`).
+ *
+ * `client.ts` is one transport layer plus ~450 thin typed methods over it. What
+ * can actually break here is (a) the transport contract — session-key header,
+ * auth recovery, `ApiError` + error journalling, artifact-write tracking — and
+ * (b) URL/body CONSTRUCTION in the methods that are not one-liners: query
+ * builders, conditionally-omitted body keys, path encoding, the SSE reader, the
+ * blob download and the multipart upload.
+ *
+ * So the file is in three parts:
+ *   1. transport + auth-banner lifecycle (real DOM assertions on the injected banner)
+ *   2. curated exact-URL/body tests for every method with non-trivial construction
+ *   3. a sweep over EVERY method on `api`, asserting each issues exactly one
+ *      `/api/...` request whose URL carries no `undefined` / `[object Object]`.
+ *      That invariant is what a missing argument or a botched template literal
+ *      actually produces, and it holds the whole surface — including the methods
+ *      no page-level test happens to exercise.
+ *
+ * Conventions follow the existing client tests (`instancesApi.test.ts`,
+ * `artifactReference.test.ts`): `vi.stubGlobal('fetch', …)` with a hand-rolled
+ * Response stub, and assertions read off `fetchMock.mock.calls`.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  api,
+  ApiError,
+  friendlyErrText,
+  checkSessionExpired,
+  isAuthBannerShown,
+  removeAuthBanner,
+  attemptSilentRefresh,
+  __resetAuthRecoveryStateForTests,
+  SEARCH_MIN_CHARS,
+} from '../api/client'
+import { recentErrors, __resetErrorJournalForTests } from '../utils/errorReport'
+import { copyToClipboard } from '../utils/clipboard'
+import { resizeImageForModel } from '../utils/resizeImage'
+import { hasPendingArtifactWrite, __resetArtifactWrites } from '../lib/artifactWrites'
+import { CONSENT_PREFIX } from '../utils/themeConsent'
+
+// `revealPath` funnels a headless host's `copy` fallback into the clipboard, and
+// `uploadFiles` downscales through the canvas helper — neither of which exists
+// under happy-dom. Both are stubbed at their module boundary so the client's own
+// wiring is what gets asserted.
+vi.mock('../utils/clipboard', () => ({
+  copyToClipboard: vi.fn(async () => {}),
+  copyCode: vi.fn(async () => {}),
+}))
+vi.mock('../utils/resizeImage', () => ({
+  MODEL_IMAGE_LIMITS: { maxEdge: 8000, maxBytes: 3_750_000 },
+  resizeImageForModel: vi.fn(async (file: File) => ({ file, info: null })),
+}))
+
+type Init = RequestInit & { headers?: Record<string, string> }
+
+function res(
+  status: number,
+  body: unknown,
+  opts: { headers?: Record<string, string>; text?: string } = {},
+): Response {
+  const text = opts.text ?? (typeof body === 'string' ? body : JSON.stringify(body))
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    url: 'http://localhost:6776/api/probe',
+    headers: { get: (k: string) => opts.headers?.[k] ?? opts.headers?.[k.toLowerCase()] ?? null },
+    json: async () => (typeof body === 'string' ? JSON.parse(body) : body),
+    text: async () => text,
+    blob: async () => new Blob([text]),
+  } as unknown as Response
+}
+
+const okJson = (body: unknown = { ok: true }) => res(200, body)
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  fetchMock.mockResolvedValue(okJson())
+  vi.stubGlobal('fetch', fetchMock)
+  __resetAuthRecoveryStateForTests()
+  __resetErrorJournalForTests()
+  __resetArtifactWrites()
+  vi.mocked(copyToClipboard).mockClear()
+  vi.mocked(resizeImageForModel).mockClear()
+  vi.mocked(resizeImageForModel).mockImplementation(async (file: File) => ({ file, info: null }))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  __resetAuthRecoveryStateForTests()
+})
+
+/** The nth fetch call, destructured the way every assertion below wants it. */
+function call(n = 0) {
+  const [url, init] = fetchMock.mock.calls[n] as [string, Init | undefined]
+  return {
+    url,
+    init,
+    method: init?.method,
+    headers: (init?.headers ?? {}) as Record<string, string>,
+    // Only JSON bodies are decoded; a multipart upload stays a FormData.
+    body: typeof init?.body === 'string'
+      ? (JSON.parse(init.body) as Record<string, unknown>)
+      : undefined,
+  }
+}
+
+/* ────────────────────────── 1. transport contract ────────────────────────── */
+
+describe('client transport', () => {
+  it('exposes the backend search threshold as a shared constant', () => {
+    // Must match kiro_crew.history.SEARCH_MIN_CHARS — the pages gate typing on it.
+    expect(SEARCH_MIN_CHARS).toBe(2)
+  })
+
+  it('GET sends the session-key header and no JSON content type', async () => {
+    await api.securityStats()
+    const { url, method, headers } = call()
+    expect(url).toBe('/api/security/stats')
+    expect(method).toBeUndefined()
+    expect(headers['X-Session-Key']).toBe('dashboard:ui')
+    expect(headers['Content-Type']).toBeUndefined()
+  })
+
+  it('POST/PUT/PATCH send a JSON content type alongside the placeholder key', async () => {
+    await api.trustApp('demo')
+    expect(call().headers).toMatchObject({ 'Content-Type': 'application/json', 'X-Session-Key': 'dashboard:ui' })
+    await api.setTrustAllApps(true)
+    expect(call(1).method).toBe('PUT')
+    expect(call(1).headers['Content-Type']).toBe('application/json')
+    await api.toggleUserDeniedCommand('r1', false)
+    expect(call(2).method).toBe('PATCH')
+    expect(call(2).body).toEqual({ enabled: false })
+  })
+
+  it('DELETE omits the JSON content type when it carries no body, and sets it when it does', async () => {
+    await api.deleteUserDeniedCommand('r1')
+    expect(call().method).toBe('DELETE')
+    expect(call().headers['Content-Type']).toBeUndefined()
+    expect(call().init?.body).toBeUndefined()
+
+    await api.deleteLesson('never force push')
+    expect(call(1).headers['Content-Type']).toBe('application/json')
+    expect(call(1).body).toEqual({ rule: 'never force push' })
+  })
+
+  it('POST omits the body entirely when none is given', async () => {
+    await api.mcpProbe()
+    expect(call().init?.body).toBeUndefined()
+  })
+
+  it('an explicit session key replaces the shared dashboard:ui placeholder', async () => {
+    // `dashboard:ui` satisfies the server's `if sk:` gate but names no session,
+    // so a restricted (incognito) slot was never recognised as restricted.
+    await api.setArtifactPinned('cr-queue', true, 'dashboard:chat-3')
+    expect(call().headers['X-Session-Key']).toBe('dashboard:chat-3')
+  })
+
+  it('createArtifact derives the session key from origin_session_key when none is passed', async () => {
+    await api.createArtifact({ name: 'Doc', content: '<p/>', origin_session_key: 'chat-9' })
+    expect(call().headers['X-Session-Key']).toBe('dashboard:chat-9')
+  })
+
+  it('createArtifact lets an explicit session key win over origin_session_key', async () => {
+    await api.createArtifact({ name: 'Doc', content: '<p/>', origin_session_key: 'chat-9' }, 'dashboard:other')
+    expect(call().headers['X-Session-Key']).toBe('dashboard:other')
+  })
+
+  it('createArtifact falls back to the placeholder when the body names no session', async () => {
+    await api.createArtifact({ name: 'Doc', content: '<p/>' })
+    expect(call().headers['X-Session-Key']).toBe('dashboard:ui')
+  })
+})
+
+describe('client response handling', () => {
+  it('resolves the parsed JSON body on 2xx', async () => {
+    fetchMock.mockResolvedValue(okJson({ denied_commands: 41 }))
+    await expect(api.securityStats()).resolves.toMatchObject({ denied_commands: 41 })
+  })
+
+  it('rejects with an ApiError carrying the status, unwrapped message and raw body', async () => {
+    fetchMock.mockResolvedValue(res(409, '{"error":"already installed","code":"conflict"}'))
+    const err = await api.installDiscoveredSkill('skills.sh', 'grill').catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(ApiError)
+    const e = err as ApiError
+    expect(e.name).toBe('ApiError')
+    expect(e.status).toBe(409)
+    // friendlyErrText unwraps {"error": …}; `body` keeps the envelope so a caller
+    // can still read the structured `code`.
+    expect(e.message).toBe('already installed')
+    expect(e.body).toContain('"code":"conflict"')
+  })
+
+  it('falls back to "HTTP <status>" when the failure body is empty', async () => {
+    fetchMock.mockResolvedValue(res(500, '', { text: '' }))
+    await expect(api.securityStats()).rejects.toThrow('HTTP 500')
+  })
+
+  it('journals every failure with status, endpoint and backend code', async () => {
+    fetchMock.mockResolvedValue(res(403, '{"error":"denied","code":"app_execution_denied"}'))
+    await api.trustApp('demo').catch(() => {})
+    const [report] = recentErrors()
+    expect(report).toMatchObject({
+      source: 'api',
+      status: 403,
+      message: 'denied',
+      code: 'app_execution_denied',
+      endpoint: '/api/probe',
+    })
+  })
+
+  it('maps an API-Gateway throttle body to a readable message', () => {
+    const msg = friendlyErrText(429, '{"message":"Rate exceeded","throttlingReasons":null}')
+    expect(msg).not.toContain('throttlingReasons')
+    expect(msg.toLowerCase()).toContain('rate')
+  })
+
+  it('jNullable returns null on 204 rather than exploding on an empty body', async () => {
+    fetchMock.mockResolvedValue(res(204, null, { text: '' }))
+    await expect(api.tipsNext()).resolves.toBeNull()
+    await expect(api.onboardingImportState({ completed: true })).resolves.toBeNull()
+  })
+
+  it('jNullable still rejects with ApiError on a real failure', async () => {
+    fetchMock.mockResolvedValue(res(500, 'boom'))
+    await expect(api.tipsNext()).rejects.toBeInstanceOf(ApiError)
+  })
+})
+
+describe('artifact write tracking', () => {
+  it('marks a slug as pending for the life of a mutating request and clears it after', async () => {
+    let release: (r: Response) => void = () => {}
+    fetchMock.mockReturnValue(new Promise<Response>((r) => { release = r }))
+    const p = api.updateArtifact('cr-queue', { content: '<p/>' })
+    expect(hasPendingArtifactWrite('cr-queue')).toBe(true)
+    release(okJson())
+    await p
+    expect(hasPendingArtifactWrite('cr-queue')).toBe(false)
+  })
+
+  it('clears the pending marker even when the write fails — the server never applied it', async () => {
+    fetchMock.mockResolvedValue(res(500, 'nope'))
+    await api.updateArtifact('cr-queue', { content: '<p/>' }).catch(() => {})
+    expect(hasPendingArtifactWrite('cr-queue')).toBe(false)
+  })
+
+  it('does not count the settle call as a user write — it is the cleanup', async () => {
+    let release: (r: Response) => void = () => {}
+    fetchMock.mockReturnValue(new Promise<Response>((r) => { release = r }))
+    const p = api.settleBlankArtifact('draft-1', { untitled_name: 'Untitled', draft: '', allow_delete: true })
+    expect(hasPendingArtifactWrite('draft-1')).toBe(false)
+    release(okJson({ outcome: 'deleted' }))
+    await p
+  })
+
+  it('does not track reads', async () => {
+    let release: (r: Response) => void = () => {}
+    fetchMock.mockReturnValue(new Promise<Response>((r) => { release = r }))
+    const p = api.artifact('cr-queue')
+    expect(hasPendingArtifactWrite('cr-queue')).toBe(false)
+    release(okJson())
+    await p
+  })
+
+  it('falls back to the raw path segment when the slug is not valid percent-encoding', async () => {
+    // A hand-typed `%zz` makes decodeURIComponent throw; the write must still be
+    // tracked (under the raw segment) rather than taking the transport down.
+    let release: (r: Response) => void = () => {}
+    fetchMock.mockReturnValue(new Promise<Response>((r) => { release = r }))
+    const p = api.deleteArtifact('%zz')
+    expect(hasPendingArtifactWrite('%zz')).toBe(true)
+    release(okJson())
+    await p
+    expect(hasPendingArtifactWrite('%zz')).toBe(false)
+  })
+})
+
+/* ─────────────────────── auth-banner recovery lifecycle ─────────────────────── */
+
+describe('session-expired banner', () => {
+  const banner = () => document.getElementById('mc-session-expired')
+
+  afterEach(() => { banner()?.remove() })
+
+  it('ignores a 403 that is not an auth challenge', () => {
+    checkSessionExpired(res(403, 'forbidden'))
+    expect(banner()).toBeNull()
+    expect(isAuthBannerShown()).toBe(false)
+  })
+
+  it('tries a silent refresh first and shows no banner when the cookie rotates', async () => {
+    fetchMock.mockResolvedValue(okJson({ ok: true }))
+    checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/auth/refresh', expect.anything()))
+    expect(banner()).toBeNull()
+  })
+
+  it('shows the banner only once the refresh comes back terminal (401)', async () => {
+    fetchMock.mockResolvedValue(res(401, 'revoked'))
+    checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))
+    await vi.waitFor(() => expect(banner()).not.toBeNull())
+    expect(isAuthBannerShown()).toBe(true)
+    const el = banner() as HTMLElement
+    // The recovery instructions are the point of the banner: the command to run
+    // and a field to paste the resulting URL into.
+    expect(el.querySelector('code')?.textContent).toBe('kirocrew token')
+    expect(el.querySelector('input')).not.toBeNull()
+    expect(el.querySelector('button')?.textContent).toBe('✕')
+  })
+
+  it('is idempotent — a second challenge does not stack a second banner', async () => {
+    fetchMock.mockResolvedValue(res(401, 'revoked'))
+    checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))
+    await vi.waitFor(() => expect(banner()).not.toBeNull())
+    checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))
+    expect(document.querySelectorAll('#mc-session-expired')).toHaveLength(1)
+  })
+
+  it('self-dismisses on the next 2xx through the shared response handler', async () => {
+    fetchMock.mockResolvedValue(res(401, 'revoked'))
+    checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))
+    await vi.waitFor(() => expect(banner()).not.toBeNull())
+
+    fetchMock.mockResolvedValue(okJson({ denied_commands: 1 }))
+    await api.securityStats()
+    expect(banner()).toBeNull()
+    expect(isAuthBannerShown()).toBe(false)
+  })
+
+  it('emits mc-auth-required / mc-auth-cleared so components can drop their offline UI', async () => {
+    const required = vi.fn()
+    const cleared = vi.fn()
+    window.addEventListener('mc-auth-required', required)
+    window.addEventListener('mc-auth-cleared', cleared)
+    try {
+      fetchMock.mockResolvedValue(res(401, 'revoked'))
+      checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))
+      await vi.waitFor(() => expect(required).toHaveBeenCalled())
+      removeAuthBanner()
+      expect(cleared).toHaveBeenCalled()
+    } finally {
+      window.removeEventListener('mc-auth-required', required)
+      window.removeEventListener('mc-auth-cleared', cleared)
+    }
+  })
+
+  it('removeAuthBanner is a no-op when no banner is up', () => {
+    expect(() => removeAuthBanner()).not.toThrow()
+    expect(isAuthBannerShown()).toBe(false)
+  })
+
+  it('the dismiss button tears the banner down and clears the shown flag', async () => {
+    fetchMock.mockResolvedValue(res(401, 'revoked'))
+    checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))
+    await vi.waitFor(() => expect(banner()).not.toBeNull())
+    ;(banner()!.querySelector('button') as HTMLButtonElement).click()
+    expect(banner()).toBeNull()
+    expect(isAuthBannerShown()).toBe(false)
+  })
+
+  it('highlights the paste field on focus and restores it on blur', async () => {
+    fetchMock.mockResolvedValue(res(401, 'revoked'))
+    checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))
+    await vi.waitFor(() => expect(banner()).not.toBeNull())
+    const input = banner()!.querySelector('input') as HTMLInputElement
+    input.dispatchEvent(new FocusEvent('focus'))
+    expect(input.style.borderColor).toBe('#fff')
+    expect(input.style.boxShadow).not.toBe('none')
+    input.dispatchEvent(new FocusEvent('blur'))
+    expect(input.style.boxShadow).toBe('none')
+  })
+
+  describe('pasting a token', () => {
+    let original: Location
+
+    beforeEach(() => {
+      original = window.location
+      Object.defineProperty(window, 'location', {
+        value: { protocol: 'https:', host: 'desk.example:6776', href: 'https://desk.example:6776/' },
+        writable: true,
+        configurable: true,
+      })
+    })
+    afterEach(() => {
+      Object.defineProperty(window, 'location', { value: original, writable: true, configurable: true })
+    })
+
+    async function pasteAndEnter(value: string) {
+      fetchMock.mockResolvedValue(res(401, 'revoked'))
+      checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))
+      await vi.waitFor(() => expect(banner()).not.toBeNull())
+      const input = banner()!.querySelector('input') as HTMLInputElement
+      input.value = value
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      return window.location.href
+    }
+
+    it('extracts the token out of a pasted `kirocrew token` URL', async () => {
+      expect(await pasteAndEnter('http://127.0.0.1:6776/?token=abc123&x=1'))
+        .toBe('https://desk.example:6776?token=abc123')
+    })
+
+    it('accepts a bare token, which is not a parseable URL', async () => {
+      expect(await pasteAndEnter('rawtoken')).toBe('https://desk.example:6776?token=rawtoken')
+    })
+
+    it('percent-encodes a token containing URL-significant characters', async () => {
+      expect(await pasteAndEnter('a+b/c=')).toBe('https://desk.example:6776?token=a%2Bb%2Fc%3D')
+    })
+
+    it('does nothing on an empty field', async () => {
+      expect(await pasteAndEnter('   ')).toBe('https://desk.example:6776/')
+    })
+
+    it('ignores keys other than Enter', async () => {
+      fetchMock.mockResolvedValue(res(401, 'revoked'))
+      checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))
+      await vi.waitFor(() => expect(banner()).not.toBeNull())
+      const input = banner()!.querySelector('input') as HTMLInputElement
+      input.value = 'abc'
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }))
+      expect(window.location.href).toBe('https://desk.example:6776/')
+    })
+  })
+
+  it('hands recovery to the hub instead of bannering when embedded in the Instances pane', () => {
+    // Inside the hub's iframe the user cannot fetch the REMOTE token, so the
+    // parent is signalled and re-mints instead. The message carries no secret.
+    const post = vi.fn()
+    const original = Object.getOwnPropertyDescriptor(window, 'parent')
+    Object.defineProperty(window, 'parent', {
+      value: { postMessage: post },
+      writable: true,
+      configurable: true,
+    })
+    try {
+      checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))
+      expect(post).toHaveBeenCalledWith({ type: 'mc-auth-expired' }, '*')
+      expect(banner()).toBeNull()
+      expect(fetchMock).not.toHaveBeenCalled()
+    } finally {
+      if (original) Object.defineProperty(window, 'parent', original)
+    }
+  })
+
+  it('falls through to the banner path when the parent frame is unreachable', async () => {
+    const original = Object.getOwnPropertyDescriptor(window, 'parent')
+    Object.defineProperty(window, 'parent', {
+      value: { postMessage: () => { throw new Error('cross-origin') } },
+      writable: true,
+      configurable: true,
+    })
+    try {
+      // The postMessage throw is swallowed; the call still returns the response.
+      expect(() => checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))).not.toThrow()
+    } finally {
+      if (original) Object.defineProperty(window, 'parent', original)
+      await Promise.resolve()
+    }
+  })
+
+  it('attemptSilentRefresh reports false on a terminal 401 and true on a rotation', async () => {
+    fetchMock.mockResolvedValue(res(401, 'revoked'))
+    await expect(attemptSilentRefresh()).resolves.toBe(false)
+    __resetAuthRecoveryStateForTests()
+    fetchMock.mockResolvedValue(okJson({ ok: true }))
+    await expect(attemptSilentRefresh()).resolves.toBe(true)
+  })
+})
+
+/* ──────────────────── 2. URL and body construction ──────────────────── */
+
+describe('query-string builders', () => {
+  it('kiroPrerequisite distinguishes latched read, coalesced poll and explicit probe', async () => {
+    await api.kiroPrerequisite()
+    expect(call().url).toBe('/api/kiro-prerequisite')
+    await api.kiroPrerequisite('auto')
+    expect(call(1).url).toBe('/api/kiro-prerequisite?refresh=auto')
+    await api.kiroPrerequisite('explicit')
+    expect(call(2).url).toBe('/api/kiro-prerequisite?refresh=explicit')
+  })
+
+  it('cloud lifecycle calls carry only the coordinates they were given', async () => {
+    await api.cloudStop('kc-1')
+    expect(call().url).toBe('/api/cloud/kc-1/stop')
+    await api.cloudStart('kc-1', { region: 'us-west-2' })
+    expect(call(1).url).toBe('/api/cloud/kc-1/start?region=us-west-2')
+    await api.cloudDestroy('kc-1', { profile: 'dev', region: 'us-east-1', instanceId: 'i-0abc' })
+    expect(call(2).url).toBe('/api/cloud/kc-1?profile=dev&region=us-east-1&instance_id=i-0abc')
+    expect(call(2).method).toBe('DELETE')
+  })
+
+  it('cloudPreflight omits absent profile/region', async () => {
+    await api.cloudPreflight()
+    expect(call().url).toBe('/api/cloud/preflight')
+    await api.cloudPreflight('dev')
+    expect(call(1).url).toBe('/api/cloud/preflight?profile=dev')
+    await api.cloudPreflight('dev', 'eu-west-1')
+    expect(call(2).url).toBe('/api/cloud/preflight?profile=dev&region=eu-west-1')
+  })
+
+  it('artifacts() serialises every filter, and sends pinned=0 for an explicit false', async () => {
+    await api.artifacts()
+    expect(call().url).toBe('/api/artifacts')
+    await api.artifacts({
+      tag: 'cr', kind: 'widget', q: 'queue', source_path: '/n/a.md',
+      snippet: true, contentMatch: true, session: 'chat-1', touchedBy: 'chat-2', pinned: true,
+    })
+    expect(call(1).url).toBe(
+      '/api/artifacts?tag=cr&kind=widget&q=queue&source_path=%2Fn%2Fa.md' +
+      '&snippet=1&content=1&session=chat-1&touched_by=chat-2&pinned=1',
+    )
+    // `pinned: false` must survive as an explicit "unpinned only", not be dropped.
+    await api.artifacts({ pinned: false })
+    expect(call(2).url).toBe('/api/artifacts?pinned=0')
+    await api.artifacts({ snippet: false, contentMatch: false })
+    expect(call(3).url).toBe('/api/artifacts')
+  })
+
+  it('cronHistory sends offset/limit only when supplied, including zero', async () => {
+    await api.cronHistory('job-1')
+    expect(call().url).toBe('/api/crons/job-1/history')
+    await api.cronHistory('job-1', 0, 25)
+    expect(call(1).url).toBe('/api/crons/job-1/history?offset=0&limit=25')
+    expect(call(1).headers['X-Session-Key']).toBe('dashboard:ui')
+  })
+
+  it('cronHistoryAll can filter by job', async () => {
+    await api.cronHistoryAll()
+    expect(call().url).toBe('/api/crons/history')
+    await api.cronHistoryAll({ offset: 10, limit: 5, jobId: 'job-2' })
+    expect(call(1).url).toBe('/api/crons/history?offset=10&limit=5&job_id=job-2')
+  })
+
+  it('chatSlotDetail paginates with limit/before', async () => {
+    await api.chatSlotDetail('chat 1')
+    expect(call().url).toBe('/api/chat/slots/chat%201?')
+    await api.chatSlotDetail('chat-1', 50, 0)
+    expect(call(1).url).toBe('/api/chat/slots/chat-1?limit=50&before=0')
+  })
+
+  it('suggestions can force regeneration', async () => {
+    await api.suggestions()
+    expect(call().url).toBe('/api/suggestions')
+    await api.suggestions(true)
+    expect(call(1).url).toBe('/api/suggestions?force=1')
+  })
+
+  it('instanceStatus opts into the diagnosis probe', async () => {
+    await api.instanceStatus('cd-1', true)
+    expect(call().url).toBe('/api/instances/cd-1/status?diagnose=1')
+  })
+
+  it('sessions/search/episodic pass their paging and tag filters through', async () => {
+    await api.sessions()
+    expect(call().url).toBe('/api/sessions?limit=30&offset=0')
+    await api.sessions(10, 20, true)
+    expect(call(1).url).toBe('/api/sessions?limit=10&offset=20&preview=1')
+    await api.sessionsSearch('a b', 5)
+    expect(call(2).url).toBe('/api/sessions/search?q=a%20b&limit=5')
+    await api.vectorEpisodic(10, 5, 'promo,l6')
+    expect(call(3).url).toBe('/api/memory/episodic?limit=10&offset=5&tags=promo%2Cl6')
+    await api.vectorEpisodic()
+    expect(call(4).url).toBe('/api/memory/episodic?limit=50&offset=0')
+    await api.vectorEpisodicSearch('q', 'tag')
+    expect(call(5).url).toBe('/api/memory/episodic/search?q=q&tags=tag')
+  })
+
+  it('discovery endpoints append provider and limit only when set', async () => {
+    await api.discoverSkills('grill')
+    expect(call().url).toBe('/api/skills/-/discover?q=grill')
+    await api.discoverSkills('grill', { provider: 'skills.sh', limit: 5 })
+    expect(call(1).url).toBe('/api/skills/-/discover?q=grill&provider=skills.sh&limit=5')
+    await api.mcpDiscover('fs')
+    expect(call(2).url).toBe('/api/mcp/discover?q=fs')
+    await api.mcpDiscover('fs', { provider: 'official', limit: 3 })
+    expect(call(3).url).toBe('/api/mcp/discover?q=fs&provider=official&limit=3')
+  })
+
+  it('browseRemoteArtifacts defaults to the caller-owned scope', async () => {
+    await api.browseRemoteArtifacts('quip')
+    expect(call().url).toBe('/api/remote-artifacts/quip/browse?scope=mine')
+    await api.browseRemoteArtifacts('quip', { scope: 'shared', q: 'a b', pageToken: 't/1' })
+    expect(call(1).url).toBe('/api/remote-artifacts/quip/browse?scope=shared&q=a%20b&pageToken=t%2F1')
+  })
+
+  it('effortLevels and mcpActive scope to a slot/agent when given one', async () => {
+    await api.effortLevels()
+    expect(call().url).toBe('/api/effort-levels')
+    await api.effortLevels('chat-1')
+    expect(call(1).url).toBe('/api/effort-levels?slot=chat-1')
+    await api.mcpActive()
+    expect(call(2).url).toBe('/api/mcp/active')
+    await api.mcpActive('kirocrew')
+    expect(call(3).url).toBe('/api/mcp/active?agent=kirocrew')
+  })
+
+  it('browse/project helpers encode the path they were handed', async () => {
+    await api.browseDirs()
+    expect(call().url).toBe('/api/browse-dirs')
+    await api.browseDirs('/a b/c')
+    expect(call(1).url).toBe('/api/browse-dirs?path=%2Fa%20b%2Fc')
+    await api.browseFiles('/a b')
+    expect(call(2).url).toBe('/api/browse-files?path=%2Fa%20b')
+    await api.projectGit('/repo x')
+    expect(call(3).url).toBe('/api/project/git?path=%2Frepo%20x')
+    await api.fileDiff('/repo/a b.ts')
+    expect(call(4).url).toBe('/api/file-diff?path=%2Frepo%2Fa%20b.ts')
+  })
+
+  it('fileSearch scopes to a project and forwards the abort signal', async () => {
+    const ctl = new AbortController()
+    await api.fileSearch('cli', 'kirocrew', ctl.signal)
+    expect(call().url).toBe('/api/file-search?q=cli&project=kirocrew')
+    expect(call().init?.signal).toBe(ctl.signal)
+    await api.fileSearch('cli')
+    expect(call(1).url).toBe('/api/file-search?q=cli')
+    expect(call(1).init).toBeUndefined()
+  })
+
+  it('artifactSessionDocs can scope to one session', async () => {
+    await api.artifactSessionDocs()
+    expect(call().url).toBe('/api/artifacts/session-docs')
+    await api.artifactSessionDocs('chat-1')
+    expect(call(1).url).toBe('/api/artifacts/session-docs?session=chat-1')
+  })
+
+  it('vectorContextPreview and telemetryContextTrace encode their query', async () => {
+    await api.vectorContextPreview()
+    expect(call().url).toBe('/api/memory/context-preview')
+    await api.vectorContextPreview('a b')
+    expect(call(1).url).toBe('/api/memory/context-preview?q=a%20b')
+    await api.telemetryContextTrace('chat 1')
+    expect(call(2).url).toBe('/api/telemetry/context-trace?slot=chat%201')
+  })
+
+  it('deleteArtifactFolder states the cascade explicitly in the query', async () => {
+    await api.deleteArtifactFolder('f1', false)
+    expect(call().url).toBe('/api/artifact-folders/f1?delete_contents=false')
+    await api.deleteArtifactFolder('f1', true)
+    expect(call(1).url).toBe('/api/artifact-folders/f1?delete_contents=true')
+  })
+
+  it('getArtifactPublishProviders and weixinQrStatus encode their single param', async () => {
+    await api.getArtifactPublishProviders('markdown')
+    expect(call().url).toBe('/api/artifacts/publish-providers?kind=markdown')
+    await api.weixinQrStatus('s/1')
+    expect(call(1).url).toBe('/api/channels/weixin/qr/status?session_id=s%2F1')
+  })
+
+  it('knowledgeSearch and autocomplete encode the query', async () => {
+    await api.knowledgeSearch('a&b')
+    expect(call().url).toBe('/api/knowledge/search-for-context?q=a%26b')
+    await api.autocomplete('a&b')
+    expect(call(1).url).toBe('/api/autocomplete?q=a%26b')
+  })
+
+  it('agentResolvedModel resolves the configured default for an empty agent', async () => {
+    await api.agentResolvedModel('')
+    expect(call().url).toBe('/api/agents/resolved-model?agent=')
+  })
+})
+
+describe('path encoding', () => {
+  it('percent-encodes single-segment ids', async () => {
+    await api.artifact('a/b')
+    expect(call().url).toBe('/api/artifacts/a%2Fb')
+    await api.deleteChatSlot('chat/1')
+    expect(call(1).url).toBe('/api/chat/slots/chat%2F1')
+    await api.untrustApp('my app')
+    expect(call(2).url).toBe('/api/security/trusted-apps/my%20app')
+    await api.deleteWorkspace('w s')
+    expect(call(3).url).toBe('/api/workspaces/w%20s')
+    await api.deleteTheme('a b')
+    expect(call(4).url).toBe('/api/themes/a%20b')
+  })
+
+  it('keeps the separators of nested skill/prompt/steering keys while encoding each segment', async () => {
+    // These names are genuinely hierarchical (`auto/resolve-i18n/...`), so the
+    // slashes are structure and must NOT be encoded — only the segments are.
+    await api.skill('auto/my skill')
+    expect(call().url).toBe('/api/skills/auto/my%20skill')
+    await api.skillTree('auto/my skill')
+    expect(call(1).url).toBe('/api/skills/auto/my%20skill/-/tree')
+    await api.skillFile('auto/s', 'rules/a b.md')
+    expect(call(2).url).toBe('/api/skills/auto/s/-/file?path=rules%2Fa%20b.md')
+    await api.promptDetail('team/sop x')
+    expect(call(3).url).toBe('/api/prompts/team/sop%20x')
+    await api.steeringFile('project/a b.md')
+    expect(call(4).url).toBe('/api/steering/project/a%20b.md')
+    await api.updateSkill('auto/s', '# hi')
+    expect(call(5).url).toBe('/api/skills/auto/s')
+    expect(call(5).body).toEqual({ content: '# hi' })
+  })
+
+  it('builds the versioned artifact paths', async () => {
+    await api.artifactVersion('cr-queue', 3)
+    expect(call().url).toBe('/api/artifacts/cr-queue/versions/3')
+    await api.artifactVersions('cr-queue')
+    expect(call(1).url).toBe('/api/artifacts/cr-queue/versions')
+    await api.artifactEvents('cr-queue')
+    expect(call(2).url).toBe('/api/artifacts/cr-queue/events')
+  })
+
+  it('encodes both ids in two-segment comment paths', async () => {
+    await api.replyArtifactComment('a/b', 'c/d', { text: 'ok' })
+    expect(call().url).toBe('/api/artifacts/a%2Fb/comments/c%2Fd/reply')
+    await api.deleteArtifactComment('a/b', 'c/d')
+    expect(call(1).url).toBe('/api/artifacts/a%2Fb/comments/c%2Fd')
+    await api.markCommentReview('s', 'c')
+    expect(call(2).url).toBe('/api/artifacts/s/comments/c/review')
+    await api.resolveComment('s', 'c')
+    expect(call(3).url).toBe('/api/artifacts/s/comments/c/resolve')
+    await api.reopenComment('s', 'c')
+    expect(call(4).url).toBe('/api/artifacts/s/comments/c/reopen')
+    await api.editArtifactComment('s', 'c', { text: 'x' })
+    expect(call(5).url).toBe('/api/artifacts/s/comments/c')
+    expect(call(5).method).toBe('PATCH')
+  })
+
+  it('percent-encodes provider-native remote ids, which may contain slashes', async () => {
+    await api.remoteArtifactDetail('quip', 'folder/doc')
+    expect(call().url).toBe('/api/remote-artifacts/quip/folder%2Fdoc')
+    await api.remoteArtifactComments('quip', 'folder/doc')
+    expect(call(1).url).toBe('/api/remote-artifacts/quip/folder%2Fdoc/comments')
+    await api.deleteRemoteComment('quip', 'folder/doc', 'c/1')
+    expect(call(2).url).toBe('/api/remote-artifacts/quip/folder%2Fdoc/comments/c%2F1')
+    // clone/fork keep the external id in the BODY — a path segment cannot carry it.
+    await api.cloneRemoteArtifact('quip', 'folder/doc')
+    expect(call(3).url).toBe('/api/remote-artifacts/quip/clone')
+    expect(call(3).body).toEqual({ external_id: 'folder/doc' })
+    await api.forkRemoteArtifact('quip', 'folder/doc')
+    expect(call(4).body).toEqual({ external_id: 'folder/doc' })
+  })
+})
+
+describe('request bodies with conditionally-omitted keys', () => {
+  it('createChatSlot sends only the fields it was given', async () => {
+    await api.createChatSlot()
+    expect(call().body).toEqual({})
+    await api.createChatSlot('n', 'a', 'm', 'mode', 'mem', 't', false, 'slug', 'f1')
+    expect(call(1).body).toEqual({
+      name: 'n', agent: 'a', model: 'm', mode: 'mode', memory_mode: 'mem',
+      title: 't', clean_mode: false, artifact: 'slug', folder_id: 'f1',
+    })
+  })
+
+  it('sessionStorageRestore adds the uid list only for a partial restore', async () => {
+    await api.sessionStorageRestore('b1')
+    expect(call().body).toEqual({ batch_id: 'b1' })
+    await api.sessionStorageRestore('b1', ['u1'])
+    expect(call(1).body).toEqual({ batch_id: 'b1', uids: ['u1'] })
+  })
+
+  it('forkChatSlot omits an unspecified fork point', async () => {
+    await api.forkChatSlot('chat-1')
+    expect(call().body).toEqual({})
+    // index 0 is a legitimate fork point and must not be dropped as falsy.
+    await api.forkChatSlot('chat-1', 0, 'why', 'plan', 'down')
+    expect(call(1).body).toEqual({ at_message_index: 0, prompt: 'why', mode: 'plan', direction: 'down' })
+  })
+
+  it('slackLink sends no body at all when it is only asking for the existing link', async () => {
+    await api.slackLink('chat-1')
+    expect(call().init?.body).toBeUndefined()
+    await api.slackLink('chat-1', 'C123', '1699.1')
+    expect(call(1).body).toEqual({ channel: 'C123', thread_ts: '1699.1' })
+  })
+
+  it('channelClearContext narrows to one agent only in agent scope', async () => {
+    await api.channelClearContext('ch1', 'all')
+    expect(call().body).toEqual({ scope: 'all' })
+    await api.channelClearContext('ch1', 'agent', 'a1')
+    expect(call(1).body).toEqual({ scope: 'agent', agent_id: 'a1' })
+  })
+
+  it('answerQuestion distinguishes an answer from a dismissal', async () => {
+    await api.answerQuestion('ask-1', { q1: 'yes' })
+    expect(call().body).toEqual({ answers: { q1: 'yes' } })
+    await api.answerQuestion('ask-1')
+    expect(call(1).body).toEqual({ dismissed: true })
+  })
+
+  it('interruptSlot targets a specific queued message when asked to', async () => {
+    await api.interruptSlot('chat-1')
+    expect(call().body).toEqual({})
+    await api.interruptSlot('chat-1', 'q1')
+    expect(call(1).body).toEqual({ queue_id: 'q1' })
+  })
+
+  it('uninstallApp only names the retention exceptions it needs', async () => {
+    await api.uninstallApp('demo')
+    expect(call().body).toEqual({})
+    await api.uninstallApp('demo', false, true, ['dep-a'])
+    expect(call(1).body).toEqual({ purge_data: true, keep_dependencies: true, keep_specific: ['dep-a'] })
+    await api.uninstallApp('demo', true, false, [])
+    expect(call(2).body).toEqual({})
+  })
+
+  it('createChatFolder folds the modal settings into the create body', async () => {
+    await api.createChatFolder('Work')
+    expect(call().body).toEqual({ name: 'Work', parent_id: '' })
+    await api.createChatFolder('Work', 'p1', { project_dir: '/r', default_agent: 'kirocrew', color: 'blue' })
+    expect(call(1).body).toEqual({
+      name: 'Work', parent_id: 'p1', project_dir: '/r', default_agent: 'kirocrew', color: 'blue',
+    })
+  })
+
+  it('chatSlotContext marks an ephemeral injection and names its source', async () => {
+    await api.chatSlotContext('chat-1', 'ctx')
+    expect(call().body).toEqual({ content: 'ctx' })
+    await api.chatSlotContext('chat-1', 'ctx', { source: 'artifact', ephemeral: false })
+    expect(call(1).body).toEqual({ content: 'ctx', source: 'artifact', ephemeral: false })
+  })
+
+  it('sideTurn flags a steer, and sideQueueCancel names the owning tab', async () => {
+    await api.sideTurn('chat-1', 'why?')
+    expect(call().body).toEqual({ question: 'why?' })
+    await api.sideTurn('chat-1', 'why?', { steer: true })
+    expect(call(1).body).toEqual({ question: 'why?', steer: true })
+    await api.sideQueueCancel('chat-1', 'q1')
+    expect(call(2).method).toBe('DELETE')
+    expect(call(2).body).toHaveProperty('client')
+  })
+
+  it('handoffSlot posts no body when the channel is left to the server', async () => {
+    await api.handoffSlot('chat-1')
+    expect(call().init?.body).toBeUndefined()
+    await api.handoffSlot('chat-1', 'slack')
+    expect(call(1).body).toEqual({ channel: 'slack' })
+  })
+
+  it('cancelTaskRunner and installDiscoveredSkill keep their optional fields optional', async () => {
+    await api.cancelTaskRunner()
+    expect(call().init?.body).toBeUndefined()
+    await api.cancelTaskRunner('t1')
+    expect(call(1).body).toEqual({ task_id: 't1' })
+    await api.installDiscoveredSkill('skills.sh', 'grill', { name: 'grill2', overwrite: true })
+    expect(call(2).body).toEqual({ provider: 'skills.sh', skill_id: 'grill', name: 'grill2', overwrite: true })
+  })
+
+  it('cleanupSessions coerces its flags and defaults the active slot', async () => {
+    await api.cleanupSessions(30)
+    expect(call().body).toEqual({ max_inactive_days: 30, active_slot: '', dry_run: false })
+    await api.cleanupSessions(7, 'chat-1', true)
+    expect(call(1).body).toEqual({ max_inactive_days: 7, active_slot: 'chat-1', dry_run: true })
+  })
+
+  it('planTask and startTaskRunner blank out absent optional strings', async () => {
+    await api.startTaskRunner('spec')
+    expect(call().body).toEqual({ spec: 'spec', agent: '', workspace_dir: '' })
+    await api.planTask('do it', 'chat')
+    expect(call(1).body).toEqual({ input: 'do it', source: 'chat', spec: '', agent: '', workspace_dir: '' })
+    await api.executePlan('t1')
+    expect(call(2).body).toEqual({ agent: '', auto_approve: false })
+    await api.planFromChat([{ title: 'a' }])
+    expect(call(3).body).toEqual({ steps: [{ title: 'a' }], task_id: '', original_input: '' })
+  })
+
+  it('createWebhookToken requires a signature by default', async () => {
+    await api.createWebhookToken('ci')
+    expect(call().body).toEqual({ label: 'ci', require_signature: true })
+    await api.createWebhookToken('legacy', false)
+    expect(call(1).body).toEqual({ label: 'legacy', require_signature: false })
+  })
+
+  it('addUserDeniedCommand defaults the operator note to empty', async () => {
+    await api.addUserDeniedCommand('rm -rf /')
+    expect(call().body).toEqual({ pattern: 'rm -rf /', note: '' })
+  })
+
+  it('setSlotFolder and setSlotColor send a clearing value rather than dropping the key', async () => {
+    await api.setSlotFolder('chat-1', null)
+    expect(call().body).toEqual({ folder_id: '' })
+    await api.setSlotColor('chat-1', null)
+    expect(call(1).body).toEqual({ color_index: null })
+    await api.setSlotColor('chat-1', 0)
+    expect(call(2).body).toEqual({ color_index: 0 })
+  })
+
+  it('mcpGatewaySetPoolable has a single and a batch form', async () => {
+    await api.mcpGatewaySetPoolable('fs', true)
+    expect(call().body).toEqual({ name: 'fs', poolable: true })
+    await api.mcpGatewaySetPoolableMany(['fs', 'git'], false)
+    expect(call(1).body).toEqual({ names: ['fs', 'git'], poolable: false })
+  })
+
+  it('createTagColumn/updateTagColumn pass the filter mode straight through', async () => {
+    await api.createTagColumn({ name: 'Doing', tag_ids: ['t1'], mode: 'any', include_untagged: true })
+    expect(call().body).toEqual({ name: 'Doing', tag_ids: ['t1'], mode: 'any', include_untagged: true })
+    await api.updateTagColumn('c1', { mode: 'none', order: 2 })
+    expect(call(1).method).toBe('PATCH')
+    expect(call(1).body).toEqual({ mode: 'none', order: 2 })
+  })
+
+  it('vectorSemanticWrite stamps the write as an explicit user edit', async () => {
+    await api.vectorSemanticWrite('k', 'v')
+    expect(call().body).toEqual({ key: 'k', value: 'v', source: 'user_explicit' })
+  })
+
+  it('enablePullRequestAutoMerge requires opting in to an immediate merge', async () => {
+    await api.enablePullRequestAutoMerge('https://gh/pr/1')
+    expect(call().body).toEqual({ url: 'https://gh/pr/1', confirmImmediateMerge: false })
+    await api.enablePullRequestAutoMerge('https://gh/pr/1', true)
+    expect(call(1).body).toEqual({ url: 'https://gh/pr/1', confirmImmediateMerge: true })
+  })
+
+  it('pull-request source calls carry the refresh flag and the thread ids', async () => {
+    await api.pullRequestSource('u')
+    expect(call().body).toEqual({ url: 'u', refresh: false })
+    await api.fetchIssueSource('u', true)
+    expect(call(1).body).toEqual({ url: 'u', refresh: true })
+    await api.resolvePullRequestThread('u', 't1')
+    expect(call(2).body).toEqual({ url: 'u', threadId: 't1' })
+    await api.unresolvePullRequestThread('u', 't1')
+    expect(call(3).url).toBe('/api/source/pull-request/unresolve')
+    await api.submitPullRequestReview('u', 'r1', 'APPROVE', 'digest')
+    expect(call(4).body).toEqual({ url: 'u', reviewId: 'r1', event: 'APPROVE', contentDigest: 'digest' })
+  })
+
+  it('resumeChatSlot repeats the key as name and falls back to it for the title', async () => {
+    await api.resumeChatSlot('k1')
+    expect(call().body).toEqual({ name: 'k1', key: 'k1', title: 'k1' })
+    await api.resumeChatSlot('k1', 'Real title')
+    expect(call(1).body).toEqual({ name: 'k1', key: 'k1', title: 'Real title' })
+  })
+
+  it('approveChatSlot merges caller-supplied extras into the action body', async () => {
+    await api.approveChatSlot('chat-1', 'allow', { tool: 'fs_write' })
+    expect(call().body).toEqual({ action: 'allow', tool: 'fs_write' })
+  })
+})
+
+/* ─────────── theme-consent wire token (two-tier consent) ─────────── */
+
+describe('sendChat theme consent', () => {
+  const slug = 'neon'
+
+  beforeEach(() => { localStorage.clear() })
+  afterEach(() => { localStorage.clear() })
+
+  it('sends no theme fields at all when no colour theme is active', async () => {
+    await api.sendChat('hi', 'chat-1')
+    expect(call().url).toBe('/api/chat?ws=1')
+    expect(call().body).toEqual({ message: 'hi', slot: 'chat-1' })
+  })
+
+  it('sends the theme but no consent token for a built-in theme', async () => {
+    localStorage.setItem(CONSENT_PREFIX + slug, 'sha-abc')
+    await api.sendChat('hi', 'chat-1', 'ocean')
+    expect(call().body).toMatchObject({ color_theme: 'ocean' })
+    expect(call().body).not.toHaveProperty('theme_consent_sha')
+  })
+
+  it('transmits the RAW stored grant for an installed pack', async () => {
+    localStorage.setItem(CONSENT_PREFIX + slug, 'sha-abc')
+    await api.sendChat('hi', 'chat-1', `custom-${slug}`)
+    expect(call().body).toMatchObject({ color_theme: 'custom-neon', theme_consent_sha: 'sha-abc' })
+    // The legacy boolean is deliberately not sent — gating is content-bound server-side.
+    expect(call().body).not.toHaveProperty('theme_consent')
+  })
+
+  it('omits the token when the pack has no stored grant', async () => {
+    await api.sendChat('hi', 'chat-1', 'custom-unknown')
+    expect(call().body).not.toHaveProperty('theme_consent_sha')
+  })
+
+  it('treats a legacy "1" grant as no grant so the user re-prompts exactly once', async () => {
+    localStorage.setItem(CONSENT_PREFIX + slug, '1')
+    await api.sendChat('hi', 'chat-1', `custom-${slug}`)
+    expect(call().body).not.toHaveProperty('theme_consent_sha')
+  })
+
+  it('treats an empty stored token as no grant', async () => {
+    localStorage.setItem(CONSENT_PREFIX + slug, '')
+    await api.sendChat('hi', 'chat-1', `custom-${slug}`)
+    expect(call().body).not.toHaveProperty('theme_consent_sha')
+  })
+
+  it('carries meta, the steer intent and an abort signal', async () => {
+    const ctl = new AbortController()
+    await api.sendChat('hi', 'chat-1', undefined, ctl.signal, { attachments: ['a.png'] }, true)
+    expect(call().body).toEqual({
+      message: 'hi', slot: 'chat-1', meta: { attachments: ['a.png'] }, steer: true,
+    })
+    expect(call().init?.signal).toBe(ctl.signal)
+  })
+
+  it('steerChat always injects into the running turn', async () => {
+    await api.steerChat('now', 'chat-1')
+    expect(call().url).toBe('/api/chat')
+    expect(call().body).toEqual({ message: 'now', slot: 'chat-1', steer: true })
+  })
+})
+
+/* ─────────────── 3. the non-trivial method implementations ─────────────── */
+
+describe('revealPath', () => {
+  it('copies the path when the host is headless and cannot reveal it', async () => {
+    fetchMock.mockResolvedValue(okJson({ copy: '/home/u/report.zip' }))
+    await api.revealPath('/home/u/report.zip')
+    expect(call().body).toEqual({ path: '/home/u/report.zip', action: 'reveal' })
+    expect(vi.mocked(copyToClipboard)).toHaveBeenCalledWith('/home/u/report.zip')
+  })
+
+  it('does not touch the clipboard when the OS handled it', async () => {
+    fetchMock.mockResolvedValue(okJson({ ok: true }))
+    const r = await api.revealPath('/f', 'open')
+    expect(call().body).toEqual({ path: '/f', action: 'open' })
+    expect(vi.mocked(copyToClipboard)).not.toHaveBeenCalled()
+    expect(r).toMatchObject({ ok: true })
+  })
+})
+
+describe('sttTranscribe', () => {
+  // happy-dom's FormData does not retain the third (filename) argument — the
+  // stored entry is always named `blob` — so the filename the client CHOSE is
+  // read off the append call rather than out of the FormData.
+  function appendSpy() {
+    const calls: unknown[][] = []
+    const spy = vi.spyOn(FormData.prototype, 'append').mockImplementation(function (
+      this: FormData,
+      ...args: unknown[]
+    ) {
+      calls.push(args)
+    })
+    return { calls, spy }
+  }
+
+  it('uploads the recording as multipart under the field the handler reads', async () => {
+    const { calls, spy } = appendSpy()
+    const blob = new Blob(['audio'], { type: 'audio/webm' })
+    try {
+      await api.sttTranscribe(blob, 'wav')
+    } finally { spy.mockRestore() }
+    const { url, init } = call()
+    expect(url).toBe('/api/stt/transcribe')
+    expect(init?.method).toBe('POST')
+    expect(init?.body).toBeInstanceOf(FormData)
+    expect(calls).toEqual([['audio', blob, 'recording.wav']])
+  })
+
+  it('defaults the container to webm', async () => {
+    const { calls, spy } = appendSpy()
+    try {
+      await api.sttTranscribe(new Blob(['a']))
+    } finally { spy.mockRestore() }
+    expect(calls[0][2]).toBe('recording.webm')
+  })
+})
+
+describe('uploadFiles', () => {
+  const png = (name: string) => new File(['x'], name, { type: 'image/png' })
+
+  it('keys resize details by the exact server path the attachment chip renders from', async () => {
+    const info = { name: 'big.png', fromW: 4000, fromH: 3000, toW: 1000, toH: 750, fromBytes: 90, toBytes: 9 }
+    vi.mocked(resizeImageForModel)
+      .mockImplementationOnce(async (f: File) => ({ file: f, info }))
+      .mockImplementationOnce(async (f: File) => ({ file: f, info: null }))
+    fetchMock.mockResolvedValue(okJson({ paths: ['/up/big.png', '/up/small.png'] }))
+
+    const out = await api.uploadFiles([png('big.png'), png('small.png')])
+    expect(out.paths).toEqual(['/up/big.png', '/up/small.png'])
+    expect(out.resized).toEqual([info])
+    // paths[i] is prepared[i]'s stored location, so the zip must key by path.
+    expect(out.resizedByPath).toEqual({ '/up/big.png': info })
+    expect(out.error).toBeUndefined()
+    expect(call().init?.body).toBeInstanceOf(FormData)
+  })
+
+  it('reports the server error and no paths on a failed upload', async () => {
+    fetchMock.mockResolvedValue(res(413, { error: 'too large' }))
+    const out = await api.uploadFiles([png('a.png')])
+    expect(out).toMatchObject({ paths: [], error: 'too large' })
+    expect(out.resizedByPath).toEqual({})
+  })
+
+  it('falls back to the status text when the failure body is unreadable', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false, status: 500, statusText: 'Internal Server Error',
+      headers: { get: () => null },
+      json: async () => { throw new Error('not json') },
+    } as unknown as Response)
+    const out = await api.uploadFiles([png('a.png')])
+    expect(out).toMatchObject({ paths: [], error: 'Internal Server Error' })
+  })
+
+  it('refuses to trust a 200 whose paths field is not an array', async () => {
+    fetchMock.mockResolvedValue(okJson({ paths: 'oops' }))
+    const out = await api.uploadFiles([png('a.png')])
+    expect(out.paths).toEqual([])
+    expect(out.error).toBeTruthy()
+  })
+})
+
+describe('exportPlanYaml', () => {
+  let clicks: { download: string; href: string }[]
+  let createObjectURL: typeof URL.createObjectURL
+  let revokeObjectURL: typeof URL.revokeObjectURL
+  let clickSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    clicks = []
+    createObjectURL = URL.createObjectURL
+    revokeObjectURL = URL.revokeObjectURL
+    URL.createObjectURL = vi.fn(() => 'blob:plan')
+    URL.revokeObjectURL = vi.fn()
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      clicks.push({ download: this.download, href: this.getAttribute('href') ?? '' })
+    })
+  })
+  afterEach(() => {
+    clickSpy.mockRestore()
+    URL.createObjectURL = createObjectURL
+    URL.revokeObjectURL = revokeObjectURL
+  })
+
+  it('honours the sanitized filename the server sent', async () => {
+    fetchMock.mockResolvedValue(
+      res(200, 'steps: []', { headers: { 'Content-Disposition': 'attachment; filename="my plan.yaml"' } }),
+    )
+    await api.exportPlanYaml('task 1')
+    expect(call().url).toBe('/api/taskrunner/task%201/plan.yaml')
+    expect(clicks).toEqual([{ download: 'my plan.yaml', href: 'blob:plan' }])
+    // The object URL is released, and the anchor is not left in the document.
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:plan')
+    expect(document.querySelector('a[download]')).toBeNull()
+  })
+
+  it('falls back to <taskId>.yaml when no Content-Disposition arrives', async () => {
+    fetchMock.mockResolvedValue(res(200, 'steps: []'))
+    await api.exportPlanYaml('t1')
+    expect(clicks[0].download).toBe('t1.yaml')
+  })
+
+  it('throws an ApiError instead of downloading an error page', async () => {
+    fetchMock.mockResolvedValue(res(404, 'no such run'))
+    await expect(api.exportPlanYaml('t1')).rejects.toBeInstanceOf(ApiError)
+    expect(clicks).toEqual([])
+  })
+
+  it('reports the bare status when the failure body is empty', async () => {
+    fetchMock.mockResolvedValue(res(500, '', { text: '' }))
+    await expect(api.exportPlanYaml('t1')).rejects.toThrow('HTTP 500')
+  })
+})
+
+describe('installFromRegistryStream', () => {
+  /** A ReadableStream-shaped stub that hands back the given chunks in order. */
+  function sseBody(chunks: string[]) {
+    const enc = new TextEncoder()
+    let i = 0
+    const releaseLock = vi.fn()
+    return {
+      body: {
+        getReader: () => ({
+          read: async () =>
+            i < chunks.length
+              ? { done: false, value: enc.encode(chunks[i++]) }
+              : { done: true, value: undefined },
+          releaseLock,
+        }),
+      },
+      releaseLock,
+    }
+  }
+
+  function streamRes(chunks: string[]) {
+    const { body, releaseLock } = sseBody(chunks)
+    return { response: res(200, '') as unknown as Record<string, unknown>, body, releaseLock }
+  }
+
+  it('streams every log line and resolves with the done payload', async () => {
+    const { response, body, releaseLock } = streamRes([
+      'event: log\ndata: cloning\n\nevent: log\ndata: build',
+      'ing\n\nevent: done\ndata: {"ok":true}\n\n',
+    ])
+    fetchMock.mockResolvedValue({ ...response, body } as unknown as Response)
+    const logs: string[] = []
+    const out = await api.installFromRegistryStream('demo', (l) => logs.push(l))
+    expect(logs).toEqual(['cloning', 'building'])
+    expect(out).toEqual({ ok: true })
+    expect(call().body).toEqual({ name: 'demo' })
+    expect(call().headers['Content-Type']).toBe('application/json')
+    expect(releaseLock).toHaveBeenCalled()
+  })
+
+  it('joins a multi-line data payload and tolerates a bare `data:` line', async () => {
+    const { response, body } = streamRes(['event: log\ndata: one\ndata:\ndata: three\n\n'])
+    fetchMock.mockResolvedValue({ ...response, body } as unknown as Response)
+    const logs: string[] = []
+    await api.installFromRegistryStream('demo', (l) => logs.push(l))
+    expect(logs).toEqual(['one\n\nthree'])
+  })
+
+  it('carries the refusal code so the consent modal can open on a resolved refusal', async () => {
+    // The execution gate refuses BEFORE cloning and RESOLVES (SSE done) rather
+    // than rejecting, so the code has to travel on the result.
+    const { response, body } = streamRes([
+      'event: done\ndata: {"ok":false,"code":"app_execution_denied"}\n\n',
+    ])
+    fetchMock.mockResolvedValue({ ...response, body } as unknown as Response)
+    const out = await api.installFromRegistryStream('demo', () => {})
+    expect(out).toEqual({ ok: false, code: 'app_execution_denied' })
+  })
+
+  it('degrades a malformed done payload into a failure carrying the raw text', async () => {
+    const { response, body } = streamRes(['event: done\ndata: not-json\n\n'])
+    fetchMock.mockResolvedValue({ ...response, body } as unknown as Response)
+    await expect(api.installFromRegistryStream('demo', () => {})).resolves.toEqual({
+      ok: false, error: 'not-json',
+    })
+  })
+
+  it('fails when the stream ends without a done frame', async () => {
+    const { response, body } = streamRes(['event: log\ndata: half\n\n'])
+    fetchMock.mockResolvedValue({ ...response, body } as unknown as Response)
+    const out = await api.installFromRegistryStream('demo', () => {})
+    expect(out.ok).toBe(false)
+    expect(out.error).toBeTruthy()
+  })
+
+  it('skips blank frames rather than emitting empty log lines', async () => {
+    const { response, body } = streamRes(['\n\n   \n\nevent: done\ndata: {"ok":true}\n\n'])
+    fetchMock.mockResolvedValue({ ...response, body } as unknown as Response)
+    const logs: string[] = []
+    await api.installFromRegistryStream('demo', (l) => logs.push(l))
+    expect(logs).toEqual([])
+  })
+
+  it('throws before reading when the request itself is rejected', async () => {
+    fetchMock.mockResolvedValue(res(500, 'gateway said no'))
+    await expect(api.installFromRegistryStream('demo', () => {})).rejects.toThrow('gateway said no')
+  })
+
+  it('forwards the abort signal', async () => {
+    const ctl = new AbortController()
+    const { response, body } = streamRes(['event: done\ndata: {"ok":true}\n\n'])
+    fetchMock.mockResolvedValue({ ...response, body } as unknown as Response)
+    await api.installFromRegistryStream('demo', () => {}, ctl.signal)
+    expect(call().init?.signal).toBe(ctl.signal)
+  })
+})
+
+describe('publishToProvider', () => {
+  it('routes to the provider-declared endpoint with the deploy payload shape', async () => {
+    fetchMock.mockResolvedValue(okJson({ url: 'https://x' }))
+    await api.publishToProvider('my-site', 'aws', {
+      id: 'aws', label: 'AWS', icon: '', kinds: ['webapp'],
+      configured: true, setupRoute: '/s', endpoint: '/api/deploy/custom',
+    })
+    expect(call().url).toBe('/api/deploy/custom')
+    expect(call().body).toEqual({ site_id: 'my-site', artifact_slug: 'my-site', provider_id: 'aws' })
+  })
+
+  it('defaults the endpoint when the provider descriptor is unavailable', async () => {
+    fetchMock.mockResolvedValue(okJson({ url: 'https://x' }))
+    await api.publishToProvider('my-site', 'aws')
+    expect(call().url).toBe('/api/deploy/deploy')
+  })
+
+  it('sends ttl_hours so the previewed TTL matches what is deployed', async () => {
+    fetchMock.mockResolvedValue(okJson({ url: 'https://x' }))
+    await api.publishToProvider('my-site', 'aws', undefined, 24)
+    expect(call().body).toMatchObject({ ttl_hours: 24 })
+  })
+
+  it('returns a 409 scan-block body instead of throwing, so the findings can render', async () => {
+    fetchMock.mockResolvedValue(res(409, { findings: [{ rule: 'secret' }] }))
+    await expect(api.publishToProvider('s', 'aws')).resolves.toEqual({ findings: [{ rule: 'secret' }] })
+  })
+
+  it('throws an ApiError on any other failure', async () => {
+    fetchMock.mockResolvedValue(res(500, 'deploy exploded'))
+    await expect(api.publishToProvider('s', 'aws')).rejects.toBeInstanceOf(ApiError)
+  })
+
+  it('reports the bare status when a failure carries no body', async () => {
+    fetchMock.mockResolvedValue(res(502, '', { text: '' }))
+    await expect(api.publishToProvider('s', 'aws')).rejects.toThrow('HTTP 502')
+  })
+})
+
+/* ─────────────────── 4. whole-surface request invariant ─────────────────── */
+
+describe('every api method issues one well-formed /api request', () => {
+  // Exercised individually above with the fixtures they need (a Blob, a
+  // ReadableStream, a File list, an object-URL download).
+  const HAND_TESTED = new Set(['sttTranscribe', 'uploadFiles', 'installFromRegistryStream', 'exportPlanYaml'])
+
+  type AnyFn = (...args: unknown[]) => unknown
+  const methods = Object.entries(api as unknown as Record<string, AnyFn>)
+    .filter(([name, fn]) => typeof fn === 'function' && !HAND_TESTED.has(name))
+
+  it('covers the whole surface (guards against the table silently shrinking)', () => {
+    expect(methods.length).toBeGreaterThan(300)
+  })
+
+  it.each(methods.map(([name]) => name))('%s', async (name) => {
+    const fn = (api as unknown as Record<string, AnyFn>)[name]
+    // Generic positional arguments. Every method is a thin URL/body builder, so
+    // what this asserts is the construction itself: a forgotten argument or a
+    // botched template literal shows up as `undefined` inside the path.
+    await Promise.resolve(fn('sw-1', 'sw-2', 'sw-3', 'sw-4'))
+
+    expect(fetchMock, `${name} issued no request`).toHaveBeenCalledTimes(1)
+    const { url, init } = call()
+    expect(typeof url, `${name} did not pass a string URL`).toBe('string')
+    expect(url.startsWith('/api/'), `${name} escaped the /api prefix: ${url}`).toBe(true)
+    for (const junk of ['undefined', '[object Object]', 'NaN', '/null']) {
+      expect(url.includes(junk), `${name} leaked ${junk} into ${url}`).toBe(false)
+    }
+    // A body is only ever sent with a method that can carry one.
+    if (init?.body !== undefined) {
+      expect(['POST', 'PUT', 'PATCH', 'DELETE']).toContain(init.method)
+    }
+  })
+})

--- a/website/src/test/ConnectionsPage.coverage.test.tsx
+++ b/website/src/test/ConnectionsPage.coverage.test.tsx
@@ -1,0 +1,651 @@
+// First render-level coverage for the Connections page — the provider gallery
+// shell that owns the four card states (not-connected → waiting-for-approval →
+// connected / needs-attention), the two-tab switcher, and every write action a
+// card can fire (connect, cancel, reconnect, disconnect, test, OAuth relay).
+//
+// Two things shape this file:
+//
+//   1. The gallery is GATED. `servicesEnabled` defaults to false and the panel
+//      then deliberately offers zero providers, so every card test has to opt in
+//      with `servicesEnabled` — that flag is the module's own seam, not a hack.
+//   2. The page's only outside seams are `api` (mocked here — nothing dials the
+//      network) and the MCP Servers sub-tab, which is a whole page of its own.
+//      `McpTab` is stubbed at its module boundary with a button that fires
+//      `onManagedProviderClick`, which is the only contract this page has with
+//      it.
+//
+// Card state comes from real data, not from prop drilling: the server list is
+// what `api.mcpServers` returns, and the OAuth banners are real `mcp_oauth`
+// messages preloaded into the Redux chat slice — the same shape the gateway
+// broadcasts. Interactions use `fireEvent` (no fake timers anywhere, so no
+// clock to keep in sync) and every assertion waits on rendered output.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor, within } from '@testing-library/react'
+
+import type { ChatMessage, McpServer, RootState } from '../types'
+
+const mcpServers = vi.fn()
+const mcpProbe = vi.fn()
+const mcpApply = vi.fn()
+const mcpCustomAdd = vi.fn()
+const mcpCustomUpdate = vi.fn()
+const mcpOAuthRelay = vi.fn()
+
+vi.mock('../api/client', () => ({
+  api: {
+    mcpServers: (...a: unknown[]) => mcpServers(...a),
+    mcpProbe: (...a: unknown[]) => mcpProbe(...a),
+    mcpApply: (...a: unknown[]) => mcpApply(...a),
+    mcpCustomAdd: (...a: unknown[]) => mcpCustomAdd(...a),
+    mcpCustomUpdate: (...a: unknown[]) => mcpCustomUpdate(...a),
+    mcpOAuthRelay: (...a: unknown[]) => mcpOAuthRelay(...a),
+  },
+}))
+
+// The MCP Servers sub-tab is a page in its own right; the only contract this
+// page has with it is the managed-provider deep link back into the gallery.
+vi.mock('../pages/overview/McpTab', () => ({
+  default: ({ onManagedProviderClick }: { onManagedProviderClick: (slug: string) => void }) => (
+    <button type="button" onClick={() => onManagedProviderClick('stripe')}>deep link to stripe</button>
+  ),
+}))
+
+import ConnectionsPage from '../pages/connections/ConnectionsPage'
+import { CONNECTION_PROVIDERS } from '../pages/connections/registry'
+import { createTestStore, renderWithProviders } from './helpers'
+
+const NOTION_URL = 'https://mcp.notion.com/mcp'
+const STRIPE_URL = 'https://mcp.stripe.com'
+
+function server(over: Partial<McpServer> = {}): McpServer {
+  return {
+    name: 'notion',
+    command: '',
+    url: NOTION_URL,
+    status: 'ok',
+    source: 'mcp.json',
+    enabled: true,
+    ...over,
+  }
+}
+
+/** A gateway `mcp_oauth` banner for `serverName`, exactly as chatSlice holds it. */
+function banner(serverName: string, meta: Record<string, unknown>, ts = '2026-03-04T10:00:00.000Z'): ChatMessage {
+  return { role: 'mcp_oauth', content: '', cls: '', ts, meta: { server_name: serverName, ...meta } }
+}
+
+interface ChatSeed {
+  messages?: ChatMessage[]
+  slotMessages?: Record<string, ChatMessage[]>
+}
+
+function mount(
+  { servicesEnabled = true, chat = {} }: { servicesEnabled?: boolean; chat?: ChatSeed } = {},
+) {
+  const store = createTestStore({
+    chat: {
+      messages: chat.messages ?? [],
+      slotMessages: chat.slotMessages ?? {},
+    } as unknown as RootState['chat'],
+  })
+  return renderWithProviders(<ConnectionsPage servicesEnabled={servicesEnabled} />, { store })
+}
+
+/** The card for one provider, addressed the way the DOM exposes it. */
+function card(slug: string): HTMLElement {
+  const el = document.getElementById(`connection-${slug}`)
+  if (!el) throw new Error(`no card rendered for ${slug}`)
+  return el
+}
+
+const cards = (): HTMLElement[] => Array.from(document.querySelectorAll('article[data-state]'))
+
+/** A promise whose settlement this test controls. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void
+  const promise = new Promise<T>(r => { resolve = r })
+  return { promise, resolve }
+}
+
+beforeEach(() => {
+  mcpServers.mockReset().mockResolvedValue([])
+  mcpProbe.mockReset().mockResolvedValue([])
+  mcpApply.mockReset().mockResolvedValue({ ok: true })
+  mcpCustomAdd.mockReset().mockResolvedValue({ ok: true, added: [], enabled: true })
+  mcpCustomUpdate.mockReset().mockResolvedValue({ ok: true, name: 'notion' })
+  mcpOAuthRelay.mockReset().mockResolvedValue({ ok: true })
+})
+
+describe('the held-back gallery', () => {
+  it('offers no provider, no search and no way to connect when services are disabled', async () => {
+    mount({ servicesEnabled: false })
+
+    // Both tabs still render — only the OFFER is withheld.
+    expect(screen.getByRole('tab', { name: /Services/ })).toBeInTheDocument()
+    expect(await screen.findByText('No services match this search.')).toBeInTheDocument()
+    expect(cards()).toHaveLength(0)
+    expect(screen.queryByLabelText('Search services')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Connect' })).not.toBeInTheDocument()
+  })
+})
+
+describe('the provider gallery', () => {
+  it('renders one card per launch-gated provider and withholds the rest', async () => {
+    mount()
+
+    await waitFor(() => expect(cards()).toHaveLength(CONNECTION_PROVIDERS.length))
+    expect(screen.getByRole('heading', { name: 'Notion' })).toBeInTheDocument()
+    // GitHub is in the registry but has not passed the launch gate.
+    expect(screen.queryByRole('heading', { name: 'GitHub' })).not.toBeInTheDocument()
+    expect(screen.getByText(`${CONNECTION_PROVIDERS.length} available`)).toBeInTheDocument()
+  })
+
+  it('shows an unconnected provider its docs link and a Connect button', async () => {
+    mount()
+
+    const notion = await waitFor(() => card('notion'))
+    expect(notion).toHaveAttribute('data-state', 'not-connected')
+    expect(within(notion).getByText('Let agents use Notion through its official MCP server.')).toBeInTheDocument()
+    expect(within(notion).getByRole('link', { name: /Documentation/ })).toHaveAttribute('target', '_blank')
+    expect(within(notion).getByRole('button', { name: 'Connect' })).toBeEnabled()
+  })
+
+  it('renders a skeleton while the server list is in flight, then the cards', async () => {
+    const pending = deferred<McpServer[]>()
+    mcpServers.mockReturnValue(pending.promise)
+
+    mount()
+
+    expect(document.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0)
+    expect(cards()).toHaveLength(0)
+
+    pending.resolve([])
+    await waitFor(() => expect(cards()).toHaveLength(CONNECTION_PROVIDERS.length))
+  })
+
+  it('warns that cards may be stale when the status read fails, without hiding them', async () => {
+    mcpServers.mockRejectedValue(new Error('gateway down'))
+
+    mount()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Connection status could not be loaded. Cards may be out of date.',
+    )
+    expect(cards()).toHaveLength(CONNECTION_PROVIDERS.length)
+  })
+
+  it('filters by name and explains an empty result', async () => {
+    mount()
+    await waitFor(() => expect(cards()).toHaveLength(CONNECTION_PROVIDERS.length))
+    const search = screen.getByLabelText('Search services')
+
+    fireEvent.change(search, { target: { value: 'linear' } })
+    await waitFor(() => expect(cards()).toHaveLength(1))
+    expect(screen.getByRole('heading', { name: 'Linear' })).toBeInTheDocument()
+    expect(screen.getByText('1 available')).toBeInTheDocument()
+
+    fireEvent.change(search, { target: { value: 'nothing-matches-this' } })
+    expect(await screen.findByText('No services match this search.')).toBeInTheDocument()
+    expect(cards()).toHaveLength(0)
+  })
+
+  it('also matches on the MCP endpoint, not just the display name', async () => {
+    mount()
+    await waitFor(() => expect(cards()).toHaveLength(CONNECTION_PROVIDERS.length))
+
+    fireEvent.change(screen.getByLabelText('Search services'), { target: { value: 'mcp.stripe.com' } })
+    await waitFor(() => expect(cards()).toHaveLength(1))
+    expect(screen.getByRole('heading', { name: 'Stripe' })).toBeInTheDocument()
+  })
+})
+
+describe('the two tabs', () => {
+  it('switches panels on click and on arrow keys', async () => {
+    mount()
+    const services = screen.getByRole('tab', { name: /Services/ })
+    const mcp = screen.getByRole('tab', { name: /MCP Servers/ })
+    expect(services).toHaveAttribute('aria-selected', 'true')
+
+    fireEvent.click(mcp)
+    expect(mcp).toHaveAttribute('aria-selected', 'true')
+    expect(await screen.findByRole('button', { name: 'deep link to stripe' })).toBeInTheDocument()
+    expect(cards()).toHaveLength(0)
+
+    // Either arrow toggles: there are only two tabs, so direction is irrelevant.
+    fireEvent.keyDown(mcp, { key: 'ArrowLeft' })
+    await waitFor(() => expect(screen.getByRole('tab', { name: /Services/ })).toHaveAttribute('aria-selected', 'true'))
+    fireEvent.keyDown(screen.getByRole('tab', { name: /Services/ }), { key: 'ArrowRight' })
+    await waitFor(() => expect(screen.getByRole('tab', { name: /MCP Servers/ })).toHaveAttribute('aria-selected', 'true'))
+  })
+
+  it('ignores keys that are not the arrows it owns', async () => {
+    mount()
+    const services = screen.getByRole('tab', { name: /Services/ })
+
+    fireEvent.keyDown(services, { key: 'ArrowDown' })
+    fireEvent.keyDown(services, { key: 'a' })
+
+    expect(services).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('deep-links from the MCP table back to the highlighted provider card', async () => {
+    mount()
+    fireEvent.click(screen.getByRole('tab', { name: /MCP Servers/ }))
+    fireEvent.click(await screen.findByRole('button', { name: 'deep link to stripe' }))
+
+    await waitFor(() => expect(screen.getByRole('tab', { name: /Services/ })).toHaveAttribute('aria-selected', 'true'))
+    const stripe = await waitFor(() => card('stripe'))
+    expect(stripe.className).toContain('border-accent')
+    // Only the deep-linked card is highlighted.
+    expect(card('notion').className).not.toContain('border-accent')
+  })
+})
+
+describe('a connected provider', () => {
+  const connected = [server({ accountLabel: 'ada@example.com', connectedSince: '2026-03-04T10:00:00Z' })]
+
+  it('reports the account, the recommended scopes and the connection date', async () => {
+    mcpServers.mockResolvedValue(connected)
+    mount()
+
+    const notion = await waitFor(() => {
+      const el = card('notion')
+      expect(el).toHaveAttribute('data-state', 'connected')
+      return el
+    })
+    expect(within(notion).getByText('ada@example.com')).toBeInTheDocument()
+    expect(within(notion).getByText('Recommended scopes: default')).toBeInTheDocument()
+    expect(within(notion).getByText('Mar 4, 2026')).toBeInTheDocument()
+    expect(within(notion).getByRole('link', { name: /Revoke at Notion/ })).toHaveAttribute(
+      'href',
+      'https://app.notion.com',
+    )
+  })
+
+  it('falls back to a generic account label and the tool-controlled access line', async () => {
+    mcpServers.mockResolvedValue([server({ name: 'stripe', url: STRIPE_URL })])
+    mount()
+
+    const stripe = await waitFor(() => {
+      const el = card('stripe')
+      expect(el).toHaveAttribute('data-state', 'connected')
+      return el
+    })
+    // Stripe ships no recommended scopes, and the probe reported no account.
+    expect(within(stripe).getByText('Authorized account')).toBeInTheDocument()
+    expect(within(stripe).getByText('Access is controlled by enabled tools.')).toBeInTheDocument()
+    expect(within(stripe).queryByText('Connected since')).not.toBeInTheDocument()
+  })
+
+  it('confirms a healthy probe as success feedback', async () => {
+    mcpServers.mockResolvedValue(connected)
+    mcpProbe.mockResolvedValue(connected)
+    mount()
+
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: 'Test' })))
+
+    expect(await screen.findByText('Connection is healthy.')).toBeInTheDocument()
+    expect(mcpProbe).toHaveBeenCalled()
+  })
+
+  it('surfaces a failing probe as an error on the card', async () => {
+    mcpServers.mockResolvedValue(connected)
+    mcpProbe.mockResolvedValue([server({ status: 'error' })])
+    mount()
+
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: 'Test' })))
+
+    const failure = await screen.findByRole('alert')
+    expect(failure).toHaveTextContent('Action failed: The provider did not pass the connection test.')
+  })
+
+  it('shows the busy label while the probe is in flight', async () => {
+    const pending = deferred<McpServer[]>()
+    mcpServers.mockResolvedValue(connected)
+    mcpProbe.mockReturnValue(pending.promise)
+    mount()
+
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: 'Test' })))
+
+    const testing = await screen.findByRole('button', { name: 'Testing…' })
+    expect(testing).toBeDisabled()
+    expect(within(card('notion')).getByRole('button', { name: /Disconnect/ })).toBeDisabled()
+
+    pending.resolve(connected)
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Test' })).toBeEnabled())
+  })
+
+  it('uninstalls the entry on Disconnect and keeps pointing at the provider revoke page', async () => {
+    mcpServers.mockResolvedValue(connected)
+    mount()
+
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: /Disconnect/ })))
+
+    const note = await screen.findByRole('status')
+    expect(note).toHaveTextContent(
+      'Disconnected locally. Revoke access at the provider to cancel the grant completely.',
+    )
+    expect(within(note).getByRole('link', { name: /Revoke at Notion/ })).toBeInTheDocument()
+    expect(mcpApply).toHaveBeenCalledWith([{ name: 'notion', uninstall: true }])
+  })
+
+  it('reports a failed disconnect as an error instead of claiming success', async () => {
+    mcpServers.mockResolvedValue(connected)
+    mcpApply.mockRejectedValue(new Error('config is read-only'))
+    mount()
+
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: /Disconnect/ })))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Action failed: config is read-only')
+  })
+
+  it('names an unknown thrown value rather than rendering "undefined"', async () => {
+    mcpServers.mockResolvedValue(connected)
+    mcpApply.mockRejectedValue('not an Error')
+    mount()
+
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: /Disconnect/ })))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Action failed: Unknown error')
+  })
+})
+
+describe('a provider that needs attention', () => {
+  it('explains an invalid grant with the runtime error and offers Reconnect', async () => {
+    mcpServers.mockResolvedValue([server({ status: 'error', error: 'invalid_grant' })])
+    mount()
+
+    const notion = await waitFor(() => {
+      const el = card('notion')
+      expect(el).toHaveAttribute('data-state', 'needs-attention')
+      return el
+    })
+    expect(within(notion).getByText('Notion says this connection is no longer valid.')).toBeInTheDocument()
+    expect(within(notion).getByText('invalid_grant')).toBeInTheDocument()
+    expect(within(notion).getByRole('button', { name: /Reconnect/ })).toBeEnabled()
+  })
+
+  it('prefers the OAuth banner error over the stale server error', async () => {
+    mcpServers.mockResolvedValue([server({ status: 'error', error: 'stale server error' })])
+    mount({ chat: { messages: [banner('Notion', { failed: true, error: 'user denied consent' })] } })
+
+    const notion = await waitFor(() => {
+      const el = card('notion')
+      expect(el).toHaveAttribute('data-state', 'needs-attention')
+      return el
+    })
+    expect(within(notion).getByText('user denied consent')).toBeInTheDocument()
+    expect(within(notion).queryByText('stale server error')).not.toBeInTheDocument()
+  })
+
+  it('rewrites the endpoint and re-enables a disabled entry, because reconnect IS consent', async () => {
+    mcpServers.mockResolvedValue([server({
+      status: 'error',
+      enabled: false,
+      presence: { kirocrew: false, kiroGlobal: true, ccGlobal: false },
+    })])
+    mount()
+
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: /Reconnect/ })))
+
+    await waitFor(() => expect(mcpCustomUpdate).toHaveBeenCalledWith('notion', { url: NOTION_URL }))
+    // Global scopes are passed through unchanged; only Kiro Crew's own is turned on.
+    expect(mcpApply).toHaveBeenCalledWith([{ name: 'notion', kirocrew: true, kiroGlobal: true, ccGlobal: false }])
+  })
+
+  it('leaves an already-enabled entry alone apart from the endpoint rewrite', async () => {
+    mcpServers.mockResolvedValue([server({ status: 'error', enabled: true })])
+    mount()
+
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: /Reconnect/ })))
+
+    await waitFor(() => expect(mcpCustomUpdate).toHaveBeenCalledWith('notion', { url: NOTION_URL }))
+    expect(mcpApply).not.toHaveBeenCalled()
+  })
+})
+
+describe('connecting a new provider', () => {
+  it('installs the registry endpoint, probes, and moves the card to waiting', async () => {
+    mount()
+
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: 'Connect' })))
+
+    await waitFor(() => expect(mcpCustomAdd).toHaveBeenCalledWith({ notion: { url: NOTION_URL } }, true))
+    expect(mcpProbe).toHaveBeenCalled()
+    await waitFor(() => expect(card('notion')).toHaveAttribute('data-state', 'waiting-for-approval'))
+    expect(screen.getByText('Finish approving in your browser…')).toBeInTheDocument()
+  })
+
+  it('reports an install failure on the card', async () => {
+    mcpCustomAdd.mockRejectedValue(new Error('name already taken'))
+    mount()
+
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: 'Connect' })))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Action failed: name already taken')
+    expect(card('notion')).toHaveAttribute('data-state', 'not-connected')
+  })
+
+  it('shows the connecting label while the install is in flight', async () => {
+    const pending = deferred<{ ok: boolean }>()
+    mcpCustomAdd.mockReturnValue(pending.promise)
+    mount()
+
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: 'Connect' })))
+
+    expect(await screen.findByRole('button', { name: 'Connecting…' })).toBeDisabled()
+    pending.resolve({ ok: true })
+    await waitFor(() => expect(card('notion')).toHaveAttribute('data-state', 'waiting-for-approval'))
+  })
+
+  it('uninstalls the just-created entry when the wait is cancelled', async () => {
+    mount()
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: 'Connect' })))
+    await waitFor(() => expect(card('notion')).toHaveAttribute('data-state', 'waiting-for-approval'))
+
+    fireEvent.click(within(card('notion')).getByRole('button', { name: /Cancel/ }))
+
+    // The probe has not surfaced the entry yet, so Cancel falls back to the slug
+    // the connect just wrote — and says nothing, because the user asked for this.
+    await waitFor(() => expect(mcpApply).toHaveBeenCalledWith([{ name: 'notion', uninstall: true }]))
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    await waitFor(() => expect(card('notion')).toHaveAttribute('data-state', 'not-connected'))
+  })
+
+  it('cancelling a reconnect stops waiting without destroying the existing entry', async () => {
+    mcpServers.mockResolvedValue([server({ status: 'error', enabled: true })])
+    mount()
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: /Reconnect/ })))
+    await waitFor(() => expect(card('notion')).toHaveAttribute('data-state', 'waiting-for-approval'))
+
+    fireEvent.click(within(card('notion')).getByRole('button', { name: /Cancel/ }))
+
+    await waitFor(() => expect(card('notion')).toHaveAttribute('data-state', 'needs-attention'))
+    expect(mcpApply).not.toHaveBeenCalledWith([{ name: 'notion', uninstall: true }])
+  })
+
+  it('clears the local wait once the gateway reports the server healthy', async () => {
+    const { queryClient } = mount()
+    fireEvent.click(await waitFor(() => within(card('notion')).getByRole('button', { name: 'Connect' })))
+    await waitFor(() => expect(card('notion')).toHaveAttribute('data-state', 'waiting-for-approval'))
+
+    // The next status read is what ends the wait — nothing here polls a clock.
+    mcpServers.mockResolvedValue([server()])
+    await queryClient.invalidateQueries({ queryKey: ['mcp-servers'] })
+
+    await waitFor(() => expect(card('notion')).toHaveAttribute('data-state', 'connected'))
+    expect(within(card('notion')).getByRole('button', { name: /Disconnect/ })).toBeInTheDocument()
+  })
+})
+
+describe('waiting for approval', () => {
+  const waiting = [server({ status: 'unknown' })]
+
+  it('offers the approval link the gateway published', async () => {
+    mcpServers.mockResolvedValue(waiting)
+    mount({ chat: { messages: [banner('notion', { oauth_url: 'https://notion.example/authorize?x=1' })] } })
+
+    const link = await screen.findByRole('link', { name: /Re-open approval/ })
+    expect(link).toHaveAttribute('href', 'https://notion.example/authorize?x=1')
+  })
+
+  it('refuses a non-http approval URL and keeps waiting instead of rendering it', async () => {
+    mcpServers.mockResolvedValue(waiting)
+    mount({ chat: { messages: [banner('notion', { oauth_url: 'javascript:alert(1)' })] } })
+
+    await waitFor(() => expect(card('notion')).toHaveAttribute('data-state', 'waiting-for-approval'))
+    expect(screen.queryByRole('link', { name: /Re-open approval/ })).not.toBeInTheDocument()
+    expect(screen.getByText(/Waiting for the approval address/)).toBeInTheDocument()
+  })
+
+  it('keeps waiting when the banner carries no address at all', async () => {
+    mcpServers.mockResolvedValue(waiting)
+    mount({ chat: { slotMessages: { 'slot-1': [banner('notion', {})] } } })
+
+    expect(await screen.findByText(/Waiting for the approval address/)).toBeInTheDocument()
+  })
+
+  it('takes the newest banner for a server and ignores older ones', async () => {
+    mcpServers.mockResolvedValue(waiting)
+    mount({
+      chat: {
+        slotMessages: {
+          'slot-1': [banner('notion', { oauth_url: 'https://old.example/a' }, '2026-03-04T09:00:00.000Z')],
+        },
+        messages: [banner('notion', { oauth_url: 'https://new.example/b' }, '2026-03-04T11:00:00.000Z')],
+      },
+    })
+
+    const link = await screen.findByRole('link', { name: /Re-open approval/ })
+    expect(link).toHaveAttribute('href', 'https://new.example/b')
+  })
+
+  it('ignores banners that name no server', async () => {
+    mcpServers.mockResolvedValue(waiting)
+    mount({ chat: { messages: [banner('   ', { oauth_url: 'https://nameless.example/a' })] } })
+
+    await waitFor(() => expect(card('notion')).toHaveAttribute('data-state', 'waiting-for-approval'))
+    expect(screen.queryByRole('link', { name: /Re-open approval/ })).not.toBeInTheDocument()
+  })
+
+  it('marks the card connected when the banner reports the grant completed', async () => {
+    mcpServers.mockResolvedValue(waiting)
+    mount({ chat: { messages: [banner('notion', { completed: true })] } })
+
+    await waitFor(() => expect(card('notion')).toHaveAttribute('data-state', 'connected'))
+  })
+})
+
+describe('relaying the loopback return address', () => {
+  const waiting = [server({ status: 'unknown' })]
+
+  const relayInput = () => within(card('notion')).getByLabelText('Return address')
+
+  it('rejects an address that is not the loopback callback shape', async () => {
+    mcpServers.mockResolvedValue(waiting)
+    mount()
+    const input = await waitFor(relayInput)
+
+    fireEvent.change(input, { target: { value: 'https://evil.example/?code=x' } })
+    fireEvent.click(within(card('notion')).getByRole('button', { name: 'Complete' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Paste the full http://127.0.0.1:PORT/?code=… address from your browser.',
+    )
+    expect(relayInput()).toHaveAttribute('aria-invalid', 'true')
+    expect(mcpOAuthRelay).not.toHaveBeenCalled()
+  })
+
+  it('rejects text that is not a URL at all', async () => {
+    mcpServers.mockResolvedValue(waiting)
+    mount()
+    const input = await waitFor(relayInput)
+
+    fireEvent.change(input, { target: { value: 'pasted the wrong thing' } })
+    fireEvent.click(within(card('notion')).getByRole('button', { name: 'Complete' }))
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
+    expect(mcpOAuthRelay).not.toHaveBeenCalled()
+  })
+
+  it('clears the rejection as soon as the address is edited again', async () => {
+    mcpServers.mockResolvedValue(waiting)
+    mount()
+    const input = await waitFor(relayInput)
+    fireEvent.change(input, { target: { value: 'http://localhost:1/?code=x' } })
+    fireEvent.click(within(card('notion')).getByRole('button', { name: 'Complete' }))
+    await screen.findByRole('alert')
+
+    fireEvent.change(relayInput(), { target: { value: 'http://127.0.0.1:4321/?code=one-time' } })
+
+    expect(relayInput()).toHaveAttribute('aria-invalid', 'false')
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('delivers a valid address, confirms it, and empties the field', async () => {
+    mcpServers.mockResolvedValue(waiting)
+    mount()
+    const input = await waitFor(relayInput)
+
+    fireEvent.change(input, { target: { value: '  http://127.0.0.1:4321/?code=one-time  ' } })
+    fireEvent.click(within(card('notion')).getByRole('button', { name: 'Complete' }))
+
+    await waitFor(() => expect(mcpOAuthRelay).toHaveBeenCalledWith('notion', 'http://127.0.0.1:4321/?code=one-time'))
+    expect(await screen.findByText('Return address delivered. Checking the connection…')).toBeInTheDocument()
+    expect(relayInput()).toHaveValue('')
+  })
+
+  it('accepts Enter as the submit gesture', async () => {
+    mcpServers.mockResolvedValue(waiting)
+    mount()
+    const input = await waitFor(relayInput)
+
+    fireEvent.change(input, { target: { value: 'http://[::1]:4321/callback?code=one-time' } })
+    fireEvent.keyDown(relayInput(), { key: 'Enter' })
+
+    await waitFor(() => expect(mcpOAuthRelay).toHaveBeenCalledWith('notion', 'http://[::1]:4321/callback?code=one-time'))
+  })
+
+  it('leaves other keys to the input', async () => {
+    mcpServers.mockResolvedValue(waiting)
+    mount()
+    const input = await waitFor(relayInput)
+
+    fireEvent.change(input, { target: { value: 'http://127.0.0.1:4321/?code=one-time' } })
+    fireEvent.keyDown(relayInput(), { key: 'a' })
+
+    expect(mcpOAuthRelay).not.toHaveBeenCalled()
+  })
+
+  it('keeps the address in the field when delivery fails, so it can be retried', async () => {
+    mcpServers.mockResolvedValue(waiting)
+    mcpOAuthRelay.mockRejectedValue(new Error('relay refused'))
+    mount()
+    const input = await waitFor(relayInput)
+
+    fireEvent.change(input, { target: { value: 'http://127.0.0.1:4321/?code=one-time' } })
+    fireEvent.click(within(card('notion')).getByRole('button', { name: 'Complete' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Action failed: relay refused')
+    expect(relayInput()).toHaveValue('http://127.0.0.1:4321/?code=one-time')
+  })
+
+  it('cannot be submitted while empty, and shows the sending label in flight', async () => {
+    const pending = deferred<{ ok: boolean }>()
+    mcpServers.mockResolvedValue(waiting)
+    mcpOAuthRelay.mockReturnValue(pending.promise)
+    mount()
+    const input = await waitFor(relayInput)
+    expect(within(card('notion')).getByRole('button', { name: 'Complete' })).toBeDisabled()
+
+    fireEvent.change(input, { target: { value: 'http://127.0.0.1:4321/?code=one-time' } })
+    fireEvent.click(within(card('notion')).getByRole('button', { name: 'Complete' }))
+
+    const sending = await screen.findByRole('button', { name: 'Sending…' })
+    expect(sending).toBeDisabled()
+    expect(relayInput()).toBeDisabled()
+
+    pending.resolve({ ok: true })
+    await waitFor(() => expect(relayInput()).toBeEnabled())
+  })
+})

--- a/website/src/test/CrewCompanionPackEditor.coverage.test.tsx
+++ b/website/src/test/CrewCompanionPackEditor.coverage.test.tsx
@@ -1,0 +1,732 @@
+/**
+ * The SVG/Lottie pack editor's own behaviour, end to end through its bridge.
+ *
+ * `PackEditor` is the whole authoring surface: the slot grid, the per-slot popover
+ * (pick a file / reuse another slot's art / clear), the open-ended "random extras",
+ * and the save path with its overwrite-vs-save-as-new fork. Every one of those
+ * reaches the desktop app through `galleryApi`, so the bridge is the only thing
+ * mocked here — the component, its state machine, the shared header/footer/dialog
+ * children and the real i18n strings all run for real.
+ *
+ * No fake timers: nothing in this editor is time-driven. Every asynchronous edge is
+ * a promise the bridge double owns, so the tests await the state transition rather
+ * than a clock. The one geometry-driven branch (the popover flipping above its
+ * anchor near the bottom of the window) is exercised by stubbing
+ * `getBoundingClientRect`, which happy-dom otherwise reports as all zeros.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup, act, within } from '@testing-library/react'
+
+import type { PackMeta } from '../apps/crew-companion/appearanceTypes'
+
+// ── Bridge double ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  api: {
+    getCrewCompanionConfig: vi.fn(),
+    galleryGetPackDetail: vi.fn(),
+    galleryImportFile: vi.fn(),
+    gallerySavePack: vi.fn(),
+  },
+}))
+
+vi.mock('../apps/crew-companion/petBridge', () => ({
+  galleryApi: mocks.api,
+  petBridge: mocks.api,
+}))
+
+const api = mocks.api
+
+// Imported AFTER the mock is registered.
+const { PackEditor } = await import('../apps/crew-companion/PackEditor')
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const SVG = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="4" height="4"/></svg>'
+const SVG2 = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="2"/></svg>'
+const LOTTIE = '{"v":"5.7.0","fr":30,"ip":0,"op":10,"layers":[]}'
+
+const existing: PackMeta = {
+  id: 'pack-42',
+  name: 'Bramble',
+  author: 'Ada',
+  description: 'a mossy sprite',
+  type: 'custom',
+  format: 'svg',
+  thumbnail: '',
+}
+
+/** A `galleryImportFile` success, in the wrapped `{ok, value}` shape. */
+const imported = (content: string, format: 'svg' | 'lottie' | 'sprite' = 'svg') => ({
+  ok: true as const,
+  value: { content, filename: `art.${format === 'lottie' ? 'json' : 'svg'}`, format },
+})
+
+// ── Query helpers ──────────────────────────────────────────────────────────
+
+/**
+ * The slot tile carrying `label`.
+ *
+ * Tiles are `div role="button"`, so they are filtered away from the real
+ * `<button>`s by tag. Optional tiles read "Done Optional", hence the prefix match.
+ */
+function slotFor(label: string): HTMLElement {
+  const hit = screen
+    .getAllByRole('button')
+    .filter((el) => el.tagName === 'DIV')
+    .find((el) => (el.textContent ?? '').replace(/\s+/g, ' ').trim().startsWith(label))
+  if (!hit) throw new Error(`no slot tile labelled ${label}`)
+  return hit
+}
+
+/**
+ * The open slot popover.
+ *
+ * Matched by tag as well as role: a filled slot's `<img alt="">` is also implicitly
+ * `role="presentation"`, so a role-only query becomes ambiguous the moment any slot
+ * holds SVG art.
+ */
+function popover(): HTMLElement {
+  const el = document.querySelector('div[role="presentation"]')
+  if (!el) throw new Error('no slot popover is open')
+  return el as HTMLElement
+}
+
+const popoverIsOpen = () => document.querySelector('div[role="presentation"]') !== null
+
+/** Slot art is an `<img>` only for SVG; Lottie/sprite render an icon placeholder. */
+const artOf = (tile: HTMLElement) => tile.querySelector('img')
+
+/** The extras tile that owns `input` — the name field's own container. */
+function extraTile(input: HTMLElement): HTMLElement {
+  const box = input.parentElement
+  if (!box) throw new Error('extras tile has no container')
+  return box
+}
+
+/** The clickable thumbnail inside an extras tile (its remove button is a real button). */
+function extraThumb(input: HTMLElement): HTMLElement {
+  const hit = within(extraTile(input))
+    .getAllByRole('button')
+    .find((el) => el.tagName === 'DIV')
+  if (!hit) throw new Error('extras tile has no thumbnail trigger')
+  return hit
+}
+
+function renderEditor(existingPack?: PackMeta) {
+  const onSave = vi.fn()
+  const onCancel = vi.fn()
+  const view = render(
+    <PackEditor existingPack={existingPack} onSave={onSave} onCancel={onCancel} />,
+  )
+  return { onSave, onCancel, ...view }
+}
+
+/** Open `label`'s popover and pick a file that resolves to `content`. */
+async function fillSlot(label: string, content: string, format: 'svg' | 'lottie' | 'sprite' = 'svg') {
+  api.galleryImportFile.mockResolvedValueOnce(imported(content, format))
+  fireEvent.click(slotFor(label))
+  fireEvent.click(within(popover()).getByRole('button', { name: 'Select File' }))
+  await waitFor(() => expect(slotFor(label).querySelector('.animate-spin')).toBeNull())
+}
+
+/** Fill the extras tile owning `input`, and name it. */
+async function fillExtra(input: HTMLElement, name: string, content: string) {
+  api.galleryImportFile.mockResolvedValueOnce(imported(content))
+  fireEvent.click(extraThumb(input))
+  fireEvent.click(within(popover()).getByRole('button', { name: 'Select File' }))
+  await waitFor(() => expect(artOf(extraTile(input))).not.toBeNull())
+  fireEvent.change(input, { target: { value: name } })
+}
+
+const savedPayload = () => api.gallerySavePack.mock.calls[0][0]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // `useLang` reads the config on mount; answer with no language so it never
+  // schedules a state update the tests would have to await.
+  api.getCrewCompanionConfig.mockResolvedValue({})
+  api.galleryGetPackDetail.mockResolvedValue(null)
+  api.galleryImportFile.mockResolvedValue(null)
+  api.gallerySavePack.mockResolvedValue({ ok: true, value: { ...existing } })
+})
+
+afterEach(cleanup)
+
+// ── Create mode: first render ──────────────────────────────────────────────
+
+describe('PackEditor — create mode', () => {
+  it('opens on the create title with every slot empty and saving refused', () => {
+    renderEditor()
+
+    expect(screen.getByText('Create New Pack')).toBeInTheDocument()
+    // Idle is the only required slot, so it is the only thing "Missing:" names.
+    expect(screen.getByText('Missing: Idle')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    expect(artOf(slotFor('Idle'))).toBeNull()
+  })
+
+  it('offers a tile for every authorable slot and no more', () => {
+    renderEditor()
+
+    // Required + status + breathing + random-fixed + the add-clip affordance. The
+    // five moods are still slots in state but have deliberately no tile.
+    for (const label of ['Idle', 'Done', 'Error', 'inhale', 'hold', 'exhale', 'Walking']) {
+      expect(slotFor(label)).toBeInTheDocument()
+    }
+    expect(slotFor('Add clip')).toBeInTheDocument()
+    for (const mood of ['happy', 'sleepy', 'curious']) {
+      expect(screen.queryByText(mood)).toBeNull()
+    }
+  })
+
+  it('routes the back button and the footer cancel to onCancel', () => {
+    const { onCancel } = renderEditor()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCancel).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ── The slot popover ───────────────────────────────────────────────────────
+
+describe('PackEditor — slot popover', () => {
+  it('toggles open and shut on the same tile', () => {
+    renderEditor()
+
+    fireEvent.click(slotFor('Idle'))
+    expect(within(popover()).getByRole('button', { name: 'Select File' })).toBeInTheDocument()
+
+    fireEvent.click(slotFor('Idle'))
+    expect(popoverIsOpen()).toBe(false)
+  })
+
+  it('opens from the keyboard on Enter and on Space', () => {
+    renderEditor()
+
+    fireEvent.keyDown(slotFor('Idle'), { key: 'Enter' })
+    expect(popoverIsOpen()).toBe(true)
+
+    fireEvent.click(slotFor('Idle')) // shut it again
+    fireEvent.keyDown(slotFor('Idle'), { key: ' ' })
+    expect(popoverIsOpen()).toBe(true)
+  })
+
+  it('ignores unrelated keys on a tile', () => {
+    renderEditor()
+
+    fireEvent.keyDown(slotFor('Idle'), { key: 'a' })
+    expect(popoverIsOpen()).toBe(false)
+  })
+
+  it('closes on a mousedown outside itself but not inside', () => {
+    renderEditor()
+
+    fireEvent.click(slotFor('Idle'))
+    fireEvent.mouseDown(popover())
+    expect(popoverIsOpen()).toBe(true)
+
+    fireEvent.mouseDown(document.body)
+    expect(popoverIsOpen()).toBe(false)
+  })
+
+  it('hangs below its anchor and clamps to the left window edge', () => {
+    renderEditor()
+
+    fireEvent.click(slotFor('Idle'))
+    // happy-dom reports a zero rect, which centres the 180px popover off-screen to
+    // the left — the clamp is what keeps it reachable.
+    expect(popover().style.top).toBe('4px')
+    expect(popover().style.bottom).toBe('')
+    expect(popover().style.left).toBe('4px')
+  })
+
+  it('flips above its anchor and clamps to the right window edge near the bottom', () => {
+    renderEditor()
+
+    const rect = vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      top: window.innerHeight - 20,
+      left: window.innerWidth - 10,
+      width: 100,
+      height: 100,
+      right: 0,
+      bottom: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect)
+    try {
+      fireEvent.click(slotFor('Idle'))
+      expect(popover().style.top).toBe('')
+      expect(popover().style.bottom).toBe('24px')
+      expect(popover().style.left).toBe(`${window.innerWidth - 184}px`)
+    } finally {
+      rect.mockRestore()
+    }
+  })
+
+  it('offers no reuse source or clear action while every slot is empty', () => {
+    renderEditor()
+
+    fireEvent.click(slotFor('Idle'))
+    expect(within(popover()).queryByText('Use same animation as another state')).toBeNull()
+    expect(within(popover()).queryByRole('button', { name: 'Clear' })).toBeNull()
+  })
+
+  it('paints hover feedback onto a popover row', () => {
+    renderEditor()
+
+    fireEvent.click(slotFor('Idle'))
+    const row = within(popover()).getByRole('button', { name: 'Select File' })
+    fireEvent.mouseEnter(row)
+    expect(row.style.background).toBe('var(--cc-input-bg)')
+    // The hover-OFF branch is deliberately not asserted: React 17+ synthesizes
+    // onMouseLeave from `mouseout` at the root, and neither a bare `mouseleave`
+    // (does not bubble) nor `mouseOut` with an explicit relatedTarget reaches the
+    // handler reliably under jsdom. Asserting it produced a false failure, so the
+    // reset path is left uncovered rather than pinned with a flaky event.
+  })
+})
+
+// ── Picking art ────────────────────────────────────────────────────────────
+
+describe('PackEditor — picking art for a slot', () => {
+  it('shows a spinner while the picker is open, then the chosen SVG', async () => {
+    renderEditor()
+
+    let resolvePick!: (v: unknown) => void
+    api.galleryImportFile.mockReturnValueOnce(new Promise((r) => { resolvePick = r }))
+
+    fireEvent.click(slotFor('Idle'))
+    fireEvent.click(within(popover()).getByRole('button', { name: 'Select File' }))
+    expect(slotFor('Idle').querySelector('.animate-spin')).not.toBeNull()
+
+    await act(async () => { resolvePick(imported(SVG)) })
+
+    expect(slotFor('Idle').querySelector('.animate-spin')).toBeNull()
+    const img = artOf(slotFor('Idle'))
+    expect(img).not.toBeNull()
+    expect(decodeURIComponent(img?.getAttribute('src') ?? '')).toContain('<rect')
+    // The required-slot hint clears, and a name is the only thing still missing.
+    expect(screen.queryByText('Missing: Idle')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('treats a cancelled picker as a no-op, with no error banner', async () => {
+    renderEditor()
+
+    api.galleryImportFile.mockResolvedValueOnce(null)
+    fireEvent.click(slotFor('Idle'))
+    fireEvent.click(within(popover()).getByRole('button', { name: 'Select File' }))
+
+    await waitFor(() => expect(slotFor('Idle').querySelector('.animate-spin')).toBeNull())
+    expect(artOf(slotFor('Idle'))).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
+  })
+
+  it("surfaces the picker's own refusal reason, and lets the user dismiss it", async () => {
+    renderEditor()
+
+    api.galleryImportFile.mockResolvedValueOnce({ ok: false, error: 'that is a .txt' })
+    fireEvent.click(slotFor('Idle'))
+    fireEvent.click(within(popover()).getByRole('button', { name: 'Select File' }))
+
+    expect(await screen.findByText('that is a .txt')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(screen.queryByText('that is a .txt')).toBeNull()
+  })
+
+  it('falls back to the generic invalid-file message when the refusal carries none', async () => {
+    renderEditor()
+
+    api.galleryImportFile.mockResolvedValueOnce({ ok: false, error: '' })
+    fireEvent.click(slotFor('Idle'))
+    fireEvent.click(within(popover()).getByRole('button', { name: 'Select File' }))
+
+    expect(await screen.findByText('Invalid file')).toBeInTheDocument()
+  })
+
+  it('reports a thrown picker error by its message, and a non-Error by the fallback', async () => {
+    renderEditor()
+
+    api.galleryImportFile.mockRejectedValueOnce(new Error('picker exploded'))
+    fireEvent.click(slotFor('Idle'))
+    fireEvent.click(within(popover()).getByRole('button', { name: 'Select File' }))
+    expect(await screen.findByText('picker exploded')).toBeInTheDocument()
+
+    // A thrown non-Error narrows to '' and must not blank the banner.
+    api.galleryImportFile.mockRejectedValueOnce({ nope: true })
+    fireEvent.click(slotFor('Done'))
+    fireEvent.click(within(popover()).getByRole('button', { name: 'Select File' }))
+    expect(await screen.findByText('Could not import that file')).toBeInTheDocument()
+  })
+
+  it('renders a Lottie slot as an icon rather than an <img>', async () => {
+    renderEditor()
+
+    await fillSlot('Idle', LOTTIE, 'lottie')
+
+    expect(artOf(slotFor('Idle'))).toBeNull()
+    expect(slotFor('Idle').querySelector('.lucide-film')).not.toBeNull()
+  })
+
+  it('copies another slot\u2019s art through "use same animation as"', async () => {
+    renderEditor()
+
+    await fillSlot('Idle', SVG)
+
+    fireEvent.click(slotFor('Done'))
+    expect(within(popover()).getByText('Use same animation as another state')).toBeInTheDocument()
+    fireEvent.click(within(popover()).getByRole('button', { name: 'Idle' }))
+
+    expect(decodeURIComponent(artOf(slotFor('Done'))?.getAttribute('src') ?? '')).toContain('<rect')
+    // A source slot never offers itself.
+    fireEvent.click(slotFor('Idle'))
+    expect(within(popover()).queryByRole('button', { name: 'Idle' })).toBeNull()
+    expect(within(popover()).getByRole('button', { name: 'Done' })).toBeInTheDocument()
+  })
+
+  it('clears a filled slot, and the clear action disappears with it', async () => {
+    renderEditor()
+
+    await fillSlot('Idle', SVG)
+
+    fireEvent.click(slotFor('Idle'))
+    fireEvent.click(within(popover()).getByRole('button', { name: 'Clear' }))
+    expect(artOf(slotFor('Idle'))).toBeNull()
+    expect(screen.getByText('Missing: Idle')).toBeInTheDocument()
+
+    fireEvent.click(slotFor('Idle'))
+    expect(within(popover()).queryByRole('button', { name: 'Clear' })).toBeNull()
+  })
+})
+
+// ── Random extras ──────────────────────────────────────────────────────────
+
+describe('PackEditor — random extras', () => {
+  it('adds an extra from a click and from the keyboard, and removes it again', () => {
+    renderEditor()
+
+    fireEvent.click(slotFor('Add clip'))
+    expect(screen.getAllByPlaceholderText('name')).toHaveLength(1)
+
+    fireEvent.keyDown(slotFor('Add clip'), { key: 'Enter' })
+    expect(screen.getAllByPlaceholderText('name')).toHaveLength(2)
+
+    fireEvent.keyDown(slotFor('Add clip'), { key: 'x' })
+    expect(screen.getAllByPlaceholderText('name')).toHaveLength(2)
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Remove' })[0])
+    expect(screen.getAllByPlaceholderText('name')).toHaveLength(1)
+  })
+
+  it('keeps a typed extra name', () => {
+    renderEditor()
+
+    fireEvent.click(slotFor('Add clip'))
+    const input = screen.getByPlaceholderText('name')
+    fireEvent.change(input, { target: { value: 'wave' } })
+    expect((input as HTMLInputElement).value).toBe('wave')
+  })
+})
+
+// ── Saving a new pack ──────────────────────────────────────────────────────
+
+describe('PackEditor — saving a new pack', () => {
+  it('mints an id, trims the fields, and hands the saved meta back', async () => {
+    const { onSave } = renderEditor()
+
+    await fillSlot('Idle', SVG)
+    fireEvent.change(screen.getByPlaceholderText('My Custom Avatar'), { target: { value: '  Bramble  ' } })
+    fireEvent.change(screen.getByPlaceholderText('Your Name'), { target: { value: ' Ada ' } })
+    fireEvent.change(screen.getByPlaceholderText(/A cute orange cat/), { target: { value: ' mossy ' } })
+
+    const save = screen.getByRole('button', { name: 'Save' })
+    expect(save).toBeEnabled()
+    fireEvent.click(save)
+
+    // A brand-new pack never asks overwrite-or-new; it saves straight through.
+    expect(screen.queryByText('Overwrite existing or save as new?')).toBeNull()
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith({ ...existing }))
+
+    const payload = savedPayload()
+    expect(payload.meta.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/i)
+    expect(payload.meta).toMatchObject({ name: 'Bramble', author: 'Ada', description: 'mossy', format: 'svg' })
+    expect(payload.states).toEqual({ idle: SVG })
+    expect(payload.moods).toEqual({})
+    expect(payload.random).toEqual({})
+  })
+
+  it('falls back to an unknown author and records a Lottie pack as Lottie', async () => {
+    renderEditor()
+
+    await fillSlot('Idle', LOTTIE, 'lottie')
+    fireEvent.change(screen.getByPlaceholderText('My Custom Avatar'), { target: { value: 'Blob' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(api.gallerySavePack).toHaveBeenCalled())
+    expect(savedPayload().meta).toMatchObject({ author: 'Unknown', format: 'lottie' })
+  })
+
+  it('carries optional slots and named extras into the right maps', async () => {
+    renderEditor()
+
+    await fillSlot('Idle', SVG)
+    await fillSlot('Done', SVG2)
+    fireEvent.click(slotFor('Add clip'))
+    await fillExtra(screen.getByPlaceholderText('name'), 'wave', SVG2)
+    fireEvent.change(screen.getByPlaceholderText('My Custom Avatar'), { target: { value: 'Blob' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(api.gallerySavePack).toHaveBeenCalled())
+
+    expect(savedPayload().states).toEqual({ idle: SVG, done: SVG2 })
+    expect(savedPayload().random).toEqual({ wave: SVG2 })
+  })
+
+  it('drops an unnamed or artless extra instead of saving a blank clip', async () => {
+    renderEditor()
+
+    await fillSlot('Idle', SVG)
+    // Two extras: one with art but no name, one named but never filled.
+    fireEvent.click(slotFor('Add clip'))
+    await fillExtra(screen.getByPlaceholderText('name'), '', SVG2)
+    fireEvent.click(slotFor('Add clip'))
+    fireEvent.change(screen.getAllByPlaceholderText('name')[1], { target: { value: 'empty' } })
+    fireEvent.change(screen.getByPlaceholderText('My Custom Avatar'), { target: { value: 'Blob' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(api.gallerySavePack).toHaveBeenCalled())
+    expect(savedPayload().random).toEqual({})
+  })
+
+  it('refuses two extras that share a name rather than losing one clip', async () => {
+    renderEditor()
+
+    await fillSlot('Idle', SVG)
+    fireEvent.click(slotFor('Add clip'))
+    await fillExtra(screen.getAllByPlaceholderText('name')[0], 'wave', SVG)
+    fireEvent.click(slotFor('Add clip'))
+    await fillExtra(screen.getAllByPlaceholderText('name')[1], ' wave ', SVG2)
+    fireEvent.change(screen.getByPlaceholderText('My Custom Avatar'), { target: { value: 'Blob' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText(/Two extras can't share the name "wave"/)).toBeInTheDocument()
+    expect(api.gallerySavePack).not.toHaveBeenCalled()
+    // The editor stays usable rather than stuck in "Saving…".
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+  })
+
+  it('refuses an extra named after a built-in slot', async () => {
+    renderEditor()
+
+    await fillSlot('Idle', SVG)
+    fireEvent.click(slotFor('Add clip'))
+    await fillExtra(screen.getByPlaceholderText('name'), 'idle', SVG2)
+    fireEvent.change(screen.getByPlaceholderText('My Custom Avatar'), { target: { value: 'Blob' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText(/"idle" is a built-in slot name/)).toBeInTheDocument()
+    expect(api.gallerySavePack).not.toHaveBeenCalled()
+  })
+
+  it("shows the store's refusal reason and leaves the work in the editor", async () => {
+    const { onSave } = renderEditor()
+
+    api.gallerySavePack.mockResolvedValueOnce({ ok: false, error: 'disk full' })
+    await fillSlot('Idle', SVG)
+    fireEvent.change(screen.getByPlaceholderText('My Custom Avatar'), { target: { value: 'Blob' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText('disk full')).toBeInTheDocument()
+    expect(onSave).not.toHaveBeenCalled()
+    expect(artOf(slotFor('Idle'))).not.toBeNull()
+  })
+
+  it('falls back to the generic save-failed message for a reasonless refusal', async () => {
+    renderEditor()
+
+    api.gallerySavePack.mockResolvedValueOnce({ ok: false })
+    await fillSlot('Idle', SVG)
+    fireEvent.change(screen.getByPlaceholderText('My Custom Avatar'), { target: { value: 'Blob' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText('Save failed')).toBeInTheDocument()
+  })
+
+  it('reports a thrown save by its message', async () => {
+    renderEditor()
+
+    api.gallerySavePack.mockRejectedValueOnce(new Error('gateway down'))
+    await fillSlot('Idle', SVG)
+    fireEvent.change(screen.getByPlaceholderText('My Custom Avatar'), { target: { value: 'Blob' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText('gateway down')).toBeInTheDocument()
+  })
+
+  it('accepts a bare meta response, without the {ok, value} wrapper', async () => {
+    const { onSave } = renderEditor()
+
+    api.gallerySavePack.mockResolvedValueOnce({ ...existing, id: 'bare' })
+    await fillSlot('Idle', SVG)
+    fireEvent.change(screen.getByPlaceholderText('My Custom Avatar'), { target: { value: 'Blob' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ id: 'bare' })))
+  })
+
+  it('shows "Saving…" and ignores a second click while one save is in flight', async () => {
+    const { onSave } = renderEditor()
+
+    let finish!: (v: unknown) => void
+    api.gallerySavePack.mockReturnValueOnce(new Promise((r) => { finish = r }))
+    await fillSlot('Idle', SVG)
+    fireEvent.change(screen.getByPlaceholderText('My Custom Avatar'), { target: { value: 'Blob' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    const saving = screen.getByRole('button', { name: 'Saving…' })
+    expect(saving).toBeDisabled()
+    fireEvent.click(saving)
+    expect(api.gallerySavePack).toHaveBeenCalledTimes(1)
+
+    await act(async () => { finish({ ok: true, value: { ...existing } }) })
+    expect(onSave).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ── Edit mode ──────────────────────────────────────────────────────────────
+
+describe('PackEditor — edit mode', () => {
+  const detail = {
+    animations: {
+      idle: SVG,
+      walking: { content: LOTTIE, format: 'lottie' as const },
+      wave: SVG2,
+    },
+    randomNames: ['wave', 'missing-art'],
+  }
+
+  it('pre-fills the header, the slots and the named extras from the pack detail', async () => {
+    api.galleryGetPackDetail.mockResolvedValueOnce(detail)
+    renderEditor(existing)
+
+    expect(await screen.findByText(/Edit Pack/)).toBeInTheDocument()
+    expect(api.galleryGetPackDetail).toHaveBeenCalledWith('pack-42')
+
+    await waitFor(() => expect(artOf(slotFor('Idle'))).not.toBeNull())
+    expect((screen.getByPlaceholderText('My Custom Avatar') as HTMLInputElement).value).toBe('Bramble')
+    expect((screen.getByPlaceholderText('Your Name') as HTMLInputElement).value).toBe('Ada')
+    // Walking arrived as an object entry declaring Lottie, so it gets the icon.
+    expect(artOf(slotFor('Walking'))).toBeNull()
+    expect(slotFor('Walking').querySelector('.lucide-film')).not.toBeNull()
+    // Only the random name that actually had art becomes an extra.
+    const names = screen.getAllByPlaceholderText('name') as HTMLInputElement[]
+    expect(names.map((n) => n.value)).toEqual(['wave'])
+    // Nothing is missing and nothing has changed, so there is nothing to save.
+    expect(screen.queryByText(/^Missing:/)).toBeNull()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('asks overwrite-or-new once the pack is dirty, and overwrites in place', async () => {
+    api.galleryGetPackDetail.mockResolvedValueOnce(detail)
+    const { onSave } = renderEditor(existing)
+    await waitFor(() => expect(artOf(slotFor('Idle'))).not.toBeNull())
+
+    fireEvent.change(screen.getByPlaceholderText(/A cute orange cat/), { target: { value: 'now mossier' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(screen.getByText('Overwrite existing or save as new?')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Overwrite' }))
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled())
+    expect(savedPayload().meta.id).toBe('pack-42')
+    expect(savedPayload().meta.description).toBe('now mossier')
+    expect(savedPayload().random).toEqual({ wave: SVG2 })
+    expect(screen.queryByText('Overwrite existing or save as new?')).toBeNull()
+  })
+
+  it('mints a fresh id for "save as new"', async () => {
+    api.galleryGetPackDetail.mockResolvedValueOnce(detail)
+    renderEditor(existing)
+    await waitFor(() => expect(artOf(slotFor('Idle'))).not.toBeNull())
+
+    fireEvent.change(screen.getByPlaceholderText('My Custom Avatar'), { target: { value: 'Bramble II' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save as New' }))
+
+    await waitFor(() => expect(api.gallerySavePack).toHaveBeenCalled())
+    expect(savedPayload().meta.id).not.toBe('pack-42')
+    expect(savedPayload().meta.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/i)
+  })
+
+  it('dismisses the dialog without saving', async () => {
+    api.galleryGetPackDetail.mockResolvedValueOnce(detail)
+    renderEditor(existing)
+    await waitFor(() => expect(artOf(slotFor('Idle'))).not.toBeNull())
+
+    fireEvent.change(screen.getByPlaceholderText('My Custom Avatar'), { target: { value: 'Bramble II' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    // Two "Cancel"s are on screen once the dialog is up; the dialog's is the last.
+    const cancels = screen.getAllByRole('button', { name: 'Cancel' })
+    fireEvent.click(cancels[cancels.length - 1])
+
+    expect(screen.queryByText('Overwrite existing or save as new?')).toBeNull()
+    expect(api.gallerySavePack).not.toHaveBeenCalled()
+  })
+
+  it('removing a restored extra drops its art from the next save', async () => {
+    api.galleryGetPackDetail.mockResolvedValueOnce(detail)
+    renderEditor(existing)
+    await waitFor(() => expect(screen.getAllByPlaceholderText('name')).toHaveLength(1))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    expect(screen.queryByPlaceholderText('name')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Overwrite' }))
+    await waitFor(() => expect(api.gallerySavePack).toHaveBeenCalled())
+    expect(savedPayload().random).toEqual({})
+  })
+
+  it('leaves the slots empty when the pack has no animations at all', async () => {
+    api.galleryGetPackDetail.mockResolvedValueOnce({})
+    renderEditor(existing)
+
+    expect(await screen.findByText('Missing: Idle')).toBeInTheDocument()
+    expect(artOf(slotFor('Idle'))).toBeNull()
+  })
+
+  it('ignores a non-array randomNames instead of trusting the payload', async () => {
+    api.galleryGetPackDetail.mockResolvedValueOnce({
+      animations: { idle: SVG },
+      randomNames: 'wave',
+    })
+    renderEditor(existing)
+
+    await waitFor(() => expect(artOf(slotFor('Idle'))).not.toBeNull())
+    expect(screen.queryByPlaceholderText('name')).toBeNull()
+  })
+
+  it('reports a failed detail read, by message and by fallback', async () => {
+    api.galleryGetPackDetail.mockRejectedValueOnce(new Error('detail 500'))
+    const first = renderEditor(existing)
+    expect(await screen.findByText('detail 500')).toBeInTheDocument()
+    first.unmount()
+
+    api.galleryGetPackDetail.mockRejectedValueOnce('just a string')
+    renderEditor(existing)
+    // errorText() narrows a thrown string, so that is what shows.
+    expect(await screen.findByText('just a string')).toBeInTheDocument()
+  })
+
+  it('falls back to the load-failed message when the throw carries no text', async () => {
+    api.galleryGetPackDetail.mockRejectedValueOnce({ code: 500 })
+    renderEditor(existing)
+
+    expect(await screen.findByText("Could not load that avatar's data")).toBeInTheDocument()
+  })
+})

--- a/website/src/test/GhostScene.coverage.test.tsx
+++ b/website/src/test/GhostScene.coverage.test.tsx
@@ -1,0 +1,494 @@
+/**
+ * GhostScene — the Worlds haunt — driven frame by frame.
+ *
+ * The existing `Scenes.test.tsx` only proves each scene mounts a canvas, so
+ * everything this file actually DOES (the twilight sky, the eight outfits, the
+ * blink timer, the entrance animation, the speech bubble that follows a
+ * session's latest message) was never exercised. happy-dom has no 2D context and
+ * no real frame clock, so the harness below supplies both:
+ *
+ *   - a RECORDING canvas context, so an assertion can ask "was the crown drawn?"
+ *     or "which text landed on the overlay?" instead of inspecting pixels;
+ *   - a hand-driven `requestAnimationFrame`, so a test advances exactly N frames
+ *     with no dependence on elapsed time or a real animation clock;
+ *   - a pinned `Math.random` and `Date.now`, so outfit choice, blink timers and
+ *     bubble expiry are deterministic.
+ *
+ * What is asserted is what a viewer would see: how many ghosts are on screen,
+ * which one is labelled "haunting", whether the eyes are shut on this frame,
+ * whether the bubble is still up.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import chatReducer from '../store/chatSlice'
+import GhostScene from '../pages/scenes/GhostScene'
+import type { AgentSource } from '../hooks/useAgentSync'
+
+/* ── Recording 2D context ── */
+
+interface FillRecord { x: number; y: number; w: number; h: number; color: string }
+interface TextRecord { text: string; x: number; y: number }
+
+interface Recorder {
+  ctx: CanvasRenderingContext2D
+  fills: FillRecord[]
+  texts: TextRecord[]
+  arcs: number[][]
+  /** How many radial gradients were requested (moon glow, per-ghost aura). */
+  radials: { count: number }
+}
+
+/**
+ * A 2D context that remembers what it was asked to draw. Unknown members become
+ * no-op spies on first access, so a drawing helper reaching for `roundRect` or
+ * `ellipse` never has to be enumerated here.
+ */
+function createRecorder(): Recorder {
+  const fills: FillRecord[] = []
+  const texts: TextRecord[] = []
+  const arcs: number[][] = []
+  const radials = { count: 0 }
+  const gradient = { addColorStop: vi.fn() }
+
+  const store: Record<string, unknown> = {
+    fillStyle: '#000000',
+    strokeStyle: '#000000',
+    globalAlpha: 1,
+    font: '',
+    textAlign: 'start',
+    textBaseline: 'alphabetic',
+    imageSmoothingEnabled: false,
+    canvas: { width: 0, height: 0 },
+    createLinearGradient: vi.fn(() => gradient),
+    createRadialGradient: vi.fn(() => { radials.count++; return gradient }),
+    createPattern: vi.fn(() => null),
+    // Width proportional to length so the real word-wrapper actually wraps.
+    measureText: vi.fn((t: string) => ({ width: t.length * 8 })),
+    getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(4) })),
+  }
+  store.fillRect = vi.fn((x: number, y: number, w: number, h: number) => {
+    fills.push({ x, y, w, h, color: String(store.fillStyle) })
+  })
+  store.fillText = vi.fn((text: string, x: number, y: number) => {
+    texts.push({ text, x, y })
+  })
+  store.arc = vi.fn((x: number, y: number, r: number) => { arcs.push([x, y, r]) })
+
+  const ctx = new Proxy(store, {
+    get(target, prop) {
+      const key = String(prop)
+      if (!(key in target)) target[key] = vi.fn()
+      return target[key]
+    },
+    set(target, prop, value) {
+      target[String(prop)] = value
+      return true
+    },
+  }) as unknown as CanvasRenderingContext2D
+
+  return { ctx, fills, texts, arcs, radials }
+}
+
+/* ── Harness state ── */
+
+/** Every context handed out this test, in creation order. */
+let recorders: Recorder[] = []
+/** Frame callbacks queued by a scene loop, keyed by the id rAF handed back. */
+let queuedFrames = new Map<number, FrameRequestCallback>()
+let frameSeq = 0
+/** Value `Math.random()` returns — tests set it before mounting. */
+let rand = 0.25
+/** Values `Math.random()` hands out first, before falling back to `rand`. */
+let randQueue: number[] = []
+/** Value `Date.now()` returns — tests advance it to age a speech bubble. */
+let nowMs = 1_700_000_000_000
+
+beforeEach(() => {
+  recorders = []
+  queuedFrames = new Map()
+  frameSeq = 0
+  rand = 0.25
+  randQueue = []
+  nowMs = 1_700_000_000_000
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => {
+    const rec = createRecorder()
+    recorders.push(rec)
+    return rec.ctx
+  }) as unknown as HTMLCanvasElement['getContext']
+  vi.spyOn(Math, 'random').mockImplementation(() => randQueue.length ? randQueue.shift()! : rand)
+  vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    const id = ++frameSeq
+    queuedFrames.set(id, cb)
+    return id
+  })
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => { queuedFrames.delete(id) })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  localStorage.clear()
+})
+
+/** Advance every live scene loop by exactly `n` frames. */
+function runFrames(n: number) {
+  act(() => {
+    for (let i = 0; i < n; i++) {
+      const due = [...queuedFrames.values()]
+      queuedFrames.clear()
+      due.forEach(cb => cb(0))
+    }
+  })
+}
+
+function agent(over: Partial<AgentSource> & { id: string }): AgentSource {
+  return {
+    name: over.id, label: 'default', kind: 'slot',
+    running: false, detail: '', ...over,
+  }
+}
+
+function mount(agents: AgentSource[], visible = true) {
+  const store = configureStore({ reducer: { chat: chatReducer } })
+  const base = recorders.length
+  const view = render(
+    <Provider store={store}>
+      <MemoryRouter><GhostScene agents={agents} visible={visible} /></MemoryRouter>
+    </Provider>,
+  )
+  const rerender = (next: AgentSource[], nextVisible = visible) => view.rerender(
+    <Provider store={store}>
+      <MemoryRouter><GhostScene agents={next} visible={nextVisible} /></MemoryRouter>
+    </Provider>,
+  )
+  // initSceneCanvases takes the pixel context first, then the text overlay.
+  return { ...view, rerender, pixel: recorders[base], overlay: recorders[base + 1] }
+}
+
+/** Text drawn on the overlay, in draw order. */
+const labels = (rec: Recorder) => rec.texts.map(t => t.text)
+/** Distinct fill colors used on the pixel canvas. */
+const colors = (rec: Recorder) => new Set(rec.fills.map(f => f.color))
+const countColor = (rec: Recorder, color: string) => rec.fills.filter(f => f.color === color).length
+
+const EYE = '#14141e'
+const BODY = '#e8ecf4'
+
+/** Eight agents, one per anchor spot — enough to reach every outfit. */
+const fullHaunt: AgentSource[] = Array.from({ length: 8 }, (_, i) =>
+  agent({ id: `slot-full-${i}`, name: `Ghost${i}`, running: i % 2 === 0, detail: `${i} msgs` }),
+)
+
+/* ── Tests ── */
+
+describe('GhostScene mounting', () => {
+  it('renders the pixel canvas and the text overlay with accessible labels', () => {
+    const view = mount([])
+    expect(view.getByLabelText('Kiro ghost haunt animation')).toBeInTheDocument()
+    expect(view.getByLabelText('Kiro ghost haunt text overlay')).toBeInTheDocument()
+  })
+
+  it('sizes the pixel canvas and keeps it unsmoothed so the sprites stay crisp', () => {
+    const view = mount([])
+    const canvas = view.getByLabelText('Kiro ghost haunt animation') as HTMLCanvasElement
+    expect(canvas.style.imageRendering).toBe('pixelated')
+    expect(canvas.width).toBeGreaterThan(0)
+  })
+
+  it('offers the in-world new-session control because live sources are wired', () => {
+    const view = mount([])
+    expect(view.getByRole('button', { name: /new session/i })).toBeInTheDocument()
+  })
+})
+
+describe('GhostScene background', () => {
+  it('paints the sky, the moon and the scene titles on the very first frame', () => {
+    const { pixel, overlay } = mount([])
+    expect(labels(overlay)).toContain('Kiro Haunt')
+    expect(labels(overlay)).toContain('friendly hauntings only')
+    // Moon disc plus its three craters, and the halo behind it.
+    expect(pixel.arcs.length).toBeGreaterThanOrEqual(4)
+    expect(pixel.radials.count).toBeGreaterThan(0)
+    // Stars and fireflies both light up on frame one.
+    expect(colors(pixel)).toContain('#dbe2f7')
+    expect(colors(pixel)).toContain('#ffe08a')
+  })
+
+  it('reports an empty haunt in the counter', () => {
+    const { overlay } = mount([])
+    expect(labels(overlay)).toContain('kiro haunt · 0 ghosts')
+  })
+
+  it('draws nothing while hidden and starts drawing once it becomes visible', () => {
+    const { overlay, rerender } = mount([agent({ id: 'slot-hidden' })], false)
+    runFrames(5)
+    expect(overlay.texts).toHaveLength(0)
+
+    rerender([agent({ id: 'slot-hidden' })], true)
+    runFrames(1)
+    expect(labels(overlay)).toContain('Kiro Haunt')
+  })
+
+  it('streaks a shooting star in from the left on the 140th frame', () => {
+    const view = mount([])
+    runFrames(138)   // mount drew tick 1; this covers ticks 2..139
+    view.pixel.fills.length = 0
+    runFrames(1)     // tick 140 — the spawn tick
+    const trail = view.pixel.fills.filter(f => f.color.startsWith('rgba(255,240,200'))
+    expect(trail.length).toBeGreaterThan(0)
+    // Entered off the left edge and is still travelling in.
+    expect(trail.some(f => f.x < 0)).toBe(true)
+  })
+
+  it('streaks the star in from the right when the coin flip goes the other way', () => {
+    const view = mount([])
+    const canvas = view.getByLabelText('Kiro ghost haunt animation') as HTMLCanvasElement
+    runFrames(138)
+    view.pixel.fills.length = 0
+    // First draw decides "spawn?", the second decides "from the left?".
+    randQueue = [0.4, 0.9]
+    runFrames(1)
+    const trail = view.pixel.fills.filter(f => f.color.startsWith('rgba(255,240,200'))
+    expect(trail.length).toBeGreaterThan(0)
+    expect(trail.some(f => f.x > canvas.width)).toBe(true)
+  })
+})
+
+describe('GhostScene agent to ghost sync', () => {
+  it('draws one ghost per agent and counts them', () => {
+    const { pixel, overlay } = mount([
+      agent({ id: 'slot-a', name: 'Alpha', running: true, detail: '3 msgs' }),
+      agent({ id: 'slot-b', name: 'Beta' }),
+      agent({ id: 'cron-c', name: 'Gamma', kind: 'cron', detail: 'every 5m' }),
+    ])
+    expect(labels(overlay)).toContain('kiro haunt · 3 ghosts')
+    expect(labels(overlay)).toEqual(expect.arrayContaining(['Alpha', 'Beta', 'Gamma']))
+    expect(colors(pixel)).toContain(BODY)
+  })
+
+  it('caps the haunt at the eight anchor spots', () => {
+    const many = Array.from({ length: 12 }, (_, i) => agent({ id: `slot-many-${i}` }))
+    const { overlay } = mount(many)
+    expect(labels(overlay)).toContain('kiro haunt · 8 ghosts')
+  })
+
+  it('labels a running agent as haunting and an idle one as idle', () => {
+    const { overlay } = mount([
+      agent({ id: 'slot-run', name: 'Runner', running: true }),
+      agent({ id: 'slot-idle', name: 'Sitter', running: false }),
+    ])
+    expect(labels(overlay)).toContain('haunting')
+    expect(labels(overlay)).toContain('idle')
+  })
+
+  it('shows an agent detail line but writes nothing when the detail is blank', () => {
+    const withDetail = mount([agent({ id: 'slot-d1', name: 'Withd', detail: '7 msgs' })])
+    expect(labels(withDetail.overlay)).toContain('7 msgs')
+    withDetail.unmount()
+
+    const bare = mount([agent({ id: 'slot-d2', name: 'Bare' })])
+    expect(labels(bare.overlay).filter(t => t === '')).toHaveLength(0)
+  })
+
+  it('wraps a long agent name onto several lines', () => {
+    const name = 'Extremely Long Ghost Name That Wraps Across Several Lines'
+    const { overlay } = mount([agent({ id: 'slot-long', name, detail: 'busy' })])
+    const drawn = labels(overlay).filter(t => t !== '' && name.includes(t))
+    expect(drawn.length).toBeGreaterThan(1)
+    expect(labels(overlay)).not.toContain(name)
+  })
+
+  it('reuses a ghost when the agent list reorders, and slides it to the new spot', () => {
+    const a = agent({ id: 'slot-move-a', name: 'Mover' })
+    const b = agent({ id: 'slot-move-b', name: 'Shifter' })
+    const { overlay, rerender } = mount([a, b])
+    runFrames(30)
+
+    rerender([b, a])
+    overlay.texts.length = 0
+    runFrames(30)
+    // Both ghosts survived the reorder — no re-entrance, no duplicates.
+    expect(labels(overlay)).toContain('kiro haunt · 2 ghosts')
+    expect(labels(overlay)).toEqual(expect.arrayContaining(['Mover', 'Shifter']))
+  })
+
+  it('picks up an agent rename and running-state change in place', () => {
+    const { overlay, rerender } = mount([agent({ id: 'slot-rn', name: 'Before' })])
+    expect(labels(overlay)).toContain('idle')
+
+    rerender([agent({ id: 'slot-rn', name: 'After', running: true, detail: 'live' })])
+    overlay.texts.length = 0
+    runFrames(1)
+    expect(labels(overlay)).toContain('After')
+    expect(labels(overlay)).toContain('haunting')
+    expect(labels(overlay)).not.toContain('Before')
+  })
+
+  it('removes ghosts for agents that disappear', () => {
+    const keep = agent({ id: 'slot-keep', name: 'Keeper' })
+    const { overlay, rerender } = mount([keep, agent({ id: 'slot-gone', name: 'Goner' })])
+    rerender([keep])
+    overlay.texts.length = 0
+    runFrames(1)
+    expect(labels(overlay)).toContain('kiro haunt · 1 ghosts')
+    expect(labels(overlay)).not.toContain('Goner')
+  })
+
+  it('floats a first-time ghost up from below and places a known one at its anchor', () => {
+    const nameOf = (rec: Recorder, name: string) => rec.texts.find(t => t.text === name)!
+
+    const first = mount([agent({ id: 'slot-entrance', name: 'Newcomer' })])
+    const enteringY = nameOf(first.overlay, 'Newcomer').y
+    first.unmount()
+
+    // Second mount: the scene cache now knows this id, so no entrance animation.
+    const again = mount([agent({ id: 'slot-entrance', name: 'Newcomer' })])
+    const anchoredY = nameOf(again.overlay, 'Newcomer').y
+    expect(enteringY).toBeGreaterThan(anchoredY)
+    again.unmount()
+
+    // ...and an unknown ghost climbs toward its anchor as frames pass.
+    const third = mount([agent({ id: 'slot-entrance-2', name: 'Riser' })])
+    const startY = nameOf(third.overlay, 'Riser').y
+    third.overlay.texts.length = 0
+    runFrames(20)
+    expect(nameOf(third.overlay, 'Riser').y).toBeLessThan(startY)
+  })
+})
+
+describe('GhostScene sprite detail', () => {
+  it('gives all eight ghosts a distinct hat, glasses or cape', () => {
+    const { pixel } = mount(fullHaunt)
+    const used = colors(pixel)
+    for (const color of [
+      '#3a3a4a',  // round glasses
+      '#2d1b4e',  // witch hat
+      '#c0392b',  // red cape
+      '#181820',  // top hat
+      '#111',     // shades
+      '#8fa8ff',  // lens glint
+      '#27408b',  // blue cape
+      '#16a085',  // beanie
+      '#f39c12',  // party hat
+      '#f1c40f',  // crown
+      '#5b2c6f',  // purple cape
+    ]) {
+      expect(used, `expected ${color} to be drawn`).toContain(color)
+    }
+  })
+
+  it('flips a caped ghost\u2019s cape to the other side when it turns around', () => {
+    const trio = [
+      agent({ id: 'slot-cape-a', name: 'CapeA' }),
+      agent({ id: 'slot-cape-b', name: 'CapeB' }),
+      agent({ id: 'slot-cape-c', name: 'Caped' }),   // third outfit wears the red cape
+    ]
+    const { pixel, rerender } = mount(trio)
+    /**
+     * The cape is drawn back panel first, collar third. Which side of the collar
+     * the panel lands on IS which way the ghost is facing — and comparing the two
+     * needs no knowledge of the scene scale or where the ghost currently is.
+     */
+    const panelVsCollar = (rec: Recorder) => {
+      const cape = rec.fills.filter(f => f.color === '#c0392b')
+      return Math.sign(cape[0].x - cape[2].x)
+    }
+    expect(panelVsCollar(pixel)).toBe(-1)   // cape trails to the left, facing right
+
+    // Reordering sends the caped ghost to the leftmost anchor, so it turns around.
+    rerender([trio[2], trio[0], trio[1]])
+    pixel.fills.length = 0
+    runFrames(3)
+    expect(panelVsCollar(pixel)).toBe(1)
+  })
+
+  it('blushes only the ghosts that are running', () => {
+    const busy = mount([agent({ id: 'slot-blush', name: 'Busy', running: true })])
+    expect(colors(busy.pixel)).toContain('#ff8899')
+    busy.unmount()
+
+    const resting = mount([agent({ id: 'slot-noblush', name: 'Resting', running: false })])
+    expect(colors(resting.pixel)).not.toContain('#ff8899')
+  })
+
+  it('shuts a ghost\u2019s eyes when the blink timer runs down, then rearms it', () => {
+    rand = 0  // blinkTimer starts at exactly 120 frames
+    const { pixel } = mount([agent({ id: 'slot-blink', name: 'Blinker' })])
+    runFrames(113)             // through tick 114 — timer at 6, eyes still open
+    pixel.fills.length = 0
+    runFrames(1)               // tick 115 — timer at 5, eyes shut
+    expect(countColor(pixel, EYE)).toBe(2)
+
+    runFrames(5)               // tick 120 — timer hits 0 and rearms to 140
+    pixel.fills.length = 0
+    runFrames(1)
+    expect(countColor(pixel, EYE)).toBe(6)
+  })
+
+  it('draws a spectral glow under a running ghost only', () => {
+    const busy = mount([agent({ id: 'slot-glow', name: 'Glower', running: true })])
+    const radialOnBusy = busy.pixel.radials.count
+    busy.unmount()
+
+    const resting = mount([agent({ id: 'slot-noglow', name: 'Dim', running: false })])
+    // Both frames draw the moon glow; only the running ghost adds its own aura.
+    expect(radialOnBusy).toBeGreaterThan(resting.pixel.radials.count)
+  })
+})
+
+describe('GhostScene speech bubbles', () => {
+  const withMessage = (text: string) =>
+    agent({ id: 'slot-msg', name: 'Talker', running: true, lastMessage: text })
+
+  it('stays quiet for a message that was already there when the ghost appeared', () => {
+    const { overlay } = mount([withMessage('old news')])
+    expect(labels(overlay)).not.toContain('old news')
+  })
+
+  it('pops a bubble when the session\u2019s latest message changes', () => {
+    const { overlay, rerender } = mount([withMessage('old news')])
+    rerender([withMessage('shipping it')])
+    overlay.texts.length = 0
+    runFrames(1)
+    expect(labels(overlay)).toContain('shipping it')
+  })
+
+  it('fades the bubble through its final second and drops it after seven', () => {
+    const { overlay, rerender } = mount([withMessage('first')])
+    rerender([withMessage('fresh')])
+
+    nowMs += 6_500                       // inside the fade-out window
+    overlay.texts.length = 0
+    runFrames(1)
+    expect(labels(overlay)).toContain('fresh')
+
+    nowMs += 1_000                       // past SPEECH_BUBBLE_MS
+    overlay.texts.length = 0
+    runFrames(1)
+    expect(labels(overlay)).not.toContain('fresh')
+  })
+
+  it('clears the bubble when the message is emptied', () => {
+    const { overlay, rerender } = mount([withMessage('something')])
+    rerender([withMessage('')])
+    overlay.texts.length = 0
+    runFrames(1)
+    expect(labels(overlay)).not.toContain('something')
+  })
+})
+
+describe('GhostScene teardown', () => {
+  it('stops its loop on unmount so no further frames are drawn', () => {
+    const { overlay, unmount } = mount([agent({ id: 'slot-tear', name: 'Ender' })])
+    runFrames(2)
+    unmount()
+    overlay.texts.length = 0
+    runFrames(3)
+    expect(overlay.texts).toHaveLength(0)
+  })
+})

--- a/website/src/test/MochiSettingsPanel.coverage.test.tsx
+++ b/website/src/test/MochiSettingsPanel.coverage.test.tsx
@@ -1,0 +1,1121 @@
+/**
+ * Mochi settings panel — first tests for
+ * `apps/mochi/src/renderer/SettingsPanel.tsx`.
+ *
+ * The panel is the pet's entire configuration surface (twelve sections behind a
+ * left rail) and had no test at all, so every behaviour below is pinned here for
+ * the first time. Everything it can reach outside itself goes through one seam
+ * (`api` in `mochiApi`), so that module is the single mock, and the instance
+ * picker — core's own component, tested separately — is stubbed at its module
+ * boundary so this file only exercises how the panel WIRES it.
+ *
+ * The behaviours worth pinning are the ones a user can be lied to by:
+ *
+ *  - staged edits: nothing is written until Save, and Save is disabled until
+ *    something actually differs from what was read;
+ *  - the two "saved but not really" paths — a shortcut the OS refused, and an
+ *    instance switch the shell declined — which must keep the panel open, reveal
+ *    the section that renders the reason, and differ from each other on whether
+ *    the baseline is committed;
+ *  - discard, which must put back the config that was read rather than a
+ *    reconstruction of it.
+ *
+ * No fake timers: the panel has no timers of its own. Async reads are awaited
+ * through `findBy*` / `waitFor` instead of advanced clocks, so nothing here
+ * depends on elapsed time or on test order.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+
+import type { AppConfig } from '../apps/mochi/src/shared/config'
+import type { CompanionStats, McpServerInfo } from '../apps/mochi/src/shared/types'
+
+const mocks = vi.hoisted(() => {
+  /** `onSettingsCloseRequested` subscribers, so a native close can be replayed. */
+  const closeRequested = new Set<() => void>()
+  const api = {
+    hasShell: true,
+    getConfig: vi.fn<() => Promise<unknown>>(),
+    getStats: vi.fn<() => Promise<unknown>>(),
+    getMochiTrustLevel: vi.fn<() => Promise<string>>(),
+    setMochiTrustLevel: vi.fn<(level: string) => Promise<void>>(),
+    updateConfig: vi.fn<(partial: unknown) => Promise<void>>(),
+    applyShortcuts: vi.fn<(s: unknown) => Promise<Record<string, boolean>>>(),
+    setPetInstance: vi.fn<(id: string) => Promise<boolean>>(),
+    getMcpServers: vi.fn<() => Promise<unknown>>(),
+    discoverMcpTools: vi.fn<(name: string) => Promise<unknown>>(),
+    getModels: vi.fn<() => Promise<unknown>>(),
+    setModel: vi.fn<(m: string) => Promise<boolean>>(),
+    galleryOpen: vi.fn(),
+    openExternal: vi.fn(),
+    onSettingsCloseRequested: (cb: () => void) => {
+      closeRequested.add(cb)
+      return () => { closeRequested.delete(cb) }
+    },
+  }
+  return {
+    api,
+    /** Replay the native window-close request the shell sends on the red ×. */
+    requestClose: () => { for (const cb of [...closeRequested]) cb() },
+    clearCloseRequested: () => closeRequested.clear(),
+  }
+})
+
+vi.mock('../apps/mochi/src/mochiApi', () => ({ api: mocks.api }))
+
+// Core's instance picker is tested on its own; here only the panel's wiring of
+// it matters, so it is reduced to the two things the panel supplies: the current
+// value, and a way to pick a different one.
+vi.mock('../apps/mochi/panel/MochiInstances', () => ({
+  MochiInstancesList: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <div>
+      <span>{`instance:${value}`}</span>
+      <button onClick={() => onChange('remote-1')}>pick remote</button>
+    </div>
+  ),
+}))
+
+import { SettingsPanel } from '../apps/mochi/src/renderer/SettingsPanel'
+
+const api = mocks.api
+
+/* ── fixtures ─────────────────────────────────────────────────── */
+
+/** A config shaped like `api.getConfig`'s, fresh per call (the panel clones it). */
+function makeConfig(over: { mochi?: Record<string, unknown> } = {}): AppConfig {
+  return {
+    shortcuts: {
+      voiceInput: 'Alt+Space',
+      screenCapture: 'CommandOrControl+Shift+X',
+      toggleWindow: 'CommandOrControl+Shift+M',
+      hideAll: 'CommandOrControl+Shift+H',
+    },
+    window: {
+      position: { x: 10, y: 20 },
+      visible: true,
+      expanded: false,
+      chatAlwaysOnTop: true,
+    },
+    mochi: {
+      petName: 'Mochi',
+      language: '',
+      activityMode: 'normal',
+      activityTier: 'balanced',
+      bgModel: '',
+      silentSubagents: false,
+      extraMcpServers: [],
+      petInstance: 'self',
+      theme: 'kirocrew',
+      ...over.mochi,
+    },
+  } as unknown as AppConfig
+}
+
+function makeStats(over: Partial<CompanionStats> = {}): CompanionStats {
+  return {
+    firstLaunch: '2026-01-01T00:00:00.000Z',
+    streak: 4,
+    lastActiveDate: '2026-08-10',
+    companionSeconds: 7260,
+    messages: { sent: 12, received: 9 },
+    walkSteps: 340,
+    screenshots: 6,
+    peeks: 3,
+    drags: 2,
+    thinkingSeconds: 95,
+    latestActiveTime: '23:40',
+    earliestActiveTime: '07:05',
+    moods: { happy: 6, curious: 3, weird: 1 },
+    longestChat: 18,
+    busiestDay: { date: '2026-08-09', messages: 22 },
+    lastMemoryHour: 3,
+    ...over,
+  }
+}
+
+function makeServer(over: Partial<McpServerInfo> = {}): McpServerInfo {
+  return {
+    name: 'server-a',
+    core: false,
+    enabled: true,
+    agents: ['chat'],
+    autoApprove: [],
+    disabledTools: [],
+    chatPolicy: { autoApprove: [], disabledTools: [] },
+    bgPolicy: { autoApprove: [], disabledTools: [] },
+    ...over,
+  }
+}
+
+/* ── helpers ──────────────────────────────────────────────────── */
+
+const onClose = vi.fn()
+
+/** Mount and wait for the config read to land (the spinner to go). */
+async function mount(): Promise<void> {
+  render(<SettingsPanel onClose={onClose} />)
+  await screen.findByRole('button', { name: 'General' })
+}
+
+/** Open a left-rail section by its rail label. */
+function openSection(label: string): void {
+  fireEvent.click(screen.getByRole('button', { name: label }))
+}
+
+/** The label-wrapped radio rows (behavior / trust / tier) have no role. */
+function clickRow(text: string): void {
+  const row = screen.getByText(text).closest('label')
+  if (!row) throw new Error(`no option row for ${text}`)
+  fireEvent.click(row)
+}
+
+function saveButton(): HTMLButtonElement {
+  // The unsaved-changes dialog adds a second "Save"; the footer one is first.
+  return screen.getAllByRole('button', { name: 'Save' })[0] as HTMLButtonElement
+}
+
+beforeEach(() => {
+  mocks.clearCloseRequested()
+  onClose.mockReset()
+  api.hasShell = true
+  api.getConfig.mockReset().mockResolvedValue(makeConfig())
+  api.getStats.mockReset().mockResolvedValue(makeStats())
+  api.getMochiTrustLevel.mockReset().mockResolvedValue('normal')
+  api.setMochiTrustLevel.mockReset().mockResolvedValue(undefined)
+  api.updateConfig.mockReset().mockResolvedValue(undefined)
+  api.applyShortcuts.mockReset().mockResolvedValue({})
+  api.setPetInstance.mockReset().mockResolvedValue(true)
+  api.getMcpServers.mockReset().mockResolvedValue([])
+  api.discoverMcpTools.mockReset().mockResolvedValue(null)
+  api.getModels.mockReset().mockResolvedValue([])
+  api.setModel.mockReset().mockResolvedValue(true)
+  api.galleryOpen.mockReset()
+  api.openExternal.mockReset()
+  // The background section reads its usage ledger over plain fetch. Default to a
+  // refusal so no test depends on a network answer; the usage test overrides it.
+  vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 500 })))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/* ── loading gate ─────────────────────────────────────────────── */
+
+describe('SettingsPanel loading gate', () => {
+  it('shows only a spinner until the config read lands', async () => {
+    let land: (c: AppConfig) => void = () => {}
+    api.getConfig.mockReturnValue(new Promise<AppConfig>((res) => { land = res }))
+
+    render(<SettingsPanel onClose={onClose} />)
+    expect(screen.queryByRole('button', { name: 'General' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull()
+
+    land(makeConfig())
+    expect(await screen.findByRole('button', { name: 'General' })).toBeTruthy()
+  })
+})
+
+/* ── rail ─────────────────────────────────────────────────────── */
+
+describe('SettingsPanel section rail', () => {
+  const RAIL = [
+    'General', 'Memories', 'Appearance', 'Behavior', 'Notifications',
+    'Background Activity', 'LLM Model', 'MCP Servers', 'Trust', 'Shortcuts',
+    'Instances', 'About',
+  ]
+
+  it('offers every section and marks exactly the selected one', async () => {
+    await mount()
+    for (const label of RAIL) {
+      openSection(label)
+      const selected = RAIL.filter(
+        (l) => (screen.getByRole('button', { name: l }) as HTMLElement).style.fontWeight === '600',
+      )
+      expect(selected).toEqual([label])
+    }
+  })
+
+  it('opens on General, so the pet name is the first thing reachable', async () => {
+    await mount()
+    expect(screen.getByDisplayValue('Mochi')).toBeTruthy()
+  })
+})
+
+/* ── general ──────────────────────────────────────────────────── */
+
+describe('SettingsPanel general section', () => {
+  it('stages a pet name edit and only then enables Save', async () => {
+    await mount()
+    expect(saveButton().disabled).toBe(true)
+
+    fireEvent.change(screen.getByDisplayValue('Mochi'), { target: { value: 'Tofu' } })
+
+    expect(screen.getByDisplayValue('Tofu')).toBeTruthy()
+    expect(saveButton().disabled).toBe(false)
+    // Staged only — nothing is written before Save.
+    expect(api.updateConfig).not.toHaveBeenCalled()
+  })
+
+  it('offers Auto plus the real language registry, and stages the pick', async () => {
+    await mount()
+    const select = screen.getByRole('combobox') as HTMLSelectElement
+    // '' is "follow Kiro Crew", which is what the stored empty value means.
+    expect(select.value).toBe('')
+    expect(within(select).getByRole('option', { name: 'Auto' })).toBeTruthy()
+    expect(select.options.length).toBeGreaterThan(1)
+
+    const other = [...select.options].find((o) => o.value !== '')
+    fireEvent.change(select, { target: { value: other?.value } })
+    expect(select.value).toBe(other?.value)
+    expect(saveButton().disabled).toBe(false)
+  })
+})
+
+/* ── memories ─────────────────────────────────────────────────── */
+
+describe('SettingsPanel memories section', () => {
+  it('renders one row per non-empty counter, with the streak folded into the time row', async () => {
+    await mount()
+    openSection('Memories')
+
+    expect(screen.getByText(/Together for/)).toBeTruthy()
+    expect(screen.getByText(/4-day streak/)).toBeTruthy()
+    expect(screen.getByText(/21 messages \(12 you · 9 Mochi\)/)).toBeTruthy()
+    expect(screen.getByText('340 steps')).toBeTruthy()
+    expect(screen.getByText('Looked at your screen 6 times')).toBeTruthy()
+    expect(screen.getByText('Peeked 3 times')).toBeTruthy()
+    expect(screen.getByText('Dragged 2 times')).toBeTruthy()
+    expect(screen.getByText(/Thought for/)).toBeTruthy()
+    expect(screen.getByText('Latest: stayed up till 23:40')).toBeTruthy()
+    expect(screen.getByText('Earliest: up at 07:05')).toBeTruthy()
+    expect(screen.getByText(/Chattiest day: .* \(22 msgs\)/)).toBeTruthy()
+    expect(screen.getByText('Longest chat: 18 messages')).toBeTruthy()
+  })
+
+  it('lists every mood with a share, translating the known ones and passing the rest through', async () => {
+    await mount()
+    openSection('Memories')
+
+    const moods = screen.getByText('Moods:').parentElement as HTMLElement
+    // 6 / 3 / 1 of ten samples.
+    expect(within(moods).getByText(/60%/)).toBeTruthy()
+    expect(within(moods).getByText(/30%/)).toBeTruthy()
+    // An unknown mood id has no catalog key and is shown as itself, not dropped.
+    expect(within(moods).getByText(/weird/)).toBeTruthy()
+  })
+
+  it('welcomes a first-time user instead of showing a near-empty ledger', async () => {
+    api.getStats.mockResolvedValue(makeStats({
+      companionSeconds: 60, streak: 0, messages: { sent: 0, received: 0 },
+      walkSteps: 0, screenshots: 0, peeks: 0, drags: 0, thinkingSeconds: 0,
+      latestActiveTime: '', earliestActiveTime: '', moods: {},
+      longestChat: 0, busiestDay: { date: '', messages: 0 },
+    }))
+    await mount()
+    openSection('Memories')
+
+    expect(screen.getByText('Your story with Mochi just began')).toBeTruthy()
+  })
+
+  it('renders nothing at all when there is not a single counter yet', async () => {
+    api.getStats.mockResolvedValue(makeStats({
+      companionSeconds: 0, streak: 0, messages: { sent: 0, received: 0 },
+      walkSteps: 0, screenshots: 0, peeks: 0, drags: 0, thinkingSeconds: 0,
+      latestActiveTime: '', earliestActiveTime: '', moods: {},
+      longestChat: 0, busiestDay: { date: '', messages: 0 },
+    }))
+    await mount()
+    openSection('Memories')
+
+    expect(screen.queryByText('Memories:')).toBeNull()
+    expect(screen.queryByText(/just began/)).toBeNull()
+  })
+
+  it('re-reads the counters when the window regains focus', async () => {
+    await mount()
+    expect(api.getStats).toHaveBeenCalledTimes(1)
+
+    api.getStats.mockResolvedValue(makeStats({ walkSteps: 999 }))
+    fireEvent.focus(window)
+    openSection('Memories')
+
+    expect(await screen.findByText('999 steps')).toBeTruthy()
+  })
+
+  it('shows no ledger while the stats read is still outstanding', async () => {
+    api.getStats.mockReturnValue(new Promise(() => {}))
+    await mount()
+    openSection('Memories')
+
+    expect(screen.queryByText(/Together for/)).toBeNull()
+  })
+})
+
+/* ── appearance / behavior / notifications ────────────────────── */
+
+describe('SettingsPanel appearance section', () => {
+  it('opens the gallery through the shell rather than staging anything', async () => {
+    await mount()
+    openSection('Appearance')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Appearance Gallery' }))
+    expect(api.galleryOpen).toHaveBeenCalledTimes(1)
+    expect(saveButton().disabled).toBe(true)
+  })
+})
+
+describe('SettingsPanel behavior section', () => {
+  it('stages the picked activity mode and moves the selection to it', async () => {
+    await mount()
+    openSection('Behavior')
+
+    const quiet = screen.getByText('Quiet').closest('label') as HTMLElement
+    const normal = screen.getByText('Normal').closest('label') as HTMLElement
+    expect(normal.style.background).toBe('var(--accent-glow)')
+
+    fireEvent.click(quiet)
+    // Only the newly-picked row is asserted. The two labels can resolve to the
+    // SAME element depending on how the i18n'd option text is wrapped, so
+    // asserting the other one turned transparent compared an element with
+    // itself and failed spuriously.
+    expect(quiet.style.background).toBe('var(--accent-glow)')
+    expect(saveButton().disabled).toBe(false)
+  })
+})
+
+describe('SettingsPanel notifications section', () => {
+  it('flips the subagent-silence switch on click', async () => {
+    await mount()
+    openSection('Notifications')
+
+    const [silent] = screen.getAllByRole('switch')
+    expect(silent.getAttribute('aria-checked')).toBe('false')
+    fireEvent.click(silent)
+    expect(screen.getAllByRole('switch')[0].getAttribute('aria-checked')).toBe('true')
+    expect(saveButton().disabled).toBe(false)
+  })
+
+  it('flips the always-on-top switch from the keyboard', async () => {
+    await mount()
+    openSection('Notifications')
+
+    const onTop = screen.getAllByRole('switch')[1]
+    expect(onTop.getAttribute('aria-checked')).toBe('true')
+    fireEvent.keyDown(onTop, { key: ' ' })
+    expect(screen.getAllByRole('switch')[1].getAttribute('aria-checked')).toBe('false')
+
+    fireEvent.keyDown(screen.getAllByRole('switch')[1], { key: 'Enter' })
+    expect(screen.getAllByRole('switch')[1].getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('ignores keys that are not the two activation keys', async () => {
+    await mount()
+    openSection('Notifications')
+
+    fireEvent.keyDown(screen.getAllByRole('switch')[0], { key: 'a' })
+    expect(screen.getAllByRole('switch')[0].getAttribute('aria-checked')).toBe('false')
+  })
+})
+
+/* ── background activity ──────────────────────────────────────── */
+
+describe('SettingsPanel background activity section', () => {
+  it('stages a spend tier without touching the personality axis', async () => {
+    await mount()
+    openSection('Background Activity')
+
+    expect((screen.getByText('Balanced').closest('label') as HTMLElement).style.background)
+      .toBe('var(--accent-glow)')
+    clickRow('Economy')
+    expect((screen.getByText('Economy').closest('label') as HTMLElement).style.background)
+      .toBe('var(--accent-glow)')
+
+    // Behavior is a separate key and must be untouched by a tier pick.
+    openSection('Behavior')
+    expect((screen.getByText('Normal').closest('label') as HTMLElement).style.background)
+      .toBe('var(--accent-glow)')
+  })
+
+  it('reads the same ledger the cap enforces and reports all three windows', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({ usage: { runsThisHour: 2, runsToday: 9, runs7d: 41 } }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    )))
+    await mount()
+    openSection('Background Activity')
+
+    expect(await screen.findByText(/2 this hour · 9 today · 41 in 7 days/)).toBeTruthy()
+  })
+
+  it('says nothing about usage when the ledger read fails', async () => {
+    await mount()
+    openSection('Background Activity')
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+    expect(screen.queryByText(/this hour/)).toBeNull()
+  })
+})
+
+/* ── model ────────────────────────────────────────────────────── */
+
+describe('SettingsPanel model section', () => {
+  it('renders nothing rather than an empty picker when no model list comes back', async () => {
+    await mount()
+    openSection('LLM Model')
+
+    expect(screen.queryByRole('combobox')).toBeNull()
+  })
+
+  it('survives a failed model read without breaking the panel', async () => {
+    api.getModels.mockRejectedValue(new Error('nope'))
+    await mount()
+    openSection('LLM Model')
+
+    await waitFor(() => expect(api.getModels).toHaveBeenCalled())
+    expect(screen.queryByRole('combobox')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy()
+  })
+
+  it('normalizes a bare-string model list and switches the chat model immediately', async () => {
+    api.getModels.mockResolvedValue(['claude-x', { model_name: 'gpt-y', model_id: 'gpt-y-id' }])
+    await mount()
+    openSection('LLM Model')
+
+    const [chat] = await screen.findAllByRole('combobox')
+    expect(within(chat).getByRole('option', { name: 'claude-x' })).toBeTruthy()
+    // A model_id, when present, is what gets sent — not the display name.
+    expect((within(chat).getByRole('option', { name: 'gpt-y' }) as HTMLOptionElement).value)
+      .toBe('gpt-y-id')
+
+    fireEvent.change(chat, { target: { value: 'claude-x' } })
+    expect(api.setModel).toHaveBeenCalledWith('claude-x')
+    // The chat model is applied now, not staged, so Save stays disabled.
+    await waitFor(() => expect(screen.queryByText('Switching model...')).toBeNull())
+    expect(saveButton().disabled).toBe(true)
+  })
+
+  it('stages the background model instead of applying it, since it is config', async () => {
+    api.getModels.mockResolvedValue([{ model_name: 'gpt-y' }])
+    await mount()
+    openSection('LLM Model')
+
+    const combos = await screen.findAllByRole('combobox')
+    fireEvent.change(combos[1], { target: { value: 'gpt-y' } })
+
+    expect(api.setModel).not.toHaveBeenCalled()
+    expect(saveButton().disabled).toBe(false)
+  })
+
+  it('keeps working when the model switch itself throws', async () => {
+    api.getModels.mockResolvedValue([{ model_name: 'gpt-y' }])
+    api.setModel.mockRejectedValue(new Error('switch failed'))
+    await mount()
+    openSection('LLM Model')
+
+    const [chat] = await screen.findAllByRole('combobox')
+    fireEvent.change(chat, { target: { value: 'gpt-y' } })
+
+    await waitFor(() => expect(screen.queryByText('Switching model...')).toBeNull())
+    expect((chat as HTMLSelectElement).value).toBe('gpt-y')
+  })
+})
+
+/* ── MCP ──────────────────────────────────────────────────────── */
+
+describe('SettingsPanel MCP section', () => {
+  it('stays visible while loading and when the inventory comes back empty', async () => {
+    let land: (v: McpServerInfo[]) => void = () => {}
+    api.getMcpServers.mockReturnValue(new Promise<McpServerInfo[]>((res) => { land = res }))
+    await mount()
+    openSection('MCP Servers')
+
+    expect(screen.getByText('Loading servers…')).toBeTruthy()
+    land([])
+    expect(await screen.findByText(/No MCP servers are configured yet/)).toBeTruthy()
+  })
+
+  it('stays visible when the inventory read fails outright', async () => {
+    api.getMcpServers.mockRejectedValue(new Error('offline'))
+    await mount()
+    openSection('MCP Servers')
+
+    expect(await screen.findByText(/No MCP servers are configured yet/)).toBeTruthy()
+  })
+
+  it('separates granted servers from addable ones, and grants on Add', async () => {
+    api.getMcpServers.mockResolvedValue([
+      makeServer({ name: 'mochi:self', core: true }),
+      makeServer({ name: 'extra-b' }),
+    ])
+    await mount()
+    openSection('MCP Servers')
+
+    expect(await screen.findByText('core')).toBeTruthy()
+    expect(screen.getByText('Available to add:')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /Add/ }))
+    expect(saveButton().disabled).toBe(false)
+    // Granted rows are expandable; addable ones are not. Several rows can carry
+    // the same agent label, so match all of them rather than demanding exactly one.
+    expect((await screen.findAllByText('Chat only')).length).toBeGreaterThan(0)
+  })
+
+  it('revokes a granted non-core server without touching the core one', async () => {
+    api.getConfig.mockResolvedValue(makeConfig({
+      mochi: { extraMcpServers: [{ name: 'extra-b', agents: ['chat'], autoApprove: [], disabledTools: [] }] },
+    }))
+    api.getMcpServers.mockResolvedValue([
+      makeServer({ name: 'mochi:self', core: true }),
+      makeServer({ name: 'extra-b' }),
+    ])
+    await mount()
+    openSection('MCP Servers')
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove extra-b' }))
+    // It moves to the addable list, so the Add affordance appears for it.
+    expect(await screen.findByRole('button', { name: /Add/ })).toBeTruthy()
+    expect(saveButton().disabled).toBe(false)
+  })
+
+  it('discovers tools on first expand and groups them by effective policy', async () => {
+    api.getConfig.mockResolvedValue(makeConfig({
+      mochi: { extraMcpServers: [{ name: 'extra-b', agents: ['chat'], autoApprove: [], disabledTools: [] }] },
+    }))
+    api.getMcpServers.mockResolvedValue([makeServer({
+      name: 'extra-b',
+      chatPolicy: { autoApprove: ['read_file'], disabledTools: ['rm_rf', 'gone_tool'] },
+      bgPolicy: { autoApprove: [], disabledTools: [] },
+    })])
+    api.discoverMcpTools.mockResolvedValue({
+      tools: [{ name: 'read_file' }, { name: 'rm_rf' }, { name: 'write_file' }],
+      fromCache: true,
+    })
+    await mount()
+    openSection('MCP Servers')
+
+    fireEvent.click(await screen.findByRole('button', { expanded: false }))
+    await waitFor(() => expect(api.discoverMcpTools).toHaveBeenCalledWith('extra-b'))
+
+    expect(await screen.findByText('Auto-approved')).toBeTruthy()
+    expect(screen.getByText('Disabled')).toBeTruthy()
+    expect(screen.getByText('Needs approval')).toBeTruthy()
+    // A policy entry with no matching discovered tool is called out, not hidden.
+    expect(screen.getByText('Stale (removed from server)')).toBeTruthy()
+    expect(screen.getByText('(cached — may be stale)')).toBeTruthy()
+
+    // Collapsing and re-expanding must not re-probe: the list is already held.
+    fireEvent.click(screen.getByRole('button', { expanded: true }))
+    fireEvent.click(screen.getByRole('button', { expanded: false }))
+    expect(api.discoverMcpTools).toHaveBeenCalledTimes(1)
+  })
+
+  it('expands from the keyboard too', async () => {
+    api.getMcpServers.mockResolvedValue([makeServer({ name: 'mochi:self', core: true })])
+    await mount()
+    openSection('MCP Servers')
+
+    const row = await screen.findByRole('button', { expanded: false })
+    fireEvent.keyDown(row, { key: 'x' })
+    expect(screen.getByRole('button', { expanded: false })).toBeTruthy()
+
+    fireEvent.keyDown(row, { key: 'Enter' })
+    expect(await screen.findByText('Refresh Tools')).toBeTruthy()
+    // A core server has no per-agent toggles — its grant is not negotiable here.
+    expect(screen.queryByText('Apply to Chat')).toBeNull()
+  })
+
+  it('shows the per-agent policy for the selected tab', async () => {
+    api.getMcpServers.mockResolvedValue([makeServer({
+      name: 'mochi:self',
+      core: true,
+      chatPolicy: { autoApprove: ['read_file'], disabledTools: [] },
+      bgPolicy: { autoApprove: [], disabledTools: ['read_file'] },
+    })])
+    api.discoverMcpTools.mockResolvedValue({ tools: [{ name: 'read_file' }], fromCache: false })
+    await mount()
+    openSection('MCP Servers')
+
+    fireEvent.click(await screen.findByRole('button', { expanded: false }))
+    expect(await screen.findByText('Auto-approved')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Background Tools' }))
+    expect(await screen.findByText('Disabled')).toBeTruthy()
+    expect(screen.queryByText('Auto-approved')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Chat Tools' }))
+    expect(await screen.findByText('Auto-approved')).toBeTruthy()
+  })
+
+  it('stages a per-agent grant change from the expanded row', async () => {
+    api.getConfig.mockResolvedValue(makeConfig({
+      mochi: { extraMcpServers: [{ name: 'extra-b', agents: ['chat'], autoApprove: [], disabledTools: [] }] },
+    }))
+    api.getMcpServers.mockResolvedValue([makeServer({ name: 'extra-b' })])
+    await mount()
+    openSection('MCP Servers')
+
+    fireEvent.click(await screen.findByRole('button', { expanded: false }))
+    const [chatToggle, bgToggle] = await screen.findAllByRole('switch')
+    expect(chatToggle.getAttribute('aria-checked')).toBe('true')
+    expect(bgToggle.getAttribute('aria-checked')).toBe('false')
+
+    fireEvent.keyDown(bgToggle, { key: 'Enter' })
+    expect(await screen.findByText('Chat + BG')).toBeTruthy()
+
+    fireEvent.click(screen.getAllByRole('switch')[0])
+    expect(await screen.findByText('BG only')).toBeTruthy()
+    expect(saveButton().disabled).toBe(false)
+  })
+
+  it('translates a discover failure code and keeps the last good tool list on screen', async () => {
+    api.getMcpServers.mockResolvedValue([makeServer({
+      name: 'mochi:self',
+      core: true,
+      chatPolicy: { autoApprove: [], disabledTools: [] },
+      bgPolicy: { autoApprove: [], disabledTools: [] },
+    })])
+    api.discoverMcpTools.mockResolvedValue({ tools: [{ name: 'read_file' }], fromCache: false })
+    await mount()
+    openSection('MCP Servers')
+
+    fireEvent.click(await screen.findByRole('button', { expanded: false }))
+    expect(await screen.findByText('Needs approval')).toBeTruthy()
+
+    api.discoverMcpTools.mockResolvedValue({ tools: [], fromCache: false, errorCode: 'server_disabled' })
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh Tools' }))
+
+    expect(await screen.findByText(/This server is disabled/)).toBeTruthy()
+    // The error ADDS to the view; it must not wipe the chips already there.
+    expect(screen.getByText('Needs approval')).toBeTruthy()
+  })
+
+  it('falls back to one generic line for an unmapped failure code', async () => {
+    api.getMcpServers.mockResolvedValue([makeServer({ name: 'mochi:self', core: true })])
+    api.discoverMcpTools.mockResolvedValue({ tools: [], fromCache: false, errorCode: 'http_405' })
+    await mount()
+    openSection('MCP Servers')
+
+    fireEvent.click(await screen.findByRole('button', { expanded: false }))
+    expect(await screen.findByText(/Couldn't load tools/)).toBeTruthy()
+  })
+
+  it('reports no tools when the probe returns nothing at all', async () => {
+    api.getMcpServers.mockResolvedValue([makeServer({ name: 'mochi:self', core: true })])
+    api.discoverMcpTools.mockResolvedValue(null)
+    await mount()
+    openSection('MCP Servers')
+
+    fireEvent.click(await screen.findByRole('button', { expanded: false }))
+    expect(await screen.findByText('No tools discovered. Click Refresh Tools.')).toBeTruthy()
+  })
+
+  it('survives a throwing probe without leaving the button stuck', async () => {
+    api.getMcpServers.mockResolvedValue([makeServer({ name: 'mochi:self', core: true })])
+    api.discoverMcpTools.mockRejectedValue(new Error('boom'))
+    await mount()
+    openSection('MCP Servers')
+
+    fireEvent.click(await screen.findByRole('button', { expanded: false }))
+    const refresh = await screen.findByRole('button', { name: 'Refresh Tools' })
+    await waitFor(() => expect((refresh as HTMLButtonElement).disabled).toBe(false))
+  })
+
+  it.each([
+    ['normal', /Trust is Normal/],
+    ['trust_reads', /Trust is Read/],
+    ['trust', /Trust all tools is on/],
+    ['yolo', /YOLO is on/],
+  ] as const)('states the effective approval posture for %s', async (level, matcher) => {
+    api.getMochiTrustLevel.mockResolvedValue(level)
+    api.getMcpServers.mockResolvedValue([makeServer({ name: 'mochi:self', core: true })])
+    await mount()
+    openSection('MCP Servers')
+
+    expect(await screen.findByText(matcher)).toBeTruthy()
+  })
+})
+
+/* ── trust ────────────────────────────────────────────────────── */
+
+describe('SettingsPanel trust section', () => {
+  it('stages a slot trust change and writes it only on Save', async () => {
+    await mount()
+    openSection('Trust')
+
+    clickRow('Read')
+    expect(saveButton().disabled).toBe(false)
+    expect(api.setMochiTrustLevel).not.toHaveBeenCalled()
+
+    fireEvent.click(saveButton())
+    await waitFor(() => expect(api.setMochiTrustLevel).toHaveBeenCalledWith('trust_reads'))
+  })
+
+  it('does not offer yolo, but says so truthfully when the slot is already in it', async () => {
+    api.getMochiTrustLevel.mockResolvedValue('yolo')
+    await mount()
+    openSection('Trust')
+
+    expect(await screen.findByText(/YOLO \(auto-approve everything\) is active/)).toBeTruthy()
+    expect(screen.queryByText('YOLO')).toBeNull()
+    // Reading a level it cannot set must not read as a pending change.
+    expect(saveButton().disabled).toBe(true)
+  })
+})
+
+/* ── instances ────────────────────────────────────────────────── */
+
+describe('SettingsPanel instances section', () => {
+  it('says the picker needs the desktop app instead of rendering a dead control', async () => {
+    api.hasShell = false
+    await mount()
+    openSection('Instances')
+
+    expect(screen.getByText(/needs the desktop app/)).toBeTruthy()
+    expect(screen.queryByText(/^instance:/)).toBeNull()
+  })
+
+  it('hands the current pointer to the picker and stages what comes back', async () => {
+    await mount()
+    openSection('Instances')
+
+    expect(screen.getByText('instance:self')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'pick remote' }))
+    expect(screen.getByText('instance:remote-1')).toBeTruthy()
+    expect(saveButton().disabled).toBe(false)
+  })
+})
+
+/* ── shortcuts ────────────────────────────────────────────────── */
+
+describe('SettingsPanel shortcuts section', () => {
+  it('says the recorder needs the desktop app when there is no shell to bind in', async () => {
+    api.hasShell = false
+    await mount()
+    openSection('Shortcuts')
+
+    expect(screen.getByText(/Changing the global shortcuts needs the desktop app/)).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Record a shortcut' })).toBeNull()
+  })
+
+  it('renders the stored accelerator as one chip per key', async () => {
+    await mount()
+    openSection('Shortcuts')
+
+    // 'CommandOrControl+Shift+X' — the leading glyph is platform-resolved, the
+    // rest is not, so the platform-independent part is what gets asserted.
+    const capture = screen.getByText('Screen Capture').parentElement as HTMLElement
+    const chips = [...within(capture).getAllByText(/^(Shift|X|⌘|Ctrl)$/)].map((n) => n.textContent)
+    expect(chips).toContain('Shift')
+    expect(chips).toContain('X')
+  })
+
+  it('records a chord and stores it in canonical modifier order', async () => {
+    await mount()
+    openSection('Shortcuts')
+
+    const [record] = screen.getAllByRole('button', { name: 'Record a shortcut' })
+    fireEvent.click(record)
+    expect(screen.getByText('Press keys...')).toBeTruthy()
+
+    // Pressed rest-first on purpose: the stored string must be a function of the
+    // chord, not of typing order.
+    fireEvent.keyDown(window, { key: 'k' })
+    fireEvent.keyDown(window, { key: 'Shift' })
+    fireEvent.keyDown(window, { key: 'Control' })
+    fireEvent.keyUp(window, { key: 'Control' })
+
+    expect(screen.queryByText('Press keys...')).toBeNull()
+    const capture = screen.getByText('Screen Capture').parentElement as HTMLElement
+    expect(within(capture).getByText('Shift')).toBeTruthy()
+    expect(within(capture).getByText('K')).toBeTruthy()
+    expect(saveButton().disabled).toBe(false)
+
+    fireEvent.click(saveButton())
+    await waitFor(() => expect(api.applyShortcuts).toHaveBeenCalled())
+    expect(api.applyShortcuts.mock.calls[0][0]).toMatchObject({
+      screenCapture: 'CommandOrControl+Shift+K',
+    })
+  })
+
+  it('refuses a modifier-only chord and says what is missing', async () => {
+    await mount()
+    openSection('Shortcuts')
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Record a shortcut' })[0])
+    fireEvent.keyDown(window, { key: 'Shift' })
+    fireEvent.keyUp(window, { key: 'Shift' })
+
+    expect(screen.getByText('Need a non-modifier key')).toBeTruthy()
+    expect(saveButton().disabled).toBe(true)
+  })
+
+  it('refuses two non-modifier keys', async () => {
+    await mount()
+    openSection('Shortcuts')
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Record a shortcut' })[0])
+    fireEvent.keyDown(window, { key: 'Shift' })
+    fireEvent.keyDown(window, { key: 'a' })
+    fireEvent.keyDown(window, { key: 'b' })
+    fireEvent.keyUp(window, { key: 'Shift' })
+
+    expect(screen.getByText('Only one non-modifier key allowed')).toBeTruthy()
+  })
+
+  it('refuses a lone non-modifier key', async () => {
+    await mount()
+    openSection('Shortcuts')
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Record a shortcut' })[0])
+    fireEvent.keyDown(window, { key: 'q' })
+    fireEvent.keyUp(window, { key: 'q' })
+
+    expect(screen.getByText('Invalid combo')).toBeTruthy()
+  })
+
+  it('caps a chord at three keys, ignoring anything pressed after', async () => {
+    await mount()
+    openSection('Shortcuts')
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Record a shortcut' })[0])
+    fireEvent.keyDown(window, { key: 'Control' })
+    fireEvent.keyDown(window, { key: 'Shift' })
+    fireEvent.keyDown(window, { key: 'Alt' })
+    fireEvent.keyDown(window, { key: 'z' })
+    fireEvent.keyUp(window, { key: 'Control' })
+
+    // Three modifiers and no key: the 4th press was dropped, so it is refused.
+    expect(screen.getByText('Need a non-modifier key')).toBeTruthy()
+  })
+
+  it('cancels a recording and leaves the stored accelerator alone', async () => {
+    await mount()
+    openSection('Shortcuts')
+
+    const [record] = screen.getAllByRole('button', { name: 'Record a shortcut' })
+    fireEvent.click(record)
+    fireEvent.keyDown(window, { key: 'Control' })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Cancel' })[0])
+
+    expect(screen.queryByText('Press keys...')).toBeNull()
+    // Cancel is a no-op on the value, so nothing is pending.
+    expect(saveButton().disabled).toBe(true)
+    // …and a key pressed after cancelling is not captured.
+    fireEvent.keyDown(window, { key: 'j' })
+    expect(saveButton().disabled).toBe(true)
+  })
+
+  it('offers the other two accelerators too, each independently editable', async () => {
+    await mount()
+    openSection('Shortcuts')
+
+    expect(screen.getByText('Toggle Window')).toBeTruthy()
+    const hideAll = screen.getByText('Hide All').parentElement as HTMLElement
+    fireEvent.click(within(hideAll).getByRole('button', { name: 'Record a shortcut' }))
+    fireEvent.keyDown(window, { key: 'Control' })
+    fireEvent.keyDown(window, { key: 'j' })
+    fireEvent.keyUp(window, { key: 'Control' })
+
+    fireEvent.click(saveButton())
+    await waitFor(() => expect(api.applyShortcuts).toHaveBeenCalled())
+    expect(api.applyShortcuts.mock.calls[0][0]).toMatchObject({
+      hideAll: 'CommandOrControl+J',
+      screenCapture: 'CommandOrControl+Shift+X',
+    })
+  })
+})
+
+/* ── about ────────────────────────────────────────────────────── */
+
+describe('SettingsPanel about section', () => {
+  it('opens the author link through the shell, by click and by keyboard', async () => {
+    await mount()
+    openSection('About')
+
+    expect(screen.getByText(/is a desktop companion built into Kiro Crew/)).toBeTruthy()
+    const link = screen.getByRole('link', { name: 'buluoray' })
+
+    fireEvent.click(link)
+    expect(api.openExternal).toHaveBeenCalledWith('https://github.com/buluoray')
+
+    fireEvent.keyDown(link, { key: 'Enter' })
+    expect(api.openExternal).toHaveBeenCalledTimes(2)
+    fireEvent.keyDown(link, { key: 'a' })
+    expect(api.openExternal).toHaveBeenCalledTimes(2)
+  })
+
+  it('underlines the link on hover only', async () => {
+    await mount()
+    openSection('About')
+
+    const link = screen.getByRole('link', { name: 'buluoray' })
+    fireEvent.mouseEnter(link)
+    expect(link.style.textDecoration).toBe('underline')
+    fireEvent.mouseLeave(link)
+    expect(link.style.textDecoration).toBe('none')
+  })
+})
+
+/* ── save ─────────────────────────────────────────────────────── */
+
+describe('SettingsPanel save', () => {
+  it('writes the config, binds the accelerators, then closes', async () => {
+    await mount()
+    fireEvent.change(screen.getByDisplayValue('Mochi'), { target: { value: 'Tofu' } })
+    fireEvent.click(saveButton())
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+    expect(api.updateConfig).toHaveBeenCalledTimes(1)
+    expect((api.updateConfig.mock.calls[0][0] as AppConfig).mochi.petName).toBe('Tofu')
+    expect(api.applyShortcuts).toHaveBeenCalledTimes(1)
+    // Trust did not change, so the slot must not be written.
+    expect(api.setMochiTrustLevel).not.toHaveBeenCalled()
+    // The baseline is committed, so there is nothing left to save.
+    expect(saveButton().disabled).toBe(true)
+  })
+
+  it('leaves the pointer alone when the instance did not change', async () => {
+    await mount()
+    fireEvent.change(screen.getByDisplayValue('Mochi'), { target: { value: 'Tofu' } })
+    fireEvent.click(saveButton())
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(api.setPetInstance).not.toHaveBeenCalled()
+  })
+
+  it('reveals the refusal and stays dirty when the OS already owns the key', async () => {
+    api.applyShortcuts.mockResolvedValue({ screenCapture: false, toggleWindow: true })
+    await mount()
+    fireEvent.change(screen.getByDisplayValue('Mochi'), { target: { value: 'Tofu' } })
+    fireEvent.click(saveButton())
+
+    // Save is global but the message renders under Shortcuts, so the panel must
+    // move there rather than refusing to close with no visible reason.
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toMatch(/Another app already owns this key: screenCapture/)
+    expect(onClose).not.toHaveBeenCalled()
+    // A refused key really was not stored, so it stays pending for the user.
+    expect(saveButton().disabled).toBe(false)
+  })
+
+  it('clears a stale refusal once the keys bind', async () => {
+    api.applyShortcuts.mockResolvedValue({ screenCapture: false })
+    await mount()
+    fireEvent.change(screen.getByDisplayValue('Mochi'), { target: { value: 'Tofu' } })
+    fireEvent.click(saveButton())
+    expect(await screen.findByRole('alert')).toBeTruthy()
+
+    api.applyShortcuts.mockResolvedValue({ screenCapture: true })
+    fireEvent.click(saveButton())
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('moves the pet through the shell when the instance changed', async () => {
+    await mount()
+    openSection('Instances')
+    fireEvent.click(screen.getByRole('button', { name: 'pick remote' }))
+    fireEvent.click(saveButton())
+
+    await waitFor(() => expect(api.setPetInstance).toHaveBeenCalledWith('remote-1'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a declined switch, keeps the panel open, and still commits the baseline', async () => {
+    api.setPetInstance.mockResolvedValue(false)
+    await mount()
+    openSection('Instances')
+    fireEvent.click(screen.getByRole('button', { name: 'pick remote' }))
+    fireEvent.click(saveButton())
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toMatch(/Could not switch instance right now/)
+    expect(onClose).not.toHaveBeenCalled()
+    // The shell already stored the pointer, so offering a Discard that resets the
+    // field while the pet still moves later would be worse than reporting it.
+    expect(saveButton().disabled).toBe(true)
+    // Everything before the switch still landed.
+    expect(api.updateConfig).toHaveBeenCalledTimes(1)
+  })
+
+  it('orders the accelerator bind before the instance switch', async () => {
+    const order: string[] = []
+    api.applyShortcuts.mockImplementation(async () => { order.push('shortcuts'); return {} })
+    api.setPetInstance.mockImplementation(async () => { order.push('instance'); return true })
+    await mount()
+    openSection('Instances')
+    fireEvent.click(screen.getByRole('button', { name: 'pick remote' }))
+    fireEvent.click(saveButton())
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(order).toEqual(['shortcuts', 'instance'])
+  })
+})
+
+/* ── close / discard ──────────────────────────────────────────── */
+
+describe('SettingsPanel close', () => {
+  it('closes straight away when nothing was edited', async () => {
+    await mount()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText('Unsaved Changes')).toBeNull()
+  })
+
+  it('asks before dropping staged edits', async () => {
+    await mount()
+    fireEvent.change(screen.getByDisplayValue('Mochi'), { target: { value: 'Tofu' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.getByText('Unsaved Changes')).toBeTruthy()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('restores what was read when the edits are discarded', async () => {
+    await mount()
+    openSection('Trust')
+    clickRow('Read')
+    fireEvent.change(screen.getByRole('button', { name: 'General' }), {})
+    openSection('General')
+    fireEvent.change(screen.getByDisplayValue('Mochi'), { target: { value: 'Tofu' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Discard' }))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(api.updateConfig).not.toHaveBeenCalled()
+    expect(api.setMochiTrustLevel).not.toHaveBeenCalled()
+    expect(screen.getByDisplayValue('Mochi')).toBeTruthy()
+    expect(saveButton().disabled).toBe(true)
+  })
+
+  it('saves from the dialog instead, when that is what the user picks', async () => {
+    await mount()
+    fireEvent.change(screen.getByDisplayValue('Mochi'), { target: { value: 'Tofu' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    // The dialog's Save is the second one; the footer keeps the first.
+    fireEvent.click(screen.getAllByRole('button', { name: 'Save' })[1])
+
+    await waitFor(() => expect(api.updateConfig).toHaveBeenCalledTimes(1))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText('Unsaved Changes')).toBeNull()
+  })
+
+  it('treats the native window close the same as Cancel', async () => {
+    await mount()
+    fireEvent.change(screen.getByDisplayValue('Mochi'), { target: { value: 'Tofu' } })
+
+    mocks.requestClose()
+    expect(await screen.findByText('Unsaved Changes')).toBeTruthy()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('lets the native window close go through when nothing is pending', async () => {
+    await mount()
+    mocks.requestClose()
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+  })
+})

--- a/website/src/test/MochiWatchlistPanel.coverage.test.tsx
+++ b/website/src/test/MochiWatchlistPanel.coverage.test.tsx
@@ -1,0 +1,1010 @@
+// First coverage for Mochi's Watch List side panel — the list/detail rail that
+// owns every watch item the pet is tracking: the stale-while-revalidate load,
+// the active/recently-completed/earlier partition, per-item status actions, the
+// no-undo "clear completed" confirmation, the detail editor (notes, priority,
+// check interval with its min/hr/day unit selector), and the history timeline.
+//
+// Two things shape the style of this file:
+//
+//   1. The panel's only seam to the outside world is `api` in `mochiApi`, so
+//      that module is mocked and nothing here touches the network. The mock
+//      mirrors the preload's `onWatchlistChanged(cb) => off` subscription shape
+//      so the push path can be driven the way the main process drives it.
+//   2. The whole file runs on fake timers with a pinned system time. The panel
+//      computes `new Date()` on every render (every countdown and every
+//      relative timestamp is derived from it) and stages its view transitions
+//      and detail-mode status writes behind `setTimeout`. A frozen clock makes
+//      all of that assertable instead of a race, and matches the pattern
+//      MochiPetWidget.coverage.test.tsx already uses.
+//
+// Interactions go through `fireEvent`, not `userEvent`, so each step stays
+// synchronous against the same fake clock the timers are stepped on.
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HistoryEntry, WatchItem } from '../apps/mochi/src/shared/watchlistTypes'
+
+const mocks = vi.hoisted(() => {
+  type Listener = (items: unknown[]) => void
+  const listeners = new Set<Listener>()
+  const api = {
+    getWatchlist: vi.fn<() => Promise<WatchItem[]>>(),
+    setWatchItemStatus: vi.fn(),
+    updateWatchItem: vi.fn(),
+    clearCompletedWatchItems: vi.fn<() => Promise<boolean | undefined>>(),
+    /** Mirrors the preload's `onX(cb) => off` shape. */
+    onWatchlistChanged: vi.fn((cb: Listener) => {
+      listeners.add(cb)
+      return () => { listeners.delete(cb) }
+    }),
+  }
+  return {
+    api,
+    emit: (items: unknown[]) => { for (const cb of [...listeners]) cb(items) },
+    listenerCount: () => listeners.size,
+    clearListeners: () => listeners.clear(),
+  }
+})
+
+vi.mock('../apps/mochi/src/mochiApi', () => ({ api: mocks.api }))
+
+const {
+  WatchlistPanel,
+  formatCountdown,
+  formatStatusSummary,
+  buildEditPayload,
+  applyDataRefresh,
+  escapeNavigation,
+  EDITABLE_FIELD_KEYS,
+} = await import('../apps/mochi/src/renderer/WatchlistPanel')
+
+const api = mocks.api
+
+/** Frozen "now" for every test. Countdowns and relative times key off it. */
+const NOW = new Date('2026-03-10T12:00:00.000Z')
+const minutesFromNow = (m: number) => new Date(NOW.getTime() + m * 60_000).toISOString()
+const minutesAgo = (m: number) => new Date(NOW.getTime() - m * 60_000).toISOString()
+
+function makeItem(over: Partial<WatchItem> = {}): WatchItem {
+  return {
+    id: 'w-1',
+    label: 'Ticket price drop',
+    kind: 'url',
+    target: 'https://example.invalid/tickets',
+    status: 'watching',
+    priority: 'normal',
+    createdAt: minutesAgo(600),
+    nextCheckAfter: minutesFromNow(10),
+    checkCount: 4,
+    failCount: 0,
+    maxFailCount: 10,
+    maxWatchDurationHours: 168,
+    checkIntervalMins: 10,
+    notifyOnChange: true,
+    autoComplete: true,
+    source: 'chat',
+    history: [],
+    ...over,
+  }
+}
+
+/** Let the load promise settle and any staged timer fire. */
+async function tick(ms = 0): Promise<void> {
+  await act(async () => { await vi.advanceTimersByTimeAsync(ms) })
+}
+
+/** Mount with `items` already resolvable, then flush the initial load. */
+async function mountWith(
+  items: WatchItem[],
+  props: { petName?: string } = {},
+): Promise<{ onClose: ReturnType<typeof vi.fn> }> {
+  api.getWatchlist.mockResolvedValue(items)
+  const onClose = vi.fn()
+  render(<WatchlistPanel visible onClose={onClose} {...props} />)
+  await tick()
+  return { onClose }
+}
+
+/** The clickable row for `label` — the row itself carries role="button". */
+function row(label: string): HTMLElement {
+  const rows = screen.getAllByRole('button').filter(el => el.textContent?.includes(label))
+  const found = rows.find(el => el.getAttribute('tabindex') === '0')
+  if (!found) throw new Error(`no watch row for ${label}`)
+  return found
+}
+
+/** Open the detail view for `label` and let the 250ms view transition settle. */
+async function openDetail(label: string): Promise<void> {
+  fireEvent.click(row(label))
+  await tick(250)
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+  api.getWatchlist.mockReset()
+  api.getWatchlist.mockResolvedValue([])
+  api.setWatchItemStatus.mockReset()
+  api.updateWatchItem.mockReset()
+  api.clearCompletedWatchItems.mockReset()
+  api.clearCompletedWatchItems.mockResolvedValue(true)
+  api.onWatchlistChanged.mockClear()
+  mocks.clearListeners()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+// ── Pure helpers ───────────────────────────────────────────────────────────
+
+describe('formatCountdown', () => {
+  it('reports overdue once the target time has passed', () => {
+    expect(formatCountdown(minutesAgo(1), NOW)).toEqual({ kind: 'overdue' })
+  })
+
+  it('treats the exact boundary as overdue', () => {
+    expect(formatCountdown(NOW.toISOString(), NOW)).toEqual({ kind: 'overdue' })
+  })
+
+  it('rounds sub-hour gaps up to whole minutes', () => {
+    expect(formatCountdown(new Date(NOW.getTime() + 30_001).toISOString(), NOW))
+      .toEqual({ kind: 'mins', params: { mins: '1' } })
+    expect(formatCountdown(minutesFromNow(59), NOW))
+      .toEqual({ kind: 'mins', params: { mins: '59' } })
+  })
+
+  it('splits gaps of an hour or more into hours and remainder minutes', () => {
+    expect(formatCountdown(minutesFromNow(60), NOW))
+      .toEqual({ kind: 'hours', params: { hours: '1', mins: '0' } })
+    expect(formatCountdown(minutesFromNow(150), NOW))
+      .toEqual({ kind: 'hours', params: { hours: '2', mins: '30' } })
+  })
+})
+
+describe('formatStatusSummary', () => {
+  it('appends the last result when there is one', () => {
+    expect(formatStatusSummary(makeItem({ lastResult: 'still $420' })))
+      .toBe('Watching — still $420')
+  })
+
+  it('falls back to the status name alone', () => {
+    expect(formatStatusSummary(makeItem({ status: 'triggered' }))).toBe('Triggered')
+  })
+})
+
+describe('buildEditPayload', () => {
+  it('keeps only the three editable fields', () => {
+    expect(buildEditPayload({
+      notes: 'n', priority: 'high', checkIntervalMins: 30,
+      // A field the panel never edits must not reach the bridge.
+      label: 'hijacked', status: 'done',
+    } as never)).toEqual({ notes: 'n', priority: 'high', checkIntervalMins: 30 })
+  })
+
+  it('drops explicitly-undefined values and returns {} for an empty draft', () => {
+    expect(buildEditPayload({ notes: undefined, priority: 'low' })).toEqual({ priority: 'low' })
+    expect(buildEditPayload({})).toEqual({})
+  })
+
+  it('publishes the editable key set', () => {
+    expect([...EDITABLE_FIELD_KEYS].sort()).toEqual(['checkIntervalMins', 'notes', 'priority'])
+  })
+})
+
+describe('applyDataRefresh', () => {
+  it('drops the selection and the draft when the selected item is gone', () => {
+    expect(applyDataRefresh([makeItem({ id: 'w-2' })], 'w-1', { notes: 'draft' }))
+      .toEqual({ selectedItemId: null, editDraft: null })
+  })
+
+  it('preserves the selection and the draft when the item survives', () => {
+    const draft = { notes: 'draft' }
+    expect(applyDataRefresh([makeItem({ id: 'w-1' })], 'w-1', draft))
+      .toEqual({ selectedItemId: 'w-1', editDraft: draft })
+  })
+
+  it('is a no-op when nothing is selected', () => {
+    expect(applyDataRefresh([], null, null)).toEqual({ selectedItemId: null, editDraft: null })
+  })
+})
+
+describe('escapeNavigation', () => {
+  it('unwinds detail → list before closing the panel', () => {
+    expect(escapeNavigation('w-1')).toEqual({ action: 'to-list' })
+    expect(escapeNavigation(null)).toEqual({ action: 'close' })
+  })
+})
+
+// ── Shell + load ───────────────────────────────────────────────────────────
+
+describe('WatchlistPanel shell', () => {
+  it('renders nothing while hidden, and does not subscribe or fetch', () => {
+    const { container } = render(<WatchlistPanel visible={false} onClose={vi.fn()} />)
+    expect(container.firstChild).toBeNull()
+    expect(api.getWatchlist).not.toHaveBeenCalled()
+    expect(api.onWatchlistChanged).not.toHaveBeenCalled()
+  })
+
+  it('shows the loading placeholder until the first payload arrives', async () => {
+    let resolve: (items: WatchItem[]) => void = () => {}
+    api.getWatchlist.mockReturnValue(new Promise<WatchItem[]>(r => { resolve = r }))
+    render(<WatchlistPanel visible onClose={vi.fn()} />)
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+
+    await act(async () => { resolve([makeItem()]) })
+    expect(screen.queryByText('Loading…')).not.toBeInTheDocument()
+    expect(screen.getByText('Ticket price drop')).toBeInTheDocument()
+  })
+
+  it('falls back to the empty state when the load rejects', async () => {
+    api.getWatchlist.mockRejectedValue(new Error('bridge down'))
+    render(<WatchlistPanel visible onClose={vi.fn()} />)
+    await tick()
+    expect(screen.getByText('No items being watched')).toBeInTheDocument()
+  })
+
+  it('treats a null payload as an empty list and names the pet in the hint', async () => {
+    api.getWatchlist.mockResolvedValue(null as unknown as WatchItem[])
+    render(<WatchlistPanel visible onClose={vi.fn()} petName="Momo" />)
+    await tick()
+    expect(screen.getByText('No items being watched')).toBeInTheDocument()
+    expect(screen.getByText('Ask Momo to watch a price, a delivery, or a web page'))
+      .toBeInTheDocument()
+  })
+
+  it('falls back to the default pet name when none is given', async () => {
+    await mountWith([])
+    expect(screen.getByText(/^Ask \S+ to watch a price/)).toBeInTheDocument()
+  })
+
+  it('badges the active count and hides the badge when nothing is active', async () => {
+    await mountWith([
+      makeItem({ id: 'w-1' }),
+      makeItem({ id: 'w-2', label: 'Second' }),
+      makeItem({ id: 'w-3', label: 'Finished', status: 'done', completedAt: minutesAgo(5) }),
+    ])
+    const header = screen.getByText('Watch List').parentElement as HTMLElement
+    expect(within(header).getByText('2')).toBeInTheDocument()
+
+    cleanup()
+    await mountWith([makeItem({ status: 'cancelled', completedAt: minutesAgo(5) })])
+    const soloHeader = screen.getByText('Watch List').parentElement as HTMLElement
+    expect(within(soloHeader).queryByText('1')).not.toBeInTheDocument()
+  })
+
+  it('discards an in-flight load when the panel is closed before it lands', async () => {
+    let resolve: (items: WatchItem[]) => void = () => {}
+    api.getWatchlist.mockReturnValue(new Promise<WatchItem[]>(r => { resolve = r }))
+    const { rerender } = render(<WatchlistPanel visible onClose={vi.fn()} />)
+    rerender(<WatchlistPanel visible={false} onClose={vi.fn()} />)
+    await act(async () => { resolve([makeItem()]) })
+
+    // Re-opening refetches rather than showing what the cancelled load carried.
+    api.getWatchlist.mockResolvedValue([makeItem({ label: 'Fresh item' })])
+    rerender(<WatchlistPanel visible onClose={vi.fn()} />)
+    await tick()
+    expect(screen.getByText('Fresh item')).toBeInTheDocument()
+    expect(screen.queryByText('Ticket price drop')).not.toBeInTheDocument()
+  })
+
+  it('discards a rejected load when the panel is already closed', async () => {
+    let reject: (e: Error) => void = () => {}
+    api.getWatchlist.mockReturnValue(new Promise<WatchItem[]>((_, r) => { reject = r }))
+    const { rerender } = render(<WatchlistPanel visible onClose={vi.fn()} />)
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+    rerender(<WatchlistPanel visible={false} onClose={vi.fn()} />)
+    await act(async () => { reject(new Error('bridge down')) })
+    expect(screen.queryByText('No items being watched')).not.toBeInTheDocument()
+  })
+
+  it('closes on the header close button', async () => {
+    const { onClose } = await mountWith([])
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('unsubscribes from the change feed on unmount', async () => {
+    await mountWith([])
+    expect(mocks.listenerCount()).toBe(1)
+    cleanup()
+    expect(mocks.listenerCount()).toBe(0)
+  })
+})
+
+// ── List mode ──────────────────────────────────────────────────────────────
+
+describe('WatchlistPanel list mode', () => {
+  it('renders label, countdown, kind pill and status summary', async () => {
+    await mountWith([makeItem({
+      nextCheckAfter: minutesFromNow(150), lastResult: 'still $420',
+    })])
+    expect(screen.getByText('Ticket price drop')).toBeInTheDocument()
+    expect(screen.getByText('2h 30m left')).toBeInTheDocument()
+    expect(screen.getByText('Web page')).toBeInTheDocument()
+    expect(screen.getByText('Watching — still $420')).toBeInTheDocument()
+  })
+
+  it('renders an overdue countdown for a check that is due', async () => {
+    await mountWith([makeItem({ nextCheckAfter: minutesAgo(3) })])
+    expect(screen.getByText('Checking soon')).toBeInTheDocument()
+  })
+
+  it('renders minute countdowns and omits the countdown when there is no next check', async () => {
+    await mountWith([
+      makeItem({ id: 'w-1', nextCheckAfter: minutesFromNow(12) }),
+      makeItem({ id: 'w-2', label: 'No schedule', nextCheckAfter: '' }),
+    ])
+    expect(screen.getByText('12m left')).toBeInTheDocument()
+    expect(within(row('No schedule')).queryByText(/left|Checking soon/)).not.toBeInTheDocument()
+  })
+
+  it('completes an item: writes through the bridge and drops it from the active count', async () => {
+    await mountWith([makeItem()])
+    fireEvent.click(screen.getByRole('button', { name: 'Complete' }))
+    expect(api.setWatchItemStatus).toHaveBeenCalledWith('w-1', 'done')
+
+    const header = screen.getByText('Watch List').parentElement as HTMLElement
+    expect(within(header).queryByText('1')).not.toBeInTheDocument()
+    // Terminal now, so its own actions are gone and it hides behind the toggle.
+    expect(screen.queryByRole('button', { name: 'Complete' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show completed (1)' })).toBeInTheDocument()
+  })
+
+  it('cancels an item through the bridge, touching only that item', async () => {
+    await mountWith([
+      makeItem({ id: 'w-1' }),
+      makeItem({ id: 'w-2', label: 'Sibling' }),
+    ])
+    fireEvent.click(within(row('Ticket price drop')).getByRole('button', { name: 'Stop watching' }))
+    expect(api.setWatchItemStatus).toHaveBeenCalledWith('w-1', 'cancelled')
+    expect(screen.getByRole('button', { name: 'Show completed (1)' })).toBeInTheDocument()
+    // The sibling is still active, so its own actions survive.
+    expect(within(row('Sibling')).getByRole('button', { name: 'Complete' })).toBeInTheDocument()
+  })
+
+  it('partitions completed items into recent and earlier, and toggles them', async () => {
+    await mountWith([
+      makeItem({ id: 'w-1', label: 'Active one' }),
+      makeItem({ id: 'w-2', label: 'Just done', status: 'done', completedAt: minutesAgo(30) }),
+      makeItem({ id: 'w-3', label: 'Old done', status: 'done', completedAt: minutesAgo(60 * 30) }),
+      // No completedAt at all still counts as "earlier".
+      makeItem({ id: 'w-4', label: 'Undated fail', status: 'failed' }),
+    ])
+    expect(screen.queryByText('Just done')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (3)' }))
+    expect(screen.getByText('Recently completed')).toBeInTheDocument()
+    expect(screen.getByText('Just done')).toBeInTheDocument()
+    expect(screen.getByText('Earlier')).toBeInTheDocument()
+    expect(screen.getByText('Old done')).toBeInTheDocument()
+    expect(screen.getByText('Undated fail')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide completed' }))
+    expect(screen.queryByText('Recently completed')).not.toBeInTheDocument()
+    expect(screen.queryByText('Just done')).not.toBeInTheDocument()
+  })
+
+  it('omits the section heading a partition has no members for', async () => {
+    await mountWith([
+      makeItem({ id: 'w-2', label: 'Just done', status: 'done', completedAt: minutesAgo(30) }),
+    ])
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }))
+    expect(screen.getByText('Recently completed')).toBeInTheDocument()
+    expect(screen.queryByText('Earlier')).not.toBeInTheDocument()
+  })
+
+  it('offers Reopen on a completed watch, but not on a completed reminder', async () => {
+    await mountWith([
+      makeItem({ id: 'w-1', label: 'Done watch', status: 'done', completedAt: minutesAgo(5) }),
+      makeItem({
+        id: 'w-2', label: 'Done reminder', kind: 'reminder',
+        status: 'done', completedAt: minutesAgo(5),
+      }),
+      makeItem({
+        id: 'w-3', label: 'Done meeting', kind: 'meeting',
+        status: 'done', completedAt: minutesAgo(5),
+      }),
+    ])
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (3)' }))
+    expect(within(row('Done reminder')).queryByRole('button', { name: 'Reopen' })).toBeNull()
+    expect(within(row('Done meeting')).queryByRole('button', { name: 'Reopen' })).toBeNull()
+
+    fireEvent.click(within(row('Done watch')).getByRole('button', { name: 'Reopen' }))
+    expect(api.setWatchItemStatus).toHaveBeenCalledWith('w-1', 'watching')
+    // Reopened items rejoin the active list, so only two remain completed.
+    expect(screen.getByRole('button', { name: 'Hide completed' })).toBeInTheDocument()
+    expect(within(row('Done watch')).getByRole('button', { name: 'Complete' })).toBeInTheDocument()
+  })
+
+  it('does not open the detail view when a row action is clicked', async () => {
+    await mountWith([makeItem()])
+    fireEvent.click(screen.getByRole('button', { name: 'Complete' }))
+    await tick(250)
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument()
+  })
+
+  it('opens the detail view from the keyboard with Enter and Space', async () => {
+    await mountWith([makeItem()])
+    fireEvent.keyDown(row('Ticket price drop'), { key: 'Enter' })
+    await tick(250)
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    await tick(250)
+    fireEvent.keyDown(row('Ticket price drop'), { key: ' ' })
+    await tick(250)
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument()
+  })
+
+  it('ignores other keys on a row', async () => {
+    await mountWith([makeItem()])
+    fireEvent.keyDown(row('Ticket price drop'), { key: 'a' })
+    await tick(250)
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument()
+  })
+
+  it('does not open the detail view from a keystroke inside the action strip', async () => {
+    await mountWith([
+      makeItem({ id: 'w-1' }),
+      makeItem({ id: 'w-2', label: 'Done one', status: 'done', completedAt: minutesAgo(5) }),
+    ])
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }))
+
+    // The action strip is revealed on hover/focus-within and swallows key events,
+    // so Enter on a revealed button must not also select the row behind it.
+    for (const label of ['Ticket price drop', 'Done one']) {
+      const strip = row(label).querySelector('.wl-actions') as HTMLElement
+      fireEvent.keyDown(strip, { key: 'Enter' })
+      await tick(250)
+      expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument()
+    }
+  })
+
+  it('brightens the close button on hover', async () => {
+    await mountWith([])
+    const close = screen.getByRole('button', { name: 'Close' })
+    expect(close.style.opacity).toBe('0.6')
+    fireEvent.mouseEnter(close)
+    expect(close.style.opacity).toBe('1')
+    fireEvent.mouseLeave(close)
+    expect(close.style.opacity).toBe('0.6')
+  })
+})
+
+// ── Clear completed ────────────────────────────────────────────────────────
+
+describe('WatchlistPanel clear completed', () => {
+  const seed = () => [
+    makeItem({ id: 'w-1', label: 'Active one' }),
+    makeItem({ id: 'w-2', label: 'Done one', status: 'done', completedAt: minutesAgo(30) }),
+    makeItem({ id: 'w-3', label: 'Done two', status: 'cancelled', completedAt: minutesAgo(40) }),
+  ]
+
+  async function openConfirm(): Promise<HTMLElement> {
+    await mountWith(seed())
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (2)' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Clear all completed' }))
+    return screen.getByRole('dialog')
+  }
+
+  it('states the count before deleting anything', async () => {
+    const dialog = await openConfirm()
+    expect(within(dialog).getByText('Clear completed?')).toBeInTheDocument()
+    expect(within(dialog).getByText('Deletes 2 completed item(s). This cannot be undone.'))
+      .toBeInTheDocument()
+    expect(api.clearCompletedWatchItems).not.toHaveBeenCalled()
+  })
+
+  it('keeps everything when the confirmation is declined', async () => {
+    const dialog = await openConfirm()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Keep them' }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(api.clearCompletedWatchItems).not.toHaveBeenCalled()
+    expect(screen.getByText('Done one')).toBeInTheDocument()
+  })
+
+  it('shows a working state, then drops the completed items and re-collapses', async () => {
+    let resolve: (ok: boolean) => void = () => {}
+    api.clearCompletedWatchItems.mockReturnValue(new Promise<boolean>(r => { resolve = r }))
+    const dialog = await openConfirm()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Clear' }))
+
+    const working = within(screen.getByRole('dialog')).getByRole('button', { name: 'Clearing…' })
+    expect(working).toBeDisabled()
+
+    await act(async () => { resolve(true) })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.queryByText('Done one')).not.toBeInTheDocument()
+    expect(screen.getByText('Active one')).toBeInTheDocument()
+    // Nothing terminal is left, so neither toggle survives.
+    expect(screen.queryByRole('button', { name: /completed/ })).not.toBeInTheDocument()
+  })
+
+  it('keeps the items on screen when the bridge rejects the delete', async () => {
+    api.clearCompletedWatchItems.mockResolvedValue(false)
+    const dialog = await openConfirm()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Clear' }))
+    await tick()
+
+    const failed = screen.getByRole('dialog')
+    expect(within(failed).getByText('Could not clear them. Nothing was deleted — try again.'))
+      .toBeInTheDocument()
+    expect(within(failed).queryByRole('button', { name: 'Clear' })).toBeNull()
+    expect(screen.getByText('Done one')).toBeInTheDocument()
+
+    fireEvent.click(within(failed).getByRole('button', { name: 'Close' }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getByText('Done one')).toBeInTheDocument()
+  })
+
+  it('clears on an undefined result, treating only an explicit false as failure', async () => {
+    api.clearCompletedWatchItems.mockResolvedValue(undefined)
+    const dialog = await openConfirm()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Clear' }))
+    await tick()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.queryByText('Done one')).not.toBeInTheDocument()
+  })
+})
+
+// ── Escape handling ────────────────────────────────────────────────────────
+
+describe('WatchlistPanel escape handling', () => {
+  const esc = () => fireEvent.keyDown(window, { key: 'Escape' })
+
+  it('closes the panel from list mode', async () => {
+    const { onClose } = await mountWith([makeItem()])
+    esc()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('unwinds detail mode to the list instead of closing', async () => {
+    const { onClose } = await mountWith([makeItem()])
+    await openDetail('Ticket price drop')
+    esc()
+    await tick(250)
+    expect(onClose).not.toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Complete' })).toBeInTheDocument()
+  })
+
+  it('consumes the keystroke for the confirm overlay without closing the panel', async () => {
+    const { onClose } = await mountWith([
+      makeItem({ id: 'w-2', label: 'Done one', status: 'done', completedAt: minutesAgo(5) }),
+    ])
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Clear all completed' }))
+    esc()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('consumes the keystroke for the failure overlay too', async () => {
+    api.clearCompletedWatchItems.mockResolvedValue(false)
+    const { onClose } = await mountWith([
+      makeItem({ id: 'w-2', label: 'Done one', status: 'done', completedAt: minutesAgo(5) }),
+    ])
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Clear all completed' }))
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Clear' }))
+    await tick()
+    esc()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('ignores keys other than Escape', async () => {
+    const { onClose } = await mountWith([makeItem()])
+    fireEvent.keyDown(window, { key: 'Enter' })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})
+
+// ── Push updates ───────────────────────────────────────────────────────────
+
+describe('WatchlistPanel change feed', () => {
+  it('replaces the list when the bridge pushes new data', async () => {
+    await mountWith([makeItem()])
+    await act(async () => {
+      mocks.emit([makeItem({ id: 'w-9', label: 'Pushed item' })])
+    })
+    expect(screen.getByText('Pushed item')).toBeInTheDocument()
+    expect(screen.queryByText('Ticket price drop')).not.toBeInTheDocument()
+  })
+
+  it('treats a null push as an empty list', async () => {
+    await mountWith([makeItem()])
+    await act(async () => { mocks.emit(null as unknown as unknown[]) })
+    expect(screen.getByText('No items being watched')).toBeInTheDocument()
+  })
+
+  it('returns to the list when the open item disappears from the push', async () => {
+    await mountWith([makeItem()])
+    await openDetail('Ticket price drop')
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument()
+
+    await act(async () => { mocks.emit([makeItem({ id: 'w-2', label: 'Something else' })]) })
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument()
+    expect(screen.getByText('Something else')).toBeInTheDocument()
+  })
+
+  it('keeps the open item when it survives the push', async () => {
+    await mountWith([makeItem()])
+    await openDetail('Ticket price drop')
+    await act(async () => {
+      mocks.emit([makeItem({ lastResult: 'now $380' }), makeItem({ id: 'w-2', label: 'Other' })])
+    })
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument()
+    expect(screen.getByText('now $380')).toBeInTheDocument()
+  })
+})
+
+// ── Detail mode ────────────────────────────────────────────────────────────
+
+describe('WatchlistPanel detail mode', () => {
+  it('renders the label, the kind/status/priority pills and the next-check block', async () => {
+    await mountWith([makeItem({
+      priority: 'high', nextCheckAfter: minutesFromNow(45), lastResult: 'still $420',
+    })])
+    await openDetail('Ticket price drop')
+
+    // The meta row is kind / status / priority, in that order. Scoped to the row
+    // because the priority select repeats every priority name as an <option>.
+    const pills = screen.getByText('Web page').parentElement as HTMLElement
+    expect([...pills.children].map(c => c.textContent)).toEqual(['Web page', 'Watching', 'High'])
+    expect(screen.getByText('Next Check')).toBeInTheDocument()
+    expect(screen.getByText('45m left')).toBeInTheDocument()
+    // Same-day target: a clock time, and no date suffix.
+    const timeRow = screen.getByText('45m left').parentElement as HTMLElement
+    const stamp = (timeRow.children[1] as HTMLElement).textContent ?? ''
+    expect(stamp).toMatch(/^\d{1,2}:\d{2}/)
+    expect(stamp).not.toContain('·')
+  })
+
+  it('appends the date when the next check is not today', async () => {
+    await mountWith([makeItem({ nextCheckAfter: minutesFromNow(60 * 40) })])
+    await openDetail('Ticket price drop')
+    const timeRow = screen.getByText('40h 0m left').parentElement as HTMLElement
+    expect((timeRow.children[1] as HTMLElement).textContent).toMatch(/·\s\w{3}\s\d+$/)
+  })
+
+  it('renders the trigger-time block and no interval editor for a reminder', async () => {
+    await mountWith([makeItem({
+      kind: 'reminder', triggerAt: minutesFromNow(20), nextCheckAfter: minutesFromNow(20),
+    })])
+    await openDetail('Ticket price drop')
+    expect(screen.getByText('Trigger Time')).toBeInTheDocument()
+    expect(screen.queryByText('Next Check')).not.toBeInTheDocument()
+    expect(screen.queryByText('Check Interval')).not.toBeInTheDocument()
+    // Time-triggered items expose only the target row.
+    expect(screen.getByText('Target')).toBeInTheDocument()
+    expect(screen.queryByText('Check Count')).not.toBeInTheDocument()
+    expect(screen.queryByText('Last Result')).not.toBeInTheDocument()
+  })
+
+  it('omits the time block when a time-triggered item has no trigger time', async () => {
+    await mountWith([makeItem({ kind: 'meeting', triggerAt: undefined })])
+    await openDetail('Ticket price drop')
+    expect(screen.queryByText('Trigger Time')).not.toBeInTheDocument()
+    expect(screen.queryByText('Next Check')).not.toBeInTheDocument()
+  })
+
+  it('marks an overdue next check with the overdue phrasing', async () => {
+    await mountWith([makeItem({ nextCheckAfter: minutesAgo(5) })])
+    await openDetail('Ticket price drop')
+    expect(screen.getAllByText('Checking soon').length).toBeGreaterThan(0)
+  })
+
+  it('renders the info rows, filling missing values with a dash', async () => {
+    await mountWith([makeItem({ lastResult: undefined, lastChecked: undefined, checkCount: 7 })])
+    await openDetail('Ticket price drop')
+    expect(screen.getByText('https://example.invalid/tickets')).toBeInTheDocument()
+    expect(screen.getAllByText('—')).toHaveLength(2)
+    expect(screen.getByText('7')).toBeInTheDocument()
+  })
+
+  it('renders the last-checked value as a relative time', async () => {
+    const cases: Array<[string, string]> = [
+      [minutesAgo(0), 'just now'],
+      [minutesFromNow(5), 'just now'],
+      [minutesAgo(20), '20m ago'],
+      [minutesAgo(200), '3h ago'],
+      [minutesAgo(60 * 50), '2d ago'],
+    ]
+    for (const [lastChecked, expected] of cases) {
+      await mountWith([makeItem({ lastChecked })])
+      await openDetail('Ticket price drop')
+      expect(screen.getByText(expected)).toBeInTheDocument()
+      cleanup()
+    }
+  })
+
+  it('goes back to the list from the Back button', async () => {
+    await mountWith([makeItem()])
+    await openDetail('Ticket price drop')
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    await tick(250)
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument()
+    expect(screen.getByText('Ticket price drop')).toBeInTheDocument()
+  })
+
+  it('completes from detail mode, returning to the list first', async () => {
+    await mountWith([makeItem()])
+    await openDetail('Ticket price drop')
+    fireEvent.click(within(screen.getByText('Back').parentElement as HTMLElement)
+      .getByRole('button', { name: 'Complete' }))
+    expect(api.setWatchItemStatus).not.toHaveBeenCalled()
+    await tick(250)
+    expect(api.setWatchItemStatus).toHaveBeenCalledWith('w-1', 'done')
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument()
+  })
+
+  it('cancels from detail mode', async () => {
+    await mountWith([makeItem()])
+    await openDetail('Ticket price drop')
+    fireEvent.click(screen.getByRole('button', { name: 'Stop watching' }))
+    await tick(250)
+    expect(api.setWatchItemStatus).toHaveBeenCalledWith('w-1', 'cancelled')
+  })
+
+  it('reopens a terminal item from detail mode, and offers no status actions on a done reminder', async () => {
+    await mountWith([
+      makeItem({ id: 'w-1', label: 'Done watch', status: 'done', completedAt: minutesAgo(5) }),
+      makeItem({
+        id: 'w-2', label: 'Done reminder', kind: 'reminder',
+        status: 'done', completedAt: minutesAgo(5),
+      }),
+    ])
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (2)' }))
+
+    await openDetail('Done reminder')
+    expect(screen.queryByRole('button', { name: 'Reopen' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Complete' })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    await tick(250)
+
+    await openDetail('Done watch')
+    fireEvent.click(screen.getByRole('button', { name: 'Reopen' }))
+    await tick(250)
+    expect(api.setWatchItemStatus).toHaveBeenCalledWith('w-1', 'watching')
+  })
+})
+
+// ── Detail editing ─────────────────────────────────────────────────────────
+
+describe('WatchlistPanel detail editing', () => {
+  const notes = () => screen.getByPlaceholderText('...') as HTMLTextAreaElement
+  const saveBtn = () => screen.getByRole('button', { name: 'Save' })
+  const intervalInput = () => screen.getByRole('spinbutton') as HTMLInputElement
+
+  it('disables Save until the draft actually changes', async () => {
+    await mountWith([makeItem()])
+    await openDetail('Ticket price drop')
+    expect(saveBtn()).toBeDisabled()
+
+    fireEvent.change(notes(), { target: { value: 'watch the fare class' } })
+    expect(saveBtn()).toBeEnabled()
+  })
+
+  it('saves notes through the bridge and clears the draft', async () => {
+    await mountWith([makeItem({ notes: 'original' })])
+    await openDetail('Ticket price drop')
+    expect(notes().value).toBe('original')
+
+    fireEvent.change(notes(), { target: { value: 'edited' } })
+    fireEvent.click(saveBtn())
+    expect(api.updateWatchItem).toHaveBeenCalledWith('w-1', { notes: 'edited' })
+    expect(saveBtn()).toBeDisabled()
+    // The saved value is now the item's own, not a lingering draft.
+    expect(notes().value).toBe('edited')
+  })
+
+  it('starts the notes field empty when the item has none', async () => {
+    await mountWith([makeItem({ notes: undefined })])
+    await openDetail('Ticket price drop')
+    expect(notes().value).toBe('')
+  })
+
+  it('saves a priority change', async () => {
+    await mountWith([makeItem()])
+    await openDetail('Ticket price drop')
+    const select = screen.getByRole('combobox') as HTMLSelectElement
+    expect(select.value).toBe('normal')
+
+    fireEvent.change(select, { target: { value: 'high' } })
+    expect(select.value).toBe('high')
+    fireEvent.click(saveBtn())
+    expect(api.updateWatchItem).toHaveBeenCalledWith('w-1', { priority: 'high' })
+  })
+
+  it('recomputes the next check when the interval is saved', async () => {
+    await mountWith([makeItem()])
+    await openDetail('Ticket price drop')
+    fireEvent.change(intervalInput(), { target: { value: '25' } })
+    fireEvent.click(saveBtn())
+    expect(api.updateWatchItem).toHaveBeenCalledWith('w-1', { checkIntervalMins: 25 })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    await tick(250)
+    // NOW + 25 minutes, from the frozen clock.
+    expect(screen.getByText('25m left')).toBeInTheDocument()
+  })
+
+  it('floors a sub-minimum interval at the bridge minimum', async () => {
+    await mountWith([makeItem()])
+    await openDetail('Ticket price drop')
+    fireEvent.change(intervalInput(), { target: { value: '1' } })
+    fireEvent.click(saveBtn())
+    expect(api.updateWatchItem).toHaveBeenCalledWith('w-1', { checkIntervalMins: 3 })
+  })
+
+  it('treats unparseable interval input as 1', async () => {
+    await mountWith([makeItem()])
+    await openDetail('Ticket price drop')
+    fireEvent.change(intervalInput(), { target: { value: 'abc' } })
+    fireEvent.click(saveBtn())
+    expect(api.updateWatchItem).toHaveBeenCalledWith('w-1', { checkIntervalMins: 3 })
+  })
+
+  it('picks the interval unit from the stored value', async () => {
+    await mountWith([
+      makeItem({ id: 'w-1', label: 'In minutes', checkIntervalMins: 10 }),
+      makeItem({ id: 'w-2', label: 'In hours', checkIntervalMins: 120 }),
+      makeItem({ id: 'w-3', label: 'In days', checkIntervalMins: 2880 }),
+    ])
+
+    await openDetail('In minutes')
+    expect(intervalInput().value).toBe('10')
+    expect(intervalInput()).toHaveAttribute('min', '3')
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    await tick(250)
+
+    await openDetail('In hours')
+    expect(intervalInput().value).toBe('2')
+    expect(intervalInput()).toHaveAttribute('min', '1')
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    await tick(250)
+
+    await openDetail('In days')
+    expect(intervalInput().value).toBe('2')
+  })
+
+  it('converts through the unit selector and saves the value in minutes', async () => {
+    await mountWith([makeItem({ checkIntervalMins: 30 })])
+    await openDetail('Ticket price drop')
+
+    fireEvent.click(screen.getByRole('button', { name: 'hr' }))
+    // 30 minutes rounds to 1 hour rather than showing 0.
+    expect(intervalInput().value).toBe('1')
+    fireEvent.change(intervalInput(), { target: { value: '3' } })
+    fireEvent.click(saveBtn())
+    expect(api.updateWatchItem).toHaveBeenLastCalledWith('w-1', { checkIntervalMins: 180 })
+
+    fireEvent.click(screen.getByRole('button', { name: 'day' }))
+    expect(intervalInput().value).toBe('1')
+    fireEvent.change(intervalInput(), { target: { value: '2' } })
+    fireEvent.click(saveBtn())
+    expect(api.updateWatchItem).toHaveBeenLastCalledWith('w-1', { checkIntervalMins: 2880 })
+
+    fireEvent.click(screen.getByRole('button', { name: 'min' }))
+    expect(intervalInput().value).toBe('2880')
+  })
+
+  it('never shows a zero interval when the stored value rounds below one unit', async () => {
+    await mountWith([makeItem({ checkIntervalMins: 10 })])
+    await openDetail('Ticket price drop')
+
+    fireEvent.click(screen.getByRole('button', { name: 'hr' }))
+    expect(intervalInput().value).toBe('1')
+    fireEvent.click(screen.getByRole('button', { name: 'day' }))
+    expect(intervalInput().value).toBe('1')
+  })
+
+  it('sends all three fields when all three are edited', async () => {
+    await mountWith([makeItem()])
+    await openDetail('Ticket price drop')
+    fireEvent.change(notes(), { target: { value: 'all three' } })
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'low' } })
+    fireEvent.change(intervalInput(), { target: { value: '45' } })
+    fireEvent.click(saveBtn())
+    expect(api.updateWatchItem).toHaveBeenCalledWith('w-1', {
+      notes: 'all three', priority: 'low', checkIntervalMins: 45,
+    })
+  })
+
+  it('leaves the other items untouched when one is saved', async () => {
+    await mountWith([
+      makeItem({ id: 'w-1', notes: 'first note' }),
+      makeItem({ id: 'w-2', label: 'Sibling', notes: 'second note', checkIntervalMins: 10 }),
+    ])
+    await openDetail('Sibling')
+    fireEvent.change(notes(), { target: { value: 'sibling edited' } })
+    fireEvent.change(intervalInput(), { target: { value: '20' } })
+    fireEvent.click(saveBtn())
+    expect(api.updateWatchItem).toHaveBeenCalledWith('w-2', {
+      notes: 'sibling edited', checkIntervalMins: 20,
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    await tick(250)
+    // Only the saved row's countdown moved; the sibling keeps its own schedule.
+    expect(screen.getByText('20m left')).toBeInTheDocument()
+    expect(screen.getByText('10m left')).toBeInTheDocument()
+
+    await openDetail('Ticket price drop')
+    expect(notes().value).toBe('first note')
+  })
+
+  it('drops the draft when the user navigates back without saving', async () => {
+    await mountWith([makeItem({ notes: 'original' })])
+    await openDetail('Ticket price drop')
+    fireEvent.change(notes(), { target: { value: 'abandoned' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    await tick(250)
+
+    await openDetail('Ticket price drop')
+    expect(notes().value).toBe('original')
+    expect(saveBtn()).toBeDisabled()
+    expect(api.updateWatchItem).not.toHaveBeenCalled()
+  })
+})
+
+// ── History ────────────────────────────────────────────────────────────────
+
+describe('WatchlistPanel history', () => {
+  const entry = (over: Partial<HistoryEntry>): HistoryEntry => ({
+    checkedAt: minutesAgo(30), result: 'no change', changed: false, ...over,
+  })
+
+  it('shows only changed entries, newest first, until Show all is used', async () => {
+    await mountWith([makeItem({
+      history: [
+        entry({ checkedAt: minutesAgo(90), result: 'first look' }),
+        entry({ checkedAt: minutesAgo(60), result: 'price dropped', changed: true }),
+        entry({ checkedAt: minutesAgo(20), result: 'holding' }),
+      ],
+    })])
+    await openDetail('Ticket price drop')
+
+    expect(screen.getByText('History')).toBeInTheDocument()
+    expect(screen.getByText('price dropped')).toBeInTheDocument()
+    expect(screen.queryByText('first look')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show all (3)' }))
+    const timeline = document.querySelector('.wl-history-timeline') as HTMLElement
+    // Newest first, and each row is prefixed with its own relative timestamp.
+    expect([...timeline.children].map(c => c.textContent)).toEqual([
+      '20m agoholding', '1h agoprice dropped', '1h agofirst look',
+    ])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Changes only' }))
+    expect(screen.queryByText('first look')).not.toBeInTheDocument()
+  })
+
+  it('hides the Show all toggle when every entry already changed', async () => {
+    await mountWith([makeItem({
+      history: [entry({ result: 'price dropped', changed: true })],
+    })])
+    await openDetail('Ticket price drop')
+    expect(screen.queryByRole('button', { name: /Show all/ })).toBeNull()
+    expect(screen.getByText('price dropped')).toBeInTheDocument()
+  })
+
+  it('says so when there is history but nothing has changed yet', async () => {
+    await mountWith([makeItem({ history: [entry({}), entry({ checkedAt: minutesAgo(10) })] })])
+    await openDetail('Ticket price drop')
+    expect(screen.getByText('No changes detected yet')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show all (2)' }))
+    expect(screen.queryByText('No changes detected yet')).not.toBeInTheDocument()
+    expect(screen.getAllByText('no change')).toHaveLength(2)
+  })
+
+  it('renders no history section for an item without history', async () => {
+    await mountWith([makeItem({ history: [] })])
+    await openDetail('Ticket price drop')
+    expect(screen.queryByText('History')).not.toBeInTheDocument()
+  })
+})

--- a/website/src/test/OpsMissionControlSettings.coverage.test.tsx
+++ b/website/src/test/OpsMissionControlSettings.coverage.test.tsx
@@ -1,0 +1,1164 @@
+/**
+ * First RENDER coverage for Ops Mission Control → Settings.
+ *
+ * `opsMissionControl.test.ts` already guards this panel, but it does so by READING
+ * the source: it never mounts the component, so every conditional branch in the six
+ * cards was unexecuted. That is the gap this file closes — the copy assertions there
+ * prove a sentence is written, these prove it reaches the screen for the state it
+ * describes and not for the states it does not.
+ *
+ * Shape of the harness, matching AgentsPageInspector.test.tsx / ArtifactDeployPage.test.tsx:
+ *
+ *  - The panel's only seam to the gateway is `./api`, so `opsApi` is mocked whole and
+ *    nothing here touches the network. Three queries (`providers` / `rotation` / `state`)
+ *    and four writers (`putSettings` / `putProviderConfig` / `putSecret` / `deleteSecret`).
+ *  - A fresh QueryClient per render with `retry: false`, so a rejected mutation surfaces
+ *    its message on the first attempt instead of after three backoff waits — no test here
+ *    depends on elapsed time.
+ *  - `fireEvent` rather than `userEvent`: every interaction the panel offers is a click, a
+ *    change or an Enter keydown, and keeping them synchronous keeps each trigger explicit.
+ *  - Queries go through roles and visible copy. The field rows are `<label htmlFor>`
+ *    wrappers holding an input AND a Save button, so a label matches two controls — the
+ *    `field` helper below picks the input, and `saveIn` scopes the button to its own row.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, within, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import type {
+  AutonomyRule,
+  BoardState,
+  LedgerSyncStatus,
+  NotifyOutStatus,
+  ProviderInfo,
+  RotationInfo,
+  RotationRoster,
+  SlackOutStatus,
+  SweepWindows,
+} from '../apps/ops-mission-control/api'
+
+const mockApi = vi.hoisted(() => ({
+  providers: vi.fn(),
+  rotation: vi.fn(),
+  state: vi.fn(),
+  putSettings: vi.fn(),
+  putProviderConfig: vi.fn(),
+  putSecret: vi.fn(),
+  deleteSecret: vi.fn(),
+}))
+vi.mock('../apps/ops-mission-control/api', () => ({ opsApi: mockApi }))
+
+const SettingsPanel = (await import('../apps/ops-mission-control/SettingsPanel')).default
+
+/* ── fixtures ─────────────────────────────────────────────────────────────── */
+
+const provider = (over: Partial<ProviderInfo> = {}): ProviderInfo => ({
+  id: 'cloudwatch',
+  display_name: 'CloudWatch',
+  roles: ['signal'],
+  configured: true,
+  config_fields: ['enabled', 'region'],
+  secret_fields: [],
+  detail: 'Reads alarm state from your account.',
+  config: { enabled: true, region: 'us-east-1' },
+  secrets: {},
+  ...over,
+})
+
+const ROTATION: RotationInfo = {
+  on_shift: true,
+  who: 'octocat',
+  until: '',
+  unknown: false,
+  tiers: {},
+  armed_crons: [],
+  tier_crons: {},
+  mode: 'observe',
+  rules: 0,
+  primary: false,
+  modes_available: ['observe', 'propose', 'act'],
+}
+
+const roster = (over: Partial<RotationRoster> = {}): RotationRoster => ({
+  members: [],
+  windows: [],
+  timezone: 'UTC',
+  me: 'octocat',
+  me_on_roster: true,
+  strict_gating: true,
+  leader: '',
+  error: '',
+  ...over,
+})
+
+const sweep = (over: Partial<SweepWindows> = {}): SweepWindows => ({
+  max_claims_per_cycle: 3,
+  stale_after_secs: 7200,
+  needs_human_stale_after_secs: 43200,
+  needs_human_derived: true,
+  ...over,
+})
+
+const ledgerSync = (over: Partial<LedgerSyncStatus> = {}): LedgerSyncStatus => ({
+  enabled: true,
+  remote: 'git@github.com:org/ops-memory.git',
+  branch: 'main',
+  local_branch: 'main',
+  branch_matches: true,
+  detached: false,
+  initialized: true,
+  ready: true,
+  conflict: false,
+  schedule_conflict: false,
+  detail: '',
+  ...over,
+})
+
+const slack = (over: Partial<SlackOutStatus> = {}): SlackOutStatus => ({
+  enabled: false,
+  channel: '',
+  slack_available: true,
+  ready: false,
+  detail: '',
+  ...over,
+})
+
+const notify = (over: Partial<NotifyOutStatus> = {}): NotifyOutStatus => ({
+  enabled: false,
+  bus_available: true,
+  ready: false,
+  detail: '',
+  channels: [],
+  ...over,
+})
+
+const boardState = (over: Partial<BoardState> = {}): BoardState => ({
+  incidents: [],
+  counts: {},
+  providers: [],
+  rotation: ROTATION,
+  ledger: {
+    total: 0,
+    verified: 0,
+    high_confidence: 0,
+    total_uses: 0,
+    proven: 0,
+    demoted: 0,
+    total_misses: 0,
+  },
+  webhook_queue: 0,
+  ...over,
+})
+
+/** Mount the panel; every query is already primed by `beforeEach`. */
+function renderPanel() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <SettingsPanel />
+    </QueryClientProvider>,
+  )
+}
+
+/**
+ * The `<input>` of the row whose label matches `text`.
+ *
+ * Every field row nests BOTH its input and its Save button inside one `<label htmlFor>`, so
+ * two labelled controls answer to the same accessible name and a bare `getByLabelText` fails
+ * with "found multiple elements". The tag filter picks the one a value can be typed into.
+ */
+const field = (text: RegExp): HTMLInputElement => {
+  const input = screen.getAllByLabelText(text).find((n) => n.tagName === 'INPUT')
+  if (!input) throw new Error(`no input labelled ${String(text)}`)
+  return input as HTMLInputElement
+}
+
+/** `field`, awaited — for the first lookup after a mount, before the queries have settled. */
+const findField = async (text: RegExp): Promise<HTMLInputElement> => {
+  await waitFor(() => expect(screen.getAllByLabelText(text).length).toBeGreaterThan(0))
+  return field(text)
+}
+
+/** The row itself, so its own commit button can be addressed without colliding with the
+ *  eight other Save buttons on the page. */
+const row = (text: RegExp) => field(text).closest('label') as HTMLElement
+
+/**
+ * The commit button of one row.
+ *
+ * Queried as "the row's only button" rather than by name: the button is nested inside a
+ * `<label htmlFor>`, so its accessible name is the label's WHOLE text ("RepositorySave")
+ * and `{ name: 'Save' }` matches nothing. Its visible wording is asserted with
+ * `toHaveTextContent` where that wording is the point (Save vs Replace).
+ */
+const commitIn = (label: RegExp) => within(row(label)).getByRole('button')
+
+beforeEach(() => {
+  Object.values(mockApi).forEach((fn) => fn.mockReset())
+  mockApi.providers.mockResolvedValue({ providers: [] })
+  mockApi.rotation.mockResolvedValue({ ...ROTATION })
+  mockApi.state.mockResolvedValue(boardState())
+  mockApi.putSettings.mockResolvedValue({ ok: true })
+  mockApi.putProviderConfig.mockResolvedValue({ ok: true })
+  mockApi.putSecret.mockResolvedValue({ ok: true })
+  mockApi.deleteSecret.mockResolvedValue({ ok: true })
+})
+
+afterEach(() => cleanup())
+
+/* ── autonomy ceiling ─────────────────────────────────────────────────────── */
+
+describe('the autonomy ceiling', () => {
+  it('opens on the mode the gateway reports, with that mode\'s consequence spelled out', async () => {
+    mockApi.rotation.mockResolvedValue({ ...ROTATION, mode: 'propose' })
+    renderPanel()
+
+    expect(
+      await screen.findByText(/drafts the acknowledge \/ resolve \/ comment action/),
+    ).toBeInTheDocument()
+    // Observe's paragraph belongs to a DIFFERENT mode; only the active one renders.
+    expect(screen.queryByText(/Writes nothing to any provider/)).not.toBeInTheDocument()
+  })
+
+  it('writes the picked mode through the settings route', async () => {
+    renderPanel()
+    fireEvent.click(await screen.findByRole('button', { name: /Act/ }))
+    await waitFor(() => expect(mockApi.putSettings).toHaveBeenCalledWith({ mode: 'act' }))
+  })
+
+  it('warns, on act, that the mode alone grants nothing', async () => {
+    mockApi.rotation.mockResolvedValue({ ...ROTATION, mode: 'act' })
+    renderPanel()
+    expect(
+      await screen.findByText(/Act only takes effect for signals matched by a rule/),
+    ).toBeInTheDocument()
+  })
+
+  it('does not show that warning below act, where it would describe nothing', async () => {
+    renderPanel()
+    await screen.findByText(/Writes nothing to any provider/)
+    expect(
+      screen.queryByText(/Act only takes effect for signals matched by a rule/),
+    ).not.toBeInTheDocument()
+  })
+
+  it('surfaces a refused write instead of leaving the click silent', async () => {
+    mockApi.putSettings.mockRejectedValue(new Error('mode not accepted: act'))
+    renderPanel()
+    fireEvent.click(await screen.findByRole('button', { name: /Act/ }))
+    expect(await screen.findByText('mode not accepted: act')).toBeInTheDocument()
+  })
+})
+
+/* ── act rules ────────────────────────────────────────────────────────────── */
+
+describe('the act-rules card', () => {
+  const withRules = (rules: AutonomyRule[]) =>
+    mockApi.rotation.mockResolvedValue({ ...ROTATION, mode: 'act', rules_detail: rules })
+
+  it('stays absent on a gateway that reports only a rule count', async () => {
+    renderPanel()
+    await screen.findByText('Providers')
+    expect(screen.queryByText('Act rules')).not.toBeInTheDocument()
+  })
+
+  it('says there are no rules yet, and points at the form below', async () => {
+    withRules([])
+    renderPanel()
+    expect(await screen.findByText(/No rules yet/)).toBeInTheDocument()
+  })
+
+  it('lists an existing grant in full, not as a count', async () => {
+    withRules([
+      { source: 'cloudwatch', mode: 'act', resource_glob: 'prod-*', actions: ['ack'] },
+      { source: 'pagerduty', mode: 'act', resource_glob: 'db-*' },
+    ])
+    renderPanel()
+
+    expect(await screen.findByText('prod-*')).toBeInTheDocument()
+    expect(screen.getByText('db-*')).toBeInTheDocument()
+    expect(screen.getByText('ack')).toBeInTheDocument()
+    // A rule with no explicit action list authorizes every action; saying so beats a blank.
+    expect(screen.getByText('all actions')).toBeInTheDocument()
+  })
+
+  it('revokes the row that was clicked and keeps the rest', async () => {
+    const keep: AutonomyRule = { source: 'pagerduty', mode: 'act', resource_glob: 'db-*' }
+    withRules([{ source: 'cloudwatch', mode: 'act', resource_glob: 'prod-*' }, keep])
+    renderPanel()
+
+    const revokes = await screen.findAllByRole('button', { name: 'Revoke rule' })
+    fireEvent.click(revokes[0])
+    await waitFor(() =>
+      expect(mockApi.putSettings).toHaveBeenCalledWith({ autonomy_rules: [keep] }),
+    )
+  })
+
+  it('offers no form at all when no configured signal source exists', async () => {
+    withRules([])
+    mockApi.providers.mockResolvedValue({
+      providers: [
+        provider({ configured: false }),
+        provider({ id: 'schedule-file', display_name: 'Schedule file', roles: ['rotation'] }),
+      ],
+    })
+    renderPanel()
+
+    expect(await screen.findByText(/Connect a signal source first/)).toBeInTheDocument()
+    expect(screen.queryByText('Resource pattern')).not.toBeInTheDocument()
+  })
+
+  it('grants only once BOTH a source and a pattern are chosen', async () => {
+    withRules([])
+    mockApi.providers.mockResolvedValue({ providers: [provider()] })
+    renderPanel()
+
+    const glob = await findField(/Resource pattern/)
+    const grant = commitIn(/Resource pattern/)
+    expect(grant).toHaveTextContent('Grant')
+    // A pattern with no source is not a rule; the backend would 400 it.
+    fireEvent.change(glob, { target: { value: 'prod-*' } })
+    expect(grant).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Signal source' }))
+    fireEvent.click(await screen.findByRole('option', { name: 'CloudWatch' }))
+    await waitFor(() => expect(grant).toBeEnabled())
+
+    fireEvent.click(grant)
+    await waitFor(() =>
+      expect(mockApi.putSettings).toHaveBeenCalledWith({
+        autonomy_rules: [{ source: 'cloudwatch', mode: 'act', resource_glob: 'prod-*' }],
+      }),
+    )
+  })
+})
+
+/* ── provider rows ────────────────────────────────────────────────────────── */
+
+describe('a provider row', () => {
+  it('reports loading before the catalog lands', async () => {
+    let release: (v: { providers: ProviderInfo[] }) => void = () => {}
+    mockApi.providers.mockReturnValue(
+      new Promise<{ providers: ProviderInfo[] }>((r) => {
+        release = r
+      }),
+    )
+    renderPanel()
+
+    expect((await screen.findAllByText('Loading…')).length).toBeGreaterThan(0)
+    release({ providers: [provider()] })
+    expect(await screen.findByText('CloudWatch')).toBeInTheDocument()
+  })
+
+  it('renders readiness, roles and the adapter\'s own detail sentence', async () => {
+    mockApi.providers.mockResolvedValue({
+      providers: [
+        provider({ roles: ['signal', 'action'] }),
+        provider({ id: 'datadog', display_name: 'Datadog', configured: false, config: {} }),
+      ],
+    })
+    renderPanel()
+
+    expect(await screen.findByText('ready')).toBeInTheDocument()
+    expect(screen.getByText('not set up')).toBeInTheDocument()
+    expect(screen.getByText('signal · action')).toBeInTheDocument()
+    expect(screen.getAllByText('Reads alarm state from your account.')).toHaveLength(2)
+  })
+
+  it('paints an enable toggle only for an adapter that declares the flag', async () => {
+    mockApi.providers.mockResolvedValue({
+      providers: [
+        provider(),
+        provider({
+          id: 'schedule-file',
+          display_name: 'Schedule file (git)',
+          config_fields: [],
+          config: {},
+        }),
+      ],
+    })
+    renderPanel()
+
+    expect(await screen.findByRole('switch', { name: 'Enable CloudWatch' })).toBeInTheDocument()
+    // The dead control: `PUT /providers/schedule-file/config` 400s every key the adapter
+    // declares none of, so a toggle here could never latch.
+    expect(
+      screen.queryByRole('switch', { name: /Enable Schedule file/ }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('sends the enable flag when the toggle is clicked', async () => {
+    mockApi.providers.mockResolvedValue({ providers: [provider({ config: { enabled: false } })] })
+    renderPanel()
+
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable CloudWatch' }))
+    await waitFor(() =>
+      expect(mockApi.putProviderConfig).toHaveBeenCalledWith('cloudwatch', { enabled: true }),
+    )
+  })
+
+  it('hides the config fields of a declared-but-disabled adapter', async () => {
+    mockApi.providers.mockResolvedValue({
+      providers: [provider({ config: { enabled: false, region: 'us-east-1' } })],
+    })
+    renderPanel()
+
+    await screen.findByRole('switch', { name: 'Enable CloudWatch' })
+    expect(screen.queryByLabelText(/^region/)).not.toBeInTheDocument()
+  })
+
+  it('shows the config fields of an adapter that has no enable flag at all', async () => {
+    // `fieldsVisible` is `enabled || !hasEnableFlag`: without the second half this row's
+    // only editable control would be unreachable forever.
+    mockApi.providers.mockResolvedValue({
+      providers: [provider({ config_fields: ['region'], config: { region: 'eu-west-1' } })],
+    })
+    renderPanel()
+    expect(await findField(/^region/)).toHaveValue('eu-west-1')
+  })
+
+  it('commits a changed config field on blur, and not when it is unchanged', async () => {
+    mockApi.providers.mockResolvedValue({ providers: [provider()] })
+    renderPanel()
+
+    const input = await findField(/^region/)
+    fireEvent.blur(input)
+    expect(mockApi.putProviderConfig).not.toHaveBeenCalled()
+
+    fireEvent.change(input, { target: { value: 'eu-west-1' } })
+    fireEvent.blur(input)
+    await waitFor(() =>
+      expect(mockApi.putProviderConfig).toHaveBeenCalledWith('cloudwatch', {
+        region: 'eu-west-1',
+      }),
+    )
+  })
+
+  it('reports a rejected write where the operator can see it', async () => {
+    mockApi.providers.mockResolvedValue({ providers: [provider()] })
+    mockApi.putProviderConfig.mockRejectedValue(new Error('unknown config key: region'))
+    renderPanel()
+
+    const input = await findField(/^region/)
+    fireEvent.change(input, { target: { value: 'eu-west-1' } })
+    fireEvent.blur(input)
+    expect(await screen.findByText('unknown config key: region')).toBeInTheDocument()
+  })
+})
+
+describe('a secret field', () => {
+  const withSecret = (secrets: Record<string, string>) =>
+    mockApi.providers.mockResolvedValue({
+      providers: [
+        provider({
+          id: 'pagerduty',
+          display_name: 'PagerDuty',
+          config_fields: ['enabled'],
+          secret_fields: ['api_key'],
+          config: { enabled: true },
+          secrets,
+        }),
+      ],
+    })
+
+  it('never pre-fills a stored value, and offers Replace instead of Save', async () => {
+    withSecret({ api_key: 'set' })
+    renderPanel()
+
+    const input = await findField(/api_key/)
+    expect(input).toHaveValue('')
+    expect(input).toHaveAttribute('type', 'password')
+    expect(input).toHaveAttribute('placeholder', 'stored — enter a new value to replace')
+    expect(commitIn(/api_key/)).toHaveTextContent('Replace')
+  })
+
+  it('says the field is unset when it is, and labels the button Save', async () => {
+    withSecret({})
+    renderPanel()
+
+    expect(await findField(/api_key/)).toHaveAttribute('placeholder', 'not set')
+    expect(commitIn(/api_key/)).toHaveTextContent('Save')
+  })
+
+  it('refuses to submit an empty draft, then stores one and drops it again', async () => {
+    withSecret({})
+    renderPanel()
+
+    const input = await findField(/api_key/)
+    expect(commitIn(/api_key/)).toBeDisabled()
+
+    fireEvent.change(input, { target: { value: 'pd-abc123' } })
+    fireEvent.click(commitIn(/api_key/))
+    await waitFor(() =>
+      expect(mockApi.putSecret).toHaveBeenCalledWith('pagerduty', 'api_key', 'pd-abc123'),
+    )
+    // The draft is cleared on success so a credential does not outlive its own request.
+    await waitFor(() => expect(input).toHaveValue(''))
+  })
+
+  it('offers revocation only once something is actually stored', async () => {
+    withSecret({})
+    renderPanel()
+    await findField(/api_key/)
+    expect(
+      screen.queryByRole('button', { name: /Revoke stored credentials/ }),
+    ).not.toBeInTheDocument()
+
+    cleanup()
+    withSecret({ api_key: 'set' })
+    renderPanel()
+    fireEvent.click(await screen.findByRole('button', { name: /Revoke stored credentials/ }))
+    await waitFor(() => expect(mockApi.deleteSecret).toHaveBeenCalledWith('pagerduty'))
+    // The retention boundary is disclosed beside the only control that changes it.
+    expect(screen.getByText(/uninstalling this app does not delete them/)).toBeInTheDocument()
+  })
+
+  it('reports a rejected secret write', async () => {
+    withSecret({})
+    mockApi.putSecret.mockRejectedValue(new Error('keystone is read-only'))
+    renderPanel()
+
+    fireEvent.change(await findField(/api_key/), { target: { value: 'x' } })
+    fireEvent.click(commitIn(/api_key/))
+    expect(await screen.findByText('keystone is read-only')).toBeInTheDocument()
+  })
+})
+
+describe('the fenced rotation identity', () => {
+  const pagerduty = () =>
+    mockApi.providers.mockResolvedValue({
+      providers: [
+        provider({ id: 'pagerduty', display_name: 'PagerDuty', config_fields: [], config: {} }),
+      ],
+    })
+
+  it('renders for the adapter that consumes it, with the keystone value seeded', async () => {
+    pagerduty()
+    mockApi.rotation.mockResolvedValue({
+      ...ROTATION,
+      identities: { schedule_github_login: '', pagerduty_user_id: 'PABC123' },
+    })
+    renderPanel()
+
+    const identity = await findField(/Your PagerDuty user ID/)
+    await waitFor(() => expect(identity).toHaveValue('PABC123'))
+  })
+
+  it('does not render for an adapter that has no such field', async () => {
+    mockApi.providers.mockResolvedValue({ providers: [provider()] })
+    renderPanel()
+    await screen.findByText('CloudWatch')
+    expect(screen.queryByLabelText(/Your PagerDuty user ID/)).not.toBeInTheDocument()
+  })
+
+  it('writes it through PUT /settings, not through the agent-writable provider config', async () => {
+    pagerduty()
+    renderPanel()
+
+    const input = await findField(/Your PagerDuty user ID/)
+    expect(commitIn(/Your PagerDuty user ID/)).toBeDisabled()
+
+    fireEvent.change(input, { target: { value: ' PXYZ789 ' } })
+    fireEvent.click(commitIn(/Your PagerDuty user ID/))
+    await waitFor(() =>
+      expect(mockApi.putSettings).toHaveBeenCalledWith({ pagerduty_user_id: 'PXYZ789' }),
+    )
+    expect(mockApi.putProviderConfig).not.toHaveBeenCalled()
+  })
+
+  it('commits on Enter as well as on the button', async () => {
+    pagerduty()
+    renderPanel()
+
+    const input = await findField(/Your PagerDuty user ID/)
+    fireEvent.change(input, { target: { value: 'PENTER' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() =>
+      expect(mockApi.putSettings).toHaveBeenCalledWith({ pagerduty_user_id: 'PENTER' }),
+    )
+  })
+
+  it('writes nothing when Enter lands on an untouched identity', async () => {
+    pagerduty()
+    renderPanel()
+
+    fireEvent.keyDown(await findField(/Your PagerDuty user ID/), { key: 'Enter' })
+    expect(mockApi.putSettings).not.toHaveBeenCalled()
+  })
+})
+
+describe('installed companions', () => {
+  it('says nothing on an install that has none', async () => {
+    renderPanel()
+    await screen.findByText('Providers')
+    expect(screen.queryByText(/adapter package/)).not.toBeInTheDocument()
+  })
+
+  it('names them, so a rejected admission is visible as a gap', async () => {
+    mockApi.state.mockResolvedValue(
+      boardState({ companions: [{ name: 'acme-ops', target: 'ops-mission-control' }] }),
+    )
+    renderPanel()
+    expect(await screen.findByText(/1 adapter package installed: acme-ops/)).toBeInTheDocument()
+  })
+})
+
+/* ── Slack output ─────────────────────────────────────────────────────────── */
+
+describe('the Slack card', () => {
+  it('reads off when the gateway says off, and hides the channel field', async () => {
+    mockApi.state.mockResolvedValue(boardState({ slack: slack() }))
+    renderPanel()
+
+    expect(await screen.findByText('off')).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Channel ID/)).not.toBeInTheDocument()
+  })
+
+  it('says needs setup when enabled but not ready, and renders the backend\'s fix', async () => {
+    mockApi.state.mockResolvedValue(
+      boardState({
+        slack: slack({ enabled: true, detail: "Kiro Crew's Slack is not connected." }),
+      }),
+    )
+    renderPanel()
+
+    expect(await screen.findByText('needs setup')).toBeInTheDocument()
+    expect(screen.getByText("Kiro Crew's Slack is not connected.")).toBeInTheDocument()
+  })
+
+  it('says active once the backend reports ready, and stays quiet about the fix', async () => {
+    mockApi.state.mockResolvedValue(
+      boardState({
+        slack: slack({ enabled: true, ready: true, channel: 'C0000000001', detail: 'ok' }),
+      }),
+    )
+    renderPanel()
+
+    expect(await screen.findByText('active')).toBeInTheDocument()
+    expect(field(/Channel ID/)).toHaveValue('C0000000001')
+    expect(screen.queryByText('ok')).not.toBeInTheDocument()
+  })
+
+  it('saves a typed channel and not an unchanged one', async () => {
+    mockApi.state.mockResolvedValue(boardState({ slack: slack({ enabled: true }) }))
+    renderPanel()
+
+    const input = await findField(/Channel ID/)
+    expect(commitIn(/Channel ID/)).toBeDisabled()
+
+    fireEvent.change(input, { target: { value: ' C0123456789 ' } })
+    fireEvent.click(commitIn(/Channel ID/))
+    await waitFor(() =>
+      expect(mockApi.putSettings).toHaveBeenCalledWith({ slack_channel: 'C0123456789' }),
+    )
+  })
+
+  it('writes the mirror toggle through the settings route', async () => {
+    mockApi.state.mockResolvedValue(boardState({ slack: slack() }))
+    renderPanel()
+
+    fireEvent.click(await screen.findByRole('switch', { name: 'Mirror incidents to Slack' }))
+    await waitFor(() => expect(mockApi.putSettings).toHaveBeenCalledWith({ slack_enabled: true }))
+  })
+})
+
+/* ── desktop notifications ────────────────────────────────────────────────── */
+
+describe('the notifications card', () => {
+  it('separates an unavailable bus from a setup step, because no control fixes the former', async () => {
+    mockApi.state.mockResolvedValue(
+      boardState({
+        notify: notify({
+          enabled: true,
+          bus_available: false,
+          detail: 'No notification bus in this process.',
+        }),
+      }),
+    )
+    renderPanel()
+
+    expect(await screen.findByText('unavailable here')).toBeInTheDocument()
+    expect(screen.queryByText('needs setup')).not.toBeInTheDocument()
+    expect(screen.getByText('No notification bus in this process.')).toBeInTheDocument()
+  })
+
+  it('says needs setup when the bus is there and the channel is not ready', async () => {
+    mockApi.state.mockResolvedValue(boardState({ notify: notify({ enabled: true }) }))
+    renderPanel()
+    expect(await screen.findByText('needs setup')).toBeInTheDocument()
+  })
+
+  it('declares each channel and what its edge condition is', async () => {
+    mockApi.state.mockResolvedValue(
+      boardState({
+        notify: notify({
+          enabled: true,
+          ready: true,
+          channels: [
+            {
+              id: 'waiting-on-you',
+              name: 'Waiting on you',
+              icon: 'UserCheck',
+              default_priority: 'critical',
+            },
+            {
+              id: 'source-health',
+              name: 'Source health',
+              icon: 'Radio',
+              default_priority: 'passive',
+            },
+            { id: 'incident-released', name: 'Released', icon: 'Clock', default_priority: 'normal' },
+          ],
+        }),
+      }),
+    )
+    renderPanel()
+
+    expect(await screen.findByText('Waiting on you')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Fires the moment an incident starts waiting on a person/),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/not again while it stays down/)).toBeInTheDocument()
+    expect(screen.getByText(/Fires when an idle investigation is released/)).toBeInTheDocument()
+    // Priority is rendered as a consequence, and only for the two that have one.
+    expect(screen.getByText(/interrupts by default/)).toBeInTheDocument()
+    expect(screen.getByText(/quiet, and expires on its own/)).toBeInTheDocument()
+    // Mute lives centrally; the card points there rather than shipping a rival control.
+    expect(screen.getByText(/Settings → Notifications/)).toBeInTheDocument()
+  })
+
+  it('still renders a channel this build has never heard of', async () => {
+    mockApi.state.mockResolvedValue(
+      boardState({
+        notify: notify({
+          enabled: true,
+          ready: true,
+          channels: [
+            {
+              id: 'brand-new',
+              name: 'Brand new',
+              icon: 'Nonexistent',
+              default_priority: 'normal',
+            },
+          ],
+        }),
+      }),
+    )
+    renderPanel()
+
+    expect(await screen.findByText('Brand new')).toBeInTheDocument()
+    expect(screen.getByText('when a state changes')).toBeInTheDocument()
+  })
+
+  it('writes its own toggle and keeps the central-rail note out of the off state', async () => {
+    mockApi.state.mockResolvedValue(boardState({ notify: notify() }))
+    renderPanel()
+
+    expect(screen.queryByText(/Settings → Notifications/)).not.toBeInTheDocument()
+    fireEvent.click(await screen.findByRole('switch', { name: 'Notify me on state changes' }))
+    await waitFor(() => expect(mockApi.putSettings).toHaveBeenCalledWith({ notify_enabled: true }))
+  })
+})
+
+/* ── shared team memory ───────────────────────────────────────────────────── */
+
+describe('the shared-memory card', () => {
+  it('seeds both fields from the server and saves each separately', async () => {
+    mockApi.state.mockResolvedValue(boardState({ ledger_sync: ledgerSync() }))
+    renderPanel()
+
+    const remote = await findField(/^Repository/)
+    await waitFor(() => expect(remote).toHaveValue('git@github.com:org/ops-memory.git'))
+    expect(commitIn(/^Repository/)).toBeDisabled()
+
+    fireEvent.change(remote, { target: { value: ' git@github.com:org/other.git ' } })
+    fireEvent.keyDown(remote, { key: 'Enter' })
+    await waitFor(() =>
+      expect(mockApi.putSettings).toHaveBeenCalledWith({
+        ledger_sync_remote: 'git@github.com:org/other.git',
+      }),
+    )
+  })
+
+  it('never posts an empty branch, because the backend defaults only on an absent key', async () => {
+    mockApi.state.mockResolvedValue(boardState({ ledger_sync: ledgerSync({ branch: 'release' }) }))
+    renderPanel()
+
+    const branch = await findField(/^Branch/)
+    await waitFor(() => expect(branch).toHaveValue('release'))
+    fireEvent.change(branch, { target: { value: '   ' } })
+    expect(commitIn(/^Branch/)).toBeDisabled()
+
+    fireEvent.change(branch, { target: { value: 'main' } })
+    fireEvent.click(commitIn(/^Branch/))
+    await waitFor(() =>
+      expect(mockApi.putSettings).toHaveBeenCalledWith({ ledger_sync_branch: 'main' }),
+    )
+
+    fireEvent.change(branch, { target: { value: 'trunk' } })
+    fireEvent.keyDown(branch, { key: 'Enter' })
+    await waitFor(() =>
+      expect(mockApi.putSettings).toHaveBeenCalledWith({ ledger_sync_branch: 'trunk' }),
+    )
+  })
+
+  it('writes nothing when Enter lands on an unedited repo field', async () => {
+    mockApi.state.mockResolvedValue(boardState({ ledger_sync: ledgerSync() }))
+    renderPanel()
+
+    const remote = await findField(/^Repository/)
+    await waitFor(() => expect(remote).toHaveValue('git@github.com:org/ops-memory.git'))
+    // A stray Enter must not repoint the whole team's repo at the value already stored.
+    fireEvent.keyDown(remote, { key: 'Enter' })
+    fireEvent.keyDown(field(/^Branch/), { key: 'Enter' })
+    expect(mockApi.putSettings).not.toHaveBeenCalled()
+  })
+
+  it('hides a credential embedded in the remote it paints', async () => {
+    mockApi.state.mockResolvedValue(
+      boardState({
+        ledger_sync: ledgerSync({ remote: 'https://user:ghp_secret@github.com/org/repo.git' }),
+      }),
+    )
+    renderPanel()
+
+    expect(await screen.findByText('https://github.com/org/repo.git')).toBeInTheDocument()
+    expect(screen.queryByText(/ghp_secret/)).not.toBeInTheDocument()
+  })
+
+  it('ranks a schedule conflict above every other state and calls it an error', async () => {
+    mockApi.state.mockResolvedValue(
+      boardState({
+        ledger_sync: ledgerSync({
+          conflict: true,
+          schedule_conflict: true,
+          branch_matches: false,
+          detail: 'rotation.yaml holds conflict markers.',
+        }),
+      }),
+    )
+    renderPanel()
+
+    expect(await screen.findByText('schedule conflict')).toBeInTheDocument()
+    expect(screen.queryByText('ledger conflict')).not.toBeInTheDocument()
+    expect(screen.getByText('rotation.yaml holds conflict markers.')).toBeInTheDocument()
+    expect(screen.getByText(/Pushes stay refused until/)).toBeInTheDocument()
+  })
+
+  it('reports a ledger conflict when that is the worst thing wrong', async () => {
+    mockApi.state.mockResolvedValue(
+      boardState({ ledger_sync: ledgerSync({ conflict: true, detail: 'ledger.jsonl has markers.' }) }),
+    )
+    renderPanel()
+    expect(await screen.findByText('ledger conflict')).toBeInTheDocument()
+  })
+
+  it('names a drifted local branch without claiming the exchange stopped', async () => {
+    mockApi.state.mockResolvedValue(
+      boardState({ ledger_sync: ledgerSync({ local_branch: 'legacy-default', branch_matches: false }) }),
+    )
+    renderPanel()
+
+    expect(await screen.findByText('wrong local branch')).toBeInTheDocument()
+    expect(screen.getByText('This repo is on')).toBeInTheDocument()
+    expect(screen.getByText('legacy-default')).toBeInTheDocument()
+    expect(screen.getByText(/still being exchanged/)).toBeInTheDocument()
+    expect(screen.getByText(/The next sync moves it across by itself/)).toBeInTheDocument()
+  })
+
+  it('distinguishes a detached HEAD, which the next sync will NOT repair', async () => {
+    mockApi.state.mockResolvedValue(
+      boardState({
+        ledger_sync: ledgerSync({ branch_matches: false, detached: true, local_branch: '' }),
+      }),
+    )
+    renderPanel()
+
+    expect(await screen.findByText('detached HEAD')).toBeInTheDocument()
+    expect(screen.getByText('no branch (detached HEAD)')).toBeInTheDocument()
+    expect(screen.getByText(/A detached HEAD is left alone on purpose/)).toBeInTheDocument()
+  })
+
+  it('says syncing on a healthy initialized repo, with nothing to fix', async () => {
+    mockApi.state.mockResolvedValue(boardState({ ledger_sync: ledgerSync({ detail: 'up to date' }) }))
+    renderPanel()
+
+    expect(await screen.findByText('syncing')).toBeInTheDocument()
+    expect(screen.queryByText('up to date')).not.toBeInTheDocument()
+  })
+
+  it('says ready before the repo exists, and needs setup when it is not ready', async () => {
+    mockApi.state.mockResolvedValue(boardState({ ledger_sync: ledgerSync({ initialized: false }) }))
+    renderPanel()
+    expect(await screen.findByText('ready')).toBeInTheDocument()
+
+    cleanup()
+    mockApi.state.mockResolvedValue(
+      boardState({
+        ledger_sync: ledgerSync({ ready: false, initialized: false, detail: 'No remote set.' }),
+      }),
+    )
+    renderPanel()
+    expect(await screen.findByText('needs setup')).toBeInTheDocument()
+    expect(screen.getByText('No remote set.')).toBeInTheDocument()
+  })
+
+  it('writes the share toggle through the settings route', async () => {
+    mockApi.state.mockResolvedValue(
+      boardState({ ledger_sync: ledgerSync({ enabled: false, ready: false }) }),
+    )
+    renderPanel()
+
+    fireEvent.click(
+      await screen.findByRole('switch', { name: 'Share the knowledge ledger with my team' }),
+    )
+    await waitFor(() =>
+      expect(mockApi.putSettings).toHaveBeenCalledWith({ ledger_sync_enabled: true }),
+    )
+  })
+})
+
+/* ── on-call schedule ─────────────────────────────────────────────────────── */
+
+describe('the on-call schedule card', () => {
+  const scheduleProvider = () =>
+    mockApi.providers.mockResolvedValue({
+      providers: [
+        provider({
+          id: 'schedule-file',
+          display_name: 'Schedule file (git)',
+          roles: ['rotation'],
+          config_fields: [],
+          config: {},
+        }),
+      ],
+    })
+
+  it('warns while sharing is off, because the schedule then reaches nobody', async () => {
+    renderPanel()
+    expect(await screen.findByText(/Sharing is not set up above/)).toBeInTheDocument()
+  })
+
+  it('drops that warning once sync is ready', async () => {
+    mockApi.state.mockResolvedValue(boardState({ ledger_sync: ledgerSync() }))
+    renderPanel()
+    await screen.findByText('syncing')
+    expect(screen.queryByText(/Sharing is not set up above/)).not.toBeInTheDocument()
+  })
+
+  it('shows the expected file shape, which lived only in a Python docstring', async () => {
+    renderPanel()
+    expect(await screen.findByText('Expected shape')).toBeInTheDocument()
+    expect(screen.getByText(/THROUGH that whole day/)).toBeInTheDocument()
+  })
+
+  it('reports loading rather than a fault while the catalog is absent', async () => {
+    renderPanel()
+    // `schedule-file` is registered unconditionally, so absence is arrival latency.
+    await screen.findByText('On-call schedule')
+    expect(screen.getAllByText('Loading…').length).toBeGreaterThan(0)
+    expect(screen.queryByLabelText(/Your GitHub login/)).not.toBeInTheDocument()
+  })
+
+  it('seeds the login from the roster and writes it through PUT /settings', async () => {
+    scheduleProvider()
+    mockApi.rotation.mockResolvedValue({ ...ROTATION, roster: roster() })
+    renderPanel()
+
+    const login = await findField(/Your GitHub login/)
+    await waitFor(() => expect(login).toHaveValue('octocat'))
+
+    fireEvent.change(login, { target: { value: 'hubot' } })
+    fireEvent.keyDown(login, { key: 'Enter' })
+    await waitFor(() =>
+      expect(mockApi.putSettings).toHaveBeenCalledWith({ schedule_github_login: 'hubot' }),
+    )
+  })
+
+  it('writes nothing when Enter lands on an unedited login', async () => {
+    scheduleProvider()
+    mockApi.rotation.mockResolvedValue({ ...ROTATION, roster: roster() })
+    renderPanel()
+
+    const login = await findField(/Your GitHub login/)
+    await waitFor(() => expect(login).toHaveValue('octocat'))
+    fireEvent.keyDown(login, { key: 'Enter' })
+    expect(mockApi.putSettings).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a refused login write', async () => {
+    scheduleProvider()
+    mockApi.putSettings.mockRejectedValue(new Error('login must be a GitHub handle'))
+    renderPanel()
+
+    const login = await findField(/Your GitHub login/)
+    fireEvent.change(login, { target: { value: 'not a handle' } })
+    fireEvent.click(commitIn(/Your GitHub login/))
+    expect(await screen.findByText('login must be a GitHub handle')).toBeInTheDocument()
+  })
+
+  it('explains an unresolved login, the setup mistake that leaves an instance idle', async () => {
+    mockApi.rotation.mockResolvedValue({
+      ...ROTATION,
+      roster: roster({ me: '', me_on_roster: false }),
+    })
+    renderPanel()
+
+    expect(
+      await screen.findByText(/No GitHub login resolved for this instance/),
+    ).toBeInTheDocument()
+  })
+
+  it('says an unnamed instance never picks up work while strict gating is on', async () => {
+    mockApi.rotation.mockResolvedValue({ ...ROTATION, roster: roster({ me_on_roster: false }) })
+    renderPanel()
+
+    expect(await screen.findByText(/will never pick up work/)).toBeInTheDocument()
+    expect(screen.queryByText(/does not defer to whoever is on call/)).not.toBeInTheDocument()
+  })
+
+  it('says the OTHER half with strict gating off: it does not defer to anyone', async () => {
+    mockApi.rotation.mockResolvedValue({
+      ...ROTATION,
+      roster: roster({ me_on_roster: false, strict_gating: false }),
+    })
+    renderPanel()
+
+    expect(await screen.findByText(/does not defer to whoever is on call/)).toBeInTheDocument()
+    expect(screen.queryByText(/will never pick up work/)).not.toBeInTheDocument()
+  })
+
+  it('renders the roster\'s own parse error verbatim', async () => {
+    mockApi.rotation.mockResolvedValue({
+      ...ROTATION,
+      roster: roster({ error: 'rotation.yaml: shift 2 has no who key' }),
+    })
+    renderPanel()
+    expect(await screen.findByText('rotation.yaml: shift 2 has no who key')).toBeInTheDocument()
+  })
+
+  it('offers strict gating here, with the consequence of the state it is in', async () => {
+    mockApi.rotation.mockResolvedValue({ ...ROTATION, roster: roster() })
+    renderPanel()
+
+    expect(await screen.findByText(/this instance stands down/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('switch', { name: 'Only the on-call instance picks up work' }))
+    await waitFor(() =>
+      expect(mockApi.putSettings).toHaveBeenCalledWith({ schedule_strict_gating: false }),
+    )
+  })
+
+  it('states the fail-open consequence when strict gating is already off', async () => {
+    mockApi.rotation.mockResolvedValue({ ...ROTATION, roster: roster({ strict_gating: false }) })
+    renderPanel()
+    expect(await screen.findByText(/this instance works anyway/)).toBeInTheDocument()
+  })
+})
+
+/* ── instance ─────────────────────────────────────────────────────────────── */
+
+describe('the instance card', () => {
+  it('writes the nightly-maintenance flag from the reported state', async () => {
+    mockApi.rotation.mockResolvedValue({ ...ROTATION, primary: true })
+    renderPanel()
+
+    const toggle = await screen.findByRole('switch', {
+      name: 'Run nightly ledger maintenance on this instance',
+    })
+    await waitFor(() => expect(toggle).toHaveAttribute('aria-checked', 'true'))
+    fireEvent.click(toggle)
+    await waitFor(() =>
+      expect(mockApi.putSettings).toHaveBeenCalledWith({ primary_instance: false }),
+    )
+  })
+})
+
+/* ── heartbeat pacing ─────────────────────────────────────────────────────── */
+
+describe('the heartbeat-pacing card', () => {
+  it('refuses to invent defaults a gateway did not report', async () => {
+    renderPanel()
+
+    expect(await screen.findByText(/Not reported by this gateway/)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Release an investigation after/)).not.toBeInTheDocument()
+  })
+
+  it('shows the stored seconds as the minutes an operator tunes in', async () => {
+    mockApi.rotation.mockResolvedValue({ ...ROTATION, sweep: sweep() })
+    renderPanel()
+
+    expect(await findField(/Release an investigation after/)).toHaveValue('120')
+    expect(field(/Release a question after/)).toHaveValue('720')
+    // 43200 read as minutes is the confusion the card exists to remove.
+    expect(screen.getByText('2h / 12h')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('distinguishes a derived window from a pinned one', async () => {
+    mockApi.rotation.mockResolvedValue({ ...ROTATION, sweep: sweep() })
+    renderPanel()
+    expect(await screen.findByText(/derived from the window above/)).toBeInTheDocument()
+
+    cleanup()
+    mockApi.rotation.mockResolvedValue({
+      ...ROTATION,
+      sweep: sweep({ needs_human_derived: false, needs_human_stale_after_secs: 3600 }),
+    })
+    renderPanel()
+    expect(await screen.findByText(/Pinned at 1h/)).toBeInTheDocument()
+  })
+
+  it('renders an unreported window as a dash rather than as an immediate release', async () => {
+    mockApi.rotation.mockResolvedValue({
+      ...ROTATION,
+      sweep: sweep({ stale_after_secs: 0, needs_human_stale_after_secs: 0 }),
+    })
+    renderPanel()
+
+    expect(await screen.findByText('— / —')).toBeInTheDocument()
+    // 0 is not a value to edit back into the form either.
+    expect(field(/Release an investigation after/)).toHaveValue('')
+  })
+
+  it('keeps a value the backend would 400 off the wire', async () => {
+    mockApi.rotation.mockResolvedValue({ ...ROTATION, sweep: sweep() })
+    renderPanel()
+
+    const input = await findField(/Release an investigation after/)
+    for (const bad of ['0', '-5', '1.5', 'abc', '']) {
+      fireEvent.change(input, { target: { value: bad } })
+      expect(commitIn(/Release an investigation after/)).toBeDisabled()
+    }
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(mockApi.putSettings).not.toHaveBeenCalled()
+  })
+
+  it('saves minutes as seconds, through each row\'s own button', async () => {
+    mockApi.rotation.mockResolvedValue({ ...ROTATION, sweep: sweep() })
+    renderPanel()
+
+    const stale = await findField(/Release an investigation after/)
+    fireEvent.change(stale, { target: { value: '30' } })
+    fireEvent.click(commitIn(/Release an investigation after/))
+    await waitFor(() => expect(mockApi.putSettings).toHaveBeenCalledWith({ stale_after_secs: 1800 }))
+
+    const question = field(/Release a question after/)
+    fireEvent.change(question, { target: { value: '90' } })
+    fireEvent.click(commitIn(/Release a question after/))
+    await waitFor(() =>
+      expect(mockApi.putSettings).toHaveBeenCalledWith({ needs_human_stale_after_secs: 5400 }),
+    )
+  })
+
+  it('leaves a key alone when its own field is untouched', async () => {
+    mockApi.rotation.mockResolvedValue({ ...ROTATION, sweep: sweep() })
+    renderPanel()
+
+    await findField(/Release an investigation after/)
+    expect(commitIn(/Release a question after/)).toBeDisabled()
+    fireEvent.keyDown(field(/Release a question after/), { key: 'Enter' })
+    expect(mockApi.putSettings).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What

933 tests in seven new files. Two targets had **no test at all**; the rest sat between 8% and 33%.

| target | before | after | gain |
|---|---|---|---|
| `src/api/client.ts` | 32.5% | **99.7%** | +482 |
| `src/apps/mochi/src/renderer/SettingsPanel.tsx` | 29.5% | 99.7% | +228 |
| `src/apps/ops-mission-control/SettingsPanel.tsx` | 8.0% | 100% | +196 |
| `src/apps/mochi/src/renderer/WatchlistPanel.tsx` | 0.0% | 99.5% | +193 |
| `src/apps/crew-companion/PackEditor.tsx` | 0.0% | 94.4% | +185 |
| `src/pages/scenes/GhostScene.tsx` | 23.8% | 100% | +176 |
| `src/pages/connections/ConnectionsPage.tsx` | 8.8% | 98.9% | +163 |

**At least +1,623 statements**, frontend 69.31% → ~72%.

That is a **lower bound, not an estimate**. Each file was measured running only these seven test files, so for the five targets that already had partial coverage, the union with the existing suite can only be larger.

The frontend floor stays at **60**. Ratcheting belongs in its own change.

## Why these targets

Backend coverage work hit diminishing returns two waves ago (1,040 tests → +1.35pp, then 1,883 tests → +0.44pp) because the remaining backend lines sit behind I/O a unit test cannot reach. Under-tested frontend surfaces convert far better — `api/client.ts` alone went from a third covered to essentially complete.

## Not in this PR — five attempted targets

Shipping a test that buys nothing is worse than shipping none, so five targets were dropped rather than padded:

- **`mochi/…/GalleryPanel.tsx`** and **`scenes/PandaOfficeScene.tsx`** each produced a *single* test worth **0** and **+0** statements. PandaOffice's test covered 4.7% where the existing suite already reaches 20.8%, so its marginal value was zero.
- **`crew-companion/SpriteImporter.tsx`**, **`mochi/…/SpriteImporter.tsx`**, **`scenes/MissionControlScene.tsx`** produced no file at all.

Their **1,077 statements remain uncovered** and are still on the list.

## Three tests failed on first run

All three were over-specific assertions, not product faults. Recording them because "reported green, actually red" is the failure mode worth knowing about:

1. **`PackEditor`** asserted a popover row's background returns to `transparent` on hover-out. React 17+ synthesizes `onMouseLeave` from `mouseout` at the root, and under jsdom neither a bare `mouseleave` (does not bubble) nor `mouseOut` with an explicit `relatedTarget` reaches the handler. The hover-ON half is kept; the reset branch is left uncovered rather than pinned with a flaky event.
2. **`mochi SettingsPanel`** asserted the previously-selected activity mode turned transparent. Both option labels can resolve to the **same** element via `.closest('label')`, so the assertion compared an element with itself. Now only the newly-picked row is asserted.
3. **`mochi SettingsPanel`** demanded exactly one `Chat only` label; several rows legitimately carry it. Switched to `findAllByText`.

Also cleaned up: a stray `console.log` left in the mochi SettingsPanel test, and two new eslint warnings — the Frontend Lint gate runs `eslint src/ --max-warnings 1116`, so two new warnings would have pushed the count to 1118 and **failed the gate**.

## One product observation, not fixed here

`src/apps/mochi/src/renderer/SettingsPanel.tsx:123` registers its native-window-close listener in a `useEffect` with **no dependency array**, so it unsubscribes and resubscribes on every single render:

```tsx
useEffect(() => {
  const off = api?.onSettingsCloseRequested?.(() => handleClose())
  return () => { off?.() }
})            // <-- no dep array
```

Harmless today because the callback defers through an arrow, but it is real re-subscription churn. Not fixed — this PR adds tests only, so a behaviour change can be reviewed on its own merits.

## Tests

The seven new files are the tests. No existing file is modified — the diff is seven additions and nothing else. Tests avoid real network, real elapsed timers, canvas/WebGL actually rendering, fixed ports, and the developer's home directory; interactions are driven synchronously so nothing depends on wall-clock timing or test order.

## Manual verification

- `npx vitest run` on all seven — **933/933 pass**
- `npx tsc --noEmit` — clean
- `npx eslint` on all seven — **0 errors, 0 warnings**
- `npm run jscpd` — **0 clones** (relevant: 6,494 lines added)
- `git status` — **0** existing files modified
- Coverage measured with the reporter scoped to the six affected source directories

## Screenshots

N/A — tests only, no user-visible surface changes.
