### PR TITLE
fix(cloud): install Node >=22 on the EC2 crew so the dashboard build succeeds

### DIFF
--- a/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
+++ b/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
@@ -359,43 +359,51 @@ Resources:
           dnf install -y ripgrep || echo "ripgrep unavailable (optional), continuing"
 
           echo "--- installing Node.js ---"
-          # AL2023's default AppStream nodejs is the reliable primary path
-          # (validated on AL2023, no external repo); the supported floor is
-          # Node 22+ (24 LTS recommended). The NodeSource fallback does
-          # NOT pipe a remote script into bash (a supply-chain risk if NodeSource
-          # is MITM'd/compromised); instead it imports NodeSource's GPG key over
-          # pinned TLS and writes a signed dnf repo with gpgcheck=1, so every RPM
-          # is signature-verified before install.
+          # The frontend build (vite 8 + rolldown) REQUIRES Node >=22: AL2023's
+          # default AppStream `nodejs` is 18, on which the build dies with
+          # "SyntaxError: ... 'node:util' does not provide an export named
+          # 'styleText'". So enforce a floor -- keep AppStream node only if it is
+          # already >=22, otherwise install Node 24 from the signed NodeSource repo.
+          # The NodeSource path does NOT pipe a remote script into bash (a supply-
+          # chain risk if NodeSource is MITM'd); it imports NodeSource's GPG key
+          # over pinned TLS and writes a signed dnf repo with gpgcheck=1, so every
+          # RPM is signature-verified before install.
+          NODE_MAJOR_MIN=22
           if ! command -v node >/dev/null 2>&1; then
             if ! dnf install -y nodejs npm; then
               # A transient dnf cache/mirror race can drop a dependency RPM
               # mid-transaction ("No such file: .../libbrotli-...rpm"); clean the
-              # cache and retry once before falling back to the NodeSource repo.
+              # cache and retry once.
               echo "nodejs install failed - cleaning dnf cache and retrying"
               dnf clean packages || true
               dnf makecache || true
-            fi
-            if ! command -v node >/dev/null 2>&1 && ! dnf install -y nodejs npm; then
-              echo "AppStream nodejs unavailable - trying signed NodeSource repo"
-              # NodeSource rotated its GPG key URL; the old nodesource-repo.gpg.key
-              # now 404s (caused BOOTSTRAP FAILED). Current: ns-operations-public.key.
-              NS_KEY=https://rpm.nodesource.com/gpgkey/ns-operations-public.key
-              rpm --import "$NS_KEY" || fail "could not import NodeSource GPG key"
-              # Write the repo file line-by-line (kept indented so the YAML |
-              # block stays well-formed; a column-1 heredoc body would break it).
-              # gpgcheck=1 makes dnf verify every RPM signature against the key
-              # imported above — no unverified curl|bash of a remote script.
-              {
-                printf '%s\n' '[nodesource-nodejs]'
-                printf '%s\n' 'name=Node.js Packages'
-                printf '%s\n' 'baseurl=https://rpm.nodesource.com/pub_24.x/nodistro/nodejs/$basearch'
-                printf '%s\n' 'enabled=1'
-                printf '%s\n' 'gpgcheck=1'
-                printf '%s\n' "gpgkey=$NS_KEY"
-              } >/etc/yum.repos.d/nodesource.repo
-              dnf install -y nodejs || fail "Node.js install failed (signed NodeSource repo)"
+              dnf install -y nodejs npm || true
             fi
           fi
+          NODE_MAJOR=$(node --version 2>/dev/null | sed -n 's/^v\([0-9][0-9]*\).*/\1/p' | head -1)
+          [ -n "$NODE_MAJOR" ] || NODE_MAJOR=0
+          if [ "$NODE_MAJOR" -lt "$NODE_MAJOR_MIN" ]; then
+            echo "Node major $NODE_MAJOR is below the required $NODE_MAJOR_MIN - installing Node 24 from the signed NodeSource repo"
+            # NodeSource rotated its GPG key URL; the old nodesource-repo.gpg.key
+            # now 404s (caused BOOTSTRAP FAILED). Current: ns-operations-public.key.
+            NS_KEY=https://rpm.nodesource.com/gpgkey/ns-operations-public.key
+            rpm --import "$NS_KEY" || fail "could not import NodeSource GPG key"
+            # Write the repo file line-by-line (kept indented so the YAML |
+            # block stays well-formed; a column-1 heredoc body would break it).
+            {
+              printf '%s\n' '[nodesource-nodejs]'
+              printf '%s\n' 'name=Node.js Packages'
+              printf '%s\n' 'baseurl=https://rpm.nodesource.com/pub_24.x/nodistro/nodejs/$basearch'
+              printf '%s\n' 'enabled=1'
+              printf '%s\n' 'gpgcheck=1'
+              printf '%s\n' "gpgkey=$NS_KEY"
+            } >/etc/yum.repos.d/nodesource.repo
+            # --allowerasing so NodeSource's nodejs can replace an AppStream node 18.
+            dnf install -y --allowerasing nodejs || fail "Node.js >=$NODE_MAJOR_MIN install failed (signed NodeSource repo)"
+            NODE_MAJOR=$(node --version 2>/dev/null | sed -n 's/^v\([0-9][0-9]*\).*/\1/p' | head -1)
+            [ -n "$NODE_MAJOR" ] || NODE_MAJOR=0
+          fi
+          [ "$NODE_MAJOR" -ge "$NODE_MAJOR_MIN" ] || fail "Node.js too old (major $NODE_MAJOR, need >=$NODE_MAJOR_MIN)"
           echo "node: $(command -v node) $(node --version 2>/dev/null || echo missing)"
           echo "npm:  $(command -v npm) $(npm --version 2>/dev/null || echo missing)"
 

--- a/test/test_cloud_ec2.py
+++ b/test/test_cloud_ec2.py
@@ -32,6 +32,17 @@ class TestSubTemplateSyntax:
         ]
         assert not bad, f"illegal !Sub variable(s): {bad}"
 
+    def test_bootstrap_enforces_node_major_floor(self):
+        # The frontend build (vite 8 + rolldown) needs Node >=22; AL2023's default
+        # AppStream nodejs is 18, which fails with a node:util/styleText SyntaxError.
+        # The template must (a) declare the >=22 floor, (b) upgrade via the signed
+        # NodeSource 24 repo when the installed node is too old, and (c) fail the
+        # bootstrap if it still cannot reach the floor.
+        text = ec2.load_template()
+        assert "NODE_MAJOR_MIN=22" in text
+        assert "pub_24.x" in text
+        assert 'fail "Node.js too old' in text
+
 
 class TestValidation:
     def test_valid_tag(self):


### PR DESCRIPTION
## Problem

Launching an EC2 crew now gets past stack creation but the bootstrap fails at the
dashboard build, and the stack rolls back:

```
kirocrew install.sh failed :: ... > tsc -b && vite build
node_modules/rolldown/dist/shared/create-bundler-option-...mjs:8
import { formatWithOptions, styleText } from 'node:util';
SyntaxError: The requested module 'node:util' does not provide an export named 'styleText'
Node.js v18.20.8
```

(The real error is now visible thanks to the diagnostics from #2059/#2596 — this PR
fixes the underlying cause.)

## Why it matters

Every dashboard-launched EC2 crew fails to build its frontend and rolls back, so the
feature is unusable end to end. `styleText` from `node:util` only exists in Node 20+/22+;
the crew ran Node 18.

## Fix

- **Symptom:** `vite build` (via `rolldown`) throws `node:util … styleText` and exits; the
  `WaitCondition` fails and the stack rolls back.
- **Root cause:** the repo requires Node **>=22** (`website/package.json` `engines`,
  `.nvmrc` = 24), but the EC2 UserData installed AL2023's default AppStream `nodejs`,
  which is **18**. The signed NodeSource-24 fallback was guarded on node being *absent*
  (`if ! command -v node`), so once AppStream installed 18 the fallback never ran.
- **Change:** enforce a `NODE_MAJOR_MIN=22` floor. Parse the installed node major; if it
  is below 22 (including the AppStream-18 case), install Node 24 from the existing signed
  NodeSource repo (`--allowerasing` so it replaces node 18), then hard-`fail` the bootstrap
  if the floor still isn't met (rollback with a clear reason rather than a broken crew).
  The NodeSource path is unchanged (GPG key imported over pinned TLS, `gpgcheck=1`; no
  `curl | bash`). Only plain `$var` is used — no `${...}` that a `!Sub` would choke on.

## Tests

- New `test_bootstrap_enforces_node_major_floor` asserts the template declares the floor,
  uses the NodeSource 24 repo, and fails closed when it can't reach it.
- `test_every_sub_variable_is_legal` (from #2596) still passes, confirming the new block
  introduces no illegal `!Sub` token.
- `test/test_cloud_ec2.py`: 75 passed locally.

## Manual verification

Not yet re-launched. Next EC2 launch should install Node 24 and complete the frontend
build. (Follow-up, out of scope: `install.sh`'s non-mise `dnf install nodejs` path has the
same latent floor gap for local Linux CLI installs; the mise path already pins Node 24.)
