### PR TITLE
fix(mcp-apps): withhold app-only tools from the agent's tools/list

### DIFF
--- a/src/kiro_crew/mcp_gateway/apps.py
+++ b/src/kiro_crew/mcp_gateway/apps.py
@@ -35,7 +35,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 
 from kiro_crew import platform_compat
 from kiro_crew.mcp_apps_render import MAX_SPOOL_BYTES, SPOOL_SCHEMA_VERSION
@@ -213,6 +213,98 @@ def extract_ui_resource_uri(result: dict) -> Optional[str]:
     if isinstance(uri, str) and uri.startswith(_UI_SCHEME):
         return uri
     return None
+
+
+class WithheldTools(NamedTuple):
+    """Tool names withheld from the agent's listing, split by WHY.
+
+    The split exists so the caller can log the two cases at different levels.
+    ``declared`` is the server doing exactly what SEP-1865 provides for and
+    needs no operator attention; ``unreadable`` means this host could not parse
+    a ``visibility`` the server did set, so a tool disappeared on a judgement
+    call and somebody should see it.
+    """
+
+    declared: list[str]
+    unreadable: list[str]
+
+    @property
+    def names(self) -> list[str]:
+        return [*self.declared, *self.unreadable]
+
+    def __bool__(self) -> bool:
+        return bool(self.declared or self.unreadable)
+
+
+def strip_model_hidden_tools(result: dict) -> WithheldTools:
+    """Remove tools the agent may not see from a ``tools/list`` result IN PLACE.
+
+    SEP-1865: the host MUST NOT include a tool in the agent's tool list when its
+    ``_meta.ui.visibility`` does not include ``"model"``. Returns the withheld
+    names split by cause, so the caller can log an unreadable declaration more
+    loudly than a well-formed one.
+
+    How each shape of ``visibility`` is read:
+
+    ==========================  ==========================================
+    ``visibility``              Verdict
+    ==========================  ==========================================
+    absent                      KEEP — spec default is ``["model", "app"]``
+    ``["model", ...]``          KEEP
+    ``["app"]`` / ``[]``        DROP — explicit list without "model"
+    ``"model"`` (bare string)   KEEP — read as ``["model"]``
+    ``"app"`` (bare string)     DROP — read as ``["app"]``
+    present, uninterpretable    DROP
+    ==========================  ==========================================
+
+    Only ABSENCE gets the permissive default. A present-but-unreadable value is
+    an attempt to restrict the tool that this host cannot parse, and the two
+    errors are not symmetric: an over-drop is loud (the name is logged and the
+    tool simply does not appear) while a leak silently hands the model a tool
+    the server withheld, which it may then execute.
+
+    Bare strings are coerced rather than lumped in with the unreadable values,
+    because the realistic typo for this field is a scalar instead of a
+    one-element list — and blanket-dropping every malformed value would discard
+    a tool whose author wrote ``"model"`` meaning to expose it.
+
+    Note this is the OPPOSITE default from the app-call direction in
+    :mod:`kiro_crew.mcp_gateway.app_call`, which denies unless ``"app"`` is
+    explicitly present.
+    """
+    tools = result.get("tools")
+    if not isinstance(tools, list):
+        return WithheldTools([], [])
+    kept: list[Any] = []
+    declared: list[str] = []
+    unreadable: list[str] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            kept.append(tool)
+            continue
+        meta = tool.get("_meta")
+        ui = meta.get("ui") if isinstance(meta, dict) else None
+        # Absence is the ONLY permissive case, so it is tested by key presence
+        # rather than by value — an explicit ``"visibility": null`` is a
+        # declaration this host cannot read, not an omission.
+        if not isinstance(ui, dict) or "visibility" not in ui:
+            kept.append(tool)
+            continue
+        raw = ui["visibility"]
+        vis = [raw] if isinstance(raw, str) else raw
+        if isinstance(vis, list):
+            if "model" in vis:
+                kept.append(tool)
+                continue
+            bucket = declared
+        else:
+            bucket = unreadable
+        name = tool.get("name")
+        bucket.append(name if isinstance(name, str) else "<unnamed>")
+    withheld = WithheldTools(declared, unreadable)
+    if withheld:
+        result["tools"] = kept
+    return withheld
 
 
 def extract_declared_ui_uris(result: dict) -> dict[str, str]:

--- a/src/kiro_crew/mcp_gateway/backend.py
+++ b/src/kiro_crew/mcp_gateway/backend.py
@@ -35,9 +35,11 @@ from kiro_crew.mcp_caller import (
     build_caller_meta,
 )
 from kiro_crew.mcp_gateway.apps import (
+    WithheldTools,
     append_marker,
     extract_declared_ui_uris,
     extract_ui_resource_uri,
+    strip_model_hidden_tools,
     write_spool,
 )
 from kiro_crew.mcp_gateway.pool import READ_BUFFER_LIMIT_BYTES, RESPONSE_SPILL_THRESHOLD_BYTES
@@ -1351,24 +1353,75 @@ class Backend:
         must NOT deliver it. Returns ``False`` (the common/off path) when the
         caller should deliver the response normally right now. Never raises:
         any classification hiccup falls back to normal delivery.
+
+        The tools/list visibility filter runs even when the feature gate is
+        OFF — see below for why — so this is not a pure no-op in that state.
         """
-        if not _mcp_apps_enabled():
-            return False
         # App-originated callbacks (the app-call relay forwards a tools/call on
         # a ``__app_call__*`` stub) must NEVER be re-intercepted: if the called
         # tool itself declares a ui:// resource, re-spooling would replace the
         # app's real result with an internal marker string and mint a stray
         # spool record. The render/spool path is only for MODEL-originated tool
         # results; app callbacks return verbatim to the requesting app.
+        #
+        # Checked ahead of the feature gate because it also exempts a listing
+        # from the visibility filter, which runs gate-independently.
         if pending.stub_uuid.startswith("__app_call__"):
             return False
-        # Passive harvest: tool declarations are the SEP-1865 PRIMARY place a
-        # server associates a tool with its ui:// resource (the real
-        # pdf-server and Excalidraw declare it ONLY here, not on results).
-        # Every tools/list response that flows through updates the map.
         if pending.method == "tools/list":
             result = msg.get("result")
             if isinstance(result, dict):
+                # SEP-1865 MUST: a tool whose visibility omits "model" is not
+                # the agent's to see. Mutates the response in place before the
+                # caller delivers it. Reachable ONLY for model-facing listings —
+                # the __app_call__ guard above returns first, so an app's
+                # authorization snapshot keeps its app-only tools and the
+                # visibility gate in app_call still sees them.
+                #
+                # DELIBERATELY OUTSIDE the feature gate: visibility is the
+                # SERVER's statement about who may call a tool, not a property
+                # of our renderer. With apps disabled there is no app to call
+                # an app-only tool, so filtering makes it unreachable — which is
+                # the server's own consequence and strictly better than handing
+                # the model a tool the server withheld from it.
+                hidden = strip_model_hidden_tools(result)
+                if hidden.declared:
+                    logger.info(
+                        "mcp-apps: withheld %d app-only tool(s) from the agent's "
+                        "listing for server=%s: %s",
+                        len(hidden.declared), self.pool_key.server_name,
+                        ", ".join(hidden.declared),
+                    )
+                if hidden.unreadable:
+                    # WARNING, not INFO: the server DID declare a visibility and
+                    # this host could not parse it, so a tool disappeared on our
+                    # judgement rather than the server's instruction. That is the
+                    # one drop an operator needs to see — it is the failure mode
+                    # where a real server's shape trips the parser.
+                    logger.warning(
+                        "mcp-apps: withheld %d tool(s) from the agent's listing "
+                        "for server=%s because their _meta.ui.visibility could "
+                        "not be read: %s",
+                        len(hidden.unreadable), self.pool_key.server_name,
+                        ", ".join(hidden.unreadable),
+                    )
+                if hidden:
+                    self._audit_visibility_withhold(pending, hidden)
+                # Passive harvest: tool declarations are the SEP-1865 PRIMARY
+                # place a server associates a tool with its ui:// resource (the
+                # real pdf-server and Excalidraw declare it ONLY here, not on
+                # results). Every tools/list response updates the map.
+                #
+                # Runs AFTER the strip, so a withheld tool's ui:// never enters
+                # the map. That ordering is load-bearing, not incidental: it
+                # means a model-originated call naming an app-only tool cannot
+                # find a declared resource to render. Keep the strip first.
+                #
+                # Also runs REGARDLESS of the feature gate, so the map always
+                # reflects the server's CURRENT declarations. Gating it would
+                # let a listing that arrives while apps are disabled leave a
+                # WITHDRAWN tool→ui association cached, which a later re-enable
+                # would then render from.
                 try:
                     declared = extract_declared_ui_uris(result)
                 except Exception:  # pragma: no cover — defensive; extract is total
@@ -1379,6 +1432,9 @@ class Backend:
                 # so later successful calls would still render the withdrawn
                 # app resource.
                 self._apps_declared_uris = declared
+            return False
+        # Everything below is the RENDER path, which the feature gate owns.
+        if not _mcp_apps_enabled():
             return False
         if pending.method != "tools/call":
             return False
@@ -1407,6 +1463,39 @@ class Backend:
         self._apps_tasks.add(task)
         task.add_done_callback(self._apps_tasks.discard)
         return True
+
+    def _audit_visibility_withhold(
+        self, pending: _PendingRequest, hidden: WithheldTools
+    ) -> None:
+        """SEL-audit a tools/list visibility withhold.
+
+        Removing a tool from the agent's listing is an authorization decision
+        this gateway makes, and the sibling direction (an app calling a tool,
+        in :mod:`kiro_crew.mcp_gateway.app_call`) audits every outcome — so the
+        direction that silently takes capability AWAY from the model must not
+        be the unaudited one. Log lines rotate; the SEL chain is the durable
+        record of what was hidden and why.
+
+        ONE event per listing that actually withheld something, not one per
+        tool and not one per tools/list — a server with a permanent app-only
+        tool would otherwise mint an event on every listing forever.
+        """
+        try:
+            SecurityEventLog().log_api_access(
+                caller=pending.session_key or "unknown",
+                operation="mcp-gateway.tools-list-visibility",
+                outcome="denied",
+                source="gateway",
+                resources=(
+                    f"server={self.pool_key.server_name} "
+                    f"declared={','.join(hidden.declared) or '-'} "
+                    f"unreadable={','.join(hidden.unreadable) or '-'}"
+                ),
+            )
+        except Exception:  # pragma: no cover — audit must never break delivery
+            logger.debug(
+                "SEL audit for tools/list visibility withhold failed", exc_info=True
+            )
 
     async def _fetch_and_deliver_ui(
         self, pending: _PendingRequest, msg: dict[str, Any], resource_uri: str

--- a/test/test_mcp_apps_e2e.py
+++ b/test/test_mcp_apps_e2e.py
@@ -272,9 +272,15 @@ async def test_declared_only_without_tools_list_no_interception(apps_flag_on, sp
         await live.aclose()
 
 
-async def test_app_only_tool_listed_with_visibility(apps_flag_on, spool_tmp):
-    """tools/list exposes save_state as an app-only tool — the shape the
-    callback endpoint's visibility enforcement consumes."""
+async def test_app_only_tool_withheld_from_agent_listing(apps_flag_on, spool_tmp):
+    """The agent's tools/list omits save_state (visibility ["app"]) but keeps
+    draw, while the app-call path's own listing still sees both.
+
+    Both halves matter and they pull in opposite directions: the model must not
+    be offered an app-only tool (SEP-1865 MUST), and app_call's authorization
+    snapshot must still contain it or every app-only call would be refused as
+    non-existent.
+    """
     live = await _spawn_live_server()
     try:
         inbox = await live.backend.attach_stub("s1")
@@ -287,6 +293,17 @@ async def test_app_only_tool_listed_with_visibility(apps_flag_on, spool_tmp):
         reply = await _recv(inbox)
         tools = {t["name"]: t for t in reply["result"]["tools"]}
         assert tools["draw"]["_meta"]["ui"]["visibility"] == ["model", "app"]
-        assert tools["save_state"]["_meta"]["ui"]["visibility"] == ["app"]
+        assert "save_state" not in tools
+
+        # The app-call stub prefix is what exempts a listing from the filter.
+        app_inbox = await live.backend.attach_stub("__app_call__e2e0")
+        await live.backend.forward_from_stub(
+            "__app_call__e2e0",
+            {"jsonrpc": "2.0", "id": 8, "method": "tools/list", "params": {}},
+        )
+        app_reply = await _recv(app_inbox)
+        app_tools = {t["name"]: t for t in app_reply["result"]["tools"]}
+        assert app_tools["save_state"]["_meta"]["ui"]["visibility"] == ["app"]
+        assert "draw" in app_tools
     finally:
         await live.aclose()

--- a/test/test_mcp_gateway_apps_spool.py
+++ b/test/test_mcp_gateway_apps_spool.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import logging
 import os
 import stat
 import sys
@@ -36,6 +37,7 @@ from kiro_crew.mcp_gateway.apps import (
     append_marker,
     extract_ui_resource_uri,
     spool_dir,
+    strip_model_hidden_tools,
     sweep_spool,
     write_spool,
 )
@@ -43,6 +45,7 @@ from kiro_crew.mcp_gateway.backend import (
     MCP_APPS_ENV_FLAG,
     MCP_APPS_MIME_TYPE,
     Backend,
+    _PendingRequest,
 )
 from kiro_crew.mcp_gateway.pool import PoolKey
 
@@ -325,6 +328,118 @@ class TestExtractDeclaredUiUris:
 
 
 # --------------------------------------------------------------------------
+# strip_model_hidden_tools
+# --------------------------------------------------------------------------
+
+def _tool(name: str, visibility=...) -> dict:
+    """A tools/list entry, with ``_meta.ui.visibility`` only when given.
+
+    ``visibility=...`` (the default) omits the key entirely, which is the shape
+    the SEP-1865 default applies to.
+    """
+    tool: dict = {"name": name, "inputSchema": {"type": "object"}}
+    if visibility is not ...:
+        tool["_meta"] = {"ui": {"visibility": visibility}}
+    return tool
+
+
+class TestStripModelHiddenTools:
+    def test_drops_app_only_tool(self):
+        result = {"tools": [_tool("refresh", ["app"]), _tool("get_weather", ["model", "app"])]}
+        withheld = strip_model_hidden_tools(result)
+        assert withheld.declared == ["refresh"]
+        assert withheld.unreadable == []
+        assert [t["name"] for t in result["tools"]] == ["get_weather"]
+
+    def test_keeps_tool_with_no_visibility(self):
+        """Absent visibility defaults to ["model", "app"] per SEP-1865."""
+        result = {"tools": [_tool("plain")]}
+        assert strip_model_hidden_tools(result).names == []
+        assert [t["name"] for t in result["tools"]] == ["plain"]
+
+    def test_keeps_model_only_tool(self):
+        result = {"tools": [_tool("hidden_from_app", ["model"])]}
+        assert strip_model_hidden_tools(result).names == []
+        assert [t["name"] for t in result["tools"]] == ["hidden_from_app"]
+
+    @pytest.mark.parametrize(
+        "vis",
+        ["app", []],
+        ids=["bare-app", "empty-list"],
+    )
+    def test_readable_declaration_without_model_drops_as_declared(self, vis):
+        """A parseable declaration that omits "model" is the server doing what
+        the spec provides for — routine, so it lands in ``declared``."""
+        result = {"tools": [_tool("t", vis)]}
+        withheld = strip_model_hidden_tools(result)
+        assert withheld.declared == ["t"]
+        assert withheld.unreadable == []
+        assert result["tools"] == []
+
+    @pytest.mark.parametrize(
+        "vis",
+        [None, {}, 42, {"app": True}],
+        ids=["explicit-null", "empty-dict", "int", "dict"],
+    )
+    def test_unreadable_visibility_drops_and_is_reported_separately(self, vis):
+        """A PRESENT visibility this host cannot parse drops, but is bucketed
+        apart so the caller can warn: the tool vanished on OUR judgement, not
+        the server's instruction.
+
+        Only absence gets the permissive default. A leak is silent and lets the
+        model execute a tool the server withheld; an over-drop is logged.
+        """
+        result = {"tools": [_tool("t", vis)]}
+        withheld = strip_model_hidden_tools(result)
+        assert withheld.declared == []
+        assert withheld.unreadable == ["t"]
+        assert result["tools"] == []
+
+    @pytest.mark.parametrize(
+        "vis",
+        ["model", ["model"], ["model", "app"], ["app", "model"]],
+        ids=["bare-model", "list-model", "both", "both-reversed"],
+    )
+    def test_visibility_including_model_keeps(self, vis):
+        """A bare ``"model"`` string is coerced, not treated as unreadable —
+        blanket-dropping malformed values would hide a tool meant to be seen."""
+        result = {"tools": [_tool("t", vis)]}
+        assert strip_model_hidden_tools(result).names == []
+        assert [t["name"] for t in result["tools"]] == ["t"]
+
+    def test_unnamed_app_only_tool_reported_as_placeholder(self):
+        result = {"tools": [{"_meta": {"ui": {"visibility": ["app"]}}}]}
+        assert strip_model_hidden_tools(result).declared == ["<unnamed>"]
+        assert result["tools"] == []
+
+    def test_non_dict_entries_preserved(self):
+        result = {"tools": ["junk", 7, _tool("ok")]}
+        assert strip_model_hidden_tools(result).names == []
+        assert len(result["tools"]) == 3
+
+    def test_missing_or_malformed_tools_key(self):
+        assert strip_model_hidden_tools({}).names == []
+        assert strip_model_hidden_tools({"tools": "nope"}).names == []
+        assert strip_model_hidden_tools({"tools": None}).names == []
+
+    def test_untouched_when_nothing_dropped(self):
+        """The list object is left as-is when no tool is withheld, so a caller
+        holding a reference to it does not see a surprise rebind."""
+        tools = [_tool("a"), _tool("b", ["model"])]
+        result = {"tools": tools}
+        assert strip_model_hidden_tools(result).names == []
+        assert result["tools"] is tools
+
+    def test_both_buckets_populated_together(self):
+        result = {"tools": [_tool("declared_hidden", ["app"]), _tool("bad_shape", 42)]}
+        withheld = strip_model_hidden_tools(result)
+        assert withheld.declared == ["declared_hidden"]
+        assert withheld.unreadable == ["bad_shape"]
+        assert sorted(withheld.names) == ["bad_shape", "declared_hidden"]
+        assert result["tools"] == []
+
+
+# --------------------------------------------------------------------------
 # Backend interception seam (async)
 # --------------------------------------------------------------------------
 
@@ -385,6 +500,217 @@ async def _drain_inbox(inbox: "asyncio.Queue[bytes]", timeout: float = 2.0) -> d
 @pytest.fixture
 def apps_flag_on(monkeypatch):
     monkeypatch.setenv(MCP_APPS_ENV_FLAG, "1")
+
+
+def _listing_pending(stub_uuid: str) -> _PendingRequest:
+    return _PendingRequest(
+        stub_uuid=stub_uuid, original_id=1, method="tools/list", t_start_ms=0.0
+    )
+
+
+def _listing_msg() -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"tools": [_tool("refresh", ["app"]), _tool("draw")]},
+    }
+
+
+@pytest.mark.asyncio
+async def test_model_listing_withholds_app_only_tools(apps_flag_on):
+    """SEP-1865 MUST: the agent's tools/list omits a tool whose visibility
+    does not include "model"."""
+    backend = _make_backend()
+    msg = _listing_msg()
+    # False = "caller delivers normally"; the filter mutates in place.
+    assert await backend._maybe_intercept_ui_result(_listing_pending("s1"), msg) is False
+    assert [t["name"] for t in msg["result"]["tools"]] == ["draw"]
+
+
+@pytest.mark.asyncio
+async def test_app_call_listing_keeps_app_only_tools(apps_flag_on):
+    """The app-call authorization snapshot MUST keep app-only tools.
+
+    ``app_call`` authorizes an app's tools/call against a fresh tools/list. If
+    the filter reached that listing, every app-only tool would look
+    non-existent and the interactive-refresh pattern the visibility split
+    exists for would be dead. Pins the ordering of the ``__app_call__`` guard
+    ahead of the tools/list branch in ``_maybe_intercept_ui_result``.
+    """
+    backend = _make_backend()
+    msg = _listing_msg()
+    pending = _listing_pending("__app_call__deadbeef")
+    assert await backend._maybe_intercept_ui_result(pending, msg) is False
+    assert [t["name"] for t in msg["result"]["tools"]] == ["refresh", "draw"]
+
+
+@pytest.mark.asyncio
+async def test_listing_filtered_even_when_feature_disabled(monkeypatch):
+    """The visibility filter is NOT gated on the MCP Apps feature flag.
+
+    ``visibility`` is the server's statement about who may call a tool, not a
+    property of our renderer. With apps disabled there is no app to call an
+    app-only tool, so filtering makes it unreachable — the server's own
+    consequence, and strictly better than handing the model a tool the server
+    withheld from it. The stdout pump calls the interception hook
+    unconditionally, so without this the flag-off path leaked app-only tools.
+    """
+    monkeypatch.setenv(MCP_APPS_ENV_FLAG, "0")
+    backend = _make_backend()
+    msg = _listing_msg()
+    assert await backend._maybe_intercept_ui_result(_listing_pending("s1"), msg) is False
+    assert [t["name"] for t in msg["result"]["tools"]] == ["draw"]
+
+
+@pytest.mark.asyncio
+async def test_app_call_listing_unfiltered_when_feature_disabled(monkeypatch):
+    """The app-call exemption still wins with the flag off, since its guard is
+    checked ahead of both the filter and the gate."""
+    monkeypatch.setenv(MCP_APPS_ENV_FLAG, "0")
+    backend = _make_backend()
+    msg = _listing_msg()
+    pending = _listing_pending("__app_call__off01")
+    assert await backend._maybe_intercept_ui_result(pending, msg) is False
+    assert [t["name"] for t in msg["result"]["tools"]] == ["refresh", "draw"]
+
+
+@pytest.mark.asyncio
+async def test_unreadable_visibility_drop_warns_declared_drop_informs(apps_flag_on, caplog):
+    """The two drop causes must not log at the same level.
+
+    A well-formed ``["app"]`` is routine (INFO). An unparseable declaration
+    means a tool vanished on THIS host's judgement, which is the case an
+    operator has to be able to find — so it warns.
+    """
+    backend = _make_backend()
+    msg = {
+        "jsonrpc": "2.0", "id": 1,
+        "result": {"tools": [_tool("routine", ["app"]), _tool("bad_shape", 42)]},
+    }
+    with caplog.at_level(logging.INFO, logger="kiro_crew.mcp_gateway.backend"):
+        assert await backend._maybe_intercept_ui_result(_listing_pending("s1"), msg) is False
+    warned = [r for r in caplog.records if r.levelno == logging.WARNING]
+    informed = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert any("bad_shape" in r.getMessage() for r in warned)
+    assert not any("bad_shape" in r.getMessage() for r in informed)
+    assert any("routine" in r.getMessage() for r in informed)
+    assert not any("routine" in r.getMessage() for r in warned)
+
+
+@pytest.mark.asyncio
+async def test_disabled_listing_still_refreshes_declarations(monkeypatch):
+    """A listing that arrives while apps are DISABLED must still refresh the
+    declaration map, or a withdrawn ui:// stays cached and a later re-enable
+    renders it.
+
+    Sequence: enabled listing caches ui://old -> apps disabled -> server
+    withdraws the declaration -> apps re-enabled -> a tools/call falling back
+    to the map must NOT find ui://old.
+    """
+    backend = _make_backend()
+    monkeypatch.setenv(MCP_APPS_ENV_FLAG, "1")
+    declared = _tool("draw")
+    declared["_meta"] = {"ui": {"resourceUri": "ui://srv/old.html"}}
+    msg = {"jsonrpc": "2.0", "id": 1, "result": {"tools": [declared]}}
+    await backend._maybe_intercept_ui_result(_listing_pending("s1"), msg)
+    assert backend._apps_declared_uris == {"draw": "ui://srv/old.html"}
+
+    # Apps off; the server's new listing no longer declares the resource.
+    monkeypatch.setenv(MCP_APPS_ENV_FLAG, "0")
+    msg2 = {"jsonrpc": "2.0", "id": 2, "result": {"tools": [_tool("draw")]}}
+    await backend._maybe_intercept_ui_result(_listing_pending("s1"), msg2)
+    assert backend._apps_declared_uris == {}
+
+
+@pytest.mark.asyncio
+async def test_visibility_withhold_is_sel_audited(apps_flag_on, monkeypatch):
+    """Withholding a tool is an authorization decision and must reach the SEL
+    chain — the sibling app-call direction audits every outcome, so the
+    direction that takes capability AWAY from the model cannot be the
+    unaudited one.
+
+    Exactly ONE event per listing that withheld something: a server with a
+    permanent app-only tool would otherwise mint an event on every listing.
+    """
+    calls: list[dict] = []
+
+    class _FakeSel:
+        def log_api_access(self, **kw):
+            calls.append(kw)
+
+    monkeypatch.setattr(
+        "kiro_crew.mcp_gateway.backend.SecurityEventLog", lambda: _FakeSel()
+    )
+    backend = _make_backend()
+    pending = _PendingRequest(
+        stub_uuid="s1", original_id=1, method="tools/list",
+        t_start_ms=0.0, session_key="dashboard:sess-9",
+    )
+    msg = {
+        "jsonrpc": "2.0", "id": 1,
+        "result": {"tools": [_tool("routine", ["app"]), _tool("bad", 42), _tool("ok")]},
+    }
+    assert await backend._maybe_intercept_ui_result(pending, msg) is False
+    assert len(calls) == 1
+    ev = calls[0]
+    assert ev["caller"] == "dashboard:sess-9"
+    assert ev["operation"] == "mcp-gateway.tools-list-visibility"
+    assert ev["outcome"] == "denied"
+    assert "declared=routine" in ev["resources"]
+    assert "unreadable=bad" in ev["resources"]
+    assert "excalidraw-mcp" in ev["resources"]
+
+
+@pytest.mark.asyncio
+async def test_no_sel_event_when_nothing_withheld(apps_flag_on, monkeypatch):
+    calls: list[dict] = []
+
+    class _FakeSel:
+        def log_api_access(self, **kw):
+            calls.append(kw)
+
+    monkeypatch.setattr(
+        "kiro_crew.mcp_gateway.backend.SecurityEventLog", lambda: _FakeSel()
+    )
+    backend = _make_backend()
+    msg = {"jsonrpc": "2.0", "id": 1, "result": {"tools": [_tool("ok")]}}
+    assert await backend._maybe_intercept_ui_result(_listing_pending("s1"), msg) is False
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_sel_failure_does_not_break_the_filter(apps_flag_on, monkeypatch):
+    """A broken audit sink must not cost the user their tools/list response, and
+    must not undo the withhold."""
+    class _ExplodingSel:
+        def log_api_access(self, **kw):
+            raise RuntimeError("sel disk full")
+
+    monkeypatch.setattr(
+        "kiro_crew.mcp_gateway.backend.SecurityEventLog", lambda: _ExplodingSel()
+    )
+    backend = _make_backend()
+    msg = _listing_msg()
+    assert await backend._maybe_intercept_ui_result(_listing_pending("s1"), msg) is False
+    assert [t["name"] for t in msg["result"]["tools"]] == ["draw"]
+
+
+@pytest.mark.asyncio
+async def test_hidden_tool_ui_uri_is_not_harvested(apps_flag_on):
+    """A withheld tool's declared ui:// must never enter _apps_declared_uris.
+
+    The strip runs before the harvest, so a model-originated call naming an
+    app-only tool cannot find a declared resource to render. Pins that
+    ordering — reversing it would resurrect hidden-tool rendering.
+    """
+    backend = _make_backend()
+    hidden = _tool("refresh", ["app"])
+    hidden["_meta"]["ui"]["resourceUri"] = "ui://srv/hidden.html"
+    shown = _tool("draw")
+    shown["_meta"] = {"ui": {"resourceUri": "ui://srv/draw.html"}}
+    msg = {"jsonrpc": "2.0", "id": 1, "result": {"tools": [hidden, shown]}}
+    assert await backend._maybe_intercept_ui_result(_listing_pending("s1"), msg) is False
+    assert backend._apps_declared_uris == {"draw": "ui://srv/draw.html"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
> Was stacked on #2617, which has since **merged**. This PR is now rebased directly onto `main` as a single commit; GitHub auto-retargeted it when the base branch was deleted.

## Problem

SEP-1865 Stable 2026-01-26, Visibility section:

> **tools/list behavior:** Host MUST NOT include tools in the agent's tool list when their visibility does not include `"model"` (e.g., `visibility: ["app"]`)

We enforced visibility in **one direction only**. `app_call.py` requires `"app"` before letting an embedded app call a tool, but nothing filtered the agent's listing — so a tool a server deliberately marked `visibility: ["app"]` (a refresh button, a form submit, an internal `save_state`) was handed to the model anyway.

## Change

`strip_model_hidden_tools()` drops those tools from a `tools/list` result in place, wired into the existing `_maybe_intercept_ui_result` seam that already sees every `tools/list` response.

How each shape of `visibility` is read:

| `visibility` | Verdict |
|---|---|
| absent | KEEP — spec default is `["model", "app"]` |
| `["model", ...]` | KEEP |
| `["app"]` / `[]` | DROP (logged INFO — routine) |
| `"model"` (bare string) | KEEP — coerced to `["model"]` |
| `"app"` (bare string) | DROP (logged INFO) |
| present, uninterpretable (`null`, `{}`, `42`, …) | DROP (logged **WARNING**) |

Only **absence** gets the permissive default, tested by key presence rather than value so an explicit `"visibility": null` counts as an unreadable declaration rather than an omission. The two errors are not symmetric: an over-drop is loud and diagnosable, a leak silently hands the model a tool the server withheld, which it may then execute.

Bare strings are coerced rather than lumped in with unreadable values, because a scalar instead of a one-element list is *the* realistic typo for this field and it carries readable intent in both directions.

## Behavior changes worth calling out explicitly

**1. The filter runs regardless of `KIROCREW_MCP_APPS`.** The stdout pump calls the interception hook unconditionally, so gating the filter behind the feature flag left the whole leak open whenever apps were off. `visibility` is the *server's* statement about who may call a tool, not a property of our renderer — with apps disabled there is no app to call an app-only tool, so filtering makes it unreachable, which is the server's own consequence and strictly better than handing it to the model. There is **no separate toggle** for the filter; the render path below it keeps its gate.

The risk this carries: if a real server ships a `visibility` shape this parser misreads, its tools disappear from every agent. That is why unreadable drops log at **WARNING** naming the server and the tool names, while routine declared drops stay at INFO — the one case that needs an operator's eyes is the one that isn't the server's instruction.

**2. Enforcement is list-time only.** Withholding from `tools/list` hides the name; it does not deny a model-originated `tools/call` on a hidden tool whose name was learned from history or guessed. The symmetric deny on the call path is deliberately **not** in this PR — it belongs with the `_tool_visible_to_app` default correction in #2633, which pulls the same seam in the opposite direction.

**3. The app-call path is exempt.** `app_call` authorizes each app-originated call against a *fresh* `tools/list`; if the filter reached that snapshot, every app-only tool would look non-existent and the interactive-refresh pattern the visibility split exists for would be dead. The filter sits behind the pre-existing `__app_call__` guard, which returns before the `tools/list` branch — pinned by tests in both unit and e2e form, in both flag states.

**4. Strip runs before harvest, and that ordering is load-bearing.** A withheld tool's declared `ui://` never enters `_apps_declared_uris`, so a model-originated call naming an app-only tool cannot find a declared resource to render. Pinned by a test so a future reorder fails loudly.

## A rewritten test, and why

`test_app_only_tool_listed_with_visibility` asserted that `save_state` **was** present in a model-facing listing — the exact leak this PR closes. Its docstring justified that as "the shape the callback endpoint's visibility enforcement consumes," but that premise is wrong: `app_call` issues its own `tools/list` over an `__app_call__` stub and never reads the model-facing listing. Rewritten as `test_app_only_tool_withheld_from_agent_listing`, asserting both halves end-to-end against the real fake server.

## Verification

- **Revert-verified three ways.** Restoring the original fail-open fails 5 tests. Re-introducing the early feature gate fails the flag-off leak test. Applying a blanket drop-all-malformed (no string coercion) fails exactly the bare-`"model"` keep case — so the coercion is load-bearing, not gold-plating.
- 96 MCP-apps tests pass · 660 in the gateway slice · mypy 866 files clean · isort/flake8 clean. The one failing test in the slice (`test_worktree_create.py`) is a pre-existing host-env failure (no OS sandbox backend), verified by reverting both source files to the parent commit and re-running.
- Log levels are pinned by a test, not just asserted in prose.
