### PR TITLE
fix: unpin a managed model when the global returns to auto (#2558)

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -598,6 +598,15 @@ name:
   seeds managed-state on a fresh/clean install (never clobbering a frozen pick).
 - `_refresh_dynamic_fields()` sources managed-state from the sidecar and strips
   any stray `model_managed`/`cc_model` from the spec (steady-state self-heal).
+  A **managed** spec's `model` is set on every refresh to the shipped default,
+  or to the `"auto"` sentinel when the shipped template pins none — never left
+  as-is. That is what makes the global `agent.model` reversible: the global is
+  propagated into the spec when it is a concrete pick, and because a spec pin
+  outranks the global in `resolve_effective_model`, returning the global to
+  `"auto"` must take the pin back off or `"auto"` is unreachable from the
+  configuration surface. Ownership decides who may clear: `model_managed=false`
+  (an explicit user pick) and an **absent** sidecar entry (legacy status, owner
+  unknown) both keep their pin untouched.
 - `migrate_agent_specs()` runs at startup (top of `rebuild_agent_config`): lifts
   the keys out of every `~/.kiro/agents/*.json` into the sidecar and removes
   them (idempotent), fixing installs polluted by older builds.

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -1646,22 +1646,47 @@ def _refresh_dynamic_fields(config: dict) -> None:
             agent_state.set_cc_model(name, str(config["cc_model"]))
         del config["cc_model"]
 
+    # Imported lazily: config.loader imports this module, so a top-level import
+    # would close the cycle. Warm by the time this runs (importing agent pulls
+    # config.loader in), so the lookup costs nothing on the caller's thread.
+    from kiro_crew.config.loader import DEFAULT_MODEL, normalize_agent_model
+
     # Default-model tracking: when the model is managed (not an explicit user
     # pick), re-sync it from the shipped defaults.json so a default bump
     # propagates to existing installs. Agents with no sidecar entry are
     # grandfathered and left untouched (never force-changed).
+    #
+    # The assignment is unconditional for a managed spec, falling back to the
+    # inherit sentinel when the template pins nothing: "track the shipped
+    # default" and "pin whatever happens to be in the spec already" are not the
+    # same state, and only the sentinel makes a managed spec converge on the
+    # same value a clean install writes. It is also what lets the global below
+    # return to "auto" — leaving the field alone here would strand a concrete
+    # model that this propagation itself wrote, and a spec pin outranks the
+    # global in resolve_effective_model, so "auto" would be unreachable from the
+    # configuration surface. Writing the sentinel rather than deleting the key
+    # is equivalent to the resolver (normalize_agent_model collapses "auto" and
+    # an absent key to the same "inherit") and keeps the spec shaped like the
+    # shipped template.
     if agent_state.get_model_managed(name):
         shipped_model = (_load_json(_shipped_defaults()) or {}).get("model")
-        if shipped_model:
-            config["model"] = shipped_model
+        config["model"] = shipped_model or DEFAULT_MODEL
 
     # config.json agent.model is the user-facing authority (kirocrew config set
     # agent.model). An explicit pick (not the "auto" sentinel) is propagated into
     # the agent file so kiro-cli's --agent startup load matches it; otherwise the
     # stale agent-file model shadows config.json and session/set_model loses the
     # startup race. "auto" defers to managed/shipped resolution above.
-    mc_model = (mc_cfg.get("agent") or {}).get("model")
-    if mc_model and mc_model != "auto":
+    #
+    # Read through normalize_agent_model, the resolver's own chokepoint for
+    # hand-edited values: it collapses "auto", surrounding whitespace and any
+    # non-string to "" (inherit). That keeps this branch's notion of "the global
+    # defers" identical to the resolver's, and it is what stops a junk value
+    # (` auto `, an int) from reaching a spec kiro-cli validates with
+    # deny_unknown_fields — a spec it rejects wholesale, silently falling back to
+    # the default agent.
+    mc_model = normalize_agent_model((mc_cfg.get("agent") or {}).get("model"))
+    if mc_model:
         config["model"] = mc_model
 
     # Ensure kiro-cli uses agent-level mcpServers exclusively (not global

--- a/test/test_agent_model_unpin.py
+++ b/test/test_agent_model_unpin.py
@@ -1,0 +1,210 @@
+"""Returning the global ``agent.model`` to "auto" clears a managed spec pin.
+
+``_refresh_dynamic_fields`` propagates the global ``agent.model`` from
+config.json INTO the kiro agent spec. A spec pin outranks the global in
+``resolve_effective_model``, so if the propagation never reverses itself the
+"auto" setting is unreachable from the configuration surface: the write succeeds
+and is honoured nowhere, and the stale pin keeps going out on the wire.
+
+Ownership is the sidecar's ``model_managed`` flag, and it is the whole scope
+boundary here:
+
+- ``True``  -> the propagation owns the field, so it may clear it.
+- ``False`` -> an explicit user pick, frozen against default bumps; untouched.
+- unset     -> legacy status (ownership unknown); untouched. Migrating those is
+  tracked separately and deliberately NOT done here.
+
+The shipped template that ships today happens to pin "auto", which masks the
+defect, so the tests below pin a template that declares no model — the condition
+under which a managed spec kept a stale concrete pin forever.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest.mock
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import agent_state
+from kiro_crew.agent import _refresh_dynamic_fields
+from kiro_crew.config import config_path
+from kiro_crew.config.loader import DEFAULT_MODEL, KiroCrewConfig, resolve_effective_model
+
+_AGENT = "kirocrew"
+_PINNED = "claude-opus-5"
+
+
+@pytest.fixture
+def shipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point ``_shipped_defaults`` at a template whose model we control."""
+
+    def _write(model: str | None) -> Path:
+        payload: dict[str, object] = {"name": _AGENT}
+        if model is not None:
+            payload["model"] = model
+        path = tmp_path / "shipped-defaults.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        monkeypatch.setattr("kiro_crew.agent._shipped_defaults", lambda: path)
+        return path
+
+    return _write
+
+
+def _set_global(model: str) -> None:
+    """Write the user-facing global ``agent.model`` the propagation reads."""
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"agent": {"model": model}}), encoding="utf-8")
+
+
+def _refresh(spec_model: str) -> dict:
+    config: dict = {"name": _AGENT, "model": spec_model, "tools": []}
+    _refresh_dynamic_fields(config)
+    return config
+
+
+class TestManagedPinFollowsTheGlobal:
+    """A pin this propagation wrote must come back off when the global does."""
+
+    def test_managed_pin_cleared_when_the_global_returns_to_auto(self, shipped) -> None:
+        shipped(None)
+        agent_state.set_model_managed(_AGENT, True)
+        _set_global("auto")
+
+        # Cleared means the inherit sentinel, not a deleted key: it is what a
+        # clean install writes, and the resolver reads the two identically.
+        assert _refresh(_PINNED)["model"] == DEFAULT_MODEL
+
+    def test_a_concrete_global_still_propagates(self, shipped) -> None:
+        """The forward direction is unchanged: an explicit global reaches the spec."""
+        shipped(None)
+        agent_state.set_model_managed(_AGENT, True)
+        _set_global("claude-haiku-4.5")
+
+        assert _refresh(_PINNED)["model"] == "claude-haiku-4.5"
+
+    def test_managed_spec_still_tracks_a_concrete_shipped_default(self, shipped) -> None:
+        """Clearing must not fight the re-sync branch it sits next to.
+
+        A managed spec under a global of "auto" resolves to the SHIPPED default,
+        not to the sentinel — otherwise a shipped default bump would stop
+        reaching existing installs, and the two branches would disagree about
+        what a managed spec holds.
+        """
+        shipped("claude-sonnet-4.6")
+        agent_state.set_model_managed(_AGENT, True)
+        _set_global("auto")
+
+        assert _refresh(_PINNED)["model"] == "claude-sonnet-4.6"
+
+    def test_an_absent_global_is_treated_as_auto(self, shipped) -> None:
+        """No ``agent.model`` key at all is the same deferral as "auto"."""
+        shipped(None)
+        agent_state.set_model_managed(_AGENT, True)
+        config_path().parent.mkdir(parents=True, exist_ok=True)
+        config_path().write_text(json.dumps({}), encoding="utf-8")
+
+        assert _refresh(_PINNED)["model"] == DEFAULT_MODEL
+
+
+class TestTheGlobalIsReadThroughTheResolversNormalizer:
+    """config.json is hand-editable, and the spec it feeds is schema-validated.
+
+    kiro-cli validates ``~/.kiro/agents/*.json`` with ``deny_unknown_fields`` and
+    rejects the whole spec on a bad value, silently falling back to the default
+    agent. Judging "does the global defer?" with ``normalize_agent_model`` — the
+    same chokepoint the resolver uses — keeps a junk value out of the spec and
+    keeps the two surfaces from disagreeing about what "auto" means.
+    """
+
+    @pytest.mark.parametrize("spelling", ["auto", "  auto  ", "", "   "])
+    def test_an_inherit_spelling_defers_instead_of_being_propagated(
+        self, shipped, spelling: str
+    ) -> None:
+        shipped(None)
+        agent_state.set_model_managed(_AGENT, True)
+        _set_global(spelling)
+
+        assert _refresh(_PINNED)["model"] == DEFAULT_MODEL
+
+    @pytest.mark.parametrize("junk", [123, 1.5, [], {}, None])
+    def test_a_non_string_global_never_reaches_the_spec(self, shipped, junk: object) -> None:
+        shipped(None)
+        agent_state.set_model_managed(_AGENT, True)
+        config_path().parent.mkdir(parents=True, exist_ok=True)
+        config_path().write_text(json.dumps({"agent": {"model": junk}}), encoding="utf-8")
+
+        assert _refresh(_PINNED)["model"] == DEFAULT_MODEL
+
+    def test_a_concrete_global_is_propagated_trimmed(self, shipped) -> None:
+        shipped(None)
+        agent_state.set_model_managed(_AGENT, True)
+        _set_global("  claude-haiku-4.5  ")
+
+        assert _refresh(_PINNED)["model"] == "claude-haiku-4.5"
+
+
+class TestOwnershipBoundary:
+    """Only a pin the propagation owns may be cleared."""
+
+    def test_a_spec_with_no_sidecar_entry_keeps_its_pin(self, shipped) -> None:
+        """A legacy-status agent is untouched: ownership is unknown, so clearing
+        could silently drop a model the user chose. Migrating them is a separate
+        decision and this test is the guard that it did not happen here."""
+        shipped(None)
+        assert agent_state.get_model_managed(_AGENT) is None
+        _set_global("auto")
+
+        assert _refresh(_PINNED)["model"] == _PINNED
+
+    def test_an_explicit_user_pick_keeps_its_pin(self, shipped) -> None:
+        """``model_managed=False`` is a pick frozen against default bumps."""
+        shipped(None)
+        agent_state.set_model_managed(_AGENT, False)
+        _set_global("auto")
+
+        assert _refresh(_PINNED)["model"] == _PINNED
+
+
+class TestResolverOracle:
+    """``resolve_effective_model`` is the regression oracle: "" means Auto."""
+
+    def test_round_trip_concrete_then_auto_reports_auto(
+        self, shipped, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        shipped(None)
+        agent_state.set_model_managed(_AGENT, True)
+        specs = tmp_path / "agents"
+        specs.mkdir()
+        monkeypatch.setattr("kiro_crew.config.loader.kiro_agents_dir", lambda: specs)
+
+        # Global set to a concrete model: the spec carries it, and the resolver
+        # reports it.
+        _set_global(_PINNED)
+        pinned_spec = _refresh("")
+        (specs / f"{_AGENT}.json").write_text(json.dumps(pinned_spec), encoding="utf-8")
+        assert resolve_effective_model(_load_config(), _AGENT) == _PINNED
+
+        # Global back to "auto": the pin must come off, so the resolver defers.
+        _set_global("auto")
+        cleared_spec = _refresh(pinned_spec["model"])
+        (specs / f"{_AGENT}.json").write_text(json.dumps(cleared_spec), encoding="utf-8")
+        assert resolve_effective_model(_load_config(), _AGENT) == ""
+
+
+def _load_config() -> KiroCrewConfig:
+    """Load a config whose global ``agent.model`` is the one just written."""
+    data = json.loads(config_path().read_text(encoding="utf-8"))
+    data.setdefault("agents", {_AGENT: {"kiro_agent": _AGENT}})
+    data.setdefault("default_agent", _AGENT)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(data, f)
+        tmp = Path(f.name)
+    try:
+        with unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=tmp):
+            return KiroCrewConfig.load()
+    finally:
+        tmp.unlink(missing_ok=True)


### PR DESCRIPTION
## Problem

Setting the global `agent.model` back to `auto` does not take effect. The write
succeeds, the dashboard's model chip and
`GET /api/agents/resolved-model?agent=default` still report the concrete model,
and that model keeps going out on the wire every turn. `auto` is unreachable
from the configuration surface.

## Why it matters

The user believes they turned a model off and keeps paying for it. There is no
way to undo a global pin from the setting that created it, and the only visible
symptom is a chip that disagrees with the config the user just wrote, so the
natural next step is to pin *another* model rather than to suspect the config.

## Fix (symptom → root cause → change)

`_refresh_dynamic_fields` propagates the global into the kiro agent spec only in
the forward direction:

```python
if agent_state.get_model_managed(name):
    shipped_model = (_load_json(_shipped_defaults()) or {}).get("model")
    if shipped_model:                      # <- conditional
        config["model"] = shipped_model
mc_model = (mc_cfg.get("agent") or {}).get("model")
if mc_model and mc_model != "auto":        # <- no reverse branch
    config["model"] = mc_model
```

A spec pin outranks the global in `resolve_effective_model`, so once a concrete
model has been written into the spec nothing takes it back out. The reason this
is not visible on a stock install is incidental: the shipped `defaults.json`
happens to pin `"auto"`, so the re-sync branch above overwrites the stale pin by
accident. The moment the shipped template declares no model — a
`KIROCREW_PROJECT_DIR` dev override, or any future/edition template — the
conditional does nothing and the pin is permanent.

The change makes that clearing intentional instead of accidental: a **managed**
spec's `model` is now always resolved on refresh, to the shipped default or to
the inherit sentinel when the template pins none.

- **Clearing writes the `"auto"` sentinel, not a deleted key.** Verified against
  the resolver rather than assumed: `normalize_agent_model` collapses `"auto"`
  and an absent key to the same `""`, and `_resolve_agent_model` falls through a
  missing key to the bundled `defaults.json`, which itself ships `"auto"`. The
  two are equivalent at the oracle, so the tiebreaker is that the sentinel is
  exactly what `build_agent_config()` writes on a clean install — a managed spec
  now holds the same value no matter which path produced it — and it keeps the
  key present, so nothing depends on `model` being optional in the spec schema
  kiro-cli validates.
- **The two branches do not fight.** Clearing is folded into the existing
  managed re-sync rather than added as a competing `else`, so a managed spec
  under a global of `auto` lands on the *shipped* resolution and a shipped
  default bump still reaches existing installs. There is one assignment per
  branch and no oscillation.
- **The global is read through `normalize_agent_model`.** The raw read treated
  `" auto "` as a concrete pin and would write a hand-edited non-string (`123`)
  straight into the spec — which kiro-cli rejects wholesale under
  `deny_unknown_fields`, silently falling back to the default agent. Using the
  resolver's own chokepoint keeps this branch's notion of "the global defers"
  identical to the resolver's.

### Scope boundary

Only a pin the propagation **owns** is cleared, i.e. only when the sidecar
records `model_managed: true`:

| sidecar | meaning | behavior |
|---|---|---|
| `true` | the propagation wrote it | cleared / re-resolved |
| `false` | explicit user pick, frozen | untouched |
| absent | grandfathered, owner unknown | untouched |

Grandfathered agents are deliberately left alone — clearing a pin whose origin
is unknown could silently change a model the user chose. Migrating them needs a
maintainer decision on migration semantics and is tracked separately as #2559.
No historical-shipped-defaults list is introduced and no agent is stamped
`model_managed` that lacks an entry.

### Designed residual

A `model_managed: false` spec that a *global* pin later overwrote keeps that
value when the global returns to `auto`. The sidecar cannot distinguish "user's
own pick" from "global's pin" in that state, and inventing a second notion of
ownership to tell them apart is out of scope here.

## Tests

`test/test_agent_model_unpin.py`, 17 cases. Each was verified against unmodified
source first: **13 fail before the change, all 17 pass after.** The shipped
template in the fixture declares no model, which is the condition under which a
managed spec kept a stale pin forever.

- managed pin + global `auto` → spec holds the sentinel (the defect)
- round trip concrete → `auto` through `resolve_effective_model`, the oracle
  named in the issue: `""` after, the concrete model before
- managed spec + concrete shipped default → still tracks the shipped default
  (the guard that clearing does not clobber default-bump tracking)
- absent sidecar entry → pin untouched (the guard on the scope boundary)
- `model_managed: false` → pin untouched
- absent / whitespace / non-string global → deferral, never propagated
- concrete global → propagated as today, trimmed

## Manual verification

N/A — unit coverage is sufficient. The behavior is a pure function of the
sidecar, config.json and the shipped template, and the tests drive the real
`_refresh_dynamic_fields` and the real `agent_state` accessor through the
resolver that the issue names as the oracle.

## Screenshots

N/A — backend only, no user-visible UI change. The user-visible *value* (the
model chip / `resolved-model`) is asserted through the resolver in tests.

Closes #2558
