### PR TITLE
fix(ci): derive the review diff base from merge-base, not base tip

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -18,11 +18,26 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve diff base (merge-base)
+        id: diffbase
+        env:
+          BASE_TIP: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # base.sha is the base branch tip when the PR event fired, not the
+          # branch-off point, so diffing it directly pulls in sibling commits.
+          if ! MERGE_BASE=$(git merge-base "$BASE_TIP" "$HEAD_SHA"); then
+            echo "::error::Could not resolve the merge-base of $BASE_TIP and $HEAD_SHA (this job needs fetch-depth: 0)"
+            exit 1
+          fi
+          echo "Diff base: $MERGE_BASE"
+          echo "sha=$MERGE_BASE" >> "$GITHUB_OUTPUT"
+
       - name: Get changed files
         id: changed
         run: |
           echo "files<<EOF" >> $GITHUB_OUTPUT
-          git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} >> $GITHUB_OUTPUT
+          git diff --name-only ${{ steps.diffbase.outputs.sha }}..${{ github.event.pull_request.head.sha }} >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       # Deterministic replication of the blocking rules from
@@ -33,7 +48,7 @@ jobs:
         if: contains(steps.changed.outputs.files, 'website/src/')
         working-directory: website
         env:
-          BASE: ${{ github.event.pull_request.base.sha }}
+          BASE: ${{ steps.diffbase.outputs.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           echo "::group::use-lucide-icons — no inline SVGs"
@@ -105,7 +120,7 @@ jobs:
       - name: Check backend security rules
         if: contains(steps.changed.outputs.files, 'src/kiro_crew/')
         env:
-          BASE: ${{ github.event.pull_request.base.sha }}
+          BASE: ${{ steps.diffbase.outputs.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           echo "::group::sensitive-path reads must go through is_sensitive_path()"
@@ -185,6 +200,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve diff base (merge-base)
+        id: diffbase
+        env:
+          BASE_TIP: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if ! MERGE_BASE=$(git merge-base "$BASE_TIP" "$HEAD_SHA"); then
+            echo "::error::Could not resolve the merge-base of $BASE_TIP and $HEAD_SHA (this job needs fetch-depth: 0)"
+            exit 1
+          fi
+          echo "Diff base: $MERGE_BASE"
+          echo "sha=$MERGE_BASE" >> "$GITHUB_OUTPUT"
+
       - name: Install woke
         env:
           WOKE_VERSION: "0.19.0"
@@ -205,7 +233,7 @@ jobs:
 
       - name: Scan only changed lines
         env:
-          BASE: ${{ github.event.pull_request.base.sha }}
+          BASE: ${{ steps.diffbase.outputs.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           # _vendor is third-party code (llama-cpp-python) whose upstream URLs
@@ -257,9 +285,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve diff base (merge-base)
+        id: diffbase
+        env:
+          BASE_TIP: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if ! MERGE_BASE=$(git merge-base "$BASE_TIP" "$HEAD_SHA"); then
+            echo "::error::Could not resolve the merge-base of $BASE_TIP and $HEAD_SHA (this job needs fetch-depth: 0)"
+            exit 1
+          fi
+          echo "Diff base: $MERGE_BASE"
+          echo "sha=$MERGE_BASE" >> "$GITHUB_OUTPUT"
+
       - name: Semgrep scan (diff only)
         env:
-          SEMGREP_BASELINE_REF: ${{ github.event.pull_request.base.sha }}
+          SEMGREP_BASELINE_REF: ${{ steps.diffbase.outputs.sha }}
         run: |
           semgrep scan \
             --config p/python \
@@ -282,6 +323,19 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+
+      - name: Resolve diff base (merge-base)
+        id: diffbase
+        env:
+          BASE_TIP: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if ! MERGE_BASE=$(git merge-base "$BASE_TIP" "$HEAD_SHA"); then
+            echo "::error::Could not resolve the merge-base of $BASE_TIP and $HEAD_SHA (this job needs fetch-depth: 0)"
+            exit 1
+          fi
+          echo "Diff base: $MERGE_BASE"
+          echo "sha=$MERGE_BASE" >> "$GITHUB_OUTPUT"
 
       # ── Conventional commit format on PR title ──────────────────────
       # PR title becomes the squash-merge commit message, so it must
@@ -313,7 +367,7 @@ jobs:
       # This keeps PRs atomic and reviewable as a single logical change.
       - name: Enforce single commit
         env:
-          BASE: ${{ github.event.pull_request.base.sha }}
+          BASE: ${{ steps.diffbase.outputs.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           COMMIT_COUNT=$(git rev-list --count "$BASE".."$HEAD")


### PR DESCRIPTION
## Problem / Motivation

`code-review.yml` derives its diff base from `github.event.pull_request.base.sha`. That field is the tip of the base branch at the moment the `pull_request` event fired, not the merge-base with the head. When the base branch moves between the event and the run, the workflow diffs a *sibling* commit against the head, so `git diff base..head` reverse-includes every commit the base gained and presents other contributors' changes as additions belonging to this PR.

This is not theoretical — it happened on #2576. The gate ran with a base that is not an ancestor of that PR's head, and the base landed 30 seconds before the push, so a normal push loses this race whenever anyone merges nearby. `Automated Rule Check` then failed the `model-selection` rule on a line in a Python file while that PR's own diff was two TypeScript files. The flagged line was the *inverse* of what the other commit did: it had replaced a hardcoded model id with a variable, and reversing the diff re-introduced the literal. The gate saw 15 files, +180/-550; the real change was 2 files, +167/-4.

Clicking re-run cannot clear this. The replay carries the same event payload and therefore the same `base.sha`, so today the only escape is pushing again and winning the race.

It failed loudly there, which was luck. The same skew makes the diff-scoped scanners in this file examine the wrong range and pass **vacuously** — a false green that is indistinguishable from a real one.

## Why it matters

Both failure directions cost real work, and the quiet one is worse. Loudly, the gate fails naming code the author never wrote — on #2576 it reported 15 files and +180/-550 against a change that was 2 files and +167/-4, and blamed a Python line in a TypeScript-only PR. That is a confusing block a contributor cannot clear by re-running, because the replay carries the same event payload and therefore the same base. Quietly, the same skew makes the diff-scoped scanners in this file examine the wrong range and pass vacuously — a false green indistinguishable from a real one, on gates that are required for merge. Any PR loses this race whenever someone merges nearby, so it is a matter of timing rather than of doing something unusual.

## What changed (motivation → approach → change)

Each job that needs a diff base resolves it once in a named `Resolve diff base (merge-base)` step and exports it as a step output. Six call sites consume that output instead of reading `base.sha`:

| Job                  | Consumer                               |
| -------------------- | -------------------------------------- |
| `autosde-rules`      | Get changed files                      |
| `autosde-rules`      | Check frontend blocking rules (`BASE`) |
| `autosde-rules`      | Check backend security rules (`BASE`)  |
| `inclusive-language` | Scan only changed lines (`BASE`)       |
| `sast`               | Semgrep (`SEMGREP_BASELINE_REF`)       |
| `pr-hygiene`         | Enforce single commit (`BASE`)         |

All four of these jobs already check out with `fetch-depth: 0`, so both commits are present and no extra fetch is needed. That is what keeps the change small.

Decisions worth calling out:

- **It fails closed.** If `git merge-base` cannot resolve, the step prints an error naming both shas and exits non-zero. It does not fall back to `base.sha`, because a silent fallback would reintroduce this bug invisibly.
- **A separate named step** rather than six inline substitutions, so a resolution failure shows up as its own step instead of masquerading as a rule failure.
- **A step output rather than `$GITHUB_ENV`**, matching the existing `id: changed` idiom, so each consumer keeps an explicit `env:` block and a reader can still see where `BASE` comes from. The `run:` bodies are untouched.
- **Semgrep was already correct.** At the pinned `semgrep/semgrep:1.78`, `--baseline-commit` without `--baseline-commit-is-mergebase` makes Semgrep append `--merge-base` to its own `git diff` and check out `git merge-base <base> HEAD` for the baseline worktree, so that line was not affected by the bug. It is changed anyway: the change is idempotent (the merge-base of an ancestor is itself), Semgrep has a documented fallback that compares the baseline commit directly when git reports multiple merge bases — which degrades to exactly this bug — and leaving one of six sites reading `base.sha` invites the pattern being copied back. Semgrep's own log message recommends `--baseline-commit=$(git merge-base ... HEAD)`.
- **`Enforce single commit` is unaffected for a rebased branch.** `git rev-list --count` returns the same number under either base, because reachability excludes the base branch's own commits either way. It differs only when the head has merged the base branch in, where the merge-base correctly counts those commits and reports more than one — consistent with what that rule is for.

## Tests

Reproduced against the real shas from #2576: the recorded base is not an ancestor of that head, and the merge-base is the head's true parent. The base-tip range reads 15 files, +180/-550 and matches the `model-selection` rule once; the merge-base range reads the real 2 files, +167/-4 and matches it zero times.

The new step was also exercised three ways: it emits the merge-base for the skewed pair, fails closed with no output on an unresolvable sha, and is a no-op when handed a base that is already the merge-base. The YAML parses, and every job carrying the new step was confirmed to check out with `fetch-depth: 0`.

## Expect a red here until a maintainer labels this

`fork-workflow-guard` blocks fork PRs that modify `.github/**`, and that is correct — a fork could otherwise use a workflow change to fake CI results. That check will report a failure, and the companion job strips the label on each subsequent push, so it re-blocks on every revision.

Could a maintainer review this and apply `allow-fork-workflow-change`? I have not attempted to work around the guard.

