### PR TITLE
fix(browser): sync native address bar and keep Browser view across panel close

### DIFF
--- a/website/src/components/WebPreviewPanel.tsx
+++ b/website/src/components/WebPreviewPanel.tsx
@@ -394,6 +394,9 @@ export default function WebPreviewPanel({ sessionKey, active = true }: { session
   const [deviceId, setDeviceId] = useState('responsive')
   const [deviceMenuOpen, setDeviceMenuOpen] = useState(false)
   const deviceMenuRef = useRef<HTMLDivElement>(null)
+  // The native address-bar input. The view-URL sync effect reads its focus so a
+  // view-initiated navigation never overwrites the field while the user types.
+  const nativeInputRef = useRef<HTMLInputElement>(null)
 
   const url = nav.index >= 0 ? nav.stack[nav.index] : ''
   const canBack = nav.index > 0
@@ -530,6 +533,27 @@ export default function WebPreviewPanel({ sessionKey, active = true }: { session
     window.addEventListener(PREVIEW_PENDING_EVENT, onPending)
     return () => window.removeEventListener(PREVIEW_PENDING_EVENT, onPending)
   }, [sessionKey])
+
+  // Reflect view-initiated navigation (agent browser_navigate, in-page link
+  // clicks, redirects) into the native address bar. `did-navigate` already
+  // updates `native.state.url`, but the input is bound to `draft`, which
+  // otherwise only changes on typing or back/forward — so an agent-opened page
+  // left the bar empty and showing its placeholder. Mirror the live URL into
+  // `draft`, but never while the user is editing the field, so a slow redirect
+  // cannot overwrite what they are typing.
+  //
+  // Display only — deliberately does NOT persist. `native.state` carries no
+  // session tag, and on a slot switch this component instance is reused (its
+  // `sessionKey` changes) while `useNativeBrowser` may still hold the previous
+  // slot's state until `getState` resolves; persisting here would write that
+  // stale URL into the NEW slot's storage. User-typed navigation persists via
+  // `commitNative`; view-initiated navigation stays display-only, as before.
+  useEffect(() => {
+    const u = native.state?.url
+    if (!nativeOpen || !u) return
+    if (document.activeElement === nativeInputRef.current) return
+    setDraft(u)
+  }, [nativeOpen, native.state?.url])
 
   // Close the device menu on outside click.
   useEffect(() => {
@@ -729,6 +753,7 @@ export default function WebPreviewPanel({ sessionKey, active = true }: { session
       >
         <div className="flex-1 min-w-0 flex items-center gap-0.5 h-7 pl-1 pr-1 rounded-md bg-bg-elevated border border-border focus-within:border-accent transition-colors">
           <input
+            ref={nativeInputRef}
             type="text"
             value={draft}
             onChange={e => setDraft(e.target.value)}

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -2165,6 +2165,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // belonging to another chat lives in this panel subtree, so deciding to unmount
   // on the active slot's (possibly empty) tab list would destroy that canvas.
   const hasLiveAppTab = useAnyLiveAppTab()
+  // Current slot only — unlike app tabs (hosted cross-slot via `allAppTabs`), a
+  // Browser tab renders solely from the active slot's strip, and a background
+  // slot's browser view already unmounts (its WebContentsView released) on the
+  // slot switch. So keep-mounted follows THIS slot's tabs, not every slot's.
+  const hasBrowserTab = tabsCtl.tabs.some(t => t.kind === 'browser')
   // Which file (if any) the Files tab is showing inline — kept PER SLOT (above
   // the SidePanel subtree so it survives panel collapse). Per-slot (not a single
   // value reset on switch) so it stays consistent with the per-slot tab buckets
@@ -6861,7 +6866,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       <AnimatePresence initial={false}>
         {/* Inline side panel — mobile / embed frames where there's no actbar
             grid column. Desktop uses the actbar portal below. */}
-        {shouldMountSidePanel({ activityOpen, hasLiveAppTab, searchOpen: search.isOpen }) && !activitySlot && (
+        {shouldMountSidePanel({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen: search.isOpen }) && !activitySlot && (
           <motion.div
             key="side-panel-inline"
             initial={{ width: 0 }}
@@ -6871,7 +6876,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
             className="h-full overflow-hidden flex justify-end shrink-0"
             // Kept mounted for a live app tab: hide instead of unmounting so the
             // iframe (and the drawing inside it) survives a panel close.
-            style={isSidePanelHidden({ activityOpen, hasLiveAppTab, searchOpen: search.isOpen }) ? { display: 'none' } : undefined}
+            style={isSidePanelHidden({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen: search.isOpen }) ? { display: 'none' } : undefined}
           >
             <SidePanel
               tabsCtl={tabsCtl}
@@ -6899,7 +6904,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
           the window edge — both sides move together instead of snapping. */}
       {activitySlot && createPortal(
         <AnimatePresence initial={false}>
-          {shouldMountSidePanel({ activityOpen, hasLiveAppTab, searchOpen: search.isOpen }) && (
+          {shouldMountSidePanel({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen: search.isOpen }) && (
             <motion.div
               key="side-panel"
               initial={{ width: 0, opacity: 0 }}
@@ -6907,7 +6912,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
               exit={{ width: 0, opacity: 0 }}
               transition={{ duration: 0.18, ease: [0.2, 0, 0, 1] }}
               className="h-full overflow-visible flex justify-end"
-              style={isSidePanelHidden({ activityOpen, hasLiveAppTab, searchOpen: search.isOpen }) ? { display: 'none' } : undefined}
+              style={isSidePanelHidden({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen: search.isOpen }) ? { display: 'none' } : undefined}
             >
               <SidePanel
                 tabsCtl={tabsCtl}

--- a/website/src/pages/chat/sidePanelMount.ts
+++ b/website/src/pages/chat/sidePanelMount.ts
@@ -19,6 +19,10 @@ export interface SidePanelMountInput {
   activityOpen: boolean
   /** True while at least one `app` tab exists in the current slot's strip. */
   hasLiveAppTab: boolean
+  /** True while a `browser` tab is live. Its Electron WebContentsView is
+   *  destroyed on unmount, so — like an app tab — closing the panel must hide,
+   *  not unmount, or the loaded page is lost. */
+  hasBrowserTab: boolean
   /** The find pane takes the dock slot exclusively. */
   searchOpen: boolean
 }
@@ -28,12 +32,14 @@ export interface SidePanelMountInput {
  *  A live app tab makes this UNCONDITIONAL. Everything else — the user closing
  *  the panel, the find pane claiming the dock — controls *visibility* only
  *  (`isSidePanelHidden`), never mounting. Deciding not to mount is deciding to
- *  destroy the drawing, and no transient UI state is worth that.
+ *  destroy the drawing, and no transient UI state is worth that. A live
+ *  `browser` tab is kept mounted for the same reason: its WebContentsView is
+ *  destroyed on unmount, so a close would lose the loaded page.
  *
  *  With no app tab, behaviour is exactly as before: the find pane takes the dock
  *  exclusively and closing the panel unmounts it, preserving the exit animation. */
-export function shouldMountSidePanel({ activityOpen, hasLiveAppTab, searchOpen }: SidePanelMountInput): boolean {
-  if (hasLiveAppTab) return true
+export function shouldMountSidePanel({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen }: SidePanelMountInput): boolean {
+  if (hasLiveAppTab || hasBrowserTab) return true
   if (searchOpen) return false
   return activityOpen
 }

--- a/website/src/test/sidePanelMount.test.ts
+++ b/website/src/test/sidePanelMount.test.ts
@@ -6,8 +6,8 @@
 import { describe, it, expect } from 'vitest'
 import { shouldMountSidePanel, isSidePanelHidden } from '../pages/chat/sidePanelMount'
 
-const S = (activityOpen: boolean, hasLiveAppTab: boolean, searchOpen = false) =>
-  ({ activityOpen, hasLiveAppTab, searchOpen })
+const S = (activityOpen: boolean, hasLiveAppTab: boolean, searchOpen = false, hasBrowserTab = false) =>
+  ({ activityOpen, hasLiveAppTab, hasBrowserTab, searchOpen })
 
 describe('side panel mount decision', () => {
   it('mounts while open, with or without an app tab', () => {
@@ -54,5 +54,25 @@ describe('side panel mount decision', () => {
         expect(shouldMountSidePanel(S(activityOpen, true, searchOpen))).toBe(true)
       }
     }
+  })
+
+  describe('a live browser tab', () => {
+    // The Browser tab hosts an Electron WebContentsView that useNativeBrowser
+    // destroys on unmount (api.close). Closing the panel must hide, not unmount,
+    // or the loaded page (and its scroll/history) is lost — same shape as the
+    // app-tab invariant above.
+    it('STAYS MOUNTED and hidden on close', () => {
+      expect(shouldMountSidePanel(S(false, false, false, true))).toBe(true)
+      expect(isSidePanelHidden(S(false, false, false, true))).toBe(true)
+    })
+
+    it('survives the find pane claiming the dock', () => {
+      expect(shouldMountSidePanel(S(true, false, true, true))).toBe(true)
+      expect(isSidePanelHidden(S(true, false, true, true))).toBe(true)
+    })
+
+    it('is shown while the panel is open and unobstructed', () => {
+      expect(isSidePanelHidden(S(true, false, false, true))).toBe(false)
+    })
   })
 })


### PR DESCRIPTION
## Problem

Two defects in the dashboard's right-side **Browser** panel:

1. **Address bar stuck on the placeholder.** After the agent opens a page (`browser_navigate`), the URL bar keeps showing its grey `localhost:5173` placeholder instead of the page that's actually loaded. Link clicks and redirects inside the view don't update it either.
2. **The browser vanishes on close+reopen.** Closing the side panel and reopening it shows a blank Browser tab — the loaded page (scroll, history, form state) is gone.

## Why it matters

The Browser panel is how the agent shows the user real pages. An address bar that never reflects the current URL makes it impossible to tell where the view is, and losing the whole page just because the panel was collapsed is surprising data loss — a real browser keeps a background tab alive.

## Fix (symptom → root cause → change)

**Address bar.** Symptom: bar shows the placeholder for agent-opened pages. Root cause: the `<input>` is bound to local `draft` state, which only changes on typing or back/forward; view-initiated navigation fires `did-navigate` → updates `native.state.url`, but nothing mirrored that into `draft`. (Proof: the adjacent "open in browser" link reads `native.state.url` and worked.) Change: a **display-only** effect in `WebPreviewPanel` mirrors `native.state.url` into `draft` on navigation, guarded by `document.activeElement` so it never clobbers what the user is typing. It deliberately does **not** persist — `native.state` carries no session tag, and on a slot switch this component instance is reused, so persisting could write a stale URL into the new slot's storage; user-typed navigation still persists via `commitNative`, exactly as before.

**Panel persistence.** Symptom: page gone after close+reopen. Root cause: closing the panel unmounts the whole `SidePanel` subtree, and `useNativeBrowser`'s unmount cleanup calls `api.close()`, which **destroys** the Electron `WebContentsView`. Change: treat a live Browser tab like a live app tab — thread `hasBrowserTab` (scoped to the **current slot**, since browser tabs aren't hosted cross-slot) through `shouldMountSidePanel`/`isSidePanelHidden` so the subtree stays **mounted and hidden** (`display:none`) on close instead of unmounting. When hidden, the host rect measures 0 and the native layer auto-hides; on reopen the `ResizeObserver` re-reports real bounds and the page reappears — the same "hide, never destroy" rule already used for tab switches.

## Tests

- `website/src/test/sidePanelMount.test.ts`: added a `a live browser tab` group asserting the panel stays **mounted + hidden** on close and while the find pane claims the dock, and is shown when open — mirroring the existing app-tab invariant. Threaded `hasBrowserTab` through the test helper.
- Full frontend build (`npm run build`) + `tsc -b` clean; `npx vitest run` = 12330 passed (the 2 `App.test.tsx` "Kiro credits pill" failures are a pre-existing base breakage on `origin/main`, unrelated — this diff touches no `App` files).

## Manual verification

The address-bar and view-persistence behaviors live in the Electron **native** `WebContentsView`, which does not render in a headless pod / dev-backend (it's composited by the Electron main process). Verified here by: unit tests on the mount decision, `tsc`, eslint, and two independent code reviews (GPT + Opus) plus a focused verifier confirming the cross-session-write blocker is closed. Full visual confirmation (bar reflects the navigated URL; page survives close+reopen) needs a desktop build of this branch — happy to capture on request.

## Screenshots

N/A in CI — the affected surface is the native Electron browser view, which cannot be captured in a headless/pod environment. See Manual verification.
