### PR TITLE
test(website): cover nine more frontend modules, eight to 100%

### DIFF
--- a/website/src/test/CliPanelCoverage.test.tsx
+++ b/website/src/test/CliPanelCoverage.test.tsx
@@ -1,0 +1,677 @@
+/**
+ * Behavioural coverage for CliPanel — the terminal pane host.
+ *
+ * A real xterm `Terminal` cannot boot under the test DOM (it measures a canvas
+ * character cell), so this file follows the same approach as
+ * `TerminalCompletion.test.tsx`: substitute a minimal xterm stand-in and drive
+ * the contract CliPanel actually depends on (open/focus/selection events,
+ * mutable `options`, `element.offsetParent`). What is under test here is
+ * CliPanel's own logic — DOM attach, visibility gating, the floating selection
+ * toolbar (clamping, copy, send-to-chat redaction handoff), the module-level
+ * theme/font observers, and the teardown + delete-session exports.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent, act, waitFor, cleanup } from '@testing-library/react'
+import { renderWithProviders, renderHookWithProviders } from './helpers'
+import { i18nT } from '../i18n/t'
+
+/* ── xterm stand-in ───────────────────────────────────────────────────────── */
+
+const xt = vi.hoisted(() => {
+  interface FakeOptions {
+    cursorBlink?: boolean
+    fontSize?: number
+    fontFamily?: string
+    theme?: Record<string, string>
+  }
+  class FakeTerminal {
+    static instances: FakeTerminal[] = []
+    options: FakeOptions
+    element: HTMLElement | undefined = undefined
+    /** Ordered log of every fontFamily write — proves the re-measure toggle. */
+    fontFamilyWrites: string[] = []
+    openCalls = 0
+    focusCalls = 0
+    disposed = false
+    clearCalls = 0
+    addons: unknown[] = []
+    selection = ''
+    selectionListeners: (() => void)[] = []
+    scrollListeners: (() => void)[] = []
+    /** Controls `remeasureAndFit`'s laid-out-pane guard. */
+    offsetParent: unknown = {}
+
+    constructor(options: FakeOptions) {
+      // Proxy fontFamily so writes are observable without hiding the value.
+      this.options = new Proxy(options, {
+        set: (target: FakeOptions, key: string, value: unknown) => {
+          if (key === 'fontFamily') this.fontFamilyWrites.push(String(value))
+          Reflect.set(target, key, value)
+          return true
+        },
+      }) as FakeOptions
+      FakeTerminal.instances.push(this)
+    }
+    loadAddon(addon: unknown) { this.addons.push(addon) }
+    open(container: HTMLElement) {
+      this.openCalls += 1
+      const el = document.createElement('div')
+      el.className = 'xterm'
+      Object.defineProperty(el, 'offsetParent', { get: () => this.offsetParent, configurable: true })
+      container.appendChild(el)
+      this.element = el
+    }
+    focus() { this.focusCalls += 1 }
+    dispose() { this.disposed = true }
+    hasSelection() { return this.selection.length > 0 }
+    getSelection() { return this.selection }
+    clearSelection() { this.clearCalls += 1; this.selection = '' }
+    onSelectionChange(cb: () => void) {
+      this.selectionListeners.push(cb)
+      return { dispose: () => { this.selectionListeners = this.selectionListeners.filter(c => c !== cb) } }
+    }
+    onScroll(cb: () => void) {
+      this.scrollListeners.push(cb)
+      return { dispose: () => { this.scrollListeners = this.scrollListeners.filter(c => c !== cb) } }
+    }
+  }
+  class FakeFitAddon {
+    static instances: FakeFitAddon[] = []
+    fit = vi.fn()
+    constructor() { FakeFitAddon.instances.push(this) }
+  }
+  return { FakeTerminal, FakeFitAddon }
+})
+
+vi.mock('@xterm/xterm', () => ({ Terminal: xt.FakeTerminal }))
+vi.mock('@xterm/addon-fit', () => ({ FitAddon: xt.FakeFitAddon }))
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: class {} }))
+
+const registry = vi.hoisted(() => ({
+  ensureTerminalConnection: vi.fn(),
+  disposeTerminalConnection: vi.fn(),
+  getTerminalCwd: vi.fn<(id: string) => string | undefined>(() => undefined),
+}))
+vi.mock('../utils/terminalRegistry', () => registry)
+
+// Both children own their own xterm hooks and are covered by their own suites;
+// stub them so this file exercises CliPanel alone.
+vi.mock('../components/TerminalCompletion', () => ({ default: () => <div data-testid="completion" /> }))
+vi.mock('../components/TerminalKeyBar', () => ({ default: () => <div data-testid="key-bar" /> }))
+
+const touch = vi.hoisted(() => ({ value: false }))
+vi.mock('../hooks/useIsTouchDevice', () => ({ useIsTouchDevice: () => touch.value }))
+
+import CliPanel, { disposeTerminalSession, useDeleteTerminalSession } from '../components/CliPanel'
+import { setTerminalFontSize, __resetTerminalFontStore } from '../hooks/useTerminalFont'
+
+/* ── harness ──────────────────────────────────────────────────────────────── */
+
+const SEND_LABEL = i18nT('components.cliPanel.send_to_chat')
+const COPY_LABEL = i18nT('components.cliPanel.copy')
+const COPIED_LABEL = i18nT('components.cliPanel.copied')
+const COPY_FAILED_LABEL = i18nT('components.cliPanel.copy_failed')
+const SEND_FAILED_LABEL = i18nT('components.cliPanel.failed_retry')
+
+/** Layout numbers for the clamp maths — pane 400x300, toolbar 120x32. */
+const boxProps = ['clientWidth', 'clientHeight', 'offsetWidth', 'offsetHeight'] as const
+const savedBox = new Map<string, PropertyDescriptor | undefined>()
+const sizes: Record<string, number> = { clientWidth: 400, clientHeight: 300, offsetWidth: 120, offsetHeight: 32 }
+function stubLayout() {
+  sizes.clientWidth = 400
+  sizes.clientHeight = 300
+  sizes.offsetWidth = 120
+  sizes.offsetHeight = 32
+  for (const p of boxProps) {
+    savedBox.set(p, Object.getOwnPropertyDescriptor(HTMLElement.prototype, p))
+    Object.defineProperty(HTMLElement.prototype, p, { get: () => sizes[p], configurable: true })
+  }
+}
+function restoreLayout() {
+  for (const p of boxProps) {
+    const d = savedBox.get(p)
+    if (d) Object.defineProperty(HTMLElement.prototype, p, d)
+    else Reflect.deleteProperty(HTMLElement.prototype, p)
+  }
+  savedBox.clear()
+}
+
+function setClipboard(value: unknown) {
+  Object.defineProperty(navigator, 'clipboard', { value, configurable: true, writable: true })
+}
+
+let seq = 0
+/** Unique id per test — `termCache` is module-level and outlives a render. */
+function nextId() { seq += 1; return `pty-${seq}` }
+
+const live = new Set<string>()
+function mount(props: Partial<{ sessionId: string; cwd: string; visible: boolean; onSendToChat: (t: string) => void }> = {}) {
+  const sessionId = props.sessionId ?? nextId()
+  live.add(sessionId)
+  const view = renderWithProviders(
+    <CliPanel
+      sessionId={sessionId}
+      cwd={props.cwd}
+      visible={props.visible ?? true}
+      onSendToChat={props.onSendToChat}
+    />,
+  )
+  const term = xt.FakeTerminal.instances[xt.FakeTerminal.instances.length - 1]
+  const fit = xt.FakeFitAddon.instances[xt.FakeFitAddon.instances.length - 1]
+  return { ...view, sessionId, term, fit }
+}
+
+/** Finish the drag: the toolbar appears on the wrapper's mouseup. */
+function endDrag(container: HTMLElement, at: { x: number; y: number }) {
+  const wrap = container.firstElementChild!.firstElementChild as HTMLElement
+  act(() => { fireEvent.mouseUp(wrap, { clientX: at.x, clientY: at.y }) })
+  return wrap
+}
+
+beforeEach(() => {
+  // Synchronous animation frames: CliPanel defers the selection read and the
+  // theme/font refreshes by one frame, and a test must not wait on real ones.
+  // Returning 0 matters — the coalescing guards store this handle and clear it
+  // to 0 inside the callback, so a non-zero return would land AFTER the clear
+  // and wedge every later refresh behind a permanently "pending" frame.
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => { cb(0); return 0 })
+  vi.stubGlobal('cancelAnimationFrame', () => {})
+  vi.stubGlobal('fetch', vi.fn())
+  registry.ensureTerminalConnection.mockClear()
+  registry.disposeTerminalConnection.mockClear()
+  registry.getTerminalCwd.mockReset()
+  registry.getTerminalCwd.mockReturnValue(undefined)
+  xt.FakeTerminal.instances = []
+  xt.FakeFitAddon.instances = []
+  touch.value = false
+  stubLayout()
+  setClipboard({ writeText: vi.fn(() => Promise.resolve()) })
+})
+
+afterEach(() => {
+  cleanup()
+  for (const id of live) disposeTerminalSession(id)
+  live.clear()
+  restoreLayout()
+  __resetTerminalFontStore()
+  vi.unstubAllGlobals()
+  document.documentElement.removeAttribute('data-theme')
+  for (const s of Array.from(document.head.querySelectorAll('style'))) {
+    if (s.id.startsWith('mc-custom-theme-') || s.id === 'unrelated-style') s.remove()
+  }
+})
+
+/* ── mount / attach ───────────────────────────────────────────────────────── */
+
+describe('CliPanel mount', () => {
+  it('opens one xterm into the pane, fits it, and wires the persistent connection', () => {
+    const { term, fit, sessionId, container } = mount({ cwd: '/srv/app' })
+    expect(term.openCalls).toBe(1)
+    expect(container.querySelector('.xterm')).not.toBeNull()
+    expect(fit.fit).toHaveBeenCalled()
+    expect(registry.ensureTerminalConnection).toHaveBeenCalledWith(sessionId, term, fit, '/srv/app')
+    // A visible pane takes focus and is re-measured (monospace toggle + restore).
+    expect(term.focusCalls).toBe(1)
+    expect(term.fontFamilyWrites.slice(-2)).toEqual(['monospace', term.options.fontFamily])
+  })
+
+  it('loads the fit and web-links addons and seeds the theme from CSS custom properties', () => {
+    const { term } = mount()
+    expect(term.addons).toHaveLength(2)
+    // No custom properties are set in the test document, so every slot falls
+    // back to its hard-coded default rather than an empty string.
+    expect(term.options.theme).toEqual({
+      background: '#1e1e2e',
+      foreground: '#cdd6f4',
+      cursor: '#89b4fa',
+      selectionBackground: '#313244',
+    })
+  })
+
+  it('reads the theme from --bg/--text/--accent when the document defines them', () => {
+    document.documentElement.style.setProperty('--bg', '#101010')
+    document.documentElement.style.setProperty('--text', '#f0f0f0')
+    try {
+      const { term } = mount()
+      expect(term.options.theme?.background).toBe('#101010')
+      expect(term.options.theme?.foreground).toBe('#f0f0f0')
+    } finally {
+      document.documentElement.style.removeProperty('--bg')
+      document.documentElement.style.removeProperty('--text')
+    }
+  })
+
+  it('hides the pane and skips focus when not visible', () => {
+    const { term, container } = mount({ visible: false })
+    const wrap = container.firstElementChild!.firstElementChild as HTMLElement
+    expect(wrap.style.display).toBe('none')
+    expect(term.focusCalls).toBe(0)
+  })
+
+  it('re-attaches the cached xterm on remount instead of opening a second one', () => {
+    const sessionId = nextId()
+    const first = mount({ sessionId })
+    cleanup()
+    const second = mount({ sessionId })
+    expect(second.term).toBe(first.term)
+    expect(xt.FakeTerminal.instances).toHaveLength(1)
+    expect(first.term.openCalls).toBe(1) // second mount took the appendChild path
+    expect(second.container.querySelector('.xterm')).not.toBeNull()
+  })
+
+  it('renders the soft key bar only on a touch device', () => {
+    mount()
+    expect(screen.queryByTestId('key-bar')).toBeNull()
+    cleanup()
+    touch.value = true
+    mount()
+    expect(screen.getByTestId('key-bar')).toBeInTheDocument()
+  })
+
+  it('refits when the pane is resized, and skips a pane that has collapsed to zero height', () => {
+    const observers: ResizeObserverCallback[] = []
+    class CapturingResizeObserver {
+      constructor(cb: ResizeObserverCallback) { observers.push(cb) }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal('ResizeObserver', CapturingResizeObserver)
+    const { fit } = mount()
+    fit.fit.mockClear()
+    const notify = () => act(() => {
+      for (const cb of observers) cb([], {} as ResizeObserver)
+    })
+    notify()
+    expect(fit.fit).toHaveBeenCalledTimes(1)
+    sizes.offsetHeight = 0 // collapsed / hidden pane
+    notify()
+    expect(fit.fit).toHaveBeenCalledTimes(1) // no second fit
+  })
+})
+
+/* ── selection toolbar ────────────────────────────────────────────────────── */
+
+describe('CliPanel selection toolbar', () => {
+  it('stays hidden when the drag selected nothing but whitespace', () => {
+    const { term, container } = mount({ onSendToChat: vi.fn() })
+    term.selection = '   \n '
+    endDrag(container, { x: 200, y: 100 })
+    expect(screen.queryByRole('button', { name: COPY_LABEL })).toBeNull()
+  })
+
+  it('stays hidden when xterm reports no selection at all on mouseup', () => {
+    const { term, container } = mount({ onSendToChat: vi.fn() })
+    term.selection = '' // hasSelection() false → nothing is captured
+    endDrag(container, { x: 200, y: 100 })
+    expect(screen.queryByRole('button', { name: COPY_LABEL })).toBeNull()
+  })
+
+  it('keeps the toolbar when the selection merely changes rather than clearing', () => {
+    const { term, container } = mount()
+    term.selection = 'first'
+    endDrag(container, { x: 200, y: 100 })
+    term.selection = 'grown wider'
+    act(() => { for (const cb of term.selectionListeners) cb() })
+    expect(screen.getByRole('button', { name: COPY_LABEL })).toBeInTheDocument()
+  })
+
+  it('appears above the pointer with both actions once text is selected', () => {
+    const { term, container } = mount({ onSendToChat: vi.fn() })
+    term.selection = 'total 12'
+    endDrag(container, { x: 200, y: 100 })
+    const copy = screen.getByRole('button', { name: COPY_LABEL })
+    expect(copy).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: SEND_LABEL })).toBeInTheDocument()
+    // left = clamp(200 - 120/2) = 140; top = 100 - 32 - 8 = 60 (room above)
+    const bar = copy.parentElement as HTMLElement
+    expect(bar.style.left).toBe('140px')
+    expect(bar.style.top).toBe('60px')
+    expect(bar.style.opacity).toBe('1')
+  })
+
+  it('clamps to the left edge and flips below the line when there is no room above', () => {
+    const { term, container } = mount({ onSendToChat: vi.fn() })
+    term.selection = 'x'
+    endDrag(container, { x: 4, y: 10 })
+    const bar = screen.getByRole('button', { name: COPY_LABEL }).parentElement as HTMLElement
+    expect(bar.style.left).toBe('8px')  // 4 - 60 is off-pane → margin
+    expect(bar.style.top).toBe('26px')  // 10 - 40 < 8 → drop below (10 + 16)
+  })
+
+  it('omits the send action when the host provides no chat sink', () => {
+    const { term, container } = mount()
+    term.selection = 'ls -la'
+    endDrag(container, { x: 200, y: 100 })
+    expect(screen.getByRole('button', { name: COPY_LABEL })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: SEND_LABEL })).toBeNull()
+  })
+
+  it('dismisses itself when xterm reports the selection was cleared', () => {
+    const { term, container } = mount()
+    term.selection = 'kept'
+    endDrag(container, { x: 200, y: 100 })
+    expect(screen.getByRole('button', { name: COPY_LABEL })).toBeInTheDocument()
+    term.selection = ''
+    act(() => { for (const cb of term.selectionListeners) cb() })
+    expect(screen.queryByRole('button', { name: COPY_LABEL })).toBeNull()
+  })
+
+  it('dismisses itself when the viewport scrolls under it', () => {
+    const { term, container } = mount()
+    term.selection = 'kept'
+    endDrag(container, { x: 200, y: 100 })
+    act(() => { for (const cb of term.scrollListeners) cb() })
+    expect(screen.queryByRole('button', { name: COPY_LABEL })).toBeNull()
+  })
+
+  it('prevents the default on its own mousedown so pressing a button cannot restart a drag', () => {
+    const { term, container } = mount()
+    term.selection = 'kept'
+    endDrag(container, { x: 200, y: 100 })
+    const bar = screen.getByRole('button', { name: COPY_LABEL }).parentElement as HTMLElement
+    expect(fireEvent.mouseDown(bar, { clientX: 10, clientY: 10 })).toBe(false)
+    expect(screen.getByRole('button', { name: COPY_LABEL })).toBeInTheDocument()
+  })
+
+  it('survives a mouseup on itself while the selection is still live', () => {
+    const { term, container } = mount()
+    term.selection = 'kept'
+    endDrag(container, { x: 200, y: 100 })
+    const bar = screen.getByRole('button', { name: COPY_LABEL }).parentElement as HTMLElement
+    act(() => { fireEvent.mouseUp(bar, { clientX: 200, clientY: 100 }) })
+    expect(screen.getByRole('button', { name: COPY_LABEL })).toBeInTheDocument()
+  })
+
+  it('re-measures the toolbar position for a second selection', () => {
+    const { term, container } = mount()
+    term.selection = 'first'
+    endDrag(container, { x: 200, y: 100 })
+    expect((screen.getByRole('button', { name: COPY_LABEL }).parentElement as HTMLElement).style.top).toBe('60px')
+    term.selection = 'second'
+    endDrag(container, { x: 60, y: 200 })
+    const bar = screen.getByRole('button', { name: COPY_LABEL }).parentElement as HTMLElement
+    expect(bar.style.left).toBe('8px')
+    expect(bar.style.top).toBe('160px')
+  })
+})
+
+/* ── copy ─────────────────────────────────────────────────────────────────── */
+
+describe('CliPanel copy action', () => {
+  it('copies the captured text, confirms, then dismisses the toolbar', async () => {
+    // Only the timer is faked: vitest's default fake set includes
+    // requestAnimationFrame, which would displace the synchronous stub the
+    // deferred selection read depends on.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      const writeText = vi.fn(() => Promise.resolve())
+      setClipboard({ writeText })
+      const { term, container } = mount()
+      term.selection = 'drwxr-xr-x  4 user'
+      endDrag(container, { x: 200, y: 100 })
+      await act(async () => { fireEvent.click(screen.getByRole('button', { name: COPY_LABEL })) })
+      expect(writeText).toHaveBeenCalledWith('drwxr-xr-x  4 user')
+      expect(screen.getByRole('button', { name: COPIED_LABEL })).toBeInTheDocument()
+      // The confirmation lingers deliberately, then the toolbar goes away.
+      await act(async () => { await vi.advanceTimersByTimeAsync(900) })
+      expect(screen.queryByRole('button', { name: COPIED_LABEL })).toBeNull()
+      expect(term.clearCalls).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reports failure and keeps the selection when the clipboard is unavailable', () => {
+    setClipboard(undefined)
+    const { term, container } = mount()
+    term.selection = 'secret-free output'
+    endDrag(container, { x: 200, y: 100 })
+    act(() => { fireEvent.click(screen.getByRole('button', { name: COPY_LABEL })) })
+    expect(screen.getByRole('button', { name: COPY_FAILED_LABEL })).toBeInTheDocument()
+    expect(term.clearCalls).toBe(0)
+  })
+
+  it('reports failure when the clipboard write is rejected', async () => {
+    setClipboard({ writeText: vi.fn(() => Promise.reject(new Error('denied'))) })
+    const { term, container } = mount()
+    term.selection = 'output'
+    endDrag(container, { x: 200, y: 100 })
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: COPY_LABEL })) })
+    expect(screen.getByRole('button', { name: COPY_FAILED_LABEL })).toBeInTheDocument()
+    expect(term.clearCalls).toBe(0)
+  })
+})
+
+/* ── send to chat ─────────────────────────────────────────────────────────── */
+
+/** Answer POST /api/terminal/redact with `text`, or a failure status. */
+function mockRedact(text: string, ok = true, status = 200) {
+  const f = vi.fn(() => Promise.resolve({
+    ok, status, json: () => Promise.resolve({ text }),
+  } as unknown as Response))
+  vi.stubGlobal('fetch', f)
+  return f
+}
+
+describe('CliPanel send-to-chat', () => {
+  it('redacts the whole selection server-side, then hands off a fenced block with the live cwd', async () => {
+    const f = mockRedact('token REDACTED here')
+    registry.getTerminalCwd.mockReturnValue('/srv/app/sub')
+    const onSendToChat = vi.fn()
+    const { term, container, sessionId } = mount({ cwd: '/srv/app', onSendToChat })
+    term.selection = 'token abc123 here'
+    endDrag(container, { x: 200, y: 100 })
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: SEND_LABEL })) })
+
+    expect(f).toHaveBeenCalledWith('/api/terminal/redact', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ text: 'token abc123 here' }),
+    }))
+    expect(registry.getTerminalCwd).toHaveBeenCalledWith(sessionId)
+    // Live cwd wins over the spawn dir, and the fence is the default three ticks.
+    expect(onSendToChat).toHaveBeenCalledWith(
+      'Terminal output (`/srv/app/sub`):\n```\ntoken REDACTED here\n```',
+    )
+    expect(term.clearCalls).toBe(1)
+    expect(screen.queryByRole('button', { name: SEND_LABEL })).toBeNull()
+  })
+
+  it('falls back to the spawn cwd when the live cwd is unknown', async () => {
+    mockRedact('plain')
+    const onSendToChat = vi.fn()
+    const { term, container } = mount({ cwd: '/spawn/dir', onSendToChat })
+    term.selection = 'plain'
+    endDrag(container, { x: 200, y: 100 })
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: SEND_LABEL })) })
+    expect(onSendToChat).toHaveBeenCalledWith('Terminal output (`/spawn/dir`):\n```\nplain\n```')
+  })
+
+  it('omits the path entirely when no cwd is known', async () => {
+    mockRedact('plain')
+    const onSendToChat = vi.fn()
+    const { term, container } = mount({ onSendToChat })
+    term.selection = 'plain'
+    endDrag(container, { x: 200, y: 100 })
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: SEND_LABEL })) })
+    expect(onSendToChat).toHaveBeenCalledWith('Terminal output:\n```\nplain\n```')
+  })
+
+  it('widens the fence past the longest backtick run in the output', async () => {
+    mockRedact('see ```code``` and ````wide```` here')
+    const onSendToChat = vi.fn()
+    const { term, container } = mount({ onSendToChat })
+    term.selection = 'anything'
+    endDrag(container, { x: 200, y: 100 })
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: SEND_LABEL })) })
+    const handoff = onSendToChat.mock.calls[0][0] as string
+    expect(handoff).toContain('\n`````\nsee ```code``` and ````wide```` here\n`````')
+  })
+
+  it('fails closed on a redaction error: nothing is inserted and the selection survives', async () => {
+    mockRedact('', false, 500)
+    const onSendToChat = vi.fn()
+    const { term, container } = mount({ onSendToChat })
+    term.selection = 'token abc123'
+    endDrag(container, { x: 200, y: 100 })
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: SEND_LABEL })) })
+    expect(onSendToChat).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: SEND_FAILED_LABEL })).toBeInTheDocument()
+    expect(term.clearCalls).toBe(0) // toolbar kept so the user can retry
+  })
+
+  it('fails closed when the redaction request itself throws', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('offline'))))
+    const onSendToChat = vi.fn()
+    const { term, container } = mount({ onSendToChat })
+    term.selection = 'output'
+    endDrag(container, { x: 200, y: 100 })
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: SEND_LABEL })) })
+    expect(onSendToChat).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: SEND_FAILED_LABEL })).toBeInTheDocument()
+  })
+})
+
+/* ── theme + font observers ───────────────────────────────────────────────── */
+
+describe('CliPanel theme and font sync', () => {
+  it('repaints cached terminals when the document theme attribute flips', async () => {
+    const { term } = mount()
+    document.documentElement.style.setProperty('--bg', '#222233')
+    try {
+      act(() => { document.documentElement.setAttribute('data-theme', 'legacy-default') })
+      await waitFor(() => expect(term.options.theme?.background).toBe('#222233'))
+    } finally {
+      document.documentElement.style.removeProperty('--bg')
+    }
+  })
+
+  it('repaints when a custom-theme style element resolves into <head>', async () => {
+    const { term } = mount()
+    // Drain records queued by earlier tests so the only mutation the observer
+    // sees here is the <head> insertion (a custom theme's vars arrive that way,
+    // with no data-theme change to notice).
+    await act(async () => { await new Promise(r => setTimeout(r, 0)) })
+    const style = document.createElement('style')
+    style.id = 'mc-custom-theme-probe'
+    style.textContent = ':root { --accent: #ff8800; }'
+    act(() => { document.head.appendChild(style) })
+    await waitFor(() => expect(term.options.theme?.cursor).toBe('#ff8800'))
+  })
+
+  it('ignores an unrelated style element added to <head>', async () => {
+    const { term } = mount()
+    // Drain any observer records queued by earlier tests before measuring.
+    await act(async () => { await new Promise(r => setTimeout(r, 0)) })
+    const before = term.options.theme
+    const style = document.createElement('style')
+    style.id = 'unrelated-style'
+    act(() => { document.head.appendChild(style) })
+    await act(async () => { await new Promise(r => setTimeout(r, 0)) })
+    expect(term.options.theme).toBe(before) // same object → no refresh ran
+  })
+
+  it('pushes a font-size preference change onto every live terminal and refits', () => {
+    const { term, fit } = mount()
+    fit.fit.mockClear()
+    act(() => { setTerminalFontSize(19) })
+    expect(term.options.fontSize).toBe(19)
+    expect(term.fontFamilyWrites.slice(-2)).toEqual(['monospace', term.options.fontFamily])
+    expect(fit.fit).toHaveBeenCalled()
+  })
+
+  it('skips the refit for a hidden pane whose cell would measure zero', () => {
+    const { term, fit } = mount()
+    term.offsetParent = null // display:none / detached
+    fit.fit.mockClear()
+    const writesBefore = term.fontFamilyWrites.length
+    act(() => { setTerminalFontSize(21) })
+    expect(term.options.fontSize).toBe(21) // option still applied
+    // Only the plain family assignment — no monospace/restore re-measure toggle.
+    expect(term.fontFamilyWrites).toHaveLength(writesBefore + 1)
+    expect(fit.fit).not.toHaveBeenCalled()
+  })
+})
+
+/* ── web font readiness ───────────────────────────────────────────────────── */
+
+describe('CliPanel web-font refit', () => {
+  const original = Object.getOwnPropertyDescriptor(Document.prototype, 'fonts')
+  function setFonts(value: unknown) {
+    Object.defineProperty(document, 'fonts', { value, configurable: true })
+  }
+  afterEach(() => {
+    Reflect.deleteProperty(document, 'fonts')
+    if (original) Object.defineProperty(Document.prototype, 'fonts', original)
+  })
+
+  it('refits once the pending web fonts settle and after explicitly loading the terminal font', async () => {
+    const load = vi.fn(() => Promise.resolve([]))
+    setFonts({ ready: Promise.resolve(), load })
+    const { term, fit } = mount()
+    await act(async () => { await Promise.resolve() })
+    expect(load).toHaveBeenCalledWith(expect.stringContaining('"JetBrains Mono"'))
+    expect(fit.fit).toHaveBeenCalled()
+    expect(term.fontFamilyWrites).toContain('monospace')
+  })
+
+  it('survives an engine that rejects the font-load spec', async () => {
+    setFonts({ ready: Promise.resolve(), load: () => { throw new Error('bad spec') } })
+    const { fit } = mount()
+    await act(async () => { await Promise.resolve() })
+    expect(fit.fit).toHaveBeenCalled() // the `ready` handler still refits
+  })
+
+  it('swallows a rejected font load without escaping the effect', async () => {
+    setFonts({ ready: Promise.resolve(), load: () => Promise.reject(new Error('nope')) })
+    mount()
+    await act(async () => { await Promise.resolve(); await Promise.resolve() })
+    expect(screen.getByTestId('completion')).toBeInTheDocument()
+  })
+
+  it('no-ops when the document exposes no font set', () => {
+    setFonts(undefined)
+    const { term } = mount()
+    expect(term.openCalls).toBe(1)
+  })
+})
+
+/* ── teardown + PTY delete ────────────────────────────────────────────────── */
+
+describe('disposeTerminalSession', () => {
+  it('closes the socket, disposes the xterm, and evicts it from the cache', () => {
+    const sessionId = nextId()
+    const first = mount({ sessionId })
+    cleanup()
+    disposeTerminalSession(sessionId)
+    expect(registry.disposeTerminalConnection).toHaveBeenCalledWith(sessionId)
+    expect(first.term.disposed).toBe(true)
+    // Evicted: the next mount of the same id constructs a fresh terminal.
+    const second = mount({ sessionId })
+    expect(second.term).not.toBe(first.term)
+    expect(xt.FakeTerminal.instances).toHaveLength(2)
+  })
+
+  it('is a safe no-op for a session that was never cached', () => {
+    expect(() => disposeTerminalSession('never-opened')).not.toThrow()
+    expect(registry.disposeTerminalConnection).toHaveBeenCalledWith('never-opened')
+  })
+})
+
+describe('useDeleteTerminalSession', () => {
+  it('DELETEs the backend PTY for the given session', async () => {
+    const f = vi.fn(() => Promise.resolve({ ok: true, status: 200 } as unknown as Response))
+    vi.stubGlobal('fetch', f)
+    const { result } = renderHookWithProviders(() => useDeleteTerminalSession())
+    await act(async () => { await result.current.mutateAsync('pty-42') })
+    expect(f).toHaveBeenCalledWith('/api/terminal/sessions/pty-42', { method: 'DELETE' })
+  })
+
+  it('surfaces a non-ok response as a mutation error carrying the status', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false, status: 409 } as unknown as Response)))
+    const { result } = renderHookWithProviders(() => useDeleteTerminalSession())
+    await expect(
+      act(async () => { await result.current.mutateAsync('pty-43') }),
+    ).rejects.toThrow('Failed to delete terminal session (409)')
+  })
+})

--- a/website/src/test/IssueRadarApiCoverage.test.tsx
+++ b/website/src/test/IssueRadarApiCoverage.test.tsx
@@ -1,0 +1,487 @@
+// Issue Radar API client, tested at the FETCH boundary — deliberately without
+// mocking `issueRadarApi`, the same contract as IssueRadarApiClient.test.tsx and
+// MeetingsApiClient.test.ts.
+//
+// This is a thin wrapper over ~35 endpoints, and the three things it translates
+// are all silent when they break:
+//   • the ENDPOINT and VERB each method targets — a method pointed at the wrong
+//     path still resolves in every component test, because those mock the client;
+//   • the backend `{"error": …}` body becoming the thrown message, so a failure
+//     surfaces the server's reason instead of a bare status;
+//   • the optional query flags (`refresh`, `poll`, `state`, `first_page`) and the
+//     identity fields (`provider`/`host`) reaching the wire at all — a dropped
+//     `provider` sends a GitLab request to GitHub and quietly answers about a
+//     different repo.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const {
+  issueRadarApi, accountQuery, repoQuery, repoBody, DEFAULT_REPO_SETTINGS, SettingsConflictError,
+} = await import('../apps/issue-radar/api')
+
+const REF = { owner: 'acme', repo: 'widgets' }
+const GL_REF = { owner: 'group/sub', repo: 'svc', provider: 'gitlab' as const, host: 'gl.internal' }
+
+function jsonResponse(status: number, body: unknown, { json = true } = {}): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => {
+      if (!json) throw new SyntaxError('not json')
+      return body
+    },
+  } as unknown as Response
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/** The URL the single recorded call went to, with any query string removed. */
+const calledPath = () => String(fetchMock.mock.calls[0][0]).split('?')[0]
+const calledUrl = () => String(fetchMock.mock.calls[0][0])
+const calledInit = () => (fetchMock.mock.calls[0][1] ?? {}) as RequestInit
+const sentBody = () => JSON.parse(calledInit().body as string)
+
+/** Every endpoint the client exposes: which path it must hit, with which verb.
+ * Driven as a table so a new method cannot be added without a boundary test, and
+ * so the error path of each one is exercised rather than one representative. */
+const ENDPOINTS: Array<{
+  name: string
+  path: string
+  method?: string
+  run: () => Promise<unknown>
+}> = [
+  { name: 'connect', path: '/api/apps/issue-radar/connect', method: 'POST', run: () => issueRadarApi.connect('https://github.com/acme/widgets') },
+  { name: 'issues', path: '/api/apps/issue-radar/issues', run: () => issueRadarApi.issues(REF) },
+  { name: 'issuesFirstPage', path: '/api/apps/issue-radar/issues', run: () => issueRadarApi.issuesFirstPage(REF) },
+  { name: 'issueDetail', path: '/api/apps/issue-radar/issue', run: () => issueRadarApi.issueDetail(REF, 12) },
+  { name: 'pulls', path: '/api/apps/issue-radar/pulls', run: () => issueRadarApi.pulls(REF) },
+  { name: 'pullsFirstPage', path: '/api/apps/issue-radar/pulls', run: () => issueRadarApi.pullsFirstPage(REF) },
+  { name: 'searchPulls', path: '/api/apps/issue-radar/pulls/search', run: () => issueRadarApi.searchPulls(REF, { author: 'ann' }) },
+  { name: 'pullDetail', path: '/api/apps/issue-radar/pull', run: () => issueRadarApi.pullDetail(REF, 12) },
+  { name: 'refSummary', path: '/api/apps/issue-radar/ref', run: () => issueRadarApi.refSummary(REF, 12) },
+  { name: 'issueAi', path: '/api/apps/issue-radar/issue-ai', run: () => issueRadarApi.issueAi(REF, 12) },
+  { name: 'pullAi', path: '/api/apps/issue-radar/pull-ai', run: () => issueRadarApi.pullAi(REF, 12) },
+  { name: 'applyLabels', path: '/api/apps/issue-radar/labels/apply', method: 'POST', run: () => issueRadarApi.applyLabels(REF, 12, ['bug'], ['stale']) },
+  { name: 'setIssueState', path: '/api/apps/issue-radar/issue/state', method: 'POST', run: () => issueRadarApi.setIssueState(REF, 12, 'closed') },
+  { name: 'setPrState', path: '/api/apps/issue-radar/pull/state', method: 'POST', run: () => issueRadarApi.setPrState(REF, 12, 'closed') },
+  { name: 'submitPrReview', path: '/api/apps/issue-radar/pull/review', method: 'POST', run: () => issueRadarApi.submitPrReview(REF, 12, 'approve') },
+  { name: 'addPrComment', path: '/api/apps/issue-radar/pull/comment', method: 'POST', run: () => issueRadarApi.addPrComment(REF, 12, 'looks good') },
+  { name: 'mergePr', path: '/api/apps/issue-radar/pull/merge', method: 'POST', run: () => issueRadarApi.mergePr(REF, 12, 'abc123') },
+  { name: 'setPrAutoMerge', path: '/api/apps/issue-radar/pull/auto-merge', method: 'POST', run: () => issueRadarApi.setPrAutoMerge(REF, 12, true) },
+  { name: 'pullRuns', path: '/api/apps/issue-radar/pull/runs', run: () => issueRadarApi.pullRuns(REF, 12, 'abc123') },
+  { name: 'pullRunAction', path: '/api/apps/issue-radar/pull/run', method: 'POST', run: () => issueRadarApi.pullRunAction(REF, 12, 99, 'cancel') },
+  { name: 'bulkPrAction', path: '/api/apps/issue-radar/pulls/bulk', method: 'POST', run: () => issueRadarApi.bulkPrAction(REF, [1, 2], 'approve') },
+  { name: 'labels', path: '/api/apps/issue-radar/labels', run: () => issueRadarApi.labels(REF) },
+  { name: 'members', path: '/api/apps/issue-radar/members', run: () => issueRadarApi.members(REF) },
+  { name: 'repos', path: '/api/apps/issue-radar/repos', run: () => issueRadarApi.repos() },
+  { name: 'recentRepos', path: '/api/apps/issue-radar/recent-repos', run: () => issueRadarApi.recentRepos(30) },
+  { name: 'me', path: '/api/apps/issue-radar/me', run: () => issueRadarApi.me() },
+  { name: 'getSettings', path: '/api/apps/issue-radar/settings', run: () => issueRadarApi.getSettings(REF) },
+  { name: 'disconnect', path: '/api/apps/issue-radar/repos', method: 'DELETE', run: () => issueRadarApi.disconnect(REF) },
+  { name: 'getInvestigation', path: '/api/apps/issue-radar/investigation', run: () => issueRadarApi.getInvestigation(REF, 12) },
+  { name: 'saveInvestigation', path: '/api/apps/issue-radar/investigation', method: 'PUT', run: () => issueRadarApi.saveInvestigation(REF, 12, {}) },
+  { name: 'getRecommendations', path: '/api/apps/issue-radar/recommendations', run: () => issueRadarApi.getRecommendations(REF) },
+  { name: 'generateRecommendations', path: '/api/apps/issue-radar/recommendations', method: 'POST', run: () => issueRadarApi.generateRecommendations(REF) },
+  { name: 'createLabel', path: '/api/apps/issue-radar/labels/create', method: 'POST', run: () => issueRadarApi.createLabel(REF, { name: 'bug' }) },
+  { name: 'tagging', path: '/api/apps/issue-radar/tagging', run: () => issueRadarApi.tagging(REF) },
+  { name: 'generateTagging', path: '/api/apps/issue-radar/tagging', method: 'POST', run: () => issueRadarApi.generateTagging(REF) },
+  { name: 'addSettingLabel', path: '/api/apps/issue-radar/settings/role', method: 'POST', run: () => issueRadarApi.addSettingLabel(REF, 'triage_labels', 'needs-triage') },
+  { name: 'applyLabelsBulk', path: '/api/apps/issue-radar/labels/apply-bulk', method: 'POST', run: () => issueRadarApi.applyLabelsBulk(REF, [{ number: 1, add: ['bug'] }]) },
+  { name: 'putSettings', path: '/api/apps/issue-radar/settings', method: 'PUT', run: () => issueRadarApi.putSettings(REF, DEFAULT_REPO_SETTINGS) },
+]
+
+describe('issueRadarApi transport', () => {
+  it.each(ENDPOINTS)('$name targets $path and returns the parsed body', async ({ path, method, run }) => {
+    const body = { owner: 'acme', repo: 'widgets', marker: path }
+    fetchMock.mockResolvedValue(jsonResponse(200, body))
+
+    await expect(run()).resolves.toEqual(body)
+
+    expect(calledPath()).toBe(path)
+    expect(calledInit().method ?? 'GET').toBe(method ?? 'GET')
+    // Every call must carry the session cookie: the gateway rejects an
+    // unauthenticated request, and omitting this turns the whole app 401.
+    expect(calledInit().credentials).toBe('same-origin')
+  })
+
+  it.each(ENDPOINTS)('$name surfaces the backend error message', async ({ run }) => {
+    fetchMock.mockResolvedValue(jsonResponse(500, { error: 'gh rate limit exceeded' }))
+    await expect(run()).rejects.toThrow('gh rate limit exceeded')
+  })
+
+  it('falls back to the status when the error body is not JSON', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(503, 'gateway down', { json: false }))
+    await expect(issueRadarApi.repos()).rejects.toThrow('HTTP 503')
+  })
+
+  it('falls back to the status when the error body has no message', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(404, {}))
+    await expect(issueRadarApi.issues(REF)).rejects.toThrow('HTTP 404')
+  })
+
+  it('sends JSON content type on every write', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.addPrComment(REF, 4, 'hi')
+    expect(calledInit().headers).toEqual({ 'Content-Type': 'application/json' })
+  })
+})
+
+describe('ref identity on the wire', () => {
+  it('repoQuery carries provider and host when present', () => {
+    expect(repoQuery(GL_REF)).toEqual({
+      owner: 'group/sub', repo: 'svc', provider: 'gitlab', host: 'gl.internal',
+    })
+  })
+
+  it('repoQuery omits provider and host for a legacy record', () => {
+    expect(repoQuery(REF)).toEqual({ owner: 'acme', repo: 'widgets' })
+  })
+
+  it('repoBody matches repoQuery so a POST names the same repo as a GET', () => {
+    expect(repoBody(GL_REF)).toEqual(repoQuery(GL_REF))
+  })
+
+  it('accountQuery is empty without a scope', () => {
+    expect(accountQuery()).toEqual({})
+    expect(accountQuery({})).toEqual({})
+  })
+
+  it('accountQuery carries provider and host independently', () => {
+    expect(accountQuery({ provider: 'gitlab' })).toEqual({ provider: 'gitlab' })
+    expect(accountQuery({ host: 'gl.internal' })).toEqual({ host: 'gl.internal' })
+  })
+
+  it('puts the provider on a GET query string', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.pulls(GL_REF)
+    expect(calledUrl()).toContain('provider=gitlab')
+    expect(calledUrl()).toContain('host=gl.internal')
+  })
+
+  it('puts the provider in a POST body', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.applyLabels(GL_REF, 3, ['bug'], [])
+    expect(sentBody()).toMatchObject({ provider: 'gitlab', host: 'gl.internal', number: 3 })
+  })
+})
+
+describe('list query flags', () => {
+  it('omits state, refresh and poll when no options are given', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.issues(REF)
+    const url = calledUrl()
+    expect(url).not.toContain('state=')
+    expect(url).not.toContain('refresh=1')
+    expect(url).not.toContain('poll=1')
+  })
+
+  it('sends state, refresh and poll for issues when asked', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.issues(REF, { state: 'closed', refresh: true, poll: true })
+    const url = calledUrl()
+    expect(url).toContain('state=closed')
+    expect(url).toContain('refresh=1')
+    expect(url).toContain('poll=1')
+  })
+
+  it('sends state, refresh and poll for pulls when asked', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.pulls(REF, { state: 'closed', refresh: true, poll: true })
+    const url = calledUrl()
+    expect(url).toContain('state=closed')
+    expect(url).toContain('refresh=1')
+    expect(url).toContain('poll=1')
+  })
+
+  it('marks the issues fast path with first_page and no refresh', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.issuesFirstPage(REF)
+    expect(calledUrl()).toContain('first_page=1')
+    expect(calledUrl()).not.toContain('refresh=1')
+  })
+
+  it('marks the pulls fast path with first_page', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.pullsFirstPage(REF)
+    expect(calledUrl()).toContain('first_page=1')
+  })
+
+  it.each([
+    ['issueDetail', (refresh?: boolean) => issueRadarApi.issueDetail(REF, 7, refresh === undefined ? undefined : { refresh })],
+    ['pullDetail', (refresh?: boolean) => issueRadarApi.pullDetail(REF, 7, refresh === undefined ? undefined : { refresh })],
+    ['refSummary', (refresh?: boolean) => issueRadarApi.refSummary(REF, 7, refresh === undefined ? undefined : { refresh })],
+    ['issueAi', (refresh?: boolean) => issueRadarApi.issueAi(REF, 7, refresh === undefined ? undefined : { refresh })],
+    ['pullAi', (refresh?: boolean) => issueRadarApi.pullAi(REF, 7, refresh === undefined ? undefined : { refresh })],
+  ] as const)('%s sets refresh only when asked, and always sends the number', async (_name, call) => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await call(undefined)
+    expect(calledUrl()).toContain('number=7')
+    expect(calledUrl()).not.toContain('refresh=1')
+
+    fetchMock.mockClear()
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await call(true)
+    expect(calledUrl()).toContain('refresh=1')
+  })
+
+  it.each([
+    ['labels', (refresh?: boolean) => issueRadarApi.labels(REF, refresh === undefined ? undefined : { refresh })],
+    ['members', (refresh?: boolean) => issueRadarApi.members(REF, refresh === undefined ? undefined : { refresh })],
+  ] as const)('%s sets refresh only when asked', async (_name, call) => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await call(undefined)
+    expect(calledUrl()).not.toContain('refresh=1')
+
+    fetchMock.mockClear()
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await call(true)
+    expect(calledUrl()).toContain('refresh=1')
+  })
+
+  it('sends every person filter searchPulls was given', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.searchPulls(REF, {
+      state: 'merged', author: 'ann', assignee: 'bo', reviewRequested: 'cy',
+    })
+    const url = calledUrl()
+    expect(url).toContain('state=merged')
+    expect(url).toContain('author=ann')
+    expect(url).toContain('assignee=bo')
+    // Snake case on the wire — the server reads `review_requested`, so a
+    // camelCase leak would silently drop the reviewer filter.
+    expect(url).toContain('review_requested=cy')
+  })
+
+  it('sends no person filter searchPulls was not given', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.searchPulls(REF, {})
+    const url = calledUrl()
+    expect(url).not.toContain('author=')
+    expect(url).not.toContain('assignee=')
+    expect(url).not.toContain('review_requested=')
+    expect(url).not.toContain('state=')
+  })
+
+  it('sends the sha pull runs hang off', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.pullRuns(REF, 7, 'deadbee')
+    expect(calledUrl()).toContain('sha=deadbee')
+    expect(calledUrl()).toContain('number=7')
+  })
+
+  it('sends the window recentRepos was asked for, with an account scope', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { repos: [] }))
+    await issueRadarApi.recentRepos(14, { provider: 'gitlab', host: 'gl.internal' })
+    const url = calledUrl()
+    expect(url).toContain('days=14')
+    expect(url).toContain('provider=gitlab')
+    expect(url).toContain('host=gl.internal')
+  })
+
+  it('asks /me about one provider', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { login: 'ann' }))
+    await issueRadarApi.me({ provider: 'gitlab' })
+    expect(calledUrl()).toContain('provider=gitlab')
+  })
+})
+
+describe('write bodies', () => {
+  it('sends only the url on connect — the server resolves the provider', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.connect('https://gl.internal/group/sub/svc')
+    expect(sentBody()).toEqual({ url: 'https://gl.internal/group/sub/svc' })
+  })
+
+  it('sends both label add and remove sets', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.applyLabels(REF, 5, ['bug', 'p1'], ['stale'])
+    expect(sentBody()).toEqual({
+      owner: 'acme', repo: 'widgets', number: 5, add: ['bug', 'p1'], remove: ['stale'],
+    })
+  })
+
+  it('sends a close reason when given one', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.setIssueState(REF, 5, 'closed', 'not_planned')
+    expect(sentBody()).toMatchObject({ state: 'closed', state_reason: 'not_planned' })
+  })
+
+  it('leaves the close reason undefined when not given one', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.setIssueState(REF, 5, 'open')
+    expect(sentBody()).not.toHaveProperty('state_reason')
+  })
+
+  it('sends a review with its body and head sha', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.submitPrReview(REF, 5, 'request_changes', 'needs a test', 'cafe01')
+    expect(sentBody()).toMatchObject({
+      event: 'request_changes', body: 'needs a test', head_sha: 'cafe01',
+    })
+  })
+
+  it('sends empty strings rather than omitting review body and sha', async () => {
+    // The server requires both keys; omitting them is a 400 rather than a
+    // bodyless approval.
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.submitPrReview(REF, 5, 'approve')
+    expect(sentBody()).toMatchObject({ event: 'approve', body: '', head_sha: '' })
+  })
+
+  it('pins a merge to the reviewed sha and squashes by default', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.mergePr(REF, 5, 'cafe01')
+    expect(sentBody()).toMatchObject({ number: 5, head_sha: 'cafe01', method: 'SQUASH' })
+  })
+
+  it('honours an explicit merge method', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.mergePr(REF, 5, 'cafe01', 'REBASE')
+    expect(sentBody()).toMatchObject({ method: 'REBASE' })
+  })
+
+  it('sends the enabled flag and method when arming auto-merge', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.setPrAutoMerge(REF, 5, true, 'MERGE')
+    expect(sentBody()).toMatchObject({ enabled: true, method: 'MERGE' })
+  })
+
+  it('sends the disarm as enabled false, not as an omission', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.setPrAutoMerge(REF, 5, false)
+    expect(sentBody()).toMatchObject({ enabled: false, method: 'SQUASH' })
+  })
+
+  it('defaults a run action to re-running everything', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.pullRunAction(REF, 5, 4242, 'rerun')
+    expect(sentBody()).toMatchObject({ run_id: 4242, action: 'rerun', failed_only: false })
+  })
+
+  it('sends failed_only when re-running just the failures', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.pullRunAction(REF, 5, 4242, 'rerun', true)
+    expect(sentBody()).toMatchObject({ failed_only: true })
+  })
+
+  it('sends a head-sha map keyed by number for a bulk approve', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { applied: [], failed: [] }))
+    await issueRadarApi.bulkPrAction(REF, [3, 4], 'approve', {
+      body: 'ship it', method: 'REBASE', headShas: { '3': 'aaa', '4': 'bbb' },
+    })
+    expect(sentBody()).toMatchObject({
+      numbers: [3, 4], action: 'approve', body: 'ship it', method: 'REBASE',
+      head_shas: { '3': 'aaa', '4': 'bbb' },
+    })
+  })
+
+  it('fills bulk defaults rather than omitting the keys', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { applied: [], failed: [] }))
+    await issueRadarApi.bulkPrAction(REF, [3], 'close')
+    expect(sentBody()).toMatchObject({ body: '', method: 'SQUASH', head_shas: {} })
+  })
+
+  it('sends only the ref when generating recommendations', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.generateRecommendations(REF)
+    expect(sentBody()).toEqual({ owner: 'acme', repo: 'widgets' })
+  })
+
+  it('spreads the new label fields alongside the ref', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.createLabel(REF, { name: 'area/api', color: 'ff0000', description: 'API' })
+    expect(sentBody()).toEqual({
+      owner: 'acme', repo: 'widgets', name: 'area/api', color: 'ff0000', description: 'API',
+    })
+  })
+
+  it('sends the role and label when appending a settings label', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.addSettingLabel(REF, 'good_first_issue_labels', 'good first issue')
+    expect(sentBody()).toMatchObject({
+      role: 'good_first_issue_labels', label: 'good first issue',
+    })
+  })
+
+  it('sends per-issue additions for a bulk label apply', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { applied: [], failed: [] }))
+    await issueRadarApi.applyLabelsBulk(REF, [
+      { number: 1, add: ['bug'] },
+      { number: 2, add: ['docs', 'p2'] },
+    ])
+    expect(sentBody().changes).toEqual([
+      { number: 1, add: ['bug'] },
+      { number: 2, add: ['docs', 'p2'] },
+    ])
+  })
+
+  it('sends the whole settings document, revision included', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    const settings = { ...DEFAULT_REPO_SETTINGS, triage_labels: ['needs-triage'], revision: 3 }
+    await issueRadarApi.putSettings(REF, settings)
+    expect(sentBody().settings).toEqual(settings)
+  })
+
+  it('merges an investigation patch into the ref body', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}))
+    await issueRadarApi.saveInvestigation(REF, 9, {
+      slot_key: 'slot-1', folder_id: 'f-1', status: 'resolved',
+      findings: { verdict: 'confirmed' },
+    }, 'pull')
+    expect(sentBody()).toEqual({
+      owner: 'acme', repo: 'widgets', number: 9, kind: 'pull',
+      slot_key: 'slot-1', folder_id: 'f-1', status: 'resolved',
+      findings: { verdict: 'confirmed' },
+    })
+  })
+
+  it('deletes a connection by query string, carrying no body', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { ok: true }))
+    await issueRadarApi.disconnect(GL_REF)
+    expect(calledUrl()).toContain('provider=gitlab')
+    expect(calledInit().body).toBeUndefined()
+  })
+})
+
+describe('putSettings conflict fallbacks', () => {
+  // A 409 whose body is missing or unparseable is still a CONFLICT: the caller
+  // branches on the error type to rebase its edit, so degrading to a generic
+  // Error there loses the edit instead of retrying it.
+  it('stays a conflict when the 409 body is not JSON at all', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(409, 'nginx conflict page', { json: false }))
+    const err = await issueRadarApi.putSettings(REF, DEFAULT_REPO_SETTINGS).catch((e) => e)
+    expect(err).toBeInstanceOf(SettingsConflictError)
+    // Nothing to rebase onto, so the defaults stand in rather than `undefined`,
+    // which would crash the caller reading `.current.revision`.
+    expect((err as InstanceType<typeof SettingsConflictError>).current)
+      .toEqual(DEFAULT_REPO_SETTINGS)
+  })
+
+  it('supplies a message when the 409 body carries no error text', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(409, {}))
+    const err = await issueRadarApi.putSettings(REF, DEFAULT_REPO_SETTINGS).catch((e) => e)
+    expect(err).toBeInstanceOf(SettingsConflictError)
+    expect((err as Error).message).not.toBe('')
+    expect((err as Error).name).toBe('SettingsConflictError')
+  })
+})
+
+describe('DEFAULT_REPO_SETTINGS', () => {
+  it('treats unlabeled as untriaged, which is the pre-settings heuristic', () => {
+    expect(DEFAULT_REPO_SETTINGS).toEqual({
+      triage_labels: [],
+      unlabeled_is_untriaged: true,
+      good_first_issue_labels: [],
+      notify_on_new_issue: false,
+      revision: 0,
+    })
+  })
+})

--- a/website/src/test/KnowledgeGraphCoverage.test.tsx
+++ b/website/src/test/KnowledgeGraphCoverage.test.tsx
@@ -1,0 +1,504 @@
+/**
+ * KnowledgeGraph renders an entity graph with real d3: the force layout is
+ * pre-ticked 300 times synchronously and then drawn, so the whole draw path is
+ * reachable under happy-dom without waiting on animation frames.
+ *
+ * Two deliberate harness choices:
+ *  - d3 is NOT mocked. The component's draw code passes accessor callbacks to
+ *    d3 (`.attr('x1', d => ...)`), and only the real selection API invokes them.
+ *  - The React Query cache is seeded in some tests so the first committed render
+ *    already has data. That makes the svg exist on mount, which is the only way
+ *    the highlight effect can observe an un-initialised zoom handle and take its
+ *    polling branch.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { GraphData } from '../pages/knowledge/types'
+
+const mockKnowledgeApi = vi.fn()
+vi.mock('../pages/knowledge/api', () => ({
+  knowledgeApi: (...args: unknown[]) => mockKnowledgeApi(...args),
+}))
+
+const KnowledgeGraph = (await import('../pages/knowledge/KnowledgeGraph')).default
+
+// The shared setup file installs an inert ResizeObserver stub that never fires.
+// Swap in a capturing one so the resize-refit effect body can be exercised.
+let resizeCallbacks: ResizeObserverCallback[] = []
+const realResizeObserver = globalThis.ResizeObserver
+class CapturingResizeObserver {
+  constructor(cb: ResizeObserverCallback) { resizeCallbacks.push(cb) }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// happy-dom exposes SVGSVGElement.createSVGPoint but the point it returns has no
+// matrixTransform, so d3's pointer() throws on its preferred path. Removing the
+// method makes d3 take its documented getBoundingClientRect fallback, which in
+// turn needs clientLeft/clientTop — also absent on happy-dom's SVG elements, and
+// omitting them turns every pointer coordinate into NaN.
+// Vitest isolates the environment per test file, so neither patch leaks.
+Reflect.deleteProperty(SVGSVGElement.prototype, 'createSVGPoint')
+for (const prop of ['clientLeft', 'clientTop'] as const) {
+  if (!(prop in SVGElement.prototype)) {
+    Object.defineProperty(SVGElement.prototype, prop, { get: () => 0, configurable: true })
+  }
+}
+
+/** Read the numeric pair out of a `translate(x,y)` transform attribute. */
+function translateOf(el: Element): [number, number] {
+  const m = /translate\(([^,]+),([^)]+)\)/.exec(el.getAttribute('transform') ?? '')
+  if (!m) throw new Error(`no translate on ${el.getAttribute('data-entity')}`)
+  return [Number(m[1]), Number(m[2])]
+}
+
+const GRAPH: GraphData = {
+  nodes: [
+    { id: 'n1', name: 'Gateway', type: 'service' },
+    { id: 'n2', name: 'Postgres', type: 'technology' },
+    { id: 'n3', name: 'Retrieval', type: 'concept' },
+    { id: 'n4', name: 'Platform', type: 'org' },
+    // Unknown type exercises the TYPE_COLORS fallback colour.
+    { id: 'n5', name: 'Widgets', type: 'gizmo' },
+  ],
+  edges: [
+    { source: 'n1', target: 'n2', type: 'depends_on', weight: 3 },
+    { source: 'n1', target: 'n3', type: 'implements' },
+    { source: 'n3', target: 'n4', type: 'owned_by', weight: 1 },
+    { source: 'n4', target: 'n5', type: 'ships' },
+  ],
+}
+
+let qc: QueryClient
+
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function renderGraph(props: {
+  onSelectEntity?: (name: string) => void
+  highlightEntity?: string | null
+} = {}) {
+  const view = render(
+    <QueryClientProvider client={qc}>
+      <KnowledgeGraph {...props} />
+    </QueryClientProvider>
+  )
+  const rerender = (next: typeof props) => view.rerender(
+    <QueryClientProvider client={qc}>
+      <KnowledgeGraph {...next} />
+    </QueryClientProvider>
+  )
+  return { ...view, rerender }
+}
+
+/** Wait until d3 has finished the async draw for every node. */
+async function drawn(container: HTMLElement, count = GRAPH.nodes.length) {
+  await waitFor(() => {
+    expect(container.querySelectorAll('g[data-entity]')).toHaveLength(count)
+  })
+}
+
+function circleOf(container: HTMLElement, name: string): SVGCircleElement {
+  const circle = container.querySelector(`g[data-entity="${name}"] circle`)
+  if (!circle) throw new Error(`no circle for ${name}`)
+  return circle as SVGCircleElement
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resizeCallbacks = []
+  globalThis.ResizeObserver = CapturingResizeObserver as unknown as typeof ResizeObserver
+  qc = makeClient()
+  mockKnowledgeApi.mockResolvedValue(GRAPH)
+})
+
+afterEach(() => {
+  cleanup()
+  globalThis.ResizeObserver = realResizeObserver
+  qc.clear()
+})
+
+describe('KnowledgeGraph — pre-data states', () => {
+  it('shows the loading line while the graph query is in flight', () => {
+    mockKnowledgeApi.mockImplementation(() => new Promise(() => {}))
+    renderGraph()
+    expect(screen.getByText('Loading graph...')).toBeInTheDocument()
+  })
+
+  it('requests the graph endpoint with the node cap', async () => {
+    renderGraph()
+    await waitFor(() => expect(mockKnowledgeApi).toHaveBeenCalled())
+    expect(mockKnowledgeApi).toHaveBeenCalledWith('/graph?limit=200')
+  })
+
+  it('shows the empty state when the graph has no nodes', async () => {
+    mockKnowledgeApi.mockResolvedValue({ nodes: [], edges: [] })
+    renderGraph()
+    expect(await screen.findByText('No graph data yet')).toBeInTheDocument()
+    expect(screen.getByText('Ingest documents to build the entity graph')).toBeInTheDocument()
+  })
+
+  it('shows the empty state when the query resolves with no graph at all', async () => {
+    mockKnowledgeApi.mockResolvedValue(null)
+    renderGraph()
+    expect(await screen.findByText('No graph data yet')).toBeInTheDocument()
+  })
+
+  it('draws no svg in the empty state, so neither layout effect can run', async () => {
+    mockKnowledgeApi.mockResolvedValue({ nodes: [], edges: [] })
+    const { container } = renderGraph()
+    await screen.findByText('No graph data yet')
+    expect(container.querySelector('svg[class*="bg-bg-elevated"]')).toBeNull()
+  })
+})
+
+describe('KnowledgeGraph — chrome', () => {
+  it('reports the node and edge counts', async () => {
+    renderGraph()
+    expect(await screen.findByText('5 nodes, 4 edges')).toBeInTheDocument()
+  })
+
+  it('renders a legend swatch for every known entity type', async () => {
+    renderGraph()
+    await screen.findByText('5 nodes, 4 edges')
+    for (const label of ['service', 'technology', 'concept', 'org']) {
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+  })
+
+  it('renders the recenter control', async () => {
+    renderGraph()
+    expect(await screen.findByRole('button', { name: /recenter/i })).toBeInTheDocument()
+  })
+})
+
+describe('KnowledgeGraph — d3 draw', () => {
+  it('draws one group per node, tagged with the entity name', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    const names = Array.from(container.querySelectorAll('g[data-entity]'))
+      .map(g => g.getAttribute('data-entity'))
+    expect(names).toEqual(['Gateway', 'Postgres', 'Retrieval', 'Platform', 'Widgets'])
+  })
+
+  it('colours each node by its entity type and falls back for unknown types', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    expect(circleOf(container, 'Gateway').getAttribute('fill')).toBe('#3b82f6')
+    expect(circleOf(container, 'Postgres').getAttribute('fill')).toBe('#22c55e')
+    expect(circleOf(container, 'Retrieval').getAttribute('fill')).toBe('#a855f7')
+    expect(circleOf(container, 'Platform').getAttribute('fill')).toBe('#f97316')
+    expect(circleOf(container, 'Widgets').getAttribute('fill')).toBe('#6b7280')
+  })
+
+  it('gives unhighlighted nodes the default radius and stroke width', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    const circle = circleOf(container, 'Gateway')
+    expect(circle.getAttribute('r')).toBe('8')
+    expect(circle.getAttribute('stroke-width')).toBe('1.5')
+  })
+
+  it('labels every node with its name', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    const labels = Array.from(container.querySelectorAll('g[data-entity] text'))
+      .map(t => t.textContent)
+    expect(labels).toEqual(['Gateway', 'Postgres', 'Retrieval', 'Platform', 'Widgets'])
+  })
+
+  it('draws one line per edge with positions resolved from the layout', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    const lines = Array.from(container.querySelectorAll('line'))
+    expect(lines).toHaveLength(GRAPH.edges.length)
+    for (const line of lines) {
+      for (const attr of ['x1', 'y1', 'x2', 'y2']) {
+        expect(Number.isFinite(Number(line.getAttribute(attr)))).toBe(true)
+      }
+    }
+  })
+
+  it('scales edge stroke width with the relation weight', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    const widths = Array.from(container.querySelectorAll('line'))
+      .map(l => l.getAttribute('stroke-width'))
+    // weight 3 -> 4.5; weight 1 and missing weight both floor at 1.5.
+    expect(widths).toEqual(['4.5', '1.5', '1.5', '1.5'])
+  })
+
+  it('labels each edge with its relation type at the segment midpoint', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    for (const type of ['depends_on', 'implements', 'owned_by', 'ships']) {
+      const label = Array.from(container.querySelectorAll('text'))
+        .find(t => t.textContent === type)
+      expect(label, `edge label ${type}`).toBeTruthy()
+      expect(Number.isFinite(Number(label?.getAttribute('x')))).toBe(true)
+      expect(Number.isFinite(Number(label?.getAttribute('y')))).toBe(true)
+    }
+  })
+
+  it('applies a fit transform to the drawn group', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    const outer = container.querySelector('svg > g')
+    expect(outer?.getAttribute('transform')).toMatch(/translate\(.+\)\s*scale\(.+\)/)
+  })
+
+  it('positions every node group with a translate transform', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    for (const g of container.querySelectorAll('g[data-entity]')) {
+      expect(g.getAttribute('transform')).toMatch(/^translate\(-?[\d.]+,-?[\d.]+\)$/)
+    }
+  })
+
+  it('does not redraw when new graph data carries the same node ids and edge count', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    const first = container.querySelector('g[data-entity="Gateway"]')
+    // Renaming a node changes the data identity, so the effect re-runs — but the
+    // render key is derived from ids plus edge count only, so the existing
+    // drawing is kept and the new name is never picked up.
+    qc.setQueryData(['knowledge-graph'], {
+      nodes: GRAPH.nodes.map(n => (n.id === 'n1' ? { ...n, name: 'Renamed' } : { ...n })),
+      edges: GRAPH.edges.map(e => ({ ...e })),
+    })
+    await waitFor(() => {
+      expect(container.querySelectorAll('g[data-entity]')).toHaveLength(GRAPH.nodes.length)
+    })
+    expect(container.querySelector('g[data-entity="Gateway"]')).toBe(first)
+    expect(container.querySelector('g[data-entity="Renamed"]')).toBeNull()
+  })
+
+  it('abandons the draw when the component unmounts before d3 resolves', async () => {
+    qc.setQueryData(['knowledge-graph'], GRAPH)
+    const { container, unmount } = renderGraph()
+    // No await between mount and unmount, so the dynamic d3 import has not had a
+    // microtask to settle and must observe the aborted flag.
+    unmount()
+    await waitFor(() => expect(mockKnowledgeApi).toHaveBeenCalled())
+    expect(container.querySelectorAll('g[data-entity]')).toHaveLength(0)
+  })
+
+  it('redraws from scratch when the node set changes', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    qc.setQueryData(['knowledge-graph'], {
+      nodes: [{ id: 'z1', name: 'Solo', type: 'service' }],
+      edges: [],
+    })
+    await drawn(container, 1)
+    expect(container.querySelector('g[data-entity="Gateway"]')).toBeNull()
+    expect(container.querySelectorAll('line')).toHaveLength(0)
+  })
+})
+
+describe('KnowledgeGraph — interaction', () => {
+  it('reports the clicked entity name to the parent', async () => {
+    const onSelectEntity = vi.fn()
+    const { container } = renderGraph({ onSelectEntity })
+    await drawn(container)
+    fireEvent.click(container.querySelector('g[data-entity="Retrieval"]')!)
+    expect(onSelectEntity).toHaveBeenCalledWith('Retrieval')
+  })
+
+  it('survives a click when no selection handler is supplied', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    expect(() => fireEvent.click(container.querySelector('g[data-entity="Gateway"]')!)).not.toThrow()
+  })
+
+  it('accents a node on hover and restores it on leave', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    const group = container.querySelector('g[data-entity="Postgres"]')!
+    fireEvent.mouseEnter(group)
+    expect(circleOf(container, 'Postgres').getAttribute('stroke')).toBe('#fbbf24')
+    expect(circleOf(container, 'Postgres').getAttribute('stroke-width')).toBe('3')
+    fireEvent.mouseLeave(group)
+    expect(circleOf(container, 'Postgres').getAttribute('stroke')).toBe('#ccc')
+    expect(circleOf(container, 'Postgres').getAttribute('stroke-width')).toBe('1.5')
+  })
+
+  it('restores a hovered node to the highlighted style, not the default one', async () => {
+    const { container, rerender } = renderGraph()
+    await drawn(container)
+    rerender({ highlightEntity: 'Postgres' })
+    const group = container.querySelector('g[data-entity="Postgres"]')!
+    fireEvent.mouseEnter(group)
+    fireEvent.mouseLeave(group)
+    expect(circleOf(container, 'Postgres').getAttribute('stroke-width')).toBe('4')
+  })
+
+  it('recenters without throwing when the control is pressed', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    const before = container.querySelector('svg > g')?.getAttribute('transform')
+    fireEvent.click(screen.getByRole('button', { name: /recenter/i }))
+    expect(container.querySelector('svg > g')?.getAttribute('transform')).toBe(before)
+  })
+
+  it('pins a dragged node to the pointer and releases it on drop', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    const group = container.querySelector('g[data-entity="Gateway"]') as SVGGElement
+    const line = container.querySelector('line') as SVGLineElement
+    const [x0, y0] = translateOf(group)
+    // Fake timers drive the force simulation the drag restarts, so the redraw a
+    // running layout performs is exercised without waiting on real frames.
+    vi.useFakeTimers()
+    try {
+      fireEvent.mouseDown(group, { button: 0, clientX: 10, clientY: 10, view: window, bubbles: true })
+      await vi.advanceTimersByTimeAsync(64)
+      fireEvent.mouseMove(window, { clientX: 90, clientY: 70, view: window, bubbles: true })
+      await vi.advanceTimersByTimeAsync(64)
+      // While pinned, the node sits exactly at the pointer delta from where it
+      // started, overriding whatever the layout forces want.
+      const [x1, y1] = translateOf(group)
+      expect(Math.round(x1 - x0)).toBe(80)
+      expect(Math.round(y1 - y0)).toBe(60)
+      fireEvent.mouseUp(window, { clientX: 90, clientY: 70, view: window, bubbles: true })
+      await vi.advanceTimersByTimeAsync(64)
+    } finally {
+      vi.useRealTimers()
+    }
+    // Released: the layout owns the node again and every drawn element stays finite.
+    const [x2, y2] = translateOf(group)
+    expect(Number.isFinite(x2) && Number.isFinite(y2)).toBe(true)
+    for (const attr of ['x1', 'y1', 'x2', 'y2']) {
+      expect(Number.isFinite(Number(line.getAttribute(attr)))).toBe(true)
+    }
+  })
+
+  it('ignores the recenter control before the layout has been measured', async () => {
+    mockKnowledgeApi.mockImplementation(() => new Promise(() => {}))
+    renderGraph()
+    await screen.findByText('Loading graph...')
+    // No button yet — the loading branch owns the tree.
+    expect(screen.queryByRole('button', { name: /recenter/i })).toBeNull()
+  })
+})
+
+describe('KnowledgeGraph — highlight', () => {
+  it('enlarges and accents the highlighted node while shrinking the others', async () => {
+    const { container, rerender } = renderGraph()
+    await drawn(container)
+    rerender({ highlightEntity: 'Platform' })
+    const target = circleOf(container, 'Platform')
+    expect(target.getAttribute('r')).toBe('12')
+    expect(target.getAttribute('stroke-width')).toBe('4')
+    expect(target.getAttribute('stroke')).toBe('#fbbf24')
+    const other = circleOf(container, 'Gateway')
+    expect(other.getAttribute('r')).toBe('8')
+    expect(other.getAttribute('stroke-width')).toBe('1.5')
+    expect(other.getAttribute('stroke')).toBe('#fff')
+  })
+
+  it('resets every node when the highlight is cleared', async () => {
+    const { container, rerender } = renderGraph()
+    await drawn(container)
+    rerender({ highlightEntity: 'Platform' })
+    expect(circleOf(container, 'Platform').getAttribute('r')).toBe('12')
+    rerender({ highlightEntity: null })
+    for (const name of ['Gateway', 'Postgres', 'Retrieval', 'Platform', 'Widgets']) {
+      expect(circleOf(container, name).getAttribute('r')).toBe('8')
+      expect(circleOf(container, name).getAttribute('stroke-width')).toBe('1.5')
+      expect(circleOf(container, name).getAttribute('stroke')).toBe('#fff')
+    }
+  })
+
+  it('leaves the drawing intact when the highlight names an unknown entity', async () => {
+    const { container, rerender } = renderGraph()
+    await drawn(container)
+    rerender({ highlightEntity: 'NotInGraph' })
+    for (const name of ['Gateway', 'Widgets']) {
+      expect(circleOf(container, name).getAttribute('r')).toBe('8')
+    }
+  })
+
+  it('pre-accents the highlighted node on the very first draw', async () => {
+    const { container } = renderGraph({ highlightEntity: 'Widgets' })
+    await drawn(container)
+    const target = circleOf(container, 'Widgets')
+    expect(target.getAttribute('r')).toBe('12')
+    expect(target.getAttribute('stroke-width')).toBe('4')
+    expect(target.getAttribute('stroke')).toBe('#fbbf24')
+  })
+
+  it('polls for the zoom handle when the highlight is set before d3 has drawn', async () => {
+    // Seeding the cache means the svg exists on the first committed render, so
+    // the highlight effect runs while the zoom handle is still uninitialised.
+    qc.setQueryData(['knowledge-graph'], GRAPH)
+    vi.useFakeTimers()
+    try {
+      const { container } = renderGraph({ highlightEntity: 'Gateway' })
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(200)
+      await vi.advanceTimersByTimeAsync(200)
+      expect(container.querySelectorAll('g[data-entity]')).toHaveLength(GRAPH.nodes.length)
+      expect(circleOf(container, 'Gateway').getAttribute('r')).toBe('12')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+  it('gives up polling for the zoom handle after twenty attempts', async () => {
+    qc.setQueryData(['knowledge-graph'], GRAPH)
+    vi.useFakeTimers()
+    try {
+      renderGraph({ highlightEntity: 'Gateway' })
+      // Advancing without awaiting keeps the microtask queue frozen, so the d3
+      // import never settles and every poll observes an unset zoom handle.
+      vi.advanceTimersByTime(200 * 22)
+      // One more interval period proves the poll was cleared, not still firing.
+      expect(() => vi.advanceTimersByTime(200)).not.toThrow()
+    } finally {
+      vi.useRealTimers()
+    }
+    await waitFor(() => expect(mockKnowledgeApi).toHaveBeenCalled())
+  })
+})
+
+describe('KnowledgeGraph — resize refit', () => {
+  it('observes the svg once the graph is drawn', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    expect(resizeCallbacks.length).toBeGreaterThan(0)
+  })
+
+  it('recomputes the fit transform when the svg is resized', async () => {
+    const { container } = renderGraph()
+    await drawn(container)
+    const before = container.querySelector('svg > g')?.getAttribute('transform')
+    const observer = { disconnect() {}, observe() {}, unobserve() {} } as unknown as ResizeObserver
+    for (const cb of resizeCallbacks) cb([], observer)
+    const after = container.querySelector('svg > g')?.getAttribute('transform')
+    expect(after).toMatch(/translate\(.+\)\s*scale\(.+\)/)
+    expect(after).toBe(before)
+  })
+
+  it('ignores a resize that arrives before any layout has been measured', async () => {
+    mockKnowledgeApi.mockResolvedValue({ nodes: [], edges: [] })
+    renderGraph()
+    await screen.findByText('No graph data yet')
+    const observer = { disconnect() {}, observe() {}, unobserve() {} } as unknown as ResizeObserver
+    expect(() => { for (const cb of resizeCallbacks) cb([], observer) }).not.toThrow()
+  })
+
+  it('ignores a resize that lands while the svg exists but d3 has not drawn', async () => {
+    qc.setQueryData(['knowledge-graph'], GRAPH)
+    const { container } = renderGraph()
+    // Fired synchronously after mount: the observer is registered but the d3
+    // import has had no microtask to record the graph bounds yet.
+    const observer = { disconnect() {}, observe() {}, unobserve() {} } as unknown as ResizeObserver
+    expect(resizeCallbacks.length).toBeGreaterThan(0)
+    for (const cb of resizeCallbacks) cb([], observer)
+    expect(container.querySelector('svg > g')).toBeNull()
+    await drawn(container)
+  })
+})

--- a/website/src/test/MissionControlPartsCoverage.test.tsx
+++ b/website/src/test/MissionControlPartsCoverage.test.tsx
@@ -1,0 +1,597 @@
+/**
+ * Mission Control scene "parts" module — pure drawing / geometry helpers.
+ *
+ * Every export here takes a `DrawFn` callback instead of touching a canvas, so the
+ * whole module is testable under jsdom by recording the rects it asks for. These
+ * tests assert real behaviour: which glyph pixels the pixel-font emits, how the
+ * agent sprite changes with facing / walking / drinking / carried item, how the
+ * waypoint router picks aisles, and where the level ladder steps.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  W, H, S, P, MAX_STATIONS, DOOR, WALL_H,
+  STATION_POSITIONS, AGENT_COLORS, C,
+  drawText, darken, lighten, drawAgent,
+  spawnParticles, updateParticles, drawParticles,
+  DESTINATIONS, buildEntryPath, buildExitPath, buildPath, buildReturnPath,
+  getLevel, DESK_CONVOS, BREAK_CONVOS,
+} from '../pages/scenes/mission-control/parts'
+import type { MCAgent, Particle } from '../pages/scenes/mission-control/parts'
+
+/* ── Recording draw sink ── */
+interface Rect { x: number; y: number; w: number; h: number; c: string }
+
+function recorder() {
+  const calls: Rect[] = []
+  const d = (x: number, y: number, w: number, h: number, c: string) => {
+    calls.push({ x, y, w, h, c })
+  }
+  return { d, calls }
+}
+
+const withColor = (calls: Rect[], c: string) => calls.filter(r => r.c === c)
+
+function makeAgent(over: Partial<MCAgent> = {}): MCAgent {
+  return {
+    id: 'slot-1', name: 'Alpha', label: 'default', kind: 'slot',
+    x: 100, y: 200, tx: 100, ty: 200,
+    stationIdx: 0, color: '#3498db', running: false,
+    detail: '3 msgs', facing: 'left', activity: 'sitting',
+    waypoints: [], enterProgress: 1, walkFrame: 0,
+    item: 'none', destKey: null,
+    idleTimer: 0, waitTimer: 0, drinkTimer: 0,
+    chatTimer: 0, chatDelay: 0, chatLine: '',
+    bubbleUp: false, deskOn: true, leaving: false,
+    ...over,
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+/* ────────────────────────── Layout constants ────────────────────────── */
+
+describe('layout constants', () => {
+  it('exposes a 480x320 stage with a positive device scale', () => {
+    expect(W).toBe(480)
+    expect(H).toBe(320)
+    expect(P).toBe(2)
+    expect(S).toBeGreaterThan(0)
+    expect(WALL_H).toBe(110)
+  })
+
+  it('has exactly MAX_STATIONS desk positions split into two rows', () => {
+    expect(STATION_POSITIONS).toHaveLength(MAX_STATIONS)
+    // First four are the top row, last four sit lower on the floor.
+    for (const p of STATION_POSITIONS.slice(0, 4)) expect(p.y).toBe(180)
+    for (const p of STATION_POSITIONS.slice(4)) expect(p.y).toBe(256)
+  })
+
+  it('gives every station its own agent colour', () => {
+    expect(AGENT_COLORS).toHaveLength(MAX_STATIONS)
+    expect(new Set(AGENT_COLORS).size).toBe(MAX_STATIONS)
+    for (const c of AGENT_COLORS) expect(c).toMatch(/^#[0-9a-f]{6}$/)
+  })
+
+  it('places the door on the left wall inside the stage', () => {
+    expect(DOOR.x).toBe(0)
+    expect(DOOR.y + DOOR.h).toBeLessThanOrEqual(H)
+  })
+
+  it('palette carries the four LED states used by the desk indicators', () => {
+    expect(Object.keys(C.led).sort()).toEqual(['err', 'off', 'on', 'warn'])
+    expect(C.led.on).not.toBe(C.led.off)
+  })
+})
+
+/* ────────────────────────── Pixel font ────────────────────────── */
+
+describe('drawText', () => {
+  it('emits one rect per lit pixel of a glyph', () => {
+    const { d, calls } = recorder()
+    // 'I' is [7,2,2,2,7] -> 3 + 1 + 1 + 1 + 3 lit pixels.
+    drawText(d, 'I', 0, 0, '#fff')
+    expect(calls).toHaveLength(9)
+    expect(calls.every(r => r.w === 1 && r.h === 1 && r.c === '#fff')).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    const upper = recorder(); drawText(upper.d, 'A', 0, 0, '#fff')
+    const lower = recorder(); drawText(lower.d, 'a', 0, 0, '#fff')
+    expect(lower.calls).toEqual(upper.calls)
+  })
+
+  it('draws nothing for a blank glyph but still advances the cursor', () => {
+    const { d, calls } = recorder()
+    drawText(d, ' I', 0, 0, '#fff')
+    expect(calls).toHaveLength(9)
+    // The space consumed 4px, so the 'I' starts at x=4 rather than x=0.
+    expect(Math.min(...calls.map(r => r.x))).toBe(4)
+  })
+
+  it('skips unknown characters entirely', () => {
+    const { d, calls } = recorder()
+    drawText(d, '#~', 0, 0, '#fff')
+    expect(calls).toHaveLength(0)
+  })
+
+  it('scales both the pixel size and the advance', () => {
+    const { d, calls } = recorder()
+    drawText(d, 'II', 0, 0, '#fff', 2)
+    expect(calls).toHaveLength(18)
+    expect(calls.every(r => r.w === 2 && r.h === 2)).toBe(true)
+    // Second glyph is 4*scale to the right of the first.
+    expect(Math.max(...calls.map(r => r.x))).toBe(8 + 2 * 2)
+  })
+
+  it('covers digits and punctuation from the font table', () => {
+    const { d, calls } = recorder()
+    drawText(d, '0123456789:[]-.!?/', 0, 0, '#0f0')
+    expect(calls.length).toBeGreaterThan(50)
+  })
+
+  it('covers the full letter range', () => {
+    const { d, calls } = recorder()
+    drawText(d, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 0, 0, '#0f0')
+    expect(calls.length).toBeGreaterThan(200)
+  })
+})
+
+/* ────────────────────────── Colour helpers ────────────────────────── */
+
+describe('darken / lighten', () => {
+  it('subtracts the amount from every channel', () => {
+    expect(darken('#808080', 0x10)).toBe('#707070')
+  })
+
+  it('clamps at black instead of wrapping', () => {
+    expect(darken('#010203', 40)).toBe('#000000')
+  })
+
+  it('pads a short hex result back to six digits', () => {
+    // r/g/b all collapse to 0 -> toString(16) is "0" and must be padded.
+    expect(darken('#000000')).toBe('#000000')
+    expect(darken('#101010', 0x0f)).toBe('#010101')
+  })
+
+  it('adds the amount when lightening', () => {
+    expect(lighten('#101010', 0x10)).toBe('#202020')
+  })
+
+  it('clamps at white instead of wrapping', () => {
+    expect(lighten('#f0f0f0', 100)).toBe('#ffffff')
+  })
+
+  it('uses documented defaults', () => {
+    expect(darken('#646464')).toBe(darken('#646464', 40))
+    expect(lighten('#646464')).toBe(lighten('#646464', 30))
+  })
+})
+
+/* ────────────────────────── Agent sprite ────────────────────────── */
+
+describe('drawAgent', () => {
+  it('draws the shirt logo and legs in side view', () => {
+    const { d, calls } = recorder()
+    drawAgent(d, makeAgent({ facing: 'left' }), 0)
+    // Orange logo stripe is side-view only.
+    expect(withColor(calls, '#f90').length).toBe(2)
+    expect(withColor(calls, '#2a2a4a').length).toBe(2)
+  })
+
+  it('omits the shirt logo and legs when seen from behind', () => {
+    const { d, calls } = recorder()
+    drawAgent(d, makeAgent({ facing: 'back' }), 0)
+    expect(withColor(calls, '#f90')).toHaveLength(0)
+    expect(withColor(calls, '#2a2a4a')).toHaveLength(0)
+  })
+
+  it('mirrors the eyes when facing right', () => {
+    const eyesOf = (facing: MCAgent['facing']) => {
+      const { d, calls } = recorder()
+      drawAgent(d, makeAgent({ facing }), 0)
+      return withColor(calls, '#222').map(r => r.x)
+    }
+    expect(eyesOf('left')).toEqual([102, 104])
+    expect(eyesOf('right')).toEqual([104, 106])
+  })
+
+  it('swings the legs while walking and holds them still while sitting', () => {
+    const legs = (over: Partial<MCAgent>) => {
+      const { d, calls } = recorder()
+      drawAgent(d, makeAgent(over), 0)
+      return withColor(calls, '#2a2a4a').map(r => r.h)
+    }
+    expect(legs({ activity: 'sitting', walkFrame: 8 })).toEqual([6, 4])
+    expect(legs({ activity: 'walking', walkFrame: 0 })).toEqual([6, 4])
+    expect(legs({ activity: 'walking', walkFrame: 8 })).toEqual([4, 6])
+    expect(legs({ activity: 'entering', walkFrame: 8 })).toEqual([4, 6])
+    expect(legs({ activity: 'leaving', walkFrame: 8 })).toEqual([4, 6])
+  })
+
+  it.each([
+    ['mug', '#ddd'],
+    ['cup', '#aaddff'],
+    ['snack', '#f39c12'],
+  ] as const)('draws a carried %s in side view', (item, color) => {
+    const { d, calls } = recorder()
+    drawAgent(d, makeAgent({ item }), 0)
+    expect(withColor(calls, color).length).toBeGreaterThan(0)
+  })
+
+  it.each([
+    ['mug', '#ddd'],
+    ['cup', '#aaddff'],
+    ['snack', '#f39c12'],
+  ] as const)('holds a %s on the mirrored side when facing right', (item, color) => {
+    const itemX = (facing: MCAgent['facing']) => {
+      const { d, calls } = recorder()
+      drawAgent(d, makeAgent({ facing, item }), 0)
+      return withColor(calls, color)[0].x
+    }
+    expect(itemX('right')).toBeGreaterThan(itemX('left'))
+  })
+
+  it('draws nothing extra for an empty-handed agent', () => {
+    const { d, calls } = recorder()
+    drawAgent(d, makeAgent({ item: 'none' }), 0)
+    expect(withColor(calls, '#ddd')).toHaveLength(0)
+    expect(withColor(calls, '#aaddff')).toHaveLength(0)
+    expect(withColor(calls, '#f39c12')).toHaveLength(0)
+  })
+
+  it('raises one arm and shows the drink when drinking from behind', () => {
+    const { d, calls } = recorder()
+    drawAgent(d, makeAgent({ facing: 'back', drinkTimer: 30, item: 'mug' }), 0)
+    expect(withColor(calls, '#ddd').length).toBe(1)
+    // The raised hand uses the lighter skin tone reserved for the drinking pose.
+    expect(withColor(calls, '#f0c8a0').length).toBe(2)
+  })
+
+  it('shows a cup rather than a mug when drinking a cup', () => {
+    const { d, calls } = recorder()
+    drawAgent(d, makeAgent({ facing: 'back', drinkTimer: 30, item: 'cup' }), 0)
+    expect(withColor(calls, '#aaddff')).toHaveLength(1)
+    expect(withColor(calls, '#ddd')).toHaveLength(0)
+  })
+
+  it('draws no drink when the agent is drinking with empty hands', () => {
+    const { d, calls } = recorder()
+    drawAgent(d, makeAgent({ facing: 'back', drinkTimer: 30, item: 'none' }), 0)
+    expect(withColor(calls, '#ddd')).toHaveLength(0)
+    expect(withColor(calls, '#aaddff')).toHaveLength(0)
+  })
+
+  it('bounces the typing arms on alternating frames', () => {
+    const armYs = (walkFrame: number) => {
+      const { d, calls } = recorder()
+      drawAgent(d, makeAgent({
+        facing: 'back', activity: 'sitting', running: true, walkFrame,
+      }), 0)
+      return withColor(calls, '#f0c8a0').map(r => r.y)
+    }
+    // walkFrame bit 3 clear -> right arm lifts; set -> left arm lifts.
+    expect(armYs(0)).toEqual([205, 204])
+    expect(armYs(8)).toEqual([204, 205])
+  })
+
+  it('keeps both arms down when idle at the desk', () => {
+    const { d, calls } = recorder()
+    drawAgent(d, makeAgent({ facing: 'back', activity: 'sitting', running: false, walkFrame: 8 }), 0)
+    expect(withColor(calls, '#f0c8a0').map(r => r.y)).toEqual([205, 205])
+  })
+
+  it('truncates a long name to eight characters in the label', () => {
+    const { d, calls } = recorder()
+    drawAgent(d, makeAgent({ name: 'ABCDEFGHIJKL' }), 0)
+    const label = withColor(calls, '#fff')
+    // 8 glyphs at 4px advance -> the label spans less than 32px.
+    const span = Math.max(...label.map(r => r.x)) - Math.min(...label.map(r => r.x))
+    expect(span).toBeLessThan(32)
+  })
+
+  it('rounds fractional positions to whole pixels', () => {
+    const { d, calls } = recorder()
+    drawAgent(d, makeAgent({ x: 100.6, y: 200.4 }), 0)
+    expect(calls.every(r => Number.isInteger(r.x) && Number.isInteger(r.y))).toBe(true)
+  })
+})
+
+/* ────────────────────────── Speech bubble (via drawAgent) ────────────────────────── */
+
+describe('speech bubble', () => {
+  const bubbleRects = (over: Partial<MCAgent>) => {
+    const { d, calls } = recorder()
+    drawAgent(d, makeAgent(over), 0)
+    // The bubble body is the only white rect taller than the tail and the top edge.
+    return withColor(calls, '#fff').filter(r => r.h > 2)
+  }
+
+  it('appears once the chat timer is running with a line to say', () => {
+    expect(bubbleRects({ chatTimer: 40, chatLine: 'ship it' })).toHaveLength(1)
+  })
+
+  it('stays hidden while the chat is still delayed', () => {
+    expect(bubbleRects({ chatTimer: 40, chatDelay: 10, chatLine: 'ship it' })).toHaveLength(0)
+  })
+
+  it('stays hidden with no timer or no line', () => {
+    expect(bubbleRects({ chatTimer: 0, chatLine: 'ship it' })).toHaveLength(0)
+    expect(bubbleRects({ chatTimer: 40, chatLine: '' })).toHaveLength(0)
+  })
+
+  it('widens with the length of the line', () => {
+    const short = bubbleRects({ chatTimer: 40, chatLine: 'hi' })[0]
+    const long = bubbleRects({ chatTimer: 40, chatLine: 'is it in prod?' })[0]
+    expect(long.w).toBeGreaterThan(short.w)
+  })
+
+  it('lifts the bubble by 20px when bubbleUp avoids an overlap', () => {
+    const low = bubbleRects({ chatTimer: 40, chatLine: 'hi' })[0]
+    const high = bubbleRects({ chatTimer: 40, chatLine: 'hi', bubbleUp: true })[0]
+    expect(low.y - high.y).toBe(20)
+  })
+
+  it('renders from behind as well as from the side', () => {
+    expect(bubbleRects({ facing: 'back', chatTimer: 40, chatLine: 'hi' })).toHaveLength(1)
+  })
+})
+
+/* ────────────────────────── Particles ────────────────────────── */
+
+describe('particles', () => {
+  it('spawns the requested count with the default drift', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    const pool: Particle[] = []
+    spawnParticles(pool, 10, 20, '#fff', 3)
+    expect(pool).toHaveLength(3)
+    expect(pool[0]).toMatchObject({
+      x: 10, y: 20, vx: 0, vy: -0.15, life: 0, maxLife: 100, color: '#fff', size: 1,
+    })
+  })
+
+  it('honours explicit velocity, spread, lifetime and size', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    const pool: Particle[] = []
+    spawnParticles(pool, 0, 0, '#0f0', 2, { vx: 1, vy: -2, spread: 4, maxLife: 50, size: 3 })
+    expect(pool).toHaveLength(2)
+    expect(pool[0]).toMatchObject({ vx: 1, vy: -2, maxLife: 50, size: 3 })
+  })
+
+  it('appends to an existing pool rather than replacing it', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    const pool: Particle[] = []
+    spawnParticles(pool, 0, 0, '#fff', 2)
+    spawnParticles(pool, 5, 5, '#f00', 1)
+    expect(pool).toHaveLength(3)
+    expect(pool[2].color).toBe('#f00')
+  })
+
+  it('spreads velocity across the requested range', () => {
+    const seq = [0, 0, 0, 1, 1, 1]
+    let i = 0
+    vi.spyOn(Math, 'random').mockImplementation(() => seq[i++ % seq.length])
+    const pool: Particle[] = []
+    spawnParticles(pool, 0, 0, '#fff', 2, { spread: 2 })
+    expect(pool[0].vx).toBeLessThan(pool[1].vx)
+  })
+
+  it('advances position and age on update', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    const pool: Particle[] = [
+      { x: 0, y: 0, vx: 2, vy: -1, life: 0, maxLife: 10, color: '#fff', size: 1 },
+    ]
+    const next = updateParticles(pool)
+    expect(next[0]).toMatchObject({ x: 2, y: -1, life: 1 })
+  })
+
+  it('drops particles that reached their lifetime', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    const pool: Particle[] = [
+      { x: 0, y: 0, vx: 0, vy: 0, life: 9, maxLife: 10, color: '#a', size: 1 },
+      { x: 0, y: 0, vx: 0, vy: 0, life: 0, maxLife: 10, color: '#b', size: 1 },
+    ]
+    const next = updateParticles(pool)
+    expect(next.map(p => p.color)).toEqual(['#b'])
+  })
+
+  it('returns an empty array for an empty pool', () => {
+    expect(updateParticles([])).toEqual([])
+  })
+
+  it('fades particles out and restores full opacity afterwards', () => {
+    const alphas: number[] = []
+    const rects: number[][] = []
+    const ctx = {
+      fillStyle: '',
+      globalAlpha: 1,
+      fillRect: (x: number, y: number, w: number, h: number) => {
+        alphas.push(ctx.globalAlpha)
+        rects.push([x, y, w, h])
+      },
+    }
+    const pool: Particle[] = [
+      { x: 1, y: 2, vx: 0, vy: 0, life: 0, maxLife: 10, color: '#fff', size: 2 },
+      { x: 0, y: 0, vx: 0, vy: 0, life: 10, maxLife: 10, color: '#fff', size: 1 },
+    ]
+    drawParticles(() => {}, ctx as unknown as CanvasRenderingContext2D, pool)
+    // Fresh particle is at half alpha; a spent one is clamped to zero.
+    expect(alphas[0]).toBeCloseTo(0.5)
+    expect(alphas[1]).toBe(0)
+    // Coordinates are multiplied by the scene scale.
+    expect(rects[0]).toEqual([1 * S, 2 * S, 2 * S, 2 * S])
+    expect(ctx.globalAlpha).toBe(1)
+  })
+})
+
+/* ────────────────────────── Waypoint navigation ────────────────────────── */
+
+describe('destinations', () => {
+  it('keeps every break-area destination on the right or far left of the floor', () => {
+    expect(Object.keys(DESTINATIONS).sort()).toEqual(['coffee', 'trash', 'vending', 'water'])
+    for (const p of Object.values(DESTINATIONS)) {
+      expect(p.x).toBeGreaterThanOrEqual(0)
+      expect(p.y).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('buildEntryPath', () => {
+  it('routes a top-row desk down the left aisle and along the corridor', () => {
+    expect(buildEntryPath(0)).toEqual([
+      { x: 30, y: 228 }, { x: 81, y: 228 }, { x: 81, y: 200 },
+    ])
+  })
+
+  it('routes a back-row desk behind the desks instead of the corridor', () => {
+    expect(buildEntryPath(4)).toEqual([
+      { x: 30, y: 290 }, { x: 81, y: 290 }, { x: 81, y: 276 },
+    ])
+  })
+
+  it('always ends at the chair of the requested station', () => {
+    for (let i = 0; i < MAX_STATIONS; i++) {
+      const path = buildEntryPath(i)
+      expect(path[path.length - 1]).toEqual({
+        x: STATION_POSITIONS[i].x + 21, y: STATION_POSITIONS[i].y + 20,
+      })
+    }
+  })
+})
+
+describe('buildExitPath', () => {
+  it('steps out to the corridor, then the aisle, then the door', () => {
+    expect(buildExitPath(0, 120)).toEqual([
+      { x: 120, y: 228 }, { x: 30, y: 228 }, { x: DOOR.x + 6, y: DOOR.y + 20 },
+    ])
+  })
+
+  it('uses the rear lane for back-row desks', () => {
+    expect(buildExitPath(7, 300)[0]).toEqual({ x: 300, y: 290 })
+  })
+
+  it('always finishes at the door', () => {
+    for (let i = 0; i < MAX_STATIONS; i++) {
+      const path = buildExitPath(i, 200)
+      expect(path[path.length - 1]).toEqual({ x: DOOR.x + 6, y: DOOR.y + 20 })
+    }
+  })
+})
+
+describe('buildPath', () => {
+  it('walks the right aisle and changes level for the coffee machine', () => {
+    expect(buildPath(0, DESTINATIONS.coffee)).toEqual([
+      { x: 81, y: 228 }, { x: 340, y: 228 }, { x: 340, y: 270 }, { x: 390, y: 270 },
+    ])
+  })
+
+  it('skips the aisle leg when the destination is already on the lane', () => {
+    // The trash can sits on the rear lane, so no vertical walk is needed.
+    expect(buildPath(4, DESTINATIONS.trash)).toEqual([
+      { x: 81, y: 290 }, { x: 30, y: 290 }, { x: 25, y: 290 },
+    ])
+  })
+
+  it('picks the left aisle for a destination on the left half', () => {
+    expect(buildPath(0, DESTINATIONS.trash)[1]).toEqual({ x: 30, y: 228 })
+  })
+
+  it('always ends on the destination', () => {
+    for (const dest of Object.values(DESTINATIONS)) {
+      const path = buildPath(2, dest)
+      expect(path[path.length - 1]).toEqual({ x: dest.x, y: dest.y })
+    }
+  })
+})
+
+describe('buildReturnPath', () => {
+  it('comes back down the right aisle from the break area', () => {
+    expect(buildReturnPath(0, 390, 270)).toEqual([
+      { x: 340, y: 270 }, { x: 340, y: 228 }, { x: 81, y: 228 }, { x: 81, y: 200 },
+    ])
+  })
+
+  it('comes back down the left aisle from the near side of the floor', () => {
+    expect(buildReturnPath(4, 25, 290)).toEqual([
+      { x: 30, y: 290 }, { x: 30, y: 290 }, { x: 81, y: 290 }, { x: 81, y: 276 },
+    ])
+  })
+
+  it('always ends at the chair', () => {
+    for (let i = 0; i < MAX_STATIONS; i++) {
+      const path = buildReturnPath(i, 400, 190)
+      expect(path[path.length - 1]).toEqual({
+        x: STATION_POSITIONS[i].x + 21, y: STATION_POSITIONS[i].y + 20,
+      })
+    }
+  })
+})
+
+/* ────────────────────────── Level ladder ────────────────────────── */
+
+describe('getLevel', () => {
+  it('starts at level 1 for a brand new agent', () => {
+    expect(getLevel(0)).toEqual({ level: 1, title: 'Intern' })
+  })
+
+  it('never drops below level 1 even for a negative count', () => {
+    expect(getLevel(-5)).toEqual({ level: 1, title: 'Intern' })
+  })
+
+  it.each([
+    [10, 1, 'Intern'],
+    [11, 2, 'Prompt Monkey'],
+    [31, 3, 'Token Burner'],
+    [81, 4, 'Hallucination Specialist'],
+    [201, 5, 'Senior Gaslighter'],
+    [401, 6, 'Chief Yapper'],
+    [801, 7, 'Distinguished Delulu'],
+    [1201, 8, 'VP of Vibes'],
+    [1601, 9, 'Sentience Candidate'],
+    [2001, 10, 'AGI'],
+  ])('maps %i messages to level %i (%s)', (msgs, level, title) => {
+    expect(getLevel(msgs)).toEqual({ level, title })
+  })
+
+  it('caps at the top rung however many messages accumulate', () => {
+    expect(getLevel(1_000_000)).toEqual({ level: 10, title: 'AGI' })
+  })
+
+  it('is monotonic across the whole ladder', () => {
+    let prev = 0
+    for (let m = 0; m <= 2100; m += 7) {
+      const { level } = getLevel(m)
+      expect(level).toBeGreaterThanOrEqual(prev)
+      prev = level
+    }
+  })
+})
+
+/* ────────────────────────── Conversation tables ────────────────────────── */
+
+describe('conversation tables', () => {
+  it('pairs every desk line with a reply', () => {
+    expect(DESK_CONVOS.length).toBeGreaterThan(0)
+    for (const pair of DESK_CONVOS) {
+      expect(pair).toHaveLength(2)
+      expect(pair[0].length).toBeGreaterThan(0)
+      expect(pair[1].length).toBeGreaterThan(0)
+    }
+  })
+
+  it('pairs every break-room line with a reply', () => {
+    expect(BREAK_CONVOS.length).toBeGreaterThan(0)
+    for (const pair of BREAK_CONVOS) {
+      expect(pair).toHaveLength(2)
+    }
+  })
+
+  it('keeps every line short enough for a speech bubble on the 480px stage', () => {
+    for (const [a, b] of [...DESK_CONVOS, ...BREAK_CONVOS]) {
+      // Bubble width is line length * 4 + 4 pixels.
+      expect(a.length * 4 + 4).toBeLessThan(W)
+      expect(b.length * 4 + 4).toBeLessThan(W)
+    }
+  })
+})

--- a/website/src/test/MochiApiCoverage.test.tsx
+++ b/website/src/test/MochiApiCoverage.test.tsx
@@ -1,0 +1,903 @@
+/**
+ * `mochiApi` — the WEB TRANSPORTS half of the Mochi seam.
+ *
+ * `mochiApiSeam.test.ts` already pins the config nesting, the pack-detail
+ * inlining and the panel-width arithmetic. What it does not reach is the set of
+ * functions that exist only because a browser tab cannot do what the original's
+ * Electron main process did: every one of them talks to a Kiro Crew HTTP route,
+ * a transient `<input type="file">`, or a blob download.
+ *
+ * Those are exactly the paths that fail SILENTLY. The vendored call sites are all
+ * written `api?.name?.(...)`, so a transport that throws, reads the wrong body
+ * shape, or resolves `undefined` renders an empty list or a dead button with no
+ * error anywhere. So each case below pins one of three things: the request that
+ * actually goes out (route, method, body), the value handed back for the shape
+ * the backend really returns, and the degraded answer on failure — a list must
+ * come back empty rather than throw, and a `Result` must carry a reason rather
+ * than resolve nothing.
+ *
+ * The harness mocks the three modules the seam composes (`api`, `panelBridge`,
+ * `petBridge`) and re-imports the seam per test, because `impl` captures the
+ * shell channels and the rail state at module evaluation.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ── the modules the seam composes ───────────────────────────────────────────
+
+const storedSettings: Record<string, unknown> = {
+  petName: 'Mochi',
+  mode: 'quiet',
+  shortcuts: { toggleWindow: 'CommandOrControl+Shift+M' },
+  extraMcpServers: [] as unknown[],
+  colorMaps: {} as Record<string, unknown>,
+  customPresets: [] as unknown[],
+  chatAlwaysOnTop: true,
+}
+
+const getSettings = vi.fn(async (): Promise<Record<string, unknown>> => storedSettings)
+const updateSettings = vi.fn(async (patch: Record<string, unknown>) => ({
+  ...storedSettings,
+  ...patch,
+}))
+
+const panelCalls = {
+  deleteHistory: vi.fn(async (): Promise<void> => undefined),
+  disableApp: vi.fn(async (): Promise<void> => undefined),
+  openDashboard: vi.fn(),
+  galleryListPacks: vi.fn(async (): Promise<unknown[]> => []),
+  galleryDeletePack: vi.fn(async () => true),
+  gallerySetActive: vi.fn(async (): Promise<void> => undefined),
+  galleryGetPackDetail: vi.fn(async (): Promise<unknown> => null),
+  getWatchlistItems: vi.fn(async (): Promise<unknown[]> => []),
+}
+
+const petCalls = {
+  openChat: vi.fn(),
+  openAvatars: vi.fn(),
+  openSettings: vi.fn(),
+  openMemories: vi.fn(),
+}
+
+vi.mock('../apps/mochi/api', () => ({
+  getSettings: () => getSettings(),
+  getStats: async () => ({}),
+  updateSettings: (patch: Record<string, unknown>) => updateSettings(patch),
+}))
+
+vi.mock('../apps/mochi/panel/panelBridge', () => ({
+  deleteHistory: () => panelCalls.deleteHistory(),
+  disableApp: () => panelCalls.disableApp(),
+  openDashboard: () => panelCalls.openDashboard(),
+  galleryListPacks: () => panelCalls.galleryListPacks(),
+  galleryDeletePack: (id: string) => panelCalls.galleryDeletePack(id),
+  gallerySetActive: (id: string) => panelCalls.gallerySetActive(id),
+  galleryGetPackDetail: (id: string) => panelCalls.galleryGetPackDetail(id),
+  getWatchlistItems: () => panelCalls.getWatchlistItems(),
+  localFileUrl: (path: string) => `/api/file-raw?path=${encodeURIComponent(path)}`,
+  galleryPackFileUrl: (packId: string, filename: string) => `/packs/${packId}/${filename}`,
+}))
+
+vi.mock('../apps/mochi/pet/petBridge', () => ({
+  openChat: () => petCalls.openChat(),
+  openAvatars: () => petCalls.openAvatars(),
+  openSettings: () => petCalls.openSettings(),
+  openMemories: () => petCalls.openMemories(),
+  hasShell: false,
+  machinePrefs: async () => null,
+  setPetInstance: vi.fn(async () => true),
+  instancesList: vi.fn(async () => null),
+}))
+
+// ── fetch double ────────────────────────────────────────────────────────────
+
+interface FetchReply {
+  ok?: boolean
+  status?: number
+  json?: unknown
+  /** A body that is not JSON at all — the seam's `.catch(() => ...)` path. */
+  jsonThrows?: boolean
+  bytes?: number[]
+  blob?: Blob
+}
+
+function makeResponse(r: FetchReply): Response {
+  return {
+    ok: r.ok ?? true,
+    status: r.status ?? (r.ok === false ? 500 : 200),
+    json: async () => {
+      if (r.jsonThrows === true) throw new SyntaxError('not json')
+      return r.json ?? {}
+    },
+    arrayBuffer: async () => new Uint8Array(r.bytes ?? []).buffer,
+    blob: async () => r.blob ?? new Blob(['bundle']),
+  } as unknown as Response
+}
+
+type Route = FetchReply | 'reject'
+
+function stubFetch(next: Route | ((url: string) => Route)) {
+  const calls: { url: string; init?: RequestInit }[] = []
+  const fn = vi.fn(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init })
+    const r = typeof next === 'function' ? next(url) : next
+    if (r === 'reject') throw new TypeError('network down')
+    return makeResponse(r)
+  })
+  vi.stubGlobal('fetch', fn)
+  return { fn, calls }
+}
+
+function bodyOf(call: { init?: RequestInit }): Record<string, unknown> {
+  return JSON.parse(String(call.init?.body ?? '{}')) as Record<string, unknown>
+}
+
+// ── DOM doubles: the transient <input> and the download <a> ─────────────────
+//
+// jsdom opens no file dialog and performs no navigation, so both elements have
+// to be driven from the test. `createElement` is intercepted rather than the
+// elements queried afterwards: `importSpriteFile` removes its input again, so by
+// the time the promise settles there is nothing left in the DOM to find.
+
+interface DomHarness {
+  /** What the "dialog" answers on the next `click()`. */
+  gesture: 'change' | 'cancel' | 'none'
+  files: File[]
+  anchors: HTMLAnchorElement[]
+  anchorClicks: string[]
+  inputs: HTMLInputElement[]
+}
+
+function setFiles(input: HTMLInputElement, files: File[]): void {
+  Object.defineProperty(input, 'files', {
+    configurable: true,
+    value: { length: files.length, 0: files[0], item: (i: number) => files[i] ?? null },
+  })
+}
+
+function installDomHarness(): DomHarness {
+  const h: DomHarness = {
+    gesture: 'change',
+    files: [],
+    anchors: [],
+    anchorClicks: [],
+    inputs: [],
+  }
+  const create = document.createElement.bind(document)
+  vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
+    const el = create(tag)
+    if (tag === 'a') {
+      const anchor = el as HTMLAnchorElement
+      h.anchors.push(anchor)
+      anchor.click = () => {
+        h.anchorClicks.push(anchor.download)
+      }
+    }
+    if (tag === 'input') {
+      const input = el as HTMLInputElement
+      h.inputs.push(input)
+      input.click = () => {
+        if (h.gesture === 'none') return
+        if (h.gesture === 'cancel') {
+          input.dispatchEvent(new Event('cancel'))
+          return
+        }
+        setFiles(input, h.files)
+        input.dispatchEvent(new Event('change'))
+      }
+    }
+    return el
+  }) as typeof document.createElement)
+  return h
+}
+
+// ── seam loading ────────────────────────────────────────────────────────────
+
+const shell = { setPanelWidth: vi.fn(), hideAll: vi.fn() }
+
+async function loadSeam() {
+  vi.resetModules()
+  return await import('../apps/mochi/src/mochiApi')
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  ;(window as unknown as { mochi?: unknown }).mochi = shell
+  const url = URL as unknown as Record<string, unknown>
+  url.createObjectURL = vi.fn(() => 'blob:mochi-export')
+  url.revokeObjectURL = vi.fn()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+// ── MCP inventory ───────────────────────────────────────────────────────────
+
+describe('mochiApi MCP inventory', () => {
+  const inventory = [
+    { name: 'plain-name', tools: [{ name: 'a' }, { name: 'b' }] },
+    { name: 'slack-mcp', tool_count: 7 },
+    { name: 'mochi:tools' },
+    { name: 'kirocrew-core' },
+    { name: 'unconfigured' },
+  ]
+
+  it("merges core's inventory with Mochi's own per-server assignment", async () => {
+    getSettings.mockResolvedValueOnce({
+      ...storedSettings,
+      extraMcpServers: [
+        'plain-name',
+        { name: 'slack-mcp', agents: ['bg'], autoApprove: ['post'], disabledTools: ['nuke'] },
+      ],
+    })
+    const { calls } = stubFetch({ json: inventory })
+    const seam = await loadSeam()
+
+    const rows = await seam.api.getMcpServers()
+
+    // Inventory comes from core, assignment from Mochi's settings. Without the
+    // merge every row renders default policy no matter what the user configured.
+    expect(calls[0].url).toBe('/api/mcp')
+    const plain = rows.find((r) => r.name === 'plain-name')
+    expect(plain).toMatchObject({ enabled: true, agents: ['chat'], toolCount: 2 })
+    const slack = rows.find((r) => r.name === 'slack-mcp')
+    expect(slack).toMatchObject({
+      enabled: true,
+      agents: ['bg'],
+      autoApprove: ['post'],
+      disabledTools: ['nuke'],
+      toolCount: 7,
+    })
+    expect(rows.find((r) => r.name === 'unconfigured')).toMatchObject({
+      enabled: false,
+      agents: ['chat'],
+      toolCount: undefined,
+    })
+  })
+
+  it('marks already-granted servers core so they are not offered as addable', async () => {
+    stubFetch({ json: inventory })
+    const seam = await loadSeam()
+
+    const rows = await seam.api.getMcpServers()
+
+    // The app's OWN server and the host-managed ones are already in the
+    // baseline grant; listing them as addable was the bug.
+    expect(rows.find((r) => r.name === 'mochi:tools')?.core).toBe(true)
+    expect(rows.find((r) => r.name === 'kirocrew-core')?.core).toBe(true)
+    expect(rows.find((r) => r.name === 'plain-name')?.core).toBe(false)
+  })
+
+  it('reads a wrapped body as well as the bare array core actually returns', async () => {
+    stubFetch({ json: { servers: [{ name: 'wrapped' }] } })
+    const seam = await loadSeam()
+
+    expect((await seam.api.getMcpServers()).map((r) => r.name)).toEqual(['wrapped'])
+  })
+
+  it('yields an empty list when the route fails rather than throwing at the panel', async () => {
+    stubFetch({ ok: false, status: 500 })
+    const seam = await loadSeam()
+
+    expect(await seam.api.getMcpServers()).toEqual([])
+  })
+
+  it('yields an empty list when the request throws', async () => {
+    stubFetch('reject')
+    const seam = await loadSeam()
+
+    expect(await seam.api.getMcpServers()).toEqual([])
+  })
+
+  it('still lists the inventory when the settings read fails', async () => {
+    getSettings.mockRejectedValueOnce(new Error('settings down'))
+    stubFetch({ json: inventory })
+    const seam = await loadSeam()
+
+    const rows = await seam.api.getMcpServers()
+
+    // Assignment is unknown, so every row reports unconfigured — but the
+    // section must still render its servers.
+    expect(rows).toHaveLength(5)
+    expect(rows.every((r) => r.enabled === false)).toBe(true)
+  })
+})
+
+// ── binary reads ────────────────────────────────────────────────────────────
+
+describe('mochiApi binary reads', () => {
+  it('returns base64 for a readable local file', async () => {
+    // The caller wraps the result in a `data:image/png;base64,` URL, so a plain
+    // URL cannot be substituted for the encoded bytes.
+    const { calls } = stubFetch({ bytes: [72, 105] })
+    const seam = await loadSeam()
+
+    expect(await seam.api.readLocalImage('/tmp/a.png')).toBe('SGk=')
+    expect(calls[0].url).toContain('/api/file-raw?path=')
+  })
+
+  it('returns null when the local file cannot be read', async () => {
+    stubFetch({ ok: false, status: 404 })
+    const seam = await loadSeam()
+
+    expect(await seam.api.readLocalImage('/tmp/missing.png')).toBeNull()
+  })
+
+  it('returns null when the local read throws', async () => {
+    stubFetch('reject')
+    const seam = await loadSeam()
+
+    expect(await seam.api.readLocalImage('/tmp/a.png')).toBeNull()
+  })
+
+  it('returns base64 for one file inside a pack', async () => {
+    const { calls } = stubFetch({ bytes: [72, 105] })
+    const seam = await loadSeam()
+
+    expect(await seam.api.galleryReadPackFile('p1', 'idle.png')).toBe('SGk=')
+    expect(calls[0].url).toBe('/packs/p1/idle.png')
+  })
+
+  it('returns null for a missing pack file', async () => {
+    stubFetch({ ok: false, status: 404 })
+    const seam = await loadSeam()
+
+    expect(await seam.api.galleryReadPackFile('p1', 'nope.png')).toBeNull()
+  })
+
+  it('returns null when the pack file read throws', async () => {
+    stubFetch('reject')
+    const seam = await loadSeam()
+
+    expect(await seam.api.galleryReadPackFile('p1', 'idle.png')).toBeNull()
+  })
+})
+
+// ── voice config ────────────────────────────────────────────────────────────
+
+describe('mochiApi speech-to-text config', () => {
+  it('posts the patch to the core route as JSON', async () => {
+    const { calls } = stubFetch({ json: { ok: true } })
+    const seam = await loadSeam()
+
+    await seam.api.updateSttConfig({ provider: 'whisper' })
+
+    expect(calls[0].url).toBe('/api/config/stt')
+    expect(calls[0].init?.method).toBe('POST')
+    expect(bodyOf(calls[0])).toEqual({ provider: 'whisper' })
+  })
+
+  it('swallows a failed write — voice must not take the settings window down', async () => {
+    stubFetch('reject')
+    const seam = await loadSeam()
+
+    await expect(seam.api.updateSttConfig({ provider: 'whisper' })).resolves.toBeUndefined()
+  })
+})
+
+// ── petdex.dev ──────────────────────────────────────────────────────────────
+
+describe('mochiApi petdex import', () => {
+  it('lists the pets the CLI already installed', async () => {
+    const { calls } = stubFetch({ json: { pets: [{ slug: 'fox' }] } })
+    const seam = await loadSeam()
+
+    expect(await seam.api.petdexListInstalled()).toEqual([{ slug: 'fox' }])
+    expect(calls[0].url).toBe('/api/apps/mochi/petdex/installed')
+  })
+
+  it('drives the list with an empty array when the body carries no pets', async () => {
+    stubFetch({ json: { pets: 'not-an-array' } })
+    const seam = await loadSeam()
+
+    expect(await seam.api.petdexListInstalled()).toEqual([])
+  })
+
+  it('never throws out of the installed list', async () => {
+    stubFetch((url) => (url.includes('installed') ? 'reject' : {}))
+    const seam = await loadSeam()
+
+    expect(await seam.api.petdexListInstalled()).toEqual([])
+  })
+
+  it('drives the list with an empty array when the route fails', async () => {
+    stubFetch({ ok: false, status: 403 })
+    const seam = await loadSeam()
+
+    expect(await seam.api.petdexListInstalled()).toEqual([])
+  })
+
+  it('returns the obtained pet on success', async () => {
+    const { calls } = stubFetch({ json: { ok: true, slug: 'fox', frames: 9 } })
+    const seam = await loadSeam()
+
+    const result = await seam.api.petdexImport('fox', 'remote')
+
+    expect(calls[0].url).toBe('/api/apps/mochi/petdex/import')
+    expect(bodyOf(calls[0])).toEqual({ slug: 'fox', source: 'remote' })
+    expect(result).toMatchObject({ ok: true, value: { slug: 'fox' } })
+  })
+
+  it("reports the backend's own reason when the import is refused", async () => {
+    stubFetch({ ok: false, status: 502, json: { error: 'petdex unreachable' } })
+    const seam = await loadSeam()
+
+    expect(await seam.api.petdexImport('fox', 'remote')).toEqual({
+      ok: false,
+      error: 'petdex unreachable',
+    })
+  })
+
+  it('falls back to the status when a refusal carries no reason', async () => {
+    // A 200 whose body never says ok is a failure too, not a silent success.
+    stubFetch({ ok: false, status: 418, json: {} })
+    const seam = await loadSeam()
+
+    expect(await seam.api.petdexImport('fox', 'local')).toEqual({
+      ok: false,
+      error: 'Import failed (HTTP 418)',
+    })
+  })
+
+  it('treats a 200 that never confirms ok as a failure', async () => {
+    stubFetch({ json: { slug: 'fox' } })
+    const seam = await loadSeam()
+
+    expect(await seam.api.petdexImport('fox', 'local')).toMatchObject({ ok: false })
+  })
+
+  it("reports a thrown error's message rather than escaping the button", async () => {
+    stubFetch('reject')
+    const seam = await loadSeam()
+
+    expect(await seam.api.petdexImport('fox', 'remote')).toEqual({
+      ok: false,
+      error: 'network down',
+    })
+  })
+
+  it('survives a body that is not JSON at all', async () => {
+    // An HTML error page from a proxy is not a parse the caller should die on.
+    stubFetch({ ok: false, status: 502, jsonThrows: true })
+    const seam = await loadSeam()
+
+    expect(await seam.api.petdexImport('fox', 'remote')).toEqual({
+      ok: false,
+      error: 'Import failed (HTTP 502)',
+    })
+  })
+})
+
+// ── pack export / import ────────────────────────────────────────────────────
+
+describe('mochiApi pack export', () => {
+  it('downloads the bundle under its pack id and revokes the blob URL after', async () => {
+    vi.useFakeTimers()
+    const dom = installDomHarness()
+    const { calls } = stubFetch({ blob: new Blob(['zip-bytes']) })
+    const seam = await loadSeam()
+
+    const result = await seam.api.galleryExport('my pack')
+
+    expect(result).toEqual({ ok: true, value: null })
+    expect(calls[0].url).toBe('/api/apps/mochi/packs/my%20pack/export')
+    // The name is what makes a bundle exported here importable upstream.
+    expect(dom.anchorClicks).toEqual(['my pack.mochipack.zip'])
+    const url = URL as unknown as { revokeObjectURL: ReturnType<typeof vi.fn> }
+    expect(url.revokeObjectURL).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(60_000)
+    expect(url.revokeObjectURL).toHaveBeenCalledWith('blob:mochi-export')
+  })
+
+  it("reports the backend's reason when the export is refused", async () => {
+    installDomHarness()
+    stubFetch({ ok: false, status: 500, json: { error: 'pack is locked' } })
+    const seam = await loadSeam()
+
+    expect(await seam.api.galleryExport('p1')).toEqual({ ok: false, error: 'pack is locked' })
+  })
+
+  it('falls back to the status when the refusal body is not JSON', async () => {
+    installDomHarness()
+    stubFetch({ ok: false, status: 503, jsonThrows: true })
+    const seam = await loadSeam()
+
+    expect(await seam.api.galleryExport('p1')).toEqual({ ok: false, error: 'Export failed (503)' })
+  })
+
+  it('reports a thrown error rather than resolving nothing', async () => {
+    installDomHarness()
+    stubFetch('reject')
+    const seam = await loadSeam()
+
+    expect(await seam.api.galleryExport('p1')).toEqual({ ok: false, error: 'network down' })
+  })
+})
+
+describe('mochiApi bundle import', () => {
+  it('posts the picked file as a zip body and returns the stored meta', async () => {
+    const dom = installDomHarness()
+    dom.files = [new File(['zip'], 'pack.mochipack.zip', { type: 'application/zip' })]
+    const { calls } = stubFetch({ json: { meta: { id: 'imported', name: 'Imported' } } })
+    const seam = await loadSeam()
+
+    const result = await seam.api.galleryImportBundle()
+
+    expect(calls[0].url).toBe('/api/apps/mochi/packs/import')
+    expect(calls[0].init?.method).toBe('POST')
+    expect(calls[0].init?.body).toBe(dom.files[0])
+    expect(result).toEqual({ ok: true, value: { id: 'imported', name: 'Imported' } })
+  })
+
+  it('resolves null when the user picks nothing, so the button un-busies', async () => {
+    const dom = installDomHarness()
+    dom.files = []
+    const { fn } = stubFetch({})
+    const seam = await loadSeam()
+
+    expect(await seam.api.galleryImportBundle()).toBeNull()
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('reports a reason when the bundle is rejected', async () => {
+    const dom = installDomHarness()
+    dom.files = [new File(['zip'], 'pack.zip', { type: 'application/zip' })]
+    stubFetch({ ok: false, status: 400, json: { error: 'not a pack' } })
+    const seam = await loadSeam()
+
+    expect(await seam.api.galleryImportBundle()).toEqual({ ok: false, error: 'not a pack' })
+  })
+
+  it('reports a reason when a 200 comes back with no meta', async () => {
+    const dom = installDomHarness()
+    dom.files = [new File(['zip'], 'pack.zip', { type: 'application/zip' })]
+    stubFetch({ json: {} })
+    const seam = await loadSeam()
+
+    expect(await seam.api.galleryImportBundle()).toMatchObject({ ok: false })
+  })
+
+  it('falls back to the status when the refusal body is not JSON', async () => {
+    const dom = installDomHarness()
+    dom.files = [new File(['zip'], 'pack.zip', { type: 'application/zip' })]
+    stubFetch({ ok: false, status: 413, jsonThrows: true })
+    const seam = await loadSeam()
+
+    expect(await seam.api.galleryImportBundle()).toEqual({
+      ok: false,
+      error: 'Import failed (413)',
+    })
+  })
+})
+
+describe('mochiApi sprite import', () => {
+  it("carries the file's REAL mime, not a hard-coded png", async () => {
+    const dom = installDomHarness()
+    // petdex ships WebP; hard-coding png left the decode to browser sniffing.
+    dom.files = [new File([new Uint8Array([1, 2, 3])], 'sheet.webp', { type: 'image/webp' })]
+    const seam = await loadSeam()
+
+    expect(await seam.api.importSpriteFile()).toEqual({
+      ok: true,
+      value: { content: 'AQID', mime: 'image/webp' },
+    })
+  })
+
+  it('resolves on cancel, because the importer awaits it', async () => {
+    const dom = installDomHarness()
+    dom.gesture = 'cancel'
+    const seam = await loadSeam()
+
+    expect(await seam.api.importSpriteFile()).toBeNull()
+  })
+
+  it('resolves null when the dialog closes with no file selected', async () => {
+    const dom = installDomHarness()
+    dom.files = []
+    const seam = await loadSeam()
+
+    expect(await seam.api.importSpriteFile()).toBeNull()
+  })
+
+  it('leaves no transient input behind in the document', async () => {
+    const dom = installDomHarness()
+    dom.files = [new File([new Uint8Array([1])], 'sheet.png', { type: 'image/png' })]
+    const seam = await loadSeam()
+
+    await seam.api.importSpriteFile()
+
+    expect(document.querySelectorAll('input[type="file"]')).toHaveLength(0)
+  })
+
+  it('settles once — a late cancel after a pick cannot re-resolve', async () => {
+    const dom = installDomHarness()
+    dom.files = [new File([new Uint8Array([9])], 'sheet.png', { type: 'image/png' })]
+    const seam = await loadSeam()
+
+    const first = await seam.api.importSpriteFile()
+    // The listeners outlive the promise, so the guard is what keeps a late
+    // dialog event from settling an already-settled import.
+    expect(() => dom.inputs[0].dispatchEvent(new Event('cancel'))).not.toThrow()
+    expect(first).toMatchObject({ ok: true })
+  })
+})
+
+// ── capture handshake ───────────────────────────────────────────────────────
+
+describe('mochiApi capture handshake', () => {
+  it('routes a request to the host and the PNG back to the chat panel', async () => {
+    const seam = await loadSeam()
+    const requests = vi.fn()
+    const delivered = vi.fn()
+    const stopHost = seam.onCaptureRequested(requests)
+    const stopPanel = seam.api.onCaptureDone(delivered)
+
+    // The flow is split because the seam is not a React tree: startCapture only
+    // RAISES the request; the snip host performs it and delivers the bytes.
+    seam.api.startCapture()
+    expect(requests).toHaveBeenCalledTimes(1)
+    seam.deliverCapture('iVBORw0=')
+    expect(delivered).toHaveBeenCalledWith('iVBORw0=')
+
+    stopHost()
+    stopPanel()
+    seam.api.startCapture()
+    seam.deliverCapture('second')
+    expect(requests).toHaveBeenCalledTimes(1)
+    expect(delivered).toHaveBeenCalledTimes(1)
+  })
+
+  it('delivers one capture to every subscriber', async () => {
+    const seam = await loadSeam()
+    const first = vi.fn()
+    const second = vi.fn()
+    seam.api.onCaptureDone(first)
+    seam.api.onCaptureDone(second)
+
+    seam.deliverCapture('png')
+
+    expect(first).toHaveBeenCalledWith('png')
+    expect(second).toHaveBeenCalledWith('png')
+  })
+})
+
+// ── reset ───────────────────────────────────────────────────────────────────
+
+describe('mochiApi reset', () => {
+  it('clears the chat slot BEFORE rewriting settings', async () => {
+    const order: string[] = []
+    panelCalls.deleteHistory.mockImplementationOnce(async () => {
+      order.push('history')
+    })
+    const { calls } = stubFetch({ json: { ok: true } })
+    const seam = await loadSeam()
+
+    await seam.api.resetMochi()
+
+    order.push(calls[0].url)
+    // History first: if it fails the user still has their settings, which is
+    // the recoverable half.
+    expect(order).toEqual(['history', '/api/apps/mochi/reset'])
+    expect(calls[0].init?.method).toBe('POST')
+  })
+
+  it('throws with the status when the reset route fails', async () => {
+    stubFetch({ ok: false, status: 503 })
+    const seam = await loadSeam()
+
+    await expect(seam.api.resetMochi()).rejects.toThrow('reset failed: 503')
+  })
+})
+
+// ── pack authoring ──────────────────────────────────────────────────────────
+
+describe('mochiApi pack authoring', () => {
+  it('saves per-slot content and returns the stored meta', async () => {
+    const { calls } = stubFetch({ json: { meta: { id: 'edited' } } })
+    const seam = await loadSeam()
+
+    const result = await seam.api.gallerySavePack({ id: 'edited', states: {} })
+
+    expect(calls[0].url).toBe('/api/apps/mochi/packs/content')
+    expect(bodyOf(calls[0])).toMatchObject({ id: 'edited' })
+    expect(result).toEqual({ ok: true, value: { id: 'edited' } })
+  })
+
+  it('reports a reason when the save is refused', async () => {
+    stubFetch({ ok: false, status: 409, json: { error: 'name taken' } })
+    const seam = await loadSeam()
+
+    expect(await seam.api.gallerySavePack({})).toEqual({ ok: false, error: 'name taken' })
+  })
+
+  it('falls back to the status when a save answers 200 with no meta', async () => {
+    stubFetch({ json: {} })
+    const seam = await loadSeam()
+
+    expect(await seam.api.gallerySavePack({})).toEqual({ ok: false, error: 'Save failed (200)' })
+  })
+
+  it('reports a thrown save error', async () => {
+    stubFetch('reject')
+    const seam = await loadSeam()
+
+    expect(await seam.api.gallerySavePack({})).toEqual({ ok: false, error: 'network down' })
+  })
+
+  it('falls back to the status when the refusal body is not JSON', async () => {
+    stubFetch({ ok: false, status: 507, jsonThrows: true })
+    const seam = await loadSeam()
+
+    expect(await seam.api.gallerySavePack({})).toEqual({ ok: false, error: 'Save failed (507)' })
+  })
+
+  it("reports a reason for the authoring paths a page cannot do at all", async () => {
+    const seam = await loadSeam()
+
+    // Absent would be a no-op button; the vendored window renders `error`.
+    expect(await seam.api.galleryImportFile()).toEqual({
+      ok: false,
+      error: 'Not available in this build',
+    })
+  })
+})
+
+describe('mochiApi colour maps and presets', () => {
+  it("persists one pack's colour map without clobbering the others", async () => {
+    getSettings.mockResolvedValueOnce({
+      ...storedSettings,
+      colorMaps: { other: { body: '#111' } },
+    })
+    const seam = await loadSeam()
+
+    await seam.api.gallerySetColorMap('p1', { body: '#fff' })
+
+    expect(updateSettings).toHaveBeenCalledWith({
+      colorMaps: { other: { body: '#111' }, p1: { body: '#fff' } },
+    })
+  })
+
+  it('still writes the one map when the current settings cannot be read', async () => {
+    getSettings.mockRejectedValueOnce(new Error('settings down'))
+    const seam = await loadSeam()
+
+    await seam.api.gallerySetColorMap('p1', { body: '#fff' })
+
+    expect(updateSettings).toHaveBeenCalledWith({ colorMaps: { p1: { body: '#fff' } } })
+  })
+
+  it('round-trips the custom cat presets', async () => {
+    getSettings.mockResolvedValueOnce({ ...storedSettings, customPresets: [{ id: 'dusk' }] })
+    const seam = await loadSeam()
+
+    expect(await seam.api.presetsLoadCustom()).toEqual([{ id: 'dusk' }])
+    await seam.api.presetsSaveCustom([{ id: 'dawn' }] as never)
+    expect(updateSettings).toHaveBeenCalledWith({ customPresets: [{ id: 'dawn' }] })
+  })
+
+  it('reports no presets when the settings read fails', async () => {
+    getSettings.mockRejectedValueOnce(new Error('settings down'))
+    const seam = await loadSeam()
+
+    expect(await seam.api.presetsLoadCustom()).toEqual([])
+  })
+})
+
+// ── quiet mode ──────────────────────────────────────────────────────────────
+
+describe('mochiApi quiet mode', () => {
+  it('reads the quiet expiry off the pet-state pull', async () => {
+    const { calls } = stubFetch({ json: { silentUntil: 1770000000000 } })
+    const seam = await loadSeam()
+
+    expect(await seam.api.getQuietUntil()).toBe(1770000000000)
+    expect(calls[0].url).toBe('/api/apps/mochi/pet-state')
+  })
+
+  it('treats a non-numeric expiry as not quiet', async () => {
+    stubFetch({ json: { silentUntil: 'soon' } })
+    const seam = await loadSeam()
+
+    expect(await seam.api.getQuietUntil()).toBe(0)
+  })
+
+  it('reports not quiet when the pet-state route fails', async () => {
+    stubFetch({ ok: false, status: 500 })
+    const seam = await loadSeam()
+
+    expect(await seam.api.getQuietUntil()).toBe(0)
+  })
+
+  it('reports not quiet when the pet-state read throws', async () => {
+    stubFetch('reject')
+    const seam = await loadSeam()
+
+    // A menu that cannot reach the gateway shows the normal item, not a throw.
+    expect(await seam.api.getQuietUntil()).toBe(0)
+  })
+
+  it('enters quiet mode by posting minutes and returns the new expiry', async () => {
+    const { calls } = stubFetch({ json: { silentUntil: 1770000060000 } })
+    const seam = await loadSeam()
+
+    expect(await seam.api.setQuiet(60)).toBe(1770000060000)
+    expect(calls[0].url).toBe('/api/apps/mochi/quiet')
+    expect(bodyOf(calls[0])).toEqual({ minutes: 60 })
+  })
+
+  it('leaves quiet mode by posting zero', async () => {
+    const { calls } = stubFetch({ json: { silentUntil: 0 } })
+    const seam = await loadSeam()
+
+    expect(await seam.api.setQuiet(0)).toBe(0)
+    expect(bodyOf(calls[0])).toEqual({ minutes: 0 })
+  })
+
+  it('reports not quiet when the write fails or throws', async () => {
+    stubFetch({ ok: false, status: 500 })
+    const failing = await loadSeam()
+    expect(await failing.api.setQuiet(60)).toBe(0)
+
+    stubFetch('reject')
+    const throwing = await loadSeam()
+    expect(await throwing.api.setQuiet(60)).toBe(0)
+  })
+
+  it('reports not quiet when the write answers with no expiry', async () => {
+    stubFetch({ json: {} })
+    const seam = await loadSeam()
+
+    expect(await seam.api.setQuiet(60)).toBe(0)
+  })
+})
+
+// ── pet context menu ────────────────────────────────────────────────────────
+
+describe('mochiApi context-menu dispatch', () => {
+  it('maps every menu id onto the bridge call behind it', async () => {
+    const seam = await loadSeam()
+
+    seam.api.contextMenuAction('chat')
+    seam.api.contextMenuAction('openChat')
+    expect(petCalls.openChat).toHaveBeenCalledTimes(2)
+
+    seam.api.contextMenuAction('avatars')
+    seam.api.contextMenuAction('gallery')
+    expect(petCalls.openAvatars).toHaveBeenCalledTimes(2)
+
+    seam.api.contextMenuAction('settings')
+    expect(petCalls.openSettings).toHaveBeenCalledTimes(1)
+    seam.api.contextMenuAction('memories')
+    expect(petCalls.openMemories).toHaveBeenCalledTimes(1)
+    seam.api.contextMenuAction('dashboard')
+    expect(panelCalls.openDashboard).toHaveBeenCalledTimes(1)
+  })
+
+  it('separates hide from disable — they are different user intents', async () => {
+    const seam = await loadSeam()
+
+    seam.api.contextMenuAction('hide')
+    expect(shell.hideAll).toHaveBeenCalledTimes(1)
+    expect(panelCalls.disableApp).not.toHaveBeenCalled()
+
+    seam.api.contextMenuAction('disable')
+    expect(panelCalls.disableApp).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores an unknown id instead of throwing', async () => {
+    const seam = await loadSeam()
+
+    // A menu entry that outlives its handler should be inert, not fatal.
+    expect(() => seam.api.contextMenuAction('no-such-action')).not.toThrow()
+  })
+
+  it('is inert for hide when there is no shell to hide into', async () => {
+    ;(window as unknown as { mochi?: unknown }).mochi = {}
+    const seam = await loadSeam()
+
+    expect(() => seam.api.contextMenuAction('hide')).not.toThrow()
+    expect(shell.hideAll).not.toHaveBeenCalled()
+  })
+})

--- a/website/src/test/MochiPanelBridgeCoverage.test.tsx
+++ b/website/src/test/MochiPanelBridgeCoverage.test.tsx
@@ -1,0 +1,1355 @@
+/**
+ * panelBridge — the Mochi panel's whole transport seam.
+ *
+ * Every ported component talks to the gateway through this module, so the
+ * behaviours worth pinning are the ones a component cannot see: which HTTP route
+ * and body a call produces, what a degraded response degrades TO (an empty list,
+ * a named error, a thrown refusal), and how one WebSocket frame fans out to the
+ * right subscriber set.
+ *
+ * The module is a singleton that opens its socket at import time and captures
+ * `window.mochi` once, so each test re-imports it through `loadBridge()` after
+ * the socket, `fetch` and the shell table are stubbed. `fetch` is answered from a
+ * per-test route table (matched on URL substring plus method, because GET and
+ * POST `/api/chat/slots` mean two different things), and frames are pushed
+ * through the captured socket rather than a real one — nothing here touches the
+ * network, a real timer or an animation frame.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+type Bridge = typeof import('../apps/mochi/panel/panelBridge')
+type ShellFn = (...args: unknown[]) => unknown
+type ShellTable = Record<string, ShellFn | undefined>
+
+/** `../apps/mochi/api` is the only collaborator module; the rest is raw fetch. */
+const api = vi.hoisted(() => ({
+  getWatchlist: vi.fn(async (): Promise<{ items: unknown[] }> => ({ items: [] })),
+  updateWatchlist: vi.fn(async (_p: unknown): Promise<{ ok: boolean }> => ({ ok: true })),
+  getPinned: vi.fn(async (): Promise<{ pins: unknown[] }> => ({ pins: [] })),
+  markPinnedSeen: vi.fn(async (_p: string): Promise<{ ok: boolean }> => ({ ok: true })),
+  unpinFile: vi.fn(async (_p: string): Promise<{ ok: boolean }> => ({ ok: true })),
+}))
+
+vi.mock('../apps/mochi/api', () => api)
+
+// ── fetch route table ───────────────────────────────────────────────────────
+
+interface Reply {
+  ok?: boolean
+  status?: number
+  body?: unknown
+  /** Response arrives but its body is not JSON. */
+  jsonThrows?: boolean
+  /** The request itself never completes. */
+  reject?: boolean
+}
+
+interface Route {
+  url: string
+  method?: string
+  reply: Reply
+}
+
+let routes: Route[] = []
+
+/** Register a reply; later registrations win, so a test can override a default. */
+function route(url: string, reply: Reply, method?: string): void {
+  routes.unshift({ url, method, reply })
+}
+
+const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+  const url = String(input)
+  const method = (init?.method ?? 'GET').toUpperCase()
+  const hit = routes.find(
+    (r) => url.includes(r.url) && (r.method === undefined || r.method === method),
+  )
+  const reply = hit?.reply ?? {}
+  if (reply.reject === true) throw new Error('network down')
+  const ok = reply.ok ?? true
+  return {
+    ok,
+    status: reply.status ?? (ok ? 200 : 500),
+    json: async () => {
+      if (reply.jsonThrows === true) throw new Error('not json')
+      return reply.body ?? {}
+    },
+  }
+})
+
+interface SeenCall {
+  url: string
+  init: RequestInit
+}
+
+/** Requests made to a route, in order. */
+function calls(url: string, method?: string): SeenCall[] {
+  return fetchMock.mock.calls
+    .map((c) => ({ url: String(c[0]), init: (c[1] ?? {}) as RequestInit }))
+    .filter((c) => c.url.includes(url))
+    .filter((c) => method === undefined || (c.init.method ?? 'GET').toUpperCase() === method)
+}
+
+function bodyOf(call: SeenCall): Record<string, unknown> {
+  return JSON.parse(String(call.init.body ?? '{}')) as Record<string, unknown>
+}
+
+// ── socket double ───────────────────────────────────────────────────────────
+
+class MockSocket {
+  static instances: MockSocket[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  send = vi.fn()
+  close = vi.fn(() => {
+    this.onclose?.()
+  })
+
+  constructor(public url: string) {
+    MockSocket.instances.push(this)
+  }
+}
+
+function socket(): MockSocket {
+  const last = MockSocket.instances[MockSocket.instances.length - 1]
+  if (last === undefined) throw new Error('no socket was opened')
+  return last
+}
+
+/** Push a raw gateway frame through the socket the bridge holds. */
+function emit(frame: unknown): void {
+  socket().onmessage?.({ data: JSON.stringify(frame) } as unknown as MessageEvent)
+}
+
+/** Push an app-scoped broadcast in the wire envelope the gateway namespaces it under. */
+function emitApp(event: string, payload: unknown): void {
+  emit({ type: 'app_event', data: { event, data: payload } })
+}
+
+// ── module loader ───────────────────────────────────────────────────────────
+
+async function loadBridge(shell?: ShellTable): Promise<Bridge> {
+  vi.resetModules()
+  MockSocket.instances.length = 0
+  const win = window as unknown as { mochi?: ShellTable }
+  if (shell === undefined) delete win.mochi
+  else win.mochi = shell
+  return await import('../apps/mochi/panel/panelBridge')
+}
+
+/** Let the module's own `void`-ed promises settle before asserting. */
+async function settle(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+beforeEach(() => {
+  routes = []
+  fetchMock.mockClear()
+  api.getWatchlist.mockClear()
+  api.updateWatchlist.mockClear()
+  api.getPinned.mockClear()
+  api.markPinnedSeen.mockClear()
+  api.unpinFile.mockClear()
+  api.getWatchlist.mockResolvedValue({ items: [] })
+  api.getPinned.mockResolvedValue({ pins: [] })
+  vi.stubGlobal('WebSocket', MockSocket)
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  const win = window as unknown as { mochi?: ShellTable }
+  delete win.mochi
+})
+
+// ── trust level ─────────────────────────────────────────────────────────────
+
+describe('panelBridge trust level is scoped to the pet slot', () => {
+  it('writes the level against the slot, never the global posture', async () => {
+    const bridge = await loadBridge()
+    await bridge.setMochiTrustLevel('trust_reads')
+    const [call] = calls('/api/chat/mode', 'POST')
+    expect(bodyOf(call)).toEqual({ mode: 'trust_reads', slot: bridge.MOCHI_SLOT })
+  })
+
+  it('reads the level off the BARE ARRAY the slots route returns', async () => {
+    route('/api/chat/slots', { body: [{ key: 'mochi', trust: true }] }, 'GET')
+    const bridge = await loadBridge()
+    expect(await bridge.getMochiTrustLevel()).toBe('trust')
+  })
+
+  it('still reads a `slots`-wrapped payload', async () => {
+    route('/api/chat/slots', { body: { slots: [{ key: 'mochi', trust_reads: true }] } }, 'GET')
+    const bridge = await loadBridge()
+    expect(await bridge.getMochiTrustLevel()).toBe('trust_reads')
+  })
+
+  it('reports yolo from the slot mode', async () => {
+    route('/api/chat/slots', { body: [{ key: 'mochi', mode: 'yolo', trust: true }] }, 'GET')
+    const bridge = await loadBridge()
+    expect(await bridge.getMochiTrustLevel()).toBe('yolo')
+  })
+
+  it('is normal when the slot carries no trust flags', async () => {
+    route('/api/chat/slots', { body: [{ key: 'mochi' }] }, 'GET')
+    const bridge = await loadBridge()
+    expect(await bridge.getMochiTrustLevel()).toBe('normal')
+  })
+
+  it('is normal when our slot is absent, the read fails, or the fetch throws', async () => {
+    route('/api/chat/slots', { body: [{ key: 'other', trust: true }] }, 'GET')
+    let bridge = await loadBridge()
+    expect(await bridge.getMochiTrustLevel()).toBe('normal')
+
+    route('/api/chat/slots', { ok: false, status: 500 }, 'GET')
+    bridge = await loadBridge()
+    expect(await bridge.getMochiTrustLevel()).toBe('normal')
+
+    route('/api/chat/slots', { reject: true }, 'GET')
+    bridge = await loadBridge()
+    expect(await bridge.getMochiTrustLevel()).toBe('normal')
+  })
+})
+
+describe('panelBridge stat reporting', () => {
+  it('posts the countable kind and cannot reject', async () => {
+    route('/api/apps/mochi/stat', { reject: true })
+    const bridge = await loadBridge()
+    expect(() => bridge.reportStat('screenshot')).not.toThrow()
+    await settle()
+    expect(bodyOf(calls('/api/apps/mochi/stat')[0])).toEqual({ kind: 'screenshot' })
+  })
+
+  it('a dropped pet-event report cannot fail the turn it describes', async () => {
+    route('/pet-event', { reject: true })
+    const bridge = await loadBridge()
+    let done = 0
+    bridge.onChatDone(() => { done += 1 })
+    emit({ type: 'chat_done', data: { slot: 'mochi' } })
+    await settle()
+    expect(done).toBe(1)
+  })
+})
+
+// ── watchlist ───────────────────────────────────────────────────────────────
+
+describe('panelBridge watchlist subscription', () => {
+  it('delivers a first value immediately instead of after one poll interval', async () => {
+    api.getWatchlist.mockResolvedValue({ items: [{ id: 'w1' }] })
+    const bridge = await loadBridge()
+    const seen: unknown[][] = []
+    const off = bridge.onWatchlistChanged((items) => seen.push(items))
+    await settle()
+    off()
+    expect(seen).toEqual([[{ id: 'w1' }]])
+  })
+
+  it('delivers the pushed items directly, without a second fetch', async () => {
+    const bridge = await loadBridge()
+    const seen: unknown[][] = []
+    const off = bridge.onWatchlistChanged((items) => seen.push(items))
+    await settle()
+    const before = api.getWatchlist.mock.calls.length
+    emitApp('mochi:watchlist-changed', { items: [{ id: 'pushed' }] })
+    off()
+    expect(seen[seen.length - 1]).toEqual([{ id: 'pushed' }])
+    expect(api.getWatchlist.mock.calls.length).toBe(before)
+  })
+
+  it('skips an identical publish so the panel does not re-render mid-animation', async () => {
+    const bridge = await loadBridge()
+    const seen: unknown[][] = []
+    const off = bridge.onWatchlistChanged((items) => seen.push(items))
+    await settle()
+    emitApp('mochi:watchlist-changed', { items: [{ id: 'same' }] })
+    emitApp('mochi:watchlist-changed', { items: [{ id: 'same' }] })
+    off()
+    expect(seen.filter((s) => JSON.stringify(s) === JSON.stringify([{ id: 'same' }]))).toHaveLength(1)
+  })
+
+  it('falls back to a fetch when the publish carries no items', async () => {
+    const bridge = await loadBridge()
+    const off = bridge.onWatchlistChanged(() => undefined)
+    await settle()
+    const before = api.getWatchlist.mock.calls.length
+    api.getWatchlist.mockResolvedValue({ items: [{ id: 'refetched' }] })
+    emitApp('mochi:watchlist-changed', {})
+    await settle()
+    off()
+    expect(api.getWatchlist.mock.calls.length).toBeGreaterThan(before)
+  })
+
+  it('a transient fetch failure keeps the last state instead of throwing', async () => {
+    api.getWatchlist.mockRejectedValue(new Error('offline'))
+    const bridge = await loadBridge()
+    const seen: unknown[][] = []
+    const off = bridge.onWatchlistChanged((items) => seen.push(items))
+    await settle()
+    off()
+    expect(seen).toEqual([])
+  })
+
+  it('stops delivering once unsubscribed', async () => {
+    const bridge = await loadBridge()
+    const seen: unknown[][] = []
+    const off = bridge.onWatchlistChanged((items) => seen.push(items))
+    await settle()
+    off()
+    emitApp('mochi:watchlist-changed', { items: [{ id: 'after' }] })
+    expect(seen.some((s) => JSON.stringify(s).includes('after'))).toBe(false)
+  })
+
+  it('exposes the raw list for a one-shot read', async () => {
+    api.getWatchlist.mockResolvedValue({ items: [{ id: 'a' }, { id: 'b' }] })
+    const bridge = await loadBridge()
+    expect(await bridge.getWatchlistItems()).toHaveLength(2)
+  })
+})
+
+describe('panelBridge watchlist writes', () => {
+  it('a status change is an update, and a delete is a removal', async () => {
+    const bridge = await loadBridge()
+    await bridge.setWatchItemStatus('w1', 'cancelled')
+    expect(api.updateWatchlist).toHaveBeenCalledWith({ update: [{ id: 'w1', status: 'cancelled' }] })
+
+    await bridge.deleteWatchItem('w1')
+    expect(api.updateWatchlist).toHaveBeenCalledWith({ remove: ['w1'] })
+    await settle()
+  })
+
+  it('an arbitrary field patch merges into the item update', async () => {
+    const bridge = await loadBridge()
+    await bridge.updateWatchItem('w2', { label: 'renamed', intervalMins: 30 })
+    expect(api.updateWatchlist).toHaveBeenCalledWith({
+      update: [{ id: 'w2', label: 'renamed', intervalMins: 30 }],
+    })
+    await settle()
+  })
+
+  it('clear-completed reports whether the SERVER agreed', async () => {
+    const bridge = await loadBridge()
+    expect(await bridge.clearCompletedWatchItems()).toBe(true)
+
+    route('/watchlist/clear-completed', { ok: false, status: 409 })
+    expect(await bridge.clearCompletedWatchItems()).toBe(false)
+
+    route('/watchlist/clear-completed', { reject: true })
+    expect(await bridge.clearCompletedWatchItems()).toBe(false)
+    await settle()
+  })
+})
+
+// ── pinned files ────────────────────────────────────────────────────────────
+
+describe('panelBridge pinned files', () => {
+  it('reads, marks seen and unpins through the shared api module', async () => {
+    api.getPinned.mockResolvedValue({ pins: [{ path: '/u/a.md' }] })
+    const bridge = await loadBridge()
+    expect(await bridge.getPinnedFiles()).toHaveLength(1)
+    await bridge.markPinnedSeen('/u/a.md')
+    expect(api.markPinnedSeen).toHaveBeenCalledWith('/u/a.md')
+    await bridge.unpinFile('/u/a.md')
+    expect(api.unpinFile).toHaveBeenCalledWith('/u/a.md')
+  })
+
+  it('preview reveals through the shell, and sleeps without one', async () => {
+    const revealFile = vi.fn()
+    let bridge = await loadBridge({ revealFile })
+    bridge.previewFile('/u/a.md')
+    expect(revealFile).toHaveBeenCalledWith('/u/a.md')
+
+    bridge = await loadBridge()
+    expect(() => bridge.previewFile('/u/a.md')).not.toThrow()
+  })
+})
+
+// ── chat frame shaping ──────────────────────────────────────────────────────
+
+describe('panelBridge renderable-role filter', () => {
+  it('admits only the three roles the panel can draw', async () => {
+    const bridge = await loadBridge()
+    expect(bridge.isRenderableChatRole('user')).toBe(true)
+    expect(bridge.isRenderableChatRole('assistant')).toBe(true)
+    expect(bridge.isRenderableChatRole('error')).toBe(true)
+    expect(bridge.isRenderableChatRole('tool')).toBe(false)
+    expect(bridge.isRenderableChatRole('permission')).toBe(false)
+    expect(bridge.isRenderableChatRole(undefined)).toBe(false)
+  })
+})
+
+describe('panelBridge rebuilds an approval from a permission frame', () => {
+  it('carries the id, title, input, scoped commands and declared purpose', async () => {
+    const bridge = await loadBridge()
+    const req = bridge.permissionApprovalFromFrame({
+      content: 'fallback title',
+      cls: JSON.stringify({
+        request_id: 'req-1',
+        tool_title: 'Run command',
+        tool_input: JSON.stringify({ command: 'ls', __tool_use_purpose: 'list the directory' }),
+        full_command: 'ls -la /tmp',
+        base_command: 'ls',
+      }),
+    })
+    expect(req).toEqual({
+      id: 'req-1',
+      tool: 'Run command',
+      toolInput: JSON.stringify({ command: 'ls', __tool_use_purpose: 'list the directory' }),
+      purpose: 'list the directory',
+      fullCommand: 'ls -la /tmp',
+      baseCommand: 'ls',
+    })
+  })
+
+  it('falls back to the frame content when the meta names no tool title', async () => {
+    const bridge = await loadBridge()
+    const req = bridge.permissionApprovalFromFrame({
+      content: 'execute_bash',
+      cls: JSON.stringify({ request_id: 'req-2', tool_input: 'not json at all' }),
+    })
+    expect(req?.tool).toBe('execute_bash')
+    expect(req?.toolInput).toBe('not json at all')
+    // A bare shell string declares no purpose, so none is invented.
+    expect(req?.purpose).toBeUndefined()
+  })
+
+  it('returns null for unparseable, shapeless, id-less and already-resolved meta', async () => {
+    const bridge = await loadBridge()
+    expect(bridge.permissionApprovalFromFrame({ cls: '{not json' })).toBeNull()
+    expect(bridge.permissionApprovalFromFrame({ cls: '"a string"' })).toBeNull()
+    expect(bridge.permissionApprovalFromFrame({ cls: JSON.stringify({ tool_title: 't' }) })).toBeNull()
+    expect(bridge.permissionApprovalFromFrame({ cls: JSON.stringify({ request_id: '' }) })).toBeNull()
+    expect(
+      bridge.permissionApprovalFromFrame({
+        cls: JSON.stringify({ request_id: 'req-3', resolved: true }),
+      }),
+    ).toBeNull()
+  })
+})
+
+// ── WebSocket dispatcher ────────────────────────────────────────────────────
+
+describe('panelBridge WebSocket dispatcher', () => {
+  it('opens the socket against the same origin as the page', async () => {
+    await loadBridge()
+    expect(socket().url).toBe(`ws://${location.host}/api/ws`)
+  })
+
+  it('ignores a frame that is not JSON', async () => {
+    const bridge = await loadBridge()
+    const seen: string[] = []
+    bridge.onChatChunk((c) => seen.push(c))
+    socket().onmessage?.({ data: 'not json' } as unknown as MessageEvent)
+    expect(seen).toEqual([])
+  })
+
+  it('fans out the global slots list', async () => {
+    const bridge = await loadBridge()
+    const seen: unknown[][] = []
+    bridge.onSlotsUpdate((slots) => seen.push(slots))
+    emit({ type: 'slots', data: { slots: [{ key: 'mochi' }] } })
+    emit({ type: 'slots', data: {} })
+    expect(seen).toEqual([[{ key: 'mochi' }], []])
+  })
+
+  it('re-arms the agent binding when a slots frame shows our slot is gone', async () => {
+    route('/api/chat/slots', { body: { agent: 'mochi' } }, 'POST')
+    const bridge = await loadBridge()
+    await bridge.sendMessage('one')
+    await bridge.sendMessage('two')
+    // Idempotent: the second send reuses the bind.
+    expect(calls('/api/chat/slots', 'POST')).toHaveLength(1)
+
+    emit({ type: 'slots', data: { slots: [{ key: 'other' }] } })
+    await bridge.sendMessage('three')
+    expect(calls('/api/chat/slots', 'POST')).toHaveLength(2)
+  })
+
+  it('routes pet state and mood, which carry no slot', async () => {
+    const bridge = await loadBridge()
+    const states: string[] = []
+    const moods: Array<[string, number]> = []
+    bridge.onStateChange((s) => states.push(s))
+    bridge.onMood((m, intensity) => moods.push([m, intensity]))
+    emitApp('pet:state-change', { args: ['working'] })
+    emitApp('mochi:mood', { args: ['happy', 0.5] })
+    emitApp('mochi:mood', { args: ['sad'] })
+    expect(states).toEqual(['working'])
+    // Intensity is optional upstream; an unreported one reads as "as reported".
+    expect(moods).toEqual([['happy', 0.5], ['sad', 1]])
+  })
+
+  it('delivers an approval for our slot only, and reports the pet transition', async () => {
+    const bridge = await loadBridge()
+    const seen: Record<string, unknown>[] = []
+    bridge.onApprovalRequest((req) => seen.push(req))
+    emit({ type: 'approval', data: { slot: 'other', id: 'x' } })
+    emit({ type: 'approval', data: { slot: 'mochi', id: 'req-9' } })
+    await settle()
+    expect(seen).toHaveLength(1)
+    expect(seen[0].id).toBe('req-9')
+    expect(calls('/pet-event').map((c) => bodyOf(c).event)).toContain('approval_required')
+  })
+
+  it('learns about a resolution made on another surface', async () => {
+    const bridge = await loadBridge()
+    const seen: Record<string, unknown>[] = []
+    bridge.onApprovalResolvedExternal((r) => seen.push(r))
+    emit({ type: 'approval_resolved', data: { id: 'req-9', approved: true } })
+    emit({ type: 'approval_resolved', data: { id: 'req-8', approved: false } })
+    await settle()
+    expect(seen.map((r) => r.id)).toEqual(['req-9', 'req-8'])
+    const events = calls('/pet-event').map((c) => bodyOf(c).event)
+    expect(events).toContain('approval_granted')
+    expect(events).toContain('approval_rejected')
+  })
+
+  it('streams chunks and completes the turn', async () => {
+    const bridge = await loadBridge()
+    const chunks: string[] = []
+    let done = 0
+    bridge.onChatChunk((c) => chunks.push(c))
+    bridge.onChatDone(() => { done += 1 })
+    emit({ type: 'chat_chunk', data: { slot: 'mochi', content: 'hel' } })
+    emit({ type: 'chat_chunk', data: { slot: 'mochi' } })
+    emit({ type: 'chat_done', data: { slot: 'mochi' } })
+    await settle()
+    expect(chunks).toEqual(['hel', ''])
+    expect(done).toBe(1)
+    expect(calls('/pet-event').map((c) => bodyOf(c).event)).toContain('task_complete')
+  })
+
+  it('drops every frame belonging to another slot', async () => {
+    const bridge = await loadBridge()
+    const chunks: string[] = []
+    bridge.onChatChunk((c) => chunks.push(c))
+    emit({ type: 'chat_chunk', data: { slot: 'dashboard', content: 'not ours' } })
+    expect(chunks).toEqual([])
+  })
+
+  it('reports context usage as a number', async () => {
+    const bridge = await loadBridge()
+    const pcts: number[] = []
+    bridge.onContextUsage((p) => pcts.push(p))
+    emit({ type: 'context_usage', data: { slot: 'mochi', pct: 42 } })
+    emit({ type: 'context_usage', data: { slot: 'mochi' } })
+    expect(pcts).toEqual([42, 0])
+  })
+
+  it('gives every chat message the id and timestamp the renderer reads unguarded', async () => {
+    const bridge = await loadBridge()
+    const seen: Record<string, unknown>[] = []
+    bridge.onChatMessage((m) => seen.push(m))
+    emit({ type: 'chat_message', data: { slot: 'mochi', role: 'assistant' } })
+    emit({
+      type: 'chat_message',
+      data: { slot: 'mochi', role: 'user', id: 'given', content: 'hi', timestamp: 5 },
+    })
+    expect(String(seen[0].id).startsWith('assistant-')).toBe(true)
+    expect(seen[0].content).toBe('')
+    expect(typeof seen[0].timestamp).toBe('number')
+    expect(seen[1]).toMatchObject({ id: 'given', content: 'hi', timestamp: 5 })
+  })
+
+  it('turns tool and error frames into pet transitions without rendering them', async () => {
+    const bridge = await loadBridge()
+    const seen: Record<string, unknown>[] = []
+    bridge.onChatMessage((m) => seen.push(m))
+    emit({ type: 'chat_message', data: { slot: 'mochi', role: 'tool', content: 'ls' } })
+    emit({ type: 'chat_message', data: { slot: 'mochi', role: 'system', content: 'noise' } })
+    await settle()
+    const events = calls('/pet-event').map((c) => bodyOf(c).event)
+    expect(events).toContain('tool_call')
+    expect(seen).toHaveLength(0)
+  })
+
+  it('renders an error frame, because the panel has no other failure surface', async () => {
+    const bridge = await loadBridge()
+    const seen: Record<string, unknown>[] = []
+    bridge.onChatMessage((m) => seen.push(m))
+    emit({ type: 'chat_message', data: { slot: 'mochi', role: 'error', content: 'turn failed' } })
+    await settle()
+    expect(seen).toHaveLength(1)
+    expect(calls('/pet-event').map((c) => bodyOf(c).event)).toContain('error')
+  })
+
+  it('turns a permission frame into the same approval card as an approval frame', async () => {
+    const bridge = await loadBridge()
+    const approvals: Record<string, unknown>[] = []
+    const messages: Record<string, unknown>[] = []
+    bridge.onApprovalRequest((r) => approvals.push(r))
+    bridge.onChatMessage((m) => messages.push(m))
+    emit({
+      type: 'chat_message',
+      data: {
+        slot: 'mochi',
+        role: 'permission',
+        content: 'execute_bash',
+        cls: JSON.stringify({ request_id: 'req-p', tool_title: 'Run command' }),
+      },
+    })
+    // A permission frame with no usable meta must open no card at all.
+    emit({
+      type: 'chat_message',
+      data: { slot: 'mochi', role: 'permission', content: 'x', cls: 'garbage' },
+    })
+    await settle()
+    expect(approvals.map((r) => r.id)).toEqual(['req-p'])
+    expect(messages).toHaveLength(0)
+  })
+
+  it('unsubscribing detaches every chat, turn and approval listener', async () => {
+    const bridge = await loadBridge()
+    const seen: string[] = []
+    bridge.onChatChunk(() => seen.push('chunk'))()
+    bridge.onChatMessage(() => seen.push('message'))()
+    bridge.onChatDone(() => seen.push('done'))()
+    bridge.onContextUsage(() => seen.push('context'))()
+    bridge.onSlotsUpdate(() => seen.push('slots'))()
+    bridge.onStateChange(() => seen.push('state'))()
+    bridge.onMood(() => seen.push('mood'))()
+    bridge.onApprovalRequest(() => seen.push('approval'))()
+    bridge.onApprovalResolvedExternal(() => seen.push('resolved'))()
+    emit({ type: 'chat_chunk', data: { slot: 'mochi', content: 'x' } })
+    emit({ type: 'chat_message', data: { slot: 'mochi', role: 'assistant', content: 'x' } })
+    emit({ type: 'chat_done', data: { slot: 'mochi' } })
+    emit({ type: 'context_usage', data: { slot: 'mochi', pct: 1 } })
+    emit({ type: 'slots', data: { slots: [{ key: 'mochi' }] } })
+    emitApp('pet:state-change', { args: ['idle'] })
+    emitApp('mochi:mood', { args: ['happy'] })
+    emit({ type: 'approval', data: { slot: 'mochi', id: 'r' } })
+    emit({ type: 'approval_resolved', data: { id: 'r', approved: true } })
+    await settle()
+    expect(seen).toEqual([])
+  })
+})
+
+// ── connection status ───────────────────────────────────────────────────────
+
+describe('panelBridge connection indicator tracks the socket', () => {
+  it('is offline until the socket opens, and fires only on a transition', async () => {
+    const bridge = await loadBridge()
+    const seen: boolean[] = []
+    const off = bridge.onBackendStatus((online) => seen.push(online))
+    expect(await bridge.getBackendStatus()).toBe(false)
+    socket().onopen?.()
+    socket().onopen?.()
+    expect(seen).toEqual([true])
+    expect(await bridge.getBackendStatus()).toBe(true)
+    off()
+    socket().onclose?.()
+    expect(seen).toEqual([true])
+  })
+
+  it('reconnects with a capped backoff after the socket drops', async () => {
+    vi.useFakeTimers()
+    try {
+      const bridge = await loadBridge()
+      bridge.onChatDone(() => undefined)
+      socket().onopen?.()
+      const first = MockSocket.instances.length
+      socket().onclose?.()
+      expect(await bridge.getBackendStatus()).toBe(false)
+      vi.advanceTimersByTime(1000)
+      expect(MockSocket.instances.length).toBe(first + 1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('an error closes the socket rather than leaving it half-dead', async () => {
+    vi.useFakeTimers()
+    try {
+      await loadBridge()
+      const ws = socket()
+      ws.onerror?.()
+      expect(ws.close).toHaveBeenCalled()
+      vi.clearAllTimers()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('a manual retry cancels the pending backoff and reopens now', async () => {
+    vi.useFakeTimers()
+    try {
+      const bridge = await loadBridge()
+      socket().onclose?.()
+      const afterClose = MockSocket.instances.length
+      const result = await bridge.retryConnect()
+      expect(result).toEqual({ ok: true })
+      expect(MockSocket.instances.length).toBe(afterClose + 1)
+      // The cancelled timer must not open a second socket later.
+      vi.advanceTimersByTime(60_000)
+      expect(MockSocket.instances.length).toBe(afterClose + 1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('a retry on a live socket is a no-op', async () => {
+    const bridge = await loadBridge()
+    const before = MockSocket.instances.length
+    expect(await bridge.retryConnect()).toEqual({ ok: true })
+    expect(MockSocket.instances.length).toBe(before)
+  })
+})
+
+// ── send + slot binding ─────────────────────────────────────────────────────
+
+describe('panelBridge send', () => {
+  it('echoes the user message locally, because core does not echo it back', async () => {
+    route('/api/chat/slots', { body: { agent: 'mochi' } }, 'POST')
+    const bridge = await loadBridge()
+    const seen: Record<string, unknown>[] = []
+    bridge.onChatMessage((m) => seen.push(m))
+    await bridge.sendMessage('hello there', 'data:image/png;base64,AAA')
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toMatchObject({
+      role: 'user',
+      content: 'hello there',
+      screenshot: 'data:image/png;base64,AAA',
+    })
+    const body = bodyOf(calls('/api/chat?ws=1', 'POST')[0])
+    expect(body).toMatchObject({
+      message: 'hello there',
+      slot: 'mochi',
+      meta: { screenshot: 'data:image/png;base64,AAA' },
+    })
+  })
+
+  it('sends without a meta block when there is no screenshot', async () => {
+    route('/api/chat/slots', { body: { agent: 'mochi' } }, 'POST')
+    const bridge = await loadBridge()
+    await bridge.sendMessage('plain')
+    expect(bodyOf(calls('/api/chat?ws=1', 'POST')[0]).meta).toBeUndefined()
+  })
+
+  it('refuses to send into a slot another agent owns', async () => {
+    route('/api/chat/slots', { body: { agent: 'someone-else' } }, 'POST')
+    const bridge = await loadBridge()
+    await expect(bridge.ensureSlot()).rejects.toThrow(/bound to another agent/)
+    expect(calls('/api/chat?ws=1', 'POST')).toHaveLength(0)
+  })
+
+  it('refuses when the binding cannot be verified at all', async () => {
+    route('/api/chat/slots', { jsonThrows: true }, 'POST')
+    const bridge = await loadBridge()
+    await expect(bridge.ensureSlot()).rejects.toThrow(/could not verify/)
+  })
+
+  it('leaves the latch off when the bind request fails, so the next send retries', async () => {
+    route('/api/chat/slots', { ok: false, status: 503 }, 'POST')
+    const bridge = await loadBridge()
+    await bridge.ensureSlot()
+    await bridge.ensureSlot()
+    expect(calls('/api/chat/slots', 'POST')).toHaveLength(2)
+  })
+
+  it('stops a running turn on the slot', async () => {
+    const bridge = await loadBridge()
+    await bridge.stopGeneration()
+    expect(calls('/api/chat/slots/mochi/stop', 'POST')).toHaveLength(1)
+  })
+
+  it('disabling the app is the honest stand-in for quitting', async () => {
+    const bridge = await loadBridge()
+    await bridge.disableApp()
+    expect(calls('/api/apps/mochi/disable', 'POST')).toHaveLength(1)
+  })
+})
+
+// ── history and sessions ────────────────────────────────────────────────────
+
+describe('panelBridge history', () => {
+  it('filters persisted tool and system rows out of the backfill', async () => {
+    route('/api/chat/slots/mochi', {
+      body: {
+        messages: [
+          { role: 'user', content: 'hi' },
+          { role: 'tool', content: 'ls' },
+          { role: 'assistant', content: 'hello' },
+        ],
+      },
+    })
+    const bridge = await loadBridge()
+    const history = await bridge.getChatHistory()
+    expect(history.map((m) => m.role)).toEqual(['user', 'assistant'])
+  })
+
+  it('is empty for a slot that does not exist yet, a shapeless body, or a failed read', async () => {
+    route('/api/chat/slots/mochi', { ok: false, status: 404 })
+    let bridge = await loadBridge()
+    expect(await bridge.getChatHistory()).toEqual([])
+
+    route('/api/chat/slots/mochi', { body: { messages: 'nope' } })
+    bridge = await loadBridge()
+    expect(await bridge.getChatHistory()).toEqual([])
+
+    route('/api/chat/slots/mochi', { reject: true })
+    bridge = await loadBridge()
+    expect(await bridge.getChatHistory()).toEqual([])
+  })
+
+  it('a new session deletes the slot and disarms the binding latch itself', async () => {
+    route('/api/chat/slots', { body: { agent: 'mochi' } }, 'POST')
+    const bridge = await loadBridge()
+    await bridge.sendMessage('first')
+    expect(calls('/api/chat/slots', 'POST')).toHaveLength(1)
+
+    await bridge.newSession()
+    expect(calls('/api/chat/slots/mochi', 'DELETE')).toHaveLength(1)
+
+    // Without the self-disarm a socket-less panel would recreate the slot on the
+    // default agent instead of the pet's own.
+    await bridge.sendMessage('second')
+    expect(calls('/api/chat/slots', 'POST')).toHaveLength(2)
+  })
+
+  it('an already-absent slot is a successful reset, but a real failure throws', async () => {
+    route('/api/chat/slots/mochi', { ok: false, status: 404 }, 'DELETE')
+    let bridge = await loadBridge()
+    await expect(bridge.newSession()).resolves.toBeUndefined()
+
+    route('/api/chat/slots/mochi', { ok: false, status: 500 }, 'DELETE')
+    bridge = await loadBridge()
+    await expect(bridge.clearChat()).rejects.toThrow(/newSession failed: 500/)
+  })
+
+  it('deleting history erases the session rather than archiving the slot', async () => {
+    const bridge = await loadBridge()
+    await bridge.deleteHistory()
+    const [call] = calls('/api/sessions/', 'DELETE')
+    expect(call.url).toBe(`/api/sessions/${encodeURIComponent('dashboard:mochi')}`)
+
+    route('/api/sessions/', { ok: false, status: 500 }, 'DELETE')
+    const again = await loadBridge()
+    await expect(again.deleteHistory()).rejects.toThrow(/deleteHistory failed: 500/)
+  })
+})
+
+// ── pet state read ──────────────────────────────────────────────────────────
+
+describe('panelBridge pet state read', () => {
+  it('returns both the state and the mood the route reports', async () => {
+    route('/pet-state', { body: { state: 'working', mood: 'excited' } })
+    const bridge = await loadBridge()
+    expect(await bridge.getPetStateInfo()).toEqual({ state: 'working', mood: 'excited' })
+    expect(await bridge.getPetState()).toBe('working')
+  })
+
+  it('degrades to the cold-start values instead of throwing', async () => {
+    route('/pet-state', { body: { state: 'idle', mood: '' } })
+    let bridge = await loadBridge()
+    expect(await bridge.getPetStateInfo()).toEqual({ state: 'idle', mood: 'neutral' })
+
+    route('/pet-state', { ok: false, status: 500 })
+    bridge = await loadBridge()
+    expect(await bridge.getPetStateInfo()).toEqual({ state: 'offline', mood: 'neutral' })
+
+    route('/pet-state', { reject: true })
+    bridge = await loadBridge()
+    expect(await bridge.getPetState()).toBe('offline')
+  })
+})
+
+// ── shell bridge ────────────────────────────────────────────────────────────
+
+describe('panelBridge shell actions', () => {
+  it('forwards each window action to the shell', async () => {
+    const shell: ShellTable = {
+      openAvatars: vi.fn(),
+      openDashboard: vi.fn(),
+      closeChat: vi.fn(),
+      revealFile: vi.fn(),
+      openExternal: vi.fn(),
+      openImage: vi.fn(),
+    }
+    const bridge = await loadBridge(shell)
+    bridge.openAvatars()
+    bridge.openDashboard()
+    bridge.closeChat()
+    bridge.revealFile('/u/a.md')
+    bridge.openExternal('https://example.com')
+    bridge.openLightbox('/u/shot.png')
+    expect(shell.openAvatars).toHaveBeenCalled()
+    expect(shell.openDashboard).toHaveBeenCalled()
+    expect(shell.closeChat).toHaveBeenCalled()
+    expect(shell.revealFile).toHaveBeenCalledWith('/u/a.md')
+    expect(shell.openExternal).toHaveBeenCalledWith('https://example.com')
+    expect(shell.openImage).toHaveBeenCalledWith('/u/shot.png')
+  })
+
+  it('the lightbox refuses an empty target and a data URL, which the viewer cannot open', async () => {
+    const openImage = vi.fn()
+    const bridge = await loadBridge({ openImage })
+    bridge.openLightbox('')
+    bridge.openLightbox('data:image/png;base64,AAA')
+    expect(openImage).not.toHaveBeenCalled()
+  })
+
+  it('every shell action degrades to a no-op in the browser preview', async () => {
+    const bridge = await loadBridge()
+    expect(() => {
+      bridge.openAvatars()
+      bridge.openDashboard()
+      bridge.closeChat()
+      bridge.revealFile('/u/a.md')
+      bridge.openExternal('https://example.com')
+      bridge.openLightbox('/u/shot.png')
+    }).not.toThrow()
+  })
+
+  it('a pet menu subscription hands back the shell unsubscribe', async () => {
+    const off = vi.fn()
+    const shell: ShellTable = {
+      onOpenMemories: vi.fn(() => off),
+      onClearScreen: vi.fn(() => off),
+      // A shell that returns nothing must still leave the caller an `off()`.
+      onDeleteHistory: vi.fn(() => undefined),
+    }
+    const bridge = await loadBridge(shell)
+    bridge.onOpenMemories(() => undefined)()
+    bridge.onClearScreen(() => undefined)()
+    expect(off).toHaveBeenCalledTimes(2)
+    expect(() => bridge.onDeleteHistory(() => undefined)()).not.toThrow()
+  })
+
+  it('a pet menu subscription without a shell is inert', async () => {
+    const bridge = await loadBridge()
+    expect(() => bridge.onOpenMemories(() => undefined)()).not.toThrow()
+  })
+})
+
+// ── appearance packs ────────────────────────────────────────────────────────
+
+describe('panelBridge appearance packs', () => {
+  it('lists packs, and reads an empty list rather than crashing on a bad body', async () => {
+    route('/api/apps/mochi/packs', { body: { packs: [{ id: 'p1' }] } }, 'GET')
+    let bridge = await loadBridge()
+    expect(await bridge.galleryListPacks()).toHaveLength(1)
+
+    route('/api/apps/mochi/packs', { body: {} }, 'GET')
+    bridge = await loadBridge()
+    expect(await bridge.galleryListPacks()).toEqual([])
+
+    route('/api/apps/mochi/packs', { ok: false, status: 500 }, 'GET')
+    bridge = await loadBridge()
+    expect(await bridge.galleryListPacks()).toEqual([])
+  })
+
+  it('reads one pack manifest, and null when it is gone', async () => {
+    route('/api/apps/mochi/packs/p%201', { body: { id: 'p 1', frames: {} } })
+    const bridge = await loadBridge()
+    expect(await bridge.galleryGetPackDetail('p 1')).toMatchObject({ id: 'p 1' })
+
+    route('/api/apps/mochi/packs/', { ok: false, status: 404 })
+    const missing = await loadBridge()
+    expect(await missing.galleryGetPackDetail('nope')).toBeNull()
+  })
+
+  it('builds a directly usable image URL, encoding both segments', async () => {
+    const bridge = await loadBridge()
+    expect(bridge.galleryPackFileUrl('my pack', 'a b.png')).toBe(
+      '/api/apps/mochi/packs/my%20pack/file/a%20b.png',
+    )
+  })
+
+  it('surfaces a failed save instead of letting the user believe it stored', async () => {
+    route('/api/apps/mochi/packs', { body: { packId: 'saved' } }, 'POST')
+    let bridge = await loadBridge()
+    expect(await bridge.gallerySaveSpritePack({ name: 'p' })).toEqual({ ok: true, packId: 'saved' })
+
+    route('/api/apps/mochi/packs', { ok: false, status: 422, body: { error: 'bad frames' } }, 'POST')
+    bridge = await loadBridge()
+    expect(await bridge.gallerySaveSpritePack({})).toEqual({ ok: false, error: 'bad frames' })
+
+    route('/api/apps/mochi/packs', { ok: false, status: 500, jsonThrows: true }, 'POST')
+    bridge = await loadBridge()
+    expect(await bridge.gallerySaveSpritePack({})).toEqual({ ok: false, error: 'save failed (500)' })
+  })
+
+  it('an apply confirms itself by reading the persisted value back', async () => {
+    route('/api/apps/mochi/settings', { body: { activeAppearance: 'p1' } }, 'POST')
+    const bridge = await loadBridge()
+    await expect(bridge.gallerySetActive('p1')).resolves.toBeUndefined()
+  })
+
+  it('an apply that did not stick is a named error, not a silent success', async () => {
+    route('/api/apps/mochi/settings', { body: { activeAppearance: 'other' } }, 'POST')
+    let bridge = await loadBridge()
+    await expect(bridge.gallerySetActive('p1')).rejects.toThrow(/did not stick/)
+
+    route('/api/apps/mochi/settings', { ok: false, status: 500 }, 'POST')
+    bridge = await loadBridge()
+    await expect(bridge.gallerySetActive('p1')).rejects.toThrow(/could not apply/)
+  })
+
+  it('an unreadable settings response is accepted rather than mis-reported', async () => {
+    route('/api/apps/mochi/settings', { jsonThrows: true }, 'POST')
+    const bridge = await loadBridge()
+    await expect(bridge.gallerySetActive('p1')).resolves.toBeUndefined()
+  })
+
+  it('reports whether a delete happened', async () => {
+    route('/api/apps/mochi/packs/p1', { ok: true }, 'DELETE')
+    let bridge = await loadBridge()
+    expect(await bridge.galleryDeletePack('p1')).toBe(true)
+
+    route('/api/apps/mochi/packs/p1', { ok: false, status: 404 }, 'DELETE')
+    bridge = await loadBridge()
+    expect(await bridge.galleryDeletePack('p1')).toBe(false)
+  })
+})
+
+// ── live-refresh subscribers ────────────────────────────────────────────────
+
+describe('panelBridge live-refresh subscribers', () => {
+  it('the pin rail refreshes from the pushed list, and tolerates a shapeless one', async () => {
+    const bridge = await loadBridge()
+    const seen: unknown[][] = []
+    const off = bridge.onPinnedFilesChanged((pins) => seen.push(pins))
+    emitApp('pinned:files-changed', { args: [[{ path: '/u/a.md' }]] })
+    emitApp('pinned:files-changed', { args: ['nonsense'] })
+    off()
+    expect(seen).toEqual([[{ path: '/u/a.md' }], []])
+  })
+
+  it('a changed pinned file carries a timestamp even when the frame omits one', async () => {
+    const bridge = await loadBridge()
+    const seen: Array<{ path: string; updatedAt: number }> = []
+    const off = bridge.onPinnedFileUpdated((info) => seen.push(info))
+    emitApp('pinned:file-updated', { args: [{ path: '/u/a.md', updatedAt: 7 }] })
+    emitApp('pinned:file-updated', { args: [{ path: '/u/b.md' }] })
+    off()
+    expect(seen[0]).toEqual({ path: '/u/a.md', updatedAt: 7 })
+    expect(seen[1].path).toBe('/u/b.md')
+    expect(typeof seen[1].updatedAt).toBe('number')
+  })
+
+  it('a deleted pinned file names its path', async () => {
+    const bridge = await loadBridge()
+    const seen: Array<{ path: string }> = []
+    const off = bridge.onPinnedFileDeleted((info) => seen.push(info))
+    emitApp('pinned:file-deleted', { args: [{ path: '/u/gone.md' }] })
+    off()
+    expect(seen).toEqual([{ path: '/u/gone.md' }])
+  })
+
+  it('peeking is strictly boolean, whatever the frame says', async () => {
+    const bridge = await loadBridge()
+    const seen: boolean[] = []
+    const off = bridge.onPeeking((p) => seen.push(p))
+    emitApp('mochi:peeking', { args: [{ peeking: true }] })
+    emitApp('mochi:peeking', { args: [{ peeking: 'yes' }] })
+    emitApp('mochi:peeking', { args: [{}] })
+    off()
+    expect(seen).toEqual([true, false, false])
+  })
+
+  it('a notification published as a bare dict is delivered, not dropped', async () => {
+    const bridge = await loadBridge()
+    const seen: Array<{ title?: string }> = []
+    const off = bridge.onNotification((n) => seen.push(n))
+    // `publish()` sends the payload DIRECTLY — reading args[0] here handed the
+    // panel undefined and its bubbles never appeared.
+    emitApp('mochi:notify', { title: 'watch hit', body: 'a page changed' })
+    off()
+    expect(seen[0].title).toBe('watch hit')
+  })
+
+  it('an agent-pushed message reaches the transcript, and an empty one does not', async () => {
+    const bridge = await loadBridge()
+    const seen: Record<string, unknown>[] = []
+    bridge.onChatMessage((m) => seen.push(m))
+    emitApp('mochi:chat-push', { content: 'I finished the check', timestamp: 11 })
+    emitApp('mochi:chat-push', { content: '' })
+    emitApp('mochi:chat-push', {})
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toMatchObject({ role: 'assistant', content: 'I finished the check', timestamp: 11 })
+    expect(String(seen[0].id).startsWith('push-')).toBe(true)
+  })
+
+  it('a pack change tells consumers to re-read the list, and a colour map carries its payload', async () => {
+    const bridge = await loadBridge()
+    const packSignals: string[] = []
+    const maps: unknown[] = []
+    const offPacks = bridge.onGalleryPacksChanged((id) => packSignals.push(id))
+    const offMap = bridge.onColorMapChanged((m) => maps.push(m))
+    emitApp('mochi:gallery-packs-changed', { args: [{ packId: 'p1' }] })
+    emitApp('mochi:color-map-changed', { args: [{ body: '#fff' }] })
+    offPacks()
+    offMap()
+    expect(packSignals).toEqual([''])
+    expect(maps).toEqual([{ body: '#fff' }])
+  })
+
+  it('an unsubscribed app-event listener stops receiving', async () => {
+    const bridge = await loadBridge()
+    const seen: unknown[] = []
+    const off = bridge.subscribeAppEvent('mochi:peeking', (p) => seen.push(p))
+    off()
+    emitApp('mochi:peeking', { args: [{ peeking: true }] })
+    expect(seen).toEqual([])
+  })
+})
+
+// ── approvals ───────────────────────────────────────────────────────────────
+
+describe('panelBridge approvals', () => {
+  it('rehydrates only the pet slot pending requests', async () => {
+    route('/api/approvals', {
+      body: [
+        { id: 'a', slot: 'mochi' },
+        { id: 'b', slot: 'dashboard' },
+      ],
+    })
+    const bridge = await loadBridge()
+    expect((await bridge.getPendingApprovals()).map((a) => a.id)).toEqual(['a'])
+  })
+
+  it('rehydrates empty on a shapeless body, a failed read or a dead fetch', async () => {
+    route('/api/approvals', { body: { approvals: [] } })
+    let bridge = await loadBridge()
+    expect(await bridge.getPendingApprovals()).toEqual([])
+
+    route('/api/approvals', { ok: false, status: 500 })
+    bridge = await loadBridge()
+    expect(await bridge.getPendingApprovals()).toEqual([])
+
+    route('/api/approvals', { reject: true })
+    bridge = await loadBridge()
+    expect(await bridge.getPendingApprovals()).toEqual([])
+  })
+
+  it('approve and reject go to the approvals route', async () => {
+    const bridge = await loadBridge()
+    expect(await bridge.respondApproval('req 1', 'approve')).toEqual({ ok: true })
+    expect(calls('/api/approvals/req%201/approve', 'POST')).toHaveLength(1)
+
+    await bridge.respondApproval('req2', 'reject')
+    expect(calls('/api/approvals/req2/reject', 'POST')).toHaveLength(1)
+  })
+
+  it('a scoped trust grant goes to the slot route, carrying its pattern', async () => {
+    const bridge = await loadBridge()
+    await bridge.respondApproval('req3', 'trust_command', 'ls -la')
+    const [call] = calls('/api/chat/slots/mochi/approve', 'POST')
+    expect(bodyOf(call)).toEqual({ action: 'trust_command', request_id: 'req3', pattern: 'ls -la' })
+
+    await bridge.respondApproval('req4', 'trust')
+    expect(bodyOf(calls('/api/chat/slots/mochi/approve', 'POST')[1]).pattern).toBeUndefined()
+  })
+
+  it('never claims a tool was approved when the request failed', async () => {
+    route('/api/approvals/', { ok: false, status: 400 }, 'POST')
+    let bridge = await loadBridge()
+    expect(await bridge.respondApproval('req5', 'approve')).toEqual({
+      ok: false,
+      error: 'approval failed (400)',
+    })
+
+    route('/api/approvals/', { reject: true }, 'POST')
+    bridge = await loadBridge()
+    const result = await bridge.respondApproval('req6', 'approve')
+    expect(result.ok).toBe(false)
+    expect(String(result.error)).toContain('network down')
+  })
+})
+
+// ── models, edit-resend, files ──────────────────────────────────────────────
+
+describe('panelBridge model selection', () => {
+  it('reads a bare array and a wrapped list of models', async () => {
+    route('/api/models', { body: [{ model_name: 'a' }] })
+    let bridge = await loadBridge()
+    expect(await bridge.getModels()).toHaveLength(1)
+
+    route('/api/models', { body: { models: [{ model_name: 'a' }, { model_name: 'b' }] } })
+    bridge = await loadBridge()
+    expect(await bridge.getModels()).toHaveLength(2)
+  })
+
+  it('hides the selector rather than offering a dropdown that cannot switch', async () => {
+    route('/api/models', { ok: false, status: 503 })
+    let bridge = await loadBridge()
+    expect(await bridge.getModels()).toEqual([])
+
+    route('/api/models', { body: { models: 'nope' } })
+    bridge = await loadBridge()
+    expect(await bridge.getModels()).toEqual([])
+
+    route('/api/models', { reject: true })
+    bridge = await loadBridge()
+    expect(await bridge.getModels()).toEqual([])
+  })
+
+  it('opens on the model the slot is actually on', async () => {
+    route('/api/chat/slots', { body: [{ key: 'mochi', model: 'sonnet' }] }, 'GET')
+    const bridge = await loadBridge()
+    expect(await bridge.getSlotModel()).toBe('sonnet')
+  })
+
+  it('reads the gateway default as an empty string in every degraded case', async () => {
+    route('/api/chat/slots', { body: [{ key: 'other', model: 'sonnet' }] }, 'GET')
+    let bridge = await loadBridge()
+    expect(await bridge.getSlotModel()).toBe('')
+
+    route('/api/chat/slots', { body: { slots: 'nope' } }, 'GET')
+    bridge = await loadBridge()
+    expect(await bridge.getSlotModel()).toBe('')
+
+    route('/api/chat/slots', { ok: false, status: 500 }, 'GET')
+    bridge = await loadBridge()
+    expect(await bridge.getSlotModel()).toBe('')
+
+    route('/api/chat/slots', { reject: true }, 'GET')
+    bridge = await loadBridge()
+    expect(await bridge.getSlotModel()).toBe('')
+  })
+
+  it('switches the slot model and reports failure honestly', async () => {
+    const bridge = await loadBridge()
+    expect(await bridge.setModel('sonnet')).toBe(true)
+    expect(bodyOf(calls('/api/chat/slots/mochi/model', 'POST')[0])).toEqual({ model: 'sonnet' })
+
+    route('/api/chat/slots/mochi/model', { ok: false, status: 400 }, 'POST')
+    const failing = await loadBridge()
+    expect(await failing.setModel('bogus')).toBe(false)
+
+    route('/api/chat/slots/mochi/model', { reject: true }, 'POST')
+    const offline = await loadBridge()
+    expect(await offline.setModel('sonnet')).toBe(false)
+  })
+})
+
+describe('panelBridge edit-and-resend and file URLs', () => {
+  it('addresses the edited message by timestamp, as core requires', async () => {
+    const bridge = await loadBridge()
+    expect(await bridge.editResend('fixed text', '1712345678')).toEqual({ ok: true })
+    expect(bodyOf(calls('/edit-resend', 'POST')[0])).toEqual({
+      ts: '1712345678',
+      content: 'fixed text',
+    })
+  })
+
+  it('reports a failed edit so the caller can fall back to a plain send', async () => {
+    route('/edit-resend', { reject: true }, 'POST')
+    const bridge = await loadBridge()
+    expect(await bridge.editResend('t', '1')).toEqual({ ok: false })
+  })
+
+  it('serves a local image through the guarded core route', async () => {
+    const bridge = await loadBridge()
+    expect(bridge.localFileUrl('/u/my shot.png')).toBe('/api/file-raw?path=%2Fu%2Fmy%20shot.png')
+  })
+})
+
+// ── remote instances ────────────────────────────────────────────────────────
+
+describe('panelBridge remote instances keep core three answers apart', () => {
+  it('403 means the feature is off, not that there are no instances', async () => {
+    route('/api/instances', { ok: false, status: 403 })
+    const bridge = await loadBridge()
+    expect(await bridge.listInstances()).toEqual({ state: 'disabled' })
+  })
+
+  it('a gateway started without the flag reads as inactive, with its list intact', async () => {
+    route('/api/instances', { body: { active: false, instances: [{ id: 'i1', name: 'desk' }] } })
+    const bridge = await loadBridge()
+    expect(await bridge.listInstances()).toEqual({
+      state: 'inactive',
+      instances: [{ id: 'i1', name: 'desk' }],
+    })
+  })
+
+  it('a ready gateway reports its instances from either body shape', async () => {
+    route('/api/instances', { body: [{ id: 'i1', name: 'desk' }] })
+    let bridge = await loadBridge()
+    expect(await bridge.listInstances()).toEqual({
+      state: 'ready',
+      instances: [{ id: 'i1', name: 'desk' }],
+    })
+
+    route('/api/instances', { body: { instances: 'nope' } })
+    bridge = await loadBridge()
+    expect(await bridge.listInstances()).toEqual({ state: 'ready', instances: [] })
+  })
+
+  it('any other failure is an error state of its own', async () => {
+    route('/api/instances', { ok: false, status: 500 })
+    let bridge = await loadBridge()
+    expect(await bridge.listInstances()).toEqual({ state: 'error' })
+
+    route('/api/instances', { reject: true })
+    bridge = await loadBridge()
+    expect(await bridge.listInstances()).toEqual({ state: 'error' })
+  })
+
+  it('reads one instance status, and undefined when it cannot', async () => {
+    route('/api/instances/i%201/status', { body: { state: 'connected' } })
+    const bridge = await loadBridge()
+    expect(await bridge.getInstanceStatus('i 1')).toEqual({ state: 'connected' })
+
+    route('/api/instances/', { ok: false, status: 404 })
+    const missing = await loadBridge()
+    expect(await missing.getInstanceStatus('gone')).toBeUndefined()
+
+    route('/api/instances/', { reject: true })
+    const offline = await loadBridge()
+    expect(await offline.getInstanceStatus('i1')).toBeUndefined()
+  })
+})
+
+// ── speech to text ──────────────────────────────────────────────────────────
+
+describe('panelBridge speech-to-text reuses the core stack', () => {
+  it('reads the shared config, and undefined when it is unavailable', async () => {
+    route('/api/config/stt', { body: { backend: 'whisper', installed: true } })
+    let bridge = await loadBridge()
+    expect(await bridge.getSttConfig()).toMatchObject({ backend: 'whisper' })
+
+    route('/api/config/stt', { ok: false, status: 404 })
+    bridge = await loadBridge()
+    expect(await bridge.getSttConfig()).toBeUndefined()
+
+    route('/api/config/stt', { reject: true })
+    bridge = await loadBridge()
+    expect(await bridge.getSttConfig()).toBeUndefined()
+  })
+
+  it('an install failure carries its reason to the settings panel', async () => {
+    const bridge = await loadBridge()
+    expect(await bridge.installStt()).toEqual({ ok: true })
+
+    route('/api/stt/install', { ok: false, status: 500 }, 'POST')
+    const failing = await loadBridge()
+    expect(await failing.installStt()).toEqual({ ok: false, error: 'install failed (500)' })
+  })
+
+  it('transcribes a clip and defaults the mime type', async () => {
+    route('/api/stt/transcribe', { body: { text: 'hello there' } }, 'POST')
+    const bridge = await loadBridge()
+    expect(await bridge.transcribeAudio('AAAA')).toBe('hello there')
+    expect(bodyOf(calls('/api/stt/transcribe', 'POST')[0])).toEqual({
+      audio: 'AAAA',
+      mime: 'audio/webm',
+    })
+  })
+
+  it('returns nothing when the transcription is unusable', async () => {
+    route('/api/stt/transcribe', { body: {} }, 'POST')
+    let bridge = await loadBridge()
+    expect(await bridge.transcribeAudio('AAAA', 'audio/ogg')).toBeUndefined()
+
+    route('/api/stt/transcribe', { ok: false, status: 500 }, 'POST')
+    bridge = await loadBridge()
+    expect(await bridge.transcribeAudio('AAAA')).toBeUndefined()
+
+    route('/api/stt/transcribe', { reject: true }, 'POST')
+    bridge = await loadBridge()
+    expect(await bridge.transcribeAudio('AAAA')).toBeUndefined()
+  })
+})

--- a/website/src/test/OpsMissionControlPageCoverage.test.tsx
+++ b/website/src/test/OpsMissionControlPageCoverage.test.tsx
@@ -1,0 +1,1330 @@
+/**
+ * Coverage for the Ops Mission Control board page.
+ *
+ * The page is a builtin dashboard route that talks to its backend through
+ * `opsApi` (plain same-origin fetch, not the app-sdk hooks), so the seam under
+ * test is that module: every route is stubbed and the real helpers
+ * (`describeVerification`, `entryIsProven`, `blockedLabel`, …) are kept, since
+ * the page's branches are decided by what those helpers return.
+ *
+ * The three sibling tabs and the embedded chat are replaced with markers. They
+ * own their own queries — `IncidentChat` mounts the dashboard's real chat embed
+ * behind an `AppApiProvider` — and mounting them here would test them rather
+ * than the board.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, waitFor, fireEvent, act } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+import {
+  SIGNALS_QUERY_KEY,
+  opsApi,
+  type BoardState,
+  type Incident,
+  type IncidentStatus,
+  type LedgerEntry,
+  type LedgerStats,
+  type OperatingMode,
+  type PendingProposal,
+  type ProviderInfo,
+  type RotationInfo,
+  type Signal,
+  type SignalsResult,
+} from '../apps/ops-mission-control/api'
+import OpsMissionControlPage from '../apps/ops-mission-control/OpsMissionControlPage'
+
+vi.mock('../apps/ops-mission-control/api', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../apps/ops-mission-control/api')>()
+  return {
+    ...actual,
+    opsApi: {
+      state: vi.fn(),
+      incidents: vi.fn(),
+      incident: vi.fn(),
+      transition: vi.fn(),
+      dispatch: vi.fn(),
+      ledger: vi.fn(),
+      decideProposal: vi.fn(),
+      signals: vi.fn(),
+    },
+  }
+})
+
+vi.mock('../apps/ops-mission-control/SettingsPanel', () => ({
+  default: () => <div data-testid="stub-settings" />,
+}))
+vi.mock('../apps/ops-mission-control/SignalsPanel', () => ({
+  default: () => <div data-testid="stub-signals" />,
+}))
+vi.mock('../apps/ops-mission-control/HandoverPanel', () => ({
+  default: () => <div data-testid="stub-handover" />,
+}))
+vi.mock('../apps/ops-mission-control/IncidentChat', () => ({
+  default: ({ incidentId }: { incidentId: string }) => (
+    <div data-testid="stub-chat" data-incident={incidentId} />
+  ),
+}))
+
+const agoIso = (secs: number) => new Date(Date.now() - secs * 1000).toISOString()
+
+const mkSignal = (over: Partial<Signal> = {}): Signal => ({
+  id: 'sig-1',
+  source: 'cloudwatch',
+  title: 'Checkout latency above threshold',
+  severity: 'critical',
+  state: 'firing',
+  fired_at: agoIso(600),
+  resource: 'svc/checkout',
+  url: 'https://console.example.com/alarm/1',
+  labels: {},
+  fingerprint: 'fp-1',
+  provider_key: '',
+  suppressed_by: '',
+  suppressed_reason: '',
+  ...over,
+})
+
+const mkIncident = (over: Partial<Incident> = {}): Incident => ({
+  incident_id: 'omc-0001',
+  signal: mkSignal(),
+  status: 'investigating',
+  operating_mode: 'propose',
+  claimed_at: agoIso(600),
+  updated_at: agoIso(90),
+  slot_key: 'ops-mission-control-omc-0001',
+  slack_thread_ts: '',
+  ledger_matches: [],
+  diagnosis: '',
+  proposed_action: null,
+  resolution: '',
+  ...over,
+})
+
+const mkEntry = (over: Partial<LedgerEntry> = {}): LedgerEntry => ({
+  entry_id: 'entry-aaaabbbb',
+  pattern: 'Latency spike on a cold cache',
+  fix: 'Warm the cache and re-check',
+  fingerprints: ['fp-1'],
+  provider_keys: [],
+  confidence: 'high',
+  trust: 'verified',
+  use_count: 4,
+  miss_count: 0,
+  last_miss: '',
+  first_seen: agoIso(90000),
+  last_used: agoIso(400),
+  source: 'cloudwatch',
+  ...over,
+})
+
+const mkProvider = (over: Partial<ProviderInfo> = {}): ProviderInfo => ({
+  id: 'cloudwatch',
+  display_name: 'CloudWatch',
+  roles: ['signal'],
+  configured: true,
+  config_fields: [],
+  secret_fields: [],
+  detail: '',
+  config: {},
+  secrets: {},
+  ...over,
+})
+
+const mkRotation = (over: Partial<RotationInfo> = {}): RotationInfo => ({
+  on_shift: true,
+  who: '',
+  until: '',
+  unknown: false,
+  tiers: {},
+  armed_crons: [],
+  tier_crons: {},
+  mode: 'observe',
+  rules: 0,
+  primary: true,
+  modes_available: ['observe', 'propose', 'act'],
+  ...over,
+})
+
+const mkStats = (over: Partial<LedgerStats> = {}): LedgerStats => ({
+  total: 7,
+  verified: 3,
+  high_confidence: 3,
+  total_uses: 12,
+  proven: 2,
+  demoted: 0,
+  total_misses: 0,
+  ...over,
+})
+
+const mkState = (over: Partial<BoardState> = {}): BoardState => ({
+  incidents: [],
+  counts: {},
+  providers: [mkProvider()],
+  rotation: mkRotation(),
+  ledger: mkStats(),
+  webhook_queue: 0,
+  ...over,
+})
+
+const mkSignalsResult = (over: Partial<SignalsResult> = {}): SignalsResult => ({
+  signals: [],
+  firing: [],
+  cleared: [],
+  suppressed: [],
+  unclaimed: [],
+  errors: {},
+  poll_health: { cloudwatch: { ok: true, detail: '', at: agoIso(30), signals: 0 } },
+  all_sources_healthy: true,
+  ...over,
+})
+
+const mkProposal = (over: Partial<PendingProposal> = {}): PendingProposal => ({
+  state: 'pending',
+  action: 'silence',
+  sink: 'cloudwatch',
+  note: 'Silencing while the deploy rolls back.',
+  duration_secs: 900,
+  digest: 'digest-abc',
+  proposed_at: agoIso(120),
+  expires_at: agoIso(-3600),
+  decided_at: '',
+  ...over,
+})
+
+/** Default happy-path stubs; individual tests override the route they exercise. */
+function stubRoutes(state: BoardState = mkState(), entries: LedgerEntry[] = []) {
+  vi.mocked(opsApi.state).mockResolvedValue(state)
+  vi.mocked(opsApi.ledger).mockResolvedValue({ entries, stats: state.ledger })
+  vi.mocked(opsApi.incidents).mockResolvedValue({ incidents: [] })
+}
+
+/** Open the expanded detail panel of the first incident row. */
+async function expandFirstRow() {
+  const row = await waitFor(() => screen.getAllByTestId('omc-incident-row')[0])
+  fireEvent.click(row)
+  await waitFor(() => expect(screen.getByTestId('stub-chat')).toBeInTheDocument())
+}
+
+/**
+ * Pick a tab. jsdom reports zero width for every element, so `SegmentedControl`
+ * measures its parent as too narrow and collapses to its dropdown form: one
+ * trigger button carrying the ACTIVE label, and the options only in the open
+ * popup. The trigger precedes the popup in the DOM, hence the last-match pick —
+ * when the target is already active, both exist and only the popup one selects.
+ */
+async function switchTab(label: 'Board' | 'Signals' | 'Handover' | 'Settings') {
+  const trigger = screen.getAllByRole('button', {
+    name: /^(Board|Signals|Handover|Settings)$/,
+  })[0]
+  fireEvent.click(trigger)
+  const options = await waitFor(() => screen.getAllByRole('button', { name: label }))
+  fireEvent.click(options[options.length - 1])
+}
+
+describe('OpsMissionControlPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows a loading board while /state is in flight', async () => {
+    vi.mocked(opsApi.state).mockReturnValue(new Promise<BoardState>(() => {}))
+    vi.mocked(opsApi.ledger).mockReturnValue(
+      new Promise<{ entries: LedgerEntry[]; stats: LedgerStats }>(() => {}),
+    )
+    vi.mocked(opsApi.incidents).mockReturnValue(
+      new Promise<{ incidents: Incident[] }>(() => {}),
+    )
+    renderWithProviders(<OpsMissionControlPage />)
+    expect(screen.getByText('Mission Control')).toBeInTheDocument()
+    // Both the board and the closed-postmortems card are waiting.
+    await waitFor(() => expect(screen.getAllByText('Loading…')).toHaveLength(2))
+  })
+
+  it('reports an unverified quiet board when no poll has been made', async () => {
+    stubRoutes()
+    renderWithProviders(<OpsMissionControlPage />)
+    await waitFor(() =>
+      expect(screen.getByText('No incidents claimed')).toBeInTheDocument(),
+    )
+    expect(
+      screen.getByText(/Source health has not been verified this session/),
+    ).toBeInTheDocument()
+  })
+
+  it('tells a brand-new install to connect a provider first', async () => {
+    stubRoutes(mkState({ providers: [] }))
+    renderWithProviders(<OpsMissionControlPage />)
+    await waitFor(() =>
+      expect(
+        screen.getByText('Connect a provider in Settings to start watching.'),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('claims the quiet is real only when the cached poll says every source answered', async () => {
+    stubRoutes()
+    const { queryClient } = renderWithProviders(<OpsMissionControlPage />)
+    await waitFor(() =>
+      expect(screen.getByText('No incidents claimed')).toBeInTheDocument(),
+    )
+    act(() => {
+      queryClient.setQueryData(SIGNALS_QUERY_KEY, mkSignalsResult())
+    })
+    await waitFor(() => expect(screen.getByText('Nothing is firing')).toBeInTheDocument())
+    expect(
+      screen.getByText('Every configured source answered the last poll, so this quiet is real.'),
+    ).toBeInTheDocument()
+  })
+
+  it('names the sources that did not answer instead of calling the board quiet', async () => {
+    stubRoutes()
+    const { queryClient } = renderWithProviders(<OpsMissionControlPage />)
+    await waitFor(() =>
+      expect(screen.getByText('No incidents claimed')).toBeInTheDocument(),
+    )
+    act(() => {
+      queryClient.setQueryData(
+        SIGNALS_QUERY_KEY,
+        mkSignalsResult({
+          all_sources_healthy: false,
+          errors: { cloudwatch: 'expired credentials' },
+          poll_health: { cloudwatch: { ok: false, detail: 'expired credentials', at: agoIso(30) } },
+        }),
+      )
+    })
+    await waitFor(() =>
+      expect(
+        screen.getByText('Nothing claimed — but the board is not verified'),
+      ).toBeInTheDocument(),
+    )
+    expect(
+      screen.getByText(
+        'CloudWatch did not answer the last poll, so absence of a signal does not mean recovery.',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('falls back to an unnamed source when the failing one is not a signal provider', async () => {
+    stubRoutes(mkState({ providers: [mkProvider({ roles: ['action'] })] }))
+    const { queryClient } = renderWithProviders(<OpsMissionControlPage />)
+    await waitFor(() =>
+      expect(screen.getByText('No incidents claimed')).toBeInTheDocument(),
+    )
+    act(() => {
+      queryClient.setQueryData(
+        SIGNALS_QUERY_KEY,
+        mkSignalsResult({ all_sources_healthy: false }),
+      )
+    })
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'At least one source did not answer the last poll, so absence of a signal does not mean recovery.',
+        ),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('renders the five stat cards from the board and the ledger rollup', async () => {
+    stubRoutes(
+      mkState({
+        incidents: [
+          mkIncident(),
+          mkIncident({
+            incident_id: 'omc-0002',
+            status: 'needs_human',
+            blocked_reason: 'awaiting_approval',
+            signal: mkSignal({ id: 'sig-2', title: 'Queue backing up', severity: 'warning' }),
+          }),
+          mkIncident({ incident_id: 'omc-0003', status: 'resolved' }),
+        ],
+      }),
+    )
+    renderWithProviders(<OpsMissionControlPage />)
+    await waitFor(() =>
+      expect(screen.getAllByTestId('omc-incident-row')).toHaveLength(3),
+    )
+    const cardValue = (label: string) => {
+      const el = screen.getByText(label).closest('[data-testid="stat-card"]')
+      return el?.querySelector('[data-testid="stat-card-value"]')?.textContent
+    }
+    expect(cardValue('Active')).toBe('2')
+    expect(cardValue('Waiting on you')).toBe('1')
+    expect(cardValue('Sources wired')).toBe('1')
+    expect(cardValue('Patterns known')).toBe('7')
+    expect(cardValue('Patterns proven')).toBe('2')
+    // The blocked reason replaces the bare status in the row.
+    expect(screen.getByText('Approve to continue')).toBeInTheDocument()
+    expect(screen.getByText('Investigating')).toBeInTheDocument()
+    expect(screen.getByText('Resolved')).toBeInTheDocument()
+  })
+
+  it('renders a compact age per row and an em dash for an unparseable timestamp', async () => {
+    stubRoutes(
+      mkState({
+        incidents: [
+          mkIncident({ incident_id: 'omc-secs', updated_at: agoIso(20) }),
+          mkIncident({ incident_id: 'omc-mins', updated_at: agoIso(90) }),
+          mkIncident({ incident_id: 'omc-hours', updated_at: agoIso(7200) }),
+          mkIncident({ incident_id: 'omc-days', updated_at: agoIso(200000) }),
+          mkIncident({ incident_id: 'omc-bad', updated_at: 'not-a-date', claimed_at: '' }),
+        ],
+      }),
+    )
+    renderWithProviders(<OpsMissionControlPage />)
+    await waitFor(() =>
+      expect(screen.getAllByTestId('omc-incident-row')).toHaveLength(5),
+    )
+    expect(screen.getByText('20s')).toBeInTheDocument()
+    expect(screen.getByText('1m')).toBeInTheDocument()
+    expect(screen.getByText('2h')).toBeInTheDocument()
+    expect(screen.getByText('2d')).toBeInTheDocument()
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('expands a row into its detail panel and mounts the investigation chat', async () => {
+    stubRoutes(
+      mkState({
+        incidents: [mkIncident({ diagnosis: 'The cache was cold after the deploy.' })],
+      }),
+    )
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    expect(screen.getByText('Source')).toBeInTheDocument()
+    expect(screen.getByText('svc/checkout')).toBeInTheDocument()
+    expect(screen.getByText('Known patterns')).toBeInTheDocument()
+    expect(screen.getByText('none matched')).toBeInTheDocument()
+    expect(screen.getByText('The cache was cold after the deploy.')).toBeInTheDocument()
+    // The incident's own operating mode, distinct from the header's rotation badge.
+    expect(screen.getByText('Propose')).toBeInTheDocument()
+    expect(screen.getByTestId('stub-chat')).toHaveAttribute('data-incident', 'omc-0001')
+    // Clicking the same row again collapses it.
+    fireEvent.click(screen.getAllByTestId('omc-incident-row')[0])
+    await waitFor(() => expect(screen.queryByTestId('stub-chat')).toBeNull())
+  })
+
+  it('warns that a ledger match is only a shape match when the provider publishes no identity', async () => {
+    stubRoutes(mkState({ incidents: [mkIncident()] }))
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    expect(screen.getByText('Match basis')).toBeInTheDocument()
+    expect(
+      screen.getByText(/This provider published no exact identity/),
+    ).toBeInTheDocument()
+    expect(screen.getByText('No diagnosis recorded yet.')).toBeInTheDocument()
+  })
+
+  it('reports an exact match basis and truncates the provider key', async () => {
+    stubRoutes(
+      mkState({
+        incidents: [
+          mkIncident({
+            signal: mkSignal({ provider_key: 'k'.repeat(40) }),
+          }),
+        ],
+      }),
+    )
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    expect(
+      screen.getByText(`cloudwatch publishes an exact identity for this failure (${'k'.repeat(24)}), which the ledger prefers over our shape hash.`),
+    ).toBeInTheDocument()
+  })
+
+  it('renders a matched ledger entry with its fix, counts and fast-path verdict', async () => {
+    stubRoutes(
+      mkState({ incidents: [mkIncident({ ledger_matches: ['entry-aaaabbbb'] })] }),
+      [mkEntry()],
+    )
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    expect(screen.getByText('1 matched')).toBeInTheDocument()
+    expect(screen.getByText('Fix: Warm the cache and re-check')).toBeInTheDocument()
+    expect(screen.getByText('proven — agent may propose directly')).toBeInTheDocument()
+    // The pattern renders in the match card AND in the ledger table below.
+    expect(screen.getAllByText('Latency spike on a cold cache')).toHaveLength(2)
+  })
+
+  it('shows the miss count and the demotion note for a refuted entry', async () => {
+    stubRoutes(
+      mkState({ incidents: [mkIncident({ ledger_matches: ['entry-aaaabbbb'] })] }),
+      [mkEntry({ miss_count: 2, last_miss: '2026-08-01' })],
+    )
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    expect(screen.getByText(/failed 2×/)).toBeInTheDocument()
+    expect(screen.getByText(/Demoted: this fix was applied/)).toBeInTheDocument()
+    expect(screen.getByText(/most recently 2026-08-01/)).toBeInTheDocument()
+    expect(screen.getByText('hypothesis — agent must confirm first')).toBeInTheDocument()
+    // The table's own column marks the same entry demoted rather than locked.
+    expect(screen.getByText('demoted')).toBeInTheDocument()
+  })
+
+  it('explains a locked entry whose only shortfall is the use floor', async () => {
+    stubRoutes(
+      mkState({ incidents: [mkIncident({ ledger_matches: ['entry-aaaabbbb'] })] }),
+      [mkEntry({ use_count: 1 })],
+    )
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    expect(
+      screen.getByText(/Marked verified and high confidence, but used only/),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/the fast path also needs/)).toBeInTheDocument()
+  })
+
+  it('names a matched entry that is no longer in the ledger rather than rendering nothing', async () => {
+    stubRoutes(mkState({ incidents: [mkIncident({ ledger_matches: ['pruned-entry-id'] })] }))
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    expect(screen.getByText(/Matched entry/)).toBeInTheDocument()
+    expect(screen.getByText(/pruned-e/)).toBeInTheDocument()
+    expect(screen.getByText(/is no longer in the/)).toBeInTheDocument()
+  })
+
+  it('renders the post-action verification verdict with the backend detail verbatim', async () => {
+    stubRoutes(
+      mkState({
+        incidents: [
+          mkIncident({
+            last_action: 'silence',
+            last_action_at: agoIso(300),
+            verification: 'still_firing',
+            verification_detail: 'cloudwatch reported the alarm in ALARM at 12:04.',
+          }),
+        ],
+      }),
+    )
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    expect(screen.getByText('still firing after this action')).toBeInTheDocument()
+    expect(screen.getByText(/sent 5m ago/)).toBeInTheDocument()
+    expect(
+      screen.getByText('cloudwatch reported the alarm in ALARM at 12:04.'),
+    ).toBeInTheDocument()
+  })
+
+  it('says an action was sent without a timestamp when none was recorded', async () => {
+    stubRoutes(
+      mkState({
+        incidents: [
+          mkIncident({ last_action: 'ack', last_action_at: '', verification: 'not_checkable' }),
+        ],
+      }),
+    )
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    expect(screen.getByText('sent, not confirmed')).toBeInTheDocument()
+    expect(screen.getByText(/^ack sent —$/)).toBeInTheDocument()
+  })
+
+  it('renders a pending verification with the muted clock branch', async () => {
+    stubRoutes(
+      mkState({
+        incidents: [
+          mkIncident({
+            last_action: 'comment',
+            last_action_at: agoIso(60),
+            verification: 'pending',
+            verify_after: '2026-08-10T21:00:00Z',
+          }),
+        ],
+      }),
+    )
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    expect(screen.getByText('not checked yet')).toBeInTheDocument()
+  })
+
+  it('links out through the URL guard and drops a non-http scheme', async () => {
+    stubRoutes(mkState({ incidents: [mkIncident()] }))
+    const { unmount } = renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    const link = screen.getByText('Open in provider').closest('a')
+    expect(link).toHaveAttribute('href', 'https://console.example.com/alarm/1')
+    unmount()
+
+    stubRoutes(
+      mkState({
+        incidents: [mkIncident({ signal: mkSignal({ url: 'javascript:alert(1)' }) })],
+      }),
+    )
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    expect(screen.queryByText('Open in provider')).toBeNull()
+  })
+
+  it('transitions an incident to resolved and reports that Slack replies land', async () => {
+    const incident = mkIncident()
+    stubRoutes(mkState({ incidents: [incident] }))
+    vi.mocked(opsApi.transition).mockResolvedValue({
+      incident,
+      slack_thread_replyable: true,
+    })
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    fireEvent.click(screen.getByRole('button', { name: 'Mark resolved' }))
+    await waitFor(() =>
+      expect(opsApi.transition).toHaveBeenCalledWith('omc-0001', 'resolved'),
+    )
+    await waitFor(() =>
+      expect(
+        screen.getByText('Replies in the Slack thread reach this investigation.'),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('warns when a Slack reply would not reach the investigation', async () => {
+    const incident = mkIncident({ status: 'needs_human' })
+    stubRoutes(mkState({ incidents: [incident] }))
+    vi.mocked(opsApi.transition).mockResolvedValue({
+      incident,
+      slack_thread_replyable: false,
+    })
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    fireEvent.click(screen.getByRole('button', { name: 'Mark resolved' }))
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Replies in the Slack thread will NOT reach this investigation/),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('surfaces a failed transition on the row that triggered it', async () => {
+    stubRoutes(mkState({ incidents: [mkIncident()] }))
+    vi.mocked(opsApi.transition).mockRejectedValue(new Error('no rule grants resolve'))
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    fireEvent.click(screen.getByRole('button', { name: 'Mark resolved' }))
+    await waitFor(() =>
+      expect(screen.getByText('no rule grants resolve')).toBeInTheDocument(),
+    )
+  })
+
+  it('offers no resolve button for a status that cannot be resolved from the board', async () => {
+    stubRoutes(mkState({ incidents: [mkIncident({ status: 'dispatched' })] }))
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    expect(screen.queryByRole('button', { name: 'Mark resolved' })).toBeNull()
+  })
+
+  it('renders a pending proposal with its stored terms and approves with the shown digest', async () => {
+    stubRoutes(mkState({ incidents: [mkIncident({ proposed_action: mkProposal() })] }))
+    vi.mocked(opsApi.decideProposal).mockResolvedValue({
+      ok: true,
+      proposal: mkProposal({ state: 'approved' }),
+      executed: true,
+    })
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    expect(screen.getByText('Awaiting your approval')).toBeInTheDocument()
+    expect(screen.getByText('through cloudwatch for 900s')).toBeInTheDocument()
+    expect(
+      screen.getByText('Silencing while the deploy rolls back.'),
+    ).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Approve and run' }))
+    await waitFor(() =>
+      expect(opsApi.decideProposal).toHaveBeenCalledWith('omc-0001', true, 'digest-abc'),
+    )
+  })
+
+  it('rejects a proposal without echoing a digest', async () => {
+    stubRoutes(
+      mkState({
+        incidents: [
+          mkIncident({ proposed_action: mkProposal({ action: 'ack', duration_secs: null }) }),
+        ],
+      }),
+    )
+    vi.mocked(opsApi.decideProposal).mockResolvedValue({
+      ok: true,
+      proposal: mkProposal({ state: 'rejected' }),
+      executed: false,
+    })
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    expect(screen.getByText('through cloudwatch')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }))
+    await waitFor(() =>
+      expect(opsApi.decideProposal).toHaveBeenCalledWith('omc-0001', false, undefined),
+    )
+  })
+
+  it('shows the gate refusal when a decision comes back not ok', async () => {
+    stubRoutes(mkState({ incidents: [mkIncident({ proposed_action: mkProposal() })] }))
+    vi.mocked(opsApi.decideProposal).mockResolvedValue({
+      ok: false,
+      proposal: null,
+      executed: false,
+      error: 'the draft moved since you read it',
+    })
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    fireEvent.click(screen.getByRole('button', { name: 'Approve and run' }))
+    await waitFor(() =>
+      expect(screen.getByText('the draft moved since you read it')).toBeInTheDocument(),
+    )
+  })
+
+  it('shows a refusal with no reason as the generic decision message', async () => {
+    stubRoutes(mkState({ incidents: [mkIncident({ proposed_action: mkProposal() })] }))
+    vi.mocked(opsApi.decideProposal).mockResolvedValue({
+      ok: false,
+      proposal: null,
+      executed: false,
+    })
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    fireEvent.click(screen.getByRole('button', { name: 'Approve and run' }))
+    await waitFor(() =>
+      expect(screen.getByText('The decision was refused.')).toBeInTheDocument(),
+    )
+  })
+
+  it('surfaces a decision error from the autonomy gate', async () => {
+    stubRoutes(mkState({ incidents: [mkIncident({ proposed_action: mkProposal() })] }))
+    vi.mocked(opsApi.decideProposal).mockRejectedValue(new Error('403 no rule grants ack'))
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    fireEvent.click(screen.getByRole('button', { name: 'Approve and run' }))
+    await waitFor(() =>
+      expect(screen.getByText('403 no rule grants ack')).toBeInTheDocument(),
+    )
+  })
+
+  it('hides a proposal that is no longer pending', async () => {
+    stubRoutes(
+      mkState({
+        incidents: [mkIncident({ proposed_action: mkProposal({ state: 'expired' }) })],
+      }),
+    )
+    renderWithProviders(<OpsMissionControlPage />)
+    await expandFirstRow()
+    expect(screen.queryByText('Awaiting your approval')).toBeNull()
+  })
+
+  it('reports a dispatch cycle that changed nothing, counting parked signals', async () => {
+    stubRoutes()
+    vi.mocked(opsApi.dispatch).mockResolvedValue({
+      claimed: [],
+      released: [],
+      polled: 3,
+      unclaimed_remaining: 0,
+      errors: {},
+      changed: false,
+      skipped_reason: '',
+      briefs: {},
+      suppressed: 2,
+      verifications: {},
+    })
+    renderWithProviders(<OpsMissionControlPage />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Poll & claim' })).toBeEnabled(),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Poll & claim' }))
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'Polled 3 firing signals, plus 2 parked at the provider and left alone; nothing new to claim.',
+        ),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('reports a plain polled summary when nothing was parked', async () => {
+    stubRoutes()
+    vi.mocked(opsApi.dispatch).mockResolvedValue({
+      claimed: [],
+      released: [],
+      polled: 1,
+      unclaimed_remaining: 0,
+      errors: {},
+      changed: false,
+      skipped_reason: '',
+      briefs: {},
+      suppressed: 0,
+      verifications: {},
+    })
+    renderWithProviders(<OpsMissionControlPage />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Poll & claim' })).toBeEnabled(),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Poll & claim' }))
+    await waitFor(() =>
+      expect(
+        screen.getByText('Polled 1 firing signal; nothing new to claim.'),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('tells an unconfigured install why a cycle did nothing', async () => {
+    stubRoutes(mkState({ providers: [] }))
+    vi.mocked(opsApi.dispatch).mockResolvedValue({
+      claimed: [],
+      released: [],
+      polled: 0,
+      unclaimed_remaining: 0,
+      errors: {},
+      changed: false,
+      skipped_reason: '',
+      briefs: {},
+      suppressed: 0,
+      verifications: {},
+    })
+    renderWithProviders(<OpsMissionControlPage />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Poll & claim' })).toBeEnabled(),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Poll & claim' }))
+    await waitFor(() =>
+      expect(
+        screen.getByText('No providers are set up yet — open Settings to connect one.'),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('prefers the backend skip reason over its own wording', async () => {
+    stubRoutes()
+    vi.mocked(opsApi.dispatch).mockResolvedValue({
+      claimed: [],
+      released: [],
+      polled: 0,
+      unclaimed_remaining: 0,
+      errors: {},
+      changed: false,
+      skipped_reason: 'off shift — a teammate holds the pager',
+      briefs: {},
+      suppressed: 0,
+      verifications: {},
+    })
+    renderWithProviders(<OpsMissionControlPage />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Poll & claim' })).toBeEnabled(),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Poll & claim' }))
+    await waitFor(() =>
+      expect(
+        screen.getByText('off shift — a teammate holds the pager'),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('retracts its own claim when a verification came back still firing', async () => {
+    stubRoutes()
+    vi.mocked(opsApi.dispatch).mockResolvedValue({
+      claimed: [],
+      released: [],
+      polled: 1,
+      unclaimed_remaining: 0,
+      errors: {},
+      changed: true,
+      skipped_reason: '',
+      briefs: {},
+      suppressed: 0,
+      verifications: { 'omc-0001': 'still_firing', 'omc-0009': 'cleared' },
+    })
+    renderWithProviders(<OpsMissionControlPage />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Poll & claim' })).toBeEnabled(),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Poll & claim' }))
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /omc-0001 was still firing when we re-read it after the action this app reported as applied\./,
+        ),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('summarises several failed verifications by id', async () => {
+    stubRoutes()
+    vi.mocked(opsApi.dispatch).mockResolvedValue({
+      claimed: [],
+      released: [],
+      polled: 2,
+      unclaimed_remaining: 0,
+      errors: {},
+      changed: true,
+      skipped_reason: '',
+      briefs: {},
+      suppressed: 0,
+      verifications: { 'omc-0001': 'still_firing', 'omc-0002': 'still_firing' },
+    })
+    renderWithProviders(<OpsMissionControlPage />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Poll & claim' })).toBeEnabled(),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Poll & claim' }))
+    await waitFor(() =>
+      expect(
+        screen.getByText(/2 incidents were still firing .*omc-0001, omc-0002/),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('surfaces a dispatch failure', async () => {
+    stubRoutes()
+    vi.mocked(opsApi.dispatch).mockRejectedValue(new Error('provider timed out'))
+    renderWithProviders(<OpsMissionControlPage />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Poll & claim' })).toBeEnabled(),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Poll & claim' }))
+    await waitFor(() =>
+      expect(screen.getByText('provider timed out')).toBeInTheDocument(),
+    )
+  })
+
+  it('switches to each sibling tab and hides the board action button', async () => {
+    stubRoutes()
+    renderWithProviders(<OpsMissionControlPage />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Board' })).toBeInTheDocument(),
+    )
+    await switchTab('Signals')
+    await waitFor(() => expect(screen.getByTestId('stub-signals')).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: 'Poll & claim' })).toBeNull()
+
+    await switchTab('Handover')
+    await waitFor(() => expect(screen.getByTestId('stub-handover')).toBeInTheDocument())
+
+    await switchTab('Settings')
+    await waitFor(() => expect(screen.getByTestId('stub-settings')).toBeInTheDocument())
+
+    await switchTab('Board')
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Poll & claim' })).toBeInTheDocument(),
+    )
+  })
+
+  describe('shift and mode badges', () => {
+    const cases: [string, Partial<RotationInfo>, string][] = [
+      ['on shift with no name', { on_shift: true }, 'On shift'],
+      [
+        'on shift with a name and a parsed shift end',
+        { on_shift: true, who: 'octocat', until: '2026-08-11T02:00:00Z' },
+        'On shift: octocat until',
+      ],
+      [
+        'off shift naming who holds the pager',
+        { on_shift: false, who: 'octocat' },
+        'off shift — octocat is on call',
+      ],
+      ['off shift with nobody named', { on_shift: false }, 'off shift'],
+      [
+        'indeterminate but still armed',
+        { on_shift: true, unknown: true },
+        'rotation unknown — tier armed',
+      ],
+      [
+        'indeterminate and disarmed',
+        { on_shift: false, unknown: true },
+        'rotation unknown — not picking up work',
+      ],
+    ]
+
+    for (const [name, rotation, expected] of cases) {
+      it(`labels the header badge: ${name}`, async () => {
+        stubRoutes(mkState({ rotation: mkRotation(rotation) }))
+        renderWithProviders(<OpsMissionControlPage />)
+        await waitFor(() =>
+          expect(screen.getByText(new RegExp(expected))).toBeInTheDocument(),
+        )
+      })
+    }
+
+    it('omits the shift end when the rotation source published an unparseable one', async () => {
+      stubRoutes(
+        mkState({ rotation: mkRotation({ on_shift: true, who: 'octocat', until: 'soon' }) }),
+      )
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() =>
+        expect(screen.getByText('On shift: octocat until')).toBeInTheDocument(),
+      )
+    })
+
+    const modes: [OperatingMode, string][] = [
+      ['observe', 'Observe'],
+      ['propose', 'Propose'],
+      ['act', 'Act'],
+    ]
+    for (const [mode, label] of modes) {
+      it(`renders the ${mode} mode badge`, async () => {
+        stubRoutes(mkState({ rotation: mkRotation({ mode }) }))
+        renderWithProviders(<OpsMissionControlPage />)
+        await waitFor(() => expect(screen.getByText(label)).toBeInTheDocument())
+      })
+    }
+  })
+
+  describe('on-call roster card', () => {
+    const roster = (over: Record<string, unknown> = {}) =>
+      mkState({
+        rotation: mkRotation({
+          on_shift: true,
+          who: 'octocat',
+          roster: {
+            members: [
+              { login: 'octocat', shifts: 2, on_call_now: true },
+              { login: 'hubot', shifts: 1, on_call_now: false },
+            ],
+            windows: [],
+            timezone: 'UTC',
+            me: 'octocat',
+            me_on_roster: true,
+            strict_gating: true,
+            leader: 'hubot',
+            error: '',
+            ...over,
+          },
+        }),
+      })
+
+    it('marks this instance, the on-call member, the leader and the shift counts', async () => {
+      stubRoutes(roster())
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() => expect(screen.getByText('On-call team')).toBeInTheDocument())
+      expect(screen.getByText('octocat (this instance)')).toBeInTheDocument()
+      expect(screen.getByText('hubot')).toBeInTheDocument()
+      expect(screen.getByText('On call now')).toBeInTheDocument()
+      expect(screen.getByText('leader')).toBeInTheDocument()
+      expect(screen.getByText('2 shifts')).toBeInTheDocument()
+      expect(screen.getByText('1 shift')).toBeInTheDocument()
+      expect(
+        screen.getByText('UTC · only the on-call instance picks up work'),
+      ).toBeInTheDocument()
+    })
+
+    it('shows the bare timezone when gating is lenient', async () => {
+      stubRoutes(roster({ strict_gating: false }))
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() => expect(screen.getByText('UTC')).toBeInTheDocument())
+    })
+
+    it('warns that an unnamed instance will never pick up work under strict gating', async () => {
+      stubRoutes(roster({ me: 'ghost', me_on_roster: false }))
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() =>
+        expect(
+          screen.getByText(/This instance \(ghost\) is not named in the schedule, so under strict gating/),
+        ).toBeInTheDocument(),
+      )
+    })
+
+    it('notes that an unnamed instance still works when gating is lenient', async () => {
+      stubRoutes(roster({ me: 'ghost', me_on_roster: false, strict_gating: false }))
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() =>
+        expect(
+          screen.getByText(/Strict gating is off, so it still picks up work/),
+        ).toBeInTheDocument(),
+      )
+    })
+
+    it('warns when no login could be resolved and surfaces a schedule error', async () => {
+      stubRoutes(roster({ me: '', error: 'duplicate who: key on line 12' }))
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() =>
+        expect(screen.getByText(/No GitHub login resolved for this instance/)).toBeInTheDocument(),
+      )
+      expect(
+        screen.getByText('Schedule problem: duplicate who: key on line 12'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('knowledge ledger table', () => {
+    it('explains itself when the ledger is empty', async () => {
+      stubRoutes()
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() =>
+        expect(screen.getByText(/Each investigation that finds a reusable fix/)).toBeInTheDocument(),
+      )
+    })
+
+    it('renders a row per entry with an em dash for a clean record', async () => {
+      stubRoutes(mkState(), [mkEntry()])
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() => expect(screen.getByText('Pattern')).toBeInTheDocument())
+      expect(screen.getByText('Fast path')).toBeInTheDocument()
+      expect(screen.getByText('4×')).toBeInTheDocument()
+      expect(screen.getByText('—')).toBeInTheDocument()
+      expect(screen.getByText('unlocked')).toBeInTheDocument()
+      expect(screen.getByText(/means an investigation may propose this fix directly/)).toBeInTheDocument()
+    })
+
+    it('marks an unproven entry locked', async () => {
+      stubRoutes(mkState(), [mkEntry({ trust: 'observed' })])
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() => expect(screen.getByText('locked')).toBeInTheDocument())
+      expect(screen.getByText('observed')).toBeInTheDocument()
+    })
+
+    it('reports one refuted entry the top rows may not show', async () => {
+      stubRoutes(mkState({ ledger: mkStats({ demoted: 1, total: 7 }) }), [mkEntry()])
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() =>
+        expect(screen.getByText(/1 of 7 entry has been refuted/)).toBeInTheDocument(),
+      )
+    })
+
+    it('reports several refuted entries with the plural wording', async () => {
+      stubRoutes(mkState({ ledger: mkStats({ demoted: 3, total: 9 }) }), [mkEntry()])
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() =>
+        expect(screen.getByText(/3 of 9 entries have been refuted/)).toBeInTheDocument(),
+      )
+    })
+  })
+
+  describe('closed postmortems', () => {
+    const closedIncident = mkIncident({
+      incident_id: 'omc-9001',
+      status: 'resolved',
+      signal: mkSignal({ id: 'sig-9', title: 'Disk filled on the build host' }),
+    })
+
+    it('says nothing has closed yet when the history is empty', async () => {
+      stubRoutes()
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() =>
+        expect(screen.getByText(/Nothing has closed yet/)).toBeInTheDocument(),
+      )
+      expect(screen.getByText('Closed — postmortems')).toBeInTheDocument()
+    })
+
+    it('surfaces a failed history fetch', async () => {
+      vi.mocked(opsApi.state).mockResolvedValue(mkState())
+      vi.mocked(opsApi.ledger).mockResolvedValue({ entries: [], stats: mkStats() })
+      vi.mocked(opsApi.incidents).mockRejectedValue(new Error('history unreadable'))
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() =>
+        expect(screen.getByText('history unreadable')).toBeInTheDocument(),
+      )
+    })
+
+    it('lists closed incidents and says when the server clipped the list', async () => {
+      vi.mocked(opsApi.state).mockResolvedValue(mkState())
+      vi.mocked(opsApi.ledger).mockResolvedValue({ entries: [], stats: mkStats() })
+      vi.mocked(opsApi.incidents).mockResolvedValue({
+        incidents: [
+          closedIncident,
+          mkIncident({ incident_id: 'omc-9002', status: 'dispatched' }),
+        ],
+        truncated: true,
+        total: 640,
+      })
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() =>
+        expect(screen.getAllByTestId('omc-closed-row')).toHaveLength(1),
+      )
+      expect(screen.getByText('Disk filled on the build host')).toBeInTheDocument()
+      expect(
+        screen.getByText(/Showing the 1 closed incident in the most recent/),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(/2 of 640 — older ones are on disk but not in this list/),
+      ).toBeInTheDocument()
+    })
+
+    it('reads the postmortem on expand, with its path and a copy button', async () => {
+      vi.mocked(opsApi.state).mockResolvedValue(mkState())
+      vi.mocked(opsApi.ledger).mockResolvedValue({ entries: [], stats: mkStats() })
+      vi.mocked(opsApi.incidents).mockResolvedValue({ incidents: [closedIncident] })
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        configurable: true,
+      })
+      vi.mocked(opsApi.incident).mockResolvedValue({
+        incident: closedIncident,
+        log: '# Postmortem\n\nThe build host ran out of disk.',
+        log_path: '/home/u/.kiro/crew/ops/incidents/omc-9001.md',
+      })
+      renderWithProviders(<OpsMissionControlPage />)
+      const row = await waitFor(() => screen.getAllByTestId('omc-closed-row')[0])
+      fireEvent.click(row)
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Copy postmortem/ })).toBeInTheDocument(),
+      )
+      expect(
+        screen.getByText('/home/u/.kiro/crew/ops/incidents/omc-9001.md'),
+      ).toBeInTheDocument()
+      expect(screen.getByText(/The build host ran out of disk/)).toBeInTheDocument()
+      fireEvent.click(screen.getByRole('button', { name: /Copy postmortem/ }))
+      await waitFor(() =>
+        expect(writeText).toHaveBeenCalledWith('# Postmortem\n\nThe build host ran out of disk.'),
+      )
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Copied/ })).toBeInTheDocument(),
+      )
+      // Collapsing the row unmounts the postmortem again.
+      fireEvent.click(screen.getAllByTestId('omc-closed-row')[0])
+      await waitFor(() => expect(screen.queryByText(/Copy postmortem/)).toBeNull())
+    })
+
+    it('stays silent when the clipboard refuses the copy', async () => {
+      vi.mocked(opsApi.state).mockResolvedValue(mkState())
+      vi.mocked(opsApi.ledger).mockResolvedValue({ entries: [], stats: mkStats() })
+      vi.mocked(opsApi.incidents).mockResolvedValue({ incidents: [closedIncident] })
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: vi.fn().mockRejectedValue(new Error('permission denied')) },
+        configurable: true,
+      })
+      vi.mocked(opsApi.incident).mockResolvedValue({
+        incident: closedIncident,
+        log: 'the record',
+        log_path: '',
+      })
+      renderWithProviders(<OpsMissionControlPage />)
+      const row = await waitFor(() => screen.getAllByTestId('omc-closed-row')[0])
+      fireEvent.click(row)
+      const copy = await waitFor(() =>
+        screen.getByRole('button', { name: /Copy postmortem/ }),
+      )
+      fireEvent.click(copy)
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Copy postmortem/ })).toBeInTheDocument(),
+      )
+      expect(screen.queryByText(/Copied/)).toBeNull()
+    })
+
+    it('distinguishes an incident that never got a postmortem from an empty one', async () => {
+      vi.mocked(opsApi.state).mockResolvedValue(mkState())
+      vi.mocked(opsApi.ledger).mockResolvedValue({ entries: [], stats: mkStats() })
+      vi.mocked(opsApi.incidents).mockResolvedValue({ incidents: [closedIncident] })
+      vi.mocked(opsApi.incident).mockResolvedValue({
+        incident: closedIncident,
+        log: '',
+        log_path: '',
+      })
+      renderWithProviders(<OpsMissionControlPage />)
+      const row = await waitFor(() => screen.getAllByTestId('omc-closed-row')[0])
+      fireEvent.click(row)
+      await waitFor(() =>
+        expect(
+          screen.getByText(/No postmortem was written for this incident/),
+        ).toBeInTheDocument(),
+      )
+    })
+
+    it('surfaces a failed postmortem read', async () => {
+      vi.mocked(opsApi.state).mockResolvedValue(mkState())
+      vi.mocked(opsApi.ledger).mockResolvedValue({ entries: [], stats: mkStats() })
+      vi.mocked(opsApi.incidents).mockResolvedValue({ incidents: [closedIncident] })
+      vi.mocked(opsApi.incident).mockRejectedValue(new Error('artifact missing on disk'))
+      renderWithProviders(<OpsMissionControlPage />)
+      const row = await waitFor(() => screen.getAllByTestId('omc-closed-row')[0])
+      fireEvent.click(row)
+      await waitFor(() =>
+        expect(screen.getByText('artifact missing on disk')).toBeInTheDocument(),
+      )
+    })
+
+    it('shows a per-status label and age on the closed row', async () => {
+      vi.mocked(opsApi.state).mockResolvedValue(mkState())
+      vi.mocked(opsApi.ledger).mockResolvedValue({ entries: [], stats: mkStats() })
+      vi.mocked(opsApi.incidents).mockResolvedValue({
+        incidents: [
+          closedIncident,
+          mkIncident({
+            incident_id: 'omc-9003',
+            status: 'escalated',
+            updated_at: agoIso(7200),
+            signal: mkSignal({ id: 'sig-esc', title: 'Paged out', severity: 'info' }),
+          }),
+        ],
+      })
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() =>
+        expect(screen.getAllByTestId('omc-closed-row')).toHaveLength(2),
+      )
+      expect(screen.getByText('Escalated')).toBeInTheDocument()
+      expect(screen.getByText('info')).toBeInTheDocument()
+      expect(screen.getByText('2h')).toBeInTheDocument()
+    })
+  })
+
+  describe('row status icons', () => {
+    const statuses: IncidentStatus[] = [
+      'investigating',
+      'dispatched',
+      'needs_human',
+      'resolved',
+      'escalated',
+      'stale',
+      'unclaimed',
+    ]
+
+    it('renders one row per status without falling over on any of them', async () => {
+      stubRoutes(
+        mkState({
+          incidents: statuses.map((status, i) =>
+            mkIncident({ incident_id: `omc-${i}`, status }),
+          ),
+        }),
+      )
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() =>
+        expect(screen.getAllByTestId('omc-incident-row')).toHaveLength(statuses.length),
+      )
+      expect(screen.getByText('Stale')).toBeInTheDocument()
+      expect(screen.getByText('Unclaimed')).toBeInTheDocument()
+      expect(screen.getByText('Needs human')).toBeInTheDocument()
+    })
+
+    it('degrades to the plain status for a blocked reason it has no wording for', async () => {
+      stubRoutes(
+        mkState({
+          incidents: [
+            mkIncident({
+              // A future backend value the catalog has no copy for yet. The row
+              // shows the STATUS in that case — `blockedLabel`'s
+              // underscore-stripping fallback is unreachable from here, because
+              // `statusText` only consults it for a reason it already knows.
+              blocked_reason: 'awaiting_parts' as Incident['blocked_reason'],
+            }),
+          ],
+        }),
+      )
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() => expect(screen.getByText('Investigating')).toBeInTheDocument())
+      expect(screen.queryByText(/awaiting.parts/)).toBeNull()
+      // It still counts as work waiting on a person, from `blocked_reason` alone.
+      const card = screen.getByText('Waiting on you').closest('[data-testid="stat-card"]')
+      expect(card?.querySelector('[data-testid="stat-card-value"]')?.textContent).toBe('1')
+    })
+
+    it('renders every severity variant', async () => {
+      stubRoutes(
+        mkState({
+          incidents: [
+            mkIncident({ incident_id: 'a', signal: mkSignal({ severity: 'critical' }) }),
+            mkIncident({ incident_id: 'b', signal: mkSignal({ severity: 'warning' }) }),
+            mkIncident({ incident_id: 'c', signal: mkSignal({ severity: 'info' }) }),
+          ],
+        }),
+      )
+      renderWithProviders(<OpsMissionControlPage />)
+      await waitFor(() => expect(screen.getByText('critical')).toBeInTheDocument())
+      expect(screen.getByText('warning')).toBeInTheDocument()
+      expect(screen.getByText('info')).toBeInTheDocument()
+    })
+
+    it('renders an em dash for an incident whose signal carries no resource', async () => {
+      stubRoutes(
+        mkState({ incidents: [mkIncident({ signal: mkSignal({ resource: '' }) })] }),
+      )
+      renderWithProviders(<OpsMissionControlPage />)
+      await expandFirstRow()
+      expect(screen.getByText('Resource')).toBeInTheDocument()
+      expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+})

--- a/website/src/test/PetBridgeCoverage.test.tsx
+++ b/website/src/test/PetBridgeCoverage.test.tsx
@@ -1,0 +1,848 @@
+// The parts of the pet bridge that the existing suites never reach: the browser
+// file pickers, the read helpers' failure arms, the coalesced position write, the
+// listener fan-out and the context-menu actions.
+//
+// The bridge is the whole boundary between the Crew Companion pages and the
+// gateway, and most of its methods have a refusal arm that is only visible when
+// the network says no. Those arms are where the interesting regressions live —
+// a refusal read back as a success discards the user's artwork — so they are
+// exercised here alongside the happy paths.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { petBridge } from '../apps/crew-companion/petBridge'
+import {
+  APPEARANCE_COLOURS_PATH,
+  APPEARANCE_DELETE_PATH,
+  APPEARANCE_DETAIL_PATH,
+  APPEARANCE_EXPORT_PATH,
+  APPEARANCE_IMPORT_PATH,
+  APPEARANCE_SAVE_PATH,
+  APPEARANCES_PATH,
+  CONFIG_PATH,
+  PETDEX_FETCH_PATH,
+  REMINDERS_PATH,
+  REMOVE_PATH,
+} from '../apps/crew-companion/constants'
+
+/** One answer for one request: a status, a body, or a transport failure. */
+interface Reply {
+  ok?: boolean
+  body?: unknown
+  /** Reject instead of answering — the "gateway is gone" case. */
+  fails?: boolean
+  /** Answer with a body that is not JSON, so `r.json()` throws. */
+  badJson?: boolean
+}
+
+interface Call {
+  url: string
+  method: string
+  body: unknown
+}
+
+/**
+ * A fetch double that routes by URL.
+ *
+ * The bridge reads `r.ok` (postJson), `r.json()` (getJson / postForJson) or both,
+ * so every reply exposes both and the route decides which arm the caller lands in.
+ */
+function stubFetch(route: (url: string) => Reply) {
+  const calls: Call[] = []
+  const fn = vi.fn(async (url: string, init?: RequestInit) => {
+    const raw = init?.body
+    calls.push({
+      url,
+      method: init?.method ?? 'GET',
+      body: typeof raw === 'string' ? JSON.parse(raw) : undefined,
+    })
+    const reply = route(url)
+    if (reply.fails) throw new Error('network down')
+    return {
+      ok: reply.ok ?? true,
+      json: async () => {
+        if (reply.badJson) throw new Error('not json')
+        return reply.body ?? {}
+      },
+    } as unknown as Response
+  })
+  vi.stubGlobal('fetch', fn)
+  return { fn, calls }
+}
+
+/** Every request answers the same way. */
+function stubFetchAll(reply: Reply) {
+  return stubFetch(() => reply)
+}
+
+/**
+ * Answer the browser file dialog.
+ *
+ * `pickJsonFile` / `pickImageFile` / `pickArtFile` build a hidden <input type=file>,
+ * attach their listeners and click it. Intercepting the click is what lets a test
+ * hand back a chosen file — or a cancel — without a real dialog.
+ */
+function armPicker(file: File | null) {
+  return vi
+    .spyOn(HTMLInputElement.prototype, 'click')
+    .mockImplementation(function mockClick(this: HTMLInputElement) {
+      if (file) {
+        Object.defineProperty(this, 'files', { value: [file], configurable: true })
+        this.dispatchEvent(new Event('change'))
+      } else {
+        this.dispatchEvent(new Event('cancel'))
+      }
+    })
+}
+
+interface PreloadStub {
+  appearanceChanged: ReturnType<typeof vi.fn>
+  onAppearanceChanged: ReturnType<typeof vi.fn>
+  contextMenuAction: ReturnType<typeof vi.fn>
+  galleryOpen: ReturnType<typeof vi.fn>
+  galleryClose: ReturnType<typeof vi.fn>
+  openExternal: ReturnType<typeof vi.fn>
+  updateHitbox: ReturnType<typeof vi.fn>
+  setMenuHitbox: ReturnType<typeof vi.fn>
+}
+
+/** Install the preload bridge the desktop windows have and a browser tab does not. */
+function stubPreload(offBridge = vi.fn()): PreloadStub {
+  const bridge: PreloadStub = {
+    appearanceChanged: vi.fn(),
+    onAppearanceChanged: vi.fn(() => offBridge),
+    contextMenuAction: vi.fn(),
+    galleryOpen: vi.fn(),
+    galleryClose: vi.fn(),
+    openExternal: vi.fn(),
+    updateHitbox: vi.fn(),
+    setMenuHitbox: vi.fn(),
+  }
+  ;(window as unknown as { crewCompanion?: unknown }).crewCompanion = bridge
+  return bridge
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  delete (window as unknown as { crewCompanion?: unknown }).crewCompanion
+})
+
+describe('getWindowPosition', () => {
+  it('reads petX/petY off the FLAT snapshot', async () => {
+    const { calls } = stubFetchAll({ body: { petX: 120, petY: 340 } })
+    expect(await petBridge.getWindowPosition!()).toEqual({ x: 120, y: 340 })
+    expect(calls[0].url).toBe(REMINDERS_PATH)
+  })
+
+  it('reports "never moved" as null so the renderer keeps its own placement', async () => {
+    stubFetchAll({ body: { petX: null, petY: null } })
+    expect(await petBridge.getWindowPosition!()).toBeNull()
+  })
+
+  it('reports null when only one axis was stored', async () => {
+    stubFetchAll({ body: { petX: 10 } })
+    expect(await petBridge.getWindowPosition!()).toBeNull()
+  })
+
+  it('reports null on a non-2xx snapshot', async () => {
+    stubFetchAll({ ok: false })
+    expect(await petBridge.getWindowPosition!()).toBeNull()
+  })
+
+  it('reports null when the gateway is unreachable', async () => {
+    stubFetchAll({ fails: true })
+    expect(await petBridge.getWindowPosition!()).toBeNull()
+  })
+})
+
+describe('savePosition coalescing', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    // Drain the pending write so the module's timer handle is back to null for
+    // the next test — otherwise a later savePosition would never schedule.
+    vi.advanceTimersByTime(500)
+    vi.useRealTimers()
+  })
+
+  it('writes ONCE for a burst, keeping the last position and rounding both axes', () => {
+    const { fn, calls } = stubFetchAll({ body: { ok: true } })
+    petBridge.savePosition!(10.4, 20.6)
+    petBridge.savePosition!(30.2, 40.8)
+    // Nothing goes out until the coalescing window closes.
+    expect(fn).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(250)
+
+    expect(fn).toHaveBeenCalledOnce()
+    expect(calls[0].url).toBe(CONFIG_PATH)
+    expect(calls[0].method).toBe('POST')
+    // Both axes together: the backend refuses half a position.
+    expect(calls[0].body).toEqual({ petX: 30, petY: 41 })
+  })
+
+  it('swallows a failed write — the companion stays where it is on screen', async () => {
+    stubFetchAll({ fails: true })
+    petBridge.savePosition!(1, 2)
+    vi.advanceTimersByTime(250)
+    // No unhandled rejection escapes; the call simply had no effect.
+    await Promise.resolve()
+    expect(true).toBe(true)
+  })
+})
+
+describe('config and export reads', () => {
+  it('getCrewCompanionConfig hands back the snapshot verbatim', async () => {
+    stubFetchAll({ body: { activeAppearance: 'ghost', petX: 4 } })
+    expect(await petBridge.getCrewCompanionConfig!()).toEqual({ activeAppearance: 'ghost', petX: 4 })
+  })
+
+  it('getCrewCompanionConfig reports null when the body is not JSON', async () => {
+    stubFetchAll({ badJson: true })
+    expect(await petBridge.getCrewCompanionConfig!()).toBeNull()
+  })
+
+  it('galleryExport encodes the pack id into the query', async () => {
+    const { calls } = stubFetchAll({ body: { bundle: 1 } })
+    expect(await petBridge.galleryExport!('a b/c')).toEqual({ bundle: 1 })
+    expect(calls[0].url).toBe(`${APPEARANCE_EXPORT_PATH}?id=a%20b%2Fc`)
+  })
+
+  it('galleryGetPackDetail asks for the detail route with the id as a query param', async () => {
+    const { calls } = stubFetchAll({ body: { animations: {} } })
+    await petBridge.galleryGetPackDetail!('pack/one')
+    expect(calls[0].url).toBe(`${APPEARANCE_DETAIL_PATH}?id=pack%2Fone`)
+  })
+
+  it('presetsLoadCustom returns the stored presets, and [] when they are not a list', async () => {
+    stubFetchAll({ body: { customPresets: [{ name: 'dusk' }] } })
+    expect(await petBridge.presetsLoadCustom!()).toEqual([{ name: 'dusk' }])
+
+    vi.unstubAllGlobals()
+    stubFetchAll({ body: { customPresets: 'nope' } })
+    expect(await petBridge.presetsLoadCustom!()).toEqual([])
+  })
+
+  it('presetsSaveCustom posts the list to the config route', async () => {
+    const { calls } = stubFetchAll({ ok: true })
+    expect(await petBridge.presetsSaveCustom!([{ name: 'dusk' }])).toBe(true)
+    expect(calls[0].url).toBe(CONFIG_PATH)
+    expect(calls[0].body).toEqual({ customPresets: [{ name: 'dusk' }] })
+  })
+
+  it('remindersRemove posts the id and reports the HTTP outcome', async () => {
+    const { calls } = stubFetchAll({ ok: true })
+    expect(await petBridge.remindersRemove!('r-1')).toBe(true)
+    expect(calls[0].url).toBe(REMOVE_PATH)
+    expect(calls[0].body).toEqual({ id: 'r-1' })
+
+    vi.unstubAllGlobals()
+    stubFetchAll({ fails: true })
+    expect(await petBridge.remindersRemove!('r-1')).toBe(false)
+  })
+
+  it('galleryListPacks asks the appearances route', async () => {
+    const { calls } = stubFetchAll({ body: { packs: [] } })
+    await petBridge.galleryListPacks!()
+    expect(calls[0].url).toBe(APPEARANCES_PATH)
+  })
+
+  it('presetsGetColorMap reads the map off the detail payload, null when absent', async () => {
+    stubFetchAll({ body: { colorMap: { '#fff': '#f0f' } } })
+    expect(await petBridge.presetsGetColorMap!('p')).toEqual({ '#fff': '#f0f' })
+
+    vi.unstubAllGlobals()
+    stubFetchAll({ body: {} })
+    expect(await petBridge.presetsGetColorMap!('p')).toBeNull()
+  })
+})
+
+describe('galleryReadPackFile', () => {
+  it('returns the ORIGINAL sheet when the requested name is the sprite source', async () => {
+    stubFetchAll({ body: { sprite: { source: 'source.png' }, sourceImage: 'QkFTRTY0' } })
+    expect(await petBridge.galleryReadPackFile!('p', 'source.png')).toBe('QkFTRTY0')
+  })
+
+  it('falls back to the animation slot when the name is not the sprite source', async () => {
+    stubFetchAll({ body: { sprite: { source: 'source.png' }, animations: { idle: '<svg/>' } } })
+    expect(await petBridge.galleryReadPackFile!('p', 'idle.svg')).toBe('<svg/>')
+  })
+
+  it('unwraps an animation slot stored as an object with content', async () => {
+    stubFetchAll({ body: { animations: { idle: { content: '<svg>obj</svg>', format: 'svg' } } } })
+    expect(await petBridge.galleryReadPackFile!('p', 'idle.svg')).toBe('<svg>obj</svg>')
+  })
+
+  it('returns null for a filename the pack does not have', async () => {
+    stubFetchAll({ body: { animations: {} } })
+    expect(await petBridge.galleryReadPackFile!('p', 'missing.svg')).toBeNull()
+  })
+
+  it('returns null when the detail read itself fails', async () => {
+    stubFetchAll({ ok: false })
+    expect(await petBridge.galleryReadPackFile!('p', 'idle.svg')).toBeNull()
+  })
+})
+
+describe('galleryImportBundle — the browser file dialog', () => {
+  it('installs the parsed bundle and tells the packs listeners', async () => {
+    const { calls } = stubFetchAll({ body: { ok: true, packId: 'imported' } })
+    armPicker(new File(['{"meta":{"id":"imported"}}'], 'pack.json', { type: 'application/json' }))
+    const heard = vi.fn()
+    const off = petBridge.onGalleryPacksChanged!(heard)
+
+    const result = await petBridge.galleryImportBundle!()
+    off()
+
+    expect(result).toEqual({ ok: true, packId: 'imported' })
+    expect(calls[0].url).toBe(APPEARANCE_IMPORT_PATH)
+    expect(calls[0].body).toEqual({ bundle: { meta: { id: 'imported' } } })
+    expect(heard).toHaveBeenCalledOnce()
+  })
+
+  it('treats a cancelled dialog as a silent refusal with no message and no request', async () => {
+    const { fn } = stubFetchAll({ body: { ok: true } })
+    armPicker(null)
+    expect(await petBridge.galleryImportBundle!()).toEqual({ ok: false, error: '' })
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('refuses a file that is not valid JSON before touching the network', async () => {
+    const { fn } = stubFetchAll({ body: { ok: true } })
+    armPicker(new File(['not json at all'], 'pack.json', { type: 'application/json' }))
+    expect(await petBridge.galleryImportBundle!()).toEqual({
+      ok: false,
+      error: 'That file is not valid JSON',
+    })
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('reports a generic failure when the import request never answers', async () => {
+    stubFetchAll({ fails: true })
+    armPicker(new File(['{}'], 'pack.json', { type: 'application/json' }))
+    expect(await petBridge.galleryImportBundle!()).toEqual({ ok: false, error: 'Import failed' })
+  })
+
+  it('does not notify the packs listeners when the import is refused', async () => {
+    stubFetchAll({ ok: false, body: { error: 'already installed' } })
+    armPicker(new File(['{}'], 'pack.json', { type: 'application/json' }))
+    const heard = vi.fn()
+    const off = petBridge.onGalleryPacksChanged!(heard)
+
+    const result = await petBridge.galleryImportBundle!()
+    off()
+
+    // postForJson stamps ok:false on a non-2xx body while keeping its reason.
+    expect(result).toEqual({ ok: false, error: 'already installed' })
+    expect(heard).not.toHaveBeenCalled()
+  })
+})
+
+describe('galleryImportFile — one art file for one editor slot', () => {
+  it('reads an SVG as markup', async () => {
+    armPicker(new File(['<svg>art</svg>'], 'Idle.SVG', { type: 'image/svg+xml' }))
+    expect(await petBridge.galleryImportFile!()).toEqual({
+      ok: true,
+      value: { content: '<svg>art</svg>', filename: 'Idle.SVG', format: 'svg' },
+    })
+  })
+
+  it('reads a valid JSON file as lottie', async () => {
+    armPicker(new File(['{"v":"5.7"}'], 'wiggle.json', { type: 'application/json' }))
+    expect(await petBridge.galleryImportFile!()).toEqual({
+      ok: true,
+      value: { content: '{"v":"5.7"}', filename: 'wiggle.json', format: 'lottie' },
+    })
+  })
+
+  it('refuses broken lottie now rather than at render time', async () => {
+    armPicker(new File(['{oops'], 'wiggle.json', { type: 'application/json' }))
+    expect(await petBridge.galleryImportFile!()).toEqual({
+      ok: false,
+      error: 'Could not read wiggle.json',
+    })
+  })
+
+  it('base64-encodes a PNG into a data URI', async () => {
+    armPicker(new File([new Uint8Array([104, 105])], 'sheet.png', { type: 'image/png' }))
+    expect(await petBridge.galleryImportFile!()).toEqual({
+      ok: true,
+      value: { content: `data:image/png;base64,${btoa('hi')}`, filename: 'sheet.png', format: 'sprite' },
+    })
+  })
+
+  it('names the unsupported type in its refusal', async () => {
+    armPicker(new File(['x'], 'notes.txt', { type: 'text/plain' }))
+    expect(await petBridge.galleryImportFile!()).toEqual({
+      ok: false,
+      error: 'Unsupported file type: notes.txt',
+    })
+  })
+
+  it('answers null on cancel, so the caller shows no message', async () => {
+    armPicker(null)
+    expect(await petBridge.galleryImportFile!()).toBeNull()
+  })
+
+  it('settles once when the dialog reports both a choice and a cancel', async () => {
+    const file = new File(['<svg/>'], 'idle.svg', { type: 'image/svg+xml' })
+    // Some browsers fire `cancel` after `change`; the second event must not
+    // overwrite the chosen file with a null.
+    vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(function mockClick(
+      this: HTMLInputElement,
+    ) {
+      Object.defineProperty(this, 'files', { value: [file], configurable: true })
+      this.dispatchEvent(new Event('change'))
+      this.dispatchEvent(new Event('cancel'))
+    })
+
+    const result = await petBridge.galleryImportFile!()
+    expect(result).toEqual({
+      ok: true,
+      value: { content: '<svg/>', filename: 'idle.svg', format: 'svg' },
+    })
+  })
+})
+
+describe('importSpriteFile', () => {
+  it('hands back the sheet bytes with the data-URL prefix stripped', async () => {
+    armPicker(new File([new Uint8Array([104, 105])], 'sheet.png', { type: 'image/png' }))
+    const result = await petBridge.importSpriteFile!()
+    expect(result.ok).toBe(true)
+    expect(result.value?.content).toBe(btoa('hi'))
+  })
+
+  it('answers with an empty message on cancel', async () => {
+    armPicker(null)
+    expect(await petBridge.importSpriteFile!()).toEqual({ ok: false, error: '' })
+  })
+
+  it('reports an unreadable image rather than saving nothing', async () => {
+    armPicker(new File(['x'], 'sheet.png', { type: 'image/png' }))
+    // A reader that fails is the only way to reach the "could not read" arm; a
+    // real FileReader always produces a data URL for a Blob it was handed.
+    vi.stubGlobal(
+      'FileReader',
+      class {
+        onload: (() => void) | null = null
+        onerror: (() => void) | null = null
+        result: string | null = null
+        readAsDataURL() {
+          this.onerror?.()
+        }
+      },
+    )
+    expect(await petBridge.importSpriteFile!()).toEqual({
+      ok: false,
+      error: 'That image could not be read',
+    })
+  })
+})
+
+describe('gallerySetActive', () => {
+  it('notifies in-page listeners AND broadcasts to the overlay window', async () => {
+    const { calls } = stubFetchAll({ ok: true })
+    const bridge = stubPreload()
+    const heard = vi.fn()
+    const off = petBridge.onGalleryActiveChanged!(heard)
+
+    const result = await petBridge.gallerySetActive!('ghost')
+    off()
+
+    expect(result).toEqual({ ok: true, packId: 'ghost' })
+    expect(calls[0].url).toBe(CONFIG_PATH)
+    expect(calls[0].body).toEqual({ activeAppearance: 'ghost' })
+    expect(heard).toHaveBeenCalledOnce()
+    expect(bridge.appearanceChanged).toHaveBeenCalledOnce()
+  })
+
+  it('reports a refusal with a reason and repaints nothing', async () => {
+    stubFetchAll({ ok: false })
+    const bridge = stubPreload()
+    const heard = vi.fn()
+    const off = petBridge.onGalleryActiveChanged!(heard)
+
+    expect(await petBridge.gallerySetActive!('ghost')).toEqual({
+      ok: false,
+      error: 'Could not switch avatar',
+    })
+    off()
+    expect(heard).not.toHaveBeenCalled()
+    expect(bridge.appearanceChanged).not.toHaveBeenCalled()
+  })
+})
+
+describe('listener registration', () => {
+  it('onGalleryActiveChanged also subscribes to the cross-window broadcast and drops both on unsubscribe', async () => {
+    const offBridge = vi.fn()
+    const bridge = stubPreload(offBridge)
+    const heard = vi.fn()
+
+    const off = petBridge.onGalleryActiveChanged!(heard)
+    expect(bridge.onAppearanceChanged).toHaveBeenCalledWith(heard)
+    off()
+    expect(offBridge).toHaveBeenCalledOnce()
+
+    // Unsubscribed: a later switch reaches nobody.
+    stubFetchAll({ ok: true })
+    await petBridge.gallerySetActive!('ghost')
+    expect(heard).not.toHaveBeenCalled()
+  })
+
+  it('onGalleryActiveChanged works in a plain browser tab with no preload bridge', async () => {
+    const heard = vi.fn()
+    const off = petBridge.onGalleryActiveChanged!(heard)
+    stubFetchAll({ ok: true })
+    await petBridge.gallerySetActive!('ghost')
+    expect(heard).toHaveBeenCalledOnce()
+    // Dropping the subscription must not throw when there was no bridge to drop.
+    expect(() => off()).not.toThrow()
+  })
+
+  it('onColorMapChanged receives the pack id and map, and stops after unsubscribe', async () => {
+    stubFetchAll({ ok: true })
+    const heard = vi.fn()
+    const off = petBridge.onColorMapChanged!(heard)
+
+    await petBridge.gallerySetColorMap!('ghost', { '#fff': '#f0f' })
+    expect(heard).toHaveBeenCalledWith({ packId: 'ghost', colorMap: { '#fff': '#f0f' } })
+
+    off()
+    await petBridge.gallerySetColorMap!('ghost', { '#fff': '#000' })
+    expect(heard).toHaveBeenCalledOnce()
+  })
+
+  it('gallerySetColorMap reports a refusal with a reason', async () => {
+    stubFetchAll({ ok: false })
+    const { calls } = stubFetch(() => ({ ok: false }))
+    expect(await petBridge.gallerySetColorMap!('ghost', { '#fff': '#f0f' })).toEqual({
+      ok: false,
+      error: 'Could not save those colours',
+    })
+    expect(calls[0].url).toBe(APPEARANCE_COLOURS_PATH)
+  })
+
+  it('onConfigUpdated fires on a successful save and stops after unsubscribe', async () => {
+    stubFetchAll({ body: { ok: true } })
+    const heard = vi.fn()
+    const off = petBridge.onConfigUpdated!(heard)
+
+    await petBridge.updateConfig!({ activeAppearance: 'ghost' })
+    expect(heard).toHaveBeenCalledOnce()
+
+    off()
+    await petBridge.updateConfig!({ activeAppearance: 'other' })
+    expect(heard).toHaveBeenCalledOnce()
+  })
+
+  it('an activeAppearance patch repaints the overlay window', async () => {
+    stubFetchAll({ body: { ok: true } })
+    const bridge = stubPreload()
+    expect(await petBridge.updateConfig!({ activeAppearance: 'ghost' })).toBe(true)
+    expect(bridge.appearanceChanged).toHaveBeenCalledOnce()
+  })
+
+  it('updateConfig reports false when the gateway never answers', async () => {
+    stubFetchAll({ fails: true })
+    expect(await petBridge.updateConfig!({ activeAppearance: 'ghost' })).toBe(false)
+  })
+})
+
+describe('galleryDelete', () => {
+  it('deletes the pack and tells the packs listeners', async () => {
+    const { calls } = stubFetchAll({ ok: true })
+    const heard = vi.fn()
+    const off = petBridge.onGalleryPacksChanged!(heard)
+
+    expect(await petBridge.galleryDelete!('ghost')).toBe(true)
+    off()
+
+    expect(calls[0].url).toBe(APPEARANCE_DELETE_PATH)
+    expect(calls[0].body).toEqual({ id: 'ghost' })
+    expect(heard).toHaveBeenCalledOnce()
+  })
+
+  it('a refused delete notifies nobody', async () => {
+    stubFetchAll({ ok: false })
+    const heard = vi.fn()
+    const off = petBridge.onGalleryPacksChanged!(heard)
+    expect(await petBridge.galleryDelete!('ghost')).toBe(false)
+    off()
+    expect(heard).not.toHaveBeenCalled()
+  })
+})
+
+describe('gallerySaveSpritePack — slot classification and fallbacks', () => {
+  const sheet = 'data:image/png;base64,QQ=='
+
+  it('files an unknown slot as a MOOD and keeps the source sheet for re-editing', async () => {
+    const { calls } = stubFetchAll({ body: { ok: true } })
+    await petBridge.gallerySaveSpritePack!({
+      name: 'Ghost',
+      author: 'me',
+      description: '',
+      frameWidth: 32,
+      frameHeight: 32,
+      fps: 8,
+      flipX: false,
+      offsetY: 0,
+      assignments: { idle: sheet, celebrating: sheet, blank: '' },
+      randomAssignments: {},
+      rowAssignments: {},
+      sourceImage: sheet,
+      overwriteId: 'ghost',
+    })
+
+    const payload = calls[0].body as {
+      id: string
+      manifest: {
+        states: Record<string, string>
+        moods: Record<string, string>
+        sprite: { source?: string }
+      }
+      files: Record<string, string>
+    }
+    expect(payload.id).toBe('ghost')
+    expect(payload.manifest.states).toHaveProperty('idle')
+    // `celebrating` is not a known state, so it must land in moods.
+    expect(payload.manifest.moods).toHaveProperty('celebrating')
+    expect(payload.manifest.states).not.toHaveProperty('celebrating')
+    // An empty strip is skipped rather than written as an empty file.
+    expect(payload.files).not.toHaveProperty('blank.png')
+    expect(payload.manifest.sprite.source).toBe('source.png')
+    expect(payload.files['source.png']).toBe('QQ==')
+  })
+
+  it('omits the sprite source when the pack kept no sheet', async () => {
+    const { calls } = stubFetchAll({ body: { ok: true } })
+    await petBridge.gallerySaveSpritePack!({
+      name: 'Ghost',
+      author: '',
+      description: '',
+      frameWidth: 32,
+      frameHeight: 32,
+      fps: 8,
+      flipX: false,
+      offsetY: 0,
+      assignments: { idle: sheet },
+      randomAssignments: {},
+      rowAssignments: {},
+    })
+    const payload = calls[0].body as { manifest: { sprite: { source?: string } }; files: Record<string, string> }
+    expect(payload.manifest.sprite.source).toBeUndefined()
+    expect(payload.files).not.toHaveProperty('source.png')
+  })
+
+  it('refuses a sprite pack with no art and does not hit the network', async () => {
+    const { fn } = stubFetchAll({ body: { ok: true } })
+    const result = await petBridge.gallerySaveSpritePack!({
+      name: 'Ghost',
+      author: '',
+      description: '',
+      frameWidth: 32,
+      frameHeight: 32,
+      fps: 8,
+      flipX: false,
+      offsetY: 0,
+      assignments: {},
+      randomAssignments: {},
+      rowAssignments: {},
+    })
+    expect(result.ok).toBe(false)
+    expect(typeof result.error).toBe('string')
+    expect(result.error).not.toBe('')
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('reports a failure when the save request never answers', async () => {
+    stubFetchAll({ fails: true })
+    const result = await petBridge.gallerySaveSpritePack!({
+      name: 'Ghost',
+      author: '',
+      description: '',
+      frameWidth: 32,
+      frameHeight: 32,
+      fps: 8,
+      flipX: false,
+      offsetY: 0,
+      assignments: { idle: sheet },
+      randomAssignments: {},
+      rowAssignments: {},
+    })
+    expect(result.ok).toBe(false)
+    expect(result.error).not.toBe('')
+  })
+})
+
+describe('gallerySavePack and petdexFetch fallbacks', () => {
+  it('gallerySavePack notifies both packs and active listeners on success', async () => {
+    stubFetchAll({ body: { ok: true } })
+    const packs = vi.fn()
+    const active = vi.fn()
+    const offPacks = petBridge.onGalleryPacksChanged!(packs)
+    const offActive = petBridge.onGalleryActiveChanged!(active)
+
+    await petBridge.gallerySavePack!({ meta: { id: 'p' }, states: { idle: '<svg/>' } })
+    offPacks()
+    offActive()
+
+    expect(packs).toHaveBeenCalledOnce()
+    expect(active).toHaveBeenCalledOnce()
+  })
+
+  it('gallerySavePack reports a generic failure when the request never answers', async () => {
+    stubFetchAll({ fails: true })
+    expect(await petBridge.gallerySavePack!({ meta: { id: 'p' }, states: { idle: '<svg/>' } })).toEqual({
+      ok: false,
+      error: 'Save failed',
+    })
+  })
+
+  it('gallerySavePack files a lottie random clip under an indexed json name', async () => {
+    const { calls } = stubFetchAll({ body: { ok: true } })
+    await petBridge.gallerySavePack!({
+      meta: { id: 'p' },
+      states: { idle: '<svg/>' },
+      random: { 'Look Up': '{"v":"5.7"}', skipped: '   ' },
+    })
+    const payload = calls[0].body as {
+      manifest: { meta: { format: string }; random: Record<string, string> }
+    }
+    expect(payload.manifest.random['Look Up']).toBe('random-0.json')
+    expect(payload.manifest.random).not.toHaveProperty('skipped')
+    expect(payload.manifest.meta.format).toBe('lottie')
+    expect(calls[0].url).toBe(APPEARANCE_SAVE_PATH)
+  })
+
+  it('petdexFetch passes the input through and falls back to a message on failure', async () => {
+    const { calls } = stubFetchAll({ body: { ok: true, name: 'Ghost' } })
+    expect(await petBridge.petdexFetch!('ghost')).toEqual({ ok: true, name: 'Ghost' })
+    expect(calls[0].url).toBe(PETDEX_FETCH_PATH)
+    expect(calls[0].body).toEqual({ input: 'ghost' })
+
+    vi.unstubAllGlobals()
+    stubFetchAll({ fails: true })
+    expect(await petBridge.petdexFetch!('ghost')).toEqual({
+      ok: false,
+      error: 'PetDex import failed',
+    })
+  })
+
+  it('a non-2xx body with no ok field is still reported as a refusal', async () => {
+    stubFetchAll({ ok: false, body: { error: 'too large', code: 'payload_too_big' } })
+    expect(await petBridge.petdexFetch!('ghost')).toEqual({
+      ok: false,
+      error: 'too large',
+      code: 'payload_too_big',
+    })
+  })
+
+  it('a non-2xx body that is not an object still reports a refusal', async () => {
+    stubFetchAll({ ok: false, body: 'plain text' })
+    expect(await petBridge.petdexFetch!('ghost')).toEqual({ ok: false })
+  })
+})
+
+describe('openExternal', () => {
+  it('hands an https link to the main process when the bridge is there', () => {
+    const bridge = stubPreload()
+    petBridge.openExternal!('https://petdex.dev/ghost')
+    expect(bridge.openExternal).toHaveBeenCalledWith('https://petdex.dev/ghost')
+  })
+
+  it('opens a new tab when there is no bridge', () => {
+    const open = vi.fn()
+    vi.stubGlobal('open', open)
+    petBridge.openExternal!('https://petdex.dev/ghost')
+    expect(open).toHaveBeenCalledWith('https://petdex.dev/ghost', '_blank', 'noopener,noreferrer')
+  })
+
+  it('refuses a non-https scheme outright', () => {
+    const bridge = stubPreload()
+    const open = vi.fn()
+    vi.stubGlobal('open', open)
+    petBridge.openExternal!('file:///etc/hosts')
+    petBridge.openExternal!('http://petdex.dev')
+    expect(bridge.openExternal).not.toHaveBeenCalled()
+    expect(open).not.toHaveBeenCalled()
+  })
+})
+
+describe('window-level bridge calls', () => {
+  it('closeGallery asks the main process to close its window', () => {
+    const bridge = stubPreload()
+    petBridge.closeGallery!()
+    expect(bridge.galleryClose).toHaveBeenCalledOnce()
+  })
+
+  it('updateHitbox and setMenuHitbox forward their rects', () => {
+    const bridge = stubPreload()
+    const pet = { x: 1, y: 2, w: 3, h: 4 }
+    petBridge.updateHitbox!(pet, null)
+    petBridge.setMenuHitbox!(pet)
+    petBridge.setMenuHitbox!(null)
+    expect(bridge.updateHitbox).toHaveBeenCalledWith(pet, null)
+    expect(bridge.setMenuHitbox).toHaveBeenNthCalledWith(1, pet)
+    expect(bridge.setMenuHitbox).toHaveBeenNthCalledWith(2, null)
+  })
+
+  it('every window-level call is a no-op in a plain browser tab', () => {
+    expect(() => {
+      petBridge.closeGallery!()
+      petBridge.updateHitbox!(null, null)
+      petBridge.setMenuHitbox!(null)
+      petBridge.contextMenuAction!('gallery')
+    }).not.toThrow()
+  })
+})
+
+describe('contextMenuAction', () => {
+  it('"quit" disables the app instead of quitting Kiro Crew itself', async () => {
+    const { calls } = stubFetchAll({ ok: true })
+    const bridge = stubPreload()
+    petBridge.contextMenuAction!('quit')
+    await Promise.resolve()
+    expect(calls[0].url).toBe('/api/apps/crew-companion/disable')
+    expect(calls[0].method).toBe('POST')
+    // Disabling is a gateway call, not a window-level one.
+    expect(bridge.contextMenuAction).not.toHaveBeenCalled()
+  })
+
+  it('a failed disable request is swallowed', async () => {
+    stubFetchAll({ fails: true })
+    expect(() => petBridge.contextMenuAction!('quit')).not.toThrow()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+
+  it('"gallery" opens the gallery window', () => {
+    const bridge = stubPreload()
+    petBridge.contextMenuAction!('gallery')
+    expect(bridge.galleryOpen).toHaveBeenCalledOnce()
+    expect(bridge.contextMenuAction).not.toHaveBeenCalled()
+  })
+
+  it('anything else is forwarded to the main process verbatim', () => {
+    const bridge = stubPreload()
+    petBridge.contextMenuAction!('panel')
+    expect(bridge.contextMenuAction).toHaveBeenCalledWith('panel')
+  })
+})
+
+describe('cross-display hooks are deliberately absent', () => {
+  // Left undefined and documented rather than deleted, so the ported hooks'
+  // `api?.on*?.()` guards resolve to no-ops on a single display.
+  it('drag and walk hooks are undefined so the hooks degrade to no-ops', () => {
+    expect(petBridge.dragStart).toBeUndefined()
+    expect(petBridge.dragEnd).toBeUndefined()
+    expect(petBridge.onDragUpdate).toBeUndefined()
+    expect(petBridge.onDragEnded).toBeUndefined()
+    expect(petBridge.onWalk).toBeUndefined()
+    expect(petBridge.onWalkPath).toBeUndefined()
+    expect(petBridge.onWalkCancel).toBeUndefined()
+    expect(petBridge.onWalkAppend).toBeUndefined()
+    expect(petBridge.onHide).toBeUndefined()
+    expect(petBridge.walkDone).toBeUndefined()
+  })
+})

--- a/website/src/test/UseMeetingTranscriptionCoverage.test.tsx
+++ b/website/src/test/UseMeetingTranscriptionCoverage.test.tsx
@@ -1,0 +1,594 @@
+/**
+ * The meetings live-transcription hook, driven end to end over mocked audio and
+ * a mocked STT socket.
+ *
+ * `captionWindow` already has direct tests (`MeetingsSessionLogic.test.ts`); the
+ * hook body did not, so everything here aims at the stateful half: the pre-`ready`
+ * PCM buffer and its cap, the server frame handlers, the stall watchdog, the
+ * deferred stop, and the dispatch retry ladder that is the only path a final
+ * segment reaches the agents.
+ *
+ * Timers are faked for every test so nothing depends on real elapsed time, and
+ * the socket / AudioContext / worklet doubles follow the harness in
+ * `useStreamingStt.stopBeforeReady.test.tsx`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+type HookModule = typeof import('../apps/meetings/hooks/useMeetingTranscription')
+type ApiModule = typeof import('../apps/meetings/api')
+
+type Sent = { kind: 'audio' | 'stop' | 'other'; bytes: number }
+
+const sockets: MockSocket[] = []
+const lastSocket = () => sockets[sockets.length - 1]
+
+class MockSocket {
+  static readonly OPEN = 1
+  static readonly CLOSED = 3
+  /** Set by a test to make the NEXT socket report a failure to open. */
+  static failNextOpen = false
+
+  readyState = 1
+  binaryType = ''
+  readonly url: string
+  sent: Sent[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((e: { data: unknown }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    sockets.push(this)
+    const fail = MockSocket.failNextOpen
+    MockSocket.failNextOpen = false
+    // A real socket opens on a later task, never inside the constructor.
+    setTimeout(() => { if (fail) this.onerror?.(); else this.onopen?.() }, 0)
+  }
+
+  send(payload: unknown) {
+    if (typeof payload === 'string') {
+      this.sent.push({ kind: payload.includes('"stop"') ? 'stop' : 'other', bytes: payload.length })
+    } else {
+      this.sent.push({ kind: 'audio', bytes: (payload as ArrayBuffer).byteLength })
+    }
+  }
+
+  close() {
+    // cleanup() also calls close(), so a mock that re-fired would recurse
+    // through the hook's own close handler.
+    if (this.readyState === MockSocket.CLOSED) return
+    this.readyState = MockSocket.CLOSED
+    const fire = this.onclose
+    this.onclose = null
+    fire?.()
+  }
+
+  emit(msg: unknown) { this.onmessage?.({ data: JSON.stringify(msg) }) }
+  becomeReady() { this.emit({ type: 'ready' }) }
+  kinds() { return this.sent.map(s => s.kind) }
+  audioBytes() { return this.sent.filter(s => s.kind === 'audio').map(s => s.bytes) }
+}
+
+const nodes: MockWorkletNode[] = []
+const lastNode = () => nodes[nodes.length - 1]
+
+class MockWorkletNode {
+  port: { onmessage: ((e: { data: ArrayBuffer }) => void) | null } = { onmessage: null }
+  constructor() { nodes.push(this) }
+  connect() {}
+  disconnect() {}
+  /** One frame of captured audio, as the real pcm-worklet emits. */
+  speak(bytes = 640) { this.port.onmessage?.({ data: new ArrayBuffer(bytes) }) }
+}
+
+let workletFails = false
+
+class MockAudioContext {
+  static closed = 0
+  audioWorklet = {
+    addModule: () =>
+      workletFails ? Promise.reject(new Error('no worklet')) : Promise.resolve(),
+  }
+  createMediaStreamSource() { return { connect() {}, disconnect() {} } }
+  close() { MockAudioContext.closed += 1; return Promise.resolve() }
+}
+
+const stoppedTracks: string[] = []
+
+function makeStream(label = 'mic') {
+  const track = {
+    stop: () => { stoppedTracks.push(label) },
+    readyState: 'live',
+    getSettings: () => ({ deviceId: 'dev-1' }),
+  }
+  return { getAudioTracks: () => [track], getTracks: () => [track] } as unknown as MediaStream
+}
+
+let getUserMedia: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.resetModules()
+  sockets.length = 0
+  nodes.length = 0
+  stoppedTracks.length = 0
+  workletFails = false
+  MockSocket.failNextOpen = false
+  MockAudioContext.closed = 0
+  getUserMedia = vi.fn().mockResolvedValue(makeStream())
+  vi.stubGlobal('WebSocket', MockSocket as unknown as typeof WebSocket)
+  vi.stubGlobal('AudioContext', MockAudioContext as unknown as typeof AudioContext)
+  vi.stubGlobal('AudioWorkletNode', MockWorkletNode as unknown as typeof AudioWorkletNode)
+  Object.defineProperty(navigator, 'mediaDevices', {
+    value: { getUserMedia, enumerateDevices: vi.fn().mockResolvedValue([]) },
+    configurable: true,
+    writable: true,
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+/** Advance fake time and let every microtask the hook awaits settle. */
+async function flush(ms = 1) {
+  await act(async () => { await vi.advanceTimersByTimeAsync(ms) })
+}
+
+interface Harness {
+  mod: HookModule
+  api: ApiModule
+  dispatch: ReturnType<typeof vi.fn>
+  onCaption: ReturnType<typeof vi.fn>
+  onError: ReturnType<typeof vi.fn>
+  onFinal: ReturnType<typeof vi.fn>
+  hook: ReturnType<typeof renderHook<ReturnType<HookModule['useMeetingTranscription']>, unknown>>
+  captions: () => string[]
+  errors: () => string[]
+}
+
+/**
+ * Fresh module instances per test so `transcriptionSupported` — computed at
+ * import time — sees this test's globals, and so the api object the hook closes
+ * over is the same one the spy is installed on.
+ */
+async function mount(onFinalImpl?: (text: string) => string | boolean | void): Promise<Harness> {
+  const api = await import('../apps/meetings/api')
+  const mod = await import('../apps/meetings/hooks/useMeetingTranscription')
+  const dispatch = vi.fn().mockResolvedValue({ dispatched: 1, text: 'ok' })
+  vi.spyOn(api.meetingsApi, 'dispatch').mockImplementation(
+    (id: string, text: string) => dispatch(id, text) as Promise<{ dispatched: number; text: string }>,
+  )
+  const onCaption = vi.fn()
+  const onError = vi.fn()
+  const onFinal = vi.fn(onFinalImpl)
+  const hook = renderHook(() =>
+    mod.useMeetingTranscription({ meetingId: 'meet-1', onCaption, onError, onFinal }),
+  )
+  return {
+    mod,
+    api,
+    dispatch,
+    onCaption,
+    onError,
+    onFinal,
+    hook,
+    captions: () => onCaption.mock.calls.map(c => String(c[0])),
+    errors: () => onError.mock.calls.map(c => String(c[0])),
+  }
+}
+
+/** Start capture and settle through getUserMedia, the socket open and the worklet. */
+async function startCapture(h: Harness) {
+  await act(async () => { void h.hook.result.current.start() })
+  await flush()
+  return lastSocket()
+}
+
+describe('useMeetingTranscription — starting up', () => {
+  it('opens the STT socket, arms capture and reports itself active', async () => {
+    const h = await mount()
+    const ws = await startCapture(h)
+
+    expect(ws.url).toBe(`ws://${window.location.host}/api/ws/stt`)
+    expect(ws.binaryType).toBe('arraybuffer')
+    expect(h.hook.result.current.active).toBe(true)
+    expect(h.hook.result.current.supported).toBe(true)
+    expect(lastNode()).toBeTruthy()
+    expect(h.errors()).toEqual([])
+  })
+
+  it('buffers PCM until the server is ready, then flushes it in order', async () => {
+    const h = await mount()
+    const ws = await startCapture(h)
+
+    await act(async () => { lastNode().speak(100); lastNode().speak(200) })
+    expect(ws.kinds()).toEqual([])
+
+    await act(async () => { ws.becomeReady() })
+    await flush()
+    expect(ws.audioBytes()).toEqual([100, 200])
+
+    // Past `ready` frames go straight out instead of accumulating.
+    await act(async () => { lastNode().speak(300) })
+    expect(ws.audioBytes()).toEqual([100, 200, 300])
+  })
+
+  it('drops the OLDEST buffered frames once the pre-ready cap is passed', async () => {
+    const h = await mount()
+    const ws = await startCapture(h)
+    const big = 200 * 1024 // two of these already exceed the ~262 KB cap
+
+    await act(async () => { lastNode().speak(big); lastNode().speak(big); lastNode().speak(big) })
+    await act(async () => { ws.becomeReady() })
+    await flush()
+
+    // The most recent speech wins: only the last frame survived the trim.
+    expect(ws.audioBytes()).toEqual([big])
+  })
+
+  it('does not send live audio once the socket has closed', async () => {
+    const h = await mount()
+    const ws = await startCapture(h)
+    await act(async () => { ws.becomeReady() })
+    await flush()
+
+    ws.readyState = MockSocket.CLOSED
+    await act(async () => { lastNode().speak(640) })
+    expect(ws.audioBytes()).toEqual([])
+  })
+
+  it('reports a microphone failure and stays inactive', async () => {
+    const h = await mount()
+    getUserMedia.mockRejectedValue(Object.assign(new Error('nope'), { name: 'NotAllowedError' }))
+    await startCapture(h)
+
+    expect(h.errors()).toEqual(['microphone'])
+    expect(sockets).toHaveLength(0)
+    expect(h.hook.result.current.active).toBe(false)
+  })
+
+  it('reports a socket that never opens and releases the microphone', async () => {
+    const h = await mount()
+    MockSocket.failNextOpen = true
+    await startCapture(h)
+
+    // The teardown closes the half-open socket, whose close handler also fires,
+    // so the failure is reported twice — the first message is the cause.
+    expect(h.errors()).toEqual(['connection', 'disconnected'])
+    expect(h.hook.result.current.active).toBe(false)
+    expect(stoppedTracks).toEqual(['mic'])
+    expect(lastNode()).toBeUndefined()
+  })
+
+  it('reports a missing audio worklet module', async () => {
+    const h = await mount()
+    workletFails = true
+    await startCapture(h)
+
+    expect(h.errors()).toEqual(['worklet', 'disconnected'])
+    expect(h.hook.result.current.active).toBe(false)
+    expect(MockAudioContext.closed).toBe(1)
+  })
+
+  it('surfaces a post-open transport error without tearing capture down', async () => {
+    const h = await mount()
+    const ws = await startCapture(h)
+
+    await act(async () => { ws.onerror?.() })
+    expect(h.errors()).toEqual(['connection'])
+    expect(h.hook.result.current.active).toBe(true)
+  })
+
+  it('ignores a second start while one socket is already live', async () => {
+    const h = await mount()
+    await startCapture(h)
+    await startCapture(h)
+
+    expect(sockets).toHaveLength(1)
+    expect(getUserMedia).toHaveBeenCalledTimes(1)
+  })
+
+  it('collapses two starts that race inside the await window', async () => {
+    const h = await mount()
+    await act(async () => {
+      void h.hook.result.current.start()
+      void h.hook.result.current.start()
+    })
+    await flush()
+
+    // Two microphone streams and two sockets would dispatch every final twice.
+    expect(sockets).toHaveLength(1)
+    expect(getUserMedia).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports unsupported when the browser has no audio worklet', async () => {
+    vi.stubGlobal('AudioWorkletNode', undefined)
+    vi.resetModules()
+    const h = await mount()
+    expect(h.mod.transcriptionSupported).toBe(false)
+
+    await act(async () => { await h.hook.result.current.start() })
+    expect(h.errors()).toEqual(['unsupported'])
+    expect(h.hook.result.current.supported).toBe(false)
+    expect(getUserMedia).not.toHaveBeenCalled()
+  })
+})
+
+describe('useMeetingTranscription — server frames', () => {
+  it('drives the caption from partials and commits finals', async () => {
+    const h = await mount()
+    const ws = await startCapture(h)
+    await act(async () => { ws.becomeReady() })
+    await flush()
+
+    await act(async () => { ws.emit({ type: 'partial', text: 'hello wor' }) })
+    expect(h.captions()).toEqual(['hello wor'])
+
+    await act(async () => { ws.emit({ type: 'final', text: '  hello world  ' }) })
+    expect(h.captions()).toEqual(['hello wor', 'hello world'])
+
+    // A later partial is appended to the committed finals, not shown alone.
+    await act(async () => { ws.emit({ type: 'partial', text: 'and then' }) })
+    expect(h.captions().at(-1)).toBe('hello world and then')
+
+    await flush()
+    expect(h.dispatch).toHaveBeenCalledWith('meet-1', 'hello world')
+  })
+
+  it('ignores an empty final and a partial with no text', async () => {
+    const h = await mount()
+    const ws = await startCapture(h)
+
+    await act(async () => { ws.emit({ type: 'final', text: '   ' }) })
+    expect(h.onFinal).not.toHaveBeenCalled()
+    expect(h.dispatch).not.toHaveBeenCalled()
+
+    await act(async () => { ws.emit({ type: 'partial' }) })
+    expect(h.captions()).toEqual([''])
+  })
+
+  it('ignores binary frames and unparseable text frames', async () => {
+    const h = await mount()
+    const ws = await startCapture(h)
+
+    await act(async () => {
+      ws.onmessage?.({ data: new ArrayBuffer(8) })
+      ws.onmessage?.({ data: 'not json at all' })
+      ws.onmessage?.({ data: JSON.stringify({ type: 'unknown-kind' }) })
+    })
+
+    expect(h.captions()).toEqual([])
+    expect(h.errors()).toEqual([])
+    expect(h.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('suppresses the dispatch when the caller rejects the segment', async () => {
+    const h = await mount(() => false)
+    const ws = await startCapture(h)
+
+    await act(async () => { ws.emit({ type: 'final', text: 'duplicate line' }) })
+    await flush()
+
+    // A rejected final still belongs in the caption, just not with the agents.
+    expect(h.captions()).toEqual(['duplicate line'])
+    expect(h.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('dispatches only the suffix the caller hands back', async () => {
+    const h = await mount(() => 'please')
+    const ws = await startCapture(h)
+
+    await act(async () => { ws.emit({ type: 'final', text: 'yes please' }) })
+    await flush()
+
+    expect(h.dispatch).toHaveBeenCalledWith('meet-1', 'please')
+  })
+
+  it('skips a dispatch when the caller returns a blank suffix', async () => {
+    const h = await mount(() => '   ')
+    const ws = await startCapture(h)
+
+    await act(async () => { ws.emit({ type: 'final', text: 'already sent' }) })
+    await flush()
+
+    expect(h.captions()).toEqual(['already sent'])
+    expect(h.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('reports a server error frame and unblocks the start', async () => {
+    const h = await mount()
+    let settled = false
+    await act(async () => { void h.hook.result.current.start().then(() => { settled = true }) })
+    await flush()
+    const ws = lastSocket()
+
+    // `start` is still awaiting the server's `ready` gate at this point.
+    expect(settled).toBe(false)
+
+    await act(async () => { ws.emit({ type: 'error', message: 'model unavailable' }) })
+    await flush()
+    expect(h.errors()).toEqual(['model unavailable'])
+    // An error resolves the same gate, so a backend that fails to start its
+    // stream does not leave `start` hanging forever.
+    expect(settled).toBe(true)
+
+    await act(async () => { ws.emit({ type: 'error' }) })
+    expect(h.errors()).toEqual(['model unavailable', 'error'])
+  })
+
+  it('reports an unexpected close as a disconnect', async () => {
+    const h = await mount()
+    const ws = await startCapture(h)
+
+    await act(async () => { ws.close() })
+    expect(h.errors()).toEqual(['disconnected'])
+    expect(h.hook.result.current.active).toBe(false)
+    expect(stoppedTracks).toEqual(['mic'])
+  })
+
+  it('ignores the close of a socket that has already been replaced', async () => {
+    const h = await mount()
+    const first = await startCapture(h)
+    const staleClose = first.onclose
+    expect(staleClose).toBeTruthy()
+
+    // A stall reconnect installs a NEW socket; the old close lands afterwards.
+    await act(async () => { await vi.advanceTimersByTimeAsync(25_000) })
+    await flush()
+    expect(sockets).toHaveLength(2)
+    const errorsBefore = h.errors().length
+
+    await act(async () => { staleClose?.() })
+    expect(h.errors()).toHaveLength(errorsBefore)
+    expect(h.hook.result.current.active).toBe(true)
+  })
+})
+
+describe('useMeetingTranscription — watchdog and stop', () => {
+  it('reconnects when no server frame has arrived for the stall window', async () => {
+    const h = await mount()
+    await startCapture(h)
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(25_000) })
+    await flush()
+
+    expect(sockets).toHaveLength(2)
+    expect(h.hook.result.current.active).toBe(true)
+  })
+
+  it('leaves a socket alone while frames keep arriving', async () => {
+    const h = await mount()
+    const ws = await startCapture(h)
+
+    for (let i = 0; i < 5; i += 1) {
+      await act(async () => { await vi.advanceTimersByTimeAsync(6_000) })
+      await act(async () => { ws.emit({ type: 'partial', text: `chunk ${i}` }) })
+    }
+
+    expect(sockets).toHaveLength(1)
+    expect(h.errors()).toEqual([])
+  })
+
+  it('sends the stop frame and lets the server close, forcing it after the grace', async () => {
+    const h = await mount()
+    const ws = await startCapture(h)
+    await act(async () => { ws.becomeReady() })
+    await flush()
+
+    await act(async () => { h.hook.result.current.stop() })
+    expect(ws.kinds()).toEqual(['stop'])
+    // Still up, so a trailing final can arrive after the stop frame.
+    expect(ws.readyState).toBe(MockSocket.OPEN)
+
+    await act(async () => { ws.emit({ type: 'final', text: 'trailing words' }) })
+    await flush()
+    expect(h.dispatch).toHaveBeenCalledWith('meet-1', 'trailing words')
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(8_000) })
+    expect(ws.readyState).toBe(MockSocket.CLOSED)
+    expect(h.hook.result.current.active).toBe(false)
+    // A stop we asked for is not reported as a disconnect.
+    expect(h.errors()).toEqual([])
+  })
+
+  it('cleans up immediately when there is no open socket to stop', async () => {
+    const h = await mount()
+
+    await act(async () => { h.hook.result.current.stop() })
+    expect(h.hook.result.current.active).toBe(false)
+    expect(sockets).toHaveLength(0)
+  })
+
+  it('the grace timer never tears down a socket that replaced the stopped one', async () => {
+    const h = await mount()
+    const first = await startCapture(h)
+    await act(async () => { first.becomeReady() })
+    await flush()
+
+    await act(async () => { h.hook.result.current.stop() })
+    await act(async () => { first.close() })
+    const second = await startCapture(h)
+    expect(second).not.toBe(first)
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(8_000) })
+    expect(second.readyState).toBe(MockSocket.OPEN)
+    expect(h.hook.result.current.active).toBe(true)
+  })
+
+  it('releases the microphone when the component unmounts', async () => {
+    const h = await mount()
+    const ws = await startCapture(h)
+
+    h.hook.unmount()
+    expect(ws.readyState).toBe(MockSocket.CLOSED)
+    expect(stoppedTracks).toEqual(['mic'])
+    expect(MockAudioContext.closed).toBe(1)
+  })
+})
+
+describe('useMeetingTranscription — dispatch retries', () => {
+  async function sendFinal(h: Harness, text = 'a spoken segment') {
+    const ws = await startCapture(h)
+    await act(async () => { ws.becomeReady() })
+    await flush()
+    await act(async () => { ws.emit({ type: 'final', text }) })
+    return ws
+  }
+
+  it('retries a segment the server explicitly rejected, then succeeds', async () => {
+    const h = await mount()
+    const rejected = new h.api.MeetingsApiError('bad gateway', 502)
+    h.dispatch.mockRejectedValueOnce(rejected).mockResolvedValue({ dispatched: 1, text: 'ok' })
+
+    await sendFinal(h)
+    expect(h.dispatch).toHaveBeenCalledTimes(1)
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(400) })
+    expect(h.dispatch).toHaveBeenCalledTimes(2)
+    expect(h.errors()).toEqual([])
+  })
+
+  it('gives up after the retry ladder and reports the lost segment', async () => {
+    const h = await mount()
+    h.dispatch.mockRejectedValue(new h.api.MeetingsApiError('server error', 500))
+
+    await sendFinal(h)
+    for (const delay of [400, 1_200, 3_000]) {
+      await act(async () => { await vi.advanceTimersByTimeAsync(delay) })
+    }
+    await flush()
+
+    // Four attempts, then the caller is told rather than the gap being silent.
+    expect(h.dispatch).toHaveBeenCalledTimes(4)
+    expect(h.errors()).toEqual(['dispatch'])
+  })
+
+  it('never retries an ambiguous failure, because the segment may have landed', async () => {
+    const h = await mount()
+    h.dispatch.mockRejectedValue(new TypeError('network down'))
+
+    await sendFinal(h)
+    await act(async () => { await vi.advanceTimersByTimeAsync(5_000) })
+
+    expect(h.dispatch).toHaveBeenCalledTimes(1)
+    expect(h.errors()).toEqual(['dispatch'])
+  })
+
+  it('keeps the stream alive after a dispatch failure', async () => {
+    const h = await mount()
+    h.dispatch.mockRejectedValueOnce(new TypeError('network down'))
+
+    const ws = await sendFinal(h, 'first segment')
+    await flush()
+    expect(h.errors()).toEqual(['dispatch'])
+    expect(h.hook.result.current.active).toBe(true)
+
+    await act(async () => { ws.emit({ type: 'final', text: 'second segment' }) })
+    await flush()
+    expect(h.dispatch).toHaveBeenLastCalledWith('meet-1', 'second segment')
+  })
+})


### PR DESCRIPTION
## What

617 tests across nine new files. Measured on the **full suite**: **+1,365 statements**. Eight of the nine targets reach **100%**.

| target | before | after | gain |
|---|---|---|---|
| `pages/knowledge/KnowledgeGraph.tsx` | **0.0%** | **100%** | +156 |
| `apps/meetings/hooks/useMeetingTranscription.ts` | 12.0% | **100%** | +154 |
| `components/CliPanel.tsx` | 7.2% | **100%** | +154 |
| `apps/crew-companion/petBridge.ts` | 45.0% | **100%** | +144 |
| `apps/mochi/panel/panelBridge.ts` | 64.8% | **100%** | +141 |
| `apps/issue-radar/api.ts` | 19.9% | **100%** | +141 |
| `apps/ops-mission-control/OpsMissionControlPage.tsx` | **0.0%** | 99.3% | +140 |
| `pages/scenes/mission-control/parts.ts` | 15.2% | **100%** | +139 |
| `apps/mochi/src/mochiApi.ts` | 33.2% | 99.0% | +135 |

Two of the nine (`KnowledgeGraph`, `OpsMissionControlPage`) had **no test at all** before this.

Per-file gains sum to 1,304; the full-suite delta is +1,365, the difference being incidental coverage these tests pull in elsewhere.

The frontend floor stays at **60**. Ratcheting belongs in its own change.

## Not in this PR

Three targets produced nothing usable and remain uncovered: `App.tsx` (146), `apps/issue-radar/components/PrDetail.tsx` (149), `pages/DevFleetPage.tsx` (139).

## Nothing needed repair

Worth recording, because the two preceding waves both did. Every file here passed on the first run — no unhandled rejections, no over-specific queries, no lint warnings. The difference is that the constraints earlier waves learned the hard way were stated up front:

- `vitest` must exit **0 with no unhandled-error line** — a run can report every test passing and still fail the build
- do not assert text that appears more than once
- spread a Redux slice's real defaults before overriding, because `preloadedState` **replaces** rather than merges
- **zero eslint warnings**, not zero errors (the gate is a `--max-warnings 1116` ratchet)
- "Kiro Crew" as two words in prose; no flagged inclusive-language terms

## Tests

The nine new files are the tests. No existing file is modified. Tests avoid real network, real elapsed timers, canvas/WebGL rendering, fixed ports, and the developer's home directory.

## Manual verification

- `npx vitest run` on all nine — **617/617 pass, zero unhandled errors, exit 0**
- Full suite — **903 files / 12,933 tests pass**, no `Errors` line; this is how +1,365 was measured
- `npx tsc --noEmit` — clean
- `npx eslint` on all nine — **zero warnings**
- `npm run jscpd` — **0 clones** (7,295 lines added)
- `scripts/check_brand_name.py` — clean
- No flagged terms or debug output in added lines
- `git status` — **0** existing files modified

## Screenshots

N/A — tests only, no user-visible surface changes.
