### PR TITLE
fix(cloud): get dashboard EC2 crews to a working, signed-in state

### DIFF
--- a/src/kiro_crew/cloud/login.py
+++ b/src/kiro_crew/cloud/login.py
@@ -109,9 +109,14 @@ def parse_login_output(text: str) -> LoginPrompt:
         return LoginPrompt(already_logged_in=True, raw=text)
 
     url = ""
-    m = _URL_RE.search(text)
-    if m:
-        url = m.group(0).rstrip(".,)")
+    # kiro-cli prints BOTH the bare verification_uri (a generic sign-in page) and
+    # the "complete" verification_uri_complete that embeds the code
+    # (…?user_code=…) and deep-links straight to the approve screen. Prefer the
+    # latter so the user isn't dropped on a general login with nowhere obvious to
+    # type the code; fall back to the first URL when no complete one is printed.
+    urls = [u.rstrip(".,)") for u in _URL_RE.findall(text)]
+    if urls:
+        url = next((u for u in urls if "user_code=" in u), urls[0])
     code = ""
     cm = _CODE_RE.search(text)
     if cm:

--- a/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
+++ b/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
@@ -445,34 +445,34 @@ Resources:
           dnf install -y ripgrep || echo "ripgrep unavailable (optional), continuing"
 
           echo "--- installing Node.js ---"
-          # The frontend build needs Node >= 22; AL2023 AppStream nodejs is 18.
-          # Signed-repo upgrade path, no curl-pipe-bash: see "Node.js" above.
+          # The frontend build (vite 8 + rolldown) needs Node >=22; AL2023 ships
+          # node 18 (build dies with node:util/styleText). Try AppStream first, then
+          # fall back to a pinned official nodejs.org tarball -- we AVOID
+          # dnf/NodeSource because AL2023's modular filtering kept reinstalling the
+          # distro node 18. /usr/local/bin precedes /usr/bin so the tarball shadows it.
           NODE_MAJOR_MIN=22
-          if ! command -v node >/dev/null 2>&1; then
-            if ! dnf install -y nodejs npm; then
-              # Transient dnf cache/mirror races happen: see "Node.js" above.
-              echo "nodejs install failed - cleaning dnf cache and retrying"
-              dnf clean packages || true
-              dnf makecache || true
-              dnf install -y nodejs npm || true
-            fi
-          fi
+          command -v node >/dev/null 2>&1 || dnf install -y nodejs npm || true
           NODE_MAJOR=$(node --version 2>/dev/null | sed -n 's/^v\([0-9][0-9]*\).*/\1/p' | head -1)
           [ -n "$NODE_MAJOR" ] || NODE_MAJOR=0
           if [ "$NODE_MAJOR" -lt "$NODE_MAJOR_MIN" ]; then
-            echo "Node major $NODE_MAJOR is below the required $NODE_MAJOR_MIN - installing Node 24 from the signed NodeSource repo"
-            NS_KEY=https://rpm.nodesource.com/gpgkey/ns-operations-public.key
-            rpm --import "$NS_KEY" || fail "could not import NodeSource GPG key"
-            # printf (not a heredoc): a column-1 body would break the YAML block.
-            {
-              printf '%s\n' '[nodesource-nodejs]'
-              printf '%s\n' 'name=Node.js Packages'
-              printf '%s\n' 'baseurl=https://rpm.nodesource.com/pub_24.x/nodistro/nodejs/$basearch'
-              printf '%s\n' 'enabled=1'
-              printf '%s\n' 'gpgcheck=1'
-              printf '%s\n' "gpgkey=$NS_KEY"
-            } >/etc/yum.repos.d/nodesource.repo
-            dnf install -y --allowerasing nodejs || fail "Node.js >=$NODE_MAJOR_MIN install failed (signed NodeSource repo)"
+            NODE_V=v22.12.0
+            case "$(uname -m)" in
+              aarch64) NODE_ARCH=linux-arm64; NODE_SHA=9e7905fdee722f9650a03ae644b51c4c6effd3b98ac93c588700072ab35c9ddb ;;
+              x86_64) NODE_ARCH=linux-x64; NODE_SHA=e05a4d65232ae2b27b3d77da2e368522fb46b923335b8e0d5f77624c32484044 ;;
+              *) fail "unsupported arch for Node install: $(uname -m)" ;;
+            esac
+            NODE_TARB=node-$NODE_V-$NODE_ARCH
+            echo "installing Node $NODE_V ($NODE_ARCH) from the official nodejs.org tarball"
+            curl --proto '=https' --tlsv1.2 -fsSL "https://nodejs.org/dist/$NODE_V/$NODE_TARB.tar.gz" -o /tmp/node.tar.gz || fail "Node download failed"
+            # Verify the PINNED SHA-256 before extracting as root: TLS protects the
+            # transport, not the artifact, so a tampered/compromised mirror must not
+            # get its Node extracted and run. Fails closed on any mismatch.
+            echo "$NODE_SHA  /tmp/node.tar.gz" | sha256sum -c - || fail "Node tarball checksum mismatch (possible tampering)"
+            tar -xzf /tmp/node.tar.gz -C /usr/local || fail "Node extract failed"
+            ln -sf /usr/local/$NODE_TARB/bin/node /usr/local/bin/node
+            ln -sf /usr/local/$NODE_TARB/bin/npm /usr/local/bin/npm
+            ln -sf /usr/local/$NODE_TARB/bin/npx /usr/local/bin/npx
+            hash -r 2>/dev/null || true
             NODE_MAJOR=$(node --version 2>/dev/null | sed -n 's/^v\([0-9][0-9]*\).*/\1/p' | head -1)
             [ -n "$NODE_MAJOR" ] || NODE_MAJOR=0
           fi
@@ -502,6 +502,10 @@ Resources:
           cat > /tmp/kcfetch.sh <<KCFETCH
           #!/bin/bash
           set -e
+          # sudo resets PATH to secure_path, which can resolve `node` to the distro
+          # node 18 in /usr/bin over the Node 22 tarball in /usr/local/bin -- so the
+          # vite build would still fail. Prepend /usr/local/bin so the build sees 22.
+          export PATH="/usr/local/bin:\$PATH"
           cd "$RUN_HOME"
           rm -rf kirocrew && mkdir kirocrew
           if [ -n "${SourceBucket}" ]; then

--- a/test/test_cloud_ec2.py
+++ b/test/test_cloud_ec2.py
@@ -35,13 +35,19 @@ class TestSubTemplateSyntax:
     def test_bootstrap_enforces_node_major_floor(self):
         # The frontend build (vite 8 + rolldown) needs Node >=22; AL2023's default
         # AppStream nodejs is 18, which fails with a node:util/styleText SyntaxError.
-        # The template must (a) declare the >=22 floor, (b) upgrade via the signed
-        # NodeSource 24 repo when the installed node is too old, and (c) fail the
+        # The template must (a) declare the >=22 floor, (b) upgrade via a PINNED
+        # official nodejs.org tarball when the installed node is too old (dnf/NodeSource
+        # is a dead end on AL2023 — its modular filtering keeps reinstalling node 18),
+        # verifying the tarball's SHA-256 before extracting as root, and (c) fail the
         # bootstrap if it still cannot reach the floor.
         text = ec2.load_template()
         assert "NODE_MAJOR_MIN=22" in text
-        assert "pub_24.x" in text
+        assert "nodejs.org/dist/" in text
         assert 'fail "Node.js too old' in text
+        # The tarball MUST be integrity-checked before it is extracted as root.
+        assert "sha256sum -c" in text
+        assert "9e7905fdee722f9650a03ae644b51c4c6effd3b98ac93c588700072ab35c9ddb" in text
+        assert "e05a4d65232ae2b27b3d77da2e368522fb46b923335b8e0d5f77624c32484044" in text
 
 
 class TestValidation:

--- a/test/test_cloud_login.py
+++ b/test/test_cloud_login.py
@@ -38,6 +38,20 @@ class TestParseLoginOutput:
         assert p.actionable is True
         assert p.already_logged_in is False
 
+    def test_prefers_complete_url_over_bare_verification_uri(self):
+        # kiro-cli prints the bare verification_uri FIRST and the code-embedded
+        # verification_uri_complete second. We must surface the complete one so the
+        # user deep-links to the approve screen instead of a generic sign-in page.
+        text = (
+            "To sign in, open:\n"
+            "  https://device.sso.us-east-1.amazonaws.com/\n"
+            "and enter code ABCD-1234, or open:\n"
+            "  https://device.sso.us-east-1.amazonaws.com/?user_code=ABCD-1234\n"
+        )
+        p = login.parse_login_output(text)
+        assert p.url == "https://device.sso.us-east-1.amazonaws.com/?user_code=ABCD-1234"
+        assert p.code == "ABCD-1234"
+
     def test_already_logged_in(self):
         p = login.parse_login_output("You are already logged in as user@example.com")
         assert p.already_logged_in is True


### PR DESCRIPTION
## Problem

A dashboard-launched EC2 crew doesn't reach a usable, signed-in state even after
the 16 KB UserData cap (#2730) and the Node >=22 floor (#2626) landed on main:

- The dashboard never builds, so the crew serves no UI.
- The sign-in link drops the user on a generic login page with nowhere obvious to
  enter the device code.

## Why it matters

Both are hard stops for a dashboard-launched cloud crew: no dashboard is a dead,
billing box; a confusing sign-in means the user can't actually connect. Neither is
caught by `cfn-lint` or unit tests — only a real launch surfaces them.

## Fix (symptom → root cause → change)

1. **No dashboard build.** main installs Node >=22 from the NodeSource dnf repo,
   but on AL2023 that is a dead end: the distro's modular filtering keeps
   reinstalling node 18 (confirmed empirically on real instances), so vite 8 +
   rolldown die on `node:util/styleText` and `install.sh` produces no `dist`.
   **Change:** install a PINNED official nodejs.org tarball (v22.12.0),
   SHA-256-verified per-arch **before** extraction, symlinked into `/usr/local/bin`
   (which precedes `/usr/bin`, shadowing the distro node 18) — no package-manager
   fights.
2. **Sign-in dead-ends.** `parse_login_output` returned the FIRST URL, which is the
   bare `verification_uri` (a generic sign-in page). **Change:** prefer the
   code-embedded `verification_uri_complete` (`…?user_code=…`) so the user
   deep-links straight to the approve screen; fall back to the first URL otherwise.

## Tests

- `test_bootstrap_enforces_node_major_floor` now asserts the nodejs.org tarball
  path + the pinned per-arch SHA-256 verification (replacing the NodeSource
  assertions).
- `test_cloud_login` covers the `verification_uri_complete` preference.
- 100 cloud + login tests pass; the #2730 UserData 16 KB size guard still holds
  with the (larger) tarball block.

## Manual verification

Validated end-to-end earlier on a real dashboard-launched aarch64 AL2023 crew:
with the tarball install it reached the vite build on Node 22, and the device-code
sign-in deep-linked to the Builder ID approve screen. A re-launch is recommended
after merge to reconfirm on current main.

## Screenshots

N/A — backend/template + login-parsing change; no user-visible UI surface changed
in this PR.

---

**Scope note:** this PR was intentionally narrowed. The 16 KB UserData cap, the
Node-floor plumbing, and the delete-UX/durable-launch work already merged to main
via #2730 / #2626 / #2059; the remaining delta here is the two fixes above, which
those left broken on AL2023.
