### PR TITLE
fix(dashboard): base the Slack status badge on the socket connect outcome

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -2506,9 +2506,17 @@ class DashboardState:
             # The dashboard uses this to give prerelease users an obvious way to
             # report a bug; see release_channel.py for the full rule.
             "release_channel": _release_channel_of_build(),
-            # True when the gateway has wired up a live Slack client (Socket Mode
-            # connected). None in pure-dashboard mode or when Slack is disabled.
-            "slack_connected": self.slack_client is not None,
+            # True only when Socket Mode actually connected this session, not
+            # merely that tokens were present at boot. slack_client is set
+            # whenever tokens existed, even if connect() then failed
+            # (invalid_auth, a network error), so keying the status badge on it
+            # alone painted a green "Connected" over a Slack that never came up.
+            # Require BOTH a wired client and the real connect outcome the
+            # gateway records after _connect_slack. This is the same field
+            # /api/slack/config already reports to the settings badge.
+            "slack_connected": (
+                self.slack_client is not None and self.slack_socket_connected
+            ),
             # Governance enforcement health: "active" (enforcing),
             # "disabled" (permissive default / not restricting), "degraded" (a
             # fail-closed trip, integrity mismatch, or unverified policy this

--- a/test/test_dashboard_status_snapshot.py
+++ b/test/test_dashboard_status_snapshot.py
@@ -50,12 +50,20 @@ class TestStatusSnapshot:
         state.subagents = None
         assert state.status_snapshot()["subagents"] == 0
 
-    def test_slack_connected_reflects_client(self, state: DashboardState) -> None:
+    def test_slack_connected_reflects_socket_outcome(self, state: DashboardState) -> None:
         # No Slack client wired up (pure-dashboard / Slack disabled).
         assert state.slack_client is None
         assert state.status_snapshot()["slack_connected"] is False
-        # Gateway wires up a live Slack client once Socket Mode connects.
+        # Tokens were present at boot (client wired) but the socket connect
+        # failed, e.g. invalid_auth or a network error. The badge must NOT show
+        # green: slack_client alone only proves tokens existed, not that Socket
+        # Mode came up. This is the reported bug (#1770): a green "Connected"
+        # over a Slack that never received an event.
         state.slack_client = MagicMock()
+        state.slack_socket_connected = False
+        assert state.status_snapshot()["slack_connected"] is False
+        # Socket Mode actually connected this session.
+        state.slack_socket_connected = True
         assert state.status_snapshot()["slack_connected"] is True
 
     def test_new_fields_propagate_to_all_callers(self, state: DashboardState) -> None:


### PR DESCRIPTION
## What

The dashboard status payload reported `slack_connected` as `self.slack_client is not None`, which is true whenever Slack tokens were present at boot, even if the Socket Mode connect then failed. So the System page Services badge showed a green "Connected" for a Slack that never actually came up (bad token, network error, etc.), with no reply and nothing in the gateway log for incoming messages.

This changes `status_snapshot()` to report `slack_connected` only when both a client is wired AND the socket connect actually succeeded this session (`slack_socket_connected`, the outcome the gateway already records after `_connect_slack`). That is the same field `/api/slack/config` already uses for the Settings > Channels > Slack badge, so the two surfaces now agree.

## Why

`slack_client` being set only proves tokens existed at startup, not that Socket Mode connected. The state field's own docstring says the value is "read by the status badge" and should mean "Socket Mode connected", but the snapshot keyed it on client presence instead. The result is a status badge that reports health it has not verified, which is exactly the failure the reporter hit: a green badge over a dead connection.

## Scope

This addresses the badge-accuracy half of #1770 (the part the issue's own triage flagged as actionable, and the part that reproduces on any OS: a failed connect leaves `slack_client` set but `slack_socket_connected` false). It does not attempt the Windows ProactorEventLoop Socket Mode teardown investigation, which needs a Windows host to reproduce and is a separate fault. Making the badge honest is the prerequisite the issue asked for either way, since a truthful badge is what makes that underlying connection failure visible instead of silent.

## Tests

`test_dashboard_status_snapshot.py::test_slack_connected_reflects_socket_outcome` now covers three states: Slack disabled (no client) is not connected; client wired but socket connect failed is NOT connected (the reported bug); client wired and socket connected is connected. The middle case fails on the pre-fix code.

## Manual verification

Confirmed on the current tree that `/api/slack/config` (`handlers/messaging.py`) already returns `connected = slack_socket_connected`, so the Settings panel badge was already correct; only the `/status` payload consumed by the System page Services tab keyed on the wrong field. No frontend change is needed: `ServicesTab.tsx` reads `status.slack_connected`, whose meaning is now correct.

Refs #1770

I have deliberately not used a closing keyword: this fixes the badge-accuracy half, and the Windows Socket Mode teardown that #1770 leads with still needs a Windows host to reproduce, so the issue should stay open for that. Happy to add "Closes" if you would rather track the remaining Windows work in a fresh issue.
