### PR TITLE
fix(memory): render an imported lesson as its rule, not a dict repr

### DIFF
--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -253,6 +253,43 @@ def _lesson_slug(rule: str) -> str:
     return hashlib.md5(rule.encode(), usedforsecurity=False).hexdigest()[:12]
 
 
+def _lesson_display_text(decoded: object) -> str:
+    """Render a decoded lesson value as the prose that goes into the prompt.
+
+    Two writers produce two shapes, and only one of them is a string. ``learn_add``
+    stores the value as ``"<rule>"`` or ``"<rule><sep><negative>"``
+    (see ``_LESSON_NEGATIVE_SEP``), while the onboarding import stores a mapping —
+    ``{"rule": ..., "category": ..., "negative": ...}`` — because it carries fields
+    the string form has nowhere to put. Interpolating the decoded value directly
+    therefore pasted a Python ``dict`` repr into the system prompt for every
+    imported lesson: the model was handed ``{'rule': 'Prefer dark mode',
+    'category': 'preference', 'negative': None}`` instead of the rule, spending
+    tokens on punctuation and field names while burying the instruction it is
+    supposed to follow.
+
+    Normalizing at READ time rather than converting the rows keeps this a pure
+    rendering fix: stored bytes are untouched, so no migration runs, downgrading
+    stays safe, and the dedup/enrichment paths that parse the string form
+    (``_split_stored``) keep seeing exactly what they see today.
+
+    An unrecognized shape yields ``""`` and is skipped by the caller rather than
+    being stringified as a guess. This runs while a session's prompt is being
+    built, where a raise costs the whole turn, so every branch has to produce a
+    string without trusting the value's type.
+    """
+    if isinstance(decoded, str):
+        return decoded.strip()
+    if isinstance(decoded, dict):
+        rule = decoded.get("rule")
+        if not isinstance(rule, str) or not rule.strip():
+            return ""
+        negative = decoded.get("negative")
+        if isinstance(negative, str) and negative.strip():
+            return f"{rule.strip()}{_LESSON_NEGATIVE_SEP}{negative.strip()}"
+        return rule.strip()
+    return ""
+
+
 def _split_stored(existing_val: str, rule_norm: str, existing_key: str) -> tuple[str | None, bool]:
     """Split a stored lesson value against a normalized rule.
 
@@ -2242,7 +2279,9 @@ class VectorMemoryStore:
             "ALWAYS follow these. They override default behavior.]"
         ]
         for e in lessons:
-            lines.append(f"- {json.loads(e['value_json'])}")
+            text = _lesson_display_text(json.loads(e["value_json"]))
+            if text:
+                lines.append(f"- {text}")
         lines.append("[End of learned corrections]\n")
         return "\n".join(lines)
 

--- a/test/test_vector_memory_coverage.py
+++ b/test/test_vector_memory_coverage.py
@@ -13,6 +13,7 @@ requirement.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import struct
 import time
@@ -1209,6 +1210,67 @@ class TestLessonDedupPaths:
     def test_lessons_context_is_empty_without_lessons(self, tmp_path: Path) -> None:
         store = _store(tmp_path)
         assert store.get_lessons_context() == ""
+
+    def test_lessons_context_renders_imported_dict_lesson_as_prose(self, tmp_path: Path) -> None:
+        """An imported lesson is injected as its rule, not as a Python dict repr.
+
+        The onboarding import stores a mapping rather than the string
+        ``learn_add`` writes, and both shapes land in the same prompt block. The
+        formatter used to interpolate the decoded value directly, so an imported
+        row reached the model as ``{'rule': ..., 'category': ...}`` — the
+        instruction buried inside punctuation and field names.
+        """
+        store = _store(tmp_path)
+        store.set_semantic_if_absent(
+            f"lesson.{hashlib.sha256(b'Prefer dark mode').hexdigest()[:16]}",
+            {"rule": "Prefer dark mode", "category": "preference", "negative": None},
+            1.0,
+            "import",
+        )
+        ctx = store.get_lessons_context()
+        assert "- Prefer dark mode" in ctx
+        # The repr's own punctuation is the assertion: no dict may survive into
+        # the prompt, and `category`/`negative` are storage fields the model has
+        # no use for.
+        assert "{'rule'" not in ctx
+        assert "category" not in ctx
+        assert "negative" not in ctx
+
+    def test_lessons_context_renders_an_imported_not_clause(self, tmp_path: Path) -> None:
+        """A dict-form lesson's NOT-clause is joined with the same separator.
+
+        The string form spells a clause as ``<rule> — NOT: <negative>``, so the
+        mapping form has to render identically — otherwise the same lesson reads
+        two different ways depending on which writer stored it.
+        """
+        store = _store(tmp_path)
+        store.set_semantic_if_absent(
+            f"lesson.{hashlib.sha256(b'Pin dependency versions').hexdigest()[:16]}",
+            {
+                "rule": "Pin dependency versions",
+                "category": "preference",
+                "negative": "never use open ranges",
+            },
+            1.0,
+            "import",
+        )
+        ctx = store.get_lessons_context()
+        assert "- Pin dependency versions — NOT: never use open ranges" in ctx
+        assert "{'rule'" not in ctx
+
+    def test_lessons_context_skips_an_unrenderable_row(self, tmp_path: Path) -> None:
+        """A shape with no usable rule is dropped, not stringified as a guess.
+
+        This runs while a session's prompt is being built, where a raise costs
+        the whole turn, so an unexpected value has to degrade to "omit it".
+        """
+        store = _store(tmp_path)
+        store.set_semantic_if_absent("lesson.emptyrule000", {"category": "preference"}, 1.0, "import")
+        store.set_semantic_if_absent("lesson.listshape000", ["not", "a", "lesson"], 1.0, "import")
+        ctx = store.get_lessons_context()
+        assert "category" not in ctx
+        assert "not a lesson" not in ctx
+        assert "['not'" not in ctx
 
 
 class TestContradictionCandidateBanding:


### PR DESCRIPTION
## The bug

Two writers store a lesson in two different shapes, and only one of them is a string.

- `learn_add` writes the value as `"<rule>"`, or `"<rule> — NOT: <negative>"` when the rule carries a NOT-clause (`_LESSON_NEGATIVE_SEP`).
- The onboarding import writes a **mapping** — `{"rule": ..., "category": ..., "negative": ...}` — because it carries fields the string form has nowhere to put.

Both land in the same injected prompt block, and `get_lessons_context()` interpolated the decoded value straight into it:

```python
for e in lessons:
    lines.append(f"- {json.loads(e['value_json'])}")
```

So every imported lesson reached the model as a Python `dict` repr instead of the instruction it holds.

## Before / after

Both shapes written to a throwaway store, then rendered through the real `get_lessons_context()`:

**Before**

```text
[Learned corrections — user-taught rules from past mistakes.
ALWAYS follow these. They override default behavior.]
- {'rule': 'Always run the tests before pushing', 'category': 'preference', 'negative': 'never push on a red suite'}
- {'rule': 'Prefer dark mode', 'category': 'preference', 'negative': None}
- Pin dependency versions — NOT: never use open ranges
[End of learned corrections]
```

**After**

```text
[Learned corrections — user-taught rules from past mistakes.
ALWAYS follow these. They override default behavior.]
- Always run the tests before pushing — NOT: never push on a red suite
- Prefer dark mode
- Pin dependency versions — NOT: never use open ranges
[End of learned corrections]
```

The third line is the `learn_add` row in both runs — unchanged, which is the point: only the mapping rows move.

## Why it matters

The rule text was always in there, but wrapped in punctuation and storage field names the model has no use for, and `'negative': None` reads as a value rather than as an absence. This block is injected into the system prompt of every session, so the cost is paid on every turn.

Not an edge case either. On the install where this surfaced, **30 of 107** `lesson.*` rows are dict-form (all `source='import'`) — 28% of stored lessons:

```text
total lesson rows : 107
dict-form (broken): 30
string-form (ok)  : 77
other             : 0
```

## The fix

A read-time normaliser, `_lesson_display_text()`. Deliberately **not** a conversion of the stored rows:

- stored bytes are untouched, so no migration runs and downgrading stays safe;
- `_split_stored()` and the dedup/enrichment paths that parse the string form keep seeing exactly what they see today;
- an unrecognised shape renders as `""` and is skipped by the caller rather than stringified as a guess — this runs while a session's prompt is being built, where a raise costs the whole turn, so every branch produces a string without trusting the value's type.

## Tests

Three added to `TestLessonDedupPaths`, all of which **fail before the fix**:

```text
FAILED test_lessons_context_renders_imported_dict_lesson_as_prose - assert '- Prefer dark mode' in "[Learned corrections — user-taught rules fr...
FAILED test_lessons_context_skips_an_unrenderable_row            - AssertionError: assert 'category' not in '[Learned co...rrections]\n'
FAILED test_lessons_context_renders_an_imported_not_clause       - assert '- Pin dependency versions — NOT: never use open ranges' in "[Learne...
=================== 3 failed, 1 passed, 13 warnings in 2.27s ===================
```

After, with the surrounding suites:

```text
574 passed, 10 skipped, 17 warnings in 6.16s
```

(`test_vector_memory_coverage.py`, `test_vector_memory.py`, `test_lesson_contradiction.py`, `test_onboarding_import.py`)

`isort` and `flake8` clean. `mypy src/kiro_crew/vector_memory.py` reports only 3 pre-existing `os.setxattr` errors in `hooks.py`, byte-identical on unmodified `main` (macOS-only; the attribute exists on the Linux CI runner).

## Relationship to #2321

Distinct, and this one is a prerequisite rather than a subset. #2321 is about the NOT-clause **storage format** and the two enrichment cases an in-band separator blocks; its remedy is a format change plus a migration. This is a **read-time rendering** fix with no format change. Notably, #2321's proposed structured-value fix would put *every* lesson into mapping form — which would route all of them through the defect fixed here.
