### PR TITLE
perf(chat): coalesce slot activity bumps into one dispatch per frame

### DIFF
--- a/website/src/hooks/useWebSocket.ts
+++ b/website/src/hooks/useWebSocket.ts
@@ -143,6 +143,13 @@ export function useWebSocket() {
   const chunkRafRef = useRef<number | null>(null)
   const chunkTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // Slot-recency coalescing: last ts seen per slot, flushed once per frame.
+  // Last-seen wins — the reducer is last-write-wins, so this is the burst's end state.
+  const slotActivityBufRef = useRef<Map<string, string>>(new Map())
+  const slotActivityFlushScheduledRef = useRef(false)
+  const slotActivityRafRef = useRef<number | null>(null)
+  const slotActivityTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   const stopVoice = useCallback(() => {
     voiceMutedRef.current = true
     if (activeAudioRef.current) {
@@ -346,6 +353,38 @@ export function useWebSocket() {
     else chunkTimerRef.current = setTimeout(() => flushChunks(), 16)
   }, [flushChunks])
 
+  /** Flush buffered slot-recency bumps: one touchSlotActivity per slot, not per
+   *  event. Cancels any pending frame first, mirroring flushChunks. */
+  const flushSlotActivity = useCallback(() => {
+    if (slotActivityRafRef.current != null && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(slotActivityRafRef.current)
+    if (slotActivityTimerRef.current != null) clearTimeout(slotActivityTimerRef.current)
+    slotActivityFlushScheduledRef.current = false
+    slotActivityRafRef.current = null
+    slotActivityTimerRef.current = null
+    const buf = slotActivityBufRef.current
+    if (buf.size === 0) return
+    // A frame firing during reconnect backoff must drop, not dispatch: the on-open
+    // refetch is authoritative. Unmount sets closingRef and still flushes deliberately.
+    const ws = wsRef.current
+    if (!closingRef.current && (!ws || ws.readyState !== WebSocket.OPEN)) { buf.clear(); return }
+    const slots = store.getState().dashboard.slots
+    for (const [key, ts] of buf) {
+      // Never move last_ts backwards: an authoritative slots snapshot can land between
+      // buffering and this flush, and overwriting it with our arrival time reorders the sidebar.
+      const current = slots.find(s => s.key === key)?.last_ts
+      if (current && Date.parse(current) > Date.parse(ts)) continue
+      dispatch(touchSlotActivity({ key, ts }))
+    }
+    buf.clear()
+  }, [dispatch])
+
+  const scheduleSlotActivityFlush = useCallback(() => {
+    if (slotActivityFlushScheduledRef.current) return
+    slotActivityFlushScheduledRef.current = true
+    if (typeof requestAnimationFrame === 'function') slotActivityRafRef.current = requestAnimationFrame(() => flushSlotActivity())
+    else slotActivityTimerRef.current = setTimeout(() => flushSlotActivity(), 16)
+  }, [flushSlotActivity])
+
   const connect = useCallback(() => {
     // Guard against double-connect in StrictMode (dev) — if we already
     // have a WS that's open OR still connecting, reuse it.
@@ -389,6 +428,13 @@ export function useWebSocket() {
         chunkTimerRef.current = null
         chunkFlushScheduledRef.current = false
         chunkBufRef.current.clear()  // drop pre-disconnect partial chunks; refreshSlot recovers state
+        // Same for pending recency bumps: the fetchSlots below carries authoritative last_ts.
+        if (slotActivityRafRef.current != null && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(slotActivityRafRef.current)
+        if (slotActivityTimerRef.current != null) clearTimeout(slotActivityTimerRef.current)
+        slotActivityRafRef.current = null
+        slotActivityTimerRef.current = null
+        slotActivityFlushScheduledRef.current = false
+        slotActivityBufRef.current.clear()
         dispatch(sseConnected())
         dispatch(fetchSlots()).finally(() => { reconnectingRef.current = false })
         seedGoalLoops()
@@ -658,7 +704,8 @@ export function useWebSocket() {
             // message of any role), instead of waiting for the next full slots push. Fallback
             // ts is computed here so the touchSlotActivity reducer stays pure (Redux contract).
             if (data.slot && (data.role === 'user' || data.role === 'assistant' || data.role === 'tool_call' || data.role === 'tool_result')) {
-              dispatch(touchSlotActivity({ key: data.slot, ts: data.ts || new Date().toISOString() }))
+              slotActivityBufRef.current.set(data.slot, data.ts || new Date().toISOString())
+              scheduleSlotActivityFlush()
             }
             if (data.slot && data.slot !== store.getState().chat.activeSlot && !reconnectingRef.current) dispatch(markSlotUnread(data.slot))
             // Theme audio: an agent reply arriving is the `message-received`
@@ -1167,7 +1214,7 @@ export function useWebSocket() {
     }
 
     ws.onerror = () => { /* onclose will fire */ }
-  }, [dispatch, flushChunks, scheduleChunkFlush, playNextVoiceChunk, queryClient, stopVoice, syncPendingApprovals, syncPendingQuestions, seedGoalLoops, recordResolvedAskId])
+  }, [dispatch, flushChunks, scheduleChunkFlush, scheduleSlotActivityFlush, playNextVoiceChunk, queryClient, stopVoice, syncPendingApprovals, syncPendingQuestions, seedGoalLoops, recordResolvedAskId])
 
   /**
    * Force an immediate reconnect: cancels any pending backoff timer, closes
@@ -1215,12 +1262,15 @@ export function useWebSocket() {
       clearTimeout(reconnectTimerRef.current)
       if (chunkRafRef.current != null && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(chunkRafRef.current)
       if (chunkTimerRef.current != null) clearTimeout(chunkTimerRef.current)
+      // Flush rather than drop: the store outlives the hook, so a pending bump would
+      // otherwise leave a stale sidebar tint. The flush also cancels the scheduled frame.
+      flushSlotActivity()
       wsRef.current?.close()
       wsRef.current = null
       window.removeEventListener('voice-stop', onVoiceStop)
       window.removeEventListener('voice-config-changed', onVoiceConfigChanged)
     }
-  }, [connect, stopVoice])
+  }, [connect, stopVoice, flushSlotActivity])
 
   /** Subscribe to log events — call with callback on mount, null on unmount. */
   const subscribeLogs = useCallback((cb: LogCallback) => {

--- a/website/src/test/useWebSocket.slotActivityCoalesce.test.ts
+++ b/website/src/test/useWebSocket.slotActivityCoalesce.test.ts
@@ -1,0 +1,317 @@
+/**
+ * `chat_message` must not dispatch `touchSlotActivity` once per event.
+ *
+ * The reducer writes `slot.last_ts` in place, which changes the `slots` array
+ * identity every dispatch, so every whole-array subscriber (ChatSidebar) re-renders
+ * once per event. A streaming burst therefore costs N sidebar renders to arrive at
+ * one final timestamp. These tests pin that the bumps coalesce to one dispatch per
+ * frame per slot, that the coalesced value matches what the un-buffered path would
+ * have left behind, and that nothing is lost or fires late on teardown.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { createElement } from 'react'
+import { Provider } from 'react-redux'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useWebSocket } from '../hooks/useWebSocket'
+import { api } from '../api/client'
+import { store as globalStore } from '../store'
+import { setActiveSlot, clearSlotState } from '../store/chatSlice'
+import { sseSlots } from '../store/dashboardSlice'
+import type { ChatSlot } from '../types'
+
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    voiceConfig: vi.fn().mockResolvedValue({ autoSpeak: false }),
+    approvals: vi.fn().mockResolvedValue([]),
+    notifications: vi.fn().mockResolvedValue({ notifications: [], unread: 0 }),
+    chatSlotDetail: vi.fn().mockResolvedValue({ messages: [], running: false, has_more: false, total: 0, queue: [] }),
+  },
+}))
+
+const WS_INSTANCES: MockWebSocket[] = []
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  static CLOSED = 3
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor() {
+    WS_INSTANCES.push(this)
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: object) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+
+  /** A real socket is CLOSED by the time onclose runs; the gate under test reads readyState. */
+  simulateClose() {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close'))
+  }
+}
+
+const slotA: ChatSlot = { key: 'slot-1', title: 'A', messages: 0, running: false, pending_approval: false, waiting_for_input: false, last_activity_ts: undefined }
+const slotB: ChatSlot = { key: 'slot-2', title: 'B', messages: 0, running: false, pending_approval: false, waiting_for_input: false, last_activity_ts: undefined }
+
+/** Deliberately the SINGLETON store: useWebSocket dispatches via useAppDispatch()
+ *  but reads state off the imported singleton, so a separate Provider store would
+ *  let reads and writes diverge. */
+function seedStore() {
+  globalStore.dispatch(clearSlotState())
+  globalStore.dispatch(setActiveSlot('slot-1'))
+  globalStore.dispatch(sseSlots([{ ...slotA }, { ...slotB }]))
+  return globalStore
+}
+
+const lastTs = (key: string) =>
+  globalStore.getState().dashboard.slots.find(s => s.key === key)?.last_ts
+
+const msg = (slot: string, ts?: string) => ({
+  type: 'chat_message',
+  data: { slot, role: 'assistant', content: 'x', ts },
+})
+
+describe('useWebSocket slot-activity coalescing', () => {
+  let queryClient: QueryClient
+  let rafQueue: FrameRequestCallback[]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    WS_INSTANCES.length = 0
+    rafQueue = []
+    // Leave the on-open slots refetch pending forever: fetchSlots.fulfilled assigns
+    // state.slots wholesale, which would replace the seeded fixtures mid-test.
+    vi.mocked(api.chatSlots).mockReturnValue(new Promise<ChatSlot[]>(() => {}))
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    // Hand-driven frames: nothing flushes until runFrames() is called, which is
+    // what lets a burst be observed mid-flight rather than after the fact.
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => { rafQueue.push(cb); return rafQueue.length })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => { rafQueue[id - 1] = () => {} })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    globalStore.dispatch(clearSlotState())
+    globalStore.dispatch(setActiveSlot(null))
+    globalStore.dispatch(sseSlots([]))
+  })
+
+  function runFrames() {
+    const pending = rafQueue
+    rafQueue = []
+    act(() => { pending.forEach(cb => cb(performance.now())) })
+  }
+
+  function mount() {
+    function wrapper({ children }: { children: React.ReactNode }) {
+      return createElement(Provider, { store: globalStore },
+        createElement(QueryClientProvider, { client: queryClient }, children))
+    }
+    const hook = renderHook(() => useWebSocket(), { wrapper })
+    const ws = WS_INSTANCES[0]
+    act(() => { ws.simulateOpen() })
+    return { hook, ws }
+  }
+
+  it('does not bump last_ts synchronously on each event', () => {
+    seedStore()
+    const { ws } = mount()
+
+    act(() => { ws.simulateMessage(msg('slot-1', '2026-08-10T10:00:00Z')) })
+
+    // Un-coalesced code writes last_ts here; buffered code has not flushed yet.
+    expect(lastTs('slot-1')).toBeUndefined()
+
+    runFrames()
+    expect(lastTs('slot-1')).toBe('2026-08-10T10:00:00Z')
+  })
+
+  it('collapses a burst into one dispatch per slot and keeps the last ts seen', () => {
+    const store = seedStore()
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+    const { ws } = mount()
+    dispatchSpy.mockClear()
+
+    act(() => {
+      for (let i = 0; i < 30; i++) ws.simulateMessage(msg('slot-1', `2026-08-10T10:00:${String(i).padStart(2, '0')}Z`))
+    })
+    runFrames()
+
+    const touches = dispatchSpy.mock.calls.filter(
+      ([a]) => (a as { type?: string })?.type === 'dashboard/touchSlotActivity')
+    expect(touches).toHaveLength(1)
+    // Last-seen wins, matching the un-buffered path's terminal state.
+    expect(lastTs('slot-1')).toBe('2026-08-10T10:00:29Z')
+    dispatchSpy.mockRestore()
+  })
+
+  it('keeps the slots array reference stable across a burst until the frame lands', () => {
+    const store = seedStore()
+    const { ws } = mount()
+    const before = store.getState().dashboard.slots
+
+    act(() => {
+      for (let i = 0; i < 12; i++) ws.simulateMessage(msg('slot-1', '2026-08-10T10:00:00Z'))
+    })
+    expect(store.getState().dashboard.slots).toBe(before)
+
+    runFrames()
+    expect(store.getState().dashboard.slots).not.toBe(before)
+  })
+
+  it('keeps per-slot bumps independent within one frame', () => {
+    seedStore()
+    const { ws } = mount()
+
+    act(() => {
+      ws.simulateMessage(msg('slot-1', '2026-08-10T10:00:01Z'))
+      ws.simulateMessage(msg('slot-2', '2026-08-10T10:00:02Z'))
+      ws.simulateMessage(msg('slot-1', '2026-08-10T10:00:03Z'))
+    })
+    runFrames()
+
+    expect(lastTs('slot-1')).toBe('2026-08-10T10:00:03Z')
+    expect(lastTs('slot-2')).toBe('2026-08-10T10:00:02Z')
+  })
+
+  it('falls back to arrival time, not frame time, when the event carries no ts', async () => {
+    seedStore()
+    const { ws } = mount()
+
+    const beforeArrival = new Date().toISOString()
+    act(() => { ws.simulateMessage(msg('slot-1')) })
+    const afterArrival = new Date().toISOString()
+    // Real delay so frame time is strictly later than arrival: a fallback computed
+    // at flush time would land after afterArrival and fail the upper bound.
+    await new Promise(r => globalThis.setTimeout(r, 25))
+    runFrames()
+
+    const ts = lastTs('slot-1')
+    expect(ts).toBeDefined()
+    expect(ts! >= beforeArrival).toBe(true)
+    expect(ts! <= afterArrival).toBe(true)
+  })
+
+  it('flushes a pending bump on unmount instead of dropping it', () => {
+    seedStore()
+    const { ws, hook } = mount()
+
+    act(() => { ws.simulateMessage(msg('slot-1', '2026-08-10T11:00:00Z')) })
+    expect(lastTs('slot-1')).toBeUndefined()
+
+    act(() => { hook.unmount() })
+    expect(lastTs('slot-1')).toBe('2026-08-10T11:00:00Z')
+  })
+
+  it('does not dispatch from a frame that fires after unmount', () => {
+    const store = seedStore()
+    const { ws, hook } = mount()
+
+    act(() => { ws.simulateMessage(msg('slot-1', '2026-08-10T12:00:00Z')) })
+    act(() => { hook.unmount() })
+
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+    runFrames()  // the frame the unmount flush should have cancelled
+    const touches = dispatchSpy.mock.calls.filter(
+      ([a]) => (a as { type?: string })?.type === 'dashboard/touchSlotActivity')
+    expect(touches).toHaveLength(0)
+    dispatchSpy.mockRestore()
+  })
+
+  it('drops pending bumps on reconnect, since the slots refetch is authoritative', () => {
+    // Only the reconnect backoff timer — faking rAF too would clobber the
+    // hand-driven frame stub and flush the buffer before the reconnect clear.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      seedStore()
+      const { ws } = mount()
+
+      act(() => { ws.simulateMessage(msg('slot-1', '2026-08-10T13:00:00Z')) })
+      act(() => { ws.simulateClose() })
+      act(() => { vi.advanceTimersByTime(5000) })  // reconnect backoff
+      const reconnected = WS_INSTANCES[WS_INSTANCES.length - 1]
+      expect(reconnected).not.toBe(ws)
+      act(() => { reconnected.simulateOpen() })
+      runFrames()
+
+      expect(lastTs('slot-1')).toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('drops a frame that fires during reconnect backoff, before the socket reopens', () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      seedStore()
+      const { ws } = mount()
+
+      act(() => { ws.simulateMessage(msg('slot-1', '2026-08-10T15:00:00Z')) })
+      // Socket is down and the backoff timer has NOT fired, so the on-open clear has
+      // not run yet. A frame landing in this window must drop rather than dispatch.
+      act(() => { ws.simulateClose() })
+      runFrames()
+
+      expect(lastTs('slot-1')).toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not overwrite a newer authoritative snapshot that lands before the flush', () => {
+    seedStore()
+    const { ws } = mount()
+
+    // No ts, so the bump falls back to arrival time...
+    act(() => { ws.simulateMessage(msg('slot-1')) })
+    // ...then an authoritative slots push lands a strictly newer last_ts, still
+    // before the frame runs. The deferred flush must not walk it backwards.
+    act(() => {
+      ws.simulateMessage({
+        type: 'slots',
+        data: [{ ...slotA, last_ts: '2099-01-01T00:00:00Z' }, { ...slotB }],
+      })
+    })
+    expect(lastTs('slot-1')).toBe('2099-01-01T00:00:00Z')
+
+    runFrames()
+
+    expect(lastTs('slot-1')).toBe('2099-01-01T00:00:00Z')
+  })
+
+  it('still applies a bump that is newer than the snapshot it lands after', () => {
+    seedStore()
+    const { ws } = mount()
+
+    act(() => { ws.simulateMessage(msg('slot-1')) })
+    // Snapshot carries an OLD last_ts, so the buffered arrival time is genuinely
+    // newer and must win — the guard suppresses regressions, not every write.
+    act(() => {
+      ws.simulateMessage({
+        type: 'slots',
+        data: [{ ...slotA, last_ts: '2000-01-01T00:00:00Z' }, { ...slotB }],
+      })
+    })
+    runFrames()
+
+    const ts = lastTs('slot-1')
+    expect(ts).toBeDefined()
+    expect(ts).not.toBe('2000-01-01T00:00:00Z')
+    expect(Date.parse(ts!)).toBeGreaterThan(Date.parse('2000-01-01T00:00:00Z'))
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

`touchSlotActivity` dispatched on every `chat_message`. The reducer writes `slot.last_ts` in place, so each dispatch changed the `slots` array identity and re-rendered every whole-array subscriber — the sidebar — once per event.

## Why it matters

Only the last timestamp in a run is observable, so every dispatch but the last is redundant by construction. Scoping this honestly: streamed tokens arrive as `chat_chunk`, which never touches this path, so the redundancy is **per complete message** (user send, assistant final, tool_call/tool_result) rather than per token. It is worth most in rapid tool-call loops.

## What changed (motivation → approach → change)

Symptom: one store update, and one sidebar re-render, per `chat_message`.

Root cause: the dispatch site is unconditional and per-event while the reducer is last-write-wins.

Change: buffer the last timestamp seen per slot and flush once per animation frame, mirroring the streaming-chunk coalescing already in this hook (`flushChunks` / `scheduleChunkFlush`). The reducer is untouched.

**Ordering guard.** Deferring the write introduces a hazard the synchronous dispatch did not have: an authoritative slots snapshot (`sseSlots`, or a `fetchSlots()` refetch resolving) can land between buffering and the flush, and writing our arrival time over the server's value would walk `last_ts` backwards and reorder the sidebar. The flush therefore never moves `last_ts` backwards. That check lives at the flush rather than at each snapshot site deliberately — `fetchSlots()` is a thunk whose replacement happens on `fulfilled` rather than at dispatch, so a per-site clear cannot cover it, and a snapshot site added later cannot silently reintroduce the hazard.

The fallback timestamp stays at the dispatch site and is computed at buffer time, not flush time, so it records arrival rather than the frame boundary and the reducer stays pure.

Teardown: unmount **flushes** pending bumps and cancels the frame — the store outlives the hook, so dropping would leave a stale sidebar tint until the next push. Reconnect **drops** them, since the on-open slots refetch is authoritative.

## Scope of the win

`sseChatMessage` and `markSlotUnread` still dispatch synchronously per event on this same path, so this removes one store update of the two or three already occurring per message — not a burst collapse. I have not measured browser render counts, so I am not claiming a figure.

## Tests

10 cases in `website/src/test/useWebSocket.slotActivityCoalesce.test.ts`:

- no synchronous `last_ts` bump on each event
- a 30-event burst collapses to one dispatch per slot, keeping the last timestamp seen
- the `slots` array reference stays stable across a burst until the frame lands
- per-slot bumps stay independent within one frame
- the `ts` fallback records arrival time, not frame time
- unmount flushes a pending bump instead of dropping it
- a frame firing after unmount dispatches nothing
- reconnect drops pending bumps
- **a newer authoritative snapshot interleaved between buffer and flush is not overwritten**
- **a bump genuinely newer than the snapshot still applies** — the guard suppresses regressions, not every write

Negative-controlled: removing the guard fails the interleaved-snapshot case and only that case. Reverting the dispatch site to the immediate dispatch fails 6 of the others. Moving the fallback into the flush fails exactly the arrival-time case.

## Manual verification

N/A — unit coverage sufficient. The behaviour is dispatch count, store-identity churn, and write ordering, all asserted directly rather than inferred.

## Related Issues

Supersedes #2620, which I closed after the review there found the ordering hazard described above. Reopening it was not possible once the branch had been rebased and amended, so this is a fresh PR against the same branch. The review discussion on #2620 has the original findings.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality — typecheck and lint clean; 254 tests across the `useWebSocket` / `dashboardSlice` / `ChatSidebar` suites pass
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing or API surface change
- [x] No secrets, credentials, or internal references in the diff — `scripts/scrub-lint.sh --no-history` passes
