### PR TITLE
perf(chat): freeze sidebar row order during a drag

### DIFF
--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -1482,14 +1482,20 @@ function ChatSidebar({
     [foldersWithActiveSubtree],
   )
 
+  // State and in the memo deps on purpose, not a ref: a frozen run caches its
+  // stale list against new deps, so clearing a ref would invalidate nothing.
+  const [dragFrozen, setDragFrozen] = useState(false)
+  const frozenSlotsRef = useRef<Slot[]>([])
+
   const filteredSlots = useMemo(() => {
+    if (dragFrozen) return frozenSlotsRef.current
     const activeFilterDefs = SESSION_FILTERS.filter(filterDef => activeFilters.has(filterDef.key))
     // Active content search: order by the backend's relevance ranking instead
     // of the sidebar sort (mirrors the Older Sessions lane and the command
     // palette). Pinning stays a reachability promise for browsing, not a
     // ranking hint inside explicit search results.
     const searchRanked = slotFilter.trim().length >= SEARCH_MIN_CHARS ? slotSearchRanks : null
-    return enrichedSlots
+    const next = enrichedSlots
       .filter(slot => {
         if (activeFilterDefs.length > 0 && !activeFilterDefs.some(filterDef => slot[filterDef.key])) return false
         if (!slotFilter) return true
@@ -1499,8 +1505,10 @@ function ChatSidebar({
       .sort((a, b) => searchRanked
         ? (searchRanked.get(a.key) ?? Infinity) - (searchRanked.get(b.key) ?? Infinity)
         : comparePinnedThenSort(a, b, sortKey, pinned))
+    frozenSlotsRef.current = next
+    return next
   },
-    [enrichedSlots, slotFilter, slotSearchRanks, pinned, sortKey, activeFilters]
+    [enrichedSlots, slotFilter, slotSearchRanks, pinned, sortKey, activeFilters, dragFrozen]
   )
 
   // Folder IDs whose sessions are excluded from the flat lane because the
@@ -1784,12 +1792,14 @@ function ChatSidebar({
   // (draggable rows + droppable folder/root targets); the active item's
   // data.type routes the drop.
   const handleSidebarDragStart = useCallback((e: DragStartEvent) => {
+    setDragFrozen(true)
     const d = e.active.data.current as { type?: string; key?: string } | undefined
     if (d?.type === 'session' && d.key) setActiveDrag({ type: 'session', id: d.key })
     else if (d?.type === 'folder') setActiveDrag({ type: 'folder', id: e.active.id as string })
   }, [])
   const handleSidebarDragEnd = useCallback((event: DragEndEvent) => {
     setActiveDrag(null)
+    setDragFrozen(false)
     if (dragExpandTimer.current) { clearTimeout(dragExpandTimer.current.timer); dragExpandTimer.current = null }
     const { active, over } = event
     if (!over) return
@@ -1834,7 +1844,7 @@ function ChatSidebar({
       else if (o?.type === 'folder') assignToFolder(a.key, over.id as string)
     }
   }, [reorderFolders, assignToFolder, moveFolderTo, slots, activeSlot, onDropSessionRef])
-  const handleSidebarDragCancel = useCallback(() => { setActiveDrag(null); if (dragExpandTimer.current) { clearTimeout(dragExpandTimer.current.timer); dragExpandTimer.current = null } }, [])
+  const handleSidebarDragCancel = useCallback(() => { setActiveDrag(null); setDragFrozen(false); if (dragExpandTimer.current) { clearTimeout(dragExpandTimer.current.timer); dragExpandTimer.current = null } }, [])
   // Auto-expand collapsed folders when a dragged item hovers over them for 500ms.
   const dragExpandTimer = useRef<{ id: string; timer: ReturnType<typeof setTimeout> } | null>(null)
   const handleSidebarDragOver = useCallback((event: DragOverEvent) => {

--- a/website/src/test/ChatSidebar.dragFreezeOrder.test.tsx
+++ b/website/src/test/ChatSidebar.dragFreezeOrder.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Sidebar row order holds for the duration of a dnd-kit drag.
+ *
+ * dnd-kit measures the active node's rect once at drag start and never
+ * recomputes it, so a row that reorders mid-gesture leaves the collision math
+ * offset and the drop resolves to the wrong row or to nothing. The default sort
+ * is date-desc, so a background session going active reproduces it.
+ *
+ * The pointer-drag lifecycle can't be faithfully simulated in jsdom (it needs
+ * real PointerEvents plus layout measurement), so this stubs the drag context,
+ * invokes the real lifecycle handlers, and drives a reorder by re-rendering
+ * with a bumped timestamp. That exercises the hold rather than the gesture.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createTestStore } from './helpers'
+import { ThemeProvider } from '../hooks/useTheme'
+
+// Captured lifecycle props from the sidebar's DndContext. Stubbing the context
+// (children pass through) is what lets the real handlers run without a gesture.
+const dnd = vi.hoisted(() => ({ handlers: {} as Record<string, ((e: unknown) => void) | undefined> }))
+
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>()
+  return {
+    ...actual,
+    DndContext: (props: { children?: unknown; onDragStart?: (e: unknown) => void; onDragEnd?: (e: unknown) => void }) => {
+      dnd.handlers.onDragStart = props.onDragStart
+      dnd.handlers.onDragEnd = props.onDragEnd
+      return props.children as never
+    },
+  }
+})
+
+vi.mock('../api/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: {
+      ...Object.fromEntries(
+        [
+          'sessions', 'chatSlots', 'chatSlotDetail', 'createChatSlot', 'deleteChatSlot',
+          'resumeChatSlot', 'deleteSession', 'agentDetail', 'spawnList', 'fetchHistory',
+          'renameSlot', 'forkSession',
+        ].map(k => [k, vi.fn().mockResolvedValue({})]),
+      ),
+      chatFolders: vi.fn().mockResolvedValue([]),
+      sessionsSearch: vi.fn().mockResolvedValue({ sessions: [] }),
+    },
+  }
+})
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+})
+globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }) as unknown as typeof fetch
+
+import ChatSidebar from '../pages/ChatSidebar'
+import type { ChatSlot } from '../types'
+import type { RootState } from '../store'
+
+const TITLE_A = 'Alpha session'
+const TITLE_B = 'Bravo session'
+const TITLE_C = 'Charlie session'
+
+const slot = (key: string, title: string, lastTs: string): ChatSlot => ({
+  key, title, messages: 1, running: false, mode: '', created: '', last_ts: lastTs, pinned: false,
+} as ChatSlot)
+
+// date-desc: A (newest), B, C (oldest).
+const SLOTS_INITIAL = [
+  slot('chat-a', TITLE_A, '2026-03-01T00:00:00Z'),
+  slot('chat-b', TITLE_B, '2026-02-01T00:00:00Z'),
+  slot('chat-c', TITLE_C, '2026-01-01T00:00:00Z'),
+]
+
+// C goes active mid-drag and becomes the newest → date-desc order is C, A, B.
+const SLOTS_REORDERED = [
+  SLOTS_INITIAL[0],
+  SLOTS_INITIAL[1],
+  slot('chat-c', TITLE_C, '2026-04-01T00:00:00Z'),
+]
+
+function renderSidebar(slots: ChatSlot[]) {
+  const store = createTestStore({
+    dashboard: {
+      status: { platform: 'darwin' },
+      connected: true,
+      slots,
+      approvalMode: 'normal', channelTrusted: false, refreshTrigger: 0, unreadSlots: [], updateProgress: null,
+      subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      sessionDefaultColor: null, sessionColorsMode: 'tint', sessionColorsPalette: 'horizon', sessionColorsIntensity: 'clear',
+      slotsLoaded: true,
+    } as unknown as RootState['dashboard'],
+    chat: {
+      activeSlot: 'chat-a',
+      messages: [], slotRunning: false, slotStopping: false, slotState: 'idle',
+      slotStatusDetail: {}, slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+      lastChunkSeq: undefined,
+      history: [], historyHasMore: false, historyOffset: 0,
+      pendingInput: null, slotContextPct: {}, voicePlaying: false, voiceAudio: null,
+      subagents: {}, toolLog: [], activityOpen: false, activityTab: 'tools', slotActivity: {}, slotHistory: [],
+      slotMessages: {}, slotLoading: false,
+    } as unknown as RootState['chat'],
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const tree = (s: ChatSlot[]) => (
+    <QueryClientProvider client={qc}>
+      <Provider store={store}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <ChatSidebar
+              slots={s}
+              activeSlot={'chat-a'}
+              unreadSlots={[]}
+              history={[]}
+              historyHasMore={false}
+              defaultAgent={'default'}
+              installedAgents={[]}
+            />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    </QueryClientProvider>
+  )
+  const { rerender } = render(tree(slots))
+  return { rerender: (s: ChatSlot[]) => rerender(tree(s)) }
+}
+
+/** Rendered order of the three fixture rows, top to bottom. */
+function renderedOrder(): string[] {
+  const nodes = [TITLE_A, TITLE_B, TITLE_C].map(t => ({ t, el: screen.getByText(t) }))
+  return nodes
+    .sort((x, y) => (x.el.compareDocumentPosition(y.el) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1))
+    .map(n => n.t)
+}
+
+describe('ChatSidebar – sidebar row order is held during a dnd-kit drag', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    dnd.handlers = {}
+  })
+
+  it('holds order while a drag is live and re-derives once it ends', () => {
+    const { rerender } = renderSidebar(SLOTS_INITIAL)
+
+    // Guard: a missed capture would make the drag steps silent no-ops.
+    expect(typeof dnd.handlers.onDragStart).toBe('function')
+    expect(typeof dnd.handlers.onDragEnd).toBe('function')
+
+    expect(renderedOrder()).toEqual([TITLE_A, TITLE_B, TITLE_C])
+
+    act(() => {
+      dnd.handlers.onDragStart!({ active: { id: 'chat-a', data: { current: { type: 'session', key: 'chat-a' } } } })
+    })
+
+    // C becomes the newest mid-drag. Frozen, so the order must not move — this
+    // is the assertion that fails without the hold.
+    rerender(SLOTS_REORDERED)
+    expect(renderedOrder()).toEqual([TITLE_A, TITLE_B, TITLE_C])
+
+    act(() => {
+      dnd.handlers.onDragEnd!({ active: { id: 'chat-a', data: { current: { type: 'session', key: 'chat-a' } } }, over: null })
+    })
+
+    expect(renderedOrder()).toEqual([TITLE_C, TITLE_A, TITLE_B])
+  })
+
+  it('the fixture actually reorders under date-desc (guards fixture validity)', () => {
+    // If the bumped `last_ts` failed to change the sort, the mid-drag assertion
+    // above would pass vacuously.
+    const order = (slots: ChatSlot[]) => [...slots]
+      .sort((a, b) => new Date(b.last_ts!).getTime() - new Date(a.last_ts!).getTime())
+      .map(s => s.key)
+    expect(order(SLOTS_INITIAL)).toEqual(['chat-a', 'chat-b', 'chat-c'])
+    expect(order(SLOTS_REORDERED)).toEqual(['chat-c', 'chat-a', 'chat-b'])
+  })
+})


### PR DESCRIPTION
## What

Hold sidebar row order for the duration of a dnd-kit drag.

## Why

dnd-kit measures the active node's rect once at drag start and never recomputes it. If a row moves mid-gesture the collision math stays offset for the rest of the drag, so the drop resolves to the wrong row or to nothing — then works again once the list settles. The sidebar sorts by `date-desc` by default, so a background session going active reorders the list under the cursor and reproduces it.

Freezing the order is the fix rather than disabling the layout animation: without the spring rows would jump instead of animating, but the stale rect would be equally wrong.

## Design note

The flag is `useState` and sits in the memo's dependency array, not a ref. A ref looks cheaper, but `useMemo` caches its result against the deps present when the body last ran — a frozen run would cache the stale list against the new deps, and clearing a ref on drag-end would invalidate nothing. Under a continuous message stream that self-corrects within a frame, but a drag ending on a one-off change (title edit, status flip, final activity flush) would strand the sidebar until the next unrelated dep change. Cost is nil: both flips already share a render with the existing drag-state update, and the drag-start recompute early-returns the cached array, preserving identity. A source comment records this so it isn't "optimised" back into a ref later.

## Scope

Board-scope rows use native HTML5 drag and are untouched. The flat view inherits the frozen array transitively and carries no DnD of its own. Known limit: a session created or removed mid-drag is not reflected until the gesture ends — sub-second and self-correcting; a briefly stale row beats a broken drop.

## Tests

The pointer-drag lifecycle can't be faithfully simulated in jsdom (it needs real `PointerEvent`s plus layout measurement), a constraint already recorded in this suite. The new test stubs the drag context, invokes the real lifecycle handlers, and drives a reorder by re-rendering with a bumped timestamp.

Both halves are negative-controlled:

- Disabling the hold fails the mid-drag assertion (the list reorders under the cursor).
- Dropping the flag from the memo deps fails *after* drag-end, with the list stranded — the exact failure the design note describes.

A fixture-validity guard prevents a vacuous pass. Full suite is green apart from a pre-existing, load-sensitive i18n scan timeout that reproduces on an unmodified baseline (it passes in isolation; this change adds no `i18nT` calls).

---

Third of three slices from one review; siblings are #2576 and #2631. Independently shippable — different files, no ordering dependency.
