### PR TITLE
fix(dashboard): surface why a /compact failed

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -711,6 +711,12 @@ POISONED_SESSION_CYCLES = 2
 _POISON_CANARY_PROMPT = "Reply with the single word OK."
 _POISON_CANARY_TIMEOUT_SECS = 30.0
 
+# Cap the backend-echoed reason interpolated into the "Compaction failed"
+# notice. The notice is a one-line receipt in the transcript, so an unbounded
+# provider string (a stack trace, an echoed payload) would scroll the
+# conversation away instead of explaining it.
+_COMPACT_FAIL_REASON_MAX_CHARS = 300
+
 
 def _truncate_snapshot(content: str) -> str:
     """Cap content at _MAX_SNAPSHOT chars, appending a marker if truncated.
@@ -6559,7 +6565,30 @@ async def _run_chat(
                         else "✅ Conversation compacted."
                     )
                 elif compaction_result["type"] == "failed":
-                    msg = "❌ Compaction failed."
+                    # The provider ships the reason on `failed` too, and every
+                    # other surface already tells the user what it was — Slack,
+                    # Telegram, Discord, and this dashboard's own AUTO-compact
+                    # notice (see chat_utils._compaction_notice_text). Dropping
+                    # it here left the one path a user takes deliberately as the
+                    # only one that says nothing, so a `/compact` that fails
+                    # because the conversation is too large is indistinguishable
+                    # from one that failed because the backend was unreachable —
+                    # and the user's next move differs in those two cases.
+                    #
+                    # Redacted with the same pair as the completed branch above:
+                    # the text is backend-echoed, so it is not trusted to be
+                    # free of credentials or exfiltration URLs even though the
+                    # provider already redacts once at its own boundary.
+                    error, _ = redact_credentials(compaction_result.get("summary", ""))
+                    error, _ = redact_exfiltration_urls(error)
+                    error = error.strip()
+                    if len(error) > _COMPACT_FAIL_REASON_MAX_CHARS:
+                        # A notice is a one-line receipt, not a log: a provider
+                        # that echoes a wall of text (a stack trace, a dumped
+                        # payload) would otherwise push the whole transcript out
+                        # of the reader's view.
+                        error = error[:_COMPACT_FAIL_REASON_MAX_CHARS].rstrip() + "…"
+                    msg = f"❌ Compaction failed: {error}" if error else "❌ Compaction failed."
                 else:
                     msg = "⚠️ Compaction timed out."
                 _append_compaction_notice(state, slot, msg)

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -3857,6 +3857,98 @@ class TestRunChatCompactDeferredWait:
             "window_tokens": 200_000,
         }
 
+    @staticmethod
+    def _compaction_notice(slot) -> str:
+        """The text of the compaction notice appended to the transcript."""
+        notices = [
+            m["content"]
+            for m in slot.messages
+            if m.get("meta", {}).get("kind") == "compaction" and "Compaction" in m.get("content", "")
+        ]
+        assert notices, "no compaction notice was appended"
+        return notices[-1]
+
+    async def _run_failed_compaction(self, tmp_path, monkeypatch, summary):
+        """Drive /compact to a `failed` result carrying *summary*."""
+        from kiro_crew.providers.base import EVENT_COMPLETE, LLMEvent
+
+        state = self._make_state_for_run_chat(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+
+        client = self._make_mock_client([LLMEvent(kind=EVENT_COMPLETE)])
+        result = {"type": "failed"}
+        if summary is not None:
+            result["summary"] = summary
+        client.wait_for_compaction = AsyncMock(return_value=result)
+        client.context_window_tokens = MagicMock(return_value=200_000)
+        client.context_used_tokens = MagicMock(return_value=150_000)
+        state.sessions.get_or_create = AsyncMock(return_value=(client, True, False))
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner.is_claude_backend", lambda _provider: False
+        )
+
+        from kiro_crew.dashboard.chat import _run_chat
+
+        await _run_chat(state, slot, "/compact")
+        return slot
+
+    @pytest.mark.asyncio
+    async def test_failed_compaction_surfaces_the_reason(self, tmp_path, monkeypatch):
+        """The provider's reason reaches the user instead of being discarded.
+
+        Without it, a /compact that failed because the conversation is too large
+        is indistinguishable from one that failed because the backend was
+        unreachable — and those two call for different next moves. Every other
+        surface (Slack/Telegram/Discord, and this dashboard's own auto-compact
+        notice) already says which.
+        """
+        slot = await self._run_failed_compaction(
+            tmp_path, monkeypatch, "context too large to summarize"
+        )
+        assert self._compaction_notice(slot) == (
+            "❌ Compaction failed: context too large to summarize"
+        )
+
+    @pytest.mark.asyncio
+    async def test_failed_compaction_without_a_reason_keeps_the_bare_notice(
+        self, tmp_path, monkeypatch
+    ):
+        """No reason means no dangling colon — the old wording stands."""
+        slot = await self._run_failed_compaction(tmp_path, monkeypatch, None)
+        assert self._compaction_notice(slot) == "❌ Compaction failed."
+
+    @pytest.mark.asyncio
+    async def test_failed_compaction_blank_reason_keeps_the_bare_notice(
+        self, tmp_path, monkeypatch
+    ):
+        """A whitespace-only reason is treated as absent, not printed."""
+        slot = await self._run_failed_compaction(tmp_path, monkeypatch, "   ")
+        assert self._compaction_notice(slot) == "❌ Compaction failed."
+
+    @pytest.mark.asyncio
+    async def test_failed_compaction_reason_is_redacted(self, tmp_path, monkeypatch):
+        """A backend-echoed reason is not trusted to be credential-free.
+
+        Same redact pair as the sibling `completed` branch, which already treats
+        the provider's text as untrusted.
+        """
+        slot = await self._run_failed_compaction(
+            tmp_path, monkeypatch, "auth failed for AKIAIOSFODNN7EXAMPLE key"
+        )
+        notice = self._compaction_notice(slot)
+        assert "AKIAIOSFODNN7EXAMPLE" not in notice
+        assert "Compaction failed:" in notice
+
+    @pytest.mark.asyncio
+    async def test_failed_compaction_reason_is_length_capped(self, tmp_path, monkeypatch):
+        """A wall of provider text cannot scroll the transcript away."""
+        from kiro_crew.dashboard.chat_runner import _COMPACT_FAIL_REASON_MAX_CHARS
+
+        slot = await self._run_failed_compaction(tmp_path, monkeypatch, "x" * 5_000)
+        notice = self._compaction_notice(slot)
+        assert notice.endswith("…")
+        assert len(notice) < _COMPACT_FAIL_REASON_MAX_CHARS + 60
+
 
 class TestTokenPersistenceBackfill:
     """Regression tests for the late-backfill of slot.model before


### PR DESCRIPTION
Fixes #792

## The bug

The deferred-compaction handler in `_run_chat` hardcoded the failure notice:

```python
elif compaction_result["type"] == "failed":
    msg = "❌ Compaction failed."
```

The reason was available the whole time. `session_handle` returns it for `failed` as well as `completed`, and says so explicitly:

```python
# Redact backend-echoed summary before it reaches callers
# (compact() surfaces this to the dashboard).
return {"type": s_type, "summary": redact_text(...)}
```

So the dashboard asked for the reason, received it, and dropped it on the floor.

## Why it matters

**Every other surface already tells the user which failure they hit** — `slack/handler.py`, `telegram/transport_dispatch.py`, `discord/transport_dispatch.py`, and this dashboard's own **auto**-compact notice in `chat_utils.py`:

```python
error, _ = redact_credentials(event.title or "unknown error")
error, _ = redact_exfiltration_urls(error)
msg_text = f"❌ Compaction failed: {error}"
```

The manual `/compact` — the one path a user takes *deliberately*, having decided their context needs shrinking — was the lone holdout. A compaction that failed because the conversation is too large to summarize looked identical to one that failed because the backend was unreachable. Those call for different next moves: start a new chat, or retry in a minute.

## Before / after

Driving `/compact` to a `failed` result carrying `"context too large to summarize"`:

**Before**

```text
test_dashboard_chat.py:3644: AssertionError: assert '❌ Compaction failed.' == '❌ Compaction... to summarize'
test_dashboard_chat.py:3676: AssertionError: assert 'Compaction failed:' in '❌ Compaction failed.'
FAILED TestRunChatCompactDeferredWait::test_failed_compaction_surfaces_the_reason
FAILED TestRunChatCompactDeferredWait::test_failed_compaction_reason_is_redacted
FAILED TestRunChatCompactDeferredWait::test_failed_compaction_reason_is_length_capped
=================== 3 failed, 3 passed, 14 warnings in 2.92s ===================
```

**After**

```text
6 passed, 15 warnings in 1.63s
```

The notice now reads `❌ Compaction failed: context too large to summarize`.

## The fix

Mirrors the sibling `completed` branch a few lines above rather than inventing a pattern:

- **Redacted with the same pair** (`redact_credentials` + `redact_exfiltration_urls`). The text is backend-echoed, so it is not trusted to be credential-free even though the provider already redacts once at its own boundary. This is defence in depth, matching what `completed` does with its summary and what the auto-compact path does with its title.
- **Length-capped** at `_COMPACT_FAIL_REASON_MAX_CHARS = 300`. A notice is a one-line receipt in the transcript; an unbounded provider string (a stack trace, an echoed payload) would scroll the conversation away instead of explaining it.
- **No reason still yields the bare notice**, so there is no dangling colon. A whitespace-only reason is treated as absent.

Scope is deliberately narrow: only the discarded-reason defect. #792 also reports a `/compact` failure and a retry timeout, and neither is touched here. `COMPACT_WAIT_TIMEOUT_SECS` has since moved 120s → 300s (#2183), and the known stranded-wait cause was already fixed in `3130d294`, which the reporter's build already contained — so the remaining timeout symptom has a different, unconfirmed cause and does not belong in this change.

## Tests

Five added to `TestRunChatCompactDeferredWait`. Three assert the new behaviour and fail before the fix; two are regression guards on the bare notice and pass either way, which is the intended shape:

- `test_failed_compaction_surfaces_the_reason`
- `test_failed_compaction_reason_is_redacted` — a credential-shaped reason does not reach the transcript
- `test_failed_compaction_reason_is_length_capped`
- `test_failed_compaction_without_a_reason_keeps_the_bare_notice`
- `test_failed_compaction_blank_reason_keeps_the_bare_notice`

Full file:

```text
546 passed, 435 warnings in 3.24s
```

`isort` and `flake8` clean. `mypy src/kiro_crew/dashboard/chat_runner.py` reports only 3 pre-existing `os.setxattr` errors in `hooks.py`, byte-identical on unmodified `main` (macOS-only; the attribute exists on the Linux CI runner).

## Note on the prior attempt

PR #1168 targeted this same issue and was closed **by its own author**, not rejected — the sole review comment was a maintainer noting CI/E2E was failing the gate into AI review. Its 332/−212 diff across 2 files suggests scope was the problem. This change is +31/−1 in the source file and stays strictly on the discarded reason.
