### PR TITLE
perf(stt): cap Whisper subprocess threads on many-core hosts

### DIFF
--- a/docs/reference/kiro-cli/chat/voice.md
+++ b/docs/reference/kiro-cli/chat/voice.md
@@ -91,6 +91,27 @@ status badge stays "not installed".
 dependency because the `mlx` wheel is arm64-only; Kiro Crew invokes the
 `mlx_whisper` CLI as a subprocess, exactly like the `whisper` provider.
 
+### CPU threads (many-core hosts)
+
+Kiro Crew derives the Whisper subprocess's thread count from the host: **half the
+available cores**, capped at 16. To control it yourself, set `OMP_NUM_THREADS` or
+`OPENBLAS_NUM_THREADS` — if either is set, Kiro Crew leaves both alone and your
+value is used as-is. The count comes from `sched_getaffinity` where available, so
+a CPU-restricted container gets its real budget rather than the whole machine's.
+
+Why not use every core: Whisper decodes one output step at a time, and each step
+is a small matmul that ends in a thread barrier. Wide thread pools therefore cost
+latency per step instead of buying throughput, and on a host that is doing other
+work — a Kiro Crew host runs the gateway and agent sessions alongside — the
+workers get time-sliced, so each barrier waits on threads the scheduler has not
+run yet.
+
+Measured on a 32-vCPU Graviton3 host with an 11-second clip, 16 threads beat 31
+(`base` 4.9s vs 7.3s, `turbo` 20.8s vs 26.9s), and restricted to 16 cores with
+`taskset`, 8 threads beat 16 (5s vs 7s). The headroom buys predictability more
+than raw speed: 8 threads measured 4.9–5.0s across repeats, while taking all 32
+ranged 8.1–68.4s depending on how busy the machine was.
+
 ## Voice Output (Text-to-Speech)
 
 Kiro Crew can speak responses aloud using Amazon Polly. Two modes are available:

--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -573,6 +573,96 @@ def _collect_whisper_output(
     return txt_files[0].read_text().strip() or None
 
 
+#: Ceiling on the derived thread count (see :func:`_whisper_thread_count`). The
+#: count itself is host-derived; this only bounds EXTRAPOLATION above the widths
+#: that were measured. Decode-heavy models stop benefiting early — in-process
+#: ``base``, an 11s clip: 8 threads 0.96s, 16 1.13s, 24 1.18s, i.e. flat-to-worse
+#: — while encoder-heavy ``turbo`` keeps gaining to 24 (6.26s / 5.13s / 4.81s).
+#: 16 is where both model shapes sit within 7% of their own best, so a 64- or
+#: 128-core host gets 16 rather than an untested 32+.
+_WHISPER_THREAD_CEILING = 16
+
+#: Vars that bound the subprocess's intra-op parallelism. ``OMP_NUM_THREADS``
+#: governs torch's own thread pool plus any OpenMP-threaded BLAS (and MKL, which
+#: falls back to it). A pthread-built OpenBLAS — what the aarch64 torch wheels
+#: link — reads ``OPENBLAS_NUM_THREADS`` instead and ignores the OpenMP one, so
+#: both are required to cover the wheel matrix rather than just the common case.
+#:
+#: torch and OpenBLAS keep SEPARATE pools (measured peak OS threads: omp=8/blas=8
+#: -> 16, omp=32/blas=32 -> 64, omp=32/blas=1 -> 33), so these two values add
+#: rather than multiply. Setting both to the same count — rather than handing the
+#: whole budget to one pool — is deliberate: omp=16/blas=1 and omp=16/blas=16
+#: measured within 3-5% of each other, while omp=31/blas=1 was 30-50% WORSE than
+#: omp=16/blas=16 at the same 32 total threads. Pool width, not thread total, is
+#: what costs.
+_THREAD_ENV_VARS = ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS")
+
+
+def _available_cpus() -> int:
+    """Return the core count this process may actually run on.
+
+    ``os.sched_getaffinity`` rather than ``os.cpu_count``: under a CPU-set
+    restriction (containers, cgroups, ``taskset``) the latter reports the whole
+    machine, which is exactly the environment that over-threads worst. Falls back
+    to ``os.cpu_count`` where affinity is unavailable (macOS, Windows).
+    """
+    if hasattr(os, "sched_getaffinity"):
+        try:
+            return len(os.sched_getaffinity(0)) or 1
+        except OSError:
+            pass
+    return os.cpu_count() or 1
+
+
+def _whisper_thread_count() -> int:
+    """Derive the Whisper subprocess's intra-op thread count from the host.
+
+    Half the available cores, bounded by :data:`_WHISPER_THREAD_CEILING`.
+
+    Whisper decoding is autoregressive: thousands of tiny parallel regions, each
+    ending in a barrier that completes only when its slowest worker arrives. Wide
+    pools therefore cost latency per step rather than buying throughput, and on a
+    host with other work (a Kiro Crew host runs the gateway and agent sessions
+    alongside) the workers are time-sliced, so a barrier waits on threads the
+    scheduler has not run yet.
+
+    Half the cores is measured, not assumed, at two widths on this 32-core
+    Graviton3 host: at 32 visible cores 16 threads beat 31 (base 4.9s vs 7.3s,
+    turbo 20.8s vs 26.9s), and under ``taskset`` to 16 visible cores 8 threads
+    beat 16 (5s vs 7s). Taking every core also destabilises the runtime far more
+    than it slows it: 8 threads measured 4.9-5.0s across repeats while 32 threads
+    ranged 8.1-68.4s depending on background load. The headroom buys
+    predictability first and mean latency second.
+    """
+    return max(1, min(_WHISPER_THREAD_CEILING, _available_cpus() // 2))
+
+
+def _thread_capped_env() -> dict[str, str]:
+    """Return the subprocess environment with intra-op threads bounded.
+
+    Also strips ``PYTHONPATH``/``PYTHONHOME``: the Whisper CLIs are installed
+    out-of-band and run under their own interpreter, so Kiro Crew's bundled
+    packages (numpy, torch) must not leak into their runtime.
+
+    An operator who has set ANY of :data:`_THREAD_ENV_VARS` is left completely
+    alone — all of them, not just the one they set. Someone who pins
+    ``OPENBLAS_NUM_THREADS=32`` for a reason has expressed an intent about this
+    process's threading, and silently capping the sibling var would half-honour
+    it in a way that is worse than either choice. That deliberately gives up the
+    speedup for those hosts in exchange for never overriding an explicit
+    setting.
+    """
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    env.pop("PYTHONHOME", None)
+    if any(env.get(var) for var in _THREAD_ENV_VARS):
+        return env
+    threads = str(_whisper_thread_count())
+    for var in _THREAD_ENV_VARS:
+        env[var] = threads
+    return env
+
+
 async def _run_whisper_cli(
     binary: str,
     build_args,  # Callable[[str], list[str]]: out_dir -> CLI args (excluding binary)
@@ -582,19 +672,16 @@ async def _run_whisper_cli(
     """Run a Whisper-style CLI in an isolated subprocess and read its transcript.
 
     Shared by ``_transcribe_native`` (openai-whisper) and ``_transcribe_mlx``
-    (mlx_whisper). Both CLIs are installed out-of-band and run under their own
-    Python interpreter, so we strip ``PYTHONPATH``/``PYTHONHOME`` to stop
-    KiroCrew's bundled packages (numpy, torch) from leaking into their runtime.
-    Each writes a ``.txt`` transcript into a temp ``out_dir`` we own and clean
-    up. ``build_args`` lets callers express their differing flags (the two CLIs
-    use hyphenated vs underscored option names).
+    (mlx_whisper). The environment comes from :func:`_thread_capped_env`, which
+    isolates the CLI from Kiro Crew's own Python packages and bounds its intra-op
+    parallelism. Each writes a ``.txt`` transcript into a temp ``out_dir`` we own
+    and clean up. ``build_args`` lets callers express their differing flags (the
+    two CLIs use hyphenated vs underscored option names).
     """
     out_dir = await asyncio.to_thread(tempfile.mkdtemp)
     proc = None
     try:
-        clean_env = os.environ.copy()
-        clean_env.pop("PYTHONPATH", None)
-        clean_env.pop("PYTHONHOME", None)
+        clean_env = _thread_capped_env()
         proc = await asyncio.create_subprocess_exec(
             binary,
             *build_args(out_dir),

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -13,11 +13,14 @@ import pytest
 from kiro_crew import platform_compat as _pc
 from kiro_crew.config.loader import SttConfig
 from kiro_crew.transcribe import (
+    _THREAD_ENV_VARS,
+    _WHISPER_THREAD_CEILING,
     BREW_PATH_DIRS,
     _find_mlx_whisper,
     _find_whisper,
     _is_openai_whisper,
     _ProfileCredentialResolver,
+    _thread_capped_env,
     find_brew,
     is_available,
     transcribe_audio,
@@ -232,6 +235,165 @@ class TestNativeFp16Gating:
         assert "--fp16" not in args
         # The rest of the invocation is unchanged — the engine still gets its model/output flags.
         assert "--model" in args and "--output_format" in args
+
+
+# ---------------------------------------------------------------------------
+# _thread_capped_env
+# ---------------------------------------------------------------------------
+
+
+class TestWhisperThreadCap:
+    """The Whisper subprocess must not fan its tiny matmuls out to every core.
+
+    Whisper decodes autoregressively, so a wide pool pays a barrier per output
+    step and gets SLOWER: at 32 visible cores 16 threads beat 31 (base 4.9s vs
+    7.3s), and taking all 32 ranged 8.1-68.4s against a steady 4.9s. The count is
+    derived from the host — half the available cores — so these tests pin the
+    derivation, its bounds, and the operator-override escape hatch.
+    """
+
+    def _env(
+        self,
+        monkeypatch,
+        *,
+        cpus,
+        affinity: set[int] | None = None,
+        preset: dict[str, str] | None = None,
+    ) -> dict[str, str]:
+        for var in _THREAD_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        for key, value in (preset or {}).items():
+            monkeypatch.setenv(key, value)
+        monkeypatch.setattr("kiro_crew.transcribe.os.cpu_count", lambda: cpus)
+        if affinity is None:
+            monkeypatch.delattr("kiro_crew.transcribe.os.sched_getaffinity", raising=False)
+        else:
+            # raising=False because Windows has no os.sched_getaffinity to
+            # replace — monkeypatch CREATES it there, which is what lets this
+            # test cover the affinity branch on every platform rather than
+            # erroring out on the ones that lack the syscall.
+            monkeypatch.setattr(
+                "kiro_crew.transcribe.os.sched_getaffinity",
+                lambda _pid: affinity,
+                raising=False,
+            )
+        return _thread_capped_env()
+
+    @pytest.mark.parametrize(
+        "cpus,expected",
+        [
+            (32, 16),  # measured host: 16 beat both 8 and 31
+            (16, 8),  # measured under taskset: 8 beat 16
+            (8, 4),
+            (4, 2),
+            (2, 1),
+            (1, 1),  # never 0 — a 0 would let the runtime pick all cores again
+        ],
+    )
+    def test_half_the_cores(self, monkeypatch, cpus, expected):
+        env = self._env(monkeypatch, cpus=cpus)
+        assert all(env[var] == str(expected) for var in _THREAD_ENV_VARS)
+
+    def test_huge_host_stops_at_the_ceiling(self, monkeypatch):
+        # Half of 128 would be 64 — wider than anything measured, and decode-heavy
+        # models already stop gaining above 8.
+        env = self._env(monkeypatch, cpus=128)
+        assert all(env[var] == str(_WHISPER_THREAD_CEILING) for var in _THREAD_ENV_VARS)
+
+    def test_affinity_beats_cpu_count(self, monkeypatch):
+        """A cgroup/taskset restriction is the case that over-threads worst.
+
+        os.cpu_count() reports the whole machine there, so deriving from it would
+        hand a 4-CPU container the thread budget of a 32-core host.
+        """
+        env = self._env(monkeypatch, cpus=32, affinity={0, 1, 2, 3})
+        assert all(env[var] == "2" for var in _THREAD_ENV_VARS)
+
+    def test_falls_back_to_cpu_count_without_affinity_support(self, monkeypatch):
+        # macOS and Windows have no sched_getaffinity.
+        env = self._env(monkeypatch, cpus=32, affinity=None)
+        assert all(env[var] == "16" for var in _THREAD_ENV_VARS)
+
+    def test_unknowable_cpu_count_falls_back_to_one(self, monkeypatch):
+        # os.cpu_count() returns None on platforms that cannot report it.
+        env = self._env(monkeypatch, cpus=None, affinity=None)
+        assert all(env[var] == "1" for var in _THREAD_ENV_VARS)
+
+    def test_operator_setting_is_never_overridden(self, monkeypatch):
+        env = self._env(monkeypatch, cpus=32, preset={"OMP_NUM_THREADS": "32"})
+        assert env["OMP_NUM_THREADS"] == "32"
+
+    def test_sibling_var_is_left_alone_when_operator_set_either_one(self, monkeypatch):
+        """Pinning one var must not get half-honoured by capping the other.
+
+        A host that sets only OPENBLAS_NUM_THREADS has still expressed intent
+        about this process's threading, so we inject NEITHER var rather than
+        producing a mixed configuration the operator never asked for.
+        """
+        env = self._env(monkeypatch, cpus=32, preset={"OPENBLAS_NUM_THREADS": "32"})
+        assert env["OPENBLAS_NUM_THREADS"] == "32"
+        assert "OMP_NUM_THREADS" not in env
+
+    def test_empty_value_counts_as_unset(self, monkeypatch):
+        # An exported-but-empty var configures nothing, so it must not be read
+        # as an operator override that suppresses the derivation.
+        env = self._env(monkeypatch, cpus=32, preset={"OMP_NUM_THREADS": ""})
+        assert all(env[var] == "16" for var in _THREAD_ENV_VARS)
+
+    def test_both_pools_get_the_same_count(self, monkeypatch):
+        """torch and OpenBLAS keep separate pools; width is what costs, not total.
+
+        omp=31/blas=1 measured 30-50% worse than omp=16/blas=16 at the same 32
+        total threads, so the budget is applied per pool rather than split.
+        """
+        env = self._env(monkeypatch, cpus=32)
+        assert env["OMP_NUM_THREADS"] == env["OPENBLAS_NUM_THREADS"]
+
+    def test_bundled_python_env_is_still_stripped(self, monkeypatch):
+        # Pre-existing contract: the out-of-band CLI runs under its own
+        # interpreter and must not import Kiro Crew's numpy/torch.
+        env = self._env(
+            monkeypatch,
+            cpus=32,
+            preset={"PYTHONPATH": "/opt/kirocrew/lib", "PYTHONHOME": "/opt/kirocrew"},
+        )
+        assert "PYTHONPATH" not in env
+        assert "PYTHONHOME" not in env
+
+    def test_unrelated_environment_survives(self, monkeypatch):
+        # ffmpeg is found via PATH, so the env must be a copy, not a clean slate.
+        env = self._env(monkeypatch, cpus=32, preset={"PATH": "/custom/bin"})
+        assert env["PATH"] == "/custom/bin"
+
+    @pytest.mark.asyncio
+    async def test_cap_reaches_the_real_subprocess(self, tmp_path, monkeypatch):
+        """Wiring test: the helper is useless if _run_whisper_cli ignores it."""
+        for var in _THREAD_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr("kiro_crew.transcribe._whisper_thread_count", lambda: 16)
+
+        audio = tmp_path / "test.webm"
+        audio.write_text("fake audio")
+        cfg = SttConfig(enabled=True, provider="whisper", timeout_secs=10)
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        captured: dict = {}
+
+        async def fake_exec(*args, **kwargs):
+            captured["env"] = kwargs["env"]
+            out_dir = args[args.index("--output_dir") + 1]
+            Path(out_dir).joinpath("test.txt").write_text("hello world")
+            return mock_proc
+
+        with patch("kiro_crew.transcribe._find_whisper", return_value="/usr/bin/whisper"):
+            with patch(
+                "kiro_crew.transcribe.asyncio.create_subprocess_exec", side_effect=fake_exec
+            ):
+                assert await transcribe_audio(str(audio), cfg) == "hello world"
+
+        assert all(captured["env"][var] == "16" for var in _THREAD_ENV_VARS), captured["env"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`_run_whisper_cli` passed the environment straight through to the Whisper
subprocess with no bound on intra-op parallelism, so the thread pools defaulted to
the full machine. Whisper decodes autoregressively -- thousands of tiny parallel
regions, each ending in a barrier that completes only when its slowest worker
arrives -- so a wide pool costs latency per step instead of buying throughput. On a
host that is doing other work (a Kiro Crew host runs the gateway and agent
sessions alongside) the workers are time-sliced, and every barrier waits on
threads the scheduler has not run yet.

Found while enabling the `whisper` provider on a 32-vCPU Graviton3 dev desk, where
dictation took ~30s for a ~10s clip.

## What actually costs: pool width, not thread total

Peak OS threads sampled from `/proc/<pid>/status` during real runs, `base` model,
11-second clip:

| config | peak OS threads | time |
|---|---|---|
| omp=8, blas=8 | 16 | 5.1s |
| omp=16, blas=16 | 32 | **4.9s** |
| omp=16, blas=1 | 17 | 5.1s |
| omp=31, blas=1 | 32 | 7.3s |
| omp=32, blas=32 | 64 | 15.0s |

torch and OpenBLAS keep **separate** pools, so the two values add rather than
multiply. But the thread total is not the governing variable: `omp=31/blas=1` and
`omp=16/blas=16` are both 32 threads, and the former is 30-50% slower (`turbo`:
26.9s vs 20.8s). Collapsing the BLAS pool buys nothing measurable
(`omp=16/blas=1` lands within 3-5% of `omp=16/blas=16`), so both vars get the same
count rather than handing the whole budget to one pool.

## The rule

`max(1, min(16, available // 2))` -- half the available cores.

Half is measured at two widths, not assumed: at 32 visible cores 16 threads beat
31 (`base` 4.9s vs 7.3s, `turbo` 20.8s vs 26.9s), and restricted to 16 cores with
`taskset`, 8 beat 16 (5s vs 7s).

The 16 is a ceiling on **extrapolation**, not a tuning value. Decode-heavy `base`
stops gaining above 8 (0.96s / 1.13s / 1.18s at 8 / 16 / 24 threads) while
encoder-heavy `turbo` keeps gaining to 24 (6.26s / 5.13s / 4.81s); 16 is where
both model shapes sit within 7% of their own best. A 128-core host therefore gets
16 rather than an untested 64.

Availability comes from `sched_getaffinity` where present. `os.cpu_count()`
reports the whole machine under a cgroup or `taskset` restriction -- exactly the
environment that over-threads worst -- so deriving from it would hand a 4-CPU
container a 32-core budget.

An operator who has set *either* variable is left entirely alone, including the
sibling they did not set: half-honouring an explicit threading choice is worse
than either extreme.

## Honest scoping of the win

An earlier revision of this PR claimed a "17x regression" from using all cores.
That number was real but **load-dependent**, and presenting it as a property of
the thread count was an over-claim. Alternating repeats (so background-load drift
hits both arms) at load ~24 measured **2.0x** median:

```
8/8    min 4.9s  median  4.9s  max  5.0s
32/32  min 8.1s  median 10.1s  max 12.2s
```

The 13-17x figures came from load 32-47 on the same box. The robust finding is
**variance, not the mean**: the narrow config held 4.9-5.0s across every repeat,
while taking all cores ranged 8.1-68.4s depending on how busy the machine was.
This change buys predictability first and mean latency second.

`OMP_WAIT_POLICY=passive` was also tested and made things *worse* (27.9s), which
rules out spin-waiting as the mechanism and points at barrier latency under CPU
starvation -- sleeping adds a futex wake-up to each of thousands of barriers.

## Verification

On the host: derived count 16, `base` 4.9s, `turbo` 20.3s through the real
`transcribe_audio` path with the actual binary and byte-identical transcripts.

13 tests in `TestWhisperThreadCap`: the derivation across six core counts, the
ceiling, the affinity path, the no-affinity fallback (macOS/Windows), the
unknowable-`cpu_count` fallback, the override escape hatch and its sibling-var
rule, empty-value-is-not-an-override, both-pools-equal, the pre-existing
`PYTHONPATH`/`PYTHONHOME` stripping contract (previously untested), and a wiring
test asserting the env reaches `create_subprocess_exec`.

Red-before-green verified on the wiring test: reverting only the `_run_whisper_cli`
call site while keeping the helper fails that test and nothing else.

Local gates: 86 passed / 1 skipped in `test_transcribe.py` (163 passed / 17
skipped across the three STT test files), isort clean, flake8 clean, zero mypy
errors in `transcribe.py`.

## Scope note

The cap lands in `_run_whisper_cli`, shared by the `whisper` and `mlx_whisper`
CLIs. `mlx` does its compute on the Metal GPU and Apple Silicon core counts sit
well below where this bites, so the derivation is inert there rather than a
regression.

Not addressed here: the aarch64 torch wheels are OpenBLAS-only (`BLAS_INFO=open`,
no oneDNN+ACL), so they never use the bf16/i8mm units these CPUs have. That is the
next ceiling -- `turbo`'s ~3.6s encoder is honest GEMM -- and it needs a different
build, not an env var.
