### PR TITLE
fix: keep the nav and sessions toggles live in preview expand mode

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1044,12 +1044,33 @@ export default function App() {
   useRumPageView()
   useNotificationSound()
   const [navCollapsed, setNavCollapsed] = useState(() => localStorage.getItem('mc-nav') === '1')
-  // Preview focus (expand) mode from the Web Preview tab: force the left nav
-  // collapsed while active (restored automatically when it turns off, since we
-  // OR a transient flag rather than mutating navCollapsed).
-  const [previewFocused, setPreviewFocused] = useState(false)
+  const navCollapsedRef = useRef(navCollapsed)
+  navCollapsedRef.current = navCollapsed
+  // Preview focus (expand) mode from the Web Preview tab collapses the left nav
+  // as a STARTING layout, not a lock — the brand toggle keeps its standard
+  // behavior while focus mode is on, so the rail can be brought back without
+  // leaving the preview. This ref holds the pre-focus state to restore on exit,
+  // and is cleared the moment the user toggles the rail themselves so their
+  // choice is not undone. `navCollapsed` is driven directly rather than ORed
+  // with a transient flag, because an OR makes the toggle look broken.
+  //
+  // The ref is read and cleared HERE, in the handler, and only plain values are
+  // passed to the setter: a state updater must be pure, and React invokes one
+  // twice under StrictMode, which would make the second pass read an
+  // already-cleared ref and lose the restore value.
+  const navAutoCollapsed = useRef<boolean | null>(null)
   useEffect(() => {
-    const onFocus = (e: Event) => setPreviewFocused(!!(e as CustomEvent<{ focused?: boolean }>).detail?.focused)
+    const onFocus = (e: Event) => {
+      const focused = !!(e as CustomEvent<{ focused?: boolean }>).detail?.focused
+      if (focused) {
+        if (navAutoCollapsed.current === null) navAutoCollapsed.current = navCollapsedRef.current
+        setNavCollapsed(true)
+        return
+      }
+      const prior = navAutoCollapsed.current
+      navAutoCollapsed.current = null
+      if (prior !== null) setNavCollapsed(prior)
+    }
     window.addEventListener(PREVIEW_FOCUS_EVENT, onFocus)
     return () => window.removeEventListener(PREVIEW_FOCUS_EVENT, onFocus)
   }, [])
@@ -1577,6 +1598,9 @@ export default function App() {
   const toggleNav = () => {
     if (isMobile) { setMobileNavOpen(p => !p) }
     else {
+      // The user has taken ownership of the rail: leaving preview focus mode
+      // must not overwrite this with the pre-focus state.
+      navAutoCollapsed.current = null
       setNavCollapsed(prev => { const next = !prev; safeSetItem('mc-nav', next ? '1' : '0'); return next })
     }
   }
@@ -1584,7 +1608,7 @@ export default function App() {
   useEffect(() => { if (isMobile) setMobileNavOpen(false) }, [location.pathname]) // eslint-disable-line react-hooks/exhaustive-deps
   // Reset mobile nav state when leaving mobile viewport
   useEffect(() => { if (!isMobile) setMobileNavOpen(false) }, [isMobile])
-  const effectiveCollapsed = (navCollapsed || previewFocused) && !isMobile
+  const effectiveCollapsed = navCollapsed && !isMobile
   // Publish the rail track so consumers outside the shell can size against the
   // space actually left for content — ChatPage's activity panel decides
   // beside-vs-fill from it. Kept in sync with the gridTemplateColumns value

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -4544,6 +4544,12 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     ? ''
     : projectGit?.branch || (projectGit?.detached ? projectGit.head || '' : '')
   const [sidebarPinned, setSidebarPinned] = useState(() => localStorage.getItem('mc-sidebar-pinned') !== 'false')
+  const sidebarPinnedRef = useRef(sidebarPinned)
+  sidebarPinnedRef.current = sidebarPinned
+  // Pre-focus session-list state while the Web Preview expand mode auto-hides
+  // it, so exiting focus mode restores what the user had. null = focus mode is
+  // not the reason the list is hidden (the user owns the state).
+  const sidebarAutoHidden = useRef<boolean | null>(null)
   const isMobile = useIsMobile()
   const [sidebarWidth, setSidebarWidth] = useState(() => {
     const v = parseInt(localStorage.getItem('mc-sidebar-width') || '', 10)
@@ -4765,6 +4771,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       // Always-available collapse. Only guard is no-sessions (the sidebar is
       // force-open then anyway, so there is nothing to collapse).
       if (filteredSlotsRef.current.length === 0) return
+      // Explicit user intent outranks the preview-focus auto-hide, so exiting
+      // focus mode leaves this choice alone.
+      sidebarAutoHidden.current = null
       setSidebarPinned(p => {
         const next = !p
         safeSetItem('mc-sidebar-pinned', String(next))
@@ -5696,16 +5705,49 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     return true
   }, [dispatch, isMobile, selectSource])
   // Web Preview "focus" (expand) mode — broadcast by the Web Preview tab's
-  // expand toggle. When on, hide the session list (below) and maximize the side
-  // panel (passed to SidePanel), so the preview gets max room and chat shrinks
-  // to its minimum. App collapses the left nav off the same event.
+  // expand toggle. When on, hide the session list and maximize the side panel
+  // (passed to SidePanel), so the preview gets max room and chat shrinks to its
+  // minimum. App collapses the left nav off the same event.
+  //
+  // Hiding the list drives `sidebarPinned` directly instead of overriding
+  // `sidebarOpen`: an override leaves the sessions toggle visibly present but
+  // inert. Driving the real state keeps that toggle working normally inside
+  // focus mode. `sidebarAutoHidden` holds the pre-focus state to restore on
+  // exit, and is cleared once the user toggles the list themselves. Neither
+  // transition persists `mc-sidebar-pinned` — only a user toggle does.
+  //
+  // The ref is read and cleared HERE, in the handler, and only plain values
+  // reach the setter: a state updater must be pure, and React invokes one twice
+  // under StrictMode, which would make the second pass read an already-cleared
+  // ref and lose the restore value.
+  //
+  // The mobile drawer is a separate state, so it is closed outright rather than
+  // suppressed — a swipe or a tap still reopens it, which an override would not
+  // allow.
   const [previewFocused, setPreviewFocused] = useState(false)
   useEffect(() => {
-    const onFocus = (e: Event) => setPreviewFocused(!!(e as CustomEvent<{ focused?: boolean }>).detail?.focused)
+    const onFocus = (e: Event) => {
+      const focused = !!(e as CustomEvent<{ focused?: boolean }>).detail?.focused
+      setPreviewFocused(focused)
+      if (focused) {
+        setMobileSessions(false)
+        if (sidebarAutoHidden.current === null) sidebarAutoHidden.current = sidebarPinnedRef.current
+        setSidebarPinned(false)
+        return
+      }
+      const prior = sidebarAutoHidden.current
+      sidebarAutoHidden.current = null
+      if (prior !== null) setSidebarPinned(prior)
+    }
     window.addEventListener(PREVIEW_FOCUS_EVENT, onFocus)
     return () => window.removeEventListener(PREVIEW_FOCUS_EVENT, onFocus)
   }, [])
-  const sidebarOpen = !previewFocused && (isMobile ? mobileSessions : (sidebarPinned || filteredSlots.length === 0))
+  // The no-sessions force-open yields to focus mode: with an empty list no
+  // sessions toggle is rendered, so suppressing it makes nothing inert, and the
+  // preview would otherwise stay covered by a list that cannot be dismissed.
+  const sidebarOpen = isMobile
+    ? mobileSessions
+    : (sidebarPinned || (filteredSlots.length === 0 && !previewFocused))
 
   // ── Collapsed-sidebar hover flyout ──────────────────────────────────────
   // Hovering the toggle while collapsed opens a recents list over the chat, so
@@ -5718,7 +5760,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   const flyoutSurfaceRef = useRef<HTMLDivElement>(null)
   // Touch is a second gate beyond isMobile: a desktop-width touch device has no
   // hover, so the flyout would only ever appear as a tap artefact.
-  const flyoutEligible = !isMobile && !isTouchDevice() && !previewFocused && !splitMode
+  const flyoutEligible = !isMobile && !isTouchDevice() && !splitMode
     && embedMode !== 'chat' && embedMode !== 'sessions'
     && !sidebarOpen && filteredSlots.length > 0
   const flyout = useHoverIntent({
@@ -5761,12 +5803,17 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     focusComposerAfter(dispatch(createSlot({ agent: defaultAgent || undefined, mode: effectiveMode })).unwrap())
   }, [dispatch, defaultAgent, mode, flyout])
 
+  // Force the list open when there is nothing in it, so a user with no sessions
+  // still has the surface that creates one. Skipped while focus mode owns the
+  // hidden state: re-pinning there would fight the auto-hide and, worse, persist
+  // 'true' over the user's stored preference, which the restore on exit then
+  // contradicts in the live state.
   useEffect(() => {
-    if (filteredSlots.length === 0 && !sidebarPinned) {
+    if (filteredSlots.length === 0 && !sidebarPinned && !previewFocused) {
       setSidebarPinned(true)
       safeSetItem('mc-sidebar-pinned', 'true')
     }
-  }, [filteredSlots.length, sidebarPinned])
+  }, [filteredSlots.length, sidebarPinned, previewFocused])
 
   // Horizontal space (px) the detail panel must keep clear so it never grows
   // past its flex row and collapses the chat pane: the open sidebar's width
@@ -5820,7 +5867,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
           mode, morphTarget below). Desktop, non-embed, with sessions only.
           While collapsed, hovering it opens the recents flyout below; clicking
           hands that flyout's rect to the drawer so the panel grows out of it. */}
-      {!isMobile && embedMode !== 'chat' && embedMode !== 'sessions' && !previewFocused && filteredSlots.length > 0 && (
+      {!isMobile && embedMode !== 'chat' && embedMode !== 'sessions' && filteredSlots.length > 0 && (
         <button
           ref={flyoutTriggerRef}
           type="button"
@@ -5985,7 +6032,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
                 <ChatHeaderMenu
                   activeSlot={activeSlot}
                   agent={currentSlot?.agent}
-                  onReveal={activeSlot ? () => { if (!sidebarPinned) setSidebarPinned(true); window.dispatchEvent(new CustomEvent('reveal-slot', { detail: activeSlot })) } : undefined}
+                  onReveal={activeSlot ? () => { sidebarAutoHidden.current = null; if (!sidebarPinned) setSidebarPinned(true); window.dispatchEvent(new CustomEvent('reveal-slot', { detail: activeSlot })) } : undefined}
                   onRename={activeSlot ? () => { setEditingTitle(true); setTitleDraft(title) } : undefined}
                   mode={effectiveMode}
                 />

--- a/website/src/test/App.test.tsx
+++ b/website/src/test/App.test.tsx
@@ -784,6 +784,48 @@ describe('App routing', () => {
     localStorage.removeItem('mc-nav')
   })
 
+  it('lets the brand toggle expand the rail while preview focus mode is active', () => {
+    localStorage.removeItem('mc-nav')
+    renderWithProviders(<App />, { route: '/chat' })
+    const nav = screen.getByRole('navigation', { name: 'Main navigation' })
+
+    // Entering the Web Preview's expand mode collapses the rail.
+    act(() => {
+      window.dispatchEvent(new CustomEvent('kirocrew-preview-focus', { detail: { focused: true } }))
+    })
+    expect(within(nav).getByRole('button', { name: 'Expand sidebar' })).toBeInTheDocument()
+
+    // The logo keeps its standard behavior inside focus mode: it expands.
+    fireEvent.click(within(nav).getByRole('button', { name: 'Expand sidebar' }))
+    expect(within(nav).getByRole('button', { name: 'Collapse sidebar' })).toBeInTheDocument()
+
+    // Leaving focus mode must not undo that explicit choice.
+    act(() => {
+      window.dispatchEvent(new CustomEvent('kirocrew-preview-focus', { detail: { focused: false } }))
+    })
+    expect(within(nav).getByRole('button', { name: 'Collapse sidebar' })).toBeInTheDocument()
+    localStorage.removeItem('mc-nav')
+  })
+
+  it('restores the pre-focus rail state when preview focus mode ends untouched', () => {
+    localStorage.removeItem('mc-nav') // start expanded
+    renderWithProviders(<App />, { route: '/chat' })
+    const nav = screen.getByRole('navigation', { name: 'Main navigation' })
+    expect(within(nav).getByRole('button', { name: 'Collapse sidebar' })).toBeInTheDocument()
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('kirocrew-preview-focus', { detail: { focused: true } }))
+    })
+    expect(within(nav).getByRole('button', { name: 'Expand sidebar' })).toBeInTheDocument()
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('kirocrew-preview-focus', { detail: { focused: false } }))
+    })
+    expect(within(nav).getByRole('button', { name: 'Collapse sidebar' })).toBeInTheDocument()
+    // The auto-collapse is transient: it never writes the persisted preference.
+    expect(localStorage.getItem('mc-nav')).toBeNull()
+  })
+
   it('hides the community row when the sidebar is collapsed', () => {
     localStorage.removeItem('mc-nav')
     renderWithProviders(<App />, { route: '/chat' })

--- a/website/src/test/ChatPage.previewFocusSessions.test.tsx
+++ b/website/src/test/ChatPage.previewFocusSessions.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * Preview "focus" (expand) mode must not disable the sessions toggle.
+ *
+ * Entering focus mode (the Browser panel's expand button) hides the session
+ * list to give the preview room, but that is a starting layout, not a lock:
+ * the sessions toggle stays mounted and keeps working, and leaving focus mode
+ * restores the pre-focus state only when the user did not override it.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { StrictMode } from 'react'
+import { render, act, screen, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+import { __resetPanelTabs } from '../hooks/usePanelTabs'
+import { sseSlots } from '../store/dashboardSlice'
+
+vi.mock('react-virtuoso', () => ({ Virtuoso: () => null }))
+vi.mock('../components/ChatInput', () => ({ default: () => null }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: () => null }))
+vi.mock('../components/TypewriterText', () => ({ default: () => null }))
+// The drawer stands in for `sidebarOpen` itself, so a test can assert the
+// session list's real visibility rather than inferring it from the toggle label
+// (which is not rendered at all on mobile, or with an empty list).
+vi.mock('../components/OverlayDrawer', () => ({
+  default: ({ open, children }: { open?: boolean; children?: React.ReactNode }) =>
+    (open ? <div data-testid="sessions-drawer">{children}</div> : null),
+}))
+vi.mock('../components/AgentDropdownList', () => ({ default: () => null }))
+vi.mock('../components/ModelDropdownList', () => ({ default: () => null }))
+vi.mock('../components/InfoTip', () => ({ default: () => null }))
+vi.mock('../components/SegmentedControl', () => ({ default: () => null }))
+vi.mock('../pages/chat/CollapsibleToolGroup', () => ({ default: () => null }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../pages/chat/SessionColorPicker', () => ({ default: () => null }))
+vi.mock('../pages/chat', () => ({ ChatFooter: () => null, AssistantMessage: () => null, McpInfoButton: () => null }))
+vi.mock('../pages/ChatSidebar', () => ({ default: () => null, SIDEBAR_MIN: 200, SIDEBAR_MAX: 500 }))
+vi.mock('../pages/chat/ChatSettings', () => ({ loadChatConfig: () => ({ contentWidth: 'compact' }), CONTENT_WIDTH: { compact: { messages: '800px', input: '816px' }, comfortable: { messages: '84%', input: '85%' }, full: { messages: '92%', input: '93%' } } }))
+vi.mock('../pages/chat/SidePanel', () => ({
+  default: () => <div data-testid="side-panel" />,
+  SIDE_PANEL_MIN_W: 320,
+  SIDE_PANEL_RESERVED_W: 560,
+  CHAT_PANE_MIN_W: 320,
+  measureSidePanelReservedW: () => 560,
+  sidePanelFillWidth: () => undefined,
+}))
+vi.mock('../hooks/usePanelState', () => ({ usePanelState: () => ({ isOpen: false, openPanel: vi.fn(), closePanel: vi.fn() }), useDiffPanel: () => ({ isOpen: false, filePath: '', original: '', modified: '', openDiff: vi.fn(), closeDiff: vi.fn() }) }))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: null }) }))
+vi.mock('../hooks/useFilteredDropdown', () => ({ useFilteredDropdown: () => ({ filtered: [], query: '', setQuery: vi.fn(), selectedIndex: 0, setSelectedIndex: vi.fn(), onKeyDown: vi.fn() }) }))
+vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
+// useIsMobile reads matchMedia at module load, so a per-test matchMedia stub
+// cannot move it. Mock the hook with a mutable flag instead.
+let mockIsMobile = false
+vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => mockIsMobile }))
+vi.mock('../api/client', () => ({
+  api: Object.fromEntries(
+    ['sessions', 'chatSlotDetail', 'createChatSlot', 'deleteChatSlot', 'resumeChatSlot',
+      'deleteSession', 'agentDetail', 'approveChatSlot', 'chatSlotAgent', 'chatSlotModel',
+      'chatSlotWorkspace', 'models', 'planAction', 'planFromChat', 'renameSlot',
+      'resolveApproval', 'screenshot', 'slackChannels', 'slackLink', 'spawnList',
+      'stopChatSlot', 'uploadFiles', 'voiceSynthesize', 'workspaces', 'chatSlots',
+      'notifications', 'status', 'generateTitle'].map(k => [k, vi.fn().mockResolvedValue(
+      k === 'chatSlotDetail' ? { messages: [], has_more: false, total: 0 } : {},
+    )]),
+  ),
+}))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }) as any
+globalThis.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} } as any
+
+import ChatPage from '../pages/ChatPage'
+
+const setFocus = (focused: boolean) => act(() => {
+  window.dispatchEvent(new CustomEvent('kirocrew-preview-focus', { detail: { focused } }))
+})
+
+function renderChat({ slots = 1, strict = false }: { slots?: number; strict?: boolean } = {}) {
+  const store = createTestStore()
+  // The sessions toggle only renders when there is a session to show.
+  act(() => {
+    store.dispatch(sseSlots(
+      Array.from({ length: slots }, (_, i) => ({ key: `slot-${i}`, title: `Session ${i}` }) as any),
+    ))
+  })
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  const tree = (
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter initialEntries={['/chat']}>
+            <Routes><Route path="/chat/:slug?" element={<ChatPage />} /></Routes>
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>
+  )
+  render(strict ? <StrictMode>{tree}</StrictMode> : tree)
+  return store
+}
+
+describe('ChatPage — sessions toggle inside preview focus mode', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1400 })
+    localStorage.clear()
+    __resetPanelTabs()
+  })
+
+  it('keeps the toggle mounted and working while focus mode is active', () => {
+    renderChat()
+    expect(screen.getByRole('button', { name: 'Hide sessions sidebar' })).toBeInTheDocument()
+
+    setFocus(true)
+    // Focus mode hides the list, but the toggle is still there to bring it back.
+    const toggle = screen.getByRole('button', { name: 'Show sessions sidebar' })
+
+    fireEvent.click(toggle)
+    expect(screen.getByRole('button', { name: 'Hide sessions sidebar' })).toBeInTheDocument()
+
+    // Leaving focus mode must not undo that explicit choice.
+    setFocus(false)
+    expect(screen.getByRole('button', { name: 'Hide sessions sidebar' })).toBeInTheDocument()
+  })
+
+  it('restores the pre-focus session list when focus mode ends untouched', () => {
+    renderChat()
+    expect(screen.getByRole('button', { name: 'Hide sessions sidebar' })).toBeInTheDocument()
+
+    setFocus(true)
+    expect(screen.getByRole('button', { name: 'Show sessions sidebar' })).toBeInTheDocument()
+
+    setFocus(false)
+    expect(screen.getByRole('button', { name: 'Hide sessions sidebar' })).toBeInTheDocument()
+    // The auto-hide is transient: only a user toggle writes the preference.
+    expect(localStorage.getItem('mc-sidebar-pinned')).toBeNull()
+  })
+
+  it('restores the list under StrictMode, where a state updater runs twice', () => {
+    // The restore value lives in a ref. Reading and clearing it inside a
+    // setState updater would lose it here: StrictMode double-invokes the
+    // updater, and the second pass would see an already-cleared ref.
+    renderChat({ strict: true })
+    expect(screen.getByRole('button', { name: 'Hide sessions sidebar' })).toBeInTheDocument()
+
+    setFocus(true)
+    expect(screen.getByRole('button', { name: 'Show sessions sidebar' })).toBeInTheDocument()
+
+    setFocus(false)
+    expect(screen.getByRole('button', { name: 'Hide sessions sidebar' })).toBeInTheDocument()
+  })
+
+  it('keeps the hover recents flyout available while focus mode hides the list', () => {
+    renderChat()
+    setFocus(true)
+    // aria-haspopup mirrors flyoutEligible, which focus mode no longer suppresses.
+    expect(screen.getByRole('button', { name: 'Show sessions sidebar' }))
+      .toHaveAttribute('aria-haspopup', 'menu')
+  })
+
+  it('does not let focus mode overwrite the stored preference when the list drains to empty', () => {
+    // The force-open rule persists 'true' whenever the list is empty and
+    // unpinned. Focus mode also unpins, so without the guard, draining the list
+    // to zero inside focus mode would write 'true' over a user who chose
+    // hidden — and the restore on exit would then contradict it in the live state.
+    const store = renderChat()
+    fireEvent.click(screen.getByRole('button', { name: 'Hide sessions sidebar' }))
+    expect(localStorage.getItem('mc-sidebar-pinned')).toBe('false')
+
+    setFocus(true)
+    act(() => { store.dispatch(sseSlots([])) })
+    expect(localStorage.getItem('mc-sidebar-pinned')).toBe('false')
+
+    setFocus(false)
+    // Out of focus mode the empty list is the force-open rule's business again.
+    expect(localStorage.getItem('mc-sidebar-pinned')).toBe('true')
+  })
+
+  it('renders no sessions toggle when there is nothing in the list', () => {
+    renderChat({ slots: 0 })
+    expect(screen.queryByRole('button', { name: /sessions sidebar/ })).not.toBeInTheDocument()
+  })
+
+  it('closes the list in focus mode even with an empty session list', () => {
+    // The toggle is unrendered either way here, so assert the list itself: the
+    // force-open rule must not leave the preview covered by an undismissable list.
+    renderChat({ slots: 0 })
+    expect(screen.getByTestId('sessions-drawer')).toBeInTheDocument()
+
+    setFocus(true)
+    expect(screen.queryByTestId('sessions-drawer')).not.toBeInTheDocument()
+
+    setFocus(false)
+    expect(screen.getByTestId('sessions-drawer')).toBeInTheDocument()
+  })
+})
+
+describe('ChatPage — mobile session drawer inside preview focus mode', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 420 })
+    localStorage.clear()
+    __resetPanelTabs()
+    mockIsMobile = true
+  })
+  afterEach(() => { mockIsMobile = false })
+
+  it('closes the open drawer on entry and leaves it reopenable', () => {
+    // Mobile has its own state (`mobileSessions`) and no sessions toggle, so
+    // focus mode closes the drawer outright instead of suppressing it.
+    const openDrawer = () =>
+      fireEvent.click(screen.getAllByRole('button', { name: 'Toggle sessions' })[0])
+    renderChat()
+    openDrawer()
+    expect(screen.getByTestId('sessions-drawer')).toBeInTheDocument()
+
+    setFocus(true)
+    expect(screen.queryByTestId('sessions-drawer')).not.toBeInTheDocument()
+
+    // Still reachable — an override would have made this button do nothing.
+    openDrawer()
+    expect(screen.getByTestId('sessions-drawer')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
<!-- pr-marker: expand-mode-nav-toggles -->
## Problem

With the chat right-side **Browser** panel expanded (its header's Expand button), the
left nav and the session list are hidden — and both of their controls stop working
for as long as the preview stays expanded:

- Clicking the left-nav **logo** does nothing. No rail, no visual response.
- The **sessions toggle** is not in the chat header at all, so there is nothing to
  click where the user expects it (the 60px slot and its divider still render, so the
  gap looks like a control that vanished).

Neither control behaves the way it does everywhere else in the app.

## Why it matters

Expand mode becomes a trap rather than a layout. Once in it, the only way to see your
sessions or the nav rail is to leave the preview entirely — so a workflow that mixes
"look at the preview" with "switch sessions" forces an expand/collapse cycle every
time. Worse, the logo is not visibly disabled, it just silently does nothing, which
reads as a broken button rather than an intentional mode.

## Fix (symptom → root cause → change)

**Symptom:** two controls are inert (one of them missing) while the preview is expanded.

**Root cause:** expand mode was implemented as an *override on top of* the two layout
states rather than as a change *to* them. The Browser panel broadcasts a
`kirocrew-preview-focus` window event, and:

- `App.tsx` computed `effectiveCollapsed = (navCollapsed || previewFocused)`. Clicking
  the logo **did** flip `navCollapsed` — the `||` simply swallowed the result.
- `ChatPage.tsx` computed `sidebarOpen = !previewFocused && (…)` and additionally
  unmounted the sessions toggle and disabled its hover flyout while focused.

**Change:** drive the two real states (`navCollapsed`, `sidebarPinned`) instead of
overriding their consumers. Entering expand mode collapses the rail and hides the list
exactly as before, but both controls keep their standard behavior. A ref per state
holds the pre-expand value so leaving expand mode restores it, and is cleared the
moment the user toggles that control themselves, so an explicit choice is never undone
on exit. Every path that sets either state on the user's behalf clears the ref —
including the header menu's reveal-in-sidebar action.

The ref is read and cleared **in the event handler, not inside a `setState` updater**:
an updater must be pure, and StrictMode double-invokes it, so the second pass would
read an already-cleared ref and drop the restore. This was not theoretical — the
`StrictMode` test below fails against the pre-fix commit for exactly that reason.

Two states cannot be driven this way and are handled explicitly:

- **The mobile session drawer** is separate state (`mobileSessions`) with no toggle
  button, so it is closed outright on entry. A swipe or tap still reopens it, which an
  override would not have allowed.
- **An empty session list** is force-open by a separate rule (so a user with no
  sessions still has the surface that creates one). That rule now yields to expand
  mode — legitimate here precisely because no toggle is rendered with an empty list,
  so nothing is made inert — and it no longer persists `mc-sidebar-pinned` while
  expand mode owns the state, which would otherwise overwrite a stored preference that
  the restore-on-exit then contradicts in the live state.

Neither auto-transition writes `mc-nav` or `mc-sidebar-pinned`. Only a real user
toggle does, so expanding and collapsing the preview cannot mutate a saved layout
preference.

## Tests

8 tests, all of which fail against the pre-fix code (verified by reverting each source
file and re-running, not by assumption).

`website/src/test/ChatPage.previewFocusSessions.test.tsx` (new, 8 tests):

| Test | What it locks in |
|---|---|
| keeps the toggle mounted and working while focus mode is active | the toggle exists in expand mode, toggles the list, and the click survives exit |
| restores the pre-focus session list when focus mode ends untouched | restore-on-exit, and that the auto-hide writes no preference |
| restores the list under StrictMode, where a state updater runs twice | the impure-updater regression — this is the one that catches a ref read/clear moved back into a `setState` updater |
| keeps the hover recents flyout available while focus mode hides the list | `aria-haspopup` mirrors `flyoutEligible`, which expand mode no longer suppresses |
| does not let focus mode overwrite the stored preference when the list drains to empty | the force-open rule cannot persist `'true'` over a user who chose hidden |
| renders no sessions toggle when there is nothing in the list | the precondition that makes the empty-list override legitimate |
| closes the list in focus mode even with an empty session list | the preview is not left covered by an undismissable list |
| closes the open drawer on entry and leaves it reopenable (mobile) | the mobile leg: closed outright, and still reopenable |

`website/src/test/App.test.tsx` (2 added): the logo toggle expands the rail inside
expand mode and that choice survives exit; and an untouched expand/collapse cycle
restores the pre-expand rail state without ever writing `mc-nav`.

## Manual verification

Open a chat, open the right panel's **Browser** tab, click Expand, then:

1. Click the logo — the rail expands; click again — it collapses.
2. Click the sessions toggle — the list appears; hover it while hidden — the recents
   flyout opens.
3. Click Minimize without having touched either control — the pre-expand layout returns.
4. Repeat, but open the rail first — after Minimize the rail stays open.
5. Reload — the saved layout is whatever you last clicked, never a side effect of
   expanding.

**No screenshots.** This change adds no new visual element: it restores the behavior
of two existing controls, so the meaningful evidence is a recording of the interaction
rather than a still frame — and neither could be captured in the environment this was
built in. Driving the dashboard needs an authenticated gateway, and minting a
dashboard token is blocked for the agent by a Kiro Crew deny rule (correctly). An
isolated gateway was built and run from this branch to confirm the bundle compiles and
serves, but the authenticated click-through is left for a human reviewer via the steps
above.

## Known gap

The reveal-in-sidebar ref clear (`onReveal`) has no test — exercising it means driving
the chat header menu open. It is a one-line clear symmetric with the two paths that
are covered, so the risk is low, but it is a real gap rather than an oversight.
