### PR TITLE
perf(security): retire whole runs the bare-secret slide cannot match

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -6104,6 +6104,35 @@ def _shannon_entropy(token: str) -> float:
     return -sum((c / length) * math.log2(c / length) for c in counts.values())
 
 
+def _has_all_three_char_classes(text: str) -> bool:
+    """Return True if *text* holds at least one lowercase, uppercase AND digit.
+
+    One pass with early exit, rather than three ``any()`` scans. Semantically
+    identical, but this is the hottest predicate in the redaction path:
+    :func:`_contains_bare_secret` slides a 40-char window BYTE BY BYTE across
+    every base64-alphabet run, so a single 512-char run asks this question 473
+    times. Three ``any()`` scans build three generators per call and cost the
+    SUM of their three first-match offsets; one loop breaks on completion and
+    costs the MAX. Both forms short-circuit, so the saving is generator frames
+    plus that sum-vs-max difference.
+
+    Absence of a class is closed under substring, which is what lets
+    :func:`_contains_bare_secret` ask this about a whole run and retire every
+    window at once.
+    """
+    has_lower = has_upper = has_digit = False
+    for ch in text:
+        if not has_lower and ch.islower():
+            has_lower = True
+        elif not has_upper and ch.isupper():
+            has_upper = True
+        elif not has_digit and ch.isdigit():
+            has_digit = True
+        if has_lower and has_upper and has_digit:
+            return True
+    return False
+
+
 def _decodes_to_printable_text(token: str) -> bool:
     """Return True if *token* base64-decodes to mostly-printable ASCII.
 
@@ -6181,10 +6210,7 @@ def _looks_like_secret_key(token: str) -> bool:
     """
     if len(token) != _SECRET_KEY_LEN:
         return False
-    has_lower = any(ch.islower() for ch in token)
-    has_upper = any(ch.isupper() for ch in token)
-    has_digit = any(ch.isdigit() for ch in token)
-    if not (has_lower and has_upper and has_digit):
+    if not _has_all_three_char_classes(token):
         return False
     if _HEX_ONLY_RE.match(token):
         return False
@@ -6225,6 +6251,23 @@ def _contains_bare_secret(run: str) -> bool:
     """
     if len(run) < _SECRET_KEY_LEN:
         return False
+    # RUN-LEVEL FAST PATH. Two of the per-window gates reject on a property that
+    # is closed under substring, so asking about the whole run once can retire
+    # every window without classifying any of them:
+    #   gate 2 -- a character class absent from the run is absent from all of its
+    #             substrings, so no window can hold all three;
+    #   gate 3 -- every substring of an all-hex run is itself all-hex.
+    # Both answers are False either way, so this only reorders WHICH check
+    # returns False, never the verdict. Guarded on a run longer than one window,
+    # because at exactly 40 chars the sole window pays the same two gates anyway
+    # and the pre-check would be pure duplicate work. This is what keeps the
+    # slide affordable on long non-secret runs (hex digests, lowercase blobs),
+    # which are the common shape in tool output.
+    if len(run) > _SECRET_KEY_LEN:
+        if not _has_all_three_char_classes(run):
+            return False
+        if _HEX_ONLY_RE.match(run):
+            return False
     if _decodes_to_printable_text(run):
         return False
     for start in range(len(run) - _SECRET_KEY_LEN + 1):

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import base64
 import json
 import os
+import random
+import string
 import sys
 from pathlib import Path
 
 import pytest
 from oauth_url_corpus import OPERATOR_EXTENSION_OAUTH_URLS
 
+from kiro_crew import security
 from kiro_crew.security import (
+    _SECRET_KEY_LEN,
     apply_resource_limits,
     audit_bash_command,
     audit_bash_exfiltration,
@@ -894,6 +898,149 @@ class TestBareSecretKeyRedaction:
         result, warnings = redact_credentials(blob)
         assert result == blob
         assert not warnings
+
+
+class TestBareSecretRunLevelFastPath:
+    """The run-level fast path must be an optimization ONLY, never a hole.
+
+    ``_contains_bare_secret`` slides a 40-char window byte by byte, so a long
+    base64-alphabet run costs one full classification per offset. Two per-window
+    gates reject on a property closed under substring -- a missing character
+    class (gate 2) and all-hex (gate 3) -- so the whole run can be asked once and
+    every window retired. These tests pin both halves of that claim: the fast
+    path really fires (a behaviour-only test cannot see it), and it cannot
+    swallow a genuine secret hidden inside a long run.
+    """
+
+    @staticmethod
+    def _count_window_classifications(run: str, monkeypatch: pytest.MonkeyPatch) -> int:
+        """Return how many 40-char windows of *run* got fully classified."""
+        calls = []
+        original = security._looks_like_secret_key
+
+        def counting(token: str) -> bool:
+            calls.append(token)
+            return original(token)
+
+        monkeypatch.setattr(security, "_looks_like_secret_key", counting)
+        security._contains_bare_secret(run)
+        return len(calls)
+
+    def test_run_missing_a_char_class_skips_every_window(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # 520 lowercase chars: no window can hold an uppercase char or a digit,
+        # so gate 2 rejects all 481 of them. Without the fast path this is 481
+        # full classifications; with it, zero.
+        run = "abcdefghijklmnopqrstuvwxyz" * 20
+        assert len(run) == 520
+        assert security._contains_bare_secret(run) is False
+        assert self._count_window_classifications(run, monkeypatch) == 0
+
+    def test_all_hex_run_skips_every_window(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A long mixed-case hex digest passes gate 2 in every window but dies at
+        # gate 3 in every window. All-hex is closed under substring, so one
+        # whole-run test retires the slide -- 137 classifications become zero.
+        run = "0123456789abcdefABCDEF" * 8
+        assert len(run) == 176
+        assert security._HEX_ONLY_RE.match(run)
+        assert security._contains_bare_secret(run) is False
+        assert self._count_window_classifications(run, monkeypatch) == 0
+
+    def test_exactly_one_window_run_is_still_classified(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # BOUNDARY: the fast path is gated on `len(run) > _SECRET_KEY_LEN`, so a
+        # 40-char run must still reach the classifier.
+        #
+        # The fixture must FAIL one of the two fast-path gates, or this test
+        # cannot detect the boundary being wrong. With 40 lowercase chars: under
+        # `>` the fast path is skipped and the sole window is classified (1);
+        # under a mutated `>=` the fast path fires, the class check rejects, and
+        # nothing is classified (0). A fixture that clears both gates -- an AWS
+        # example key, say -- passes either way and pins nothing.
+        run = "abcdefghijklmnopqrstuvwxyz" + "abcdefghijklmn"
+        assert len(run) == _SECRET_KEY_LEN
+        assert not security._has_all_three_char_classes(run)
+        assert self._count_window_classifications(run, monkeypatch) == 1
+
+    def test_secret_glued_into_a_long_mixed_run_is_still_found(self) -> None:
+        # The fast path must not retire a run that DOES contain a secret. A real
+        # key glued to base64 padding on both sides makes a 60-char run whose
+        # only qualifying window is at a non-zero offset.
+        secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        run = "abc123XYZ/" + secret + "0123456789"
+        assert len(run) > _SECRET_KEY_LEN
+        assert security._contains_bare_secret(run) is True
+        result, warnings = redact_credentials(f"token={run}")
+        assert secret not in result
+        assert warnings
+
+    def test_run_with_all_three_classes_is_fully_slid(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # NEGATIVE CONTROL: the fast path may skip a run only when it can PROVE
+        # no window qualifies. This run holds all three classes and is not
+        # all-hex, so every one of its 21 windows must still be classified --
+        # 60 - 40 + 1 == 21. (Beware fixtures like "aB3" * 30: a, B and 3 are
+        # all hex digits, so that run is all-hex and is legitimately skipped.)
+        run = "Zz9" * 20
+        assert len(run) == 60
+        assert not security._HEX_ONLY_RE.match(run)
+        assert security._contains_bare_secret(run) is False
+        assert self._count_window_classifications(run, monkeypatch) == 21
+
+
+class TestCharClassHelperMatchesTheThreeScanDefinition:
+    """``_has_all_three_char_classes`` replaced three ``any()`` scans.
+
+    The single-pass early-exit loop must agree with the definition it replaced on
+    every input, including the elif-chain cases where one character could be
+    considered for more than one class.
+    """
+
+    @staticmethod
+    def _reference(text: str) -> bool:
+        return (
+            any(ch.islower() for ch in text)
+            and any(ch.isupper() for ch in text)
+            and any(ch.isdigit() for ch in text)
+        )
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "",
+            "a",
+            "A",
+            "1",
+            "aA1",
+            "1Aa",
+            "A1a",
+            "aaaaaaaa",
+            "AAAAAAAA",
+            "12345678",
+            "aaaa1111",
+            "AAAA1111",
+            "aaaaAAAA",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "0123456789abcdef0123456789abcdef01234567",
+            "+/+/+/+/",
+            "MASSE",
+            "straße",
+        ],
+    )
+    def test_agrees_with_reference_on_representative_shapes(self, text: str) -> None:
+        assert security._has_all_three_char_classes(text) is self._reference(text)
+
+    def test_agrees_with_reference_across_a_random_corpus(self) -> None:
+        rng = random.Random(20260810)
+        alphabet = string.ascii_letters + string.digits + "+/=-_ "
+        for _ in range(4000):
+            text = "".join(rng.choice(alphabet) for _ in range(rng.randint(0, 44)))
+            assert security._has_all_three_char_classes(text) is self._reference(
+                text
+            ), f"disagreement on {text!r}"
 
 
 class TestSandboxDeniedCommands:


### PR DESCRIPTION
## Problem

`redact_credentials` spends 72 ms on 16 KB of hex digests — worse than the 51 ms it
spends on 121 KB of ordinary prose. The bare-secret pass is the reason:
`_contains_bare_secret` slides a 40-char window **byte by byte** across every
base64-alphabet run and fully classifies each offset, so one 512-char run costs 473
classifications and 16 KB of such runs costs 15,136.

## Why it matters

Long non-secret runs are the common shape in the text this function is asked to
redact — git SHAs, sha256 digests, base64url ids, tool-output dumps. Every one of
them pays the full slide. `redact_credentials` runs on the redaction path, so this
is CPU held on the event loop during session restore and streamed output, for runs
that could never have contained a secret.

## Fix (symptom → root cause → change)

**Symptom:** hex- and lowercase-heavy payloads are dramatically more expensive per
byte than prose.

**Root cause:** the cost is per *window*, but the reason those windows are rejected
is a property of the *whole run*. Every window of an all-hex run is rejected for
being all-hex; every window of an all-lowercase run is rejected for missing a
character class. The slide rediscovers the same answer at every offset.

**Change:** two of the per-window gates reject on a property that is **closed under
substring**, so the run can be asked once and every window retired without
classifying any of them:

| gate | property | why it is substring-closed |
|---|---|---|
| 2 | run holds lower + upper + digit | a class absent from the run is absent from every substring of it |
| 3 | run is entirely hex | every substring of an all-hex string is all-hex |

Both paths return `False` either way, so this only reorders **which** check returns
`False` — never the verdict. The fast path is guarded on a run longer than one
window, because at exactly 40 chars the sole window pays those same two gates anyway
and the pre-check would be duplicate work.

Gate 2 itself moves from three `any()` generator scans to one early-exit pass in a
new `_has_all_three_char_classes` helper, shared by the per-window gate and the
run-level check. Both forms short-circuit; the saving is generator frames plus a
scan length that is now the MAX of the three first-match offsets rather than their
SUM.

### Measured

Window counts are exact and load-independent. The host was loaded (1-min average
swung between 22 and 81 during measurement), so timings are ranges from *alternating*
baseline/branch runs — a single non-alternating comparison gave a spurious result and
was discarded.

| payload | window classifications | wall clock |
|---|---|---|
| 16 KB of hex digests | 15,136 → **0** | 72 → 5.3 ms |
| 16 KB of lowercase blobs | 15,136 → **0** | 96 → 5.5 ms |
| 16 KB of mixed non-hex runs | 15,072 → 15,072 (unchanged) | ~7-30% faster |
| exactly-40 runs | 1 each (unchanged) | ~5% faster |
| 121 KB restore-shaped text | 780 (unchanged) | ~4% faster |

## Tests

The change is deliberately verdict-neutral, so a behaviour test passes with or
without it. The new tests therefore assert on **work done**, not just output.

`TestBareSecretRunLevelFastPath` monkeypatches `_looks_like_secret_key` and counts
window classifications:

- a 520-char lowercase run and a 176-char mixed-case hex run must drop to **zero**
  classifications — both assertions fail on `main`;
- the exactly-40 boundary must still classify its one window. This fixture
  deliberately **fails** a fast-path gate, because a fixture that clears both gates
  (an AWS example key, say) passes under both `>` and `>=` and pins nothing. Verified
  by mutation: flipping the guard to `>=` fails this test, reverting passes it;
- a real key glued inside a 60-char run must still be found and redacted — the
  direction in which a wrong class check would leak a credential;
- a negative control (`"Zz9" * 20`) must still slide all 21 of its windows, proving
  the fast path skips only what it can prove.

`TestCharClassHelperMatchesTheThreeScanDefinition` diffs the helper against the
three-scan definition it replaced over 18 named shapes plus a 4,000-case seeded
corpus.

## Manual verification

N/A — unit coverage is sufficient, and the load-bearing claims are covered
mechanically: the window-count assertions fail on `main`, and the boundary guard is
mutation-proven.

Gates run against a pristine `origin/main` worktree for comparison: `test_security.py`
388 pass vs 364 on baseline (the +24 are these tests) with **byte-identical failure
sets**; `isort` and `flake8` clean; `mypy` reports the same 6 pre-existing errors on
both sides, none in `security.py`.

Two caveats stated plainly. The 44 shared `test_security.py` failures and the 6 mypy
errors are pre-existing on `main` in this environment: the failures come from running
under `--noconftest` (a sandbox constraint prevented installing the package's runtime
deps, so `conftest.py` could not import `slack_sdk`) and the mypy errors from a local
1.20.1 against the 1.14.1 pin in `pyproject.toml`. Neither is CI parity, so CI is the
authority on both.

## Screenshots

N/A — no user-visible UI change.
